### PR TITLE
fix(skills): enforce managed policies during discovery

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -586,6 +586,9 @@ def reload_skills() -> Dict[str, Any]:
 
     # Rescan the skills dir. ``scan_skill_commands`` resets
     # ``_skill_commands = {}`` internally and repopulates it.
+    from agent.skill_utils import _external_dirs_cache_clear
+
+    _external_dirs_cache_clear()
     new_commands = scan_skill_commands()
 
     after = _snapshot(new_commands)

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -1,8 +1,9 @@
 """Lightweight skill metadata utilities shared by prompt_builder and skills_tool.
 
 This module intentionally avoids importing the tool registry, CLI config, or any
-heavy dependency chain.  It is safe to import at module level without triggering
-tool registration or provider resolution.
+heavy dependency chain at module import time. Behavioral config reads load the
+canonical read-only CLI config lazily; importing this module alone does not
+trigger tool registration or provider resolution.
 """
 
 import ast
@@ -13,7 +14,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from hermes_constants import get_config_path, get_skills_dir, is_termux
+from hermes_constants import get_skills_dir, is_termux
 
 logger = logging.getLogger(__name__)
 
@@ -391,47 +392,16 @@ def skill_matches_environment(frontmatter: Dict[str, Any]) -> bool:
 # ── Disabled skills ───────────────────────────────────────────────────────
 
 
-_RAW_CONFIG_CACHE: Dict[Tuple[str, int, int], Dict[str, Any]] = {}
+def _load_skill_config() -> Dict[str, Any]:
+    """Return the canonical effective config for read-only skill consumers.
 
-
-def _raw_config_cache_clear() -> None:
-    """Test hook — drop the shared raw config cache."""
-    _RAW_CONFIG_CACHE.clear()
-
-
-def _load_raw_config() -> Dict[str, Any]:
-    """Read config.yaml with a shared mtime+size keyed cache.
-
-    This module intentionally avoids importing ``hermes_cli.config`` on the
-    skill prompt/build path. A tiny local cache gives the same repeated-read
-    win without pulling the heavier CLI config stack into startup.
+    Import lazily so importing skill metadata helpers remains lightweight. The
+    shared loader owns profile and managed signatures, environment expansion,
+    normalization, and the shared read-only warm-path cache.
     """
-    config_path = get_config_path()
-    if not config_path.exists():
-        return {}
-    try:
-        stat = config_path.stat()
-        cache_key = (str(config_path), stat.st_mtime_ns, stat.st_size)
-    except OSError:
-        cache_key = None
+    from hermes_cli.config import load_config_readonly
 
-    if cache_key is not None:
-        cached = _RAW_CONFIG_CACHE.get(cache_key)
-        if cached is not None:
-            return cached
-
-    try:
-        parsed = yaml_load(config_path.read_text(encoding="utf-8"))
-    except Exception as e:
-        logger.debug("Could not read skill config %s: %s", config_path, e)
-        return {}
-    if not isinstance(parsed, dict):
-        return {}
-
-    if cache_key is not None:
-        _RAW_CONFIG_CACHE.clear()
-        _RAW_CONFIG_CACHE[cache_key] = parsed
-    return parsed
+    return load_config_readonly()
 
 
 def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
@@ -445,10 +415,10 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
             platform is resolved (a globally-disabled skill stays disabled
             on every platform).
 
-    Reads the config file directly (no CLI config imports) to stay
-    lightweight.
+    Reads the canonical effective config lazily so administrator-disabled
+    skills cannot load and environment references match other config readers.
     """
-    parsed = _load_raw_config()
+    parsed = _load_skill_config()
     if not parsed:
         return set()
 
@@ -464,8 +434,12 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
     )
     global_disabled = _normalize_string_set(skills_cfg.get("disabled"))
     if resolved_platform:
-        platform_disabled = (skills_cfg.get("platform_disabled") or {}).get(
-            resolved_platform
+        from hermes_cli.config import cfg_get
+
+        platform_disabled = cfg_get(
+            skills_cfg,
+            "platform_disabled",
+            resolved_platform,
         )
         if platform_disabled is not None:
             return global_disabled | _normalize_string_set(platform_disabled)
@@ -504,19 +478,69 @@ def _normalize_string_set(values) -> Set[str]:
 
 # ── External skills directories ──────────────────────────────────────────
 
-# (config_path_str, mtime_ns) -> resolved external dirs list.  Keyed by
-# mtime_ns so a config.yaml edit mid-run is picked up automatically;
-# otherwise every call would re-read + re-YAML-parse the 15KB config,
-# which becomes the dominant cost of ``hermes`` startup when ~120 skills
-# each trigger a category lookup during banner construction (10+ seconds
-# of pure waste).
-_EXTERNAL_DIRS_CACHE: Dict[Tuple[str, int], List[Path]] = {}
+# Cache configured roots after environment expansion, path resolution, and the
+# initial availability check. The key contains the effective values and profile
+# home, so user, managed, env, and profile changes select the right entry. Both
+# configured ownership and discovered availability stay stable until an explicit
+# cache clear; otherwise a transient mount outage could change the system prompt
+# mid-conversation or make an externally-owned skill curator-writable. This
+# function is called once per skill during banner and tool-registry scans, so the
+# cache also avoids repeated resolve/stat syscalls on that hot path.
+_ExternalDirsCacheKey = Tuple[str, Tuple[str, ...]]
+_ExternalDirsCacheValue = Tuple[Tuple[Path, ...], Tuple[Path, ...]]
+_EXTERNAL_DIRS_CACHE: Dict[_ExternalDirsCacheKey, _ExternalDirsCacheValue] = {}
 
 
 def _external_dirs_cache_clear() -> None:
-    """Test hook — drop the in-process cache."""
+    """Test and reload hook — drop resolved external directory roots."""
     _EXTERNAL_DIRS_CACHE.clear()
-    _raw_config_cache_clear()
+
+
+def _external_skills_dirs(*, include_unavailable: bool) -> List[Path]:
+    """Return cached external roots with optional unavailable ownership roots."""
+    parsed = _load_skill_config()
+    from hermes_cli.config import cfg_get
+
+    raw_dirs = parse_config_string_list(cfg_get(parsed, "skills", "external_dirs"))
+
+    from hermes_constants import get_hermes_home
+
+    hermes_home = get_hermes_home()
+    # Environment references are already expanded by load_config_readonly().
+    # Expand ~ before deriving the path-cache key.
+    expanded_dirs = tuple(
+        os.path.expanduser(entry.strip()) for entry in raw_dirs if entry.strip()
+    )
+    cache_key = (str(hermes_home), expanded_dirs)
+    cached = _EXTERNAL_DIRS_CACHE.get(cache_key)
+    if cached is not None:
+        configured, available = cached
+        return list(configured if include_unavailable else available)
+
+    local_skills = get_skills_dir().resolve()
+    seen: Set[Path] = set()
+    configured: List[Path] = []
+    available: List[Path] = []
+
+    for entry in expanded_dirs:
+        p = Path(entry)
+        # Resolve relative paths against HERMES_HOME, not cwd
+        if not p.is_absolute():
+            p = (hermes_home / p).resolve()
+        else:
+            p = p.resolve()
+        if p == local_skills or p in seen:
+            continue
+        seen.add(p)
+        configured.append(p)
+        if p.is_dir():
+            available.append(p)
+        else:
+            logger.debug("External skills dir does not exist, skipping: %s", p)
+
+    cached = (tuple(configured), tuple(available))
+    _EXTERNAL_DIRS_CACHE[cache_key] = cached
+    return list(configured if include_unavailable else available)
 
 
 def get_external_skills_dirs() -> List[Path]:
@@ -526,80 +550,12 @@ def get_external_skills_dirs() -> List[Path]:
     path.  Only directories that actually exist are returned.  Duplicates and
     paths that resolve to the local ``~/.hermes/skills/`` are silently skipped.
 
-    Cached in-process, keyed on ``config.yaml`` mtime — the function is
-    called once per skill during banner / tool-registry scans, and YAML
-    parsing a non-trivial config dominates ``hermes`` cold-start time
-    when the cache is absent.
+    Resolution and initial availability are cached in-process because this
+    function is called once per skill during banner and tool-registry scans.
+    Call :func:`_external_dirs_cache_clear` before an explicit rescan when a
+    mount's availability may have changed.
     """
-    config_path = get_config_path()
-    if not config_path.exists():
-        return []
-
-    # Cache key: (absolute path, mtime_ns).  stat() is ~2us vs ~85ms for
-    # the full YAML parse, so the fast path is nearly free.
-    try:
-        stat = config_path.stat()
-        cache_key: Tuple[str, int] = (str(config_path), stat.st_mtime_ns)
-    except OSError:
-        cache_key = None  # type: ignore[assignment]
-
-    if cache_key is not None:
-        cached = _EXTERNAL_DIRS_CACHE.get(cache_key)
-        if cached is not None:
-            # Return a copy so callers can't mutate the cached list.
-            return list(cached)
-
-    parsed = _load_raw_config()
-    if not parsed:
-        return []
-
-    skills_cfg = parsed.get("skills")
-    if not isinstance(skills_cfg, dict):
-        return []
-
-    raw_dirs = skills_cfg.get("external_dirs")
-    if not raw_dirs:
-        result: List[Path] = []
-        if cache_key is not None:
-            _EXTERNAL_DIRS_CACHE[cache_key] = list(result)
-        return result
-    if isinstance(raw_dirs, str):
-        raw_dirs = [raw_dirs]
-    if not isinstance(raw_dirs, list):
-        return []
-
-    from hermes_constants import get_hermes_home
-
-    hermes_home = get_hermes_home()
-    local_skills = get_skills_dir().resolve()
-    seen: Set[Path] = set()
-    result = []
-
-    for entry in raw_dirs:
-        entry = str(entry).strip()
-        if not entry:
-            continue
-        # Expand ~ and environment variables
-        expanded = os.path.expanduser(os.path.expandvars(entry))
-        p = Path(expanded)
-        # Resolve relative paths against HERMES_HOME, not cwd
-        if not p.is_absolute():
-            p = (hermes_home / p).resolve()
-        else:
-            p = p.resolve()
-        if p == local_skills:
-            continue
-        if p in seen:
-            continue
-        if p.is_dir():
-            seen.add(p)
-            result.append(p)
-        else:
-            logger.debug("External skills dir does not exist, skipping: %s", p)
-
-    if cache_key is not None:
-        _EXTERNAL_DIRS_CACHE[cache_key] = list(result)
-    return result
+    return _external_skills_dirs(include_unavailable=False)
 
 
 def get_all_skills_dirs() -> List[Path]:
@@ -698,7 +654,7 @@ def find_project_root(start: Optional[Path] = None) -> Optional[Path]:
 
 def _project_trusted_dirs_from_config() -> Set[Path]:
     """Resolved set of trusted project roots from ``skills.trusted_project_dirs``."""
-    parsed = _load_raw_config()
+    parsed = _load_skill_config()
     if not parsed:
         return set()
     skills_cfg = parsed.get("skills")
@@ -755,7 +711,7 @@ def get_project_skills_dirs() -> List[Path]:
     discovery is disabled (``skills.project_discovery: false``), or the
     project root is not trusted.
     """
-    parsed = _load_raw_config()
+    parsed = _load_skill_config()
     skills_cfg = parsed.get("skills") if isinstance(parsed, dict) else None
     if isinstance(skills_cfg, dict) and skills_cfg.get("project_discovery") is False:
         return []
@@ -774,7 +730,7 @@ def get_untrusted_project_skills_root() -> Optional[Tuple[Path, int]]:
     ``hermes skills trust``. Returns None when there is nothing to notify
     about (no project, no skills, already trusted, or discovery disabled).
     """
-    parsed = _load_raw_config()
+    parsed = _load_skill_config()
     skills_cfg = parsed.get("skills") if isinstance(parsed, dict) else None
     if isinstance(skills_cfg, dict) and skills_cfg.get("project_discovery") is False:
         return None
@@ -973,7 +929,9 @@ def is_external_skill_path(path) -> bool:
     not each need to re-interpret the config.
     """
     candidate = _resolve_for_skill_ownership(path)
-    roots: List[Path] = list(get_external_skills_dirs())
+    # Ownership follows configuration, not current availability. A transiently
+    # unavailable external mount must never make its skills curator-writable.
+    roots: List[Path] = _external_skills_dirs(include_unavailable=True)
     # Trusted project-local dirs are repo-owned — same read-only boundary
     # for autonomous lifecycle maintenance as configured external dirs.
     try:
@@ -1139,7 +1097,7 @@ def resolve_skill_config_values(
     current values (or the declared default if the key isn't set).
     Path values are expanded via ``os.path.expanduser``.
     """
-    config = _load_raw_config()
+    config = _load_skill_config()
 
     resolved: Dict[str, Any] = {}
     for var in config_vars:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -41,6 +41,10 @@ logger = logging.getLogger(__name__)
 # so concurrent CLI/gateway loads of a broken config.yaml don't spam stderr
 # every time. Cleared automatically when the file changes (different mtime).
 _CONFIG_PARSE_WARNED: set = set()
+# Read failures are operational, not proof that YAML is corrupt. Deduplicate
+# their warning independently so a later genuine parse error for the same file
+# still gets its corruption-specific warning and backup.
+_CONFIG_READ_WARNED: set = set()
 
 
 def _backup_corrupt_config(config_path: Path) -> Optional[Path]:
@@ -154,6 +158,43 @@ def _warn_config_parse_failure(
         sys.stderr.flush()
     except Exception:
         pass
+
+
+def _warn_config_read_failure(
+    config_path: Path,
+    exc: OSError,
+    *,
+    fallback: str = "defaults",
+) -> None:
+    """Surface a transient config read failure without classifying corruption."""
+    try:
+        st = config_path.stat()
+        key = (str(config_path), st.st_mtime_ns, st.st_size)
+    except OSError:
+        key = (str(config_path), 0, 0)
+    if key in _CONFIG_READ_WARNED:
+        return
+    _CONFIG_READ_WARNED.add(key)
+
+    if fallback == "last-known-good":
+        msg = (
+            f"Could not read {config_path}: {exc}. "
+            "Keeping the previously loaded config for this attempt; "
+            "the next load will retry."
+        )
+    else:
+        msg = (
+            f"Could not read {config_path}: {exc}. "
+            "Falling back to default config for this attempt; "
+            "the next load will retry."
+        )
+    logger.warning(msg)
+    try:
+        sys.stderr.write(f"⚠️  hermes config: {msg}\n")
+        sys.stderr.flush()
+    except Exception:
+        pass
+
 
 _IS_WINDOWS = platform.system() == "Windows"
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -3544,11 +3585,15 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
         config_path = get_config_path()
         path_key = str(config_path)
 
+        user_stat_error: Optional[OSError] = None
         try:
             st = config_path.stat()
             user_sig: Optional[Tuple[int, int]] = (st.st_mtime_ns, st.st_size)
         except FileNotFoundError:
             user_sig = None
+        except OSError as e:
+            user_sig = None
+            user_stat_error = e
 
         # Managed scope: fold the managed config file's (mtime, size) into the
         # cache signature so editing /etc/hermes/config.yaml invalidates the
@@ -3563,19 +3608,22 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
         except OSError:
             managed_sig = (0, 0)
 
-        # Combined cache signature: user file + managed file. None only when the
-        # user config is absent AND no managed file exists (nothing to cache on).
-        if user_sig is not None:
-            cache_sig: Optional[Tuple[int, int, int, int]] = (
+        # Combined cache signature: user file + managed file. Zero pairs mean
+        # an absent source; caching that default-only state keeps repeated
+        # read-only consumers cheap, while a later file creation changes the
+        # signature and invalidates it normally.
+        cache_sig: Optional[Tuple[int, int, int, int]]
+        if user_stat_error is not None:
+            cache_sig = None
+        elif user_sig is not None:
+            cache_sig = (
                 user_sig[0],
                 user_sig[1],
                 managed_sig[0],
                 managed_sig[1],
             )
-        elif managed_sig != (0, 0):
-            cache_sig = (0, 0, managed_sig[0], managed_sig[1])
         else:
-            cache_sig = None
+            cache_sig = (0, 0, managed_sig[0], managed_sig[1])
 
         cached = _LOAD_CONFIG_CACHE.get(path_key)
         if cached is not None and cache_sig is not None and cached[:4] == cache_sig:
@@ -3589,6 +3637,18 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                 return copy.deepcopy(cached[4]) if want_deepcopy else cached[4]
 
         config = copy.deepcopy(DEFAULT_CONFIG)
+        user_read_failed = user_stat_error is not None
+
+        if user_stat_error is not None:
+            lkg = _LAST_EXPANDED_CONFIG_BY_PATH.get(path_key)
+            _warn_config_read_failure(
+                config_path,
+                user_stat_error,
+                fallback="last-known-good" if lkg is not None else "defaults",
+            )
+            if lkg is not None:
+                lkg_copy = copy.deepcopy(lkg)
+                return copy.deepcopy(lkg_copy) if want_deepcopy else lkg_copy
 
         if user_sig is not None:
             try:
@@ -3603,6 +3663,25 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                     user_config.pop("max_turns", None)
 
                 config = _deep_merge(config, user_config)
+            except OSError as e:
+                # Operational read failures are not evidence of malformed YAML:
+                # do not create a corruption backup or cache fallback data under
+                # the valid file signature. The next call must retry the read.
+                user_read_failed = True
+                cache_sig = None
+                lkg = _LAST_EXPANDED_CONFIG_BY_PATH.get(path_key)
+                _warn_config_read_failure(
+                    config_path,
+                    e,
+                    fallback="last-known-good" if lkg is not None else "defaults",
+                )
+                if lkg is not None:
+                    from typing import cast as _cast
+
+                    lkg_copy: Dict[str, Any] = _cast(
+                        Dict[str, Any], _expand_env_vars(copy.deepcopy(lkg))
+                    )
+                    return copy.deepcopy(lkg_copy) if want_deepcopy else lkg_copy
             except Exception as e:
                 # Last-known-good fallback (port of openai/codex#31188's
                 # invariant: a parse failure in a policy/config file must not
@@ -3651,7 +3730,22 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
         # against the process environment, never against user-config-defined refs.
         # This deliberately inverts the usual env-over-config precedence for the
         # keys the managed layer pins — see docs/design/managed-scope.md §4.1.
-        managed_config = managed_scope.load_managed_config()
+        managed_read_failed = False
+        try:
+            managed_config = managed_scope.load_managed_config(fail_open=False)
+        except Exception:  # noqa: BLE001 — managed policy is a fail-open boundary
+            # Do not cache a user-only result under the managed file's valid
+            # signature. Preserve the prior effective policy when available;
+            # otherwise return the user/default config for this attempt and
+            # retry the managed read on the next call.
+            managed_read_failed = True
+            cache_sig = None
+            logger.warning("managed scope: failed to load config overlay", exc_info=True)
+            lkg = _LAST_EXPANDED_CONFIG_BY_PATH.get(path_key)
+            if lkg is not None:
+                lkg_copy = copy.deepcopy(lkg)
+                return copy.deepcopy(lkg_copy) if want_deepcopy else lkg_copy
+            managed_config = {}
         if managed_config:
             # Normalize the managed overlay through the same canonicalization as
             # the user config BEFORE merging (parity with
@@ -3666,7 +3760,8 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                 managed_normalized["model"] = {"default": managed_normalized["model"]}
             managed_expanded = _expand_env_vars(managed_normalized)
             expanded = _deep_merge(expanded, managed_expanded)
-        _LAST_EXPANDED_CONFIG_BY_PATH[path_key] = copy.deepcopy(expanded)
+        if not user_read_failed and not managed_read_failed:
+            _LAST_EXPANDED_CONFIG_BY_PATH[path_key] = copy.deepcopy(expanded)
         if cache_sig is not None:
             # Cache stores a separate deepcopy so subsequent ``load_config()``
             # (deepcopy=True) callers can mutate freely without affecting the
@@ -3691,8 +3786,8 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
         # First-load result is a fresh dict (not aliased to the cache); safe
         # to return directly. For the deepcopy=True path this is the
         # canonical "freshly-built mutable result" the function has always
-        # returned. For the deepcopy=False path with no cache (e.g. config
-        # file missing), it's also fine — callers get an isolated object.
+        # returned. For the deepcopy=False path after an operational read
+        # failure, it's also fine — callers get an isolated fallback object.
         return expanded
 
 

--- a/hermes_cli/managed_scope.py
+++ b/hermes_cli/managed_scope.py
@@ -15,6 +15,7 @@ is the single seam for adding macOS / Windows native locations later.
 
 Attribution: do not reference any third-party product by name in this file.
 """
+
 from __future__ import annotations
 
 import copy
@@ -78,13 +79,19 @@ def invalidate_managed_cache() -> None:
         _ENV_CACHE.clear()
 
 
-def _cached_read(path: Path, cache: Dict[str, tuple], parse):
+def _cached_read(
+    path: Path,
+    cache: Dict[str, tuple],
+    parse,
+    *,
+    fail_open: bool = True,
+):
     """Shared (mtime_ns, size)-keyed read. Returns a deepcopy of the parsed value.
 
-    Returns ``None`` when the file is absent or fails to parse (fail-open). A
-    parse failure is logged LOUDLY — the admin needs to know their policy isn't
-    being applied — but never raises, so a malformed managed file can't brick
-    startup.
+    Returns ``None`` when the file is absent. With ``fail_open=True``, read or
+    parse failures are logged LOUDLY and also return ``None`` so malformed
+    managed files cannot brick standalone callers. Canonical loaders can opt to
+    propagate the failure when they own a last-known-good fallback.
     """
     try:
         st = path.stat()
@@ -99,30 +106,56 @@ def _cached_read(path: Path, cache: Dict[str, tuple], parse):
     try:
         with open(path, encoding="utf-8") as f:
             parsed = parse(f)
-    except Exception as exc:  # noqa: BLE001 — fail-open, but LOUD
+    except Exception as exc:  # noqa: BLE001 — managed config is a trust boundary
         logger.warning(
-            "managed scope: failed to parse %s: %s — IGNORING this managed file. "
-            "Admin policy from this file is NOT being applied. Fix and restart.",
+            "managed scope: failed to read or parse %s: %s — IGNORING this "
+            "managed file. Admin policy from this file is NOT being applied. "
+            "Fix the file; the next load will retry.",
             path,
             exc,
         )
+        if not fail_open:
+            raise
         return None
     with _CACHE_LOCK:
         cache[path_key] = (key[0], key[1], copy.deepcopy(parsed))
     return parsed
 
 
-def load_managed_config() -> dict:
-    """Parsed managed config.yaml, or {} when absent/malformed (fail-open)."""
+def _parse_managed_config(file_obj) -> dict:
+    """Parse and normalize managed config at its trust boundary."""
+    parsed = yaml.safe_load(file_obj) or {}
+    if not isinstance(parsed, dict):
+        logger.warning(
+            "managed scope: config root must be a mapping; ignoring managed config"
+        )
+        return {}
+    if "skills" in parsed and not isinstance(parsed["skills"], dict):
+        logger.warning(
+            "managed scope: skills must be a mapping; ignoring managed skills policy"
+        )
+        parsed = dict(parsed)
+        parsed.pop("skills")
+    return parsed
+
+
+def load_managed_config(*, fail_open: bool = True) -> dict:
+    """Return parsed managed config, optionally propagating read/parse errors.
+
+    Standalone callers default to fail-open. The canonical config loader passes
+    ``fail_open=False`` so it can preserve last-known-good policy and avoid
+    caching a user-only result under the managed file's valid signature.
+    """
     managed_dir = get_managed_dir()
     if managed_dir is None:
         return {}
     parsed = _cached_read(
         managed_dir / "config.yaml",
         _CONFIG_CACHE,
-        lambda f: yaml.safe_load(f) or {},
+        _parse_managed_config,
+        fail_open=fail_open,
     )
-    return parsed if isinstance(parsed, dict) else {}
+    return parsed or {}
 
 
 def load_managed_env() -> Dict[str, str]:
@@ -159,7 +192,11 @@ def apply_managed_overlay(config: dict) -> dict:
         if not managed:
             return config
         # Imported lazily to avoid an import cycle (config imports managed_scope).
-        from hermes_cli.config import _deep_merge, _expand_env_vars, _normalize_root_model_keys
+        from hermes_cli.config import (
+            _deep_merge,
+            _expand_env_vars,
+            _normalize_root_model_keys,
+        )
 
         managed_expanded = _normalize_root_model_keys(_expand_env_vars(managed))
         # A bare ``model: x/y`` string in the managed file must merge as

--- a/tests/agent/test_external_skills_dirs_cache.py
+++ b/tests/agent/test_external_skills_dirs_cache.py
@@ -1,15 +1,16 @@
-"""Guards for ``get_external_skills_dirs`` mtime-based memo.
+"""Guards for ``get_external_skills_dirs`` config loading.
 
 ``get_external_skills_dirs()`` is called once per skill during banner
 construction and tool registration — on a typical install that's 120+
-calls.  Without caching, each call re-reads + YAML-parses the full
-config.yaml (~85ms each, 10+ seconds total).  This test pins the
-behavior: first call parses, subsequent calls return cached result,
-cache invalidates when config.yaml's mtime changes.
+calls. Profile and managed loaders cache YAML parsing, while configured path
+resolution and initial availability are cached separately until an explicit
+refresh. These tests pin managed precedence, recovery, ownership, and
+invalidation behavior.
 """
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -19,8 +20,22 @@ import pytest
 from agent import skill_utils
 from agent.skill_utils import (
     _external_dirs_cache_clear,
+    get_disabled_skill_names,
     get_external_skills_dirs,
+    is_external_skill_path,
+    is_project_root_trusted,
 )
+
+
+def _clear_skill_config_caches() -> None:
+    """Reset each independently-owned cache used by these isolated fixtures."""
+    from hermes_cli import config as config_mod
+    from hermes_cli import managed_scope
+
+    _external_dirs_cache_clear()
+    config_mod._LOAD_CONFIG_CACHE.clear()
+    config_mod._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+    managed_scope.invalidate_managed_cache()
 
 
 @pytest.fixture
@@ -28,32 +43,410 @@ def hermes_home_with_config(tmp_path, monkeypatch):
     """Isolated ``~/.hermes/`` with a config.yaml referencing one external dir."""
     home = tmp_path / ".hermes"
     home.mkdir()
-    external = tmp_path / "external_skills"
+    external = tmp_path / "external_alpha"
     external.mkdir()
 
     config = home / "config.yaml"
     config.write_text(
-        "skills:\n"
-        f"  external_dirs:\n"
-        f"    - {external}\n",
+        f"skills:\n  external_dirs:\n    - {external}\n",
         encoding="utf-8",
     )
 
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    _external_dirs_cache_clear()
+    _clear_skill_config_caches()
     yield home, external, config
-    _external_dirs_cache_clear()
+    _clear_skill_config_caches()
 
 
+@pytest.fixture
+def managed_external_dirs(tmp_path, monkeypatch):
+    """Isolated user and managed configs with external skill directories."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    managed_external = tmp_path / "managed_alpha"
+    managed_external.mkdir()
+    user_external = tmp_path / "user_external"
+    user_external.mkdir()
+
+    (home / "config.yaml").write_text(
+        "skills:\n  template_vars: true\n",
+        encoding="utf-8",
+    )
+    managed_config = managed / "config.yaml"
+    managed_config.write_text(
+        f"skills:\n  external_dirs:\n    - {managed_external}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    _clear_skill_config_caches()
+    yield home, managed_config, managed_external, user_external
+    _clear_skill_config_caches()
 
 
+def test_managed_external_dirs_are_used_when_user_config_omits_them(
+    managed_external_dirs,
+):
+    """A managed-only external_dirs value participates in skill discovery."""
+    _home, _managed_config, managed_external, _user_external = managed_external_dirs
+
+    assert get_external_skills_dirs() == [managed_external.resolve()]
 
 
-def test_cache_invalidates_on_mtime_change(hermes_home_with_config):
-    """A config.yaml edit invalidates the cache on the next call."""
+def test_managed_external_dirs_are_used_without_user_config(managed_external_dirs):
+    """Managed external_dirs works when the profile config does not exist."""
+    home, _managed_config, managed_external, _user_external = managed_external_dirs
+    (home / "config.yaml").unlink()
+
+    assert get_external_skills_dirs() == [managed_external.resolve()]
+
+
+def test_managed_external_dirs_override_user_config(managed_external_dirs):
+    """Managed external_dirs wins over the user value at the same leaf."""
+    home, _managed_config, managed_external, user_external = managed_external_dirs
+    (home / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {user_external}\n",
+        encoding="utf-8",
+    )
+
+    assert get_external_skills_dirs() == [managed_external.resolve()]
+
+
+def test_managed_skills_enforce_disabled_and_project_policy(
+    managed_external_dirs,
+    monkeypatch,
+):
+    """All managed skills policy leaves are enforced by behavioral readers."""
+    home, managed_config, managed_external, user_external = managed_external_dirs
+    (managed_external / ".git").mkdir()
+    (managed_external / ".hermes" / "skills" / "project-skill").mkdir(parents=True)
+    monkeypatch.chdir(managed_external)
+    (home / "config.yaml").write_text(
+        f"skills:\n  trusted_project_dirs:\n    - {user_external}\n",
+        encoding="utf-8",
+    )
+    managed_config.write_text(
+        "skills:\n"
+        f"  external_dirs:\n    - {managed_external}\n"
+        f"  trusted_project_dirs:\n    - {managed_external}\n"
+        "  project_discovery: false\n"
+        "  disabled: [risky-skill]\n",
+        encoding="utf-8",
+    )
+
+    assert get_external_skills_dirs() == [managed_external.resolve()]
+    assert get_disabled_skill_names() == {"risky-skill"}
+    assert not is_project_root_trusted(user_external)
+    assert is_project_root_trusted(managed_external)
+    assert skill_utils.get_project_skills_dirs() == []
+
+
+def test_invalid_managed_skills_shape_preserves_user_config(
+    managed_external_dirs,
+    caplog,
+):
+    """An invalid managed skills section does not discard valid user settings."""
+    home, managed_config, _managed_external, user_external = managed_external_dirs
+    (home / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {user_external}\n",
+        encoding="utf-8",
+    )
+    managed_config.write_text("skills: []\n", encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING):
+        first = get_external_skills_dirs()
+        second = get_external_skills_dirs()
+
+    warnings = [
+        record
+        for record in caplog.records
+        if "skills must be a mapping" in record.getMessage()
+    ]
+    assert first == [user_external.resolve()]
+    assert second == [user_external.resolve()]
+    assert len(warnings) == 1
+
+
+def test_managed_external_dirs_expand_environment_variables(
+    managed_external_dirs,
+    monkeypatch,
+):
+    """Managed external directories retain documented environment expansion."""
+    _home, managed_config, managed_external, _user_external = managed_external_dirs
+    monkeypatch.setenv("SHARED_SKILLS_ROOT", str(managed_external.parent))
+    managed_config.write_text(
+        'skills:\n  external_dirs:\n    - "${env:SHARED_SKILLS_ROOT}/managed_alpha"\n',
+        encoding="utf-8",
+    )
+
+    assert get_external_skills_dirs() == [managed_external.resolve()]
+
+
+def test_user_external_dirs_expand_prefixed_environment_variables(
+    hermes_home_with_config,
+    monkeypatch,
+):
+    """User and managed paths share the documented ${env:VAR} expansion."""
     _home, external, config = hermes_home_with_config
-    other = external.parent / "other_skills"
+    monkeypatch.setenv("SHARED_SKILLS_ROOT", str(external.parent))
+    config.write_text(
+        'skills:\n  external_dirs:\n    - "${env:SHARED_SKILLS_ROOT}/external_alpha"\n',
+        encoding="utf-8",
+    )
+
+    assert get_external_skills_dirs() == [external.resolve()]
+
+
+def test_json_array_string_external_dirs_is_parsed(hermes_home_with_config):
+    """Stringified list values retain config-set list compatibility."""
+    _home, external, config = hermes_home_with_config
+    config.write_text(
+        f"skills:\n  external_dirs: '[\"{external}\"]'\n",
+        encoding="utf-8",
+    )
+
+    assert get_external_skills_dirs() == [external.resolve()]
+
+
+def test_malformed_platform_disabled_does_not_crash(hermes_home_with_config):
+    """A malformed nested policy value is treated as absent."""
+    _home, _external, config = hermes_home_with_config
+    config.write_text(
+        "skills:\n  disabled: [global-skill]\n  platform_disabled: broken\n",
+        encoding="utf-8",
+    )
+
+    assert get_disabled_skill_names("telegram") == {"global-skill"}
+
+
+@pytest.mark.parametrize("managed_value", ["[]", "null"])
+def test_managed_empty_external_dirs_disable_user_value(
+    managed_external_dirs,
+    managed_value,
+):
+    """An administrator can disable user external directories wholesale."""
+    home, managed_config, _managed_external, user_external = managed_external_dirs
+    (home / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {user_external}\n",
+        encoding="utf-8",
+    )
+    managed_config.write_text(
+        f"skills:\n  external_dirs: {managed_value}\n",
+        encoding="utf-8",
+    )
+
+    assert get_external_skills_dirs() == []
+
+
+def test_managed_overlay_failure_is_fail_open(managed_external_dirs):
+    """A managed loader failure preserves the usable profile config."""
+    home, _managed_config, _managed_external, user_external = managed_external_dirs
+    (home / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {user_external}\n",
+        encoding="utf-8",
+    )
+    from hermes_cli import managed_scope
+
+    with patch.object(
+        managed_scope,
+        "load_managed_config",
+        side_effect=OSError("transient managed read failure"),
+    ):
+        assert get_external_skills_dirs() == [user_external.resolve()]
+
+
+def test_external_cache_clear_does_not_invalidate_managed_env(
+    managed_external_dirs,
+):
+    """Skill discovery cache resets do not touch the managed env subsystem."""
+    _home, managed_config, _managed_external, _user_external = managed_external_dirs
+    from hermes_cli import managed_scope
+
+    managed_env = managed_config.parent / ".env"
+    managed_env.write_text("ORG_POLICY=locked\n", encoding="utf-8")
+    assert managed_scope.load_managed_env() == {"ORG_POLICY": "locked"}
+
+    with patch.object(
+        managed_scope,
+        "_parse_env",
+        side_effect=AssertionError("managed env cache was unexpectedly cleared"),
+    ):
+        _external_dirs_cache_clear()
+        cached = managed_scope.load_managed_env()
+
+    assert cached == {"ORG_POLICY": "locked"}
+
+
+def test_environment_change_is_visible_without_config_edit(
+    hermes_home_with_config,
+    monkeypatch,
+):
+    """Resolved paths follow environment changes while YAML stays cached."""
+    _home, external, config = hermes_home_with_config
+    other = external.parent / "external_bravo"
+    other.mkdir()
+    config.write_text(
+        "skills:\n  external_dirs:\n    - ${EXTERNAL_SKILLS_DIR}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("EXTERNAL_SKILLS_DIR", str(external))
+    first = get_external_skills_dirs()
+    monkeypatch.setenv("EXTERNAL_SKILLS_DIR", str(other))
+    second = get_external_skills_dirs()
+
+    assert first == [external.resolve()]
+    assert second == [other.resolve()]
+
+
+def test_directory_availability_changes_only_after_explicit_cache_clear(
+    hermes_home_with_config,
+):
+    """Availability stays stable until an explicit skill-directory refresh."""
+    _home, _external, config = hermes_home_with_config
+    later = config.parent.parent / "external_later"
+    config.write_text(
+        f"skills:\n  external_dirs:\n    - {later}\n",
+        encoding="utf-8",
+    )
+
+    before = get_external_skills_dirs()
+    later.mkdir()
+    cached = get_external_skills_dirs()
+    _external_dirs_cache_clear()
+    refreshed = get_external_skills_dirs()
+
+    assert before == []
+    assert cached == []
+    assert refreshed == [later.resolve()]
+
+
+def test_external_directory_outage_does_not_change_system_prompt(
+    hermes_home_with_config,
+):
+    """A transient external outage does not mutate the conversation prefix."""
+    home, external, _config = hermes_home_with_config
+    skill_dir = external / "watch"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: watch\ndescription: Observe a process.\n---\n",
+        encoding="utf-8",
+    )
+    from agent import prompt_builder
+
+    prompt_builder.clear_skills_system_prompt_cache(clear_snapshot=True)
+    before = prompt_builder.build_skills_system_prompt(
+        skills_dir_override=home / "skills"
+    )
+    external.rename(external.parent / "external-offline")
+    after = prompt_builder.build_skills_system_prompt(
+        skills_dir_override=home / "skills"
+    )
+
+    assert "watch" in before
+    assert after == before
+
+
+def test_external_ownership_survives_directory_unavailability(
+    hermes_home_with_config,
+):
+    """Configured roots remain externally owned while their storage is offline."""
+    _home, external, _config = hermes_home_with_config
+    skill_file = external / "watch" / "SKILL.md"
+    skill_file.parent.mkdir()
+    skill_file.write_text("---\nname: watch\n---\n", encoding="utf-8")
+
+    before = is_external_skill_path(skill_file)
+    external.rename(external.parent / "external-offline")
+    after = is_external_skill_path(skill_file)
+
+    assert before is True
+    assert after is True
+
+
+def test_managed_config_mtime_invalidates_same_size_content(managed_external_dirs):
+    """Managed mtime changes invalidate content whose byte size is unchanged."""
+    _home, managed_config, managed_external, _user_external = managed_external_dirs
+    other = managed_external.parent / "managed_bravo"
+    other.mkdir()
+
+    assert get_external_skills_dirs() == [managed_external.resolve()]
+
+    original_size = managed_config.stat().st_size
+    managed_config.write_text(
+        f"skills:\n  external_dirs:\n    - {other}\n",
+        encoding="utf-8",
+    )
+    stat = managed_config.stat()
+    # This is a load-bearing precondition: equal size ensures the cache miss
+    # comes from mtime rather than the size component of the signature.
+    assert stat.st_size == original_size
+    future_mtime = stat.st_mtime_ns + 10_000_000_000
+    os.utime(managed_config, ns=(stat.st_atime_ns, future_mtime))
+
+    assert get_external_skills_dirs() == [other.resolve()]
+
+
+def test_repeated_calls_do_not_reparse_unchanged_user_config(
+    managed_external_dirs,
+    monkeypatch,
+):
+    """Profile YAML parsing stays cached across repeated calls."""
+    _home, _managed_config, managed_external, _user_external = managed_external_dirs
+
+    from hermes_cli import config as config_mod
+
+    user_parse = config_mod.fast_safe_load
+    parse_count = 0
+
+    def count_user_parse(content):
+        nonlocal parse_count
+        parse_count += 1
+        return user_parse(content)
+
+    monkeypatch.setattr(config_mod, "fast_safe_load", count_user_parse)
+
+    assert get_external_skills_dirs() == [managed_external.resolve()]
+    assert get_external_skills_dirs() == [managed_external.resolve()]
+    assert parse_count == 1
+
+
+def test_repeated_calls_reuse_resolved_external_roots(
+    hermes_home_with_config,
+    monkeypatch,
+):
+    """Repeated discovery avoids resolving an unchanged configured root."""
+    _home, external, _config = hermes_home_with_config
+    expected = external.resolve()
+    original_resolve = Path.resolve
+    external_resolve_count = 0
+
+    def count_external_resolve(path, *args, **kwargs):
+        nonlocal external_resolve_count
+        if path == external:
+            external_resolve_count += 1
+        return original_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", count_external_resolve)
+
+    first = get_external_skills_dirs()
+    second = get_external_skills_dirs()
+
+    assert first == [expected]
+    assert second == [expected]
+    assert external_resolve_count == 1
+
+
+def test_user_config_mtime_invalidates_same_size_content(hermes_home_with_config):
+    """Profile mtime changes invalidate content whose byte size is unchanged."""
+    _home, external, config = hermes_home_with_config
+    other = external.parent / "external_bravo"
     other.mkdir()
 
     # Prime cache with original contents.
@@ -63,26 +456,27 @@ def test_cache_invalidates_on_mtime_change(hermes_home_with_config):
     # Rewrite config; bump mtime forward explicitly so filesystems with
     # coarse mtime granularity still register the change on fast test
     # systems.
+    original_size = config.stat().st_size
     config.write_text(
-        "skills:\n"
-        f"  external_dirs:\n"
-        f"    - {other}\n",
+        f"skills:\n  external_dirs:\n    - {other}\n",
         encoding="utf-8",
     )
     stat = config.stat()
-    future = stat.st_atime + 10
-    os.utime(config, (future, future))
+    # This is a load-bearing precondition: equal size ensures the cache miss
+    # comes from mtime rather than the size component of the signature.
+    assert stat.st_size == original_size
+    future_mtime = stat.st_mtime_ns + 10_000_000_000
+    os.utime(config, ns=(stat.st_atime_ns, future_mtime))
 
     second = get_external_skills_dirs()
     assert second == [other.resolve()]
 
 
-
-
-
-
-def test_cache_key_is_per_config_path(tmp_path, monkeypatch):
-    """Two different HERMES_HOMEs keep separate cache entries."""
+def test_profile_switch_reuses_each_profiles_resolved_external_dirs(
+    tmp_path,
+    monkeypatch,
+):
+    """A → B → A profile switching reuses both profiles' resolved roots."""
     home_a = tmp_path / "home_a" / ".hermes"
     home_a.mkdir(parents=True)
     ext_a = tmp_path / "ext_a"
@@ -99,14 +493,26 @@ def test_cache_key_is_per_config_path(tmp_path, monkeypatch):
         f"skills:\n  external_dirs:\n    - {ext_b}\n", encoding="utf-8"
     )
 
-    _external_dirs_cache_clear()
+    _clear_skill_config_caches()
+
+    expected_a = ext_a.resolve()
+    expected_b = ext_b.resolve()
+    original_resolve = Path.resolve
+    resolve_counts = {ext_a: 0, ext_b: 0}
+
+    def count_external_resolve(path, *args, **kwargs):
+        if path in resolve_counts:
+            resolve_counts[path] += 1
+        return original_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", count_external_resolve)
 
     monkeypatch.setenv("HERMES_HOME", str(home_a))
-    assert get_external_skills_dirs() == [ext_a.resolve()]
-
+    assert get_external_skills_dirs() == [expected_a]
     monkeypatch.setenv("HERMES_HOME", str(home_b))
-    assert get_external_skills_dirs() == [ext_b.resolve()]
+    assert get_external_skills_dirs() == [expected_b]
 
-    # And switching back still works — both entries coexist in the cache.
+    # Switching back must reuse A, not resolve it again or leak B's entry.
     monkeypatch.setenv("HERMES_HOME", str(home_a))
-    assert get_external_skills_dirs() == [ext_a.resolve()]
+    assert get_external_skills_dirs() == [expected_a]
+    assert resolve_counts == {ext_a: 1, ext_b: 1}

--- a/tests/agent/test_skill_commands_reload.py
+++ b/tests/agent/test_skill_commands_reload.py
@@ -1,7 +1,7 @@
 """Tests for ``agent.skill_commands.reload_skills``.
 
 Covers the helper that powers ``/reload-skills`` (CLI + gateway slash command).
-The helper rescans the skills directory and returns a diff of what changed.
+The helper revalidates and rescans the skills directories, then returns a diff.
 It does NOT invalidate the skills system-prompt cache — skills are invoked
 at runtime via ``/skill-name``, ``skills_list``, or ``skill_view`` and don't
 need to live in the system prompt.
@@ -109,3 +109,22 @@ class TestReloadSkillsHelper:
             "prompt cache snapshot should be preserved — skills don't live "
             "in the system prompt so there's no reason to invalidate it"
         )
+
+    def test_revalidates_external_directory_availability(self, hermes_home):
+        """An explicit reload discovers a configured mount that came online."""
+        from agent.skill_commands import reload_skills
+
+        external = hermes_home / "external"
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external}\n",
+            encoding="utf-8",
+        )
+
+        first = reload_skills()
+        _write_skill(external, "mounted-later", "available after mount")
+        second = reload_skills()
+
+        assert first["total"] == 0
+        assert second["added"] == [
+            {"name": "mounted-later", "description": "available after mount"}
+        ]

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -31,9 +31,10 @@ from agent.skill_utils import (
 
 
 
-def test_skill_config_helpers_share_raw_config_parse_cache(tmp_path, monkeypatch):
+def test_skill_config_helpers_share_canonical_config_cache(tmp_path, monkeypatch):
     """Repeated skill config helpers should parse config.yaml only once."""
     from agent import skill_utils
+    from hermes_cli import config as config_mod
 
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()
@@ -54,17 +55,18 @@ skills:
         encoding="utf-8",
     )
     parse_count = 0
-    real_yaml_load = skill_utils.yaml_load
+    real_fast_safe_load = config_mod.fast_safe_load
 
-    def counting_yaml_load(text):
+    def counting_parse(text):
         nonlocal parse_count
         parse_count += 1
-        return real_yaml_load(text)
+        return real_fast_safe_load(text)
 
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     skill_utils._external_dirs_cache_clear()
-    getattr(skill_utils, "_raw_config_cache_clear", lambda: None)()
-    monkeypatch.setattr(skill_utils, "yaml_load", counting_yaml_load)
+    config_mod._LOAD_CONFIG_CACHE.clear()
+    config_mod._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+    monkeypatch.setattr(config_mod, "fast_safe_load", counting_parse)
 
     assert get_disabled_skill_names() == {"hidden-skill"}
     assert get_external_skills_dirs() == [external.resolve()]
@@ -124,9 +126,9 @@ class TestDisabledSkillsJsonArrayString:
             encoding="utf-8",
         )
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        from agent import skill_utils
+        from hermes_cli import config as config_mod
 
-        getattr(skill_utils, "_raw_config_cache_clear", lambda: None)()
+        config_mod._LOAD_CONFIG_CACHE.clear()
 
         assert get_disabled_skill_names() == {"skill-a", "skill-b"}
 
@@ -140,9 +142,9 @@ class TestDisabledSkillsJsonArrayString:
             encoding="utf-8",
         )
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        from agent import skill_utils
+        from hermes_cli import config as config_mod
 
-        getattr(skill_utils, "_raw_config_cache_clear", lambda: None)()
+        config_mod._LOAD_CONFIG_CACHE.clear()
 
         assert get_disabled_skill_names() == {"hidden-skill"}
 
@@ -381,4 +383,3 @@ class TestBOMToleranceSiblingSites:
         fm = _split_frontmatter("\ufeff---\nname: bp\n---\nbody")
         assert fm is not None
         assert fm.get("name") == "bp"
-

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -76,6 +76,24 @@ class TestLoadConfigDefaults:
             assert config["terminal"]["backend"] == "local"
             assert config["display"]["interim_assistant_messages"] is True
 
+    def test_readonly_missing_config_is_cached_until_file_appears(self, tmp_path):
+        """Default-only reads share a cache that invalidates on file creation."""
+        from hermes_cli import config as cfg_mod
+
+        cfg_mod._LOAD_CONFIG_CACHE.clear()
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            first = cfg_mod.load_config_readonly()
+            second = cfg_mod.load_config_readonly()
+            (tmp_path / "config.yaml").write_text(
+                "skills:\n  disabled: [late-skill]\n",
+                encoding="utf-8",
+            )
+            after_creation = cfg_mod.load_config_readonly()
+
+        assert second is first
+        assert after_creation is not first
+        assert after_creation["skills"]["disabled"] == ["late-skill"]
+
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
             config_path = tmp_path / "config.yaml"
@@ -98,6 +116,124 @@ class TestLoadConfigParseFailure:
       * dedup on (path, mtime_ns, size) so concurrent loads don't spam
       * re-warn after the user edits the file (different mtime)
     """
+
+
+
+    def test_transient_read_failure_recovers_without_corrupt_backup(
+        self,
+        tmp_path,
+    ):
+        """A one-shot I/O failure must not poison the successful cache key."""
+        from hermes_cli import config as cfg_mod
+
+        config_path = tmp_path / "config.yaml"
+        external = tmp_path / "external"
+        external.mkdir()
+        config_path.write_text(
+            f"skills:\n  external_dirs:\n    - {external}\n",
+            encoding="utf-8",
+        )
+        cfg_mod._LOAD_CONFIG_CACHE.clear()
+        cfg_mod._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+        cfg_mod._CONFIG_PARSE_WARNED.clear()
+        cfg_mod._CONFIG_READ_WARNED.clear()
+        real_open = open
+        attempts = 0
+
+        def flaky_open(file, mode="r", *args, **kwargs):
+            nonlocal attempts
+            if Path(file) == config_path and "r" in mode and attempts == 0:
+                attempts += 1
+                raise OSError("transient read failure")
+            return real_open(file, mode, *args, **kwargs)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with patch("builtins.open", side_effect=flaky_open):
+                first = cfg_mod.load_config_readonly()
+                second = cfg_mod.load_config_readonly()
+
+        assert first["skills"]["external_dirs"] == []
+        assert second["skills"]["external_dirs"] == [str(external)]
+        assert attempts == 1
+        assert list(tmp_path.glob("config.yaml.corrupt.*.bak")) == []
+
+    def test_transient_stat_failure_recovers_without_caching_defaults(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """A one-shot metadata I/O failure also retries on the next load."""
+        from hermes_cli import config as cfg_mod
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "skills:\n  disabled: [stat-recovered]\n",
+            encoding="utf-8",
+        )
+        cfg_mod._LOAD_CONFIG_CACHE.clear()
+        cfg_mod._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+        cfg_mod._CONFIG_READ_WARNED.clear()
+        real_stat = Path.stat
+        attempts = 0
+
+        def flaky_stat(path, *args, **kwargs):
+            nonlocal attempts
+            if path == config_path and attempts == 0:
+                attempts += 1
+                raise OSError("transient stat failure")
+            return real_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "stat", flaky_stat)
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            first = cfg_mod.load_config_readonly()
+            second = cfg_mod.load_config_readonly()
+
+        assert first["skills"].get("disabled", []) == []
+        assert second["skills"]["disabled"] == ["stat-recovered"]
+        assert attempts == 1
+
+    def test_transient_managed_read_failure_recovers_without_cache_poisoning(
+        self,
+        tmp_path,
+    ):
+        """A one-shot managed I/O failure must retry before any cache hit."""
+        from hermes_cli import config as cfg_mod
+        from hermes_cli import managed_scope
+
+        managed_dir = tmp_path / "managed"
+        managed_dir.mkdir()
+        managed_config = managed_dir / "config.yaml"
+        managed_config.write_text(
+            "skills:\n  disabled: [managed-skill]\n",
+            encoding="utf-8",
+        )
+        cfg_mod._LOAD_CONFIG_CACHE.clear()
+        cfg_mod._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+        managed_scope.invalidate_managed_cache()
+        real_open = open
+        attempts = 0
+
+        def flaky_open(file, mode="r", *args, **kwargs):
+            nonlocal attempts
+            if Path(file) == managed_config and "r" in mode and attempts == 0:
+                attempts += 1
+                raise OSError("transient managed read failure")
+            return real_open(file, mode, *args, **kwargs)
+
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_HOME": str(tmp_path / "home"),
+                "HERMES_MANAGED_DIR": str(managed_dir),
+            },
+        ):
+            with patch("builtins.open", side_effect=flaky_open):
+                first = cfg_mod.load_config_readonly()
+                second = cfg_mod.load_config_readonly()
+
+        assert first["skills"].get("disabled", []) == []
+        assert second["skills"]["disabled"] == ["managed-skill"]
+        assert attempts == 1
 
 
 

--- a/tests/hermes_cli/test_managed_scope.py
+++ b/tests/hermes_cli/test_managed_scope.py
@@ -1,14 +1,11 @@
 """Unit tests for hermes_cli.managed_scope (resolver + loaders + key helpers)."""
+
 import textwrap
 
 import pytest
 
 
 # ── Directory resolver ───────────────────────────────────────────────────────
-
-
-
-
 
 
 # ── Loaders + key helpers ────────────────────────────────────────────────────
@@ -28,12 +25,6 @@ def _write_managed(tmp_path, monkeypatch, *, config=None, env=None):
     return managed
 
 
-
-
-
-
-
-
 def test_load_managed_env_and_is_env_managed(tmp_path, monkeypatch):
     from hermes_cli import managed_scope
 
@@ -47,6 +38,34 @@ def test_load_managed_env_and_is_env_managed(tmp_path, monkeypatch):
     assert managed_scope.is_env_managed("OTHER") is False
 
 
+def test_invalid_skills_section_is_ignored_and_warned_once(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    """Invalid managed skills policy is normalized once at the parse boundary."""
+    from hermes_cli import managed_scope
+
+    _write_managed(
+        tmp_path,
+        monkeypatch,
+        config="display:\n  skin: managed\nskills: []\n",
+    )
+
+    with caplog.at_level("WARNING"):
+        first = managed_scope.load_managed_config()
+        second = managed_scope.load_managed_config()
+
+    warnings = [
+        record
+        for record in caplog.records
+        if "skills must be a mapping" in record.getMessage()
+    ]
+    assert first == {"display": {"skin": "managed"}}
+    assert second == {"display": {"skin": "managed"}}
+    assert managed_scope.is_key_managed("display.skin") is True
+    assert managed_scope.is_key_managed("skills") is False
+    assert len(warnings) == 1
 
 
 def test_managed_dir_env_scrubbed_by_default():


### PR DESCRIPTION
## What does this PR do?

Managed deployments can pin `skills.external_dirs` in `/etc/hermes/config.yaml`, but the skill runtime was reading only the profile config from `HERMES_HOME/config.yaml`. Shared skills therefore disappeared silently even though the managed value was present and the configuration surface still advertised it.

The same split-brain behavior affected sibling policies: the CLI reported managed `skills.disabled`, `skills.project_discovery`, and `skills.trusted_project_dirs` as locked, while discovery could still use the user's values. This PR routes behavioral skill reads through the canonical read-only loader so the policy shown by the CLI is the policy enforced at runtime.

The fix keeps the hot path inexpensive: YAML/config merging stays in the existing canonical cache, while resolved external roots are cached separately by profile and effective values. Availability and ownership remain stable during transient mount outages and are deliberately revalidated by `/reload-skills`.

## Related Issue

No issue filed. The regression was reproduced directly against current `main` with a managed-only `skills.external_dirs` configuration.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] ✅ Tests (adding or improving test coverage)

## Changes Made

- Route all behavioral `skills.*` reads in `agent/skill_utils.py` through `load_config_readonly()`, restoring managed precedence and consistent `${VAR}` / `${env:VAR}` expansion.
- Validate malformed managed `skills` sections at the managed-config boundary without discarding unrelated administrator policy.
- Cache resolved external roots by profile and effective values, preserving prompt and ownership stability when a mount is transiently unavailable.
- Make `/reload-skills` explicitly revalidate external directory availability.
- Prevent transient user or managed config I/O errors from poisoning a valid cache signature or creating a false `.corrupt` backup.
- Cover managed empty-list lockdown, sibling policy enforcement, JSON-array strings, environment changes, same-size mtime invalidation, A → B → A profile switching, mount outages, reload, and transient I/O recovery.

## How to Test

1. Put `skills.external_dirs: [/shared/skills]` only in the managed config and omit it from the profile config.
2. Confirm `get_external_skills_dirs()` and skill discovery include `/shared/skills`; also verify managed disabled/trust/discovery leaves override profile values.
3. Run:

   ```bash
   scripts/run_tests.sh \
     tests/agent/test_external_skills.py \
     tests/agent/test_external_skills_dirs_cache.py \
     tests/agent/test_skill_utils.py \
     tests/agent/test_project_skills.py \
     tests/agent/test_skill_commands.py \
     tests/agent/test_skill_commands_reload.py \
     tests/agent/test_prompt_builder.py \
     tests/agent/test_system_prompt.py \
     tests/hermes_cli/test_config.py \
     tests/hermes_cli/test_config_env_expansion.py \
     tests/hermes_cli/test_config_read_guard.py \
     tests/hermes_cli/test_managed_scope.py \
     tests/hermes_cli/test_managed_scope_config.py \
     tests/hermes_cli/test_managed_scope_overlay.py \
     tests/hermes_cli/test_managed_scope_loaders.py \
     tests/hermes_cli/test_skills_config.py \
     tests/tools/test_skills_sync.py \
     tests/tools/test_skills_tool.py -q
   ```

Result: **374 passed, 1 skipped, 0 failed**. Ruff passes for all nine changed files. Warm-path measurements were approximately 20.6 µs/call without a profile config and 21.4 µs/call with one configured external directory.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs and issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the entire `pytest tests/ -q` suite; the focused 18-file regression suite above passes
- [x] I've added tests for the bug and adjacent cache/policy invariants
- [x] Tested on macOS 26.6.2 arm64 with Python 3.11.16

### Documentation & Housekeeping

- [x] Relevant docstrings and invariants were updated; no user-facing config key changed
- [x] `cli-config.yaml.example` update: N/A — no config key was added or changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A — no contributor workflow changed
- [x] Cross-platform impact considered: path handling remains based on `pathlib`; no platform-specific behavior was added
- [x] Tool descriptions/schemas update: N/A

## Screenshots / Logs

Not applicable; this is config-loading and skill-discovery behavior covered by regression tests.
