### PR TITLE
fix(cli): handle Ghostty lock-state key modifiers

### DIFF
--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -244,18 +244,29 @@ def install_modify_other_keys_aliases() -> int:
 
     changed = 0
 
+    def _modifier_lock_variants(modifier: int) -> tuple[int, ...]:
+        """Return modifier values with terminal lock-state bits preserved.
+
+        xterm/Kitty modifiers are 1-based bitfields. Ghostty can include
+        lock-state bits such as Num Lock (128) and Caps Lock (64), so Ctrl+C
+        may arrive as modifier 133 (5 + 128), and plain arrows may arrive as
+        129 (1 + 128).  Those lock bits should not change the semantic key.
+        """
+        return (modifier, modifier + 64, modifier + 128, modifier + 192)
+
     def _install_paired(modifier: int, mapping: dict) -> None:
         """Install both modifyOtherKeys (ESC[27;N;CP~) and CSI-u (ESC[CP;Nu)
         mappings for the given modifier and codepoint→key mapping."""
         nonlocal changed
         for codepoint, key_val in mapping.items():
-            for seq in (
-                f"\x1b[27;{modifier};{codepoint}~",
-                f"\x1b[{codepoint};{modifier}u",
-            ):
-                if seq not in ANSI_SEQUENCES:
-                    ANSI_SEQUENCES[seq] = key_val
-                    changed += 1
+            for mod in _modifier_lock_variants(modifier):
+                for seq in (
+                    f"\x1b[27;{mod};{codepoint}~",
+                    f"\x1b[{codepoint};{mod}u",
+                ):
+                    if seq not in ANSI_SEQUENCES:
+                        ANSI_SEQUENCES[seq] = key_val
+                        changed += 1
 
     # Ctrl+letter / Ctrl+digit / Ctrl+symbol (modifier 5)
     _install_paired(5, ctrl_key_map)
@@ -379,6 +390,50 @@ def install_modify_other_keys_aliases() -> int:
         if seq not in ANSI_SEQUENCES:
             ANSI_SEQUENCES[seq] = key_val
             changed += 1
+
+    # -- Lock-state variants for navigation keys ----
+    # Ghostty can preserve Num Lock / Caps Lock state in the modifier value
+    # (e.g. 129 = 1 + Num Lock).  prompt_toolkit already knows the ordinary
+    # modified navigation forms like ESC[1;5D (Ctrl+Left), but not the same
+    # sequences with lock bits included, so those leaked into the prompt.
+    nav_arrow_keys = {
+        "A": Keys.Up,
+        "B": Keys.Down,
+        "C": Keys.Right,
+        "D": Keys.Left,
+        "H": Keys.Home,
+        "F": Keys.End,
+    }
+    nav_tilde_keys = {
+        2: Keys.Insert,
+        3: Keys.Delete,
+        5: Keys.PageUp,
+        6: Keys.PageDown,
+    }
+
+    for final, plain_key in nav_arrow_keys.items():
+        for mod in range(1, 17):
+            base_seq = f"\x1b[1;{mod}{final}"
+            key_val = plain_key if mod == 1 else ANSI_SEQUENCES.get(base_seq)
+            if key_val is None:
+                continue
+            for lock_mod in _modifier_lock_variants(mod)[1:]:
+                seq = f"\x1b[1;{lock_mod}{final}"
+                if seq not in ANSI_SEQUENCES:
+                    ANSI_SEQUENCES[seq] = key_val
+                    changed += 1
+
+    for code, plain_key in nav_tilde_keys.items():
+        for mod in range(1, 17):
+            base_seq = f"\x1b[{code};{mod}~"
+            key_val = plain_key if mod == 1 else ANSI_SEQUENCES.get(base_seq)
+            if key_val is None:
+                continue
+            for lock_mod in _modifier_lock_variants(mod)[1:]:
+                seq = f"\x1b[{code};{lock_mod}~"
+                if seq not in ANSI_SEQUENCES:
+                    ANSI_SEQUENCES[seq] = key_val
+                    changed += 1
 
     # New longer sequences can flip "is this a prefix of a longer match?"
     # answers the VT100 parser already cached — drop the cache so parsers

--- a/tests/cli/test_modify_other_keys_aliases.py
+++ b/tests/cli/test_modify_other_keys_aliases.py
@@ -415,6 +415,45 @@ def test_keypad_navigation_maps_to_arrows():
     assert _parse("\x1b[57420u") == [Keys.Down]
 
 
+# ---------------------------------------------------------------------------
+# Lock-state modifier variants (Num Lock / Caps Lock)
+# ---------------------------------------------------------------------------
+
+
+def test_numlock_plain_navigation_variants_do_not_leak():
+    """Ghostty can report navigation keys with modifier 129 (1 + Num Lock).
+
+    prompt_toolkit knows the plain legacy sequences, but not the lock-state
+    variants, so they used to leak as literal text like ``[1;129D``.
+    """
+    assert _parse("\x1b[1;129A") == [Keys.Up]
+    assert _parse("\x1b[1;129B") == [Keys.Down]
+    assert _parse("\x1b[1;129C") == [Keys.Right]
+    assert _parse("\x1b[1;129D") == [Keys.Left]
+    assert _parse("\x1b[1;129H") == [Keys.Home]
+    assert _parse("\x1b[1;129F") == [Keys.End]
+    assert _parse("\x1b[2;129~") == [Keys.Insert]
+    assert _parse("\x1b[3;129~") == [Keys.Delete]
+    assert _parse("\x1b[5;129~") == [Keys.PageUp]
+    assert _parse("\x1b[6;129~") == [Keys.PageDown]
+
+
+def test_numlock_modified_navigation_variants_preserve_modifier_semantics():
+    """Lock-state bits must not erase real Ctrl/Alt navigation modifiers."""
+    assert _parse("\x1b[1;133D") == [Keys.ControlLeft]
+    assert _parse("\x1b[1;133C") == [Keys.ControlRight]
+    assert _parse("\x1b[1;131D") == [Keys.Escape, Keys.Left]
+    assert _parse("\x1b[1;131C") == [Keys.Escape, Keys.Right]
+
+
+def test_numlock_ctrl_letter_variants_preserve_control_keys():
+    """Ctrl+C / Ctrl+D can arrive as CSI-u with the Num Lock state bit set."""
+    assert _parse("\x1b[99;133u") == [Keys.ControlC]
+    assert _parse("\x1b[100;133u") == [Keys.ControlD]
+    assert _parse("\x1b[27;133;99~") == [Keys.ControlC]
+    assert _parse("\x1b[27;133;100~") == [Keys.ControlD]
+
+
 def test_f13_maps_to_f13():
     assert _parse("\x1b[57376u") == [Keys.F13]
 


### PR DESCRIPTION
## Summary

- Normalize terminal lock-state modifier bits (Num Lock / Caps Lock) for extended key aliases.
- Preserve existing Ctrl/Alt/Shift semantics while accepting Ghostty variants like modifier 129 and 133.
- Add regression coverage for Ghostty lock-state navigation and Ctrl+C/Ctrl+D sequences.

## Problem

After the recent extended-key handling changes, Ghostty can report keys with lock-state bits included in the modifier value. For example:

- Plain Left with Num Lock: `ESC[1;129D`
- Ctrl+C with Num Lock: `ESC[99;133u`
- Ctrl+D with Num Lock: `ESC[100;133u`

prompt_toolkit does not map these variants by default, so they leak into the prompt as literal text such as `[1;129D`, and Ctrl+C/Ctrl+D do not trigger their expected bindings.

## Fix

This keeps the current extended-key strategy, but treats lock-state bits as non-semantic modifiers:

- base modifier
- base + 64
- base + 128
- base + 192

For navigation keys, the patch reuses prompt_toolkit's existing modified-navigation mappings where available, and adds lock-state variants for arrows, Home/End, Insert/Delete, and PageUp/PageDown.

## Verification

- `uv run --extra dev python -m pytest tests/cli/test_modify_other_keys_aliases.py -q -o 'addopts='`
  - `174 passed in 1.35s`
- Runtime parser smoke checks passed for:
  - `ESC[1;129D` → `Keys.Left`
  - `ESC[1;129C` → `Keys.Right`
  - `ESC[99;133u` → `Keys.ControlC`
  - `ESC[100;133u` → `Keys.ControlD`
  - `ESC[27;133;99~` → `Keys.ControlC`
  - `ESC[27;133;100~` → `Keys.ControlD`
  - `ESC[1;133D` → `Keys.ControlLeft`
