### PR TITLE
fix(codex): identify Hermes requests

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1269,7 +1269,9 @@ def init_agent(
                 client_kwargs["default_headers"] = _ra()._qwen_portal_headers()
             elif base_url_host_matches(effective_base, "chatgpt.com"):
                 from agent.auxiliary_client import _codex_cloudflare_headers
-                client_kwargs["default_headers"] = _codex_cloudflare_headers(api_key)
+                client_kwargs["default_headers"] = _codex_cloudflare_headers(
+                    api_key, base_url=effective_base,
+                )
             elif base_url_host_matches(effective_base, "x.ai"):
                 from tools.xai_http import hermes_xai_default_headers
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2574,6 +2574,15 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             client_kwargs["default_headers"] = existing
     except Exception:
         _ra().logger.debug("Copilot default-header guard skipped", exc_info=True)
+    # All primary construction and recovery paths must identify Hermes to the
+    # official Codex endpoint, including snapshots with custom header overrides.
+    from agent.auxiliary_client import _apply_required_codex_headers
+
+    _apply_required_codex_headers(
+        client_kwargs,
+        access_token=client_kwargs.get("api_key", ""),
+        base_url=str(client_kwargs.get("base_url", "")),
+    )
     # Uses the module-level `OpenAI` name, resolved lazily on first
     # access via __getattr__ below. Tests patch via `run_agent.OpenAI`.
     client = _ra().OpenAI(**client_kwargs)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -262,6 +262,7 @@ def _create_openai_client(*, api_key: str, base_url: str, **kwargs: Any) -> Any:
         # answer. Skip the openai import + httpx/SSL construction entirely.
         return _AuxProbeClientStub(api_key=api_key, base_url=base_url)
     kwargs = {**_openai_http_client_kwargs(base_url), **kwargs}
+    _apply_required_codex_headers(kwargs, access_token=api_key, base_url=base_url)
     # Hermes owns auxiliary retry + provider/model fallback policy (the
     # same-provider transient retry in call_llm plus the except-chain
     # fallback). The OpenAI SDK's own default (max_retries=2 → up to 3
@@ -1191,19 +1192,31 @@ _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
 _CODEX_AUX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 
 
-def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
-    """Headers required to avoid Cloudflare 403s on chatgpt.com/backend-api/codex.
+def _is_official_codex_base_url(base_url: str) -> bool:
+    """Identify OpenAI's Codex endpoint without matching custom proxies."""
+    try:
+        parsed = urlparse(base_url)
+        path = parsed.path.rstrip("/")
+        return (
+            parsed.scheme == "https"
+            and parsed.hostname == "chatgpt.com"
+            and parsed.port in (None, 443)
+            and (path == "/backend-api/codex" or path.startswith("/backend-api/codex/"))
+        )
+    except (TypeError, ValueError):
+        return False
 
-    The Cloudflare layer in front of the Codex endpoint whitelists a small set of
-    first-party originators (``codex_cli_rs``, ``codex_vscode``, ``codex_sdk_ts``,
-    anything starting with ``Codex``). Requests from non-residential IPs (VPS,
-    server-hosted agents) that don't advertise an allowed originator are served
-    a 403 with ``cf-mitigated: challenge`` regardless of auth correctness.
 
-    We pin ``originator: codex_cli_rs`` to match the upstream codex-rs CLI, set
-    ``User-Agent`` to a codex_cli_rs-shaped string (beats SDK fingerprinting),
-    and extract ``ChatGPT-Account-ID`` (canonical casing, from codex-rs
-    ``auth.rs``) out of the OAuth JWT's ``chatgpt_account_id`` claim.
+def _codex_cloudflare_headers(
+    access_token: str, *, base_url: str = _CODEX_AUX_BASE_URL,
+) -> Dict[str, str]:
+    """Identity and account headers for chatgpt.com/backend-api/codex.
+
+    OpenAI requires third-party harnesses to identify themselves. Requests to
+    the official endpoint always send Hermes' originator and version. Custom
+    endpoints retain the existing compatibility identity. In either case,
+    preserve ``ChatGPT-Account-ID`` from the OAuth JWT's
+    ``chatgpt_account_id`` claim.
 
     Malformed tokens are tolerated — we drop the account-ID header rather than
     raise, so a bad token still surfaces as an auth error (401) instead of a
@@ -1213,6 +1226,13 @@ def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
         "User-Agent": "codex_cli_rs/0.0.0 (Hermes Agent)",
         "originator": "codex_cli_rs",
     }
+    if _is_official_codex_base_url(base_url):
+        from hermes_cli import __version__
+
+        headers.update({
+            "User-Agent": f"HermesAgent/{__version__}",
+            "originator": "hermes-agent",
+        })
     if not isinstance(access_token, str) or not access_token.strip():
         return headers
     try:
@@ -1228,6 +1248,22 @@ def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
     except Exception:
         pass
     return headers
+
+
+def _apply_required_codex_headers(
+    client_kwargs: Dict[str, Any], *, access_token: str, base_url: str,
+) -> None:
+    """Keep required Codex identity after user/provider header overrides."""
+    if not _is_official_codex_base_url(base_url):
+        return
+    required = _codex_cloudflare_headers(access_token, base_url=base_url)
+    required_names = {name.lower() for name in required}
+    existing = client_kwargs.get("default_headers") or {}
+    client_kwargs["default_headers"] = {
+        **{name: value for name, value in existing.items()
+           if str(name).lower() not in required_names},
+        **required,
+    }
 
 
 # Hosts that expose BOTH an Anthropic-style ``…/anthropic`` path and a sibling
@@ -3750,7 +3786,7 @@ def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
     real_client = _create_openai_client(
         api_key=codex_token,
         base_url=base_url,
-        default_headers=_codex_cloudflare_headers(codex_token),
+        default_headers=_codex_cloudflare_headers(codex_token, base_url=base_url),
     )
     return CodexAuxiliaryClient(real_client, model), model
 
@@ -6147,6 +6183,10 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
         async_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
     elif base_url_host_matches(sync_base_url, "integrate.api.nvidia.com"):
         async_kwargs["default_headers"] = build_nvidia_nim_headers(sync_base_url)
+    elif _is_official_codex_base_url(sync_base_url):
+        async_kwargs["default_headers"] = _codex_cloudflare_headers(
+            sync_client.api_key, base_url=sync_base_url,
+        )
     elif base_url_host_matches(sync_base_url, "x.ai"):
         from tools.xai_http import hermes_xai_default_headers
 
@@ -6168,6 +6208,9 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     _merged_async = _apply_user_default_headers(async_kwargs.get("default_headers"))
     if _merged_async:
         async_kwargs["default_headers"] = _merged_async
+    _apply_required_codex_headers(
+        async_kwargs, access_token=sync_client.api_key, base_url=sync_base_url,
+    )
     async_kwargs = {
         **_openai_http_client_kwargs(sync_base_url, async_mode=True),
         **async_kwargs,

--- a/run_agent.py
+++ b/run_agent.py
@@ -6277,7 +6277,7 @@ class AIAgent:
         elif base_url_host_matches(base_url, "chatgpt.com"):
             from agent.auxiliary_client import _codex_cloudflare_headers
             self._client_kwargs["default_headers"] = _codex_cloudflare_headers(
-                self._client_kwargs.get("api_key", "")
+                self._client_kwargs.get("api_key", ""), base_url=base_url,
             )
         elif base_url_host_matches(base_url, "x.ai"):
             # Cover both provider=xai and provider=xai-oauth (api.x.ai).

--- a/tests/agent/test_codex_cloudflare_headers.py
+++ b/tests/agent/test_codex_cloudflare_headers.py
@@ -1,11 +1,8 @@
-"""Regression guard: Codex Cloudflare 403 mitigation headers.
+"""Regression coverage for required Codex identity and account headers.
 
-The ``chatgpt.com/backend-api/codex`` endpoint sits behind a Cloudflare layer
-that whitelists a small set of first-party originators (``codex_cli_rs``,
-``codex_vscode``, ``codex_sdk_ts``, ``Codex*``). Requests from non-residential
-IPs (VPS, always-on servers, some corporate egress) that don't advertise an
-allowed originator are served 403 with ``cf-mitigated: challenge`` regardless
-of auth correctness.
+The official Codex endpoint must receive Hermes' own harness identity, rather
+than the historical first-party compatibility identity. Live endpoint
+acceptance is a separate smoke test; these tests verify request construction.
 
 ``_codex_cloudflare_headers`` in ``agent.auxiliary_client`` centralizes the
 header set so the primary chat client (``run_agent.AIAgent.__init__`` +
@@ -14,8 +11,8 @@ header set so the primary chat client (``run_agent.AIAgent.__init__`` +
 all emit the same headers.
 
 These tests pin:
-- the originator value (must be ``codex_cli_rs`` — the whitelisted one)
-- the User-Agent shape (codex_cli_rs-prefixed)
+- the required Hermes originator
+- the versioned Hermes User-Agent
 - ``ChatGPT-Account-ID`` extraction from the OAuth JWT (canonical casing,
   from codex-rs ``auth.rs``)
 - graceful handling of malformed tokens (drop the account-ID header, don't
@@ -29,6 +26,7 @@ import base64
 import json
 from unittest.mock import MagicMock, patch
 
+from hermes_cli import __version__
 
 
 # ---------------------------------------------------------------------------
@@ -59,10 +57,11 @@ def _make_codex_jwt(account_id: str = "acct-test-123") -> str:
 
 class TestCodexCloudflareHeaders:
 
-    def test_user_agent_advertises_codex_cli_rs(self):
+    def test_user_agent_advertises_hermes_version(self):
         from agent.auxiliary_client import _codex_cloudflare_headers
         headers = _codex_cloudflare_headers(_make_codex_jwt())
-        assert headers["User-Agent"].startswith("codex_cli_rs/")
+        assert headers["User-Agent"] == f"HermesAgent/{__version__}"
+        assert headers["originator"] == "hermes-agent"
 
 
     def test_canonical_header_casing(self):
@@ -86,7 +85,7 @@ class TestCodexCloudflareHeaders:
         payload = b64url(_json.dumps({"sub": "user-xyz", "exp": 9999999999}).encode())
         token = f"{b64url(b'{}')}.{payload}.{b64url(b'sig')}"
         headers = _codex_cloudflare_headers(token)
-        assert headers["originator"] == "codex_cli_rs"
+        assert headers["originator"] == "hermes-agent"
         assert "ChatGPT-Account-ID" not in headers
 
 
@@ -117,9 +116,9 @@ class TestPrimaryClientWiring:
                 "https://chatgpt.com/backend-api/codex"
             )
             headers = agent._client_kwargs.get("default_headers") or {}
-            assert headers.get("originator") == "codex_cli_rs"
+            assert headers.get("originator") == "hermes-agent"
             assert headers.get("ChatGPT-Account-ID") == "acct-rotation"
-            assert headers.get("User-Agent", "").startswith("codex_cli_rs/")
+            assert headers.get("User-Agent") == f"HermesAgent/{__version__}"
 
     def test_apply_client_headers_clears_codex_headers_off_chatgpt(self):
         """Switching AWAY from chatgpt.com must drop the codex headers."""
@@ -173,9 +172,9 @@ class TestAuxiliaryClientWiring:
             client, model = auxiliary_client._build_codex_client("gpt-5.4")
             assert client is not None
             headers = mock_openai.call_args.kwargs.get("default_headers") or {}
-            assert headers.get("originator") == "codex_cli_rs"
+            assert headers.get("originator") == "hermes-agent"
             assert headers.get("ChatGPT-Account-ID") == "acct-aux-try-codex"
-            assert headers.get("User-Agent", "").startswith("codex_cli_rs/")
+            assert headers.get("User-Agent") == f"HermesAgent/{__version__}"
 
     def test_resolve_provider_client_raw_codex_passes_codex_headers(self, monkeypatch):
         """The ``raw_codex=True`` branch (used by the main agent loop for direct
@@ -193,6 +192,6 @@ class TestAuxiliaryClientWiring:
             )
             assert client is not None
             headers = mock_openai.call_args.kwargs.get("default_headers") or {}
-            assert headers.get("originator") == "codex_cli_rs"
+            assert headers.get("originator") == "hermes-agent"
             assert headers.get("ChatGPT-Account-ID") == "acct-aux-raw-codex"
-            assert headers.get("User-Agent", "").startswith("codex_cli_rs/")
+            assert headers.get("User-Agent") == f"HermesAgent/{__version__}"

--- a/tests/agent/test_codex_usage_attribution.py
+++ b/tests/agent/test_codex_usage_attribution.py
@@ -1,0 +1,360 @@
+"""Exercise required Codex attribution through real SDK request construction."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+import yaml
+
+from hermes_cli import __version__
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+CODEX_URL = "https://chatgpt.com/backend-api/codex"
+MODEL = "gpt-5.4"
+
+
+def _jwt(account_id="acct-attribution-test"):
+    payload = json.dumps({
+        "https://api.openai.com/auth": {"chatgpt_account_id": account_id},
+    }).encode()
+    encoded = base64.urlsafe_b64encode(payload).rstrip(b"=").decode()
+    return f"e30.{encoded}.test-signature"
+
+
+@pytest.fixture
+def profile(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    token = set_hermes_home_override(home)
+    try:
+        yield home
+    finally:
+        reset_hermes_home_override(token)
+
+
+def _set_legacy_attribution(profile, enabled):
+    """Old draft settings must not disable required harness identification."""
+    if enabled is not None:
+        (profile / "config.yaml").write_text(
+            yaml.safe_dump({
+                "telemetry": {"usage_attribution": {"enabled": enabled}},
+            }),
+            encoding="utf-8",
+        )
+
+
+@pytest.fixture
+def wire(profile, monkeypatch):
+    """Replace only HTTP transports; use Hermes routing and the real SDK."""
+    from agent import auxiliary_client
+    from run_agent import AIAgent
+
+    requests = []
+    response = {
+        "id": "resp_attribution_test",
+        "object": "response",
+        "created_at": 0,
+        "status": "completed",
+        "model": MODEL,
+        "output": [{
+            "type": "message",
+            "id": "msg_test",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "ok", "annotations": []}],
+        }],
+    }
+
+    def respond(request):
+        requests.append(request)
+        if json.loads(request.content).get("stream"):
+            events = [
+                {
+                    "type": "response.output_item.done",
+                    "output_index": 0,
+                    "item": response["output"][0],
+                },
+                {"type": "response.completed", "response": response},
+            ]
+            content = "".join(f"data: {json.dumps(event)}\n\n" for event in events)
+            return httpx.Response(
+                200,
+                headers={"Content-Type": "text/event-stream"},
+                content=content + "data: [DONE]\n\n",
+            )
+        return httpx.Response(200, json=response)
+
+    def http_client(*_args, async_mode=False, **_kwargs):
+        cls = httpx.AsyncClient if async_mode else httpx.Client
+        return cls(transport=httpx.MockTransport(respond))
+
+    monkeypatch.setattr(
+        auxiliary_client, "_openai_http_client_kwargs",
+        lambda _url, *, async_mode=False: {
+            "http_client": http_client(async_mode=async_mode),
+        },
+    )
+    monkeypatch.setattr(AIAgent, "_build_keepalive_http_client", staticmethod(http_client))
+    return requests
+
+
+def _assert_identity(request, account_id="acct-attribution-test"):
+    assert request.headers["originator"] == "hermes-agent"
+    assert request.headers["user-agent"] == f"HermesAgent/{__version__}"
+    assert request.headers["chatgpt-account-id"] == account_id
+    assert "extra_headers" not in json.loads(request.content)
+
+
+@pytest.mark.parametrize("legacy_enabled", [None, False, True])
+def test_required_identity_preserves_account_id(profile, legacy_enabled):
+    from agent.auxiliary_client import _codex_cloudflare_headers
+
+    _set_legacy_attribution(profile, legacy_enabled)
+    headers = _codex_cloudflare_headers(_jwt())
+
+    assert headers["originator"] == "hermes-agent"
+    assert headers["User-Agent"] == f"HermesAgent/{__version__}"
+    assert headers["ChatGPT-Account-ID"] == "acct-attribution-test"
+    assert "ChatGPT-Account-ID" not in _codex_cloudflare_headers("not-a-jwt")
+
+
+@pytest.mark.parametrize(
+    ("base_url", "attributed"),
+    [
+        (CODEX_URL, True),
+        (CODEX_URL + "/", True),
+        (CODEX_URL + "/responses", True),
+        ("https://CHATGPT.COM:443/backend-api/codex", True),
+        ("http://chatgpt.com/backend-api/codex", False),
+        ("https://chatgpt.com:8443/backend-api/codex", False),
+        ("https://api.openai.com/v1", False),
+        ("https://proxy.example/backend-api/codex", False),
+        ("https://chatgpt.com.example/backend-api/codex", False),
+        ("https://subdomain.chatgpt.com/backend-api/codex", False),
+        ("https://chatgpt.com/backend-api/codex-other", False),
+        ("https://chatgpt.com/backend-api/other", False),
+        ("https://chatgpt.com:invalid/backend-api/codex", False),
+    ],
+)
+def test_new_identity_is_limited_to_the_official_endpoint(base_url, attributed):
+    from agent.auxiliary_client import _codex_cloudflare_headers
+
+    headers = _codex_cloudflare_headers(_jwt(), base_url=base_url)
+
+    assert headers["originator"] == ("hermes-agent" if attributed else "codex_cli_rs")
+    assert headers["User-Agent"] == (
+        f"HermesAgent/{__version__}"
+        if attributed else "codex_cli_rs/0.0.0 (Hermes Agent)"
+    )
+
+
+@pytest.mark.parametrize("legacy_enabled", [None, False, True])
+def test_primary_client_and_credential_rebuild_send_expected_headers(
+    profile, wire, legacy_enabled,
+):
+    from run_agent import AIAgent
+
+    _set_legacy_attribution(profile, legacy_enabled)
+    agent = AIAgent(
+        api_key=_jwt(),
+        base_url=CODEX_URL,
+        provider="openai-codex",
+        model=MODEL,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    clients = [agent.client]
+    try:
+        agent.client.responses.create(model=MODEL, input="test")
+        _assert_identity(wire[-1])
+
+        agent._client_kwargs["api_key"] = _jwt("acct-rotated")
+        agent._apply_client_headers_for_base_url(CODEX_URL)
+        assert agent._replace_primary_openai_client(reason="attribution-test")
+        clients.append(agent.client)
+        agent.client.responses.create(model=MODEL, input="test")
+        _assert_identity(wire[-1], "acct-rotated")
+
+        direct_url = "https://api.openai.com/v1"
+        agent._client_kwargs.update(api_key="test-direct-key", base_url=direct_url)
+        agent._apply_client_headers_for_base_url(direct_url)
+        assert agent._replace_primary_openai_client(reason="attribution-route-change")
+        clients.append(agent.client)
+        agent.client.responses.create(model=MODEL, input="test")
+        assert "originator" not in wire[-1].headers
+        assert "chatgpt-account-id" not in wire[-1].headers
+        assert not wire[-1].headers["user-agent"].startswith("HermesAgent/")
+    finally:
+        for client in clients:
+            client.close()
+
+
+@pytest.mark.parametrize("legacy_enabled", [None, False, True])
+def test_auxiliary_raw_and_async_clients_send_expected_headers(
+    profile, wire, monkeypatch, legacy_enabled,
+):
+    from agent import auxiliary_client
+
+    _set_legacy_attribution(profile, legacy_enabled)
+    monkeypatch.setattr(auxiliary_client, "_select_pool_entry", lambda _p: (False, None))
+    monkeypatch.setattr(auxiliary_client, "_read_codex_access_token", _jwt)
+
+    wrapped, model = auxiliary_client._build_codex_client(MODEL)
+    raw, raw_model = auxiliary_client.resolve_provider_client(
+        "openai-codex", model=MODEL, raw_codex=True,
+    )
+    try:
+        result = wrapped.chat.completions.create(
+            model=model, messages=[{"role": "user", "content": "test"}],
+        )
+        assert result.choices[0].message.content == "ok"
+        _assert_identity(wire[-1])
+
+        raw.responses.create(model=raw_model, input="test")
+        _assert_identity(wire[-1])
+
+        async def send_async():
+            async_wrapped, _ = auxiliary_client._to_async_client(wrapped, model)
+            result = await async_wrapped.chat.completions.create(
+                model=model, messages=[{"role": "user", "content": "test"}],
+            )
+            assert result.choices[0].message.content == "ok"
+            _assert_identity(wire[-1])
+
+            async_raw, _ = auxiliary_client._to_async_client(raw, raw_model)
+            try:
+                await async_raw.responses.create(model=raw_model, input="test")
+                _assert_identity(wire[-1])
+            finally:
+                await async_raw.close()
+
+        asyncio.run(send_async())
+    finally:
+        wrapped.close()
+        raw.close()
+
+
+def test_credential_pool_custom_endpoint_keeps_existing_identity(
+    wire, monkeypatch,
+):
+    from agent import auxiliary_client
+
+    entry = SimpleNamespace(
+        runtime_api_key=_jwt(),
+        runtime_base_url="https://proxy.example/backend-api/codex",
+    )
+    monkeypatch.setattr(auxiliary_client, "_select_pool_entry", lambda _p: (True, entry))
+
+    client, model = auxiliary_client._build_codex_client(MODEL)
+    try:
+        client.chat.completions.create(
+            model=model, messages=[{"role": "user", "content": "test"}],
+        )
+        assert wire[-1].url.host == "proxy.example"
+        assert wire[-1].headers["originator"] == "codex_cli_rs"
+        assert wire[-1].headers["user-agent"] == "codex_cli_rs/0.0.0 (Hermes Agent)"
+        assert wire[-1].headers["chatgpt-account-id"] == "acct-attribution-test"
+    finally:
+        client.close()
+
+
+def test_legacy_disabled_setting_cannot_disable_attribution_for_new_clients(
+    profile, wire, monkeypatch,
+):
+    from agent import auxiliary_client
+
+    monkeypatch.setattr(auxiliary_client, "_read_codex_access_token", _jwt)
+    _set_legacy_attribution(profile, True)
+    old, _ = auxiliary_client.resolve_provider_client(
+        "openai-codex", model=MODEL, raw_codex=True,
+    )
+    _set_legacy_attribution(profile, False)
+    new, _ = auxiliary_client.resolve_provider_client(
+        "openai-codex", model=MODEL, raw_codex=True,
+    )
+    try:
+        old.responses.create(model=MODEL, input="test")
+        _assert_identity(wire[-1])
+        new.responses.create(model=MODEL, input="test")
+        _assert_identity(wire[-1])
+    finally:
+        old.close()
+        new.close()
+
+
+def test_required_identity_wins_over_configured_header_defaults(
+    profile, wire,
+):
+    from agent import auxiliary_client
+    from run_agent import AIAgent
+
+    overrides = {
+        "Originator": "codex_cli_rs",
+        "user-agent": "custom-client",
+        "X-Test-Header": "preserved",
+    }
+    (profile / "config.yaml").write_text(
+        yaml.safe_dump({"model": {"default_headers": overrides}}),
+        encoding="utf-8",
+    )
+    agent = AIAgent(
+        api_key=_jwt(),
+        base_url=CODEX_URL,
+        provider="openai-codex",
+        model=MODEL,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    raw = auxiliary_client._create_openai_client(
+        api_key=_jwt(), base_url=CODEX_URL, default_headers=overrides,
+    )
+    proxy = auxiliary_client._create_openai_client(
+        api_key="test-proxy-key",
+        base_url="https://proxy.example/v1",
+        default_headers=overrides,
+    )
+    clients = [agent.client, raw, proxy]
+    try:
+        for client in (agent.client, raw):
+            client.responses.create(model=MODEL, input="test")
+            _assert_identity(wire[-1])
+            assert wire[-1].headers["x-test-header"] == "preserved"
+
+        agent._apply_client_headers_for_base_url(CODEX_URL)
+        assert agent._replace_primary_openai_client(reason="required-identity-test")
+        clients.append(agent.client)
+        agent.client.responses.create(model=MODEL, input="test")
+        _assert_identity(wire[-1])
+        assert wire[-1].headers["x-test-header"] == "preserved"
+
+        async def send_async():
+            async_raw, _ = auxiliary_client._to_async_client(raw, MODEL)
+            try:
+                await async_raw.responses.create(model=MODEL, input="test")
+                _assert_identity(wire[-1])
+                assert wire[-1].headers["x-test-header"] == "preserved"
+            finally:
+                await async_raw.close()
+
+        asyncio.run(send_async())
+
+        proxy.responses.create(model=MODEL, input="test")
+        assert wire[-1].headers["originator"] == "codex_cli_rs"
+        assert "custom-client" in wire[-1].headers.get_list("user-agent")
+        assert "HermesAgent/" not in wire[-1].headers["user-agent"]
+        assert wire[-1].headers["x-test-header"] == "preserved"
+        assert "chatgpt-account-id" not in wire[-1].headers
+    finally:
+        for client in clients:
+            client.close()

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1930,6 +1930,15 @@ When `redact_pii` is `true`, the gateway redacts personally identifiable informa
 
 Hashes are deterministic — the same user always maps to the same hash, so the model can still distinguish between users in group chats. Routing and delivery use the original values internally.
 
+### OpenAI Codex request identity
+
+OpenAI requires third-party Codex harnesses to identify themselves.
+ChatGPT-authenticated requests to the official Codex endpoint automatically
+send `originator: hermes-agent` and `User-Agent: HermesAgent/<version>`.
+The existing ChatGPT account header is preserved. No additional prompt content
+or telemetry request is sent.
+Direct OpenAI API requests and custom proxy endpoints are unchanged.
+
 ## Speech-to-Text (STT)
 
 ```yaml


### PR DESCRIPTION
## Summary

OpenAI requires third-party Codex harnesses to identify the originating harness. This change sends `originator: hermes-agent` and `User-Agent: HermesAgent/<version>` on ChatGPT-authenticated requests to the official Codex endpoint.

The existing ChatGPT account header is preserved. Primary client construction and recovery, auxiliary clients, raw Responses clients, and async clients share the same headers. Required headers take precedence over configured client-header defaults; unrelated headers are preserved. Direct OpenAI API requests and custom proxy endpoints are unchanged.

Related: [OpenCode #42959](https://github.com/anomalyco/opencode/pull/42959), [Pi's Codex harness attribution change](https://github.com/earendil-works/pi/commit/6dcb64565a66de609413de6c98457ca7ab450da9), and [Hermes direct-API attribution #38603](https://github.com/NousResearch/hermes-agent/pull/38603). This change covers the ChatGPT/Codex route.

## Verification

Tested on macOS with Python 3.12.12 and the locked development dependencies. **470 tests passed across 22 files**; `ruff check .` and `git diff --check` also passed. The request tests use the real OpenAI SDK with `httpx.MockTransport`, without live credentials or provider calls. The full repository suite was not run.

<details>
<summary>Test command</summary>

```sh
scripts/run_tests.sh \
  tests/hermes_cli/test_setup_telemetry.py \
  tests/hermes_cli/test_setup_reconfigure.py \
  tests/hermes_cli/test_setup_noninteractive.py \
  tests/hermes_cli/test_setup_openclaw_migration.py \
  tests/hermes_cli/test_tools_config.py \
  tests/hermes_cli/test_mcp_tools_config.py \
  tests/hermes_cli/test_auth_codex_provider.py \
  tests/agent/test_codex_usage_attribution.py \
  tests/agent/test_codex_cloudflare_headers.py \
  tests/agent/test_auxiliary_client.py \
  tests/agent/test_auxiliary_user_default_headers.py \
  tests/agent/test_auxiliary_client_base_url_host_validation_52608.py \
  tests/agent/test_auxiliary_client_resolve_dedup.py \
  tests/agent/transports/test_codex_transport.py \
  tests/run_agent/test_create_openai_client_reuse.py \
  tests/run_agent/test_create_openai_client_proxy_env.py \
  tests/run_agent/test_create_openai_client_kwargs_isolation.py \
  tests/run_agent/test_primary_runtime_restore.py \
  tests/run_agent/test_create_openai_client_ssl_verify.py \
  tests/run_agent/test_create_openai_client_disables_sdk_retries.py \
  tests/run_agent/test_custom_provider_extra_headers_client.py \
  tests/plugins/image_gen/test_openai_codex_provider.py \
  -j 4
ruff check .
```

For a development environment outside the checkout, set `HERMES_PYTHON` to that environment's Python before running the test script.

</details>

## Before merge

A live Codex smoke test is still needed to confirm backend acceptance of `originator: hermes-agent`.
