### PR TITLE
fix(acp): isolate decision session tools

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -72,7 +72,12 @@ from acp_adapter.events import (
 )
 from acp_adapter.permissions import make_approval_callback
 from acp_adapter.provenance import session_provenance_meta
-from acp_adapter.session import SessionManager, SessionState, _expand_acp_enabled_toolsets
+from acp_adapter.session import (
+    ACP_TOOL_PROFILE_DECISION_ONLY,
+    SessionManager,
+    SessionState,
+    _expand_acp_enabled_toolsets,
+)
 from acp_adapter.tools import build_tool_complete, build_tool_start
 from agent.context_compressor import (
     COMPRESSED_SUMMARY_METADATA_KEY,
@@ -1165,7 +1170,7 @@ class HermesACPAgent(acp.Agent):
             from agent.memory_manager import inject_memory_provider_tools
 
             enabled_toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
+                getattr(state.agent, "enabled_toolsets", None),
                 mcp_server_names=[server.name for server in mcp_servers],
             )
             state.agent.enabled_toolsets = enabled_toolsets
@@ -1594,7 +1599,17 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> NewSessionResponse:
-        state = self.session_manager.create_session(cwd=cwd)
+        hermes_meta = kwargs.get("hermes")
+        tool_profile = (
+            hermes_meta.get("toolProfile")
+            if isinstance(hermes_meta, dict)
+            else None
+        )
+        if tool_profile not in (None, ACP_TOOL_PROFILE_DECISION_ONLY):
+            raise ValueError(f"unsupported Hermes ACP tool profile: {tool_profile}")
+        state = self.session_manager.create_session(
+            cwd=cwd, tool_profile=tool_profile
+        )
         await self._register_session_mcp_servers(state, mcp_servers)
         self._schedule_mcp_late_refresh(state)
         logger.info("New session %s (cwd=%s)", state.session_id, cwd)
@@ -2337,6 +2352,7 @@ class HermesACPAgent(acp.Agent):
             cwd=state.cwd,
             model=new_model,
             requested_provider=target_provider,
+            tool_profile=state.tool_profile,
         )
         self.session_manager.save_session(state.session_id)
         provider_label = getattr(state.agent, "provider", None) or target_provider or current_provider
@@ -2350,7 +2366,7 @@ class HermesACPAgent(acp.Agent):
             from agent.memory_manager import inject_memory_provider_tools
 
             toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"]
+                getattr(state.agent, "enabled_toolsets", None)
             )
             tools = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True)
             tool_view = SimpleNamespace(
@@ -2589,6 +2605,7 @@ class HermesACPAgent(acp.Agent):
                 requested_provider=requested_provider,
                 base_url=current_base_url,
                 api_mode=current_api_mode,
+                tool_profile=state.tool_profile,
             )
             self.session_manager.save_session(session_id)
             logger.info(

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1165,13 +1165,30 @@ class HermesACPAgent(acp.Agent):
             )
             return
 
+        state.acp_mcp_server_names = list(
+            dict.fromkeys(server.name for server in mcp_servers if server.name)
+        )
+        self._restore_session_mcp_tool_surface(state)
+
+    def _restore_session_mcp_tool_surface(self, state: SessionState) -> None:
+        """Re-enable ACP-supplied MCP tools after constructing a session agent.
+
+        MCP registration is process-global, while each AIAgent snapshots its
+        enabled toolsets and schemas. Model switches replace the AIAgent, so
+        the per-session ACP toolsets must be applied to the replacement before
+        the next prompt. Only server names are retained; credentials and
+        command arguments are never copied into session persistence.
+        """
+        if not state.acp_mcp_server_names:
+            return
+
         try:
             from model_tools import get_tool_definitions
             from agent.memory_manager import inject_memory_provider_tools
 
             enabled_toolsets = _expand_acp_enabled_toolsets(
                 getattr(state.agent, "enabled_toolsets", None),
-                mcp_server_names=[server.name for server in mcp_servers],
+                mcp_server_names=state.acp_mcp_server_names,
             )
             state.agent.enabled_toolsets = enabled_toolsets
             disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
@@ -1183,14 +1200,20 @@ class HermesACPAgent(acp.Agent):
             state.agent.valid_tool_names = {
                 tool["function"]["name"] for tool in state.agent.tools or []
             }
-            inject_memory_provider_tools(state.agent)
+            # A decision-only evaluation may expose only its explicitly
+            # supplied constrained MCP. Native memory/context injectors are
+            # part of the ordinary Hermes surface and must not be reintroduced.
+            if state.tool_profile != ACP_TOOL_PROFILE_DECISION_ONLY:
+                inject_memory_provider_tools(state.agent)
             invalidate = getattr(state.agent, "_invalidate_system_prompt", None)
             if callable(invalidate):
                 invalidate()
             logger.info(
-                "Session %s: refreshed tool surface after ACP MCP registration (%d tools)",
+                "Session %s: refreshed ACP tool surface profile=%s toolsets=%s tools=%s",
                 state.session_id,
-                len(state.agent.tools or []),
+                state.tool_profile or "default",
+                enabled_toolsets,
+                sorted(state.agent.valid_tool_names),
             )
         except Exception:
             logger.warning(
@@ -1226,6 +1249,12 @@ class HermesACPAgent(acp.Agent):
         No-op when discovery already finished, when the join times out, when the
         registry was unchanged, or when the session was closed while waiting.
         """
+        # The constrained server is registered synchronously above. The global
+        # configured-server discovery path may also re-inject native
+        # memory/context tools, so it is never applicable to decision sessions.
+        if state.tool_profile == ACP_TOOL_PROFILE_DECISION_ONLY:
+            return
+
         try:
             from hermes_cli.mcp_startup import mcp_discovery_in_flight
         except Exception:
@@ -2354,6 +2383,7 @@ class HermesACPAgent(acp.Agent):
             requested_provider=target_provider,
             tool_profile=state.tool_profile,
         )
+        self._restore_session_mcp_tool_surface(state)
         self.session_manager.save_session(state.session_id)
         provider_label = getattr(state.agent, "provider", None) or target_provider or current_provider
         logger.info("Session %s: model switched to %s", state.session_id, new_model)
@@ -2607,6 +2637,7 @@ class HermesACPAgent(acp.Agent):
                 api_mode=current_api_mode,
                 tool_profile=state.tool_profile,
             )
+            self._restore_session_mcp_tool_surface(state)
             self.session_manager.save_session(session_id)
             logger.info(
                 "Session %s: model switched to %s via provider %s",

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -180,6 +180,11 @@ class SessionState:
     # ACP client-requested capability reduction. This is persisted so a
     # restored evaluation session cannot silently regain the default tools.
     tool_profile: str | None = None
+    # Names of MCP servers supplied by the ACP client for this live session.
+    # The registry itself is process-global; retaining only names is sufficient
+    # to restore the permitted toolsets after an in-session agent rebuild
+    # without persisting command arguments or environment secrets.
+    acp_mcp_server_names: List[str] = field(default_factory=list)
     history: List[Dict[str, Any]] = field(default_factory=list)
     cancel_event: Any = None  # threading.Event
     is_running: bool = False
@@ -712,6 +717,14 @@ class SessionManager:
             logger.debug("ACP: bounded MCP discovery wait failed", exc_info=True)
 
         agent = AIAgent(**kwargs)
+        if tool_profile == ACP_TOOL_PROFILE_DECISION_ONLY:
+            # AIAgent appends memory/context-engine schemas after registry
+            # filtering. Remove those native additions as well: the ACP server
+            # will add only the explicitly supplied constrained decision MCP.
+            agent.tools = []
+            agent.valid_tool_names = set()
+            agent._context_engine_tool_names = set()
+            agent._skip_mcp_refresh = True
         # Codex app-server sessions are spawned lazily on the first turn. Stamp
         # the ACP workspace onto the agent so the Codex runtime starts from the
         # editor/session cwd instead of the Hermes daemon's process cwd.

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -25,6 +25,8 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
+ACP_TOOL_PROFILE_DECISION_ONLY = "decision-only"
+
 
 def _translate_acp_cwd(cwd: str) -> str:
     """Translate Windows ACP cwd values when Hermes itself is running in WSL.
@@ -143,7 +145,8 @@ def _expand_acp_enabled_toolsets(
 ) -> List[str]:
     """Return ACP toolsets plus explicit MCP server toolsets for this session."""
     expanded: List[str] = []
-    for name in list(toolsets or ["hermes-acp"]):
+    selected = ["hermes-acp"] if toolsets is None else toolsets
+    for name in list(selected):
         if name and name not in expanded:
             expanded.append(name)
 
@@ -174,6 +177,9 @@ class SessionState:
     agent: Any  # AIAgent instance
     cwd: str = "."
     model: str = ""
+    # ACP client-requested capability reduction. This is persisted so a
+    # restored evaluation session cannot silently regain the default tools.
+    tool_profile: str | None = None
     history: List[Dict[str, Any]] = field(default_factory=list)
     cancel_event: Any = None  # threading.Event
     is_running: bool = False
@@ -207,18 +213,23 @@ class SessionManager:
 
     # ---- public API ---------------------------------------------------------
 
-    def create_session(self, cwd: str = ".") -> SessionState:
+    def create_session(
+        self, cwd: str = ".", tool_profile: str | None = None
+    ) -> SessionState:
         """Create a new session with a unique ID and a fresh AIAgent."""
         import threading
 
         cwd = _translate_acp_cwd(cwd)
         session_id = str(uuid.uuid4())
-        agent = self._make_agent(session_id=session_id, cwd=cwd)
+        agent = self._make_agent(
+            session_id=session_id, cwd=cwd, tool_profile=tool_profile
+        )
         state = SessionState(
             session_id=session_id,
             agent=agent,
             cwd=cwd,
             model=getattr(agent, "model", "") or "",
+            tool_profile=tool_profile,
             cancel_event=threading.Event(),
         )
         with self._lock:
@@ -264,12 +275,14 @@ class SessionManager:
             session_id=new_id,
             cwd=cwd,
             model=original.model or None,
+            tool_profile=original.tool_profile,
         )
         state = SessionState(
             session_id=new_id,
             agent=agent,
             cwd=cwd,
             model=getattr(agent, "model", original.model) or original.model,
+            tool_profile=original.tool_profile,
             history=copy.deepcopy(original.history),
             cancel_event=threading.Event(),
         )
@@ -433,6 +446,8 @@ class SessionManager:
         # Ensure model is a plain string (not a MagicMock or other proxy).
         model_str = str(state.model) if state.model else None
         session_meta = {"cwd": state.cwd}
+        if state.tool_profile:
+            session_meta["acp_tool_profile"] = state.tool_profile
         provider = getattr(state.agent, "provider", None)
         base_url = getattr(state.agent, "base_url", None)
         api_mode = getattr(state.agent, "api_mode", None)
@@ -452,7 +467,7 @@ class SessionManager:
                     session_id=state.session_id,
                     source="acp",
                     model=model_str,
-                    model_config={"cwd": state.cwd},
+                    model_config=session_meta,
                 )
             else:
                 # Update model_config (contains cwd) if changed.
@@ -532,6 +547,7 @@ class SessionManager:
         requested_provider = row.get("billing_provider")
         restored_base_url = row.get("billing_base_url")
         restored_api_mode = None
+        tool_profile = None
         mc = row.get("model_config")
         if mc:
             try:
@@ -541,6 +557,7 @@ class SessionManager:
                     requested_provider = meta.get("provider") or requested_provider
                     restored_base_url = meta.get("base_url") or restored_base_url
                     restored_api_mode = meta.get("api_mode") or restored_api_mode
+                    tool_profile = meta.get("acp_tool_profile") or tool_profile
             except (json.JSONDecodeError, TypeError):
                 pass
 
@@ -567,6 +584,7 @@ class SessionManager:
                 requested_provider=requested_provider,
                 base_url=restored_base_url,
                 api_mode=restored_api_mode,
+                tool_profile=tool_profile,
             )
         except Exception:
             logger.warning("Failed to recreate agent for ACP session %s", session_id, exc_info=True)
@@ -577,6 +595,7 @@ class SessionManager:
             agent=agent,
             cwd=cwd,
             model=model or getattr(agent, "model", "") or "",
+            tool_profile=tool_profile,
             history=history,
             cancel_event=threading.Event(),
         )
@@ -608,6 +627,7 @@ class SessionManager:
         requested_provider: str | None = None,
         base_url: str | None = None,
         api_mode: str | None = None,
+        tool_profile: str | None = None,
     ):
         if self._agent_factory is not None:
             return self._agent_factory()
@@ -632,11 +652,18 @@ class SessionManager:
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
         ]
 
+        if tool_profile not in (None, ACP_TOOL_PROFILE_DECISION_ONLY):
+            raise ValueError(f"unsupported ACP tool profile: {tool_profile}")
+        native_toolsets = [] if tool_profile == ACP_TOOL_PROFILE_DECISION_ONLY else ["hermes-acp"]
+        mcp_server_names = (
+            [] if tool_profile == ACP_TOOL_PROFILE_DECISION_ONLY else configured_mcp_servers
+        )
+
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
-                mcp_server_names=configured_mcp_servers,
+                native_toolsets,
+                mcp_server_names=mcp_server_names,
             ),
             "quiet_mode": True,
             "session_id": session_id,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -757,6 +757,65 @@ class TestRegisterSessionMcpServers:
         assert state.agent.enabled_toolsets == ["mcp-buzz-dev-mcp"]
         assert "hermes-acp" not in state.agent.enabled_toolsets
 
+    @pytest.mark.parametrize("switch_path", ["slash", "protocol"])
+    @pytest.mark.asyncio
+    async def test_decision_only_model_switch_restores_explicit_mcp_only(
+        self, agent, mock_manager, switch_path
+    ):
+        state = mock_manager.create_session(
+            cwd="/tmp", tool_profile=ACP_TOOL_PROFILE_DECISION_ONLY
+        )
+        state.acp_mcp_server_names = ["buzz-dev-mcp"]
+        state.agent.provider = "openai-codex"
+        state.agent.model = "old-model"
+
+        replacement = MagicMock(name="ReplacementDecisionAgent")
+        replacement.enabled_toolsets = []
+        replacement.disabled_toolsets = None
+        replacement.tools = []
+        replacement.valid_tool_names = set()
+        replacement.provider = "openai-codex"
+        replacement.model = "new-model"
+        replacement.base_url = None
+        replacement.api_mode = "codex_app_server"
+
+        decision_tools = [
+            {"function": {"name": "jobs_accept"}},
+            {"function": {"name": "jobs_reject"}},
+        ]
+        with patch.object(
+            mock_manager, "_make_agent", return_value=replacement
+        ) as make_agent, patch.object(
+            agent,
+            "_resolve_model_selection",
+            return_value=("openai-codex", "new-model"),
+        ), patch(
+            "model_tools.get_tool_definitions", return_value=decision_tools
+        ) as get_defs, patch(
+            "agent.memory_manager.inject_memory_provider_tools"
+        ) as inject_memory:
+            if switch_path == "slash":
+                response = agent._cmd_model("new-model", state)
+                assert response.startswith("Model switched to: new-model")
+            else:
+                response = await agent.set_session_model(
+                    "new-model", state.session_id
+                )
+                assert isinstance(response, SetSessionModelResponse)
+
+        assert make_agent.call_args.kwargs["tool_profile"] == (
+            ACP_TOOL_PROFILE_DECISION_ONLY
+        )
+        get_defs.assert_called_once_with(
+            enabled_toolsets=["mcp-buzz-dev-mcp"],
+            disabled_toolsets=None,
+            quiet_mode=True,
+        )
+        inject_memory.assert_not_called()
+        assert replacement.enabled_toolsets == ["mcp-buzz-dev-mcp"]
+        assert replacement.valid_tool_names == {"jobs_accept", "jobs_reject"}
+        assert "hermes-acp" not in replacement.enabled_toolsets
+
     @pytest.mark.asyncio
     async def test_register_failure_logs_warning(self, agent, mock_manager):
         """If register_mcp_servers raises, warning is logged but no crash."""

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -41,7 +41,7 @@ from acp_adapter.server import (
     HermesACPAgent,
     HERMES_VERSION,
 )
-from acp_adapter.session import SessionManager
+from acp_adapter.session import ACP_TOOL_PROFILE_DECISION_ONLY, SessionManager
 from hermes_state import SessionDB
 
 
@@ -69,6 +69,24 @@ async def test_new_session_exposes_edit_approvals_as_modes_not_config_options(ag
         ("accept_edits", "Accept Edits"),
         ("dont_ask", "Don't Ask"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_new_session_applies_decision_only_profile_from_hermes_meta(agent):
+    resp = await agent.new_session(
+        cwd="/tmp",
+        hermes={"toolProfile": ACP_TOOL_PROFILE_DECISION_ONLY},
+    )
+    state = agent.session_manager.get_session(resp.session_id)
+
+    assert state is not None
+    assert state.tool_profile == ACP_TOOL_PROFILE_DECISION_ONLY
+
+
+@pytest.mark.asyncio
+async def test_new_session_rejects_unknown_hermes_tool_profile(agent):
+    with pytest.raises(ValueError, match="unsupported Hermes ACP tool profile"):
+        await agent.new_session(cwd="/tmp", hermes={"toolProfile": "full-access"})
 
 
 @pytest.mark.asyncio
@@ -709,6 +727,35 @@ class TestRegisterSessionMcpServers:
         }
         # _invalidate_system_prompt should have been called
         state.agent._invalidate_system_prompt.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_decision_only_session_adds_only_explicit_mcp_toolset(
+        self, agent, mock_manager
+    ):
+        from acp.schema import McpServerStdio
+
+        state = mock_manager.create_session(
+            cwd="/tmp", tool_profile=ACP_TOOL_PROFILE_DECISION_ONLY
+        )
+        state.agent.enabled_toolsets = []
+        state.agent.disabled_toolsets = None
+        state.agent.tools = []
+        state.agent.valid_tool_names = set()
+        server = McpServerStdio(
+            name="buzz-dev-mcp", command="buzz-dev-mcp", args=[], env=[]
+        )
+
+        with patch("tools.mcp_tool.register_mcp_servers", return_value=["read_file"]), \
+             patch("model_tools.get_tool_definitions", return_value=[]) as mock_defs:
+            await agent._register_session_mcp_servers(state, [server])
+
+        mock_defs.assert_called_once_with(
+            enabled_toolsets=["mcp-buzz-dev-mcp"],
+            disabled_toolsets=None,
+            quiet_mode=True,
+        )
+        assert state.agent.enabled_toolsets == ["mcp-buzz-dev-mcp"]
+        assert "hermes-acp" not in state.agent.enabled_toolsets
 
     @pytest.mark.asyncio
     async def test_register_failure_logs_warning(self, agent, mock_manager):

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -133,6 +133,8 @@ class TestCreateSession:
             def __init__(self, **kwargs):
                 self.enabled_toolsets = kwargs["enabled_toolsets"]
                 self.kwargs = kwargs
+                self.tools = [{"function": {"name": "native_memory_write"}}]
+                self.valid_tool_names = {"native_memory_write"}
 
         monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
         monkeypatch.setattr(
@@ -163,6 +165,9 @@ class TestCreateSession:
         if tool_profile == ACP_TOOL_PROFILE_DECISION_ONLY:
             assert "hermes-acp" not in state.agent.enabled_toolsets
             assert "mcp-configured" not in state.agent.enabled_toolsets
+            assert state.agent.tools == []
+            assert state.agent.valid_tool_names == set()
+            assert state.agent._skip_mcp_refresh is True
 
     def test_decision_only_profile_survives_persisted_restore(self, monkeypatch, tmp_path):
         created_toolsets = []

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -9,7 +9,11 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from acp_adapter import session as acp_session
-from acp_adapter.session import SessionManager, SessionState
+from acp_adapter.session import (
+    ACP_TOOL_PROFILE_DECISION_ONLY,
+    SessionManager,
+    SessionState,
+)
 from hermes_state import SessionDB
 
 
@@ -112,6 +116,97 @@ class TestCreateSession:
 
 
 
+
+    @pytest.mark.parametrize(
+        ("tool_profile", "expected_toolsets"),
+        [
+            (None, ["hermes-acp", "mcp-configured"]),
+            (ACP_TOOL_PROFILE_DECISION_ONLY, []),
+        ],
+    )
+    def test_acp_tool_profile_reduces_native_and_configured_capabilities(
+        self, monkeypatch, tool_profile, expected_toolsets
+    ):
+        class FakeAgent:
+            model = "fake-model"
+
+            def __init__(self, **kwargs):
+                self.enabled_toolsets = kwargs["enabled_toolsets"]
+                self.kwargs = kwargs
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {"default": "fake-model"},
+                "mcp_servers": {"configured": {"enabled": True}},
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None: {},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build",
+            lambda **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "acp_adapter.session._register_task_cwd", lambda task_id, cwd: None
+        )
+
+        state = SessionManager(db=None).create_session(
+            cwd="/tmp/project", tool_profile=tool_profile
+        )
+
+        assert state.tool_profile == tool_profile
+        assert state.agent.enabled_toolsets == expected_toolsets
+        if tool_profile == ACP_TOOL_PROFILE_DECISION_ONLY:
+            assert "hermes-acp" not in state.agent.enabled_toolsets
+            assert "mcp-configured" not in state.agent.enabled_toolsets
+
+    def test_decision_only_profile_survives_persisted_restore(self, monkeypatch, tmp_path):
+        created_toolsets = []
+
+        class FakeAgent:
+            model = "fake-model"
+            provider = None
+            base_url = None
+            api_mode = None
+
+            def __init__(self, **kwargs):
+                self.enabled_toolsets = kwargs["enabled_toolsets"]
+                self._session_db = None
+                self._session_db_created = False
+                created_toolsets.append(list(self.enabled_toolsets))
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"model": {"default": "fake-model"}, "mcp_servers": {}},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None: {},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build",
+            lambda **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "acp_adapter.session._register_task_cwd", lambda task_id, cwd: None
+        )
+
+        first = SessionManager(db=db)
+        state = first.create_session(
+            cwd="/tmp/project", tool_profile=ACP_TOOL_PROFILE_DECISION_ONLY
+        )
+        first._sessions.clear()
+        restored = first.get_session(state.session_id)
+
+        assert restored is not None
+        assert restored.tool_profile == ACP_TOOL_PROFILE_DECISION_ONLY
+        assert created_toolsets == [[], []]
 
 # ---------------------------------------------------------------------------
 # WSL cwd translation


### PR DESCRIPTION
## What changed

- Adds an ACP `_meta.hermes.toolProfile = "decision-only"` session profile.
- Removes Hermes native and configured MCP toolsets only for that profile.
- Keeps ACP-supplied MCP servers available, so a client can provide a constrained decision surface.
- Persists the capability reduction across session restore, fork, and model switching.

## Why

ACP clients can restrict the MCP servers they supply, but Hermes currently always adds its native `hermes-acp` toolset. A proposal-evaluation session therefore still exposes terminal, file mutation, code execution, delegation, and browser capabilities even when the client intends a read/decide-only turn.

The extension is reduction-only: unknown profiles fail closed, ordinary ACP sessions keep existing behavior, and no capability can be expanded through metadata.

## Validation

- `scripts/run_tests.sh tests/acp/test_session.py tests/acp/test_server.py -q`
- 55 targeted tests passed.
