### PR TITLE
fix(cron): allow multiplex live-adapter preflight

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2662,7 +2662,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
         from gateway.delivery import resolve_delivery_transport
 
-        transport = resolve_delivery_transport(platform, config, adapters)
+        live_loop_ready = (
+            loop is not None
+            and getattr(loop, "is_running", lambda: False)()
+        )
+        transport = resolve_delivery_transport(
+            platform,
+            config,
+            adapters,
+            allow_live_native_if_disabled=live_loop_ready,
+        )
         if transport is not None:
             pconfig = transport.config
             runtime_adapter = transport.adapter
@@ -2683,7 +2692,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             if pconfig is None:
                 from gateway.config import PlatformConfig
                 pconfig = PlatformConfig(enabled=True)
-        elif not pconfig or not pconfig.enabled:
+        elif (not pconfig or not pconfig.enabled) and not (
+            runtime_adapter is not None and live_loop_ready
+        ):
             msg = f"platform '{platform_name}' not configured/enabled"
             logger.warning("Job '%s': %s", job["id"], msg)
             delivery_errors.append(msg)
@@ -2701,8 +2712,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         # standalone path — which cannot seed the flat session (r3609147550).
         live_adapter_ready = (
             runtime_adapter is not None
-            and loop is not None
-            and getattr(loop, "is_running", lambda: False)()
+            and live_loop_ready
         )
         delivered = False
         target_errors = []
@@ -2883,7 +2893,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 if text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
 
-                    router = DeliveryRouter(config, adapters)
+                    router = DeliveryRouter(
+                        config,
+                        adapters,
+                        allow_live_native_if_disabled=True,
+                    )
                     route_target = DeliveryTarget(
                         platform=platform,
                         chat_id=str(chat_id),
@@ -4315,7 +4329,7 @@ def _preflight_check_provider_key(job: dict, cfg: dict) -> Optional[str]:
     return None
 
 
-def _preflight_check_delivery(job: dict) -> Optional[str]:
+def _preflight_check_delivery(job: dict, *, adapters=None, loop=None) -> Optional[str]:
     """Check the job's delivery target(s) resolve to configured platforms.
 
     ``local``/``origin`` (and the ``all`` routing token) need no gateway
@@ -4323,9 +4337,9 @@ def _preflight_check_delivery(job: dict) -> Optional[str]:
     gateway-config load. For concrete platform targets, an unknown platform
     always blocks; a known platform additionally blocks when the gateway
     config is loadable and reports it unconnected (enabled + credentials —
-    the same source `cron_delivery_targets` uses). Gateway-config load
-    failures fail OPEN so a transient config hiccup never wedges delivery
-    that would have worked.
+    the same source `cron_delivery_targets` uses) and no supplied live adapter
+    can deliver it. Gateway-config load failures fail OPEN so a transient
+    config hiccup never wedges delivery that would have worked.
     """
     deliver_value = _normalize_deliver_value(job.get("deliver", "local"))
     platform_parts: list[str] = []
@@ -4354,6 +4368,27 @@ def _preflight_check_delivery(job: dict) -> Optional[str]:
                     p.value for p in gateway_config.get_connected_platforms()
                 }
                 connected |= _relay_fronted_delivery_platforms(connected)
+                live_adapter_ready = (
+                    adapters
+                    and loop is not None
+                    and getattr(loop, "is_running", lambda: False)()
+                )
+                if live_adapter_ready:
+                    from gateway.config import Platform
+                    from gateway.delivery import resolve_delivery_transport
+
+                    for candidate in platform_parts:
+                        try:
+                            platform = Platform(candidate.lower())
+                        except (ValueError, KeyError):
+                            continue
+                        if resolve_delivery_transport(
+                            platform,
+                            gateway_config,
+                            adapters,
+                            allow_live_native_if_disabled=True,
+                        ) is not None:
+                            connected.add(platform.value)
             except Exception:
                 logger.debug(
                     "preflight: gateway config unavailable — skipping "
@@ -4425,7 +4460,9 @@ def _preflight_check_skills(job: dict) -> Optional[str]:
     return None
 
 
-def _preflight_job_config(job: dict, cfg: dict) -> Optional[str]:
+def _preflight_job_config(
+    job: dict, cfg: dict, *, adapters=None, loop=None
+) -> Optional[str]:
     """Pre-dispatch configuration validation (T1-26).
 
     Returns a human-readable reason when the job's configuration cannot
@@ -4444,7 +4481,10 @@ def _preflight_job_config(job: dict, cfg: dict) -> Optional[str]:
     for name, check in (
         ("provider_key", lambda: _preflight_check_provider_key(job, cfg)),
         ("skills", lambda: _preflight_check_skills(job)),
-        ("delivery", lambda: _preflight_check_delivery(job)),
+        (
+            "delivery",
+            lambda: _preflight_check_delivery(job, adapters=adapters, loop=loop),
+        ),
     ):
         try:
             reason = check()
@@ -4588,6 +4628,8 @@ def run_job(
     defer_agent_teardown: Optional[list] = None,
     extra_prompt: Optional[str] = None,
     cancel_event: Optional[_CancelEventLike] = None,
+    adapters=None,
+    loop=None,
 ) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
@@ -5262,7 +5304,9 @@ def run_job(
         _pf_reason = None
         try:
             if _cron_preflight_enabled(_cfg):
-                _pf_reason = _preflight_job_config(job, _cfg)
+                _pf_reason = _preflight_job_config(
+                    job, _cfg, adapters=adapters, loop=loop
+                )
                 if not _pf_reason and job.get("preflight_alerted"):
                     # Configuration validates again — clear the alert-once
                     # marker so a FUTURE config break re-alerts.
@@ -6290,12 +6334,18 @@ def _run_one_job_body(
         # below once delivery is done. Defense-in-depth alongside the
         # interpreter-shutdown guard in _deliver_result.
         _deferred_agents: list = []
+        _adapter_kwargs = {}
+        if adapters is not None:
+            _adapter_kwargs["adapters"] = adapters
+        if loop is not None:
+            _adapter_kwargs["loop"] = loop
         try:
             if fire_claim_lost is None:
                 success, output, final_response, error = run_job(
                     job,
                     defer_agent_teardown=_deferred_agents,
                     extra_prompt=extra_prompt,
+                    **_adapter_kwargs,
                 )
             else:
                 success, output, final_response, error = run_job(
@@ -6303,6 +6353,7 @@ def _run_one_job_body(
                     defer_agent_teardown=_deferred_agents,
                     extra_prompt=extra_prompt,
                     cancel_event=fire_claim_lost,
+                    **_adapter_kwargs,
                 )
         except BaseException:
             # run_job's finally still hands back the agent when it raises; tear

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -93,6 +93,8 @@ def resolve_delivery_transport(
     platform: Platform,
     config: GatewayConfig,
     adapters: Optional[Dict[Platform, Any]],
+    *,
+    allow_live_native_if_disabled: bool = False,
 ) -> Optional[DeliveryTransport]:
     """Resolve a logical platform to its live delivery transport.
 
@@ -107,7 +109,11 @@ def resolve_delivery_transport(
     # Preserve DeliveryRouter's historical support for explicitly supplied live
     # adapters with no config block, but never let an explicitly disabled native
     # adapter shadow an enabled Relay transport.
-    if native is not None and (native_config is None or native_config.enabled):
+    if native is not None and (
+        allow_live_native_if_disabled
+        or native_config is None
+        or native_config.enabled
+    ):
         return DeliveryTransport(
             adapter=native,
             config=native_config,
@@ -300,7 +306,8 @@ class DeliveryRouter:
     """
     
     def __init__(self, config: GatewayConfig, adapters: Dict[Platform, Any] = None,
-                 dead_targets: Optional[DeadTargetRegistry] = None):
+                 dead_targets: Optional[DeadTargetRegistry] = None, *,
+                 allow_live_native_if_disabled: bool = False):
         """
         Initialize the delivery router.
         
@@ -309,11 +316,14 @@ class DeliveryRouter:
             adapters: Dict mapping platforms to their adapter instances
             dead_targets: Optional shared registry of confirmed-unreachable
                 targets.  When omitted, a profile-local registry is created.
+            allow_live_native_if_disabled: Trust a concrete live native adapter
+                even when this scoped profile has no local platform credential.
         """
         self.config = config
         self.adapters = adapters or {}
         self.output_dir = get_hermes_home() / "cron" / "output"
         self.dead_targets = dead_targets or DeadTargetRegistry()
+        self.allow_live_native_if_disabled = allow_live_native_if_disabled
     
     async def deliver(
         self,
@@ -464,7 +474,12 @@ class DeliveryRouter:
         metadata: Optional[Dict[str, Any]]
     ) -> Dict[str, Any]:
         """Deliver content to a messaging platform."""
-        transport = resolve_delivery_transport(target.platform, self.config, self.adapters)
+        transport = resolve_delivery_transport(
+            target.platform,
+            self.config,
+            self.adapters,
+            allow_live_native_if_disabled=self.allow_live_native_if_disabled,
+        )
         if transport is None:
             raise ValueError(f"No adapter configured for {target.platform.value}")
         adapter = transport.adapter

--- a/tests/cron/test_cron_relay_delivery_guards.py
+++ b/tests/cron/test_cron_relay_delivery_guards.py
@@ -26,6 +26,7 @@ from cron.scheduler import (
     _resolve_single_delivery_target,
     cron_delivery_targets,
 )
+from gateway.config import Platform
 
 
 def _slack_home(monkeypatch, chat_id="D0BJTDCSR7C", thread_id=None):
@@ -146,3 +147,43 @@ class TestPreflightRelayFronted:
             ids = {t["id"] for t in cron_delivery_targets()}
         assert "slack" in ids
         assert "telegram" not in ids
+
+
+class TestPreflightLiveAdapter:
+    def test_profile_without_credential_accepts_shared_live_adapter(self):
+        """A multiplexed profile may deliver through the gateway's live adapter."""
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        with patch("gateway.config.load_gateway_config",
+                   return_value=_gateway_config(set())):
+            assert _preflight_check_delivery(
+                {"deliver": "telegram:123456789"},
+                adapters={Platform.TELEGRAM: object()},
+                loop=loop,
+            ) is None
+
+    def test_live_adapter_without_running_loop_stays_blocked(self):
+        """An adapter map alone cannot prove fire-time delivery is usable."""
+        with patch("gateway.config.load_gateway_config",
+                   return_value=_gateway_config(set())):
+            reason = _preflight_check_delivery(
+                {"deliver": "telegram:123456789"},
+                adapters={Platform.TELEGRAM: object()},
+                loop=None,
+            )
+        assert reason is not None
+        assert "telegram" in reason
+
+    def test_live_adapter_with_stopped_loop_stays_blocked(self):
+        """A present but stopped gateway loop is not a usable live transport."""
+        loop = MagicMock()
+        loop.is_running.return_value = False
+        with patch("gateway.config.load_gateway_config",
+                   return_value=_gateway_config(set())):
+            reason = _preflight_check_delivery(
+                {"deliver": "telegram:123456789"},
+                adapters={Platform.TELEGRAM: object()},
+                loop=loop,
+            )
+        assert reason is not None
+        assert "telegram" in reason

--- a/tests/cron/test_preflight_config.py
+++ b/tests/cron/test_preflight_config.py
@@ -26,6 +26,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 import cron.jobs as cron_jobs
 from cron.scheduler import run_job
 import cron.scheduler as sched
+from gateway.config import Platform
 
 
 _RUNTIME = {
@@ -340,3 +341,50 @@ class TestDeliveryPlatform:
 
         assert success is True
         assert agent_constructed is True
+
+    def test_live_multiplex_adapter_reaches_preflight(self, tmp_path):
+        """Gateway-fired profile cron accepts its shared live Telegram adapter."""
+        job = _job(deliver="telegram:123456789")
+        gateway_config = MagicMock()
+        gateway_config.get_connected_platforms.return_value = []
+        gateway_config.platforms = {}
+        fake_db = MagicMock()
+        live_adapter = object()
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_deliver(_job, _content, adapters=None, loop=None):
+            assert adapters == {Platform.TELEGRAM: live_adapter}
+            assert loop is gateway_loop
+            return None
+
+        gateway_loop = loop
+
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            fresh = cron_jobs.load_jobs()[0]
+            with patch("cron.scheduler._hermes_home", tmp_path), \
+                 patch("cron.scheduler._resolve_origin", return_value=None), \
+                 patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+                 patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+                 patch("hermes_state.SessionDB", return_value=fake_db), \
+                 patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), \
+                 patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                       return_value=dict(_RUNTIME)), \
+                 patch("gateway.config.load_gateway_config",
+                       return_value=gateway_config), \
+                 patch.object(sched, "_deliver_result", side_effect=fake_deliver), \
+                 patch("run_agent.AIAgent") as mock_agent_cls:
+                mock_agent_cls.return_value.run_conversation.return_value = {
+                    "final_response": "ok"
+                }
+                assert sched.run_one_job(
+                    fresh,
+                    adapters={Platform.TELEGRAM: live_adapter},
+                    loop=gateway_loop,
+                ) is True
+
+            stored = cron_jobs.load_jobs()[0]
+
+        assert mock_agent_cls.called is True
+        assert stored["last_status"] == "ok"

--- a/tests/cron/test_relay_fronted_delivery.py
+++ b/tests/cron/test_relay_fronted_delivery.py
@@ -174,3 +174,42 @@ class TestRelayDeliveryGate:
         result = self._run({}, config)
         assert result is not None
         assert "not configured/enabled" in result
+
+
+class TestNativeMultiplexDeliveryGate:
+    def test_shared_live_native_adapter_bypasses_profile_local_config(self):
+        """A running gateway adapter can deliver for a credential-less profile."""
+        adapter = AsyncMock()
+        adapter.send.return_value = {"success": True, "raw_response": None}
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        config = MagicMock()
+        config.platforms = {}
+        config.get_home_channel.return_value = None
+
+        def fake_run_coro(coro, _loop):
+            future = Future()
+            try:
+                future.set_result(asyncio.run(coro))
+            except BaseException as exc:  # noqa: BLE001
+                future.set_exception(exc)
+            return future
+
+        job = {
+            "id": "multiplex-native",
+            "name": "Multiplex Native",
+            "deliver": "telegram:123456789",
+        }
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("cron.scheduler.load_config",
+                   return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            result = _deliver_result(
+                job,
+                "Inbox update.",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        adapter.send.assert_awaited_once()


### PR DESCRIPTION
## Summary

- let gateway-fired cron preflight recognize a shared live native adapter only when its owning event loop is running
- keep profile-local credential strictness for standalone/manual paths without a usable live loop
- align fire-time `DeliveryRouter` behavior with the same narrowly scoped live-native predicate
- preserve existing native/relay defaults and legacy `run_job` call signatures when no adapter or loop is supplied

## Root cause

Under `gateway.multiplex_profiles`, the default profile owns the Telegram bot token and live adapter. A secondary profile cron job runs under its isolated credential scope, so preflight sees Telegram as disconnected and returns `blocked_config` before the shared gateway adapter can deliver the result.

The fix threads the gateway-owned adapter map and event loop through `run_one_job -> run_job -> preflight`. A live native adapter may bypass the scoped profile's missing/disabled platform config only when the owning loop is running; otherwise existing strict validation remains.

## Tests

- TDD regression tests observed failing before implementation
- `scripts/run_tests.sh tests/cron -q` — 805 passed, 0 failed, 5 skipped
- canonical gateway delivery/relay scope — 69 passed, 0 failed
- `ruff check` on all changed Python files — passed
- `git diff --check` — passed
- added-line security scan — no secret, injection, eval/exec, pickle, or SQL-format findings

## Production reproduction

A multiplexed secondary profile with no local Telegram token had a cron job delivering to `telegram:<synthetic_chat_id>`. The shared default gateway had a live Telegram adapter, but preflight returned `delivery platform 'telegram' has no gateway credentials configured (not connected)` before any LLM call. Disabling preflight made the same gateway-fired job deliver successfully.
