### PR TITLE
fix(hermes-bots): Active-now chip resumes the bot's live session

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -6474,11 +6474,23 @@ function BotsPane() {
             $botUnread.set(next)
           }
 
-          void openBotCanonicalChat(bot.name, allMeta[bot.name]?.chat).catch(() => {
-            if (typeof host.newChat === 'function') {
-              host.newChat(bot.name)
-            }
-          })
+          // "Active now" means the bot has a live session right now, so the
+          // chip should resume THAT session rather than open (or create) the
+          // canonical "Bot Chat". Fall back to the canonical chat only when
+          // there is no live session (e.g. a busy turn before its first reply).
+          const fallback = () =>
+            openBotCanonicalChat(bot.name, allMeta[bot.name]?.chat).catch(() => {
+              if (typeof host.newChat === 'function') {
+                host.newChat(bot.name)
+              }
+            })
+
+          const liveId = bot.last_session?.id
+          if (liveId && typeof host.openSession === 'function') {
+            void host.openSession(liveId, { profile: bot.name }).catch(fallback)
+          } else {
+            void fallback()
+          }
         }
       }),
       roster.length

--- a/apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs
@@ -74,6 +74,17 @@ test('roster without profiles never throws', () => {
   assert.equal(activeBots([], 'default', 'open', NOW).length, 0)
 })
 
+test('ActiveNowStrip chip prefers the bot live session over opening/creating a new chat', () => {
+  const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+  // "Active now" means the bot is mid-conversation, so its chip must resume the
+  // live session (bot.last_session.id) rather than open — or worse, CREATE — the
+  // canonical "Bot Chat" that may not yet exist. The canonical path stays as the
+  // fallback for when there is no live session yet.
+  assert.match(source, /const liveId = bot\.last_session\?\.id/)
+  assert.match(source, /host\.openSession\(liveId, \{ profile: bot\.name \}\)/)
+  assert.match(source, /openBotCanonicalChat\(bot\.name, allMeta\[bot\.name\]\?\.chat\)/)
+})
+
 test('ActiveNowStrip renders above the roster, is a live region, and is click-accessible', () => {
   // Strip is placed between the pane header and the search field.
   const headerEnd = source.indexOf("children: 'Bots'")


### PR DESCRIPTION
## Problem

In the desktop **Bots** tab, the **Active now** strip shows bots that are working right now. Clicking one of those chips should take you to the session the bot is **currently streaming into** — but instead it opens (and when none exists, **creates**) the bot's canonical "Bot Chat". The reported symptom: *"clicking an active bot redirects to a new session instead of the active one."*

Root cause is in `apps/desktop/src/plugins/hermes-bots/plugin.js` — `ActiveNowStrip`'s `onOpen` handler calls `openBotCanonicalChat(name, meta.chat)`:

- If the canonical Bot Chat was never pinned (`meta.chat` is null), `createCanonicalChat()` starts a **brand-new** session and even submits a kickoff prompt.
- If the pinned chat fails to resume, it clears the pin and creates another new session.
- The outer `.catch` additionally falls back to `host.newChat()` — yet another new session.

Meanwhile the chip already carries the exact session the user wants: every "active now" bot has a live session in `bot.last_session.id` (surfaced by `profiles.list` → `_latest_profile_session_row`, used to compute the 90s liveness window). The click just never used it.

## Fix

For "active now" chips, resume `bot.last_session.id` (the live session that made the bot active) via `host.openSession`. Fall back to the existing canonical-chat path only when there is no live session yet (e.g. a busy turn before its first reply). Regular roster rows are intentionally unchanged — for those, opening the stable canonical Bot Chat remains the correct behavior; only the "active now" chip carries the "currently working" semantic.

## Verification

- Added a structural unit test in `active-now-strip.test.mjs` alongside the existing suite.
- `node --test` in `apps/desktop/src/plugins/hermes-bots/tests`: **150 pass, 0 fail**.

Behavior contract: `bot.last_session.id` is a single most-recent session per bot (the roster only surfaces one), so "multiple active sessions" is not a case this UI has to disambiguate.