### PR TITLE
fix(cron): give script subprocess a deterministic stdin (DEVNULL)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3620,6 +3620,7 @@ def _run_job_script(
         _script_cwd = workdir or str(path.parent)
         proc = subprocess.Popen(
             argv,
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -106,6 +106,46 @@ class TestRunJobScript:
         assert output == "relative works"
 
 
+    def test_script_subprocess_gets_clean_stdin(self, cron_env, monkeypatch):
+        """Cron scripts must not inherit the gateway's stdin.
+
+        The gateway is launched detached (`nohup ... &`), so its FD 0 can be a
+        dead/closed descriptor. When the script child inherited that FD,
+        CPython aborted at interpreter startup with
+        ``Fatal Python error: init_sys_streams ... Bad file descriptor`` —
+        before the script body ever ran. The runner must hand the child a
+        deterministic /dev/null stdin instead.
+        """
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n')
+
+        captured = {}
+
+        class FakeProc:
+            def __init__(self, argv, **kwargs):
+                captured["kwargs"] = kwargs
+                self.returncode = 0
+
+            def poll(self):
+                return self.returncode
+
+            def communicate(self, timeout=None):
+                return ("ok\n", "")
+
+            def wait(self, timeout=None):
+                return self.returncode
+
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", FakeProc)
+
+        success, output = _run_job_script("probe.py")
+
+        assert success is True
+        assert output == "ok"
+        assert captured["kwargs"]["stdin"] == sched_mod.subprocess.DEVNULL
+
     def test_script_subprocess_env_sanitized(self, cron_env, monkeypatch):
         """Cron scripts must not inherit Hermes provider env (SECURITY.md §2.3)."""
         from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in `cron/scheduler.py::_run_job_script()` where `no-agent` script jobs inherit the gateway's stdin.

The scheduler spawns the script with `subprocess.Popen(..., stdout=PIPE, stderr=PIPE)` and **no `stdin=` argument**, so the child inherits FD 0 from the gateway process. The gateway is launched detached (`nohup hermes gateway run --replace >/dev/null 2>&1 &`), so its stdin can be a dead/closed descriptor. When that happens, CPython aborts at **interpreter startup — before the script body ever runs** — with:

```
Fatal Python error: init_sys_streams: can't initialize sys standard streams
Python runtime state: core initialized
OSError: [Errno 9] Bad file descriptor
```

Only `no-agent` script jobs hit this path; LLM-agent jobs never spawn the subprocess, which is why the failure looks isolated to a single job.

The fix passes `stdin=subprocess.DEVNULL` so the child always receives a clean, deterministic stdin regardless of the gateway's own descriptor state.

## Related Issue

No existing issue found (searched `init_sys_streams`, "Bad file descriptor", "cron stdin", and `DEVNULL` across open/closed issues and PRs).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py` — add `stdin=subprocess.DEVNULL` to the script `subprocess.Popen`.
- `tests/cron/test_cron_script.py` — add `test_script_subprocess_gets_clean_stdin`, asserting the runner passes `stdin=DEVNULL`.

## How to Test

1. Reproduce: start the gateway detached from a terminal (`nohup hermes gateway run --replace >/dev/null 2>&1 &`), then close that terminal so FD 0 goes stale.
2. Fire a `no-agent` script job (`hermes cron run <id>`). Before the fix it aborts with `init_sys_streams: Bad file descriptor`; after, the script runs normally.
3. Run the affected cron tests:
   ```bash
   scripts/run_tests.sh tests/cron/test_cron_script.py tests/cron/test_cron_no_agent.py tests/cron/test_scheduler.py
   ```
   140 tests pass (28 + 112; 1 Windows-only skip on this host).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass *(ran the affected cron test subset — 140 tests — not the full suite)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `subprocess.DEVNULL` is cross-platform; the Windows branch (creationflags/encoding) is unaffected
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A