### PR TITLE
fix(web): serve dashboard assets behind prefixed reverse proxies (#90068)

### DIFF
--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -165,6 +165,18 @@ def mount_spa(application: FastAPI):
             for attr in ('href="/assets/', 'src="/assets/', 'href="/favicon.ico"', 'href="/fonts/',
                          'href="/ds-assets/', 'src="/ds-assets/'):
                 html = html.replace(attr, attr.replace('"/', f'"{prefix}/', 1))
+        # Anchor Vite's relative asset URLs to the external prefix so lazy
+        # chunks and their dependencies do not escape a prefixed proxy
+        # (#90068).
+        asset_prefix = prefix or ""
+        asset_root = f"{asset_prefix}/assets/" if asset_prefix else "/assets/"
+        html = html.replace('href="./assets/', f'href="{asset_root}')
+        html = html.replace('src="./assets/', f'src="{asset_root}')
+        if prefix:
+            html = html.replace('href="./favicon.ico"', f'href="{prefix}/favicon.ico"')
+            html = html.replace('href="./fonts/', f'href="{prefix}/fonts/')
+            html = html.replace('href="./ds-assets/', f'href="{prefix}/ds-assets/')
+            html = html.replace('src="./ds-assets/', f'src="{prefix}/ds-assets/')
         theme_bootstrap = _render_active_theme_bootstrap_css()
         if theme_bootstrap:
             html = html.replace("</head>", f"{theme_bootstrap}</head>", 1)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3979,6 +3979,102 @@ class TestThemeBootstrapCSS:
         assert "hermes-theme-bootstrap" in head
 
 
+class TestMountSpaAssetPaths:
+    """Regression coverage for dashboard assets behind a path prefix (#90068)."""
+
+    @staticmethod
+    def _client(tmp_path, monkeypatch, *, gated=False):
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+        import hermes_cli.web_server as ws
+
+        dist = tmp_path / "web_dist"
+        (dist / "assets").mkdir(parents=True)
+        (dist / "index.html").write_text(
+            "<html><head>"
+            '<link rel="modulepreload" href="./assets/index-t.js">'
+            '<link rel="stylesheet" href="./assets/index-t.css">'
+            '<link rel="icon" href="./assets/favicon.ico">'
+            '<link rel="preload" href="./assets/font-t.woff2">'
+            "</head><body><script type=\"module\" "
+            'src="./assets/index-t.js"></script></body></html>',
+            encoding="utf-8",
+        )
+        (dist / "assets" / "index-t.js").write_text(
+            'import "./ChatPage-t.js";', encoding="utf-8"
+        )
+        (dist / "assets" / "ChatPage-t.js").write_text(
+            "export const page = true;", encoding="utf-8"
+        )
+        (dist / "assets" / "index-t.css").write_text(
+            "body { color: teal; }", encoding="utf-8"
+        )
+        (dist / "assets" / "favicon.ico").write_bytes(b"ico")
+        (dist / "assets" / "font-t.woff2").write_bytes(b"font")
+        monkeypatch.setattr(ws, "WEB_DIST", dist)
+        monkeypatch.delenv("HERMES_SERVE_HEADLESS", raising=False)
+        # mount_spa reads the shared auth state while serving (#90068).
+        monkeypatch.setattr(ws.app.state, "auth_required", gated, raising=False)
+        spa_app = FastAPI()
+        ws.mount_spa(spa_app)
+        return TestClient(spa_app), ws
+
+    def test_mount_spa_relative_assets_prefixed(self, tmp_path, monkeypatch):
+        client, ws = self._client(tmp_path, monkeypatch)
+        response = client.get(
+            "/chat", headers={"X-Forwarded-Prefix": "/hugin-agent"}
+        )
+        assert response.status_code == 200
+        assert "/hugin-agent/assets/index-t.js" in response.text
+        assert "/hugin-agent/assets/favicon.ico" in response.text
+        assert "/hugin-agent/assets/font-t.woff2" in response.text
+        assert "./assets/" not in response.text
+        assert f'window.__HERMES_SESSION_TOKEN__="{ws._SESSION_TOKEN}"' in response.text
+
+    def test_mount_spa_relative_assets_root_mount(self, tmp_path, monkeypatch):
+        client, ws = self._client(tmp_path, monkeypatch)
+        response = client.get("/")
+        assert response.status_code == 200
+        assert "/assets/index-t.js" in response.text
+        assert "//assets/" not in response.text
+        assert f'window.__HERMES_SESSION_TOKEN__="{ws._SESSION_TOKEN}"' in response.text
+
+    def test_mount_spa_deep_route_fallback_anchors_assets(self, tmp_path, monkeypatch):
+        client, _ws = self._client(tmp_path, monkeypatch)
+        headers = {"X-Forwarded-Prefix": "/hugin-agent"}
+        response = client.get("/chat/123", headers=headers)
+        assert response.status_code == 200
+        assert "/hugin-agent/assets/index-t.js" in response.text
+        entry = client.get("/assets/index-t.js", headers=headers)
+        sibling = client.get("/assets/ChatPage-t.js", headers=headers)
+        assert entry.status_code == 200
+        assert sibling.status_code == 200
+
+    def test_mount_spa_relative_assets_preserves_auth_gate(self, tmp_path, monkeypatch):
+        client, ws = self._client(tmp_path, monkeypatch, gated=True)
+        response = client.get(
+            "/chat", headers={"X-Forwarded-Prefix": "/hugin-agent"}
+        )
+        assert response.status_code == 200
+        assert "/hugin-agent/assets/index-t.js" in response.text
+        assert "__HERMES_SESSION_TOKEN__" not in response.text
+        assert "__HERMES_AUTH_REQUIRED__=true" in response.text
+
+    def test_mount_spa_keeps_root_absolute_assets_compatible(
+        self, tmp_path, monkeypatch
+    ):
+        client, ws = self._client(tmp_path, monkeypatch)
+        index = tmp_path / "web_dist" / "index.html"
+        index.write_text(
+            '<script src="/assets/index-old.js"></script>', encoding="utf-8"
+        )
+        response = client.get(
+            "/chat", headers={"X-Forwarded-Prefix": "/hugin-agent"}
+        )
+        assert response.status_code == 200
+        assert "/hugin-agent/assets/index-old.js" in response.text
+
+
 
 
 class TestNormaliseThemeExtensions:

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,8 @@
     "preview": "vite preview",
     "typecheck": "tsc -p . --noEmit",
     "test": "vitest run",
-    "check": "npm run typecheck && npm run test && npm run lint"
+    "test:build-output": "node scripts/assert-relative-build.mjs",
+    "check": "npm run typecheck && npm run test && npm run lint && npm run build && npm run test:build-output"
   },
   "dependencies": {
     "@hermes/shared": "file:../apps/shared",

--- a/web/scripts/assert-relative-build.mjs
+++ b/web/scripts/assert-relative-build.mjs
@@ -1,0 +1,45 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Keep generated dashboard asset URLs relative so prefixed proxies can serve
+// lazy chunks, styles, and workers (#90068).
+const dist = fileURLToPath(new URL("../../hermes_cli/web_dist/", import.meta.url));
+
+async function filesUnder(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...(await filesUnder(path)));
+    else files.push(path);
+  }
+  return files;
+}
+
+const files = [join(dist, "index.html"), ...(await filesUnder(dist))];
+const generated = files.filter((path) => /\.(html|js|css)$/.test(path));
+const rootAsset = /(?:["'`]|url\(\s*["']?)\/assets\//;
+const violations = [];
+for (const path of generated) {
+  const contents = await readFile(path, "utf8");
+  if (rootAsset.test(contents)) violations.push(relative(dist, path));
+}
+
+if (violations.length > 0) {
+  console.error(
+    `Root-absolute generated asset URLs found in: ${violations.join(", ")}`,
+  );
+  process.exit(1);
+}
+
+const jsFiles = files.filter((path) => path.endsWith(".js"));
+if (jsFiles.length < 2) {
+  console.error("Expected split JavaScript chunks in the dashboard build");
+  process.exit(1);
+}
+
+console.log(
+  `Relative dashboard build verified: ${generated.length} generated files, ` +
+    `${jsFiles.length} JavaScript chunks`,
+);

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -69,6 +69,9 @@ function hermesDevToken(): Plugin {
 }
 
 export default defineConfig({
+  // Emit relative asset URLs so prefixed reverse proxies can serve every
+  // dashboard chunk through the external path (#90068).
+  base: "./",
   plugins: [
     react(),
     babel({ presets: [compilerPreset()] }),


### PR DESCRIPTION
## Summary

The dashboard SPA is built with root-absolute asset URLs (vite default `base: '/'`), so when it is served behind a prefixed reverse proxy (`/hugin-agent/*` -> backend `/*` with `X-Forwarded-Prefix: /hugin-agent`), the entry HTML loads but every dynamic chunk, CSS file, font and worker is requested from origin-root `/assets/*` and 404s, leaving `#root` blank.

Fix, per external review: build with a relative base (`base: './'` in `web/vite.config.ts`) so rolldown emits `./assets/...` everywhere (index.html, dep maps, dynamic imports, CSS url(), workers), and extend `mount_spa`'s existing index.html rewrite table to anchor those relative forms to the external base, the same mechanism it already uses for root-absolute forms. No `<base>` tag, no runtime BASE_URL patching, no response-body rewriting.

Fixes #90068

## Changes

1. `tests/hermes_cli/test_web_server.py`: `TestMountSpaAssetPaths`, 5 regression tests (prefixed, root mount, deep-route fallback + chunk fetch, auth gate preserved, legacy root-absolute compatibility) using a synthetic dist with relative asset URLs.
2. `web/scripts/assert-relative-build.mjs` + `web/package.json`: build-output contract (`npm run test:build-output`) fails if generated dist files contain root-absolute asset URLs; wired into the web `check` script, which the JS CI matrix runs.
3. `web/vite.config.ts`: add `base: './'` only.
4. `hermes_cli/web_server.py` `mount_spa`: anchor `href="./assets/"` / `src="./assets/"` (and relative favicon/font/ds-assets variants) to `{prefix}/assets/...`, normalizing the root mount to `/assets/...`. Existing absolute pairs untouched.

## Verification

- Red before the fix: 2 failed / 1 passed in the focused tests; contract script failed on the pre-change build (root-absolute URLs in index.html and generated CSS).
- Green after: full `tests/hermes_cli/test_web_server.py` suite 170/170, focused 3/3, `npm run build` OK, `npm run test:build-output` OK (43 generated files, 39 JS chunks), no root-absolute asset URLs in `web/dist` (rg), no U+2014 characters in the diff.
- Sibling sweep: no `import.meta.env.BASE_URL` consumers and no `new Worker`/`SharedWorker` URL construction in `web/src`; prefix handling is confined to `mount_spa` and its tests.

## Residual risk

`experimental.renderBuiltUrl` was considered but rejected as primary (experimental API); it remains a documented fallback. Relative URLs in a desktop/file-embedded context resolve against the embedding document, which is the previous behavior for the root mount (normalized to `/assets/...`, never `//assets/`).
