### PR TITLE
fix(gateway): query owning systemd manager for timeout

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -342,12 +342,14 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
 
     # Try to identify our unit name and ask systemctl for its config.
     unit_name: Optional[str] = None
+    under_user_manager = False
     try:
         # /proc/self/cgroup gives us "0::/user.slice/.../hermes-gateway.service"
         with open("/proc/self/cgroup", encoding="utf-8") as fh:
             for line in fh:
                 # systemd cgroup line ends with the unit name
                 if ".service" in line:
+                    under_user_manager = "user.slice" in line
                     parts = line.strip().split("/")
                     for p in reversed(parts):
                         if p.endswith(".service"):
@@ -360,22 +362,31 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
     if not unit_name:
         return None
 
-    # Query systemctl for TimeoutStopUSec.  Use --user OR system depending
-    # on which manager actually owns the unit.  Try user first since
-    # that's the common case for hermes.
+    # Query the manager that owns our cgroup first.  ``systemctl --user show``
+    # returns synthetic defaults even when the unit is not found, so blindly
+    # preferring the user manager can turn a healthy 210s system unit into a
+    # false 90s mismatch warning.
     timeout_us: Optional[int] = None
-    for flag in (["--user"], []):
+    manager_flags = (["--user"], []) if under_user_manager else ([], ["--user"])
+    for flag in manager_flags:
         try:
             result = subprocess.run(
-                ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],
+                [
+                    "systemctl", *flag, "show", unit_name,
+                    "--property=LoadState", "--property=TimeoutStopUSec",
+                ],
                 capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=2.0,
             )
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             continue
         if result.returncode != 0:
             continue
-        # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
+        load_state: Optional[str] = None
+        # Output includes ``LoadState=loaded`` plus
+        # "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000".
         for line in result.stdout.splitlines():
+            if line.startswith("LoadState="):
+                load_state = line.split("=", 1)[1].strip()
             if line.startswith("TimeoutStopUSec="):
                 value = line.split("=", 1)[1].strip()
                 # Try numeric microseconds first
@@ -383,8 +394,9 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
                     timeout_us = int(value)
                 else:
                     timeout_us = _parse_systemd_duration_to_us(value)
-                if timeout_us is not None:
-                    break
+        if load_state != "loaded":
+            timeout_us = None
+            continue
         if timeout_us is not None:
             break
 

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -8,6 +8,8 @@ import signal
 import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import mock_open, patch
 
 import pytest
 
@@ -133,6 +135,33 @@ class TestParseSystemdDuration:
 # ---------------------------------------------------------------------------
 
 class TestCheckSystemdTimingAlignment:
+
+    def test_system_slice_queries_system_manager_before_user_default(self, monkeypatch):
+        """A system service must not read a synthetic user-manager timeout."""
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+        calls = []
+
+        def fake_run(command, **_kwargs):
+            calls.append(command)
+            if "--user" in command:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="LoadState=not-found\nTimeoutStopUSec=1min 30s\n",
+                )
+            return SimpleNamespace(
+                returncode=0,
+                stdout="TimeoutStopUSec=3min 30s\nLoadState=loaded\n",
+            )
+
+        cgroup = "0::/system.slice/hermes-gateway.service\n"
+        with patch("builtins.open", mock_open(read_data=cgroup)), \
+             patch("subprocess.run", side_effect=fake_run):
+            result = sf.check_systemd_timing_alignment(180.0)
+
+        assert result is not None
+        assert result["timeout_stop_sec"] == 210.0
+        assert result["mismatch"] is False
+        assert "--user" not in calls[0]
 
     def test_returns_none_when_unit_undeterminable(self, monkeypatch):
         monkeypatch.setenv("INVOCATION_ID", "abc")

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -163,6 +163,57 @@ class TestCheckSystemdTimingAlignment:
         assert result["mismatch"] is False
         assert "--user" not in calls[0]
 
+    def test_not_found_preferred_manager_falls_back(self, monkeypatch):
+        """A synthetic timeout from a missing preferred unit is ignored."""
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+        calls = []
+
+        def fake_run(command, **_kwargs):
+            calls.append(command)
+            if "--user" not in command:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="LoadState=not-found\nTimeoutStopUSec=1min 30s\n",
+                )
+            return SimpleNamespace(
+                returncode=0,
+                stdout="LoadState=loaded\nTimeoutStopUSec=3min 30s\n",
+            )
+
+        cgroup = "0::/system.slice/hermes-gateway.service\n"
+        with patch("builtins.open", mock_open(read_data=cgroup)), \
+             patch("subprocess.run", side_effect=fake_run):
+            result = sf.check_systemd_timing_alignment(180.0)
+
+        assert result is not None
+        assert result["timeout_stop_sec"] == 210.0
+        assert "--user" not in calls[0]
+        assert "--user" in calls[1]
+
+    def test_user_slice_queries_user_manager_first(self, monkeypatch):
+        """A user-slice service asks the user manager before the system manager."""
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+        calls = []
+
+        def fake_run(command, **_kwargs):
+            calls.append(command)
+            return SimpleNamespace(
+                returncode=0,
+                stdout="LoadState=loaded\nTimeoutStopUSec=3min 30s\n",
+            )
+
+        cgroup = (
+            "0::/user.slice/user-1000.slice/user@1000.service/"
+            "app.slice/hermes-gateway.service\n"
+        )
+        with patch("builtins.open", mock_open(read_data=cgroup)), \
+             patch("subprocess.run", side_effect=fake_run):
+            result = sf.check_systemd_timing_alignment(180.0)
+
+        assert result is not None
+        assert result["mismatch"] is False
+        assert "--user" in calls[0]
+
     def test_returns_none_when_unit_undeterminable(self, monkeypatch):
         monkeypatch.setenv("INVOCATION_ID", "abc")
         # /proc/self/cgroup likely doesn't end in .service for the test runner


### PR DESCRIPTION
## Summary

- select the systemd manager from `/proc/self/cgroup` instead of always querying the user manager first
- ignore synthetic `systemctl show` defaults when `LoadState` is not `loaded`
- parse all requested properties before validation so behavior is independent of output order

## Root cause

A gateway running as `/system.slice/hermes-gateway.service` had an active system unit with `TimeoutStopSec=210`, but `check_systemd_timing_alignment()` queried `systemctl --user show` first. For a nonexistent user unit, systemd returned success with `LoadState=not-found` and a synthetic 90-second timeout. Hermes accepted that default and logged a false stale-unit warning.

## Tests

- TDD regression observed `90.0` before implementation
- reversed property order (`TimeoutStopUSec` before `LoadState`) observed RED before parser fix
- timing-alignment and duration-parser tests: 4 passed
- Ruff: passed
- `git diff --check`: passed
- added-line security scan: clean

An unrelated `spawn_async_diagnostic` test fails identically on pristine upstream on this macOS host; the modified timing tests are green.
