### PR TITLE
feat(desktop): rebindable busy composer steer/queue/cancel

### DIFF
--- a/apps/desktop/src/app/chat/composer/help-hint.tsx
+++ b/apps/desktop/src/app/chat/composer/help-hint.tsx
@@ -1,26 +1,35 @@
+import { useStore } from '@nanostores/react'
 import type { ReactNode } from 'react'
 
 import { KbdCombo } from '@/components/ui/kbd'
 import { useI18n } from '@/i18n'
+import { $bindings, bindingsFor } from '@/store/keybinds'
 
 import { COMPLETION_DRAWER_CLASS } from './completion-drawer'
 
 const COMMON_COMMAND_KEYS = ['/help', '/clear', '/resume', '/details', '/copy', '/quit']
 
 /** Stable ids → i18n `hotkeyDescs` keys. Combos resolve mod labels per OS. */
-const COMPOSER_HOTKEY_ROWS = [
+interface ComposerHotkeyRow {
+  id: string
+  combos: readonly string[]
+  actionId?: string
+}
+
+const COMPOSER_HOTKEY_ROWS: readonly ComposerHotkeyRow[] = [
   { id: 'composer.mention', combos: ['@'] },
   { id: 'composer.slash', combos: ['/'] },
   { id: 'composer.help', combos: ['?'] },
   { id: 'composer.sendNewline', combos: ['enter', 'shift+enter'] },
   { id: 'composer.sendQueued', combos: ['mod+shift+k'] },
   { id: 'keybinds.openPanel', combos: ['mod+/'] },
-  { id: 'composer.cancel', combos: ['escape'] },
+  { id: 'composer.cancel', actionId: 'composer.cancel', combos: [] },
   { id: 'composer.history', combos: ['up', 'down'] }
-] as const
+]
 
 export function HelpHint() {
   const { t } = useI18n()
+  const bindings = useStore($bindings)
   const c = t.composer
 
   return (
@@ -33,7 +42,11 @@ export function HelpHint() {
 
       <Section title={c.hotkeys}>
         {COMPOSER_HOTKEY_ROWS.map(row => (
-          <HotkeyRow combos={[...row.combos]} description={c.hotkeyDescs[row.id] ?? ''} key={row.id} />
+          <HotkeyRow
+            combos={row.actionId ? bindingsFor(row.actionId, bindings) : [...row.combos]}
+            description={c.hotkeyDescs[row.id] ?? ''}
+            key={row.id}
+          />
         ))}
       </Section>
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-esc-cancel.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-esc-cancel.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { useComposerEscCancel } from './use-composer-esc-cancel'
+import { resetBinding, setBinding } from '@/store/keybinds'
 
 function Harness({ busy, onCancel }: { busy: boolean; onCancel: () => void }) {
   useComposerEscCancel({ awaitingInput: false, busy, onCancel, target: 'main' })
@@ -12,6 +13,7 @@ function Harness({ busy, onCancel }: { busy: boolean; onCancel: () => void }) {
 afterEach(() => {
   cleanup()
   document.body.innerHTML = ''
+  resetBinding('composer.cancel')
 })
 
 describe('useComposerEscCancel', () => {
@@ -19,7 +21,7 @@ describe('useComposerEscCancel', () => {
     const onCancel = vi.fn()
     render(<Harness busy onCancel={onCancel} />)
 
-    fireEvent.keyDown(window, { key: 'Escape' })
+    fireEvent.keyDown(window, { code: 'Escape', key: 'Escape' })
 
     expect(onCancel).toHaveBeenCalledTimes(1)
   })
@@ -28,9 +30,19 @@ describe('useComposerEscCancel', () => {
     const onCancel = vi.fn()
     render(<Harness busy={false} onCancel={onCancel} />)
 
-    fireEvent.keyDown(window, { key: 'Escape' })
+    fireEvent.keyDown(window, { code: 'Escape', key: 'Escape' })
 
     expect(onCancel).not.toHaveBeenCalled()
+  })
+
+  it('cancels with a rebound busy-composer key', () => {
+    const onCancel = vi.fn()
+    setBinding('composer.cancel', ['mod+q'])
+    render(<Harness busy onCancel={onCancel} />)
+
+    fireEvent.keyDown(window, { code: 'KeyQ', ctrlKey: true, key: 'q' })
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
   })
 
   it('does not cancel on Esc while an overlay surface covers the chat', () => {
@@ -43,7 +55,7 @@ describe('useComposerEscCancel', () => {
     overlay.setAttribute('data-overlay-surface', '')
     document.body.appendChild(overlay)
 
-    fireEvent.keyDown(window, { key: 'Escape' })
+    fireEvent.keyDown(window, { code: 'Escape', key: 'Escape' })
 
     expect(onCancel).not.toHaveBeenCalled()
   })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-esc-cancel.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-esc-cancel.ts
@@ -1,7 +1,9 @@
 import { useEffect, useRef } from 'react'
 
 import { triggerHaptic } from '@/lib/haptics'
+import { comboFromEvent } from '@/lib/keybinds/combo'
 import { composerFocusBlockedBySurface } from '@/lib/keybinds/composer-focus-keys'
+import { bindingsFor } from '@/store/keybinds'
 
 import { type ComposerTarget, getActiveComposer } from '../focus'
 
@@ -32,7 +34,15 @@ export function useComposerEscCancel({ awaitingInput, busy, onCancel, target }: 
     // `awaitingInput`: the turn is parked on a clarify / approval / sudo / secret
     // prompt, which owns Esc (or is meant to persist) — never cancel the stream
     // out from under it.
-    if (event.key !== 'Escape' || event.defaultPrevented || !busy || awaitingInput) {
+    const combo = comboFromEvent(event)
+
+    if (
+      event.defaultPrevented ||
+      !busy ||
+      awaitingInput ||
+      combo === null ||
+      !bindingsFor('composer.cancel').includes(combo)
+    ) {
       return
     }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -140,7 +140,7 @@ describe('useComposerQueue park integration', () => {
     })
 
     expect(onSteer).toHaveBeenCalledWith('steer me')
-    // A redirect rides the live turn: no interrupt, no submit.
+    // A steer rides the live turn: no interrupt, no submit.
     expect(onCancel).not.toHaveBeenCalled()
     expect(onSubmit).not.toHaveBeenCalled()
     expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(0)

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -286,12 +286,11 @@ export function useComposerQueue({
     [activeQueueSessionKey, busy, onCancel, queueEdit, runDrain]
   )
 
-  // Deliver a queued entry as a mid-turn redirect — the queue-panel sibling of
-  // the composer's steer-on-Enter. No interrupt, no drain lock: a redirect
-  // rides the live turn (the gateway either restarts the active request with
-  // its displayed context or waits for the current tool boundary), so the turn
-  // keeps flowing and the remaining queue is untouched. Only meaningful while
-  // busy — idle has no turn to redirect, and `sendQueuedNow` already covers it.
+  // Deliver a queued entry as a mid-turn steer — the queue-panel sibling of
+  // the composer's steer-on-Enter. No interrupt, no drain lock: the gateway
+  // injects it at the next tool boundary, so the turn keeps flowing and the
+  // remaining queue is untouched. Only meaningful while busy — idle has no
+  // turn to steer, and `sendQueuedNow` already covers it.
   const steerQueuedNow = useCallback(
     async (id: string): Promise<boolean> => {
       if (!onSteer || !busy || !activeQueueSessionKey || id === queueEditRef.current?.entryId) {
@@ -310,7 +309,7 @@ export function useComposerQueue({
 
       // Rejected (turn already settling, gateway said no): leave the entry
       // queued exactly where it was — the settle drain picks it up, so the
-      // words are never lost. Only a delivered redirect consumes the entry.
+      // words are never lost. Only a delivered steer consumes the entry.
       if (!accepted) {
         return false
       }

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -48,7 +48,7 @@ interface UseComposerSubmitArgs {
  * queue meet. `submitDraft` is the one decision tree (queue-edit save · slash-
  * now-while-busy · queue · drain · send · stop); `dispatchSubmit` is the shared
  * send-with-restore primitive (re-loads + re-stashes the draft if the gateway
- * rejects, so nothing is ever lost); `steerDraft` redirects the live turn. Reads
+ * rejects, so nothing is ever lost); `steerDraft` steers the live turn. Reads
  * the draft + queue APIs; owns no state of its own beyond the stable
  * external-submit listener ref.
  */
@@ -203,12 +203,12 @@ export function useComposerSubmit({
         clearDraft()
         dispatchSubmit(text)
       } else if (!compacting && !blockingPrompt && !attachments.length && text.trim()) {
-        // Cursor-style stop-and-correct: interrupt the live turn and redirect
-        // it with this text. redirect() preserves the shown reasoning/work; if
-        // the turn already ended, steerDraft re-queues so nothing is lost.
+        // Steer the live turn without interrupting it. The gateway injects the
+        // text at the next tool boundary; if that window is gone, steerDraft
+        // re-queues so nothing is lost.
         steerDraft()
       } else if (payloadPresent) {
-        // Attachments can't ride a redirect (no tool-result image carriage) —
+        // Attachments can't ride a steer (no tool-result image carriage) —
         // queue the whole payload for the next turn. Same for a turn parked on
         // an approval/sudo/secret prompt: a steer can't reach the model while
         // the tool batch is blocked, so the message runs as the next turn.
@@ -233,13 +233,12 @@ export function useComposerSubmit({
     focusInput()
   }
 
-  // Redirect the live turn with a correction. The gateway either restarts the
-  // active model request with its displayed context or waits for the current
-  // tool boundary. If the turn already ended, queue the words instead.
+  // Steer the live turn with a correction at its next tool boundary. If that
+  // boundary is gone, queue the words instead.
   const steerDraft = () => {
     const text = draftRef.current.trim()
 
-    // Guard on live editor state, not the render-lagged `canSteer`: a redirect
+    // Guard on live editor state, not the render-lagged `canSteer`: a steer
     // fired on a fast Enter must not be dropped because state hasn't synced.
     if (!onSteer || !text || attachments.length > 0 || SLASH_COMMAND_RE.test(text)) {
       return

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -14,6 +14,8 @@ import { DATA_IMAGE_URL_RE } from '@/lib/embedded-images'
 import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
 import { interceptsTypedVoiceStop } from '@/lib/voice-stop-word'
+import { comboFromEvent } from '@/lib/keybinds/combo'
+import { bindingsFor } from '@/store/keybinds'
 import { sessionCompacting } from '@/store/compaction'
 import { browseBackward, browseForward, deriveUserHistory, isBrowsingHistory } from '@/store/composer-input-history'
 import { POPOUT_WIDTH_REM } from '@/store/composer-popout'
@@ -338,7 +340,7 @@ export function ChatBar({
   // is parked on the user, so a steer can't reach the model — text queues.
   const canSteer = busy && !compacting && !blockingPrompt && !!onSteer && attachments.length === 0 && isSteerableText
 
-  // While busy: text redirects the live turn (Cursor-style stop-and-correct),
+  // While busy: text steers the live turn at its next safe boundary,
   // attachments queue for the next turn, an empty composer stops.
   const busyAction: 'steer' | 'queue' | 'stop' = canSteer
     ? 'steer'
@@ -818,9 +820,14 @@ export function ChatBar({
       return
     }
 
-    // Cmd/Ctrl+Enter queues a follow-up while a turn runs. Plain Enter steers
-    // a text-only draft, so both live-turn actions stay reachable by keyboard.
-    if (event.key === 'Enter' && (event.metaKey || event.ctrlKey) && !event.shiftKey) {
+    const combo = comboFromEvent(event.nativeEvent)
+    const matchesBusyQueue = busy && combo !== null && bindingsFor('composer.queue').includes(combo)
+    const matchesBusySteer = busy && combo !== null && bindingsFor('composer.steer').includes(combo)
+    const matchesBusyCancel = busy && combo !== null && bindingsFor('composer.cancel').includes(combo)
+
+    // Queue is a busy-only action; its key may be rebound without changing the
+    // idle composer keys.
+    if (matchesBusyQueue) {
       event.preventDefault()
 
       if (busy && !disabled) {
@@ -839,7 +846,11 @@ export function ChatBar({
       return
     }
 
-    if (event.key === 'Enter' && !event.shiftKey) {
+    const isIdleSend = !busy && event.key === 'Enter' && !event.shiftKey
+
+    // Idle Enter still sends. Busy Enter only steers when it is the bound
+    // steer combo — otherwise a rebound steer would keep aborting on Enter.
+    if (isIdleSend || matchesBusySteer) {
       event.preventDefault()
 
       // Decide from the DOM, not React state. `hasComposerPayload` is derived
@@ -884,8 +895,8 @@ export function ChatBar({
       return
     }
 
-    if (event.key === 'Escape') {
-      // Editing a queued turn → Esc cancels the edit, restoring the prior draft.
+    if (matchesBusyCancel) {
+      // The cancel binding also exits a queued edit, restoring the prior draft.
       if (queueEdit) {
         event.preventDefault()
         exitQueuedEdit('cancel')

--- a/apps/desktop/src/app/chat/session-tile-actions.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.test.ts
@@ -99,21 +99,21 @@ describe('useSessionTileActions sleep/wake session recovery', () => {
     expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID })
   })
 
-  it('resumes the stored session and retries once when session.redirect (steer) reports "session not found"', async () => {
+  it('resumes the stored session and retries once when session.steer reports "session not found"', async () => {
     const calls: { method: string; params?: Record<string, unknown> }[] = []
-    let redirectAttempts = 0
+    let steerAttempts = 0
 
     requestGatewayMock.mockImplementation(async (method: string, params?: Record<string, unknown>) => {
       calls.push({ method, params })
 
-      if (method === 'session.redirect') {
-        redirectAttempts += 1
+      if (method === 'session.steer') {
+        steerAttempts += 1
 
-        if (redirectAttempts === 1) {
+        if (steerAttempts === 1) {
           throw new Error('session not found')
         }
 
-        return { status: 'redirected' }
+        return { status: 'queued' }
       }
 
       if (method === 'session.resume') {
@@ -128,7 +128,7 @@ describe('useSessionTileActions sleep/wake session recovery', () => {
     const ok = await act(async () => result.current.steerPrompt('actually use Postgres'))
 
     expect(ok).toBe(true)
-    expect(calls.map(c => c.method)).toEqual(['session.redirect', 'session.resume', 'session.redirect'])
+    expect(calls.map(c => c.method)).toEqual(['session.steer', 'session.resume', 'session.steer'])
     expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID, text: 'actually use Postgres' })
   })
 })

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -14,7 +14,6 @@ import { useCallback, useMemo, useRef } from 'react'
 import { useGatewayRequest } from '@/app/gateway/hooks/use-gateway-request'
 import type { ClientSessionState } from '@/app/types'
 import { useI18n } from '@/i18n'
-import { textPart } from '@/lib/chat-messages'
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
 import { clearClarifyRequest } from '@/store/clarify'
@@ -33,7 +32,6 @@ import type { SessionInfo } from '@/types/hermes'
 
 import { uploadComposerAttachment } from '../session/hooks/use-prompt-actions'
 import {
-  appendMidTurnUserMessage,
   applyBranchVisibility,
   applyReloadOptimistic,
   applyRewindOptimistic,
@@ -327,46 +325,11 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
         return false
       }
 
-      const messageId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-
-      const mutate = (updater: (state: ClientSessionState) => ClientSessionState) =>
-        sessionTileDelegate()?.updateSession(sessionId, updater)
-
-      // Match the primary composer: record the correction in arrival order —
-      // sealed already-streamed output above, correction below, post-redirect
-      // deltas below that — before awaiting the redirect RPC, whose completion
-      // can race us. The old insert-before-the-active-reply splice put the
-      // bubble above output the user had already read (#73793), and its
-      // last-assistant fallback could land it mid-thread when the stream id
-      // was missing or stale (#83151).
-      mutate(state =>
-        appendMidTurnUserMessage(state, {
-          id: messageId,
-          role: 'user' as const,
-          parts: [textPart(text)]
-        })
-      )
-
-      const discardOptimisticMessage = () =>
-        mutate(state => ({
-          ...state,
-          messages: state.messages.filter(message => message.id !== messageId)
-        }))
-
-      const moveOptimisticMessageToEnd = () =>
-        mutate(state => {
-          const message = state.messages.find(candidate => candidate.id === messageId)
-
-          return message
-            ? { ...state, messages: [...state.messages.filter(candidate => candidate.id !== messageId), message] }
-            : state
-        })
-
       try {
         const { result } = await withSessionNotFoundResume(
           sessionId,
           storedIdRef.current,
-          liveId => requestGateway<{ status?: string }>('session.redirect', { session_id: liveId, text }),
+          liveId => requestGateway<{ status?: 'queued' | 'rejected' }>('session.steer', { session_id: liveId, text }),
           {
             requestGateway,
             onRecovered: recoveredId => {
@@ -375,26 +338,16 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
           }
         )
 
-        if (result?.status === 'redirected') {
-          triggerHaptic('submit')
-
-          return true
-        }
-
         if (result?.status === 'queued') {
-          moveOptimisticMessageToEnd()
           triggerHaptic('submit')
 
           return true
         }
       } catch {
-        discardOptimisticMessage()
         // Swallow — the caller queues the text so nothing is lost.
 
         return false
       }
-
-      discardOptimisticMessage()
 
       return false
     },

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -86,7 +86,6 @@ interface HarnessHandle {
   reloadFromMessage: (parentId: null | string) => Promise<void>
   restoreToMessage: (messageId: string, target?: { text?: string; userOrdinal?: number | null }) => Promise<void>
   redirectPrompt: (text: string) => Promise<boolean>
-  /** @deprecated Use `redirectPrompt`. */
   steerPrompt: (text: string) => Promise<boolean>
   submitTextRaw: (text: string, options?: SubmitTextOptions) => Promise<boolean>
   submitText: (text: string, options?: SubmitTextOptions) => Promise<boolean>
@@ -2471,6 +2470,46 @@ describe('usePromptActions redirectPrompt', () => {
     expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop', omit_messages: true })
     expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID, text: 'reconnect nudge' })
     expect(handle!.activeSessionIdRef.current).toBe(RECOVERED_SESSION_ID)
+  })
+})
+
+describe('usePromptActions steerPrompt', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('queues an in-flight steer without redirecting or adding a user turn', async () => {
+    const requestGateway = vi.fn(async () => ({ status: 'queued' }) as never)
+    let handle: HarnessHandle | null = null
+    const capturedStates: Record<string, unknown>[] = []
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={state => capturedStates.push(state)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    expect(await handle!.steerPrompt('  use Postgres  ')).toBe(true)
+    expect(requestGateway).toHaveBeenCalledWith('session.steer', {
+      session_id: RUNTIME_SESSION_ID,
+      text: 'use Postgres'
+    })
+    expect(requestGateway).not.toHaveBeenCalledWith('session.redirect', expect.anything())
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything())
+    expect(capturedStates.some(state => Array.isArray(state.messages) && state.messages.length > 0)).toBe(false)
+  })
+
+  it('returns false when the gateway rejects the steer so the composer queues it', async () => {
+    const requestGateway = vi.fn(async () => ({ status: 'rejected' }) as never)
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    expect(await handle!.steerPrompt('too late')).toBe(false)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -48,7 +48,8 @@ import type {
   HandoffRequestResponse,
   HandoffStateResponse,
   ImageAttachResponse,
-  SessionRedirectResponse
+  SessionRedirectResponse,
+  SessionSteerResponse
 } from '../../../types'
 
 import {
@@ -714,7 +715,7 @@ export function usePromptActions({
     }
   }, [activeSessionIdRef, busyRef, copy.stopFailed, requestGateway, selectedStoredSessionIdRef, updateSessionState])
 
-  // The desktop steering action is an immediate correction: the core cancels
+  // Redirect is an immediate correction: the core cancels
   // model generation and rebuilds the live turn with displayed reasoning and
   // completed work intact. During a tool it waits for the safe result boundary.
   // Returns false when the turn raced to completion so the composer can queue.
@@ -805,6 +806,46 @@ export function usePromptActions({
       return false
     },
     [activeSessionIdRef, appendSessionTextMessage, requestGateway, selectedStoredSessionIdRef, updateSessionState]
+  )
+
+  // Steering preserves the live turn and lets the gateway inject the note at
+  // its next tool-result boundary. A rejection means that boundary is gone,
+  // so the composer falls back to its normal queue path.
+  const steerPrompt = useCallback(
+    async (rawText: string): Promise<boolean> => {
+      const text = sanitizeComposerInput(rawText).trim()
+      const sessionId = activeSessionIdRef.current
+
+      if (!text || !sessionId) {
+        return false
+      }
+
+      try {
+        const { result } = await withSessionNotFoundResume(
+          sessionId,
+          selectedStoredSessionIdRef.current,
+          liveId => requestGateway<SessionSteerResponse>('session.steer', { session_id: liveId, text }),
+          {
+            requestGateway,
+            onRecovered: recoveredId => {
+              activeSessionIdRef.current = recoveredId
+              setActiveSessionId(recoveredId)
+            }
+          }
+        )
+
+        if (result?.status === 'queued') {
+          triggerHaptic('submit')
+
+          return true
+        }
+      } catch {
+        // Swallow — caller queues the text so nothing is lost.
+      }
+
+      return false
+    },
+    [activeSessionIdRef, requestGateway, selectedStoredSessionIdRef]
   )
 
   // After a durable rewind the surviving bubbles' cached rowIds are stale (the
@@ -1138,8 +1179,7 @@ export function usePromptActions({
     reloadFromMessage,
     restoreToMessage,
     redirectPrompt,
-    /** @deprecated Use `redirectPrompt` — this is an active-turn redirect, not tool steer. */
-    steerPrompt: redirectPrompt,
+    steerPrompt,
     submitText,
     transcribeVoiceAudio
   }

--- a/apps/desktop/src/lib/keybinds/actions.test.ts
+++ b/apps/desktop/src/lib/keybinds/actions.test.ts
@@ -31,3 +31,16 @@ describe('session.archive keybind action', () => {
     expect(matches).toHaveLength(1)
   })
 })
+
+describe('busy composer keybind actions', () => {
+  it.each([
+    ['composer.steer', ['enter']],
+    ['composer.queue', ['mod+enter']],
+    ['composer.cancel', ['escape']]
+  ])('ships %s as a rebindable composer-owned action', (id, defaults) => {
+    const action = keybindAction(id)
+
+    expect(action?.defaults).toEqual(defaults)
+    expect(action?.ownedBy).toBe('composer')
+  })
+})

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -24,6 +24,12 @@ export interface KeybindActionMeta {
   category: KeybindCategory
   /** Default combos. Empty = shipped unbound (user can assign one). */
   defaults: readonly string[]
+  /**
+   * This action is handled by its focused surface, rather than the global
+   * dispatcher. It remains rebindable and visible in Settings, but cannot
+   * claim a combo from context-sensitive actions such as `composer.focus`.
+   */
+  ownedBy?: 'composer'
   /** Display label for CONTRIBUTED actions (built-ins use i18n). */
   label?: string
 }
@@ -56,6 +62,11 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   // ── Composer ─────────────────────────────────────────────────────────────
   // Soft `/` / Enter focus (gated); other printables type-to-focus unbound.
   { id: 'composer.focus', category: 'composer', defaults: ['/', 'enter'] },
+  // Busy-composer actions are handled by the focused rich editor. They stay
+  // out of the global combo index so idle Enter can still focus/send.
+  { id: 'composer.steer', category: 'composer', defaults: ['enter'], ownedBy: 'composer' },
+  { id: 'composer.queue', category: 'composer', defaults: ['mod+enter'], ownedBy: 'composer' },
+  { id: 'composer.cancel', category: 'composer', defaults: ['escape'], ownedBy: 'composer' },
   // ⌘⇧M — "m" for model; the convention chat apps converged on (LibreChat,
   // Open WebUI, and Cherry Studio all ship the same chord). Opens the pill's
   // live dropdown on the pane under the pointer, else the active composer.
@@ -242,14 +253,11 @@ export interface KeybindReadonly {
 export const KEYBIND_READONLY: readonly KeybindReadonly[] = [
   { id: 'composer.send', category: 'composer', keys: ['enter'] },
   { id: 'composer.newline', category: 'composer', keys: ['shift+enter'] },
-  { id: 'composer.steer', category: 'composer', keys: ['enter'] },
-  { id: 'composer.queue', category: 'composer', keys: ['mod+enter'] },
   { id: 'composer.sendQueued', category: 'composer', keys: ['mod+shift+k'] },
   { id: 'composer.mention', category: 'composer', keys: ['@'] },
   { id: 'composer.slash', category: 'composer', keys: ['/'] },
   { id: 'composer.help', category: 'composer', keys: ['?'] },
   { id: 'composer.history', category: 'composer', keys: ['up', 'down'] },
-  { id: 'composer.cancel', category: 'composer', keys: ['escape'] },
   // Fixed, context-local shortcuts surfaced for discoverability.
   { id: 'view.terminalSelection', category: 'view', keys: ['mod+l'] },
   // Terminal clipboard. ⌘C/⌘V on macOS, Ctrl+Shift+C/V elsewhere — matching VS

--- a/apps/desktop/src/lib/keybinds/use-keybind-hint.ts
+++ b/apps/desktop/src/lib/keybinds/use-keybind-hint.ts
@@ -7,7 +7,7 @@ import { KEYBIND_READONLY } from './actions'
 import { formatCombo } from './combo'
 
 // The formatted first combo for `actionId`, or null when unbound. Rebindable
-// actions read live from the store; readonly shortcuts (e.g. `composer.steer`)
+// actions read live from the store; readonly shortcuts
 // fall back to their fixed combo. Returns null for unknown action ids so the
 // tooltip shows just the text label with no trailing hint.
 export function useKeybindHint(actionId: string): string | null {

--- a/apps/desktop/src/store/keybinds.test.ts
+++ b/apps/desktop/src/store/keybinds.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { $comboIndex, resetAllBindings, setBinding } from './keybinds'
+
+describe('$comboIndex', () => {
+  afterEach(() => resetAllBindings())
+
+  it('leaves busy composer Enter out of the global index', () => {
+    expect($comboIndex.get().get('enter')).toBe('composer.focus')
+    expect($comboIndex.get().get('mod+enter')).not.toBe('composer.queue')
+    expect($comboIndex.get().get('escape')).not.toBe('composer.cancel')
+  })
+
+  it('keeps rebound busy composer actions out of the global index', () => {
+    setBinding('composer.steer', ['mod+alt+s'])
+
+    expect($comboIndex.get().get('mod+alt+s')).not.toBe('composer.steer')
+  })
+})

--- a/apps/desktop/src/store/keybinds.ts
+++ b/apps/desktop/src/store/keybinds.ts
@@ -85,6 +85,13 @@ export const $comboIndex = computed([$bindings, $registryVersion], bindings => {
   const index = new Map<string, string>()
 
   for (const action of allKeybindActions()) {
+    // Busy composer keys are resolved by the focused composer only. Indexing
+    // them globally would let `composer.steer`'s default Enter steal the idle
+    // `composer.focus`/send path (first action wins).
+    if (action.ownedBy === 'composer') {
+      continue
+    }
+
     for (const combo of bindingsFor(action.id, bindings)) {
       const key = canonicalizeCombo(combo)
 


### PR DESCRIPTION
## Problem

Busy-turn **Steer / Queue / Cancel** were hardcoded (`Enter`, `Ctrl+Enter`, `Escape`) and listed as read-only in Settings → Keyboard. Users could not set those combos to preference.

Labeled **Steer** also called `session.redirect`, which aborts the live model request. Real steer is `session.steer` (inject after the next tool).

## Approach

- Promote `composer.steer`, `composer.queue`, and `composer.cancel` to rebindable Settings rows.
- Mark them `ownedBy: 'composer'` so `$comboIndex` skips them. Otherwise default Enter would steal idle `composer.focus` / send.
- Composer keydown and Esc-cancel read `bindingsFor(...)`.
- Idle Enter still sends. Busy Enter only steers when it is the bound steer combo.
- `onSteer` calls `session.steer`. Rejected steers fall back to the existing queue path.

Defaults unchanged: Enter / Ctrl+Enter / Escape.

## Tests

```
cd apps/desktop
npx vitest run src/lib/keybinds src/store/keybinds.test.ts \
  src/app/chat/composer/hooks/use-composer-submit.test.tsx \
  src/app/chat/composer/hooks/use-composer-queue.test.tsx \
  src/app/chat/composer/hooks/use-composer-esc-cancel.test.tsx \
  src/app/session/hooks/use-prompt-actions/index.test.tsx \
  src/app/chat/session-tile-actions.test.ts
```

211 passing.

## Risk

Low. Defaults and idle send are unchanged. Composer-owned actions cannot claim global Enter.
