### PR TITLE
fix(a2a): fail closed on zero-tool hollow completions (#90160)

### DIFF
--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -128,6 +128,48 @@ def _safe_context_slug(value: str, max_len: int = 96) -> str:
     return (slug or "ctx")[:max_len]
 
 
+# Hollow-completion guard (#90160): reason returned when a forwarded worker's
+# reply shows no tool-call evidence. Kept as a constant so tests and callers
+# can match on the canonical reason string.
+_ZERO_TOOL_FAILURE_REASON = (
+    "[task failed: tool-execution-unavailable — the worker replied without "
+    "executing any tool calls (zero tool messages in the worker session), so "
+    "this is not a valid execution receipt; the served agent likely has no "
+    "tool-calling capability]"
+)
+
+
+def _session_has_tool_evidence(db_path: Optional[str], session_id: str, since: float) -> bool:
+    """True when the worker session shows tool-call evidence at/after ``since``.
+
+    Evidence is any ``role='tool'``/``role='function'`` result row or an
+    assistant message carrying non-empty ``tool_calls``. This is the
+    execution-receipt invariant for forwarded A2A tasks (#90160): a completed
+    task must mean the worker demonstrably executed tools. Any lookup problem
+    (missing DB/table/session, unreadable file) returns False so callers fail
+    closed instead of trusting an unverifiable reply.
+    """
+    if not db_path or not session_id:
+        return False
+    try:
+        con = sqlite3.connect(db_path, timeout=5)
+        try:
+            row = con.execute(
+                "SELECT COUNT(*) FROM messages "
+                "WHERE session_id = ? AND timestamp >= ? "
+                "AND (role IN ('tool', 'function') "
+                "     OR (role = 'assistant' AND tool_calls IS NOT NULL "
+                "         AND tool_calls != '' AND tool_calls != '[]'))",
+                (session_id, since),
+            ).fetchone()
+        finally:
+            con.close()
+        return bool(row and row[0] > 0)
+    except Exception:
+        logger.debug("A2A: tool-evidence check failed for session %s", session_id, exc_info=True)
+        return False
+
+
 def _method_info(method: str) -> tuple[str, bool]:
     """Return (canonical_operation, is_v1_method).
 
@@ -891,7 +933,25 @@ class A2AAdapter(BasePlatformAdapter):
                 if session_id:
                     self._profile_sessions[key] = session_id
                     self._title_forward_session(profile, session_id, session_title)
-            return security.redact_outbound((proc.stdout or "").strip()), protocol.STATE_COMPLETED
+            reply = security.redact_outbound((proc.stdout or "").strip())
+            # Fail closed on hollow completions (#90160): a forwarded worker's
+            # reply is only a valid execution receipt when its session shows
+            # tool-call evidence. A text-only / completion-only served agent
+            # cannot call tools but still answers — promoting that to
+            # STATE_COMPLETED makes downstream automation treat fabricated
+            # results as executed work. Zero tool messages → fail the task
+            # with an explicit reason instead of a hollow-but-green success.
+            if not _session_has_tool_evidence(
+                self._profile_state_db(profile), session_id, start - 2.0
+            ):
+                protocol.metrics.zero_tool_completions += 1
+                logger.warning(
+                    "A2A: forwarded task for context %s failed closed — zero "
+                    "tool-call evidence in worker session %r (profile %r)",
+                    context_id, session_id, profile,
+                )
+                return _ZERO_TOOL_FAILURE_REASON, protocol.STATE_FAILED
+            return reply, protocol.STATE_COMPLETED
 
     def _finalize_task(self, pending: dict, state: str, reply: str) -> tuple[str, str]:
         """Record the outcome of a dispatched task. Returns (state, reply) after

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -536,6 +536,7 @@ class Metrics:
         self.push_failed = 0
         self.tasks_completed = 0
         self.tasks_failed = 0
+        self.zero_tool_completions = 0
         self.anti_loop_triggers = 0
         self.rate_limit_triggers = 0
         self._start_time = time.time()
@@ -561,6 +562,7 @@ class Metrics:
             "push_failed": self.push_failed,
             "tasks_completed": self.tasks_completed,
             "tasks_failed": self.tasks_failed,
+            "zero_tool_completions": self.zero_tool_completions,
             "anti_loop_triggers": self.anti_loop_triggers,
             "rate_limit_triggers": self.rate_limit_triggers,
             "avg_latency_ms": round(self.avg_latency() * 1000, 1),

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -1593,9 +1593,12 @@ with open(calls, 'a') as f:
     f.write(json.dumps(sys.argv[1:]) + '\\n')
 home = os.environ['HERMES_HOME']
 con = sqlite3.connect(os.path.join(home, 'state.db'))
+con.execute('CREATE TABLE IF NOT EXISTS messages (session_id TEXT, role TEXT, content TEXT, tool_calls TEXT, timestamp REAL)')
 if '--resume' not in sys.argv:
     con.execute('INSERT INTO sessions (id, source, started_at, title) VALUES (?, ?, ?, ?)', ('sess-1', 'a2a', time.time(), None))
-    con.commit()
+# A healthy worker executes tools: record a tool result as execution evidence.
+con.execute("INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)", ('sess-1', 'tool', 'ok', time.time()))
+con.commit()
 print('fake reply')
 """)
         hermes.chmod(0o755)
@@ -1618,3 +1621,125 @@ print('fake reply')
         title = con.execute("SELECT title FROM sessions WHERE id='sess-1'").fetchone()[0]
         con.close()
         assert title == "a2a-dev-ctx-unsafe-value"
+
+
+class TestZeroToolHollowCompletionGuard:
+    """#90160 — forwarded A2A tasks must fail closed when the worker reply
+    shows zero tool calls.
+
+    A served agent that resolves to a text-only / completion-only model
+    (no tool-calling) still answers, but it executes nothing. Promoting such
+    a hollow reply to STATE_COMPLETED makes downstream automation treat
+    fabricated results as executed work, so the completion chokepoint requires
+    tool-call evidence from the worker session: zero tool messages → the task
+    is failed with an explicit reason instead of a hollow-but-green success.
+    """
+
+    @staticmethod
+    def _make_adapter_and_fake_hermes(monkeypatch, tmp_path, tool_evidence):
+        """Adapter + fake `hermes` subprocess writing a worker session whose
+        messages table has (tool_evidence=True) or lacks (False) tool rows."""
+        from plugins.platforms.a2a.adapter import A2AAdapter
+        from gateway.config import PlatformConfig
+
+        profile_home = tmp_path / "profile"
+        profile_home.mkdir()
+        db = profile_home / "state.db"
+        import sqlite3
+        con = sqlite3.connect(db)
+        con.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, started_at REAL, title TEXT)")
+        con.execute("CREATE TABLE messages (session_id TEXT, role TEXT, content TEXT, tool_calls TEXT, timestamp REAL)")
+        con.commit()
+        con.close()
+
+        fakebin = tmp_path / "bin"
+        fakebin.mkdir()
+        calls = tmp_path / "calls.jsonl"
+        hermes = fakebin / "hermes"
+        tool_insert = (
+            "con.execute(\"INSERT INTO messages (session_id, role, content, timestamp) "
+            "VALUES (?, ?, ?, ?)\", ('sess-1', 'tool', 'result ok', time.time()))\n"
+            if tool_evidence else ""
+        )
+        hermes.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, os, sqlite3, sys, time\n"
+            "with open(os.environ['FAKE_HERMES_CALLS'], 'a') as f:\n"
+            "    f.write(json.dumps(sys.argv[1:]) + '\\n')\n"
+            "con = sqlite3.connect(os.path.join(os.environ['HERMES_HOME'], 'state.db'))\n"
+            "if '--resume' not in sys.argv:\n"
+            "    con.execute('INSERT INTO sessions (id, source, started_at, title) "
+            "VALUES (?, ?, ?, ?)', ('sess-1', 'a2a', time.time(), None))\n"
+            + tool_insert +
+            "con.commit()\n"
+            "print('fake reply')\n"
+        )
+        hermes.chmod(0o755)
+        monkeypatch.setenv("PATH", str(fakebin) + os.pathsep + os.environ.get("PATH", ""))
+        monkeypatch.setenv("FAKE_HERMES_CALLS", str(calls))
+        monkeypatch.setattr("plugins.platforms.a2a.adapter._profile_home", lambda profile: str(profile_home))
+
+        adapter = A2AAdapter(PlatformConfig(enabled=True, extra={
+            "agents": {"dev": {"profile": "dev", "tenant": "dev", "timeout": 5}}
+        }))
+        return adapter, adapter._agents["dev"]
+
+    def test_text_only_worker_zero_tool_reply_fails_closed(self, monkeypatch, tmp_path):
+        """(a) Zero tool calls + text-only worker → STATE_FAILED, not COMPLETED."""
+        adapter, agent = self._make_adapter_and_fake_hermes(monkeypatch, tmp_path, tool_evidence=False)
+        reply, state = adapter._forward_to_profile(agent, "peer", "ctx-1", "do the thing")
+        assert state == protocol.STATE_FAILED
+        assert "tool-execution-unavailable" in reply
+        assert "zero tool" in reply
+
+    def test_worker_reply_with_tool_calls_completes(self, monkeypatch, tmp_path):
+        """(b) Normal worker reply with tool calls still completes."""
+        adapter, agent = self._make_adapter_and_fake_hermes(monkeypatch, tmp_path, tool_evidence=True)
+        reply, state = adapter._forward_to_profile(agent, "peer", "ctx-1", "do the thing")
+        assert (reply, state) == ("fake reply", protocol.STATE_COMPLETED)
+
+    def test_zero_tool_forwarded_task_lands_failed_in_task_store(self, monkeypatch, tmp_path):
+        """The hollow completion never reaches the task store as COMPLETED and
+        counts as a failed task."""
+        adapter, agent = self._make_adapter_and_fake_hermes(monkeypatch, tmp_path, tool_evidence=False)
+        before_failed = protocol.metrics.tasks_failed
+        before_zero_tool = protocol.metrics.zero_tool_completions
+        terminal, pending = adapter._prepare_task(
+            {"tenant": "dev", "message": protocol.text_message(
+                protocol.ROLE_USER, "do the thing", context_id="ctx-1")},
+            "peer-x",
+            agent=agent,
+        )
+        assert pending is None
+        assert terminal["status"]["state"] == protocol.STATE_FAILED
+        assert "tool-execution-unavailable" in protocol.extract_text(terminal["status"]["message"])
+        assert adapter.tasks.get(terminal["id"])["state"] == protocol.STATE_FAILED
+        assert protocol.metrics.tasks_failed == before_failed + 1
+        assert protocol.metrics.zero_tool_completions == before_zero_tool + 1
+
+    def test_session_tool_evidence_helper(self, tmp_path):
+        from plugins.platforms.a2a.adapter import _session_has_tool_evidence
+
+        db = tmp_path / "state.db"
+        import sqlite3
+        con = sqlite3.connect(db)
+        con.execute("CREATE TABLE messages (session_id TEXT, role TEXT, content TEXT, tool_calls TEXT, timestamp REAL)")
+        con.execute("INSERT INTO messages (session_id, role, content, timestamp) VALUES ('s1', 'assistant', 'hi', 100.0)")
+        con.execute("INSERT INTO messages (session_id, role, content, tool_calls, timestamp) VALUES ('s1', 'assistant', 'calling', '[{\"id\": \"c1\"}]', 110.0)")
+        con.execute("INSERT INTO messages (session_id, role, content, timestamp) VALUES ('s2', 'tool', 'result', 100.0)")
+        con.execute("INSERT INTO messages (session_id, role, content, timestamp) VALUES ('s3', 'assistant', 'plain', 100.0)")
+        con.execute("INSERT INTO messages (session_id, role, content, tool_calls, timestamp) VALUES ('s3', 'assistant', 'empty', '[]', 110.0)")
+        con.commit()
+        con.close()
+        # tool result rows count as evidence
+        assert _session_has_tool_evidence(str(db), "s2", 0.0) is True
+        # assistant tool_calls rows count as evidence
+        assert _session_has_tool_evidence(str(db), "s1", 0.0) is True
+        # no tool rows (and empty '[]' tool_calls) → no evidence
+        assert _session_has_tool_evidence(str(db), "s3", 0.0) is False
+        # evidence older than the `since` window does not count
+        assert _session_has_tool_evidence(str(db), "s2", 200.0) is False
+        # missing db / missing session fail closed
+        assert _session_has_tool_evidence(str(tmp_path / "nope.db"), "s1", 0.0) is False
+        assert _session_has_tool_evidence(str(db), "", 0.0) is False
+        assert _session_has_tool_evidence("", "s1", 0.0) is False


### PR DESCRIPTION
## Summary

A2A forwarded tasks (served agents routed to another local profile via `_forward_to_profile`) completed as **normal success** (`STATE_COMPLETED`) whenever the worker subprocess exited 0 — even when the worker executed **zero tool calls**. When a served agent resolves to a text-only / completion-only model (no tool-calling), the worker cannot execute anything but still answers, producing hollow-but-green completions that downstream automation treats as real execution receipts (fabricated results observed).

This PR makes the completion chokepoint **fail closed**: a forwarded worker's reply is only promoted to `STATE_COMPLETED` when the worker session shows tool-call evidence. Zero tool messages → the task is failed with an explicit `tool-execution-unavailable` reason.

## Root Cause

In `plugins/platforms/a2a/adapter.py`, `_forward_to_profile()` returned `(reply, STATE_COMPLETED)` unconditionally on a successful subprocess run. The A2A server therefore reported `TASK_STATE_COMPLETED` and incremented `tasks_completed` for replies that claimed work without executing any tool — the peer (and any downstream automation) cannot distinguish a fabricated answer from an executed result.

## Change

- **`plugins/platforms/a2a/adapter.py`**
  - Added `_session_has_tool_evidence(db_path, session_id, since)`: queries the worker profile's `state.db` for tool-call evidence (`role='tool'`/`'function'` result rows, or assistant rows with non-empty `tool_calls`) within the task's run window.
  - `_forward_to_profile()` now checks evidence before returning `STATE_COMPLETED`. With zero evidence it returns `STATE_FAILED` with the canonical reason `tool-execution-unavailable` ("the worker replied without executing any tool calls … not a valid execution receipt"). Any lookup problem (missing DB/table/session) also fails closed — an unverifiable reply is never a completion.
- **`plugins/platforms/a2a/protocol.py`** — new `zero_tool_completions` metric (surfaced in `/metrics` snapshot).
- **`tests/plugins/test_a2a_plugin.py`** — new `TestZeroToolHollowCompletionGuard` regression tests.

### Invariant (documented in code)

> A completed forwarded A2A task must mean the worker demonstrably executed tools. A reply with zero tool-call evidence is a hollow completion and is failed with an explicit reason instead of being reported green.

Scope: the forwarded path only (`local: false` served agents — the exact scenario in the issue). The default local agent (the operator's own live gateway session) is intentionally untouched: its tool usage is governed by the gateway itself and its session DB is written concurrently with reply resolution, so no race-free evidence chokepoint exists at the adapter boundary.

## Verification

- `uv run pytest tests/plugins/test_a2a_plugin.py -q -p no:cacheprovider` → **110 passed**
- `uv run pytest tests/plugins/test_a2a_phase23.py -q -p no:cacheprovider` → **45 passed**
- New tests prove:
  - (a) worker reply with zero tool calls (text-only worker) → `STATE_FAILED`, reason contains `tool-execution-unavailable`; never lands in the task store as `COMPLETED`, counts as a failed task
  - (b) normal worker reply with tool calls → still `STATE_COMPLETED`
  - helper unit tests for the evidence query (tool rows, assistant `tool_calls`, empty `[]`, window filter, missing DB/session fail closed)

Closes #90160