### PR TITLE
fix(opencode): route Muse Spark through the Responses API

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -5060,6 +5060,7 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
 
     - GPT-5 / Codex models on Zen use ``/v1/responses``
     - GPT models on Go (gpt-5.6-luna) use ``/v1/responses``
+    - Muse Spark on Go and Zen uses ``/v1/responses`` (chat/completions 503s)
     - Claude models on Zen use ``/v1/messages``
     - MiniMax and Qwen models on Go use ``/v1/messages``
     - GLM / Kimi / DeepSeek / MiMo on Go use ``/v1/chat/completions``
@@ -5081,6 +5082,11 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
             # per the published Go endpoint table, same as GPT on Zen:
             # https://opencode.ai/docs/go/#endpoints
             return "codex_responses"
+        if normalized.startswith("muse-spark"):
+            # Muse Spark (standard + contributor) is Responses-only on Go.
+            # /v1/chat/completions returns HTTP 503 with an empty assistant
+            # message; /v1/responses completes. See opencode.ai/docs/go.
+            return "codex_responses"
         if normalized.startswith("minimax-"):
             return "anthropic_messages"
         if normalized.startswith("qwen"):
@@ -5093,6 +5099,10 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
         if normalized.startswith("claude-"):
             return "anthropic_messages"
         if normalized.startswith("gpt-"):
+            return "codex_responses"
+        if normalized.startswith("muse-spark"):
+            # Standard Muse Spark on Zen is served via /v1/responses:
+            # https://opencode.ai/docs/zen/#endpoints
             return "codex_responses"
         if normalized.startswith("qwen"):
             # Qwen models on Zen moved to /v1/messages per the published

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -2,8 +2,8 @@
 
 Both use per-model api_mode routing:
   - OpenCode Zen: Claude → anthropic_messages, GPT-5/Codex → codex_responses,
-    everything else → chat_completions (this profile)
-  - OpenCode Go: GPT → codex_responses, MiniMax/Qwen → anthropic_messages,
+    Muse Spark → codex_responses, everything else → chat_completions (this profile)
+  - OpenCode Go: GPT / Muse Spark → codex_responses, MiniMax/Qwen → anthropic_messages,
     GLM/Kimi/DeepSeek/MiMo → chat_completions (this profile)
 """
 

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -272,6 +272,12 @@ class TestCopilotNormalization:
         # GPT models on Go are Responses-only (Go endpoint table).
         assert opencode_model_api_mode("opencode-go", "gpt-5.6-luna") == "codex_responses"
         assert opencode_model_api_mode("opencode-go", "opencode-go/gpt-5.6-luna") == "codex_responses"
+        # Muse Spark on Go is Responses-only. chat/completions returns HTTP 503.
+        assert opencode_model_api_mode("opencode-go", "muse-spark-1.2-contributor") == "codex_responses"
+        assert opencode_model_api_mode("opencode-go", "opencode-go/muse-spark-1.2-contributor") == "codex_responses"
+        assert opencode_model_api_mode("opencode-go", "muse-spark-1.2") == "codex_responses"
+        # Zen serves the standard Muse Spark variant on /v1/responses too.
+        assert opencode_model_api_mode("opencode-zen", "muse-spark-1.2") == "codex_responses"
 
 
 class TestNormalizeOpencodeBaseUrl:

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -278,6 +278,7 @@ class TestCopilotNormalization:
         assert opencode_model_api_mode("opencode-go", "muse-spark-1.2") == "codex_responses"
         # Zen serves the standard Muse Spark variant on /v1/responses too.
         assert opencode_model_api_mode("opencode-zen", "muse-spark-1.2") == "codex_responses"
+        assert opencode_model_api_mode("opencode-zen", "opencode-zen/muse-spark-1.2") == "codex_responses"
 
 
 class TestNormalizeOpencodeBaseUrl:


### PR DESCRIPTION
## What does this PR do?

OpenCode Go/Zen Muse Spark was coming back as HTTP 503 in Hermes. The token and the model were fine — Hermes was hitting the wrong wire.

Published Go/Zen endpoint tables serve `muse-spark*` only on `/v1/responses`. Hermes' `opencode_model_api_mode()` left those IDs on `chat_completions`, so the relay returned 503 with an empty assistant message. Same token + `deepseek-v4-flash` on `/chat/completions` succeeded; `/responses` for Muse Spark returned `HEALTH_OK`.

This routes `muse-spark*` the same way we already route `gpt-*` on those providers.

## Related Issue

No existing issue. Reproduced against `https://opencode.ai/zen/go/v1` with `muse-spark-1.2-contributor`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/models.py` — `opencode_model_api_mode()` returns `codex_responses` for `muse-spark*` on both `opencode-go` and `opencode-zen`
- `plugins/model-providers/opencode-zen/__init__.py` — module docstring matches the new routing
- `tests/hermes_cli/test_model_validation.py` — regression asserts for contributor, standard, and prefixed IDs

## How to Test

1. `pytest tests/hermes_cli/test_model_validation.py::TestCopilotNormalization::test_opencode_go_api_modes_match_docs -v`
2. With an OpenCode Go key: `hermes chat --provider opencode-go -m muse-spark-1.2-contributor -q "Reply with exactly: HEALTH_OK"` (accept the contributor-tier prompt)
3. Confirm the request goes to `/v1/responses` (not `/chat/completions`) and completes instead of 503

## Checklist

- [x] I have tested these changes locally
- [x] Related tests added/updated
- [x] No secrets in the diff