### PR TITLE
fix(gateway): scope display and approvals by topic

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -68,6 +68,9 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     # (Slack's default), and costs no extra API calls — the existing typing
     # refresh cadence just renders different text.
     "live_status": "full",
+    # System notices returned as EphemeralReply use this TTL when no explicit
+    # TTL is attached. 0 keeps the historical permanent-message behavior.
+    "ephemeral_system_ttl": 0,
 }
 
 # ---------------------------------------------------------------------------
@@ -189,26 +192,35 @@ def resolve_display_setting(
     platform_key: str,
     setting: str,
     fallback: Any = None,
+    *,
+    chat_id: Any = None,
+    thread_id: Any = None,
+    parent_id: Any = None,
 ) -> Any:
-    """Resolve a display setting with per-platform override support.
+    """Resolve a display setting for a platform and optional channel/topic.
 
-    Parameters
-    ----------
-    user_config : dict
-        The full parsed config.yaml dict.
-    platform_key : str
-        Platform config key (e.g. ``"telegram"``, ``"slack"``).  Use
-        ``_platform_config_key(source.platform)`` from gateway/run.py.
-    setting : str
-        Display setting name (e.g. ``"tool_progress"``, ``"show_reasoning"``).
-    fallback : Any
-        Fallback value when the setting isn't found anywhere.
-
-    Returns
-    -------
-    The resolved value, or *fallback* if nothing is configured.
+    Resolution order: exact ``display.channels.<platform>.<chat>:<thread>``,
+    channel-wide ``display.channels.<platform>.<chat>``, per-platform,
+    global, built-in platform and global defaults.  ``parent_id`` is a final
+    channel lookup fallback for adapters with separate parent channels.
     """
     display_cfg = user_config.get("display") or {}
+
+    channels = display_cfg.get("channels") or {}
+    platform_channels = channels.get(platform_key) if isinstance(channels, dict) else None
+    if isinstance(platform_channels, dict):
+        lookup_keys: list[str] = []
+        if chat_id is not None and thread_id is not None:
+            lookup_keys.append(f"{chat_id}:{thread_id}")
+        for identifier in (chat_id, parent_id):
+            if identifier is not None:
+                key = str(identifier)
+                if key not in lookup_keys:
+                    lookup_keys.append(key)
+        for key in lookup_keys:
+            channel_cfg = platform_channels.get(key)
+            if isinstance(channel_cfg, dict) and setting in channel_cfg:
+                return _normalise(setting, channel_cfg[setting])
 
     # 1. Explicit per-platform override (display.platforms.<platform>.<key>)
     platforms = display_cfg.get("platforms") or {}
@@ -285,6 +297,11 @@ def _normalise(setting: str, value: Any) -> Any:
         if isinstance(value, str):
             return value.lower() in {"true", "1", "yes", "on"}
         return bool(value)
+    if setting == "ephemeral_system_ttl":
+        try:
+            return max(0, min(3600, int(value)))
+        except (TypeError, ValueError):
+            return 0
     if setting == "live_status":
         # Tri-state: "full" (verb + preview), "verb" (verb only), "off".
         if value is True:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4082,28 +4082,20 @@ class BasePlatformAdapter(ABC):
         """
         return False
 
-    def _get_ephemeral_system_ttl_default(self) -> int:
-        """Read ``display.ephemeral_system_ttl`` from config.
-
-        Returns the TTL in seconds to use when an :class:`EphemeralReply`
-        does not specify one explicitly.  ``0`` (the default) disables
-        auto-deletion.  Non-fatal if config is unreadable.
-        """
+    def _get_ephemeral_system_ttl_default(self, source: Optional[SessionSource] = None) -> int:
+        """Resolve the global or exact-channel EphemeralReply TTL safely."""
         try:
             from hermes_cli.config import load_config_readonly as _load_config
+            from gateway.display_config import resolve_display_setting
+            cfg = _load_config()
+            platform = source.platform.value if source and source.platform else ""
+            return int(resolve_display_setting(
+                cfg, platform, "ephemeral_system_ttl", 0,
+                chat_id=getattr(source, "chat_id", None),
+                thread_id=getattr(source, "thread_id", None),
+                parent_id=getattr(source, "parent_chat_id", None),
+            ))
         except Exception:
-            return 0
-        try:
-            cfg = _load_config()  # read-only: .get() only, never mutated
-        except Exception:
-            return 0
-        display = cfg.get("display", {}) if isinstance(cfg, dict) else {}
-        if not isinstance(display, dict):
-            return 0
-        raw = display.get("ephemeral_system_ttl", 0)
-        try:
-            return int(raw)
-        except (TypeError, ValueError):
             return 0
 
     def _schedule_ephemeral_delete(
@@ -5475,7 +5467,9 @@ class BasePlatformAdapter(ABC):
         lowered = error.lower()
         return "timed out" in lowered or "readtimeout" in lowered or "writetimeout" in lowered
 
-    def _unwrap_ephemeral(self, response: Any) -> Tuple[Optional[str], int]:
+    def _unwrap_ephemeral(
+        self, response: Any, source: Optional[SessionSource] = None
+    ) -> Tuple[Optional[str], int]:
         """Unwrap a handler response into (text, ttl_seconds).
 
         Accepts a plain string, ``None``, or an :class:`EphemeralReply`.
@@ -5489,7 +5483,7 @@ class BasePlatformAdapter(ABC):
             ttl = response.ttl_seconds
             if ttl is None:
                 try:
-                    ttl = int(self._get_ephemeral_system_ttl_default())
+                    ttl = int(self._get_ephemeral_system_ttl_default(source))
                 except Exception:
                     ttl = 0
             if ttl and ttl > 0 and type(self).delete_message is BasePlatformAdapter.delete_message:
@@ -5992,7 +5986,7 @@ class BasePlatformAdapter(ABC):
 
         try:
             response = await self._message_handler(event)
-            _text, _eph_ttl = self._unwrap_ephemeral(response)
+            _text, _eph_ttl = self._unwrap_ephemeral(response, event.source)
             # Send the response BEFORE cancelling the old task so the send
             # cannot be affected by task-cancellation side effects (race
             # condition fix — issue #18912).  Previously the send happened
@@ -6132,7 +6126,7 @@ class BasePlatformAdapter(ABC):
                 try:
                     _thread_meta = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
                     response = await self._message_handler(event)
-                    _text, _eph_ttl = self._unwrap_ephemeral(response)
+                    _text, _eph_ttl = self._unwrap_ephemeral(response, event.source)
                     if _text:
                         _r = await self._send_with_retry(
                             chat_id=event.source.chat_id,
@@ -6185,7 +6179,7 @@ class BasePlatformAdapter(ABC):
                             event.source, _reply_anchor_for_event(event)
                         )
                         response = await self._message_handler(event)
-                        _text, _eph_ttl = self._unwrap_ephemeral(response)
+                        _text, _eph_ttl = self._unwrap_ephemeral(response, event.source)
                         if _text:
                             _r = await self._send_with_retry(
                                 chat_id=event.source.chat_id,
@@ -6343,7 +6337,7 @@ class BasePlatformAdapter(ABC):
             # downstream extract_media / text-processing logic sees a plain
             # string, and remember the TTL + platform capability so the
             # post-send block can schedule the deletion.
-            response, _ephemeral_ttl = self._unwrap_ephemeral(response)
+            response, _ephemeral_ttl = self._unwrap_ephemeral(response, event.source)
 
             # Send response if any.  A None/empty response is normal when
             # streaming already delivered the text (already_sent=True) or

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5972,7 +5972,10 @@ class TurnRunner:
         # to the user immediately.
         from tools.approval import (
             register_gateway_notify,
+            reset_current_approval_mode_override,
             reset_current_session_key,
+            resolve_approval_mode,
+            set_current_approval_mode_override,
             set_current_session_key,
             unregister_gateway_notify,
         )
@@ -6212,6 +6215,13 @@ class TurnRunner:
 
         _approval_session_key = ctx.session_key or ""
         _approval_session_token = set_current_session_key(_approval_session_key)
+        _approval_mode = resolve_approval_mode(
+            ctx.user_config,
+            ctx.source.platform.value if ctx.source.platform else "",
+            ctx.source.chat_id,
+            getattr(ctx.source, "thread_id", None),
+        )
+        _approval_mode_token = set_current_approval_mode_override(_approval_mode)
         register_gateway_notify(_approval_session_key, _approval_notify_sync)
         try:
             # If _prepare_inbound_message_text buffered image paths for native
@@ -6280,6 +6290,7 @@ class TurnRunner:
                 _clear_clarify_session(_approval_session_key)
             except Exception:
                 pass
+            reset_current_approval_mode_override(_approval_mode_token)
             reset_current_session_key(_approval_session_token)
         ctx.result_holder[0] = result
 
@@ -27840,10 +27851,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # display.<key> global, then built-in platform defaults.
         from gateway.display_config import resolve_display_setting
 
+        # Resolve all turn-visible display surfaces against the concrete chat/topic.
+        # This lets a shared Telegram forum topic stay clean without weakening
+        # the owner's DM visibility or changing other Telegram channels.
+        def _resolve_turn_display(setting: str, fallback: Any = None) -> Any:
+            return resolve_display_setting(
+                user_config,
+                platform_key,
+                setting,
+                fallback,
+                chat_id=source.chat_id,
+                thread_id=source.thread_id,
+                parent_id=source.parent_chat_id,
+            )
+
         # Apply tool preview length config (0 = no limit)
         try:
             from agent.display import set_tool_preview_max_len
-            _tpl = resolve_display_setting(user_config, platform_key, "tool_preview_length", 0)
+            _tpl = _resolve_turn_display("tool_preview_length", 0)
             set_tool_preview_max_len(int(_tpl) if _tpl else 0)
         except Exception:
             pass
@@ -27851,20 +27876,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Apply friendly tool labels config (default on) — per-platform aware
         try:
             from agent.display import set_friendly_tool_labels
-            _ftl = resolve_display_setting(user_config, platform_key, "friendly_tool_labels", True)
+            _ftl = _resolve_turn_display("friendly_tool_labels", True)
             set_friendly_tool_labels(bool(_ftl))
         except Exception:
             pass
 
         # Tool progress mode — resolved per-platform with env var fallback
-        _resolved_tp = resolve_display_setting(user_config, platform_key, "tool_progress")
+        _resolved_tp = _resolve_turn_display("tool_progress")
         _env_tp = os.getenv("HERMES_TOOL_PROGRESS_MODE")
         _display_cfg = display_config if isinstance(display_config, dict) else {}
         _platforms_cfg = _display_cfg.get("platforms") or {}
         _platform_cfg = _platforms_cfg.get(platform_key) or {}
+        _channels_cfg = _display_cfg.get("channels") or {}
+        _channel_cfg = _channels_cfg.get(platform_key) if isinstance(_channels_cfg, dict) else None
+        _channel_keys = []
+        if source.chat_id is not None and source.thread_id is not None:
+            _channel_keys.append(f"{source.chat_id}:{source.thread_id}")
+        _channel_keys.extend(
+            str(value) for value in (source.chat_id, source.parent_chat_id) if value is not None
+        )
+        _channel_tool_progress_configured = any(
+            isinstance(_channel_cfg, dict)
+            and isinstance(_channel_cfg.get(key), dict)
+            and "tool_progress" in _channel_cfg[key]
+            for key in _channel_keys
+        )
         _legacy_tp_overrides = _display_cfg.get("tool_progress_overrides") or {}
         _tool_progress_configured = (
             "tool_progress" in _display_cfg
+            or _channel_tool_progress_configured
             or (
                 isinstance(_platform_cfg, dict)
                 and "tool_progress" in _platform_cfg
@@ -27880,7 +27920,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else (_resolved_tp or _env_tp or "all")
         )
         # Tool progress grouping: "accumulate" (edit one bubble) or "separate" (one msg per tool)
-        progress_grouping = resolve_display_setting(user_config, platform_key, "tool_progress_grouping") or "accumulate"
+        progress_grouping = _resolve_turn_display("tool_progress_grouping") or "accumulate"
         from gateway.status_phrases import choose_status_phrase, resolve_status_phrase_catalog
         _generic_status_recent: List[str] = []
         _generic_status_catalog = resolve_status_phrase_catalog(user_config, platform_key)
@@ -27904,7 +27944,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     and not _has_platform_display_override(user_config, platform_key, setting)
                 ):
                     return "off"
-            value = resolve_display_setting(user_config, platform_key, setting, default)
+            value = _resolve_turn_display(setting, default)
             if isinstance(value, str) and value.strip().lower() == "generic":
                 return "generic" if allow_generic else "off"
             return "raw" if bool(value) else "off"
@@ -27933,9 +27973,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # there. Rendering rides the existing _keep_typing refresh: the
         # callback only stores a phrase on the adapter, costing zero extra
         # platform API calls.
-        _live_status_mode = resolve_display_setting(
-            user_config, platform_key, "live_status", "full"
-        )
+        _live_status_mode = _resolve_turn_display("live_status", "full")
         _live_status_adapter = self._adapter_for_source(source)
         if not getattr(_live_status_adapter, "supports_status_text", False):
             _live_status_adapter = None

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -34,6 +34,103 @@ class TestResolveDisplaySetting:
         }
         assert resolve_display_setting(config, "telegram", "tool_progress") == "new"
 
+    def test_topic_override_wins_without_affecting_dm(self):
+        """A Telegram forum topic can be quiet while the DM remains transparent."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "tool_progress": "all",
+                "channels": {
+                    "telegram": {
+                        "-1003703764467:1666": {
+                            "tool_progress": "off",
+                            "interim_assistant_messages": False,
+                        }
+                    }
+                },
+            }
+        }
+        assert resolve_display_setting(
+            config, "telegram", "tool_progress", chat_id="-1003703764467", thread_id="1666"
+        ) == "off"
+        assert resolve_display_setting(
+            config, "telegram", "tool_progress", chat_id="457500237"
+        ) == "all"
+
+    def test_channel_override_falls_back_from_topic_to_chat(self):
+        """A channel-wide setting applies when the topic has no exact override."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "channels": {"telegram": {"-1003703764467": {"tool_progress": "new"}}}
+            }
+        }
+        assert resolve_display_setting(
+            config, "telegram", "tool_progress", chat_id="-1003703764467", thread_id="1666"
+        ) == "new"
+
+    def test_channel_override_falls_back_to_parent_chat(self):
+        """Thread adapters may have a distinct parent channel identity."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {"display": {"channels": {"discord": {"parent": {"tool_progress": "off"}}}}}
+
+        assert resolve_display_setting(
+            config,
+            "discord",
+            "tool_progress",
+            chat_id="thread",
+            thread_id="message",
+            parent_id="parent",
+        ) == "off"
+
+    def test_yaml_topic_mapping_disables_all_quiet_display_surfaces(self):
+        """The persisted YAML form is a mapping and affects only its exact topic."""
+        import yaml
+        from gateway.display_config import resolve_display_setting
+
+        config = yaml.safe_load(
+            '''
+            display:
+              tool_progress: all
+              channels:
+                telegram:
+                  "-1003703764467:1666":
+                    tool_progress: off
+                    interim_assistant_messages: false
+                    long_running_notifications: false
+                    busy_ack_detail: false
+                    live_status: off
+            '''
+        )
+        topic_policy = config["display"]["channels"]["telegram"]["-1003703764467:1666"]
+        assert isinstance(topic_policy, dict)
+        topic_kwargs = {"chat_id": "-1003703764467", "thread_id": "1666"}
+        assert resolve_display_setting(config, "telegram", "tool_progress", **topic_kwargs) == "off"
+        assert resolve_display_setting(config, "telegram", "interim_assistant_messages", **topic_kwargs) is False
+        assert resolve_display_setting(config, "telegram", "long_running_notifications", **topic_kwargs) is False
+        assert resolve_display_setting(config, "telegram", "busy_ack_detail", **topic_kwargs) is False
+        assert resolve_display_setting(config, "telegram", "live_status", **topic_kwargs) == "off"
+        assert resolve_display_setting(
+            config, "telegram", "tool_progress", chat_id="-1003703764467", thread_id="130"
+        ) == "all"
+
+    def test_string_topic_policy_is_ignored_without_crashing(self):
+        """A legacy JSON string is not mistaken for a structured channel policy."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "tool_progress": "all",
+                "channels": {"telegram": {"-1003703764467:1666": '{"tool_progress":"off"}'}},
+            }
+        }
+        assert resolve_display_setting(
+            config, "telegram", "tool_progress", chat_id="-1003703764467", thread_id="1666"
+        ) == "all"
+
 
     def test_platform_override_only_affects_that_platform(self):
         """Other platforms are unaffected by a specific platform override."""

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -340,7 +340,8 @@ class LongPreviewAgent:
         self.tools = []
 
     def run_conversation(self, message, conversation_history=None, task_id=None):
-        self.tool_progress_callback("tool.started", "terminal", self.LONG_CMD, {})
+        if self.tool_progress_callback:
+            self.tool_progress_callback("tool.started", "terminal", self.LONG_CMD, {})
         time.sleep(0.35)
         return {
             "final_response": "done",
@@ -677,7 +678,7 @@ def _extract_progress_preview(content: str) -> str | None:
     return None
 
 
-def _run_long_preview_helper(monkeypatch, tmp_path, preview_length=0):
+def _run_long_preview_helper(monkeypatch, tmp_path, preview_length=0, *, display_extra=None, source=None):
     """Shared setup for long-preview truncation tests.
 
     Returns (adapter, result) after running the agent with LongPreviewAgent.
@@ -698,7 +699,9 @@ def _run_long_preview_helper(monkeypatch, tmp_path, preview_length=0):
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
 
     # Write config.yaml so _run_agent picks up tool_preview_length
-    config = {"display": {"tool_preview_length": preview_length}}
+    display = {"tool_preview_length": preview_length}
+    display.update(display_extra or {})
+    config = {"display": display}
     (tmp_path / "config.yaml").write_text(yaml.dump(config), encoding="utf-8")
 
     adapter = ProgressCaptureAdapter()
@@ -707,7 +710,7 @@ def _run_long_preview_helper(monkeypatch, tmp_path, preview_length=0):
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
 
-    source = SessionSource(
+    source = source or SessionSource(
         platform=Platform.TELEGRAM,
         chat_id="12345",
         chat_type="dm",
@@ -725,6 +728,38 @@ def _run_long_preview_helper(monkeypatch, tmp_path, preview_length=0):
         )
     )
     return adapter, result
+
+
+def test_topic_override_suppresses_progress_but_dm_keeps_it(monkeypatch, tmp_path):
+    """Topic-level quiet mode affects only the targeted Telegram forum topic."""
+    display_extra = {
+        "tool_progress": "all",
+        "channels": {
+            "telegram": {
+                "-1003703764467:1666": {"tool_progress": "off"},
+            }
+        },
+    }
+    topic_source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1003703764467",
+        chat_type="group",
+        thread_id="1666",
+    )
+    topic_adapter, topic_result = _run_long_preview_helper(
+        monkeypatch, tmp_path, display_extra=display_extra, source=topic_source
+    )
+    assert topic_result["final_response"] == "done"
+    assert topic_adapter.sent == []
+
+    dm_tmp = tmp_path / "dm"
+    dm_tmp.mkdir()
+    dm_adapter, dm_result = _run_long_preview_helper(
+        monkeypatch, dm_tmp, display_extra=display_extra
+    )
+    assert dm_result["final_response"] == "done"
+    assert dm_adapter.sent
+
 
 
 def test_all_mode_respects_custom_preview_length(monkeypatch, tmp_path):

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -494,6 +494,23 @@ def test_gating_forum_general_topic_normalizes_to_one():
     assert adapter2._should_process_message(general) is False
 
 
+def test_forum_message_builds_display_routable_source():
+    """A real Telegram forum update preserves chat/topic identity for display policy."""
+    adapter = _make_adapter(require_mention=False)
+    message = _forum_message(
+        chat_id=-1003703764467,
+        thread_id=1666,
+        is_topic_message=True,
+        is_forum=True,
+    )
+
+    source = adapter._source_from_message_for_auth(message)
+
+    assert source.chat_id == "-1003703764467"
+    assert source.thread_id == "1666"
+    assert source.chat_type == "forum"
+
+
 def test_bot_self_messages_are_ignored_in_dm_and_group():
     """Bot-authored messages must not re-enter as fresh user turns (issue #11905).
 

--- a/tests/gateway/test_topic_approval_policy.py
+++ b/tests/gateway/test_topic_approval_policy.py
@@ -1,0 +1,41 @@
+"""Regression tests for exact channel/topic approval-mode resolution."""
+
+import tools.approval as approval
+
+
+def test_exact_topic_override_beats_global_without_affecting_siblings():
+    config = {
+        "approvals": {
+            "mode": "smart",
+            "channels": {"telegram": {"-1003703764467:1666": {"mode": "off"}}},
+        }
+    }
+
+    assert approval.resolve_approval_mode(config, "telegram", "-1003703764467", "1666") == "off"
+    assert approval.resolve_approval_mode(config, "telegram", "-1003703764467", "130") == "smart"
+    assert approval.resolve_approval_mode(config, "telegram", "457500237", None) == "smart"
+
+
+def test_malformed_topic_policy_falls_back_to_global_smart():
+    config = {"approvals": {"mode": "smart", "channels": {"telegram": {"-100:1666": "off"}}}}
+
+    assert approval.resolve_approval_mode(config, "telegram", "-100", "1666") == "smart"
+
+
+def test_bare_yaml_off_is_accepted_as_topic_bypass():
+    config = {"approvals": {"mode": "smart", "channels": {"telegram": {"-100:1666": {"mode": False}}}}}
+
+    assert approval.resolve_approval_mode(config, "telegram", "-100", "1666") == "off"
+
+
+def test_context_override_is_scoped_and_reset():
+    outer_token = approval.set_current_approval_mode_override("smart")
+    try:
+        inner_token = approval.set_current_approval_mode_override("off")
+        try:
+            assert approval._get_approval_mode() == "off"
+        finally:
+            approval.reset_current_approval_mode_override(inner_token)
+        assert approval._get_approval_mode() == "smart"
+    finally:
+        approval.reset_current_approval_mode_override(outer_token)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17075,6 +17075,41 @@ def test_session_create_records_ui_model_as_session_override(monkeypatch):
         server._sessions.clear()
 
 
+def test_session_create_infers_codex_provider_for_legacy_desktop_model(monkeypatch):
+    """Older Desktop clients omitted provider when restoring a Codex model."""
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+    try:
+        desktop = server._methods["session.create"](
+            "r1", {"cols": 80, "source": "desktop", "model": "gpt-5.6-terra"}
+        )
+        desktop_session = server._sessions[desktop["result"]["session_id"]]
+        assert desktop_session["model_override"] == {
+            "model": "gpt-5.6-terra",
+            "provider": "openai-codex",
+        }
+
+        # Explicit clients and non-Desktop sessions keep their supplied/inherited
+        # provider behavior unchanged.
+        explicit = server._methods["session.create"](
+            "r2",
+            {
+                "cols": 80,
+                "source": "desktop",
+                "model": "gpt-5.6-terra",
+                "provider": "custom:codex-compatible",
+            },
+        )
+        assert server._sessions[explicit["result"]["session_id"]]["model_override"]["provider"] == "custom:codex-compatible"
+
+        tui = server._methods["session.create"](
+            "r3", {"cols": 80, "source": "tui", "model": "gpt-5.6-terra"}
+        )
+        assert server._sessions[tui["result"]["session_id"]]["model_override"]["provider"] is None
+    finally:
+        server._sessions.clear()
+
+
 @pytest.mark.parametrize("service_tier_override", ["priority", ""])
 def test_start_agent_build_passes_session_model_override(
     monkeypatch, service_tier_override

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -62,6 +62,12 @@ _approval_session_id: contextvars.ContextVar[str] = contextvars.ContextVar(
     "approval_session_id",
     default="",
 )
+# Turn-local policy resolved by the gateway from a trusted SessionSource.
+# It intentionally never reads process-global environment state.
+_approval_mode_override: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "approval_mode_override",
+    default=None,
+)
 
 # Interactive-CLI flag. Concurrent ACP sessions run on a shared
 # ThreadPoolExecutor (acp_adapter/server.py), so mutating the process-global
@@ -3184,10 +3190,51 @@ def _get_approval_config() -> dict:
         return {}
 
 
+def set_current_approval_mode_override(mode: str | None) -> contextvars.Token:
+    """Bind a validated per-turn gateway approval mode override."""
+    return _approval_mode_override.set(
+        _normalize_approval_mode(mode) if mode is not None else None
+    )
+
+
+def reset_current_approval_mode_override(token: contextvars.Token) -> None:
+    """Restore the preceding turn-local approval mode."""
+    _approval_mode_override.reset(token)
+
+
+def resolve_approval_mode(
+    config: dict, platform: str, chat_id: object = None, thread_id: object = None
+) -> str:
+    """Resolve exact topic, then channel, then global approval mode safely."""
+    approvals = config.get("approvals", {}) if isinstance(config, dict) else {}
+    if not isinstance(approvals, dict):
+        return "manual"
+    channels = approvals.get("channels", {})
+    platform_channels = channels.get(platform) if isinstance(channels, dict) else None
+    if isinstance(platform_channels, dict):
+        keys = []
+        if chat_id is not None and thread_id is not None:
+            keys.append(f"{chat_id}:{thread_id}")
+        if chat_id is not None:
+            keys.append(str(chat_id))
+        for key in keys:
+            policy = platform_channels.get(key)
+            if isinstance(policy, dict) and "mode" in policy:
+                raw_mode = policy["mode"]
+                # YAML 1.1 parses bare `off` as False; accept that conventional
+                # config spelling without widening any other invalid values.
+                if raw_mode is False:
+                    return "off"
+                return _normalize_approval_mode(raw_mode)
+    return _normalize_approval_mode(approvals.get("mode", "manual"))
+
+
 def _get_approval_mode() -> str:
-    """Read the approval mode from config. Returns 'manual', 'smart', or 'off'."""
-    mode = _get_approval_config().get("mode", "manual")
-    return _normalize_approval_mode(mode)
+    """Read a turn-local override first, then the global config mode."""
+    override = _approval_mode_override.get()
+    if override is not None:
+        return override
+    return _normalize_approval_mode(_get_approval_config().get("mode", "manual"))
 
 
 def is_approval_bypass_active_for_session(session_key: str) -> bool:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -48,8 +48,28 @@ def _(rid, params: dict) -> dict:
     # for a new chat can't mutate the profile default. provider is optional
     # (resolved at build).
     create_model = str(params.get("model") or "").strip()
+    create_provider = str(params.get("provider") or "").strip()
+    # Compatibility guard for older Desktop builds: they could persist the
+    # selected model while dropping its provider from session.create.  Falling
+    # back to the profile provider then routes Codex-only GPT models to an
+    # unrelated endpoint (for example OpenCode Go) and surfaces a misleading
+    # HTTP 401 "model is not supported".  Restrict the repair to Desktop and
+    # to Hermes' explicit Codex catalog so arbitrary model names still follow
+    # the configured provider exactly as before.
+    if create_model and not create_provider and source == "desktop":
+        try:
+            from hermes_cli.codex_models import DEFAULT_CODEX_MODELS
+
+            if create_model in DEFAULT_CODEX_MODELS:
+                create_provider = "openai-codex"
+        except Exception:
+            logger.debug(
+                "failed to infer provider for unqualified desktop model %s",
+                create_model,
+                exc_info=True,
+            )
     session_model_override = (
-        {"model": create_model, "provider": str(params.get("provider") or "").strip() or None}
+        {"model": create_model, "provider": create_provider or None}
         if create_model
         else None
     )


### PR DESCRIPTION
## Summary
- Resolve display settings by channel/forum topic, including parent-channel fallback.
- Scope approval modes to each gateway turn with `ContextVar`.
- Preserve the `openai-codex` provider for legacy Desktop requests that omit it.

## Test plan
- `scripts/run_tests.sh tests/gateway/test_display_config.py tests/gateway/test_run_progress_topics.py tests/gateway/test_telegram_group_gating.py tests/gateway/test_topic_approval_policy.py tests/test_tui_gateway_server.py`
- `ruff check` on modified files
