### PR TITLE
fix(desktop): isolate pooled profile backends

### DIFF
--- a/apps/desktop/electron/backend-command.test.ts
+++ b/apps/desktop/electron/backend-command.test.ts
@@ -9,7 +9,16 @@ test('serveBackendArgs builds a headless serve invocation', () => {
 })
 
 test('serveBackendArgs pins a profile when provided', () => {
-  assert.deepEqual(serveBackendArgs('worker'), ['--profile', 'worker', 'serve', '--host', '127.0.0.1', '--port', '0'])
+  assert.deepEqual(serveBackendArgs('worker'), [
+    '--profile',
+    'worker',
+    'serve',
+    '--isolated',
+    '--host',
+    '127.0.0.1',
+    '--port',
+    '0'
+  ])
 })
 
 test('dashboardFallbackArgs rewrites serve -> dashboard --no-open, keeping the -m prefix', () => {
@@ -27,7 +36,19 @@ test('dashboardFallbackArgs rewrites serve -> dashboard --no-open, keeping the -
 })
 
 test('dashboardFallbackArgs preserves a --profile flag ahead of serve', () => {
-  const serve = ['-m', 'hermes_cli.main', '--profile', 'worker', 'serve', '--host', '127.0.0.1', '--port', '0']
+  const serve = [
+    '-m',
+    'hermes_cli.main',
+    '--profile',
+    'worker',
+    'serve',
+    '--isolated',
+    '--host',
+    '127.0.0.1',
+    '--port',
+    '0'
+  ]
+
   assert.deepEqual(dashboardFallbackArgs(serve), [
     '-m',
     'hermes_cli.main',

--- a/apps/desktop/electron/backend-command.test.ts
+++ b/apps/desktop/electron/backend-command.test.ts
@@ -2,7 +2,17 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { dashboardFallbackArgs, serveBackendArgs, sourceDeclaresServe } from './backend-command'
+import {
+  dashboardFallbackArgs,
+  helpDeclaresIsolated,
+  serveBackendArgs,
+  sourceDeclaresIsolated,
+  sourceDeclaresServe,
+  withoutIsolated
+} from './backend-command'
+
+const BS = String.fromCharCode(92)
+const NEWLINE = String.fromCharCode(10)
 
 test('serveBackendArgs builds a headless serve invocation', () => {
   assert.deepEqual(serveBackendArgs(), ['serve', '--host', '127.0.0.1', '--port', '0'])
@@ -83,4 +93,71 @@ test('sourceDeclaresServe does not false-positive on the substring "server"', ()
   `
 
   assert.equal(sourceDeclaresServe(oldSource), false)
+})
+
+test('dashboardFallbackArgs keeps a second --isolated the user supplied', () => {
+  const serve = ['--profile', 'worker', 'serve', '--isolated', '--isolated', '--port', '0']
+
+  assert.deepEqual(dashboardFallbackArgs(serve), [
+    '--profile',
+    'worker',
+    'dashboard',
+    '--no-open',
+    '--isolated',
+    '--port',
+    '0'
+  ])
+})
+
+test('withoutIsolated drops only the first occurrence and copies', () => {
+  const args = ['serve', '--isolated', '--host', '127.0.0.1', '--isolated']
+  const out = withoutIsolated(args)
+
+  assert.deepEqual(out, ['serve', '--host', '127.0.0.1', '--isolated'])
+  assert.notEqual(out, args, 'should return a copy, not the same reference')
+})
+
+test('withoutIsolated is a no-op (copy) when the flag is absent', () => {
+  const args = ['serve', '--host', '127.0.0.1']
+  const out = withoutIsolated(args)
+
+  assert.deepEqual(out, args)
+  assert.notEqual(out, args, 'should return a copy, not the same reference')
+})
+
+test('sourceDeclaresIsolated detects the --isolated flag registration', () => {
+  assert.equal(sourceDeclaresIsolated('parser.add_argument(' + BS + 'n        "--isolated",' + BS + 'n)'), true)
+  assert.equal(sourceDeclaresIsolated("parser.add_argument('--isolated', action='store_true')"), true)
+})
+
+test('sourceDeclaresIsolated is false for a serve-capable runtime that predates the flag', () => {
+  const preIsolatedSource = `
+    serve_parser = subparsers.add_parser("serve", help="Run the headless gateway")
+    serve_parser.add_argument("--port", type=int, default=9119)
+    serve_parser.add_argument("--host", default="127.0.0.1")
+  `
+
+  assert.equal(sourceDeclaresServe(preIsolatedSource), true)
+  assert.equal(sourceDeclaresIsolated(preIsolatedSource), false)
+})
+
+test('helpDeclaresIsolated reads the flag out of a --help listing', () => {
+  const help = [
+    'usage: hermes serve [-h] [--port PORT] [--host HOST] [--isolated]',
+    '',
+    'options:',
+    '  --isolated            Run a dedicated server scoped to that profile'
+  ].join(NEWLINE)
+
+  assert.equal(helpDeclaresIsolated(help), true)
+})
+
+test('helpDeclaresIsolated is false for help text without the flag', () => {
+  const help = ['usage: hermes serve [-h] [--port PORT] [--host HOST]', '', 'options:', '  --port PORT'].join(
+    NEWLINE
+  )
+
+  assert.equal(helpDeclaresIsolated(help), false)
+  assert.equal(helpDeclaresIsolated(''), false)
+  assert.equal(helpDeclaresIsolated(null), false)
 })

--- a/apps/desktop/electron/backend-command.ts
+++ b/apps/desktop/electron/backend-command.ts
@@ -17,8 +17,9 @@
  */
 export function serveBackendArgs(profile?: string) {
   const head = profile ? ['--profile', profile] : []
+  const isolation = profile ? ['--isolated'] : []
 
-  return [...head, 'serve', '--host', '127.0.0.1', '--port', '0']
+  return [...head, 'serve', ...isolation, '--host', '127.0.0.1', '--port', '0']
 }
 
 /**
@@ -34,7 +35,11 @@ export function dashboardFallbackArgs(args) {
     return args.slice()
   }
 
-  return [...args.slice(0, i), 'dashboard', '--no-open', ...args.slice(i + 1)]
+  // `--isolated` is a serve-era flag. Older dashboard runtimes already use
+  // the profile-scoped behavior and do not necessarily recognize it.
+  const tail = args.slice(i + 1).filter(arg => arg !== '--isolated')
+
+  return [...args.slice(0, i), 'dashboard', '--no-open', ...tail]
 }
 
 /**

--- a/apps/desktop/electron/backend-command.ts
+++ b/apps/desktop/electron/backend-command.ts
@@ -36,10 +36,28 @@ export function dashboardFallbackArgs(args) {
   }
 
   // `--isolated` is a serve-era flag. Older dashboard runtimes already use
-  // the profile-scoped behavior and do not necessarily recognize it.
-  const tail = args.slice(i + 1).filter(arg => arg !== '--isolated')
+  // the profile-scoped behavior and do not necessarily recognize it. Only the
+  // flag serveBackendArgs itself appended is dropped (first occurrence) so a
+  // second one a user supplied through extra-args config still reaches the
+  // runtime and fails loudly there rather than being silently swallowed here.
+  const tail = withoutIsolated(args.slice(i + 1))
 
   return [...args.slice(0, i), 'dashboard', '--no-open', ...tail]
+}
+
+/**
+ * Drop the first `--isolated` token from an argv, returning a copy. Used both
+ * by the legacy `dashboard` rewrite and by the serve path when the resolved
+ * runtime understands `serve` but predates the `--isolated` flag.
+ */
+export function withoutIsolated(args) {
+  const i = args.indexOf('--isolated')
+
+  if (i === -1) {
+    return args.slice()
+  }
+
+  return [...args.slice(0, i), ...args.slice(i + 1)]
 }
 
 /**
@@ -50,4 +68,24 @@ export function dashboardFallbackArgs(args) {
  */
 export function sourceDeclaresServe(dashboardPySource) {
   return /add_parser\(\s*["']serve["']/.test(String(dashboardPySource || ''))
+}
+
+/**
+ * True when a runtime's `hermes_cli/subcommands/dashboard.py` source registers
+ * the `--isolated` flag. `serve` predates `--isolated` (added by the unified
+ * multi-profile dashboard work), so "understands serve" does NOT imply
+ * "accepts --isolated" — an in-between runtime would die on an unrecognized
+ * argument instead of starting the pooled backend.
+ */
+export function sourceDeclaresIsolated(dashboardPySource) {
+  return /["']--isolated["']/.test(String(dashboardPySource || ''))
+}
+
+/**
+ * True when `serve --help` output lists `--isolated`. Used only on the probe
+ * fallback path, where the runtime's source is unreadable (a bare `hermes`
+ * resolved from PATH).
+ */
+export function helpDeclaresIsolated(helpText) {
+  return /(^|[\s,[])--isolated(\s|,|=|\]|$)/m.test(String(helpText || ''))
 }

--- a/apps/desktop/electron/backend-probes.ts
+++ b/apps/desktop/electron/backend-probes.ts
@@ -87,6 +87,9 @@ function isTimeoutError(err: unknown): boolean {
 /**
  * Run execFileSync; on timeout only, retry once before failing.
  * Non-timeout failures (ENOENT, non-zero exit) fail immediately.
+ *
+ * Returns the captured stdout with `stdio: 'pipe'` (callers that need to read
+ * a `--help` listing), or null with `stdio: 'ignore'` (exit-code-only probes).
  */
 function execProbeSync(
   command: string,
@@ -94,21 +97,21 @@ function execProbeSync(
   options: {
     cwd?: string
     env?: NodeJS.ProcessEnv
-    stdio: 'ignore'
+    stdio: 'ignore' | 'pipe'
     timeout: number
     shell?: boolean
     windowsHide?: boolean
   }
-): void {
+): Buffer | null {
   try {
-    execFileSync(command, args, options)
+    return execFileSync(command, args, options)
   } catch (err) {
     if (!isTimeoutError(err)) {
       throw err
     }
 
     // One cold-cache / AV miss should not force hermes-setup --update (#61764).
-    execFileSync(command, args, options)
+    return execFileSync(command, args, options)
   }
 }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -44,7 +44,14 @@ import {
   probeStartMarker,
   processStartMarker
 } from './backend-claim'
-import { dashboardFallbackArgs, serveBackendArgs, sourceDeclaresServe } from './backend-command'
+import {
+  dashboardFallbackArgs,
+  helpDeclaresIsolated,
+  serveBackendArgs,
+  sourceDeclaresIsolated,
+  sourceDeclaresServe,
+  withoutIsolated
+} from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { BackendDialClaims } from './backend-dial-claim'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
@@ -2292,41 +2299,48 @@ function unwrapWindowsVenvHermesCommand(command, backendArgs) {
   })
 }
 
-// Does the resolved runtime understand the `serve` subcommand? The desktop
-// spawns `hermes serve`; runtimes older than serve only have `dashboard`. We
-// detect support so getBackendArgsForRuntime() can route old runtimes through
-// the legacy `dashboard --no-open` form instead of crashing on an unknown
-// subcommand (would brick every user mid-upgrade — #54568 follow-up).
+// What does the resolved runtime understand? The desktop spawns
+// `hermes serve --isolated`; runtimes older than serve only have `dashboard`,
+// and runtimes between the two know `serve` but not `--isolated`. We detect
+// both so getBackendArgsForRuntime() can downgrade the invocation instead of
+// crashing on an unknown subcommand or an unrecognized argument (either would
+// brick users mid-upgrade — #54568 follow-up).
 //
 // Fast path: read the runtime's own dashboard.py (instant, covers managed
 // installs, dev checkouts, and the Windows venv). Fallback: probe the CLI once
 // (covers a bare `hermes` resolved from PATH with no known source root). Result
 // is cached per resolved runtime so we probe at most once per backend.
-const _serveSupportCache = new Map()
+const _backendCapabilityCache = new Map()
 
-function backendSupportsServe(backend) {
+// Both capabilities come from one source read (or one probe): `serve` and the
+// `--isolated` flag landed in different releases, so a runtime can understand
+// the subcommand and still reject the flag.
+const SERVE_CAPABLE_RUNTIME = { serve: true, isolated: true }
+const LEGACY_DASHBOARD_RUNTIME = { serve: false, isolated: false }
+
+function backendCapabilities(backend) {
   if (!backend || !backend.command) {
-    return true
+    return SERVE_CAPABLE_RUNTIME
   }
 
   const key = `${backend.command}::${backend.root || ''}`
 
-  if (_serveSupportCache.has(key)) {
-    return _serveSupportCache.get(key)
+  if (_backendCapabilityCache.has(key)) {
+    return _backendCapabilityCache.get(key)
   }
 
-  let supported = null
+  let caps = null
 
   if (backend.root) {
     try {
       const src = fs.readFileSync(path.join(backend.root, 'hermes_cli', 'subcommands', 'dashboard.py'), 'utf8')
-      supported = sourceDeclaresServe(src)
+      caps = { serve: sourceDeclaresServe(src), isolated: sourceDeclaresIsolated(src) }
     } catch {
-      supported = null // source unreadable — fall through to the probe
+      caps = null // source unreadable — fall through to the probe
     }
   }
 
-  if (supported === null) {
+  if (caps === null) {
     try {
       const prefix = backend.args && backend.args[0] === '-m' ? backend.args.slice(0, 2) : []
       // Same cold-Windows Python-startup class as the runtime probes
@@ -2335,11 +2349,16 @@ function backendSupportsServe(backend) {
       // is cached for the process lifetime, silently routing a modern
       // runtime through the legacy `dashboard` form. Share the probe budget
       // and its timeout-only retry instead of a thinner local bound.
-      execProbeSync(backend.command, [...prefix, 'serve', '--help'], {
+      //
+      // stdio: 'pipe' because the help listing is also how we learn whether
+      // this runtime accepts `--isolated` — an exit code alone cannot say
+      // (argparse honors `--help` before rejecting an unknown flag).
+
+      const help = execProbeSync(backend.command, [...prefix, 'serve', '--help'], {
         cwd: backend.root || undefined,
         env: { ...process.env, HERMES_HOME, ...(backend.env || {}) },
         timeout: PROBE_TIMEOUT_MS,
-        stdio: 'ignore',
+        stdio: 'pipe',
         // `.cmd`/`.bat` shim backends carry shell: true in their descriptor
         // (see resolveHermesBackend step 4); execFileSync of a .cmd without
         // shell throws EINVAL on modern Node, which the catch below would
@@ -2347,25 +2366,34 @@ function backendSupportsServe(backend) {
         shell: Boolean(backend.shell),
         windowsHide: true
       })
-      supported = true
+
+      caps = { serve: true, isolated: helpDeclaresIsolated(String(help || '')) }
     } catch {
-      supported = false
+      caps = LEGACY_DASHBOARD_RUNTIME
     }
   }
 
-  _serveSupportCache.set(key, supported)
+  _backendCapabilityCache.set(key, caps)
   rememberLog(
-    `[backend] \`serve\` ${supported ? 'supported' : 'unsupported → routing via legacy `dashboard`'} for ${backend.label || key}`
+    `[backend] \`serve\` ${caps.serve ? 'supported' : 'unsupported → routing via legacy `dashboard`'}` +
+      `${caps.serve && !caps.isolated ? ' (no --isolated — dropping the flag)' : ''} for ${backend.label || key}`
   )
 
-  return supported
+  return caps
 }
 
 // Given a resolved backend whose args target `serve`, return the args the
-// runtime actually understands: unchanged when `serve` is supported, or
-// rewritten to `dashboard --no-open` for older runtimes.
+// runtime actually understands: unchanged when `serve` and `--isolated` are
+// both supported, `--isolated` stripped for a serve-capable runtime that
+// predates the flag, or rewritten to `dashboard --no-open` for older runtimes.
 function getBackendArgsForRuntime(backend) {
-  return backendSupportsServe(backend) ? backend.args : dashboardFallbackArgs(backend.args)
+  const caps = backendCapabilities(backend)
+
+  if (!caps.serve) {
+    return dashboardFallbackArgs(backend.args)
+  }
+
+  return caps.isolated ? backend.args : withoutIsolated(backend.args)
 }
 
 function normalizeExecutablePathForCompare(commandPath) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -44,7 +44,7 @@ import {
   probeStartMarker,
   processStartMarker
 } from './backend-claim'
-import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
+import { dashboardFallbackArgs, serveBackendArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { BackendDialClaims } from './backend-dial-claim'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
@@ -12117,7 +12117,7 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   // --profile wins over the inherited HERMES_HOME env (see _apply_profile_override
   // step 3 in hermes_cli/main.py), so the child re-homes to this profile.
   // --port 0: the OS assigns an ephemeral port; the child announces it on stdout.
-  const backendArgs = ['--profile', profile, 'serve', '--host', '127.0.0.1', '--port', '0']
+  const backendArgs = serveBackendArgs(profile)
   const backend = await ensureRuntime(resolveHermesBackend(backendArgs))
   // Route old runtimes (no `serve`) through the legacy `dashboard --no-open`.
   backend.args = getBackendArgsForRuntime(backend)


### PR DESCRIPTION
## Summary

- launch Desktop pooled named-profile backends with `serve --isolated`
- keep the default/non-profile Desktop backend unified and unchanged
- strip the serve-only `--isolated` flag from the legacy `dashboard --no-open` fallback
- route the pooled backend call site through the tested shared argument builder

## Problem

`hermes serve` is unified across profiles by default. Desktop's pooled named-profile backends are intended to be dedicated to one profile, but `spawnPoolBackend()` launched them with only `--profile <name> serve`. That selected the profile without opting out of unified server behavior.

## Fix

Named profile backends now use:

```text
--profile <name> serve --isolated --host 127.0.0.1 --port 0
```

The default backend remains:

```text
serve --host 127.0.0.1 --port 0
```

For older runtimes that do not support `serve`, `dashboardFallbackArgs()` removes only the serve-era `--isolated` flag and preserves the profile prefix and remaining flag order:

```text
--profile <name> dashboard --no-open --host 127.0.0.1 --port 0
```

## Verification

- `npm exec -- vitest run electron/backend-command.test.ts --project electron` — 7 passed
- `npm run typecheck` — passed
- `npm run lint -- --quiet` — passed
- `npm exec -- prettier --check electron/backend-command.ts electron/backend-command.test.ts electron/main.ts` — passed
- `git diff --check` — passed
- independent RepoKeeper review — `ship_status: ship`

## Scope and security

Exactly three files change:

- `apps/desktop/electron/backend-command.ts`
- `apps/desktop/electron/backend-command.test.ts`
- `apps/desktop/electron/main.ts`

No credentials, profile data, Bot Mode changes, local configuration, or generated artifacts are included. A local fallback secret/risk scan returned no findings. GitHub MCP secret scanning was unavailable in this session, so no MCP result is claimed.

## Related work

- #48652 and #77125 scope data exposed by an already isolated server.
- #68786 scrubs inherited credential environment variables for profile backends.

This PR covers the separate missing launch boundary: pooled named-profile Desktop backends were not invoking `serve --isolated`.

## AI assistance disclosure

Prepared and independently reviewed with Hermes Agent.