### PR TITLE
fix(errors): classify Anthropic third-party extra-usage 400 as billing

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -133,6 +133,10 @@ _BILLING_PATTERNS = [
     "account is deactivated",
     "plan does not include",
     "out of extra usage",  # Anthropic OAuth Pro/Max overage bucket depleted (HTTP 400)
+    # Anthropic OAuth used by a third-party app with an empty overage bucket
+    # (2026-08 policy wording, HTTP 400 invalid_request_error): plan limits no
+    # longer apply, so the request can never succeed until credits are added.
+    "draw from your extra usage",
     "out of funds",
     "run out of funds",
     "balance_depleted",

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -213,6 +213,24 @@ class TestClassifyApiError:
         assert result.retryable is False
 
 
+    def test_400_anthropic_third_party_extra_usage_is_billing(self):
+        """Anthropic's 2026-08 policy wording for subscription OAuth used by a
+        third-party app with an empty overage bucket arrives as HTTP 400
+        invalid_request_error.  Unclassified it armed no cooldown, so the
+        primary was re-hit (and re-400ed) on every single call (observed:
+        telegram gateway 2026-08-16, claude-opus-5)."""
+        e = MockAPIError(
+            "Error code: 400 - {'type': 'error', 'error': {'type': "
+            "'invalid_request_error', 'message': 'Third-party apps now draw "
+            "from your extra usage, not your plan limits. Add more at "
+            "claude.ai/settings/usage and keep going.'}}",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="anthropic", model="claude-opus-5")
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
+
 
 
     def test_404_free_tier_model_block_is_billing(self):


### PR DESCRIPTION
Since Anthropic's 2026-08 policy change, OAuth-subscription setups get a 400 "Third-party apps now draw from your extra usage" on every call. The error classifier treated it as a generic request error, so the runtime hammered the provider on each call and failed over silently every time.

Classify it as a billing error → exponential cooldown instead of per-call retries, and an explicit reason in logs. Covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)