### PR TITLE
feat(pricing): DeepSeek peak/off-peak billing (tariffs effective 2026-08-16)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -127,6 +127,13 @@ class PricingEntry:
     source_url: Optional[str] = None
     pricing_version: Optional[str] = None
     fetched_at: Optional[datetime] = None
+    # Time-of-day billing (DeepSeek introduced peak/off-peak on 2026-08-16):
+    # the per-million rates above are the BASE (off-peak) rates; requests whose
+    # UTC hour falls inside any [start, end) window in ``peak_windows_utc``
+    # are billed at ``peak_multiplier`` × base.  Both fields must be set
+    # together; entries without them keep flat pricing.
+    peak_multiplier: Optional[Decimal] = None
+    peak_windows_utc: Optional[tuple[tuple[int, int], ...]] = None
 
 
 @dataclass(frozen=True)
@@ -506,52 +513,71 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         pricing_version="anthropic-pricing-2026-05",
     ),
     # DeepSeek
-    # Snapshot of https://api-docs.deepseek.com/quick_start/pricing (2026-07).
-    # deepseek-chat / deepseek-reasoner are deprecated 2026-07-24 and now alias
+    # Snapshot of https://api-docs.deepseek.com/quick_start/pricing, updated
+    # 2026-08-16 16:00 UTC: peak/off-peak billing reintroduced with a general
+    # price INCREASE.  Base rates below are OFF-PEAK; peak hours
+    # (01:00-04:00 and 06:00-10:00 UTC) bill at 2× — carried by
+    # peak_multiplier/peak_windows_utc so estimates follow the clock.
+    # Cache WRITES are free on DeepSeek (only hit/miss/output are billed):
+    # the explicit 0 keeps a future cache_write_tokens report from
+    # collapsing the whole estimate to "unknown".
+    # deepseek-chat / deepseek-reasoner are deprecated 2026-07-24 and alias
     # deepseek-v4-flash's non-thinking / thinking modes — same rates.
     (
         "deepseek",
         "deepseek-chat",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.14"),
-        output_cost_per_million=Decimal("0.28"),
-        cache_read_cost_per_million=Decimal("0.0028"),
+        input_cost_per_million=Decimal("0.22"),
+        output_cost_per_million=Decimal("0.66"),
+        cache_read_cost_per_million=Decimal("0.007"),
+        cache_write_cost_per_million=Decimal("0"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-07",
+        pricing_version="deepseek-pricing-2026-08-16",
+        peak_multiplier=Decimal("2"),
+        peak_windows_utc=((1, 4), (6, 10)),
     ),
     (
         "deepseek",
         "deepseek-reasoner",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.14"),
-        output_cost_per_million=Decimal("0.28"),
-        cache_read_cost_per_million=Decimal("0.0028"),
+        input_cost_per_million=Decimal("0.22"),
+        output_cost_per_million=Decimal("0.66"),
+        cache_read_cost_per_million=Decimal("0.007"),
+        cache_write_cost_per_million=Decimal("0"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-07",
+        pricing_version="deepseek-pricing-2026-08-16",
+        peak_multiplier=Decimal("2"),
+        peak_windows_utc=((1, 4), (6, 10)),
     ),
     (
         "deepseek",
         "deepseek-v4-pro",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.435"),
-        output_cost_per_million=Decimal("0.87"),
-        cache_read_cost_per_million=Decimal("0.003625"),
+        input_cost_per_million=Decimal("0.66"),
+        output_cost_per_million=Decimal("1.98"),
+        cache_read_cost_per_million=Decimal("0.022"),
+        cache_write_cost_per_million=Decimal("0"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-07",
+        pricing_version="deepseek-pricing-2026-08-16",
+        peak_multiplier=Decimal("2"),
+        peak_windows_utc=((1, 4), (6, 10)),
     ),
     (
         "deepseek",
         "deepseek-v4-flash",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.14"),
-        output_cost_per_million=Decimal("0.28"),
-        cache_read_cost_per_million=Decimal("0.0028"),
+        input_cost_per_million=Decimal("0.22"),
+        output_cost_per_million=Decimal("0.66"),
+        cache_read_cost_per_million=Decimal("0.007"),
+        cache_write_cost_per_million=Decimal("0"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-07",
+        pricing_version="deepseek-pricing-2026-08-16",
+        peak_multiplier=Decimal("2"),
+        peak_windows_utc=((1, 4), (6, 10)),
     ),
     # Google Gemini
     (
@@ -1423,6 +1449,14 @@ def normalize_usage(
     )
 
 
+def _in_peak_window(entry: PricingEntry, at: datetime) -> bool:
+    """Whether *at* falls inside one of the entry's UTC peak windows."""
+    if not entry.peak_multiplier or not entry.peak_windows_utc:
+        return False
+    hour = at.astimezone(timezone.utc).hour
+    return any(start <= hour < end for start, end in entry.peak_windows_utc)
+
+
 def estimate_usage_cost(
     model_name: str,
     usage: CanonicalUsage,
@@ -1430,6 +1464,7 @@ def estimate_usage_cost(
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
+    at: Optional[datetime] = None,
 ) -> CostResult:
     route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
     if route.billing_mode == "subscription_included":
@@ -1482,6 +1517,15 @@ def estimate_usage_cost(
         amount += Decimal(usage.cache_write_tokens) * entry.cache_write_cost_per_million / _ONE_MILLION
     if entry.request_cost is not None and usage.request_count:
         amount += Decimal(usage.request_count) * entry.request_cost
+
+    # Time-of-day billing: applied to the whole amount because every
+    # component (input/cache/output) shares the same multiplier on providers
+    # that bill this way (DeepSeek peak = 2× off-peak across the board).
+    # ``at`` is the request time; per-call callers omit it and get "now",
+    # keeping historical estimates possible by passing the stored timestamp.
+    if _in_peak_window(entry, at or datetime.now(timezone.utc)):
+        amount *= entry.peak_multiplier
+        notes.append(f"peak-hours ×{entry.peak_multiplier} applied")
 
     status: CostStatus = "estimated"
     label = format_cost_label(amount)

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -89,8 +89,9 @@ def test_deepseek_v4_pro_pricing_entry_exists():
 
     Before this fix, deepseek-v4-pro sessions showed as unknown cost
     in hermes insights because the _OFFICIAL_DOCS_PRICING table had no
-    entry for that model.  See #24218.  Rates track the 2026-07 price cut
-    ($1.74/$3.48 → $0.435/$0.87).
+    entry for that model.  See #24218.  Rates track the 2026-08-16
+    peak/off-peak change (base = off-peak; peak billed via
+    peak_multiplier, see the peak-window tests below).
     """
     entry = get_pricing_entry(
         "deepseek-v4-pro",
@@ -100,9 +101,14 @@ def test_deepseek_v4_pro_pricing_entry_exists():
     assert entry is not None
     assert entry.input_cost_per_million is not None
     assert entry.output_cost_per_million is not None
-    assert float(entry.input_cost_per_million) == 0.435
-    assert float(entry.output_cost_per_million) == 0.87
-    assert float(entry.cache_read_cost_per_million) == 0.003625
+    assert float(entry.input_cost_per_million) == 0.66
+    assert float(entry.output_cost_per_million) == 1.98
+    assert float(entry.cache_read_cost_per_million) == 0.022
+    # Cache writes are free on DeepSeek — the explicit 0 keeps a reported
+    # cache_write_tokens count from collapsing the estimate to "unknown".
+    assert float(entry.cache_write_cost_per_million) == 0.0
+    assert float(entry.peak_multiplier) == 2.0
+    assert entry.peak_windows_utc == ((1, 4), (6, 10))
 
 
 
@@ -124,6 +130,70 @@ def test_deepseek_deprecated_aliases_price_as_v4_flash():
         ), alias
 
 
+
+
+def test_deepseek_peak_hours_double_the_estimate():
+    """DeepSeek bills peak hours (01-04 and 06-10 UTC) at 2× the off-peak
+    base rates since 2026-08-16.  The estimator prices by request time —
+    otherwise every peak-hour call under-reports by half (the 02:00 AST
+    night-cycle sits entirely inside the 06-10 UTC window)."""
+    from datetime import datetime, timezone
+
+    usage = CanonicalUsage(
+        input_tokens=1_000_000, output_tokens=1_000_000, cache_read_tokens=0,
+    )
+    off_peak = estimate_usage_cost(
+        "deepseek-v4-pro", usage, provider="deepseek",
+        at=datetime(2026, 8, 17, 12, 0, tzinfo=timezone.utc),
+    )
+    peak = estimate_usage_cost(
+        "deepseek-v4-pro", usage, provider="deepseek",
+        at=datetime(2026, 8, 17, 7, 0, tzinfo=timezone.utc),
+    )
+    assert float(off_peak.amount_usd) == 0.66 + 1.98
+    assert float(peak.amount_usd) == 2 * (0.66 + 1.98)
+    assert any("peak" in n for n in peak.notes)
+    assert not any("peak" in n for n in off_peak.notes)
+
+
+def test_deepseek_peak_window_boundaries_utc():
+    """[start, end) semantics: 06:00 is peak, 10:00 is not; the request's
+    own timezone must not matter (07:00 UTC expressed as 03:00 AST-0400
+    is still peak)."""
+    from datetime import datetime, timezone, timedelta
+
+    usage = CanonicalUsage(input_tokens=1_000_000)
+
+    def cost_at(dt):
+        return float(
+            estimate_usage_cost(
+                "deepseek-v4-pro", usage, provider="deepseek", at=dt
+            ).amount_usd
+        )
+
+    base = 0.66
+    assert cost_at(datetime(2026, 8, 17, 6, 0, tzinfo=timezone.utc)) == 2 * base
+    assert cost_at(datetime(2026, 8, 17, 10, 0, tzinfo=timezone.utc)) == base
+    assert cost_at(datetime(2026, 8, 17, 0, 59, tzinfo=timezone.utc)) == base
+    ast = timezone(timedelta(hours=-4))
+    assert cost_at(datetime(2026, 8, 17, 3, 0, tzinfo=ast)) == 2 * base
+
+
+def test_flat_pricing_entries_ignore_clock():
+    """Entries without peak fields (every non-DeepSeek provider) must price
+    identically at any hour — the multiplier is strictly opt-in."""
+    from datetime import datetime, timezone
+
+    usage = CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+    at_peak_hour = estimate_usage_cost(
+        "claude-3-haiku-20240307", usage, provider="anthropic",
+        at=datetime(2026, 8, 17, 7, 0, tzinfo=timezone.utc),
+    )
+    at_noon = estimate_usage_cost(
+        "claude-3-haiku-20240307", usage, provider="anthropic",
+        at=datetime(2026, 8, 17, 12, 0, tzinfo=timezone.utc),
+    )
+    assert at_peak_hour.amount_usd == at_noon.amount_usd
 
 
 def test_bedrock_claude_rows_all_carry_cache_pricing():


### PR DESCRIPTION
DeepSeek reintroduced peak/off-peak pricing on 2026-08-16 16:00 UTC (peak = 01:00-04:00 + 06:00-10:00 UTC, off-peak -50%). Cost accounting with the old flat rates over/under-bills depending on hour.

Implements time-of-day aware pricing for V4-Pro / V4-Flash, verified against api-docs.deepseek.com/quick_start/pricing on the effective date. Covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)