### PR TITLE
fix(codex): strip unsupported prompt_cache_retention at wire boundary (#89897)

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1305,6 +1305,37 @@ def _consume_codex_event_stream(
     return final
 
 
+def _sanitize_consumer_codex_request(
+    agent: Any,
+    request: dict[str, Any],
+) -> dict[str, Any]:
+    """Drop unsupported fields at the ChatGPT OAuth Codex wire boundary.
+
+    This guard intentionally executes at the final wire boundary, after Relay
+    or other request middleware has had a chance to transform the request.
+    The normal transport builder omits ``prompt_cache_retention`` for
+    consumer Codex, but a late Relay overlay or explicit ``request_overrides``
+    could otherwise inject the unsupported parameter and trigger a non-retryable
+    HTTP 400 Bad Request.
+
+    Compatible Responses API backends (e.g. Meta Model API, Bedrock Mantle)
+    are preserved as supported.
+    """
+    sanitized = dict(request)
+    backend_predicate = getattr(agent, "_is_codex_backend", None)
+    is_consumer_codex = (
+        bool(backend_predicate()) if callable(backend_predicate) else False
+    )
+    if is_consumer_codex and "prompt_cache_retention" in sanitized:
+        sanitized.pop("prompt_cache_retention", None)
+        logger.warning(
+            "Dropped unsupported prompt_cache_retention at consumer Codex "
+            "wire boundary (model=%s).",
+            sanitized.get("model", getattr(agent, "model", "unknown")),
+        )
+    return sanitized
+
+
 def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta=None):
     """Execute one streaming Responses API request and return the final response.
 
@@ -1347,7 +1378,10 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         writer_token = {"value": None}
 
         def _open_codex_stream(next_api_kwargs: dict[str, Any]):
-            stream_kwargs = dict(next_api_kwargs)
+            stream_kwargs = _sanitize_consumer_codex_request(
+                agent,
+                next_api_kwargs,
+            )
             stream_kwargs["stream"] = True
             return active_client.responses.create(**stream_kwargs)
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -625,6 +625,10 @@ class ResponsesApiTransport(ProviderTransport):
             kwargs.pop("timeout", None)
 
         if is_codex_backend:
+            # Consumer ChatGPT Codex rejects prompt_cache_retention with HTTP 400.
+            # Strip it at build time to protect against request_overrides injection (#89897).
+            kwargs.pop("prompt_cache_retention", None)
+
             # The Codex backend rejects body-level ``extra_headers`` with
             # HTTP 400, but the OpenAI SDK's ``extra_headers`` kwarg maps
             # to actual HTTP request headers (not body fields).  ``session_id``

--- a/tests/agent/test_relay_llm.py
+++ b/tests/agent/test_relay_llm.py
@@ -207,6 +207,33 @@ def test_relay_metadata_preserves_provider_name():
     }
 
 
+def test_provider_request_overlays_interceptor_added_codex_field():
+    """Relay rewrites may introduce provider fields absent from the original."""
+    original = {"model": "gpt-5.6-sol", "input": "hello"}
+    relay_request_body = relay_llm._relay_request_body(
+        original,
+        {"api_mode": "codex_responses"},
+    )
+    intercepted = SimpleNamespace(
+        content={
+            **relay_request_body,
+            "prompt_cache_retention": "24h",
+        },
+        headers={},
+    )
+
+    provider_request = relay_llm._provider_request(
+        original,
+        intercepted,
+        relay_request_body=relay_request_body,
+        codec_baseline_body=dict(relay_request_body),
+        metadata={"api_mode": "codex_responses"},
+    )
+
+    assert "prompt_cache_retention" not in original
+    assert provider_request["prompt_cache_retention"] == "24h"
+
+
 def test_stream_uses_rewritten_request_and_post_intercept_chunks(relay_turn):
     relay, turn = relay_turn
     captured_requests = []

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -207,6 +207,30 @@ class TestCodexBuildKwargs:
         )
         assert "prompt_cache_retention" not in kw
 
+    def test_build_kwargs_strips_request_overrides_retention_on_consumer_codex(self, transport):
+        """Defense-in-depth: build_kwargs strips prompt_cache_retention for consumer
+        Codex backend even when injected via request_overrides (#89897)."""
+        kw = transport.build_kwargs(
+            model="gpt-5.6-sol",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            is_codex_backend=True,
+            base_url="https://chatgpt.com/backend-api/codex",
+            request_overrides={"prompt_cache_retention": "24h"},
+        )
+        assert "prompt_cache_retention" not in kw
+
+    def test_build_kwargs_preserves_request_overrides_retention_on_compatible_endpoint(self, transport):
+        """Compatible backends (e.g. Meta) keep prompt_cache_retention from request_overrides."""
+        kw = transport.build_kwargs(
+            model="llama-3.3-70b-instruct",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url="https://api.meta.ai",
+            request_overrides={"prompt_cache_retention": "24h"},
+        )
+        assert kw.get("prompt_cache_retention") == "24h"
+
     def test_xai_responses_sends_cache_key_via_extra_body(self, transport):
         """xAI's Responses API documents ``prompt_cache_key`` as the
         body-level cache-routing key (the ``x-grok-conv-id`` header is

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -231,6 +231,22 @@ class TestCodexBuildKwargs:
         )
         assert kw.get("prompt_cache_retention") == "24h"
 
+    def test_build_kwargs_preserves_cache_key_when_stripping_retention(self, transport):
+        """Mitigate cache degradation: stripping unsupported prompt_cache_retention
+        does NOT degrade or drop prompt_cache_key, keeping prefix caching intact (#89897)."""
+        kw = transport.build_kwargs(
+            model="gpt-5.6-sol",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            session_id="session_123",
+            is_codex_backend=True,
+            base_url="https://chatgpt.com/backend-api/codex",
+            request_overrides={"prompt_cache_retention": "24h"},
+        )
+        assert "prompt_cache_retention" not in kw
+        assert "prompt_cache_key" in kw
+        assert kw["prompt_cache_key"].startswith("pck_")
+
     def test_xai_responses_sends_cache_key_via_extra_body(self, transport):
         """xAI's Responses API documents ``prompt_cache_key`` as the
         body-level cache-routing key (the ``x-grok-conv-id`` header is

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -633,6 +633,38 @@ def test_run_codex_stream_strips_request_overrides_retention_at_consumer_wire(
     )
 
 
+def test_run_codex_stream_preserves_other_kwargs_and_cache_key(monkeypatch):
+    """Mitigate payload degradation: wire sanitizer drops only retention while
+    preserving tools, prompt_cache_key, and input intact (#89897)."""
+    agent = _build_agent(monkeypatch)
+    captured = {}
+
+    def _fake_create(**kwargs):
+        captured.update(kwargs)
+        return _FakeCreateStream([
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed"),
+            )
+        ])
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=_fake_create),
+    )
+    request = {
+        **_codex_request_kwargs(),
+        "model": "gpt-5.6-sol",
+        "prompt_cache_key": "pck_test123",
+        "prompt_cache_retention": "24h",
+    }
+
+    agent._run_codex_stream(request)
+
+    assert "prompt_cache_retention" not in captured
+    assert captured["prompt_cache_key"] == "pck_test123"
+    assert captured["model"] == "gpt-5.6-sol"
+
+
 def test_run_codex_stream_returns_collected_items_when_stream_ends_without_terminal(monkeypatch):
     """The event-driven path tolerates streams that end without a terminal frame.
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -531,10 +531,106 @@ def _build_xai_agent_with_slash_enum_tool(monkeypatch):
     return agent
 
 
+def test_run_codex_stream_strips_relay_added_retention_at_consumer_wire(
+    monkeypatch,
+    caplog,
+):
+    """A Relay-added unsupported field cannot reach consumer ChatGPT Codex."""
+    from agent import relay_llm
+
+    agent = _build_agent(monkeypatch)
+    captured = {}
+
+    def _fake_create(**kwargs):
+        captured.update(kwargs)
+        return _FakeCreateStream([
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed"),
+            )
+        ])
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=_fake_create),
+    )
+    original = _codex_request_kwargs()
+    relay_request_body = relay_llm._relay_request_body(
+        original,
+        {"api_mode": "codex_responses"},
+    )
+    relayed = relay_llm._provider_request(
+        original,
+        SimpleNamespace(
+            content={
+                **relay_request_body,
+                "prompt_cache_retention": "24h",
+            },
+            headers={},
+        ),
+        relay_request_body=relay_request_body,
+        codec_baseline_body=dict(relay_request_body),
+        metadata={"api_mode": "codex_responses"},
+    )
+    assert relayed["prompt_cache_retention"] == "24h"
+
+    with caplog.at_level("WARNING", logger="agent.codex_runtime"):
+        agent._run_codex_stream(relayed)
+
+    assert "prompt_cache_retention" not in captured
+    assert any(
+        "Dropped unsupported prompt_cache_retention at consumer Codex wire boundary"
+        in record.message
+        for record in caplog.records
+    )
 
 
+def test_consumer_codex_wire_guard_preserves_compatible_endpoint_retention():
+    """Endpoints supporting prompt_cache_retention (e.g. Meta, Bedrock) keep the parameter."""
+    from agent.codex_runtime import _sanitize_consumer_codex_request
+
+    agent = SimpleNamespace(_is_codex_backend=lambda: False)
+    request = {"model": "openai.gpt-5.5", "prompt_cache_retention": "24h"}
+
+    sanitized = _sanitize_consumer_codex_request(agent, request)
+
+    assert sanitized["prompt_cache_retention"] == "24h"
+    assert sanitized is not request
 
 
+def test_run_codex_stream_strips_request_overrides_retention_at_consumer_wire(
+    monkeypatch,
+    caplog,
+):
+    """Explicit request_overrides setting prompt_cache_retention is dropped with a warning."""
+    agent = _build_agent(monkeypatch)
+    captured = {}
+
+    def _fake_create(**kwargs):
+        captured.update(kwargs)
+        return _FakeCreateStream([
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed"),
+            )
+        ])
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=_fake_create),
+    )
+    request = {
+        **_codex_request_kwargs(),
+        "prompt_cache_retention": "24h",
+    }
+
+    with caplog.at_level("WARNING", logger="agent.codex_runtime"):
+        agent._run_codex_stream(request)
+
+    assert "prompt_cache_retention" not in captured
+    assert any(
+        "Dropped unsupported prompt_cache_retention at consumer Codex wire boundary"
+        in record.message
+        for record in caplog.records
+    )
 
 
 def test_run_codex_stream_returns_collected_items_when_stream_ends_without_terminal(monkeypatch):


### PR DESCRIPTION
## Summary

- Sanitize consumer ChatGPT Codex Responses API requests immediately before calling `active_client.responses.create()` in `run_codex_stream()`.
- Drop unsupported `prompt_cache_retention` with an explicit structured warning when targeted at `chatgpt.com/backend-api/codex`, protecting against both Relay LLM interceptor overlay mutations and explicit `request_overrides` collisions.
- Preserve `prompt_cache_retention: "24h"` on compatible Responses API endpoints (Meta Model API, Bedrock Mantle).
- Add regression tests covering the Relay overlay entry mechanism, the wire boundary sanitization, `request_overrides` drop with warning, and compatible endpoint preservation.

Fixes #89897.

---

## Root Cause Analysis

Hermes's Codex transport helper `_default_prompt_cache_retention_for_request()` correctly returns `None` for `chatgpt.com/backend-api/codex`. However, on turns involving tool follow-ups where a Relay interceptor rewrites or augments the request, `relay_llm._provider_request()` compares against the codec baseline:

```python
for key in baseline.keys() | intercepted.keys():
    if key not in intercepted:
        final.pop(key, None)
    elif key not in baseline or not _json_equal(intercepted[key], baseline[key]):
        final[key] = intercepted[key]  # <-- admits newly introduced provider fields
```

When an interceptor or provider middleware adds `prompt_cache_retention`, it is overlaid onto `final_request`. Similarly, user-supplied `request_overrides` merged into `kwargs` after `setdefault` could inject the parameter. When sent to the ChatGPT OAuth Codex backend, the endpoint returns a non-retryable HTTP 400 Bad Request.

---

## Why the Guard Lives at the Wire Boundary

`agent/codex_runtime.py::_open_codex_stream()` is the final Relay-mediated `responses.create()` send boundary. Sanitizing at this exact boundary enforces the consumer endpoint contract after all middleware transformations (Relay, decorators, plugins, and overrides) have run.

- Uses `_is_codex_backend()`, which checks the specific hostname (`chatgpt.com`) and path (`/backend-api/codex`).
- Compatible endpoints (such as Meta Model API `api.meta.ai` and Bedrock Mantle `bedrock-mantle.*.api.aws`) retain their supported `24h` prompt caching.
- Emits `logger.warning("Dropped unsupported prompt_cache_retention at consumer Codex wire boundary (model=%s).", model)` so that developers using `request_overrides` have explicit visibility into why the override was dropped rather than causing an endpoint failure.

---

## Verification & Tests

- `test_provider_request_overlays_interceptor_added_codex_field`: Verifies Relay overlay reproduces the entry mechanism where an interceptor introduces `prompt_cache_retention`.
- `test_run_codex_stream_strips_relay_added_retention_at_consumer_wire`: Verifies that Relay-added retention is dropped at the wire boundary and a warning is logged.
- `test_consumer_codex_wire_guard_preserves_compatible_endpoint_retention`: Verifies that non-consumer backends preserve `prompt_cache_retention="24h"`.
- `test_run_codex_stream_strips_request_overrides_retention_at_consumer_wire`: Verifies that `request_overrides` with `prompt_cache_retention` is dropped with a warning on consumer Codex.
- Focused test suite: **186 passed** across `test_run_agent_codex_responses.py`, `test_codex_transport.py`, and `test_auxiliary_client.py`.
- `ruff check`: All checks passed.
