### PR TITLE
fix(relay): graceful degrade when nemo_relay is not provisioned

### DIFF
--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -25,6 +25,20 @@ RUNTIME_SCHEMA_VERSION = "hermes.relay.runtime.v1"
 RUNTIME_INSTANCE_KEY = "hermes.relay.runtime_instance"
 _PROFILE_KEY_CACHE: dict[str, str] = {}
 
+# Track reasons we've already announced so we don't repeat the same
+# degraded-binding notice on every profile init in a long-running gateway.
+_ANNOUNCED_REASONS: set[str] = set()
+
+# Exception types that mean "the Relay binding isn't provisioned on this
+# deployment" (the platform has no wheel, or it was deliberately excluded
+# from the installed extra set) rather than "something went wrong". These
+# are the supported fail-open path: ``RelayHostRegistry.for_profile`` still
+# falls back to ``NoopRelayRuntime`` exactly as it did before, but the log
+# line is a single INFO entry with no traceback instead of a multi-line
+# WARNING stack frame that shows up once per profile and drowns the real
+# signals in the gateway log.
+_RELAY_PROVISIONING_ERRORS: tuple[type[BaseException], ...] = (ModuleNotFoundError, ImportError)
+
 
 @dataclass
 class RelaySession:
@@ -428,9 +442,34 @@ class RelayHostRegistry:
             try:
                 host = RelayRuntime(profile_key=key)
             except Exception as exc:
-                logger.warning(
-                    "Hermes Relay runtime initialization failed", exc_info=True
-                )
+                # The two documented "Relay binding isn't provisioned on
+                # this deployment" failures (``ModuleNotFoundError`` when
+                # the platform has no wheel, ``ImportError`` when an
+                # optional transitive in the binding itself is missing)
+                # are the supported fail-open path. ``NoopRelayRuntime``
+                # takes over and the rest of the runtime is unchanged —
+                # tool intercepts become pass-through, managed execution
+                # reports disabled, and emit_mark becomes a silent no-op.
+                # Announce the degrade once per process (not once per
+                # profile, not once per request) and skip the traceback
+                # so this doesn't drown the real signals in the gateway
+                # log every time a new profile is initialised.
+                if isinstance(exc, _RELAY_PROVISIONING_ERRORS):
+                    reason = f"{type(exc).__name__}: {exc}"
+                    if reason not in _ANNOUNCED_REASONS:
+                        _ANNOUNCED_REASONS.add(reason)
+                        logger.info(
+                            "Hermes Relay runtime unavailable; falling back "
+                            "to no-op host (%s). Tool intercepts and "
+                            "managed execution will be disabled for this "
+                            "deployment.",
+                            reason,
+                        )
+                else:
+                    logger.warning(
+                        "Hermes Relay runtime initialization failed",
+                        exc_info=True,
+                    )
                 host = NoopRelayRuntime(profile_key=key, reason=str(exc))
             self._hosts[key] = host
             return host
@@ -1076,3 +1115,4 @@ def _reset_for_tests() -> None:
     SESSION_COORDINATOR._reset_active_turns_for_tests()
     HOST_REGISTRY.shutdown_all()
     _PROFILE_KEY_CACHE.clear()
+    _ANNOUNCED_REASONS.clear()

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextvars
 import asyncio
 import json
+import logging
 import sqlite3
 import threading
 from datetime import datetime, timedelta, timezone
@@ -951,8 +952,9 @@ def test_core_runtime_is_fail_open_without_a_published_binding(monkeypatch, capl
 
     monkeypatch.setattr(relay_runtime.importlib, "import_module", missing_relay)
 
-    assert relay_runtime.get_runtime() is None
-    host = relay_runtime.get_host()
+    with caplog.at_level(logging.INFO, logger="agent.relay_runtime"):
+        assert relay_runtime.get_runtime() is None
+        host = relay_runtime.get_host()
     assert isinstance(host, relay_runtime.NoopRelayRuntime)
     assert host.profile_key == relay_runtime.current_profile_key()
     assert "nemo_relay" in host.reason
@@ -962,7 +964,85 @@ def test_core_runtime_is_fail_open_without_a_published_binding(monkeypatch, capl
         args={"command": "true"},
     ) == {"command": "true"}
     assert not relay_runtime.emit_mark("hermes.probe", session_id="s1")
+    # The missing-binding case is a supported fail-open path, not a failure:
+    # log a single INFO line (no traceback) explaining the degrade so an
+    # admin can still see it in the gateway log. The old WARNING+traceback
+    # string is no longer the expected signal here.
+    assert "Hermes Relay runtime unavailable" in caplog.text
+    assert "nemo_relay" in caplog.text
+    # And critically: no multi-line traceback. We assert this both by
+    # checking no WARNING/ERROR records were emitted on this logger and
+    # by confirming caplog.text contains no Traceback frame headers.
+    relay_records = [
+        r for r in caplog.records if r.name == "agent.relay_runtime"
+    ]
+    assert all(r.levelno < logging.WARNING for r in relay_records), (
+        f"expected only INFO-or-below for the fail-open case, got: "
+        f"{[(r.levelname, r.getMessage()) for r in relay_records]}"
+    )
+    assert "Traceback (most recent call last):" not in caplog.text
+    relay_runtime._reset_for_tests()
+
+
+def test_core_runtime_fail_open_does_not_repeat_per_profile(monkeypatch, caplog):
+    """The missing-binding notice must be announced once per process, not
+    once per profile. Otherwise a multi-profile gateway floods the log
+    with the same line on every conversation turn that triggers host
+    initialisation."""
+    relay_shared_metrics._reset_for_tests()
+    relay_runtime._reset_for_tests()
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def missing_relay(name, *args, **kwargs):
+        if name == "nemo_relay":
+            raise ModuleNotFoundError(name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(relay_runtime.importlib, "import_module", missing_relay)
+
+    with caplog.at_level(logging.INFO, logger="agent.relay_runtime"):
+        # Pretend three profiles initialise — each one resolves to a
+        # different profile_key so the registry actually builds a fresh
+        # host for each. Only one log line should be emitted.
+        profile_a = relay_runtime.current_profile_key()
+        profile_b = profile_a + "::b"
+        profile_c = profile_a + "::c"
+        for pk in (profile_a, profile_b, profile_c):
+            relay_runtime.HOST_REGISTRY.for_profile(pk)
+    relay_runtime._reset_for_tests()
+
+    info_lines = [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == "agent.relay_runtime" and r.levelno == logging.INFO
+    ]
+    assert len(info_lines) == 1, (
+        f"expected exactly one degrade notice across N profiles, got "
+        f"{len(info_lines)}: {info_lines}"
+    )
+
+
+def test_core_runtime_unknown_failure_still_logs_traceback(monkeypatch, caplog):
+    """Genuinely unexpected failures during RelayRuntime init must keep
+    the WARNING+traceback so they aren't silently swallowed — only the
+    documented 'binding not provisioned' path is downgraded."""
+    relay_shared_metrics._reset_for_tests()
+    relay_runtime._reset_for_tests()
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("synthetic relay init failure")
+
+    monkeypatch.setattr(relay_runtime.RelayRuntime, "__init__", boom)
+
+    with caplog.at_level(logging.WARNING, logger="agent.relay_runtime"):
+        host = relay_runtime.get_host()
+    assert isinstance(host, relay_runtime.NoopRelayRuntime)
+    assert "synthetic relay init failure" in host.reason
     assert "Hermes Relay runtime initialization failed" in caplog.text
+    assert "Traceback (most recent call last):" in caplog.text
     relay_runtime._reset_for_tests()
 
 


### PR DESCRIPTION
## Summary

`RelayHostRegistry.for_profile` already catches the `ModuleNotFoundError` raised by `_load_nemo_relay` and falls back to `NoopRelayRuntime` — that fail-open behavior is correct, designed, and tested. The only problem was log presentation: a multi-line `WARNING + exc_info=True` traceback emitted once per profile at gateway startup, drowning real signals in `~/.hermes/hermes-gateway.log`.

This change splits the exception handler:

| Failure | Old | New |
|---|---|---|
| `ModuleNotFoundError` / `ImportError` (the documented "binding not provisioned" case) | `WARNING` + full Python traceback | Single `INFO` line with reason; emitted at most once per reason per process |
| Any other `Exception` (genuinely unexpected) | `WARNING` + traceback | unchanged — still `WARNING` + traceback |

The runtime behavior is identical: `NoopRelayRuntime` is returned with `reason=str(exc)`, tool-request intercepts become pass-through, `managed_execution_enabled()` reports `False`, `emit_mark` is a silent no-op. The contract already exercised by `test_core_runtime_is_fail_open_without_a_published_binding` is preserved.

## Streaming-timeout causality (diagnostic only, no code change)

`/home/administrator/.hermes/hermes-gateway.log` shows `Streaming failed before delivery: Request timed out or interrupted` lines interleaved with the relay traceback. These are **independent** of the missing-relay issue:

- Source: `agent/chat_completion_helpers.py:4297` via `logger.exception("Streaming failed before delivery: %s", e)`.
- Stack frames in the log: `relay_llm.stream()` (lines 43/424) — a different module from `relay_runtime.py`.
- The error message itself links to `https://docs.anthropic.com/en/api/errors#long-requests` — these are **Anthropic provider-side stream timeouts** that happen during the chat-completion request, not at gateway startup.

The relay-init traceback runs **once per profile at gateway startup**; the streaming timeouts run **once per timed-out chat-completion request**. They are co-located in the same log file purely by chance, not by causation. Not addressed by this PR — fixing provider timeouts is a separate investigation (the existing `_disable_streaming` fallback at `chat_completion_helpers.py:4285-4296` is the in-flight recovery path).

## Reproduction (before vs after, `nemo_relay` blocked via meta_path finder)

**Before** — single gateway startup, one profile init:
```
WARNING agent.relay_runtime: Hermes Relay runtime initialization failed
Traceback (most recent call last):
  File "<string>", line 29, in old_for_profile
  File ".../agent/relay_runtime.py", line 59, in __init__
    self.relay = relay or _load_nemo_relay()
                          ^^^^^^^^^^^^^^^^^^
  File ".../agent/relay_runtime.py", line 1106, in _load_nemo_relay
    return importlib.import_module("nemo_relay")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ... 8 more frames ...
ModuleNotFoundError: nemo_relay
```

**After** — single gateway startup, four profile inits (one + three extras), all blocked:
```
INFO agent.relay_runtime: Hermes Relay runtime unavailable; falling back to no-op host (ModuleNotFoundError: nemo_relay). Tool intercepts and managed execution will be disabled for this deployment.
```

No traceback. No repeat across the three additional profile inits.

## Test output

- `tests/hermes_cli/test_relay_shared_metrics_runtime.py` — **42 passed, 3 skipped** with `nemo_relay` blocked. The 3 skips are tests that legitimately require `nemo_relay` (correctly auto-skip via `pytest.importorskip`).
- New tests added:
  - `test_core_runtime_is_fail_open_without_a_published_binding` (updated) — asserts the new INFO contract and explicitly verifies no `Traceback (most recent call last):` line in caplog.
  - `test_core_runtime_fail_open_does_not_repeat_per_profile` — three distinct profile inits produce exactly one INFO line.
  - `test_core_runtime_unknown_failure_still_logs_traceback` — a synthetic `RuntimeError` in `RelayRuntime.__init__` still produces the WARNING + traceback (negative coverage so we never silently swallow real failures).
- `tests/hermes_cli/test_relay_shared_metrics.py` — 2 failures pre-existing on `main` (cross-process SQLite `disk I/O error` on this VM's filesystem). Confirmed by running the same tests on a clean `main` worktree — identical failures, unrelated to this change.

## Notes for reviewers

- The catch is deliberately narrow: `ModuleNotFoundError` + `ImportError` only. Anything else keeps the existing `WARNING + exc_info=True` so genuinely unexpected failures aren't hidden.
- `_ANNOUNCED_REASONS` is reset by `_reset_for_tests()` so the new per-process test can run in isolation.
- No public API changes. `NoopRelayRuntime.reason` still contains the original exception text (including the `nemo_relay` string the existing assertion checks).
- `pyproject.toml` already declares `nemo-relay` as an empty extra gated to a platform marker — the intent is for it to be installable on supported wheel targets and absent elsewhere. This PR makes the "absent elsewhere" path quiet rather than noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>