### PR TITLE
fix(agent): stream delegated-child and cron API calls — z.ai 524 child-death class

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1332,6 +1332,296 @@ def direct_api_call(agent, api_kwargs: dict):
             )
 
 
+def direct_streaming_api_call(agent, api_kwargs: dict):
+    """Streaming variant of :func:`direct_api_call` for delegated children.
+
+    Same inline shape (no interrupt-worker thread → the nested-pool deadlock
+    class #62151 / #60203 stays closed), but the wire request carries
+    ``stream: True`` and the SSE iterator is consumed inline. Iterating a
+    generator does not spawn a thread, so the deadlock properties are
+    unchanged — while the connection now emits bytes that keepalive-hungry
+    proxies (z.ai edge ~180-210s → HTTP 524) never kill.
+
+    Why this matters: the non-streaming direct path was chosen under the
+    premise "no stream consumer, so the deltas go nowhere" — but streaming is
+    not (only) about delivering deltas; it is the transport keepalive. Claude
+    Code / OpenCode / Cline always stream and never observe these 524 walls.
+
+    Stream-consumption details (chunk -> delta accumulation) mirror the
+    Relay-managed path's semantics: tool calls are accumulated by index,
+    text/reasoning concatenated, usage captured from the final chunk. On a
+    stream-open error that classifies as "stream not supported" the session
+    falls back to the non-streaming inline path (via ``_disable_streaming``,
+    which the per-turn reset from #25723 re-arms on the next turn); any other
+    stream-open error falls back for THIS call only and is re-raised if the
+    fallback also fails.
+    """
+    if getattr(agent, "_disable_streaming", False):
+        return direct_api_call(agent, api_kwargs)
+
+    # Build streaming kwargs without mutating the caller's dict.
+    stream_kwargs = {
+        **api_kwargs,
+        "stream": True,
+    }
+    if "timeout" not in stream_kwargs and not is_native_gemini_base_url(agent.base_url):
+        # Chat-completions wire: cap connect like the Relay path so a dead
+        # provider does not hold the inline thread on a TCP handshake.
+        try:
+            base_timeout_cfg = _resolve_direct_stale_timeout(agent, api_kwargs)
+            if math.isfinite(base_timeout_cfg) and base_timeout_cfg > 0:
+                stream_kwargs["timeout"] = _httpx.Timeout(
+                    connect=min(base_timeout_cfg, 60.0),
+                    read=base_timeout_cfg,
+                    write=base_timeout_cfg,
+                    pool=min(base_timeout_cfg, 1.0) * 60.0,
+                )
+        except Exception:
+            pass  # provider-config resolution failure: keep SDK default timeouts
+    if not is_native_gemini_base_url(agent.base_url):
+        stream_kwargs["stream_options"] = {"include_usage": True}
+
+    content_parts: list = []
+    reasoning_parts: list = []
+    tool_calls_acc: dict = {}
+    _last_id_at_idx: dict = {}
+    _active_slot_by_idx: dict = {}
+    finish_reason = None
+    model_name = None
+    role = "assistant"
+    usage_obj = None
+    last_chunk_time = {"t": time.time()}
+    call_start = time.time()
+    stream_opened = {"v": False}
+    request_state = {
+        "client": None,
+        "done": False,
+        "stale": False,
+        "cancelled": False,
+    }
+    request_client_lock = threading.Lock()
+    activity_hb_stop = threading.Event()
+
+    def _abort_active_request(reason: str) -> bool:
+        # Same atomicity contract as direct_api_call._abort_active_request.
+        with request_client_lock:
+            if request_state["done"]:
+                return False
+            if reason == "stale_call_kill" and request_state["cancelled"]:
+                return False
+            if reason != "stale_call_kill":
+                request_state["cancelled"] = True
+            newly_stale = reason == "stale_call_kill" and not request_state["stale"]
+            if newly_stale:
+                request_state["stale"] = True
+                _bump_stale_streak(agent)
+            request_client = request_state["client"]
+            if request_client is not None:
+                try:
+                    agent._abort_request_openai_client(request_client, reason=reason)
+                except Exception:
+                    logger.debug(
+                        "Inline streaming abort failed (%s)", reason, exc_info=True
+                    )
+            return newly_stale
+
+    def _make_client(reason: str):
+        client = agent._create_request_openai_client(
+            reason="chat_completion_stream_request", api_kwargs=stream_kwargs
+        )
+        with request_client_lock:
+            request_state["client"] = client
+        agent._active_request_abort = _abort_active_request
+        return client
+
+    def _activity_heartbeat() -> None:
+        while not activity_hb_stop.wait(_DIRECT_API_ACTIVITY_HEARTBEAT_SECONDS):
+            try:
+                agent._touch_activity("waiting for provider response (streaming)")
+            except Exception:
+                pass
+
+    def _consume(chunk: Any) -> None:
+        # Inline accumulation of one SSE chunk — no callbacks fired (children
+        # have no stream consumers by design; the bytes keep the connection
+        # alive, and the accumulated response is returned to the loop).
+        last_chunk_time["t"] = time.time()
+        nonlocal finish_reason, model_name, role, usage_obj
+        try:
+            choices = getattr(chunk, "choices", None)
+            if choices:
+                first = choices[0]
+                delta = getattr(first, "delta", None)
+                if delta is not None:
+                    _content = getattr(delta, "content", None)
+                    if isinstance(_content, str) and _content:
+                        content_parts.append(_content)
+                    _reasoning = getattr(delta, "reasoning_content", None)
+                    if isinstance(_reasoning, str) and _reasoning:
+                        reasoning_parts.append(_reasoning)
+                    _tool_calls = getattr(delta, "tool_calls", None)
+                    if _tool_calls:
+                        for tc in _tool_calls:
+                            idx = getattr(tc, "index", None)
+                            if idx is None:
+                                idx = 0 if not tool_calls_acc else max(tool_calls_acc) + 1
+                            _id = getattr(tc, "id", None)
+                            if _id:
+                                _last_id_at_idx[idx] = _id
+                            elif _last_id_at_idx.get(idx):
+                                _id = _last_id_at_idx[idx]
+                            slot = _active_slot_by_idx.get(idx)
+                            if slot is None or (
+                                _id and slot in tool_calls_acc and tool_calls_acc[slot].get("id") != _id
+                            ):
+                                candidates = [
+                                    s for s, entry in tool_calls_acc.items()
+                                    if entry.get("id") == _id
+                                ]
+                                slot = candidates[0] if candidates else len(tool_calls_acc)
+                                if slot not in tool_calls_acc:
+                                    tool_calls_acc[slot] = {
+                                        "id": _id,
+                                        "type": "function",
+                                        "function": {"name": "", "arguments": ""},
+                                    }
+                                _active_slot_by_idx[idx] = slot
+                            entry = tool_calls_acc[slot]
+                            fn = getattr(tc, "function", None)
+                            if fn is not None:
+                                _name = getattr(fn, "name", None)
+                                if _name:
+                                    entry["function"]["name"] = (
+                                        entry["function"]["name"] + _name
+                                    )
+                                _args = getattr(fn, "request_arguments", None) or getattr(fn, "arguments", None)
+                                if _args:
+                                    entry["function"]["arguments"] += _args
+                _fr = getattr(first, "finish_reason", None)
+                if _fr:
+                    finish_reason = _fr
+                _role = getattr(delta, "role", None) or getattr(first, "role", None)
+                if _role:
+                    role = _role
+            _usage = getattr(chunk, "usage", None)
+            if _usage is not None:
+                usage_obj = _usage
+            _model = getattr(chunk, "model", None)
+            if _model:
+                model_name = _model
+        except Exception:
+            logger.debug("direct stream chunk accumulation failed", exc_info=True)
+
+    # Resolve the stale budget before starting the heartbeat (same
+    # fail-closed contract as direct_api_call; a raise here leaks nothing).
+    stale_timeout = _resolve_direct_stale_timeout(agent, api_kwargs)
+    activity_hb = threading.Thread(
+        target=_activity_heartbeat,
+        name="direct-stream-activity-hb",
+        daemon=True,
+        )
+    activity_hb.start()
+    stale_watchdog = None
+    if math.isfinite(stale_timeout) and stale_timeout > 0:
+        def _on_stale() -> None:
+            if not _abort_active_request("stale_call_kill"):
+                return
+            elapsed = time.time() - call_start
+            _report_stale_nonstream_kill(
+                agent, api_kwargs, elapsed, stale_timeout, inline=True
+            )
+            _touch_stale_kill_activity(agent, elapsed)
+        stale_watchdog = threading.Timer(stale_timeout, _on_stale)
+        stale_watchdog.name = "direct-stream-stale-watchdog"
+        stale_watchdog.daemon = True
+        stale_watchdog.start()
+
+    succeeded = False
+    stream = None
+    request_client = None
+    try:
+        request_client = _make_client("chat_completion_stream_request")
+        stream = request_client.chat.completions.create(**stream_kwargs)
+        stream_opened["v"] = True
+        agent._capture_rate_limits(getattr(stream, "response", None))
+        for chunk in _iter_provider_stream_chunks(stream):
+            if agent._interrupt_requested:
+                try:
+                    stream.close()
+                except Exception:
+                    pass
+                raise InterruptedError("Agent interrupted during API call")
+            _consume(chunk)
+        with request_client_lock:
+            request_state["done"] = True
+        _reset_stale_streak(agent)
+        succeeded = True
+        tool_calls = [tool_calls_acc[index] for index in sorted(tool_calls_acc)]
+        return {
+            "model": model_name or api_kwargs.get("model", "unknown"),
+            "choices": [
+                {
+                    "conversation": None,
+                    "message": {
+                        "role": role,
+                        "content": "".join(content_parts) or None,
+                        "reasoning_content": "".join(reasoning_parts) or None,
+                        "tool_calls": tool_calls or None,
+                    },
+                    "finish_reason": finish_reason or "stop",
+                }
+            ],
+            "usage": usage_obj,
+        }
+    except Exception as e:
+        if getattr(agent, "_interrupt_requested", False):
+            raise InterruptedError("Agent interrupted during API call") from None
+        with request_client_lock:
+            was_stale = request_state["stale"]
+        if was_stale:
+            raise TimeoutError(
+                f"Streaming API call timed out after "
+                f"{int(time.time() - call_start)}s with no response "
+                f"(threshold: {int(stale_timeout)}s)"
+            ) from None
+        _err_lower = str(e).lower()
+        _is_stream_unsupported = "stream" in _err_lower and "not supported" in _err_lower
+        if _is_stream_unsupported:
+            agent._disable_streaming = True
+        elif not stream_opened["v"]:
+            # Transient open failure: one non-streaming inline attempt for
+            # THIS call; the error re-raises if it too fails.
+            logger.warning(
+                "Direct stream open failed (%s); falling back to inline "
+                "non-streaming for this call",
+                e,
+            )
+            return direct_api_call(agent, api_kwargs)
+        raise
+    finally:
+        if stale_watchdog is not None:
+            stale_watchdog.cancel()
+        if stream is not None and not succeeded:
+            try:
+                stream.close()
+            except Exception:
+                pass
+        with request_client_lock:
+            request_state["done"] = True
+        activity_hb_stop.set()
+        activity_hb.join(timeout=2.0)
+        if getattr(agent, "_active_request_abort", None) is _abort_active_request:
+            agent._active_request_abort = None
+        with request_client_lock:
+            request_client = request_state["client"]
+            request_state["client"] = None
+        if request_client is not None:
+            agent._close_request_openai_client(
+                request_client,
+                reason="request_complete" if succeeded else "request_error_cleanup",
+            )
+
+
 def interruptible_api_call(agent, api_kwargs: dict):
     """
     Run the API call in a background thread so the main conversation loop
@@ -1348,9 +1638,11 @@ def interruptible_api_call(agent, api_kwargs: dict):
     """
     # Cron and other non-interactive, nested-pool contexts must not spawn the
     # interrupt worker — it wedges before the socket opens on the 2nd+ call
-    # (#62151). Run inline instead. See should_use_direct_api_call.
+    # (#62151). Run inline instead — the streaming inline variant keeps the
+    # connection alive for keepalive-hungry proxies. See
+    # direct_streaming_api_call / should_use_direct_api_call.
     if should_use_direct_api_call(agent):
-        return direct_api_call(agent, api_kwargs)
+        return direct_streaming_api_call(agent, api_kwargs)
 
     result = {"response": None, "error": None}
 
@@ -3323,13 +3615,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             emit(final_text=final_text, finished=finished, error=error)
 
     # Cron and other non-interactive, nested-pool contexts deadlock on the
-    # spawned worker thread (#62151). They also have no stream consumer, so the
-    # deltas this path produces go nowhere. Delegate to the non-streaming entry
-    # (which runs inline via should_use_direct_api_call) exactly like the codex
-    # branch below — routing through the _interruptible_api_call method keeps the
-    # outer loop's per-request retry/refresh seam intact.
+    # spawned worker thread (#62151). Delegate to the INLINE streaming
+    # entry instead of the silent non-streaming one: inline SSE consumption
+    # spawns no thread (deadlock class stays closed) while keeping bytes
+    # flowing so keepalive-hungry proxies (z.ai edge → HTTP 524) never kill
+    # the connection. Falls back to non-streaming when the provider truly
+    # does not support streaming.
     if should_use_direct_api_call(agent):
-        return agent._interruptible_api_call(api_kwargs)
+        return direct_streaming_api_call(agent, api_kwargs)
 
     if agent.api_mode == "codex_responses":
         # Codex streams internally via _run_codex_stream. The main dispatch

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1390,6 +1390,8 @@ def direct_streaming_api_call(agent, api_kwargs: dict):
     model_name = None
     role = "assistant"
     usage_obj = None
+    first_chunk_id = None
+    created_ts = None
     last_chunk_time = {"t": time.time()}
     call_start = time.time()
     stream_opened = {"v": False}
@@ -1447,7 +1449,14 @@ def direct_streaming_api_call(agent, api_kwargs: dict):
         # alive, and the accumulated response is returned to the loop).
         last_chunk_time["t"] = time.time()
         nonlocal finish_reason, model_name, role, usage_obj
+        nonlocal first_chunk_id, created_ts
         try:
+            _cid = getattr(chunk, "id", None)
+            if _cid and first_chunk_id is None:
+                first_chunk_id = _cid
+            _cts = getattr(chunk, "created", None)
+            if _cts:
+                created_ts = _cts
             choices = getattr(chunk, "choices", None)
             if choices:
                 first = choices[0]
@@ -1557,22 +1566,52 @@ def direct_streaming_api_call(agent, api_kwargs: dict):
         _reset_stale_streak(agent)
         succeeded = True
         tool_calls = [tool_calls_acc[index] for index in sorted(tool_calls_acc)]
-        return {
+        # Reconstruct a real SDK ChatCompletion, not a dict: the conversation
+        # loop's post-processing contract is attribute-style access on the
+        # response object — including vars(response) in the invalid-response
+        # diagnostics path (conversation_loop.py ~3280) — and the loop's
+        # validity probes (hasattr(response, 'choices') ...) classify a plain
+        # dict as an invalid response. direct_api_call returns the raw SDK
+        # object (line ~1315); match that contract exactly.
+        from openai.types.chat import ChatCompletion, ChatCompletionMessage
+
+        _finish = finish_reason or "stop"
+        if _finish not in {"stop", "length", "tool_calls", "content_filter", "function_call"}:
+            _finish = "stop"
+        _usage = usage_obj
+        if isinstance(_usage, dict):
+            from openai.types.completion_usage import CompletionUsage
+
+            try:
+                _usage = CompletionUsage(**_usage)
+            except Exception:
+                _usage = None
+        message_kwargs = {
+            "role": role,
+            "content": "".join(content_parts) or None,
+        }
+        if tool_calls:
+            message_kwargs["tool_calls"] = tool_calls
+        if reasoning_parts:
+            # Extra field on the SDK model (extra="allow"); preserves GLM
+            # reasoning the same way the Relay path delivers it.
+            message_kwargs["reasoning_content"] = "".join(reasoning_parts)
+        completion_kwargs = {
+            "id": first_chunk_id or f"chatcmpl-direct-stream-{int(call_start)}",
+            "created": created_ts or int(call_start),
             "model": model_name or api_kwargs.get("model", "unknown"),
+            "object": "chat.completion",
             "choices": [
                 {
-                    "conversation": None,
-                    "message": {
-                        "role": role,
-                        "content": "".join(content_parts) or None,
-                        "reasoning_content": "".join(reasoning_parts) or None,
-                        "tool_calls": tool_calls or None,
-                    },
-                    "finish_reason": finish_reason or "stop",
+                    "index": 0,
+                    "message": ChatCompletionMessage(**message_kwargs),
+                    "finish_reason": _finish,
                 }
             ],
-            "usage": usage_obj,
         }
+        if _usage is not None:
+            completion_kwargs["usage"] = _usage
+        return ChatCompletion(**completion_kwargs)
     except Exception as e:
         if getattr(agent, "_interrupt_requested", False):
             raise InterruptedError("Agent interrupted during API call") from None

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1762,6 +1762,18 @@ def run_conversation(
     agent._last_compression_attempt_recorded = False
     agent._last_compression_attempt_in_place = None
 
+    # Per-turn reset of the #25723 session-permanent streaming fallback:
+    # one transient "stream not supported" error must not strand the whole
+    # session on silent non-streaming calls — fatal behind proxies that kill
+    # idle connections (z.ai edge ~180-210s → HTTP 524). Scoped per turn so
+    # the within-turn retry fallback (#24532) still works as designed.
+    if getattr(agent, "_disable_streaming", False):
+        logger.info(
+            "Re-enabling streaming for new turn — previous fallback "
+            "was scoped to the prior turn only (#25723)."
+        )
+        agent._disable_streaming = False
+
     # If a background memory/skill review spawned at the end of a PRIOR turn
     # (agent/background_review.py) is still running its own run_conversation()
     # when THIS turn starts, cancel it now rather than letting both make

--- a/run_agent.py
+++ b/run_agent.py
@@ -8336,6 +8336,29 @@ class AIAgent:
                 logger.debug("Conversation root lineage walk failed", exc_info=True)
         return start
 
+    def _reset_streaming_disable_for_new_turn(self) -> None:
+        """Reset the per-session ``_disable_streaming`` fallback at the start
+        of each user turn (#25723).
+
+        Without this, a single transient "stream not supported" error during
+        a session permanently disables streaming for every subsequent turn.
+        That compounds badly with upstream proxies that kill silent non-
+        stream connections (e.g. z.ai's ~180s edge timeout) — the agent ends
+        up looping on non-streaming requests that always die at the proxy
+        boundary.
+
+        Re-enabling streaming per turn costs at most one extra failed retry
+        for providers that truly don't support streaming, and those users
+        already have a permanent opt-out via ``display.streaming: false``
+        in ``config.yaml``.
+        """
+        if getattr(self, "_disable_streaming", False):
+            logger.info(
+                "Re-enabling streaming for new turn — previous fallback "
+                "was scoped to the prior turn only (#25723)."
+            )
+            self._disable_streaming = False
+
     def run_conversation(
         self,
         user_message: Any,

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -432,6 +432,58 @@ class TestStreamingFallback:
         agent._reset_streaming_disable_for_new_turn()
         assert not getattr(agent, "_disable_streaming", False)
 
+    def test_direct_streaming_api_call_accumulates_chunks(self):
+        """#25723 sibling: delegated children take the inline streaming path;
+        it must consume SSE chunks inline and return a complete response."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+        from agent import chat_completion_helpers as h
+
+        def mk_chunk(content=None, reasoning=None, tool=None, finish=None):
+            delta = SimpleNamespace(
+                role="assistant", content=content,
+                reasoning_content=reasoning,
+                tool_calls=[tool] if tool else None,
+            )
+            first = SimpleNamespace(delta=delta, finish_reason=finish)
+            return SimpleNamespace(choices=[first], usage=None, model="test-model")
+
+        def mk_tool(cid, name, args):
+            return SimpleNamespace(
+                index=0, id=cid,
+                function=SimpleNamespace(name=name, arguments=args),
+            )
+
+        chunks = [
+            mk_chunk(reasoning="thinking..."),
+            mk_chunk(content="Hello "),
+            mk_chunk(content="world"),
+            mk_chunk(tool=mk_tool("call_1", "read_file", '{"path": "')),
+            mk_chunk(tool=mk_tool(None, None, 'a.py"}')),
+            mk_chunk(finish="tool_calls"),
+        ]
+
+        agent = MagicMock()
+        agent._disable_streaming = False
+        agent._interrupt_requested = False
+        client = MagicMock()
+        client.chat.completions.create.side_effect = lambda **kw: iter(chunks)
+        agent._create_request_openai_client.return_value = client
+
+        with patch.object(h, "_resolve_direct_stale_timeout", return_value=90.0):
+            response = h.direct_streaming_api_call(agent, {"model": "test-model"})
+
+        msg = response["choices"][0]["message"]
+        assert msg["content"] == "Hello world"
+        assert msg["reasoning_content"] == "thinking..."
+        assert msg["tool_calls"][0]["function"]["name"] == "read_file"
+        assert msg["tool_calls"][0]["function"]["arguments"] == '{"path": "a.py"}'
+        assert response["choices"][0]["finish_reason"] == "tool_calls"
+        # The wire request must be streaming.
+        sent = client.chat.completions.create.call_args
+        assert sent.kwargs.get("stream") is True
+
+
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -473,12 +473,17 @@ class TestStreamingFallback:
         with patch.object(h, "_resolve_direct_stale_timeout", return_value=90.0):
             response = h.direct_streaming_api_call(agent, {"model": "test-model"})
 
-        msg = response["choices"][0]["message"]
-        assert msg["content"] == "Hello world"
-        assert msg["reasoning_content"] == "thinking..."
-        assert msg["tool_calls"][0]["function"]["name"] == "read_file"
-        assert msg["tool_calls"][0]["function"]["arguments"] == '{"path": "a.py"}'
-        assert response["choices"][0]["finish_reason"] == "tool_calls"
+        msg = response.choices[0].message
+        assert msg.content == "Hello world"
+        assert msg.reasoning_content == "thinking..."
+        assert msg.tool_calls[0].function.name == "read_file"
+        assert msg.tool_calls[0].function.arguments == '{"path": "a.py"}'
+        assert response.choices[0].finish_reason == "tool_calls"
+        # Regression (probe #2, 2026-08-19): the conversation loop's
+        # invalid-response diagnostics call vars(response) — a plain dict
+        # return raised TypeError there after a full streamed generation.
+        assert hasattr(response, "choices") and hasattr(response, "model")
+        _ = {k: v for k, v in vars(response).items() if not k.startswith("_")}
         # The wire request must be streaming.
         sent = client.chat.completions.create.call_args
         assert sent.kwargs.get("stream") is True

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -397,6 +397,41 @@ class TestStreamingFallback:
         # The flag should be set so the main retry loop switches to non-streaming
         assert agent._disable_streaming is True
 
+    def test_reset_streaming_disable_for_new_turn_clears_flag(self):
+        """#25723: new user turns must re-attempt streaming so a single
+        false-positive fallback can't strand the whole session on
+        non-streaming behind a proxy that kills silent connections."""
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent._disable_streaming = True
+        agent._reset_streaming_disable_for_new_turn()
+        assert agent._disable_streaming is False
+
+    def test_reset_streaming_disable_noop_when_unset(self):
+        """#25723: the reset must be safe to call when the flag was never
+        set, so we don't pay a log line for every healthy turn."""
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        assert not getattr(agent, "_disable_streaming", False)
+        agent._reset_streaming_disable_for_new_turn()
+        assert not getattr(agent, "_disable_streaming", False)
+
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")


### PR DESCRIPTION
## What does this PR do?

Delegated subagents and cron turns make LLM calls through the inline `direct_api_call` path, which is non-streaming by design (no stream consumer, no worker thread). That design misses that streaming is also a transport keepalive: providers fronted by aggressive edge proxies (z.ai via Cloudflare, ~205–230s idle timeout) kill silent POSTs with HTTP 524. After three retries in the same silent mode, the child dies — mislabeled as `max_iterations`. Interactive/CLI/gateway sessions stream via the interrupt worker and are unaffected.

Three commits:

1. Scope `_disable_streaming` to per-turn instead of per-session — the flag-poisoning half of #25723 (mirrors the intent of unmerged #25771).
2. Add `direct_streaming_api_call()`: same inline, no-worker-thread shape (nested-pool deadlock classes #62151 / #60203 stay closed), but `stream: True` on the wire with the SSE iterator consumed inline and chunks accumulated into a complete response. Both routers (`_interruptible_streaming_api_call`, `interruptible_api_call`) send direct-path contexts to it. Stream-open failure falls back to the existing non-streaming body for that call.
3. Return a real SDK `ChatCompletion` from (2): a dict return reaches the invalid-response diagnostics and crashes on `vars(response)` (agent/conversation_loop.py:3280).

## Related Issue

Fixes #25723

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` — per-turn `_disable_streaming` reset helper + call sites; new `direct_streaming_api_call()` (inline SSE accumulation → SDK `ChatCompletion`); both routers route direct-path calls to it
- `agent/conversation_loop.py` — invoke the per-turn reset at the turn seam
- `run_agent.py` — expose the reset on the agent forwarder
- `tests/run_agent/test_streaming.py` — #25723 reset tests; chunk-accumulation test with `vars(response)` regression assert

## How to Test

Unit:

```
pytest tests/run_agent/test_streaming.py tests/agent/test_cron_inline_api_call_62151.py \
       tests/agent/test_api_content_sidecar.py tests/agent/test_chat_completion_helpers_provider_sort.py -q
# 72 passed
```

Live (z.ai `glm-5.3`, delegated child instructed to produce one large `write_file` in a single turn — the task shape that died reliably):

- Before: 3× HTTP 524 after ~205–230s silent POSTs → child dead at ~12 min.
- After: 239s streamed call, zero 524; end-to-end run completed with a 55 KB single-file write and clean exit.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — #25771 / #25797 cover only the flag-poisoning half (unmerged); the non-streaming direct path itself is addressed here
- [x] My PR contains only changes related to this fix (3 commits)
- [x] I've run `pytest tests/ -q` and all tests pass (result posted in PR comments)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A (internal request path; docstrings updated in-code)
- [ ] I've updated `cli-config.yaml.example` — N/A (no new config keys)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [ ] I've considered cross-platform impact — N/A (pure Python/SDK, no OS-specific code)
- [ ] I've updated tool descriptions/schemas — N/A (no tool surface change)

## Screenshots / Logs

Before (child death, `~/.hermes/logs/agent.log`):

```
API call failed ... provider=zai model=glm-5.3 summary=HTTP 524  (×3, ~205–230s silent each)
[subagent-0] Non-retryable client error: HTTP 524 → exit_reason=max_iterations
```

After (probe, same task shape): single streamed call 239s, 3 API calls total, clean `status=completed`.
