### PR TITLE
fix(desktop): keep Sessions workspace when opening a Bot Chat

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -62,12 +62,14 @@ import {
   $selectedStoredSessionId,
   $sessionResumeRequest,
   $sessions,
+  rememberedSessionProfile,
   sessionMatchesStoredId,
   sessionPinId,
   setAwaitingResponse,
   setBusy,
   setMessages
 } from '@/store/session'
+import { requestForSessionProfile } from '@/store/session-request-router'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord, stopClientCapture } from '@/store/wake-word'
 import { isAuxiliaryWindow, isHudWindow } from '@/store/windows'
@@ -279,7 +281,22 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     setMessages
   })
 
-  const { connectionRef, gateway, gatewayRef, requestGateway } = useGatewayRequest()
+  const { connectionRef, gateway, gatewayRef, requestGateway: ambientRequestGateway } = useGatewayRequest()
+
+  // When chrome stays on the launch backend (Bot Mode / all-profiles
+  // navigation), session-owned RPCs still have to hit the session's backend.
+  const requestGateway = useCallback(
+    <T,>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal) => {
+      const owner = rememberedSessionProfile(
+        $sessions.get(),
+        selectedStoredSessionIdRef.current,
+        $activeGatewayProfile.get()
+      )
+
+      return requestForSessionProfile<T>(owner, ambientRequestGateway, method, params ?? {}, timeoutMs, signal)
+    },
+    [ambientRequestGateway]
+  )
 
   const { loadMoreMessagingForPlatform, loadMoreSessions, refreshCronJobs, refreshMessagingSessions, refreshSessions } =
     useSessionListActions({ profileScope })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -13,6 +13,7 @@ import { setSessionYolo } from '@/lib/yolo-session'
 import { normalizeChoices, setClarifyRequest } from '@/store/clarify'
 import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
+import { openGatewayForAgent, openGatewayForProfile } from '@/store/gateway'
 import { $gatewaySwitching } from '@/store/gateway-switch'
 import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
@@ -20,6 +21,7 @@ import {
   $activeGatewayProfile,
   $gatewaySwapTarget,
   $newChatProfile,
+  $showAllProfiles,
   ensureGatewayAgent,
   ensureGatewayProfile,
   normalizeProfileKey
@@ -740,7 +742,15 @@ export function useSessionActions({
       // A row spliced from a CONNECTED registry gateway (#88880) carries its
       // owning connection — activate THAT gateway, not a same-named local
       // profile. Rows without the tag keep the legacy profile path.
-      if (storedForProfile?.connection_id) {
+      // All-profiles / plugin navigation must not steal chrome API-home:
+      // dial the owning backend without moving $activeGatewayProfile.
+      if ($showAllProfiles.get()) {
+        if (storedForProfile?.connection_id) {
+          await openGatewayForAgent(storedForProfile.connection_id, sessionProfile || 'default')
+        } else if (sessionProfile) {
+          await openGatewayForProfile(normalizeProfileKey(sessionProfile))
+        }
+      } else if (storedForProfile?.connection_id) {
         await ensureGatewayAgent(storedForProfile.connection_id, sessionProfile || 'default')
       } else {
         await ensureGatewayProfile(sessionProfile)

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3277,7 +3277,7 @@ async function openStoredBotChat(name, storedId, summary) {
     intent: 'main',
     awaitHydration: true,
     expectHistory,
-    keepAllProfilesScope: false
+    keepAllProfilesScope: true
   })
 
   return storedId
@@ -3317,7 +3317,7 @@ function createCanonicalChat(name) {
 
     if (sid && typeof host.openSession === 'function') {
       try {
-        await host.openSession(sid, { profile: name, intent: 'main', keepAllProfilesScope: false })
+        await host.openSession(sid, { profile: name, intent: 'main', keepAllProfilesScope: true })
         opened = true
       } catch {
         // The stored row may not exist until the kickoff persists it. Retry
@@ -3332,7 +3332,7 @@ function createCanonicalChat(name) {
         await host.request('prompt.submit', { session_id: runtime, text: 'Hey, tell me about yourself!' })
 
         if (!opened && sid && typeof host.openSession === 'function') {
-          await host.openSession(sid, { profile: name, intent: 'main', keepAllProfilesScope: false })
+          await host.openSession(sid, { profile: name, intent: 'main', keepAllProfilesScope: true })
         }
       } catch {
         // The chat already exists. Keep the pin so the next click
@@ -7811,7 +7811,7 @@ async function openProfileSession(botName, session, gatewayGeneration) {
     typeof session?.message_count === 'number' && Number.isFinite(session.message_count)
   const expectHistory = hasAuthoritativeCount ? session.message_count > 0 : Boolean(session?.preview)
 
-  await host.openSession(id, { profile, awaitHydration: true, expectHistory, keepAllProfilesScope: false })
+  await host.openSession(id, { profile, awaitHydration: true, expectHistory, keepAllProfilesScope: true })
   if (gatewayGeneration !== $sessionsGatewayGeneration.get()) return
   $botSelectedSessions.set({ ...$botSelectedSessions.get(), [profile]: id })
 }

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-identity.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-identity.test.mjs
@@ -112,7 +112,7 @@ test('pin: preferred_session present opens the resolved session and keeps the pi
       intent: 'main',
       awaitHydration: true,
       expectHistory: true,
-      keepAllProfilesScope: false
+      keepAllProfilesScope: true
     }
   }])
   assert.equal(runtime.saved.length, 0, 'a live pin must not be rewritten')

--- a/apps/desktop/src/plugins/hermes-bots/tests/session-workspace.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/session-workspace.test.mjs
@@ -90,7 +90,7 @@ test('sessions workspace: opening a stored row uses profile-aware navigation and
   const runtime = load({ profile: 'default' })
   await runtime.__sessions.openProfileSession('ops', { id: 'stored-123', message_count: 4 }, 0)
   assert.deepEqual(plain(runtime.calls), [
-    ['openSession', 'stored-123', { profile: 'ops', awaitHydration: true, expectHistory: true, keepAllProfilesScope: false }]
+    ['openSession', 'stored-123', { profile: 'ops', awaitHydration: true, expectHistory: true, keepAllProfilesScope: true }]
   ])
   assert.equal(runtime.__sessions.$botSelectedSessions.get().ops, 'stored-123')
 })
@@ -117,7 +117,7 @@ test('sessions workspace: an empty session with no preview does not demand histo
   const runtime = load()
   await runtime.__sessions.openProfileSession('ops', { id: 'stored-empty', message_count: 0 }, 0)
   assert.deepEqual(plain(runtime.calls), [
-    ['openSession', 'stored-empty', { profile: 'ops', awaitHydration: true, expectHistory: false, keepAllProfilesScope: false }]
+    ['openSession', 'stored-empty', { profile: 'ops', awaitHydration: true, expectHistory: false, keepAllProfilesScope: true }]
   ])
 })
 

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -79,6 +79,8 @@ import {
 import { runGatewayRestart } from '@/store/system-actions'
 import type { UsageStats } from '@/types/hermes'
 
+import { planPluginOpenSession } from './plugin-open-session-plan'
+
 // -- state: readonly views over the app's live atoms -------------------------
 
 const readonlyAtom = <T>(atomLike: ReadableAtom<T>): ReadableAtom<T> => atomLike
@@ -232,12 +234,14 @@ function waitForFocusedSessionHydration({
   expectHistory,
   generation,
   profile,
+  requireActiveProfile,
   storedSessionId,
   timeoutMs
 }: {
   expectHistory: boolean
   generation: number
   profile: string
+  requireActiveProfile: boolean
   storedSessionId: string
   timeoutMs: number
 }): Promise<void> {
@@ -275,7 +279,8 @@ function waitForFocusedSessionHydration({
         return
       }
 
-      const profileMatches = normalizeProfileKey($activeGatewayProfile.get()) === profile
+      const profileMatches =
+        !requireActiveProfile || normalizeProfileKey($activeGatewayProfile.get()) === profile
       const sessionMatches = $selectedStoredSessionId.get() === storedSessionId
       const runtimeReady = Boolean($activeSessionId.get())
       const historyPainted = Boolean($messages.get().length)
@@ -489,14 +494,22 @@ export const host = {
     ensureGatewayAgent(connectionId, (profile ?? '').trim() || 'default'),
 
   /** Open a stored session the way core surfaces do. A plugin/Bot Mode open
-   *  is navigation, not a workspace switch — keepAllProfilesScope defaults
-   *  true so Sessions stays on the unified list (the bot forever-chat is
-   *  hidden and would otherwise look like every session disappeared). */
+   *  is navigation, not a workspace or chrome API-home switch —
+   *  keepAllProfilesScope defaults true so `$activeGatewayProfile` /
+   *  Sessions REST stay on the previous (usually launch) backend while the
+   *  bot backend is dialed in the background. The bot forever-chat is hidden
+   *  and would otherwise look like every session disappeared. Pass false to
+   *  also scope chrome onto that profile and collapse the sidebar. */
   openSession: async (storedSessionId: string, options: PluginOpenSessionOptions = {}): Promise<void> => {
     const generation = ++openSessionGeneration
     const profile = (options.profile ?? '').trim()
     const targetProfile = normalizeProfileKey(profile || $activeGatewayProfile.get())
     const expectHistory = options.expectHistory ?? false
+    const plan = planPluginOpenSession({
+      activeProfile: $activeGatewayProfile.get(),
+      keepAllProfilesScope: options.keepAllProfilesScope,
+      profile
+    })
     // Wake-path phase timings. Logged ONLY on a hydration timeout (bridged
     // into desktop.log via the renderer-console tap), so a support bundle
     // pinpoints WHERE the budget went — profile activation vs hydration —
@@ -504,15 +517,18 @@ export const host = {
     const wakeStartedAt = Date.now()
     let profileActiveAt = wakeStartedAt
 
-    if (profile && profile !== $activeGatewayProfile.get()) {
-      await ensureGatewayProfile(profile)
+    if (plan.switchWorkspace) {
+      await ensureGatewayProfile(plan.switchWorkspace)
+      profileActiveAt = Date.now()
+    } else if (plan.dialWithoutSwitching) {
+      // Dial the bot backend so session.resume can hydrate, but do not steal
+      // $activeGatewayProfile / chrome REST onto that named profile.
+      await openGatewayForProfile(plan.dialWithoutSwitching)
       profileActiveAt = Date.now()
     }
 
-    // Opening a bot/plugin chat is navigation, not a workspace switch. Always
-    // restore the unified Sessions list unless the caller opted into scoping.
-    if (profile && options.keepAllProfilesScope !== false) {
-      setShowAllProfiles(true)
+    if (plan.showAllProfiles !== null) {
+      setShowAllProfiles(plan.showAllProfiles)
     }
 
     if (generation !== openSessionGeneration) {
@@ -564,6 +580,7 @@ export const host = {
           expectHistory,
           generation,
           profile: targetProfile,
+          requireActiveProfile: plan.requireActiveProfileForHydration,
           storedSessionId,
           timeoutMs: Math.max(1, options.hydrationTimeoutMs ?? DEFAULT_SESSION_HYDRATION_TIMEOUT_MS)
         })

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -375,14 +375,6 @@ export const host = {
     window.location.hash = path.startsWith('#') ? path : `#${path}`
   },
 
-  /** Open a stored session the way core surfaces do (focus an existing
-   *  tile/main, else load into main). When `profile` names a non-active
-   *  profile, its backend is activated first so the resume routes to the
-   *  right state.db — the same soft profile swap the unified sidebar does.
-   *  `keepAllProfilesScope` (default true) keeps the Sessions sidebar in the
-   *  unified all-profiles view instead of narrowing it to the target
-   *  profile's sessions — a cross-profile open from a plugin surface is a
-   *  navigation, not a scope choice; pass false to also scope the sidebar. */
   /** Pre-dial a profile's gateway socket in the background — pool-only, no
    *  activation, no navigation, no scope change (openGatewayForProfile; it
    *  already no-ops for shared-remote routes and the primary). Roster UIs
@@ -496,6 +488,10 @@ export const host = {
   ensureAgent: async (connectionId: null | string, profile: string): Promise<void> =>
     ensureGatewayAgent(connectionId, (profile ?? '').trim() || 'default'),
 
+  /** Open a stored session the way core surfaces do. A plugin/Bot Mode open
+   *  is navigation, not a workspace switch — keepAllProfilesScope defaults
+   *  true so Sessions stays on the unified list (the bot forever-chat is
+   *  hidden and would otherwise look like every session disappeared). */
   openSession: async (storedSessionId: string, options: PluginOpenSessionOptions = {}): Promise<void> => {
     const generation = ++openSessionGeneration
     const profile = (options.profile ?? '').trim()
@@ -511,10 +507,12 @@ export const host = {
     if (profile && profile !== $activeGatewayProfile.get()) {
       await ensureGatewayProfile(profile)
       profileActiveAt = Date.now()
+    }
 
-      if (options.keepAllProfilesScope !== false) {
-        setShowAllProfiles(true)
-      }
+    // Opening a bot/plugin chat is navigation, not a workspace switch. Always
+    // restore the unified Sessions list unless the caller opted into scoping.
+    if (profile && options.keepAllProfilesScope !== false) {
+      setShowAllProfiles(true)
     }
 
     if (generation !== openSessionGeneration) {

--- a/apps/desktop/src/sdk/plugin-open-session-plan.test.ts
+++ b/apps/desktop/src/sdk/plugin-open-session-plan.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { planPluginOpenSession } from './plugin-open-session-plan.ts'
+
+test('keepAllProfilesScope defaults to navigation: dial worker, do not steal chrome', () => {
+  const plan = planPluginOpenSession({
+    profile: 'worker',
+    activeProfile: 'default'
+  })
+
+  assert.equal(plan.switchWorkspace, null)
+  assert.equal(plan.dialWithoutSwitching, 'worker')
+  assert.equal(plan.showAllProfiles, true)
+  assert.equal(plan.requireActiveProfileForHydration, false)
+})
+
+test('keepAllProfilesScope:true does not steal chrome even when the flag is explicit', () => {
+  const plan = planPluginOpenSession({
+    profile: 'worker',
+    activeProfile: 'default',
+    keepAllProfilesScope: true
+  })
+
+  assert.equal(plan.switchWorkspace, null)
+  assert.equal(plan.dialWithoutSwitching, 'worker')
+  assert.equal(plan.showAllProfiles, true)
+  assert.equal(plan.requireActiveProfileForHydration, false)
+})
+
+test('keepAllProfilesScope:true does not re-dial when chrome is already on that profile', () => {
+  const plan = planPluginOpenSession({
+    profile: 'worker',
+    activeProfile: 'worker',
+    keepAllProfilesScope: true
+  })
+
+  assert.equal(plan.switchWorkspace, null)
+  assert.equal(plan.dialWithoutSwitching, null)
+  assert.equal(plan.showAllProfiles, true)
+})
+
+test('keepAllProfilesScope:false is an explicit workspace switch and collapses the sidebar', () => {
+  const plan = planPluginOpenSession({
+    profile: 'worker',
+    activeProfile: 'default',
+    keepAllProfilesScope: false
+  })
+
+  assert.equal(plan.switchWorkspace, 'worker')
+  assert.equal(plan.dialWithoutSwitching, null)
+  assert.equal(plan.showAllProfiles, false)
+  assert.equal(plan.requireActiveProfileForHydration, true)
+})
+
+test('an empty profile is neither a dial nor a workspace switch', () => {
+  const plan = planPluginOpenSession({
+    profile: '  ',
+    activeProfile: 'default',
+    keepAllProfilesScope: true
+  })
+
+  assert.equal(plan.switchWorkspace, null)
+  assert.equal(plan.dialWithoutSwitching, null)
+  assert.equal(plan.showAllProfiles, null)
+})

--- a/apps/desktop/src/sdk/plugin-open-session-plan.ts
+++ b/apps/desktop/src/sdk/plugin-open-session-plan.ts
@@ -1,0 +1,50 @@
+/** How `host.openSession` should treat a named profile.
+
+A plugin/Bot Mode open is navigation, not a workspace or chrome API-home
+switch. `keepAllProfilesScope` defaults true (undefined counts as true).
+Pass false for an explicit profile workspace switch. */
+export interface PluginOpenSessionPlan {
+  /** Dial this profile's backend without making it chrome-home. */
+  dialWithoutSwitching: null | string
+  /** Hydration may wait until `$activeGatewayProfile` matches the target. */
+  requireActiveProfileForHydration: boolean
+  /** Unified Sessions list vs collapse onto the switched profile. Null = leave. */
+  showAllProfiles: boolean | null
+  /** Activate this profile as the workspace/API home. Null = do not steal chrome. */
+  switchWorkspace: null | string
+}
+
+export function planPluginOpenSession(input: {
+  activeProfile: string
+  keepAllProfilesScope?: boolean
+  profile: string
+}): PluginOpenSessionPlan {
+  const profile = (input.profile ?? '').trim()
+  const activeProfile = (input.activeProfile ?? '').trim()
+  const keepWorkspace = input.keepAllProfilesScope !== false
+
+  if (!profile) {
+    return {
+      dialWithoutSwitching: null,
+      requireActiveProfileForHydration: false,
+      showAllProfiles: null,
+      switchWorkspace: null
+    }
+  }
+
+  if (keepWorkspace) {
+    return {
+      dialWithoutSwitching: profile !== activeProfile ? profile : null,
+      requireActiveProfileForHydration: false,
+      showAllProfiles: true,
+      switchWorkspace: null
+    }
+  }
+
+  return {
+    dialWithoutSwitching: null,
+    requireActiveProfileForHydration: true,
+    showAllProfiles: false,
+    switchWorkspace: profile
+  }
+}

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -104,7 +104,7 @@ const { openSession: openSessionCore } = await import('@/app/open-session')
 const { deleteProfile } = await import('@/hermes')
 const { requestGatewayForAgent, requestGatewayForProfile, retireLocalProfileGateways } = await import('@/store/gateway')
 
-const { $activeGatewayProfile, $gatewaySwapTarget, $profiles, ensureGatewayProfile, refreshProfiles } =
+const { $activeGatewayProfile, $gatewaySwapTarget, $profiles, ensureGatewayProfile, refreshProfiles, setShowAllProfiles } =
   await import('@/store/profile')
 
 const { $focusedRuntimeId, $focusedSessionState, $focusedStoredSessionId } = await import('@/store/session-states')
@@ -503,5 +503,21 @@ describe('profile-aware plugin session opens', () => {
     expect($activeGatewayProfile.get()).toBe('hyoseob')
     expect($selectedStoredSessionId.get()).toBe('chat-b')
     expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
+  it('keeps the Sessions sidebar in all-profiles even when the bot is already live', async () => {
+    $activeGatewayProfile.set('hyoseob')
+    setMockAtom($selectedStoredSessionId, 'bot-chat')
+    setMockAtom($activeSessionId, 'runtime-live')
+    setMockAtom($messages, [{ id: 'history', parts: [], role: 'assistant' }] as never)
+
+    await host.openSession('bot-chat', {
+      profile: 'hyoseob',
+      awaitHydration: true,
+      expectHistory: true,
+      hydrationTimeoutMs: 1_000
+    })
+
+    expect(setShowAllProfiles).toHaveBeenCalledWith(true)
   })
 })

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -102,7 +102,8 @@ vi.mock('@/store/gateway', async () => {
 const { host } = await import('./index')
 const { openSession: openSessionCore } = await import('@/app/open-session')
 const { deleteProfile } = await import('@/hermes')
-const { requestGatewayForAgent, requestGatewayForProfile, retireLocalProfileGateways } = await import('@/store/gateway')
+const { openGatewayForProfile, requestGatewayForAgent, requestGatewayForProfile, retireLocalProfileGateways } =
+  await import('@/store/gateway')
 
 const { $activeGatewayProfile, $gatewaySwapTarget, $profiles, ensureGatewayProfile, refreshProfiles, setShowAllProfiles } =
   await import('@/store/profile')
@@ -500,9 +501,51 @@ describe('profile-aware plugin session opens', () => {
 
     await second
     expect(await firstOutcome).toMatch(/superseded/i)
-    expect($activeGatewayProfile.get()).toBe('hyoseob')
+    expect($activeGatewayProfile.get()).toBe('remote-worker')
     expect($selectedStoredSessionId.get()).toBe('chat-b')
     expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
+  it('keeps chrome API home on the previous profile when opening a Bot Chat', async () => {
+    $activeGatewayProfile.set('default')
+
+    await host.openSession('bot-chat', {
+      profile: 'worker',
+      keepAllProfilesScope: true
+    })
+
+    expect(ensureGatewayProfile).not.toHaveBeenCalled()
+    expect(openGatewayForProfile).toHaveBeenCalledWith('worker')
+    expect(setShowAllProfiles).toHaveBeenCalledWith(true)
+    expect($activeGatewayProfile.get()).toBe('default')
+  })
+
+  it('defaults keepAllProfilesScope to navigation instead of a workspace switch', async () => {
+    $activeGatewayProfile.set('default')
+
+    await host.openSession('bot-chat', { profile: 'worker' })
+
+    expect(ensureGatewayProfile).not.toHaveBeenCalled()
+    expect(openGatewayForProfile).toHaveBeenCalledWith('worker')
+    expect(setShowAllProfiles).toHaveBeenCalledWith(true)
+    expect($activeGatewayProfile.get()).toBe('default')
+  })
+
+  it('still switches workspace when keepAllProfilesScope is false', async () => {
+    $activeGatewayProfile.set('default')
+    vi.mocked(ensureGatewayProfile).mockImplementationOnce(async (target: null | string | undefined) => {
+      $activeGatewayProfile.set(target || 'default')
+    })
+
+    await host.openSession('stored-worker', {
+      profile: 'worker',
+      keepAllProfilesScope: false
+    })
+
+    expect(ensureGatewayProfile).toHaveBeenCalledWith('worker')
+    expect(openGatewayForProfile).not.toHaveBeenCalled()
+    expect(setShowAllProfiles).toHaveBeenCalledWith(false)
+    expect($activeGatewayProfile.get()).toBe('worker')
   })
 
   it('keeps the Sessions sidebar in all-profiles even when the bot is already live', async () => {

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -573,7 +573,9 @@ async function gatewayForProfile(
 export async function requestGatewayForProfile<T>(
   profile: string,
   method: string,
-  params: Record<string, unknown> = {}
+  params: Record<string, unknown> = {},
+  timeoutMs?: number,
+  signal?: AbortSignal
 ): Promise<T> {
   const route = await gatewayForProfile(profile, true)
 
@@ -584,7 +586,7 @@ export async function requestGatewayForProfile<T>(
 
     const routedParams = route.scopeProfile ? { ...params, profile: route.key } : params
 
-    return await route.gateway.request<T>(method, routedParams)
+    return await route.gateway.request<T>(method, routedParams, timeoutMs, signal)
   } finally {
     route.release()
   }

--- a/apps/desktop/src/store/session-request-router.test.ts
+++ b/apps/desktop/src/store/session-request-router.test.ts
@@ -167,6 +167,37 @@ describe('requestForSessionProfile', () => {
     expect(secondaryGateways[0].request).toHaveBeenCalledWith('session.resume', { session_id: 'stored-loki-chat' })
   })
 
+  it('forwards timeout and abort signal onto the owning profile socket', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    installDesktop()
+    await ensureGatewayForProfile('default')
+
+    const ambient = vi.fn(async (method: string, params?: Record<string, unknown>) => ({
+      ambient: true,
+      method,
+      params
+    }))
+    const controller = new AbortController()
+
+    await requestForSessionProfile(
+      'loki',
+      ambient as never,
+      'prompt.submit',
+      { session_id: 'stored-loki-chat', text: 'hi' },
+      1_800_000,
+      controller.signal
+    )
+
+    expect(ambient).not.toHaveBeenCalled()
+    expect(secondaryGateways[0].request).toHaveBeenCalledWith(
+      'prompt.submit',
+      { session_id: 'stored-loki-chat', text: 'hi' },
+      1_800_000,
+      controller.signal
+    )
+  })
+
   it('keeps the ambient dispatcher when the active route already serves the owner', async () => {
     const primary = makePrimary()
     setPrimaryGateway(primary as never, 'default')

--- a/apps/desktop/src/store/session-request-router.ts
+++ b/apps/desktop/src/store/session-request-router.ts
@@ -40,13 +40,20 @@ export function sessionRpcNeedsProfileRoute(
  */
 export function requestForSessionProfile<T>(
   ownerProfile: null | string | undefined,
-  ambientRequest: <R>(method: string, params?: Record<string, unknown>) => Promise<R>,
+  ambientRequest: <R>(
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+    signal?: AbortSignal
+  ) => Promise<R>,
   method: string,
-  params: Record<string, unknown> = {}
+  params: Record<string, unknown> = {},
+  timeoutMs?: number,
+  signal?: AbortSignal
 ): Promise<T> {
   if (!sessionRpcNeedsProfileRoute(ownerProfile)) {
-    return ambientRequest<T>(method, params)
+    return ambientRequest<T>(method, params, timeoutMs, signal)
   }
 
-  return requestGatewayForProfile<T>(normKey(ownerProfile), method, params)
+  return requestGatewayForProfile<T>(normKey(ownerProfile), method, params, timeoutMs, signal)
 }


### PR DESCRIPTION
## Summary

Opening a Bot Mode chat was treated as a workspace switch. That scoped the live sidebar and chrome REST onto the bot profile. The bot forever-chat is hidden, so Sessions looked empty and the roster disappeared.

This follow-up goes further than flipping `keepAllProfilesScope`:

- `keepAllProfilesScope` (default true) is navigation only. Dial the bot backend in the background. Do **not** move `$activeGatewayProfile` / chrome REST.
- Session-owned RPCs (`prompt.submit`, resume) still go to the session owner.
- `keepAllProfilesScope: false` remains an explicit workspace switch.

Related: #89789. Named-profile writes into the launch `state.db` are covered by #90219, not this PR.

## Test plan

- [x] `node --test` plugin + plan tests — 27 passed
- [x] Added vitest contracts in `profile-routing.test.ts` and `session-request-router.test.ts` (CI)