### PR TITLE
fix(update): run the Windows update hand-off unattended

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8834,6 +8834,15 @@ def _reexec_update_off_windows_shim() -> bool:
     prints its own result, and ``--gateway`` writes the true exit code to
     ``.update_exit_code`` for the gateway watcher before restarting.
 
+    It also runs unattended, with stdin closed. The child inherits the
+    console, so left alone ``sys.stdin.isatty()`` still reports a terminal and
+    the update asks its local-changes question — but this process has already
+    exited and the shell has taken the console back, so the prompt cannot be
+    answered and the update hangs forever. Closing stdin makes the update take
+    the same path it takes for the gateway and Desktop: honour
+    ``updates.non_interactive_local_changes`` (stash by default, nothing lost)
+    and keep going.
+
     Anything that stops the hand-off (no venv python, spawn refused) falls
     through to the old in-process behaviour with the manual command printed,
     so a broken venv still gets whatever the update can do rather than a
@@ -8851,12 +8860,19 @@ def _reexec_update_off_windows_shim() -> bool:
     cmd = [str(python_exe), "-m", "hermes_cli.main", *sys.argv[1:]]
     if python_exe.is_file():
         try:
-            subprocess.Popen(cmd, env={**os.environ, _UPDATE_REEXEC_ENV: "1"})
+            subprocess.Popen(
+                cmd,
+                env={**os.environ, _UPDATE_REEXEC_ENV: "1"},
+                stdin=subprocess.DEVNULL,
+            )
             print(
                 f"→ Windows: {shim.name} cannot replace itself while it runs; "
                 "continuing the update under the venv Python."
             )
-            print("  Progress continues below; this shell returns immediately.")
+            print(
+                "  It runs unattended from here — progress prints below and "
+                "this shell returns right away."
+            )
             return True
         except OSError as exc:
             logger.debug("Update re-exec via %s failed: %s", python_exe, exc)

--- a/tests/hermes_cli/test_update_shim_self_lock.py
+++ b/tests/hermes_cli/test_update_shim_self_lock.py
@@ -60,7 +60,7 @@ def _capture_popen(monkeypatch, raises: Exception | None = None):
     def fake_popen(cmd, env=None, **kwargs):
         if raises is not None:
             raise raises
-        calls.append((list(cmd), dict(env or {})))
+        calls.append((list(cmd), dict(env or {}), kwargs))
         return object()
 
     monkeypatch.setattr(cli_main.subprocess, "Popen", fake_popen)
@@ -130,12 +130,21 @@ def test_reexec_runs_same_args_under_venv_python(venv, monkeypatch, capsys):
     calls = _capture_popen(monkeypatch)
 
     assert cli_main._reexec_update_off_windows_shim() is True
-    cmd, env = calls[0]
+    cmd, env, kwargs = calls[0]
     assert cmd == [
         str(venv / "python.exe"), "-m", "hermes_cli.main", "update", "--yes",
     ]
     assert env[cli_main._UPDATE_REEXEC_ENV] == "1"
     assert "under the venv Python" in capsys.readouterr().out
+
+
+def test_reexec_child_runs_unattended(venv, monkeypatch):
+    """The parent exits, so a prompt in the child could never be answered."""
+    monkeypatch.setattr(sys, "argv", [str(venv / "hermes.exe"), "update"])
+    calls = _capture_popen(monkeypatch)
+
+    assert cli_main._reexec_update_off_windows_shim() is True
+    assert calls[0][2]["stdin"] is cli_main.subprocess.DEVNULL
 
 
 def test_reexec_does_not_recurse(venv, monkeypatch):


### PR DESCRIPTION
Follow-up to #90192, which made `hermes update` on Windows re-run itself under the venv Python so it stops locking its own launcher. That hand-off left one thing broken, and the result is worse than the bug it replaced.

The re-exec'd child inherits the console, so `sys.stdin.isatty()` still reports a terminal and the update asks its local-changes question ("Restore local changes now?"). By then the parent shim has exited and the shell has reclaimed the console, so keystrokes go to the prompt rather than to the update. It waits forever, and nothing recovers without closing the window.

Spawning the child with stdin closed puts it on the same path the gateway and Desktop updates already take: honour `updates.non_interactive_local_changes`, which stashes by default so nothing is lost, and continue without asking. An update the user cannot talk to must not ask questions.

Reported against a live Windows 11 install, where it turned the first successful hand-off into a hang.