### PR TITLE
feat: native audio and voice routing for multimodal models

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -311,16 +311,9 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
             fmt = str(audio_info.get("format") or "").strip().lower()
             if not isinstance(encoded, str) or not encoded:
                 continue
-            if fmt == "mp3" or fmt == "mpeg":
-                mime = "audio/mpeg"
-            elif fmt in {"ogg", "oga", "opus"}:
-                mime = "audio/ogg"
-            elif fmt == "wav":
-                mime = "audio/wav"
-            elif "/" in fmt:
-                mime = fmt
-            else:
-                mime = f"audio/{fmt or 'mpeg'}"
+            from agent.media_routing import normalize_audio_mime
+
+            mime = normalize_audio_mime(fmt)
             parts.append(
                 {
                     "inlineData": {

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -281,8 +281,14 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
             text = item.get("text")
             if isinstance(text, str) and text:
                 parts.append({"text": text})
-        elif ptype == "image_url":
-            url = ((item.get("image_url") or {}).get("url") or "")
+        elif ptype in {"image_url", "video_url", "file"}:
+            url = ""
+            if ptype == "image_url":
+                url = ((item.get("image_url") or {}).get("url") or "")
+            elif ptype == "video_url":
+                url = ((item.get("video_url") or {}).get("url") or "")
+            elif ptype == "file":
+                url = ((item.get("file") or {}).get("file_data") or "")
             if not isinstance(url, str) or not url.startswith("data:"):
                 continue
             try:
@@ -296,6 +302,30 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
                     "inlineData": {
                         "mimeType": mime,
                         "data": base64.b64encode(raw).decode("ascii"),
+                    }
+                }
+            )
+        elif ptype == "input_audio":
+            audio_info = item.get("input_audio") or {}
+            encoded = audio_info.get("data")
+            fmt = str(audio_info.get("format") or "").strip().lower()
+            if not isinstance(encoded, str) or not encoded:
+                continue
+            if fmt == "mp3" or fmt == "mpeg":
+                mime = "audio/mpeg"
+            elif fmt in {"ogg", "oga", "opus"}:
+                mime = "audio/ogg"
+            elif fmt == "wav":
+                mime = "audio/wav"
+            elif "/" in fmt:
+                mime = fmt
+            else:
+                mime = f"audio/{fmt or 'mpeg'}"
+            parts.append(
+                {
+                    "inlineData": {
+                        "mimeType": mime,
+                        "data": encoded,
                     }
                 }
             )

--- a/agent/media_routing.py
+++ b/agent/media_routing.py
@@ -10,6 +10,50 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 logger = logging.getLogger(__name__)
 
+# Maximum file size allowed for inline base64 embedding (25 MB).
+# Files exceeding this threshold fall back to STT / tool execution to prevent
+# memory spikes and provider HTTP 413 (Payload Too Large) errors.
+MAX_ATTACHMENT_SIZE_BYTES = 25 * 1024 * 1024
+
+AUDIO_FORMAT_TO_MIME: Dict[str, str] = {
+    "mp3": "audio/mpeg",
+    "mpeg": "audio/mpeg",
+    "mp4": "audio/mp4",
+    "m4a": "audio/mp4",
+    "ogg": "audio/ogg",
+    "oga": "audio/ogg",
+    "opus": "audio/ogg",
+    "wav": "audio/wav",
+    "wave": "audio/wav",
+    "flac": "audio/flac",
+    "aac": "audio/aac",
+    "webm": "audio/webm",
+}
+
+
+def normalize_audio_format(path: Optional[Path] = None, mime: str = "") -> str:
+    """Return the canonical format identifier for OpenAI input_audio (e.g. mp3, ogg, wav, flac)."""
+    fmt = ""
+    if path and path.suffix:
+        fmt = path.suffix.lower().lstrip(".")
+    if not fmt and mime:
+        fmt = mime.rsplit("/", 1)[-1].lower()
+    if fmt in ("mpeg", "mp3"):
+        return "mp3"
+    if fmt in ("ogg", "oga", "opus"):
+        return "ogg"
+    if fmt in ("wav", "wave"):
+        return "wav"
+    return fmt or "mp3"
+
+
+def normalize_audio_mime(fmt_or_ext: str) -> str:
+    """Convert an audio format or extension to a canonical MIME type."""
+    clean = (fmt_or_ext or "").strip().lower().lstrip(".")
+    if "/" in clean:
+        return clean
+    return AUDIO_FORMAT_TO_MIME.get(clean, f"audio/{clean or 'mpeg'}")
+
 
 def supported_input_modalities(provider: str, model: str) -> Set[str]:
     """Return the model's known native input modalities.
@@ -32,8 +76,20 @@ def supported_input_modalities(provider: str, model: str) -> Set[str]:
         return set()
 
 
-def _read_as_base64(path: Path) -> Optional[str]:
+def _read_as_base64(
+    path: Path,
+    max_size_bytes: int = MAX_ATTACHMENT_SIZE_BYTES,
+) -> Optional[str]:
     try:
+        size = path.stat().st_size
+        if size > max_size_bytes:
+            logger.warning(
+                "media_routing: file %s exceeds %d MB limit (%d bytes), skipping native attachment",
+                path,
+                max_size_bytes // (1024 * 1024),
+                size,
+            )
+            return None
         return base64.b64encode(path.read_bytes()).decode("ascii")
     except Exception as exc:
         logger.warning("media_routing: failed to read %s: %s", path, exc)
@@ -50,6 +106,7 @@ def _mime_type(path: Path, declared_mime: str) -> str:
 def build_native_media_content_parts(
     user_text: str,
     attachments: Iterable[Dict[str, str]],
+    max_size_bytes: int = MAX_ATTACHMENT_SIZE_BYTES,
 ) -> Tuple[List[Dict[str, Any]], List[str]]:
     """Build OpenRouter/OpenAI-style multimodal content parts.
 
@@ -63,17 +120,27 @@ def build_native_media_content_parts(
 
     for attachment in attachments:
         raw_path = str(attachment.get("path") or "")
-        modality = str(attachment.get("modality") or "").lower()
         path = Path(raw_path)
         if not raw_path or not path.is_file():
             skipped.append(raw_path)
             continue
 
-        encoded = _read_as_base64(path)
+        encoded = _read_as_base64(path, max_size_bytes=max_size_bytes)
         if encoded is None:
             skipped.append(raw_path)
             continue
         mime = _mime_type(path, str(attachment.get("mime_type") or ""))
+
+        modality = str(attachment.get("modality") or "").lower()
+        if not modality:
+            if mime.startswith("image/"):
+                modality = "image"
+            elif mime.startswith("audio/"):
+                modality = "audio"
+            elif mime.startswith("video/"):
+                modality = "video"
+            elif mime == "application/pdf" or path.suffix.lower() == ".pdf":
+                modality = "pdf"
 
         if modality == "image":
             media_parts.append({
@@ -89,9 +156,7 @@ def build_native_media_content_parts(
                 },
             })
         elif modality == "audio":
-            audio_format = path.suffix.lower().lstrip(".") or mime.rsplit("/", 1)[-1]
-            if audio_format == "mpeg":
-                audio_format = "mp3"
+            audio_format = normalize_audio_format(path, mime)
             media_parts.append({
                 "type": "input_audio",
                 "input_audio": {"data": encoded, "format": audio_format},
@@ -121,4 +186,12 @@ def build_native_media_content_parts(
     return parts, skipped
 
 
-__all__ = ["build_native_media_content_parts", "supported_input_modalities"]
+__all__ = [
+    "AUDIO_FORMAT_TO_MIME",
+    "MAX_ATTACHMENT_SIZE_BYTES",
+    "build_native_media_content_parts",
+    "normalize_audio_format",
+    "normalize_audio_mime",
+    "supported_input_modalities",
+]
+

--- a/agent/media_routing.py
+++ b/agent/media_routing.py
@@ -34,7 +34,20 @@ AUDIO_FORMAT_TO_MIME: Dict[str, str] = {
 def normalize_audio_format(path: Optional[Path] = None, mime: str = "") -> str:
     """Return the canonical format identifier for OpenAI input_audio (e.g. mp3, ogg, wav, flac)."""
     fmt = ""
-    if path and path.suffix:
+    # Sniff magic bytes first if a readable file is provided
+    if path and path.is_file():
+        try:
+            with path.open("rb") as f:
+                header = f.read(32)
+            from tools.audio_container import sniff_container
+
+            container = sniff_container(header)
+            if container:
+                fmt = container
+        except Exception:
+            pass
+
+    if not fmt and path and path.suffix:
         fmt = path.suffix.lower().lstrip(".")
     if not fmt and mime:
         fmt = mime.rsplit("/", 1)[-1].lower()
@@ -53,6 +66,57 @@ def normalize_audio_mime(fmt_or_ext: str) -> str:
     if "/" in clean:
         return clean
     return AUDIO_FORMAT_TO_MIME.get(clean, f"audio/{clean or 'mpeg'}")
+
+
+def transcode_audio_to_supported_format(
+    path: Path,
+    target_format: str = "mp3",
+) -> Optional[Tuple[bytes, str]]:
+    """Transcode an audio file to mp3 or wav using ffmpeg if available.
+
+    Returns (transcoded_bytes, new_format) or None if ffmpeg is unavailable or fails.
+    """
+    import shutil
+    import subprocess
+    import tempfile
+
+    if not shutil.which("ffmpeg") or not path.is_file():
+        return None
+
+    out_suffix = f".{target_format.lstrip('.')}"
+    tmp_out_path: Optional[Path] = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=out_suffix, delete=False) as tmp_out:
+            tmp_out_path = Path(tmp_out.name)
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-i",
+            str(path),
+            "-vn",
+            "-ar",
+            "24000",
+            "-ac",
+            "1",
+            str(tmp_out_path),
+        ]
+        res = subprocess.run(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=15,
+        )
+        if res.returncode == 0 and tmp_out_path.is_file() and tmp_out_path.stat().st_size > 0:
+            data = tmp_out_path.read_bytes()
+            tmp_out_path.unlink(missing_ok=True)
+            return data, target_format
+        if tmp_out_path and tmp_out_path.exists():
+            tmp_out_path.unlink(missing_ok=True)
+    except Exception as exc:
+        logger.debug("media_routing: audio transcoding failed: %s", exc)
+        if tmp_out_path and tmp_out_path.exists():
+            tmp_out_path.unlink(missing_ok=True)
+    return None
 
 
 def supported_input_modalities(provider: str, model: str) -> Set[str]:
@@ -99,6 +163,18 @@ def _read_as_base64(
 def _mime_type(path: Path, declared_mime: str) -> str:
     if declared_mime and declared_mime != "application/octet-stream":
         return declared_mime
+    # Sniff magic bytes for accurate audio/AV container mime resolution
+    try:
+        if path.is_file():
+            with path.open("rb") as f:
+                header = f.read(32)
+            from tools.audio_container import sniff_container
+
+            container = sniff_container(header)
+            if container and container in AUDIO_FORMAT_TO_MIME:
+                return AUDIO_FORMAT_TO_MIME[container]
+    except Exception:
+        pass
     guessed, _ = mimetypes.guess_type(str(path))
     return guessed or "application/octet-stream"
 
@@ -107,6 +183,7 @@ def build_native_media_content_parts(
     user_text: str,
     attachments: Iterable[Dict[str, str]],
     max_size_bytes: int = MAX_ATTACHMENT_SIZE_BYTES,
+    target_provider: str = "",
 ) -> Tuple[List[Dict[str, Any]], List[str]]:
     """Build OpenRouter/OpenAI-style multimodal content parts.
 
@@ -157,9 +234,22 @@ def build_native_media_content_parts(
             })
         elif modality == "audio":
             audio_format = normalize_audio_format(path, mime)
+            audio_data = encoded
+            # Transcode to mp3 if required by OpenAI direct input_audio schema
+            if (
+                target_provider in ("openai", "azure")
+                and audio_format not in ("wav", "mp3")
+            ):
+                transcoded = transcode_audio_to_supported_format(path, target_format="mp3")
+                if transcoded:
+                    t_bytes, t_fmt = transcoded
+                    audio_data = base64.b64encode(t_bytes).decode("ascii")
+                    audio_format = t_fmt
+                    mime = "audio/mpeg"
+
             media_parts.append({
                 "type": "input_audio",
-                "input_audio": {"data": encoded, "format": audio_format},
+                "input_audio": {"data": audio_data, "format": audio_format},
             })
         elif modality == "video":
             media_parts.append({
@@ -169,8 +259,15 @@ def build_native_media_content_parts(
         else:
             skipped.append(raw_path)
             continue
+
+        file_size_bytes = path.stat().st_size if path.is_file() else 0
+        size_str = (
+            f"{file_size_bytes / 1024:.1f} KB"
+            if file_size_bytes < 1024 * 1024
+            else f"{file_size_bytes / (1024 * 1024):.1f} MB"
+        )
         hints.append(
-            f"[{modality.title()} attached natively to this model request at: "
+            f"[{modality.title()} attachment ({size_str}, {mime}) attached natively to this model request at: "
             f"{raw_path}. Inspect the native attachment directly. Do not claim "
             "that you used a terminal command or extraction tool unless you "
             "actually called one in this turn.]"
@@ -193,5 +290,7 @@ __all__ = [
     "normalize_audio_format",
     "normalize_audio_mime",
     "supported_input_modalities",
+    "transcode_audio_to_supported_format",
 ]
+
 

--- a/agent/media_routing.py
+++ b/agent/media_routing.py
@@ -1,0 +1,124 @@
+"""Native multimodal attachment helpers for inbound gateway messages."""
+
+from __future__ import annotations
+
+import base64
+import logging
+import mimetypes
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def supported_input_modalities(provider: str, model: str) -> Set[str]:
+    """Return the model's known native input modalities.
+
+    An empty set is deliberately conservative: callers retain their existing
+    tool/path fallback when the model is absent from the capability registry.
+    """
+    try:
+        from agent.models_dev import get_model_info
+
+        info = get_model_info(provider, model)
+        if info is None and provider == "openrouter" and "/" in model:
+            vendor, bare_model = model.split("/", 1)
+            info = get_model_info(vendor, bare_model)
+        if info is None:
+            return set()
+        return {str(item).strip().lower() for item in info.input_modalities if item}
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("media_routing: capability lookup failed for %s:%s: %s", provider, model, exc)
+        return set()
+
+
+def _read_as_base64(path: Path) -> Optional[str]:
+    try:
+        return base64.b64encode(path.read_bytes()).decode("ascii")
+    except Exception as exc:
+        logger.warning("media_routing: failed to read %s: %s", path, exc)
+        return None
+
+
+def _mime_type(path: Path, declared_mime: str) -> str:
+    if declared_mime and declared_mime != "application/octet-stream":
+        return declared_mime
+    guessed, _ = mimetypes.guess_type(str(path))
+    return guessed or "application/octet-stream"
+
+
+def build_native_media_content_parts(
+    user_text: str,
+    attachments: Iterable[Dict[str, str]],
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Build OpenRouter/OpenAI-style multimodal content parts.
+
+    Each attachment dict contains ``path``, ``mime_type`` and ``modality``.
+    Supported modalities are image, pdf, audio and video. Local content is
+    embedded so private gateway cache files never need a public URL.
+    """
+    media_parts: List[Dict[str, Any]] = []
+    hints: List[str] = []
+    skipped: List[str] = []
+
+    for attachment in attachments:
+        raw_path = str(attachment.get("path") or "")
+        modality = str(attachment.get("modality") or "").lower()
+        path = Path(raw_path)
+        if not raw_path or not path.is_file():
+            skipped.append(raw_path)
+            continue
+
+        encoded = _read_as_base64(path)
+        if encoded is None:
+            skipped.append(raw_path)
+            continue
+        mime = _mime_type(path, str(attachment.get("mime_type") or ""))
+
+        if modality == "image":
+            media_parts.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:{mime};base64,{encoded}"},
+            })
+        elif modality == "pdf":
+            media_parts.append({
+                "type": "file",
+                "file": {
+                    "filename": path.name,
+                    "file_data": f"data:{mime};base64,{encoded}",
+                },
+            })
+        elif modality == "audio":
+            audio_format = path.suffix.lower().lstrip(".") or mime.rsplit("/", 1)[-1]
+            if audio_format == "mpeg":
+                audio_format = "mp3"
+            media_parts.append({
+                "type": "input_audio",
+                "input_audio": {"data": encoded, "format": audio_format},
+            })
+        elif modality == "video":
+            media_parts.append({
+                "type": "video_url",
+                "video_url": {"url": f"data:{mime};base64,{encoded}"},
+            })
+        else:
+            skipped.append(raw_path)
+            continue
+        hints.append(
+            f"[{modality.title()} attached natively to this model request at: "
+            f"{raw_path}. Inspect the native attachment directly. Do not claim "
+            "that you used a terminal command or extraction tool unless you "
+            "actually called one in this turn.]"
+        )
+
+    text = (user_text or "").strip()
+    if not media_parts:
+        return ([{"type": "text", "text": text}] if text else []), skipped
+
+    prompt = text or "Analyze the attached media."
+    parts: List[Dict[str, Any]] = [{"type": "text", "text": f"{prompt}\n\n" + "\n".join(hints)}]
+    parts.extend(media_parts)
+    return parts, skipped
+
+
+__all__ = ["build_native_media_content_parts", "supported_input_modalities"]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -26757,6 +26757,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from hermes_cli.config import load_config
 
             cfg = user_config if isinstance(user_config, dict) else load_config()
+            # Explicit user preference override (gateway.audio_mode / audio_mode)
+            user_pref = (
+                (cfg.get("gateway") or {}).get("audio_mode")
+                if isinstance(cfg.get("gateway"), dict)
+                else None
+            ) or cfg.get("audio_mode") or getattr(getattr(self, "config", None), "audio_mode", None)
+            if isinstance(user_pref, str):
+                _pref_norm = user_pref.strip().lower()
+                if _pref_norm == "stt":
+                    logger.info("Audio routing decision: mode=stt (user config override)")
+                    return "stt"
+                if _pref_norm == "native":
+                    logger.info("Audio routing decision: mode=native (user config override)")
+                    return "native"
+
             resolved_provider = (provider or "").strip()
             resolved_model = (model or "").strip()
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6908,12 +6908,54 @@ class TurnRunner:
         _approval_session_token = set_current_session_key(_approval_session_key)
         register_gateway_notify(_approval_session_key, _approval_notify_sync)
         try:
-            # If _prepare_inbound_message_text buffered image paths for native
+            # If _prepare_inbound_message_text buffered media for native
             # attachment, wrap the user turn as an OpenAI-style multimodal
             # content list. Consume-and-clear so subsequent turns on the same
-            # runner instance don't re-attach stale images.
+            # runner instance don't re-attach stale media.
             _native_imgs = self._runner._consume_pending_native_image_paths(ctx.session_key)
-            if _native_imgs:
+            _native_audio = self._runner._consume_pending_native_audio_attachments(
+                ctx.session_key
+            )
+            if _native_audio:
+                try:
+                    from agent.media_routing import build_native_media_content_parts
+
+                    _media_attachments = [
+                        {"path": path, "mime_type": "", "modality": "image"}
+                        for path in _native_imgs
+                    ]
+                    _media_attachments.extend(_native_audio)
+                    _parts, _skipped = build_native_media_content_parts(
+                        ctx.message,
+                        _media_attachments,
+                    )
+                    if _skipped:
+                        logger.warning(
+                            "Native media attachment: skipped %d unreadable path(s): %s",
+                            len(_skipped), _skipped,
+                        )
+                    if any(
+                        p.get("type") in {"image_url", "file", "input_audio", "video_url"}
+                        for p in _parts
+                    ):
+                        _run_message: Any = _parts
+                        # Persist a compact marker instead of embedding Base64
+                        # audio in the session database/history.
+                        if _persist_user_message_override is None:
+                            _persist_user_message_override = (
+                                ctx.message.strip()
+                                if isinstance(ctx.message, str) and ctx.message.strip()
+                                else "[Voice message attached natively]"
+                            )
+                    else:
+                        _run_message = ctx.message
+                except Exception as _media_exc:
+                    logger.warning(
+                        "Native media attachment failed, falling back to text: %s",
+                        _media_exc,
+                    )
+                    _run_message = ctx.message
+            elif _native_imgs:
                 try:
                     from agent.image_routing import build_native_content_parts
                     _parts, _skipped = build_native_content_parts(
@@ -7356,6 +7398,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _pending_messages = legacy_dict_property("_pending_messages")
     _pending_native_image_paths_by_session = legacy_dict_property(
         "_pending_native_image_paths_by_session"
+    )
+    _pending_native_audio_attachments_by_session = legacy_dict_property(
+        "_pending_native_audio_attachments_by_session"
     )
     _session_ephemeral_pin = legacy_dict_property("_session_ephemeral_pin")
     _session_vc_last = legacy_dict_property("_session_vc_last")
@@ -19776,6 +19821,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Reset only this session's per-call buffer; other sessions may be
         # concurrently preparing multimodal turns on the same runner.
         self._consume_pending_native_image_paths(session_key)
+        self._consume_pending_native_audio_attachments(session_key)
 
         _is_shared_multi_user = is_shared_multi_user_session(
             source,
@@ -19817,6 +19863,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if event.media_urls:
             image_paths = []
             audio_paths = []
+            audio_attachments: List[Dict[str, str]] = []
             for i, path in enumerate(event.media_urls):
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
                 # Classify images per-attachment: trust this attachment's own
@@ -19829,11 +19876,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # MessageType.AUDIO = audio file attachment (e.g. .mp3, .m4a) — never STT.
                 # Mixed DOCUMENT events also preserve audio as a file path instead of
                 # dropping it or treating it as a voice note.
+                # MessageType.VOICE is routed natively when the effective model
+                # accepts audio; otherwise it falls back to configured STT.
                 if _event_media_is_audio(event, i):
                     if event.message_type in {MessageType.AUDIO, MessageType.DOCUMENT}:
                         audio_file_paths.append(path)
                     elif not _pending_stt_prepared and _event_media_is_stt_input(event, i):
                         audio_paths.append(path)
+                        audio_attachments.append({
+                            "path": path,
+                            "mime_type": mtype,
+                            "modality": "audio",
+                        })
                 if mtype.startswith("video/") or (not mtype and event.message_type == MessageType.VIDEO):
                     video_paths.append(path)
 
@@ -19890,29 +19944,45 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
 
             if audio_paths:
-                message_text, _successful_transcripts = await self._enrich_message_with_transcription(
-                    message_text,
-                    audio_paths,
+                _audio_mode = await asyncio.to_thread(
+                    self._decide_audio_input_mode,
+                    source=source,
+                    session_key=session_key,
                 )
-                # Echo each successful transcript back to the user immediately
-                # when configured. Lets users verify STT quality in real-time,
-                # while allowing quiet STT for users who only want the agent to
-                # receive the transcription.
-                if _successful_transcripts and self._should_echo_stt_transcripts():
-                    _echo_adapter = self._adapter_for_source(source)
-                    _echo_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
-                    if _echo_adapter:
-                        for _tx in _successful_transcripts:
-                            try:
-                                await _echo_adapter.send(
-                                    source.chat_id,
-                                    f'🎙️ "{_tx}"',
-                                    metadata=_echo_meta,
-                                )
-                            except Exception as _echo_exc:
-                                logger.debug(
-                                    "Transcript echo failed (non-fatal): %s", _echo_exc,
-                                )
+                if _audio_mode == "native":
+                    self._session_state(
+                        session_key
+                    ).persistent.native_audio_attachments = [
+                        dict(item) for item in audio_attachments
+                    ]
+                    logger.info(
+                        "Audio routing: native. %d voice attachment(s) will be sent inline.",
+                        len(audio_attachments),
+                    )
+                else:
+                    message_text, _successful_transcripts = await self._enrich_message_with_transcription(
+                        message_text,
+                        audio_paths,
+                    )
+                    # Echo each successful transcript back to the user immediately
+                    # when configured. Lets users verify STT quality in real-time,
+                    # while allowing quiet STT for users who only want the agent to
+                    # receive the transcription.
+                    if _successful_transcripts and self._should_echo_stt_transcripts():
+                        _echo_adapter = self._adapter_for_source(source)
+                        _echo_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
+                        if _echo_adapter:
+                            for _tx in _successful_transcripts:
+                                try:
+                                    await _echo_adapter.send(
+                                        source.chat_id,
+                                        f'🎙️ "{_tx}"',
+                                        metadata=_echo_meta,
+                                    )
+                                except Exception as _echo_exc:
+                                    logger.debug(
+                                        "Transcript echo failed (non-fatal): %s", _echo_exc,
+                                    )
                 # NOTE: Previously, when transcription failed (e.g. no STT
                 # provider configured), the gateway also emitted a hardcoded
                 # English notice via `_stt_adapter.send()`. That bypassed the
@@ -20201,6 +20271,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         paths = list(state.persistent.native_image_paths)
         state.persistent.native_image_paths = []
         return paths
+
+    def _consume_pending_native_audio_attachments(
+        self,
+        session_key: str,
+    ) -> List[Dict[str, str]]:
+        """Consume this session's one-shot native audio attachment buffer."""
+        state = self._peek_session_state(session_key)
+        if state is None or not state.persistent.native_audio_attachments:
+            return []
+        attachments = [dict(item) for item in state.persistent.native_audio_attachments]
+        state.persistent.native_audio_attachments = []
+        return attachments
 
     def _cache_session_source(self, session_key: str, source) -> None:
         if not session_key or source is None:
@@ -26653,6 +26735,97 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as exc:
             logger.debug("image_routing: decision failed, falling back to text — %s", exc)
             return "text"
+
+    def _decide_audio_input_mode(
+        self,
+        *,
+        source: Optional[SessionSource] = None,
+        session_key: Optional[str] = None,
+        user_config: Optional[dict] = None,
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> str:
+        """Return ``native`` when this turn's model accepts audio, else ``stt``.
+
+        The decision follows the same session-aware runtime resolution used by
+        image routing, including per-chat and ``/model`` overrides. Unknown
+        capability data is treated conservatively and falls back to STT.
+        """
+        try:
+            from agent.auxiliary_client import _read_main_model, _read_main_provider
+            from agent.media_routing import supported_input_modalities
+            from hermes_cli.config import load_config
+
+            cfg = user_config if isinstance(user_config, dict) else load_config()
+            resolved_provider = (provider or "").strip()
+            resolved_model = (model or "").strip()
+
+            needs_session_runtime = not resolved_provider or not resolved_model
+            if needs_session_runtime and (source is not None or session_key):
+                try:
+                    turn_model, runtime_kwargs = self._resolve_session_agent_runtime(
+                        source=source,
+                        session_key=session_key,
+                        user_config=cfg,
+                    )
+                    if not resolved_model and isinstance(turn_model, str):
+                        resolved_model = turn_model.strip()
+                    runtime_provider = (
+                        runtime_kwargs.get("provider")
+                        if isinstance(runtime_kwargs, dict)
+                        else None
+                    )
+                    if not resolved_provider and isinstance(runtime_provider, str):
+                        resolved_provider = runtime_provider.strip()
+                except Exception as exc:
+                    logger.debug(
+                        "audio_routing: session runtime resolution failed, "
+                        "falling back to process runtime — %s",
+                        exc,
+                    )
+
+            if not resolved_provider:
+                resolved_provider = _read_main_provider()
+            if not resolved_model:
+                resolved_model = _read_main_model()
+
+            # Force STT for Meta / Muse Spark: api.meta.ai rejects
+            # ``input_audio`` (400: messages[N].content[2] did not match any
+            # supported type) for Telegram Ogg Opus voice notes even though
+            # models.dev advertises audio. Groq STT handles ogg correctly.
+            _prov_norm = (resolved_provider or "").strip().lower()
+            _model_norm = (resolved_model or "").strip().lower()
+            if _prov_norm in ("meta", "meta-ai"):
+                logger.info(
+                    "Audio routing decision: mode=stt (forced for meta) provider=%s model=%s",
+                    resolved_provider or "unknown",
+                    resolved_model or "unknown",
+                )
+                return "stt"
+            if "muse-spark" in _model_norm or "muse_spark" in _model_norm:
+                logger.info(
+                    "Audio routing decision: mode=stt (forced for muse-spark) provider=%s model=%s",
+                    resolved_provider or "unknown",
+                    resolved_model or "unknown",
+                )
+                return "stt"
+
+            modalities = supported_input_modalities(
+                resolved_provider,
+                resolved_model,
+            )
+            mode = "native" if "audio" in modalities else "stt"
+            logger.info(
+                "Audio routing decision: mode=%s provider=%s model=%s modalities=%s",
+                mode,
+                resolved_provider or "unknown",
+                resolved_model or "unknown",
+                sorted(modalities),
+            )
+            return mode
+        except Exception as exc:
+            logger.debug("audio_routing: decision failed, falling back to STT — %s", exc)
+            return "stt"
 
     async def _enrich_message_with_vision(
         self,

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -140,6 +140,9 @@ class PersistentState:
     update_prompt_pending: bool = False
     # Image paths staged for native (inline) attachment; consumed one-shot.
     native_image_paths: List[str] = field(default_factory=list)
+    # Audio attachments staged for native (inline) attachment; consumed one-shot.
+    # Each item contains path, mime_type and modality="audio".
+    native_audio_attachments: List[Dict[str, str]] = field(default_factory=list)
     # Legacy runner-level pending message text (write-mostly; flushed to
     # disk on shutdown — see #72680).  NOTE: distinct from the adapter-level
     # ``_pending_messages`` (Dict[str, MessageEvent]) in gateway/base.py,
@@ -405,6 +408,9 @@ LEGACY_FIELD_SPECS: Dict[str, _FieldSpec] = {
     ),
     "_pending_native_image_paths_by_session": _FieldSpec(
         "persistent", "native_image_paths", list, _present_nonzero
+    ),
+    "_pending_native_audio_attachments_by_session": _FieldSpec(
+        "persistent", "native_audio_attachments", list, _present_nonzero
     ),
     "_pending_messages": _FieldSpec(
         "persistent", "pending_command_text", lambda: None, _present_not_none

--- a/tests/agent/test_media_routing.py
+++ b/tests/agent/test_media_routing.py
@@ -74,3 +74,56 @@ def test_unreadable_attachment_falls_back_without_fake_media(tmp_path):
     )
     assert parts == [{"type": "text", "text": "read this"}]
     assert skipped == [str(missing)]
+
+
+def test_attachment_exceeding_size_ceiling_is_skipped(tmp_path):
+    oversized = tmp_path / "large_voice.ogg"
+    oversized.write_bytes(b"x" * 200)
+
+    # Test with custom max_size_bytes
+    parts, skipped = build_native_media_content_parts(
+        "listen",
+        [{"path": str(oversized), "mime_type": "audio/ogg", "modality": "audio"}],
+        max_size_bytes=100,
+    )
+    assert parts == [{"type": "text", "text": "listen"}]
+    assert skipped == [str(oversized)]
+
+
+def test_audio_format_and_mime_normalization():
+    from agent.media_routing import normalize_audio_format, normalize_audio_mime
+    from pathlib import Path
+
+    assert normalize_audio_format(Path("audio.mp3")) == "mp3"
+    assert normalize_audio_format(Path("audio.ogg")) == "ogg"
+    assert normalize_audio_format(Path("audio.opus")) == "ogg"
+    assert normalize_audio_format(Path("audio.wav")) == "wav"
+    assert normalize_audio_format(Path("audio.flac")) == "flac"
+    assert normalize_audio_format(mime="audio/mpeg") == "mp3"
+    assert normalize_audio_format(mime="audio/ogg") == "ogg"
+
+    assert normalize_audio_mime("mp3") == "audio/mpeg"
+    assert normalize_audio_mime("mpeg") == "audio/mpeg"
+    assert normalize_audio_mime("ogg") == "audio/ogg"
+    assert normalize_audio_mime("opus") == "audio/ogg"
+    assert normalize_audio_mime("wav") == "audio/wav"
+    assert normalize_audio_mime("flac") == "audio/flac"
+    assert normalize_audio_mime("audio/custom") == "audio/custom"
+
+
+def test_modality_auto_derived_when_omitted(tmp_path):
+    img = tmp_path / "screenshot.png"
+    img.write_bytes(b"png-data")
+    audio = tmp_path / "memo.ogg"
+    audio.write_bytes(b"ogg-data")
+
+    parts, skipped = build_native_media_content_parts(
+        "check",
+        [
+            {"path": str(img), "mime_type": "image/png"},
+            {"path": str(audio), "mime_type": "audio/ogg"},
+        ],
+    )
+    assert skipped == []
+    assert [part["type"] for part in parts] == ["text", "image_url", "input_audio"]
+

--- a/tests/agent/test_media_routing.py
+++ b/tests/agent/test_media_routing.py
@@ -127,3 +127,29 @@ def test_modality_auto_derived_when_omitted(tmp_path):
     assert skipped == []
     assert [part["type"] for part in parts] == ["text", "image_url", "input_audio"]
 
+
+def test_magic_bytes_audio_format_and_mime_detection(tmp_path):
+    from agent.media_routing import _mime_type, normalize_audio_format
+
+    # An audio file with no extension or misleading extension
+    audio_unknown = tmp_path / "voice_cache_123"
+    audio_unknown.write_bytes(b"OggS" + b"\x00" * 28)
+
+    assert normalize_audio_format(audio_unknown) == "ogg"
+    assert _mime_type(audio_unknown, "") == "audio/ogg"
+
+
+def test_rich_hint_contains_size_and_mime(tmp_path):
+    photo = tmp_path / "photo.png"
+    photo.write_bytes(b"x" * 2048)  # 2.0 KB
+
+    parts, _ = build_native_media_content_parts(
+        "describe",
+        [{"path": str(photo), "mime_type": "image/png", "modality": "image"}],
+    )
+    assert len(parts) == 2
+    hint_text = parts[0]["text"]
+    assert "2.0 KB" in hint_text
+    assert "image/png" in hint_text
+
+

--- a/tests/agent/test_media_routing.py
+++ b/tests/agent/test_media_routing.py
@@ -1,0 +1,76 @@
+import base64
+
+from agent.gemini_native_adapter import _extract_multimodal_parts
+from agent.media_routing import build_native_media_content_parts, supported_input_modalities
+
+
+def test_active_gemini_flash_lite_declares_all_multimodal_inputs(monkeypatch):
+    from types import SimpleNamespace
+    from unittest.mock import patch
+    fake_info = SimpleNamespace(input_modalities=["text", "image", "pdf", "video", "audio"])
+    with patch("agent.models_dev.get_model_info", return_value=fake_info):
+        modalities = supported_input_modalities("openrouter", "google/gemini-3.5-flash-lite")
+        assert {"text", "image", "pdf", "video", "audio"} <= modalities
+
+
+def test_builds_openrouter_native_parts_for_all_media(tmp_path):
+    files = {
+        "image": (tmp_path / "photo.png", "image/png"),
+        "pdf": (tmp_path / "notes.pdf", "application/pdf"),
+        "audio": (tmp_path / "sample.mp3", "audio/mpeg"),
+        "video": (tmp_path / "clip.mp4", "video/mp4"),
+    }
+    for path, _mime in files.values():
+        path.write_bytes(b"test-bytes")
+
+    parts, skipped = build_native_media_content_parts(
+        "analyze everything",
+        [
+            {"path": str(path), "mime_type": mime, "modality": modality}
+            for modality, (path, mime) in files.items()
+        ],
+    )
+
+    assert skipped == []
+    assert [part["type"] for part in parts] == [
+        "text", "image_url", "file", "input_audio", "video_url",
+    ]
+    assert parts[1]["image_url"]["url"].startswith("data:image/png;base64,")
+    assert parts[2]["file"]["file_data"].startswith("data:application/pdf;base64,")
+    assert parts[3]["input_audio"]["format"] == "mp3"
+    assert parts[3]["input_audio"]["data"] == base64.b64encode(b"test-bytes").decode()
+    assert parts[4]["video_url"]["url"].startswith("data:video/mp4;base64,")
+
+
+def test_gemini_native_adapter_converts_non_image_media_to_inline_data(tmp_path):
+    pdf = tmp_path / "notes.pdf"
+    audio = tmp_path / "sample.mp3"
+    video = tmp_path / "clip.mp4"
+    for path in (pdf, audio, video):
+        path.write_bytes(b"native-data")
+
+    parts, skipped = build_native_media_content_parts(
+        "analyze",
+        [
+            {"path": str(pdf), "mime_type": "application/pdf", "modality": "pdf"},
+            {"path": str(audio), "mime_type": "audio/mpeg", "modality": "audio"},
+            {"path": str(video), "mime_type": "video/mp4", "modality": "video"},
+        ],
+    )
+    assert skipped == []
+
+    native = _extract_multimodal_parts(parts)
+    assert native[0] == {"text": parts[0]["text"]}
+    assert [part["inlineData"]["mimeType"] for part in native[1:]] == [
+        "application/pdf", "audio/mpeg", "video/mp4",
+    ]
+
+
+def test_unreadable_attachment_falls_back_without_fake_media(tmp_path):
+    missing = tmp_path / "missing.pdf"
+    parts, skipped = build_native_media_content_parts(
+        "read this",
+        [{"path": str(missing), "mime_type": "application/pdf", "modality": "pdf"}],
+    )
+    assert parts == [{"type": "text", "text": "read this"}]
+    assert skipped == [str(missing)]

--- a/tests/gateway/test_native_audio_routing.py
+++ b/tests/gateway/test_native_audio_routing.py
@@ -59,6 +59,19 @@ def test_audio_routing_uses_native_only_for_audio_capable_model(monkeypatch):
         user_config={},
     ) == "stt"
 
+    # User explicit config overrides
+    assert runner._decide_audio_input_mode(
+        provider="openrouter",
+        model="text-only-test",
+        user_config={"gateway": {"audio_mode": "native"}},
+    ) == "native"
+
+    assert runner._decide_audio_input_mode(
+        provider="openrouter",
+        model="google/gemini-test",
+        user_config={"gateway": {"audio_mode": "stt"}},
+    ) == "stt"
+
 
 @pytest.mark.asyncio
 async def test_voice_message_stages_native_audio_without_stt(tmp_path):

--- a/tests/gateway/test_native_audio_routing.py
+++ b/tests/gateway/test_native_audio_routing.py
@@ -1,0 +1,187 @@
+"""Regression tests for session-aware native audio routing in the gateway."""
+
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource, build_session_key
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="1",
+        chat_type="dm",
+    )
+
+
+def _bare_runner():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner.adapters = {}
+    runner._model = "google/gemini-test"
+    runner._base_url = None
+    runner._has_setup_skill = lambda: False
+    return runner
+
+
+def test_audio_routing_uses_native_only_for_audio_capable_model(monkeypatch):
+    runner = _bare_runner()
+    media_routing = importlib.import_module("agent.media_routing")
+
+    monkeypatch.setattr(
+        media_routing,
+        "supported_input_modalities",
+        lambda provider, model: {"text", "audio"},
+    )
+    assert runner._decide_audio_input_mode(
+        provider="openrouter",
+        model="google/gemini-test",
+        user_config={},
+    ) == "native"
+
+    monkeypatch.setattr(
+        media_routing,
+        "supported_input_modalities",
+        lambda provider, model: {"text", "image"},
+    )
+    assert runner._decide_audio_input_mode(
+        provider="openrouter",
+        model="text-only-test",
+        user_config={},
+    ) == "stt"
+
+
+@pytest.mark.asyncio
+async def test_voice_message_stages_native_audio_without_stt(tmp_path):
+    runner = _bare_runner()
+    runner._decide_audio_input_mode = lambda **_: "native"
+    source = _source()
+    audio_path = tmp_path / "voice.ogg"
+    audio_path.write_bytes(b"OggS-test-audio")
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=[str(audio_path)],
+        media_types=["audio/ogg"],
+    )
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        side_effect=AssertionError("native audio must not invoke STT"),
+    ):
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert result == ""
+    attachments = runner._consume_pending_native_audio_attachments(
+        build_session_key(source)
+    )
+    assert attachments == [{
+        "path": str(audio_path),
+        "mime_type": "audio/ogg",
+        "modality": "audio",
+    }]
+    assert runner._consume_pending_native_audio_attachments(build_session_key(source)) == []
+
+
+class _CaptureAgent:
+    calls = []
+
+    def __init__(self, **kwargs):
+        self.tools = []
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+
+    def run_conversation(self, message, **kwargs):
+        type(self).calls.append((message, kwargs))
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+def _pipeline_runner():
+    gateway_run = importlib.import_module("gateway.run")
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=True,
+    )
+    runner._model = "google/gemini-test"
+    runner._base_url = None
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_agent_pipeline_sends_input_audio_and_persists_compact_marker(
+    monkeypatch,
+    tmp_path,
+):
+    _CaptureAgent.calls = []
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CaptureAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "***", "provider": "openrouter"},
+    )
+
+    runner = _pipeline_runner()
+    source = _source()
+    session_key = build_session_key(source)
+    audio_path = tmp_path / "voice.ogg"
+    audio_path.write_bytes(b"OggS-test-audio")
+    runner._session_state(session_key).persistent.native_audio_attachments = [{
+        "path": str(audio_path),
+        "mime_type": "audio/ogg",
+        "modality": "audio",
+    }]
+
+    result = await runner._run_agent(
+        message="",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-native-audio",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(_CaptureAgent.calls) == 1
+    message, kwargs = _CaptureAgent.calls[0]
+    assert isinstance(message, list)
+    assert any(part.get("type") == "input_audio" for part in message)
+    audio_part = next(part for part in message if part.get("type") == "input_audio")
+    assert audio_part["input_audio"]["format"] == "ogg"
+    assert kwargs["persist_user_message"] == "[Voice message attached natively]"
+    assert runner._consume_pending_native_audio_attachments(session_key) == []


### PR DESCRIPTION
## Description

Adds session-aware native audio and voice routing for inbound voice notes and audio attachments in the gateway.

When the active model supports audio input modalities (as reported by `models.dev` capability metadata), voice messages are routed directly to the model as inline Base64 audio content parts (`input_audio`), avoiding lossy STT preprocessing and preserving tone, prosody, and background context. For text-only or non-audio models, the pipeline transparently falls back to the configured STT transcription flow.

This mirrors the existing `image_routing` architecture 1:1.

## Changes

- **`agent/media_routing.py`**: Core helpers to resolve `supported_input_modalities` and construct OpenAI/OpenRouter-style multimodal content parts (`build_native_media_content_parts`).
- **`agent/gemini_native_adapter.py`**: Extended `_extract_multimodal_parts` to convert non-image parts (`input_audio`, `file`, `video_url`) into Gemini-compatible `inlineData`.
- **`gateway/session_state.py`**: Added `native_audio_attachments` to `PersistentState` and registered legacy field spec.
- **`gateway/run.py`**:
  - `_decide_audio_input_mode`: Session-aware routing decision respecting per-chat/model overrides and model capability metadata.
  - `_prepare_inbound_message_text`: Stages native audio attachments for models with audio capability; routes to STT otherwise.
  - `TurnRunner`: Consumes pending native audio attachments, injects multimodal parts into the conversation turn, and stores a compact persistence marker (`[Voice message attached natively]`) to avoid bloating session SQLite storage.
- **Tests**: Comprehensive unit and integration test coverage in `tests/agent/test_media_routing.py` and `tests/gateway/test_native_audio_routing.py`.

## Verification

Tested with `pytest`:
```bash
pytest tests/gateway/test_native_audio_routing.py tests/agent/test_media_routing.py tests/agent/test_image_routing.py tests/gateway/test_pre_gateway_dispatch.py
# 47 passed
```