### PR TITLE
fix(delegate): inherit coherent parent runtime after provider fallback

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -15,6 +15,7 @@ import threading
 import time
 import types
 import unittest
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 from tools.delegate_tool import (
@@ -38,7 +39,7 @@ def _make_mock_parent(depth=0):
     """Create a mock parent agent with the fields delegate_task expects."""
     parent = MagicMock()
     parent.base_url = "https://openrouter.ai/api/v1"
-    parent.api_key="***"
+    parent.api_key = "***"
     parent.provider = "openrouter"
     parent.api_mode = "chat_completions"
     parent.model = "anthropic/claude-sonnet-4"
@@ -54,6 +55,11 @@ def _make_mock_parent(depth=0):
     parent._print_fn = None
     parent.tool_progress_callback = None
     parent.thinking_callback = None
+    parent.client = None
+    parent._client_kwargs = {
+        "api_key": parent.api_key,
+        "base_url": parent.base_url,
+    }
     return parent
 
 
@@ -267,9 +273,14 @@ class TestDelegateTask(unittest.TestCase):
     def test_child_inherits_runtime_credentials(self):
         parent = _make_mock_parent(depth=0)
         parent.base_url = "https://chatgpt.com/backend-api/codex"
-        parent.api_key="***"
+        parent.api_key = "codex-primary-key"
         parent.provider = "openai-codex"
         parent.api_mode = "codex_responses"
+        parent.client = None
+        parent._client_kwargs = {
+            "api_key": "codex-primary-key",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        }
 
         with patch("run_agent.AIAgent") as MockAgent:
             mock_child = MagicMock()
@@ -287,7 +298,341 @@ class TestDelegateTask(unittest.TestCase):
             self.assertEqual(kwargs["api_key"], parent.api_key)
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["api_mode"], parent.api_mode)
+            self.assertEqual(kwargs["model"], parent.model)
 
+    def test_nous_child_rederives_api_mode_from_model(self):
+        """Portal is dual-wire — same provider + different model prefix must
+        not inherit the parent's Messages/chat_completions mode verbatim."""
+        parent = _make_mock_parent(depth=0)
+        parent.base_url = "https://inference-api.nousresearch.com/v1"
+        parent.api_key = "portal-jwt"
+        parent.provider = "nous"
+        parent.api_mode = "anthropic_messages"
+        parent.model = "anthropic/claude-opus-4.8"
+        parent._anthropic_base_url = "https://inference-api.nousresearch.com/v1"
+        parent._anthropic_api_key = "portal-jwt"
+        parent._client_kwargs = {
+            "api_key": "portal-jwt",
+            "base_url": "https://inference-api.nousresearch.com/v1",
+        }
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Stay on chat completions",
+                context=None,
+                toolsets=None,
+                model="hermes-4-405b",
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["provider"], "nous")
+            self.assertEqual(kwargs["model"], "hermes-4-405b")
+            self.assertEqual(kwargs["api_mode"], "chat_completions")
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+            parent.api_mode = "chat_completions"
+            parent.model = "hermes-4-405b"
+            parent._client_kwargs = {
+                "api_key": "portal-jwt",
+                "base_url": "https://inference-api.nousresearch.com/v1",
+            }
+
+            _build_child_agent(
+                task_index=0,
+                goal="Move onto Messages",
+                context=None,
+                toolsets=None,
+                model="anthropic/claude-opus-4.8",
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["api_mode"], "anthropic_messages")
+
+
+class TestDelegateFallbackRuntimeInheritance(unittest.TestCase):
+    """#90009: child must inherit the parent's live paired runtime identity."""
+
+    CODEX_BASE = "https://chatgpt.com/backend-api/codex"
+    ANTHROPIC_BASE = "https://api.anthropic.com"
+    CODEX_KEY = "codex-primary-key-0001"
+    ANTHROPIC_KEY = "sk-ant-oat01-fallback-token"
+
+    @staticmethod
+    def _make_codex_agent(fallback_model):
+        from run_agent import AIAgent
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "agent.context_compressor.get_model_context_length",
+                return_value=200_000,
+            ),
+        ):
+            agent = AIAgent(
+                api_key=TestDelegateFallbackRuntimeInheritance.CODEX_KEY,
+                base_url=TestDelegateFallbackRuntimeInheritance.CODEX_BASE,
+                provider="openai-codex",
+                model="gpt-5.6-sol",
+                api_mode="codex_responses",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                fallback_model=fallback_model,
+            )
+            agent.client = MagicMock()
+            agent.client.base_url = TestDelegateFallbackRuntimeInheritance.CODEX_BASE
+            agent.client.api_key = TestDelegateFallbackRuntimeInheritance.CODEX_KEY
+            return agent
+
+    @staticmethod
+    def _mock_anthropic_fallback_client():
+        mock = MagicMock()
+        mock.base_url = TestDelegateFallbackRuntimeInheritance.ANTHROPIC_BASE
+        mock.api_key = TestDelegateFallbackRuntimeInheritance.ANTHROPIC_KEY
+        return mock
+
+    @staticmethod
+    def _build_child(parent):
+        return _build_child_agent(
+            task_index=0,
+            goal="test",
+            context=None,
+            toolsets=None,
+            model=None,
+            max_iterations=5,
+            parent_agent=parent,
+            task_count=1,
+        )
+
+    @staticmethod
+    def _assert_full_runtime_tuple(testcase, kwargs, *, provider, model, base_url, api_key, api_mode):
+        testcase.assertEqual(kwargs["provider"], provider)
+        testcase.assertEqual(kwargs["model"], model)
+        testcase.assertEqual(kwargs["base_url"], base_url)
+        testcase.assertEqual(kwargs["api_key"], api_key)
+        testcase.assertEqual(kwargs["api_mode"], api_mode)
+
+    def test_fallback_then_delegate_inherits_complete_anthropic_runtime(self):
+        """Real fallback machinery → delegate inherits coherent anthropic tuple."""
+        agent = self._make_codex_agent(
+            {"provider": "anthropic", "model": "claude-sonnet-5"},
+        )
+        mock_client = self._mock_anthropic_fallback_client()
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "claude-sonnet-5"),
+        ), patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            return_value=MagicMock(),
+        ), patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            assert agent._try_activate_fallback() is True
+
+            self._build_child(agent)
+
+            _, kwargs = MockAgent.call_args
+            self._assert_full_runtime_tuple(
+                self,
+                kwargs,
+                provider="anthropic",
+                model="claude-sonnet-5",
+                base_url=self.ANTHROPIC_BASE,
+                api_key=self.ANTHROPIC_KEY,
+                api_mode="anthropic_messages",
+            )
+
+    def test_restore_then_delegate_inherits_complete_primary_runtime(self):
+        """Primary → fallback → restore → delegate matches restored primary tuple."""
+        agent = self._make_codex_agent(
+            {"provider": "anthropic", "model": "claude-sonnet-5"},
+        )
+        primary_provider = agent.provider
+        primary_model = agent.model
+        primary_base = agent.base_url
+        primary_key = agent.api_key
+        primary_mode = agent.api_mode
+
+        mock_client = self._mock_anthropic_fallback_client()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "claude-sonnet-5"),
+        ), patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            return_value=MagicMock(),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            self._build_child(agent)
+
+            _, kwargs = MockAgent.call_args
+            self._assert_full_runtime_tuple(
+                self,
+                kwargs,
+                provider=primary_provider,
+                model=primary_model,
+                base_url=primary_base,
+                api_key=primary_key,
+                api_mode=primary_mode,
+            )
+
+    def test_corrupted_parent_runtime_fails_closed_without_constructing_child(self):
+        """Split-brain parent (codex surface + anthropic key, no paired source) is rejected."""
+        parent = _make_mock_parent(depth=0)
+        parent.provider = "openai-codex"
+        parent.model = "gpt-5.6-sol"
+        parent.base_url = self.CODEX_BASE
+        parent.api_key = self.ANTHROPIC_KEY
+        parent.api_mode = "codex_responses"
+        parent._client_kwargs = {}
+        parent.client = None
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            with self.assertRaises(ValueError) as ctx:
+                self._build_child(parent)
+
+            MockAgent.assert_not_called()
+            msg = str(ctx.exception).lower()
+            self.assertIn("cannot delegate", msg)
+            self.assertNotIn(self.ANTHROPIC_KEY, str(ctx.exception))
+
+    @staticmethod
+    @contextmanager
+    def _agent_init_patches():
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "agent.context_compressor.get_model_context_length",
+                return_value=200_000,
+            ),
+        ):
+            yield
+
+    def _construct_real_child(self, parent):
+        """Build a real AIAgent child and return (child, constructor kwargs)."""
+        from run_agent import AIAgent as RealAgent
+
+        captured: dict = {}
+
+        def _construct(*args, **kwargs):
+            captured["kwargs"] = kwargs
+            captured["child"] = RealAgent(*args, **kwargs)
+            return captured["child"]
+
+        with self._agent_init_patches(), patch(
+            "run_agent.AIAgent", side_effect=_construct
+        ):
+            self._build_child(parent)
+
+        return captured["child"], captured["kwargs"]
+
+    def test_bedrock_converse_parent_delegates_native_runtime(self):
+        """Bedrock Converse parent (boto3, empty _client_kwargs) still delegates."""
+        from run_agent import AIAgent
+
+        region = "us-west-2"
+        canonical = f"https://bedrock-runtime.{region}.amazonaws.com"
+        with self._agent_init_patches():
+            parent = AIAgent(
+                api_key="aws-sdk",
+                base_url=canonical,
+                provider="bedrock",
+                model="amazon.nova-pro-v1:0",
+                api_mode="bedrock_converse",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        self.assertEqual(parent.provider, "bedrock")
+        self.assertEqual(parent.api_mode, "bedrock_converse")
+        self.assertEqual(parent._bedrock_region, region)
+        self.assertIsNone(parent.client)
+        self.assertEqual(parent._client_kwargs, {})
+
+        child, kwargs = self._construct_real_child(parent)
+
+        self._assert_full_runtime_tuple(
+            self,
+            kwargs,
+            provider="bedrock",
+            model="amazon.nova-pro-v1:0",
+            base_url=canonical,
+            api_key="aws-sdk",
+            api_mode="bedrock_converse",
+        )
+        self.assertEqual(child.provider, "bedrock")
+        self.assertEqual(child.api_mode, "bedrock_converse")
+        self.assertEqual(child.base_url, canonical)
+        self.assertEqual(child._bedrock_region, region)
+        self.assertIsNone(child.client)
+        self.assertEqual(child._client_kwargs, {})
+
+    def test_moa_parent_delegates_virtual_runtime(self):
+        """MoA parent is a virtual runtime; children inherit the sentinel tuple."""
+        from run_agent import AIAgent
+
+        with self._agent_init_patches():
+            parent = AIAgent(
+                api_key="moa-virtual-provider",
+                base_url="moa://local",
+                provider="moa",
+                model="review",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        self.assertEqual(parent.provider, "moa")
+        self.assertEqual(parent.api_mode, "chat_completions")
+        self.assertEqual(parent.base_url, "moa://local")
+        self.assertEqual(parent._client_kwargs, {})
+        self.assertIsNotNone(parent.client)
+        self.assertFalse(hasattr(parent.client, "api_key"))
+        self.assertFalse(hasattr(parent.client, "base_url"))
+
+        child, kwargs = self._construct_real_child(parent)
+
+        self._assert_full_runtime_tuple(
+            self,
+            kwargs,
+            provider="moa",
+            model="review",
+            base_url="moa://local",
+            api_key="moa-virtual-provider",
+            api_mode="chat_completions",
+        )
+        self.assertEqual(child.provider, "moa")
+        self.assertEqual(child.api_mode, "chat_completions")
+        self.assertEqual(child.base_url, "moa://local")
+        self.assertEqual(child.api_key, "moa-virtual-provider")
+        self.assertEqual(child._client_kwargs, {})
+        self.assertIsNotNone(child.client)
+        self.assertFalse(hasattr(child.client, "api_key"))
+
+
+class TestDelegateTaskSessionDb(unittest.TestCase):
     def test_child_gets_dedicated_session_db_not_parents_handle(self):
         """#81267: children must not share the parent's SessionDB object.
 
@@ -413,55 +758,6 @@ class TestDelegateTask(unittest.TestCase):
                     child_db.close()
                 parent_db.close()
 
-    def test_nous_child_rederives_api_mode_from_model(self):
-        """Portal is dual-wire — same provider + different model prefix must
-        not inherit the parent's Messages/chat_completions mode verbatim."""
-        parent = _make_mock_parent(depth=0)
-        parent.base_url = "https://inference-api.nousresearch.com/v1"
-        parent.api_key = "portal-jwt"
-        parent.provider = "nous"
-        parent.api_mode = "anthropic_messages"
-        parent.model = "anthropic/claude-opus-4.8"
-
-        with patch("run_agent.AIAgent") as MockAgent:
-            mock_child = MagicMock()
-            MockAgent.return_value = mock_child
-
-            _build_child_agent(
-                task_index=0,
-                goal="Stay on chat completions",
-                context=None,
-                toolsets=None,
-                model="hermes-4-405b",
-                max_iterations=10,
-                parent_agent=parent,
-                task_count=1,
-            )
-
-            _, kwargs = MockAgent.call_args
-            self.assertEqual(kwargs["provider"], "nous")
-            self.assertEqual(kwargs["model"], "hermes-4-405b")
-            self.assertEqual(kwargs["api_mode"], "chat_completions")
-
-        with patch("run_agent.AIAgent") as MockAgent:
-            mock_child = MagicMock()
-            MockAgent.return_value = mock_child
-            parent.api_mode = "chat_completions"
-            parent.model = "hermes-4-405b"
-
-            _build_child_agent(
-                task_index=0,
-                goal="Move onto Messages",
-                context=None,
-                toolsets=None,
-                model="anthropic/claude-opus-4.8",
-                max_iterations=10,
-                parent_agent=parent,
-                task_count=1,
-            )
-
-            _, kwargs = MockAgent.call_args
-            self.assertEqual(kwargs["api_mode"], "anthropic_messages")
 
 class TestToolNamePreservation(unittest.TestCase):
     """Verify _last_resolved_tool_names is restored after subagent runs."""
@@ -1710,9 +2006,15 @@ class TestOrchestratorEndToEnd(unittest.TestCase):
                 m.platform = "cli"
                 m.enabled_toolsets = ["terminal", "file", "delegation"]
                 m.api_key = "***"
-                m.base_url = ""
-                m.provider = None
-                m.api_mode = None
+                m.base_url = "https://openrouter.ai/api/v1"
+                m.provider = "openrouter"
+                m.api_mode = "chat_completions"
+                m.model = "anthropic/claude-sonnet-4"
+                m._client_kwargs = {
+                    "api_key": "***",
+                    "base_url": "https://openrouter.ai/api/v1",
+                }
+                m.client = None
                 m.providers_allowed = None
                 m.providers_ignored = None
                 m.providers_order = None

--- a/tests/tools/test_delegate_kanban_isolation.py
+++ b/tests/tools/test_delegate_kanban_isolation.py
@@ -109,9 +109,15 @@ def test_build_child_agent_strips_kanban_toolset_even_when_parent_is_worker(monk
         model = "test-model"
         provider = "test-provider"
         base_url = "http://example.invalid"
+        api_key = "test-key"
         api_mode = "chat_completions"
         platform = "cli"
         session_id = "parent-session"
+        client = None
+        _client_kwargs = {
+            "api_key": "test-key",
+            "base_url": "http://example.invalid",
+        }
 
     child = delegate_tool._build_child_agent(
         task_index=0,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1575,6 +1575,103 @@ def _inherit_parent_base_url(parent_agent, fallback_base_url: Optional[str]) -> 
     return fallback_base_url or None
 
 
+_BEDROCK_SENTINEL_API_KEY = "aws-sdk"
+_MOA_VIRTUAL_PROVIDER = "moa"
+_MOA_VIRTUAL_BASE_URL = "moa://local"
+_MOA_VIRTUAL_API_KEY = "moa-virtual-provider"
+_BEDROCK_REGION_RE = re.compile(r"bedrock-runtime\.([a-z0-9-]+)\.")
+
+
+def _canonical_bedrock_runtime_url(region: str) -> str:
+    return f"https://bedrock-runtime.{region}.amazonaws.com"
+
+
+def _bedrock_region_from_parent(parent_agent) -> str:
+    """Region for native Bedrock identity. Matches ``agent_init`` defaults."""
+    region = str(getattr(parent_agent, "_bedrock_region", None) or "").strip()
+    if region:
+        return region
+    match = _BEDROCK_REGION_RE.search(str(getattr(parent_agent, "base_url", "") or ""))
+    if match:
+        return match.group(1)
+    return "us-east-1"
+
+
+def _snapshot_parent_delegation_runtime(parent_agent) -> dict[str, Any]:
+    """Return the parent's live backend identity for child inheritance (#90009).
+
+    Api-mode-aware: credential-bearing OpenAI/Anthropic endpoints are read
+    from the paired stores ``try_activate_fallback`` /
+    ``restore_primary_runtime`` update atomically. Native/virtual runtimes
+    (Bedrock Converse, MoA) use their own identity semantics — never
+    independent ``provider`` / ``base_url`` / ``api_key`` surface attrs and
+    never a generic credential-format heuristic.
+    """
+    provider = getattr(parent_agent, "provider", None)
+    model = getattr(parent_agent, "model", None)
+    api_mode = getattr(parent_agent, "api_mode", None)
+    provider_norm = (provider or "").strip().lower()
+
+    if api_mode == "anthropic_messages":
+        base_url = getattr(parent_agent, "_anthropic_base_url", None)
+        api_key = getattr(parent_agent, "_anthropic_api_key", None)
+        if not base_url or not api_key:
+            raise ValueError(
+                "Cannot delegate: parent anthropic_messages runtime is "
+                "incomplete (_anthropic_base_url / _anthropic_api_key missing)."
+            )
+    elif api_mode == "bedrock_converse":
+        # Native boto3 runtime. AWS auth is resolved by the SDK at call
+        # time; the child must reconstruct the same Bedrock identity, not
+        # demand OpenAI client credentials and not copy real AWS keys.
+        region = _bedrock_region_from_parent(parent_agent)
+        provider = "bedrock"
+        base_url = _canonical_bedrock_runtime_url(region)
+        api_key = _BEDROCK_SENTINEL_API_KEY
+    elif provider_norm == _MOA_VIRTUAL_PROVIDER:
+        # Virtual aggregator. agent_init / switch_model write this sentinel
+        # tuple as one unit; the facade is not an OpenAI client.
+        provider = _MOA_VIRTUAL_PROVIDER
+        api_mode = "chat_completions"
+        base_url = _MOA_VIRTUAL_BASE_URL
+        api_key = _MOA_VIRTUAL_API_KEY
+    else:
+        kwargs_obj = getattr(parent_agent, "_client_kwargs", None)
+        kwargs: dict[str, Any] = kwargs_obj if isinstance(kwargs_obj, dict) else {}
+        client = getattr(parent_agent, "client", None)
+
+        if kwargs.get("base_url") and kwargs.get("api_key"):
+            base_url = _normalized_runtime_url(kwargs["base_url"]) or None
+            api_key = kwargs["api_key"]
+        elif client is not None:
+            base_url = _normalized_runtime_url(getattr(client, "base_url", "")) or None
+            api_key = getattr(client, "api_key", None)
+            if not base_url or not api_key:
+                raise ValueError(
+                    "Cannot delegate: parent OpenAI client is missing base_url "
+                    "or api_key."
+                )
+        else:
+            raise ValueError(
+                "Cannot delegate: parent runtime has no paired OpenAI "
+                "credentials (_client_kwargs or client). Refusing to inherit "
+                "independent provider/base_url/api_key fields."
+            )
+
+    if not provider or not model:
+        raise ValueError(
+            "Cannot delegate: parent provider or model is unavailable."
+        )
+
+    return {
+        "provider": provider,
+        "model": model,
+        "base_url": base_url,
+        "api_key": api_key,
+        "api_mode": api_mode,
+    }
+
+
 def _build_child_agent(
     task_index: int,
     goal: str,
@@ -1708,13 +1805,37 @@ def _build_child_agent(
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
     )
-    # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
-    parent_api_key = getattr(parent_agent, "api_key", None)
-    if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
-        parent_api_key = parent_agent._client_kwargs.get("api_key")
+    # Resolve effective credentials: config override > parent inherit
+    inherited_runtime = (
+        _snapshot_parent_delegation_runtime(parent_agent)
+        if override_provider is None
+        and override_base_url is None
+        and override_api_key is None
+        else None
+    )
 
-    # Resolve the child's effective model early so it can ride on every event.
-    effective_model_for_cb = model or getattr(parent_agent, "model", None)
+    effective_model = model or (
+        (inherited_runtime or {}).get("model")
+        if inherited_runtime
+        else getattr(parent_agent, "model", None)
+    )
+    if inherited_runtime:
+        effective_provider = inherited_runtime.get("provider")
+        effective_base_url = inherited_runtime.get("base_url")
+        effective_api_key = inherited_runtime.get("api_key")
+        inherited_api_mode = inherited_runtime.get("api_mode")
+    else:
+        parent_api_key = getattr(parent_agent, "api_key", None)
+        if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
+            parent_api_key = parent_agent._client_kwargs.get("api_key")
+        effective_provider = override_provider or getattr(parent_agent, "provider", None)
+        effective_base_url = override_base_url or parent_agent.base_url
+        if not override_base_url:
+            effective_base_url = _inherit_parent_base_url(parent_agent, effective_base_url)
+        effective_api_key = override_api_key or parent_api_key
+        inherited_api_mode = getattr(parent_agent, "api_mode", None)
+
+    effective_model_for_cb = effective_model
 
     # Build progress callback to relay tool calls to parent display.
     # Identity kwargs thread the subagent_id through every emitted event so the
@@ -1751,13 +1872,6 @@ def _build_child_agent(
 
         child_thinking_cb = _child_thinking
 
-    # Resolve effective credentials: config override > parent inherit
-    effective_model = model or parent_agent.model
-    effective_provider = override_provider or getattr(parent_agent, "provider", None)
-    effective_base_url = override_base_url or parent_agent.base_url
-    if not override_base_url:
-        effective_base_url = _inherit_parent_base_url(parent_agent, effective_base_url)
-    effective_api_key = override_api_key or parent_api_key
     # Bug #20558 / PR #20563: api_mode must NOT be inherited when the child uses a
     # different provider than the parent — each provider has its own API surface
     # (e.g. MiniMax uses anthropic_messages, DeepSeek uses chat_completions).
@@ -1780,7 +1894,7 @@ def _build_child_agent(
     elif effective_provider != _parent_provider:
         effective_api_mode = None  # force re-derivation from provider's defaults
     else:
-        effective_api_mode = getattr(parent_agent, "api_mode", None)
+        effective_api_mode = inherited_api_mode
     # Defensive: validate trusted delegation.command exists on PATH before
     # honoring it. An explicitly pinned transport that cannot run must fail
     # the spawn loudly (#80450) — silently falling back to the default


### PR DESCRIPTION
Fixes #90009

### Summary

- inherit delegation runtime state from an api-mode-aware authoritative source;
- use paired client state for OpenAI-compatible and Codex runtimes;
- use Anthropic adapter state for `anthropic_messages`;
- preserve native Bedrock Converse and MoA virtual runtime inheritance;
- fail closed when a credential-bearing parent has no coherent runtime pair.

### Why

`delegate_task` previously assembled the child's provider, endpoint, and
credential from independent parent surfaces. After provider fallback, that
could construct a child with a credential belonging to a different backend
than its endpoint, causing an immediate 401.

Fallback and primary-runtime restore already maintain coherent runtime state.
The defect was at the delegation inheritance boundary.

### Tests

- fallback → delegate inherits the complete Anthropic runtime;
- restore → delegate inherits the restored primary runtime;
- Bedrock Converse → delegate preserves the native Bedrock runtime;
- MoA → delegate preserves the virtual runtime;
- corrupted OpenAI/Codex state fails closed before child construction;
- mutation regression confirms the native-runtime compatibility guard;
- `tests/tools/test_delegate.py`: 74 passed;
- ruff clean.
