### PR TITLE
fix(tests): stop the suite rewriting the checkout it runs from

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4963,10 +4963,15 @@ def __getattr__(name):
         return value
     alias = _LAZY_COMMAND_ALIASES.get(name)
     if alias is not None:
-        import importlib
-
-        module_name, attr = alias
-        value = getattr(importlib.import_module(module_name), attr)
+        _module_name, attr = alias
+        # Resolve through THIS module's own attribute, not a second
+        # import_module of the backing module, so the alias and the canonical
+        # name share one cache entry. Caching them independently let them
+        # drift apart: whichever was read first pinned the function object
+        # from the module as it stood then, and if the backing module was
+        # re-imported before the other was read, the alias kept pointing at a
+        # dead function while the real name pointed at the live one.
+        value = getattr(_self(), attr)
         globals()[name] = value
         return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1487,6 +1487,75 @@ def _live_system_guard(request, monkeypatch):
                     return True
         return False
 
+    # Mutating git subcommands. Read-only git (rev-parse, log, status,
+    # diff, ls-files, ...) is deliberately absent: tests legitimately probe
+    # the checkout's state.
+    _GIT_WRITE_SUBCOMMANDS = frozenset({
+        "am", "apply", "checkout", "cherry-pick", "clean", "commit", "merge",
+        "pull", "rebase", "reset", "restore", "stash", "switch",
+    })
+
+    def _git_write_target(cmd, cwd):
+        """Return (subcommand, target_dir) for mutating git, else (None, None).
+
+        ``git -C <path>`` (and --work-tree/--git-dir) redirect the command at a
+        different repo, so the tests' own tmp_path fixtures legitimately run
+        `git -C /tmp/... commit` while cwd is still the source tree. The
+        redirect wins over cwd; only what actually lands on PROJECT_ROOT counts.
+        """
+        parts = _cmd_to_string(cmd).split()
+        if not parts or "git" not in Path(parts[0]).name:
+            return None, None
+        base = Path(cwd) if cwd is not None else Path.cwd()
+        redirect = None
+        i = 1
+        while i < len(parts):
+            token = parts[i]
+            if token in ("-C", "--work-tree", "--git-dir"):
+                if i + 1 < len(parts):
+                    redirect = parts[i + 1]
+                i += 2
+                continue
+            if token == "-c":
+                i += 2
+                continue
+            if token.startswith("-"):
+                i += 1
+                continue
+            if token not in _GIT_WRITE_SUBCOMMANDS:
+                return None, None
+            target = base if redirect is None else base / redirect
+            return token, target
+        return None, None
+
+    def _check_git_repo_mutation(name, cmd, cwd):
+        """Block mutating git aimed at THIS checkout.
+
+        The `hermes update` argv check above only catches the *spawned* CLI.
+        Called in-process (cli_main._cmd_update_impl(...)), the same code runs
+        bare `git checkout / merge / stash / reset` against PROJECT_ROOT, whose
+        argv contains no "update" at all. A test whose PROJECT_ROOT patch has
+        come unstuck -- e.g. because something replaced hermes_cli.main in
+        sys.modules, orphaning the object the patch was applied to -- then
+        rewrites the developer's real working tree mid-run: uncommitted work
+        stashed away, branch switched, origin merged. Loud failure beats that.
+        """
+        try:
+            subcommand, target = _git_write_target(cmd, cwd)
+            if not subcommand or target.resolve() != PROJECT_ROOT.resolve():
+                return
+        except (OSError, TypeError, ValueError):
+            return
+        raise RuntimeError(
+            f"tests/conftest.py live-system guard: blocked "
+            f"subprocess.{name}({cmd!r}) — `git {subcommand}` with cwd set to "
+            f"the real checkout ({target}). This rewrites the working tree the "
+            "tests are running from (stashing uncommitted work, switching "
+            "branches, merging origin). Point the command at a tmp_path repo, "
+            "or check that the test's PROJECT_ROOT patch is still reaching the "
+            "module under test."
+        )
+
     def _check_subprocess_cmd(name, cmd):
         if _is_blocked_systemctl(cmd):
             raise RuntimeError(
@@ -1543,6 +1612,7 @@ def _live_system_guard(request, monkeypatch):
     def _wrap_subprocess(name, real):
         def _guarded(cmd, *args, **kwargs):
             _check_subprocess_cmd(name, cmd)
+            _check_git_repo_mutation(name, cmd, kwargs.get("cwd"))
             return real(cmd, *args, **kwargs)
         _guarded.__name__ = f"_guarded_{name}"
         # Make the wrapper subscriptable like the wrapped callable when
@@ -1561,6 +1631,7 @@ def _live_system_guard(request, monkeypatch):
         class _GuardedPopen(real):  # type: ignore[misc, valid-type]
             def __init__(self, cmd, *args, **kwargs):
                 _check_subprocess_cmd("Popen", cmd)
+                _check_git_repo_mutation("Popen", cmd, kwargs.get("cwd"))
                 super().__init__(cmd, *args, **kwargs)
 
         _GuardedPopen.__name__ = "Popen"

--- a/tests/hermes_cli/test_skills_subparser.py
+++ b/tests/hermes_cli/test_skills_subparser.py
@@ -3,7 +3,7 @@
 import argparse
 
 
-def test_no_duplicate_skills_subparser():
+def test_no_duplicate_skills_subparser(monkeypatch):
     """Ensure 'skills' subparser is only registered once to avoid Python 3.11+ crash.
 
     Python 3.11 changed argparse to raise an exception on duplicate subparser
@@ -19,9 +19,26 @@ def test_no_duplicate_skills_subparser():
     # argparse.ArgumentError at module load time
     import sys
 
-    # Remove cached module if present
-    if 'hermes_cli.main' in sys.modules:
-        del sys.modules['hermes_cli.main']
+    # Drop the cached module so the import below really re-executes -- but
+    # put BOTH bindings back afterwards. A bare `del sys.modules[...]` leaves
+    # a second hermes_cli.main object installed for the rest of the session,
+    # while every module that already did `from hermes_cli import main as
+    # cli_main` still holds the first one. Their patch.object(cli_main, ...)
+    # then patches an orphan and never reaches the module under test: that is
+    # how test_update_orphan_backend_reap.py lost its PROJECT_ROOT patch and
+    # let _cmd_update_impl run git checkout/merge/stash against the real
+    # checkout, stashing the developer's uncommitted work mid-run.
+    #
+    # `from hermes_cli import main` resolves through the PACKAGE ATTRIBUTE,
+    # which the re-import rebinds too -- so restoring sys.modules alone is not
+    # enough. monkeypatch records the current value of each and restores both
+    # at teardown.
+    import hermes_cli
+
+    cached_main = sys.modules.get('hermes_cli.main')
+    if cached_main is not None:
+        monkeypatch.setattr(hermes_cli, 'main', cached_main, raising=False)
+    monkeypatch.delitem(sys.modules, 'hermes_cli.main', raising=False)
 
     try:
         import hermes_cli.main  # noqa: F401


### PR DESCRIPTION
Fixes #90196.

`pytest tests/hermes_cli/` rewrites the checkout it is run from: real `git checkout main`, `git merge origin/main`, `git stash push --include-untracked` and `git reset --hard HEAD` against the working tree. Uncommitted work disappears mid-run and a feature branch can come back on `main`. It ate an edit of mine before I traced it.

Reproducer, two files, under two seconds on a clean tree:

```bash
echo marker > MARKER.txt
pytest tests/hermes_cli/test_skills_subparser.py \
       tests/hermes_cli/test_update_orphan_backend_reap.py -q
git stash list   # hermes-update-autostash-<timestamp>
ls MARKER.txt    # gone
```

Order matters, which is why it stayed hidden: neither file does it alone, and `-k update` deselects the first one.

### What is happening

`test_skills_subparser` deletes `hermes_cli.main` from `sys.modules` and never restores it, leaving a second module object installed for the rest of the session. `test_update_orphan_backend_reap` had already bound `from hermes_cli import main as cli_main`, so its `patch.object(cli_main, "PROJECT_ROOT", _RootSentinel())` patches an orphan while `update_cmd._m()` re-imports and gets the live module with the real path. The sentinel never trips and `_cmd_update_impl` runs for real:

```
test_update_orphan_backend_reap.py:279  cli_main._cmd_update_impl(...)
hermes_cli/update_cmd.py:4972           _stash_local_changes_if_needed(git_cmd, _m().PROJECT_ROOT)
hermes_cli/update_cmd.py:1487           subprocess.run(cwd=PosixPath('/…/<repo>'))   # a real path
```

### Changes

**1. `test_skills_subparser.py` — restore both bindings.** Restoring `sys.modules` alone is not enough: `from hermes_cli import main` resolves through the package attribute, which the re-import rebinds too.

**2. `tests/conftest.py` — finish the live-system guard.** The guard already written for this hazard only inspects argv for `hermes update`, which catches the spawned CLI but not the in-process call, whose bare `git` argv contains no "update". It now also blocks mutating git resolving onto `PROJECT_ROOT`, honouring `git -C` / `--work-tree` / `--git-dir` so tmp_path fixtures that legitimately run `git -C /tmp/... commit` are unaffected. Read-only git is untouched.

**3. `hermes_cli/main.py` — keep a lazy alias and its canonical name on one object.** `__getattr__` cached `_warn_stale_dashboard_processes` and `_kill_stale_dashboard_processes` independently, each pinning whatever object the backing module held at that moment. If `hermes_cli.dashboard_procs` was re-imported between the two first accesses, the documented back-compat alias pointed at a dead function. Resolving the alias through this module's own attribute gives them one cache entry, making the identity true by construction. `TestBackCompatAlias` was passing only because the leaked `sys.modules` entry happened to keep both accesses on one module object, and went red once (1) was fixed — this is the real fix for it, not a weakened assertion.

### Verification

Full `tests/hermes_cli/` on this branch is at exact parity with the pre-change baseline — 245 failed / 5958 passed / 81 skipped / 9 errors, zero net-new failures — and the run no longer mutates the checkout, which the baseline run did. The reproducer above passes (17 passed) and leaves the tree untouched.

One thing I did **not** fix, flagged for you: `test_lazy_command_exports.py::test_lazy_reexports_resolve_to_real_objects` fails when run after `test_update_stale_dashboard.py`. I verified this is pre-existing and unrelated — it reproduces identically with and without these commits. `hermes_cli.main`'s lazy export cache goes stale for every `dashboard_procs` export once that module is re-imported, not just the alias; change (3) only guarantees the alias and its canonical name agree with each other. The broader staleness looked like a design call for you rather than something to settle in this PR.
