### PR TITLE
test(agent): unbreak main — MoA switch fake needs a reasoning_echo reader

### DIFF
--- a/tests/agent/test_moa_switch_api_mode.py
+++ b/tests/agent/test_moa_switch_api_mode.py
@@ -34,6 +34,12 @@ def _make_fake_agent():
     agent._config_context_length = 123456
     agent._transport_cache = {}
     agent.quiet_mode = True
+    # switch_model re-reads reasoning_echo for the incoming model as part of the
+    # core field swap, before the moa branch runs. On a real AIAgent this is a
+    # method; without it the swap raises and the rollback undoes every field
+    # this test asserts on.
+    agent._reasoning_echo_flag = False
+    agent._read_reasoning_echo_from_config = lambda: False
     return agent
 
 


### PR DESCRIPTION
`main` is currently red: `tests/agent/test_moa_switch_api_mode.py` fails all four cases with `assert 'opencode-go' == 'moa'`. Reproduced at `b2057c1685` with a clean tree, so it blocks every open PR that touches slice 9.

663fa68cd4 added `agent._reasoning_echo_flag = agent._read_reasoning_echo_from_config()` to `switch_model`'s core field swap, two lines after `agent.provider = new_provider`. The fake agent in this test is a `SimpleNamespace` carrying, by design, only the attributes `switch_model` touches — so the new call raises `AttributeError` inside the rollback-protected block. `_restore_snapshot()` then puts `provider`, `base_url` and `api_mode` back to their pre-swap values, and every assertion in the test fails.

Teaching the fake the reader matches the production `AIAgent` shape and restores what the test was written to check. The production call is left alone: it is unguarded in `agent_init.py` too, and a real agent always has the method.