### PR TITLE
fix(gitattributes): force LF for extensionless launcher scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,19 @@ Dockerfile  text eol=lf
 *.dockerfile text eol=lf
 docker/entrypoint.sh text eol=lf
 
+# Extensionless executables are not covered by the *.sh/*.py globs below, so
+# a checkout with core.autocrlf=true (the Git-for-Windows default) silently
+# rewrites their shebang line to end in CRLF, which then fails to resolve
+# (env can't find "python3<CR>"). This is the same class of bug #46227 fixes
+# for docker/cont-init.d/* and docker/s6-rc.d/**/type — this covers the two
+# paths that bug missed: the root desktop/CLI launcher and the s6 run/finish
+# scripts, both of which broke the exact same way ("no such file or
+# directory" / ModuleNotFoundError). Pin these to LF explicitly.
+/hermes text eol=lf
+/scripts/hermes-gateway text eol=lf
+docker/s6-rc.d/**/run text eol=lf
+docker/s6-rc.d/**/finish text eol=lf
+
 # Enforce LF for all source/text files. Windows editors and tools default to
 # CRLF; without normalization a Windows contributor's edit turns into a
 # whole-file phantom diff (every line "changed" by its ending), breaks


### PR DESCRIPTION
## Problem

Extensionless executables aren't matched by any `*.sh`/`*.py` glob in `.gitattributes`. On a checkout with `core.autocrlf=true` (the Git-for-Windows default, but also reachable via any global user gitconfig regardless of OS), git silently rewrites their shebang line to end in CRLF on checkout.

**Note:** #46227 already fixes this for `docker/cont-init.d/*` and `docker/s6-rc.d/**/type`. This PR is scoped to the two paths that one doesn't cover, which broke the same way in my own repro:
- `/hermes` — the root desktop/CLI launcher
- `/scripts/hermes-gateway`
- `docker/s6-rc.d/**/run` and `docker/s6-rc.d/**/finish`

For `/hermes`, this breaks the desktop app launcher: `#!/usr/bin/env python3\r` fails to resolve (`env` looks for a binary literally named `python3\r`) when invoked outside a login-shell PATH — e.g. from a taskbar/`.desktop` entry. In my case this caused the desktop icon to silently fail to launch, and after I patched the shebang locally, a retry surfaced a second unrelated bug (GNOME's ABRT crash-reporter aborting `gnome-shell` itself while handling the resulting Python traceback) — but the root trigger was this CRLF corruption.

## Fix

Add explicit path-based `eol=lf` entries for these extensionless executables so checkout normalizes them to LF regardless of the user's `core.autocrlf` setting, consistent with #46227's approach and the existing policy for `*.sh`/`*.py`/etc.

## Testing

Verified in a clean worktree off `origin/main` with `core.autocrlf=true`:
- Before: `file hermes` → `Python script, ASCII text executable, with CRLF line terminators`.
- After adding the attribute + re-checkout: `file hermes` → `Python script, ASCII text executable` (LF). No content diff, only line-ending normalization.