### PR TITLE
fix(desktop): preserve gateway when switching profiles

### DIFF
--- a/apps/desktop/src/store/profile-agent-activation.test.ts
+++ b/apps/desktop/src/store/profile-agent-activation.test.ts
@@ -35,7 +35,7 @@ vi.mock('@/hermes', () => ({
 vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }))
 vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
 
-const { $activeGatewayProfile, ensureGatewayAgent, ensureGatewayProfile } = await import('./profile')
+const { $activeGatewayProfile, ensureGatewayAgent, ensureGatewayProfile, selectProfile } = await import('./profile')
 const { $connection } = await import('./session')
 
 const agentConn = (over: Partial<HermesConnection> = {}): HermesConnection =>
@@ -63,6 +63,18 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals()
   $connection.set(null)
+})
+
+describe('profile rail preserves the active registry source', () => {
+  it('switches profiles through the current registered gateway', async () => {
+    $connection.set(agentConn({ connectionId: 'homelab', profile: 'clientwhisp' }))
+    getConnectionFor.mockResolvedValue(agentConn({ connectionId: 'homelab', profile: 'sequenzy' }))
+
+    selectProfile('sequenzy')
+
+    await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledWith('homelab', 'sequenzy'))
+    expect(ensureGatewayForProfile).not.toHaveBeenCalled()
+  })
 })
 
 describe('ensureGatewayAgent → $connection / $activeGatewayProfile sync', () => {

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -14,7 +14,7 @@ import {
 } from '@/lib/storage'
 import { invalidateCronModelImpactScopeState } from '@/store/cron-model-impact-scope'
 import { $gateway, ensureGatewayForAgent, ensureGatewayForProfile, openGatewayForProfile } from '@/store/gateway'
-import { setConnection } from '@/store/session'
+import { $connection, setConnection } from '@/store/session'
 import { resetStarmapGraph } from '@/store/starmap'
 import type { ProfileInfo } from '@/types/hermes'
 
@@ -505,7 +505,8 @@ export function selectProfile(name: string): void {
     requestFreshSession()
   }
 
-  void ensureGatewayProfile(target)
+  const connectionId = ($connection.get()?.connectionId ?? '').trim()
+  void (connectionId ? ensureGatewayAgent(connectionId, target) : ensureGatewayProfile(target))
 }
 
 // Start a fresh session in `name` WITHOUT collapsing the "All profiles" browse
@@ -518,7 +519,8 @@ export function newSessionInProfile(name: string): void {
   const target = normalizeProfileKey(name)
   $newChatProfile.set(target)
   requestFreshSession()
-  void ensureGatewayProfile(target)
+  const connectionId = ($connection.get()?.connectionId ?? '').trim()
+  void (connectionId ? ensureGatewayAgent(connectionId, target) : ensureGatewayProfile(target))
 }
 
 export function setShowAllProfiles(value: boolean): void {


### PR DESCRIPTION
## Summary
- keep the active registered connection when switching profiles from the profile rail
- route new sessions in a profile through that same connection
- add a regression test for switching from ClientWhisp to Sequenzy on a registered VPS

## Root cause
The profile rail called the legacy profile-only activation path. That discarded the active registry connection ID, so selecting a profile could leave the registered VPS route. Reselecting the VPS then restored that source's previous profile, creating a gateway/profile selection loop.

## Verification
- `npm exec -- vitest run src/store/profile.test.ts src/store/profile-share.test.ts src/store/profile-agent-activation.test.ts` (28 passed)
- `npm run typecheck` (passed)
- `git diff --check` (passed)