### PR TITLE
fix(tui): persist named-profile sessions to the profile state.db

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -407,16 +407,13 @@ def session_db_for_named_profile(current: "SessionDB | None", profile_name: str 
     name = (profile_name or "").strip()
     if current is None or not name or name in {"default", "custom"}:
         return current
-    try:
-        from hermes_cli.profiles import get_profile_dir
+    from hermes_cli.profiles import get_profile_dir
 
-        wanted = (get_profile_dir(name) / "state.db").resolve()
-        current_path = Path(current.db_path).resolve()
-        if current_path == wanted:
-            return current
-        return SessionDB(db_path=wanted)
-    except Exception:
+    wanted = (get_profile_dir(name) / "state.db").resolve()
+    current_path = Path(current.db_path).resolve()
+    if current_path == wanted:
         return current
+    return SessionDB(db_path=wanted)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -396,6 +396,29 @@ def _default_db_path() -> Path:
     return get_hermes_home() / "state.db"
 
 
+def session_db_for_named_profile(current: "SessionDB | None", profile_name: str | None) -> "SessionDB | None":
+    """Return a SessionDB that owns ``profile_name``'s store.
+
+    Desktop Bot Mode often constructs the agent against the launch/root
+    ``state.db`` while stamping ``profile_name=worker``. Writes then land in
+    the root store and the named profile's own file stays empty. If ``current``
+    already is that profile's path, it is reused.
+    """
+    name = (profile_name or "").strip()
+    if current is None or not name or name in {"default", "custom"}:
+        return current
+    try:
+        from hermes_cli.profiles import get_profile_dir
+
+        wanted = (get_profile_dir(name) / "state.db").resolve()
+        current_path = Path(current.db_path).resolve()
+        if current_path == wanted:
+            return current
+        return SessionDB(db_path=wanted)
+    except Exception:
+        return current
+
+
 # ---------------------------------------------------------------------------
 # Live-DB test-isolation guard
 # ---------------------------------------------------------------------------

--- a/tests/hermes_state/test_named_profile_session_db.py
+++ b/tests/hermes_state/test_named_profile_session_db.py
@@ -238,3 +238,87 @@ def test_agent_session_db_does_not_fallback_to_launch_on_open_failure(homes, mon
         with server._sessions_lock:
             server._sessions.pop(sid, None)
         launch.close()
+
+
+def test_agent_session_db_name_only_does_not_fallback_to_launch_on_open_failure(
+    homes, monkeypatch
+):
+    """Named-profile bind with only profile_name must raise, not reuse launch."""
+    root, _profile = homes
+    from tui_gateway import server
+
+    launch = SessionDB(db_path=root / "state.db")
+    sid = "sid-worker"
+    monkeypatch.setattr(server, "_get_db", lambda: launch)
+
+    class Boom(Exception):
+        pass
+
+    def boom_db(**_kwargs):
+        raise Boom("profile store unavailable")
+
+    monkeypatch.setattr("hermes_state.SessionDB", boom_db)
+    with server._sessions_lock:
+        server._sessions[sid] = {"profile_name": "worker"}
+    try:
+        with pytest.raises(Boom):
+            server._agent_session_db(sid, launch)
+        assert _ids(root / "state.db") == set()
+    finally:
+        with server._sessions_lock:
+            server._sessions.pop(sid, None)
+        launch.close()
+
+
+def test_agent_session_db_name_only_does_not_fallback_on_profile_dir_failure(
+    homes, monkeypatch
+):
+    """get_profile_dir / resolve failure must not bind the agent to launch."""
+    root, _profile = homes
+    from tui_gateway import server
+
+    launch = SessionDB(db_path=root / "state.db")
+    sid = "sid-worker"
+    monkeypatch.setattr(server, "_get_db", lambda: launch)
+
+    class Boom(Exception):
+        pass
+
+    def boom_dir(_name):
+        raise Boom("profile dir unavailable")
+
+    monkeypatch.setattr("hermes_cli.profiles.get_profile_dir", boom_dir)
+    with server._sessions_lock:
+        server._sessions[sid] = {"profile_name": "worker"}
+    try:
+        with pytest.raises(Boom):
+            server._agent_session_db(sid, launch)
+        assert _ids(root / "state.db") == set()
+    finally:
+        with server._sessions_lock:
+            server._sessions.pop(sid, None)
+        launch.close()
+
+
+def test_agent_session_db_reuses_existing_handle_for_profile_home(homes, monkeypatch):
+    """Deferred builds must keep the dedicated handle they already opened."""
+    root, profile = homes
+    from tui_gateway import server
+
+    launch = SessionDB(db_path=root / "state.db")
+    existing = SessionDB(db_path=profile / "state.db")
+    sid = "sid-worker"
+    monkeypatch.setattr(server, "_get_db", lambda: launch)
+    with server._sessions_lock:
+        server._sessions[sid] = {"profile_home": str(profile)}
+    db = None
+    try:
+        db = server._agent_session_db(sid, existing)
+        assert db is existing
+    finally:
+        with server._sessions_lock:
+            server._sessions.pop(sid, None)
+        if db is not None and db is not existing:
+            db.close()
+        existing.close()
+        launch.close()

--- a/tests/hermes_state/test_named_profile_session_db.py
+++ b/tests/hermes_state/test_named_profile_session_db.py
@@ -166,3 +166,75 @@ def test_make_agent_binds_named_profile_home_store(homes, monkeypatch):
 
     assert _ids(profile / "state.db") == {"20260820_tui_worker"}
     assert _ids(root / "state.db") == set()
+
+
+def test_agent_session_db_retargets_explicit_launch_handle(homes, monkeypatch):
+    root, profile = homes
+    from tui_gateway import server
+
+    launch = SessionDB(db_path=root / "state.db")
+    sid = "sid-worker"
+    monkeypatch.setattr(server, "_get_db", lambda: launch)
+    with server._sessions_lock:
+        server._sessions[sid] = {"profile_home": str(profile)}
+    try:
+        db = server._agent_session_db(sid, launch)
+        assert db is not launch
+        db.create_session("20260820_tui_worker", "tui", profile_name="worker")
+        db.close()
+    finally:
+        with server._sessions_lock:
+            server._sessions.pop(sid, None)
+        launch.close()
+
+    assert _ids(profile / "state.db") == {"20260820_tui_worker"}
+    assert _ids(root / "state.db") == set()
+
+
+def test_agent_session_db_binds_from_profile_name_without_home(homes, monkeypatch):
+    root, profile = homes
+    from tui_gateway import server
+
+    launch = SessionDB(db_path=root / "state.db")
+    sid = "sid-worker"
+    monkeypatch.setattr(server, "_get_db", lambda: launch)
+    with server._sessions_lock:
+        server._sessions[sid] = {"profile_name": "worker"}
+    try:
+        db = server._agent_session_db(sid, launch)
+        assert db is not launch
+        db.create_session("20260820_tui_worker", "tui", profile_name="worker")
+        db.close()
+    finally:
+        with server._sessions_lock:
+            server._sessions.pop(sid, None)
+        launch.close()
+
+    assert _ids(profile / "state.db") == {"20260820_tui_worker"}
+    assert _ids(root / "state.db") == set()
+
+
+def test_agent_session_db_does_not_fallback_to_launch_on_open_failure(homes, monkeypatch):
+    root, _profile = homes
+    from tui_gateway import server
+
+    launch = SessionDB(db_path=root / "state.db")
+    sid = "sid-worker"
+    monkeypatch.setattr(server, "_get_db", lambda: launch)
+
+    class Boom(Exception):
+        pass
+
+    def boom_db(**_kwargs):
+        raise Boom("profile store unavailable")
+
+    monkeypatch.setattr("hermes_state.SessionDB", boom_db)
+    with server._sessions_lock:
+        server._sessions[sid] = {"profile_home": str(root / "profiles" / "worker")}
+    try:
+        with pytest.raises(Boom):
+            server._agent_session_db(sid)
+    finally:
+        with server._sessions_lock:
+            server._sessions.pop(sid, None)
+        launch.close()

--- a/tests/hermes_state/test_named_profile_session_db.py
+++ b/tests/hermes_state/test_named_profile_session_db.py
@@ -1,0 +1,168 @@
+"""Named-profile turns must not persist into the launch/root state.db.
+
+Desktop Bot Mode often talks to the default TUI process while stamping
+``profile_name=worker``. The agent still holds the launch SessionDB handle, so
+the row and messages land in the root store. The named profile's own state.db
+never sees them, and opening that profile looks blank.
+
+#88532 made SessionStore follow HERMES_HOME. This covers the TUI/agent handle
+that is constructed once against the launch home and then reused.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import hermes_state
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from hermes_state import SessionDB, session_db_for_named_profile
+
+
+@pytest.fixture
+def homes(tmp_path, monkeypatch):
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "worker"
+    root.mkdir(parents=True)
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", hermes_state._IMPORT_DEFAULT_DB_PATH)
+    return root, profile
+
+
+def _ids(db_path: Path) -> set[str]:
+    if not db_path.exists():
+        return set()
+    conn = sqlite3.connect(str(db_path))
+    try:
+        try:
+            return {row[0] for row in conn.execute("SELECT id FROM sessions")}
+        except sqlite3.OperationalError:
+            return set()
+    finally:
+        conn.close()
+
+
+def test_named_profile_create_does_not_land_in_launch_store(homes):
+    root, profile = homes
+    launch = SessionDB(db_path=root / "state.db")
+    token = set_hermes_home_override(str(profile))
+    try:
+        db = session_db_for_named_profile(launch, "worker")
+        db.create_session("20260820_tui_worker", "tui", profile_name="worker")
+        if db is not launch:
+            db.close()
+    finally:
+        reset_hermes_home_override(token)
+        launch.close()
+
+    assert _ids(profile / "state.db") == {"20260820_tui_worker"}
+    assert _ids(root / "state.db") == set()
+
+
+def test_default_profile_keeps_the_launch_handle(homes):
+    root, _profile = homes
+    launch = SessionDB(db_path=root / "state.db")
+    try:
+        assert session_db_for_named_profile(launch, None) is launch
+        assert session_db_for_named_profile(launch, "default") is launch
+    finally:
+        launch.close()
+
+
+def _stub_make_agent_runtime(monkeypatch, launch):
+    from tui_gateway import server
+
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(server, "_resolve_startup_runtime", lambda: ("test-model", None))
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None, target_model=None: {
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "command": None,
+            "args": None,
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "off")
+    monkeypatch.setattr(server, "_load_reasoning_config", lambda model="": None)
+    monkeypatch.setattr(server, "_load_service_tier", lambda: None)
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda *_a, **_kw: None)
+    monkeypatch.setattr(server, "_get_db", lambda: launch)
+    monkeypatch.setattr(server, "_agent_cbs", lambda _sid: {})
+    return server
+
+
+def test_agent_session_db_writes_to_profile_home_store(homes, monkeypatch):
+    """Bot Mode rebuilds call _make_agent without a db; profile_home is the bind."""
+    root, profile = homes
+    from tui_gateway import server
+
+    launch = SessionDB(db_path=root / "state.db")
+    sid = "sid-worker"
+    monkeypatch.setattr(server, "_get_db", lambda: launch)
+    with server._sessions_lock:
+        server._sessions[sid] = {"profile_home": str(profile)}
+    try:
+        db = server._agent_session_db(sid)
+        db.create_session("20260820_tui_worker", "tui", profile_name="worker")
+        if db is not launch:
+            db.close()
+    finally:
+        with server._sessions_lock:
+            server._sessions.pop(sid, None)
+        launch.close()
+
+    assert _ids(profile / "state.db") == {"20260820_tui_worker"}
+    assert _ids(root / "state.db") == set()
+
+
+def test_agent_session_db_without_profile_home_keeps_launch_handle(homes, monkeypatch):
+    root, _profile = homes
+    from tui_gateway import server
+
+    launch = SessionDB(db_path=root / "state.db")
+    sid = "sid-default"
+    monkeypatch.setattr(server, "_get_db", lambda: launch)
+    with server._sessions_lock:
+        server._sessions[sid] = {}
+    try:
+        assert server._agent_session_db(sid) is launch
+        assert server._agent_session_db(sid, launch) is launch
+    finally:
+        with server._sessions_lock:
+            server._sessions.pop(sid, None)
+        launch.close()
+
+
+def test_make_agent_binds_named_profile_home_store(homes, monkeypatch):
+    """_make_agent must not default a profile_home session to the launch store."""
+    from unittest.mock import patch
+
+    root, profile = homes
+    launch = SessionDB(db_path=root / "state.db")
+    sid = "sid-worker"
+    server = _stub_make_agent_runtime(monkeypatch, launch)
+    with server._sessions_lock:
+        server._sessions[sid] = {"profile_home": str(profile)}
+    try:
+        with patch("run_agent.AIAgent") as mock_agent:
+            server._make_agent(sid, "key-worker")
+        db = mock_agent.call_args.kwargs["session_db"]
+        try:
+            db.create_session("20260820_tui_worker", "tui", profile_name="worker")
+        finally:
+            if db is not launch:
+                db.close()
+    finally:
+        with server._sessions_lock:
+            server._sessions.pop(sid, None)
+        launch.close()
+
+    assert _ids(profile / "state.db") == {"20260820_tui_worker"}
+    assert _ids(root / "state.db") == set()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7013,11 +7013,19 @@ def _agent_session_db(sid: str, session_db=None):
     if home:
         from hermes_state import SessionDB
 
-        return SessionDB(db_path=Path(home) / "state.db")
+        wanted = Path(home) / "state.db"
+        if session_db is not None and Path(session_db.db_path).resolve() == wanted.resolve():
+            return session_db
+        return SessionDB(db_path=wanted)
     from hermes_state import session_db_for_named_profile
 
     base = session_db if session_db is not None else _get_db()
-    return session_db_for_named_profile(base, name) or base
+    bound = session_db_for_named_profile(base, name)
+    if bound is not None:
+        return bound
+    if not name or name in {"default", "custom"}:
+        return base
+    return bound
 
 
 def _make_agent(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6997,6 +6997,31 @@ def _resolve_runtime_with_fallback(
         raise
 
 
+def _agent_session_db(sid: str, session_db=None):
+    """Bind the agent to the session's profile store, not the launch DB.
+
+    Bot Mode session.create stores ``profile_home`` on the live session, but
+    ``_make_agent`` used to default to ``_get_db()`` (the process launch
+    state.db). Turns then persisted under the root store with
+    ``profile_name=worker``, which is why opening the named profile looked blank.
+    """
+    if session_db is not None:
+        return session_db
+    rec = _sessions.get(sid) or {}
+    home = rec.get("profile_home")
+    if home:
+        from hermes_state import SessionDB
+
+        try:
+            return SessionDB(db_path=Path(home) / "state.db")
+        except Exception:
+            logger.debug("failed to open profile session db for agent", exc_info=True)
+    from hermes_state import session_db_for_named_profile
+
+    name = Path(home).name if home else None
+    return session_db_for_named_profile(_get_db(), name) or _get_db()
+
+
 def _make_agent(
     sid: str,
     key: str,
@@ -7174,7 +7199,7 @@ def _make_agent(
         provider_data_collection=_pr.get("data_collection"),
         platform=_resolve_agent_platform(platform_override),
         session_id=session_id or key,
-        session_db=session_db if session_db is not None else _get_db(),
+        session_db=_agent_session_db(sid, session_db),
         ephemeral_system_prompt=system_prompt or None,
         checkpoints_enabled=is_truthy_value(os.environ.get("HERMES_TUI_CHECKPOINTS")),
         pass_session_id=is_truthy_value(os.environ.get("HERMES_TUI_PASS_SESSION_ID")),

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7000,26 +7000,24 @@ def _resolve_runtime_with_fallback(
 def _agent_session_db(sid: str, session_db=None):
     """Bind the agent to the session's profile store, not the launch DB.
 
-    Bot Mode session.create stores ``profile_home`` on the live session, but
-    ``_make_agent`` used to default to ``_get_db()`` (the process launch
-    state.db). Turns then persisted under the root store with
-    ``profile_name=worker``, which is why opening the named profile looked blank.
+    Bot Mode often hands the launch ``state.db`` into ``_make_agent``. If the
+    live session is a named profile, that handle must still be retargeted.
+    A failed profile-store open must not silently fall back to launch.
     """
-    if session_db is not None:
-        return session_db
     rec = _sessions.get(sid) or {}
     home = rec.get("profile_home")
+    name = (
+        (rec.get("profile") or rec.get("profile_name") or "").strip()
+        or (Path(home).name if home else None)
+    )
     if home:
         from hermes_state import SessionDB
 
-        try:
-            return SessionDB(db_path=Path(home) / "state.db")
-        except Exception:
-            logger.debug("failed to open profile session db for agent", exc_info=True)
+        return SessionDB(db_path=Path(home) / "state.db")
     from hermes_state import session_db_for_named_profile
 
-    name = Path(home).name if home else None
-    return session_db_for_named_profile(_get_db(), name) or _get_db()
+    base = session_db if session_db is not None else _get_db()
+    return session_db_for_named_profile(base, name) or base
 
 
 def _make_agent(


### PR DESCRIPTION
## Summary

Desktop Bot Mode talks to the default TUI process. `_make_agent` used to keep the launch `state.db` handle, so named-profile turns landed in the root store.

This follow-up tightens the bind:

- An explicit launch `session_db` is still retargeted when the live session is a named profile.
- Missing `profile_home` still binds from `profile_name` / `profile`.
- A failed profile-store open no longer silently falls back to the launch DB.

Related: #87723 #89789. #88532 covered SessionStore only.

## Test plan

- [x] `pytest tests/hermes_state/test_named_profile_session_db.py tests/gateway/test_multiplex_session_db_profile_scope.py` — 15 passed