### PR TITLE
feat(desktop): add an Appearance toggle that disables the intro splash

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -26,6 +26,7 @@ import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
 import { cn } from '@/lib/utils'
 import { migrateSessionDraft } from '@/store/composer'
 import { migrateQueuedPrompts, parkQueuedPrompts } from '@/store/composer-queue'
+import { $introSplash } from '@/store/intro-splash'
 import { $pinnedSessionIds } from '@/store/layout'
 import { $petActive } from '@/store/pet'
 import { $petOverlayActive } from '@/store/pet-overlay'
@@ -60,6 +61,7 @@ import { ComposerSurfaceProvider, useComposerScope, useComposerSurfaceId } from 
 import type { ChatBarState } from './composer/types'
 import { type DroppedFile, partitionDroppedFiles } from './hooks/use-composer-actions'
 import { type DragKind, useFileDropZone } from './hooks/use-file-drop-zone'
+import { shouldShowIntro } from './intro-visibility'
 import { ProfileTag } from './profile-tag'
 import { isRouteSessionMismatch } from './route-session-state'
 import { useRuntimeMessageRepository } from './runtime-repository'
@@ -391,6 +393,7 @@ const ChatViewContent = memo(function ChatViewContent({
   const gatewayOpen = gatewayState === 'open'
   const introPersonality = useStore($introPersonality)
   const introSeed = useStore($introSeed)
+  const introSplash = useStore($introSplash)
   // PERF: ChatView must not subscribe to the view's $messages — the atom is
   // replaced on every streaming delta flush (~30×/s) and a subscription here
   // re-renders the entire chat shell (header, chat bar, thread wrapper) per
@@ -455,15 +458,18 @@ const ChatViewContent = memo(function ChatViewContent({
   const routeSessionMismatch = isPrimary ? isRouteSessionMismatch(routedSessionId, selectedSessionId, sessions) : false
 
   // The compact new-session pop-out skips the wordmark/tagline intro — it's a
-  // scratch window, not the full-height empty state.
-  const showIntro =
-    isPrimary &&
-    !isAuxiliaryWindow() &&
-    freshDraftReady &&
-    !isRoutedSessionView &&
-    !selectedSessionId &&
-    !activeSessionId &&
-    messagesEmpty
+  // scratch window, not the full-height empty state. The Appearance toggle
+  // turns it off everywhere else.
+  const showIntro = shouldShowIntro({
+    activeSessionId,
+    auxiliaryWindow: isAuxiliaryWindow(),
+    enabled: introSplash,
+    freshDraftReady,
+    messagesEmpty,
+    primary: isPrimary,
+    routedSessionView: isRoutedSessionView,
+    selectedSessionId
+  })
 
   // Session is still loading if the route references a session we haven't
   // resumed yet. Once `activeSessionId` is set (runtime has resumed), the

--- a/apps/desktop/src/app/chat/intro-visibility.test.ts
+++ b/apps/desktop/src/app/chat/intro-visibility.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldShowIntro } from './intro-visibility'
+
+const showing = {
+  activeSessionId: null,
+  auxiliaryWindow: false,
+  enabled: true,
+  freshDraftReady: true,
+  messagesEmpty: true,
+  primary: true,
+  routedSessionView: false,
+  selectedSessionId: null
+} as const
+
+describe('shouldShowIntro', () => {
+  it('shows on a fresh draft in the primary window', () => {
+    expect(shouldShowIntro(showing)).toBe(true)
+  })
+
+  it('hides when the Appearance toggle is off', () => {
+    expect(shouldShowIntro({ ...showing, enabled: false })).toBe(false)
+  })
+
+  it('keeps the toggle authoritative over every other clause', () => {
+    // Off means off: no window, session, or draft state re-enables the splash.
+    const inputs = [
+      { ...showing, auxiliaryWindow: true, enabled: false },
+      { ...showing, enabled: false, freshDraftReady: false },
+      { ...showing, enabled: false, primary: false },
+      { ...showing, enabled: false, messagesEmpty: false }
+    ]
+
+    for (const input of inputs) {
+      expect(shouldShowIntro(input)).toBe(false)
+    }
+  })
+
+  it('hides on surfaces that are not an empty primary draft', () => {
+    expect(shouldShowIntro({ ...showing, primary: false })).toBe(false)
+    expect(shouldShowIntro({ ...showing, auxiliaryWindow: true })).toBe(false)
+    expect(shouldShowIntro({ ...showing, freshDraftReady: false })).toBe(false)
+    expect(shouldShowIntro({ ...showing, routedSessionView: true })).toBe(false)
+    expect(shouldShowIntro({ ...showing, selectedSessionId: 'session-1' })).toBe(false)
+    expect(shouldShowIntro({ ...showing, activeSessionId: 'session-1' })).toBe(false)
+    expect(shouldShowIntro({ ...showing, messagesEmpty: false })).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/chat/intro-visibility.ts
+++ b/apps/desktop/src/app/chat/intro-visibility.ts
@@ -1,0 +1,32 @@
+/**
+ * Whether the empty-chat intro splash renders.
+ *
+ * The splash is the full-height empty state of the primary chat: it belongs to
+ * a fresh draft in the main window and nothing else. Auxiliary and non-primary
+ * windows are scratch surfaces, a routed or active session already owns the
+ * view, and any transcript at all means the conversation started.
+ *
+ * `enabled` is the user's Appearance toggle and outranks every other clause:
+ * turning the splash off never depends on which window asks.
+ */
+export function shouldShowIntro(input: {
+  activeSessionId: null | string
+  auxiliaryWindow: boolean
+  enabled: boolean
+  freshDraftReady: boolean
+  messagesEmpty: boolean
+  primary: boolean
+  routedSessionView: boolean
+  selectedSessionId: null | string
+}): boolean {
+  return (
+    input.enabled &&
+    input.primary &&
+    !input.auxiliaryWindow &&
+    input.freshDraftReady &&
+    !input.routedSessionView &&
+    !input.selectedSessionId &&
+    !input.activeSessionId &&
+    input.messagesEmpty
+  )
+}

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -16,6 +16,7 @@ import { cn } from '@/lib/utils'
 import { $backdrop, setBackdrop } from '@/store/backdrop'
 import { $composerPopoutGesturesEnabled, setComposerPopoutGesturesEnabled } from '@/store/composer-popout'
 import { $embedAllowed, $embedMode, clearEmbedAllowed, type EmbedMode, setEmbedMode } from '@/store/embed-consent'
+import { $introSplash, setIntroSplash } from '@/store/intro-splash'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enabled'
 import { $reasoningCollapsedByDefault, setReasoningCollapsedByDefault } from '@/store/reasoning-disclosure'
@@ -352,6 +353,7 @@ export function AppearanceSettings() {
   const glassMode = translucency.mode === 'glass' && GLASS_SUPPORTED
   const reactionsEnabled = useStore($reactionsEnabled)
   const backdrop = useStore($backdrop)
+  const introSplash = useStore($introSplash)
   const installs = useStore($marketplaceInstalls)
   const profiles = useStore($profiles)
   const activeProfileKey = normalizeProfileKey(useStore($activeGatewayProfile))
@@ -682,6 +684,25 @@ export function AppearanceSettings() {
             description={a.backdropDesc}
             id={appearanceSettingElementId(APPEARANCE_SETTING_IDS.backdrop)}
             title={a.backdropTitle}
+          />
+
+          <ListRow
+            action={
+              <SegmentedControl
+                onChange={id => {
+                  triggerHaptic('selection')
+                  setIntroSplash(id === 'on')
+                }}
+                options={[
+                  { id: 'off', label: t.common.off },
+                  { id: 'on', label: t.common.on }
+                ]}
+                value={introSplash ? 'on' : 'off'}
+              />
+            }
+            description={a.introSplashDesc}
+            id={appearanceSettingElementId(APPEARANCE_SETTING_IDS.introSplash)}
+            title={a.introSplashTitle}
           />
 
           <ToggleRow

--- a/apps/desktop/src/app/settings/settings-search.ts
+++ b/apps/desktop/src/app/settings/settings-search.ts
@@ -13,6 +13,7 @@ export type CredentialSettingsView = 'settings' | 'tools'
 export const APPEARANCE_SETTING_IDS = {
   backdrop: 'appearance.backdrop',
   embeds: 'appearance.embeds',
+  introSplash: 'appearance.intro-splash',
   language: 'appearance.language',
   theme: 'appearance.theme',
   toolView: 'appearance.tool-view',

--- a/apps/desktop/src/app/settings/use-settings-search.ts
+++ b/apps/desktop/src/app/settings/use-settings-search.ts
@@ -162,6 +162,15 @@ export function useSettingsSearchCatalog(enabled: boolean) {
     },
     {
       context: appearanceContext,
+      description: appearance.introSplashDesc,
+      icon: Palette,
+      id: `setting:${APPEARANCE_SETTING_IDS.introSplash}`,
+      keywords: ['splash', 'wordmark', 'empty chat', 'new chat'],
+      label: appearance.introSplashTitle,
+      target: { setting: APPEARANCE_SETTING_IDS.introSplash, view: 'config:appearance' }
+    },
+    {
+      context: appearanceContext,
       description: appearance.toolViewDesc,
       icon: Palette,
       id: `setting:${APPEARANCE_SETTING_IDS.toolView}`,

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -433,6 +433,8 @@ export const ar = defineLocale({
       },
       backdropTitle: 'خلفية النافذة',
       backdropDesc: 'اختيار مقدار مزج خلفية سطح المكتب مع سطح Hermes.',
+      introSplashTitle: 'شاشة المقدمة',
+      introSplashDesc: 'الشعار النصي والعبارة التمهيدية في محادثة فارغة.',
       reactionsTitle: 'تفاعلات الرسائل',
       reactionsDesc: 'تفاعلات إيموجي بأسلوب iMessage — تفاعل مع الرسائل، ويمكن لـ Hermes التفاعل مع رسائلك.',
       composerPopoutTitle: 'محرر عائم',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -542,6 +542,8 @@ export const en: Translations = {
       },
       backdropTitle: 'Chat Backdrop',
       backdropDesc: 'The faint statue image behind the conversation.',
+      introSplashTitle: 'Intro Splash',
+      introSplashDesc: 'The wordmark and prompt shown on an empty chat.',
       reactionsTitle: 'Message Reactions',
       reactionsDesc: 'iMessage-style emoji tapbacks — react to messages, and Hermes can react to yours.',
       composerPopoutTitle: 'Floating Composer',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -366,6 +366,8 @@ export const ja = defineLocale({
       },
       backdropTitle: 'チャット背景',
       backdropDesc: '会話の背後に表示される淡い彫像の画像。',
+      introSplashTitle: 'イントロ表示',
+      introSplashDesc: '空のチャットに表示されるワードマークとプロンプト。',
       reactionsTitle: 'メッセージリアクション',
       reactionsDesc:
         'iMessage風の絵文字タップバック — メッセージにリアクションでき、Hermesもあなたのメッセージにリアクションします。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -440,6 +440,8 @@ export interface Translations {
       }
       backdropTitle: string
       backdropDesc: string
+      introSplashTitle: string
+      introSplashDesc: string
       reactionsTitle: string
       reactionsDesc: string
       composerPopoutTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -358,6 +358,8 @@ export const zhHant = defineLocale({
       },
       backdropTitle: '聊天背景',
       backdropDesc: '對話後方那張淡淡的雕像圖片。',
+      introSplashTitle: '開場標識',
+      introSplashDesc: '空白對話中顯示的字標和提示語。',
       reactionsTitle: '訊息回應',
       reactionsDesc: 'iMessage 風格的表情回應 — 你可以對訊息做出回應，Hermes 也能回應你的訊息。',
       composerPopoutTitle: '懸浮輸入框',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -531,6 +531,8 @@ export const zh: Translations = {
       },
       backdropTitle: '聊天背景',
       backdropDesc: '对话后方那张淡淡的雕像图片。',
+      introSplashTitle: '开场标识',
+      introSplashDesc: '空白对话中显示的字标和提示语。',
       reactionsTitle: '消息回应',
       reactionsDesc: 'iMessage 风格的表情回应 — 你可以给消息添加回应，Hermes 也能回应你的消息。',
       composerPopoutTitle: '悬浮输入框',

--- a/apps/desktop/src/store/intro-splash.ts
+++ b/apps/desktop/src/store/intro-splash.ts
@@ -1,0 +1,14 @@
+import { atom } from 'nanostores'
+
+import { persistBoolean, storedBoolean } from '@/lib/storage'
+
+const KEY = 'hermes.desktop.intro-splash.v1'
+
+/** Whether the wordmark + tagline splash renders on an empty chat. */
+export const $introSplash = atom(storedBoolean(KEY, true))
+
+$introSplash.subscribe(on => persistBoolean(KEY, on))
+
+export function setIntroSplash(on: boolean) {
+  $introSplash.set(on)
+}


### PR DESCRIPTION
## What does this PR do?

The wordmark and tagline on an empty chat had no off switch. This PR adds an Appearance row, **Intro Splash**, that hides the splash. The row is on by default, so the current experience does not change.

The splash is renderer chrome. No other Hermes surface can change it, so `$introSplash` is a local nanostore with localStorage persistence. This matches the `$backdrop` toggle beside it in the same section. The store does **not** mirror into gateway config. Compare `$reactionsEnabled`, which must mirror to `display.message_reactions` because the backend gates the `react_to_message` tool on that value. Nothing on the backend reads the splash. If you want the setting in `config.yaml`, tell me and I will add the `config.set` call.

The visibility condition was 7 inline clauses in a god-component that a unit test cannot reach. The new clause is the toggle of the user, and that clause must win over all the others. This PR moves the condition into `shouldShowIntro()`, beside the `isRouteSessionMismatch()` helper that solves the same problem for the route.

## Related Issue

No issue exists. Ethie requested this change directly. I searched the open and closed issues and pull requests for a splash toggle and found none.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/intro-splash.ts` (new): the `$introSplash` nanostore. It persists to localStorage and defaults to on.
- `apps/desktop/src/app/chat/intro-visibility.ts` (new): `shouldShowIntro()`, the extracted condition.
- `apps/desktop/src/app/chat/intro-visibility.test.ts` (new): 4 tests for that function.
- `apps/desktop/src/app/chat/index.tsx`: subscribe to the store and call the extracted function.
- `apps/desktop/src/app/settings/appearance-settings.tsx`: the Off/On row, after Chat Backdrop.
- `apps/desktop/src/app/settings/settings-search.ts` and `use-settings-search.ts`: the search id and the command palette entry. The keywords are `splash`, `wordmark`, `empty chat`, and `new chat`.
- `apps/desktop/src/i18n/{types,en,zh,zh-hant,ja,ar}.ts`: the two strings in all five locales. `defineLocale()` merges over `en`, so an absent key shows English text in a translated pane.

## How to Test

1. Open Settings, then Appearance. Set **Intro Splash** to Off.
2. Open a new chat. The wordmark and the tagline are absent.
3. Restart the app and open a new chat. The setting holds.
4. Set the row back to On. The splash returns.
5. Open the command palette and type `new chat`. The result opens Appearance at the highlighted row.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — see the note below
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS (luna), in the repository dev shell

Note on the test line: this branch changes TypeScript only, so the Python suite covers none of it. Per `AGENTS.md`, tests about `.ts`/`.tsx` files belong in the vitest suite. From `apps/desktop`, inside `nix develop`:

- `npm run typecheck` passes.
- `npm run lint` reports 0 errors. The 118 warnings are the same count as on `main`.
- `npx vitest run src/app/chat/intro-visibility.test.ts src/components/assistant-ui/thread/streaming.test.tsx src/i18n` passes. The result is 6 files and 48 tests.

The 4 new tests prove the authority of the toggle instead of asserting it. One case walks the auxiliary-window, non-primary, no-draft, and non-empty inputs with `enabled: false`. None of them turn the splash back on.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — N/A. The row is self-describing and the description string is in all five locales.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — N/A. The setting adds no config key.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A — N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — the code is renderer TypeScript with no platform branch. It behaves the same on all three hosts.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A — N/A. No tool changes.

## Screenshots / Logs

```
$ npm run typecheck
tsc -p . --noEmit && tsc -p tsconfig.electron.json --noEmit && tsc -p tsconfig.e2e.json --noEmit

$ npx vitest run src/app/chat/intro-visibility.test.ts src/components/assistant-ui/thread/streaming.test.tsx src/i18n
 Test Files  6 passed (6)
      Tests  48 passed (48)

$ npm run lint
✖ 118 problems (0 errors, 118 warnings)
```
