### PR TITLE
fix(auth): correct MiniMax OAuth API key hint

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1321,14 +1321,8 @@ def init_agent(
                     # Look up the actual env var name from the provider
                     # config — some providers use non-standard names
                     # (e.g. alibaba → DASHSCOPE_API_KEY, not ALIBABA_API_KEY).
-                    _env_hint = f"{_explicit.upper()}_API_KEY"
-                    try:
-                        from hermes_cli.auth import PROVIDER_REGISTRY
-                        _pcfg = PROVIDER_REGISTRY.get(_explicit)
-                        if _pcfg and _pcfg.api_key_env_vars:
-                            _env_hint = _pcfg.api_key_env_vars[0]
-                    except Exception:
-                        pass
+                    from hermes_cli.auth import provider_api_key_env_hint
+                    _env_hint = provider_api_key_env_hint(_explicit)
                     # --- Init-time fallback (#17929) ---
                     _fb_entries = []
                     if isinstance(fallback_model, list):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9395,9 +9395,11 @@ def _call_llm_impl(
                     resolved_provider = fb_label or resolved_provider
                     effective_provider = resolved_provider
                 else:
+                    from hermes_cli.auth import provider_api_key_env_hint
+
                     raise RuntimeError(
                         f"Provider '{_explicit}' is set in config.yaml but no API key "
-                        f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                        f"was found. Set the {provider_api_key_env_hint(_explicit)} environment "
                         f"variable, or switch to a different provider with `hermes model`."
                     )
             # For auto/custom with no credentials, try the full auto chain
@@ -10216,9 +10218,11 @@ async def _async_call_llm_impl(
                     resolved_provider = fb_label or resolved_provider
                     effective_provider = resolved_provider
                 else:
+                    from hermes_cli.auth import provider_api_key_env_hint
+
                     raise RuntimeError(
                         f"Provider '{_explicit}' is set in config.yaml but no API key "
-                        f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                        f"was found. Set the {provider_api_key_env_hint(_explicit)} environment "
                         f"variable, or switch to a different provider with `hermes model`."
                     )
             if client is None and not resolved_base_url:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -383,6 +383,8 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         id="minimax-oauth",
         name="MiniMax (OAuth \u00b7 minimax.io)",
         auth_type="oauth_minimax",
+        # Keep api_key_env_vars empty: OAuth credential discovery must not
+        # consume MINIMAX_API_KEY, which is only a user-facing fallback hint.
         portal_base_url=MINIMAX_OAUTH_GLOBAL_BASE,
         inference_base_url=MINIMAX_OAUTH_GLOBAL_INFERENCE,
         client_id=MINIMAX_OAUTH_CLIENT_ID,
@@ -561,7 +563,9 @@ def provider_api_key_env_hint(provider_id: str) -> str:
     if config and config.api_key_env_vars:
         return config.api_key_env_vars[0]
     if provider_id == "minimax-oauth":
-        return PROVIDER_REGISTRY["minimax"].api_key_env_vars[0]
+        minimax = PROVIDER_REGISTRY.get("minimax")
+        if minimax and minimax.api_key_env_vars:
+            return minimax.api_key_env_vars[0]
     return f"{provider_id.upper()}_API_KEY"
 
 # Auto-extend PROVIDER_REGISTRY with any api-key provider registered in

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -553,6 +553,17 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
     ),
 }
 
+
+def provider_api_key_env_hint(provider_id: str) -> str:
+    """Return the user-facing API-key environment variable for a provider."""
+    provider_id = provider_id.strip().lower()
+    config = PROVIDER_REGISTRY.get(provider_id)
+    if config and config.api_key_env_vars:
+        return config.api_key_env_vars[0]
+    if provider_id == "minimax-oauth":
+        return PROVIDER_REGISTRY["minimax"].api_key_env_vars[0]
+    return f"{provider_id.upper()}_API_KEY"
+
 # Auto-extend PROVIDER_REGISTRY with any api-key provider registered in
 # providers/ that is not already declared above.  New providers only need a
 # plugins/model-providers/<name>/ plugin — no edits to this file required.

--- a/tests/agent/test_auxiliary_provider_env_hint.py
+++ b/tests/agent/test_auxiliary_provider_env_hint.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from agent.auxiliary_client import async_call_llm, call_llm
-from hermes_cli.auth import PROVIDER_REGISTRY, provider_api_key_env_hint
+from hermes_cli.auth import PROVIDER_REGISTRY, ProviderConfig, provider_api_key_env_hint
 
 
 def test_provider_api_key_env_hint_uses_registry_and_safe_fallback():
@@ -11,6 +11,21 @@ def test_provider_api_key_env_hint_uses_registry_and_safe_fallback():
     assert PROVIDER_REGISTRY["minimax-oauth"].api_key_env_vars == ()
     assert provider_api_key_env_hint("alibaba") == "DASHSCOPE_API_KEY"
     assert provider_api_key_env_hint("future-provider") == "FUTURE-PROVIDER_API_KEY"
+
+
+@pytest.mark.parametrize(
+    "minimax_config",
+    [None, ProviderConfig(id="minimax", name="MiniMax", auth_type="api_key")],
+)
+def test_minimax_oauth_hint_falls_back_when_api_key_metadata_is_unavailable(
+    monkeypatch, minimax_config
+):
+    if minimax_config is None:
+        monkeypatch.delitem(PROVIDER_REGISTRY, "minimax")
+    else:
+        monkeypatch.setitem(PROVIDER_REGISTRY, "minimax", minimax_config)
+
+    assert provider_api_key_env_hint("minimax-oauth") == "MINIMAX-OAUTH_API_KEY"
 
 
 @pytest.mark.parametrize("async_mode", [False, True])

--- a/tests/agent/test_auxiliary_provider_env_hint.py
+++ b/tests/agent/test_auxiliary_provider_env_hint.py
@@ -3,11 +3,12 @@ from unittest.mock import patch
 import pytest
 
 from agent.auxiliary_client import async_call_llm, call_llm
-from hermes_cli.auth import provider_api_key_env_hint
+from hermes_cli.auth import PROVIDER_REGISTRY, provider_api_key_env_hint
 
 
 def test_provider_api_key_env_hint_uses_registry_and_safe_fallback():
     assert provider_api_key_env_hint("minimax-oauth") == "MINIMAX_API_KEY"
+    assert PROVIDER_REGISTRY["minimax-oauth"].api_key_env_vars == ()
     assert provider_api_key_env_hint("alibaba") == "DASHSCOPE_API_KEY"
     assert provider_api_key_env_hint("future-provider") == "FUTURE-PROVIDER_API_KEY"
 

--- a/tests/agent/test_auxiliary_provider_env_hint.py
+++ b/tests/agent/test_auxiliary_provider_env_hint.py
@@ -1,0 +1,42 @@
+from unittest.mock import patch
+
+import pytest
+
+from agent.auxiliary_client import async_call_llm, call_llm
+from hermes_cli.auth import provider_api_key_env_hint
+
+
+def test_provider_api_key_env_hint_uses_registry_and_safe_fallback():
+    assert provider_api_key_env_hint("minimax-oauth") == "MINIMAX_API_KEY"
+    assert provider_api_key_env_hint("alibaba") == "DASHSCOPE_API_KEY"
+    assert provider_api_key_env_hint("future-provider") == "FUTURE-PROVIDER_API_KEY"
+
+
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.asyncio
+async def test_minimax_oauth_missing_credentials_names_supported_api_key_env(
+    async_mode,
+):
+    kwargs = {
+        "messages": [{"role": "user", "content": "summarize"}],
+        "provider": "minimax-oauth",
+        "model": "MiniMax-M2.1",
+        "task": "compression",
+    }
+    with (
+        patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(None, kwargs["model"]),
+        ),
+        patch(
+            "agent.auxiliary_client._try_configured_fallback_for_unavailable_client",
+            return_value=(None, None, None),
+        ),
+    ):
+        with pytest.raises(
+            RuntimeError, match="Set the MINIMAX_API_KEY environment variable"
+        ):
+            if async_mode:
+                await async_call_llm(**kwargs)
+            else:
+                call_llm(**kwargs)


### PR DESCRIPTION
## Summary

Fixes #89516.

MiniMax OAuth credential failures synthesized `MINIMAX-OAUTH_API_KEY`, which is not supported. This centralizes display-hint resolution and maps `minimax-oauth` to `MINIMAX_API_KEY` without adding that variable to OAuth credential discovery. Main-agent initialization plus sync and async auxiliary calls now use the same resolver.

## Evidence

- Exact proof base: `78ffd71f14021c808a959ba598b33b557f93d8b1`
- Exact current head: `0ecb55fe53f143ca4a81e093ac6d969eb0483ffd`

Before, the production unavailable-client paths reported `MINIMAX-OAUTH_API_KEY`. This head reports `MINIMAX_API_KEY`.

The current-head registry-boundary regression also pins the non-change: `provider_api_key_env_hint("minimax-oauth") == "MINIMAX_API_KEY"` while `PROVIDER_REGISTRY["minimax-oauth"].api_key_env_vars == ()`. That tuple is consumed by credential-pool, setup, inventory, model-switch, and runtime discovery paths, so populating it would change OAuth credential discovery rather than only fixing the user-facing hint.

Related approaches #89517 and #90281 populate the discovery tuple; this PR keeps hint rendering and credential discovery separate so maintainers can evaluate the ownership boundary explicitly.

## Validation

- Initial exact-head focused and neighboring validation: 62 passed
- Current-head related MiniMax OAuth/provider validation: 132 passed
- Ruff check on the four changed files: passed
- `git diff --check`: passed
- Changed-file TruffleHog scan: 0 verified / 0 unknown findings
- Hosted `CI`, Docker, and Nix workflows are currently `action_required` and await upstream approval for this fork head

Ruff format on the existing production files reports pre-existing whole-file drift on the proof base. The new regression file is formatted; no unrelated reformat is included.

