### PR TITLE
fix(approval): route check_execute_code_guard through the CLI fall-through too (salvage of #86270)

### DIFF
--- a/tests/tools/test_cli_approval_exec_ask_leak.py
+++ b/tests/tools/test_cli_approval_exec_ask_leak.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 import pytest
 
 import tools.approval as approval_module
-from tools.approval import check_all_command_guards
+from tools.approval import check_all_command_guards, check_execute_code_guard
 from tools.terminal_tool import set_approval_callback
 
 
@@ -82,6 +82,74 @@ class TestCliApprovalSurvivesExecAskLeak:
         set_approval_callback(None)
 
         result = check_all_command_guards("rm -rf /tmp/testdir", "local")
+
+        assert result.get("approved") is False
+        assert result.get("status") == "pending_approval"
+        assert result.get("approval_pending") is True
+
+
+class TestExecuteCodeGuardCliApprovalSurvivesExecAskLeak:
+    """check_execute_code_guard (the whole-script gate) had its own,
+    unfixed copy of the same notify_cb-less short-circuit — sibling of
+    check_all_command_guards, same leak, same missing CLI fall-through."""
+
+    def test_cli_callback_used_when_exec_ask_set_without_notifier(self, monkeypatch):
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        calls = []
+
+        def _cb(command, description, **kwargs):
+            calls.append((command, description))
+            return "once"
+
+        set_approval_callback(_cb)
+        result = check_execute_code_guard("print('hi')", "local")
+
+        assert calls, "CLI approval callback was never invoked"
+        assert result.get("status") != "pending_approval"
+        assert result.get("approval_pending") is not True
+        assert result.get("approved") is True
+        assert result.get("user_approved") is True
+
+    def test_cli_callback_deny_blocks_execution(self, monkeypatch):
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        set_approval_callback(lambda command, description, **kwargs: "deny")
+
+        result = check_execute_code_guard("print('hi')", "local")
+
+        assert result.get("approved") is False
+        assert result.get("outcome") == "denied"
+        assert result.get("status") != "pending_approval"
+
+    def test_cli_callback_timeout_blocks_execution(self, monkeypatch):
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        set_approval_callback(lambda command, description, **kwargs: "timeout")
+
+        result = check_execute_code_guard("print('hi')", "local")
+
+        assert result.get("approved") is False
+        assert result.get("outcome") == "timeout"
+
+    def test_cli_callback_session_choice_persists_approval(self, monkeypatch):
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        set_approval_callback(lambda command, description, **kwargs: "session")
+
+        first = check_execute_code_guard("print('hi')", "local")
+        assert first.get("approved") is True
+
+        # A second call in the same session must short-circuit on the
+        # session-approval cache without prompting again.
+        set_approval_callback(None)
+        second = check_execute_code_guard("print('again')", "local")
+        assert second.get("approved") is True
+        assert second.get("status") != "pending_approval"
+
+    def test_pending_approval_still_used_without_cli_callback(self, monkeypatch):
+        """Headless ask-mode without a CLI callback keeps the pending fallback."""
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        set_approval_callback(None)
+
+        result = check_execute_code_guard("print('hi')", "local")
 
         assert result.get("approved") is False
         assert result.get("status") == "pending_approval"

--- a/tests/tools/test_cli_approval_exec_ask_leak.py
+++ b/tests/tools/test_cli_approval_exec_ask_leak.py
@@ -51,8 +51,12 @@ def _clean_approval_env(monkeypatch):
     approval_module._session_approved.clear()
     approval_module._permanent_approved.clear()
     approval_module._pending.clear()
+    # The consecutive-denial breaker is process-global; a tally left behind by
+    # another test would leak its escalated addendum into these assertions.
+    approval_module._denial_tally.clear()
     set_approval_callback(None)
     yield
+    approval_module._denial_tally.clear()
     set_approval_callback(None)
 
 
@@ -154,6 +158,73 @@ class TestExecuteCodeGuardCliApprovalSurvivesExecAskLeak:
         assert result.get("approved") is False
         assert result.get("status") == "pending_approval"
         assert result.get("approval_pending") is True
+
+    def test_cli_callback_used_for_platform_marker_leak_without_exec_ask(
+        self, monkeypatch
+    ):
+        """The other half of the leak: a session platform marker, no ask-mode.
+
+        ``_is_gateway_approval_context()`` is true whenever
+        ``HERMES_SESSION_PLATFORM`` is set, so the whole-script gate is
+        reached with ``HERMES_EXEC_ASK`` entirely absent. That path must
+        show the CLI panel too, not a silent pending approval.
+        """
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        calls = []
+
+        def _cb(command, description, **kwargs):
+            calls.append((command, description))
+            return "once"
+
+        set_approval_callback(_cb)
+        result = check_execute_code_guard("print('marker')", "local")
+
+        assert calls, "CLI approval callback was never invoked"
+        assert result.get("approved") is True
+        assert result.get("status") != "pending_approval"
+        assert result.get("approval_pending") is not True
+
+
+class TestExecuteCodeGuardCliDenialBreakerParity:
+    """The CLI fall-through must match its sibling guards' breaker semantics.
+
+    The consecutive-denial breaker counts *guardian LLM* DENY verdicts, so a
+    deliberate human deny must not advance the tally; and once the tally has
+    tripped, the escalated addendum belongs on the timeout message too (the
+    same function's gateway arm and ``check_all_command_guards``' CLI tail
+    both include it).
+    """
+
+    def test_human_deny_does_not_advance_the_guardian_breaker(self, monkeypatch):
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        set_approval_callback(lambda command, description, **kwargs: "deny")
+
+        for _ in range(3):
+            result = check_execute_code_guard("print('hi')", "local")
+            assert result.get("outcome") == "denied"
+
+        assert not approval_module._denial_tally, (
+            "a human deny must not advance the guardian-verdict breaker "
+            "(check_all_command_guards does not)"
+        )
+
+    def test_timeout_message_carries_breaker_addendum_once_tripped(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        session_key = approval_module.get_current_session_key()
+        threshold = approval_module._get_denial_breaker_threshold()
+        for _ in range(threshold):
+            approval_module._record_denial(session_key)
+        expected = approval_module._denial_breaker_addendum(session_key)
+        assert expected, "breaker should be tripped for this fixture"
+
+        set_approval_callback(lambda command, description, **kwargs: "timeout")
+        result = check_execute_code_guard("print('hi')", "local")
+
+        assert result.get("outcome") == "timeout"
+        assert expected in (result.get("message") or "")
 
 
 class TestGatewayRunImportDoesNotSetExecAsk:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -5250,13 +5250,15 @@ def check_execute_code_guard(code: str, env_type: str,
             )
 
             if choice == "timeout":
+                breaker_addendum = _denial_breaker_addendum(session_key)
                 return {
                     "approved": False,
                     "message": (
                         "BLOCKED: Action timed out without user response. The "
                         "user has NOT consented to this action. Do NOT retry "
                         "it, do NOT rephrase it, and do NOT attempt the same "
-                        "outcome via a different path. Silence is not consent."
+                        "outcome via a different path. Silence is not "
+                        f"consent.{breaker_addendum}"
                     ),
                     "pattern_key": pattern_key,
                     "description": description,
@@ -5264,7 +5266,12 @@ def check_execute_code_guard(code: str, env_type: str,
                     "user_consent": False,
                 }
             if choice == "deny":
-                _record_denial(session_key)
+                # No _record_denial() here: the breaker counts consecutive
+                # *guardian LLM* DENY verdicts (see _record_denial), not
+                # deliberate human denials. Both sibling CLI tails
+                # (check_all_command_guards, _run_approval_gate) read the
+                # tally without incrementing it on a human deny; this arm
+                # matches them.
                 breaker_addendum = _denial_breaker_addendum(session_key)
                 return {
                     "approved": False,

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -5025,6 +5025,8 @@ def check_execute_code_guard(code: str, env_type: str,
 
     is_gateway = _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
+    is_cli = _is_interactive_cli()
+    approval_callback = _resolve_cli_approval_callback()
 
     # Single-query (-q): no user is present to approve arbitrary code. Mirrors
     # the cron branch below so the -q escape-hatch no longer auto-approves.
@@ -5074,8 +5076,13 @@ def check_execute_code_guard(code: str, env_type: str,
     #   * Local non-interactive non-gateway: documented limitation above.
     # Ask-mode (HERMES_EXEC_ASK) still takes this path even when INTERACTIVE
     # is also set — that combination is how gateway/smart tests and messaging
-    # ask-mode drive whole-script approval. Terminal-command CLI leaks are
-    # handled in check_all_command_guards via the CLI callback fall-through.
+    # ask-mode drive whole-script approval. When that combination leaks into
+    # an interactive CLI with no gateway notify callback registered, the
+    # notify_cb-less branch below falls through to the same CLI Dangerous
+    # Command panel check_all_command_guards uses, instead of a silent
+    # pending_approval. Terminal-command (not whole-script) CLI leaks from
+    # the script's own per-call terminal() guards are handled separately in
+    # check_all_command_guards.
     if not is_gateway and not is_ask:
         return {"approved": True, "message": None}
 
@@ -5203,6 +5210,89 @@ def check_execute_code_guard(code: str, env_type: str,
         notify_cb = _gateway_notify_cbs.get(session_key)
 
     if notify_cb is None:
+        # HERMES_EXEC_ASK (and sometimes a session platform marker) can leak
+        # into an interactive CLI process — most commonly via `import
+        # gateway.run`. Without this, that combination silently queued a
+        # pending approval nobody could see instead of showing the CLI panel
+        # the user can actually answer, even though a callback was
+        # registered (same class as check_all_command_guards / #85865-
+        # adjacent leak this fixes for the whole-script gate specifically).
+        if _should_fall_through_to_cli_approval(
+            is_cli=is_cli,
+            approval_callback=approval_callback,
+            notify_cb=notify_cb,
+        ):
+            _fire_approval_hook(
+                "pre_approval_request",
+                command=display_command,
+                description=display_description,
+                pattern_key=pattern_key,
+                pattern_keys=[pattern_key],
+                session_key=session_key,
+                surface="cli",
+            )
+            choice = prompt_dangerous_approval(
+                display_command,
+                display_description,
+                allow_permanent=not smart_denied_for_owner,
+                approval_callback=approval_callback,
+                smart_denied=smart_denied_for_owner,
+            )
+            _fire_approval_hook(
+                "post_approval_response",
+                command=display_command,
+                description=display_description,
+                pattern_key=pattern_key,
+                pattern_keys=[pattern_key],
+                session_key=session_key,
+                surface="cli",
+                choice=choice,
+            )
+
+            if choice == "timeout":
+                return {
+                    "approved": False,
+                    "message": (
+                        "BLOCKED: Action timed out without user response. The "
+                        "user has NOT consented to this action. Do NOT retry "
+                        "it, do NOT rephrase it, and do NOT attempt the same "
+                        "outcome via a different path. Silence is not consent."
+                    ),
+                    "pattern_key": pattern_key,
+                    "description": description,
+                    "outcome": "timeout",
+                    "user_consent": False,
+                }
+            if choice == "deny":
+                _record_denial(session_key)
+                breaker_addendum = _denial_breaker_addendum(session_key)
+                return {
+                    "approved": False,
+                    "message": (
+                        "BLOCKED: User denied execute_code script execution "
+                        f"(matched '{description}'). Do NOT retry — the user "
+                        f"has explicitly rejected it.{breaker_addendum}"
+                    ),
+                    "pattern_key": pattern_key,
+                    "description": description,
+                    "outcome": "denied",
+                    "user_consent": False,
+                }
+            if not smart_denied_for_owner:
+                if choice == "session":
+                    approve_session(session_key, pattern_key)
+                elif choice == "always":
+                    approve_session(session_key, pattern_key)
+                    approve_permanent(pattern_key)
+                    save_permanent_allowlist(_permanent_approved)
+            _reset_denials(session_key)
+            return {
+                "approved": True,
+                "message": None,
+                "user_approved": True,
+                "description": description,
+            }
+
         # No gateway callback registered (e.g. ask-mode without a notifier):
         # surface a pending approval for backward compatibility.
         pending_data = {


### PR DESCRIPTION
## Summary

`execute_code` now shows the CLI Dangerous Command panel instead of silently queuing an invisible `pending_approval`, in the one surface where the user is sitting there able to answer.

Root cause: `e37a0321eb` fixed the leaked-ask-mode-into-CLI case for `_run_approval_gate` and `check_all_command_guards`, but `check_execute_code_guard` — the whole-script gate, a separate function with its own copy of the same `notify_cb is None` short-circuit — never got the same treatment. Same leak, same missing fall-through.

Salvage of #86270 by @pierrenode (cherry-picked, authorship preserved), plus a follow-up commit closing three parity gaps found in review.

## Changes

- `tools/approval.py` — `check_execute_code_guard`: when `_should_fall_through_to_cli_approval()` says yes, run the same hook-fire → `prompt_dangerous_approval` → hook-fire → choice-branch sequence the sibling guards use. Falls back to the existing `pending_approval` behaviour when no CLI callback is available. *(@pierrenode)*
- `tools/approval.py` — follow-up parity fixes *(review findings)*:
  - timeout arm now appends the denial-breaker addendum, matching the same function's gateway arm and `check_all_command_guards`' CLI tail
  - human deny no longer calls `_record_denial()` — that tally counts *guardian LLM* DENY verdicts; neither sibling CLI tail advances it, so three deliberate user denials were escalating to breaker hard-stop text
- `tests/tools/test_cli_approval_exec_ask_leak.py` — 4 cases mirroring the existing `check_all_command_guards` pair (approve/deny/timeout/session-persistence) *(@pierrenode)*, plus a platform-marker regression test and two breaker-parity guards; the shared fixture now clears the process-global `_denial_tally` so a leaked tally can't bleed the escalated addendum into unrelated assertions.

## Validation

Side-by-side E2E through the real production caller (`_execute_code_handler` → `check_execute_code_guard`), real imports, isolated `HERMES_HOME`:

| case | pre-fix main | this branch |
|---|---|---|
| CLI panel registered | panel never invoked, `pending_approval` | panel invoked, `approved: true` |
| tool entry point + deny | no denial wording | denied, **no side-effect file written** |
| secrets in script | (panel never shown) | panel shown, **raw secret not leaked** |
| headless, no CLI callback | `pending_approval` | `pending_approval` (**unchanged**) |
| gateway `notify_cb` present | gateway notified | gateway notified, **CLI panel not hijacked** |

- **Tests:** `tests/tools/test_cli_approval_exec_ask_leak.py` 11 passed. Wider approval sweep (12 files) `18 failed, 201 passed`; the identical 18 failures with identical names occur on pre-fix main (`18 failed, 136 passed` over the 4 files containing them) — **zero new failures**. Pre-existing causes are test-order pollution and `/tmp` symlink resolution, unrelated to this diff.
- **Mutation-checked, four ways:** reverting `tools/approval.py` to base fails exactly the 4 original guards; disabling the fall-through (`if False:`) fails all 7 `execute_code` guards while the 4 `check_all_command_guards`/import tests correctly still pass; re-adding `_record_denial` fails the parity guard; stripping the timeout addendum fails the addendum guard. Working tree checksum-verified restored after every probe.
- **No regression to the desktop pending-approval replay** (#38b9005b95 / #f703e70618): the TUI gateway sets `HERMES_INTERACTIVE=1` process-wide, but `_wire_callbacks()` registers sudo/project/secret callbacks and never `set_approval_callback` — `grep set_approval_callback tui_gateway/` is empty — so `approval_callback is None` there, the fall-through cannot fire, and `submit_pending` → replay is preserved. Confirmed by the gateway E2E case above.
- **Reachability confirmed** (not dead code): `check_execute_code_guard` runs on a tool-worker thread, and `agent/tool_executor.py` wraps every submit in `propagate_context_to_thread`, which copies the parent's thread-local approval callback (`tools/thread_context.py`). Also reachable from the ACP adapter and the slash worker.
- `ruff check` clean on both changed files (and clean on base for the same files — no new issues).

## Notes

Two items deliberately left out of scope:

- **No shared helper for the three CLI tails.** Profiled side by side, only 4 of 10 behavioural axes match: `check_all_command_guards` loops a `(key, desc, is_tirith)` warnings list with tirith `always`→session downgrade and multi-key persistence; `_run_approval_gate` has no smart-deny gate, no breaker, no `_reset_denials`, no `allow_permanent`. A shared helper would need ~8 parameters to save ~30 lines while making all three paths harder to audit — a subset/superset target, not behaviour-equivalent duplication.
- **`always` persisting the coarse `execute_code` key** is broad (an unrelated later script then auto-approves), but the gateway arm of the same function already does exactly this and did so before this PR. The new branch is consistent with its own function's existing semantics; changing that breadth is a separate scoped change.

Closes #86270

---

<img width="900" alt="Approval gate infographic — PR #90224" src="https://v3b.fal.media/files/b/0aa70119/oBj8Dnl5pUuyEMo0894_0_UhN59fgP.png" />
