### PR TITLE
Add E2B terminal backend (create + attach modes)

### DIFF
--- a/tools/env_probe.py
+++ b/tools/env_probe.py
@@ -74,7 +74,7 @@ _WAIT_ALREADY_TIMED_OUT = False
 # imports nothing from tools).
 _REMOTE_BACKENDS = frozenset({
     "docker", "singularity", "modal", "daytona", "ssh", "managed_modal",
-    "vercel_sandbox",
+    "vercel_sandbox", "e2b",
 })
 
 

--- a/tools/environments/e2b.py
+++ b/tools/environments/e2b.py
@@ -1,0 +1,155 @@
+"""E2B cloud execution environment (Vugola patch — not upstream yet).
+
+Uses the E2B Python SDK to run commands in an E2B sandbox. Modeled on the
+Daytona backend: spawn-per-call via _ThreadedProcessHandle wrapping blocking
+SDK calls.
+
+Two lifecycle modes:
+
+- **create** (default): this environment creates a fresh sandbox from
+  ``TERMINAL_E2B_TEMPLATE`` and kills it on cleanup().
+- **attach**: when ``TERMINAL_E2B_SANDBOX_ID`` is set, the environment drives
+  an existing sandbox owned by an outer orchestrator (e.g. the Vugola worker,
+  which creates the sandbox before the job and kills it after settlement).
+  cleanup() then does NOT kill the sandbox — the owner does.
+
+Auth: ``E2B_API_KEY`` from the process environment. The sandbox itself never
+receives credentials (Vugola zero-credential rule); this module runs on the
+credentialed host, not in the sandbox.
+
+Deliberately NOT wired: FileSyncManager (no ~/.hermes push into the sandbox).
+The sandbox is a per-job work computer, not the brain host — the brain
+(memories/skills/state.db) stays on the harness host under $HERMES_HOME.
+"""
+
+import logging
+import os
+import threading
+
+from tools.environments.base import (
+    BaseEnvironment,
+    _ThreadedProcessHandle,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class E2BEnvironment(BaseEnvironment):
+    """E2B cloud sandbox execution backend."""
+
+    _stdin_mode = "heredoc"
+
+    # Sliding sandbox TTL. E2B's create/set_timeout value is an ABSOLUTE
+    # expiry (unlike hermes' lifetime_seconds inactivity reaper), so we renew
+    # it before every command; a long agent turn (model thinking, rate-limit
+    # backoff) between commands therefore has this long before the box reaps.
+    _TTL_SECONDS_DEFAULT = 1800
+
+    def __init__(
+        self,
+        template: str = "",
+        cwd: str = "/home/user",
+        timeout: int = 60,
+        task_id: str = "default",
+        sandbox_id: str = "",
+        ttl_seconds: int = 0,
+    ):
+        super().__init__(cwd=cwd, timeout=timeout)
+
+        try:
+            from tools.lazy_deps import ensure as _lazy_ensure
+            _lazy_ensure("terminal.e2b", prompt=False)
+        except ImportError:
+            pass
+        except Exception as e:
+            raise ImportError(str(e))
+        from e2b import Sandbox
+
+        if not os.environ.get("E2B_API_KEY"):
+            raise ValueError("E2B environment requires E2B_API_KEY in the process environment")
+
+        self._ttl_seconds = int(ttl_seconds) if int(ttl_seconds or 0) > 0 else self._TTL_SECONDS_DEFAULT
+        self._lock = threading.Lock()
+        self._owns_sandbox = not sandbox_id
+        if sandbox_id:
+            # Sandbox.connect() is the sanctioned attach API; the bare Sandbox()
+            # constructor is deprecated internal surface.
+            self._sandbox = Sandbox.connect(sandbox_id)
+            logger.info("E2B: attached to sandbox %s for task %s (owner: external)",
+                        sandbox_id, task_id)
+        else:
+            if not template:
+                # Fail closed at startup: the default E2B base image lacks the
+                # job toolkit (ffmpeg/opencv); falling back silently would fail
+                # deep inside the run instead of here.
+                raise ValueError(
+                    "E2B environment requires an explicit template "
+                    "(TERMINAL_E2B_TEMPLATE / terminal.e2b_template)"
+                )
+            self._sandbox = Sandbox.create(
+                template=template,
+                timeout=self._ttl_seconds,
+            )
+            logger.info("E2B: created sandbox %s from template %r for task %s (ttl %ss, sliding)",
+                        self._sandbox.sandbox_id, template, task_id, self._ttl_seconds)
+
+        self.init_session()
+
+    def _run_bash(self, cmd_string: str, *, login: bool = False,
+                  timeout: int = 120,
+                  stdin_data: str | None = None):
+        """Return a _ThreadedProcessHandle wrapping a blocking E2B SDK call."""
+        import shlex
+
+        sandbox = self._sandbox
+
+        shell = "bash -l -c" if login else "bash -c"
+        shell_cmd = f"{shell} {shlex.quote(cmd_string)}"
+
+        ttl = self._ttl_seconds
+
+        def exec_fn() -> tuple[str, int]:
+            try:
+                # Renew the absolute TTL so the box always has a full window
+                # ahead of the command that is about to run (sliding lease).
+                try:
+                    sandbox.set_timeout(ttl)
+                except Exception:
+                    pass  # renewal is best-effort; the command itself decides
+                res = sandbox.commands.run(shell_cmd, timeout=max(1, timeout))
+                out = (res.stdout or "") + (res.stderr or "")
+                return (out, res.exit_code or 0)
+            except Exception as e:  # CommandExitException carries the streams
+                stdout = getattr(e, "stdout", "") or ""
+                stderr = getattr(e, "stderr", "") or ""
+                exit_code = getattr(e, "exit_code", None)
+                if exit_code is None:
+                    raise
+                return (stdout + stderr, int(exit_code))
+
+        def cancel():
+            # Per-command interrupt/timeout. Deliberately NOT sandbox.kill():
+            # the base class invokes cancel_fn on every command timeout, and
+            # destroying the box would turn one slow ffmpeg pass into a dead
+            # session (every later command failing on a vanished sandbox).
+            # The SDK's own commands.run(timeout=...) terminates the remote
+            # command; the sandbox survives for the rest of the conversation
+            # and its sliding TTL reaps it if the session dies outright.
+            logger.info("E2B: command cancelled/timed out (sandbox kept alive)")
+
+        return _ThreadedProcessHandle(exec_fn, cancel_fn=cancel)
+
+    def cleanup(self):
+        with self._lock:
+            if self._sandbox is None:
+                return
+            if self._owns_sandbox:
+                try:
+                    self._sandbox.kill()
+                    logger.info("E2B: killed sandbox %s", self._sandbox.sandbox_id)
+                except Exception as e:
+                    logger.warning("E2B: cleanup failed (sandbox TTL will reap it): %s", e)
+            else:
+                logger.info("E2B: detaching from externally owned sandbox %s",
+                            self._sandbox.sandbox_id)
+            self._sandbox = None

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -256,6 +256,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "terminal.modal": ("modal==1.3.4",),
     "terminal.daytona": ("daytona==0.155.0",),
     "terminal.vercel": ("vercel==0.7.2",),
+    "terminal.e2b": ("e2b==2.40.0",),
 
     # ─── Skills ────────────────────────────────────────────────────────────
     "skill.google_workspace": (

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1491,7 +1491,7 @@ def _safe_getcwd() -> str:
 # cwd looks when it leaks toward a Linux container's ``-w`` flag.
 _HOST_CWD_PREFIXES = ("/Users/", "/home/", "C:\\", "C:/")
 
-_CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
+_CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox", "e2b"})
 
 
 def _is_unusable_container_cwd(cwd: str) -> bool:
@@ -1615,6 +1615,8 @@ def _get_env_config() -> Dict[str, Any]:
         default_cwd = "~"
     elif env_type == "vercel_sandbox":
         default_cwd = _VERCEL_SANDBOX_DEFAULT_CWD
+    elif env_type == "e2b":
+        default_cwd = "/home/user"
     else:
         default_cwd = "/root"
 
@@ -1652,6 +1654,9 @@ def _get_env_config() -> Dict[str, Any]:
         "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
         "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
         "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
+        "e2b_template": os.getenv("TERMINAL_E2B_TEMPLATE", ""),
+        "e2b_sandbox_id": os.getenv("TERMINAL_E2B_SANDBOX_ID", ""),
+        "e2b_ttl_seconds": _parse_env_var("TERMINAL_E2B_TTL_SECONDS", "0"),
         "vercel_runtime": os.getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
         "cwd": cwd,
         "host_cwd": host_cwd,
@@ -1740,6 +1745,8 @@ def _container_config_from_config(config: Dict[str, Any]) -> dict:
         "container_persistent": config.get("container_persistent", True),
         "modal_mode": config.get("modal_mode", "auto"),
         "vercel_runtime": config.get("vercel_runtime", ""),
+        "e2b_sandbox_id": config.get("e2b_sandbox_id", ""),
+        "e2b_ttl_seconds": config.get("e2b_ttl_seconds", 0),
         "docker_volumes": config.get("docker_volumes", []),
         "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
         "docker_forward_env": config.get("docker_forward_env", []),
@@ -1938,10 +1945,22 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             timeout=timeout,
         )
 
+    elif env_type == "e2b":
+        # Lazy import so the e2b SDK is only required when backend is selected.
+        from tools.environments.e2b import E2BEnvironment as _E2BEnvironment
+        return _E2BEnvironment(
+            template=image,
+            cwd=cwd,
+            timeout=timeout,
+            task_id=task_id,
+            sandbox_id=cc.get("e2b_sandbox_id", ""),
+            ttl_seconds=cc.get("e2b_ttl_seconds", 0),
+        )
+
     else:
         raise ValueError(
             f"Unknown environment type: {env_type}. Use 'local', 'docker', "
-            f"'singularity', 'modal', 'daytona', 'vercel_sandbox', or 'ssh'"
+            f"'singularity', 'modal', 'daytona', 'vercel_sandbox', 'e2b', or 'ssh'"
         )
 
 
@@ -2684,6 +2703,8 @@ def terminal_tool(
             image = overrides.get("modal_image") or config["modal_image"]
         elif env_type == "daytona":
             image = overrides.get("daytona_image") or config["daytona_image"]
+        elif env_type == "e2b":
+            image = overrides.get("e2b_template") or config["e2b_template"]
         else:
             image = ""
 
@@ -3797,10 +3818,27 @@ def check_terminal_requirements() -> bool:
             from agent.secret_scope import get_secret
             return get_secret("DAYTONA_API_KEY") is not None
 
+        elif env_type == "e2b":
+            try:
+                from e2b import Sandbox  # noqa: F401 — SDK presence check
+            except ImportError:
+                logger.error(
+                    "E2B backend selected but the e2b SDK is not installed "
+                    "(installs on demand at first terminal use, or: pip install e2b)."
+                )
+                return False
+            # Same source of truth as E2BEnvironment.__init__ and the SDK itself
+            # (os.environ) — a scoped secret the SDK can't see must fail here,
+            # not deep inside sandbox creation.
+            if not os.environ.get("E2B_API_KEY"):
+                logger.error("E2B backend selected but E2B_API_KEY is not set.")
+                return False
+            return True
+
         else:
             logger.error(
                 "Unknown TERMINAL_ENV '%s'. Use one of: local, docker, singularity, "
-                "modal, daytona, vercel_sandbox, ssh.",
+                "modal, daytona, vercel_sandbox, ssh, e2b.",
                 env_type,
             )
             return False


### PR DESCRIPTION
Adds an `e2b` terminal backend so Hermes can use [E2B](https://e2b.dev) sandboxes as its computer, alongside the existing modal/daytona/vercel cloud backends.

## What's included
- `tools/environments/e2b.py` — `E2BEnvironment` implementing `BaseEnvironment`, modeled closely on the Daytona backend (`_ThreadedProcessHandle` over blocking SDK calls, heredoc stdin mode).
- Wiring: `TERMINAL_ENV=e2b`, `TERMINAL_E2B_TEMPLATE`, `TERMINAL_E2B_SANDBOX_ID`, `TERMINAL_E2B_TTL_SECONDS`; `lazy_deps` entry (`e2b==2.40.0`); `env_probe` remote-backend registration; a guarded `check_terminal_requirements` branch (missing SDK → clear log + `False`, not a crash).

## Design decisions (learned the hard way, live-tested)
- **Sliding TTL**: E2B's `timeout` is an *absolute* expiry, unlike an idle reaper — so it's renewed via `set_timeout()` before every command; long agent turns can't lose their computer.
- **Non-destructive cancel**: `BaseEnvironment` fires `cancel_fn` on every per-command timeout; killing the sandbox there turns one slow command into a dead session (every later command failing on a vanished sandbox). Cancel logs; the SDK's own command timeout terminates the remote process; the sandbox survives.
- **Attach mode**: `TERMINAL_E2B_SANDBOX_ID` connects to an externally owned sandbox via `Sandbox.connect()` and never kills it on cleanup — for outer orchestrators that own sandbox lifecycle (create mode still kills its own).
- **Fail-closed template**: create mode refuses an empty template rather than silently falling back to E2B's base image.

## Provenance
Running in production at Vugola powering agentic video-edit jobs (the harness drives ffmpeg work inside per-job E2B sandboxes, headless via `hermes -z`). Happy to adjust to house style, add docs, or split the wiring differently — whatever makes this easiest to land.

🤖 Drafted with [Claude Code](https://claude.com/claude-code)