### PR TITLE
fix(github): preflight repository-object authority

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1618,10 +1618,35 @@ def do_publish(skill_path: str, target: str = "github", repo: str = "",
         c.print(f"[bold red]Unknown target:[/] {target}. Use 'github' or 'clawhub'.\n")
 
 
+def _github_publish_failure(auth, repository: str, operation, response) -> tuple[bool, str]:
+    """Turn an API mutation failure into a typed, actionable authority error."""
+    from tools.github_capabilities import GitHubCapabilityError
+
+    status_code = int(getattr(response, "status_code", 0) or 0)
+    message = str(getattr(response, "text", "") or "")[:500]
+    try:
+        report = auth.capability_report(repository, [operation])
+        capability = report.for_operation(operation).with_failure(status_code, message)
+        return False, str(GitHubCapabilityError(capability))
+    except Exception:
+        return False, f"GitHub {operation.value} failed: {status_code} {message[:200]}".strip()
+
+
 def _github_publish(skill_path: Path, skill_name: str, target_repo: str,
                     auth) -> tuple:
     """Create a PR to a GitHub repo with the skill. Returns (success, message)."""
     import httpx
+    from tools.github_capabilities import GitHubCapabilityError, GitHubOperation
+
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", target_repo or ""):
+        return False, "Invalid GitHub repository; expected owner/repository."
+    try:
+        # PR creation is distinct from writing the eventual fork.
+        auth.preflight(target_repo, [GitHubOperation.PULL_REQUEST_CREATE])
+    except GitHubCapabilityError as exc:
+        return False, str(exc)
+    except AttributeError:
+        return False, "GitHub authority preflight is unavailable; no mutation was attempted."
 
     headers = auth.get_headers()
 
@@ -1631,15 +1656,27 @@ def _github_publish(skill_path: Path, skill_name: str, target_repo: str,
             f"https://api.github.com/repos/{target_repo}/forks",
             headers=headers, timeout=30,
         )
-        if resp.status_code in {200, 202}:
-            fork = resp.json()
-            fork_repo = fork["full_name"]
-        elif resp.status_code == 403:
-            return False, "GitHub token lacks permission to fork repos"
-        else:
-            return False, f"Failed to fork {target_repo}: {resp.status_code}"
+        if resp.status_code not in {200, 202}:
+            return _github_publish_failure(
+                auth, target_repo, GitHubOperation.PULL_REQUEST_CREATE, resp
+            )
+        fork = resp.json()
+        fork_repo = str(fork.get("full_name") or "") if isinstance(fork, dict) else ""
+        if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", fork_repo):
+            return False, "GitHub fork response did not contain a valid repository."
     except httpx.HTTPError as e:
         return False, f"Network error forking repo: {e}"
+    except (TypeError, ValueError, KeyError) as e:
+        return False, f"Invalid fork response: {e}"
+
+    try:
+        # Fork contents and refs are separately preflighted from PR creation.
+        auth.preflight(
+            fork_repo,
+            [GitHubOperation.CONTENTS_WRITE, GitHubOperation.GIT_DATA_REFS_WRITE],
+        )
+    except GitHubCapabilityError as exc:
+        return False, str(exc)
 
     # 2. Get default branch
     try:
@@ -1647,9 +1684,18 @@ def _github_publish(skill_path: Path, skill_name: str, target_repo: str,
             f"https://api.github.com/repos/{target_repo}",
             headers=headers, timeout=15,
         )
-        default_branch = resp.json().get("default_branch", "main")
-    except Exception:
-        default_branch = "main"
+        if resp.status_code != 200:
+            return _github_publish_failure(
+                auth, target_repo, GitHubOperation.REPOSITORY_METADATA_READ, resp
+            )
+        data = resp.json()
+        default_branch = str(data.get("default_branch") or "main")
+        if not re.fullmatch(r"[A-Za-z0-9_.-]+", default_branch):
+            return False, "GitHub repository returned an invalid default branch."
+    except httpx.HTTPError as e:
+        return False, f"Network error reading repository metadata: {e}"
+    except (TypeError, ValueError, KeyError) as e:
+        return False, f"Invalid repository metadata response: {e}"
 
     # 3. Get the base tree SHA
     try:
@@ -1657,22 +1703,34 @@ def _github_publish(skill_path: Path, skill_name: str, target_repo: str,
             f"https://api.github.com/repos/{fork_repo}/git/refs/heads/{default_branch}",
             headers=headers, timeout=15,
         )
-        base_sha = resp.json()["object"]["sha"]
-    except Exception as e:
-        return False, f"Failed to get base branch: {e}"
+        if resp.status_code != 200:
+            return _github_publish_failure(
+                auth, fork_repo, GitHubOperation.GIT_DATA_REFS_WRITE, resp
+            )
+        base_sha = str(resp.json()["object"]["sha"])
+    except httpx.HTTPError as e:
+        return False, f"Network error reading base branch: {e}"
+    except (TypeError, ValueError, KeyError) as e:
+        return False, f"Invalid base branch response: {e}"
 
     # 4. Create a new branch
     branch_name = f"add-skill-{skill_name}"
     try:
-        httpx.post(
+        resp = httpx.post(
             f"https://api.github.com/repos/{fork_repo}/git/refs",
             headers=headers, timeout=15,
             json={"ref": f"refs/heads/{branch_name}", "sha": base_sha},
         )
-    except Exception as e:
-        return False, f"Failed to create branch: {e}"
+        if resp.status_code != 201:
+            return _github_publish_failure(
+                auth, fork_repo, GitHubOperation.GIT_DATA_REFS_WRITE, resp
+            )
+    except httpx.HTTPError as e:
+        return False, f"Network error creating branch: {e}"
 
     # 5. Upload skill files
+    uploaded_files = 0
+    last_commit_sha = ""
     for f in skill_path.rglob("*"):
         if not f.is_file():
             continue
@@ -1681,7 +1739,7 @@ def _github_publish(skill_path: Path, skill_name: str, target_repo: str,
         try:
             import base64
             content_b64 = base64.b64encode(f.read_bytes()).decode()
-            httpx.put(
+            resp = httpx.put(
                 f"https://api.github.com/repos/{fork_repo}/contents/{upload_path}",
                 headers=headers, timeout=15,
                 json={
@@ -1690,8 +1748,21 @@ def _github_publish(skill_path: Path, skill_name: str, target_repo: str,
                     "branch": branch_name,
                 },
             )
-        except Exception as e:
-            return False, f"Failed to upload {rel}: {e}"
+            if resp.status_code not in {200, 201}:
+                return _github_publish_failure(
+                    auth, fork_repo, GitHubOperation.CONTENTS_WRITE, resp
+                )
+            payload = resp.json()
+            commit = payload.get("commit") if isinstance(payload, dict) else None
+            commit_sha = commit.get("sha") if isinstance(commit, dict) else None
+            if not commit_sha:
+                return False, f"GitHub upload for {rel} returned no commit SHA."
+            last_commit_sha = str(commit_sha)
+            uploaded_files += 1
+        except httpx.HTTPError as e:
+            return False, f"Network error uploading {rel}: {e}"
+        except (TypeError, ValueError, KeyError) as e:
+            return False, f"Invalid upload response for {rel}: {e}"
 
     # 6. Create PR
     try:
@@ -1706,13 +1777,31 @@ def _github_publish(skill_path: Path, skill_name: str, target_repo: str,
                 "base": default_branch,
             },
         )
-        if resp.status_code == 201:
-            pr_url = resp.json().get("html_url", "")
-            return True, f"PR created: {pr_url}"
-        else:
-            return False, f"Failed to create PR: {resp.status_code} {resp.text[:200]}"
+        if resp.status_code != 201:
+            return _github_publish_failure(
+                auth, target_repo, GitHubOperation.PULL_REQUEST_CREATE, resp
+            )
+        payload = resp.json()
+        pr_url = str(payload.get("html_url") or "") if isinstance(payload, dict) else ""
+        if not pr_url:
+            return False, "GitHub PR response did not contain a URL."
     except httpx.HTTPError as e:
         return False, f"Network error creating PR: {e}"
+    except (TypeError, ValueError, KeyError) as e:
+        return False, f"Invalid PR response: {e}"
+
+    from tools.github_capabilities import CodePublicationReceipt, require_code_publication_receipt
+    try:
+        receipt = require_code_publication_receipt(CodePublicationReceipt(
+            repository=fork_repo,
+            branch=branch_name,
+            commit_sha=last_commit_sha,
+            source_diff_verified=uploaded_files > 0,
+            pull_request_url=pr_url,
+        ))
+    except RuntimeError as e:
+        return False, str(e)
+    return True, f"PR created: {receipt.pull_request_url}"
 
 
 def do_snapshot_export(output_path: str, console: Optional[Console] = None) -> None:

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -20,6 +20,13 @@ import subprocess
 from pathlib import Path
 
 from hermes_cli._subprocess_compat import noninteractive_git_env
+from tools.github_capabilities import (
+    CodePublicationReceipt,
+    GitHubAuthorityContext,
+    GitHubOperation,
+    build_capability_report,
+    require_code_publication_receipt,
+)
 
 _GIT_TIMEOUT = 30
 _GH_TIMEOUT = 30
@@ -382,7 +389,74 @@ def review_commit(cwd: str, message: str, push: bool) -> dict:
     return {"ok": True}
 
 
+def _github_ship_report(cwd: str, operations: list[GitHubOperation]):
+    """Return GitHub authority evidence when this worktree has an authenticated gh."""
+    if not shutil.which("gh"):
+        return None
+    auth_ok, _ = _gh(cwd, ["auth", "status"])
+    if not auth_ok:
+        return None
+
+    repo_ok, repo_out = _gh(
+        cwd, ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]
+    )
+    repository = repo_out.strip()
+    if not repo_ok or not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+        remote = _git_out(cwd, ["remote", "get-url", "origin"]).lower()
+        if "github.com" not in remote:
+            return None
+        context = GitHubAuthorityContext(
+            repository=repository or "unknown/unknown",
+            authenticated=True,
+        )
+        return build_capability_report(context, operations)
+
+    metadata_ok, metadata_out = _gh(cwd, ["api", f"repos/{repository}"])
+    if not metadata_ok:
+        context = GitHubAuthorityContext(repository=repository, authenticated=True)
+        return build_capability_report(context, operations)
+    try:
+        data = json.loads(metadata_out)
+    except json.JSONDecodeError:
+        data = {}
+    if not isinstance(data, dict) or not data:
+        context = GitHubAuthorityContext(repository=repository, authenticated=True)
+        return build_capability_report(context, operations)
+
+    owner = data.get("owner") or {}
+    permissions = data.get("permissions") or {}
+    viewer_permission = str(data.get("viewerPermission") or "").lower()
+    can_push = bool(
+        permissions.get("push")
+        or viewer_permission in {"push", "maintain", "admin"}
+    ) if isinstance(permissions, dict) else viewer_permission in {"push", "maintain", "admin"}
+    organization = str(
+        (data.get("organization") or {}).get("login")
+        or (owner.get("login") if str(owner.get("type") or "").lower() == "organization" else "")
+    )
+    context = GitHubAuthorityContext(
+        repository=repository,
+        account=str(owner.get("login") or ""),
+        organization=organization,
+        authenticated=True,
+        repository_permissions={"push": "write" if can_push else "read"},
+        repository_readable=True,
+    )
+    return build_capability_report(context, operations)
+
+
+def _preflight_github_mutation(cwd: str, operations: list[GitHubOperation]) -> None:
+    report = _github_ship_report(cwd, operations)
+    if report is None:
+        return
+    report.require(operations)
+
+
 def _review_push(cwd: str) -> None:
+    _preflight_github_mutation(
+        cwd,
+        [GitHubOperation.CONTENTS_WRITE, GitHubOperation.GIT_DATA_REFS_WRITE],
+    )
     upstream = _git_out(cwd, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]).strip()
     if upstream:
         _git_ok(cwd, ["push"])
@@ -557,13 +631,48 @@ def review_create_pr(cwd: str) -> dict:
     """Create a PR for the current branch (push first), letting gh fill title/body."""
     try:
         _review_push(cwd)
-    except RuntimeError:
-        pass
+    except RuntimeError as exc:
+        raise RuntimeError(f"Cannot publish code before push succeeds: {exc}") from exc
+    _preflight_github_mutation(cwd, [GitHubOperation.PULL_REQUEST_CREATE])
     created, out = _gh(cwd, ["pr", "create", "--fill"])
     if not created:
         raise RuntimeError("gh pr create failed (is gh installed and authenticated?)")
     url = next((line for line in reversed(out.strip().splitlines()) if line.strip()), "")
-    return {"url": url}
+    view_ok, view_out = _gh(
+        cwd,
+        ["pr", "view", "--json", "url,state,isDraft,headRefName,headRefOid"],
+    )
+    if not view_ok:
+        raise RuntimeError("PR was created but its completion receipt could not be read.")
+    try:
+        pr = json.loads(view_out)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("PR was created but GitHub returned invalid receipt metadata.") from exc
+    remote_url = str(pr.get("url") or url)
+    branch = str(pr.get("headRefName") or _git_out(
+        cwd, ["rev-parse", "--abbrev-ref", "HEAD"]
+    ).strip())
+    commit_sha = _git_out(cwd, ["rev-parse", "HEAD"]).strip()
+    remote_sha = str(pr.get("headRefOid") or "")
+    if remote_sha and commit_sha and remote_sha != commit_sha:
+        raise RuntimeError("PR completion receipt does not match the local HEAD commit.")
+    base = _branch_base(cwd)
+    source_diff_verified = bool(
+        base and _git_out(cwd, ["diff", f"{base}...HEAD"]).strip()
+    )
+    receipt = require_code_publication_receipt(CodePublicationReceipt(
+        repository=str((_gh(cwd, ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"])[1]).strip()),
+        branch=branch,
+        commit_sha=commit_sha,
+        source_diff_verified=source_diff_verified,
+        pull_request_url=remote_url,
+    ))
+    return {
+        "url": receipt.pull_request_url,
+        "branch": receipt.branch,
+        "commit": receipt.commit_sha,
+        "verified": True,
+    }
 
 
 # ── worktrees & branches ─────────────────────────────────────────────────────

--- a/skills/github/github-issue-to-pr/SKILL.md
+++ b/skills/github/github-issue-to-pr/SKILL.md
@@ -35,13 +35,34 @@ Before writing anything, run `gh pr list --search "#<N>" --state all` plus at le
 
 ### 3. Validate the premise against current code — and against design intent
 
+For GitHub automation, validate authority separately from token availability.
+Before any repository-object mutation, produce an effective capability report
+for the exact operation class: account/org, repository, installation ID,
+repository selection, app-declared permission, installation-granted
+permission, effective result, and reason. Treat app_not_installed,
+repository_not_selected, permission_not_granted, branch_protection_denied,
+organization_policy_denied, and resource_not_accessible_unknown as distinct
+outcomes; a successful issue comment, review, or metadata write is not evidence
+for Contents, Git Data/refs, PR creation, Actions, or workflow authority.
+
 Reproduce the bug or demonstrate the missing behavior on the current default branch with a failing test or fixture, using `search_files` and `read_file` to trace the reported path. Then check the second question: is the "bug" actually deliberate design? Run `git log -p -S "<symbol>"` on the code the issue wants changed and read the original commit's intent — a missing link or restriction is often the feature. Challenge stale or flawed issue prose instead of implementing it blindly. Done when the root cause or feature gap is demonstrated in current code AND the change doesn't fight an intentional design.
 
 ### 4. Define acceptance and risk
 
+For code publication, acceptance includes an object-specific completion receipt:
+the target repository, branch, resulting commit SHA, verified source diff, and
+PR URL when a PR is part of the workflow. A metadata receipt alone never closes
+the code task.
+
 List acceptance criteria, interfaces, migrations/state changes, compatibility, security/privacy, rollout, and rollback. Map every criterion to a test or explicit verification. Done when review has a finite contract.
 
 ### 5. Implement the smallest complete change — and fix the class
+
+Put the capability preflight immediately before the first mutation and fail
+closed on unknown authority. For each mutating response, retain the object
+class, status, and actionable recovery reason. For code publication, do not
+report completion until the commit SHA, branch, and verified source diff are
+recorded in a receipt.
 
 Work on an isolated branch or worktree, loading `systematic-debugging` or `test-driven-development` when the bug class calls for them. Add regression tests first, then implement. When the fix is in hand, `search_files` for the same bug shape at sibling call sites and fix the whole class in this PR — an incomplete fix that leaves known siblings broken is worse than none. Every changed line must trace to the issue; no drive-by cleanup. Done when targeted tests pass, the original failure no longer reproduces, and sibling sites are fixed or explicitly ruled out.
 
@@ -50,6 +71,10 @@ Work on an isolated branch or worktree, loading `systematic-debugging` or `test-
 Temporarily restore the old behavior of the exact function under test, run the new test, and confirm it FAILS; then restore the fix and confirm it passes. A regression test that passes with and without the fix proves nothing. Done when the test demonstrably fails on pre-fix code.
 
 ### 7. Run repository quality gates, then open the PR immediately
+
+Before pushing or opening a PR, verify the publication receipt and inspect the
+actual source diff. Confirm that the branch/ref and Contents authority was
+checked independently from PR metadata authority.
 
 Run the formatter, lint, typecheck, and the repo's canonical test entrypoint on affected areas; use `requesting-code-review` on the diff. Then push and open the PR right away — the PR is what dispatches CI, and CI latency is the long pole; do not sit on finished work. Load `github-pr-workflow` for PR mechanics: conventional branch/commit, body linking the issue with problem, approach, tests, risk, and exclusions. Read the PR back and verify head SHA, base, title, and files. Done when the PR exists with the intended diff and CI is running.
 
@@ -60,6 +85,9 @@ Inspect live checks and failure logs via `gh pr checks` / `gh run view --log-fai
 ## Pitfalls
 
 - Coding before reading issue comments, sweeping for duplicate PRs, or reading current code.
+- Treating token availability, a successful metadata write, or an issue/review receipt as repository-object authority.
+- Mutating before an exact operation-class preflight, or calling an unexplained 403 a permission failure.
+- Claiming code publication without a commit SHA, branch, and verified source-diff receipt.
 - "Fixing" behavior that the original commit shows is intentional design.
 - Fixing a symptom at one call site while sibling sites keep the same bug.
 - Shipping a regression test that also passes without the fix.
@@ -71,6 +99,8 @@ Inspect live checks and failure logs via `gh pr checks` / `gh run view --log-fai
 - [ ] Full issue thread read; newest comment state reflected in the plan.
 - [ ] Duplicate-PR sweep run with issue number + 2 keyword variants.
 - [ ] Premise reproduced on current code; design intent checked via git history.
+- [ ] Exact operation-class capability report and typed recovery reason recorded before mutation.
+- [ ] Code publication receipt contains target repository, branch, commit SHA, and verified source diff.
 - [ ] Regression test proven to fail without the fix.
 - [ ] Sibling call sites fixed or explicitly ruled out.
 - [ ] Every changed line traces to the issue.

--- a/tests/hermes_cli/test_web_git_authority.py
+++ b/tests/hermes_cli/test_web_git_authority.py
@@ -1,0 +1,52 @@
+"""Regression tests for the web-git GitHub authority boundary."""
+
+import json
+
+import pytest
+
+from hermes_cli import web_git
+from tools.github_capabilities import (
+    GitHubAuthorizationReason,
+    GitHubCapabilityError,
+    GitHubOperation,
+)
+
+
+def _fake_gh(_cwd, args):
+    if args == ["auth", "status"]:
+        return True, ""
+    if args == ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]:
+        return True, "owner/repository\n"
+    if args == ["api", "repos/owner/repository"]:
+        return True, json.dumps({
+            "owner": {"login": "owner", "type": "Organization"},
+            "organization": {"login": "owner"},
+            "permissions": {"pull": True, "push": False},
+        })
+    return False, ""
+
+
+def test_web_git_keeps_pr_authority_separate_from_code_write(monkeypatch):
+    monkeypatch.setattr(web_git.shutil, "which", lambda _name: "gh")
+    monkeypatch.setattr(web_git, "_gh", _fake_gh)
+
+    report = web_git._github_ship_report(
+        "C:/worktree",
+        [GitHubOperation.PULL_REQUEST_CREATE, GitHubOperation.CONTENTS_WRITE],
+    )
+
+    assert report.for_operation(GitHubOperation.PULL_REQUEST_CREATE).effective
+    contents = report.for_operation(GitHubOperation.CONTENTS_WRITE)
+    assert not contents.effective
+    assert contents.reason is GitHubAuthorizationReason.RESOURCE_NOT_ACCESSIBLE_UNKNOWN
+
+
+def test_web_git_preflight_blocks_push_without_repository_write(monkeypatch):
+    monkeypatch.setattr(web_git.shutil, "which", lambda _name: "gh")
+    monkeypatch.setattr(web_git, "_gh", _fake_gh)
+
+    with pytest.raises(GitHubCapabilityError, match="contents.write"):
+        web_git._preflight_github_mutation(
+            "C:/worktree",
+            [GitHubOperation.CONTENTS_WRITE, GitHubOperation.GIT_DATA_REFS_WRITE],
+        )

--- a/tests/tools/test_github_capabilities.py
+++ b/tests/tools/test_github_capabilities.py
@@ -1,0 +1,248 @@
+"""Regression tests for GitHub object-class authority and publication receipts."""
+
+import pytest
+
+from tools.github_capabilities import (
+    CodePublicationReceipt,
+    GitHubAuthorityContext,
+    GitHubAuthorizationReason,
+    GitHubCapabilityError,
+    GitHubOperation,
+    build_capability_report,
+    classify_github_403,
+    require_code_publication_receipt,
+)
+
+
+def test_github_auth_report_uses_installation_selection_and_grants(monkeypatch):
+    import time
+    import tools.skills_hub as skills_hub
+
+    auth = skills_hub.GitHubAuth()
+    auth._cached_token = "test-token"
+    auth._cached_method = "github-app"
+    auth._app_token_expiry = time.time() + 3600
+    auth._app_principal_configured = True
+    auth._app_installation_id = "123"
+    auth._app_installation_exists = True
+    auth._app_repository_selection = "selected"
+    auth._app_selected_repositories = {"owner/repository"}
+    auth._app_declared_permissions = {"contents": "write"}
+    auth._app_granted_permissions = {"contents": "write"}
+
+    class Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {
+                "owner": {"login": "owner", "type": "User"},
+                "permissions": {"pull": True, "push": True},
+            }
+
+    monkeypatch.setattr(skills_hub.httpx, "get", lambda *_args, **_kwargs: Response())
+    capability = auth.capability_report(
+        "owner/repository",
+        [GitHubOperation.CONTENTS_WRITE],
+    ).for_operation(GitHubOperation.CONTENTS_WRITE)
+
+    assert capability.effective
+    assert capability.app_principal
+    assert capability.repository_selected is True
+    assert capability.installation_id == "123"
+
+
+def _app_context(**overrides):
+    values = {
+        "repository": "owner/repository",
+        "authenticated": True,
+        "app_principal": True,
+        "installation_id": "123",
+        "installation_exists": True,
+        "repository_selected": True,
+        "repository_readable": True,
+        "declared_permissions": {
+            "contents": "write",
+            "pull_requests": "write",
+            "issues": "write",
+            "actions": "write",
+        },
+        "installation_permissions": {
+            "contents": "write",
+            "pull_requests": "write",
+            "issues": "write",
+            "actions": "write",
+        },
+    }
+    values.update(overrides)
+    return GitHubAuthorityContext(**values)
+
+
+def test_app_without_installation_is_reported_before_mutation():
+    report = build_capability_report(
+        _app_context(installation_id=None, installation_exists=False),
+        [GitHubOperation.CONTENTS_WRITE],
+    )
+
+    capability = report.for_operation(GitHubOperation.CONTENTS_WRITE)
+    assert not capability.effective
+    assert capability.reason is GitHubAuthorizationReason.APP_NOT_INSTALLED
+    with pytest.raises(GitHubCapabilityError, match="Install the GitHub App"):
+        report.require()
+
+
+def test_configured_app_without_installation_is_typed_even_without_token():
+    report = build_capability_report(
+        GitHubAuthorityContext(
+            repository="owner/repository",
+            app_principal=True,
+            installation_exists=False,
+        ),
+        [GitHubOperation.CONTENTS_WRITE],
+    )
+
+    assert report.for_operation(
+        GitHubOperation.CONTENTS_WRITE
+    ).reason is GitHubAuthorizationReason.APP_NOT_INSTALLED
+
+
+def test_selected_repository_is_required_even_when_app_permission_is_granted():
+    report = build_capability_report(
+        _app_context(repository_selected=False),
+        [GitHubOperation.CONTENTS_WRITE],
+    )
+    capability = report.for_operation(GitHubOperation.CONTENTS_WRITE)
+
+    assert capability.reason is GitHubAuthorizationReason.REPOSITORY_NOT_SELECTED
+    assert "Select this repository" in capability.recovery_action
+
+
+def test_declared_write_without_granted_write_is_not_effective():
+    report = build_capability_report(
+        _app_context(installation_permissions={"contents": "read"}),
+        [GitHubOperation.CONTENTS_WRITE],
+    )
+    capability = report.for_operation(GitHubOperation.CONTENTS_WRITE)
+
+    assert not capability.effective
+    assert capability.reason is GitHubAuthorizationReason.PERMISSION_NOT_GRANTED
+
+
+def test_operation_classes_do_not_inherit_authority_from_one_another():
+    report = build_capability_report(
+        _app_context(
+            installation_permissions={
+                "contents": "write",
+                "pull_requests": "write",
+                "issues": "write",
+                "actions": "read",
+            }
+        ),
+        [
+            GitHubOperation.ISSUES_COMMENTS_WRITE,
+            GitHubOperation.CONTENTS_WRITE,
+            GitHubOperation.ACTIONS_CONTROL,
+        ],
+    )
+
+    assert report.for_operation(GitHubOperation.ISSUES_COMMENTS_WRITE).effective
+    assert report.for_operation(GitHubOperation.CONTENTS_WRITE).effective
+    actions = report.for_operation(GitHubOperation.ACTIONS_CONTROL)
+    assert not actions.effective
+    assert actions.reason is GitHubAuthorizationReason.PERMISSION_NOT_GRANTED
+
+
+def test_pat_can_create_cross_repo_pr_without_upstream_code_write():
+    context = GitHubAuthorityContext(
+        repository="NousResearch/hermes-agent",
+        authenticated=True,
+        repository_readable=True,
+        repository_permissions={"push": False},
+    )
+    report = build_capability_report(
+        context,
+        [GitHubOperation.PULL_REQUEST_CREATE, GitHubOperation.CONTENTS_WRITE],
+    )
+
+    assert report.for_operation(GitHubOperation.PULL_REQUEST_CREATE).effective
+    assert not report.for_operation(GitHubOperation.CONTENTS_WRITE).effective
+
+
+def test_branch_protection_and_organization_policy_are_distinct():
+    branch = build_capability_report(
+        _app_context(branch_protected=True),
+        [GitHubOperation.CONTENTS_WRITE],
+    ).for_operation(GitHubOperation.CONTENTS_WRITE)
+    organization = build_capability_report(
+        _app_context(organization_policy_denied=True),
+        [GitHubOperation.PULL_REQUEST_CREATE],
+    ).for_operation(GitHubOperation.PULL_REQUEST_CREATE)
+
+    assert branch.reason is GitHubAuthorizationReason.BRANCH_PROTECTION_DENIED
+    assert organization.reason is GitHubAuthorizationReason.ORGANIZATION_POLICY_DENIED
+
+
+def test_generic_resource_not_accessible_403_stays_unknown():
+    reason = classify_github_403(
+        403,
+        "Resource not accessible by integration",
+        app_principal=True,
+    )
+
+    assert reason is GitHubAuthorizationReason.RESOURCE_NOT_ACCESSIBLE_UNKNOWN
+
+
+def test_known_preflight_reason_survives_generic_403_text():
+    capability = build_capability_report(
+        _app_context(installation_exists=False),
+        [GitHubOperation.CONTENTS_WRITE],
+    ).for_operation(GitHubOperation.CONTENTS_WRITE)
+
+    failed = capability.with_failure(403, "Resource not accessible by integration")
+    assert failed.reason is GitHubAuthorizationReason.APP_NOT_INSTALLED
+
+
+def test_typed_403_evidence_is_preserved():
+    assert classify_github_403(
+        403, "protected branch hook declined", branch_protected=False
+    ) is GitHubAuthorizationReason.BRANCH_PROTECTION_DENIED
+    assert classify_github_403(
+        403, "installation not found", app_principal=True
+    ) is GitHubAuthorizationReason.APP_NOT_INSTALLED
+    assert classify_github_403(
+        403, "insufficient permission for contents"
+    ) is GitHubAuthorizationReason.PERMISSION_NOT_GRANTED
+
+
+def test_capability_report_exposes_authority_evidence():
+    capability = build_capability_report(
+        _app_context(),
+        [GitHubOperation.CONTENTS_WRITE],
+    ).for_operation(GitHubOperation.CONTENTS_WRITE)
+    payload = capability.to_dict()
+
+    assert payload["operation_class"] == "contents.write"
+    assert payload["installation_id"] == "123"
+    assert payload["app_declared_permission"] == "write"
+    assert payload["installation_granted_permission"] == "write"
+    assert payload["effective"] is True
+
+
+def test_code_publication_receipt_requires_commit_and_verified_diff():
+    incomplete = CodePublicationReceipt(
+        repository="owner/repository",
+        branch="change",
+        commit_sha="",
+        source_diff_verified=False,
+    )
+    with pytest.raises(RuntimeError, match="complete receipt"):
+        require_code_publication_receipt(incomplete)
+
+    complete = require_code_publication_receipt(CodePublicationReceipt(
+        repository="owner/repository",
+        branch="change",
+        commit_sha="abc123",
+        source_diff_verified=True,
+        pull_request_url="https://github.com/owner/repository/pull/1",
+    ))
+    assert complete.is_complete

--- a/tools/github_capabilities.py
+++ b/tools/github_capabilities.py
@@ -1,0 +1,500 @@
+"""Explicit GitHub authority checks for repository-object mutations.
+
+GitHub exposes several independently governed object classes.  A token that
+can write an issue comment is not proof that it can create a ref or write
+repository contents.  This module keeps that distinction in a small,
+dependency-free model that can be used before a mutation and after a 403.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from enum import Enum
+from typing import Any, Iterable, Mapping
+
+
+class GitHubOperation(str, Enum):
+    """Object classes used by the automation paths."""
+
+    REPOSITORY_METADATA_READ = "repository.metadata.read"
+    ISSUES_COMMENTS_WRITE = "issues.comments.write"
+    PULL_REQUESTS_REVIEWS_WRITE = "pull_requests.reviews.write"
+    CONTENTS_WRITE = "contents.write"
+    GIT_DATA_REFS_WRITE = "git_data.refs.write"
+    PULL_REQUEST_CREATE = "pull_request.create"
+    ACTIONS_CONTROL = "actions.control"
+    WORKFLOWS_WRITE = "workflows.write"
+    CHECKS_STATUSES_READ = "checks.statuses.read"
+
+    @property
+    def required_permission(self) -> tuple[str, str] | None:
+        """Return the GitHub App permission required by this operation."""
+        return {
+            GitHubOperation.ISSUES_COMMENTS_WRITE: ("issues", "write"),
+            GitHubOperation.PULL_REQUESTS_REVIEWS_WRITE: ("pull_requests", "write"),
+            GitHubOperation.CONTENTS_WRITE: ("contents", "write"),
+            # Git refs are governed by the Contents permission in an App token.
+            GitHubOperation.GIT_DATA_REFS_WRITE: ("contents", "write"),
+            GitHubOperation.PULL_REQUEST_CREATE: ("pull_requests", "write"),
+            GitHubOperation.ACTIONS_CONTROL: ("actions", "write"),
+            GitHubOperation.WORKFLOWS_WRITE: ("workflows", "write"),
+            GitHubOperation.CHECKS_STATUSES_READ: ("checks", "read"),
+        }.get(self)
+
+
+class GitHubAuthorizationReason(str, Enum):
+    """Stable reasons shown to callers and used for recovery guidance."""
+
+    APP_NOT_INSTALLED = "app_not_installed"
+    REPOSITORY_NOT_SELECTED = "repository_not_selected"
+    PERMISSION_NOT_GRANTED = "permission_not_granted"
+    BRANCH_PROTECTION_DENIED = "branch_protection_denied"
+    ORGANIZATION_POLICY_DENIED = "organization_policy_denied"
+    RESOURCE_NOT_ACCESSIBLE_UNKNOWN = "resource_not_accessible_unknown"
+
+
+@dataclass(frozen=True)
+class GitHubAuthorityContext:
+    """Evidence gathered for one repository and one authentication principal."""
+
+    repository: str
+    account: str = ""
+    organization: str = ""
+    authenticated: bool = False
+    app_principal: bool = False
+    installation_id: str | None = None
+    installation_exists: bool | None = None
+    repository_selected: bool | None = None
+    declared_permissions: Mapping[str, str] = field(default_factory=dict)
+    installation_permissions: Mapping[str, str] = field(default_factory=dict)
+    repository_permissions: Mapping[str, Any] = field(default_factory=dict)
+    operation_grants: Mapping[str, bool] = field(default_factory=dict)
+    repository_readable: bool | None = None
+    branch_protected: bool = False
+    organization_policy_denied: bool = False
+
+
+def _permission_value(permissions: Mapping[str, Any], name: str) -> str | None:
+    value = permissions.get(name)
+    if isinstance(value, Mapping):
+        value = value.get("level") or value.get("permission")
+    if isinstance(value, bool):
+        # Repository metadata exposes permissions such as push as booleans;
+        # App manifests and installation tokens expose read/write strings.
+        return "write" if value else "read"
+    if value is None:
+        return None
+    return str(value).lower()
+
+
+def _permission_allows(actual: str | None, required: str) -> bool:
+    if actual is None:
+        return False
+    if required == "read":
+        return actual in {"read", "write", "admin"}
+    return actual in {"write", "admin"}
+
+
+@dataclass(frozen=True)
+class GitHubCapability:
+    """Capability result for one exact GitHub operation class."""
+
+    repository: str
+    operation: GitHubOperation
+    account: str = ""
+    organization: str = ""
+    app_principal: bool = False
+    installation_id: str | None = None
+    repository_selected: bool | None = None
+    app_declared_permission: str | None = None
+    installation_granted_permission: str | None = None
+    effective: bool = False
+    reason: GitHubAuthorizationReason | None = None
+    status_code: int | None = None
+    message: str = ""
+
+    @property
+    def required_permission(self) -> tuple[str, str] | None:
+        return self.operation.required_permission
+
+    @property
+    def recovery_action(self) -> str:
+        if self.effective:
+            return "No recovery action is required."
+        if self.reason is GitHubAuthorizationReason.APP_NOT_INSTALLED:
+            return (
+                "Install the GitHub App in the target account or organization, "
+                "then retry the operation."
+            )
+        if self.reason is GitHubAuthorizationReason.REPOSITORY_NOT_SELECTED:
+            return (
+                "Select this repository in the GitHub App installation, "
+                "then retry the operation."
+            )
+        if self.reason is GitHubAuthorizationReason.PERMISSION_NOT_GRANTED:
+            permission = self.required_permission
+            requested = f"{permission[0]}:{permission[1]}" if permission else "the required permission"
+            return f"Grant the GitHub App {requested} permission for this repository, then retry."
+        if self.reason is GitHubAuthorizationReason.BRANCH_PROTECTION_DENIED:
+            return (
+                "Use an allowed branch or complete the repository's required "
+                "reviews and status checks before retrying."
+            )
+        if self.reason is GitHubAuthorizationReason.ORGANIZATION_POLICY_DENIED:
+            return (
+                "Ask an organization administrator to allow this operation "
+                "for the principal and repository."
+            )
+        return (
+            "Inspect the target repository, installation selection, and exact "
+            "operation permission; do not retry blindly."
+        )
+
+    def with_failure(self, status_code: int, message: str) -> "GitHubCapability":
+        """Attach a server response and classify it without losing evidence."""
+        known_reason = self.reason in {
+            GitHubAuthorizationReason.APP_NOT_INSTALLED,
+            GitHubAuthorizationReason.REPOSITORY_NOT_SELECTED,
+            GitHubAuthorizationReason.PERMISSION_NOT_GRANTED,
+            GitHubAuthorizationReason.BRANCH_PROTECTION_DENIED,
+            GitHubAuthorizationReason.ORGANIZATION_POLICY_DENIED,
+        }
+        reason = self.reason if known_reason else classify_github_403(
+            status_code,
+            message,
+            app_principal=self.app_principal,
+            repository_selected=self.repository_selected,
+        )
+        return replace(
+            self,
+            effective=False,
+            reason=reason,
+            status_code=status_code,
+            message=message[:500],
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        permission = self.required_permission
+        return {
+            "repository": self.repository,
+            "account": self.account,
+            "organization": self.organization,
+            "app_principal": self.app_principal,
+            "installation_id": self.installation_id,
+            "repository_selected": self.repository_selected,
+            "operation_class": self.operation.value,
+            "app_declared_permission": self.app_declared_permission,
+            "installation_granted_permission": self.installation_granted_permission,
+            "required_permission": (
+                {"name": permission[0], "level": permission[1]} if permission else None
+            ),
+            "effective": self.effective,
+            "reason": self.reason.value if self.reason else None,
+            "status_code": self.status_code,
+            "message": self.message,
+            "recovery_action": self.recovery_action,
+        }
+
+
+@dataclass(frozen=True)
+class GitHubCapabilityReport:
+    """First-class report for all requested operation classes."""
+
+    repository: str
+    capabilities: tuple[GitHubCapability, ...]
+
+    def for_operation(self, operation: GitHubOperation) -> GitHubCapability:
+        for capability in self.capabilities:
+            if capability.operation is operation:
+                return capability
+        raise KeyError(operation.value)
+
+    def require(
+        self,
+        operations: Iterable[GitHubOperation] | None = None,
+    ) -> "GitHubCapabilityReport":
+        requested = set(operations or (capability.operation for capability in self.capabilities))
+        failures = [
+            capability for capability in self.capabilities
+            if capability.operation in requested and not capability.effective
+        ]
+        if failures:
+            raise GitHubCapabilityError(failures[0])
+        return self
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "repository": self.repository,
+            "capabilities": [capability.to_dict() for capability in self.capabilities],
+        }
+
+
+def _unknown_capability(context: GitHubAuthorityContext, operation: GitHubOperation) -> GitHubCapability:
+    permission = operation.required_permission
+    return GitHubCapability(
+        repository=context.repository,
+        operation=operation,
+        account=context.account,
+        organization=context.organization,
+        app_principal=context.app_principal,
+        installation_id=context.installation_id,
+        repository_selected=context.repository_selected,
+        app_declared_permission=(
+            _permission_value(context.declared_permissions, permission[0])
+            if permission else None
+        ),
+        installation_granted_permission=(
+            _permission_value(context.installation_permissions, permission[0])
+            if permission else None
+        ),
+        reason=GitHubAuthorizationReason.RESOURCE_NOT_ACCESSIBLE_UNKNOWN,
+    )
+
+
+def build_capability_report(
+    context: GitHubAuthorityContext,
+    operations: Iterable[GitHubOperation] | None = None,
+) -> GitHubCapabilityReport:
+    """Build a fail-closed report from known installation/repository evidence.
+
+    App tokens are evaluated against declared and installation-granted
+    permissions. PAT/gh tokens use repository permissions for repository
+    contents and require explicit operation grants for separately governed
+    Actions/workflow controls. No successful metadata operation is used as a
+    proxy for a contents or ref write.
+    """
+    requested = tuple(operations or GitHubOperation)
+    results: list[GitHubCapability] = []
+
+    for operation in requested:
+        base = _unknown_capability(context, operation)
+        permission = operation.required_permission
+        declared = base.app_declared_permission
+        granted = base.installation_granted_permission
+
+        if context.app_principal:
+            if not context.installation_id or context.installation_exists is False:
+                results.append(replace(
+                    base,
+                    reason=GitHubAuthorizationReason.APP_NOT_INSTALLED,
+                ))
+                continue
+            if context.repository_selected is False:
+                results.append(replace(
+                    base,
+                    reason=GitHubAuthorizationReason.REPOSITORY_NOT_SELECTED,
+                ))
+                continue
+            if context.installation_exists is not True or context.repository_selected is not True:
+                results.append(base)
+                continue
+
+        if not context.authenticated:
+            results.append(base)
+            continue
+
+        explicit = context.operation_grants.get(operation.value)
+        if explicit is False:
+            results.append(replace(
+                base,
+                reason=GitHubAuthorizationReason.PERMISSION_NOT_GRANTED,
+            ))
+            continue
+        if explicit is True and context.authenticated:
+            results.append(replace(base, effective=True, reason=None))
+            continue
+
+        if context.app_principal:
+            if context.organization_policy_denied:
+                results.append(replace(
+                    base,
+                    reason=GitHubAuthorizationReason.ORGANIZATION_POLICY_DENIED,
+                ))
+                continue
+            if context.branch_protected and operation in {
+                GitHubOperation.CONTENTS_WRITE,
+                GitHubOperation.GIT_DATA_REFS_WRITE,
+            }:
+                results.append(replace(
+                    base,
+                    reason=GitHubAuthorizationReason.BRANCH_PROTECTION_DENIED,
+                ))
+                continue
+            if permission and (
+                not _permission_allows(declared, permission[1])
+                or not _permission_allows(granted, permission[1])
+            ):
+                results.append(replace(
+                    base,
+                    reason=GitHubAuthorizationReason.PERMISSION_NOT_GRANTED,
+                ))
+                continue
+            if operation is GitHubOperation.REPOSITORY_METADATA_READ:
+                effective = context.repository_readable is True
+            else:
+                effective = context.repository_readable is not False
+            results.append(replace(
+                base,
+                effective=effective,
+                reason=None if effective else GitHubAuthorizationReason.RESOURCE_NOT_ACCESSIBLE_UNKNOWN,
+            ))
+            continue
+
+        if context.organization_policy_denied:
+            results.append(replace(
+                base,
+                reason=GitHubAuthorizationReason.ORGANIZATION_POLICY_DENIED,
+            ))
+            continue
+        if context.branch_protected and operation in {
+            GitHubOperation.CONTENTS_WRITE,
+            GitHubOperation.GIT_DATA_REFS_WRITE,
+        }:
+            results.append(replace(
+                base,
+                reason=GitHubAuthorizationReason.BRANCH_PROTECTION_DENIED,
+            ))
+            continue
+
+        readable = context.repository_readable is True
+        if operation is GitHubOperation.REPOSITORY_METADATA_READ:
+            effective = readable
+        elif operation is GitHubOperation.PULL_REQUEST_CREATE:
+            # A contributor can create a PR against a readable base repository
+            # while writing code only to a separately authorized fork.
+            effective = readable
+        elif operation in {
+            GitHubOperation.CONTENTS_WRITE,
+            GitHubOperation.GIT_DATA_REFS_WRITE,
+        }:
+            effective = _permission_allows(
+                _permission_value(context.repository_permissions, "push"),
+                "write",
+            )
+        elif explicit is True:
+            effective = True
+        else:
+            effective = False
+
+        results.append(replace(
+            base,
+            effective=effective,
+            reason=None if effective else GitHubAuthorizationReason.RESOURCE_NOT_ACCESSIBLE_UNKNOWN,
+        ))
+
+    return GitHubCapabilityReport(
+        repository=context.repository,
+        capabilities=tuple(results),
+    )
+
+
+def classify_github_403(
+    status_code: int,
+    message: str,
+    *,
+    app_principal: bool = False,
+    repository_selected: bool | None = None,
+    branch_protected: bool = False,
+    organization_policy_denied: bool = False,
+) -> GitHubAuthorizationReason:
+    """Classify a forbidden response only when the evidence supports it."""
+    if status_code != 403:
+        return GitHubAuthorizationReason.RESOURCE_NOT_ACCESSIBLE_UNKNOWN
+
+    lowered = (message or "").lower()
+    if organization_policy_denied or any(marker in lowered for marker in (
+        "organization policy",
+        "enterprise policy",
+        "saml",
+        "ip allow list",
+        "ip allowlist",
+    )):
+        return GitHubAuthorizationReason.ORGANIZATION_POLICY_DENIED
+    if branch_protected or any(marker in lowered for marker in (
+        "protected branch",
+        "required status check",
+        "review required",
+        "branch protection",
+    )):
+        return GitHubAuthorizationReason.BRANCH_PROTECTION_DENIED
+    if repository_selected is False or any(marker in lowered for marker in (
+        "repository not selected",
+        "not selected for this installation",
+    )):
+        return GitHubAuthorizationReason.REPOSITORY_NOT_SELECTED
+    if app_principal and any(marker in lowered for marker in (
+        "app is not installed",
+        "installation not found",
+        "not installed",
+    )):
+        return GitHubAuthorizationReason.APP_NOT_INSTALLED
+    if any(marker in lowered for marker in (
+        "insufficient permission",
+        "insufficient scope",
+        "permission denied",
+        "missing permission",
+    )):
+        return GitHubAuthorizationReason.PERMISSION_NOT_GRANTED
+    return GitHubAuthorizationReason.RESOURCE_NOT_ACCESSIBLE_UNKNOWN
+
+
+class GitHubCapabilityError(RuntimeError):
+    """Raised when a mutation has no effective authority preflight."""
+
+    def __init__(self, capability: GitHubCapability):
+        self.capability = capability
+        super().__init__(
+            f"GitHub authority preflight failed for {capability.operation.value} "
+            f"on {capability.repository}: "
+            f"{capability.reason.value if capability.reason else 'not_effective'}. "
+            f"{capability.recovery_action}"
+        )
+
+
+@dataclass(frozen=True)
+class CodePublicationReceipt:
+    """Evidence that a code publication produced the expected source object."""
+
+    repository: str
+    branch: str
+    commit_sha: str
+    source_diff_verified: bool
+    pull_request_url: str | None = None
+
+    @property
+    def is_complete(self) -> bool:
+        return bool(
+            self.repository.strip()
+            and self.branch.strip()
+            and self.commit_sha.strip()
+            and self.source_diff_verified
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "repository": self.repository,
+            "branch": self.branch,
+            "commit_sha": self.commit_sha,
+            "source_diff_verified": self.source_diff_verified,
+            "pull_request_url": self.pull_request_url,
+            "complete": self.is_complete,
+        }
+
+
+class CodePublicationReceiptError(RuntimeError):
+    """Raised when a publisher cannot prove the resulting source change."""
+
+
+def require_code_publication_receipt(
+    receipt: CodePublicationReceipt,
+) -> CodePublicationReceipt:
+    if not receipt.is_complete:
+        raise CodePublicationReceiptError(
+            "Code publication did not produce a complete receipt: "
+            "repository, branch, commit SHA, and verified source diff are required."
+        )
+    return receipt
+
+
+def is_code_publication_complete(receipt: CodePublicationReceipt | None) -> bool:
+    return bool(receipt and receipt.is_complete)

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -37,6 +37,12 @@ import yaml
 from tools.skills_guard import (
     ScanResult, content_hash, TRUSTED_REPOS,
 )
+from tools.github_capabilities import (
+    GitHubAuthorityContext,
+    GitHubCapabilityReport,
+    GitHubOperation,
+    build_capability_report,
+)
 from tools.url_safety import is_safe_url
 from tools.website_policy import check_website_access
 
@@ -365,6 +371,17 @@ class GitHubAuth:
         self._cached_token: Optional[str] = None
         self._cached_method: Optional[str] = None
         self._app_token_expiry: float = 0
+        # These fields are deliberately kept separate from authentication:
+        # receiving a token does not prove that the installation selected a
+        # repository or granted the permission for a later mutation.
+        self._app_principal_configured = False
+        self._app_installation_id: Optional[str] = None
+        self._app_installation_exists: Optional[bool] = None
+        self._app_repository_selection: Optional[str] = None
+        self._app_selected_repositories: set[str] = set()
+        self._app_declared_permissions: Dict[str, str] = {}
+        self._app_granted_permissions: Dict[str, str] = {}
+        self._app_auth_failure: Optional[tuple[int, str]] = None
 
     def get_headers(self) -> Dict[str, str]:
         """Return authorization headers for GitHub API requests."""
@@ -381,6 +398,113 @@ class GitHubAuth:
         """Return which auth method is active: 'pat', 'gh-cli', 'github-app', or 'anonymous'."""
         self._resolve_token()
         return self._cached_method or "anonymous"
+
+    def capability_report(
+        self,
+        repository: str,
+        operations: Optional[List[GitHubOperation]] = None,
+    ) -> GitHubCapabilityReport:
+        """Report effective authority for exact repository object classes."""
+        if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository or ""):
+            context = GitHubAuthorityContext(repository=repository)
+            return build_capability_report(context, operations)
+
+        token = self._resolve_token()
+        app_principal = self._app_principal_configured or self._cached_method == "github-app"
+        repository_readable: Optional[bool] = None
+        repository_permissions: Dict[str, Any] = {}
+        account = ""
+        organization = ""
+
+        try:
+            response = httpx.get(
+                f"https://api.github.com/repos/{repository}",
+                headers=self.get_headers(),
+                timeout=10,
+            )
+            if response.status_code == 200:
+                data = response.json()
+                if isinstance(data, dict):
+                    repository_readable = True
+                    owner = data.get("owner") or {}
+                    account = str(owner.get("login") or "")
+                    organization_data = data.get("organization") or {}
+                    organization = str(
+                        organization_data.get("login")
+                        or (account if str(owner.get("type") or "").lower() == "organization" else "")
+                    )
+                    permissions = data.get("permissions") or {}
+                    if isinstance(permissions, dict):
+                        repository_permissions = dict(permissions)
+            elif response.status_code in {401, 403, 404}:
+                repository_readable = False
+        except Exception as exc:
+            logger.debug("GitHub capability metadata lookup failed: %s", exc)
+
+        installation_exists = self._app_installation_exists if app_principal else None
+        repository_selected: Optional[bool] = None
+        if app_principal:
+            if not self._app_installation_id:
+                installation_exists = False
+            elif installation_exists is None and self._cached_method == "github-app":
+                installation_exists = True
+            selection = (self._app_repository_selection or "").lower()
+            if selection == "all":
+                repository_selected = True
+            elif selection == "selected":
+                normalized = repository.lower()
+                if self._app_selected_repositories:
+                    repository_selected = normalized in self._app_selected_repositories
+                elif token:
+                    repository_selected = self._repository_is_in_installation(repository)
+
+        context = GitHubAuthorityContext(
+            repository=repository,
+            account=account,
+            organization=organization,
+            authenticated=token is not None,
+            app_principal=app_principal,
+            installation_id=self._app_installation_id,
+            installation_exists=installation_exists,
+            repository_selected=repository_selected,
+            declared_permissions=self._app_declared_permissions,
+            installation_permissions=self._app_granted_permissions,
+            repository_permissions=repository_permissions,
+            repository_readable=repository_readable,
+        )
+        return build_capability_report(context, operations)
+
+    def preflight(
+        self,
+        repository: str,
+        operations: List[GitHubOperation],
+    ) -> GitHubCapabilityReport:
+        """Require effective authority before a repository mutation."""
+        return self.capability_report(repository, operations).require(operations)
+
+    def _repository_is_in_installation(self, repository: str) -> Optional[bool]:
+        """Ask GitHub's installation endpoint only when selection is unknown."""
+        try:
+            response = httpx.get(
+                "https://api.github.com/installation/repositories",
+                headers=self.get_headers(),
+                timeout=10,
+            )
+            if response.status_code != 200:
+                return None
+            data = response.json()
+            repositories = data.get("repositories") if isinstance(data, dict) else None
+            if not isinstance(repositories, list):
+                return None
+            target = repository.lower()
+            return any(
+                isinstance(item, dict)
+                and str(item.get("full_name") or "").lower() == target
+                for item in repositories
+            )
+        except Exception as exc:
+            logger.debug("GitHub installation repository lookup failed: %s", exc)
+            return None
 
     def _resolve_token(self) -> Optional[str]:
         # Return cached token if still valid
@@ -436,6 +560,10 @@ class GitHubAuth:
         key_path = get_secret("GITHUB_APP_PRIVATE_KEY_PATH")
         installation_id = get_secret("GITHUB_APP_INSTALLATION_ID")
 
+        self._app_principal_configured = bool(app_id or key_path or installation_id)
+        self._app_installation_id = str(installation_id) if installation_id else None
+        if self._app_principal_configured and not installation_id:
+            self._app_installation_exists = False
         if not all([app_id, key_path, installation_id]):
             return None
 
@@ -459,6 +587,29 @@ class GitHubAuth:
             }
             encoded_jwt = jwt.encode(payload, private_key, algorithm="RS256")
 
+            # The App manifest is the source of declared permissions. The
+            # installation token response below is the source of granted
+            # permissions and repository selection.
+            try:
+                app_resp = httpx.get(
+                    "https://api.github.com/app",
+                    headers={
+                        "Authorization": f"Bearer {encoded_jwt}",
+                        "Accept": "application/vnd.github.v3+json",
+                    },
+                    timeout=10,
+                )
+                if app_resp.status_code == 200:
+                    app_data = app_resp.json()
+                    permissions = app_data.get("permissions") if isinstance(app_data, dict) else None
+                    if isinstance(permissions, dict):
+                        self._app_declared_permissions = {
+                            str(name): str(value).lower()
+                            for name, value in permissions.items()
+                        }
+            except Exception as exc:
+                logger.debug("GitHub App manifest lookup failed: %s", exc)
+
             resp = httpx.post(
                 f"https://api.github.com/app/installations/{installation_id}/access_tokens",
                 headers={
@@ -468,7 +619,33 @@ class GitHubAuth:
                 timeout=10,
             )
             if resp.status_code == 201:
-                return resp.json().get("token")
+                data = resp.json()
+                self._app_installation_exists = True
+                if isinstance(data, dict):
+                    permissions = data.get("permissions")
+                    if isinstance(permissions, dict):
+                        self._app_granted_permissions = {
+                            str(name): str(value).lower()
+                            for name, value in permissions.items()
+                        }
+                    selection = data.get("repository_selection")
+                    if selection:
+                        self._app_repository_selection = str(selection)
+                    repositories = data.get("repositories")
+                    if isinstance(repositories, list):
+                        self._app_selected_repositories = {
+                            str(item.get("full_name")).lower()
+                            for item in repositories
+                            if isinstance(item, dict) and item.get("full_name")
+                        }
+                    return data.get("token")
+            else:
+                self._app_auth_failure = (
+                    resp.status_code,
+                    str(getattr(resp, "text", "") or "")[:300],
+                )
+                if resp.status_code == 404:
+                    self._app_installation_exists = False
         except Exception as e:
             logger.debug("GitHub App auth failed: %s", e)
 


### PR DESCRIPTION
## Summary
- Add a first-class, operation-specific GitHub capability report covering installation, repository selection, declared/granted permissions, effective authority, typed reasons, and recovery actions.
- Preflight repository Contents, Git Data/refs, and PR creation separately in Skills Hub and web-git flows.
- Require mutation status validation and a code-publication receipt containing repository, branch, commit SHA, verified source diff, and PR URL.

## Root cause
Authentication/token availability and successful metadata operations were treated as evidence of repository-object authority. That allowed later Contents/ref/PR mutations to fail with generic 403 responses or to be reported without a source-of-truth code receipt.

## Fix
The new dependency-free authority layer fails closed on unknown authority and distinguishes app_not_installed, repository_not_selected, permission_not_granted, branch_protection_denied, organization_policy_denied, and resource_not_accessible_unknown. GitHub App discovery now records declared and installation-granted permissions and selected repositories. Skills Hub and web-git use exact preflights before mutation, and publication paths verify response status and resulting source objects.

## Testing
- `scripts/run_tests.sh tests/tools/test_github_capabilities.py tests/hermes_cli/test_web_git_authority.py tests/skills/test_github_issue_to_pr_skill.py -q` — 25 passed.
- `scripts/check-windows-footguns.py` on all changed source/test files — passed.
- Python syntax compilation of all changed Python files — passed.
- Sabotage run disabling the repository-selection branch — regression failed as expected; restored implementation — 25 focused tests passed.
- A broader four-file targeted run reached 77 passed, but this checkout lacks `rich` and `python-multipart` for two collection targets and has two unrelated existing Skills Hub test failures under the available runtime; those are not represented as green.

## Issue
Fixes #90200