### PR TITLE
fix(desktop): scope skill discovery to the calling session's project

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import threading
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -29,6 +30,16 @@ _skill_commands_home: Optional[str] = None
 # freshness lookup always see a consistent snapshot. Scanning itself stays
 # outside this lock.
 _publish_lock = threading.Lock()
+# Completed scans keyed by (platform, home, project). One backend process
+# serves many sessions, each potentially in a different project; a single
+# published slot would make two sessions in two repos invalidate each other on
+# every completion request and rescan the disk each time (cache thrash). The
+# keyed store keeps repeat completions cheap per project; the legacy triple
+# above remains the "most recent scan" view that reload_skills() diffs against.
+# Bounded: session workspaces are unbounded over a process's life, the cache
+# must not be.
+_skill_commands_by_scope: "OrderedDict[tuple, Dict[str, Dict[str, Any]]]" = OrderedDict()
+_SKILL_COMMANDS_SCOPE_CACHE_MAX = 8
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
@@ -227,6 +238,26 @@ def _resolve_skill_commands_home() -> str:
     from hermes_constants import get_hermes_home
 
     return str(get_hermes_home())
+
+
+def _resolve_skill_commands_project() -> str:
+    """Return the project root the skill scan is currently scoped to.
+
+    Project skills (``.hermes/skills`` / ``.agents/skills`` under the enclosing
+    git checkout) are part of the scanned universe, but the cache only tracked
+    platform + Hermes home. One backend PROCESS serves MANY sessions on
+    Desktop/gateway/ACP, each pinning its own session cwd, so whichever session
+    scanned first froze its project's skills into the cache for everyone else.
+
+    Returns ``""`` when the current session is not inside a project.
+    """
+    try:
+        from agent.skill_utils import find_project_root
+
+        root = find_project_root()
+    except Exception:  # pragma: no cover — defensive, never break the scan
+        return ""
+    return str(root) if root else ""
 
 
 def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tuple[dict[str, Any], Path | None, str] | None:
@@ -430,6 +461,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     global _skill_commands, _skill_commands_platform, _skill_commands_home
     platform = _resolve_skill_commands_platform()
     home = _resolve_skill_commands_home()
+    project = _resolve_skill_commands_project()
     # Build into a local map and publish once, at the end. Writing straight
     # into the global made a scan's partial results visible to everything
     # else in the process: a second, overlapping scan deduped against its own
@@ -540,10 +572,18 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     # without rescanning — serving another platform's disabled-skill view,
     # exactly the leak #14536 closed. Only the publish/lookup pair is locked;
     # the scan above (file I/O, deferred imports) stays outside it.
+    # The scope tuple (platform, home, project) was resolved BEFORE the scan,
+    # in this same context, so the published entry is labeled with the scope
+    # the scan actually ran under.
     with _publish_lock:
         _skill_commands = commands
         _skill_commands_platform = platform
         _skill_commands_home = home
+        scope = (platform, home, project)
+        _skill_commands_by_scope.pop(scope, None)
+        _skill_commands_by_scope[scope] = commands
+        while len(_skill_commands_by_scope) > _SKILL_COMMANDS_SCOPE_CACHE_MAX:
+            _skill_commands_by_scope.popitem(last=False)
     return commands
 
 
@@ -552,23 +592,36 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
 
     Rescans when the active platform scope changes (e.g. a gateway
     process serving Telegram and Discord concurrently) so each platform
-    sees its own ``skills.platform_disabled`` view (#14536), and when the
+    sees its own ``skills.platform_disabled`` view (#14536), when the
     active profile's Hermes home changes (e.g. Desktop switching profiles
-    mid-session) so each profile sees its own ``skills.external_dirs`` (#88023).
+    mid-session) so each profile sees its own ``skills.external_dirs``
+    (#88023), and when the resolved PROJECT root differs so each session sees
+    the repo skills of the project it actually has open — and only those.
+
+    Scans are memoized per (platform, home, project) scope: two sessions in
+    two different repos each keep their own completed scan instead of
+    invalidating a single shared slot back and forth on every completion
+    request.
     """
     current_platform = _resolve_skill_commands_platform()
     current_home = _resolve_skill_commands_home()
-    # Read the map and its tags under the same lock that publishes them, so
-    # the freshness decision is made against a consistent snapshot.
+    current_project = _resolve_skill_commands_project()
+    # Read under the same lock that publishes, so the freshness decision is
+    # made against a consistent snapshot. An empty LEGACY map means either a
+    # by-hand cache reset (tests do this to force a rescan — several idioms
+    # exist, some nulling tags and some not, so the map itself is the only
+    # signal that catches all of them) or a scan that genuinely found zero
+    # skills. Both force a rescan. For the zero-skill case that trades the
+    # memo away — a skill-less process rescans per request, as it always has —
+    # which is the conservative side: serving a possibly-stale scoped entry
+    # after a reset would be a correctness bug, an extra rescan is only cost.
     with _publish_lock:
-        commands = _skill_commands
-        is_fresh = (
-            bool(commands)
-            and _skill_commands_platform == current_platform
-            and _skill_commands_home == current_home
+        cached = _skill_commands_by_scope.get(
+            (current_platform, current_home, current_project)
         )
-    if is_fresh:
-        return commands
+        reset_by_hand = not _skill_commands
+    if cached and not reset_by_hand:
+        return cached
     # Scan outside the lock — it does file I/O and deferred imports, and
     # concurrent scans are already safe (each builds its own map).
     return scan_skill_commands()
@@ -614,6 +667,12 @@ def reload_skills() -> Dict[str, Any]:
         return out
 
     before = _snapshot(_skill_commands)
+
+    # The disk changed, so EVERY scope's memoized scan is suspect — global
+    # skills appear in all of them. Drop the whole keyed cache; other scopes
+    # rebuild on their next request (the single-slot behaviour, made explicit).
+    with _publish_lock:
+        _skill_commands_by_scope.clear()
 
     # Rescan the skills dir. ``scan_skill_commands`` resets
     # ``_skill_commands = {}`` internally and repopulates it.

--- a/apps/desktop/src/app/chat/composer/hooks/use-at-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-at-completions.ts
@@ -160,8 +160,9 @@ export function useAtCompletions(options: {
 
   // Cache key: the completion depends on the query AND the directory it's
   // resolved against, so a cwd or session change can't serve another tree's
-  // listing.
-  const cacheKey = useCallback((query: string) => `${cwd ?? ''}|${sessionId ?? ''}|${query}`, [cwd, sessionId])
+  // listing. JSON.stringify, not a `|` join: a delimiter that can appear
+  // inside a cwd (or the query itself) lets two different scopes collide.
+  const cacheKey = useCallback((query: string) => JSON.stringify([cwd ?? '', sessionId ?? '', query]), [cwd, sessionId])
 
   const fetcher = useCallback(
     async (query: string): Promise<CompletionPayload> => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.test.tsx
@@ -41,11 +41,11 @@ const RANKED_CATALOG = {
 const commandsOf = (items: readonly Unstable_TriggerItem[]) =>
   items.map(item => (item.metadata as { command?: string })?.command)
 
-function harness(gateway: HermesGateway) {
+function harness(gateway: HermesGateway, scope?: { cwd?: string; sessionId?: string }) {
   const api: { search?: (query: string) => readonly Unstable_TriggerItem[] } = {}
 
   function Probe() {
-    const { adapter } = useSlashCompletions({ gateway })
+    const { adapter } = useSlashCompletions({ cwd: scope?.cwd ?? null, gateway, sessionId: scope?.sessionId ?? null })
     api.search = adapter.search
 
     return null
@@ -153,5 +153,38 @@ describe('useSlashCompletions', () => {
     await completions(api, '')
 
     expect(commandsOf(await completions(api, 'research'))).toEqual(['/research', '/research-paper-writing'])
+  })
+
+  // The catalog includes the session's PROJECT skills (`.hermes/skills` /
+  // `.agents/skills` in the open repo). One backend process serves every
+  // session, so it can only resolve which project that is from the session
+  // identity we send — without it the scan ran against the backend's own
+  // directory and no repo skill ever reached the popover.
+  it('scopes both completion RPCs to the session and its workspace', async () => {
+    const request = vi.fn().mockResolvedValue(CATALOG)
+    const api = harness({ request } as unknown as HermesGateway, { cwd: '/repo', sessionId: 'sid-1' })
+
+    await completions(api, '')
+    expect(request).toHaveBeenCalledWith('commands.catalog', { cwd: '/repo', session_id: 'sid-1' })
+
+    request.mockResolvedValue({ items: [{ text: '/work', display: '/work', meta: '' }] })
+    await completions(api, 'wo')
+    expect(request).toHaveBeenCalledWith('complete.slash', { cwd: '/repo', session_id: 'sid-1', text: '/wo' })
+  })
+
+  it('does not serve one workspace a catalog cached for another', async () => {
+    const request = vi.fn().mockResolvedValue(CATALOG)
+
+    const inRepo = harness({ request } as unknown as HermesGateway, { cwd: '/repo-a', sessionId: 'a' })
+    await completions(inRepo, '')
+    expect(request).toHaveBeenCalledTimes(1)
+
+    // A second session in a different repo must re-ask rather than inherit
+    // repo A's answer — the catalog is per-workspace, not per-process.
+    cleanup()
+    const elsewhere = harness({ request } as unknown as HermesGateway, { cwd: '/repo-b', sessionId: 'b' })
+    await completions(elsewhere, '')
+    expect(request).toHaveBeenCalledTimes(2)
+    expect(request).toHaveBeenLastCalledWith('commands.catalog', { cwd: '/repo-b', session_id: 'b' })
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.test.tsx
@@ -187,4 +187,21 @@ describe('useSlashCompletions', () => {
     expect(request).toHaveBeenCalledTimes(2)
     expect(request).toHaveBeenLastCalledWith('commands.catalog', { cwd: '/repo-b', session_id: 'b' })
   })
+
+  // A raw `${cwd}|${sessionId}` join lets a delimiter inside the cwd forge
+  // another scope's key: ('/repo|x', 'sid') and ('/repo', 'x|sid') both
+  // serialize to '/repo|x|sid'. Directories with `|` in their name are legal
+  // on POSIX filesystems, so these are two REAL distinct scopes.
+  it('does not collide cache keys when a cwd contains the delimiter', async () => {
+    const request = vi.fn().mockResolvedValue(CATALOG)
+
+    const first = harness({ request } as unknown as HermesGateway, { cwd: '/repo|x', sessionId: 'sid' })
+    await completions(first, '')
+    expect(request).toHaveBeenCalledTimes(1)
+
+    cleanup()
+    const second = harness({ request } as unknown as HermesGateway, { cwd: '/repo', sessionId: 'x|sid' })
+    await completions(second, '')
+    expect(request).toHaveBeenCalledTimes(2)
+  })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
@@ -83,7 +83,9 @@ export function useSlashCompletions(options: {
   // Two sessions in different projects get different catalogs, so a cached
   // response is only valid for the workspace that produced it. Mirrors the
   // `@` path cache, which is scoped the same way for the same reason.
-  const scope = `${cwd ?? ''}|${sessionId ?? ''}`
+  // JSON.stringify, not a `|` join: a delimiter that can appear inside a cwd
+  // lets two different (cwd, sessionId) pairs collide on one cache key.
+  const scope = JSON.stringify([cwd ?? '', sessionId ?? ''])
 
   const fetcher = useCallback(
     async (query: string): Promise<CompletionPayload> => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
@@ -65,13 +65,25 @@ export function useSlashCompletions(options: {
    *  come from here, not the backend (whose skin list is CLI/TUI-only). */
   skinThemes?: DesktopThemeCommandOption[]
   activeSkin?: string
+  /** Session identity for the backend's skill scan. The catalog includes the
+   *  session's PROJECT skills (`.hermes/skills` / `.agents/skills` in the open
+   *  repo), which the backend can only resolve from this session's cwd — one
+   *  backend process serves every session, so without these the scan ran
+   *  against the install tree and no repo skill ever reached the popover. */
+  sessionId?: string | null
+  cwd?: string | null
 }): {
   adapter: Unstable_TriggerAdapter
   loading: boolean
 } {
-  const { gateway, skinThemes, activeSkin } = options
+  const { gateway, skinThemes, activeSkin, sessionId, cwd } = options
   const enabled = Boolean(gateway)
   const epoch = useStore($slashCompletionsEpoch)
+
+  // Two sessions in different projects get different catalogs, so a cached
+  // response is only valid for the workspace that produced it. Mirrors the
+  // `@` path cache, which is scoped the same way for the same reason.
+  const scope = `${cwd ?? ''}|${sessionId ?? ''}`
 
   const fetcher = useCallback(
     async (query: string): Promise<CompletionPayload> => {
@@ -141,9 +153,23 @@ export function useSlashCompletions(options: {
       }
 
       try {
+        // Session identity rides on both RPCs so the backend resolves THIS
+        // session's project skills rather than the backend process's own cwd.
+        const scopeParams: Record<string, string> = {}
+
+        if (sessionId) {
+          scopeParams.session_id = sessionId
+        }
+
+        if (cwd) {
+          scopeParams.cwd = cwd
+        }
+
         if (!query) {
           const catalog = filterDesktopCommandsCatalog(
-            await cachedSlashCompletion('catalog', () => gateway.request<CommandsCatalogLike>('commands.catalog'))
+            await cachedSlashCompletion(`catalog|${scope}`, () =>
+              gateway.request<CommandsCatalogLike>('commands.catalog', scopeParams)
+            )
           )
 
           // Prefer the categorized layout so the popover renders section headers
@@ -183,8 +209,11 @@ export function useSlashCompletions(options: {
           return { items, query }
         }
 
-        const result = await cachedSlashCompletion(`slash:${text.toLowerCase()}`, () =>
-          gateway.request<{ items?: CompletionEntry[]; replace_from?: number }>('complete.slash', { text })
+        const result = await cachedSlashCompletion(`slash:${text.toLowerCase()}|${scope}`, () =>
+          gateway.request<{ items?: CompletionEntry[]; replace_from?: number }>('complete.slash', {
+            ...scopeParams,
+            text
+          })
         )
 
         // Arg-completion items (replace_from > 1) carry just the arg stub —
@@ -232,7 +261,7 @@ export function useSlashCompletions(options: {
         // search that hides a match is broken. Usage rides along on the catalog
         // response, which the popover has already fetched by the time anyone
         // types; if it somehow hasn't, order falls back to the backend's.
-        const catalogSkills = peekCachedSlashCompletion<CommandsCatalogLike>('catalog')?.skills
+        const catalogSkills = peekCachedSlashCompletion<CommandsCatalogLike>(`catalog|${scope}`)?.skills
 
         const ranked = [
           ...decorated.filter(item => item.group !== 'Skills'),
@@ -249,7 +278,7 @@ export function useSlashCompletions(options: {
         return { items: [], query }
       }
     },
-    [gateway, skinThemes, activeSkin]
+    [gateway, skinThemes, activeSkin, scope, sessionId, cwd]
   )
 
   const toItem = useCallback((entry: CompletionEntry, index: number): Unstable_TriggerItem => {
@@ -291,9 +320,9 @@ export function useSlashCompletions(options: {
         return true
       }
 
-      return hasCachedSlashCompletion(query ? `slash:${text.toLowerCase()}` : 'catalog')
+      return hasCachedSlashCompletion(query ? `slash:${text.toLowerCase()}|${scope}` : `catalog|${scope}`)
     },
-    [skinThemes]
+    [skinThemes, scope]
   )
 
   return useLiveCompletionAdapter({ enabled, epoch, fetcher, isCached, toItem })

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -203,7 +203,15 @@ export function ChatBar({
 
   const { availableThemes, themeName } = useTheme()
   const at = useAtCompletions({ gateway: gateway ?? null, sessionId: sessionId ?? null, cwd: cwd ?? null })
-  const slash = useSlashCompletions({ activeSkin: themeName, gateway: gateway ?? null, skinThemes: availableThemes })
+
+  const slash = useSlashCompletions({
+    activeSkin: themeName,
+    cwd: cwd ?? null,
+    gateway: gateway ?? null,
+    sessionId: sessionId ?? null,
+    skinThemes: availableThemes
+  })
+
   const emoji = useEmojiCompletions()
 
   const { t } = useI18n()

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -115,7 +115,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   const expanded = draft.includes('\n')
   const canSubmit = draft.trim().length > 0
   const at = useAtCompletions({ cwd, gateway, sessionId })
-  const slash = useSlashCompletions({ gateway })
+  const slash = useSlashCompletions({ cwd, gateway, sessionId })
   const emoji = useEmojiCompletions()
 
   // This is the one composer that routinely unmounts, so it is where the focus

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -482,6 +482,142 @@ class TestScanSkillCommands:
         # partial one growing from 0.
         assert observed_sizes == [skill_count] * skill_count
 
+    def test_scans_are_memoized_per_project_scope(self, tmp_path):
+        """Two sessions in two projects each keep their own completed scan.
+
+        Scoping the scan by session fixed CORRECTNESS, but with one shared
+        cache slot two sessions in different repos would invalidate each other
+        on every completion request — every keystroke a full disk rescan.
+        The cache is keyed by (platform, home, project): alternating projects
+        must trigger exactly one scan per project.
+        """
+        import agent.skill_commands as sc_mod
+        from agent.skill_commands import get_skill_commands
+
+        # A non-empty global skill: a scan that finds nothing publishes an
+        # empty map, which get_skill_commands treats as a cold cache (the
+        # pre-existing always-rescan-when-empty behaviour) and would make
+        # every call below a scan regardless of memoization.
+        skills_dir = tmp_path / "skills"
+        _make_skill(skills_dir, "global-skill")
+        repo_a = str(tmp_path / "repo_a")
+        repo_b = str(tmp_path / "repo_b")
+
+        scans = []
+        real_scan = sc_mod.scan_skill_commands
+
+        def counting_scan():
+            scans.append(sc_mod._resolve_skill_commands_project())
+            return real_scan()
+
+        current_project = {"value": ""}
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", skills_dir),
+            patch.object(sc_mod, "scan_skill_commands", counting_scan),
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch.object(sc_mod, "_skill_commands_platform", None),
+            patch.object(sc_mod, "_skill_commands_home", None),
+            patch.object(
+                sc_mod,
+                "_skill_commands_by_scope",
+                type(sc_mod._skill_commands_by_scope)(),
+            ),
+            patch.object(
+                sc_mod,
+                "_resolve_skill_commands_project",
+                lambda: current_project["value"],
+            ),
+        ):
+            for project in (repo_a, repo_b, repo_a, repo_b, repo_a):
+                current_project["value"] = project
+                assert "/global-skill" in get_skill_commands()
+
+        # One scan per project — not one per alternation.
+        assert len(scans) == 2, (
+            f"expected 2 scans (one per project), got {len(scans)}: {scans}"
+        )
+        assert set(scans) == {repo_a, repo_b}
+
+    def test_reload_skills_drops_every_scope(self, tmp_path):
+        """/reload-skills invalidates ALL memoized scopes, not just the active one.
+
+        Global skills appear in every scope's scan, so a disk change makes
+        every memoized entry suspect. A scope OTHER than the one that ran the
+        reload must rescan on its next request instead of serving its
+        pre-reload snapshot.
+        """
+        import agent.skill_commands as sc_mod
+        from agent.skill_commands import get_skill_commands, reload_skills
+
+        skills_dir = tmp_path / "skills"
+        _make_skill(skills_dir, "first")
+        repo_a = str(tmp_path / "repo_a")
+        repo_b = str(tmp_path / "repo_b")
+
+        current_project = {"value": ""}
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", skills_dir),
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch.object(sc_mod, "_skill_commands_platform", None),
+            patch.object(sc_mod, "_skill_commands_home", None),
+            patch.object(
+                sc_mod,
+                "_skill_commands_by_scope",
+                type(sc_mod._skill_commands_by_scope)(),
+            ),
+            patch.object(
+                sc_mod,
+                "_resolve_skill_commands_project",
+                lambda: current_project["value"],
+            ),
+        ):
+            # Prime both scopes with the pre-change skill set.
+            current_project["value"] = repo_a
+            assert "/first" in get_skill_commands()
+            current_project["value"] = repo_b
+            assert "/first" in get_skill_commands()
+
+            # Disk changes; scope A runs the reload.
+            _make_skill(skills_dir, "second")
+            current_project["value"] = repo_a
+            reload_skills()
+
+            # Scope B must NOT serve its pre-reload snapshot.
+            current_project["value"] = repo_b
+            assert "/second" in get_skill_commands(), (
+                "a memoized scope survived reload_skills() and served its "
+                "pre-reload snapshot"
+            )
+
+    def test_scope_cache_is_bounded(self, tmp_path):
+        """The per-scope memo cannot grow without bound as workspaces churn."""
+        import agent.skill_commands as sc_mod
+
+        empty_local_dir = tmp_path / "no-local-skills"
+        empty_local_dir.mkdir()
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", empty_local_dir),
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch.object(sc_mod, "_skill_commands_platform", None),
+            patch.object(sc_mod, "_skill_commands_home", None),
+            patch.object(sc_mod, "_skill_commands_by_scope", type(sc_mod._skill_commands_by_scope)()),
+        ):
+            for index in range(sc_mod._SKILL_COMMANDS_SCOPE_CACHE_MAX + 5):
+                project = tmp_path / f"proj-{index}"
+                project.mkdir()
+                with patch.object(
+                    sc_mod, "_resolve_skill_commands_project", lambda p=project: str(p)
+                ):
+                    scan_skill_commands()
+
+            assert (
+                len(sc_mod._skill_commands_by_scope)
+                <= sc_mod._SKILL_COMMANDS_SCOPE_CACHE_MAX
+            )
+
 
 class TestResolveSkillCommandKey:
     """Telegram bot-command names disallow hyphens, so the menu registers

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -20094,3 +20094,66 @@ def test_command_dispatch_resolves_a_project_skill_from_the_session(tmp_path, mo
     assert seen.get("project") == str(repo.resolve())
     assert resp["result"]["type"] == "skill"
     assert resp["result"]["name"] == "repo-only"
+
+
+def _slash_scope_pin_probe(method, params):
+    """Run a completion RPC and report the cwd pin the skill scan ran under.
+
+    Reads the contextvar itself rather than ``find_project_root()``, so it
+    observes the scope's own contract — WHICH cwd wins — and stays meaningful
+    on trees where the resolver does not yet honour the pin.
+    """
+    seen = {}
+
+    import agent.skill_commands as sc
+
+    real = sc.scan_skill_commands
+
+    def _probe():
+        from agent.runtime_cwd import _session_cwd_override
+
+        seen["pin"] = _session_cwd_override()
+        return {}
+
+    sc.scan_skill_commands = _probe
+    sc._skill_commands = {}
+    try:
+        server.handle_request({"id": "1", "method": method, "params": params})
+    finally:
+        sc.scan_skill_commands = real
+        sc._skill_commands = {}
+    return seen.get("pin")
+
+
+def test_completion_scope_prefers_the_session_record_over_the_client_cwd(tmp_path):
+    """The session's pinned cwd is the authority; the client param is not.
+
+    The skill scan decides which PROJECT's skills are offered and invoked, so
+    a buggy or hostile renderer must not be able to point it at an arbitrary
+    directory once a session exists. ``session.cwd.set`` / workspace moves
+    keep the record current, so honouring it never serves a stale workspace.
+    """
+    repo_a = tmp_path / "session-project"
+    repo_a.mkdir()
+    repo_b = tmp_path / "client-claimed"
+    repo_b.mkdir()
+
+    server._sessions["auth-sid"] = {"cwd": str(repo_a)}
+    try:
+        pin = _slash_scope_pin_probe(
+            "commands.catalog", {"session_id": "auth-sid", "cwd": str(repo_b)}
+        )
+    finally:
+        server._sessions.pop("auth-sid", None)
+
+    assert pin == os.path.abspath(str(repo_a))
+
+
+def test_completion_scope_falls_back_to_the_client_cwd_before_any_session(tmp_path):
+    """Pre-session (no record yet), the client's cwd param still scopes the scan."""
+    repo = tmp_path / "pre-session-project"
+    repo.mkdir()
+
+    pin = _slash_scope_pin_probe("commands.catalog", {"cwd": str(repo)})
+
+    assert pin == os.path.abspath(str(repo))

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -19907,3 +19907,190 @@ def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):
     assert captured["row_update"] == (target, str(new_cwd))
     assert live["cwd"] == str(new_cwd)
     assert live.get("explicit_cwd") is True
+
+
+def _session_cwd_is_honoured() -> bool:
+    """True when ``find_project_root()`` consults the per-session cwd pin.
+
+    These three tests assert that the completion/dispatch RPCs scan in the
+    CALLING session's project. That is only observable once the project
+    resolver reads the ``_SESSION_CWD`` contextvar this scope sets; on a tree
+    where it still resolves ``TERMINAL_CWD``/process cwd, the scope is correct
+    but has no visible effect. Skip rather than fail there, so this PR is green
+    on its own and turns green-with-teeth once the resolver lands.
+    """
+    import tempfile
+    from pathlib import Path
+
+    from agent.runtime_cwd import _SESSION_CWD, set_session_cwd
+    from agent.skill_utils import find_project_root
+
+    probe = Path(tempfile.mkdtemp()) / "proj"
+    (probe / ".git").mkdir(parents=True)
+    token = set_session_cwd(str(probe))
+    try:
+        return find_project_root() == probe.resolve()
+    finally:
+        _SESSION_CWD.reset(token)
+
+
+_needs_session_cwd = pytest.mark.skipif(
+    not _session_cwd_is_honoured(),
+    reason="find_project_root() does not yet read _SESSION_CWD; the session "
+    "scope is applied but not observable (see the PR description)",
+)
+
+
+def _slash_scope_project_probe(method, params):
+    """Run a completion RPC and report the project root the skill scan saw.
+
+    Both handlers enumerate skills through ``agent.skill_commands``; this stubs
+    that call so the test observes the resolved PROJECT — the thing that was
+    wrong — without depending on any skill actually existing on disk.
+
+    Resolves through ``find_project_root()`` rather than any skill-command
+    helper so this test exercises only the session scope it is about.
+    """
+    seen = {}
+
+    import agent.skill_commands as sc
+
+    real = sc.scan_skill_commands
+
+    def _probe():
+        from agent.skill_utils import find_project_root
+
+        root = find_project_root()
+        seen["project"] = str(root) if root else ""
+        return {}
+
+    sc.scan_skill_commands = _probe
+    sc._skill_commands = {}
+    try:
+        server.handle_request({"id": "1", "method": method, "params": params})
+    finally:
+        sc.scan_skill_commands = real
+        sc._skill_commands = {}
+    return seen.get("project")
+
+
+@_needs_session_cwd
+def test_commands_catalog_scans_skills_in_the_calling_sessions_project(tmp_path):
+    """Desktop symptom: repo skills never reached the `/` popover.
+
+    One backend process serves every session, so the catalog handler ran with
+    the PROCESS cwd (the install tree on Desktop) and found no project at all.
+    The session's cwd has to scope the scan.
+    """
+    repo = tmp_path / "proj"
+    (repo / ".git").mkdir(parents=True)
+
+    assert _slash_scope_project_probe("commands.catalog", {"cwd": str(repo)}) == str(
+        repo.resolve()
+    )
+
+
+@_needs_session_cwd
+def test_complete_slash_scans_skills_in_the_calling_sessions_project(tmp_path):
+    repo = tmp_path / "proj"
+    (repo / ".git").mkdir(parents=True)
+
+    assert _slash_scope_project_probe(
+        "complete.slash", {"text": "/", "cwd": str(repo)}
+    ) == str(repo.resolve())
+
+
+def test_completion_rpcs_do_not_leak_their_session_cwd(tmp_path):
+    """The pinned cwd must not outlive the request that set it.
+
+    A leaked contextvar would hand the NEXT session — any surface, any repo —
+    this session's project, and with it skills whose trust was granted per repo.
+    """
+    from agent.runtime_cwd import _session_cwd_override
+
+    repo = tmp_path / "proj"
+    (repo / ".git").mkdir(parents=True)
+
+    before = _session_cwd_override()
+    server.handle_request(
+        {"id": "1", "method": "commands.catalog", "params": {"cwd": str(repo)}}
+    )
+    server.handle_request(
+        {
+            "id": "2",
+            "method": "complete.slash",
+            "params": {"text": "/", "cwd": str(repo)},
+        }
+    )
+    assert _session_cwd_override() == before
+
+
+def test_complete_slash_restores_cwd_even_when_the_handler_raises(tmp_path, monkeypatch):
+    from agent.runtime_cwd import _session_cwd_override
+
+    repo = tmp_path / "proj"
+    (repo / ".git").mkdir(parents=True)
+
+    def _boom(*a, **k):
+        raise RuntimeError("completer exploded")
+
+    monkeypatch.setattr("hermes_cli.commands.SlashCommandCompleter", _boom)
+
+    before = _session_cwd_override()
+    resp = server.handle_request(
+        {"id": "1", "method": "complete.slash", "params": {"text": "/x", "cwd": str(repo)}}
+    )
+
+    assert "error" in resp
+    assert _session_cwd_override() == before
+
+
+@_needs_session_cwd
+def test_command_dispatch_resolves_a_project_skill_from_the_session(tmp_path, monkeypatch):
+    """Invocation, not just display: `/name` + Enter must find a repo skill.
+
+    `command.dispatch` looked the skill up with the backend process's own cwd,
+    so a user in a trusted repo could see the skill in the popover (once the
+    catalog was scoped) and still get "not a skill command" on Enter.
+    """
+    repo = tmp_path / "proj"
+    (repo / ".git").mkdir(parents=True)
+
+    import agent.skill_commands as sc
+
+    seen = {}
+
+    def _probe():
+        from agent.skill_utils import find_project_root
+
+        root = find_project_root()
+        seen["project"] = str(root) if root else ""
+        return {"/repo-only": {"name": "repo-only", "description": "from the repo"}}
+
+    monkeypatch.setattr(sc, "scan_skill_commands", _probe)
+    monkeypatch.setattr(
+        sc, "build_skill_invocation_message", lambda *a, **k: "expanded skill body"
+    )
+    # The stub never populates the module cache, and the scope this handler
+    # enters changes what a later scan would resolve. Reset the module state so
+    # the next file to import skill_commands doesn't inherit a half-built
+    # snapshot — cross-file order dependence here is a known trap (#57068).
+    monkeypatch.setattr(sc, "_skill_commands", {}, raising=False)
+    monkeypatch.setattr(sc, "_skill_commands_platform", None, raising=False)
+    monkeypatch.setattr(sc, "_skill_commands_home", None, raising=False)
+
+    server._sessions["disp-sid"] = {"cwd": str(repo), "session_key": "disp-key"}
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "command.dispatch",
+                "params": {"name": "/repo-only", "arg": "", "session_id": "disp-sid"},
+            }
+        )
+    finally:
+        server._sessions.pop("disp-sid", None)
+
+    assert seen.get("project") == str(repo.resolve())
+    assert resp["result"]["type"] == "skill"
+    assert resp["result"]["name"] == "repo-only"

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -333,6 +333,15 @@ def _(rid, params: dict) -> dict:
     if not text.startswith("/"):
         return _ok(rid, {"items": []})
 
+    # Skill completions resolve PROJECT skills from the calling session's cwd.
+    # Without this scope the handler runs on the bare backend process — whose
+    # cwd is the install tree on Desktop — so the popover offered only global
+    # skills AND poisoned the process-wide skill cache for every other session.
+    # Entered via the context-manager protocol rather than a `with` block so the
+    # handler body below stays byte-identical to its pre-split server.py form
+    # (see method_ctx.py); the scope itself never raises.
+    _slash_scope = _completion_session_scope(params)
+    _slash_scope.__enter__()
     try:
         from hermes_cli.commands import SlashCommandCompleter
         from prompt_toolkit.document import Document
@@ -464,6 +473,8 @@ def _(rid, params: dict) -> dict:
         )
     except Exception as e:
         return _err(rid, 5020, str(e))
+    finally:
+        _slash_scope.__exit__(None, None, None)
 
 
 @method("model.options")

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -339,7 +339,14 @@ def _(rid, params: dict) -> dict:
             # loaded once per catalog build.
             usage, origin_of = _skill_usage_lookup()
 
-            for k, info in sorted(scan_skill_commands().items()):
+            # Scoped to the CALLING session's cwd: the scan resolves project
+            # skills from it, and this handler otherwise runs on the bare
+            # backend process (whose cwd is the install tree on Desktop), so
+            # every repo skill was missing from the `/` popover.
+            with _completion_session_scope(params):
+                scanned = sorted(scan_skill_commands().items())
+
+            for k, info in scanned:
                 d = str(info.get("description", "Skill"))
                 all_pairs.append([k, d[:120] + ("…" if len(d) > 120 else "")])
                 name = str(info.get("name") or k.lstrip("/"))
@@ -547,12 +554,25 @@ def _(rid, params: dict) -> dict:
             build_skill_invocation_message,
         )
 
-        cmds = scan_skill_commands()
-        key = f"/{name}"
-        if key in cmds:
-            msg = build_skill_invocation_message(
-                key, arg, task_id=session.get("session_key", "") if session else ""
+        # Same session scope the completion RPCs use, for the same reason: the
+        # scan resolves PROJECT skills from the session's cwd. Without it a user
+        # could not INVOKE a repo skill even by typing its name and pressing
+        # Enter — the dispatcher looked for it in the backend process's own
+        # directory and reported "not a skill command". Both the lookup and the
+        # message build run inside the scope, since building the invocation
+        # re-reads the skill from disk.
+        with _completion_session_scope({"session_id": params.get("session_id"), "cwd": (session or {}).get("cwd")}):
+            cmds = scan_skill_commands()
+            key = f"/{name}"
+            msg = (
+                build_skill_invocation_message(
+                    key, arg, task_id=session.get("session_key", "") if session else ""
+                )
+                if key in cmds
+                else None
             )
+
+        if key in cmds:
             if msg:
                 return _ok(
                     rid,
@@ -1205,8 +1225,19 @@ def _(rid, params: dict) -> dict:
             set_hermes_home_override(_profile_home) if _profile_home else None
         )
         try:
-            _cmd_key = f"/{_cmd_base}"
-            if _cmd_key in get_skill_commands():
+            # Same session scope the other skill-enumerating RPCs use: this
+            # lookup decides whether a `/name` is a skill (and must be routed to
+            # command.dispatch) or a shell command to execute. Resolved against
+            # the backend process's cwd, a PROJECT skill was invisible here, so
+            # `/implement` in a repo fell through this guard and was handed to
+            # the slash worker as an ordinary command.
+            with _completion_session_scope(
+                {"session_id": params.get("session_id"), "cwd": session.get("cwd")}
+            ):
+                _cmd_key = f"/{_cmd_base}"
+                _is_skill = _cmd_key in get_skill_commands()
+
+            if _is_skill:
                 return _err(
                     rid, 4018, f"skill command: use command.dispatch for {_cmd_key}"
                 )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3487,6 +3487,41 @@ def _clear_session_context(tokens: list) -> None:
         pass
 
 
+@contextlib.contextmanager
+def _completion_session_scope(params: dict | None):
+    """Pin the calling session's cwd for the duration of a completion RPC.
+
+    Completion handlers (``commands.catalog``, ``complete.slash``) enumerate
+    skills, and the skill scan resolves PROJECT skills from the session's
+    working directory. Unlike prompt handlers, these never entered a session
+    context — they ran on the bare backend process, whose cwd is the install
+    tree on Desktop. So the `/` popover listed only global skills, and whichever
+    session scanned first also poisoned the process-wide skill cache for every
+    other session.
+
+    Pinning ``_SESSION_CWD`` (the same contextvar the prompt path sets) makes
+    the scan resolve THIS session's project. Cheap: contextvar set/reset, no
+    session lookup beyond the cwd the handler would resolve anyway.
+    """
+    token = None
+    try:
+        from agent.runtime_cwd import set_session_cwd
+
+        token = set_session_cwd(_completion_cwd(params))
+    except Exception:
+        token = None
+    try:
+        yield
+    finally:
+        if token is not None:
+            try:
+                from agent.runtime_cwd import _SESSION_CWD
+
+                _SESSION_CWD.reset(token)
+            except Exception:
+                pass
+
+
 def _enable_gateway_prompts() -> None:
     """Route approvals through gateway callbacks instead of CLI input()."""
     os.environ["HERMES_GATEWAY_SESSION"] = "1"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3487,6 +3487,35 @@ def _clear_session_context(tokens: list) -> None:
         pass
 
 
+def _completion_scope_cwd(params: dict | None) -> str:
+    """Resolve the cwd a skill-scan scope should pin, session record first.
+
+    ``_completion_cwd`` consults the CLIENT's ``cwd`` param before the session
+    record — the right order for file completion, where the renderer knows
+    which directory the user is typing a path against. For the skill scan it
+    is backwards: the scan decides which PROJECT's skills are offered and
+    invoked, and that authority belongs to the server-side session record
+    (kept current by ``session.cwd.set`` / ``session.workspace.move``), not to
+    whatever a buggy or hostile renderer names. The param remains the rung for
+    pre-session contexts — no record yet, or a record with no pinned cwd.
+    """
+    params = params or {}
+    sid = params.get("session_id")
+    session = _sessions.get(sid, {}) if isinstance(sid, str) and sid else {}
+    pinned = session.get("cwd")
+    if pinned:
+        # The pin stays authoritative even when the directory is gone (deleted
+        # worktree): the scan then simply resolves no project, which is the
+        # truth. Falling back to the client's param here would hand a hostile
+        # renderer exactly the steering this function exists to remove; the
+        # legitimate fix for a dead pin is session.cwd.set / workspace.move.
+        try:
+            return os.path.abspath(os.path.expanduser(str(pinned)))
+        except Exception:
+            pass
+    return _completion_cwd(params)
+
+
 @contextlib.contextmanager
 def _completion_session_scope(params: dict | None):
     """Pin the calling session's cwd for the duration of a completion RPC.
@@ -3500,14 +3529,15 @@ def _completion_session_scope(params: dict | None):
     other session.
 
     Pinning ``_SESSION_CWD`` (the same contextvar the prompt path sets) makes
-    the scan resolve THIS session's project. Cheap: contextvar set/reset, no
-    session lookup beyond the cwd the handler would resolve anyway.
+    the scan resolve THIS session's project. Cheap: contextvar set/reset, one
+    session lookup. Once the session has a pinned cwd, that record outranks
+    the client's ``cwd`` param — see ``_completion_scope_cwd``.
     """
     token = None
     try:
         from agent.runtime_cwd import set_session_cwd
 
-        token = set_session_cwd(_completion_cwd(params))
+        token = set_session_cwd(_completion_scope_cwd(params))
     except Exception:
         token = None
     try:


### PR DESCRIPTION
## What does this PR do?

Scopes the Desktop `/` path to the session that is actually asking, so skills
from the open project are offered and can be invoked.

Three RPCs enumerate skills — `commands.catalog`, `complete.slash`,
`command.dispatch` — plus `slash.exec`'s skill-vs-shell routing guard, and none
of them entered the calling session's context. They ran on the bare backend
process, whose cwd on Desktop is the install tree, so project-skill resolution
walked up from the wrong directory and found nothing. Global skills were
unaffected, which is why this reads as "project skills are broken" rather than
"the popover is broken."

`command.dispatch` is the worst of the four: it is the execution path, so a user
could not run a repo skill even by typing its full name and pressing Enter.
`slash.exec` is the subtlest — its guard decides whether `/name` is a skill or a
shell command, so an invisible project skill falls through and the name is
handed to the slash worker as a command to execute.

The prompt handlers already do this correctly
(`methods_prompt.py:1217` → `_set_session_context`); the completion and dispatch
handlers were never given the same treatment.

The renderer half: `use-slash-completions.ts` sent neither `session_id` nor
`cwd` and cached under process-global keys, so even a scoped backend could not
tell who was asking, and two windows in different repos shared one cached
catalog. Its sibling `use-at-completions.ts` already scopes `${cwd}|${sessionId}`
— this matches it.

Measured on one install, session workspace = a repo with 37 project skills:

| | before | after |
|---|---|---|
| `/` commands offered | 87 | 124 |
| `/implement` (a repo skill) | `4018 not a ... skill command` | resolves and runs |

## Related Issue

Fixes #90231.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

New regression tests, verified RED against a clean clone of `main` before the
fix:

- `tests/test_tui_gateway_server.py` — 3 behavioural cases:
  `commands.catalog` and `complete.slash` scan in the caller's project, and
  `command.dispatch` resolves a project skill. **These are gated on
  `_needs_session_cwd` and SKIP on current `main`**, because they are only
  observable once `find_project_root()` reads the contextvar this scope sets
  (see Sequencing). With that resolver fix applied locally they pass; without
  it they skip with an explicit reason rather than failing, so this PR is green
  on its own and gains teeth the moment the prerequisite lands.
  Two further cases assert the pinned cwd is released afterwards (including
  when the handler raises); those run unconditionally, but are **guards on the
  new code, not upstream tripwires** — they pass trivially on `main`, which
  never sets the contextvar at all.
- `apps/desktop/.../use-slash-completions.test.tsx` — 2 cases, both RED
  upstream: each RPC carries session identity, and one workspace is not served
  another's cached catalog.

Suite results, applied to `main` @ `fdf6f1d4c`:

```
tests/test_tui_gateway_server.py: 585 passed, 3 skipped, 2 failed
```

The 3 skips are the gated cases described above. Both failures are
pre-existing on clean `main` and untouched by this PR:
  - `test_load_enabled_toolsets_rejects_disabled_mcp_env` and
    `..._falls_back_when_tui_env_invalid` — both fail on the same assertion,
    `set(result) - {...} <= _RECENTLY_SHIPPED_TOOLSETS`, with
    `AssertionError: assert {'bfl', 'desktop_ui'} <= frozenset({'bfl'})`.
    `desktop_ui` shipped as a toolset but was never added to
    `hermes_cli/tools_config.py:2365`. Unrelated to this PR, and I couldn't find
    an existing issue for it — happy to file one separately. (Per the
    contribution rubric's "behavior contracts over snapshots", these two look
    like they'd be better asserting the *relationship* between the enabled set
    and the shipped-toolset registry than freezing a literal.)

`apps/desktop`: `tsc -p .` and `eslint` are clean, and the 7 cases in
`use-slash-completions.test.tsx` pass against the working tree. I could not run
the renderer suite inside the fresh PR checkout — vitest fails to initialise
there with `Cannot find module 'driver.js'`, an unrelated dependency gap in my
vendored `node_modules` snapshot rather than anything this branch changes.

Cross-file pollution: the new dispatch test resets the `skill_commands`
module globals it perturbs, so it cannot change results for suites that run
after it (this suite has a history of order dependence — #57068).

## Notes for review

**`complete.slash` uses the context-manager protocol, not a `with` block.** Its
handler body is byte-identical to the pre-split `server.py` form and is rebound
onto server globals at install time (`tui_gateway/method_ctx.py`). Reindenting
~130 lines under a `with` would have made the diff unreviewable and broken that
invariant, so the scope is entered explicitly and released in `finally`.

**Concurrency.** `complete.slash` is in `_LONG_HANDLERS`, so `dispatch()` runs it
on the shared thread pool via `ctx.run()` on a copied context
(`server.py:2123-2133`). I verified the pin cannot cross requests there: each
submission gets a fresh `copy_context()`, so a mutation inside one `ctx.run` is
invisible to the next — even on the same reused worker thread, and even if a
handler failed to reset. The `finally` reset is still load-bearing for
`commands.catalog`, `command.dispatch`, and `slash.exec`, which are *not* pooled
and run on the main dispatcher thread.

**Relationship to #81640.** Not orthogonal — I said so earlier and was wrong.
That PR restructures the *same function* (`scan_skill_commands` →
`_scan_skill_commands_locked`) and adds an `RLock` plus a `_skill_commands_home`
cache key. It scopes by **profile** where this scopes by **project**, but they
share the cache and the locking strategy, so they must be coordinated rather
than merged independently. This branch adopts the same lock-and-publish shape
deliberately. Note #81640's diff currently carries committed conflict markers
(`#<<<<<<< HEAD` in `agent/skill_commands.py`). Happy to rebase on top of it, or
to fold both scopes into one change if that's easier to review.

**Sequencing — this PR does nothing on its own. Please read before merging.**

This fix pins the session's cwd via `_SESSION_CWD`. On current `main`,
`agent/skill_utils.py:find_project_root()` resolves `TERMINAL_CWD` → `Path.cwd()`
and **never reads that contextvar**, so this PR is *inert* against `main` as it
stands — the popover would still show zero project skills.

Measured, with the completion scope applied and `find_project_root()` restored
to upstream's ladder at runtime:

```
with session-cwd resolution   : skill_count=125, /implement present
upstream main's resolution    : skill_count=88,  /implement absent
```

`find_project_root()` must read `_SESSION_CWD` first for this change to have any
effect. I've reported that separately and privately as GHSA-92jh-mqqp-27h3,
because on a pooled backend the same gap lets one session resolve another
session's repo and load its trust-gated project skills. It is a hard prerequisite
for this PR, not an independent improvement.

There is a third piece bundled with that advisory (a cache-key fix), and the
ordering constraint is entirely between those two — not between them and this PR.
This change is inert until the resolver fix lands, and cannot make anything worse
in the meantime.

So: merge order is advisory fix first, this PR second. Merging this alone is
harmless but has no visible effect. I have all the pieces implemented and tested
locally and can supply whichever you want, in whatever order suits your
disclosure process — just say where you'd like them.