### PR TITLE
Handle terminal compression exhaustion with fresh-session handoff

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -27,6 +27,10 @@ import { RemoteDisplayBanner } from '@/components/remote-display-banner'
 import { emitGatewayEvent } from '@/contrib/events'
 import { getLatestSessionMessages } from '@/hermes'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import {
+  compressionBoundaryResumePrompt,
+  shouldRequestFreshSessionAfterCompression
+} from '@/lib/gateway-events'
 import { isMessagingSource } from '@/lib/session-source'
 import { latestSessionTodos } from '@/lib/todos'
 import { activateWakeIndicator } from '@/lib/wake-indicator'
@@ -737,6 +741,19 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         }
 
         requestVoiceConversationStart()
+
+        return
+      }
+
+      const currentSessionId = activeSessionIdRef.current
+
+      if (shouldRequestFreshSessionAfterCompression(event, currentSessionId)) {
+        const resumePrompt = compressionBoundaryResumePrompt(event, currentSessionId)
+        startFreshSessionDraft()
+
+        if (resumePrompt) {
+          requestComposerInsert(resumePrompt, { mode: 'block', target: 'main' })
+        }
 
         return
       }

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -11,7 +11,7 @@ import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { recoverInFlightTurnJournal } from '@/lib/inflight-turn-journal'
 import { setSessionYolo } from '@/lib/yolo-session'
 import { normalizeChoices, setClarifyRequest } from '@/store/clarify'
-import { migrateSessionDraft } from '@/store/composer'
+import { migrateSessionDraft, setComposerDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
 import { $gatewaySwitching } from '@/store/gateway-switch'
 import { $pinnedSessionIds } from '@/store/layout'
@@ -1103,6 +1103,11 @@ export function useSessionActions({
         // Watch windows skip the prefetch — lazy resume attaches the live mirror.
         const prefetchPromise = watchWindow ? null : getLatestSessionMessages(storedSessionId, sessionProfile)
 
+        // The runtime resume is the boundary authority. A sealed-compression
+        // response may return before the REST prefetch, so consume a late
+        // prefetch rejection even when that transcript is intentionally ignored.
+        prefetchPromise?.catch(() => undefined)
+
         let resumeRuntimeBaselineMessages: ChatMessage[] = []
 
         const resumePromise = requestForSession<SessionResumeResponse>('session.resume', {
@@ -1130,9 +1135,25 @@ export function useSessionActions({
         // keeps it from surfacing as unhandled while the prefetch settles.
         resumePromise.catch(() => undefined)
 
+        const resumed = await resumePromise
+
+        if (!isCurrentResume()) {
+          return
+        }
+
+        if (resumed.compression_boundary) {
+          const resumePrompt = resumed.compression_boundary.resume_prompt?.trim()
+          startFreshSessionDraft()
+          if (resumePrompt) {
+            setComposerDraft(resumePrompt)
+          }
+
+          return
+        }
+
         // Keep both requests concurrent, but do not paint the REST result until
-        // the runtime resume has also settled. An eager prefetch paint followed
-        // by the runtime projection rebuilds large transcripts during resume.
+        // the runtime resume has also settled. The boundary branch above must
+        // win before a poisoned transcript prefetch is awaited or reconciled.
         let prefetchedResult: { messages: SessionMessage[]; session_id?: string } | null = null
 
         try {
@@ -1141,12 +1162,6 @@ export function useSessionActions({
           }
         } catch {
           // Non-fatal: gateway resume below can still hydrate the session.
-        }
-
-        const resumed = await resumePromise
-
-        if (!isCurrentResume()) {
-          return
         }
 
         if (prefetchedResult) {
@@ -1475,6 +1490,7 @@ export function useSessionActions({
       sessionStateByRuntimeIdRef,
       startFreshSessionDraft,
       syncSessionStateToView,
+      setComposerDraft,
       updateSessionState
     ]
   )

--- a/apps/desktop/src/lib/gateway-events.test.ts
+++ b/apps/desktop/src/lib/gateway-events.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { approvalReplaySessionId, gatewayEventRequiresSessionId, resolveGatewayEventSessionId } from './gateway-events'
+import {
+  approvalReplaySessionId,
+  compressionBoundaryResumePrompt,
+  gatewayEventRequiresSessionId,
+  resolveGatewayEventSessionId,
+  shouldRequestFreshSessionAfterCompression
+} from './gateway-events'
 
 describe('gateway event routing', () => {
   it('rehydrates pending approvals on reconnect ready and resumed session info', () => {
@@ -126,5 +132,61 @@ describe('gateway event routing', () => {
       pinned: true,
       sessionId: 'session-a'
     })
+  })
+
+  it('accepts only a current-session compression boundary request', () => {
+    expect(
+      shouldRequestFreshSessionAfterCompression(
+        {
+          payload: { reason: 'compression_exhausted' },
+          session_id: 'session-a',
+          type: 'dashboard.new_session_requested'
+        },
+        'session-a'
+      )
+    ).toBe(true)
+
+    expect(
+      shouldRequestFreshSessionAfterCompression(
+        {
+          payload: { reason: 'compression_exhausted' },
+          session_id: 'session-old',
+          type: 'dashboard.new_session_requested'
+        },
+        'session-a'
+      )
+    ).toBe(false)
+
+    expect(
+      shouldRequestFreshSessionAfterCompression(
+        {
+          payload: { reason: 'compression_exhausted' },
+          session_id: 'session-a',
+          type: 'dashboard.new_session_requested'
+        },
+        null
+      )
+    ).toBe(false)
+
+    expect(
+      shouldRequestFreshSessionAfterCompression(
+        {
+          payload: { reason: 'compression_exhausted' },
+          type: 'dashboard.new_session_requested'
+        },
+        null
+      )
+    ).toBe(false)
+  })
+
+  it('returns only the current boundary handoff prompt', () => {
+    const event = {
+      payload: { reason: 'compression_exhausted', resume_prompt: '  continue from checkpoint  ' },
+      session_id: 'session-a',
+      type: 'dashboard.new_session_requested'
+    }
+
+    expect(compressionBoundaryResumePrompt(event, 'session-a')).toBe('continue from checkpoint')
+    expect(compressionBoundaryResumePrompt(event, 'session-old')).toBeNull()
   })
 })

--- a/apps/desktop/src/lib/gateway-events.ts
+++ b/apps/desktop/src/lib/gateway-events.ts
@@ -4,11 +4,52 @@ const LOG_TAIL = 5
 
 interface RpcEventLike {
   payload?: unknown
+  session_id?: string
   type?: string
 }
 
 function asRecord(payload: unknown): Record<string, unknown> {
   return payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : {}
+}
+
+/**
+ * Return true only for a current-session compression boundary request.
+ *
+ * The gateway can finish a turn after the desktop has already moved to a
+ * different chat. A late boundary must not create a fresh draft in whichever
+ * session happens to be focused when it arrives.
+ */
+export function shouldRequestFreshSessionAfterCompression(
+  event: RpcEventLike,
+  activeSessionId: null | string
+): boolean {
+  if (event.type !== 'dashboard.new_session_requested') {
+    return false
+  }
+
+  if (asRecord(event.payload).reason !== 'compression_exhausted') {
+    return false
+  }
+
+  if (!activeSessionId) {
+    return false
+  }
+
+  return !event.session_id ? true : event.session_id === activeSessionId
+}
+
+/** Return the bounded, redacted handoff prompt carried by a current boundary. */
+export function compressionBoundaryResumePrompt(
+  event: RpcEventLike,
+  activeSessionId: null | string
+): string | null {
+  if (!shouldRequestFreshSessionAfterCompression(event, activeSessionId)) {
+    return null
+  }
+
+  const prompt = asRecord(event.payload).resume_prompt
+
+  return typeof prompt === 'string' && prompt.trim() ? prompt.trim() : null
 }
 
 /**

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -612,6 +612,11 @@ export interface SessionMessagesResponse {
 }
 
 export interface SessionResumeResponse {
+  compression_boundary?: {
+    old_session_id?: string
+    reason?: string
+    resume_prompt?: string
+  }
   /** Present when the backend found a fresh crash-interrupted turn and
    *  scheduled its automatic continuation; the turn arrives as a normal
    *  message.start stream right after this resume. */

--- a/hermes_cli/compression_boundary.py
+++ b/hermes_cli/compression_boundary.py
@@ -1,0 +1,172 @@
+"""Durable handoffs for terminal context-compression boundaries.
+
+The conversation transcript is intentionally not copied across a terminal
+compression boundary.  This module stores a small, redacted checkpoint in
+``state_meta`` and builds the prompt that a fresh session can use to continue
+from the workspace instead of replaying the poisoned transcript.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from agent.redact import redact_sensitive_text
+
+
+CHECKPOINT_SCHEMA_VERSION = 1
+CHECKPOINT_META_PREFIX = "compression_boundary:"
+_MAX_PROMPT_EXCERPT_CHARS = 1_600
+_MAX_QUEUED_PROMPT_CHARS = 1_200
+_MAX_GOAL_CHARS = 800
+_MAX_ERROR_CHARS = 240
+_MAX_RESUME_PROMPT_CHARS = 3_200
+
+
+def checkpoint_meta_key(session_id: str) -> str:
+    """Return the namespaced state-meta key for a session boundary."""
+    return f"{CHECKPOINT_META_PREFIX}{str(session_id or '').strip()}"
+
+
+def _redacted_excerpt(value: Any, limit: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    text = redact_sensitive_text(value, force=True).strip()
+    if len(text) <= limit:
+        return text
+    head = max(1, int(limit * 0.68))
+    tail = max(1, limit - head - 32)
+    return f"{text[:head].rstrip()}\n[… excerpt shortened …]\n{text[-tail:].lstrip()}"
+
+
+def build_compression_checkpoint(
+    session_id: str,
+    *,
+    prompt: Any = None,
+    queued_prompt: Any = None,
+    goal: Any = None,
+    cwd: Any = None,
+    model: Any = None,
+    error: Any = None,
+) -> dict[str, Any]:
+    """Build a bounded, redacted checkpoint for a failed conversation turn.
+
+    The checkpoint deliberately carries task anchors, not transcript history.
+    The old session remains available for inspection, while the fresh-session
+    prompt directs the next model turn to inspect current durable state.
+    """
+    old_session_id = str(session_id or "").strip()
+    prompt_excerpt = _redacted_excerpt(prompt, _MAX_PROMPT_EXCERPT_CHARS)
+    queued_excerpt = _redacted_excerpt(queued_prompt, _MAX_QUEUED_PROMPT_CHARS)
+    goal_excerpt = _redacted_excerpt(goal, _MAX_GOAL_CHARS)
+    error_excerpt = _redacted_excerpt(error, _MAX_ERROR_CHARS)
+    workspace = _redacted_excerpt(cwd, 500)
+    model_name = _redacted_excerpt(model, 160)
+
+    lines = [
+        "Continue the interrupted task in this fresh Hermes session.",
+        "The previous session hit terminal context-compression exhaustion and was sealed.",
+        "Do not paste or replay the previous transcript.",
+        "Start with a bounded read-only check of the current workspace and durable task files, then continue from the last verified step.",
+    ]
+    if goal_excerpt:
+        lines.append(f"A standing goal was active: {goal_excerpt}")
+    if prompt_excerpt:
+        lines.append(
+            "The last user request is included only as a bounded task anchor; do not treat it as a transcript to replay:\n"
+            f"{prompt_excerpt}"
+        )
+    if queued_excerpt:
+        lines.append(
+            "A newer user message arrived during the failed turn and was preserved as an editable handoff draft:\n"
+            f"{queued_excerpt}"
+        )
+    if workspace:
+        lines.append(f"Workspace recorded at the boundary: {workspace}")
+    lines.append(f"Sealed session id: {old_session_id}")
+    resume_prompt = "\n\n".join(lines).strip()
+    resume_prompt = _redacted_excerpt(resume_prompt, _MAX_RESUME_PROMPT_CHARS)
+
+    return {
+        "schema_version": CHECKPOINT_SCHEMA_VERSION,
+        "kind": "compression_boundary",
+        "status": "pending",
+        "reason": "compression_exhausted",
+        "old_session_id": old_session_id,
+        "created_at": time.time(),
+        "prompt_excerpt": prompt_excerpt,
+        "queued_prompt_excerpt": queued_excerpt,
+        "goal_excerpt": goal_excerpt,
+        "cwd": workspace,
+        "model": model_name,
+        "error_excerpt": error_excerpt,
+        "resume_prompt": resume_prompt,
+    }
+
+
+def persist_compression_checkpoint(db: Any, checkpoint: dict[str, Any]) -> bool:
+    """Persist one checkpoint atomically through the SessionDB meta API."""
+    session_id = str(checkpoint.get("old_session_id") or "").strip()
+    if not session_id or db is None or not hasattr(db, "set_meta"):
+        return False
+    db.set_meta(
+        checkpoint_meta_key(session_id),
+        json.dumps(checkpoint, ensure_ascii=False, separators=(",", ":")),
+    )
+    return True
+
+
+def load_compression_checkpoint(db: Any, session_id: str) -> dict[str, Any] | None:
+    """Load and validate one checkpoint, returning ``None`` on bad state."""
+    if db is None or not hasattr(db, "get_meta"):
+        return None
+    raw = db.get_meta(checkpoint_meta_key(session_id))
+    if not raw:
+        return None
+    try:
+        value = json.loads(raw)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(value, dict):
+        return None
+    if value.get("schema_version") != CHECKPOINT_SCHEMA_VERSION:
+        return None
+    if value.get("kind") != "compression_boundary":
+        return None
+    if value.get("status") != "pending":
+        return None
+    if value.get("reason") != "compression_exhausted":
+        return None
+    if str(value.get("old_session_id") or "") != str(session_id or ""):
+        return None
+    if not isinstance(value.get("resume_prompt"), str) or not value["resume_prompt"].strip():
+        return None
+    return value
+
+
+def compression_boundary_resume_payload(db: Any, session_id: str) -> dict[str, Any] | None:
+    """Return a transcript-free resume response for a sealed session."""
+    checkpoint = load_compression_checkpoint(db, session_id)
+    if checkpoint is None:
+        return None
+
+    boundary = {
+        "old_session_id": str(checkpoint["old_session_id"]),
+        "reason": "compression_exhausted",
+        "resume_prompt": str(checkpoint["resume_prompt"]).strip(),
+    }
+    return {
+        "compression_boundary": boundary,
+        "session_id": str(session_id),
+        "resumed": str(session_id),
+        "message_count": 0,
+        "messages": [],
+        "messages_omitted": True,
+        "info": None,
+        "inflight": None,
+        "running": False,
+        "session_key": str(session_id),
+        "started_at": checkpoint.get("created_at"),
+        "status": "idle",
+    }

--- a/tests/tui_gateway/test_compression_boundary.py
+++ b/tests/tui_gateway/test_compression_boundary.py
@@ -1,0 +1,93 @@
+"""Tests for the durable no-replay compression boundary contract."""
+
+from __future__ import annotations
+
+import json
+
+from hermes_cli.compression_boundary import (
+    build_compression_checkpoint,
+    compression_boundary_resume_payload,
+    checkpoint_meta_key,
+    load_compression_checkpoint,
+    persist_compression_checkpoint,
+)
+
+
+class _MetaDB:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+
+    def set_meta(self, key: str, value: str) -> None:
+        self.values[key] = value
+
+    def get_meta(self, key: str) -> str | None:
+        return self.values.get(key)
+
+
+def test_checkpoint_is_bounded_redacted_and_does_not_embed_transcript():
+    prompt = "review the current task\n" + ("x" * 10_000)
+    prompt += "\ncredential=" + ("sk-" + ("a" * 24))
+
+    checkpoint = build_compression_checkpoint(
+        "session-old",
+        prompt=prompt,
+        queued_prompt="finish the current step",
+        goal="complete the repair",
+        cwd="/workspace",
+        model="model-a",
+        error="context length exceeded",
+    )
+
+    assert checkpoint["old_session_id"] == "session-old"
+    assert checkpoint["reason"] == "compression_exhausted"
+    assert len(checkpoint["prompt_excerpt"]) <= 1_600
+    assert len(checkpoint["resume_prompt"]) <= 3_200
+    assert "sk-" not in checkpoint["prompt_excerpt"]
+    assert "Do not paste or replay the previous transcript." in checkpoint["resume_prompt"]
+    assert "finish the current step" in checkpoint["resume_prompt"]
+
+
+def test_checkpoint_round_trips_through_namespaced_state_meta():
+    db = _MetaDB()
+    checkpoint = build_compression_checkpoint("session-round-trip", prompt="continue")
+
+    assert persist_compression_checkpoint(db, checkpoint) is True
+    assert checkpoint_meta_key("session-round-trip") in db.values
+    loaded = load_compression_checkpoint(db, "session-round-trip")
+
+    assert loaded == checkpoint
+
+
+def test_invalid_or_cross_session_checkpoint_is_not_accepted():
+    db = _MetaDB()
+    db.set_meta(
+        checkpoint_meta_key("session-a"),
+        json.dumps(
+            {
+                "schema_version": 1,
+                "reason": "compression_exhausted",
+                "old_session_id": "session-b",
+            }
+        ),
+    )
+
+    assert load_compression_checkpoint(db, "session-a") is None
+    assert load_compression_checkpoint(db, "session-missing") is None
+
+
+def test_resume_payload_is_transcript_free_and_preserves_handoff_prompt():
+    db = _MetaDB()
+    checkpoint = build_compression_checkpoint(
+        "session-sealed",
+        prompt="continue the implementation",
+        queued_prompt="inspect the failing test",
+    )
+    assert persist_compression_checkpoint(db, checkpoint) is True
+
+    payload = compression_boundary_resume_payload(db, "session-sealed")
+
+    assert payload is not None
+    assert payload["compression_boundary"]["old_session_id"] == "session-sealed"
+    assert payload["messages"] == []
+    assert payload["inflight"] is None
+    assert "inspect the failing test" in payload["compression_boundary"]["resume_prompt"]

--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -256,7 +256,7 @@ def test_pending_input_commands_includes_goal(server):
 # ── active-goal recovery after compression exhaustion ───────────────
 
 
-def test_active_goal_retries_once_without_judging_failed_turn(
+def test_active_goal_pauses_and_seals_session_without_retrying_failed_turn(
     server, turn_env, monkeypatch
 ):
     from hermes_cli.goals import GoalManager
@@ -264,13 +264,11 @@ def test_active_goal_retries_once_without_judging_failed_turn(
     session_key = "goal-compression-retry"
     mgr = GoalManager(session_key)
     mgr.set("finish the current task")
-    continuation = mgr.next_continuation_prompt()
     seen_prompts = []
-    results = iter([_compression_failure(), {"final_response": "recovered work"}])
 
     def run_conversation(message, **_kwargs):
         seen_prompts.append(message)
-        return next(results)
+        return _compression_failure()
 
     judged = []
 
@@ -288,15 +286,20 @@ def test_active_goal_retries_once_without_judging_failed_turn(
 
     server._run_prompt_submit("rid", "sid", session, "initial work")
 
-    assert seen_prompts == ["initial work", continuation]
-    assert judged == ["recovered work"]
+    assert seen_prompts == ["initial work"]
+    assert judged == []
     assert GoalManager(session_key).state.turns_used == 0
+    assert GoalManager(session_key).state.status == "paused"
+    assert "fresh session required" in (GoalManager(session_key).state.paused_reason or "")
     assert server._GOAL_COMPRESSION_RECOVERY_ATTEMPTS not in session
     completes = [p for event, _sid, p in turn_env if event == "message.complete"]
-    assert [p["status"] for p in completes] == ["error", "complete"]
+    assert [p["status"] for p in completes] == ["error"]
+    assert len(
+        [p for event, _sid, p in turn_env if event == "dashboard.new_session_requested"]
+    ) == 1
 
 
-def test_second_consecutive_exhaustion_pauses_goal_instead_of_looping(
+def test_compression_exhaustion_pauses_goal_without_a_same_session_loop(
     server, turn_env, monkeypatch
 ):
     from hermes_cli.goals import GoalManager
@@ -324,23 +327,22 @@ def test_second_consecutive_exhaustion_pauses_goal_instead_of_looping(
 
     server._run_prompt_submit("rid", "sid", session, "initial work")
 
-    assert len(seen_prompts) == 2
+    assert len(seen_prompts) == 1
     assert judged == []
     state = GoalManager(session_key).state
     assert state.status == "paused"
     assert state.turns_used == 0
-    assert "compression exhausted twice" in state.paused_reason
+    assert "fresh session required" in state.paused_reason
     assert server._GOAL_COMPRESSION_RECOVERY_ATTEMPTS not in session
     notices = [
         p["text"]
         for event, _sid, p in turn_env
         if event == "status.update" and p.get("kind") == "goal"
     ]
-    assert any("Retrying the active goal once" in text for text in notices)
     assert any("Goal paused" in text for text in notices)
 
 
-def test_real_queued_prompt_preempts_goal_compression_retry(
+def test_queued_user_prompt_moves_into_compression_boundary_checkpoint(
     server, turn_env, monkeypatch
 ):
     from hermes_cli.goals import GoalManager
@@ -348,7 +350,6 @@ def test_real_queued_prompt_preempts_goal_compression_retry(
     session_key = "goal-compression-user-preempts"
     mgr = GoalManager(session_key)
     mgr.set("finish the current task")
-    continuation = mgr.next_continuation_prompt()
     seen_prompts = []
     session_holder = {}
 
@@ -357,7 +358,7 @@ def test_real_queued_prompt_preempts_goal_compression_retry(
         if len(seen_prompts) == 1:
             server._enqueue_prompt(session_holder["session"], "real user input", None)
             return _compression_failure()
-        return {"final_response": "handled the user's update"}
+        return _compression_failure()
 
     monkeypatch.setattr(
         GoalManager,
@@ -374,9 +375,15 @@ def test_real_queued_prompt_preempts_goal_compression_retry(
 
     server._run_prompt_submit("rid", "sid", session, "initial work")
 
-    assert seen_prompts == ["initial work", "real user input"]
-    assert continuation not in seen_prompts
+    assert seen_prompts == ["initial work"]
+    assert session.get("queued_prompt") is None
     assert server._GOAL_COMPRESSION_RECOVERY_ATTEMPTS not in session
+    boundary = next(
+        payload
+        for event, _sid, payload in turn_env
+        if event == "dashboard.new_session_requested"
+    )
+    assert "real user input" in boundary["resume_prompt"]
 
 
 def test_compression_deferred_is_not_treated_as_exhaustion(server):
@@ -413,6 +420,46 @@ def test_exhaustion_without_active_goal_keeps_error_only_behavior(server):
     assert server._GOAL_COMPRESSION_RECOVERY_ATTEMPTS not in session
 
 
+def test_terminal_compression_exhaustion_requests_fresh_session_without_replay(
+    server, turn_env
+):
+    session_key = "compression-session"
+    agent = types.SimpleNamespace(
+        session_id=session_key,
+        run_conversation=lambda *args, **kwargs: _compression_failure(),
+        clear_interrupt=lambda: None,
+    )
+    session = _turn_session(agent, session_key)
+
+    server._run_prompt_submit("rid", "sid", session, "do not replay me")
+
+    boundary_events = [
+        payload
+        for event, sid, payload in turn_env
+        if event == "dashboard.new_session_requested"
+    ]
+    assert len(boundary_events) == 1
+    assert boundary_events[0]["old_session_id"] == session_key
+    assert boundary_events[0]["reason"] == "compression_exhausted"
+    assert boundary_events[0]["replay_prompt"] is False
+    assert boundary_events[0]["checkpoint_persisted"] is True
+    assert "do not replay me" in boundary_events[0]["resume_prompt"]
+
+
+def test_compression_deferred_does_not_request_fresh_session(server, turn_env):
+    session_key = "compression-deferred-session"
+    agent = types.SimpleNamespace(
+        session_id=session_key,
+        run_conversation=lambda *args, **kwargs: {"compression_deferred": True, "failed": True},
+        clear_interrupt=lambda: None,
+    )
+    session = _turn_session(agent, session_key)
+
+    server._run_prompt_submit("rid", "sid", session, "retry later")
+
+    assert not any(event == "dashboard.new_session_requested" for event, _, _ in turn_env)
+
+
 def test_new_goal_does_not_inherit_previous_goal_recovery_attempt(server):
     from hermes_cli.goals import GoalManager
 
@@ -435,11 +482,10 @@ def test_new_goal_does_not_inherit_previous_goal_recovery_attempt(server):
         raw="Context length exceeded.",
     )
 
-    assert first_prompt is not None
-    assert replacement_prompt is not None
-    assert "replacement goal" in replacement_prompt
-    assert "Retrying the active goal once" in replacement_notice
-    assert GoalManager(session_key).state.status == "active"
+    assert first_prompt is None
+    assert replacement_prompt is None
+    assert replacement_notice is not None
+    assert GoalManager(session_key).state.status == "paused"
 
 
 # ── command.dispatch /moa ────────────────────────────────────────────

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -726,6 +726,60 @@ def test_session_resume_rejects_runaway_transcript_before_history_load(
     assert "safe resume limit is 20000" in response["error"]["message"]
 
 
+def test_session_resume_sealed_compression_boundary_never_loads_history(
+    server, monkeypatch
+):
+    from hermes_cli.compression_boundary import (
+        build_compression_checkpoint,
+        checkpoint_meta_key,
+    )
+
+    sealed = build_compression_checkpoint(
+        "sealed-session",
+        prompt="continue from the last verified step",
+    )
+    reopened = []
+
+    class _DB:
+        def get_session(self, sid):
+            return {"id": sid, "message_count": 50_000}
+
+        def get_session_by_title(self, _title):
+            return None
+
+        def resolve_resume_session_id(self, sid):
+            return sid
+
+        def get_meta(self, key):
+            return (
+                json.dumps(sealed)
+                if key == checkpoint_meta_key("sealed-session")
+                else None
+            )
+
+        def reopen_session(self, sid):
+            reopened.append(sid)
+            raise AssertionError("sealed compression session must not reopen")
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    response = server.handle_request(
+        {
+            "id": "sealed-resume",
+            "method": "session.resume",
+            "params": {"session_id": "sealed-session", "omit_messages": True},
+        }
+    )
+
+    result = response["result"]
+    assert result["compression_boundary"]["reason"] == "compression_exhausted"
+    assert result["messages"] == []
+    assert result["compression_boundary"]["resume_prompt"].startswith(
+        "Continue the interrupted task"
+    )
+    assert reopened == []
+
+
 def test_session_resume_guard_failure_fails_open(server, monkeypatch):
     """A transient guard error must not block resume (fail open, log only)."""
     reopened = []

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -386,6 +386,22 @@ def _(rid, params: dict) -> dict:
                 target = tip
                 found = db.get_session(target) or found
 
+        # A terminal compression boundary is never eligible for transcript or
+        # agent reconstruction. This check must precede the live-session fast
+        # path and every history read: otherwise a restart (or a second window)
+        # can re-open the poisoned transcript that the boundary event sealed.
+        # The checkpoint is namespaced by the resolved tip, so a pre-boundary
+        # parent still resumes normally when it has a healthy continuation tip.
+        try:
+            from hermes_cli.compression_boundary import compression_boundary_resume_payload
+
+            boundary_payload = compression_boundary_resume_payload(db, target)
+        except Exception:
+            logger.debug("compression boundary resume guard failed", exc_info=True)
+            boundary_payload = None
+        if boundary_payload is not None:
+            return _ok(rid, boundary_payload)
+
         # Every interactive resume path materializes the model history, even when
         # omit_messages suppresses the response copy. Count the complete lineage
         # before any reopen/history read so a runaway transcript cannot exhaust

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10476,7 +10476,6 @@ def _prepend_note(run_message: Any, note: str) -> Any:
 
 
 _GOAL_COMPRESSION_RECOVERY_ATTEMPTS = "_goal_compression_recovery_attempts"
-_GOAL_COMPRESSION_RECOVERY_LIMIT = 1
 
 
 def _is_successful_goal_turn(result: Any, status: str, raw: Any) -> bool:
@@ -10497,15 +10496,15 @@ def _plan_goal_compression_recovery(
     status: str,
     raw: Any,
 ) -> tuple[str | None, str | None]:
-    """Plan a bounded active-goal retry after compression exhaustion.
+    """Close an active goal when compression exhaustion seals its session.
 
     Compression exhaustion is a failed turn, so it must not be sent to the
-    goal judge or consume the goal's turn budget.  One fresh continuation turn
-    is allowed.  If that turn also exhausts compression, pause the goal rather
-    than spinning until an arbitrary user message happens to wake it up.
+    goal judge or consume the goal's turn budget.  Retrying inside the same
+    session would reuse the poisoned transcript, so the goal is paused and the
+    caller creates a fresh session with a bounded checkpoint.
 
-    Returns ``(continuation_prompt, status_notice)``.  Sessions without an
-    active goal retain the existing error-only behavior.
+    Returns ``(None, status_notice)`` for compression exhaustion. Sessions
+    without an active goal retain the existing error-only behavior.
     """
     compression_exhausted = bool(
         isinstance(result, dict) and result.get("compression_exhausted")
@@ -10535,39 +10534,87 @@ def _plan_goal_compression_recovery(
         session.pop(_GOAL_COMPRESSION_RECOVERY_ATTEMPTS, None)
         return None, None
 
-    goal_created_at = float(getattr(goal_mgr.state, "created_at", 0.0) or 0.0)
-    recovery_state = session.get(_GOAL_COMPRESSION_RECOVERY_ATTEMPTS)
-    attempts = 0
-    if (
-        isinstance(recovery_state, dict)
-        and recovery_state.get("goal_created_at") == goal_created_at
-        and recovery_state.get("goal") == getattr(goal_mgr.state, "goal", "")
-    ):
-        try:
-            attempts = int(recovery_state.get("attempts", 0) or 0)
-        except (TypeError, ValueError):
-            attempts = 0
-
-    continuation_prompt = goal_mgr.next_continuation_prompt()
-    if attempts < _GOAL_COMPRESSION_RECOVERY_LIMIT and continuation_prompt:
-        session[_GOAL_COMPRESSION_RECOVERY_ATTEMPTS] = {
-            "goal_created_at": goal_created_at,
-            "goal": getattr(goal_mgr.state, "goal", ""),
-            "attempts": attempts + 1,
-        }
-        return (
-            continuation_prompt,
-            "Context compression was exhausted. Retrying the active goal once.",
-        )
-
-    goal_mgr.pause(reason="context compression exhausted twice consecutively")
-    # A later explicit /goal resume gets a fresh bounded recovery cycle.
+    goal_mgr.pause(reason="context compression exhausted; fresh session required")
     session.pop(_GOAL_COMPRESSION_RECOVERY_ATTEMPTS, None)
     return (
         None,
-        "Goal paused after context compression was exhausted twice. "
-        "Run /compress, then /goal resume to continue.",
+        "Goal paused after context compression was exhausted. A fresh session is being prepared; continue from the checkpoint instead of replaying this transcript.",
     )
+
+
+def _record_compression_boundary(
+    session: dict,
+    agent: Any,
+    prompt: Any,
+    result: Any,
+) -> dict[str, Any]:
+    """Persist and describe the one-way boundary after compression exhaustion."""
+    from hermes_cli.compression_boundary import (
+        build_compression_checkpoint,
+        persist_compression_checkpoint,
+    )
+
+    old_session_id = str(
+        session.get("session_key") or getattr(agent, "session_id", "") or ""
+    ).strip()
+    goal_text = ""
+    if old_session_id:
+        try:
+            from hermes_cli.goals import GoalManager
+
+            goal_state = GoalManager(old_session_id).state
+            goal_text = str(getattr(goal_state, "goal", "") or "")
+        except Exception:
+            logger.debug("failed to read goal for compression checkpoint", exc_info=True)
+
+    error_text = result.get("error") if isinstance(result, dict) else result
+    queued_parts: list[str] = []
+    with session.get("history_lock", contextlib.nullcontext()):
+        queued_head = session.get("queued_prompt")
+        queued_tail = session.get("queued_prompts") or []
+        for queued in ([queued_head] if queued_head else []) + list(queued_tail):
+            if isinstance(queued, dict):
+                queued_text = queued.get("text")
+            else:
+                queued_text = queued
+            if isinstance(queued_text, str) and queued_text.strip():
+                queued_parts.append(queued_text.strip())
+        # A fresh session owns the handoff. Leaving these envelopes on the
+        # sealed session would either strand the user's follow-up or let a
+        # late drain dispatch it against the poisoned transcript.
+        session["queued_prompt"] = None
+        session.pop("queued_prompts", None)
+        session["_queued_prompt_generation"] = int(
+            session.get("_queued_prompt_generation", 0)
+        ) + 1
+    queued_prompt = "\n\n".join(queued_parts)
+    checkpoint = build_compression_checkpoint(
+        old_session_id,
+        prompt=prompt,
+        queued_prompt=queued_prompt,
+        goal=goal_text,
+        cwd=session.get("cwd"),
+        model=getattr(agent, "model", None),
+        error=error_text,
+    )
+    persisted = False
+    try:
+        with _session_db(session) as db:
+            persisted = persist_compression_checkpoint(db, checkpoint)
+    except Exception:
+        logger.warning(
+            "failed to persist compression boundary checkpoint for %s",
+            old_session_id or "unknown-session",
+            exc_info=True,
+        )
+
+    return {
+        "old_session_id": old_session_id,
+        "reason": "compression_exhausted",
+        "replay_prompt": False,
+        "resume_prompt": checkpoint["resume_prompt"],
+        "checkpoint_persisted": persisted,
+    }
 
 
 # Captured at import time. Several _run_prompt_submit tests monkeypatch
@@ -11492,6 +11539,26 @@ def _run_prompt_submit(
             _retire_turn_marker(session, marker_key)
             session.pop("_auto_continue_scheduled", None)
             _emit_settled_session_info(sid, session, agent)
+
+        # A terminal compression failure must move interactive surfaces onto a
+        # fresh session. Emit this only after the turn has settled so the
+        # client can close the old session without racing its finally block.
+        # Compression exhaustion is a hard boundary for every session,
+        # including sessions with active goals. The checkpoint is persisted
+        # before the event so a client never receives a continuation prompt
+        # that exists only in memory.
+        if (
+            isinstance(result, dict)
+            and result.get("compression_exhausted")
+            and not result.get("compression_deferred")
+        ):
+            boundary = _record_compression_boundary(session, agent, prompt, result)
+            _emit(
+                "dashboard.new_session_requested",
+                sid,
+                boundary,
+            )
+            return
 
         # A user prompt that arrived mid-turn (interrupt + queue) wins over
         # every auto follow-up below — drain it first and skip them this cycle;

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -927,6 +927,31 @@ describe('createGatewayEventHandler', () => {
     expect(ctx.composer.setInput).toHaveBeenCalledWith('')
   })
 
+  it('starts a fresh session for a current compression boundary only', () => {
+    const ctx = buildCtx([])
+    patchUiState({ sid: 'active-session' })
+    const onEvent = createGatewayEventHandler(ctx)
+
+    onEvent({
+      payload: { reason: 'compression_exhausted', replay_prompt: false },
+      session_id: 'old-session',
+      type: 'dashboard.new_session_requested'
+    } as any)
+    expect(ctx.session.newSession).not.toHaveBeenCalled()
+
+    onEvent({
+      payload: {
+        reason: 'compression_exhausted',
+        replay_prompt: false,
+        resume_prompt: 'continue from checkpoint'
+      },
+      session_id: 'active-session',
+      type: 'dashboard.new_session_requested'
+    } as any)
+    expect(ctx.session.newSession).toHaveBeenCalledWith('session auto-reset after compression exhaustion')
+    expect(ctx.composer.setInput).toHaveBeenCalledWith('continue from checkpoint')
+  })
+
   it('opens a fresh session before starting voice after wake detection', async () => {
     const ctx = buildCtx([])
     ctx.session.newSession = vi.fn(async () => patchUiState({ sid: 'wake-session' }))

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -784,6 +784,32 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         return
       }
 
+      case 'dashboard.new_session_requested': {
+        // Compression exhaustion is a terminal conversation boundary. Start a
+        // new session without replaying the failed prompt; the old session
+        // remains available in history for inspection.
+
+        const activeSessionId = getUiState().sid
+
+        if (
+          ev.payload?.reason === 'compression_exhausted' &&
+          Boolean(activeSessionId) &&
+          (!ev.session_id || ev.session_id === activeSessionId)
+        ) {
+          newSession('session auto-reset after compression exhaustion')
+
+          const resumePrompt = ev.payload?.resume_prompt?.trim()
+
+          if (resumePrompt) {
+            // Keep the handoff as an editable draft. The prompt is bounded and
+            // redacted by the gateway; submitting it remains a user action.
+            setInput(resumePrompt)
+          }
+        }
+
+        return
+      }
+
       case 'session.usage': {
         // Live usage tick while a turn runs (see tui_gateway
         // _start_usage_ticker) — keeps the status-bar context window current

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -342,13 +342,25 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
         const previousSid = getUiState().sid
 
         gw.request<SessionResumeResponse>('session.resume', { cols: colsRef.current, session_id: id })
-          .then(raw => {
+          .then(async raw => {
             const r = asRpcResult<SessionResumeResponse>(raw)
 
             if (!r) {
               sys('error: invalid response: session.resume')
 
               return patchUiState({ status: 'ready' })
+            }
+
+            if (r.compression_boundary) {
+              const resumePrompt = r.compression_boundary.resume_prompt?.trim()
+              const freshSessionId = await startNewSession(
+                'session auto-reset after compression exhaustion'
+              )
+              if (freshSessionId && resumePrompt) {
+                composerActions.setInput(resumePrompt)
+              }
+
+              return
             }
 
             const info = r.info ?? null
@@ -382,7 +394,20 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
           })
       })
     },
-    [closeSession, colsRef, gw, panel, resetSession, rpc, scrollRef, setHistoryItems, setSessionStartedAt, sys]
+    [
+      closeSession,
+      colsRef,
+      composerActions,
+      gw,
+      panel,
+      resetSession,
+      rpc,
+      scrollRef,
+      setHistoryItems,
+      setSessionStartedAt,
+      startNewSession,
+      sys
+    ]
   )
 
   const guardBusySessionSwitch = useCallback(

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -182,6 +182,11 @@ export interface SessionCreateResponse {
 }
 
 export interface SessionResumeResponse {
+  compression_boundary?: {
+    old_session_id?: string
+    reason?: string
+    resume_prompt?: string
+  }
   inflight?: null | SessionInflightTurn
   info?: SessionInfo
   message_count?: number
@@ -647,7 +652,17 @@ export type GatewayEvent =
       session_id?: string
       type: 'wake.detected'
     }
-  | { payload?: { reason?: string }; session_id?: string; type: 'dashboard.new_session_requested' }
+  | {
+      payload?: {
+        checkpoint_persisted?: boolean
+        old_session_id?: string
+        reason?: string
+        replay_prompt?: boolean
+        resume_prompt?: string
+      }
+      session_id?: string
+      type: 'dashboard.new_session_requested'
+    }
   | { payload: { line: string }; session_id?: string; type: 'gateway.stderr' }
   | {
       payload?: { level?: 'info' | 'warn' | 'error'; message?: string }


### PR DESCRIPTION
## Summary

- treat terminal context-compression exhaustion as a one-way session boundary
- pause active goals instead of retrying them against the same oversized transcript
- persist a versioned, bounded, redacted checkpoint in `state_meta`
- preserve queued user input as an editable handoff draft without automatically replaying it
- guard `session.resume` before history loading or model reconstruction
- handle live and explicit-resume boundaries in both Desktop and TUI clients

## Root cause

After compression reached its terminal retry limit, the interactive session remained eligible for goal continuation, queued-prompt draining, restart restoration, and explicit resume. Those paths could reconstruct or reuse the same transcript that had already proved uncompressible, causing repeated `max compression attempts reached` failures.

## Behavior after this change

The exhausted session remains available for inspection, but it is sealed for continuation. Hermes creates a small task-anchor checkpoint and asks the client to start a fresh session. The handoff prompt is bounded, redacted, and left editable; the failed prompt is never automatically resubmitted.

Sessions exhausted before this change do not have a checkpoint and still require a manually created fresh session. This PR addresses terminal session lifecycle and recovery; it does not attempt to fix every provider-specific overflow misclassification.

Related to #61932 and #9893.

## Validation

- Python compression-boundary, protocol, and active-goal suites: 82 passed
- TUI event and session-lifecycle suites: 113 passed
- Desktop gateway-event suite: 10 passed
- TUI TypeScript typecheck: passed
- Desktop TypeScript typecheck: passed
- Python syntax and staged-diff whitespace checks: passed
- Adversarial patch review: 8 verification receipts, zero findings
