### PR TITLE
fix(codex): strip unsupported cache retention at the consumer Codex wire (salvages #89969)

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1305,6 +1305,37 @@ def _consume_codex_event_stream(
     return final
 
 
+def _sanitize_consumer_codex_request(
+    agent: Any,
+    request: dict[str, Any],
+) -> dict[str, Any]:
+    """Drop fields the ChatGPT OAuth Codex endpoint does not accept.
+
+    This guard intentionally lives at the final wire boundary, after Relay or
+    other request middleware has had a chance to transform the request. The
+    normal transport builder already omits ``prompt_cache_retention`` for this
+    endpoint, but a late mutation must not be allowed to turn a valid tool
+    follow-up into a non-retryable HTTP 400.
+
+    Explicit ``request_overrides`` are subject to the same endpoint contract:
+    unsupported retention is dropped with a warning instead of being sent and
+    rejected by the provider.
+    """
+    sanitized = dict(request)
+    backend_predicate = getattr(agent, "_is_codex_backend", None)
+    is_consumer_codex = (
+        bool(backend_predicate()) if callable(backend_predicate) else False
+    )
+    if is_consumer_codex and "prompt_cache_retention" in sanitized:
+        sanitized.pop("prompt_cache_retention", None)
+        logger.warning(
+            "Dropped unsupported prompt_cache_retention at consumer Codex "
+            "wire boundary (model=%s).",
+            sanitized.get("model", getattr(agent, "model", "unknown")),
+        )
+    return sanitized
+
+
 def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta=None):
     """Execute one streaming Responses API request and return the final response.
 
@@ -1347,7 +1378,10 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         writer_token = {"value": None}
 
         def _open_codex_stream(next_api_kwargs: dict[str, Any]):
-            stream_kwargs = dict(next_api_kwargs)
+            stream_kwargs = _sanitize_consumer_codex_request(
+                agent,
+                next_api_kwargs,
+            )
             stream_kwargs["stream"] = True
             return active_client.responses.create(**stream_kwargs)
 

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1322,12 +1322,16 @@ def _sanitize_consumer_codex_request(
     rejected by the provider.
     """
     sanitized = dict(request)
+    # Resolved defensively on purpose: run_codex_stream is also driven with
+    # lightweight stand-in agents that carry only the attributes a given path
+    # needs (see tests/agent/test_codex_request_transport_diagnostics.py), so a
+    # bare agent._is_codex_backend() here would raise AttributeError on them.
     backend_predicate = getattr(agent, "_is_codex_backend", None)
     is_consumer_codex = (
         bool(backend_predicate()) if callable(backend_predicate) else False
     )
     if is_consumer_codex and "prompt_cache_retention" in sanitized:
-        sanitized.pop("prompt_cache_retention", None)
+        sanitized.pop("prompt_cache_retention")
         logger.warning(
             "Dropped unsupported prompt_cache_retention at consumer Codex "
             "wire boundary (model=%s).",

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1319,7 +1319,9 @@ def _sanitize_consumer_codex_request(
 
     Explicit ``request_overrides`` are subject to the same endpoint contract:
     unsupported retention is dropped with a warning instead of being sent and
-    rejected by the provider.
+    rejected by the provider. The check covers both the top-level kwarg and a
+    nested ``extra_body`` entry — the OpenAI SDK merges ``extra_body`` into
+    the outgoing JSON body, so either shape reaches the endpoint.
     """
     sanitized = dict(request)
     # Resolved defensively on purpose: run_codex_stream is also driven with
@@ -1330,8 +1332,26 @@ def _sanitize_consumer_codex_request(
     is_consumer_codex = (
         bool(backend_predicate()) if callable(backend_predicate) else False
     )
-    if is_consumer_codex and "prompt_cache_retention" in sanitized:
+    if not is_consumer_codex:
+        return sanitized
+    dropped = False
+    if "prompt_cache_retention" in sanitized:
         sanitized.pop("prompt_cache_retention")
+        dropped = True
+    # The OpenAI SDK merges ``extra_body`` into the outgoing JSON body, so a
+    # nested ``extra_body.prompt_cache_retention`` reaches the endpoint just
+    # like the top-level field would. Copy before editing — the caller's
+    # mapping must not be mutated — and drop the mapping when it empties.
+    extra_body = sanitized.get("extra_body")
+    if isinstance(extra_body, dict) and "prompt_cache_retention" in extra_body:
+        extra_body = dict(extra_body)
+        extra_body.pop("prompt_cache_retention")
+        if extra_body:
+            sanitized["extra_body"] = extra_body
+        else:
+            sanitized.pop("extra_body")
+        dropped = True
+    if dropped:
         logger.warning(
             "Dropped unsupported prompt_cache_retention at consumer Codex "
             "wire boundary (model=%s).",

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1334,10 +1334,10 @@ def _sanitize_consumer_codex_request(
     )
     if not is_consumer_codex:
         return sanitized
-    dropped = False
+    dropped_from: list[str] = []
     if "prompt_cache_retention" in sanitized:
         sanitized.pop("prompt_cache_retention")
-        dropped = True
+        dropped_from.append("top-level")
     # The OpenAI SDK merges ``extra_body`` into the outgoing JSON body, so a
     # nested ``extra_body.prompt_cache_retention`` reaches the endpoint just
     # like the top-level field would. Copy before editing — the caller's
@@ -1350,12 +1350,13 @@ def _sanitize_consumer_codex_request(
             sanitized["extra_body"] = extra_body
         else:
             sanitized.pop("extra_body")
-        dropped = True
-    if dropped:
+        dropped_from.append("extra_body")
+    if dropped_from:
         logger.warning(
             "Dropped unsupported prompt_cache_retention at consumer Codex "
-            "wire boundary (model=%s).",
+            "wire boundary (model=%s, via %s).",
             sanitized.get("model", getattr(agent, "model", "unknown")),
+            ", ".join(dropped_from),
         )
     return sanitized
 

--- a/contributors/emails/f4lko@pm.me
+++ b/contributors/emails/f4lko@pm.me
@@ -1,0 +1,2 @@
+thacid22
+# PR #89969 salvage

--- a/tests/agent/test_relay_llm.py
+++ b/tests/agent/test_relay_llm.py
@@ -234,6 +234,31 @@ def test_provider_request_overlays_interceptor_added_codex_field():
     assert provider_request["prompt_cache_retention"] == "24h"
 
 
+def test_provider_request_overlays_interceptor_added_extra_body():
+    """Relay rewrites may also carry provider fields through extra_body."""
+    original = {"model": "gpt-5.6-sol", "input": "hello"}
+    relay_request_body = relay_llm._relay_request_body(
+        original,
+        {"api_mode": "codex_responses"},
+    )
+    provider_request = relay_llm._provider_request(
+        original,
+        SimpleNamespace(
+            content={
+                **relay_request_body,
+                "extra_body": {"prompt_cache_retention": "24h"},
+            },
+            headers={},
+        ),
+        relay_request_body=relay_request_body,
+        codec_baseline_body=dict(relay_request_body),
+        metadata={"api_mode": "codex_responses"},
+    )
+
+    assert "extra_body" not in original
+    assert provider_request["extra_body"] == {"prompt_cache_retention": "24h"}
+
+
 def test_stream_uses_rewritten_request_and_post_intercept_chunks(relay_turn):
     relay, turn = relay_turn
     captured_requests = []

--- a/tests/agent/test_relay_llm.py
+++ b/tests/agent/test_relay_llm.py
@@ -207,6 +207,33 @@ def test_relay_metadata_preserves_provider_name():
     }
 
 
+def test_provider_request_overlays_interceptor_added_codex_field():
+    """Relay rewrites may introduce provider fields absent from the original."""
+    original = {"model": "gpt-5.6-sol", "input": "hello"}
+    relay_request_body = relay_llm._relay_request_body(
+        original,
+        {"api_mode": "codex_responses"},
+    )
+    intercepted = SimpleNamespace(
+        content={
+            **relay_request_body,
+            "prompt_cache_retention": "24h",
+        },
+        headers={},
+    )
+
+    provider_request = relay_llm._provider_request(
+        original,
+        intercepted,
+        relay_request_body=relay_request_body,
+        codec_baseline_body=dict(relay_request_body),
+        metadata={"api_mode": "codex_responses"},
+    )
+
+    assert "prompt_cache_retention" not in original
+    assert provider_request["prompt_cache_retention"] == "24h"
+
+
 def test_stream_uses_rewritten_request_and_post_intercept_chunks(relay_turn):
     relay, turn = relay_turn
     captured_requests = []

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -537,6 +537,71 @@ def _build_xai_agent_with_slash_enum_tool(monkeypatch):
 
 
 
+def test_run_codex_stream_strips_relay_added_retention_at_consumer_wire(
+    monkeypatch,
+    caplog,
+):
+    """A Relay-added unsupported field cannot reach consumer ChatGPT Codex."""
+    from agent import relay_llm
+
+    agent = _build_agent(monkeypatch)
+    captured = {}
+
+    def _fake_create(**kwargs):
+        captured.update(kwargs)
+        return _FakeCreateStream([
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed"),
+            )
+        ])
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=_fake_create),
+    )
+    original = _codex_request_kwargs()
+    relay_request_body = relay_llm._relay_request_body(
+        original,
+        {"api_mode": "codex_responses"},
+    )
+    relayed = relay_llm._provider_request(
+        original,
+        SimpleNamespace(
+            content={
+                **relay_request_body,
+                "prompt_cache_retention": "24h",
+            },
+            headers={},
+        ),
+        relay_request_body=relay_request_body,
+        codec_baseline_body=dict(relay_request_body),
+        metadata={"api_mode": "codex_responses"},
+    )
+    assert relayed["prompt_cache_retention"] == "24h"
+
+    with caplog.at_level("WARNING", logger="agent.codex_runtime"):
+        agent._run_codex_stream(relayed)
+
+    assert "prompt_cache_retention" not in captured
+    assert any(
+        "Dropped unsupported prompt_cache_retention at consumer Codex wire boundary"
+        in record.message
+        for record in caplog.records
+    )
+
+
+def test_consumer_codex_wire_guard_preserves_compatible_endpoint_retention():
+    from agent.codex_runtime import _sanitize_consumer_codex_request
+
+    agent = SimpleNamespace(_is_codex_backend=lambda: False)
+    request = {"model": "openai.gpt-5.5", "prompt_cache_retention": "24h"}
+
+    sanitized = _sanitize_consumer_codex_request(agent, request)
+
+    assert sanitized["prompt_cache_retention"] == "24h"
+    assert sanitized is not request
+
+
 def test_run_codex_stream_returns_collected_items_when_stream_ends_without_terminal(monkeypatch):
     """The event-driven path tolerates streams that end without a terminal frame.
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -590,18 +590,6 @@ def test_run_codex_stream_strips_relay_added_retention_at_consumer_wire(
     )
 
 
-def test_consumer_codex_wire_guard_preserves_compatible_endpoint_retention():
-    from agent.codex_runtime import _sanitize_consumer_codex_request
-
-    agent = SimpleNamespace(_is_codex_backend=lambda: False)
-    request = {"model": "openai.gpt-5.5", "prompt_cache_retention": "24h"}
-
-    sanitized = _sanitize_consumer_codex_request(agent, request)
-
-    assert sanitized["prompt_cache_retention"] == "24h"
-    assert sanitized is not request
-
-
 def test_consumer_codex_wire_guard_strips_nested_extra_body_retention(caplog):
     """The SDK merges ``extra_body`` into the JSON body, so a nested
     ``extra_body.prompt_cache_retention`` reaches the endpoint exactly like the
@@ -716,6 +704,9 @@ def test_wire_guard_scopes_retention_drop_by_real_endpoint(
     # disturb the prompt-cache key, on any endpoint.
     assert sanitized["prompt_cache_key"] == "cache-key-sentinel"
     assert request["prompt_cache_retention"] == "24h"
+    # The caller mutates the result (stream_kwargs["stream"] = True), so the
+    # guard must return a fresh mapping on EVERY path, including no-drop ones.
+    assert sanitized is not request
 
 
 def test_run_codex_stream_returns_collected_items_when_stream_ends_without_terminal(monkeypatch):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -590,6 +590,55 @@ def test_run_codex_stream_strips_relay_added_retention_at_consumer_wire(
     )
 
 
+def test_run_codex_stream_strips_nested_request_override_retention(
+    monkeypatch,
+    caplog,
+):
+    """Configured extra_body retention cannot cross the final wire boundary."""
+    from agent.transports.codex import ResponsesApiTransport
+
+    agent = _build_agent(monkeypatch)
+    captured = {}
+
+    def _fake_create(**kwargs):
+        captured.update(kwargs)
+        return _FakeCreateStream([
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed"),
+            )
+        ])
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=_fake_create),
+    )
+    request = ResponsesApiTransport().build_kwargs(
+        model="gpt-5.6-sol",
+        messages=[
+            {"role": "system", "content": "You are Hermes."},
+            {"role": "user", "content": "Ping"},
+        ],
+        tools=[],
+        is_codex_backend=True,
+        base_url="https://chatgpt.com/backend-api/codex",
+        request_overrides={
+            "extra_body": {"prompt_cache_retention": "24h"},
+        },
+    )
+    assert request["extra_body"] == {"prompt_cache_retention": "24h"}
+
+    with caplog.at_level("WARNING", logger="agent.codex_runtime"):
+        agent._run_codex_stream(request)
+
+    assert "extra_body" not in captured
+    assert request["extra_body"] == {"prompt_cache_retention": "24h"}
+    assert any(
+        "Dropped unsupported prompt_cache_retention at consumer Codex wire boundary"
+        in record.message
+        for record in caplog.records
+    )
+
+
 def test_consumer_codex_wire_guard_strips_nested_extra_body_retention(caplog):
     """The SDK merges ``extra_body`` into the JSON body, so a nested
     ``extra_body.prompt_cache_retention`` reaches the endpoint exactly like the

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -602,6 +602,63 @@ def test_consumer_codex_wire_guard_preserves_compatible_endpoint_retention():
     assert sanitized is not request
 
 
+@pytest.mark.parametrize(
+    "base_url,model,expect_dropped",
+    [
+        # Consumer ChatGPT Codex: the endpoint rejects retention outright.
+        ("https://chatgpt.com/backend-api/codex", "gpt-5.6-sol", True),
+        ("https://chatgpt.com/backend-api/codex", "gpt-5-codex", True),
+        # Hosts that support 24h retention must keep it (#70083, #88601).
+        ("https://api.meta.ai/v1", "gpt-5.6-sol", False),
+        ("https://bedrock-mantle.us-east-1.api.aws/v1", "openai.gpt-5.5", False),
+        # Non-Codex OpenAI and a same-host/different-path backend are both
+        # outside the consumer-Codex contract the guard enforces.
+        ("https://api.openai.com/v1", "gpt-5.6-sol", False),
+        ("https://chatgpt.com/backend-api/other", "gpt-5.6-sol", False),
+    ],
+)
+def test_wire_guard_scopes_retention_drop_by_real_endpoint(
+    monkeypatch,
+    base_url,
+    model,
+    expect_dropped,
+):
+    """The drop is scoped by the real endpoint, not by a stubbed predicate.
+
+    The sibling test above pins the helper's contract against an explicit
+    boolean. This one drives ``_is_codex_backend()`` off a real ``AIAgent``
+    built on each base URL, so a change to the hostname/path predicate that
+    widened the drop onto retention-supporting hosts would fail here.
+    """
+    from agent.codex_runtime import _sanitize_consumer_codex_request
+
+    _patch_agent_bootstrap(monkeypatch)
+    agent = run_agent.AIAgent(
+        model=model,
+        api_mode="codex_responses",
+        base_url=base_url,
+        api_key="codex-token",
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    request = {
+        "model": model,
+        "prompt_cache_key": "cache-key-sentinel",
+        "prompt_cache_retention": "24h",
+        "input": [{"role": "user", "content": "hi"}],
+    }
+    sanitized = _sanitize_consumer_codex_request(agent, request)
+
+    assert ("prompt_cache_retention" not in sanitized) is expect_dropped
+    # Cache-key routing is independent of retention: the guard must never
+    # disturb the prompt-cache key, on any endpoint.
+    assert sanitized["prompt_cache_key"] == "cache-key-sentinel"
+    assert request["prompt_cache_retention"] == "24h"
+
+
 def test_run_codex_stream_returns_collected_items_when_stream_ends_without_terminal(monkeypatch):
     """The event-driven path tolerates streams that end without a terminal frame.
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -602,6 +602,65 @@ def test_consumer_codex_wire_guard_preserves_compatible_endpoint_retention():
     assert sanitized is not request
 
 
+def test_consumer_codex_wire_guard_strips_nested_extra_body_retention(caplog):
+    """The SDK merges ``extra_body`` into the JSON body, so a nested
+    ``extra_body.prompt_cache_retention`` reaches the endpoint exactly like the
+    top-level field — the guard must strip both shapes (#89897)."""
+    from agent.codex_runtime import _sanitize_consumer_codex_request
+
+    agent = SimpleNamespace(_is_codex_backend=lambda: True, model="gpt-5.6-sol")
+    extra_body = {"prompt_cache_retention": "24h", "unrelated": "keep"}
+    request = {
+        "model": "gpt-5.6-sol",
+        "prompt_cache_key": "cache-key-sentinel",
+        "extra_body": extra_body,
+    }
+
+    with caplog.at_level("WARNING", logger="agent.codex_runtime"):
+        sanitized = _sanitize_consumer_codex_request(agent, request)
+
+    assert "prompt_cache_retention" not in sanitized.get("extra_body", {})
+    # Unrelated extra_body entries survive; the caller's mapping is untouched.
+    assert sanitized["extra_body"]["unrelated"] == "keep"
+    assert extra_body["prompt_cache_retention"] == "24h"
+    assert sanitized["prompt_cache_key"] == "cache-key-sentinel"
+    assert any(
+        "Dropped unsupported prompt_cache_retention" in record.message
+        for record in caplog.records
+    )
+
+
+def test_consumer_codex_wire_guard_drops_emptied_extra_body():
+    """When retention was extra_body's only entry, the emptied mapping is
+    removed rather than sent as ``extra_body={}``."""
+    from agent.codex_runtime import _sanitize_consumer_codex_request
+
+    agent = SimpleNamespace(_is_codex_backend=lambda: True, model="gpt-5.6-sol")
+    request = {
+        "model": "gpt-5.6-sol",
+        "extra_body": {"prompt_cache_retention": "24h"},
+    }
+
+    sanitized = _sanitize_consumer_codex_request(agent, request)
+
+    assert "extra_body" not in sanitized
+
+
+def test_consumer_codex_wire_guard_preserves_nested_retention_on_compatible_endpoint():
+    """Compatible endpoints keep a nested extra_body retention untouched."""
+    from agent.codex_runtime import _sanitize_consumer_codex_request
+
+    agent = SimpleNamespace(_is_codex_backend=lambda: False)
+    request = {
+        "model": "openai.gpt-5.5",
+        "extra_body": {"prompt_cache_retention": "24h"},
+    }
+
+    sanitized = _sanitize_consumer_codex_request(agent, request)
+
+    assert sanitized["extra_body"]["prompt_cache_retention"] == "24h"
+
+
 @pytest.mark.parametrize(
     "base_url,model,expect_dropped",
     [


### PR DESCRIPTION
## Summary

Tool follow-up requests on the ChatGPT OAuth Codex backend no longer die with `HTTP 400: prompt_cache_retention is not supported on this model` — in **either** shape the field can arrive in: the top-level kwarg or nested inside `extra_body` (which the OpenAI SDK merges into the JSON body).

Salvages #89969 by @thacid22 (commit authored as `Falko <f4lko@pm.me>`), cherry-picked onto current `main` with authorship preserved. Closes #89897.

## Root cause

Hermes never *builds* `prompt_cache_retention` for `chatgpt.com/backend-api/codex` — `_default_prompt_cache_retention_for_request()` returns `None` for that host on every model. The field enters afterwards: when a Relay interceptor rewrites a request, `relay_llm._provider_request()` overlays changed fields against the codec baseline, and its `key not in baseline` arm admits keys the original request never carried. That is why the failure tracked tool follow-ups rather than first calls — only rewritten requests can acquire it.

Root-cause analysis of the Relay overlay mechanism by @jackulau in the issue thread.

## Changes

- `agent/codex_runtime.py`: `_sanitize_consumer_codex_request()` drops `prompt_cache_retention` immediately before `responses.create()`, gated on `_is_codex_backend()` (hostname **and** path specific), with a warning naming the model. Covers the top-level kwarg **and** a nested `extra_body.prompt_cache_retention` (copy-on-write; the emptied mapping is removed rather than sent as `extra_body={}`). Applies to user-supplied `request_overrides` too — the endpoint would reject them with a deterministic 400, so warn-and-continue beats failing the turn.
- `tests/agent/test_relay_llm.py`: regression pinning the `key not in baseline` overlay arm as the entry point.
- `tests/run_agent/test_run_agent_codex_responses.py`: wire-boundary guard tests, endpoint-scoping coverage, nested-`extra_body` coverage (strip on consumer Codex, preserve on compatible endpoints, drop-when-emptied).
- `contributors/emails/f4lko@pm.me`: attribution mapping.

### Added on top of the original PR

**Nested `extra_body` bypass closed** (flagged by @egilewski's review — verified real by probe before fixing). `preflight_kwargs` preserves `extra_body` verbatim and the SDK merges it into the wire body, so `extra_body.prompt_cache_retention` reached the endpoint exactly like the top-level field. Both injection vectors are real: the Relay overlay admits an interceptor-added `extra_body`, and `request_overrides={"extra_body": {...}}` lands verbatim in `build_kwargs` output. The guard now strips both shapes, and the warning names which shape leaked (`via top-level` / `via extra_body`).

**End-to-end witnesses for the nested shape** — cherry-picked from @thacid22's test-only follow-up (`2b34edf230` → `aff674466d`, authorship preserved), closing @andrexibiza's acceptance gap: a Relay-level regression pinning the `key not in baseline` arm admitting an interceptor-added `extra_body`, and a full `build_kwargs(request_overrides={"extra_body": ...})` → `run_codex_stream()` → captured `responses.create()` wire witness with caller-input immutability.

**Endpoint-scoping test.** The original compatibility test stubbed `_is_codex_backend=lambda: False` on a `SimpleNamespace`, which proves the helper honors its own boolean but not that the boolean is correct for any real endpoint. Added a parametrized test that builds a real `AIAgent` per base URL and also asserts `prompt_cache_key` survives untouched.

**Attribution.** `f4lko@pm.me` was unmapped, so `check-attribution` failed. Added via `scripts/add_contributor.py`.

**Guard hygiene.** Removed the dead `None` default on a `pop` already gated by an `in` check; documented why the predicate is resolved via `getattr` (lightweight stand-in agents lack `_is_codex_backend`).

## Validation

Side-by-side E2E, real imports, driving the actual path: real `relay_llm._provider_request()` overlay → real `run_codex_stream()` → captured `responses.create()` kwargs.

**Top-level shape** (6 endpoints): `main` leaks on both consumer-Codex cases, this branch blocks both; Meta / Bedrock / direct OpenAI / same-host-other-path all preserve retention on both. `prompt_cache_key` preserved in all 12 runs.

**Nested `extra_body` shape**: `main` **leaks** (`extra_body={'prompt_cache_retention': '24h'}` reaches the captured create kwargs), this branch **blocks** it.

Mutation checks (both legs have teeth):
- Relaxing the endpoint predicate to drop everywhere → 4/6 endpoint-scoping cases fail.
- Removing the `extra_body` leg → both nested tests fail.

Suites: 93 passed (`test_run_agent_codex_responses.py` + `test_relay_llm.py`), 96 passed (`test_codex_transport.py` + `test_codex_request_transport_diagnostics.py`). `ruff check` and `git diff --check` clean.

Three parallel reviewers (reuse / quality+Hermes-invariants / efficiency+blast-radius) on the final diff: zero Critical, zero Warnings. Sibling-send-site audit: the auxiliary client's `responses.create()` is not Relay-mediated and `_default_prompt_cache_retention_for_request()` returns `None` for chatgpt.com, so it cannot self-poison; `run_codex_app_server_turn` is a JSON-RPC subprocess path with no `responses.create` at all.

## Scope / invariants

No Relay overlay semantics change — interceptors may still add provider fields. This only enforces the known ChatGPT Codex endpoint contract at its final send boundary.

Prompt caching is unaffected: retention and `prompt_cache_key` are independent fields, the key is preserved byte-for-byte (tested on every endpoint, both shapes), and no cached prefix or system prompt is touched.

## Credit

- Fix and wire-boundary design: @thacid22 (#89969, authorship preserved via cherry-pick)
- Relay overlay root-cause analysis: @jackulau (issue #89897)
- Nested `extra_body` bypass report: @egilewski (review on #89969); SDK-merge reproduction + nested wire witnesses: @thacid22; exact-head re-review: @andrexibiza
- `request_overrides` test-coverage suggestion: @JoaoMarcos44 (#90195)


## Infographic

![codex-wire-guard](https://v3b.fal.media/files/b/0aa703dd/c6o2auapHFQy3XSUNrza1_UVVHCuIi.png)
