### PR TITLE
fix(bedrock): omit sampling params for Claude served via inference-profile ARN

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3965,6 +3965,13 @@ def _is_unsupported_parameter_error(exc: Exception, param: str) -> bool:
         "unrecognized request argument",
         "unrecognized parameter",
         "invalid parameter",
+        # Bedrock Converse phrases the rejection as a deprecation, e.g.
+        # "`temperature` is deprecated for this model" (Claude Opus 4.7+/5.x).
+        # Match it so the reactive retry-without-param net still fires when the
+        # proactive guard misses the model (e.g. an opaque application-
+        # inference-profile ARN that carries no "claude" substring).
+        "is deprecated",
+        "deprecated for this model",
     ))
 
 

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1047,7 +1047,12 @@ def build_converse_kwargs(
 
     from agent.anthropic_adapter import _forbids_sampling_params
 
-    if not _forbids_sampling_params(model):
+    # Resolve inference-profile ARNs/IDs to the underlying foundation model so
+    # the name-based guard can classify them. An application-inference-profile
+    # ARN carries no "claude" substring, so without this the guard misses it
+    # and temperature is sent to a model that rejects it as deprecated.
+    _guard_model = _resolve_inference_profile_model(model)
+    if not _forbids_sampling_params(_guard_model):
         if temperature is not None:
             kwargs["inferenceConfig"]["temperature"] = temperature
 
@@ -1335,6 +1340,63 @@ def _extract_provider_from_arn(arn: str) -> str:
     """
     match = re.search(r"foundation-model/([^.]+)", arn)
     return match.group(1) if match else ""
+
+
+# Cache for resolved inference-profile → underlying foundation model ID.
+_inference_profile_model_cache: Dict[str, str] = {}
+
+
+def _resolve_inference_profile_model(model_id: str) -> str:
+    """Resolve an application/system inference profile to its foundation model ID.
+
+    Application-inference-profile ARNs (and opaque profile IDs) carry no model
+    version/family substring, so guards that key on the model name — e.g.
+    ``_forbids_sampling_params`` / ``_is_claude_model`` — can't classify them.
+    This calls the Bedrock control-plane ``GetInferenceProfile`` API to discover
+    the underlying foundation model, caching both hits and misses so we probe
+    the API at most once per distinct ``model_id``.
+
+    Returns the foundation model ID (e.g. ``anthropic.claude-opus-5``) or the
+    original ``model_id`` unchanged when it isn't a profile or resolution fails.
+    """
+    if not model_id:
+        return model_id
+    # Fast path: only profiles need resolving. A plain foundation-model id or a
+    # region-prefixed id (e.g. eu.anthropic.claude-...) already carries family.
+    is_profile = (
+        "application-inference-profile" in model_id
+        or "inference-profile" in model_id
+        or (model_id.startswith("arn:aws:bedrock:") and "foundation-model" not in model_id)
+    )
+    if not is_profile:
+        return model_id
+    if model_id in _inference_profile_model_cache:
+        return _inference_profile_model_cache[model_id]
+    try:
+        region = None
+        if model_id.startswith("arn:aws:bedrock:"):
+            parts = model_id.split(":")
+            if len(parts) >= 4:
+                region = parts[3]
+        if not region:
+            region = resolve_bedrock_region()
+        client = _get_bedrock_control_client(region)
+        response = client.get_inference_profile(inferenceProfileIdentifier=model_id)
+        models = response.get("models", [])
+        if models:
+            model_arn = models[0].get("modelArn", "")
+            match = re.search(r"foundation-model/(.+)$", model_arn)
+            if match:
+                resolved = match.group(1)
+                _inference_profile_model_cache[model_id] = resolved
+                logger.debug("Resolved inference profile %s → %s", model_id, resolved)
+                return resolved
+    except Exception as e:
+        logger.debug("Failed to resolve inference profile %s: %s", model_id, e)
+    # Cache the failure so we don't re-probe on every call.
+    _inference_profile_model_cache[model_id] = model_id
+    return model_id
+
 # ---------------------------------------------------------------------------
 # Error classification — Bedrock-specific exceptions
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Symptom

Every auxiliary call on a Bedrock **application-inference-profile** fails with:

```
ValidationException ... The model returned the following errors: `temperature` is deprecated for this model.
```

This breaks `vision_analyze`, `web_extract`, compression, and title generation for any user whose Bedrock model is an Opus 4.7+/5.x Claude accessed via an inference-profile ARN. Claude Code against the same Bedrock model works because it never sends `temperature`.

## Root cause

`build_converse_kwargs` already guards sampling params via `_forbids_sampling_params(model)`, and that guard is correctly wired into the Bedrock path (good — #36151 / #45675). But `_forbids_sampling_params` classifies by model **name**:

```python
def _is_claude_model(model): return "claude" in (model or "").lower()
```

When Claude is invoked through an application-inference-profile ARN —
`arn:aws:bedrock:<region>:<acct>:application-inference-profile/<id>` — the id
carries **no** `claude` substring. So `_is_claude_model` → False →
`_forbids_sampling_params` → False → `temperature`/`topP` are sent → Opus 4.7+/5.x
reject them as deprecated.

The reactive safety net (`_is_unsupported_parameter_error`) also misses it: its
marker list matches "unsupported parameter", "invalid parameter", etc., but not
Bedrock's "**is deprecated**" phrasing — so no retry-without-param fires either.

## Fix (two layers)

1. **Proactive** — add `_resolve_inference_profile_model()` in `bedrock_adapter.py`: resolves an inference-profile ARN/ID to its underlying foundation model via the Bedrock control-plane `GetInferenceProfile` API (result cached; misses cached too, so at most one probe per distinct id). `build_converse_kwargs` resolves the model before calling the guard, so an ARN wrapping a Claude model is classified correctly.

2. **Reactive** — extend `_is_unsupported_parameter_error` (`auxiliary_client.py`) to also match `"is deprecated"` / `"deprecated for this model"`, so the retry-without-param net catches any model the proactive guard misses.

## Verification

Against the real Bedrock API with an application-inference-profile ARN:

```
resolved: anthropic.claude-opus-4-8
is_claude(arn)      : False   # the bug
is_claude(resolved) : True    # fixed
forbids(arn)        : False
forbids(resolved)   : True    # temperature now omitted
net('`temperature` is deprecated for this model') : True
```

`tests/tools/test_vision_tools.py` and `tests/providers/test_transport_parity.py` pass. The resolver is a no-op fast-path for plain foundation-model / region-prefixed ids (no extra API call), so non-profile users are unaffected.