### PR TITLE
fix(gateway-windows): retarget legacy Scheduled Tasks to the hidden VBS launcher

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -38,7 +38,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from xml.sax.saxutils import escape
+from xml.sax.saxutils import escape, unescape
 
 from hermes_cli._subprocess_compat import (
     _WINDOWS_GATEWAY_BREAKAWAY_ENV,
@@ -1105,6 +1105,9 @@ def install(
         _install_startup_fallback(script_path, start_now, "administrator approval was not used")
         return
 
+    if is_task_registered() and task_launcher_is_current() is False:
+        print("ℹ Replacing outdated Scheduled Task (legacy launcher used a visible console)")
+
     ok, detail = _install_scheduled_task(task_name, script_path)
     if ok:
         print(f"✓ {detail}")
@@ -1309,6 +1312,86 @@ def _gateway_pids() -> list[int]:
     return list(find_gateway_pids())
 
 
+# ---------------------------------------------------------------------------
+# Task launcher currency (legacy-install migration)
+# ---------------------------------------------------------------------------
+#
+# The hidden-console rework (issue #45599) made install() register the
+# Scheduled Task with a ``wscript.exe`` action that runs the console-less
+# ``.vbs`` launcher. Tasks registered by older builds point at the console
+# ``.cmd`` wrapper instead: at logon they flash a console window and can be
+# reaped by the CTRL_CLOSE broadcast (0xC000013A), so the gateway silently
+# disappears on every reboot. ``hermes update`` refreshes the launcher *files*
+# in place but cannot retarget a task whose action references the ``.cmd``,
+# so legacy tasks survive updates forever unless they are detected. The
+# helpers below detect that state; status()/start() surface it and
+# install()/the post-update refresh heal it.
+
+
+def _parse_task_xml_launcher(xml_text: str) -> tuple[str, str] | None:
+    """Extract (Command, Arguments) of the first Exec action from a task XML dump.
+
+    ``schtasks /Query /XML`` emits the task definition verbatim (UTF-16 with a
+    BOM on disk, decoded here through the locale code page), so a full XML
+    parser would fight the encoding declaration. We only need the Exec
+    action's Command/Arguments, so a targeted regex is both robust and
+    encoding-agnostic (all the tokens we match are ASCII). Returns None when
+    the shape is unexpected.
+    """
+    if not xml_text:
+        return None
+    m_cmd = re.search(r"<Command>(.*?)</Command>", xml_text, re.S)
+    if not m_cmd:
+        return None
+    m_args = re.search(r"<Arguments>(.*?)</Arguments>", xml_text, re.S)
+    command = unescape(m_cmd.group(1)).strip()
+    arguments = unescape(m_args.group(1)).strip() if m_args else ""
+    return (command, arguments)
+
+
+def _task_launcher_is_current_xml(xml_text: str, expected_launcher: Path) -> bool | None:
+    """True when a task XML launches ``wscript.exe`` against ``expected_launcher``.
+
+    False = the task predates the hidden-console rework (issue #45599) and
+    still launches the console ``.cmd`` wrapper — it will flash a console
+    window at logon and can be reaped by the logon CTRL_CLOSE broadcast.
+    None = the XML is unparseable; callers should stay silent.
+    """
+    parsed = _parse_task_xml_launcher(xml_text)
+    if parsed is None:
+        return None
+    command, arguments = parsed
+    if command.lower() != "wscript.exe":
+        return False
+    # The generated XML renders the launcher as: //B //Nologo "<vbs path>".
+    # Compare the raw path (case-insensitively) so quote style differences
+    # between schtasks renderings don't matter.
+    expected = os.path.normcase(str(expected_launcher))
+    return expected in os.path.normcase(arguments)
+
+
+def task_launcher_is_current(task_name: str | None = None) -> bool | None:
+    """Whether the registered Scheduled Task launches the current hidden VBS.
+
+    True  — task launches ``wscript.exe`` against the current ``.vbs``.
+    False — task exists but was created by an older Hermes build (pre-#45599
+            installs point at the console ``.cmd`` wrapper). ``hermes update``
+            refreshes the launcher *files* but cannot retarget the task's
+            action; re-running ``hermes gateway install`` (or the post-update
+            refresh) recreates it with the hidden launcher.
+    None  — unknown (no task registered, or the query failed). Callers must
+            not alarm on None.
+    """
+    _assert_windows()
+    task_name = task_name or get_task_name()
+    if not is_task_registered():
+        return None
+    code, out, _err = _exec_schtasks(["/Query", "/TN", task_name, "/XML"])
+    if code != 0:
+        return None
+    return _task_launcher_is_current_xml(out, get_task_script_path().with_suffix(".vbs"))
+
+
 def _print_deep_probes() -> None:
     """Print PASS/FAIL per individual probe of gateway liveness.
 
@@ -1452,6 +1535,11 @@ def status(deep: bool = False) -> None:
 
     if task_installed:
         print(f"✓ Scheduled Task registered: {task_name}")
+        if task_launcher_is_current() is False:
+            print("⚠ Scheduled Task launcher is outdated: it launches the console .cmd wrapper")
+            print("  instead of the hidden VBS launcher. At logon it shows a console window and")
+            print("  can be terminated by the logon console-close event (issue #45599).")
+            print("  Fix: run 'hermes gateway install' to retarget it.")
         info = query_task_status()
         if info:
             for key in ("status", "last run time", "last run result"):
@@ -1488,13 +1576,19 @@ def status(deep: bool = False) -> None:
 def start() -> None:
     """Start the gateway using the canonical detached Windows launch path."""
     _assert_windows()
+    task_installed = is_task_registered()
+    startup_installed = is_startup_entry_installed()
+
+    if task_installed and task_launcher_is_current() is False:
+        print("⚠ Scheduled Task launcher is outdated: it launches the console .cmd wrapper")
+        print("  instead of the hidden VBS launcher (issue #45599). At logon the gateway")
+        print("  shows a console window and may be terminated by the logon close event.")
+        print("  Fix: run 'hermes gateway install' to retarget it.")
+
     running_pids = _gateway_pids()
     if running_pids:
         print(f"✓ Gateway already running (PID: {', '.join(map(str, running_pids))})")
         return
-
-    task_installed = is_task_registered()
-    startup_installed = is_startup_entry_installed()
 
     if not task_installed and not startup_installed:
         from hermes_cli.setup import prompt_yes_no

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4240,8 +4240,16 @@ def _refresh_windows_gateway_launchers() -> None:
     (#54220/#56747) and, since #70344, the console-less gateway died at
     startup with ``RuntimeError: sys.stderr is None`` (#71671).
 
-    The task's /TR points at a stable script path, so rewriting the files in
-    place retargets the task without any schtasks call (no UAC needed).
+    For installs created by the hidden-console rework the task's /TR points
+    at a stable ``.vbs`` path, so rewriting the files in place retargets the
+    task without any schtasks call (no UAC needed). Tasks registered by
+    pre-#45599 builds point at the console ``.cmd`` wrapper instead, which a
+    file rewrite cannot retarget — those are recreated here (delete+create,
+    same as ``install()``) so a legacy install is healed by the first update
+    that ships this code. If the recreate is blocked (e.g. the task lives in
+    an admin-protected namespace and the update is not elevated), a warning
+    points at ``hermes gateway install``.
+
     ``_write_task_script`` is idempotent and renders from current code, so
     this is a no-op for modern installs. Best-effort: a failed refresh must
     never fail the update.
@@ -4254,6 +4262,21 @@ def _refresh_windows_gateway_launchers() -> None:
         if not gateway_windows.is_installed():
             return
         gateway_windows._write_task_script()
+        # Legacy pre-#45599 tasks launch the console .cmd wrapper; a file
+        # rewrite cannot retarget the task's action, so recreate the task.
+        if gateway_windows.task_launcher_is_current() is False:
+            ok, detail = gateway_windows._install_scheduled_task(
+                gateway_windows.get_task_name(),
+                gateway_windows.get_task_script_path(),
+            )
+            if ok:
+                print("  ✓ Retargeted legacy Scheduled Task to the hidden VBS launcher")
+            elif "access is denied" in detail.lower():
+                print("  ⚠ Legacy Scheduled Task launcher is outdated and needs admin to fix")
+                print("    Run: hermes gateway install")
+            else:
+                first_line = (detail.splitlines() or [detail])[0]
+                print(f"  ⚠ Could not retarget legacy Scheduled Task launcher: {first_line}")
         print("  ✓ Refreshed Windows gateway launcher scripts")
     except Exception as exc:
         logger.debug("Could not refresh Windows gateway launchers after update: %s", exc)

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -370,3 +370,65 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
 
 
 
+# ---------------------------------------------------------------------------
+# Task launcher currency — legacy pre-#45599 install migration
+#
+# Tasks registered before the hidden-console rework launch the console .cmd
+# wrapper. ``hermes update`` rewrites the launcher *files* but cannot
+# retarget the task's action, so status()/start() must surface the stale
+# task and install()/the post-update refresh must recreate it. These tests
+# cover the pure XML-parsing/decision helpers (run on any host; the schtasks
+# query wrapper is windows_only and exercised end-to-end by the refresh
+# tests in test_update_gateway_launcher_refresh.py).
+# ---------------------------------------------------------------------------
+
+
+def test_parse_task_xml_launcher_roundtrips_generated_xml():
+    launcher = Path(r"C:\Users\me\AppData\Local\hermes\gateway-service\Hermes_Gateway.vbs")
+    xml_text = gateway_windows._build_scheduled_task_xml("Hermes_Gateway", launcher, None)
+
+    command, arguments = gateway_windows._parse_task_xml_launcher(xml_text)
+
+    assert command == "wscript.exe"
+    assert "Hermes_Gateway.vbs" in arguments
+
+
+def test_task_launcher_is_current_xml_matches_wscript_vbs():
+    launcher = Path(r"C:\h\gateway-service\Hermes_Gateway.vbs")
+    xml_text = gateway_windows._build_scheduled_task_xml("Hermes_Gateway", launcher, None)
+
+    assert gateway_windows._task_launcher_is_current_xml(xml_text, launcher) is True
+
+
+def test_task_launcher_is_current_xml_flags_legacy_cmd_launcher():
+    """A pre-#45599 task action (cmd.exe + .cmd wrapper) must be flagged stale."""
+    xml_text = (
+        '<?xml version="1.0" encoding="UTF-16"?><Task><Actions><Exec>'
+        "<Command>cmd.exe</Command>"
+        '<Arguments>/c "C:\\Users\\me\\gateway-service\\Hermes_Gateway.cmd"</Arguments>'
+        "</Exec></Actions></Task>"
+    )
+
+    assert (
+        gateway_windows._task_launcher_is_current_xml(
+            xml_text, Path(r"C:\Users\me\gateway-service\Hermes_Gateway.vbs")
+        )
+        is False
+    )
+
+
+def test_task_launcher_is_current_xml_unparseable_is_unknown():
+    assert gateway_windows._task_launcher_is_current_xml("", Path("x.vbs")) is None
+    assert gateway_windows._task_launcher_is_current_xml("<not a task>", Path("x.vbs")) is None
+
+
+def test_task_launcher_is_current_xml_ignores_quote_style():
+    """The vbs path may be quoted/unquoted in schtasks renderings — the raw
+    path comparison must not care."""
+    launcher = Path(r"C:\h\gateway-service\Hermes_Gateway.vbs")
+    for args in (
+        '//B //Nologo "C:\\h\\gateway-service\\Hermes_Gateway.vbs"',
+        "//B //Nologo C:\\h\\gateway-service\\Hermes_Gateway.vbs",
+    ):
+        xml_text = "<Task><Actions><Exec><Command>wscript.exe</Command><Arguments>{args}</Arguments></Exec></Actions></Task>".format(args=args)
+        assert gateway_windows._task_launcher_is_current_xml(xml_text, launcher) is True

--- a/tests/hermes_cli/test_update_gateway_launcher_refresh.py
+++ b/tests/hermes_cli/test_update_gateway_launcher_refresh.py
@@ -92,3 +92,78 @@ def test_restart_spec_normalizes_legacy_pythonw_argv(tmp_path):
 
 
 
+
+# ---------------------------------------------------------------------------
+# _refresh_windows_gateway_launchers: hermes update regenerates launchers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.windows_only
+def test_refresh_retargets_legacy_cmd_task(monkeypatch, capsys):
+    """A pre-#45599 Scheduled Task whose action launches the console .cmd
+    wrapper must be recreated (delete+create) with the hidden VBS launcher
+    during the post-update refresh — a launcher-file rewrite alone cannot
+    retarget the task's action."""
+    import hermes_cli.update_cmd as update_cmd
+
+    script_path = Path(r"C:\Users\me\AppData\Local\hermes\gateway-service\Hermes_Gateway.cmd")
+    called_with = {}
+
+    def fake_install(task_name, path):
+        called_with["task_name"] = task_name
+        called_with["path"] = path
+        return (True, "Created Scheduled Task 'Hermes_Gateway'")
+
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(gateway_windows, "is_installed", lambda: True)
+    monkeypatch.setattr(gateway_windows, "_write_task_script", lambda: script_path)
+    monkeypatch.setattr(gateway_windows, "task_launcher_is_current", lambda *a, **k: False)
+    monkeypatch.setattr(gateway_windows, "_install_scheduled_task", fake_install)
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway")
+    monkeypatch.setattr(gateway_windows, "get_task_script_path", lambda: script_path)
+
+    update_cmd._refresh_windows_gateway_launchers()
+
+    assert called_with == {"task_name": "Hermes_Gateway", "path": script_path}
+    out = capsys.readouterr().out
+    assert "Retargeted legacy Scheduled Task to the hidden VBS launcher" in out
+
+
+@pytest.mark.windows_only
+def test_refresh_leaves_current_task_alone(monkeypatch, capsys):
+    """A task that already launches the hidden VBS must not be recreated."""
+    import hermes_cli.update_cmd as update_cmd
+
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(gateway_windows, "is_installed", lambda: True)
+    monkeypatch.setattr(gateway_windows, "_write_task_script", lambda: Path("unused.cmd"))
+    monkeypatch.setattr(gateway_windows, "task_launcher_is_current", lambda *a, **k: True)
+
+    update_cmd._refresh_windows_gateway_launchers()
+
+    out = capsys.readouterr().out
+    assert "Retargeted legacy" not in out
+    assert "Refreshed Windows gateway launcher scripts" in out
+
+
+@pytest.mark.windows_only
+def test_refresh_warns_when_legacy_retarget_blocked(monkeypatch, capsys):
+    """Access-denied on the recreate must surface an actionable warning, not
+    fail the update (best-effort contract)."""
+    import hermes_cli.update_cmd as update_cmd
+
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(gateway_windows, "is_installed", lambda: True)
+    monkeypatch.setattr(gateway_windows, "_write_task_script", lambda: Path("unused.cmd"))
+    monkeypatch.setattr(gateway_windows, "task_launcher_is_current", lambda *a, **k: False)
+    monkeypatch.setattr(
+        gateway_windows,
+        "_install_scheduled_task",
+        lambda *a, **k: (False, "schtasks /Create failed (code 5): access is denied"),
+    )
+
+    update_cmd._refresh_windows_gateway_launchers()
+
+    out = capsys.readouterr().out
+    assert "needs admin to fix" in out
+    assert "hermes gateway install" in out


### PR DESCRIPTION
## Problem

Pre-#45599 Hermes installs on Windows registered the gateway Scheduled Task with an action that launches the console `.cmd` wrapper (`Hermes_Gateway.cmd` -> `python.exe`). The hidden-console rework (issue #45599) made `install()` register the task with a console-less `wscript.exe` + `.vbs` launcher instead, and `hermes update` refreshes the launcher *files* in place — but a task whose action references the `.cmd` is **not** retargeted by a file rewrite.

Consequences for affected installs (verified on a real machine):

1. Every logon flashes a **visible console window** (the banner the user sees).
2. During logon Windows broadcasts `CTRL_CLOSE_EVENT` to console process groups, which reaps the half-initialized gateway with `STATUS_CONTROL_C_EXIT` (`0xC000013A`) — Task Scheduler treats that as a user cancel, the failure policy never fires, and the gateway **silently disappears on every reboot** (`gateway.lifecycle_ledger` logs `exited UNCLEANLY (no exit path ran — SIGKILL / OOM / VM death)`).
3. `hermes gateway status` / `start` only check that a task is *registered*, so nothing ever tells the user the task is stale.

## Fix

- **Detect**: `gateway_windows.task_launcher_is_current()` queries the registered task's XML (`schtasks /Query /XML`) and compares its Exec action against the current hidden VBS launcher. The parser is regex-based because schtasks `/XML` output is UTF-16 with a BOM that gets decoded through the locale code page, which fights a full XML parser.
- **Surface**: `status()` and `start()` warn when the task is stale, pointing at `hermes gateway install`.
- **Heal**: the post-update refresh (`_refresh_windows_gateway_launchers`) now recreates a legacy task (delete+create, same as `install()`) so the first `hermes update` that ships this code fixes affected installs automatically. Best-effort: if elevation is missing it prints an actionable warning instead of failing the update. `install()` also notes when it is replacing an outdated task.

## Tests

- Pure cross-platform tests for the XML parsing / launcher decision helpers (including quote-style tolerance and unparseable input).
- `windows_only` tests for the post-update refresh: retarget on stale task, no-op on current task, actionable warning when the recreate is blocked by permissions.

19 passed on Windows 11 (real schtasks output verified against a live task).