### PR TITLE
fix(desktop): surface expired bot source login

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -15,6 +15,7 @@ import {
   backendScopeKey,
   backendScopePrefix,
   buildAgentRoster,
+  connectionAgentAuthRequired,
   connectionDialFieldsChanged,
   connectionIdForLabel,
   labelKey,
@@ -269,6 +270,17 @@ test('rememberSshEnumeration: live list wins, cache then seed default', () => {
     profiles: null,
     error: 'connect-on-demand'
   })
+})
+
+test('connectionAgentAuthRequired only marks rejected OAuth sessions', () => {
+  const oauth = { id: 'studio', kind: 'remote' as const, label: 'Studio', authMode: 'oauth' as const }
+  const token = { id: 'studio-token', kind: 'remote' as const, label: 'Studio token', authMode: 'token' as const }
+  const tagged = Object.assign(new Error('session expired'), { isReauthRequired: true })
+
+  assert.equal(connectionAgentAuthRequired(oauth, new Error('401: no_cookie')), true)
+  assert.equal(connectionAgentAuthRequired(oauth, tagged), true)
+  assert.equal(connectionAgentAuthRequired(token, new Error('401: invalid token')), false)
+  assert.equal(connectionAgentAuthRequired(oauth, new Error('Timed out connecting')), false)
 })
 
 test('shouldRetrySshInventory: first try, cooldown, then retry; cache never retries', () => {

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -27,6 +27,7 @@
  * these into the IPC layer and owns file I/O + secret encryption.
  */
 
+import { isAuthRejectionError, isReauthRequiredError } from './backend-health'
 import {
   hostLabelFromBaseUrl,
   modeIsRemoteLike,
@@ -320,12 +321,24 @@ export interface ConnectionAgents {
   profiles: null | string[]
   /** Present when profiles is null: why enumeration was skipped. */
   error?: string
+  /** The source rejected its OAuth session and needs an interactive sign-in. */
+  authRequired?: boolean
   /** Stable backend identity from the connection's /api/status (`install_id`).
    * Two connections reporting the same id are the SAME physical install
    * registered under two addresses (hostname + Tailscale IP), so the roster
    * collapses their rows. Absent on older backends → no collapse (fully
    * backward compatible). */
   installId?: string
+}
+
+/**
+ * A roster probe may meet an already-tagged boot failure or a fresh 401/403
+ * from an established descriptor whose session expired after it was cached.
+ * Only OAuth sources have a sign-in recovery path; token sources keep their
+ * ordinary unreachable/error state so the UI does not offer the wrong fix.
+ */
+export function connectionAgentAuthRequired(connection: RegistryConnection, error: unknown): boolean {
+  return connection.authMode === 'oauth' && (isReauthRequiredError(error) || isAuthRejectionError(error))
 }
 
 export interface RosterAgent {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -98,6 +98,7 @@ import {
   backendScopeKey,
   backendScopePrefix,
   buildAgentRoster,
+  connectionAgentAuthRequired,
   connectionDialFieldsChanged,
   mergeConnectionInput,
   migrateV1ToRegistry,
@@ -12585,7 +12586,13 @@ async function probeSshProfileInventory(connection) {
 async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRegistry()) {
   return Promise.all(
     registry.connections.map(async connection => {
-      let raw: { connection: typeof connection; error?: string; installId?: string; profiles: null | string[] }
+      let raw: {
+        connection: typeof connection
+        authRequired?: boolean
+        error?: string
+        installId?: string
+        profiles: null | string[]
+      }
 
       try {
         // SSH roster listing must never spawn a dashboard. A stale
@@ -12636,7 +12643,12 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
           raw = { connection, profiles, ...(installId ? { installId } : {}) }
         }
       } catch (error: any) {
-        raw = { connection, profiles: null, error: String(error?.message || error) }
+        raw = {
+          connection,
+          profiles: null,
+          error: String(error?.message || error),
+          ...(connectionAgentAuthRequired(connection, error) ? { authRequired: true } : {})
+        }
       }
 
       if (raw.profiles && raw.profiles.length > 0) {
@@ -12645,7 +12657,12 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
 
       const remembered = rememberSshEnumeration(raw, sshRosterCache.get(connection.id), connection.kind)
 
-      return { connection, ...remembered, ...(raw.installId ? { installId: raw.installId } : {}) }
+      return {
+        connection,
+        ...remembered,
+        ...(raw.authRequired ? { authRequired: true } : {}),
+        ...(raw.installId ? { installId: raw.installId } : {})
+      }
     })
   )
 }
@@ -12662,11 +12679,12 @@ ipcMain.handle('hermes:agents:roster', async () => {
     // instead of appending duplicates (remote-only desktops doubled every
     // bot otherwise; see #88344).
     primaryConnectionId: registry.primary,
-    sources: enumerations.map(({ connection, error, installId, profiles }) => ({
+    sources: enumerations.map(({ connection, authRequired, error, installId, profiles }) => ({
       connectionId: connection.id,
       label: connection.label,
       kind: connection.kind,
       reachable: profiles !== null,
+      ...(authRequired ? { authRequired: true } : {}),
       ...(installId ? { installId } : {}),
       ...(error ? { error } : {})
     }))

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -880,6 +880,8 @@ export interface DesktopAgentRoster {
     label: string
     kind: DesktopConnectionKind
     reachable: boolean
+    /** The OAuth session was rejected and needs an interactive sign-in. */
+    authRequired?: boolean
     error?: string
     // Stable backend identity (/api/status install_id) when known.
     installId?: string

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2770,6 +2770,10 @@ function useRoster() {
 function mergeMultiSourceRoster(local, union, activeConnectionId, previous = []) {
   const localProfiles = Array.isArray(local?.profiles) ? local.profiles : []
   const agents = Array.isArray(union?.agents) ? union.agents : []
+  const sources = Array.isArray(union?.sources) ? union.sources : []
+  const sourceById = new Map(
+    sources.map(source => [String(source?.connectionId || '').trim(), source]).filter(([connectionId]) => connectionId)
+  )
   // A live id of null/'' means the window is on the unscoped local backend
   // (legacy hosts reported null for mode:'local'; the SDK now reports
   // 'local'). Do NOT fall back to registry primary when the third argument
@@ -2872,6 +2876,7 @@ function mergeMultiSourceRoster(local, union, activeConnectionId, previous = [])
       connectionId,
       connectionKind: agent.connectionKind,
       connectionLabel: agent.connectionLabel,
+      connectionAuthRequired: Boolean(sourceById.get(connectionId)?.authRequired),
       remoteSource: true,
       sourceScoped: true
     })
@@ -2884,14 +2889,14 @@ function mergeMultiSourceRoster(local, union, activeConnectionId, previous = [])
     const present = new Set(profiles.map(row => `${row.connectionId || ''}::${row.name}`))
     const unionSourceIds = new Set(agents.map(agent => String(agent?.connectionId || '').trim()).filter(Boolean))
     const omitted = new Set(
-      (Array.isArray(union?.sources) ? union.sources : [])
+      sources
         .filter(source => source?.error === 'connect-on-demand' || source?.reachable === false)
         .map(source => String(source.connectionId || '').trim())
         .filter(Boolean)
     )
 
     const registered = new Set(
-      (Array.isArray(union?.sources) ? union.sources : [])
+      sources
         .map(source => String(source?.connectionId || '').trim())
         .filter(Boolean)
     )
@@ -2910,7 +2915,12 @@ function mergeMultiSourceRoster(local, union, activeConnectionId, previous = [])
       }
 
       if (omitted.has(connectionId) || !unionSourceIds.has(connectionId)) {
-        profiles.push({ ...row, remoteSource: true, sourceScoped: true })
+        profiles.push({
+          ...row,
+          connectionAuthRequired: Boolean(sourceById.get(connectionId)?.authRequired),
+          remoteSource: true,
+          sourceScoped: true
+        })
         present.add(key)
       }
     }
@@ -2930,6 +2940,39 @@ function botHandle(name, bot) {
   }
 
   return (name || '').trim().toLowerCase() === 'default' ? 'hermes' : name
+}
+
+function remoteBotNotification(bot) {
+  const handle = botHandle(bot.name, bot)
+
+  if (bot.connectionAuthRequired) {
+    const label = bot.connectionLabel || 'the remote gateway'
+
+    return {
+      kind: 'warning',
+      title: displayName(bot),
+      message: `The login for ${label} has expired. Sign in again under Settings > Gateway before messaging @${handle}.`
+    }
+  }
+
+  return {
+    kind: 'info',
+    title: displayName(bot),
+    message: `Stay in this chat and @${handle} to message them. Gateway stays on this device.`
+  }
+}
+
+function notifyRemoteBot(bot) {
+  const notification = remoteBotNotification(bot)
+
+  if (bot.connectionAuthRequired) {
+    notification.action = {
+      label: 'Open Gateway settings',
+      onClick: () => host.navigate('/settings?tab=gateway')
+    }
+  }
+
+  host.notify?.(notification)
 }
 
 function isActiveRosterBot(bot, active) {
@@ -4851,12 +4894,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
     $selectedBot.set(bot.name)
 
     if (bot.remoteSource) {
-      const handle = botHandle(bot.name, bot)
-      host.notify?.({
-        kind: 'info',
-        title: displayName(bot),
-        message: `Stay in this chat and @${handle} to message them. Gateway stays on this device.`
-      })
+      notifyRemoteBot(bot)
       return
     }
 
@@ -9724,12 +9762,7 @@ function BotsPane() {
           $selectedBot.set(bot.name)
 
           if (bot.remoteSource) {
-            const handle = botHandle(bot.name, bot)
-            host.notify?.({
-              kind: 'info',
-              title: displayName(bot),
-              message: `Stay in this chat and @${handle} to message them. Gateway stays on this device.`
-            })
+            notifyRemoteBot(bot)
             return
           }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -5,7 +5,7 @@ import vm from 'node:vm'
 
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
-function runtime() {
+function runtime(hostOverrides = {}) {
   const atom = value => ({ get: () => value, set: () => undefined })
   const jsx = (type, props = {}) => ({ type, props })
   const context = {
@@ -21,7 +21,8 @@ function runtime() {
         connectionId: { get: () => 'local', listen: () => undefined },
         profile: { get: () => 'ops', listen: () => undefined }
       },
-      request: () => undefined
+      request: () => undefined,
+      ...hostOverrides
     },
     sdk: new Proxy({}, { get: () => undefined })
   }
@@ -32,7 +33,7 @@ function runtime() {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__botRosterKey = botRosterKey;\nglobalThis.__botRosterMeta = botRosterMeta;\nglobalThis.__displayName = displayName;\nglobalThis.__filterBots = filterBots;\nglobalThis.__resolveRosterMentions = resolveRosterMentions;'
+      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__botRosterKey = botRosterKey;\nglobalThis.__botRosterMeta = botRosterMeta;\nglobalThis.__displayName = displayName;\nglobalThis.__filterBots = filterBots;\nglobalThis.__resolveRosterMentions = resolveRosterMentions;\nglobalThis.__remoteBotNotification = remoteBotNotification;\nglobalThis.__notifyRemoteBot = notifyRemoteBot;'
     )
   vm.runInNewContext(code, context)
   return context
@@ -438,6 +439,120 @@ test('merge: previously seen remotes survive a connect-on-demand empty union', (
   assert.ok(bob)
   assert.equal(bob.remoteSource, true)
   assert.equal(out.profiles.filter(p => p.name === 'default').length, 1)
+})
+
+test('merge: a retained remote row carries and clears the source reauth state', () => {
+  const { __mergeMultiSourceRoster: merge } = runtime()
+  const local = { profiles: [{ name: 'default' }] }
+  const previous = [
+    { name: 'default' },
+    {
+      name: 'bob',
+      remoteSource: true,
+      sourceScoped: true,
+      connectionId: 'studio',
+      connectionKind: 'remote',
+      connectionLabel: 'Studio',
+      handle: 'bob'
+    }
+  ]
+
+  const expired = merge(
+    local,
+    {
+      agents: [{ connectionId: 'local', connectionKind: 'local', profile: 'default', handle: 'default' }],
+      sources: [
+        { connectionId: 'local', kind: 'local', reachable: true },
+        { connectionId: 'studio', kind: 'remote', reachable: false, authRequired: true, error: '401' }
+      ]
+    },
+    'local',
+    previous
+  )
+  const staleBob = expired.profiles.find(row => row.connectionId === 'studio')
+
+  assert.ok(staleBob)
+  assert.equal(staleBob.connectionAuthRequired, true)
+
+  const recovered = merge(
+    local,
+    {
+      agents: [
+        { connectionId: 'local', connectionKind: 'local', profile: 'default', handle: 'default' },
+        {
+          connectionId: 'studio',
+          connectionKind: 'remote',
+          connectionLabel: 'Studio',
+          profile: 'bob',
+          handle: 'bob'
+        }
+      ],
+      sources: [
+        { connectionId: 'local', kind: 'local', reachable: true },
+        { connectionId: 'studio', kind: 'remote', reachable: true }
+      ]
+    },
+    'local',
+    expired.profiles
+  )
+
+  assert.equal(recovered.profiles.find(row => row.connectionId === 'studio').connectionAuthRequired, false)
+})
+
+test('remoteBotNotification: expired OAuth sources explain the sign-in recovery', () => {
+  const { __remoteBotNotification: notice } = runtime()
+  const notification = notice({
+    name: 'bob',
+    handle: 'bob',
+    connectionAuthRequired: true,
+    connectionId: 'studio',
+    connectionLabel: 'Studio',
+    remoteSource: true
+  })
+
+  assert.equal(notification.kind, 'warning')
+  assert.equal(notification.title, 'Bob')
+  assert.match(notification.message, /login for Studio has expired/)
+  assert.match(notification.message, /Settings > Gateway/)
+  assert.match(notification.message, /@bob/)
+})
+
+test('remoteBotNotification: ordinary remote sources keep the existing guidance', () => {
+  const { __remoteBotNotification: notice } = runtime()
+  const notification = notice({
+    name: 'bob',
+    handle: 'bob',
+    connectionId: 'studio',
+    connectionLabel: 'Studio',
+    remoteSource: true
+  })
+
+  assert.equal(notification.kind, 'info')
+  assert.equal(notification.title, 'Bob')
+  assert.equal(notification.message, 'Stay in this chat and @bob to message them. Gateway stays on this device.')
+})
+
+test('notifyRemoteBot: an expired source links directly to Gateway settings', () => {
+  const notifications = []
+  const navigations = []
+  const { __notifyRemoteBot: notify } = runtime({
+    navigate: path => navigations.push(path),
+    notify: notification => notifications.push(notification)
+  })
+
+  notify({
+    name: 'bob',
+    handle: 'bob',
+    connectionAuthRequired: true,
+    connectionId: 'studio',
+    connectionLabel: 'Studio',
+    remoteSource: true
+  })
+
+  assert.equal(notifications.length, 1)
+  assert.equal(notifications[0].action.label, 'Open Gateway settings')
+  notifications[0].action.onClick()
+  assert.deepEqual(navigations, ['/settings?tab=gateway'])
 })
 
 test('merge: previous remotes from a removed connection do not resurrect', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -55,6 +55,7 @@ function renderBotRow(input = 'alpha') {
     displayName: bot => bot.name,
     duplicateBot: async () => `${name}-copy`,
     haptic: () => undefined,
+    notifyRemoteBot: () => undefined,
     // #49 session-aware-row helpers referenced inside BotRow.
     previewKind: () => ({ fromBot: false, sender: null }),
     generatedSessionTitle: () => null,
@@ -184,6 +185,7 @@ test('behavior: remote default does not open this-device chat when the source di
     displayName: bot => bot.connectionLabel || bot.name,
     duplicateBot: async () => 'copy',
     haptic: () => undefined,
+    notifyRemoteBot: () => undefined,
     previewKind: () => ({ fromBot: false, sender: null }),
     generatedSessionTitle: () => null,
     openBotCanonicalChat: async (...args) => {


### PR DESCRIPTION
## What does this PR do?

Desktop keeps previously seen remote Bot Mode rows visible while their source is temporarily unreachable. When an OAuth session had expired, clicking one of those rows still showed the generic remote-bot guidance, so the user had no indication that the connection needed to be authenticated again.

This change classifies only confirmed OAuth rejections (401/403 or an already tagged reauthentication error), carries that sanitized state through the agent roster, and gives the retained bot row an actionable warning that opens Settings > Gateway. Token, SSH, timeout, and ordinary offline failures keep the existing behavior.

## Related Issue

Discord support report: https://discord.com/channels/1053877538025386074/1539713892496969849

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Classify expired OAuth agent-roster sources without treating token or connectivity failures as reauthentication failures.
- Preserve that source health state while retaining cached remote bot rows.
- Replace the generic remote-bot toast with a sign-in warning and Gateway settings action when authentication has expired.
- Cover classification, retained-row recovery, notification copy/action, and the unchanged generic path.

## How to Test

1. Run `npm run typecheck` from `apps/desktop`.
2. Run ESLint against the changed Desktop TypeScript and test files.
3. Run `node --test --test-reporter=dot src/plugins/*/tests/*.test.mjs` from `apps/desktop` (312 tests).
4. With an OAuth remote gateway connected, let its saved login expire and click a retained remote bot row. Confirm the warning explains that sign-in is required and its action opens Settings > Gateway. Confirm an ordinary unreachable source retains the existing informational toast.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No screenshot included. The behavior is covered by the focused Desktop and bundled-plugin tests above.