### PR TITLE
fix(agent): align stream drop attempt counter with execution attempt (Closes #90215)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2453,7 +2453,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         first_delta_fired["done"] = False
                         agent._emit_stream_drop(
                             error=e,
-                            attempt=_stream_attempt + 2,
+                            attempt=_stream_attempt + 1,
                             max_attempts=_max_stream_retries + 1,
                             mid_tool_call=True,
                             diag=request_client_holder.get("diag"),
@@ -2510,7 +2510,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         if _stream_attempt < _max_stream_retries:
                             agent._emit_stream_drop(
                                 error=e,
-                                attempt=_stream_attempt + 2,
+                                attempt=_stream_attempt + 1,
                                 max_attempts=_max_stream_retries + 1,
                                 mid_tool_call=False,
                                 diag=request_client_holder.get("diag"),

--- a/tests/run_agent/test_stream_drop_logging.py
+++ b/tests/run_agent/test_stream_drop_logging.py
@@ -237,6 +237,27 @@ def test_emit_stream_drop_ui_omits_suffix_without_diag():
     assert "ConnectionError" in msg
 
 
+def test_emit_stream_drop_attempt_numbering_1_indexed(caplog):
+    """Verify that _emit_stream_drop reflects 1-indexed attempt number in UI and logs."""
+    agent = _make_agent()
+    agent.provider = "openrouter"
+
+    with caplog.at_level(logging.WARNING, logger="agent.stream_diag"):
+        with patch.object(agent, "_buffer_status") as mock_emit:
+            agent._emit_stream_drop(
+                error=ConnectionError("drop"),
+                attempt=1,
+                max_attempts=3,
+                mid_tool_call=False,
+            )
+
+    msg = mock_emit.call_args.args[0]
+    assert "retry 1/3" in msg
+
+    log_msg = next(r.getMessage() for r in caplog.records if "Stream drop" in r.getMessage())
+    assert "Stream drop on attempt 1/3" in log_msg
+
+
 def test_quiet_mode_does_not_clobber_runagent_logger_level():
     """Regression guard for the parent fix — must persist across this PR."""
     _ = _make_agent()


### PR DESCRIPTION
## Summary

Fixes an off-by-one error in `agent/chat_completion_helpers.py` where transient stream drop log lines overstate the execution attempt by one on non-exhausted retry paths (logging "attempt 2/3" on the very first execution failure).

Closes #90215.

---

### Root Cause & Fix

In `agent/chat_completion_helpers.py`, the streaming retry loop is:

```python
for _stream_attempt in range(_max_stream_retries + 1):
```

On execution 0 (the 1st attempt), transient failure paths called `_emit_stream_drop` with `attempt=_stream_attempt + 2` (= 2), causing initial stream drops to log `attempt 2/3` instead of `attempt 1/3`. On execution 1, it logged `attempt 3/3`. On execution 2 (retries exhausted), the exhausted path logged `_max_stream_retries + 1` (= 3).

**Fix**:
- Updated `attempt=_stream_attempt + 2` to `attempt=_stream_attempt + 1` on both the mid-tool-call silent retry path and the plain transient retry path.
- First execution failure now accurately logs `attempt 1/3`, matching actual execution order and remaining consistent with the exhausted path (`3/3`).

---

### Key Components Touched

- `agent/chat_completion_helpers.py`: Updated `attempt=_stream_attempt + 1` on transient drop paths.
- `tests/run_agent/test_stream_drop_logging.py`: Added `test_emit_stream_drop_attempt_numbering_1_indexed`.

---

### Verification

- `pytest tests/run_agent/test_stream_drop_logging.py` (11/11 passed)
- `ruff check agent/chat_completion_helpers.py tests/run_agent/test_stream_drop_logging.py` (0 errors)
- `git status` verifies strictly 2 modified files (no unrelated additions or skill dumps).

---
*Client: cortex-cli | Provider: google | Model: gemini-3.7-flash*
