### PR TITLE
fix(tools): make DaemonThreadPoolExecutor compatible with Python 3.14+ worker context

### DIFF
--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -38,7 +38,7 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
 
     def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
+        # Mirrors CPython's implementation (3.8–3.14+) with two changes:
         # daemon=True and no _threads_queues registration.
         if self._idle_semaphore.acquire(timeout=0):
             return
@@ -49,15 +49,25 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
+            if hasattr(self, "_create_worker_context"):
+                # Python 3.14+
+                args = (
+                    weakref.ref(self, weakref_cb),
+                    self._create_worker_context(),
+                    self._work_queue,
+                )
+            else:
+                # Python 3.8-3.13
+                args = (
+                    weakref.ref(self, weakref_cb),
+                    self._work_queue,
+                    getattr(self, "_initializer", None),
+                    getattr(self, "_initargs", ()),
+                )
             t = threading.Thread(
                 name=thread_name,
                 target=_worker,
-                args=(
-                    weakref.ref(self, weakref_cb),
-                    self._work_queue,
-                    self._initializer,
-                    self._initargs,
-                ),
+                args=args,
                 daemon=True,
             )
             t.start()


### PR DESCRIPTION
### Summary of Changes
This PR fixes the crash in `DaemonThreadPoolExecutor` when running under Python 3.14+.

* **Fixed Component**: `tools/daemon_pool.py`
* **What changed**: Modified `_adjust_thread_count` to adapt to Python 3.14's new `_create_worker_context` flow for `ThreadPoolExecutor` while maintaining full backward compatibility with older Python versions (3.8 - 3.13).
* **Closes**: #90256

### Details
* Added a conditional check for `self._create_worker_context` in `_adjust_thread_count`.
* For Python 3.14+, `args` is constructed as:
  ```python
  args = (
      weakref.ref(self, weakref_cb),
      self._create_worker_context(),
      self._work_queue,
  )
  ```
* For Python 3.8-3.13, `args` remains:
  ```python
  args = (
      weakref.ref(self, weakref_cb),
      self._work_queue,
      getattr(self, "_initializer", None),
      getattr(self, "_initargs", ()),
  )
  ```

### Verification Results
All tests under `tests/tools/test_daemon_pool.py` now pass successfully on Python 3.14.1:
```bash
pytest tests/tools/test_daemon_pool.py
# Output: 3 passed in 1.95s
```
