### PR TITLE
fix(kanban): enforce review and routing invariants

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5349,6 +5349,109 @@ class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
 
+class ReviewVerdictError(ValueError):
+    """Raised when completion metadata explicitly says review did not approve."""
+
+
+_APPROVED_REVIEW_RESULTS = frozenset({
+    "approved", "approved_with_findings", "approved_with_notes", "approve",
+    "pass", "passed",
+})
+_AGGREGATE_REVIEW_AXES = frozenset({"aggregate", "final", "full"})
+
+
+def _review_completion_rejection_reason(metadata: Optional[dict]) -> Optional[str]:
+    """Return why explicit review metadata cannot represent approval.
+
+    Ordinary completion metadata stays free-form. Once any review-specific key
+    is present, every top-level and nested review field is validated together:
+    one approval cannot hide a conflicting rejection or partial review axis.
+    """
+    if not isinstance(metadata, dict):
+        return None
+
+    review_identity_keys = {
+        "review_axis", "review_result", "review_outcome", "review_verdict",
+    }
+    if not review_identity_keys.intersection(metadata):
+        return None
+
+    envelopes: list[tuple[str, dict]] = [("top-level", metadata)]
+    nested = metadata.get("review_verdict")
+    if isinstance(nested, dict):
+        recognized_nested = {
+            "approved", "blocking", "review_axis", "review_result",
+            "review_outcome",
+        }
+        if not recognized_nested.intersection(nested):
+            return "review_verdict contains no recognized review fields"
+        envelopes.append(("review_verdict", nested))
+    elif isinstance(nested, str) and nested.strip():
+        envelopes.append(("review_verdict", {"review_result": nested}))
+    elif "review_verdict" in metadata:
+        return "review_verdict must be a non-empty string or object"
+
+    explicitly_approved = False
+    aggregate_axes: list[str] = []
+    saw_verdict_field = False
+
+    for label, verdict in envelopes:
+        if "blocking" in verdict:
+            saw_verdict_field = True
+            if not isinstance(verdict["blocking"], bool):
+                return f"{label}.blocking must be a boolean"
+            if verdict["blocking"]:
+                return f"{label} review metadata marks the review as blocking"
+        if "approved" in verdict:
+            saw_verdict_field = True
+            if not isinstance(verdict["approved"], bool):
+                return f"{label}.approved must be a boolean"
+            if not verdict["approved"]:
+                return f"{label} review metadata explicitly sets approved=false"
+            explicitly_approved = True
+
+        for key in ("review_result", "review_outcome"):
+            if key not in verdict:
+                continue
+            saw_verdict_field = True
+            value = verdict[key]
+            if not isinstance(value, str) or not value.strip():
+                return f"{label}.{key} must be a non-empty string"
+            normalized = "_".join(
+                value.strip().casefold().replace("-", " ").split()
+            )
+            if normalized not in _APPROVED_REVIEW_RESULTS:
+                return (
+                    f"{label} metadata reports nonapproval or unrecognized "
+                    f"review result {normalized!r}"
+                )
+            explicitly_approved = True
+
+        if "review_axis" in verdict:
+            saw_verdict_field = True
+            axis = verdict["review_axis"]
+            if not isinstance(axis, str) or not axis.strip():
+                return f"{label}.review_axis must be a non-empty string"
+            normalized_axis = "_".join(
+                axis.strip().casefold().replace("-", " ").split()
+            )
+            if normalized_axis not in _AGGREGATE_REVIEW_AXES:
+                return (
+                    f"partial review axis {normalized_axis!r} cannot close a task; "
+                    "an aggregate approval verdict is required"
+                )
+            aggregate_axes.append(normalized_axis)
+
+    if not saw_verdict_field:
+        return "review_verdict contains no review fields"
+    if aggregate_axes and not explicitly_approved:
+        return (
+            f"aggregate review axis {aggregate_axes[0]!r} has no explicit "
+            "approval verdict"
+        )
+    return None
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -5424,6 +5527,41 @@ def complete_task(
             raise HallucinatedCardsError(phantom_cards, task_id)
     else:
         verified_cards = []
+
+    review_rejection = _review_completion_rejection_reason(metadata)
+    if review_rejection:
+        with write_txn(conn):
+            eligible = conn.execute(
+                "SELECT status, current_run_id FROM tasks WHERE id = ?",
+                (task_id,),
+            ).fetchone()
+            if eligible is None or eligible["status"] not in {
+                "running", "ready", "blocked", "review",
+            }:
+                return False
+            if eligible["current_run_id"] is None:
+                return False
+            if (
+                expected_run_id is not None
+                and eligible["current_run_id"] != int(expected_run_id)
+            ):
+                return False
+            _append_event(
+                conn,
+                task_id,
+                "completion_blocked_review_verdict",
+                {
+                    "reason": review_rejection,
+                    "metadata_keys": sorted(metadata) if isinstance(metadata, dict) else [],
+                    "summary_preview": (
+                        (summary or result or "").strip().splitlines()[0][:200]
+                        if (summary or result)
+                        else None
+                    ),
+                },
+                run_id=eligible["current_run_id"],
+            )
+        raise ReviewVerdictError(review_rejection)
 
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
@@ -7370,7 +7508,7 @@ def decompose_triage_task(
     child_ids: list[str] = []
     with write_txn(conn):
         root_row = conn.execute(
-            "SELECT id, status, tenant, workspace_kind, workspace_path "
+            "SELECT id, status, assignee, tenant, workspace_kind, workspace_path "
             "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
@@ -7466,10 +7604,13 @@ def decompose_triage_task(
                 (cid, task_id),
             )
 
-        # Flip the root: triage -> todo, set assignee to the orchestrator.
+        # Flip the root: triage -> todo. An assignee chosen or changed before
+        # this transaction is durable workflow intent; only an unassigned root
+        # receives the configured orchestrator fallback.
+        effective_root_assignee = root_row["assignee"] or root_assignee
         sets = ["status = 'todo'"]
         params: list[Any] = []
-        if root_assignee is not None:
+        if root_row["assignee"] is None and root_assignee is not None:
             sets.append("assignee = ?")
             params.append(root_assignee)
         params.append(task_id)
@@ -7496,7 +7637,7 @@ def decompose_triage_task(
             conn, task_id, "decomposed",
             {
                 "child_ids": child_ids,
-                "root_assignee": root_assignee,
+                "root_assignee": effective_root_assignee,
             },
         )
 

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -291,6 +291,9 @@ def decompose_task(
         )
 
     cfg = _load_config()
+    # This is only a fallback. decompose_triage_task() resolves final ownership
+    # from the current DB row inside its write transaction, so an assignment or
+    # unassignment made while the LLM call is running wins over this value.
     orchestrator = _resolve_orchestrator_profile(cfg)
     default_assignee = _resolve_default_assignee(cfg)
     kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -113,6 +113,96 @@ def test_decompose_with_fanout_creates_children(kanban_home):
     assert c1.assignee == "engineer"
 
 
+def test_decompose_with_fanout_preserves_existing_root_assignee(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="ship an approved workflow",
+            assignee="operator",
+            triage=True,
+        )
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "split implementation from verification",
+        "tasks": [
+            {"title": "build", "body": "implement it", "assignee": "builder", "parents": []},
+        ],
+    })
+
+    def reassign_during_decomposition(*_args, **_kwargs):
+        with kb.connect() as conn:
+            assert kb.assign_task(conn, tid, "new-owner")
+        return _fake_aux_response(llm_payload)
+
+    patches = _patch_list_profiles(["masa", "operator", "new-owner", "builder"])
+    for p in patches:
+        p.start()
+    try:
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            side_effect=reassign_during_decomposition,
+        ), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value={"kanban": {"orchestrator_profile": "masa"}},
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    with kb.connect() as conn:
+        root = kb.get_task(conn, tid)
+    assert root is not None
+    assert root.assignee == "new-owner"
+
+
+def test_decompose_with_fanout_respects_concurrent_root_unassignment(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="reroute an approved workflow",
+            assignee="operator",
+            triage=True,
+        )
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "split implementation from verification",
+        "tasks": [
+            {"title": "build", "body": "implement it", "assignee": "builder", "parents": []},
+        ],
+    })
+
+    def unassign_during_decomposition(*_args, **_kwargs):
+        with kb.connect() as conn:
+            assert kb.assign_task(conn, tid, None)
+        return _fake_aux_response(llm_payload)
+
+    patches = _patch_list_profiles(["masa", "operator", "builder"])
+    for p in patches:
+        p.start()
+    try:
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            side_effect=unassign_during_decomposition,
+        ), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value={"kanban": {"orchestrator_profile": "masa"}},
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    with kb.connect() as conn:
+        root = kb.get_task(conn, tid)
+    assert root is not None
+    assert root.assignee == "masa"
+
+
 def test_decompose_fanout_false_invalid_llm_assignee_uses_default(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="route me safely", triage=True)

--- a/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
@@ -149,6 +149,165 @@ def test_same_card_review_supports_changes_and_approval_without_block_loop(conn)
     assert completed.block_recurrences == 0
 
 
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"review_axis": "spec", "findings_count": 4},
+        {"review_axis": "spec", "review_result": "approved"},
+        {"review_axis": "aggregate", "findings_count": 4},
+        {"review_result": "changes_requested", "issues_found": ["missing guard"]},
+        {"review_result": "nonapproved"},
+        {"review_result": "non-approved"},
+        {"review_result": "rejection"},
+        {"review_result": "non approval"},
+        {"review_result": "disapproved"},
+        {"review_result": "changes required"},
+        {"review_result": "request_changes"},
+        {"review_outcome": "denied"},
+        {"review_verdict": {"review_result": "nonapproved"}},
+        {"review_verdict": "rejected"},
+        {
+            "review_verdict": {"review_result": "approved"},
+            "review_result": "rejected",
+        },
+        {
+            "review_verdict": {"review_result": "approved"},
+            "review_axis": "spec",
+        },
+        {"review_result": False},
+        {"review_result": ""},
+        {"review_outcome": None},
+        {"review_axis": False},
+        {"review_axis": ""},
+        {"review_verdict": {}},
+        {"review_result": "approved", "review_verdict": {}},
+        {
+            "review_result": "approved",
+            "review_verdict": {"verdict": "rejected"},
+        },
+        {
+            "review_result": "approved",
+            "review_verdict": {"outcomes": ["rejected"]},
+        },
+        {"review_axis": "standards", "review_outcome": "rejected"},
+        {"review_axis": "spec", "approved": False},
+        {"review_axis": "spec", "blocking": True},
+    ],
+)
+def test_completion_rejects_explicit_nonapproval_review_metadata(conn, metadata):
+    task_id = kb.create_task(conn, title="Audit release", assignee="reviewer")
+    review = kb.claim_task(conn, task_id, claimer="reviewer:1")
+    assert review is not None
+
+    with pytest.raises(kb.ReviewVerdictError):
+        kb.complete_task(
+            conn,
+            task_id,
+            summary="Review work finished.",
+            metadata=metadata,
+            expected_run_id=review.current_run_id,
+        )
+
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.status == "running"
+    rejected = [
+        event for event in kb.list_events(conn, task_id)
+        if event.kind == "completion_blocked_review_verdict"
+    ]
+    assert len(rejected) == 1
+    assert rejected[0].run_id == review.current_run_id
+    assert rejected[0].payload is not None
+    assert rejected[0].payload["reason"]
+
+
+def test_completion_accepts_explicit_approved_review_metadata(conn):
+    task_id = kb.create_task(conn, title="Audit release", assignee="reviewer")
+    review = kb.claim_task(conn, task_id, claimer="reviewer:1")
+    assert review is not None
+
+    assert kb.complete_task(
+        conn,
+        task_id,
+        summary="Approved after independent verification.",
+        metadata={
+            "review_axis": "aggregate",
+            "review_result": "approved",
+            "issues_found": [],
+        },
+        expected_run_id=review.current_run_id,
+    )
+
+
+def test_completion_keeps_unrelated_free_form_metadata_compatible(conn):
+    task_id = kb.create_task(conn, title="Implement feature", assignee="builder")
+    implementation = kb.claim_task(conn, task_id, claimer="builder:1")
+    assert implementation is not None
+
+    assert kb.complete_task(
+        conn,
+        task_id,
+        summary="Implementation complete.",
+        metadata={"approved": False, "blocking": True, "domain": "not-review"},
+        expected_run_id=implementation.current_run_id,
+    )
+
+
+def test_rejected_review_completion_with_stale_run_does_not_emit_event(conn):
+    task_id = kb.create_task(conn, title="Audit release", assignee="reviewer")
+    review = kb.claim_task(conn, task_id, claimer="reviewer:1")
+    assert review is not None
+    assert review.current_run_id is not None
+
+    assert not kb.complete_task(
+        conn,
+        task_id,
+        metadata={"review_axis": "spec", "findings_count": 1},
+        expected_run_id=review.current_run_id + 1,
+    )
+    assert not [
+        event for event in kb.list_events(conn, task_id)
+        if event.kind == "completion_blocked_review_verdict"
+    ]
+
+
+def test_rejected_review_completion_on_done_task_does_not_emit_event(conn):
+    task_id = kb.create_task(conn, title="Audit release", assignee="reviewer")
+    review = kb.claim_task(conn, task_id, claimer="reviewer:1")
+    assert review is not None
+    assert kb.complete_task(
+        conn,
+        task_id,
+        metadata={"review_result": "approved"},
+        expected_run_id=review.current_run_id,
+    )
+
+    assert not kb.complete_task(
+        conn,
+        task_id,
+        metadata={"review_axis": "spec", "findings_count": 1},
+        expected_run_id=review.current_run_id,
+    )
+    assert not [
+        event for event in kb.list_events(conn, task_id)
+        if event.kind == "completion_blocked_review_verdict"
+    ]
+
+
+def test_rejected_review_completion_without_active_run_does_not_emit_event(conn):
+    task_id = kb.create_task(conn, title="Audit release", assignee="reviewer")
+
+    assert not kb.complete_task(
+        conn,
+        task_id,
+        metadata={"review_axis": "spec", "findings_count": 1},
+    )
+    assert not [
+        event for event in kb.list_events(conn, task_id)
+        if event.kind == "completion_blocked_review_verdict"
+    ]
+
+
 @pytest.mark.parametrize("bad_payload", [None, "{not-json", "{}"])
 def test_rereview_requires_explicit_reviewer_when_provenance_is_invalid(
     conn,

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -132,6 +132,33 @@ def test_complete_happy_path(worker_env):
         conn.close()
 
 
+def test_complete_review_verdict_error_gives_actionable_guidance(worker_env):
+    from tools import kanban_tools as kt
+
+    out = kt._handle_complete({
+        "summary": "Spec-axis review found a blocking issue.",
+        "metadata": {
+            "review_axis": "spec",
+            "findings_count": 1,
+            "blocking": True,
+        },
+    })
+    result = json.loads(out)
+
+    assert "error" in result
+    assert "partial review axis must report back to its parent" in result["error"]
+    assert "kanban_request_changes" in result["error"]
+
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        assert task.status == "running"
+    finally:
+        conn.close()
+
+
 def test_complete_retry_with_empty_created_cards_succeeds(worker_env):
     """After a phantom rejection, retrying kanban_complete with
     created_cards=[] (the documented escape hatch) must complete the

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -772,6 +772,15 @@ def _handle_complete(args: dict, **kw) -> str:
                     created_cards=created_cards,
                     expected_run_id=_worker_run_id(tid),
                 )
+            except kb.ReviewVerdictError as review_err:
+                return tool_error(
+                    f"kanban_complete blocked: {review_err}. The task is still "
+                    f"in-flight and the rejected attempt was recorded. A partial "
+                    f"review axis must report back to its parent instead of closing "
+                    f"the card. If independent review found correctable defects, "
+                    f"call kanban_request_changes; complete only after an aggregate "
+                    f"approval verdict."
+                )
             except kb.ArtifactPreservationError as artifact_err:
                 return tool_error(
                     f"kanban_complete could not preserve the declared artifacts: "


### PR DESCRIPTION
## Summary
- preserve the current transaction-time root assignee during Kanban decomposition
- fail closed on partial, rejected, conflicting, or malformed explicit review verdict metadata
- emit rejected-completion events only for an active current run
- return actionable tool guidance instead of allowing a partial review to close a card

## Verification
- focused Kanban surfaces: 96 passed
- kanban_db suite: 30 passed, 1 skipped
- final deployed smoke tests: 31 passed
- compileall and git diff --check passed
- independent final review approved commit e6af006faccef844680cbc5cce90d1f9e6588d7f
