### PR TITLE
fix(desktop): clear stale MoA composer picks

### DIFF
--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -154,6 +154,15 @@ describe('manualPickRemoved', () => {
     expect(manualPickRemoved(providers, 'anthropic', 'claude-sonnet-4.6')).toBe(false)
   })
 
+  it('flags a missing virtual MoA provider when the catalog is populated', () => {
+    expect(manualPickRemoved(providers, 'moa', 'default')).toBe(true)
+  })
+
+  it('keeps a MoA pick while the catalog is unavailable', () => {
+    expect(manualPickRemoved(undefined, 'moa', 'default')).toBe(false)
+    expect(manualPickRemoved([], 'moa', 'default')).toBe(false)
+  })
+
   it('never clobbers when the provider has an empty model list (re-auth)', () => {
     expect(manualPickRemoved(providers, 'nous', 'hermes-4')).toBe(false)
   })

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -6,7 +6,9 @@ import type { ModelOptionProvider } from '@/types/hermes'
  * catalog (its provider still ships models, but no longer this one) — so a new
  * chat would keep 404'ing the dead model. Deliberately conservative to never
  * clobber a still-valid pick: an unknown/absent provider, an empty model list
- * (re-auth / unconfigured), or a not-yet-loaded catalog all return false.
+ * (re-auth / unconfigured), or a not-yet-loaded catalog all return false. The
+ * virtual `moa` provider is the exception: explicit-only catalogs omit it when
+ * no MoA preset is enabled, so its absence is authoritative.
  */
 export function manualPickRemoved(
   providers: ModelOptionProvider[] | undefined,
@@ -20,7 +22,7 @@ export function manualPickRemoved(
   const row = providers.find(p => p.slug === provider || p.name === provider)
 
   if (!row) {
-    return false
+    return provider.toLowerCase() === 'moa'
   }
 
   const models = row.models ?? []


### PR DESCRIPTION
## Summary

Treat a missing virtual `moa` provider as a removed composer selection when the explicit-only model catalog is populated.

## Root cause

Desktop deliberately preserves a manual model pick when its provider row is absent because the catalog may still be loading or the provider may need re-authentication. The virtual MoA provider is different: the explicit-only catalog omits `moa` when no MoA preset is enabled, so preserving the persisted `moa:default` selection leaves the composer pill showing a disabled provider.

## Fix

Recognize the absent virtual `moa` provider as a removed manual pick while preserving the existing conservative behavior for unavailable or empty catalogs. The next model refresh can then reseed the composer from the profile default.

## Testing

- `./../../node_modules/.bin/vitest run src/lib/model-options.test.ts src/app/session/hooks/use-model-controls.test.tsx` — 2 files, 38 tests passed
- `./../../node_modules/.bin/vitest run --project ui` — 541 files, 5,063 tests passed
- `npm run typecheck` — passed
- `npm run lint` — passed with 118 existing warnings in unrelated files
- `./../../node_modules/.bin/prettier --check src/lib/model-options.ts src/lib/model-options.test.ts` — passed

## Issue

Fixes #90244