### PR TITLE
fix(classifier): retry provider-injected parameter 400s instead of aborting the turn

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -459,6 +459,59 @@ _REQUEST_VALIDATION_PATTERNS = [
     "unsupported_parameter",
 ]
 
+# Request parameters that Hermes sends on SOME routes only, paired with the
+# providers/hosts where sending them is deliberate.
+#
+# When a host that is NOT in the allowed set rejects one of these fields, the
+# client never put it in the body — the provider's own gateway injected it —
+# so the 400 is a server-side flake rather than a deterministic request-shape
+# error.  See ``_is_server_injected_param_rejection`` and the branch in
+# ``_classify_400``.
+#
+# ``prompt_cache_retention`` is only sent for api.meta.ai and bedrock-mantle
+# hosts (agent/transports/codex.py::_default_prompt_cache_retention_for_request).
+# The Codex OAuth backend rejects it spontaneously on requests that provably
+# never carried it.
+_SERVER_INJECTED_PARAM_SENDERS: Dict[str, tuple] = {
+    "prompt_cache_retention": ("meta", "muse", "msl", "model-api", "bedrock", "mantle"),
+}
+
+
+def _is_server_injected_param_rejection(error_msg: str, provider: str) -> bool:
+    """True when a 400 blames a parameter this route never sends.
+
+    ``error_msg`` is the lowercased, concatenated message text; ``provider`` is
+    the lowercased provider slug.  A match means the rejection cannot be
+    attributed to our own request shape, so the error is transient and retrying
+    the identical request is the correct recovery.
+
+    Deliberately conservative: it fires only for known one-route-only
+    parameters AND only when the current provider is not one of the routes that
+    actually sends them, so a genuine client-side bad parameter (``max_tokens``
+    on a GPT-5 model) still fails fast as a ``format_error``.
+    """
+    if not error_msg:
+        return False
+    provider_slug = (provider or "").strip().lower()
+    for param, senders in _SERVER_INJECTED_PARAM_SENDERS.items():
+        if param not in error_msg:
+            continue
+        # Require the message to actually be a rejection of that parameter,
+        # not an incidental mention.
+        if not (
+            "not supported" in error_msg
+            or "unsupported" in error_msg
+            or "unknown" in error_msg
+            or "unrecognized" in error_msg
+        ):
+            continue
+        if any(sender in provider_slug for sender in senders):
+            # This route sends the field on purpose — a real request error.
+            return False
+        return True
+    return False
+
+
 # OpenRouter aggregator policy-block patterns.
 #
 # When a user's OpenRouter account privacy setting (or a per-request
@@ -1310,11 +1363,16 @@ def _classify_by_status(
         # server_error" rule turns one bad request into a retry flood.
         # Detect the unambiguous request-validation signals (in either the
         # message text or the structured error code) and fail fast.
+        #
+        # Exception: a parameter WE never sent on this route was injected by
+        # the provider/proxy itself, so the rejection is not deterministic and
+        # the generic retryable-5xx handling is correct. Mirrors the guard in
+        # _classify_400 — see _is_server_injected_param_rejection.
         if (
             any(p in error_msg for p in _REQUEST_VALIDATION_PATTERNS)
             or error_code.lower() in {"invalid_request_error", "unknown_parameter",
                                       "unsupported_parameter"}
-        ):
+        ) and not _is_server_injected_param_rejection(error_msg, provider):
             return result_fn(
                 FailoverReason.format_error,
                 retryable=False,
@@ -1471,6 +1529,25 @@ def _classify_400(
             FailoverReason.invalid_encrypted_content,
             retryable=True,
             should_fallback=False,
+        )
+
+    # Server-injected parameter rejection: a 400 blaming a request field the
+    # client never sent.  MUST be checked BEFORE the request-validation branch
+    # below, which would otherwise class it as a deterministic format_error and
+    # abort the turn.
+    #
+    # Observed live on the Codex OAuth backend (chatgpt.com/backend-api/codex):
+    # it intermittently adds ``prompt_cache_retention`` to its own upstream
+    # call and then rejects it, so a byte-identical request succeeds on retry
+    # (measured ~20% failure over n=20 on a minimal 1-message request that
+    # provably carried no cache parameters).  Retrying is the correct and only
+    # recovery; failing fast burnt an entire large-context request per attempt.
+    if _is_server_injected_param_rejection(error_msg, provider):
+        return result_fn(
+            FailoverReason.server_error,
+            retryable=True,
+            # The request shape was fine — never route this into compression.
+            should_compress=False,
         )
 
     # Request-validation errors (unsupported / unknown parameter) MUST be

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1292,3 +1292,152 @@ class TestExpandedOverflowPatterns:
         assert result.reason == FailoverReason.context_overflow
 
 
+class TestServerInjectedParameterRejection:
+    """A 400 blaming a parameter the client never sent is a server-side flake.
+
+    The Codex backend (chatgpt.com/backend-api/codex) intermittently adds
+    ``prompt_cache_retention`` to its own upstream call and then rejects it,
+    so an identical request succeeds on retry ~80% of the time.  Hermes never
+    sends that field on this route, so the 400 is not a deterministic
+    request-shape error and must stay retryable instead of aborting the turn.
+    """
+
+    RETENTION_BODY = {
+        "message": "prompt_cache_retention is not supported on this model",
+        "type": "invalid_request_error",
+        "param": "prompt_cache_retention",
+        "code": "invalid_parameter",
+    }
+
+    def test_codex_retention_400_is_retryable_server_error(self):
+        e = MockAPIError(
+            "Error code: 400 - {'error': {'message': 'prompt_cache_retention "
+            "is not supported on this model', 'type': 'invalid_request_error', "
+            "'param': 'prompt_cache_retention', 'code': 'invalid_parameter'}}",
+            status_code=400,
+            body=dict(self.RETENTION_BODY),
+        )
+        result = classify_api_error(
+            e,
+            provider="openai-codex",
+            model="gpt-5.6-sol",
+            approx_tokens=546912,
+            context_length=272000,
+            num_messages=576,
+        )
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+        # Retrying the identical request is the recovery — do NOT enter the
+        # compression loop (the context was never the problem).
+        assert result.should_compress is False
+
+    def test_codex_retention_400_nested_error_body_is_retryable(self):
+        """The same rejection arrives wrapped in an ``error`` envelope too."""
+        e = MockAPIError(
+            "prompt_cache_retention is not supported on this model",
+            status_code=400,
+            body={"error": dict(self.RETENTION_BODY)},
+        )
+        result = classify_api_error(
+            e, provider="openai-codex", model="gpt-5.6-sol",
+        )
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+
+    def test_codex_gateway_terse_retention_400_is_retryable(self):
+        """The Codex gateway's own validator uses a bare ``detail`` body."""
+        e = MockAPIError(
+            "Unsupported parameter: prompt_cache_retention",
+            status_code=400,
+            body={"detail": "Unsupported parameter: prompt_cache_retention"},
+        )
+        result = classify_api_error(
+            e, provider="openai-codex", model="gpt-5.6-sol",
+        )
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+
+    def test_small_session_retention_400_is_still_retryable(self):
+        """Must not depend on the context-size heuristic — a tiny request
+        gets the identical spontaneous rejection (reproduced live)."""
+        e = MockAPIError(
+            "prompt_cache_retention is not supported on this model",
+            status_code=400,
+            body=dict(self.RETENTION_BODY),
+        )
+        result = classify_api_error(
+            e,
+            provider="openai-codex",
+            model="gpt-5.6-sol",
+            approx_tokens=50,
+            num_messages=1,
+        )
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+
+    def test_other_unsupported_parameter_400_stays_non_retryable(self):
+        """Boundary: a genuine client-sent bad parameter is deterministic and
+        must keep failing fast as a format_error (the existing behaviour)."""
+        e = MockAPIError(
+            "Unsupported parameter: 'max_tokens' is not supported with this "
+            "model. Use 'max_completion_tokens' instead.",
+            status_code=400,
+            body={
+                "message": "Unsupported parameter: 'max_tokens' is not supported.",
+                "type": "invalid_request_error",
+                "param": "max_tokens",
+                "code": "unsupported_parameter",
+            },
+        )
+        result = classify_api_error(
+            e, provider="openai-codex", model="gpt-5.6-sol",
+        )
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+
+    def test_retention_rejection_from_meta_host_stays_non_retryable(self):
+        """Boundary: on api.meta.ai / Bedrock Mantle Hermes DOES send
+        ``prompt_cache_retention`` deliberately, so a rejection there is a
+        real client-side request error and must not be retried blindly."""
+        e = MockAPIError(
+            "prompt_cache_retention is not supported on this model",
+            status_code=400,
+            body=dict(self.RETENTION_BODY),
+        )
+        result = classify_api_error(
+            e, provider="meta-ai", model="muse-spark-1.2",
+        )
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+
+    @pytest.mark.parametrize("status_code", [500, 502])
+    def test_retention_rejection_via_5xx_proxy_is_retryable(self, status_code):
+        """Sibling path: a proxy in front of the route can surface the same
+        injected-parameter rejection as 5xx, where the request-validation
+        guard would also wrongly fail it fast as a format_error."""
+        e = MockAPIError(
+            "Unsupported parameter: prompt_cache_retention",
+            status_code=status_code,
+            body={"error": dict(self.RETENTION_BODY)},
+        )
+        result = classify_api_error(
+            e, provider="openai-codex", model="gpt-5.6-sol",
+        )
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+
+    @pytest.mark.parametrize("status_code", [500, 502])
+    def test_other_bad_parameter_via_5xx_stays_non_retryable(self, status_code):
+        """Boundary for the sibling path: the codex.nekos.me 502-on-bad-param
+        behaviour must keep failing fast (regression guard for that fix)."""
+        e = MockAPIError(
+            "Unknown parameter: 'frequency_penalty'",
+            status_code=status_code,
+            body={"error": {"message": "Unknown parameter: 'frequency_penalty'",
+                            "code": "unknown_parameter"}},
+        )
+        result = classify_api_error(e, provider="custom", model="m")
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+
+


### PR DESCRIPTION
## What does this PR do?

Stops a turn being aborted when the provider rejects a request parameter that Hermes never sent.

The Codex OAuth backend (`chatgpt.com/backend-api/codex`) intermittently injects `prompt_cache_retention` into its own upstream call and then rejects it with HTTP 400 `invalid_parameter`. Hermes only sets that field for `api.meta.ai` and `bedrock-mantle.*.api.aws` hosts (`agent/transports/codex.py::_default_prompt_cache_retention_for_request`) — never for the Codex route. The failing request body confirms it: no `prompt_cache_retention` key present.

`_classify_400` fell through to its catch-all and returned `format_error` / `retryable=False`, which trips the `is_client_error` abort gate in `agent/conversation_loop.py` (~line 6142) and kills the turn on the first attempt. `format_error` is right for a *deterministic* bad parameter, but this rejection is random: a byte-identical retry succeeds ~80% of the time. The cost of getting it wrong is high because the discarded requests are large-context ones.

This classifies the case as a retryable `server_error` so the existing retry loop absorbs it, and keeps genuine client-side bad-parameter 400s failing fast exactly as before.

Deliberately narrow, to avoid turning a useful fast-fail into a retry flood:

- keyed on a small map of parameters Hermes only sends on *specific* routes (`_SERVER_INJECTED_PARAM_SENDERS`);
- requires the message to actually be a rejection of that parameter, not an incidental mention;
- skipped when the current provider is one that legitimately sends the field, so a real request error there still fails fast;
- `should_compress=False` — the request shape was never the problem, so this must not enter the compression loop.

## Related Issue

Fixes #90257

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py`
  - added `_SERVER_INJECTED_PARAM_SENDERS` + `_is_server_injected_param_rejection()` helper
  - `_classify_400`: new branch **before** the request-validation branch returning retryable `server_error`
  - `_classify_by_status` (500/502 branch): guard added so a proxy surfacing the same injected-parameter rejection as 5xx keeps the generic retryable-5xx handling, instead of being fast-failed as `format_error`
- `tests/agent/test_error_classifier.py`
  - added `TestServerInjectedParameterRejection` (10 tests, incl. 4 boundary/regression guards)

## How to Test

Reproduction (what made this diagnosable) — a minimal request to the Codex endpoint carrying **no cache parameters at all**:

```python
body = {"model": "gpt-5.6-sol", "instructions": "t",
        "input": [{"role": "user", "content": "OK"}],
        "store": False, "stream": True}
```

n=20 sequential: **4 failed (20%)** with `prompt_cache_retention is not supported on this model`. n=12 concurrent: 0 failed. Random, and on a request that cannot contain the parameter.

Verifying the fix:

1. `pytest tests/agent/test_error_classifier.py -q` → 107 passed
2. Red-green verified: with the new branch disabled (`if False and _is_...`), the 4 positive tests fail with `format_error != server_error`; re-enabled, all 10 pass. The 4 boundary tests pass either way, so they can't mask a regression.
3. Abort-gate check — replicating the `is_client_error` expression from `conversation_loop.py` against the real classification yields `False`, i.e. the loop retries rather than aborting.
4. Live end-to-end against the real Codex API: injected the exact `BadRequestError` on attempt 1, let the real retry policy handle it, recovered on attempt 2, model returned the expected `RETRY_OK`.

Boundary cases held (all asserted in tests):

| Case | Verdict |
|---|---|
| Codex retention 400 (envelope + bare `detail` body) | `server_error`, retryable |
| Same on a small 1-message request | `server_error`, retryable |
| Same surfaced as 500/502 by a proxy | `server_error`, retryable |
| Retention 400 from `meta-ai` / `bedrock-mantle` (we do send it there) | `format_error`, fast-fail |
| `max_tokens` unsupported-parameter 400 | `format_error`, fast-fail |
| `unknown_parameter` 502 (the codex.nekos.me case) | `format_error`, fast-fail |
| Genuine context-overflow 400 | `context_overflow`, compress |

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(classifier): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (2 files)
- [x] I've run the test suite and all tests pass — see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.11.15

Test note: verified in a clean worktree checked out from `origin/main` (`9162ea6db`) with the change cherry-picked, so no local config or plugins are in play.

- `tests/agent/test_error_classifier.py` → **107 passed**
- Full `tests/agent/ tests/run_agent/` → **231 failed, 6296 passed, 31 skipped**

Those 231 failures are pre-existing on `main` and unrelated to this change. I ran the identical suite against a pristine `origin/main` worktree with the change absent and diffed the failure sets:

```
baseline (pristine origin/main) failures : 231
with my change                  failures : 231
NEW failures introduced by my change     : 0
failures my change FIXED                 : 0
-> identical failure sets
```

The delta is exactly `+10 passed`, which is the 10 tests added here. The pre-existing failures cluster in `test_models_dev.py` (41), `test_codex_app_server_integration.py` (17), `test_title_generator.py` (15) and ~40 other files, and appear environmental (mock-call assertions in a sandbox without provider credentials) — happy to share the log if useful.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal classification behaviour; the reasoning is captured in code comments at both branch sites)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] I've considered cross-platform impact — N/A (pure string/dict logic, no platform-specific behaviour)
- [x] I've updated tool descriptions/schemas — N/A (no tool behaviour change)

## Screenshots / Logs

Before (turn dies on first attempt):

```
WARNING agent.conversation_loop: API call failed (attempt 1/3) error_type=BadRequestError
  provider=openai-codex base_url=https://chatgpt.com/backend-api/codex model=gpt-5.6-sol
  summary=HTTP 400: prompt_cache_retention is not supported on this model
ERROR   agent.conversation_loop: Non-retryable client error: Error code: 400 - {'error':
  {'message': 'prompt_cache_retention is not supported on this model', 'type':
  'invalid_request_error', 'param': 'prompt_cache_retention', 'code': 'invalid_parameter'}}
```

Two sessions hit this 25 seconds apart, each carrying ~410-550k tokens of context — a full large-context input discarded per abort, for a fault that clears on retry.

After (same error injected, retry loop recovers):

```
[1] classification: server_error retryable=True OK
[2] abort gate: not triggered -> loop retries OK
    attempt 1: InjectedBadRequest -> server_error retryable=True
[3] recovered on attempt 2; live model said: 'RETRY_OK'
```
