### PR TITLE
feat(kanban): require completion metadata by task

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -75,6 +75,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "completed_at": t.completed_at,
         "result": t.result,
         "skills": list(t.skills) if t.skills else [],
+        "required_completion_metadata": list(t.required_completion_metadata or []),
         "max_retries": t.max_retries,
         "model_override": t.model_override,
         "provider_override": t.provider_override,
@@ -361,6 +362,14 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "(repeatable). The kanban lifecycle is already "
                                "injected automatically. Example: "
                                "--skill translation --skill github-code-review")
+    p_create.add_argument(
+        "--require-completion-metadata",
+        action="append",
+        default=[],
+        metavar="KEY",
+        help="Require a top-level metadata key on completion (repeatable). "
+             "The key may have a null value but must be present.",
+    )
     p_create.add_argument("--max-retries", type=int, default=None,
                           metavar="N",
                           help="Per-task override for the consecutive-failure "
@@ -1580,6 +1589,9 @@ def _cmd_create(args: argparse.Namespace) -> int:
             idempotency_key=getattr(args, "idempotency_key", None),
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
+            required_completion_metadata=(
+                getattr(args, "require_completion_metadata", None) or None
+            ),
             max_retries=max_retries,
             model_override=getattr(args, "model_override", None),
             provider_override=getattr(args, "provider_override", None),
@@ -2292,13 +2304,19 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                 failed.append(tid)
                 continue
 
-            if not kb.complete_task(
-                conn, tid,
-                result=args.result,
-                summary=summary,
-                metadata=metadata,
-                expected_run_id=_worker_run_id_for(tid),
-            ):
+            try:
+                completed = kb.complete_task(
+                    conn, tid,
+                    result=args.result,
+                    summary=summary,
+                    metadata=metadata,
+                    expected_run_id=_worker_run_id_for(tid),
+                )
+            except kb.MissingCompletionMetadataError as exc:
+                failed.append(tid)
+                print(f"kanban: {exc}", file=sys.stderr)
+                continue
+            if not completed:
                 failed.append(tid)
                 print(f"cannot complete {tid} (unknown id or terminal state)", file=sys.stderr)
             else:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1093,6 +1093,10 @@ class Task:
     # --skills). Stored as a JSON array of skill names. None = use only
     # the defaults; empty list = explicitly no extra skills.
     skills: Optional[list] = None
+    # Top-level keys that must be present in completion metadata. Values may
+    # be null so workers can explicitly report that an optional finding did
+    # not occur. None keeps the legacy unrestricted completion behavior.
+    required_completion_metadata: Optional[list] = None
     model_override: Optional[str] = None
     # Provider that ``model_override`` belongs to. When set, the dispatcher
     # passes ``--provider <name>`` alongside ``-m <model>`` so the worker
@@ -1154,6 +1158,14 @@ class Task:
                     skills_value = [str(s) for s in parsed if s]
             except Exception:
                 skills_value = None
+        required_completion_metadata: Optional[list] = None
+        if "required_completion_metadata" in keys and row["required_completion_metadata"]:
+            try:
+                parsed = json.loads(row["required_completion_metadata"])
+                if isinstance(parsed, list):
+                    required_completion_metadata = [str(key) for key in parsed if key]
+            except Exception:
+                required_completion_metadata = None
         return cls(
             id=row["id"],
             title=row["title"],
@@ -1204,6 +1216,7 @@ class Task:
                 row["current_step_key"] if "current_step_key" in keys else None
             ),
             skills=skills_value,
+            required_completion_metadata=required_completion_metadata,
             model_override=row["model_override"] if "model_override" in keys and row["model_override"] else None,
             provider_override=(
                 row["provider_override"]
@@ -1374,6 +1387,9 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- Force-loaded skills for the worker on this task, stored as JSON.
     -- Passed to the worker via `--skills`. NULL or empty array = no extras.
     skills               TEXT,
+    -- Optional JSON array of top-level keys that must be present in the
+    -- completing run's metadata. NULL = unrestricted legacy behavior.
+    required_completion_metadata TEXT,
     -- Per-task model override. When set, the dispatcher passes -m <model>
     -- to the worker, overriding the profile's default model. NULL = use
     -- the profile default.
@@ -2615,6 +2631,14 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # worker via --skills. NULL is fine for existing rows.
         _add_column_if_missing(conn, "tasks", "skills", "skills TEXT")
 
+    if "required_completion_metadata" not in cols:
+        _add_column_if_missing(
+            conn,
+            "tasks",
+            "required_completion_metadata",
+            "required_completion_metadata TEXT",
+        )
+
     if "max_retries" not in cols:
         # Per-task override for the consecutive-failure circuit breaker.
         # NULL = fall through to the dispatcher-level ``kanban.failure_limit``
@@ -3172,6 +3196,7 @@ def create_task(
     idempotency_key: Optional[str] = None,
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
+    required_completion_metadata: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
     model_override: Optional[str] = None,
     provider_override: Optional[str] = None,
@@ -3206,6 +3231,10 @@ def create_task(
     each name to ``hermes --skills ...``. Use this to pin a task to a
     specialist skill (e.g. ``skills=["translation"]`` so the worker loads the
     translation skill regardless of the profile's default config).
+
+    ``required_completion_metadata`` is an optional list of top-level keys
+    that must be present in the completing run's metadata. A key with a null
+    value counts as present, which supports explicit "none found" handoffs.
 
     ``model_override`` / ``provider_override`` pin the worker to a specific
     model (and optionally its provider) without touching the profile's
@@ -3393,6 +3422,26 @@ def create_task(
             )
         skills_list = cleaned
 
+    required_metadata_list: Optional[list[str]] = None
+    if required_completion_metadata is not None:
+        if isinstance(required_completion_metadata, (str, bytes)):
+            raise ValueError(
+                "required_completion_metadata must contain non-empty strings"
+            )
+        cleaned_keys: list[str] = []
+        seen_keys: set[str] = set()
+        for raw_key in required_completion_metadata:
+            if not isinstance(raw_key, str) or not raw_key.strip():
+                raise ValueError(
+                    "required_completion_metadata must contain non-empty strings"
+                )
+            key = raw_key.strip()
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            cleaned_keys.append(key)
+        required_metadata_list = cleaned_keys or None
+
     # Idempotency check — return the existing task instead of creating a
     # duplicate. Done BEFORE entering write_txn to keep the fast path fast
     # and to avoid holding a write lock during the lookup. Race is
@@ -3495,10 +3544,11 @@ def create_task(
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
-                        skills, max_retries, model_override, provider_override,
+                        skills, required_completion_metadata,
+                        max_retries, model_override, provider_override,
                         reasoning_effort,
                         goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3517,6 +3567,7 @@ def create_task(
                         idempotency_key,
                         int(max_runtime_seconds) if max_runtime_seconds is not None else None,
                         json.dumps(skills_list) if skills_list is not None else None,
+                        json.dumps(required_metadata_list) if required_metadata_list else None,
                         int(max_retries) if max_retries is not None else None,
                         model_override,
                         provider_override,
@@ -3549,6 +3600,7 @@ def create_task(
                         "branch_name": branch_name,
                         "project_id": project_id,
                         "skills": list(skills_list) if skills_list else None,
+                        "required_completion_metadata": required_metadata_list,
                         "goal_mode": bool(goal_mode) or None,
                         "model_override": model_override,
                         "provider_override": provider_override,
@@ -5345,6 +5397,17 @@ class HallucinatedCardsError(ValueError):
         )
 
 
+class MissingCompletionMetadataError(ValueError):
+    """Raised when an opt-in task completion omits required metadata keys."""
+
+    def __init__(self, missing: list[str]):
+        self.missing = list(missing)
+        super().__init__(
+            "completion blocked: missing required metadata key(s): "
+            + ", ".join(self.missing)
+        )
+
+
 class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
@@ -5376,6 +5439,8 @@ def complete_task(
     callers do not have to pass both. ``metadata`` is a free-form dict
     (e.g. ``{"changed_files": [...], "tests_run": [...]}``) — workers
     are encouraged to use it for structured handoff facts.
+    Tasks created with ``required_completion_metadata`` reject completion
+    before changing task state when any configured top-level key is absent.
 
     ``created_cards`` is an optional list of task ids the completing
     worker claims to have created. Each id is verified against
@@ -5397,6 +5462,25 @@ def complete_task(
     # final write transaction below to close the parent-reopen race.
     if not _parents_satisfied(conn, task_id):
         return False
+
+    task = get_task(conn, task_id)
+    if task is None or task.status not in {"running", "ready", "blocked", "review"}:
+        return False
+    if expected_run_id is not None and task.current_run_id != int(expected_run_id):
+        return False
+    required_metadata = task.required_completion_metadata if task else None
+    if required_metadata:
+        supplied = metadata if isinstance(metadata, dict) else {}
+        missing_metadata = [key for key in required_metadata if key not in supplied]
+        if missing_metadata:
+            with write_txn(conn):
+                _append_event(
+                    conn,
+                    task_id,
+                    "completion_blocked_missing_metadata",
+                    {"missing": missing_metadata},
+                )
+            raise MissingCompletionMetadataError(missing_metadata)
 
     # Gate: verify created_cards BEFORE the main write txn. A rejected
     # completion still needs an auditable event, so we emit it in a
@@ -11050,6 +11134,13 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     if task.tenant:
         lines.append(f"Tenant:   {task.tenant}")
     lines.append(f"Workspace: {task.workspace_kind} @ {task.workspace_path or '(unresolved)'}")
+    if task.required_completion_metadata:
+        keys = ", ".join(task.required_completion_metadata)
+        lines.append(f"Required completion metadata: {keys}")
+        lines.append(
+            "Completion is rejected unless each key is present in "
+            "kanban_complete(metadata=...). Use null when the explicit answer is none."
+        )
     if task.max_runtime_seconds is not None:
         terminal_timeout = _worker_terminal_timeout_env(
             task.max_runtime_seconds,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -897,12 +897,15 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
             s = payload.status
             ok = True
             if s == "done":
-                ok = kanban_db.complete_task(
-                    conn, task_id,
-                    result=payload.result,
-                    summary=payload.summary,
-                    metadata=payload.metadata,
-                )
+                try:
+                    ok = kanban_db.complete_task(
+                        conn, task_id,
+                        result=payload.result,
+                        summary=payload.summary,
+                        metadata=payload.metadata,
+                    )
+                except kanban_db.MissingCompletionMetadataError as e:
+                    raise HTTPException(status_code=409, detail=str(e))
             elif s == "blocked":
                 ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
             elif s == "scheduled":

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -57,6 +57,32 @@ def test_kanban_list_json_includes_session_id(kanban_home):
     )
 
 
+def test_kanban_create_accepts_required_completion_metadata(kanban_home):
+    raw = kc.run_slash(
+        "create contract --require-completion-metadata lesson --json"
+    )
+    payload = json.loads(raw)
+
+    assert payload["required_completion_metadata"] == ["lesson"]
+
+
+def test_kanban_complete_reports_missing_required_metadata(kanban_home):
+    created = json.loads(kc.run_slash(
+        "create contract --require-completion-metadata lesson --json"
+    ))
+
+    output = kc.run_slash(
+        f"complete {created['id']} --summary done --metadata '{{}}'"
+    )
+    assert "missing required metadata key(s): lesson" in output
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, created["id"])
+        assert task is not None
+        assert task.status == "ready"
+        assert task.completed_at is None
+
+
 def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):
     with kb.connect_closing() as conn:
         parent_id = kb.create_task(conn, title="parent task")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -153,11 +153,16 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
                 "SELECT name FROM sqlite_master WHERE type = 'index'"
             )
         }
+        legacy = kb.get_task(migrated, "legacy")
+        assert legacy is not None
+        assert legacy.required_completion_metadata is None
+        assert kb.complete_task(migrated, "legacy", metadata=None) is True
 
     # Additive columns added by migration:
     assert "session_id" in task_columns
     assert "tenant" in task_columns
     assert "idempotency_key" in task_columns
+    assert "required_completion_metadata" in task_columns
     assert "run_id" in event_columns
     # And their indexes — the regression scope of this test:
     assert "idx_tasks_session_id" in indexes
@@ -1614,3 +1619,51 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+def test_required_completion_metadata_blocks_missing_key_and_accepts_null(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="emit reusable lesson",
+            required_completion_metadata=["reusable_lesson_proposal"],
+        )
+
+        with pytest.raises(kb.MissingCompletionMetadataError) as exc_info:
+            kb.complete_task(conn, task_id, summary="done", metadata={})
+
+        assert exc_info.value.missing == ["reusable_lesson_proposal"]
+        assert kb.get_task(conn, task_id).status == "ready"
+        context = kb.build_worker_context(conn, task_id)
+        assert "Required completion metadata: reusable_lesson_proposal" in context
+        assert "Use null when the explicit answer is none" in context
+
+        assert kb.complete_task(
+            conn,
+            task_id,
+            summary="done",
+            metadata={"reusable_lesson_proposal": None},
+        ) is True
+        assert kb.get_task(conn, task_id).status == "done"
+
+        blocked_before = len([
+            event for event in kb.list_events(conn, task_id)
+            if event.kind == "completion_blocked_missing_metadata"
+        ])
+        assert kb.complete_task(conn, task_id, metadata={}) is False
+        blocked_after = len([
+            event for event in kb.list_events(conn, task_id)
+            if event.kind == "completion_blocked_missing_metadata"
+        ])
+        assert blocked_after == blocked_before
+
+
+@pytest.mark.parametrize("keys", [[""], [None], "lesson"])
+def test_required_completion_metadata_rejects_invalid_keys(kanban_home, keys):
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="non-empty strings"):
+            kb.create_task(
+                conn,
+                title="invalid contract",
+                required_completion_metadata=keys,
+            )

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -81,6 +81,39 @@ def test_board_empty(client):
     assert data["latest_event_id"] == 0
 
 
+def test_completion_contract_errors_are_client_facing(client):
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="contract",
+            required_completion_metadata=["lesson"],
+        )
+
+    single = client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}",
+        json={"status": "done", "metadata": {}},
+    )
+    assert single.status_code == 409
+    assert "missing required metadata key(s): lesson" in single.json()["detail"]
+
+    bulk = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={"ids": [task_id], "status": "done", "metadata": {}},
+    )
+    assert bulk.status_code == 200
+    assert bulk.json()["results"] == [{
+        "id": task_id,
+        "ok": False,
+        "error": "completion blocked: missing required metadata key(s): lesson",
+    }]
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "ready"
+        assert task.completed_at is None
+
+
 # ---------------------------------------------------------------------------
 # POST /tasks then GET /board sees it
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -132,6 +132,21 @@ def test_complete_happy_path(worker_env):
         conn.close()
 
 
+def test_create_accepts_required_completion_metadata(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    out = json.loads(kt._handle_create({
+        "title": "contract child",
+        "assignee": "test-worker",
+        "required_completion_metadata": ["lesson"],
+    }))
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, out["task_id"])
+    assert task.required_completion_metadata == ["lesson"]
+
+
 def test_complete_retry_with_empty_created_cards_succeeds(worker_env):
     """After a phantom rejection, retrying kanban_complete with
     created_cards=[] (the documented escape hatch) must complete the

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1405,6 +1405,15 @@ def _handle_create(args: dict, **kw) -> str:
         return tool_error(
             f"skills must be a list of skill names, got {type(skills).__name__}"
         )
+    required_completion_metadata = args.get("required_completion_metadata")
+    if isinstance(required_completion_metadata, str):
+        required_completion_metadata = [required_completion_metadata]
+    if required_completion_metadata is not None and not isinstance(
+        required_completion_metadata, (list, tuple)
+    ):
+        return tool_error(
+            "required_completion_metadata must be a list of top-level metadata keys"
+        )
     goal_mode, goal_bool_error = _parse_bool_arg(args, "goal_mode")
     if goal_bool_error:
         return tool_error(goal_bool_error)
@@ -1452,6 +1461,7 @@ def _handle_create(args: dict, **kw) -> str:
                     if max_runtime_seconds is not None else None
                 ),
                 skills=skills,
+                required_completion_metadata=required_completion_metadata,
                 model_override=model_override,
                 provider_override=provider_override,
                 goal_mode=goal_mode,
@@ -2258,6 +2268,15 @@ KANBAN_CREATE_SCHEMA = {
                     "task, ['github-code-review'] for a reviewer task. "
                     "The names must match skills installed on the "
                     "assignee's profile."
+                ),
+            },
+            "required_completion_metadata": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Top-level keys that must be present in the worker's "
+                    "kanban_complete metadata. Values may be null, but omitted "
+                    "keys reject completion without changing task state."
                 ),
             },
             "goal_mode": {


### PR DESCRIPTION
## Summary

- Add an opt-in `required_completion_metadata` contract to Kanban tasks.
- Expose the contract through `hermes kanban create` and `kanban_create`.
- Show required keys in worker context and reject completion before task state changes when keys are missing.
- Treat a present key with a `null` value as an explicit answer.
- Return actionable CLI, tool, dashboard, and bulk dashboard errors.
- Preserve unrestricted behavior for existing tasks and tasks without the option.

## Why

Kanban workers can currently finish without structured handoff fields requested by an orchestrator. This adds a generic per-task presence check without hardcoding any field name or changing the default completion path.

## How to use

```bash
hermes kanban create "review artifact" \
  --require-completion-metadata reusable_lesson_proposal
```

The completing worker must include the top-level key in metadata. Either a proposal object or `null` satisfies the contract.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Related Issue

None.

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove the fix/feature works
- [ ] All new and existing tests pass locally

Relevant changed-file suite:

```text
112 passed, 1 skipped
```

Additional checks:

```text
uvx ruff check ...
All checks passed!

git diff --check
clean
```

A broader Kanban run produced 15 failures both on this branch and on a clean `origin/main` worktree under the same local plugin configuration. The branch added three passing cases and introduced no new broad-suite failure.

Manual isolated E2E:

```text
create_exit=0
missing_exit=1
missing_mentions_key=true
accepted_exit=0
final_status=done
```

## Security Checklist

- [x] No secrets, API keys, or credentials are included in this PR
- [x] User input is validated and sanitized where applicable
- [x] No unsafe shell commands or code execution patterns introduced
- [x] Dependencies are from trusted sources and pinned where appropriate
- [x] File operations use safe paths and permissions

## Quality Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] No new warnings introduced
- [ ] Documentation updated if needed
- [x] Backward compatibility maintained (or breaking changes documented)

## Additional Notes

The SQLite migration is additive. Existing rows receive `NULL` and retain legacy unrestricted completion behavior. An independent pre-commit review found no security concerns or logic errors.
