### PR TITLE
feat(gateway): add per-route context hints to profile_routes

### DIFF
--- a/docs/profile-routing.md
+++ b/docs/profile-routing.md
@@ -65,6 +65,7 @@ profile_routes:
 | `chat_id` | no | Channel/group/DM id. |
 | `thread_id` | no | Thread id within a channel. |
 | `enabled` | no | Default `true`; set `false` to disable a route without removing it. |
+| `hint` | no | Optional behavior/skill-selection tag injected into the user message text as `[route: <hint>]`. See [Per-route context hints](#per-route-context-hints) below. |
 
 ## Matching rules
 
@@ -115,3 +116,65 @@ activates the per-profile runtime scope (per-profile `HERMES_HOME`, secret scope
 profile-namespaced session keys); routing is the decision layer that picks *which*
 profile a given guild/channel/thread lands in. With multiplexing off, `profile_routes`
 is ignored entirely — behavior is byte-identical to a single-profile gateway.
+
+## Per-route context hints
+
+When multiple chats or topics are routed to the **same** profile, all of them
+receive the same system-prompt context. An optional `hint` field lets you tag
+each route with a lightweight behavior selector that the profile's `AGENTS.md`
+can match on, without creating a separate profile per topic.
+
+```yaml
+profile_routes:
+  - name: calendar-group
+    platform: whatsapp
+    chat_id: "120363xxx@g.us"
+    profile: my-profile
+    hint: calendar
+
+  - name: travel-topic
+    platform: telegram
+    chat_id: "-1001234567890"
+    thread_id: "42"
+    profile: my-profile
+    hint: travel
+```
+
+When a route with a `hint` matches, the hint is injected at the top of the
+user message text:
+
+```
+[route: calendar]
+
+[User] what's on the calendar tomorrow?
+```
+
+The profile's `AGENTS.md` can then apply conditional behavior:
+
+```markdown
+## Route Context
+Messages may arrive tagged with `[route: <hint>]`. Apply route-specific behavior:
+
+### [route: calendar]
+Use the calendar skill for lookups in this route.
+
+### [route: travel]
+Prioritize flight-search skill for flight options.
+```
+
+### Hint validation
+
+Hint values are validated at config parse time:
+- Must be a string
+- Max 64 characters
+- Only alphanumeric characters, hyphens, and underscores (`[a-zA-Z0-9_-]`)
+- Invalid hints cause the route to be skipped (with a warning log)
+
+### Security note
+
+**Route hints are not a security boundary.** The `[route: <hint>]` tag is
+prepended to the user message text, which end users could theoretically forge
+by typing it in chat. The gateway strips user-typed `[route: ...]` patterns
+before injecting the system tag, but this is defense-in-depth, not a guarantee.
+**Never use route hints for access control or authorization decisions** —
+permissions stay at the profile level (tool access, memory scope, credentials).

--- a/gateway/profile_routing.py
+++ b/gateway/profile_routing.py
@@ -39,6 +39,7 @@ Configuration (config.yaml):
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -62,6 +63,10 @@ class ProfileRoute:
     chat_id: Optional[str] = None
     thread_id: Optional[str] = None
     enabled: bool = True
+    # Optional behavior/skill-selection hint injected into the user message
+    # text as ``[route: <hint>]`` when this route matches. NOT a security
+    # boundary — permissions stay at the profile level. See ``_prepare_inbound_message_text``.
+    hint: Optional[str] = None
 
     @property
     def specificity(self) -> int:
@@ -138,6 +143,21 @@ def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRou
         except (ValueError, ImportError):
             logger.warning("Skipping profile route %s: invalid profile name %r", name, profile)
             continue
+        # Optional behavior hint — injected into message text as [route: <hint>].
+        # Validate to prevent tag-format breakage from newlines, closing
+        # brackets, or excessive length. NOT a security boundary.
+        hint = entry.get("hint")
+        if hint is not None:
+            if not isinstance(hint, str):
+                logger.warning("Skipping profile route %s: hint must be a string, got %r", name, type(hint).__name__)
+                continue
+            hint = hint.strip()
+            if len(hint) > 64:
+                logger.warning("Skipping profile route %s: hint too long (max 64 chars)", name)
+                continue
+            if not re.match(r'^[a-zA-Z0-9_-]+$', hint):
+                logger.warning("Skipping profile route %s: hint %r contains invalid characters (allowed: alphanumeric, hyphen, underscore)", name, hint)
+                continue
         routes.append(
             ProfileRoute(
                 name=name,
@@ -147,6 +167,7 @@ def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRou
                 chat_id=entry.get("chat_id"),
                 thread_id=entry.get("thread_id"),
                 enabled=entry.get("enabled", True),
+                hint=hint,
             )
         )
     # Sort: most specific first so the first match wins.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2184,6 +2184,10 @@ def _platform_has_bot_credential(platform: "Platform", platform_config: "Platfor
 _DOCKER_VOLUME_SPEC_RE = re.compile(r"^(?P<host>.+):(?P<container>/[^:]+?)(?::(?P<options>[^:]+))?$")
 _DOCKER_MEDIA_OUTPUT_CONTAINER_PATHS = {"/output", "/outputs"}
 
+# Strip user-typed ``[route: ...]`` tags from inbound message text before
+# injecting the system route hint. Defense-in-depth, not a security boundary.
+_USER_ROUTE_TAG_RE = re.compile(r'^\s*\[route:[^\]]*\]\s*\n?')
+
 # This env var is internal bridge plumbing, not a user-facing configuration
 # source. Initialize it from the canonical config default after dotenv loading
 # so an ambient process/.env value can never control lease safety on its own.
@@ -17936,6 +17940,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if getattr(event, "channel_context", None):
             message_text = f"{event.channel_context}\n\n[New message]\n{message_text}"
 
+        # Inject per-route behavior hint as ``[route: <hint>]`` at the top of
+        # the message text. Strip any user-typed ``[route: ...]`` patterns
+        # first to prevent end users from forging route hints to trigger
+        # AGENTS.md conditional behavior intended for a different route context.
+        # NOT a security boundary — behavior/skill selection only.
+        _route_hint = getattr(source, "profile_route_hint", None)
+        if _route_hint:
+            message_text = _USER_ROUTE_TAG_RE.sub('', message_text)
+            message_text = f"[route: {_route_hint}]\n{message_text}"
+
         # Declare at outer scope so the audio-file-paths handling block below
         # remains safe when ``event.media_urls`` is empty (no inner block runs).
         audio_file_paths: list[str] = []
@@ -27702,6 +27716,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     matched.profile,
                 )
                 raise ProfileRouteRejected(matched.name)
+            # Store the per-route behavior hint on the source for
+            # ``_prepare_inbound_message_text`` to inject as ``[route: <hint>]``.
+            # NOT a security boundary — behavior/skill selection only.
+            if matched.hint:
+                source.profile_route_hint = matched.hint
             return matched.profile
         logger.debug(
             "No profile route matched: platform=%s chat_id=%s thread_id=%s parent_chat_id=%s",

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -185,6 +185,11 @@ class SessionSource:
     # Transport-local fail-closed signal for an explicit profile route whose
     # target is not served. Excluded from repr/equality and wire serialization.
     profile_route_rejected: bool = field(default=False, repr=False, compare=False)
+    # Transport-local per-route behavior hint (from ``ProfileRoute.hint``).
+    # Injected into the user message text as ``[route: <hint>]`` by
+    # ``_prepare_inbound_message_text``. NOT a security boundary — behavior
+    # and skill selection only. Excluded from repr/equality and wire serialization.
+    profile_route_hint: Optional[str] = field(default=None, repr=False, compare=False)
 
     # Discord auto-thread metadata.  Newly auto-created Discord threads start
     # with a fast placeholder title from the raw message, then the gateway can

--- a/tests/gateway/test_profile_route_hints.py
+++ b/tests/gateway/test_profile_route_hints.py
@@ -1,0 +1,212 @@
+"""Tests for per-route context hints (ProfileRoute.hint / SessionSource.profile_route_hint)."""
+
+import asyncio
+
+from gateway.profile_routing import (
+    ProfileRoute,
+    parse_profile_routes,
+    match_profile_route,
+)
+
+
+class TestProfileRouteHintField:
+    """U-1: ProfileRoute.hint field and parser."""
+
+    def test_hint_defaults_to_none(self):
+        route = ProfileRoute(name="test", platform="telegram", profile="p")
+        assert route.hint is None
+
+    def test_hint_set_from_config(self):
+        routes = parse_profile_routes([
+            {"name": "cal", "platform": "whatsapp", "chat_id": "123@g.us", "profile": "p", "hint": "calendar"},
+        ])
+        assert len(routes) == 1
+        assert routes[0].hint == "calendar"
+
+    def test_hint_absent_defaults_to_none(self):
+        routes = parse_profile_routes([
+            {"name": "no-hint", "platform": "whatsapp", "chat_id": "123@g.us", "profile": "p"},
+        ])
+        assert len(routes) == 1
+        assert routes[0].hint is None
+
+    def test_hint_strips_whitespace(self):
+        routes = parse_profile_routes([
+            {"name": "cal", "platform": "whatsapp", "chat_id": "123@g.us", "profile": "p", "hint": "  calendar  "},
+        ])
+        assert routes[0].hint == "calendar"
+
+    def test_hint_rejects_newlines(self):
+        routes = parse_profile_routes([
+            {"name": "bad", "platform": "whatsapp", "chat_id": "123@g.us", "profile": "p", "hint": "cal\nendar"},
+        ])
+        assert len(routes) == 0
+
+    def test_hint_rejects_closing_bracket(self):
+        routes = parse_profile_routes([
+            {"name": "bad", "platform": "whatsapp", "chat_id": "123@g.us", "profile": "p", "hint": "cal]endar"},
+        ])
+        assert len(routes) == 0
+
+    def test_hint_rejects_too_long(self):
+        routes = parse_profile_routes([
+            {"name": "bad", "platform": "whatsapp", "chat_id": "123@g.us", "profile": "p", "hint": "a" * 65},
+        ])
+        assert len(routes) == 0
+
+    def test_hint_rejects_non_string(self):
+        routes = parse_profile_routes([
+            {"name": "bad", "platform": "whatsapp", "chat_id": "123@g.us", "profile": "p", "hint": 123},
+        ])
+        assert len(routes) == 0
+
+    def test_hint_allows_hyphens_and_underscores(self):
+        routes = parse_profile_routes([
+            {"name": "ok", "platform": "whatsapp", "chat_id": "123@g.us", "profile": "p", "hint": "family-calendar_v2"},
+        ])
+        assert routes[0].hint == "family-calendar_v2"
+
+    def test_hint_at_max_length(self):
+        routes = parse_profile_routes([
+            {"name": "ok", "platform": "whatsapp", "chat_id": "123@g.us", "profile": "p", "hint": "a" * 64},
+        ])
+        assert routes[0].hint == "a" * 64
+
+
+class TestRouteMatchingWithHint:
+    """Route matching still works correctly with hints configured."""
+
+    def test_match_returns_route_with_hint(self):
+        routes = parse_profile_routes([
+            {"name": "cal", "platform": "whatsapp", "chat_id": "123@g.us", "profile": "p", "hint": "calendar"},
+        ])
+        matched = match_profile_route(routes, platform="whatsapp", chat_id="123@g.us")
+        assert matched is not None
+        assert matched.hint == "calendar"
+
+    def test_match_returns_route_without_hint(self):
+        routes = parse_profile_routes([
+            {"name": "no-hint", "platform": "whatsapp", "chat_id": "123@g.us", "profile": "p"},
+        ])
+        matched = match_profile_route(routes, platform="whatsapp", chat_id="123@g.us")
+        assert matched is not None
+        assert matched.hint is None
+
+    def test_backward_compat_routes_without_hint_still_match(self):
+        routes = parse_profile_routes([
+            {"name": "r1", "platform": "telegram", "chat_id": "-100123", "profile": "p1"},
+            {"name": "r2", "platform": "telegram", "chat_id": "-100456", "profile": "p2", "hint": "topic2"},
+        ])
+        m1 = match_profile_route(routes, platform="telegram", chat_id="-100123")
+        m2 = match_profile_route(routes, platform="telegram", chat_id="-100456")
+        assert m1.profile == "p1" and m1.hint is None
+        assert m2.profile == "p2" and m2.hint == "topic2"
+
+
+class TestSessionSourceHintField:
+    """U-2: SessionSource.profile_route_hint field."""
+
+    def test_profile_route_hint_defaults_to_none(self):
+        from gateway.platforms.base import Platform
+        from gateway.session import SessionSource
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="123")
+        assert source.profile_route_hint is None
+
+    def test_profile_route_hint_settable(self):
+        from gateway.platforms.base import Platform
+        from gateway.session import SessionSource
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="123")
+        source.profile_route_hint = "calendar"
+        assert source.profile_route_hint == "calendar"
+
+    def test_profile_route_hint_excluded_from_repr(self):
+        from gateway.platforms.base import Platform
+        from gateway.session import SessionSource
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="123", profile_route_hint="secret")
+        assert "secret" not in repr(source)
+
+    def test_profile_route_hint_excluded_from_equality(self):
+        from gateway.platforms.base import Platform
+        from gateway.session import SessionSource
+        s1 = SessionSource(platform=Platform.TELEGRAM, chat_id="123")
+        s2 = SessionSource(platform=Platform.TELEGRAM, chat_id="123")
+        s1.profile_route_hint = "calendar"
+        s2.profile_route_hint = "travel"
+        assert s1 == s2
+
+
+class TestRouteHintInjection:
+    """U-3: _prepare_inbound_message_text injects and sanitizes route hints."""
+
+    def test_hint_prepended_when_set(self):
+        """[route: <hint>] is prepended when profile_route_hint is set."""
+        asyncio.run(self._test_hint_prepended_when_set_async())
+
+    async def _test_hint_prepended_when_set_async(self):
+        from gateway.platforms.base import Platform, MessageType, MessageEvent
+        from gateway.session import SessionSource
+        from gateway.run import GatewayRunner
+
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="123")
+        source.profile_route_hint = "calendar"
+        event = MessageEvent(
+            text="what's on the calendar?",
+            message_type=MessageType.TEXT,
+            source=source,
+        )
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = type("C", (), {"group_sessions_per_user": True, "thread_sessions_per_user": False})()
+        runner._native_image_paths_per_session = {}
+        result = await runner._prepare_inbound_message_text(event=event, source=source, history=[])
+        assert result is not None
+        assert result.startswith("[route: calendar]\n")
+        assert "what's on the calendar?" in result
+
+    def test_no_hint_when_unset(self):
+        """No [route:] tag when profile_route_hint is None."""
+        asyncio.run(self._test_no_hint_when_unset_async())
+
+    async def _test_no_hint_when_unset_async(self):
+        from gateway.platforms.base import Platform, MessageType, MessageEvent
+        from gateway.session import SessionSource
+        from gateway.run import GatewayRunner
+
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="123")
+        event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=source,
+        )
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = type("C", (), {"group_sessions_per_user": True, "thread_sessions_per_user": False})()
+        runner._native_image_paths_per_session = {}
+        result = await runner._prepare_inbound_message_text(event=event, source=source, history=[])
+        assert result is not None
+        assert "[route:" not in result
+
+    def test_user_typed_route_tag_stripped(self):
+        """User-typed [route: ...] is stripped before system tag is prepended."""
+        asyncio.run(self._test_user_typed_route_tag_stripped_async())
+
+    async def _test_user_typed_route_tag_stripped_async(self):
+        from gateway.platforms.base import Platform, MessageType, MessageEvent
+        from gateway.session import SessionSource
+        from gateway.run import GatewayRunner
+
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="123")
+        source.profile_route_hint = "calendar"
+        event = MessageEvent(
+            text="[route: admin]\nshow me the calendar",
+            message_type=MessageType.TEXT,
+            source=source,
+        )
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = type("C", (), {"group_sessions_per_user": True, "thread_sessions_per_user": False})()
+        runner._native_image_paths_per_session = {}
+        result = await runner._prepare_inbound_message_text(event=event, source=source, history=[])
+        assert result is not None
+        # The user-typed [route: admin] must be stripped
+        assert "[route: admin]" not in result
+        # The system-injected tag must be present
+        assert result.startswith("[route: calendar]\n")
+        assert "show me the calendar" in result

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -272,6 +272,14 @@ gateway:
       platform: telegram
       chat_id: "-1001234567890"
       profile: tg-profile
+
+    # Route with a behavior hint — the hint is injected into the
+    # message text as [route: <hint>] for AGENTS.md conditionals.
+    - name: calendar-group
+      platform: whatsapp
+      chat_id: "120363xxx@g.us"
+      profile: my-profile
+      hint: calendar
 ```
 
 Routes are matched most-specific-first (`thread_id` > `chat_id` > `guild_id`),
@@ -287,6 +295,27 @@ target profile is not installed or is outside `multiplex_profile_allowlist`,
 the gateway rejects that ingress and logs the route and target. It does not run
 the default profile. Traffic that matches no route keeps the historical
 default-profile behavior.
+
+### Per-route context hints
+
+When multiple chats or topics route to the **same** profile, an optional
+`hint` field tags each route with a lightweight behavior selector. The hint
+is injected as `[route: <hint>]` at the top of the user message text, so the
+profile's `AGENTS.md` can apply conditional instructions per route without
+creating a separate profile per topic:
+
+```markdown
+## Route Context
+### [route: calendar]
+Use the calendar skill for lookups in this route.
+
+### [route: travel]
+Prioritize flight-search skill for flight options.
+```
+
+Hint values must be alphanumeric with hyphens/underscores, max 64 chars.
+**Route hints are not a security boundary** — never use them for access
+control. Permissions stay at the profile level.
 
 ## Start, stop, or restart all gateways at once
 


### PR DESCRIPTION
## What does this PR do?

Adds an optional `hint` field to `profile_routes` entries. When a route matches, the hint is injected as `[route: <hint>]` at the top of the user message text, enabling per-route conditional instructions in profile `AGENTS.md` files without creating separate profiles per topic.

This solves the problem where multiple chats/topics routed to the same profile all receive identical context. With hints, a profile's `AGENTS.md` can apply route-specific behavior (e.g., "use calendar skill in the calendar group, use flight-search in the travel topic") while keeping one shared profile for identity, memory, and permissions.

## Related Issue

Fixes #90249

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/profile_routing.py`: Add `hint: Optional[str]` field to `ProfileRoute` dataclass; parse and validate in `parse_profile_routes` (alphanumeric/hyphens/underscores only, max 64 chars, reject non-strings)
- `gateway/session.py`: Add `profile_route_hint: Optional[str]` field to `SessionSource` (`repr=False, compare=False`, matching `profile_route_rejected` pattern)
- `gateway/run.py`: Store `matched.hint` on `source.profile_route_hint` in `_profile_name_for_source`; inject `[route: <hint>]` in `_prepare_inbound_message_text` with user-typed route tag sanitization
- `tests/gateway/test_profile_route_hints.py`: 20 tests covering parsing, validation, matching, SessionSource field, injection, and sanitization
- `docs/profile-routing.md`: New "Per-route context hints" section with config example, AGENTS.md usage pattern, validation rules, and security note
- `website/docs/user-guide/multi-profile-gateways.md`: Hint example and usage section

## How to Test

1. `pytest tests/gateway/test_profile_route_hints.py -v` — all 20 tests pass
2. `pytest tests/gateway/ -v` — no regressions in existing multiplex/routing tests
3. Configure a route with `hint: calendar`, send a message through that route, verify `[route: calendar]` appears at the top of the message text
4. Configure a route without `hint`, send a message, verify no tag appears (backward compat)
5. Type `[route: admin]` at the start of a user message, verify it is stripped before the system tag is prepended

## Design Notes

- **Opt-in**: Routes without a `hint` field behave exactly as before — zero behavior change for existing configs
- **Message-text injection, not system-prompt**: Preserves prompt caching (the system prompt is cached per-session; route-specific content would invalidate it)
- **Not a security boundary**: The hint is a behavior/skill-selection signal. Profile-level tool access, memory scope, and credential isolation remain enforced by the existing profile mechanism. User-typed `[route: ...]` patterns are stripped as defense-in-depth, but the docs explicitly warn never to use hints for access control.
- **Hint validation**: Alphanumeric + hyphens + underscores, max 64 chars, reject at config parse time with a warning log

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(gateway): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_profile_route_hints.py -v` and all tests pass
- [x] I've added tests for my changes (20 test scenarios)
- [x] I've tested on my platform: Linux (aarch64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`docs/profile-routing.md`, `website/docs/user-guide/multi-profile-gateways.md`)
- [x] N/A — `cli-config.yaml.example` does not contain a `profile_routes` section
- [x] N/A — no architecture or workflow changes
- [x] N/A — no tool behavior changes