### PR TITLE
fix(tui): estimate inline diff blocks at the indented code width

### DIFF
--- a/ui-tui/src/__tests__/virtualHeights.test.ts
+++ b/ui-tui/src/__tests__/virtualHeights.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
+import { TERMUX_TUI_MODE } from '../config/env.js'
+import { transcriptBodyWidth } from '../lib/inputMetrics.js'
 import { estimatedMsgHeight, messageHeightKey, wrappedLines } from '../lib/virtualHeights.js'
 import type { Msg } from '../types.js'
 
@@ -25,6 +27,28 @@ describe('virtual height estimates', () => {
 
     expect(estimatedMsgHeight(msg, 30, { compact: false, details: false, userPrompt: '❯' })).toBe(3)
     expect(estimatedMsgHeight(msg, 30, { compact: false, details: false, userPrompt: 'Ψ >' })).toBe(4)
+  })
+
+  it('estimates valid diff envelopes at the indented code width without prose gaps', () => {
+    const cols = 48
+    const bodyWidth = transcriptBodyWidth(cols, 'assistant', '', TERMUX_TUI_MODE)
+    const codeWidth = Math.max(1, bodyWidth - 2)
+    const body = [`+${'x'.repeat(codeWidth - 1)}`, '', `-${'y'.repeat(codeWidth)}`, '', ' context'].join('\n')
+    const msg: Msg = { kind: 'diff', role: 'assistant', text: `\`\`\`diff\n${body}\n\`\`\`` }
+
+    expect(body).toContain('\n\n')
+    expect(body.split('\n').some(line => line.length === codeWidth + 1)).toBe(true)
+    expect(estimatedMsgHeight(msg, cols, { compact: false, details: false })).toBe(wrappedLines(body, codeWidth) + 2)
+  })
+
+  it('keeps malformed historical diff content on the generic fallback path', () => {
+    const text = '```diff\nline one\n\nline two without a closing fence'
+    const malformed: Msg = { kind: 'diff', role: 'assistant', text }
+    const generic: Msg = { role: 'assistant', text }
+
+    expect(estimatedMsgHeight(malformed, 80, { compact: false, details: false })).toBe(
+      estimatedMsgHeight(generic, 80, { compact: false, details: false }) + 2
+    )
   })
 
   it('adds one row for a group-boundary lead gap', () => {

--- a/ui-tui/src/lib/virtualHeights.ts
+++ b/ui-tui/src/lib/virtualHeights.ts
@@ -41,6 +41,8 @@ export const messageHeightKey = (msg: Msg) => {
 // ceiling was 16 lines, then full text — this is the sane middle).
 const MAX_ESTIMATE_LINES = 800
 
+const DIFF_ENVELOPE_RE = /^```diff\n([\s\S]*?)\n```$/
+
 export const wrappedLines = (text: string, width: number, maxLines: number = MAX_ESTIMATE_LINES) => {
   const w = Math.max(1, width)
   // Worst case: every cell is its own row at width=1, plus a small
@@ -107,9 +109,11 @@ export const estimatedMsgHeight = (
 
   const bodyWidth = transcriptBodyWidth(cols, msg.role, userPrompt, TERMUX_TUI_MODE)
   const text = msg.text
-  let h = wrappedLines(text || ' ', bodyWidth)
+  const diffBody = msg.kind === 'diff' ? text.match(DIFF_ENVELOPE_RE)?.[1] : undefined
+  const isValidDiff = diffBody !== undefined
+  let h = wrappedLines(isValidDiff ? diffBody : text || ' ', isValidDiff ? Math.max(1, bodyWidth - 2) : bodyWidth)
 
-  if (!compact && msg.role === 'assistant') {
+  if (!compact && msg.role === 'assistant' && !isValidDiff) {
     // Paragraph gaps add up to 6 extra rows of breathing room. Slice
     // first so the regex never walks more than the first ~16k chars of
     // a giant assistant message — post-mount Yoga measurement converges


### PR DESCRIPTION
## What does this PR do?

Scrolling a long TUI transcript appears to jump over inline code-diff blocks. The cause is a height-estimation mismatch in the virtualized transcript: inline diff segments are stored as fenced Markdown (` ```diff … ``` `) and rendered with both fences stripped inside a 2-cell-indented code column, but the height estimator wrapped the raw fenced text at full prose width and applied generic assistant paragraph-gap accounting. Near-wrap diff blocks were therefore estimated too short, and the measured-height correction above the viewport shifted the scroll anchor — the visible "skip over the diff."

The fix special-cases valid diff envelopes in `estimatedMsgHeight`: estimate the patch body alone at the indented code width (`bodyWidth - 2`), skip prose paragraph-gap accounting, and keep the existing +2 diff margins. Malformed historical diff rows keep the generic fallback path. No renderer or scroll-engine changes.

## Related Issue

Reported interactively; no tracked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/lib/virtualHeights.ts` — valid ` ```diff … ``` ` envelopes estimate the patch body at `bodyWidth - 2` without prose paragraph gaps; malformed diff rows fall back to the generic path.
- `ui-tui/src/__tests__/virtualHeights.test.ts` — regression tests covering near-wrap diff lines plus embedded blank patch lines, and the malformed-fallback invariant.

## How to Test

1. `npm test --prefix ui-tui -- --run virtualHeights.test.ts virtualHistoryOffsetCache.test.ts virtualHistoryClamp.test.ts useVirtualHistoryHeights.test.ts` — 47 passed.
2. `npx eslint ui-tui/src/lib/virtualHeights.ts ui-tui/src/__tests__/virtualHeights.test.ts` — clean.
3. `npm run typecheck --prefix ui-tui` and `npm run build --prefix ui-tui` — clean; `git diff --check` — clean.
4. Manual: scroll a long transcript containing inline diffs; the viewport no longer jumps over diff blocks as they are measured.

## Checklist

### Code

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation updates — N/A (behavior-preserving estimator fix)
- [x] Cross-platform impact considered — N/A (width math only; shared with existing wrapped-line logic)

## Known limitation

Transcripts with ambient side rails / pet gutters derive a narrower `bodyCols` than the terminal `cols` used by the estimator and cache key. That affects all wrapped content, not just diffs, and is left as a separate follow-up.
