### PR TITLE
fix(desktop): expose group deletion from roster rows

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -9403,7 +9403,7 @@ function openGroupChat(group) {
  *  (markdown flattened), relative time of the last activity, and the
  *  needs-you badge on the row itself. Sorts into the same recency ordering
  *  as bot rows; clicking opens the room in the main chat window. */
-function GroupRow({ active, group, members, needsYou, onOpen }) {
+function GroupRow({ active, group, members, needsYou, onOpen, onDisband }) {
   const rooms = useValue($groupChats)
   const allMeta = useValue($botMeta)
   const room = rooms[group] || { log: [] }
@@ -9419,7 +9419,7 @@ function GroupRow({ active, group, members, needsYou, onOpen }) {
     : 'No messages yet — say hi to the room'
   const faces = members.slice(0, 3)
 
-  return jsxs('button', {
+  const row = jsxs('button', {
     type: 'button',
     onClick: () => {
       haptic('tap')
@@ -9508,6 +9508,26 @@ function GroupRow({ active, group, members, needsYou, onOpen }) {
       })
     ]
   })
+
+  return jsxs(ContextMenu, {
+    children: [
+      jsx(ContextMenuTrigger, { asChild: true, children: row }),
+      jsxs(ContextMenuContent, {
+        children: [
+          jsx(ContextMenuItem, {
+            onSelect: () => onOpen(group),
+            children: 'Open Group Chat'
+          }),
+          jsx(ContextMenuSeparator, {}),
+          jsx(ContextMenuItem, {
+            className: 'text-destructive focus:text-destructive',
+            onSelect: () => onDisband({ name: group, members }),
+            children: 'Delete Group'
+          })
+        ]
+      })
+    ]
+  })
 }
 
 function BotsPane() {
@@ -9519,6 +9539,7 @@ function BotsPane() {
   const [groupCreateOpen, setGroupCreateOpen] = useState(false)
   const [editing, setEditing] = useState(null)
   const [deleting, setDeleting] = useState(null)
+  const [deletingGroup, setDeletingGroup] = useState(null)
   const [grouping, setGrouping] = useState(null)
   const [query, setQuery] = useState('')
   const activityToasts = useValue($activityToasts)
@@ -9857,7 +9878,8 @@ function BotsPane() {
                               group: row.name,
                               members: row.members,
                               needsYou: Boolean(groupNeedsYou[row.name]),
-                              onOpen: openGroupChat
+                              onOpen: openGroupChat,
+                              onDisband: setDeletingGroup
                             },
                             `group:${row.name}`
                           )
@@ -9931,6 +9953,23 @@ function BotsPane() {
           await deleteBot(deleting)
           await refetch()
           host.notify({ kind: 'success', message: `Deleted profile ${name}` })
+        }
+      }),
+      jsx(ConfirmDialog, {
+        open: Boolean(deletingGroup),
+        title: 'Delete group chat?',
+        description: deletingGroup
+          ? `This removes “${deletingGroup.name}” from its bots and clears the shared room log. The bots and their individual chats are kept.`
+          : null,
+        destructive: true,
+        confirmLabel: 'Delete Group',
+        busyLabel: 'Deleting…',
+        doneLabel: 'Deleted',
+        onClose: () => setDeletingGroup(null),
+        onConfirm: async () => {
+          if (!deletingGroup) return
+          await disbandGroupChat(deletingGroup.name, deletingGroup.members)
+          host.notify({ kind: 'success', message: `Deleted group “${deletingGroup.name}”` })
         }
       })
     ]

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -388,6 +388,13 @@ test('source contract: active group styling suppresses bot styling', () => {
   assert.match(pluginSource, /active: groupChatName === row\.name/)
 })
 
+test('source contract: group roster rows expose a confirmed Delete Group action', () => {
+  assert.match(pluginSource, /function GroupRow\(\{ active, group, members, needsYou, onOpen, onDisband \}\)/)
+  assert.match(pluginSource, /children: 'Delete Group'/)
+  assert.match(pluginSource, /title: 'Delete group chat\?'/)
+  assert.match(pluginSource, /await disbandGroupChat\(deletingGroup\.name, deletingGroup\.members\)/)
+})
+
 test('disband: removes only this membership, room log, workspace, and needs-you state', async () => {
   const gc = load(() => '(pass)')
 


### PR DESCRIPTION
## Problem

Bot Mode group chats can already be disbanded from the room header, but a newly created group has no delete action on its roster row. Users naturally right-click the group where it was created and conclude that groups cannot be deleted.

## Approach

- Wrap each group roster row in the existing context-menu primitives.
- Add **Open Group Chat** and destructive **Delete Group** actions.
- Route Delete Group through a `ConfirmDialog` before calling the existing `disbandGroupChat()` implementation.
- Preserve the established soft-delete semantics: remove group membership and room history while keeping agents and individual chats.

## Verification

- RED: the new group-row delete contract failed against `origin/main` before implementation.
- `node --test src/plugins/hermes-bots/tests/group-chat.test.mjs` — 41/41 passed.
- `node --test src/plugins/hermes-bots/tests/*.test.mjs` — 309/309 passed.
- `node --input-type=module --check < apps/desktop/src/plugins/hermes-bots/plugin.js` — passed.
- `git diff --check` — passed.

## Risk

Low. The change adds another UI entrance to the existing, tested disband path; it does not change deletion semantics or persisted state format.
