### PR TITLE
fix(desktop): make a failed update hand-off observable

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -292,6 +292,7 @@ import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
 import {
   collectRelaunchArgs,
   observeUpdaterHandoff,
+  openUpdaterOutputTarget,
   resolvePosixScriptHandoff,
   resolveStagedUpdaterBinary,
   resolveUpdateScriptHandoff,
@@ -2972,6 +2973,29 @@ function resolveUpdaterBinary() {
   return resolveStagedUpdaterBinary(HERMES_HOME, { fileExists, isWindows: IS_WINDOWS })
 }
 
+// Path the detached updater appends its stdout+stderr to. `stdio: 'ignore'`
+// used to discard both, so an updater that died on exec left no evidence
+// anywhere and the failure read as "the button did nothing".
+function updaterHandoffLogPath() {
+  return path.join(HERMES_HOME, 'logs', 'updater-handoff.log')
+}
+
+// `.update_exit_code` is written by `hermes update` in gateway mode and is
+// never cleared on the desktop hand-off path, so it survives from run to run.
+// A leftover "0" from a previous SUCCESSFUL update then reads as proof that
+// the latest attempt worked. Clear it before every hand-off so its presence
+// always describes THIS run. Best-effort: an unremovable marker must not
+// block the update.
+function clearStaleUpdateExitCode() {
+  const marker = path.join(HERMES_HOME, '.update_exit_code')
+
+  try {
+    fs.rmSync(marker, { force: true })
+  } catch (err) {
+    rememberLog(`[updates] could not clear stale .update_exit_code: ${err.message}`)
+  }
+}
+
 function repairMacUpdaterHelper(updater) {
   if (!IS_MAC || !updater) {
     return
@@ -3635,6 +3659,10 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
         process.execPath
       ])
 
+      clearStaleUpdateExitCode()
+
+      const wrapperOutput = openUpdaterOutputTarget(updaterHandoffLogPath())
+
       child = spawnUpdaterProcess(wrapped.command, wrapped.args, {
         cwd: HERMES_HOME,
         env: {
@@ -3643,8 +3671,11 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
           PATH: pathWithHermesManagedNode(venvBin)
         },
         detached: true,
-        stdio: 'ignore'
+        stdio: wrapperOutput.stdio
       })
+
+      // The child inherited the fd; drop the parent's copy.
+      wrapperOutput.close()
 
       // Bridge marker: child.pid is the short-lived cmd.exe WRAPPER, not the
       // script (see wrapHandoffForDetachedConsole). Write it anyway to cover
@@ -3661,6 +3692,10 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
         `[updates] launched repo hand-off script: ${scriptHandoff.scriptPath} (branch ${branch}); exiting desktop to release venv shim`
       )
     } else {
+      clearStaleUpdateExitCode()
+
+      const stagedOutput = openUpdaterOutputTarget(updaterHandoffLogPath())
+
       child = spawnUpdaterProcess(updater, updaterArgs, {
         cwd: HERMES_HOME,
         env: {
@@ -3669,8 +3704,11 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
           PATH: pathWithHermesManagedNode(venvBin)
         },
         detached: true,
-        stdio: 'ignore'
+        stdio: stagedOutput.stdio
       })
+
+      // The child inherited the fd; drop the parent's copy.
+      stagedOutput.close()
 
       // Write the update-in-progress marker IMMEDIATELY — before the 2.5s
       // quit dwell. The Tauri updater won't write its own marker for several
@@ -3713,7 +3751,12 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
     // surface the error instead. The pre-written marker names the dead child
     // pid, so readLiveUpdateMarker self-heals it; no cleanup needed.
     const dwellStartedAt = Date.now()
-    const handoffOutcome = await observeUpdaterHandoff(child, UPDATE_HANDOFF_DWELL_MS)
+
+    const handoffOutcome = await observeUpdaterHandoff(child, UPDATE_HANDOFF_DWELL_MS, {
+      // Only the cmd.exe wrapper is meant to exit at once. A directly spawned
+      // staged updater that returns 0 inside the window did nothing.
+      immediateCleanExitIsSuccess: Boolean(scriptHandoff)
+    })
 
     if (!handoffOutcome.ok) {
       const message = `Update failed to start: ${handoffOutcome.message}. Hermes will keep running — try again, or run \`hermes update\` from a terminal.`
@@ -3724,6 +3767,8 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
 
       return { ok: false, error: 'updater-spawn-failed', message }
     }
+
+    rememberLog(`[updates] hand-off settled ok; updater output → ${updaterHandoffLogPath()}`)
 
     isQuittingForHandoff = true
     setTimeout(
@@ -3796,6 +3841,10 @@ async function handOffWindowsBootstrapRecovery(reason) {
 
   await releaseBackendLockForUpdate(updateRoot)
 
+  clearStaleUpdateExitCode()
+
+  const recoveryOutput = openUpdaterOutputTarget(updaterHandoffLogPath())
+
   const child = spawnUpdaterProcess(updater, updaterArgs, {
     cwd: HERMES_HOME,
     env: {
@@ -3804,8 +3853,11 @@ async function handOffWindowsBootstrapRecovery(reason) {
       PATH: pathWithHermesManagedNode(venvBin)
     },
     detached: true,
-    stdio: 'ignore'
+    stdio: recoveryOutput.stdio
   })
+
+  // The child inherited the fd; drop the parent's copy.
+  recoveryOutput.close()
 
   // Same marker pre-write as applyUpdates — see comment there. The recovery
   // hand-off has the same window where the renderer can respawn a backend
@@ -3830,13 +3882,20 @@ async function handOffWindowsBootstrapRecovery(reason) {
   // returns false so the caller falls through to its next recovery path
   // instead of quitting into nothing.
   const dwellStartedAt = Date.now()
-  const handoffOutcome = await observeUpdaterHandoff(child, UPDATE_HANDOFF_DWELL_MS)
+
+  const handoffOutcome = await observeUpdaterHandoff(child, UPDATE_HANDOFF_DWELL_MS, {
+    // Spawned directly, with no wrapper to hand off to: an immediate exit 0
+    // means the updater returned without doing any work.
+    immediateCleanExitIsSuccess: false
+  })
 
   if (!handoffOutcome.ok) {
     rememberLog(`[bootstrap] recovery hand-off not viable, staying alive: ${handoffOutcome.message}`)
 
     return false
   }
+
+  rememberLog(`[bootstrap] recovery hand-off settled ok; updater output → ${updaterHandoffLogPath()}`)
 
   isQuittingForHandoff = true
   setTimeout(
@@ -4024,6 +4083,10 @@ async function applyUpdatesPosixHandoff(opts: any) {
     }
   }
 
+  clearStaleUpdateExitCode()
+
+  const posixOutput = openUpdaterOutputTarget(updaterHandoffLogPath())
+
   const child = spawnUpdaterProcess(handoff.command, args, {
     cwd: HERMES_HOME,
     env: {
@@ -4032,8 +4095,11 @@ async function applyUpdatesPosixHandoff(opts: any) {
       PATH: pathWithHermesManagedNode(path.join(updateRoot, 'venv', 'bin'))
     },
     detached: true,
-    stdio: 'ignore'
+    stdio: posixOutput.stdio
   })
+
+  // The child inherited the fd; drop the parent's copy.
+  posixOutput.close()
 
   // Bridge marker (same contract as the Windows hand-off): cover the gap
   // until the script claims the marker with its own pid as step 0. If the
@@ -4056,7 +4122,12 @@ async function applyUpdatesPosixHandoff(opts: any) {
   // child through the dwell; on spawn error or early death, stay alive and
   // surface the failure instead of quitting into nothing.
   const dwellStartedAt = Date.now()
-  const handoffOutcome = await observeUpdaterHandoff(child, UPDATE_HANDOFF_DWELL_MS)
+
+  const handoffOutcome = await observeUpdaterHandoff(child, UPDATE_HANDOFF_DWELL_MS, {
+    // Spawned directly, with no wrapper to hand off to: an immediate exit 0
+    // means the updater returned without doing any work.
+    immediateCleanExitIsSuccess: false
+  })
 
   if (!handoffOutcome.ok) {
     const message = `Update failed to start: ${handoffOutcome.message}. Hermes will keep running — try again, or run \`hermes update\` from a terminal.`
@@ -4066,6 +4137,8 @@ async function applyUpdatesPosixHandoff(opts: any) {
 
     return { ok: false, error: 'updater-spawn-failed', message }
   }
+
+  rememberLog(`[updates] posix hand-off settled ok; updater output → ${updaterHandoffLogPath()}`)
 
   isQuittingForHandoff = true
   setTimeout(

--- a/apps/desktop/electron/updater-process.test.ts
+++ b/apps/desktop/electron/updater-process.test.ts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict'
 import type { SpawnOptions } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, writeSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 import { test } from 'vitest'
@@ -8,6 +10,7 @@ import {
   collectRelaunchArgs,
   MARKER_SELF_ADOPT_EPOCH_MS,
   observeUpdaterHandoff,
+  openUpdaterOutputTarget,
   resolvePosixScriptHandoff,
   resolveStagedUpdaterBinary,
   resolveUpdateScriptHandoff,
@@ -418,6 +421,79 @@ test('observeUpdaterHandoff accepts a clean exit 0 (Windows cmd start wrapper)',
 
   assert.equal(outcome.ok, true)
   assert.equal(outcome.code, 0)
+})
+
+test('observeUpdaterHandoff rejects an immediate clean exit 0 for a direct spawn', async () => {
+  const child = new FakeChild()
+  const timer = manualTimer()
+
+  // No wrapper to hand off to: exiting 0 inside the window means the updater
+  // returned without doing any work. This is the silent no-op that left an
+  // install on its old commit with a success-looking log and no error.
+  const outcomePromise = observeUpdaterHandoff(child, 2500, {
+    ...timer.deps,
+    immediateCleanExitIsSuccess: false
+  })
+
+  child.emit('exit', 0, null)
+
+  const outcome = await outcomePromise
+
+  assert.equal(outcome.ok, false)
+  assert.equal(outcome.reason, 'early-exit')
+  assert.equal(outcome.code, 0)
+  assert.match(outcome.message ?? '', /without starting the update/)
+})
+
+test('observeUpdaterHandoff still settles ok for a direct spawn that survives the window', async () => {
+  const child = new FakeChild()
+  const timer = manualTimer()
+
+  const outcomePromise = observeUpdaterHandoff(child, 2500, {
+    ...timer.deps,
+    immediateCleanExitIsSuccess: false
+  })
+
+  timer.fire()
+
+  const outcome = await outcomePromise
+
+  assert.equal(outcome.ok, true)
+})
+
+// ── openUpdaterOutputTarget ────────────────────────────────────────────────
+
+test('openUpdaterOutputTarget routes the detached updater stdout+stderr to a file', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'hermes-updater-log-'))
+  const logPath = path.join(dir, 'nested', 'updater-handoff.log')
+  const target = openUpdaterOutputTarget(logPath)
+
+  assert.notEqual(target.stdio, 'ignore')
+  assert.equal(Array.isArray(target.stdio), true)
+
+  const [stdin, out, err] = target.stdio as ['ignore', number, number]
+
+  assert.equal(stdin, 'ignore')
+  // stdout and stderr share one fd so interleaving is preserved.
+  assert.equal(out, err)
+
+  writeSync(out, 'updater said something\n')
+  target.close()
+
+  assert.match(readFileSync(logPath, 'utf8'), /updater said something/)
+})
+
+test('openUpdaterOutputTarget degrades to ignore rather than blocking the update', () => {
+  // A directory where the log file must be: unopenable, and never fatal.
+  const dir = mkdtempSync(path.join(tmpdir(), 'hermes-updater-log-'))
+  const logPath = path.join(dir, 'collides')
+
+  mkdirSync(logPath)
+
+  const target = openUpdaterOutputTarget(logPath)
+
+  assert.equal(target.stdio, 'ignore')
+  target.close()
 })
 
 test('observeUpdaterHandoff settles ok when the child survives the window', async () => {

--- a/apps/desktop/electron/updater-process.ts
+++ b/apps/desktop/electron/updater-process.ts
@@ -1,5 +1,5 @@
 import { spawn, type SpawnOptions } from 'node:child_process'
-import { statSync } from 'node:fs'
+import { closeSync, mkdirSync, openSync, statSync } from 'node:fs'
 import path from 'node:path'
 
 import { hiddenWindowsChildOptions } from './windows-child-options'
@@ -291,6 +291,46 @@ export function stagedUpdaterSupportsPrewrittenMarker(
   return typeof mtimeMs === 'number' && Number.isFinite(mtimeMs) && mtimeMs >= MARKER_SELF_ADOPT_EPOCH_MS
 }
 
+export interface UpdaterOutputTarget {
+  /** Pass straight to spawn's `stdio`. */
+  stdio: 'ignore' | ['ignore', number, number]
+  /** Close the parent's copy of the inherited fd. Always safe to call. */
+  close: () => void
+}
+
+/**
+ * stdio for a detached updater that appends its stdout+stderr to `logPath`.
+ *
+ * The hand-off spawns the updater detached with `stdio: 'ignore'`, which throws
+ * away the only first-hand account of what went wrong: the desktop quits
+ * moments later, so a failing updater leaves nothing behind but an unchanged
+ * commit. Handing it an appended log file keeps that evidence without keeping
+ * a pipe open to a parent that is about to exit.
+ *
+ * Degrades to 'ignore' if the log cannot be opened — losing the transcript is
+ * strictly better than blocking the update over it.
+ */
+export function openUpdaterOutputTarget(logPath: string): UpdaterOutputTarget {
+  try {
+    mkdirSync(path.dirname(logPath), { recursive: true })
+
+    const fd = openSync(logPath, 'a')
+
+    return {
+      stdio: ['ignore', fd, fd],
+      close: () => {
+        try {
+          closeSync(fd)
+        } catch {
+          // Already closed, or never valid. Nothing to recover.
+        }
+      }
+    }
+  } catch {
+    return { stdio: 'ignore', close: () => {} }
+  }
+}
+
 export interface SpawnUpdaterProcessDeps {
   isWindows?: boolean
   spawnProcess?: (command: string, args: string[], options: SpawnOptions) => UpdaterChild
@@ -334,6 +374,16 @@ export interface UpdaterHandoffOutcome {
 export interface ObserveUpdaterHandoffDeps {
   setTimeoutFn?: (callback: () => void, ms: number) => unknown
   clearTimeoutFn?: (timer: unknown) => void
+  /**
+   * Whether a clean exit(0) INSIDE the settle window counts as a successful
+   * hand-off. True only for wrapper shapes that are supposed to exit at once
+   * (cmd.exe `start` launches the real script into its own console and
+   * returns). For a directly spawned updater or hand-off script, exiting 0
+   * before the window elapses means it did nothing at all — the silent no-op
+   * that leaves the install on its old commit with no error anywhere. Defaults
+   * to true so existing wrapper callers keep their behavior.
+   */
+  immediateCleanExitIsSuccess?: boolean
 }
 
 /**
@@ -362,6 +412,7 @@ export function observeUpdaterHandoff(
   deps: ObserveUpdaterHandoffDeps = {}
 ): Promise<UpdaterHandoffOutcome> {
   const setTimeoutFn = deps.setTimeoutFn ?? setTimeout
+  const immediateCleanExitIsSuccess = deps.immediateCleanExitIsSuccess ?? true
 
   const clearTimeoutFn =
     deps.clearTimeoutFn ?? ((timer: unknown) => clearTimeout(timer as ReturnType<typeof setTimeout>))
@@ -422,7 +473,21 @@ export function observeUpdaterHandoff(
 
       // Clean exit 0 inside the window is expected for wrapper shapes
       // (cmd.exe `start` on Windows exits immediately after launching the
-      // real script in its own console).
+      // real script in its own console). For a direct spawn there is no
+      // wrapper to hand off to, so the same exit means the updater returned
+      // without doing any work.
+      if (!immediateCleanExitIsSuccess) {
+        finish({
+          ok: false,
+          reason: 'early-exit',
+          message: `updater exited 0 immediately without starting the update`,
+          code: code ?? 0,
+          signal: null
+        })
+
+        return
+      }
+
       finish({ ok: true, code: code ?? 0, signal: null })
     }
 


### PR DESCRIPTION
## Problem

An update hand-off can fail without leaving evidence anywhere. Observed on a macOS install: the desktop logged `[updates] launched updater: ...`, quit, and the checkout stayed on its old commit. No error in `desktop.log`, none in `bootstrap-installer.log`, and `.update_exit_code` still read `0` from the previous successful run. The install sat 11 days behind before anyone noticed.

Three separate gaps combine to produce that silence.

## Changes

**1. The updater's own output was discarded.**
All four hand-off spawn sites used `stdio: 'ignore'`. Because the desktop quits moments later, a failing updater left no first-hand account at all. They now append the child's stdout and stderr to `logs/updater-handoff.log` via a new `openUpdaterOutputTarget()`. It degrades to `'ignore'` if the log cannot be opened, so a bad log path can never block an update.

**2. `observeUpdaterHandoff` accepted an immediate clean exit as success.**
\#66753 already catches spawn errors and non-zero/signalled early exits. But a clean `exit(0)` inside the settle window is treated as success on every platform. That is correct only for the Windows `cmd.exe start` wrapper, which is supposed to return at once after launching the real script into its own console. For a directly spawned staged updater or the posix hand-off script there is nothing to hand off to, so an immediate `exit(0)` means it did no work.

Adds `immediateCleanExitIsSuccess` to `ObserveUpdaterHandoffDeps`, defaulting to `true` so existing wrapper callers are unaffected, and passes `false` at the three direct-spawn sites. The settled-ok path is now logged too, so a successful hand-off and a quietly dead one are no longer indistinguishable in the log.

**3. `.update_exit_code` persisted across runs on the desktop path.**
It is written by `hermes update` in gateway mode. The gateway `/update` paths already `unlink(missing_ok=True)` it, but the desktop hand-off never did, so a leftover `0` from an earlier successful update reads as proof that the latest attempt worked. It is now cleared before every hand-off, so its presence always describes the current run.

## Tests

Four new cases in `updater-process.test.ts`: the direct-spawn `exit(0)` rejection, the survives-the-window path under the stricter flag, and both branches of `openUpdaterOutputTarget`.

`vitest --project electron`: 1477 passed, 2 skipped. `tsc -p tsconfig.electron.json --noEmit` and `eslint` clean.

## Notes

No behavior change on Windows: the wrapper site keeps `immediateCleanExitIsSuccess: true`. The only new failure classification is an immediate clean exit from a spawn that has no wrapper, which previously read as success.