### PR TITLE
fix(desktop): split About-panel update into explicit client/backend buttons

### DIFF
--- a/apps/desktop/src/app/settings/about-settings.tsx
+++ b/apps/desktop/src/app/settings/about-settings.tsx
@@ -7,7 +7,10 @@ import { Codicon } from '@/components/ui/codicon'
 import { type Translations, useI18n } from '@/i18n'
 import { AlertTriangle, CheckCircle2, ExternalLink, Loader2, RefreshCw } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { $connection } from '@/store/session'
 import {
+  $backendUpdateApply,
+  $backendUpdateStatus,
   $desktopVersion,
   $updateApply,
   $updateChecking,
@@ -15,7 +18,7 @@ import {
   checkUpdates,
   openUpdatesWindow,
   refreshDesktopVersion,
-  startActiveUpdate
+  startUpdateFor
 } from '@/store/updates'
 
 import { ListRow, SectionHeading, SettingsContent } from './primitives'
@@ -53,6 +56,9 @@ export function AboutSettings() {
   const status = useStore($updateStatus)
   const apply = useStore($updateApply)
   const checking = useStore($updateChecking)
+  const connection = useStore($connection)
+  const backendStatus = useStore($backendUpdateStatus)
+  const backendApply = useStore($backendUpdateApply)
   const [justChecked, setJustChecked] = useState(false)
 
   // The version atom is loaded once at app boot, which makes About show a
@@ -69,6 +75,17 @@ export function AboutSettings() {
   const updateAvailable = behind > 0 || Boolean(status?.updateAvailable)
   const supported = status?.supported !== false
   const applying = apply.applying || apply.stage === 'restart'
+
+  // In remote mode the client (this Electron shell) and the backend update
+  // independently, so the About panel offers a button per target. The backend
+  // side reads its own status/apply atoms; `updateAvailable` covers backends
+  // that can't count commits (behind === 0 but an update exists).
+  const remote = connection?.mode === 'remote'
+  const backendBehind = backendStatus?.behind ?? 0
+  const backendUpdateAvailable = Boolean(backendStatus?.updateAvailable) || backendBehind > 0
+  const backendSupported = backendStatus?.supported !== false
+  const backendApplying = backendApply.applying || backendApply.stage === 'restart'
+  const clientUpdatable = updateAvailable && supported && !applying
 
   const handleCheck = async () => {
     setJustChecked(false)
@@ -171,15 +188,35 @@ export function AboutSettings() {
               {checking ? a.checking : a.checkNow}
             </Button>
 
-            {updateAvailable && supported && !applying && (
+            {remote ? (
               <>
-                <Button onClick={() => startActiveUpdate()} size="sm">
-                  {a.updateNow}
-                </Button>
-                <Button onClick={() => openUpdatesWindow()} size="sm" variant="textStrong">
-                  {a.seeWhatsNew}
-                </Button>
+                {clientUpdatable && (
+                  <Button onClick={() => startUpdateFor('client')} size="sm">
+                    {a.updateThisApp}
+                  </Button>
+                )}
+                {backendUpdateAvailable && backendSupported && !backendApplying && (
+                  <Button onClick={() => startUpdateFor('backend')} size="sm">
+                    {a.updateBackend}
+                  </Button>
+                )}
+                {(clientUpdatable || backendUpdateAvailable) && (
+                  <Button onClick={() => openUpdatesWindow()} size="sm" variant="textStrong">
+                    {a.seeWhatsNew}
+                  </Button>
+                )}
               </>
+            ) : (
+              clientUpdatable && (
+                <>
+                  <Button onClick={() => startUpdateFor('client')} size="sm">
+                    {a.updateNow}
+                  </Button>
+                  <Button onClick={() => openUpdatesWindow()} size="sm" variant="textStrong">
+                    {a.seeWhatsNew}
+                  </Button>
+                </>
+              )
             )}
 
             <Button asChild className="ml-auto" size="sm" variant="text">

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -627,6 +627,8 @@ export const en: Translations = {
       checking: 'Checking…',
       seeWhatsNew: "See what's new",
       updateNow: 'Update now',
+      updateThisApp: 'Update this app',
+      updateBackend: 'Update backend',
       releaseNotes: 'Release notes',
       onLatest: "You're on the latest version.",
       installing: 'An update is currently installing.',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -520,6 +520,8 @@ export interface Translations {
       checking: string
       seeWhatsNew: string
       updateNow: string
+      updateThisApp: string
+      updateBackend: string
       releaseNotes: string
       onLatest: string
       installing: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -835,6 +835,8 @@ export const zh: Translations = {
       checking: '检查中…',
       seeWhatsNew: '查看新增内容',
       updateNow: '立即更新',
+      updateThisApp: '更新此应用',
+      updateBackend: '更新后端',
       releaseNotes: '发行说明',
       onLatest: '你已是最新版本。',
       installing: '正在安装更新。',

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -53,6 +53,7 @@ const {
   $updateOverlayOpen,
   $updateOverlayTarget,
   requestActiveUpdate,
+  startUpdateFor,
   resetUpdateApplyState,
   startUpdatePoller,
   stopUpdatePoller,
@@ -888,6 +889,64 @@ describe('applyBackendUpdate recovery', () => {
     expect(result.ok).toBe(false)
     expect($backendUpdateApply.get().stage).toBe('error')
   }, 10000)
+})
+
+describe('startUpdateFor', () => {
+  const applyMock = vi.fn()
+
+  const setRemote = (on: boolean) =>
+    setConnection({
+      baseUrl: 'http://box:9119',
+      isFullscreen: false,
+      mode: on ? 'remote' : 'local',
+      nativeOverlayWidth: 0,
+      token: 't',
+      wsUrl: 'ws://box:9119',
+      logs: [],
+      windowButtonPosition: null
+    })
+
+  beforeEach(() => {
+    storage.clear()
+    applyMock.mockReset()
+    applyMock.mockResolvedValue({ ok: true, handedOff: true })
+    updateHermesSpy.mockReset()
+    updateHermesSpy.mockResolvedValue({ ok: false, message: 'n/a', update_command: 'hermes update' })
+    resetUpdateApplyState()
+    $updateOverlayOpen.set(false)
+    ;(globalThis as unknown as { window: unknown }).window = {
+      hermesDesktop: { updates: { apply: applyMock } }
+    }
+    vi.useRealTimers()
+  })
+
+  afterEach(() => {
+    delete (globalThis as unknown as { window?: unknown }).window
+  })
+
+  it("routes 'client' to the local self-update even in remote mode (the stuck-GUI fix)", async () => {
+    setRemote(true)
+
+    startUpdateFor('client')
+    await vi.waitFor(() => expect(applyMock).toHaveBeenCalled())
+
+    // The client target must NOT fall through to the backend RPC — that silent
+    // reroute is exactly what left a remote app stranded on an old GUI.
+    expect(updateHermesSpy).not.toHaveBeenCalled()
+    expect($updateOverlayTarget.get()).toBe('client')
+    expect($updateOverlayOpen.get()).toBe(true)
+  })
+
+  it("routes 'backend' to the backend update RPC", async () => {
+    setRemote(true)
+
+    startUpdateFor('backend')
+    await vi.waitFor(() => expect(updateHermesSpy).toHaveBeenCalled())
+
+    expect(applyMock).not.toHaveBeenCalled()
+    expect($updateOverlayTarget.get()).toBe('backend')
+    expect($updateOverlayOpen.get()).toBe(true)
+  })
 })
 
 describe('startUpdatePoller', () => {

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -251,14 +251,18 @@ export function openUpdatesWindow(): void {
 }
 
 /**
- * Start applying the available update for the active target right away. Opens
- * the updates overlay first so the user sees apply progress (the overlay
- * renders ApplyingView once `applying` flips true), then kicks off the install.
- * Used by the "Update now" affordance on the About panel, which would otherwise
- * only be able to open the changelog overlay.
+ * Start applying a SPECIFIC update target, regardless of connection mode. Opens
+ * the updates overlay first so the user sees apply progress (the overlay renders
+ * ApplyingView once `applying` flips true), then kicks off that target's install.
+ *
+ * This is the explicit entry point behind the About panel's split
+ * "Update this app" / "Update backend" buttons. It exists because the
+ * mode-driven startActiveUpdate() below can only ever reach ONE target in remote
+ * mode (the backend), leaving a remote user with no in-app way to update the
+ * local Electron shell — the exact "silently stuck on an old GUI" gap this
+ * split closes.
  */
-export function startActiveUpdate(): void {
-  const target: UpdateTarget = isRemoteMode() ? 'backend' : 'client'
+export function startUpdateFor(target: UpdateTarget): void {
   $updateOverlayTarget.set(target)
   $updateOverlayOpen.set(true)
   void (target === 'backend' ? applyBackendUpdate() : applyUpdates())
@@ -281,6 +285,16 @@ export function requestActiveUpdate(): void {
   }
 
   openUpdateOverlayFor(target)
+}
+
+/**
+ * Start applying the available update for the mode-default target right away:
+ * backend in remote mode, client locally. Kept for callers that just want "the"
+ * update (e.g. the backend-skew toast). The About panel no longer routes through
+ * this — it calls startUpdateFor() per button so both targets stay reachable.
+ */
+export function startActiveUpdate(): void {
+  startUpdateFor(isRemoteMode() ? 'backend' : 'client')
 }
 
 /** Re-read the running app's version from the Electron main process and


### PR DESCRIPTION
## Problem

In remote mode the About panel's "Update now" button can only ever update the backend, never this Electron shell.

`startActiveUpdate()` picks its target from connection mode:

```ts
const target: UpdateTarget = isRemoteMode() ? 'backend' : 'client'
```

A desktop connected to a remote gateway therefore has no in-app way to update itself. The local checkout drifts behind indefinitely while the button reports success, because it did succeed, just against the other target. On the install this came from, the client sat weeks behind the backend with no in-app affordance to fix it.

## Changes

- Adds `startUpdateFor(target)` as an explicit entry point that routes to a specific target regardless of connection mode.
- `startActiveUpdate()` is kept for mode-default callers (the backend-skew toast, the command palette's `requestActiveUpdate()`) and now delegates to `startUpdateFor()`.
- In remote mode the About panel renders two buttons, "Update this app" and "Update backend", each gated on its own target's status and apply atoms. Local mode is unchanged: one "Update now" button.
- i18n strings for `en` and `zh`, plus the `Translations` interface.

## Tests

Two new cases asserting that `'client'` routes to the local self-update even in remote mode and does not fall through to the backend RPC, and that `'backend'` routes to the backend RPC and not the local apply.

`vitest --project ui src/store/updates.test.ts`: 47 passed. `tsc -p . --noEmit` and `eslint` clean.

## Notes

The client gate uses the existing `updateAvailable` rather than `behind > 0`, so a shallow clone, where the exact count is unknowable and only `status.updateAvailable` is set, still offers the button.