### PR TITLE
fix(auxiliary): reject leaked tool-call text and preserve reasoning state

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1836,6 +1836,7 @@ class _CodexCompletionsAdapter:
                     val = obj.get(key, default)
                 return val if val is not None else default
 
+            reasoning_items_raw: List[Dict[str, Any]] = []
             for item in (getattr(final, "output", None) or []):
                 item_type = _item_get(item, "type")
                 if item_type == "message":
@@ -1852,6 +1853,32 @@ class _CodexCompletionsAdapter:
                             arguments=_item_get(item, "arguments", "{}"),
                         ),
                     ))
+                elif item_type == "reasoning":
+                    # Preserve encrypted reasoning state for multi-turn
+                    # continuity, mirroring the main transport's
+                    # _normalize_codex_response. Transient items are skipped.
+                    encrypted = _item_get(item, "encrypted_content")
+                    if isinstance(encrypted, str) and encrypted:
+                        raw_item: Dict[str, Any] = {
+                            "type": "reasoning",
+                            "encrypted_content": encrypted,
+                        }
+                        item_id = _item_get(item, "id")
+                        if isinstance(item_id, str) and item_id.startswith("rs_tmp_"):
+                            continue
+                        if isinstance(item_id, str) and item_id:
+                            raw_item["id"] = item_id
+                        summary = _item_get(item, "summary")
+                        if isinstance(summary, list):
+                            raw_summary = []
+                            for part in summary:
+                                text = _item_get(part, "text")
+                                if isinstance(text, str):
+                                    raw_summary.append(
+                                        {"type": "summary_text", "text": text}
+                                    )
+                            raw_item["summary"] = raw_summary
+                        reasoning_items_raw.append(raw_item)
 
             resp_usage = getattr(final, "usage", None)
             if resp_usage:
@@ -1874,16 +1901,55 @@ class _CodexCompletionsAdapter:
 
         content = "".join(text_parts).strip() or None
 
+        # Check-6 parity with the main transport: a model that emitted
+        # ``assistant to=functions.foo {...}`` as plain text (instead of a
+        # structured function_call item) must not surface as a confident
+        # summary with no tools executed. Clear the text and mark the turn
+        # incomplete so the continuation path can re-elicit a proper tool
+        # call. Encrypted reasoning items are preserved above so the model
+        # keeps its chain-of-thought on the retry.
+        leaked_tool_call_text = False
+        if content and not tool_calls_raw:
+            try:
+                from agent.codex_responses_adapter import (
+                    _TOOL_CALL_LEAK_PATTERN,
+                    _neutralize_harmony_tokens,
+                )
+            except Exception:
+                _TOOL_CALL_LEAK_PATTERN = None
+                _neutralize_harmony_tokens = None
+            if _TOOL_CALL_LEAK_PATTERN is not None and _TOOL_CALL_LEAK_PATTERN.search(content):
+                leaked_tool_call_text = True
+                logger.warning(
+                    "Codex auxiliary response contains leaked tool-call text "
+                    "in assistant content (no structured function_call items). "
+                    "Treating as incomplete so the continuation path can "
+                    "re-elicit a proper tool call. Leaked snippet: %r",
+                    content[:300],
+                )
+                content = ""
+            elif _neutralize_harmony_tokens is not None:
+                # Reserved Harmony wire tokens must not be replayed into
+                # later requests (the backend rejects them pre-inference).
+                content = _neutralize_harmony_tokens(content)
+
         # Build a response that looks like chat.completions
         message = SimpleNamespace(
             role="assistant",
             content=content,
-            tool_calls=tool_calls_raw or None,
+            tool_calls=tool_calls_raw or [],
+            codex_reasoning_items=reasoning_items_raw or None,
         )
+        if tool_calls_raw:
+            finish_reason = "tool_calls"
+        elif leaked_tool_call_text:
+            finish_reason = "incomplete"
+        else:
+            finish_reason = "stop"
         choice = SimpleNamespace(
             index=0,
             message=message,
-            finish_reason="stop" if not tool_calls_raw else "tool_calls",
+            finish_reason=finish_reason,
         )
         return SimpleNamespace(
             choices=[choice],

--- a/tests/agent/test_auxiliary_check6_parity.py
+++ b/tests/agent/test_auxiliary_check6_parity.py
@@ -1,0 +1,121 @@
+"""Check-6 parity: the Codex auxiliary adapter must reject leaked tool-call
+text and preserve reasoning state, mirroring the main transport's
+``_normalize_codex_response`` behavior.
+
+The MoA auxiliary path (``_CodexCompletionsAdapter``) previously joined
+message text raw: a model that emitted ``assistant to=functions.foo {...}``
+as plain text (instead of a structured ``function_call`` item) produced a
+confident-looking summary with no tools executed and no audit trail. The
+main transport detects this (``_TOOL_CALL_LEAK_PATTERN``), clears the text,
+and returns ``finish_reason="incomplete"`` so the continuation path can
+re-elicit a proper tool call. The auxiliary adapter must do the same, and
+must also preserve encrypted reasoning items for multi-turn continuity.
+"""
+
+from types import SimpleNamespace
+
+from agent.auxiliary_client import _CodexCompletionsAdapter
+
+
+def _adapter_for_items(items):
+    events = [
+        SimpleNamespace(type="response.created"),
+        *[
+            SimpleNamespace(type="response.output_item.done", item=item)
+            for item in items
+        ],
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(
+                status="completed",
+                id="resp_test",
+                usage=SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+            ),
+        ),
+    ]
+
+    class _FakeCreateStream:
+        def __iter__(self):
+            return iter(events)
+
+        def close(self):
+            pass
+
+    def _create(**kwargs):
+        return _FakeCreateStream()
+
+    client = SimpleNamespace(
+        base_url="https://chatgpt.com/backend-api/codex",
+        responses=SimpleNamespace(create=_create),
+    )
+    return _CodexCompletionsAdapter(client, "gpt-5.6-sol")
+
+
+def test_aux_adapter_rejects_leaked_tool_call_text_and_preserves_reasoning():
+    reasoning = SimpleNamespace(
+        type="reasoning",
+        id="rs_1",
+        status="completed",
+        encrypted_content="sealed-reasoning",
+        summary=[SimpleNamespace(type="summary_text", text="Need a tool.")],
+    )
+    leaked = SimpleNamespace(
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[
+            SimpleNamespace(
+                type="output_text",
+                text='assistant to=functions.exec_command {"command":"pwd"}',
+            )
+        ],
+    )
+    response = _adapter_for_items([reasoning, leaked]).create(
+        messages=[{"role": "user", "content": "Run pwd."}],
+        tools=[{"type": "function", "function": {"name": "terminal", "parameters": {}}}],
+    )
+    msg = response.choices[0].message
+    assert response.choices[0].finish_reason == "incomplete"
+    assert msg.content == ""
+    assert msg.tool_calls == []
+    assert msg.codex_reasoning_items[0]["encrypted_content"] == "sealed-reasoning"
+
+
+def test_aux_adapter_preserves_clean_text_and_tool_calls():
+    function_call = SimpleNamespace(
+        type="function_call",
+        id="fc_1",
+        call_id="call_1",
+        name="terminal",
+        arguments='{"command":"pwd"}',
+        status="completed",
+    )
+    response = _adapter_for_items([function_call]).create(
+        messages=[{"role": "user", "content": "Run pwd."}],
+        tools=[{"type": "function", "function": {"name": "terminal", "parameters": {}}}],
+    )
+    call = response.choices[0].message.tool_calls[0]
+    assert response.choices[0].finish_reason == "tool_calls"
+    assert call.function.name == "terminal"
+    assert call.function.arguments == '{"command":"pwd"}'
+
+
+def test_aux_adapter_neutralizes_harmony_tokens_in_text():
+    clean = SimpleNamespace(
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[
+            SimpleNamespace(
+                type="output_text",
+                text="Summary with <|channel|> reserved token",
+            )
+        ],
+    )
+    response = _adapter_for_items([clean]).create(
+        messages=[{"role": "user", "content": "Summarize."}],
+    )
+    msg = response.choices[0].message
+    assert response.choices[0].finish_reason == "stop"
+    assert "<|channel|>" not in msg.content
+    assert "｜" in msg.content


### PR DESCRIPTION
## Problem

The MoA auxiliary path (`_CodexCompletionsAdapter` in `agent/auxiliary_client.py`) joins assistant text raw. When a model emits `assistant to=functions.foo {...}` as plain text instead of a structured `function_call` item, the auxiliary caller (MoA aggregation, compression, memory flush) receives a confident-looking summary with no tools executed and no audit trail. The main transport already detects this (`_TOOL_CALL_LEAK_PATTERN` in `_normalize_codex_response`), clears the text, and returns `finish_reason=incomplete` so the continuation path can re-elicit a proper tool call. The auxiliary adapter had no such guard.

Additionally, the auxiliary adapter dropped encrypted reasoning items entirely, breaking multi-turn reasoning continuity for auxiliary calls, and did not neutralize reserved Harmony wire tokens in assistant text before they could be replayed into later requests.

## Fix

- Detect leaked tool-call text in auxiliary assistant content; clear it and return `finish_reason=incomplete` (parity with the main transport).
- Preserve encrypted reasoning items (with summary and id, skipping transient `rs_tmp_` items) as `codex_reasoning_items` on the returned message.
- Neutralize reserved Harmony tokens in assistant text via the shared `_neutralize_harmony_tokens`.
- Empty `tool_calls` now returns `[]` instead of `None` (main-transport parity).

## Tests

- New: `tests/agent/test_auxiliary_check6_parity.py` (3 tests: leak rejection + reasoning preservation, clean tool-call pass-through, harmony neutralization).
- Existing auxiliary suites: 230 passed. Codex adapter suites: 63 passed.