### PR TITLE
Fix: Bots pane swallows roster when a group chat opens (double-render) #89788

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -9622,7 +9622,17 @@ function BotsPane() {
 
   const groupChatMembers = groupChatName ? groupChatMemberBots(groupChatName, roster, allMeta) : []
 
-  if (groupChatName && groupChatMembers.length) {
+  // The group room lives in the MAIN chat window (host.openWorkspace, newer
+  // desktops) — that is its one true surface. The Bots pane must KEEP its
+  // roster and only highlight the active group row (GroupRow's `active`
+  // already does this). Rendering the room here too double-books the group:
+  // it seizes the Bots pane AND the main window, hiding the bot list behind a
+  // duplicate room. Only fall back to the in-panel room on desktops whose SDK
+  // predates host.openWorkspace (which openGroupChat already feature-detected
+  // and skipped). See issue #89788.
+  const inPanelRoomFallback = typeof host.openWorkspace !== 'function'
+
+  if (groupChatName && groupChatMembers.length && inPanelRoomFallback) {
     return jsx(GroupChatWorkspace, { group: groupChatName, members: groupChatMembers })
   }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -107,6 +107,23 @@ test('regression: rendering BotsPane does not prewarm the entire roster', () => 
   assert.doesNotMatch(botsPaneSource, /host\.warmProfile/)
 })
 
+test('fix #89788: Bots pane keeps its roster when the group opens in the main window', () => {
+  const botsPaneSource = sourceBetween('function BotsPane(', '// ── plugin')
+
+  // The in-panel room must be gated on the absence of the main-window door:
+  // on desktops with host.openWorkspace the group room already lives in the
+  // main chat window, so the Bots pane must NOT replace its roster with a
+  // duplicate room (that double-books the group and hides the bot list).
+  assert.match(botsPaneSource, /inPanelRoomFallback = typeof host\.openWorkspace !== 'function'/)
+  assert.match(botsPaneSource, /groupChatName && groupChatMembers\.length && inPanelRoomFallback/)
+  // The roster (the bot list) is rendered through this branch when the door
+  // exists, so the group selection only highlights its row, not the room.
+  assert.doesNotMatch(
+    botsPaneSource,
+    /if \(groupChatName && groupChatMembers\.length\) \{\s*return jsx\(GroupChatWorkspace/
+  )
+})
+
 test('regression: source transitions keep BotRow hook order stable', () => {
   const botRowSource = sourceBetween('function BotRow(', '// ── model picker')
 


### PR DESCRIPTION
## What does this PR do?

Fixes #89788. On the macOS Hermes Desktop, opening or creating a group chat from the **Bots** section caused the group room to occupy **both** the Bots pane (left sidebar) **and** the main chat window / menu — hiding the bot list behind a duplicate room.

**Root cause:** `openGroupChat` (in `apps/desktop/src/plugins/hermes-bots/plugin.js`) opens the group room in the main chat window via `host.openWorkspace` (the intended, single surface) **and** sets `$groupChatWorkspace = group`. `BotsPane` then unconditionally replaced its entire roster with `GroupChatWorkspace` whenever that atom was set — even though the room was already open in the main window. The group was double-booked: it stole the Bots pane *and* appeared in the menu.

**Fix:** Gate the in-panel room render on the **absence** of the main-window door, using the same feature-detect (`typeof host.openWorkspace !== 'function'`) that `openGroupChat` already uses:
- Modern desktops (`host.openWorkspace` available): the Bots pane keeps its roster and only highlights the active group row (`GroupRow`'s existing `active` prop). The room lives solely in the main window.
- Legacy desktops (SDK predates `host.openWorkspace`): the in-panel room fallback still applies, unchanged.

## Related Issue

Fixes #89788

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js` — `BotsPane`: only render the in-panel `GroupChatWorkspace` when `host.openWorkspace` is unavailable (legacy fallback); otherwise keep the roster and let the main window own the room.
- `apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs` — added a source-contract test codifying the gating.

## How to Test

1. Build/run the desktop from this branch (`apps/desktop`, modern SDK with `host.openWorkspace`).
2. Open the **Bots** section, create or select a group chat.
3. **Expected:** the group room opens in the main chat window; the Bots pane keeps showing the bot/agent roster with the active group row highlighted — it is NOT replaced by a duplicate room.
4. **Regression guard:** `node --test src/plugins/hermes-bots/tests/profile-prewarm.test.mjs` (new test `fix #89788: Bots pane keeps its roster when the group opens in the main window` passes).

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (latest Hermes Desktop build — the one exhibiting the bug)

### Documentation & Housekeeping
- [x] N/A — no docs/config/tool-description changes

## Notes
The `GroupChatWorkspace` "Back" button still clears `$groupChatWorkspace`; the only behavioral change is *which* surface renders the room when the main-window door exists. No SDK/API changes. Commit is DCO-signed-off.