### PR TITLE
fix(delegation): isolate child session sources

### DIFF
--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -424,6 +424,7 @@ NON_MESSAGING_SESSION_SURFACES = frozenset(
         "kanban",
         "local",
         "msgraph_webhook",
+        "subagent",
         "tool",
         "tui",
         "webhook",
@@ -443,6 +444,14 @@ def session_is_messaging_surface() -> bool:
     source, and reports messaging when any of them names a surface outside
     :data:`NON_MESSAGING_SESSION_SURFACES`.
     """
+    # A delegated child retains the parent's routing ContextVars so its result
+    # can return to the owner. Those values describe the owner, not the child's
+    # audience, and must not classify internal child work as a human chat turn.
+    from agent.delegation_context import is_delegated_child_process_context
+
+    if is_delegated_child_process_context():
+        return False
+
     import os
 
     platform = os.getenv("HERMES_PLATFORM") or get_session_env("HERMES_SESSION_PLATFORM", "")

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -216,7 +216,7 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
     )
 
 
-SCHEMA_VERSION = 26
+SCHEMA_VERSION = 27
 
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -1141,6 +1141,25 @@ class SessionSchemaMixin:
                 # one large prompt copy per session.
                 self._dedupe_legacy_system_prompts(cursor)
 
+            if current_version < 27:
+                # v27: delegated children created under a gateway/CLI/cron/TUI
+                # parent inherited that parent's human-facing source through
+                # task-local session ContextVars. The _delegate_from marker
+                # identifies direct delegates and their compression lineage,
+                # including continuations whose marker intentionally points
+                # past their immediate parent. v16 also backfilled that marker
+                # onto some source='tool' children, so preserve that explicit
+                # execution surface. Change only source; preserve lineage,
+                # messages, and model_config.
+                cursor.execute(
+                    "UPDATE sessions SET source = 'subagent' "
+                    "WHERE source NOT IN ('subagent', 'tool') "
+                    "AND json_extract("
+                    "CASE WHEN json_valid(model_config) "
+                    "THEN model_config ELSE '{}' END, "
+                    "'$._delegate_from') IS NOT NULL"
+                )
+
             # The FTS storage layout is versioned independently of the main
             # schema (see the v23 note above). Stamp the current layout so the
             # main version can always advance: a fresh/optimized DB is at

--- a/run_agent.py
+++ b/run_agent.py
@@ -91,6 +91,15 @@ def _launch_cwd_for_session(source: str) -> Optional[str]:
 
 
 def _session_source_for_agent(platform: Optional[str]) -> str:
+    # A delegate_task child executes inside the parent's ContextVar snapshot so
+    # completion routing can still reach the owning conversation. That snapshot
+    # legitimately contains HERMES_SESSION_SOURCE=discord/telegram/etc., but it
+    # must never become the child session row's source: gateway recovery indexes
+    # human conversations by source and could otherwise adopt the subagent row.
+    from agent.delegation_context import is_delegated_child_process_context
+
+    if is_delegated_child_process_context():
+        return "subagent"
     try:
         from gateway.session_context import get_session_env
 

--- a/tests/gateway/test_delegation_session_source_isolation.py
+++ b/tests/gateway/test_delegation_session_source_isolation.py
@@ -1,0 +1,89 @@
+"""Delegated children must not inherit a human messaging surface identity."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent.delegation_context import (
+    DELEGATED_CHILD_ENV_MARKER,
+    delegated_child_context,
+)
+from gateway.session_context import (
+    _SESSION_PLATFORM,
+    _SESSION_SOURCE,
+    session_is_messaging_surface,
+)
+from hermes_state import SessionDB
+from run_agent import AIAgent, _session_source_for_agent
+
+
+@pytest.fixture
+def discord_parent_context():
+    platform_token = _SESSION_PLATFORM.set("discord")
+    source_token = _SESSION_SOURCE.set("discord")
+    try:
+        yield
+    finally:
+        _SESSION_SOURCE.reset(source_token)
+        _SESSION_PLATFORM.reset(platform_token)
+
+
+def test_root_agent_keeps_ambient_discord_source(discord_parent_context):
+    assert _session_source_for_agent("gateway") == "discord"
+    assert session_is_messaging_surface() is True
+
+
+def test_delegated_child_uses_subagent_source_not_parent_discord(
+    discord_parent_context,
+):
+    with delegated_child_context("child-session"):
+        assert _session_source_for_agent("subagent") == "subagent"
+        assert _session_source_for_agent("discord") == "subagent"
+
+
+def test_delegated_child_is_not_a_human_messaging_surface(
+    discord_parent_context,
+):
+    with delegated_child_context("child-session"):
+        assert session_is_messaging_surface() is False
+
+
+def test_subprocess_marker_isolates_source_and_messaging_surface(
+    discord_parent_context,
+    monkeypatch,
+):
+    monkeypatch.setenv(DELEGATED_CHILD_ENV_MARKER, "1")
+
+    assert _session_source_for_agent("discord") == "subagent"
+    assert session_is_messaging_surface() is False
+
+
+def test_delegated_child_persists_as_subagent_under_discord_parent(
+    discord_parent_context,
+    tmp_path,
+):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    child = SimpleNamespace(
+        _persist_disabled=False,
+        _session_db_created=False,
+        _session_db=db,
+        _session_init_model_config={"_delegate_from": "parent-session"},
+        _cached_system_prompt="test prompt",
+        _parent_session_id=None,
+        platform="discord",
+        session_id="child-session",
+        model="test-model",
+    )
+    try:
+        with delegated_child_context("child-session"):
+            AIAgent._ensure_db_session(child)  # type: ignore[arg-type]
+
+        row = db.get_session("child-session")
+        assert row is not None
+        assert row["source"] == "subagent"
+        assert json.loads(row["model_config"])["_delegate_from"] == "parent-session"
+    finally:
+        db.close()

--- a/tests/state/test_delegation_source_migration.py
+++ b/tests/state/test_delegation_source_migration.py
@@ -1,0 +1,98 @@
+"""Legacy delegated sessions must migrate off human-facing sources."""
+
+from __future__ import annotations
+
+import json
+
+from hermes_state import SCHEMA_VERSION, SessionDB
+
+
+def test_v26_delegation_sources_migrate_without_touching_human_sessions(tmp_path):
+    db_path = tmp_path / "legacy-delegation-sources.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        db.create_session("human", source="discord")
+        db.create_session("delegate-parent", source="discord")
+        db.create_session(
+            "direct-delegate",
+            source="discord",
+            parent_session_id="delegate-parent",
+            model_config={"_delegate_from": "delegate-parent", "keep": "direct"},
+        )
+        db.end_session("direct-delegate", "compression")
+        db.create_session(
+            "delegate-continuation",
+            source="discord",
+            parent_session_id="direct-delegate",
+            model_config={"_delegate_from": "delegate-parent", "keep": "continuation"},
+        )
+        db.create_session(
+            "branch",
+            source="discord",
+            parent_session_id="human",
+            model_config={"_branched_from": "human"},
+        )
+        db.create_session(
+            "already-subagent",
+            source="subagent",
+            parent_session_id="delegate-parent",
+            model_config={"_delegate_from": "delegate-parent"},
+        )
+        db.create_session(
+            "delegated-branch-marker",
+            source="discord",
+            parent_session_id="delegate-parent",
+            model_config={
+                "_delegate_from": "delegate-parent",
+                "_branched_from": "delegate-parent",
+            },
+        )
+        db.create_session("malformed-config", source="discord")
+        db._conn.execute(
+            "UPDATE sessions SET model_config = '{not-json' "
+            "WHERE id = 'malformed-config'"
+        )
+        db.create_session("null-config", source="discord")
+        db.create_session(
+            "tool-child",
+            source="tool",
+            parent_session_id="delegate-parent",
+            model_config={"_delegate_from": "delegate-parent"},
+        )
+        db._conn.execute("UPDATE schema_version SET version = 26")
+        db._conn.commit()
+    finally:
+        db.close()
+
+    migrated = SessionDB(db_path=db_path)
+    try:
+        sources = {
+            row["id"]: row["source"]
+            for row in migrated._conn.execute(
+                "SELECT id, source FROM sessions ORDER BY id"
+            ).fetchall()
+        }
+        assert sources == {
+            "already-subagent": "subagent",
+            "branch": "discord",
+            "delegate-continuation": "subagent",
+            "delegate-parent": "discord",
+            "delegated-branch-marker": "subagent",
+            "direct-delegate": "subagent",
+            "human": "discord",
+            "malformed-config": "discord",
+            "null-config": "discord",
+            "tool-child": "tool",
+        }
+        for session_id, expected_keep in (
+            ("direct-delegate", "direct"),
+            ("delegate-continuation", "continuation"),
+        ):
+            row = migrated.get_session(session_id)
+            assert row is not None
+            assert json.loads(row["model_config"])["keep"] == expected_keep
+        assert migrated._conn.execute(
+            "SELECT version FROM schema_version LIMIT 1"
+        ).fetchone()[0] == SCHEMA_VERSION == 27
+    finally:
+        migrated.close()

--- a/tests/state/test_session_git_metadata_generation.py
+++ b/tests/state/test_session_git_metadata_generation.py
@@ -237,7 +237,7 @@ def test_legacy_sessions_table_reconciles_generation_column(tmp_path):
         assert "git_metadata_generation" in columns
         assert reopened._conn.execute(
             "SELECT version FROM schema_version"
-        ).fetchone()[0] == SCHEMA_VERSION == 26
+        ).fetchone()[0] == SCHEMA_VERSION == 27
         reopened.create_session("session", "desktop", cwd="/repo")
         assert reopened.update_session_cwd("session", "/repo") == 1
     finally:


### PR DESCRIPTION
## Summary

- persist delegated child sessions with `source="subagent"` even when they inherit a human-facing parent platform or run through the subprocess marker path
- keep delegated execution out of human messaging-surface classification
- add schema v27 migration to backfill legacy delegated rows while preserving explicit `source="tool"` children and malformed/non-delegated records
- add regression coverage for direct delegates, compression continuations, branch markers, subprocess context, and actual session persistence

## Testing

- `scripts/run_tests.sh -j 4 tests/state/test_delegation_source_migration.py tests/gateway/test_delegation_session_source_isolation.py tests/state/test_compression_lineage_guard.py tests/state/test_session_turn_lease.py tests/hermes_state/test_session_md_export.py tests/test_delegate_cascade_49148.py tests/gateway/test_session_context_inheritance.py tests/state/test_session_git_metadata_generation.py -q` — 60 passed
- Ruff on all changed Python files — passed
- `git diff --check` — passed
- staged gitleaks scan — no leaks found

## Risk

The migration changes only `sessions.source` for rows with a valid `_delegate_from` marker and a source other than `subagent` or `tool`. It does not alter lineage fields, messages, or `model_config`, and the predicate is idempotent.
