### PR TITLE
fix(models): glm-5.3 context window is 1M (post-training refresh of glm-5.2)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -503,11 +503,17 @@ DEFAULT_CONTEXT_LENGTHS = {
     "minimax": 204800,
     # GLM — GLM-5.2 ships with a 1M context window (verified empirically:
     # needle-in-a-haystack retrieval at 789K prompt tokens succeeded with
-    # zero errors on api.z.ai/api/coding/paas/v4).  Older GLM models
-    # (5, 5.1, 5-turbo) are ~202K.  Longest-key-first substring matching
-    # ensures "glm-5.2" resolves to 1M while older variants still hit the
-    # generic 202K fallback.
+    # zero errors on api.z.ai/api/coding/paas/v4).  GLM-5.3 is a
+    # post-training-only refresh of the GLM-5.2 base (z.ai blog, 2026-08):
+    # same architecture, same 1M window; z.ai documents the 1M route as
+    # glm-5.3[1m] with a 1,000,000-token compaction window, and GET /models
+    # on the coding endpoint returns no context metadata for any glm model
+    # (so endpoint probing cannot learn this — the table is authoritative).
+    # Older GLM models (5, 5.1, 5-turbo) are ~202K.  Longest-key-first
+    # substring matching ensures glm-5.2/glm-5.3 resolve to 1M while older
+    # variants still hit the generic 202K fallback.
     "glm-5.2": 1_048_576,
+    "glm-5.3": 1_048_576,
     "glm": 202752,
     # xAI Grok — xAI /v1/models does not return context_length metadata,
     # so these hardcoded fallbacks prevent Hermes from probing-down to

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -138,6 +138,32 @@ class TestGetModelContextLengthHonorsOverride:
             patch.object(_mm, "_is_known_provider_base_url", return_value=False),
         ]
 
+    def test_glm_5_3_resolves_to_1m_not_generic_202k(self):
+        """glm-5.3 must resolve to the 1M window it shares with glm-5.2
+        (post-training refresh of the same base), not the generic ~202K
+        GLM fallback that older variants (5, 5.1, 5-turbo) hit.
+
+        Regression test for the longest-key-first substring match: before
+        the glm-5.3 table entry existed, "glm-5.3" fell through to the
+        bare "glm" key (202,752) and Hermes under-reported the context
+        window by ~5x.
+        """
+        from agent.model_metadata import get_model_context_length
+
+        patches = self._mock_all_probes()
+        for p in patches:
+            p.start()
+        try:
+            ctx = get_model_context_length(
+                "glm-5.3",
+                base_url="https://api.z.ai/api/coding/paas/v4",
+                provider="zai",
+            )
+        finally:
+            for p in patches:
+                p.stop()
+        assert ctx == 1_048_576
+
     def test_custom_providers_override_wins_over_default_fallback(self):
         from agent.model_metadata import get_model_context_length
         custom = [


### PR DESCRIPTION
## Problem

`glm-5.3` has no entry in `DEFAULT_CONTEXT_LENGTHS`, so the longest-key-first substring match falls through to the bare `"glm"` key (202,752 tokens). Hermes reports and plans against a ~5x-too-small context window for every glm-5.3 session (visible in the startup banner and `/usage`).

## Root cause

The table has `"glm-5.2": 1_048_576` but nothing for 5.3, which launched after that entry was written.

## Fix

`"glm-5.3": 1_048_576` — GLM-5.3 is a post-training-only refresh of the GLM-5.2 base (z.ai blog 2026-08): same architecture, same 1M window. z.ai documents the 1M route as `glm-5.3[1m]` with a 1,000,000-token compaction window. `GET /models` on `api.z.ai/api/coding/paas/v4` returns no context metadata for any glm model, so endpoint probing cannot learn this — the table is authoritative.

## Verification

- New regression test: glm-5.3 → 1,048,576 with all probes mocked out (10/10 pass in `tests/hermes_cli/test_custom_provider_context_length.py`).
- Resolver check on a live config: glm-5.3 → 1048576, glm-5.2 → 1000000, glm-5.1 → 200000, glm-5 → 204800 (older variants unchanged).