### PR TITLE
fix(telegram): strip nested bold from table heading conversion

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -359,6 +359,10 @@ def _render_table_block(table_block: list[str]) -> str:
             heading = next((cell for cell in cells if cell), f"Row {index}")
             data_cells = cells
 
+        # Strip markdown bold from the heading — the group wrapper adds its
+        # own **...**, and nested bold breaks Telegram MarkdownV2 conversion.
+        heading_clean = re.sub(r'\*\*(.+?)\*\*', r'\1', heading)
+
         if len(data_cells) < len(headers):
             data_cells.extend([""] * (len(headers) - len(data_cells)))
         elif len(data_cells) > len(headers):
@@ -370,7 +374,7 @@ def _render_table_block(table_block: list[str]) -> str:
                 continue
             bullets.append(f"• {header}: {value}")
 
-        group_lines = [f"**{heading}**", *bullets]
+        group_lines = [f"**{heading_clean}**", *bullets]
         rendered_groups.append("\n".join(group_lines))
 
     return "\n\n".join(rendered_groups)

--- a/tests/gateway/test_table_helpers.py
+++ b/tests/gateway/test_table_helpers.py
@@ -68,3 +68,57 @@ class TestConvertTableToBullets:
         assert "• head2: b" in out
 
 
+    def test_surrounding_prose_preserved(self):
+        text = (
+            "Scores:\n\n"
+            "| Player | Score |\n"
+            "|--------|-------|\n"
+            "| Alice  | 150   |\n"
+            "\nEnd."
+        )
+        out = convert_table_to_bullets(text)
+        assert out.startswith("Scores:")
+        assert out.endswith("End.")
+
+    def test_table_inside_code_fence_untouched(self):
+        text = "```\n| a | b |\n|---|---|\n| 1 | 2 |\n```"
+        assert convert_table_to_bullets(text) == text
+
+    def test_plain_text_with_pipes_untouched(self):
+        text = "Use the | pipe operator to chain."
+        assert convert_table_to_bullets(text) == text
+
+    def test_horizontal_rule_not_matched(self):
+        text = "Section A\n\n---\n\nSection B"
+        assert convert_table_to_bullets(text) == text
+
+    def test_no_pipe_short_circuits(self):
+        text = "Plain **bold** text."
+        assert convert_table_to_bullets(text) == text
+
+    def test_row_groups_separated_by_blank_line(self):
+        text = (
+            "| A | B |\n"
+            "|---|---|\n"
+            "| x | 1 |\n"
+            "| y | 2 |"
+        )
+        out = convert_table_to_bullets(text)
+        assert "• B: 1\n\n**y**" in out
+        assert "\n\n• " not in out
+
+    def test_bold_heading_not_doubled(self):
+        """Regression: bold first-column cells must not become ****heading****.
+
+        Nested bold markers break Telegram MarkdownV2 conversion, which makes
+        Telegram fall back to plain text with raw ** symbols visible.
+        """
+        text = (
+            "| Advantage | Real value |\n"
+            "|-----------|-----------|\n"
+            "| **Live/work in UK freely** | Only if he wants to move there |"
+        )
+        out = convert_table_to_bullets(text)
+        assert "****" not in out
+        assert "**Live/work in UK freely**" in out
+        assert "• Real value: Only if he wants to move there" in out


### PR DESCRIPTION
## Problem

When a GFM pipe table's first-column cell already contains bold markdown (e.g. `| **Live/work in UK freely** | ... |`), `convert_table_to_bullets()` wraps the heading in another `**...**`, producing `****heading****`.

Telegram's MarkdownV2 parser rejects the resulting malformed bold, and the adapter falls back to plain-text delivery — so recipients see raw `**` symbols throughout the message instead of rendered formatting. Reported by a user whose Telegram messages arrived littered with `**` markers and the staccato `• Key: value` structure.

## Reproduce

```python
from gateway.platforms.helpers import convert_table_to_bullets

text = (
    "| Advantage | Real value |\n"
    "|-----------|-----------|\n"
    "| **Live/work in UK freely** | Only if he wants to move there |"
)
print(convert_table_to_bullets(text))
# before fix: "****Live/work in UK freely****"
# after fix:  "**Live/work in UK freely**"
```

## Fix

Strip inner `**` markers from the row heading before wrapping it in the group's own `**...**` (`gateway/platforms/helpers.py::_render_table_block`). Headings are already emphasized by the group wrapper, so no information is lost; cells keep their content otherwise untouched.

## Tests

- New regression test `test_bold_heading_not_doubled` asserts no `****` appears in output and the heading renders as single-level bold.
- Full `test_table_helpers.py` (19) + `test_telegram_format.py` (109) pass.