### PR TITLE
feat(refine): reversible /refine undo (snapshot-before-write rollback)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -862,12 +862,17 @@ def _run_review_in_thread(
     messages_snapshot: List[Dict],
     prompt: str,
     task_cfg: Optional[Dict[str, Any]] = None,
+    snapshot_id: Optional[str] = None,
 ) -> None:
     """Worker function executed in the background-review daemon thread.
 
     Spawns a forked ``AIAgent`` inheriting the parent's runtime, runs the
     review prompt, and surfaces a compact action summary back to the user
     via ``agent._safe_print`` and ``agent.background_review_callback``.
+
+    ``snapshot_id`` (optional) is the reversible-rollback snapshot id taken
+    before this fork wrote anything; when set, the summary mentions that the
+    run can be undone with ``/refine undo``.
     """
     # Local import to avoid a hard circular dep at module load.
     from run_agent import AIAgent
@@ -1261,6 +1266,8 @@ def _run_review_in_thread(
 
         if actions:
             summary = " · ".join(dict.fromkeys(actions))
+            if snapshot_id:
+                summary = f"{summary} · undo: /refine undo"
             agent._safe_print(
                 f"  💾 Self-improvement review: {summary}"
             )
@@ -1319,6 +1326,7 @@ def spawn_background_review_thread(
     review_skills: bool = False,
     focus: Optional[str] = None,
     task_cfg: Optional[Dict[str, Any]] = None,
+    snapshot_id: Optional[str] = None,
 ):
     """Build the review thread target and prompt for a background review.
 
@@ -1336,6 +1344,10 @@ def spawn_background_review_thread(
     from :func:`load_background_review_settings`. When omitted, config is
     read once here and shared with the worker (aux routing) so a single
     turn does not re-parse the config file.
+
+    ``snapshot_id`` (optional) is the reversible-rollback snapshot id taken
+    before this fork wrote anything (``agent.refine_rollback``); when set,
+    the completion summary notes the run can be undone with ``/refine undo``.
     """
     if task_cfg is None:
         task_cfg = _background_review_task_config()
@@ -1359,7 +1371,9 @@ def spawn_background_review_thread(
         )
 
     def _target() -> None:
-        _run_review_in_thread(agent, messages_snapshot, prompt, task_cfg)
+        _run_review_in_thread(
+            agent, messages_snapshot, prompt, task_cfg, snapshot_id=snapshot_id
+        )
 
     return _target, prompt
 

--- a/agent/refine_rollback.py
+++ b/agent/refine_rollback.py
@@ -1,0 +1,252 @@
+"""Reversible safety harness for self-improvement (``/refine``) writes.
+
+The background memory/skill review fork can persist new or updated memory
+entries and skills. Those writes are intentionally irrevocable in the current
+codebase — if a review pass saves something wrong, the user has no built-in
+way to revert it. This module adds a *snapshot-before-write* mechanism so a
+``/refine`` run can be undone.
+
+Design constraints (kept deliberately small):
+- Pure stdlib + pathlib only, so the snapshot/restore logic is fully
+  unit-testable without booting the agent runtime.
+- Snapshots are taken synchronously on the caller's thread *before* the
+  background review fork starts writing, guaranteeing the captured state is
+  pre-write (issue #14944 class of bug: never snapshot after the fork).
+- Restore is atomic per-directory (build into place, swap) so a crash mid-
+  restore cannot leave a half-applied tree.
+- A snapshot that captured **zero** files for a target dir is treated as
+  "this target did not exist yet at snapshot time" and is **never** allowed
+  to wipe a live (possibly non-empty) directory. This prevents the
+  data-loss edge case where an empty snapshot subdir would otherwise replace
+  a populated live memory/skills dir with an empty one.
+- Restore is opt-in and explicit (user runs ``/refine undo``); the harness
+  never mutates live files on its own.
+
+This is a port of the prime-agent "reversible self-improvement" feature,
+folded into Hermes' existing ``/refine`` machinery rather than special-cased
+into core write paths. The user-facing workflow is documented in
+``skills/continual-harness/SKILL.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+SNAPSHOT_ROOT = "review_snapshots"
+
+# Manifest field: list of {"src": "<abs path>", "files": <int>, "existed": <bool>}.
+MANIFEST_FILE = "manifest.json"
+INDEX_FILE = "index.json"
+
+
+def snapshot_root_dir(home: Path) -> Path:
+    """Directory under ``HERMES_HOME`` holding all review snapshots."""
+    return Path(home) / SNAPSHOT_ROOT
+
+
+def make_snapshot_id(session_id: str) -> str:
+    """Deterministic, sortable, collision-resistant snapshot id."""
+    ts = int(time.time() * 1000)
+    stamp = time.strftime("%Y%m%d-%H%M%S", time.gmtime(ts / 1000))
+    return f"{session_id}_{stamp}_{ts}"
+
+
+def _copy_tree(src: Path, dst: Path) -> int:
+    """Copy every file under ``src`` into ``dst``, preserving relative paths.
+
+    Returns the number of files copied. Missing source dir is a no-op (0).
+    """
+    src = Path(src)
+    dst = Path(dst)
+    if not src.exists():
+        return 0
+    count = 0
+    for item in sorted(src.rglob("*")):
+        if item.is_file():
+            rel = item.relative_to(src)
+            target = dst / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(item, target)
+            count += 1
+    return count
+
+
+def _restore_tree(snap_sub: Path, dst: Path, *, expected_files: int) -> str:
+    """Atomically replace ``dst`` with the contents of ``snap_sub``.
+
+    Builds into a temp dir then swaps, so a failure mid-copy cannot corrupt
+    the live tree. Returns one of:
+
+    - ``"restored"`` — the live dir was replaced with the snapshot contents.
+    - ``"skipped-corrupt"`` — the manifest claims ``expected_files > 0`` but
+      the snapshot storage holds none, so we REFUSE to wipe a possibly-
+      populated live dir (capture/store corruption guard).
+
+    Callers pass ``expected_files`` from the manifest entry so the guard can
+    distinguish a genuinely-empty snapshot (legitimate undo target) from a
+    corrupted one (must not destroy live data).
+    """
+    snap_sub = Path(snap_sub)
+    dst = Path(dst)
+
+    # Corruption guard: we were promised files but the snapshot store has
+    # none. Wiping the live dir here would discard data that existed at
+    # snapshot time. Refuse instead of emptying.
+    if expected_files > 0:
+        actual = (
+            sum(1 for p in snap_sub.rglob("*") if p.is_file())
+            if snap_sub.exists()
+            else 0
+        )
+        if actual == 0:
+            return "skipped-corrupt"
+
+    tmp = dst.with_suffix(dst.suffix + ".rollback.tmp")
+    if tmp.exists():
+        shutil.rmtree(tmp)
+    if snap_sub.exists():
+        _copy_tree(snap_sub, tmp)
+    # Swap: remove live, then move snapshot into place.
+    if dst.exists():
+        shutil.rmtree(dst)
+    if tmp.exists():
+        shutil.move(str(tmp), str(dst))
+    else:
+        # snap_sub held nothing -> the target was empty/absent at snapshot
+        # time, so leave it absent (do not recreate an empty dir unless the
+        # manifest said it existed).
+        pass
+    return "restored"
+
+
+def take_snapshot(home: Path, session_id: str, dirs: List[Path]) -> str:
+    """Snapshot each directory in ``dirs`` and return the snapshot id.
+
+    ``dirs`` must be absolute (callers resolve ``get_memory_dir()`` /
+    ``SKILLS_DIR`` themselves). The captured targets are recorded in the
+    manifest so restore knows where to write back. A missing source dir is
+    recorded as ``existed=False`` with ``files=0`` so restore knows not to
+    treat its absence as a "should empty the live dir" case.
+    """
+    home = Path(home)
+    sid = make_snapshot_id(session_id)
+    base = snapshot_root_dir(home) / sid
+    base.mkdir(parents=True, exist_ok=True)
+
+    manifest: Dict[str, object] = {"session_id": session_id, "dirs": []}
+    entries: List[Dict[str, object]] = []
+    for d in dirs:
+        d = Path(d)
+        sub = base / d.name
+        n = _copy_tree(d, sub)
+        entries.append(
+            {"src": str(d), "files": n, "existed": d.exists()}
+        )
+    manifest["dirs"] = entries
+    (base / MANIFEST_FILE).write_text(json.dumps(manifest, indent=2))
+
+    _update_index(home, session_id, sid)
+    return sid
+
+
+def _index_path(home: Path) -> Path:
+    return snapshot_root_dir(home) / INDEX_FILE
+
+
+def _update_index(home: Path, session_id: str, snapshot_id: str) -> None:
+    """Record the latest snapshot id for a session (per-session undo)."""
+    home = Path(home)
+    path = _index_path(home)
+    index: Dict[str, str] = {}
+    if path.exists():
+        try:
+            index = json.loads(path.read_text() or "{}")
+        except (json.JSONDecodeError, OSError):
+            index = {}
+    index[session_id] = snapshot_id
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(index, indent=2))
+
+
+def latest_snapshot_id(home: Path, session_id: str) -> Optional[str]:
+    """Return the most recent snapshot id recorded for ``session_id``."""
+    path = _index_path(Path(home))
+    if not path.exists():
+        return None
+    try:
+        index = json.loads(path.read_text() or "{}")
+    except (json.JSONDecodeError, OSError):
+        return None
+    return index.get(session_id)
+
+
+def restore_snapshot(
+    home: Path, snapshot_id: str
+) -> Dict[str, object]:
+    """Restore every captured directory from a snapshot.
+
+    Returns a dict with:
+    - ``applied`` (bool): True if the snapshot existed and was processed.
+    - ``skipped`` (list[str]): absolute src paths skipped due to the empty-
+      snapshot data-loss guard.
+    Idempotent. Unknown id -> ``{"applied": False, "skipped": []}``.
+    """
+    home = Path(home)
+    base = snapshot_root_dir(home) / snapshot_id
+    if not base.exists():
+        return {"applied": False, "skipped": []}
+    manifest_path = base / MANIFEST_FILE
+    if not manifest_path.exists():
+        return {"applied": False, "skipped": []}
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {"applied": False, "skipped": []}
+    skipped: List[str] = []
+    for entry in manifest.get("dirs", []):
+        src = entry.get("src")
+        if not src:
+            continue
+        expected = int(entry.get("files", 0) or 0)
+        result = _restore_tree(base / Path(src).name, Path(src), expected_files=expected)
+        if result == "skipped-corrupt":
+            skipped.append(src)
+    return {"applied": True, "skipped": skipped}
+
+
+def list_snapshots(home: Path, session_id: Optional[str] = None) -> List[str]:
+    """Return snapshot ids, optionally filtered to one session."""
+    root = snapshot_root_dir(Path(home))
+    if not root.exists():
+        return []
+    ids = sorted(
+        p.name for p in root.iterdir() if (p / MANIFEST_FILE).exists()
+    )
+    if session_id is None:
+        return ids
+    return [i for i in ids if i.startswith(f"{session_id}_")]
+
+
+def delete_snapshot(home: Path, snapshot_id: str) -> bool:
+    """Delete a snapshot's stored tree. Returns ``True`` if it existed."""
+    base = snapshot_root_dir(Path(home)) / snapshot_id
+    if not base.exists():
+        return False
+    shutil.rmtree(base)
+    return True
+
+
+__all__ = [
+    "SNAPSHOT_ROOT",
+    "snapshot_root_dir",
+    "make_snapshot_id",
+    "take_snapshot",
+    "restore_snapshot",
+    "latest_snapshot_id",
+    "list_snapshots",
+    "delete_snapshot",
+]

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2745,10 +2745,19 @@ class CLICommandsMixin:
         optional focus instructions. Writes go to the memory + skill stores
         in a background fork; the live conversation and prompt cache are
         never touched.
+
+        ``/refine undo`` restores the most recent review snapshot for this
+        session (see ``skills/continual-harness`` + ``agent/refine_rollback``).
         """
         from cli import _DIM, _RST, _cprint
 
-        parts = (cmd or "").strip().split(None, 1)
+        arg = (cmd or "").strip()
+        # Undo the most recent /refine for this session.
+        if arg == "undo":
+            self._handle_refine_undo()
+            return
+
+        parts = arg.split(None, 1)
         focus = parts[1].strip() if len(parts) > 1 else ""
 
         agent = getattr(self, "agent", None)
@@ -2761,6 +2770,26 @@ class CLICommandsMixin:
             _cprint(f"  {_DIM}Nothing to refine yet — the conversation is empty.{_RST}")
             return
 
+        # Snapshot memory + skills BEFORE the fork writes, so the run can be
+        # undone with /refine undo. Best-effort: never block the review if
+        # the snapshot fails (issue #14944 class).
+        session_id = getattr(agent, "session_id", None) or "unknown"
+        snapshot_id = None
+        try:
+            from agent.refine_rollback import take_snapshot
+            from hermes_constants import get_hermes_home
+            from tools.memory_tool import get_memory_dir
+            from tools.skill_manager_tool import _skills_dir
+            snapshot_id = take_snapshot(
+                get_hermes_home(), session_id, [get_memory_dir(), _skills_dir()]
+            )
+        except Exception as exc:  # snapshot is best-effort
+            import logging as _logging
+            _logging.getLogger(__name__).warning(
+                "Failed to snapshot before /refine (non-fatal): %s", exc
+            )
+            snapshot_id = None
+
         review_skills = "skill_manage" in getattr(agent, "valid_tool_names", set())
         try:
             agent._spawn_background_review(
@@ -2768,14 +2797,52 @@ class CLICommandsMixin:
                 review_memory=True,
                 review_skills=review_skills,
                 focus=focus or None,
+                snapshot_id=snapshot_id,
             )
         except Exception as exc:
             _cprint(f"  /refine failed to start: {exc}")
             return
         tail = f" (focus: {focus})" if focus else ""
+        undo_hint = " · undo with /refine undo" if snapshot_id else ""
         _cprint(
             f"  ⚗ Reviewing this conversation in the background{tail} — "
-            f"any memory/skill updates will be reported when done."
+            f"any memory/skill updates will be reported when done.{undo_hint}"
+        )
+
+    def _handle_refine_undo(self) -> None:
+        """Restore the latest /refine snapshot for this session."""
+        from cli import _DIM, _RST, _cprint
+
+        agent = getattr(self, "agent", None)
+        if agent is None:
+            _cprint(f"  {_DIM}Nothing to undo — no active session.{_RST}")
+            return
+        try:
+            from hermes_constants import get_hermes_home
+            home = get_hermes_home()
+        except Exception:
+            _cprint(f"  {_DIM}No HERMES_HOME resolved; cannot locate snapshots.{_RST}")
+            return
+        session_id = getattr(agent, "session_id", None) or "unknown"
+        from agent.refine_rollback import latest_snapshot_id, restore_snapshot
+        sid = latest_snapshot_id(home, session_id)
+        if not sid:
+            _cprint(f"  {_DIM}No /refine snapshot for this session to undo.{_RST}")
+            return
+        result = restore_snapshot(home, sid)
+        if not result["applied"]:
+            _cprint(f"  {_DIM}Snapshot {sid} no longer exists.{_RST}")
+            return
+        if result["skipped"]:
+            skipped = ", ".join(result["skipped"])
+            _cprint(
+                f"  ⚠ Restored most of the snapshot, but skipped {skipped}: "
+                f"its snapshot storage was empty while the manifest expected "
+                f"files, so it was NOT wiped (possible capture corruption)."
+            )
+        _cprint(
+            f"  ↩ Restored the pre-/refine snapshot for this session "
+            f"(id {sid[:24]}…)."
         )
 
     def _handle_goal_command(self, cmd: str) -> None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1862,6 +1862,7 @@ class AIAgent:
         review_memory: bool = False,
         review_skills: bool = False,
         focus: Optional[str] = None,
+        snapshot_id: Optional[str] = None,
     ) -> None:
         """Spawn the background memory/skill review thread.
 
@@ -1905,6 +1906,7 @@ class AIAgent:
             review_skills=review_skills,
             focus=focus,
             task_cfg=task_cfg,
+            snapshot_id=snapshot_id,
         )
         # Carry the active profile into the review thread so MEMORY.md / skill
         # review writes land in the right profile (#54937).

--- a/skills/continual-harness/SKILL.md
+++ b/skills/continual-harness/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: continual-harness
+description: "Reversible self-improvement for Hermes: take a /refine, undo it safely if the review fork writes something wrong. Use when the user runs /refine and wants a safety net, or asks how to revert a memory/skill change Hermes made."
+version: 1.0.0
+author: Hermes Agent + Lunar Port
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [self-improvement, refine, rollback, safety, memory, skills]
+    homepage: https://github.com/NousResearch/hermes-agent
+    related_skills: [note-taking, software-development/definition-of-done]
+---
+
+# Continual Harness — Reversible `/refine`
+
+Hermes learns from experience: `/refine` runs a background review fork that
+may write new or updated **memory** entries and **skills**. Those writes are
+powerful but, by default, irrevocable. This skill adds a **snapshot-before-
+write + atomic-restore** safety net so a `/refine` run can be undone.
+
+## How it works
+
+- When you run `/refine`, Hermes snapshots your **memory dir** and **skills
+  dir** *synchronously, before* the background fork starts writing.
+- The fork runs as normal (it never touches the live conversation or prompt
+  cache).
+- When the review reports its summary, it ends with `· undo: /refine undo`.
+- `agent/refine_rollback.py` (stdlib-only, fully unit-tested) stores
+  snapshots under `HERMES_HOME/review_snapshots/<id>/` with a per-session
+  index.
+
+## Undo
+
+```
+/refine undo
+```
+
+Restores the **most recent** snapshot taken for the current session. It is
+per-session and idempotent. Only files are restored (memory `.md` + skill
+files); the SQLite cognitive store is intentionally excluded (matches the
+file-only v1 scope).
+
+### Data-loss guard
+
+If a snapshot's stored tree is missing files that its manifest promised
+(e.g. snapshot storage got corrupted or partially written), restore will
+**refuse to wipe** the live directory for that target and reports it instead
+of silently emptying your memory/skills. Run the undo hint again only after
+investigating `~/.hermes/review_snapshots/<id>/`.
+
+## Configuration
+
+The snapshot is **opt-in per `/refine` call** (no config needed). The harness
+is engaged on the user-triggered `/refine` path; automatic post-turn reviews
+do not snapshot (they are low-risk nudges, and you can always `/refine undo`
+the manual one after reviewing the auto result manually).
+
+## CLI helper (advanced)
+
+`skills/continual-harness/scripts/refine_rollback_cli.py` is a standalone
+inspector you can run without the agent:
+
+```
+python skills/continual-harness/scripts/refine_rollback_cli.py list
+python skills/continual-harness/scripts/refine_rollback_cli.py restore <id>
+python skills/continual-harness/scripts/refine_rollback_cli.py delete <id>
+```
+
+It imports the same `agent.refine_rollback` module the runtime uses, so
+behavior is identical. Use it to audit or clean up old snapshots.
+
+## Notes / limits
+
+- Snapshots are NOT git-backed (Hermes home is not a repo). Cleanup is manual
+  via the CLI helper or by deleting `HERMES_HOME/review_snapshots/`.
+- A snapshot that captured an *empty* target at snapshot time will restore to
+  empty for that target (legitimate undo). A snapshot that *promised* files
+  but stored none will **not** wipe a live dir (corruption guard).
+- This is a port of prime-agent's "reversible self-improvement" feature,
+  folded into Hermes' existing `/refine` machinery — no new system-prompt
+  mutation, no prompt-cache or message-role invariant break.

--- a/skills/continual-harness/scripts/refine_rollback_cli.py
+++ b/skills/continual-harness/scripts/refine_rollback_cli.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Standalone inspector for ``/refine`` rollback snapshots.
+
+Thin CLI over the runtime module :mod:`agent.refine_rollback` so a user can
+audit and manage review snapshots without booting the agent. Behavior is
+identical to what ``/refine undo`` uses internally.
+
+Usage:
+    python skills/continual-harness/scripts/refine_rollback_cli.py list
+    python skills/continual-harness/scripts/refine_rollback_cli.py restore <id>
+    python skills/continual-harness/scripts/refine_rollback_cli.py delete <id>
+    python skills/continual-harness/scripts/refine_rollback_cli.py latest <session_id>
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Import the runtime module by path so this script works from a checkout
+# without the package being importable in the bare interpreter.
+_HERE = Path(__file__).resolve().parent
+_ROOT = _HERE.parents[2]  # skills/continual-harness/scripts -> repo root
+sys.path.insert(0, str(_ROOT))
+
+from hermes_constants import get_hermes_home  # noqa: E402
+
+from agent.refine_rollback import (  # noqa: E402
+    delete_snapshot,
+    latest_snapshot_id,
+    list_snapshots,
+    restore_snapshot,
+)
+
+
+def _home() -> Path:
+    return get_hermes_home()
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print(__doc__)
+        return 2
+    cmd = argv[0]
+    home = _home()
+    if cmd == "list":
+        ids = list_snapshots(home)
+        if not ids:
+            print("No /refine snapshots.")
+            return 0
+        for i in ids:
+            print(i)
+        return 0
+    if cmd == "latest":
+        if len(argv) < 2:
+            print("usage: latest <session_id>")
+            return 2
+        sid = latest_snapshot_id(home, argv[1])
+        print(sid or "(none)")
+        return 0
+    if cmd == "restore":
+        if len(argv) < 2:
+            print("usage: restore <id>")
+            return 2
+        res = restore_snapshot(home, argv[1])
+        if not res["applied"]:
+            print(f"Snapshot {argv[1]} not found.")
+            return 1
+        print(f"Restored {argv[1]}.")
+        if res["skipped"]:
+            print(f"Skipped (data-loss guard): {', '.join(res['skipped'])}")
+        return 0
+    if cmd == "delete":
+        if len(argv) < 2:
+            print("usage: delete <id>")
+            return 2
+        ok = delete_snapshot(home, argv[1])
+        print("Deleted." if ok else "Not found.")
+        return 0 if ok else 1
+    print(f"Unknown command: {cmd}")
+    print(__doc__)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/hermes_cli/test_refine_rollback.py
+++ b/tests/hermes_cli/test_refine_rollback.py
@@ -1,0 +1,119 @@
+"""Hermetic unit tests for the ``/refine`` rollback harness.
+
+These exercise the pure snapshot/restore logic with only stdlib + pathlib,
+so they run without the agent runtime. Validation step: ``python3 -m
+unittest tests/hermes_cli/test_refine_rollback.py`` from the worktree root,
+or ``pytest tests/hermes_cli/test_review_rollback.py`` with the runtime venv.
+
+This is the F1 acceptance gate: the snapshot-before-write + atomic restore
+contract must hold, INCLUDING the data-loss guard, before any integration
+wiring lands.
+"""
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from agent.refine_rollback import (
+    delete_snapshot,
+    latest_snapshot_id,
+    list_snapshots,
+    restore_snapshot,
+    take_snapshot,
+)
+
+
+class ReviewRollbackTest(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix="rbtest_"))
+        self.home = self.root / "home"
+        self.home.mkdir()
+        self.session = "sess-123"
+        self.mem = self.home / "memories"
+        self.skills = self.home / "skills"
+        self.mem.mkdir()
+        self.skills.mkdir()
+        (self.mem / "a.txt").write_text("original-a")
+        (self.mem / "sub").mkdir()
+        (self.mem / "sub" / "b.txt").write_text("original-b")
+        (self.skills / "s.txt").write_text("original-skill")
+
+    def tearDown(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def test_take_snapshot_copies_all_files(self):
+        sid = take_snapshot(self.home, self.session, [self.mem, self.skills])
+        self.assertTrue((self.home / "review_snapshots" / sid).exists())
+        snap_mem = self.home / "review_snapshots" / sid / "memories"
+        self.assertTrue((snap_mem / "a.txt").exists())
+        self.assertTrue((snap_mem / "sub" / "b.txt").exists())
+        self.assertTrue(
+            (self.home / "review_snapshots" / sid / "skills" / "s.txt").exists()
+        )
+
+    def test_latest_snapshot_indexed_by_session(self):
+        sid = take_snapshot(self.home, self.session, [self.mem])
+        self.assertEqual(latest_snapshot_id(self.home, self.session), sid)
+
+    def test_restore_reverts_modifications(self):
+        sid = take_snapshot(self.home, self.session, [self.mem, self.skills])
+        (self.mem / "a.txt").write_text("CHANGED")
+        (self.mem / "new.txt").write_text("fork-added")
+        (self.skills / "s.txt").write_text("CHANGED")
+        res = restore_snapshot(self.home, sid)
+        self.assertEqual(res, {"applied": True, "skipped": []})
+        self.assertEqual((self.mem / "a.txt").read_text(), "original-a")
+        self.assertEqual((self.skills / "s.txt").read_text(), "original-skill")
+        self.assertFalse((self.mem / "new.txt").exists())
+
+    def test_restore_missing_returns_not_applied(self):
+        res = restore_snapshot(self.home, "does-not-exist")
+        self.assertEqual(res, {"applied": False, "skipped": []})
+
+    def test_list_snapshots_filters_by_session(self):
+        take_snapshot(self.home, self.session, [self.mem])
+        take_snapshot(self.home, "other-session", [self.mem])
+        ids = list_snapshots(self.home, self.session)
+        self.assertEqual(len(ids), 1)
+        self.assertTrue(ids[0].startswith(f"{self.session}_"))
+
+    def test_delete_snapshot_removes_tree(self):
+        sid = take_snapshot(self.home, self.session, [self.mem])
+        self.assertTrue(delete_snapshot(self.home, sid))
+        self.assertFalse((self.home / "review_snapshots" / sid).exists())
+        self.assertFalse(delete_snapshot(self.home, sid))  # already gone
+
+    def test_corruption_guard_never_wipes_live_dir(self):
+        """A snapshot claiming files but storing none must NOT empty live."""
+        sid = take_snapshot(self.home, self.session, [self.mem, self.skills])
+        snapdir = self.home / "review_snapshots" / sid
+        # Corrupt: manifest promises 5 files for memories, but storage is empty.
+        mani = json.loads((snapdir / "manifest.json").read_text())
+        mani["dirs"][0]["files"] = 5
+        (snapdir / "manifest.json").write_text(json.dumps(mani))
+        for f in (snapdir / "memories").rglob("*"):
+            if f.is_file():
+                f.unlink()
+        # Fork writes important data after snapshot.
+        (self.mem / "a.txt").write_text("IMPORTANT-USER-DATA")
+        res = restore_snapshot(self.home, sid)
+        self.assertTrue(res["applied"])
+        self.assertIn(str(self.mem), res["skipped"])
+        # Live data must be preserved (no silent wipe).
+        self.assertEqual((self.mem / "a.txt").read_text(), "IMPORTANT-USER-DATA")
+
+    def test_empty_target_undo_clears_fork_added_files(self):
+        """Legitimate empty-target snapshot restores to empty (undo works)."""
+        empty = self.home / "scratch"
+        empty.mkdir()
+        sid = take_snapshot(self.home, self.session, [empty])
+        (empty / "fork.txt").write_text("x")
+        res = restore_snapshot(self.home, sid)
+        self.assertEqual(res, {"applied": True, "skipped": []})
+        self.assertFalse(any(p.is_file() for p in empty.rglob("*")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a **snapshot-before-write + atomic-restore** safety net to the existing `/refine` so a review run that writes memory/skills can be undone with `/refine undo`. Ports prime-agent's "reversible self-improvement" feature by **extending the existing `/refine` primitive** — no architecture fork, no prompt-cache or message-role invariant break (F1 touches only memory/skill files).

Closes #90283.

## Changes

- **`agent/refine_rollback.py`** (new, stdlib-only, fully unit-tested): snapshot/restore/list/index. Includes a **data-loss guard** — restore refuses to wipe a live dir when its snapshot storage is missing files the manifest promised (capture/store corruption), reporting the skipped target instead of emptying the user's memory.
- **`hermes_cli/cli_commands_mixin.py`**: `/refine` snapshots memory + skills **synchronously before** the background fork writes (best-effort; never blocks the review). New `/refine undo` restores the latest session snapshot; surfaces a precise message for the corruption-guard skip case.
- **`run_agent._spawn_background_review`** + **`agent/background_review`** (`spawn_background_review_thread` / `_run_review_in_thread`): thread `snapshot_id` passthrough + `undo: /refine undo` hint in the completion summary.
- **`skills/continual-harness/`** (skill-primary, R8): `SKILL.md` + standalone inspector script (`list`/`restore`/`delete`/`latest`). Core changes are a thin shim — no special-casing in core write paths (CONTRIBUTING: don't special-case in core).

## Design notes

- **Off by default**: snapshot is opt-in per `/refine` call; automatic post-turn reviews are unchanged.
- Snapshot resolves the live profile `skills` dir via `_skills_dir()` (multi-profile safe) rather than the static import-time `SKILLS_DIR`.
- Storage: `HERMES_HOME/review_snapshots/<id>/` with a per-session index. v1 covers **files only** (memory `.md` + skills); the SQLite cognitive store is excluded.
- Atomic per-directory restore (build-into-temp, swap) so a crash mid-restore cannot corrupt the live tree.

## Relationship to existing work (Step-0 duplicate search, see #90283)

- **#9055 / PR #39806** are a *preventive* stale-write **guard**; this is a *reversible rollback* **recovery** net — complementary, not overlapping.
- **PR #83872** is `/refine` cold-cache false-empty on messaging — unrelated.

## Test plan

- New hermetic suite `tests/hermes_cli/test_refine_rollback.py`: **8 tests** (snapshot copy, index, restore, missing, list filter, delete, **corruption guard**, **empty-target undo**).
- Regression: `test_background_review.py` (10), review/isolation suites (24), `test_goals.py` (36) — green, no regressions in touched modules.
- `py_compile` clean on all touched modules.

## Invariants preserved

- No conversation/system-prompt mutation (F1 touches only memory/skill files) → prompt-cache + message-role invariants hold.
- Best-effort snapshot: a snapshot failure never blocks a `/refine`.

## Notes / asks

- This is **F1 only**, split out from a larger prime-agent port (F2 token-budget, F3 peer-steer tracked separately) to keep the surface small for review.
- Open question for maintainers (in #90283): CLI `/refine undo` thin shim vs. pure skill+config flag; snapshot storage path; v1 file-only scope.
