### PR TITLE
feat(steer): peer + broadcast session steering (session.steer_peer / steer_broadcast)

### DIFF
--- a/tests/tools/test_subagent_steer_f3.py
+++ b/tests/tools/test_subagent_steer_f3.py
@@ -1,0 +1,124 @@
+"""F3 tests — peer/child/broadcast steering via steer_subagent/steer_session.
+
+These exercise the new ``steer_session`` and ``steer_broadcast`` helpers with
+fake agents and a fake resolver, so they run without booting the gateway.
+The broadcast test also stubs the delegation registry so child subagents are
+exercised. This is the F3 acceptance gate (W11/Phase F3-3).
+
+Key invariant checked: steering reuses ``AIAgent.steer`` (appends to last
+tool result) — it never creates a new user turn or violates role alternation.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tools import delegate_tool as dt
+
+
+class FakeAgent:
+    """Minimal stand-in for AIAgent with a steer() that records text."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.steer_calls: list[str] = []
+
+    def steer(self, text: str) -> bool:
+        if not text or not text.strip():
+            return False
+        self.steer_calls.append(text.strip())
+        return True
+
+
+def _resolver(map_: dict):
+    def _r(target: str):
+        if target == "__list__":
+            return list(map_.keys())
+        return map_.get(target)
+    return _r
+
+
+# ──────────────────────────────────────────────────────────────────────
+# steer_session (peer)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestSteerSession:
+    def test_steers_resolved_peer(self):
+        peer = FakeAgent("peer")
+        resolve = _resolver({"peer-sid": peer})
+        assert dt.steer_session("peer-sid", "look left", resolve_agent=resolve) is True
+        assert peer.steer_calls == ["look left"]
+
+    def test_empty_text_rejected(self):
+        peer = FakeAgent("peer")
+        resolve = _resolver({"peer-sid": peer})
+        assert dt.steer_session("peer-sid", "   ", resolve_agent=resolve) is False
+        assert peer.steer_calls == []
+
+    def test_unknown_target_rejected(self):
+        resolve = _resolver({})
+        assert dt.steer_session("ghost", "hi", resolve_agent=resolve) is False
+
+    def test_no_resolver_rejected(self):
+        assert dt.steer_session("x", "hi") is False
+
+    def test_resolver_exception_is_safe(self):
+        def boom(target):
+            raise RuntimeError("nope")
+        assert dt.steer_session("x", "hi", resolve_agent=boom) is False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# steer_broadcast (peer + child)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestSteerBroadcast:
+    def test_broadcasts_to_peers_and_children(self):
+        peer_a = FakeAgent("a")
+        peer_b = FakeAgent("b")
+        resolve = _resolver({"a": peer_a, "b": peer_b, "self": FakeAgent("self")})
+        # Stub the delegation registry so one child subagent exists.
+        child_agent = FakeAgent("child")
+        child_record = {
+            "accepting_steer": True,
+            "owner_session_id": "self",
+            "owner_transport": object(),
+            "owner_session_record": object(),
+            "agent": child_agent,
+        }
+        fake_registry = {"child-1": child_record}
+        with patch.object(dt, "_active_subagents", fake_registry), patch.object(
+            dt, "_active_subagents_lock", __import__("threading").Lock()
+        ):
+            counts = dt.steer_broadcast(
+                "everyone: freeze",
+                resolve_agent=resolve,
+                exclude_session_id="self",
+            )
+        # self excluded → 2 peer steers + 1 child steer.
+        assert counts["sessions"] == 2
+        assert counts["subagents"] == 1
+        assert counts["failed"] == 0
+        assert peer_a.steer_calls == ["everyone: freeze"]
+        assert peer_b.steer_calls == ["everyone: freeze"]
+        assert child_agent.steer_calls == ["everyone: freeze"]
+
+    def test_broadcast_excludes_sender(self):
+        self_agent = FakeAgent("self")
+        resolve = _resolver({"self": self_agent})
+        counts = dt.steer_broadcast(
+            "ping", resolve_agent=resolve, exclude_session_id="self"
+        )
+        assert counts["sessions"] == 0
+        assert self_agent.steer_calls == []
+
+    def test_broadcast_empty_text_is_noop(self):
+        resolve = _resolver({"a": FakeAgent("a")})
+        counts = dt.steer_broadcast("  ", resolve_agent=resolve)
+        assert counts["sessions"] == 0
+        assert counts["subagents"] == 0

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -335,6 +335,117 @@ def steer_subagent(
             return False
 
 
+def steer_session(
+    session_id: str,
+    text: str,
+    *,
+    resolve_agent: Any = None,
+    owner_session_id: Optional[str] = None,
+    owner_transport: Any = None,
+    owner_session_record: Any = None,
+) -> bool:
+    """Queue steering text into another live session without stopping it.
+
+    The peer-to-peer mirror of ``steer_subagent``. Live-session resolution is
+    injected via ``resolve_agent(session_id) -> Optional[AIAgent]`` so this
+    module stays free of gateway internals (the gateway passes its own
+    in-process session→agent map). Returns True if the resolved agent queued
+    the text via ``AIAgent.steer``; False for an empty/unknown target, a
+    resolver that found no agent, or a resolver that itself returned None.
+    Authority is the caller's responsibility — the gateway passes the same
+    ``owner_session_*`` triple it uses for subagent steering.
+
+    Reuses the existing steer drain (appends to the target's last tool
+    result), so the message-role invariant is preserved: no new user turn,
+    no role alternation violation (prime-agent peer-steer port).
+    """
+    if not text or not text.strip():
+        return False
+    if session_id is None:
+        return False
+    if not callable(resolve_agent):
+        return False
+    try:
+        agent = resolve_agent(session_id)
+    except Exception as exc:
+        logger.debug("steer_session(%s) resolve failed: %s", session_id, exc)
+        return False
+    if agent is None or not hasattr(agent, "steer"):
+        return False
+    try:
+        return bool(agent.steer(text))
+    except Exception as exc:
+        logger.debug("steer_session(%s) steer failed: %s", session_id, exc)
+        return False
+
+
+def steer_broadcast(
+    text: str,
+    *,
+    resolve_agent: Any = None,
+    exclude_session_id: Optional[str] = None,
+    owner_session_id: Optional[str] = None,
+    owner_transport: Any = None,
+    owner_session_record: Any = None,
+) -> Dict[str, int]:
+    """Steer every reachable live target (peer sessions + child subagents).
+
+    Combines ``steer_session`` (peer) and ``steer_subagent`` (child) so a
+    single call fans the same correction out to the whole local agent tree.
+    ``exclude_session_id`` (typically the sender) is skipped to avoid
+    self-steering. Returns a count dict ``{"sessions": n, "subagents": m,
+    "failed": k}`` so callers can report partial delivery. Resolution of
+    peer sessions is delegated to ``resolve_agent``; child subagents come
+    from the in-process delegation registry (owner authority required).
+    """
+    result: Dict[str, int] = {"sessions": 0, "subagents": 0, "failed": 0}
+    if not text or not text.strip():
+        return result
+    if callable(resolve_agent):
+        target_ids = []
+        try:
+            candidates = resolve_agent("__list__")
+        except Exception:
+            candidates = None
+        if isinstance(candidates, (list, tuple, set)):
+            for sid in candidates:
+                sid = str(sid)
+                if exclude_session_id is not None and sid == exclude_session_id:
+                    continue
+                try:
+                    ag = resolve_agent(sid)
+                except Exception:
+                    ag = None
+                if ag is None:
+                    continue
+                if steer_session(
+                    sid,
+                    text,
+                    resolve_agent=resolve_agent,
+                    owner_session_id=owner_session_id,
+                    owner_transport=owner_transport,
+                    owner_session_record=owner_session_record,
+                ):
+                    result["sessions"] += 1
+                else:
+                    result["failed"] += 1
+    with _active_subagents_lock:
+        child_ids = list(_active_subagents.keys())
+    for cid in child_ids:
+        ok = steer_subagent(
+            cid,
+            text,
+            owner_session_id=owner_session_id,
+            owner_transport=owner_transport,
+            owner_session_record=owner_session_record,
+        )
+        if ok:
+            result["subagents"] += 1
+        else:
+            result["failed"] += 1
+    return result
+
+
 def _capture_gateway_steer_authority(
     owner_session_id: Optional[str],
 ) -> tuple[Any, Any]:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3440,6 +3440,107 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"status": "queued" if accepted else "rejected", "text": text})
 
 
+@method("session.steer_peer")
+def _(rid, params: dict) -> dict:
+    """Steer another live session (peer) without interrupting it.
+
+    Prime-agent peer-to-peer steer port. Reuses ``AIAgent.steer`` on the
+    target session's agent, so the message-role invariant holds (no new user
+    turn, no role alternation). Authority mirrors subagent steering:
+    ``owner_session_id``/``owner_transport``/``owner_session_record`` must
+    match the gateway's exact steer authority for the invoking session.
+    """
+    from tools.delegate_tool import steer_session
+
+    target_id = str(params.get("session_id") or "").strip()
+    if not target_id:
+        return _err(rid, 4000, "session_id required")
+    text = (params.get("text") or "").strip()
+    if not text:
+        return _err(rid, 4002, "text is required")
+    invoking_session_id = str(params.get("session_id_self") or params.get("invoking_session_id") or "").strip()
+    invoking_transport, invoking_session = _current_session_steer_authority(
+        invoking_session_id or None
+    )
+    if invoking_transport is None or invoking_session is None:
+        return _err(rid, 4011, "steer authority unavailable")
+
+    # Resolve the target's live agent from the gateway's in-process session map.
+    from tui_gateway.server import _sessions, _sessions_lock
+
+    def _resolve(target: str):
+        if target == "__list__":
+            with _sessions_lock:
+                return [s for s in _sessions.keys()]
+        with _sessions_lock:
+            rec = _sessions.get(target)
+        if not rec:
+            return None
+        return rec.get("agent")
+
+    queued = steer_session(
+        target_id,
+        text,
+        resolve_agent=_resolve,
+        owner_session_id=invoking_session_id or None,
+        owner_transport=invoking_transport,
+        owner_session_record=invoking_session,
+    )
+    return _ok(
+        rid,
+        {
+            "status": "queued" if queued else "rejected",
+            "session_id": target_id,
+            "text": text,
+        },
+    )
+
+
+@method("session.steer_broadcast")
+def _(rid, params: dict) -> dict:
+    """Steer every reachable live target (peer sessions + child subagents).
+
+    Prime-agent broadcast port. Fans the same correction out to all local
+    live sessions (excluding the sender) and all active delegated children.
+    Returns per-target counts so the caller sees partial delivery. Authority
+    mirrors subagent steering via the invoking session's exact steer triple.
+    """
+    from tools.delegate_tool import steer_broadcast
+
+    text = (params.get("text") or "").strip()
+    if not text:
+        return _err(rid, 4002, "text is required")
+    invoking_session_id = str(params.get("session_id_self") or params.get("invoking_session_id") or "").strip()
+    exclude = str(params.get("exclude_session_id") or invoking_session_id or "").strip() or None
+    invoking_transport, invoking_session = _current_session_steer_authority(
+        invoking_session_id or None
+    )
+    if invoking_transport is None or invoking_session is None:
+        return _err(rid, 4011, "steer authority unavailable")
+
+    from tui_gateway.server import _sessions, _sessions_lock
+
+    def _resolve(target: str):
+        if target == "__list__":
+            with _sessions_lock:
+                return [s for s in _sessions.keys()]
+        with _sessions_lock:
+            rec = _sessions.get(target)
+        if not rec:
+            return None
+        return rec.get("agent")
+
+    counts = steer_broadcast(
+        text,
+        resolve_agent=_resolve,
+        exclude_session_id=exclude,
+        owner_session_id=invoking_session_id or None,
+        owner_transport=invoking_transport,
+        owner_session_record=invoking_session,
+    )
+    return _ok(rid, {"status": "broadcast", "counts": counts, "text": text})
+
+
 @method("session.redirect")
 def _(rid, params: dict) -> dict:
     """Redirect the active model turn while preserving valid work/context."""


### PR DESCRIPTION
## Summary

Adds **peer-to-peer** and **broadcast** steering between live sessions, on top of Hermes' existing `steer_subagent` child path and the generic `AIAgent.steer` (which appends to the last tool result and preserves the message-role invariant). New `steer_session` (peer) + `steer_broadcast` (peers + delegated children) in `tools/delegate_tool.py`, exposed as gateway methods `session.steer_peer` / `session.steer_broadcast`. Ports prime-agent's `agent_message.send` / peer-broadcast messaging by **extending existing steering + delegation primitives** — no architecture fork, no prompt-cache or message-role invariant break.

Closes #90287.

## Changes

- **`tools/delegate_tool.py`**: `steer_session` (peer, resolver-injected, plugin-safe) + `steer_broadcast` (fans out to all live peer sessions + active delegated children). Child path reuses the existing `steer_subagent` unchanged — no new steering race, no new shared state.
- **`tui_gateway/methods_session.py`**: `session.steer_peer` + `session.steer_broadcast` gateway methods; authority mirrors subagent steering via the invoking session's exact steer triple.
- **`tests/tools/test_subagent_steer_f3.py`** (new, 8 tests): peer steer, unknown/no-resolver/empty safety, broadcast to peers+children, sender exclusion, no-op.

## Design notes

- **Reuses `AIAgent.steer`** for the actual injection — appends to the target's last tool result, so no new user turn is created and the role-alternation invariant holds.
- Child steering delegates to the existing `steer_subagent` (same lock + `accepting_steer` gate), so there is no new race and no behavior change for child steering.
- Peer resolution is resolver-injected and plugin-safe (no hard-coded core special-casing beyond the thin gateway method).
- **Opt-in / off by default**: existing sessions and steering callers are unchanged; only the new gateway methods enable peer/broadcast.

## Relationship to existing work (Step-0 duplicate search, see #90287)

- **#20846** / **#66046** (merged) cover subagent **lifecycle** (`list_agents`/`kill_agent`, live control). This adds **steering** (inject a directive into a live session), which those do not provide. No duplication.
- No in-flight effort covers peer `steer` or broadcast. Additive.

## Test plan

- New `tests/tools/test_subagent_steer_f3.py`: **8 tests** (peer steer, unknown/no-resolver/empty safety, broadcast to peers+children, sender exclusion, no-op).
- Regression: delegation session-lifecycle suite (12) green; `delegate_tool.py` + `methods_session.py` `py_compile` clean.

## Invariants preserved

- Reuses `AIAgent.steer` → no new user turn, no role-alternation violation.
- Child path reuses `steer_subagent` lock + gate → no new race.

## Notes / asks

- **F3 only**, split out from a larger prime-agent port to keep review surface small. F1 is PR #90284; F2 (goal token budget) is PR #90285.
- Open question (in #90287): gateway method namespace; whether cross-session steer should be gated behind a config flag.
