### PR TITLE
fix(desktop): keep Windows chat windows opaque with glass off

### DIFF
--- a/apps/desktop/electron/translucency-windows.test.ts
+++ b/apps/desktop/electron/translucency-windows.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_GLASS_MATERIAL,
+  DEFAULT_GLASS_SCOPE,
+  type TranslucencyState,
+  windowBackingOptionsForPlatform
+} from './translucency'
+
+const state = (intensity: number, mode: 'clear' | 'glass'): TranslucencyState => ({
+  intensity,
+  fade: 0,
+  mode,
+  material: DEFAULT_GLASS_MATERIAL,
+  scope: DEFAULT_GLASS_SCOPE
+})
+
+describe('Windows chat window backing', () => {
+  it('keeps the BrowserWindow opaque while glass is off', () => {
+    expect(windowBackingOptionsForPlatform(state(0, 'glass'), '#111111', 'win32')).toEqual({
+      backgroundColor: '#111111',
+      backgroundMaterial: undefined,
+      transparent: false
+    })
+
+    expect(windowBackingOptionsForPlatform(state(60, 'clear'), '#111111', 'win32')).toEqual({
+      backgroundColor: '#111111',
+      backgroundMaterial: undefined,
+      transparent: false
+    })
+  })
+
+  it('leaves glass-active windows available for the native material', () => {
+    expect(windowBackingOptionsForPlatform(state(60, 'glass'), '#111111', 'win32')).toEqual({})
+  })
+})

--- a/apps/desktop/electron/translucency.ts
+++ b/apps/desktop/electron/translucency.ts
@@ -49,6 +49,12 @@ export {
   type WindowsBackgroundMaterial
 } from '../../shared/src/translucency'
 
+type WindowBackingOptions = {
+  backgroundColor?: string
+  backgroundMaterial?: undefined
+  transparent?: boolean
+}
+
 /**
  * BrowserWindow constructor options for a chat window's backing, given the
  * translucency state at creation time.
@@ -60,7 +66,10 @@ export {
  * window is quietly treated as opaque.
  *
  * Glass inactive → the opaque themed backing (anti-flash paint before the
- * renderer's first paint, and what clear mode fades against).
+ * renderer's first paint, and what clear mode fades against). On Windows this
+ * also explicitly overrides the glass-capable constructor defaults so a chat
+ * window remains a normal opaque DWM window while glass is off; that preserves
+ * native Snap and FancyZones participation.
  *
  * A runtime `setBackgroundColor` swap (see applyWindowTranslucency in main)
  * only settles reliably on a window that has been compositing for a while —
@@ -68,6 +77,26 @@ export {
  * seconds of a fresh process were lost, including from 'ready-to-show' and
  * 'did-finish-load' — so creation must not rely on a post-creation fixup.
  */
-export function windowBackingOptions(state: TranslucencyState, themedColor: string): { backgroundColor?: string } {
-  return glassActive(state) ? {} : { backgroundColor: themedColor }
+export function windowBackingOptionsForPlatform(
+  state: TranslucencyState,
+  themedColor: string,
+  platform: NodeJS.Platform
+): WindowBackingOptions {
+  if (glassActive(state)) {
+    return {}
+  }
+
+  if (platform === 'win32') {
+    return {
+      backgroundColor: themedColor,
+      backgroundMaterial: undefined,
+      transparent: false
+    }
+  }
+
+  return { backgroundColor: themedColor }
+}
+
+export function windowBackingOptions(state: TranslucencyState, themedColor: string): WindowBackingOptions {
+  return windowBackingOptionsForPlatform(state, themedColor, process.platform)
 }

--- a/apps/desktop/electron/translucency.ts
+++ b/apps/desktop/electron/translucency.ts
@@ -49,6 +49,8 @@ export {
   type WindowsBackgroundMaterial
 } from '../../shared/src/translucency'
 
+// These options must be spread after any glass-capable BrowserWindow defaults
+// so the explicit Windows glass-off values can override them.
 type WindowBackingOptions = {
   backgroundColor?: string
   backgroundMaterial?: undefined


### PR DESCRIPTION
Fixes #90237

On Windows, glass-capable chat windows were still born with `transparent: true` even when glass was disabled, which breaks native Snap and FancyZones behavior.

This keeps Windows chat windows explicitly opaque while glass is inactive and clears the native background material override at construction time. Glass-active windows keep the existing transparent/material path.

Adds focused regression coverage for Windows glass-off, clear mode, and glass-active constructor backing behavior.