### PR TITLE
fix(cli): map NumLock/CapsLock modifier-bit variants under kitty protocol

### DIFF
--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -345,6 +345,56 @@ def install_modify_other_keys_aliases() -> int:
                                             # matching Ink TUI + Desktop (#78285)
     })
 
+    # -- Lock-key modifier bits (NumLock=128, CapsLock=64) under the kitty
+    # disambiguate push: kitty encodes lock state into the CSI sequence, so
+    # a plain Down with NumLock on arrives as ESC[1;129B (NumLock), ESC[1;65B
+    # (CapsLock) or ESC[1;193B (both) instead of the legacy ESC[B that stock
+    # prompt_toolkit maps. Those fall through the parser and leak as literal
+    # text ("[1;129B") in the input line. Map them to the plain key; the
+    # +shift variants (130/66/194) to the Shift* keys.
+    lock_plain = (129, 65, 193)
+    lock_shift = (130, 66, 194)
+    for mod in lock_plain:
+        for trailer, key in (
+            ("A", Keys.Up), ("B", Keys.Down), ("C", Keys.Right), ("D", Keys.Left),
+            ("H", Keys.Home), ("F", Keys.End),
+        ):
+            seq = f"\x1b[1;{mod}{trailer}"
+            if seq not in ANSI_SEQUENCES:
+                ANSI_SEQUENCES[seq] = key
+                changed += 1
+        for num, key in (
+            (2, Keys.Insert), (3, Keys.Delete), (5, Keys.PageUp), (6, Keys.PageDown),
+        ):
+            seq = f"\x1b[{num};{mod}~"
+            if seq not in ANSI_SEQUENCES:
+                ANSI_SEQUENCES[seq] = key
+                changed += 1
+        for cp, key in (
+            (13, Keys.ControlM),   # Enter
+            (9, Keys.Tab),         # Tab
+            (127, Keys.Backspace),  # Backspace
+            (32, " "),             # Space
+        ):
+            seq = f"\x1b[{cp};{mod}u"
+            if seq not in ANSI_SEQUENCES:
+                ANSI_SEQUENCES[seq] = key
+                changed += 1
+    for mod in lock_shift:
+        for trailer, key in (
+            ("A", Keys.ShiftUp), ("B", Keys.ShiftDown), ("C", Keys.ShiftRight),
+            ("D", Keys.ShiftLeft), ("H", Keys.ShiftHome), ("F", Keys.ShiftEnd),
+        ):
+            seq = f"\x1b[1;{mod}{trailer}"
+            if seq not in ANSI_SEQUENCES:
+                ANSI_SEQUENCES[seq] = key
+                changed += 1
+        for num, key in ((2, Keys.ShiftInsert), (3, Keys.ShiftDelete)):
+            seq = f"\x1b[{num};{mod}~"
+            if seq not in ANSI_SEQUENCES:
+                ANSI_SEQUENCES[seq] = key
+                changed += 1
+
     # -- Kitty functional keys (Private Use Area codepoints) ----
     # kitty emits these CSI-u encodings even in LEGACY mode for keys that
     # have no legacy encoding, so unmapped they leak as literal text in any


### PR DESCRIPTION
## Problem

With the kitty keyboard protocol push active (`CSI >1u` disambiguate, restored in #87511 / 03bf85d83), kitty encodes lock-key state into the CSI modifier field of function keys. A plain **Down** with **NumLock on** arrives as:

- `ESC[1;129B` — NumLock (bit 128)
- `ESC[1;65B` — CapsLock (bit 64)
- `ESC[1;193B` — both

…instead of the legacy `ESC[B`. Stock prompt_toolkit maps none of these, so the VT100 parser fires `Escape` and inserts the remainder (`[1;129B`) as literal text in the input line. Letters are unaffected (kitty sends those as plain text), which is why only arrow/nav keys break — and why it looks like "escape codes" appear when pressing Up/Down.

## Root cause

03bf85d83 ("restore Kitty keyboard protocol push and complete the extended-key alias table") restored the disambiguate push and mapped the modifier families 2/3/4/5/6/7/8, but left the **lock-bit** modifiers (129/65/193) unmapped. Those are exactly what the disambiguate flag makes kitty emit for a *plain* keypress whenever NumLock/CapsLock is engaged — the most common desktop state.

## Fix

Extend `install_modify_other_keys_aliases()` with the lock-bit modifier family:

- plain: 129 (NumLock), 65 (CapsLock), 193 (both) → the unmodified key
- +shift: 130/66/194 → the Shift* variant

Covered keys: arrows, Home/End, Insert/Delete/PageUp/PageDown, and the CSI-u forms of Enter/Tab/Backspace/Space (which under disambiguate also carry the lock bit).

## Verification

- `\x1b[1;129B` → `Keys.Down`, `\x1b[1;129A` → `Keys.Up`, `\x1b[1;65B`/`\x1b[1;193B` → `Keys.Down`, `\x1b[1;130B` → `Keys.ShiftDown`, etc. — 893 aliases install cleanly.
- Confirmed against kitty's own `encode_key_for_tty`: plain Down with Hermes' pushed flags → `ESC[B`; same key with NumLock → `ESC[1;129B`.
- Tested live: arrows, Home/End, PageUp/PageDown, Enter, Tab, Backspace, Space all work in the Hermes CLI with NumLock on in kitty.

Refs #87511, #86866.