### PR TITLE
fix(tui): keep transcript rows within the pet/rail-aware body width

### DIFF
--- a/ui-tui/src/__tests__/messageLineWidth.test.ts
+++ b/ui-tui/src/__tests__/messageLineWidth.test.ts
@@ -1,0 +1,70 @@
+import { createElement } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { renderToScreen } from '../../packages/hermes-ink/src/ink/render-to-screen.js'
+import { cellAtIndex } from '../../packages/hermes-ink/src/ink/screen.js'
+import { MessageLine } from '../components/messageLine.js'
+import { DEFAULT_THEME } from '../theme.js'
+import type { Msg } from '../types.js'
+
+const SCREEN_WIDTH = 100
+const BODY_COLS = 60
+
+const paintedBeyond = (screen: Parameters<typeof cellAtIndex>[0], x1: number) => {
+  for (let y = 0; y < screen.height; y++) {
+    for (let x = x1; x < SCREEN_WIDTH; x++) {
+      const cell = cellAtIndex(screen, y * SCREEN_WIDTH + x)
+
+      if (cell && cell.char.trim() !== '') {
+        return { x, y }
+      }
+    }
+  }
+
+  return null
+}
+
+describe('MessageLine width reservation', () => {
+  it('keeps tool-trail rows within the pet/rail-aware body width', () => {
+    const msg: Msg = {
+      kind: 'trail',
+      role: 'system',
+      text: '',
+      tools: [`terminal: ${'x'.repeat(160)}`]
+    }
+
+    const { screen } = renderToScreen(
+      createElement(MessageLine, {
+        cols: BODY_COLS,
+        detailsMode: 'expanded',
+        detailsModeCommandOverride: true,
+        msg,
+        t: DEFAULT_THEME
+      }),
+      SCREEN_WIDTH
+    )
+
+    expect(paintedBeyond(screen, BODY_COLS + 2)).toBeNull()
+  })
+
+  it('keeps assistant detail sections within the pet/rail-aware body width', () => {
+    const msg: Msg = {
+      role: 'assistant',
+      text: 'short reply',
+      tools: [`terminal: ${'y'.repeat(160)}`]
+    }
+
+    const { screen } = renderToScreen(
+      createElement(MessageLine, {
+        cols: BODY_COLS,
+        detailsMode: 'expanded',
+        detailsModeCommandOverride: true,
+        msg,
+        t: DEFAULT_THEME
+      }),
+      SCREEN_WIDTH
+    )
+
+    expect(paintedBeyond(screen, BODY_COLS + 2)).toBeNull()
+  })
+})

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -100,7 +100,10 @@ export const MessageLine = memo(function MessageLine({
 
   if (msg.kind === 'trail' && (msg.tools?.length || tools.length || thinking)) {
     return shouldShowThinkingTrail(msg, thinkingMode, toolsMode, activityMode) ? (
-      <Box flexDirection="column" marginTop={leadGap ? 1 : 0}>
+      // maxWidth caps the trail at the pet/rail-aware body width (cols) so long
+      // tool/progress lines wrap clear of the floating pet instead of running
+      // under it — the pet overlay would otherwise cover the line tail.
+      <Box flexDirection="column" marginTop={leadGap ? 1 : 0} maxWidth={cols}>
         <ToolTrail
           commandOverride={detailsModeCommandOverride}
           detailsMode={detailsMode}
@@ -270,6 +273,7 @@ export const MessageLine = memo(function MessageLine({
       flexDirection="column"
       marginBottom={msg.role === 'user' || isDiffSegment ? 1 : 0}
       marginTop={msg.role === 'user' || msg.kind === 'slash' || isDiffSegment || leadGap ? 1 : 0}
+      maxWidth={cols}
     >
       {showDetails && (
         <Box flexDirection="column" marginBottom={1}>


### PR DESCRIPTION
## What does this PR do?

The transcript reserves a right gutter for the floating pet and ambient rails (`bodyCols` in `TranscriptPane`), but only assistant/user message bodies were constrained to that width. Tool trails and detail sections inside `MessageLine` extended to the full transcript width, so the absolutely-positioned pet overlay painted over the tail of long expanded tool/progress lines. Affected words appear silently clipped mid-character — distinguishable from intentional truncation, which ellipsizes (`truncate-end` appends `…`).

Reproduction confirmed live: with the pet enabled, a long expanded tool line loses its tail under the pet; with the pet disabled the same content renders fully.

The fix caps `MessageLine`'s row boxes (trail early-return and main outer box) at the reserved body width (`cols`), so trails and details wrap clear of the overlay.

## Related Issue

Reported interactively; no tracked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/components/messageLine.tsx` — cap the trail row and the main message row at the pet/rail-aware body width.
- `ui-tui/src/__tests__/messageLineWidth.test.ts` — render-to-screen regressions asserting expanded trail/detail rows paint nothing beyond the reserved width (RED without the fix, GREEN with it).

## How to Test

1. `npm test --prefix ui-tui -- --run messageLineWidth.test.ts messageLine.test.ts thinkingLiveCollapse.test.tsx thinkingMoaReferenceVisibility.test.tsx virtualHeights.test.ts` — 24 passed.
2. `npx eslint ui-tui/src/components/messageLine.tsx ui-tui/src/__tests__/messageLineWidth.test.ts`, `npm run typecheck --prefix ui-tui`, `npm run build --prefix ui-tui`, `git diff --check` — all clean.
3. Manual: enable `display.pet`, run a tool with a long expanded output line, and confirm the line tail wraps instead of disappearing under the pet.

## Checklist

### Code

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation updates — N/A (render-width correction)
- [x] Cross-platform impact considered — N/A (layout-only change)

## Known limitation

The clarify/prompt zone sits below the transcript row and has no pet footprint reservation of its own; with the pet enabled it can still overlap the bottom-right rows of tall overlays. A full fix reserves the pet band from the prompt zone layout — left as a follow-up since the pet is optional and disabled in the reporter's config.
