### PR TITLE
fix(cli): don't blame .env for TERMINAL_CWD Hermes exported itself

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2223,6 +2223,30 @@ def print_config_warnings(config: Optional[Dict[str, Any]] = None) -> None:
     sys.stderr.write("\n".join(lines) + "\n\n")
 
 
+def _env_file_sets(var_name: str) -> bool:
+    """Return True only if HERMES_HOME/.env has an uncommented ``var_name=`` line.
+
+    Hermes itself exports TERMINAL_CWD into os.environ at runtime (gateway,
+    session restore, cron jobs), so the process environment alone cannot
+    distinguish "user set this in .env" from "we set it ourselves".
+    """
+    try:
+        from hermes_constants import get_hermes_home
+
+        env_path = get_hermes_home() / ".env"
+        for line in env_path.read_text().splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            if stripped.startswith("export "):
+                stripped = stripped[len("export "):].lstrip()
+            if stripped.startswith(f"{var_name}="):
+                return True
+    except OSError:
+        pass
+    return False
+
+
 def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> None:
     """Warn if MESSAGING_CWD or TERMINAL_CWD is set in .env instead of config.yaml.
 
@@ -2244,13 +2268,16 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
     config_has_explicit_cwd = config_cwd not in {".", "auto", "cwd", ""}
 
     lines: list[str] = []
-    if messaging_cwd:
+    if messaging_cwd and _env_file_sets("MESSAGING_CWD"):
         lines.append(
             f"  \033[33m⚠\033[0m MESSAGING_CWD={messaging_cwd} found in .env — "
             f"this is deprecated."
         )
-    if terminal_cwd_env and not config_has_explicit_cwd:
-        # TERMINAL_CWD in env but not from config bridge — likely from .env
+    if (
+        terminal_cwd_env
+        and not config_has_explicit_cwd
+        and _env_file_sets("TERMINAL_CWD")
+    ):
         lines.append(
             f"  \033[33m⚠\033[0m TERMINAL_CWD={terminal_cwd_env} found in .env — "
             f"this is deprecated."

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -2,9 +2,14 @@
 
 
 class TestDeprecatedCwdWarning:
-    """Warn when MESSAGING_CWD or TERMINAL_CWD is set in .env."""
+    """Warn only when MESSAGING_CWD or TERMINAL_CWD is actually set in .env."""
 
-    def test_messaging_cwd_triggers_warning(self, monkeypatch, capsys):
+    def _make_env_file(self, tmp_path, monkeypatch, content):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / ".env").write_text(content)
+
+    def test_messaging_cwd_triggers_warning(self, tmp_path, monkeypatch, capsys):
+        self._make_env_file(tmp_path, monkeypatch, "MESSAGING_CWD=/some/path\n")
         monkeypatch.setenv("MESSAGING_CWD", "/some/path")
         monkeypatch.delenv("TERMINAL_CWD", raising=False)
 
@@ -17,7 +22,12 @@ class TestDeprecatedCwdWarning:
         assert "config.yaml" in captured.err
 
 
-    def test_both_deprecated_vars_warn(self, monkeypatch, capsys):
+    def test_both_deprecated_vars_warn(self, tmp_path, monkeypatch, capsys):
+        self._make_env_file(
+            tmp_path,
+            monkeypatch,
+            "MESSAGING_CWD=/msg/path\nTERMINAL_CWD=/term/path\n",
+        )
         monkeypatch.setenv("MESSAGING_CWD", "/msg/path")
         monkeypatch.setenv("TERMINAL_CWD", "/term/path")
 
@@ -26,4 +36,40 @@ class TestDeprecatedCwdWarning:
 
         captured = capsys.readouterr()
         assert "MESSAGING_CWD" in captured.err
+        assert "TERMINAL_CWD" in captured.err
+
+
+    def test_runtime_env_var_without_env_file_entry_is_silent(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Hermes exports TERMINAL_CWD itself at runtime (gateway, session
+        restore, cron).  A process env var with no matching .env line must
+        NOT be blamed on .env — this was a false-positive warning on every
+        startup for users with a clean .env."""
+        self._make_env_file(
+            tmp_path, monkeypatch, "# TERMINAL_CWD=.\nOTHER_KEY=value\n"
+        )
+        monkeypatch.setenv("MESSAGING_CWD", "/msg/path")
+        monkeypatch.setenv("TERMINAL_CWD", "/term/path")
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        warn_deprecated_cwd_env_vars(config={})
+
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+
+    def test_export_prefix_in_env_file_still_warns(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        self._make_env_file(
+            tmp_path, monkeypatch, "export TERMINAL_CWD=/term/path\n"
+        )
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
+        monkeypatch.setenv("TERMINAL_CWD", "/term/path")
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        warn_deprecated_cwd_env_vars(config={})
+
+        captured = capsys.readouterr()
         assert "TERMINAL_CWD" in captured.err


### PR DESCRIPTION
Fixes #90299.

`warn_deprecated_cwd_env_vars()` inferred ".env sets TERMINAL_CWD" from `os.environ` alone. Hermes exports `TERMINAL_CWD` at runtime (gateway startup, session restore, cron jobs, worktree switches), so every install with a clean `.env` and the default `terminal.cwd: .` got the deprecation warning on each startup, and the suggested migration had nothing to migrate.

This adds `_env_file_sets()`: it reads `HERMES_HOME/.env` and returns true only for an uncommented `VAR=` or `export VAR=` line. Both the `MESSAGING_CWD` and `TERMINAL_CWD` warnings now require it.

Tests: reworked `tests/hermes_cli/test_deprecated_cwd_warning.py` so the two existing cases write a real `.env` under a temp `HERMES_HOME`, and added two new cases: a regression test for the false positive (env var set, `.env` clean, expect silence) and an `export`-prefix case. 4/4 pass; `tests/tools/test_terminal_config_env_sync.py` (10/10) and the rest of `tests/hermes_cli/` still pass.
