### PR TITLE
fix(agent): guard sparse-choice missing delta in chat_completions streaming

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4124,7 +4124,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     )
                 continue
 
-            delta = chunk.choices[0].delta
+            delta = getattr(chunk.choices[0], "delta", None)
             if hasattr(chunk, "model") and chunk.model:
                 model_name = chunk.model
 

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -186,6 +186,42 @@ class TestStreamingAccumulator:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_sparse_choice_allows_missing_delta(self, mock_close, mock_create):
+        """A choice object may omit `delta` entirely (not merely have a
+        sparse one) on some non-compliant OpenAI-compatible providers.
+        The finish_reason on the same choice is already read via getattr
+        for exactly this reason; delta must be too."""
+        from run_agent import AIAgent
+
+        chunks = [
+            SimpleNamespace(
+                choices=[SimpleNamespace(index=0, finish_reason=None)],
+                model="test-model",
+                usage=None,
+            ),
+            _make_stream_chunk(content="hi", finish_reason="stop", model="test-model"),
+        ]
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.choices[0].message.content == "hi"
+        assert response.choices[0].finish_reason == "stop"
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_chat_stream_closes_original_provider_resource(
         self,
         mock_close,


### PR DESCRIPTION
## What does this PR do?

`interruptible_streaming_api_call`'s chunk loop (`agent/chat_completion_helpers.py`) reads `chunk.choices[0].delta` unguarded. The same choice object's `finish_reason`, 13 lines below, is read via `getattr(chunk.choices[0], "finish_reason", None)` — hardened by 89c44c0dad ("fix(openai): cover nested sparse response fields") specifically because some non-compliant OpenAI-compatible providers send sparse choice objects. That commit hardened `tool_calls[].index`/`.id`/`.function.name`/`.function.arguments` and `finish_reason`, but missed the top-level `delta` access itself — the one thing that has to succeed before any of those nested guards can even run.

If a provider's choice object omits `delta` entirely (rather than merely sending a sparse `delta` with missing sub-fields, which 89c44c0dad already covers), the whole chunk-processing loop dies with an unhandled `AttributeError` instead of degrading gracefully — dropping the response and forcing a retry, or worse, surfacing a confusing crash mid-stream.

## Fix

```diff
-            delta = chunk.choices[0].delta
+            delta = getattr(chunk.choices[0], "delta", None)
```

Every existing downstream read of `delta` in this function already goes through `getattr(delta, "...", None)` (reasoning_content/reasoning, content, tool_calls) — so `delta` becoming `None` propagates safely through the rest of the block with no other changes needed. Confirmed by reading the full ~140-line block below the assignment: no bare `delta.attr` access exists outside an `if delta_content:`/`if delta_tool_calls:` guard that's already conditioned on the same getattr-derived value being truthy.

## Testing

- New test `test_sparse_choice_allows_missing_delta` in `tests/run_agent/test_streaming.py`, alongside 89c44c0dad's own `test_sparse_tool_delta_allows_missing_nested_fields` (same file, same class, mirrors its `SimpleNamespace`-based sparse-chunk construction) — feeds a choice object with no `delta` attribute at all, followed by a normal chunk, and asserts the stream still completes with the normal chunk's content/finish_reason.
- Mutation-verified: reverting just the `getattr` back to the bare attribute access reproduces the exact failure this PR fixes — `AttributeError: 'types.SimpleNamespace' object has no attribute 'delta'` at the `delta = chunk.choices[0].delta` line — confirming the new test genuinely exercises the bug.
- `tests/run_agent/test_streaming.py`: 32 passed, 4 skipped (3 deselected `TestAnthropicStreamCallbacks` failures are a pre-existing, environment-only gap — the `anthropic` package isn't installed under `--frozen --extra dev` in this sandbox; confirmed pre-existing and unrelated by re-running the same tests with this fix stashed out, same 3 failures).
- Broader sweep (`tests/agent/test_chat_completion_helpers*.py tests/run_agent/`): 1708 passed, 4 pre-existing/environment failures (same `anthropic`-package gap, plus one `Nous auth not configured` gap — neither touches `chat_completion_helpers.py`'s chunk-delta handling).
- `ruff check`: clean.

## Adjacent open PRs (checked, no overlap)

- **#85791** ("flatten list-typed delta.content/reasoning in auxiliary streams") touches the same function a few lines below this change (the `reasoning_content`/`reasoning` accumulation block, right after the `delta` assignment) but doesn't touch the `delta = chunk.choices[0].delta` line itself. Textual proximity in the same function only — no semantic overlap, will rebase cleanly regardless of merge order.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
