### PR TITLE
fix(terminal): forward env_passthrough entries across the Apptainer cleanenv boundary

### DIFF
--- a/tests/tools/test_singularity_env_passthrough.py
+++ b/tests/tools/test_singularity_env_passthrough.py
@@ -1,0 +1,119 @@
+"""Regression tests for env_passthrough forwarding under APPTAINER_CLEANENV (#90298).
+
+Apptainer strips every inherited variable at the container boundary when
+``APPTAINER_CLEANENV`` is active unless it carries the ``APPTAINERENV_``
+prefix. The singularity backend must forward each allowlisted
+``terminal.env_passthrough`` entry under that prefix so the documented
+passthrough exception survives cleanenv isolation — without forwarding
+anything that is not allowlisted (isolation stays default-deny).
+"""
+
+import os
+
+import pytest
+from unittest.mock import patch
+
+
+@pytest.fixture(autouse=True)
+def clean_passthrough_state():
+    from tools import env_passthrough as ep
+
+    ep.clear_env_passthrough()
+    yield
+    ep.clear_env_passthrough()
+
+
+def _exec_env(monkeypatch, allowlist_names, environ):
+    from tools.environments.singularity import _apptainer_exec_env
+
+    for name in allowlist_names:
+        monkeypatch.setenv(name, environ[name])
+    with patch(
+        "tools.env_passthrough._load_config_passthrough",
+        return_value=frozenset(allowlist_names),
+    ):
+        return _apptainer_exec_env()
+
+
+class TestApptainerExecEnv:
+    def test_allowlisted_entry_gets_apptainerenv_prefix(self, monkeypatch):
+        """The documented prefix is what survives APPTAINER_CLEANENV."""
+        env = _exec_env(
+            monkeypatch,
+            ["MY_SERVICE_TOKEN"],
+            {"MY_SERVICE_TOKEN": "tok-sandbox-forward"},
+        )
+        assert env["APPTAINERENV_MY_SERVICE_TOKEN"] == "tok-sandbox-forward"
+        assert env["MY_SERVICE_TOKEN"] == "tok-sandbox-forward"
+
+    def test_non_allowlisted_env_has_no_prefix(self, monkeypatch):
+        """Only allowlisted names are forwarded — cleanenv stays default-deny."""
+        monkeypatch.setenv("SECRET_NOT_LISTED", "should-not-be-prefixed")
+        env = _exec_env(monkeypatch, [], {})
+        assert not any(
+            key.startswith("APPTAINERENV_") for key in env
+        ), "non-allowlisted variables must not be forwarded across the cleanenv boundary"
+
+    def test_allowlisted_but_unset_entry_is_skipped(self, monkeypatch):
+        env = _exec_env(monkeypatch, ["MY_UNSET_TOKEN"], {"MY_UNSET_TOKEN": ""})
+        # Simulate an entry with no value available anywhere: nothing to forward.
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MY_UNSET_TOKEN", None)
+            from tools.environments.singularity import _apptainer_exec_env
+            with patch(
+                "tools.env_passthrough._load_config_passthrough",
+                return_value=frozenset({"MY_UNSET_TOKEN"}),
+            ):
+                env = _apptainer_exec_env()
+        assert "APPTAINERENV_MY_UNSET_TOKEN" not in env
+
+    def test_scope_resolves_value_over_host_environ(self, monkeypatch):
+        """An active profile scope is authoritative for the forwarded value."""
+        from agent import secret_scope as ss
+        from tools.environments.singularity import _apptainer_exec_env
+
+        monkeypatch.setenv("MY_SERVICE_TOKEN", "host-value")
+
+        def _fake_config_passthrough():
+            return frozenset({"MY_SERVICE_TOKEN"})
+
+        with patch(
+            "tools.env_passthrough._load_config_passthrough",
+            return_value=frozenset({"MY_SERVICE_TOKEN"}),
+        ), patch(
+            "tools.env_passthrough.resolve_passthrough_value",
+            side_effect=lambda name, fallback: "scoped-value"
+            if name == "MY_SERVICE_TOKEN"
+            else fallback,
+        ):
+            env = _apptainer_exec_env()
+        assert env["APPTAINERENV_MY_SERVICE_TOKEN"] == "scoped-value"
+
+
+class TestRunBashUsesForwardedEnv:
+    def test_run_bash_passes_exec_env(self, monkeypatch):
+        """_run_bash must hand the forwarded env to the spawned apptainer exec."""
+        from tools.environments import singularity as sing
+
+        env_obj = object.__new__(sing.SingularityEnvironment)
+        env_obj._instance_started = True
+        env_obj.executable = "apptainer"
+        env_obj.instance_id = "hermes_test"
+
+        captured = {}
+
+        class _FakeProc:
+            pass
+
+        def _fake_popen(cmd, stdin_data=None, **kwargs):
+            captured.update(kwargs)
+            return _FakeProc()
+
+        with patch.object(sing, "_popen_bash", side_effect=_fake_popen):
+            env_obj._run_bash("echo hi")
+
+        # Defuse BaseEnvironment.__del__ cleanup for the partial object.
+        env_obj._instance_started = False
+
+        assert "env" in captured, "_run_bash must pass an explicit env"
+        assert isinstance(captured["env"], dict)

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -125,7 +125,11 @@ def _apptainer_exec_env() -> dict[str, str]:
             get_all_passthrough,
             resolve_passthrough_value,
         )
-    except Exception:
+    except Exception as exc:
+        # Passthrough quietly does nothing on this install; name the reason
+        # so the silent no-op is diagnosable the first time the module
+        # layout shifts (review on #90298).
+        logger.debug("env_passthrough unavailable; Apptainer forwarding skipped: %s", exc)
         return env
     for name in get_all_passthrough():
         if not name or "=" in name or name.startswith("APPTAINERENV_"):

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -105,6 +105,39 @@ def _get_apptainer_cache_dir() -> Path:
 _sif_build_lock = threading.Lock()
 
 
+def _apptainer_exec_env() -> dict[str, str]:
+    """Build the env for ``apptainer exec`` child processes (#90298).
+
+    Apptainer/Singularity strips the entire inherited environment at the
+    container boundary when ``APPTAINER_CLEANENV`` is set (via the host
+    environment or the system ``apptainer.conf``) — every variable without
+    an ``APPTAINERENV_`` prefix is dropped, so ``terminal.env_passthrough``
+    entries silently never reach the container. Forward each allowlisted
+    entry under the documented ``APPTAINERENV_<NAME>`` prefix (the prefixed
+    value wins inside the container), resolving values through the shared
+    secret-scope resolver so profile isolation semantics match the local
+    backend. Only allowlisted names are forwarded: cleanenv's default-deny
+    isolation is preserved for everything else.
+    """
+    env = dict(os.environ)
+    try:
+        from tools.env_passthrough import (
+            get_all_passthrough,
+            resolve_passthrough_value,
+        )
+    except Exception:
+        return env
+    for name in get_all_passthrough():
+        if not name or "=" in name or name.startswith("APPTAINERENV_"):
+            continue
+        value = resolve_passthrough_value(name, os.environ.get(name))
+        if value is None:
+            continue
+        env[f"APPTAINERENV_{name}"] = value
+        env[name] = value
+    return env
+
+
 def _get_or_build_sif(image: str, executable: str = "apptainer") -> str:
     if image.endswith('.sif') and Path(image).exists():
         return image
@@ -246,7 +279,7 @@ class SingularityEnvironment(BaseEnvironment):
         else:
             cmd.extend(["bash", "-c", cmd_string])
 
-        return _popen_bash(cmd, stdin_data)
+        return _popen_bash(cmd, stdin_data, env=_apptainer_exec_env())
 
     def cleanup(self):
         """Stop the instance. If persistent, the overlay dir survives."""


### PR DESCRIPTION
## What does this PR do?

Makes `terminal.env_passthrough` effective under `terminal.backend: singularity`. Apptainer/Singularity strips the entire inherited environment at the container boundary when `APPTAINER_CLEANENV` is active (set in the host environment or the system `apptainer.conf`): only host variables carrying the `APPTAINERENV_` prefix cross into the container. The singularity backend spawned `apptainer exec` with the plain inherited environment, so allowlisted passthrough entries were silently dropped — the config key was accepted and reported by `hermes config get terminal --json`, but every listed variable read as `UNSET` inside the sandbox, with no warning anywhere (#90298).

The fix forwards each allowlisted passthrough entry under the documented `APPTAINERENV_<NAME>` prefix in the exec child env (the prefixed value is what apptainer honors inside the container), resolving values through the shared secret-scope resolver so per-profile isolation semantics match the local backend. Only allowlisted names receive the prefix — cleanenv's default-deny isolation is preserved for everything else.

## Related Issue

Fixes #90298

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/singularity.py` — new `_apptainer_exec_env()`: builds the `apptainer exec` child env, forwarding each `get_all_passthrough()` entry (config + skill registrations) as `APPTAINERENV_<NAME>` with its `resolve_passthrough_value()`-resolved value; skips unset/unresolvable entries and anything already prefixed.
- `tools/environments/singularity.py` — `_run_bash` now passes that env to `_popen_bash` instead of letting the child inherit the raw process environment.
- `tests/tools/test_singularity_env_passthrough.py` — new: prefix forwarding for allowlisted entries, no prefix for non-allowlisted variables (isolation stays default-deny), unset entries skipped, secret-scope value wins over host environ, and `_run_bash` hands the explicit env to the spawn.

## How to Test

1. `uv run --python 3.11 --with pytest --with pytest-asyncio --with pyyaml --with python-dotenv --with httpx --with pillow --with requests --with rich --with prompt_toolkit python -m pytest -q -o 'addopts=' tests/tools/test_singularity_env_passthrough.py`
2. Observed result: 5 passed on this branch; all 5 fail on unmodified `main` (`_apptainer_exec_env` does not exist and `_run_bash` passes no explicit env), confirming the regression tests pin the fix.
3. Neighboring suites on this branch: `test_singularity_preflight.py`, `test_base_environment.py`, `test_env_passthrough.py`, `test_local_cwd_permission_fallback.py` — 53 passed, no new failures.
4. Live check (Linux + Apptainer, optional): with `terminal.backend: singularity`, `env_passthrough: [MY_TOKEN]`, and `APPTAINER_CLEANENV=1` exported, a terminal `bash -c 'echo "${MY_TOKEN:-UNSET}"'` should print the host value instead of `UNSET`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (helper docstring documents the boundary semantics)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new keys; existing key now works)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (Apptainer backend is Linux-only; code path inert elsewhere)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
