### PR TITLE
fix(skills): make bundled-skill reset outcomes honest

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1318,9 +1318,11 @@ def do_list_modified(console: Optional[Console] = None,
     for entry in modified:
         c.print(f"  [yellow]~[/] {entry['name']}")
     c.print()
-    c.print("[dim]See changes:   hermes skills diff <name>[/]")
-    c.print("[dim]Resume updates: hermes skills reset <name>          (keep your copy, re-baseline)[/]")
-    c.print("[dim]Revert to stock: hermes skills reset <name> --restore[/]\n")
+    c.print("[dim]Inspect changes: hermes skills diff <name>[/]")
+    c.print(
+        "[dim]Replace your copy and resume stock updates: "
+        "hermes skills reset <name> --restore[/]\n"
+    )
 
 
 def do_diff(name: str, console: Optional[Console] = None) -> None:

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -2037,8 +2037,8 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
     elif action == "reset":
         if not args:
             c.print("[bold red]Usage:[/] /skills reset <name> [--restore] [--now]\n")
-            c.print("[dim]Clears the bundled-skills manifest entry so future updates stop marking it as user-modified.[/]")
-            c.print("[dim]Pass --restore to also replace the current copy with the bundled version.[/]\n")
+            c.print("[dim]Clears the bundled-skills manifest entry. If your local copy matches bundled, the next sync re-baselines and accepts upstream updates.[/]")
+            c.print("[dim]If your copy differs from bundled, it is preserved and keeps being skipped on updates — pass --restore to overwrite it with the bundled version.[/]\n")
             return
         name = args[0]
         restore = "--restore" in args

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -2117,7 +2117,8 @@ def _print_skills_help(console: Console) -> None:
         "  [cyan]uninstall[/] <name>            Remove a hub-installed skill\n"
         "  [cyan]list-modified[/]               List bundled skills you've edited (kept by update)\n"
         "  [cyan]diff[/] <name>                 Diff your copy of a bundled skill vs the stock version\n"
-        "  [cyan]reset[/] <name> [--restore]    Reset bundled-skill tracking (fix 'user-modified' flag)\n"
+        "  [cyan]reset[/] <name> [--restore]    Plain reset only re-baselines a byte-identical copy\n"
+        "       Modified copies stay skipped; --restore replaces them and resumes stock updates\n"
         "  [cyan]publish[/] <path> --repo <r>   Publish a skill to GitHub via PR\n"
         "  [cyan]snapshot[/] export|import      Export/import skill configurations\n"
         "  [cyan]tap[/] list|add|remove         Manage skill sources\n",

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -237,8 +237,10 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         help="Show how your copy of a bundled skill differs from the stock version",
         description=(
             "Print a unified diff between your local copy of a bundled skill and the "
-            "current bundled (stock) version, so you can confirm what changed before "
-            "running `hermes skills reset`."
+            "current bundled (stock) version. Plain reset only re-baselines a "
+            "byte-identical copy; genuinely modified copies stay preserved and "
+            "skipped. Run `hermes skills reset <name> --restore` to replace the "
+            "modified copy and resume stock updates."
         ),
     )
     skills_diff.add_argument(

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -191,11 +191,13 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
 
     skills_reset = skills_subparsers.add_parser(
         "reset",
-        help="Reset a bundled skill — clears 'user-modified' tracking so updates work again",
+        help="Reset a bundled skill — re-baselines tracking when your copy matches bundled; use --restore for modified copies",
         description=(
-            "Clear a bundled skill's entry from the sync manifest (~/.hermes/skills/.bundled_manifest) "
-            "so future 'hermes update' runs stop marking it as user-modified. Pass --restore to also "
-            "replace the current copy with the bundled version."
+            "Clear a bundled skill's entry from the sync manifest (~/.hermes/skills/.bundled_manifest). "
+            "If your local copy is byte-identical to the bundled version, the next sync re-baselines "
+            "and future 'hermes update' runs accept upstream changes. If your copy genuinely differs "
+            "from bundled, the manifest stays cleared but the skill is preserved and continues to be "
+            "skipped on updates — pass --restore to overwrite your copy with the bundled version."
         ),
     )
     skills_reset.add_argument(

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -221,8 +221,9 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         description=(
             "Show the bundled skills whose local copy differs from the version last "
             "synced, i.e. the ones `hermes update` reports as user-modified and skips. "
-            "Use `hermes skills diff <name>` to see changes and `hermes skills reset "
-            "<name>` to resume updates."
+            "Use `hermes skills diff <name>` to inspect changes. To replace the modified "
+            "copy with the bundled version and resume stock updates, run "
+            "`hermes skills reset <name> --restore`."
         ),
     )
     skills_list_modified.add_argument(

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -42,6 +42,20 @@ from hermes_constants import venv_python_path
 logger = logging.getLogger(__name__)
 
 
+def _print_user_modified_skills_notice(result: dict) -> None:
+    """Explain how to inspect and replace bundled skills kept during update."""
+    names = result.get("user_modified") or []
+    if not names:
+        return
+
+    print(f"  ~ {len(names)} user-modified (kept)")
+    print("    → inspect changes: hermes skills diff <name>")
+    print(
+        "    → replace modified copy and resume stock updates: "
+        "hermes skills reset <name> --restore"
+    )
+
+
 def _m():
     """Lazy ``hermes_cli.main`` reference.
 
@@ -1347,12 +1361,7 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
             print(
                 f"  ↑ {len(result['updated'])} updated: {', '.join(result['updated'])}"
             )
-        if result.get("user_modified"):
-            print(f"  ~ {len(result['user_modified'])} user-modified (kept)")
-            print(
-                "    → see them: hermes skills list-modified  "
-                "(diff/reset to resume updates)"
-            )
+        _print_user_modified_skills_notice(result)
         if result.get("cleaned"):
             print(f"  − {len(result['cleaned'])} removed from manifest")
         if result.get("relocated"):
@@ -5625,12 +5634,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 print(
                     f"  ↑ {len(result['updated'])} updated: {', '.join(result['updated'])}"
                 )
-            if result.get("user_modified"):
-                print(f"  ~ {len(result['user_modified'])} user-modified (kept)")
-                print(
-                    "    → see them: hermes skills list-modified  "
-                    "(diff/reset to resume updates)"
-                )
+            _print_user_modified_skills_notice(result)
             if result.get("cleaned"):
                 print(f"  − {len(result['cleaned'])} removed from manifest")
             if result.get("relocated"):

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -70,6 +70,18 @@ def _capture(source_filter: str = "all") -> str:
     return sink.getvalue()
 
 
+def test_skills_reset_slash_help_distinguishes_plain_reset_from_restore():
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    handle_skills_slash("/skills reset", console=console)
+
+    output = sink.getvalue()
+    assert "matches bundled" in output
+    assert "differs from bundled" in output
+    assert "--restore" in output
+
+
 def _capture_check(monkeypatch, results, name=None) -> str:
     import tools.skills_hub as hub
 

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -89,6 +89,24 @@ def test_skills_reset_slash_help_distinguishes_plain_reset_from_restore():
     assert "--restore" in output
 
 
+def test_skills_main_help_explains_modified_reset_contract():
+    sink = StringIO()
+    console = Console(
+        file=sink,
+        force_terminal=False,
+        color_system=None,
+        width=200,
+    )
+
+    handle_skills_slash("/skills help", console=console)
+
+    output = " ".join(sink.getvalue().split())
+    assert "Plain reset only re-baselines a byte-identical copy" in output
+    contract = output.lower()
+    assert "modified copies stay skipped" in contract
+    assert "--restore replaces them and resumes stock updates" in contract
+
+
 def test_list_modified_points_to_restore_for_resuming_stock_updates(monkeypatch):
     import tools.skills_sync as skills_sync
 

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -5,7 +5,14 @@ import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import (
+    do_check,
+    do_install,
+    do_list,
+    do_list_modified,
+    do_update,
+    handle_skills_slash,
+)
 
 
 class _DummyLockFile:
@@ -80,6 +87,29 @@ def test_skills_reset_slash_help_distinguishes_plain_reset_from_restore():
     assert "matches bundled" in output
     assert "differs from bundled" in output
     assert "--restore" in output
+
+
+def test_list_modified_points_to_restore_for_resuming_stock_updates(monkeypatch):
+    import tools.skills_sync as skills_sync
+
+    monkeypatch.setattr(
+        skills_sync,
+        "list_user_modified_bundled_skills",
+        lambda: [{"name": "edited-skill"}],
+    )
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    do_list_modified(console=console)
+
+    output = sink.getvalue()
+    normalized = " ".join(output.split())
+    assert "Inspect changes: hermes skills diff <name>" in normalized
+    assert (
+        "Replace your copy and resume stock updates: "
+        "hermes skills reset <name> --restore"
+    ) in normalized
+    assert "keep your copy, re-baseline" not in output
 
 
 def _capture_check(monkeypatch, results, name=None) -> str:

--- a/tests/hermes_cli/test_subcommands_followup.py
+++ b/tests/hermes_cli/test_subcommands_followup.py
@@ -64,3 +64,18 @@ def test_mcp_and_acp_accept_hooks_flag():
     # acp takes --accept-hooks at top level
     ns = parser.parse_args(["acp", "--accept-hooks"])
     assert ns.accept_hooks is True
+
+
+def test_skills_reset_help_distinguishes_plain_reset_from_restore(capsys):
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    build_skills_parser(sub, cmd_skills=_h("skills"))
+
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["skills", "reset", "--help"])
+
+    assert exc.value.code == 0
+    output = capsys.readouterr().out
+    assert "byte-identical" in output
+    assert "genuinely differs" in output
+    assert "--restore" in output

--- a/tests/hermes_cli/test_subcommands_followup.py
+++ b/tests/hermes_cli/test_subcommands_followup.py
@@ -79,3 +79,18 @@ def test_skills_reset_help_distinguishes_plain_reset_from_restore(capsys):
     assert "byte-identical" in output
     assert "genuinely differs" in output
     assert "--restore" in output
+
+
+def test_skills_list_modified_help_points_to_restore(capsys):
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    build_skills_parser(sub, cmd_skills=_h("skills"))
+
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["skills", "list-modified", "--help"])
+
+    assert exc.value.code == 0
+    output = " ".join(capsys.readouterr().out.split())
+    assert "hermes skills diff <name>" in output
+    assert "hermes skills reset <name> --restore" in output
+    assert "replace the modified copy" in output

--- a/tests/hermes_cli/test_subcommands_followup.py
+++ b/tests/hermes_cli/test_subcommands_followup.py
@@ -94,3 +94,19 @@ def test_skills_list_modified_help_points_to_restore(capsys):
     assert "hermes skills diff <name>" in output
     assert "hermes skills reset <name> --restore" in output
     assert "replace the modified copy" in output
+
+
+def test_skills_diff_help_explains_modified_reset_contract(capsys):
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    build_skills_parser(sub, cmd_skills=_h("skills"))
+
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["skills", "diff", "--help"])
+
+    assert exc.value.code == 0
+    output = " ".join(capsys.readouterr().out.split())
+    assert "Plain reset only re-baselines" in output
+    assert "genuinely modified copies stay preserved and skipped" in output
+    assert "hermes skills reset <name> --restore" in output
+    assert "replace the modified copy and resume stock updates" in output

--- a/tests/hermes_cli/test_update_modified_notice.py
+++ b/tests/hermes_cli/test_update_modified_notice.py
@@ -1,60 +1,21 @@
-"""Guard: every `hermes update` path that reports user-modified skills must
-also tell the user how to find them.
+"""Behavior coverage for update notices about retained skill edits."""
 
-`hermes update` keeps (does not overwrite) bundled skills the user edited and
-prints a ``~ N user-modified (kept)`` count. There are two independent update
-code paths in ``hermes_cli/main.py`` that print this notice (the git-pull path
-in ``_cmd_update_impl`` and the unpack/install path). Both must point the user
-at ``hermes skills list-modified`` so the count is actionable — otherwise,
-depending on which path a user hits, they may never learn the discovery command
-exists.
-
-This is an *invariant* test (the two sibling notices must agree), not a literal
-snapshot: it asserts the relationship "count line ⇒ discovery hint", so it
-keeps holding if the wording is reworded, as long as both sites stay in sync.
-"""
-
-import re
-from pathlib import Path
-
-import hermes_cli.main as main_mod
-import hermes_cli.update_cmd as update_mod
+from hermes_cli.update_cmd import _print_user_modified_skills_notice
 
 
-_COUNT_RE = re.compile(r"user-modified \(kept\)")
-_HINT_RE = re.compile(r"hermes skills list-modified")
-
-
-def _source_lines() -> list[str]:
-    # The update pipeline was extracted to hermes_cli/update_cmd.py
-    # (main.py decomposition); scan both homes of the notice.
-    return [
-        line
-        for mod in (main_mod, update_mod)
-        for line in Path(mod.__file__).read_text(encoding="utf-8").splitlines()
-    ]
-
-
-def test_every_user_modified_notice_points_at_list_modified():
-    lines = _source_lines()
-    count_sites = [i for i, ln in enumerate(lines) if _COUNT_RE.search(ln)]
-
-    # The notice must exist somewhere (guard against it being deleted outright),
-    # but we deliberately do NOT assert a fixed *count* of sites: consolidating
-    # the duplicated print paths into a shared helper is a welcome refactor and
-    # must not fail this test. The invariant is per-site, not how many sites.
-    assert count_sites, (
-        "no 'user-modified (kept)' notice found in main.py — the update "
-        "summary that surfaces kept user edits appears to have been removed"
+def test_user_modified_notice_explains_inspect_and_restore_commands(capsys):
+    _print_user_modified_skills_notice(
+        {"user_modified": ["edited-one", "edited-two"]}
     )
 
-    for idx in count_sites:
-        # The count print and its discovery hint sit on adjacent lines; allow a
-        # small window so wording/formatting tweaks don't break the check.
-        window = "\n".join(lines[idx : idx + 5])
-        assert _HINT_RE.search(window), (
-            "a 'user-modified (kept)' notice near line "
-            f"{idx + 1} of main.py does not point users at "
-            "`hermes skills list-modified` within the following lines — the "
-            "update paths have drifted apart again:\n" + window
-        )
+    output = capsys.readouterr().out
+    assert "2 user-modified (kept)" in output
+    assert "hermes skills diff <name>" in output
+    assert "hermes skills reset <name> --restore" in output
+    assert "plain reset" not in output
+
+
+def test_user_modified_notice_is_silent_when_nothing_was_kept(capsys):
+    _print_user_modified_skills_notice({"user_modified": []})
+
+    assert capsys.readouterr().out == ""

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -463,6 +463,22 @@ class TestSyncSkills:
         assert len(manifest["new-skill"]) == 32
         assert len(manifest["old-skill"]) == 32
 
+    def test_collision_prints_reset_hint(self, tmp_path, capsys):
+        """A collision hint must point at --restore, not loop through reset."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        user_skill = skills_dir / "category" / "new-skill"
+        user_skill.mkdir(parents=True)
+        (user_skill / "SKILL.md").write_text("# From hub, unrelated to bundled")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            sync_skills(quiet=False)
+
+        captured = capsys.readouterr().out
+        assert "new-skill" in captured
+        assert "hermes skills reset --restore new-skill" in captured
+
     def test_user_deleted_skill_not_re_added_and_stale_entries_cleaned(self, tmp_path):
         """In manifest but not on disk = user deleted it; don't re-add. And a
         manifest entry no longer present in bundled gets cleaned out."""
@@ -619,6 +635,29 @@ class TestResetBundledSkill:
 
         assert removed["ok"] is False
         assert removed["action"] == "bundled_missing"
+
+    def test_reset_on_genuinely_modified_skill_reports_preserved(self, tmp_path):
+        """Plain reset must report that a divergent local copy stays skipped."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        dest = skills_dir / "productivity" / "google-workspace"
+        dest.mkdir(parents=True)
+        (dest / "SKILL.md").write_text(
+            "---\nname: google-workspace\n---\n# user-edited content, NOT bundled\n"
+        )
+        bundled_hash = _dir_hash(bundled / "productivity" / "google-workspace")
+        manifest_file.write_text(f"google-workspace:{bundled_hash}\n")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = reset_bundled_skill("google-workspace", restore=False)
+
+            assert result["ok"] is True
+            assert result["action"] == "manifest_cleared_local_preserved"
+            assert "--restore" in result["message"]
+            assert "preserved" in result["message"]
+            assert "google-workspace" not in _read_manifest()
+            assert "user-edited" in (dest / "SKILL.md").read_text()
 
     def test_reset_restore_succeeds_on_readonly_nix_tree(self, tmp_path):
         """#34972: --restore must succeed even when the user copy is a fully

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -477,7 +477,7 @@ class TestSyncSkills:
 
         captured = capsys.readouterr().out
         assert "new-skill" in captured
-        assert "hermes skills reset --restore new-skill" in captured
+        assert "hermes skills reset new-skill --restore" in captured
 
     def test_user_deleted_skill_not_re_added_and_stale_entries_cleaned(self, tmp_path):
         """In manifest but not on disk = user deleted it; don't re-add. And a
@@ -654,7 +654,10 @@ class TestResetBundledSkill:
 
             assert result["ok"] is True
             assert result["action"] == "manifest_cleared_local_preserved"
-            assert "--restore" in result["message"]
+            assert (
+                "hermes skills reset google-workspace --restore"
+                in result["message"]
+            )
             assert "preserved" in result["message"]
             assert "google-workspace" not in _read_manifest()
             assert "user-edited" in (dest / "SKILL.md").read_text()

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -659,6 +659,28 @@ class TestResetBundledSkill:
             assert "google-workspace" not in _read_manifest()
             assert "user-edited" in (dest / "SKILL.md").read_text()
 
+    def test_reset_no_bundled_source_reports_no_bundled_action(self, tmp_path):
+        """A source-less tracked skill needs an honest, non-restore action."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        dest = skills_dir / "productivity" / "orphan-skill"
+        dest.mkdir(parents=True)
+        (dest / "SKILL.md").write_text(
+            "---\nname: orphan-skill\n---\n# Orphan\n"
+        )
+        manifest_file.write_text("orphan-skill:OLDHASH00000000000000000000000000\n")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = reset_bundled_skill("orphan-skill", restore=False)
+
+            assert result["ok"] is True
+            assert result["action"] == "manifest_cleared_no_bundled"
+            assert "no bundled source" in result["message"]
+            assert "reset --restore" not in result["message"]
+            assert "orphan-skill" not in _read_manifest()
+            assert "Orphan" in (dest / "SKILL.md").read_text()
+
     def test_reset_restore_succeeds_on_readonly_nix_tree(self, tmp_path):
         """#34972: --restore must succeed even when the user copy is a fully
         read-only tree (r-xr-xr-x dirs + files), as produced by copying a

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -845,8 +845,8 @@ def sync_skills(quiet: bool = False) -> dict:
                         print(
                             f"  ⚠ {skill_name}: bundled version shipped but you "
                             f"already have a local skill by this name — yours "
-                            f"was kept. Run `hermes skills reset --restore "
-                            f"{skill_name}` to replace it with the bundled version."
+                            f"was kept. Run `hermes skills reset {skill_name} "
+                            f"--restore` to replace it with the bundled version."
                         )
                 else:
                     dest.parent.mkdir(parents=True, exist_ok=True)
@@ -1164,7 +1164,7 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
                 f"Cleared manifest entry for '{name}', but your local copy differs "
                 f"from the bundled version, so it remains preserved and will not "
                 f"receive upstream updates. Use "
-                f"`hermes skills reset --restore {name}` to revert to the shipped "
+                f"`hermes skills reset {name} --restore` to revert to the shipped "
                 f"version."
             )
 

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -1037,14 +1037,30 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
         name: The skill name (matches the manifest key / skill frontmatter name).
         restore: If True, also delete the user's copy in the skills dir and let
                  the next sync re-copy the current bundled version. If False
-                 (default), only clear the manifest entry — the user's
-                 current copy is preserved but future updates work again.
+                 (default), only clear the manifest entry. A plain reset only
+                 re-baselines (and unsticks) the skill when the local copy is
+                 byte-identical to bundled; a genuinely modified or
+                 source-less copy is left preserved and still skipped on
+                 future syncs (see the action values below).
 
     Returns:
         dict with keys:
           - ok: bool, whether the reset succeeded
-          - action: one of "manifest_cleared", "restored", "not_in_manifest",
-                    "bundled_missing"
+          - action: one of
+                "manifest_cleared" — entry cleared and the resync re-baselined
+                    the skill, so future `hermes update` runs accept upstream
+                    changes;
+                "manifest_cleared_local_preserved" — entry cleared but the
+                    local copy differs from bundled, so it is preserved and
+                    still skipped on updates (use --restore to overwrite);
+                "manifest_cleared_no_bundled" — entry cleared but the skill has
+                    no bundled source (removed upstream / bundled unavailable),
+                    so the local copy is preserved and --restore cannot recover
+                    a shipped version;
+                "restored" — the local copy was replaced with the bundled
+                    version (restore=True);
+                "not_in_manifest" — the name is not a tracked bundled skill;
+                "bundled_missing" — restore=True but no bundled source exists.
           - message: human-readable description
           - synced: dict from sync_skills() if a sync was triggered, else None
     """
@@ -1127,6 +1143,20 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
             message = (
                 f"Cleared manifest entry for '{name}'. Future `hermes update` runs "
                 f"will re-baseline against your current copy and accept upstream changes."
+            )
+        elif not is_bundled:
+            # No bundled source backs this skill (removed upstream or the
+            # bundled dir is unavailable), so the resync had nothing to
+            # baseline against and left it out of the manifest. Don't blame a
+            # "local differs from bundled" divergence — and don't point at
+            # `--restore`, which would fail with `bundled_missing` here.
+            action = "manifest_cleared_no_bundled"
+            message = (
+                f"Cleared manifest entry for '{name}', but it has no bundled "
+                f"source (removed upstream or bundled skills are unavailable), "
+                f"so the local copy is preserved as-is and `hermes update` will "
+                f"leave it untouched. `--restore` cannot recover a shipped "
+                f"version for this skill."
             )
         else:
             action = "manifest_cleared_local_preserved"

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -845,8 +845,8 @@ def sync_skills(quiet: bool = False) -> dict:
                         print(
                             f"  ⚠ {skill_name}: bundled version shipped but you "
                             f"already have a local skill by this name — yours "
-                            f"was kept. Run `hermes skills reset {skill_name}` "
-                            f"to replace it with the bundled version."
+                            f"was kept. Run `hermes skills reset --restore "
+                            f"{skill_name}` to replace it with the bundled version."
                         )
                 else:
                     dest.parent.mkdir(parents=True, exist_ok=True)
@@ -1114,11 +1114,29 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
         action = "restored"
         message = f"Restored '{name}' (no prior user copy, re-copied from bundled)."
     else:
-        action = "manifest_cleared"
-        message = (
-            f"Cleared manifest entry for '{name}'. Future `hermes update` runs "
-            f"will re-baseline against your current copy and accept upstream changes."
-        )
+        # Non-restore path: sync_skills() above either re-baselined the manifest
+        # (when user_hash matches the current bundled hash) or skipped without
+        # writing a manifest entry (when the user's copy genuinely differs from
+        # bundled — the new-skill-collision branch). Distinguish by reading the
+        # manifest after the resync so the user-facing message reflects what
+        # actually happened: a true re-baseline vs. a preserved local copy that
+        # will keep being skipped on future syncs.
+        manifest_after = _read_manifest()
+        if name in manifest_after:
+            action = "manifest_cleared"
+            message = (
+                f"Cleared manifest entry for '{name}'. Future `hermes update` runs "
+                f"will re-baseline against your current copy and accept upstream changes."
+            )
+        else:
+            action = "manifest_cleared_local_preserved"
+            message = (
+                f"Cleared manifest entry for '{name}', but your local copy differs "
+                f"from the bundled version, so it remains preserved and will not "
+                f"receive upstream updates. Use "
+                f"`hermes skills reset --restore {name}` to revert to the shipped "
+                f"version."
+            )
 
     return {"ok": True, "action": action, "message": message, "synced": synced}
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1181,7 +1181,7 @@ Subcommands:
 | `update` | Reinstall hub skills with upstream changes when available. |
 | `audit` | Re-scan installed hub skills. |
 | `uninstall` | Remove a hub-installed skill. |
-| `reset` | Un-stick a bundled skill flagged as `user_modified` by clearing its manifest entry. With `--restore`, also replaces the user copy with the bundled version. |
+| `reset` | Clear a bundled skill's manifest entry. Plain reset only re-baselines a byte-identical local copy; a genuinely modified copy stays preserved and skipped. With `--restore`, replaces the modified copy with the bundled version and resumes stock updates. |
 | `opt-out` | Stop bundled skills from being seeded into the active profile. Writes a `.no-bundled-skills` marker so the installer, `hermes update`, and any sync skip bundled-skill seeding. Safe by default — nothing on disk is touched. With `--remove`, also deletes already-present bundled skills that are **unmodified** (user-edited, hub-installed, and hand-written skills are never removed; previews and confirms first, `--yes` to skip). |
 | `opt-in` | Undo `opt-out` by removing the `.no-bundled-skills` marker so bundled skills are seeded again on the next `hermes update`. With `--sync`, re-seed immediately. |
 | `publish` | Publish a skill to a registry. |

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -635,8 +635,8 @@ hermes skills check                               # Check installed hub skills f
 hermes skills update                              # Reinstall hub skills with upstream changes when needed
 hermes skills audit                               # Re-scan all hub skills for security
 hermes skills uninstall k8s                       # Remove a hub skill
-hermes skills reset google-workspace              # Un-stick a bundled skill from "user-modified" (see below)
-hermes skills reset google-workspace --restore    # Also restore the bundled version, deleting your local edits
+hermes skills reset google-workspace              # Re-baseline only if your copy matches bundled; modified copies stay skipped
+hermes skills reset google-workspace --restore    # Replace your modified copy and resume stock updates
 hermes skills publish skills/my-skill --to github --repo owner/repo
 hermes skills snapshot export setup.json          # Export skill config
 hermes skills tap add myorg/skills-repo           # Add a custom GitHub source
@@ -976,12 +976,13 @@ The protection is good, but it has one sharp edge. If you edit a bundled skill a
 `hermes skills reset` is the escape hatch:
 
 ```bash
-# Safe: clears the manifest entry for this skill. Your current copy is preserved,
-# but the next sync re-baselines against it so future updates work normally.
+# Plain reset: clears the manifest entry and preserves your current copy. The
+# next sync re-baselines only if that copy is byte-identical to bundled. A
+# genuinely modified copy stays preserved and skipped on future updates.
 hermes skills reset google-workspace
 
-# Full restore: also deletes your local copy and re-copies the current bundled
-# version. Use this when you want the pristine upstream skill back.
+# Full restore: deletes your modified local copy, re-copies the current bundled
+# version, and resumes stock updates.
 hermes skills reset google-workspace --restore
 
 # Non-interactive (e.g. in scripts or TUI mode) — skip the --restore confirmation.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/skills.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/skills.md
@@ -398,8 +398,8 @@ hermes skills check                               # Check installed hub skills f
 hermes skills update                              # Reinstall hub skills with upstream changes when needed
 hermes skills audit                               # Re-scan all hub skills for security
 hermes skills uninstall k8s                       # Remove a hub skill
-hermes skills reset google-workspace              # Un-stick a bundled skill from "user-modified" (see below)
-hermes skills reset google-workspace --restore    # Also restore the bundled version, deleting your local edits
+hermes skills reset google-workspace              # 仅当本地副本与捆绑版本字节一致时才重新建立基线；修改过的副本仍会被跳过
+hermes skills reset google-workspace --restore    # 替换修改过的本地副本并恢复原版更新
 hermes skills publish skills/my-skill --to github --repo owner/repo
 hermes skills snapshot export setup.json          # Export skill config
 hermes skills tap add myorg/skills-repo           # Add a custom GitHub source
@@ -718,12 +718,13 @@ Hermes 在仓库的 `skills/` 中附带一组捆绑 skills。在安装时以及�
 `hermes skills reset` 是解决此问题的方法：
 
 ```bash
-# 安全：清除此 skill 的清单条目。你当前的副本被保留，
-# 但下次同步会重新以其为基准，使未来的更新正常工作。
+# 普通 reset：清除此 skill 的清单条目并保留当前副本。只有当该副本与
+# 捆绑版本字节完全相同时，下次同步才会重新建立基线。真正修改过的副本
+# 会被保留，并在未来更新时继续跳过。
 hermes skills reset google-workspace
 
-# 完全恢复：同时删除你的本地副本并重新复制当前捆绑版本。
-# 当你想要恢复原始上游 skill 时使用此选项。
+# 完全恢复：删除修改过的本地副本，重新复制当前捆绑版本，
+# 并恢复原版更新。
 hermes skills reset google-workspace --restore
 
 # 非交互式（例如在脚本或 TUI 模式中）——跳过 --restore 确认。


### PR DESCRIPTION
## Summary

- report honest outcomes from `hermes skills reset` for byte-identical, locally modified, and source-less bundled skills
- direct users with modified copies to `hermes skills reset <name> --restore`
- align CLI help, update notices, English and Chinese guides, and the CLI reference with the runtime behavior

## Root cause

Plain reset clears the manifest entry and immediately syncs. A byte-identical local copy is re-baselined, but a genuinely modified copy enters the new-skill collision path, remains untracked, and continues to be skipped. The command previously returned the successful re-baseline message in both cases and recommended plain reset as the replacement command, creating a circular instruction.

The fix inspects the post-sync manifest and returns distinct actions for a real re-baseline, a preserved divergent copy, and a missing bundled source.

## Validation

- `scripts/run_tests.sh tests/tools/test_skills_sync.py tests/hermes_cli/test_skills_hub.py tests/hermes_cli/test_subcommands_followup.py tests/hermes_cli/test_update_modified_notice.py`, 63 passed
- Ruff checks for all affected Python files
- `git diff --check`
- independent implementation review

Fixes #29856

Builds on the closed #29863 by @briandevans. The original contributor authorship is preserved in the first two commits.
