### PR TITLE
fix(desktop): show a renamed profile's display_name in the sidebar's grouped-by-profile view

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -81,6 +81,7 @@ import {
   ALL_PROFILES,
   messagingTotalsKey,
   normalizeProfileKey,
+  profileGroupLabel,
   sidebarProfileForScope
 } from '@/store/profile'
 import {
@@ -1247,7 +1248,7 @@ export function ChatSidebar({
       const group = groups.get(key) ?? {
         color: resolveProfileColor(key, profileColors),
         id: key,
-        label: key,
+        label: profileGroupLabel(key, profiles),
         mode: 'profile',
         path: null,
         sessions: []
@@ -1262,7 +1263,7 @@ export function ChatSidebar({
     return [...groups.values()].sort((a, b) =>
       a.id === 'default' ? -1 : b.id === 'default' ? 1 : a.label.localeCompare(b.label)
     )
-  }, [profileGrouped, agentSessions, profileColors])
+  }, [profileGrouped, agentSessions, profileColors, profiles])
 
   // The flat Sessions list always shows ALL recent sessions; Projects is a
   // parallel grouped view, not a filter on this one — nothing is hidden here.

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -26,6 +26,7 @@ const {
   ensureGatewayProfile,
   invalidateProfileListFetches,
   prewarmProfileBackend,
+  profileGroupLabel,
   refreshProfiles
 } = await import('./profile')
 
@@ -237,5 +238,29 @@ describe('stale profile-list fetches across a backend switch (#85731)', () => {
     await oldFetch
 
     expect($profiles.get().map(profile => profile.name)).toEqual(['default', 'coder'])
+  })
+})
+
+describe('profileGroupLabel', () => {
+  it('shows a renamed profile\'s display_name, not its raw key', () => {
+    // Regression: the sidebar's "group by profile" view built its group
+    // headers straight from normalizeProfileKey(session.profile) — the raw,
+    // lowercase canonical key — instead of the profile's display_name. Every
+    // other profile-facing surface (the rail switcher, the settings list)
+    // already shows profileLabel(); the profile-grouped sidebar view was the
+    // one place a rename didn't show up.
+    const renamed = { ...profile('coder'), display_name: 'Coding Buddy' }
+
+    expect(profileGroupLabel('coder', [renamed])).toBe('Coding Buddy')
+  })
+
+  it('falls back to the canonical name when no display_name is set', () => {
+    expect(profileGroupLabel('coder', [profile('coder')])).toBe('coder')
+  })
+
+  it('falls back to the key itself when the profile is missing from the live list', () => {
+    // e.g. a profile removed elsewhere while a session grouped under its key
+    // is still on screen.
+    expect(profileGroupLabel('gone', [profile('coder')])).toBe('gone')
   })
 })

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -33,6 +33,15 @@ export function profileLabel(profile: Pick<ProfileInfo, 'display_name' | 'name'>
   return (profile.display_name ?? '').trim() || profile.name
 }
 
+// Resolves a normalized profile key (as stored on a session) to its display
+// label — the same profileLabel() every other profile-facing surface shows
+// (the rail switcher, the settings list), not the raw key. Falls back to the
+// key itself when the profile isn't in the live list (e.g. one that still
+// has recent sessions after being removed).
+export function profileGroupLabel(key: string, profiles: ProfileInfo[]): string {
+  return profileLabel(profiles.find(profile => normalizeProfileKey(profile.name) === key) ?? { name: key })
+}
+
 // The profile the running local backend is actually scoped to (mirrors
 // /api/profiles/active `current`). "default" is the root ~/.hermes. This is the
 // display source of truth for the statusbar pill; the desktop's *stored*


### PR DESCRIPTION
## What does this PR do?

`ChatSidebar`'s `profileGroups` memo (`apps/desktop/src/app/chat/sidebar/index.tsx`) builds each group's header straight from `normalizeProfileKey(session.profile)` — the raw, lowercase canonical profile key. Every other profile-facing surface already renders `profileLabel()` instead, which prefers a profile's `display_name` (set via a rename) over its canonical `name`:

- the rail switcher (`profile-switcher.tsx`, `label={profileLabel(profile)}` × 3 call sites)
- the settings profile list (`app/profiles/index.tsx`, `menuLabel`/`title`/heading all via `profileLabel(profile)`)

The grouped-by-profile sidebar view ("group by: profile") was the one place a rename didn't show up: the group header text, its `aria-label` (`t.profiles.switchToProfile(group.label)`), and the "New session in `<label>`" action button all rendered the internal key regardless of what the user renamed the profile to in Settings → Profiles.

## Fix

Adds `profileGroupLabel(key, profiles)` next to `profileLabel()` in `store/profile.ts` — resolves a normalized key to its live `ProfileInfo` entry and applies the same display rule `profileLabel()` uses everywhere else, falling back to the key itself when the profile isn't in the live list (e.g. one removed elsewhere while a session grouped under its key is still on screen):

```ts
export function profileGroupLabel(key: string, profiles: ProfileInfo[]): string {
  return profileLabel(profiles.find(profile => normalizeProfileKey(profile.name) === key) ?? { name: key })
}
```

Wired into the memo's label computation, with `profiles` (already subscribed via `useStore($profiles)` a few lines above, for the existing `multiProfile` check) added to the dependency array so a rename mid-session updates the group header without a reload.

`group.id` — used for routing (`selectProfile(group.id)`), the color lookup, and the default-first sort special-case — is untouched; only the *display* value changes. `projects/workspace-group.tsx` (the component that renders `group.label`) needed no change — it already renders whatever `profileGroups` hands it.

## Testing

- New `describe('profileGroupLabel', ...)` block in `store/profile.test.ts` (3 cases: renamed profile shows its display_name; unrenamed profile falls back to its canonical name; a profile missing from the live list falls back to the raw key).
- Mutation-verified: reverting `profileGroupLabel`'s body to `return key` reproduces the exact bug this PR fixes — the "shows a renamed profile's display_name" test fails with `expected 'coder' to be 'Coding Buddy'` — confirming the new test genuinely exercises the fix.
- Full neighbor sweep (`src/app/chat/sidebar/`, `store/profile.test.ts`, `store/session.test.ts`): 268 passed, 0 failures.
- `npx tsc --noEmit`: clean.
- `eslint` couldn't run in this sandbox (workspace-scoped `npm install` doesn't pull the root-only `globals` peer dependency `eslint.config.mjs` needs — a known, pre-existing environment limitation unrelated to this change); relying on the clean type-check + full test sweep above.

## Adjacent open PRs (checked, no overlap on the actual bug)

- **#89915** ("true separation by gateway in the sidebar, profile rail and Manage Profiles") rewrites this exact `profileGroups` memo block for an orthogonal purpose — disambiguating two machines that both serve a `default` profile by keying groups on `(connection, profile)` instead of profile name alone. Its own replacement label line (`` label: device ? `${profileKey} · ${device}` : profileKey ``) still uses the raw `profileKey`, not `profileLabel()`/`display_name` — so it doesn't fix this bug even if it lands first, and this PR's `profileGroupLabel()` composes cleanly with it (`` `${profileGroupLabel(profileKey, profiles)} · ${device}` ``) if rebased. Real textual overlap on the same lines, no semantic conflict — whichever lands second will need a small rebase.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
