### PR TITLE
fix(usage): update DeepSeek pricing to 2026-08 peak/off-peak rates

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -506,52 +506,57 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         pricing_version="anthropic-pricing-2026-05",
     ),
     # DeepSeek
-    # Snapshot of https://api-docs.deepseek.com/quick_start/pricing (2026-07).
+    # Snapshot of https://api-docs.deepseek.com/quick_start/pricing (2026-08).
+    # Effective 2026-08-16 16:00 UTC, DeepSeek V4 moved from flat per-token rates
+    # to peak/off-peak billing. Peak hours are 01:00-04:00 and 06:00-10:00 UTC
+    # (all other hours off-peak), and off-peak is 50% of peak. These entries
+    # record OFF-PEAK rates (the majority case for non-interactive workloads);
+    # peak-hour traffic is under-estimated by ~2x.
     # deepseek-chat / deepseek-reasoner are deprecated 2026-07-24 and now alias
     # deepseek-v4-flash's non-thinking / thinking modes — same rates.
     (
         "deepseek",
         "deepseek-chat",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.14"),
-        output_cost_per_million=Decimal("0.28"),
-        cache_read_cost_per_million=Decimal("0.0028"),
+        input_cost_per_million=Decimal("0.22"),
+        output_cost_per_million=Decimal("0.66"),
+        cache_read_cost_per_million=Decimal("0.007"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-07",
+        pricing_version="deepseek-pricing-2026-08",
     ),
     (
         "deepseek",
         "deepseek-reasoner",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.14"),
-        output_cost_per_million=Decimal("0.28"),
-        cache_read_cost_per_million=Decimal("0.0028"),
+        input_cost_per_million=Decimal("0.22"),
+        output_cost_per_million=Decimal("0.66"),
+        cache_read_cost_per_million=Decimal("0.007"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-07",
+        pricing_version="deepseek-pricing-2026-08",
     ),
     (
         "deepseek",
         "deepseek-v4-pro",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.435"),
-        output_cost_per_million=Decimal("0.87"),
-        cache_read_cost_per_million=Decimal("0.003625"),
+        input_cost_per_million=Decimal("0.66"),
+        output_cost_per_million=Decimal("1.98"),
+        cache_read_cost_per_million=Decimal("0.022"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-07",
+        pricing_version="deepseek-pricing-2026-08",
     ),
     (
         "deepseek",
         "deepseek-v4-flash",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.14"),
-        output_cost_per_million=Decimal("0.28"),
-        cache_read_cost_per_million=Decimal("0.0028"),
+        input_cost_per_million=Decimal("0.22"),
+        output_cost_per_million=Decimal("0.66"),
+        cache_read_cost_per_million=Decimal("0.007"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-07",
+        pricing_version="deepseek-pricing-2026-08",
     ),
     # Google Gemini
     (

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -89,8 +89,9 @@ def test_deepseek_v4_pro_pricing_entry_exists():
 
     Before this fix, deepseek-v4-pro sessions showed as unknown cost
     in hermes insights because the _OFFICIAL_DOCS_PRICING table had no
-    entry for that model.  See #24218.  Rates track the 2026-07 price cut
-    ($1.74/$3.48 → $0.435/$0.87).
+    entry for that model.  See #24218.  Rates track the 2026-08-16
+    peak/off-peak change; we record OFF-PEAK rates (peak is 2x during
+    UTC 01:00-04:00 and 06:00-10:00).
     """
     entry = get_pricing_entry(
         "deepseek-v4-pro",
@@ -100,9 +101,9 @@ def test_deepseek_v4_pro_pricing_entry_exists():
     assert entry is not None
     assert entry.input_cost_per_million is not None
     assert entry.output_cost_per_million is not None
-    assert float(entry.input_cost_per_million) == 0.435
-    assert float(entry.output_cost_per_million) == 0.87
-    assert float(entry.cache_read_cost_per_million) == 0.003625
+    assert float(entry.input_cost_per_million) == 0.66
+    assert float(entry.output_cost_per_million) == 1.98
+    assert float(entry.cache_read_cost_per_million) == 0.022
 
 
 


### PR DESCRIPTION
## Summary

DeepSeek moved `deepseek-v4-flash` and `deepseek-v4-pro` from flat per-token rates to **peak/off-peak** billing, effective **2026-08-16 16:00 UTC**. Off-peak is 50% of peak; peak hours are `01:00–04:00` and `06:00–10:00` UTC (all other hours off-peak).

The `_OFFICIAL_DOCS_PRICING` table still carries the 2026-07 flat rates, so `hermes insights` / `/usage` under-reports DeepSeek cost by ~2.4x for a cache-heavy agent workload.

## Change

Update the four `deepseek` provider entries to **off-peak** rates and bump `pricing_version` to `deepseek-pricing-2026-08`:

| model | input (cache miss) | cache-hit | output |
|---|---|---|---|
| deepseek-v4-pro | 0.435 → **0.66** | 0.003625 → **0.022** | 0.87 → **1.98** |
| deepseek-v4-flash (and `-chat`/`-reasoner` aliases) | 0.14 → **0.22** | 0.0028 → **0.007** | 0.28 → **0.66** |

Peak-hour traffic is under-estimated by ~2x; this is documented in the code comment (off-peak is chosen as the majority case for non-interactive workloads).

The `fireworks` provider's DeepSeek entries are untouched — those are Fireworks' own markups, not DeepSeek's direct-API rates.

## Verification

- Updated `test_deepseek_v4_pro_pricing_entry_exists` to assert the new rates.
- `tests/agent/test_usage_pricing.py` — **40 passed**.

Source: https://api-docs.deepseek.com/quick_start/pricing
