### PR TITLE
feat(plugins): carry the delivery target on stream observer payloads

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -167,6 +167,18 @@ VALID_HOOKS: Set[str] = {
     # Streaming LLM output observer hooks. Fired asynchronously off the token
     # path by agent.plugin_stream_hooks; callbacks observe immutable normalized
     # text/lifecycle payloads and cannot transform the stream.
+    #
+    # All four share a base payload: turn_id, iteration, session_id, model,
+    # provider, surface, plus the delivery target — chat_id, chat_type and
+    # thread_id. The target is what tells a per-chat observer which of the
+    # gateway's many concurrent conversations a turn belongs to; session_id
+    # answers a different question (which stored history it extends). All three
+    # are "" for a CLI turn, which has no chat.
+    #
+    # on_stream_delta adds delta + kind ("text" or "reasoning"; reasoning is
+    # opt-in via plugins.stream_reasoning_deltas). on_stream_end adds
+    # final_text, finished and error. on_interim_message adds text and
+    # already_streamed.
     "on_stream_start",
     "on_stream_delta",
     "on_stream_end",

--- a/run_agent.py
+++ b/run_agent.py
@@ -6722,12 +6722,10 @@ class AIAgent:
 
             enqueue_plugin_stream_hook(
                 "on_interim_message",
-                turn_id=getattr(self, "_current_turn_id", "") or "",
-                iteration=int(getattr(self, "_api_call_count", 0) or 0),
-                session_id=self.session_id or "",
-                model=self.model or "",
-                provider=self.provider or "",
-                surface=self.platform or "cli",
+                # Same base payload as the stream lifecycle hooks, so a plugin
+                # routing a turn by chat does not find the identity present on
+                # its deltas and missing on its interim messages.
+                **self._stream_hook_base_payload(),
                 text=visible,
                 already_streamed=already_streamed,
             )
@@ -6829,6 +6827,16 @@ class AIAgent:
             "model": self.model or "",
             "provider": self.provider or "",
             "surface": self.platform or "cli",
+            # Where the turn is being delivered. session_id identifies the
+            # conversation's stored history, which is not the same question a
+            # per-chat observer has to answer: one gateway serves many chats at
+            # once, and a plugin mirroring tokens has to know which one this
+            # turn belongs to. Defensive getattr with "" defaults — these are
+            # only populated for gateway sessions, and a CLI turn simply has no
+            # chat.
+            "chat_id": str(getattr(self, "_chat_id", "") or ""),
+            "chat_type": str(getattr(self, "_chat_type", "") or ""),
+            "thread_id": str(getattr(self, "_thread_id", "") or ""),
         }
 
     def _emit_stream_start(self) -> None:

--- a/tests/run_agent/test_plugin_stream_hooks.py
+++ b/tests/run_agent/test_plugin_stream_hooks.py
@@ -262,6 +262,88 @@ def test_stream_lifecycle_plugin_hooks_are_queued(monkeypatch):
     assert end_call[1]["error"] is None
 
 
+def _gateway_agent():
+    """An agent shaped like a gateway session — one that HAS a chat to deliver to."""
+    from run_agent import AIAgent
+
+    return AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        provider="openrouter",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="matrix",
+        chat_id="!room:example.org",
+        chat_type="group",
+        thread_id="$thread",
+    )
+
+
+def test_stream_observer_payload_carries_the_delivery_target(monkeypatch):
+    """A per-chat observer has to know WHICH chat, not just which session.
+
+    One gateway serves many conversations at once, so a plugin mirroring a
+    turn's tokens somewhere (a second client, a bridge, a web view) cannot route
+    them by session_id alone.
+    """
+    from agent.plugin_stream_hooks import shutdown_plugin_stream_hook_dispatcher
+
+    shutdown_plugin_stream_hook_dispatcher()
+    calls = []
+
+    def observe(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(
+        "hermes_cli.plugins.iter_hook_callbacks",
+        _callbacks({
+            "on_stream_start": [observe],
+            "on_stream_delta": [observe],
+            "on_stream_end": [observe],
+            "on_interim_message": [observe],
+        }),
+    )
+
+    agent = _gateway_agent()
+    agent._emit_stream_start()
+    agent._fire_stream_delta("hello")
+    agent._emit_stream_end(final_text="hello", finished=True, error=None)
+    _wait_for(lambda: len(calls) == 3)
+    shutdown_plugin_stream_hook_dispatcher()
+
+    assert len(calls) == 3
+    for payload in calls:
+        assert payload["chat_id"] == "!room:example.org"
+        assert payload["chat_type"] == "group"
+        assert payload["thread_id"] == "$thread"
+        assert payload["surface"] == "matrix"
+
+
+def test_a_cli_turn_has_no_chat_rather_than_a_missing_key(monkeypatch):
+    """The keys are always present, so a consumer never has to guess."""
+    from agent.plugin_stream_hooks import shutdown_plugin_stream_hook_dispatcher
+
+    shutdown_plugin_stream_hook_dispatcher()
+    calls = []
+
+    monkeypatch.setattr(
+        "hermes_cli.plugins.iter_hook_callbacks",
+        _callbacks({"on_stream_start": [lambda **kw: calls.append(kw)]}),
+    )
+
+    agent = _agent()
+    agent._emit_stream_start()
+    _wait_for(lambda: calls)
+    shutdown_plugin_stream_hook_dispatcher()
+
+    assert calls[0]["chat_id"] == ""
+    assert calls[0]["chat_type"] == ""
+    assert calls[0]["thread_id"] == ""
+    assert calls[0]["surface"] == "cli"
+
+
 @patch("run_agent.AIAgent._create_request_openai_client")
 @patch("run_agent.AIAgent._close_request_openai_client")
 def test_chat_completion_stream_emits_lifecycle_hooks(_mock_close, mock_create, monkeypatch):


### PR DESCRIPTION
## The gap

`on_stream_start` / `on_stream_delta` / `on_stream_end` / `on_interim_message` identify a turn by `session_id`. That answers *which stored history does this extend* — not *which conversation is this being delivered to*.

One gateway serves many chats at once. A plugin that mirrors a turn's tokens somewhere per-chat — a second client, a protocol bridge, a web view — receives every delta of every concurrent turn with no way to tell them apart, and has to patch core to recover an identity the agent is already holding.

## The change

`_stream_hook_base_payload()` gains `chat_id`, `chat_type` and `thread_id` next to the existing `surface`, so the delivery target is `(surface, chat_id)` — the same pair the gateway keys a chat on.

- Values come from the `_chat_id` / `_chat_type` / `_thread_id` attributes `agent_init` already sets for gateway sessions. Nothing new is plumbed.
- Defensive `getattr` with `""` defaults: a CLI turn reports *no chat* rather than omitting the keys and making consumers guess.
- `on_interim_message` is folded onto the same base payload instead of hand-building its half of it. A consumer routing deltas by chat should not find the identity present on its deltas and missing on its interim messages; it also picks up `turn_id` and `iteration` for free.
- Payload documented in the `VALID_HOOKS` comment block.

Observer-only, off the token path, no behaviour change for anything that ignores the new keys.

## Consumer

A standalone gateway side-channel plugin that streams a turn into the Matrix room it came from, so a phone client can render tokens live without the homeserver taking an `m.replace` edit per tick. Without the target it cannot tell two rooms apart. It ships separately, per the plugin policy.

## Relationship to #90077

Independent and adjacent — that one adds `usage` to `on_stream_end`, this one adds the target to the shared base payload. They touch the same file and the same test module, so whichever lands second will want a trivial rebase. Together they are what lets that plugin stop being a core patch.

## Tests

2 added, 14 passing in `tests/run_agent/test_plugin_stream_hooks.py`. `tests/hermes_cli/test_plugins.py` also green (64 passing).

- the target reaches all four hooks for a gateway-shaped agent
- a CLI turn reports empty strings, not missing keys