### PR TITLE
fix(buzz): dispatch forum-channel kinds instead of chat kind 9 only

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -88,6 +88,15 @@ from gateway.config import Platform
 # returns housekeeping kinds (joins, canvas updates, …) — only kind 9 is
 # dispatched to the agent.
 _CHAT_KIND = 9
+# Kinds that carry agent-relevant conversation content and are dispatched
+# (#90309): chat messages (9) plus the Buzz forum kinds — 45001 is a forum
+# post (thread root) and 45003 a comment reply on it.  Block's own ACP
+# harness documents this set (``buzz-acp --kinds 9,46010,40007,45001,
+# 45002,45003``); the stream kinds (46010/40007/45002) are left out until
+# their dispatch semantics are confirmed.  ``_is_direct_message_event``
+# deliberately keeps the kind-9-only check: widening it there would let a
+# p-tagged forum post be reclassified as a DM and bypass mention gating.
+_DISPATCH_KINDS = frozenset({_CHAT_KIND, 45001, 45003})
 # How many events to request per poll / seed call.
 _FETCH_LIMIT = 50
 # Bound on the per-channel de-dupe set (events, not bytes).
@@ -796,7 +805,7 @@ class BuzzAdapter(BasePlatformAdapter):
         request = [
             "REQ",
             subscription_id,
-            {"kinds": [_CHAT_KIND], "#h": [channel_id], "since": since},
+            {"kinds": sorted(_DISPATCH_KINDS), "#h": [channel_id], "since": since},
         ]
         await websocket.send(json.dumps(request, separators=(",", ":")))
 
@@ -1014,7 +1023,7 @@ class BuzzAdapter(BasePlatformAdapter):
         state["seen"][event_id] = None
         state["last_ts"] = max(state["last_ts"], created_at)
 
-        if int(event.get("kind") or 0) != _CHAT_KIND:
+        if int(event.get("kind") or 0) not in _DISPATCH_KINDS:
             return
         pubkey = str(event.get("pubkey") or "").lower()
         content = event.get("content")

--- a/tests/gateway/test_buzz_forum_kinds.py
+++ b/tests/gateway/test_buzz_forum_kinds.py
@@ -1,0 +1,137 @@
+"""Regression tests for Buzz forum-kind dispatch (#90309).
+
+The inbound path hardcoded Nostr kind 9 (chat) at both the WebSocket
+subscription filter and the dispatch gate, so forum channels (kind 45001
+thread roots and 45003 comment replies) were silently never dispatched.
+The DM-reclassification check deliberately stays kind-9-only: widening it
+would let a p-tagged forum post be reclassified as a DM and bypass
+mention gating.
+"""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.buzz.adapter import (
+    _CHAT_KIND,
+    _DISPATCH_KINDS,
+    BuzzAdapter,
+)
+
+CHANNEL = "7c83e8f7bb1d4db2bb4074d5c14f2a7f6a9e1c21d3b5a90f8e7d6c5b4a392801"
+SELF_PUBKEY = "aa" * 32
+OTHER_PUBKEY = "bb" * 32
+
+
+def _dummy_nsec() -> str:
+    # Test-only placeholder, assembled to avoid a credential-shaped literal.
+    return "-".join(("nsec", "1", "test"))
+
+
+def _event(event_id, content="hey @Chip", kind=9, p_tag_self=False):
+    tags = [["h", CHANNEL]]
+    if p_tag_self:
+        tags.append(["p", SELF_PUBKEY])
+    return {
+        "id": event_id,
+        "pubkey": OTHER_PUBKEY,
+        "content": content,
+        "created_at": 100,
+        "kind": kind,
+        "tags": tags,
+    }
+
+
+def _make_group_adapter():
+    adapter = BuzzAdapter(
+        PlatformConfig(enabled=True, extra={"relay_url": "https://test.relay"})
+    )
+    adapter._self_pubkey = SELF_PUBKEY
+    adapter._self_npub = "npub1" + "a" * 50
+    adapter._display_name = "Chip"
+    adapter._private_key = _dummy_nsec()
+    adapter._dispatched = []
+
+    async def capture(**kwargs):
+        adapter._dispatched.append(kwargs)
+
+    adapter._dispatch_message = capture
+    adapter._message_handler = AsyncMock()
+    adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+    return adapter
+
+
+class _ScriptedCli:
+    def __init__(self, events):
+        import copy
+
+        self._events = copy.deepcopy(events)
+
+    async def __call__(self, args, *, input_text=None):
+        return 0, json.dumps(self._events), ""
+
+
+class TestForumKindDispatch:
+    @pytest.mark.asyncio
+    async def test_forum_post_root_dispatched(self):
+        adapter = _make_group_adapter()
+        adapter._run_cli = _ScriptedCli([_event("f1", kind=45001)])
+        await adapter._poll_channel(CHANNEL)
+        assert [d["message_id"] for d in adapter._dispatched] == ["f1"]
+
+    @pytest.mark.asyncio
+    async def test_forum_comment_reply_dispatched(self):
+        adapter = _make_group_adapter()
+        adapter._run_cli = _ScriptedCli([_event("f2", kind=45003)])
+        await adapter._poll_channel(CHANNEL)
+        assert [d["message_id"] for d in adapter._dispatched] == ["f2"]
+
+    @pytest.mark.asyncio
+    async def test_undocumented_stream_kind_still_ignored(self):
+        """Stream kinds stay out of scope until their dispatch semantics are
+        confirmed — the dispatch set must not widen beyond chat + forum."""
+        adapter = _make_group_adapter()
+        adapter._run_cli = _ScriptedCli(
+            [_event("s1", kind=46010), _event("s2", kind=40007)]
+        )
+        await adapter._poll_channel(CHANNEL)
+        assert adapter._dispatched == []
+
+
+class TestSubscriptionFilter:
+    @pytest.mark.asyncio
+    async def test_websocket_subscription_includes_forum_kinds(self):
+        """The REQ filter must subscribe to every dispatchable kind, or the
+        live path never even receives forum events to drop."""
+        adapter = _make_group_adapter()
+        sent = []
+
+        class _FakeWS:
+            async def send(self, payload):
+                sent.append(json.loads(payload))
+
+        adapter._channel_state[CHANNEL]["last_ts"] = 100
+        await adapter._send_channel_subscription(_FakeWS(), "sub-1", CHANNEL)
+        assert sent, "subscription request must be sent"
+        assert sent[0][2]["kinds"] == sorted(_DISPATCH_KINDS)
+        assert 45001 in sent[0][2]["kinds"] and 45003 in sent[0][2]["kinds"]
+
+
+class TestDmReclassificationStaysChatOnly:
+    def test_ptagged_forum_post_is_not_a_dm(self):
+        """Security pin: a p-tagged kind-45001 post must NOT be reclassified
+        as a DM — that would bypass mention gating for forum content
+        (#90309 caveat). The DM check keeps the kind-9-only comparison."""
+        adapter = _make_group_adapter()
+        adapter._may_reclassify_as_dm = lambda channel_id: True
+        assert adapter._is_direct_message_event(
+            CHANNEL, _event("f3", kind=45001, p_tag_self=True)
+        ) is False
+
+    def test_ptagged_chat_message_can_still_be_a_dm(self):
+        adapter = _make_group_adapter()
+        adapter._may_reclassify_as_dm = lambda channel_id: True
+        event = _event("d1", kind=_CHAT_KIND, p_tag_self=True, content="no mention")
+        assert adapter._is_direct_message_event(CHANNEL, event) is True


### PR DESCRIPTION
## What does this PR do?

Makes the bundled `buzz` platform dispatch Buzz **forum** channels. The inbound path hardcoded Nostr kind 9 (chat) at both the WebSocket subscription filter and the dispatch gate — and the gate runs *before* mention gating — so forum posts (kind 45001 thread roots) and their comment replies (kind 45003) were silently never dispatched to the agent. Chat and stream channels kept working, which made the gap invisible; the reporter's community reached through `buzz-acp` (which treats the kind set as configurable and documents the forum kinds) answered in the same forum while the native platform did not (#90309).

Introduces `_DISPATCH_KINDS = {9, 45001, 45003}` used by the subscription filter and the dispatch gate. The stream kinds (46010/40007/45002) from the `buzz-acp` set stay out of scope until their dispatch semantics are confirmed. `_is_direct_message_event` deliberately keeps its kind-9-only comparison: widening it would let a p-tagged forum post be reclassified as a DM and bypass mention gating (the reporter's caveat). The send path already works unchanged — `send()` omits `--kind` and threads via `--reply-to`, matching observed working forum agents.

## Related Issue

Fixes #90309

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/buzz/adapter.py` — new `_DISPATCH_KINDS` frozenset (chat 9 + forum 45001/45003) with a comment documenting why the DM check is excluded from the widening.
- `plugins/platforms/buzz/adapter.py` — `_send_channel_subscription` REQ filter now subscribes to `sorted(_DISPATCH_KINDS)` so the live path actually receives forum events.
- `plugins/platforms/buzz/adapter.py` — `_handle_event` dispatch gate now uses set membership instead of the kind-9 equality (covers the polling path too, since `buzz messages get` already returns forum events).
- `tests/gateway/test_buzz_forum_kinds.py` — new: forum root/comment dispatch, stream kinds still ignored, subscription filter includes forum kinds, and the security pin that a p-tagged forum post is never reclassified as a DM while a p-tagged chat message still can be.

## How to Test

1. `uv run --python 3.11 --with pytest --with pytest-asyncio --with pyyaml --with python-dotenv --with httpx --with pillow --with requests --with rich --with prompt_toolkit --with websockets python -m pytest -q -o 'addopts=' tests/gateway/test_buzz_forum_kinds.py`
2. Observed result: 6 passed on this branch; the suite cannot even collect on unmodified `main` (`_DISPATCH_KINDS` does not exist) — the four dispatch/subscription tests fail there because kind 45001/45003 events are dropped, confirming the regression tests pin the fix.
3. Baseline: `tests/gateway/test_buzz_adapter.py` — 23 passed on this branch and on unmodified `main` (identical), so existing chat/DM/mention-gating behavior is unchanged.
4. Live check (optional, Buzz CLI connected): post in a forum channel and mention the bot — the agent should now see and answer the thread; chat channels behave exactly as before.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (in-code comment documents the kind semantics)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new keys; stream-kind widening deliberately deferred)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
