### PR TITLE
fix(tools): the provider selected in hermes tools is what runs — credential presence never reroutes

### DIFF
--- a/agent/image_gen_registry.py
+++ b/agent/image_gen_registry.py
@@ -139,6 +139,18 @@ def get_active_provider() -> Optional[ImageGenProvider]:
     except Exception as exc:
         logger.debug("Could not read image_gen.provider from config: %s", exc)
 
+    # The managed "Nous Subscription" selection is serviced by the FAL
+    # plugin through the managed fal-queue gateway (the legacy FAL pipeline
+    # routes managed when the stored selection is "nous").
+    if configured:
+        try:
+            from tools.tool_backend_helpers import NOUS_MANAGED_PROVIDER
+
+            if configured.lower() == NOUS_MANAGED_PROVIDER:
+                configured = "fal"
+        except Exception:  # pragma: no cover — helpers are in-repo
+            pass
+
     with _lock:
         snapshot = dict(_providers)
         snapshot.update(_scoped_providers.get(hermes_home_key(), {}))

--- a/agent/video_gen_registry.py
+++ b/agent/video_gen_registry.py
@@ -132,6 +132,18 @@ def get_active_provider() -> Optional[VideoGenProvider]:
     except Exception as exc:
         logger.debug("Could not read video_gen.provider from config: %s", exc)
 
+    # The managed "Nous Subscription" selection is serviced by the FAL
+    # plugin through the managed fal-queue gateway (the plugin's resolver
+    # routes managed when the stored selection is "nous").
+    if configured:
+        try:
+            from tools.tool_backend_helpers import NOUS_MANAGED_PROVIDER
+
+            if configured.lower() == NOUS_MANAGED_PROVIDER:
+                configured = "fal"
+        except Exception:  # pragma: no cover — helpers are in-repo
+            pass
+
     with _lock:
         snapshot = dict(_providers)
         snapshot.update(_scoped_providers.get(hermes_home_key(), {}))

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1667,7 +1667,11 @@ DEFAULT_CONFIG = {
         # the raw transcript is also echoed back to the user as a 🎙️ message.
         # Set false to keep STT for the agent while suppressing that user-facing echo.
         "echo_transcripts": True,
-        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe) | "deepinfra"
+        # NOTE: no seeded "provider" key. Strict selection semantics treat a
+        # stored stt.provider as an explicit user pick; seeding "local" here
+        # made a fresh install indistinguishable from a user choice. The
+        # autodetect ladder covers unset. Valid values when set:
+        # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe) | "deepinfra"
         # Global language hint applied to EVERY provider unless a per-provider
         # language overrides it. Defaults to "en" — Whisper auto-detection
         # frequently misidentifies short/accented clips, which reads as

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -54,6 +54,26 @@ def _uses_gateway(section: object) -> bool:
     return is_truthy_value(section.get("use_gateway"), default=False)
 
 
+def _selected_provider(section: object, name_key: str = "provider") -> Optional[str]:
+    """Return the stored provider string for a config section dict.
+
+    Mirrors :func:`tools.tool_backend_helpers.read_selection`'s semantics on
+    an in-memory section dict: ``"nous"`` for the managed selection (stored
+    ``nous`` value or legacy ``use_gateway: true``), a vendor name for BYOK
+    picks, or ``None`` when no selection is stored. Keeping this in lockstep
+    with the runtime resolver is what stops ``hermes status`` from lying.
+    """
+    if not isinstance(section, dict):
+        return None
+    if is_truthy_value(section.get("use_gateway"), default=False):
+        return "nous"
+    value = section.get(name_key)
+    if value is None:
+        return None
+    name = str(value).strip().lower()
+    return name or None
+
+
 @dataclass(frozen=True)
 class NousFeatureState:
     key: str
@@ -315,11 +335,14 @@ def _resolve_browser_feature_state(
     on the latter, or setup/status advertise a browser that fails on first use
     when Chromium is missing.
     """
-    if direct_camofox:
-        return "camofox", True, bool(browser_tool_enabled), False
-
     if browser_provider_explicit:
         current_provider = browser_provider or "local"
+        if current_provider == "camofox":
+            # Camofox is now a stored selection (browser.cloud_provider:
+            # camofox); CAMOFOX_URL is only the server address.
+            available = bool(direct_camofox)
+            active = bool(browser_tool_enabled and available)
+            return current_provider, available, active, False
         if current_provider == "browserbase":
             available = bool(browser_local_available and direct_browserbase)
             active = bool(browser_tool_enabled and available)
@@ -346,6 +369,11 @@ def _resolve_browser_feature_state(
         available = bool(browser_local_runnable)
         active = bool(browser_tool_enabled and available)
         return current_provider, available, active, False
+
+    # Never-configured autodetect: CAMOFOX_URL keeps activating Camofox
+    # exactly as before when no cloud_provider selection was ever stored.
+    if direct_camofox:
+        return "camofox", True, bool(browser_tool_enabled), False
 
     if managed_browser_available or direct_browser_use:
         available = bool(browser_local_available)
@@ -435,17 +463,48 @@ def get_nous_subscription_features(
         terminal_cfg.get("modal_mode")
     )
 
-    # use_gateway flags — when True, the user explicitly opted into the
-    # Tool Gateway via `hermes model`, so direct credentials should NOT
-    # prevent gateway routing.
-    web_use_gateway = _uses_gateway(web_cfg)
-    tts_use_gateway = _uses_gateway(tts_cfg)
-    stt_use_gateway = _uses_gateway(stt_cfg)
-    browser_use_gateway = _uses_gateway(browser_cfg)
+    # Stored selections (strict model): one provider string per category.
+    # "nous" (stored value or legacy use_gateway: true) = managed gateway;
+    # vendor name = that vendor direct; None = never configured (autodetect).
     image_gen_cfg = config.get("image_gen") if isinstance(config.get("image_gen"), dict) else {}
-    image_use_gateway = _uses_gateway(image_gen_cfg)
     video_gen_cfg = config.get("video_gen") if isinstance(config.get("video_gen"), dict) else {}
-    video_use_gateway = _uses_gateway(video_gen_cfg)
+    web_selected = _selected_provider(web_cfg, "backend")
+    tts_selected = _selected_provider(tts_cfg)
+    stt_selected = _selected_provider(stt_cfg)
+    browser_selected = _selected_provider(browser_cfg, "cloud_provider")
+    image_selected = _selected_provider(image_gen_cfg)
+    video_selected = _selected_provider(video_gen_cfg)
+
+    # Same seeded-value shim as tools.tool_backend_helpers.read_selection:
+    # legacy DEFAULT_CONFIG seeded ``stt.provider: local`` on every install,
+    # so that exact value with no picker-written use_gateway key is treated
+    # as never-configured.
+    if (
+        stt_selected == "local"
+        and isinstance(stt_cfg, dict)
+        and "use_gateway" not in stt_cfg
+    ):
+        stt_selected = None
+
+    # Managed selection flags (replace the legacy use_gateway reads —
+    # use_gateway is now interpreted only inside _selected_provider).
+    web_use_gateway = web_selected == "nous"
+    tts_use_gateway = tts_selected == "nous"
+    stt_use_gateway = stt_selected == "nous"
+    browser_use_gateway = browser_selected == "nous"
+    image_use_gateway = image_selected == "nous"
+    video_use_gateway = video_selected == "nous"
+
+    # The "nous" selection is serviced by a concrete vendor implementation —
+    # normalize the current-provider labels so downstream vendor checks hold.
+    if web_backend == "nous" or web_use_gateway:
+        web_backend = "firecrawl"
+    if tts_provider == "nous" or tts_use_gateway:
+        tts_provider = "openai"
+    if stt_provider == "nous" or stt_use_gateway:
+        stt_provider = "openai"
+    if browser_provider == "nous" or browser_use_gateway:
+        browser_provider = "browser-use"
 
     direct_exa = bool(get_env_value("EXA_API_KEY"))
     direct_firecrawl = bool(get_env_value("FIRECRAWL_API_KEY") or get_env_value("FIRECRAWL_API_URL"))
@@ -548,6 +607,27 @@ def get_nous_subscription_features(
         managed_ready=managed_modal_available,
         managed_enabled=managed_tools_flag,
     )
+
+    # Strict selection: a stored VENDOR selection pins the category to direct
+    # credentials — managed availability must not light the feature up (the
+    # runtime will error, not reroute), and camofox/local selections must not
+    # be pre-empted by env credentials for other providers.
+    if web_selected is not None and not web_use_gateway:
+        managed_web_available = False
+    if image_selected is not None and not image_use_gateway:
+        managed_image_available = False
+    if video_selected is not None and not video_use_gateway:
+        managed_video_available = False
+    if tts_selected is not None and not tts_use_gateway:
+        managed_tts_available = False
+    if stt_selected is not None and not stt_use_gateway:
+        managed_stt_available = False
+    if browser_selected is not None and not browser_use_gateway:
+        managed_browser_available = False
+    if browser_selected is not None and browser_selected != "camofox":
+        # CAMOFOX_URL is the server address, not a selection: an explicit
+        # different browser choice wins over the env var.
+        direct_camofox = False
 
     web_managed = web_backend == "firecrawl" and managed_web_available and not direct_firecrawl
     web_active = bool(
@@ -664,17 +744,10 @@ def get_nous_subscription_features(
         modal_active = False
         modal_direct_override = False
 
-    tts_explicit_configured = False
-    raw_tts_cfg = config.get("tts")
-    if isinstance(raw_tts_cfg, dict) and "provider" in raw_tts_cfg:
-        tts_explicit_configured = tts_provider not in {"", "edge"}
-
-    # STT considers any non-default provider explicit. "local" is the
-    # DEFAULT_CONFIG seed, so seeing it doesn't mean the user picked it.
-    stt_explicit_configured = False
-    raw_stt_cfg = config.get("stt")
-    if isinstance(raw_stt_cfg, dict) and "provider" in raw_stt_cfg:
-        stt_explicit_configured = stt_provider not in {"", "local"}
+    # Explicit-configured mirrors the stored selections computed above so
+    # status/picker markers stay in lockstep with runtime dispatch.
+    tts_explicit_configured = tts_selected is not None and tts_selected != "edge"
+    stt_explicit_configured = stt_selected is not None
 
     features = {
         "web": NousFeatureState(
@@ -698,8 +771,8 @@ def get_nous_subscription_features(
             managed_by_nous=image_managed,
             direct_override=image_active and not image_managed,
             toolset_enabled=image_tool_enabled,
-            current_provider="FAL" if direct_fal else ("Nous Subscription" if image_managed else ""),
-            explicit_configured=direct_fal,
+            current_provider="FAL" if (image_selected not in (None, "nous") or (image_selected is None and direct_fal)) else ("Nous Subscription" if (image_managed or image_use_gateway) else ""),
+            explicit_configured=image_selected is not None or direct_fal,
         ),
         "video_gen": NousFeatureState(
             key="video_gen",
@@ -710,8 +783,8 @@ def get_nous_subscription_features(
             managed_by_nous=video_managed,
             direct_override=video_active and not video_managed,
             toolset_enabled=video_tool_enabled,
-            current_provider="FAL" if direct_fal_video else ("Nous Subscription" if video_managed else ""),
-            explicit_configured=direct_fal_video,
+            current_provider="FAL" if (video_selected not in (None, "nous") or (video_selected is None and direct_fal_video)) else ("Nous Subscription" if (video_managed or video_use_gateway) else ""),
+            explicit_configured=video_selected is not None or direct_fal_video,
         ),
         "tts": NousFeatureState(
             key="tts",
@@ -823,24 +896,26 @@ def apply_nous_managed_defaults(
         or get_env_value("FIRECRAWL_API_KEY")
         or get_env_value("FIRECRAWL_API_URL")
     ):
-        web_cfg["backend"] = "firecrawl"
+        web_cfg["backend"] = "nous"
+        web_cfg.pop("use_gateway", None)
         changed.add("web")
 
     if "tts" in selected_toolsets and not features.tts.explicit_configured and not (
         resolve_openai_audio_api_key()
         or get_env_value("ELEVENLABS_API_KEY")
     ):
-        tts_cfg["provider"] = "openai"
+        tts_cfg["provider"] = "nous"
+        tts_cfg.pop("use_gateway", None)
         changed.add("tts")
 
     # STT: same pattern as TTS. The DEFAULT_CONFIG seed is "local"
     # (requires `pip install faster-whisper`); for Nous subscribers we
-    # flip it to "openai" so the managed audio gateway handles transcription
-    # via the same auth as TTS. Skipped when the user has explicitly
-    # configured STT, has direct credentials for a non-managed provider,
-    # has a working local backend (faster-whisper installed or a custom
-    # local command — strong intent signal that "local" was a choice, not
-    # just the DEFAULT_CONFIG seed), or isn't entitled to the managed
+    # flip it to the managed selection so the managed audio gateway handles
+    # transcription via the same auth as TTS. Skipped when the user has
+    # explicitly configured STT, has direct credentials for a non-managed
+    # provider, has a working local backend (faster-whisper installed or a
+    # custom local command — strong intent signal that "local" was a choice,
+    # not just the DEFAULT_CONFIG seed), or isn't entitled to the managed
     # "openai-audio" category (flipping would point at a gateway that
     # refuses them, silently breaking voice transcription).
     if (
@@ -854,14 +929,16 @@ def apply_nous_managed_defaults(
         and features.account_info is not None
         and features.account_info.tool_gateway_entitled_for("openai-audio")
     ):
-        stt_cfg["provider"] = "openai"
+        stt_cfg["provider"] = "nous"
+        stt_cfg.pop("use_gateway", None)
         changed.add("stt")
 
     if "browser" in selected_toolsets and not features.browser.explicit_configured and not (
         get_env_value("BROWSER_USE_API_KEY")
         or get_env_value("BROWSERBASE_API_KEY")
     ):
-        browser_cfg["cloud_provider"] = "browser-use"
+        browser_cfg["cloud_provider"] = "nous"
+        browser_cfg.pop("use_gateway", None)
         changed.add("browser")
 
     if "image_gen" in selected_toolsets and not fal_key_is_configured():
@@ -869,7 +946,8 @@ def apply_nous_managed_defaults(
         if not isinstance(image_cfg, dict):
             image_cfg = {}
             config["image_gen"] = image_cfg
-        image_cfg["use_gateway"] = True
+        image_cfg["provider"] = "nous"
+        image_cfg.pop("use_gateway", None)
         changed.add("image_gen")
 
     # Video gen is not funded by the free tool pool, so only wire managed video
@@ -883,8 +961,8 @@ def apply_nous_managed_defaults(
         if not isinstance(video_cfg, dict):
             video_cfg = {}
             config["video_gen"] = video_cfg
-        video_cfg["provider"] = "fal"
-        video_cfg["use_gateway"] = True
+        video_cfg["provider"] = "nous"
+        video_cfg.pop("use_gateway", None)
         changed.add("video_gen")
 
     return changed
@@ -1050,23 +1128,23 @@ def apply_gateway_defaults(
         config["browser"] = browser_cfg
 
     if "web" in tool_keys:
-        web_cfg["backend"] = "firecrawl"
-        web_cfg["use_gateway"] = True
+        web_cfg["backend"] = "nous"
+        web_cfg.pop("use_gateway", None)
         changed.add("web")
 
     if "tts" in tool_keys:
-        tts_cfg["provider"] = "openai"
-        tts_cfg["use_gateway"] = True
+        tts_cfg["provider"] = "nous"
+        tts_cfg.pop("use_gateway", None)
         changed.add("tts")
 
     if "stt" in tool_keys:
-        stt_cfg["provider"] = "openai"
-        stt_cfg["use_gateway"] = True
+        stt_cfg["provider"] = "nous"
+        stt_cfg.pop("use_gateway", None)
         changed.add("stt")
 
     if "browser" in tool_keys:
-        browser_cfg["cloud_provider"] = "browser-use"
-        browser_cfg["use_gateway"] = True
+        browser_cfg["cloud_provider"] = "nous"
+        browser_cfg.pop("use_gateway", None)
         changed.add("browser")
 
     if "image_gen" in tool_keys:
@@ -1074,7 +1152,8 @@ def apply_gateway_defaults(
         if not isinstance(image_cfg, dict):
             image_cfg = {}
             config["image_gen"] = image_cfg
-        image_cfg["use_gateway"] = True
+        image_cfg["provider"] = "nous"
+        image_cfg.pop("use_gateway", None)
         changed.add("image_gen")
 
     if "video_gen" in tool_keys:
@@ -1082,8 +1161,8 @@ def apply_gateway_defaults(
         if not isinstance(video_cfg, dict):
             video_cfg = {}
             config["video_gen"] = video_cfg
-        video_cfg["provider"] = "fal"
-        video_cfg["use_gateway"] = True
+        video_cfg["provider"] = "nous"
+        video_cfg.pop("use_gateway", None)
         changed.add("video_gen")
 
     return changed

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -475,16 +475,11 @@ def get_nous_subscription_features(
     image_selected = _selected_provider(image_gen_cfg)
     video_selected = _selected_provider(video_gen_cfg)
 
-    # Same seeded-value shim as tools.tool_backend_helpers.read_selection:
-    # legacy DEFAULT_CONFIG seeded ``stt.provider: local`` on every install,
-    # so that exact value with no picker-written use_gateway key is treated
-    # as never-configured.
-    if (
-        stt_selected == "local"
-        and isinstance(stt_cfg, dict)
-        and "use_gateway" not in stt_cfg
-    ):
-        stt_selected = None
+    # Lockstep with tools.tool_backend_helpers.read_selection: these are
+    # merged-config sections, so the legacy DEFAULT_CONFIG-seeded
+    # ``stt.provider: local`` COULD appear here without a user pick on old
+    # versions. Current DEFAULT_CONFIG no longer seeds it, so a merged
+    # ``local`` implies the raw file holds it — a genuine selection.
 
     # Managed selection flags (replace the legacy use_gateway reads —
     # use_gateway is now interpreted only inside _selected_provider).

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -5084,22 +5084,33 @@ def _reconfigure_provider(
             )
             return
 
+    # Selection model (mirrors _write_provider_config): every row writes ONE
+    # provider string per category — "nous" for managed rows, the vendor name
+    # for BYOK rows — and drops any legacy use_gateway key so the read-time
+    # shim (use_gateway: true ⇒ nous) cannot override the fresh pick.
     if provider.get("tts_provider"):
         tts_cfg = config.setdefault("tts", {})
-        tts_cfg["provider"] = provider["tts_provider"]
-        tts_cfg["use_gateway"] = bool(managed_feature)
+        tts_cfg["provider"] = (
+            NOUS_MANAGED_PROVIDER if managed_feature else provider["tts_provider"]
+        )
+        tts_cfg.pop("use_gateway", None)
         _print_success(f"  TTS provider set to: {provider['tts_provider']}")
 
     if provider.get("stt_provider"):
         stt_cfg = config.setdefault("stt", {})
-        stt_cfg["provider"] = provider["stt_provider"]
-        stt_cfg["use_gateway"] = bool(managed_feature)
+        stt_cfg["provider"] = (
+            NOUS_MANAGED_PROVIDER if managed_feature else provider["stt_provider"]
+        )
+        stt_cfg.pop("use_gateway", None)
         _print_success(f"  STT provider set to: {provider['stt_provider']}")
 
     if "browser_provider" in provider:
         bp = provider["browser_provider"]
         browser_cfg = config.setdefault("browser", {})
-        if bp == "local":
+        if managed_feature:
+            browser_cfg["cloud_provider"] = NOUS_MANAGED_PROVIDER
+            _print_success(f"  Browser cloud provider set to: {bp or 'nous'}")
+        elif bp == "local":
             browser_cfg["cloud_provider"] = "local"
             _print_success("  Browser set to local mode")
         elif bp:
@@ -5107,7 +5118,7 @@ def _reconfigure_provider(
             _print_success(f"  Browser cloud provider set to: {bp}")
         # Browser Use mode (browser.backend) composes with the provider —
         # switching providers keeps the driver choice intact.
-        browser_cfg["use_gateway"] = bool(managed_feature)
+        browser_cfg.pop("use_gateway", None)
 
     if provider.get("browser_backend"):
         browser_cfg = config.setdefault("browser", {})
@@ -5117,8 +5128,10 @@ def _reconfigure_provider(
     # Set web search backend in config if applicable
     if provider.get("web_backend"):
         web_cfg = config.setdefault("web", {})
-        web_cfg["backend"] = provider["web_backend"]
-        web_cfg["use_gateway"] = bool(managed_feature)
+        web_cfg["backend"] = (
+            NOUS_MANAGED_PROVIDER if managed_feature else provider["web_backend"]
+        )
+        web_cfg.pop("use_gateway", None)
         _print_success(f"  Web backend set to: {provider['web_backend']}")
 
     # Set computer_use backend in config if applicable
@@ -5132,13 +5145,14 @@ def _reconfigure_provider(
         if not isinstance(section, dict):
             section = {}
             config[managed_feature] = section
-        section["use_gateway"] = True
+        section["provider"] = NOUS_MANAGED_PROVIDER
+        section.pop("use_gateway", None)
     elif not managed_feature:
         for cat_key, cat in TOOL_CATEGORIES.items():
             if provider in cat.get("providers", []):
                 section = config.get(cat_key)
-                if isinstance(section, dict) and section.get("use_gateway"):
-                    section["use_gateway"] = False
+                if isinstance(section, dict):
+                    section.pop("use_gateway", None)
                 break
 
     if not env_vars:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -31,7 +31,7 @@ from hermes_cli.nous_subscription import (
     get_nous_subscription_features,
 )
 from hermes_cli.nous_account import format_nous_portal_entitlement_message
-from tools.tool_backend_helpers import fal_key_is_configured
+from tools.tool_backend_helpers import NOUS_MANAGED_PROVIDER, fal_key_is_configured
 from utils import base_url_hostname, is_truthy_value
 
 logger = logging.getLogger(__name__)
@@ -3823,39 +3823,55 @@ def _is_provider_active(
             image_cfg = config.get("image_gen", {})
             if isinstance(image_cfg, dict):
                 configured_provider = image_cfg.get("provider")
-                if configured_provider not in {None, "", "fal"}:
+                if configured_provider not in {None, "", "fal", NOUS_MANAGED_PROVIDER}:
                     return False
-                if image_cfg.get("use_gateway") is not None and not is_truthy_value(image_cfg.get("use_gateway"), default=False):
+                if (
+                    configured_provider != NOUS_MANAGED_PROVIDER
+                    and image_cfg.get("use_gateway") is not None
+                    and not is_truthy_value(image_cfg.get("use_gateway"), default=False)
+                ):
                     return False
             return feature.managed_by_nous
         if managed_feature == "video_gen":
             video_cfg = config.get("video_gen", {})
             if isinstance(video_cfg, dict):
                 configured_provider = video_cfg.get("provider")
-                if configured_provider not in {None, "", "fal"}:
+                if configured_provider not in {None, "", "fal", NOUS_MANAGED_PROVIDER}:
                     return False
-                if video_cfg.get("use_gateway") is not None and not is_truthy_value(video_cfg.get("use_gateway"), default=False):
+                if (
+                    configured_provider != NOUS_MANAGED_PROVIDER
+                    and video_cfg.get("use_gateway") is not None
+                    and not is_truthy_value(video_cfg.get("use_gateway"), default=False)
+                ):
                     return False
             return feature.managed_by_nous
         if provider.get("tts_provider"):
             return (
                 feature.managed_by_nous
-                and cfg_get(config, "tts", "provider") == provider["tts_provider"]
+                and cfg_get(config, "tts", "provider")
+                in {provider["tts_provider"], NOUS_MANAGED_PROVIDER}
             )
         if provider.get("stt_provider"):
             return (
                 feature.managed_by_nous
-                and cfg_get(config, "stt", "provider") == provider["stt_provider"]
+                and cfg_get(config, "stt", "provider")
+                in {provider["stt_provider"], NOUS_MANAGED_PROVIDER}
             )
         if "browser_provider" in provider:
             # Browser Use mode is a driver on top of the provider (it attaches
             # to the provider's CDP endpoint), so the provider row stays
             # active alongside the Browser Use row.
             current = cfg_get(config, "browser", "cloud_provider")
-            return feature.managed_by_nous and provider["browser_provider"] == current
+            return feature.managed_by_nous and current in {
+                provider["browser_provider"],
+                NOUS_MANAGED_PROVIDER,
+            }
         if provider.get("web_backend"):
             current = cfg_get(config, "web", "backend")
-            return feature.managed_by_nous and current == provider["web_backend"]
+            return feature.managed_by_nous and current in {
+                provider["web_backend"],
+                NOUS_MANAGED_PROVIDER,
+            }
         return feature.managed_by_nous
 
     if provider.get("tts_provider"):
@@ -4168,20 +4184,19 @@ def _configure_xai_imagine_storage(section_name: str, config: dict) -> None:
 def _select_plugin_image_gen_provider(plugin_name: str, config: dict, *, use_gateway: bool = False) -> None:
     """Persist a plugin-backed image generation provider selection.
 
-    ``use_gateway`` mirrors :func:`_select_plugin_video_gen_provider`: a
-    provider picked through the Nous-managed flow must keep routing through
-    the gateway. Hardcoding ``False`` here silently flipped Nous-managed FAL
-    picks onto the user's personal FAL_KEY — _write_provider_config sets
-    ``image_gen.use_gateway = True`` for a managed pick, and this function
-    runs AFTER it, so the hardcoded value clobbered the managed flag.
+    ``use_gateway=True`` marks a provider picked through the Nous-managed
+    flow: the stored selection becomes ``image_gen.provider: nous`` (the
+    single provider string the runtime switches on). BYOK picks store the
+    plugin name. Any legacy ``use_gateway`` key is removed so old-config
+    read-time shims cannot override the fresh selection.
     """
     img_cfg = config.setdefault("image_gen", {})
     if not isinstance(img_cfg, dict):
         img_cfg = {}
         config["image_gen"] = img_cfg
-    img_cfg["provider"] = plugin_name
-    img_cfg["use_gateway"] = use_gateway
-    _print_success(f"  image_gen.provider set to: {plugin_name}")
+    img_cfg["provider"] = NOUS_MANAGED_PROVIDER if use_gateway else plugin_name
+    img_cfg.pop("use_gateway", None)
+    _print_success(f"  image_gen.provider set to: {img_cfg['provider']}")
     _configure_imagegen_model_for_plugin(plugin_name, config)
     if plugin_name == "xai":
         _configure_xai_imagine_storage("image_gen", config)
@@ -4321,14 +4336,19 @@ def _configure_stt_model(stt_provider: str, config: dict) -> None:
 
 
 def _select_plugin_video_gen_provider(plugin_name: str, config: dict, *, use_gateway: bool = False) -> None:
-    """Persist a plugin-backed video generation provider selection."""
+    """Persist a plugin-backed video generation provider selection.
+
+    Mirrors :func:`_select_plugin_image_gen_provider`: managed picks store
+    ``video_gen.provider: nous``; BYOK picks store the plugin name; any
+    legacy ``use_gateway`` key is removed.
+    """
     vid_cfg = config.setdefault("video_gen", {})
     if not isinstance(vid_cfg, dict):
         vid_cfg = {}
         config["video_gen"] = vid_cfg
-    vid_cfg["provider"] = plugin_name
-    vid_cfg["use_gateway"] = use_gateway
-    _print_success(f"  video_gen.provider set to: {plugin_name}")
+    vid_cfg["provider"] = NOUS_MANAGED_PROVIDER if use_gateway else plugin_name
+    vid_cfg.pop("use_gateway", None)
+    _print_success(f"  video_gen.provider set to: {vid_cfg['provider']}")
     _configure_videogen_model_for_plugin(plugin_name, config)
     if plugin_name == "xai":
         _configure_xai_imagine_storage("video_gen", config)
@@ -4339,32 +4359,45 @@ def _write_provider_config(provider: dict, config: dict, *, managed_feature) -> 
 
     This is the pure, non-interactive core of :func:`_configure_provider` —
     it writes ``tts.provider`` / ``browser.cloud_provider`` / ``web.backend``
-    and the ``use_gateway`` flags based on the provider's markers, but does
-    NOT prompt for env vars, run post-setup hooks, gate on Nous auth, or run
-    interactive model pickers. Both the CLI configurator and the desktop GUI
-    ``PUT .../provider`` endpoint call through here so there is one code path.
+    based on the provider's markers, but does NOT prompt for env vars, run
+    post-setup hooks, gate on Nous auth, or run interactive model pickers.
+    Both the CLI configurator and the desktop GUI ``PUT .../provider``
+    endpoint call through here so there is one code path.
+
+    Selection model: every row writes exactly ONE provider string per
+    category. Managed "Nous Subscription" rows write ``nous``; BYOK rows
+    write the vendor name. ``use_gateway`` is no longer written — a fresh
+    pick removes any legacy key from the touched section so the read-time
+    legacy shim (use_gateway: true ⇒ nous) cannot override the new choice.
     """
+    def _set_selection(section_key: str, name_key: str, vendor_value) -> None:
+        section = config.setdefault(section_key, {})
+        if not isinstance(section, dict):
+            section = {}
+            config[section_key] = section
+        section[name_key] = (
+            NOUS_MANAGED_PROVIDER if managed_feature else vendor_value
+        )
+        section.pop("use_gateway", None)
+
     # Set TTS provider in config if applicable
     if provider.get("tts_provider"):
-        tts_cfg = config.setdefault("tts", {})
-        tts_cfg["provider"] = provider["tts_provider"]
-        tts_cfg["use_gateway"] = bool(managed_feature)
+        _set_selection("tts", "provider", provider["tts_provider"])
 
     # Set STT provider in config if applicable
     if provider.get("stt_provider"):
-        stt_cfg = config.setdefault("stt", {})
-        stt_cfg["provider"] = provider["stt_provider"]
-        stt_cfg["use_gateway"] = bool(managed_feature)
+        _set_selection("stt", "provider", provider["stt_provider"])
 
     # Set browser cloud provider in config if applicable
     if "browser_provider" in provider:
         bp = provider["browser_provider"]
         browser_cfg = config.setdefault("browser", {})
-        if bp:
-            browser_cfg["cloud_provider"] = bp
-        # Browser Use mode (browser.backend) composes with the provider —
-        # switching providers keeps the driver choice intact.
-        browser_cfg["use_gateway"] = bool(managed_feature)
+        if bp or managed_feature:
+            # Browser Use mode (browser.backend) composes with the provider —
+            # switching providers keeps the driver choice intact.
+            _set_selection("browser", "cloud_provider", bp)
+        else:
+            browser_cfg.pop("use_gateway", None)
 
     if provider.get("browser_backend"):
         browser_cfg = config.setdefault("browser", {})
@@ -4372,28 +4405,51 @@ def _write_provider_config(provider: dict, config: dict, *, managed_feature) -> 
 
     # Set web search backend in config if applicable
     if provider.get("web_backend"):
-        web_cfg = config.setdefault("web", {})
-        web_cfg["backend"] = provider["web_backend"]
-        web_cfg["use_gateway"] = bool(managed_feature)
+        _set_selection("web", "backend", provider["web_backend"])
 
     # Set computer_use backend in config if applicable
     if provider.get("computer_use_backend"):
         cu_cfg = config.setdefault("computer_use", {})
         cu_cfg["backend"] = provider["computer_use_backend"]
 
-    # For tools without a specific config key (e.g. image_gen), still
-    # track use_gateway so the runtime knows the user's intent.
+    # Managed rows for categories without a marker handled above (e.g. the
+    # image_gen/video_gen "Nous Subscription" rows carry only
+    # managed_nous_feature) still persist the "nous" selection.
     if managed_feature and managed_feature not in {"web", "tts", "stt", "browser"}:
-        config.setdefault(managed_feature, {})["use_gateway"] = True
+        section = config.setdefault(managed_feature, {})
+        if isinstance(section, dict):
+            section["provider"] = NOUS_MANAGED_PROVIDER
+            section.pop("use_gateway", None)
     elif not managed_feature:
-        # User picked a non-gateway provider — find which category this
-        # belongs to and clear use_gateway if it was previously set.
-        for cat_key, cat in TOOL_CATEGORIES.items():
-            if provider in cat.get("providers", []):
-                section = config.get(cat_key)
-                if isinstance(section, dict) and section.get("use_gateway"):
-                    section["use_gateway"] = False
-                break
+        # User picked a non-gateway provider — clear any stale legacy
+        # use_gateway key on the category so the read-time shim cannot
+        # override the fresh selection. Resolve the category from the
+        # provider's own markers first (plugin-injected rows are NOT in
+        # TOOL_CATEGORIES' hardcoded provider lists and previously skipped
+        # this clear), then fall back to the category-membership walk.
+        marker_sections = {
+            "tts_provider": "tts",
+            "stt_provider": "stt",
+            "browser_provider": "browser",
+            "web_backend": "web",
+            "image_gen_plugin_name": "image_gen",
+            "imagegen_backend": "image_gen",
+            "video_gen_plugin_name": "video_gen",
+        }
+        cleared = False
+        for marker, section_key in marker_sections.items():
+            if provider.get(marker) or marker in provider:
+                section = config.get(section_key)
+                if isinstance(section, dict):
+                    section.pop("use_gateway", None)
+                cleared = True
+        if not cleared:
+            for cat_key, cat in TOOL_CATEGORIES.items():
+                if provider in cat.get("providers", []):
+                    section = config.get(cat_key)
+                    if isinstance(section, dict):
+                        section.pop("use_gateway", None)
+                    break
 
 
 def apply_provider_selection(ts_key: str, provider_name: str, config: dict) -> None:
@@ -4425,15 +4481,17 @@ def apply_provider_selection(ts_key: str, provider_name: str, config: dict) -> N
     # Plugin-registered image/video gen backends record the provider name in
     # their own config section. Write that here (without the interactive
     # model picker the CLI runs afterwards — model choice is a separate GUI
-    # flow).
+    # flow). Managed picks store the "nous" selection.
     plugin_name = provider.get("image_gen_plugin_name")
     if plugin_name:
         img_cfg = config.setdefault("image_gen", {})
         if not isinstance(img_cfg, dict):
             img_cfg = {}
             config["image_gen"] = img_cfg
-        img_cfg["provider"] = plugin_name
-        img_cfg["use_gateway"] = bool(managed_feature)
+        img_cfg["provider"] = (
+            NOUS_MANAGED_PROVIDER if managed_feature else plugin_name
+        )
+        img_cfg.pop("use_gateway", None)
 
     video_plugin = provider.get("video_gen_plugin_name")
     if video_plugin:
@@ -4441,15 +4499,22 @@ def apply_provider_selection(ts_key: str, provider_name: str, config: dict) -> N
         if not isinstance(vid_cfg, dict):
             vid_cfg = {}
             config["video_gen"] = vid_cfg
-        vid_cfg["provider"] = video_plugin
-        vid_cfg["use_gateway"] = bool(managed_feature)
+        vid_cfg["provider"] = (
+            NOUS_MANAGED_PROVIDER if managed_feature else video_plugin
+        )
+        vid_cfg.pop("use_gateway", None)
 
-    # In-tree FAL imagegen backend: keep image_gen.provider on the legacy
-    # path (mirrors _configure_provider).
-    if provider.get("imagegen_backend"):
+    # In-tree FAL imagegen backend (BYOK): always persist the explicit
+    # ``image_gen.provider: fal`` selection — historically this row could
+    # leave the provider key unset, making a deliberate BYOK pick
+    # indistinguishable from a never-configured install.
+    if provider.get("imagegen_backend") and not managed_feature:
         img_cfg = config.setdefault("image_gen", {})
-        if isinstance(img_cfg, dict) and img_cfg.get("provider") not in {None, "", "fal"}:
-            img_cfg["provider"] = "fal"
+        if not isinstance(img_cfg, dict):
+            img_cfg = {}
+            config["image_gen"] = img_cfg
+        img_cfg["provider"] = "fal"
+        img_cfg.pop("use_gateway", None)
 
 
 def _configure_provider(
@@ -4503,8 +4568,10 @@ def _configure_provider(
     # Set TTS provider in config if applicable
     if provider.get("tts_provider"):
         tts_cfg = config.setdefault("tts", {})
-        tts_cfg["provider"] = provider["tts_provider"]
-        tts_cfg["use_gateway"] = bool(managed_feature)
+        tts_cfg["provider"] = (
+            NOUS_MANAGED_PROVIDER if managed_feature else provider["tts_provider"]
+        )
+        tts_cfg.pop("use_gateway", None)
 
     # Set STT provider in config if applicable
     if provider.get("stt_provider"):
@@ -4552,13 +4619,15 @@ def _configure_provider(
         backend = provider.get("imagegen_backend")
         if backend:
             _configure_imagegen_model(backend, config)
-            # In-tree FAL is the only non-plugin backend today. Keep
-            # image_gen.provider clear so the dispatch shim falls through
-            # to the legacy FAL path.
+            # In-tree FAL is the only non-plugin backend today. Persist the
+            # explicit selection: "nous" for a managed row, "fal" for BYOK.
             img_cfg = config.setdefault("image_gen", {})
-            if isinstance(img_cfg, dict) and img_cfg.get("provider") not in {None, "", "fal"}:
-                img_cfg["provider"] = "fal"
-        # STT providers prompt for model selection after provider pick
+            if isinstance(img_cfg, dict):
+                img_cfg["provider"] = (
+                    NOUS_MANAGED_PROVIDER if managed_feature else "fal"
+                )
+                img_cfg.pop("use_gateway", None)
+        # STT providers prompt for model selection after backend pick
         # (skipped for managed rows — the gateway pins the model).
         if provider.get("stt_provider") and not managed_feature:
             _configure_stt_model(provider["stt_provider"], config)
@@ -4636,8 +4705,11 @@ def _configure_provider(
         if backend:
             _configure_imagegen_model(backend, config)
             img_cfg = config.setdefault("image_gen", {})
-            if isinstance(img_cfg, dict) and img_cfg.get("provider") not in {None, "", "fal"}:
-                img_cfg["provider"] = "fal"
+            if isinstance(img_cfg, dict):
+                img_cfg["provider"] = (
+                    NOUS_MANAGED_PROVIDER if managed_feature else "fal"
+                )
+                img_cfg.pop("use_gateway", None)
         # STT providers prompt for model selection after env vars are in.
         if provider.get("stt_provider") and not managed_feature:
             _configure_stt_model(provider["stt_provider"], config)
@@ -5091,14 +5163,14 @@ def _reconfigure_provider(
             if backend == "fal":
                 img_cfg = config.setdefault("image_gen", {})
                 if isinstance(img_cfg, dict):
-                    img_cfg["provider"] = "fal"
                     # A managed (Nous Subscription) row also carries
-                    # imagegen_backend="fal" — the model picker runs AFTER
-                    # _write_provider_config set use_gateway=True, so an
-                    # unconditional False here silently flipped managed
-                    # picks onto the user's personal FAL_KEY (same class
-                    # as fe63353cb, which fixed the plugin-provider path).
-                    img_cfg["use_gateway"] = bool(managed_feature)
+                    # imagegen_backend="fal" — store the "nous" selection
+                    # for it, "fal" for BYOK, and drop any legacy
+                    # use_gateway key.
+                    img_cfg["provider"] = (
+                        NOUS_MANAGED_PROVIDER if managed_feature else "fal"
+                    )
+                    img_cfg.pop("use_gateway", None)
         # STT providers prompt for model selection on reconfig too.
         if provider.get("stt_provider") and not managed_feature:
             _configure_stt_model(provider["stt_provider"], config)
@@ -5140,10 +5212,12 @@ def _reconfigure_provider(
         if backend == "fal":
             img_cfg = config.setdefault("image_gen", {})
             if isinstance(img_cfg, dict):
-                img_cfg["provider"] = "fal"
                 # Same managed-row guard as the no-env-vars branch above:
                 # never clobber a Nous-managed pick back onto direct keys.
-                img_cfg["use_gateway"] = bool(managed_feature)
+                img_cfg["provider"] = (
+                    NOUS_MANAGED_PROVIDER if managed_feature else "fal"
+                )
+                img_cfg.pop("use_gateway", None)
 
     # STT providers prompt for model selection on reconfig too.
     if provider.get("stt_provider") and not managed_feature:

--- a/plugins/browser/browser_use/provider.py
+++ b/plugins/browser/browser_use/provider.py
@@ -134,37 +134,74 @@ class BrowserUseBrowserProvider(BrowserProvider):
             peek_nous_access_token,
             resolve_managed_tool_gateway,
         )
-        from tools.tool_backend_helpers import prefers_gateway
+        from tools.tool_backend_helpers import (
+            NOUS_MANAGED_PROVIDER,
+            read_selection,
+        )
 
-        # Direct API key wins unless the user has explicitly opted into the
-        # managed Nous gateway via ``tool_gateway.browser: gateway``.
+        def _managed_config() -> Optional[Dict[str, Any]]:
+            # Keep availability scans off the synchronous OAuth refresh path.
+            managed = resolve_managed_tool_gateway(
+                "browser-use",
+                token_reader=None if refresh_token else peek_nous_access_token,
+            )
+            if managed is None:
+                return None
+            return {
+                "api_key": managed.nous_user_token,
+                "base_url": managed.gateway_origin.rstrip("/"),
+                "managed_mode": True,
+            }
+
         api_key = get_secret("BROWSER_USE_API_KEY")
-        if api_key and not prefers_gateway("browser"):
+        selected = read_selection("browser")
+
+        # Strict selection: "nous" (or legacy use_gateway: true) → managed
+        # gateway ONLY; any other stored browser selection → direct API key
+        # ONLY (no silent managed fallback); never-configured → legacy
+        # behavior (direct key when present, else managed gateway).
+        if selected == NOUS_MANAGED_PROVIDER:
+            return _managed_config()
+        if selected is not None:
+            if api_key:
+                return {
+                    "api_key": api_key,
+                    "base_url": _BASE_URL,
+                    "managed_mode": False,
+                }
+            return None
+        if api_key:
             return {
                 "api_key": api_key,
                 "base_url": _BASE_URL,
                 "managed_mode": False,
             }
-
-        # Keep availability scans off the synchronous OAuth refresh path.
-        managed = resolve_managed_tool_gateway(
-            "browser-use",
-            token_reader=None if refresh_token else peek_nous_access_token,
-        )
-        if managed is None:
-            return None
-
-        return {
-            "api_key": managed.nous_user_token,
-            "base_url": managed.gateway_origin.rstrip("/"),
-            "managed_mode": True,
-        }
+        return _managed_config()
 
     def _get_config(self) -> Dict[str, Any]:
-        from tools.tool_backend_helpers import managed_nous_tools_enabled
+        from tools.tool_backend_helpers import (
+            NOUS_MANAGED_PROVIDER,
+            managed_nous_tools_enabled,
+            read_selection,
+            selection_error,
+        )
 
         config = self._get_config_or_none()
         if config is None:
+            selected = read_selection("browser")
+            if selected == NOUS_MANAGED_PROVIDER:
+                raise ValueError(selection_error(
+                    "browser",
+                    NOUS_MANAGED_PROVIDER,
+                    "the Nous Tool Gateway is not available (not entitled or "
+                    "unreachable)",
+                ))
+            if selected is not None:
+                raise ValueError(selection_error(
+                    "browser",
+                    selected,
+                    "BROWSER_USE_API_KEY is not set",
+                ))
             message = (
                 "Browser Use requires a direct BROWSER_USE_API_KEY credential."
             )

--- a/plugins/image_gen/krea/__init__.py
+++ b/plugins/image_gen/krea/__init__.py
@@ -178,20 +178,31 @@ def _resolve_model(explicit: Optional[str] = None) -> Tuple[str, Dict[str, Any]]
 def _resolve_managed_krea_gateway():
     """Return managed Krea gateway config when the user is on the managed path.
 
-    Mirrors ``_resolve_managed_fal_gateway`` in ``tools/image_generation_tool.py``:
-    the Nous-hosted Krea gateway wins when it is resolvable AND either no direct
-    ``KREA_API_KEY`` is configured or the user explicitly opted into the gateway
-    for ``image_gen``. Returns ``None`` (direct/BYO path) otherwise, and never
-    raises — plugin discovery and availability scans must stay robust.
+    Strict selection model: the managed Krea gateway is used when the stored
+    ``image_gen`` selection is ``nous`` (or legacy ``use_gateway: true``), or
+    on a never-configured install when no direct ``KREA_API_KEY`` exists.
+    An explicit vendor selection (``krea``, ``fal``, ...) pins the direct
+    path. Returns ``None`` (direct/BYO path) otherwise, and never raises —
+    plugin discovery and availability scans must stay robust.
     """
     try:
         from tools.managed_tool_gateway import resolve_managed_tool_gateway
-        from tools.tool_backend_helpers import prefers_gateway
+        from tools.tool_backend_helpers import (
+            NOUS_MANAGED_PROVIDER,
+            read_selection,
+        )
     except Exception as exc:  # noqa: BLE001
         logger.debug("Managed Krea gateway resolution unavailable: %s", exc)
         return None
 
-    if get_secret("KREA_API_KEY") and not prefers_gateway("image_gen"):
+    try:
+        selected = read_selection("image_gen")
+    except Exception:  # noqa: BLE001
+        selected = None
+    if selected is not None and selected != NOUS_MANAGED_PROVIDER:
+        # Explicit vendor selection: direct credentials only.
+        return None
+    if selected is None and get_secret("KREA_API_KEY"):
         return None
 
     try:

--- a/plugins/video_gen/fal/__init__.py
+++ b/plugins/video_gen/fal/__init__.py
@@ -530,14 +530,44 @@ _managed_fal_video_client_lock = threading.Lock()
 
 
 def _resolve_managed_fal_video_gateway():
-    """Return managed fal-queue gateway config when the user prefers the gateway
-    or direct FAL credentials are absent."""
-    from tools.tool_backend_helpers import fal_key_is_configured, prefers_gateway
+    """Resolve the FAL video route from the stored selection.
 
-    if fal_key_is_configured() and not prefers_gateway("video_gen"):
-        return None
+    Plain switch on the stored ``video_gen`` provider string — mirrors the
+    image FAL resolver: ``"nous"`` (or legacy ``use_gateway: true``) →
+    managed only (unentitled ⇒ selection-naming error); any other stored
+    provider → direct only (missing FAL_KEY ⇒ selection-naming error);
+    never-configured category → legacy credential autodetect.
+    """
     from tools.managed_tool_gateway import resolve_managed_tool_gateway
+    from tools.tool_backend_helpers import (
+        NOUS_MANAGED_PROVIDER,
+        fal_key_is_configured,
+        read_selection,
+        selection_error,
+    )
 
+    selected = read_selection("video_gen")
+    if selected == NOUS_MANAGED_PROVIDER:
+        gateway = resolve_managed_tool_gateway("fal-queue")
+        if gateway is None:
+            raise ValueError(selection_error(
+                "video_gen",
+                NOUS_MANAGED_PROVIDER,
+                "the Nous Tool Gateway is not available (not entitled or "
+                "unreachable)",
+            ))
+        return gateway
+    if selected is not None:
+        if not fal_key_is_configured():
+            raise ValueError(selection_error(
+                "video_gen",
+                selected,
+                "FAL_KEY is not set",
+            ))
+        return None
+    # Never-configured category: legacy credential autodetect (do NOT persist).
+    if fal_key_is_configured():
+        return None
     return resolve_managed_tool_gateway("fal-queue")
 
 
@@ -598,12 +628,28 @@ def _submit_fal_video_request(endpoint: str, arguments: Dict[str, Any]):
 
 
 def _check_fal_video_available() -> bool:
-    """True if the FAL.ai video backend is reachable (direct key or managed gateway)."""
-    from tools.tool_backend_helpers import fal_key_is_configured
+    """True if the FAL video backend selected via `hermes tools` (or, on a
+    never-configured install, any FAL backend) is reachable.
 
+    Never raises — a stored-but-broken selection reports False here; the
+    honest selection-naming error surfaces at call time from
+    ``_resolve_managed_fal_video_gateway``.
+    """
+    from tools.managed_tool_gateway import resolve_managed_tool_gateway
+    from tools.tool_backend_helpers import (
+        NOUS_MANAGED_PROVIDER,
+        fal_key_is_configured,
+        read_selection,
+    )
+
+    selected = read_selection("video_gen")
+    if selected == NOUS_MANAGED_PROVIDER:
+        return resolve_managed_tool_gateway("fal-queue") is not None
+    if selected is not None:
+        return fal_key_is_configured()
     if fal_key_is_configured():
         return True
-    return _resolve_managed_fal_video_gateway() is not None
+    return resolve_managed_tool_gateway("fal-queue") is not None
 
 
 # ---------------------------------------------------------------------------
@@ -766,6 +812,20 @@ class FALVideoGenProvider(VideoGenProvider):
         **kwargs: Any,
     ) -> Dict[str, Any]:
         if not _check_fal_video_available():
+            from tools.tool_backend_helpers import read_selection
+
+            if read_selection("video_gen") is not None:
+                # A stored selection that cannot run gets the honest
+                # selection-naming error from the strict resolver.
+                try:
+                    _resolve_managed_fal_video_gateway()
+                except ValueError as exc:
+                    return error_response(
+                        error=str(exc),
+                        error_type="auth_required",
+                        provider="fal",
+                        prompt=prompt,
+                    )
             return error_response(
                 error=(
                     "No FAL backend available. Either set FAL_KEY "

--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, NoReturn, Optional, TYPE_CHECKING
 
 from agent.web_search_provider import WebSearchProvider
 from tools.url_safety import is_safe_url
@@ -168,11 +168,22 @@ def _has_direct_firecrawl_config() -> bool:
 
 
 def check_firecrawl_api_key() -> bool:
-    """Return True when Firecrawl backend (direct or gateway) is usable.
+    """Return True when the Firecrawl backend selected via `hermes tools`
+    (or, on a never-configured install, either route) is usable.
 
     Re-exported by :mod:`tools.web_tools` for backward compatibility with
     existing tests and the ``hermes tools`` setup flow.
     """
+    from tools.tool_backend_helpers import (
+        NOUS_MANAGED_PROVIDER,
+        read_selection,
+    )
+
+    selected = read_selection("web")
+    if selected == NOUS_MANAGED_PROVIDER:
+        return _is_tool_gateway_ready()
+    if selected is not None:
+        return _has_direct_firecrawl_config()
     return _has_direct_firecrawl_config() or _is_tool_gateway_ready()
 
 
@@ -188,7 +199,7 @@ def _firecrawl_backend_help_suffix() -> str:
     )
 
 
-def _raise_web_backend_configuration_error() -> None:
+def _raise_web_backend_configuration_error() -> "NoReturn":
     """Raise a clear error for unsupported web backend configuration."""
     import tools.web_tools as _wt
 
@@ -212,46 +223,95 @@ def _raise_web_backend_configuration_error() -> None:
 def _get_firecrawl_client() -> Any:
     """Get or create the cached Firecrawl client.
 
-    When ``web.use_gateway`` is set in config, the managed Tool Gateway is
-    preferred even if direct Firecrawl credentials are present. Otherwise
-    direct Firecrawl takes precedence when explicitly configured.
+    Strict selection semantics (switch on the stored ``web`` selection):
+    - ``"nous"`` (or legacy ``use_gateway: true``) → managed Tool Gateway
+      ONLY; unavailable is a selection-naming error (a present
+      FIRECRAWL_API_KEY does not reroute).
+    - any other stored web backend → direct Firecrawl ONLY; missing config
+      is a selection-naming error — never a silent managed fallback billed
+      to Nous.
+    - never-configured web section → legacy behavior: direct config when
+      present, else the managed gateway.
 
-    Raises ValueError when neither path is usable.
+    Raises ValueError when the resolved path is unusable.
 
     The cached client is stored on :mod:`tools.web_tools` (as
     ``_firecrawl_client`` and ``_firecrawl_client_config``) rather than on
     this plugin module so that unit tests that reset the cache via
     ``tools.web_tools._firecrawl_client = None`` keep working. Helper
-    functions (``prefers_gateway``, ``resolve_managed_tool_gateway``,
-    ``_read_nous_access_token``, ``Firecrawl``) are also looked up via
-    :mod:`tools.web_tools` for the same reason — see
-    :func:`_is_tool_gateway_ready`.
+    functions (``resolve_managed_tool_gateway``, ``_read_nous_access_token``,
+    ``Firecrawl``) are also looked up via :mod:`tools.web_tools` for the same
+    reason — see :func:`_is_tool_gateway_ready`.
     """
     import tools.web_tools as _wt
+    from tools.tool_backend_helpers import (
+        NOUS_MANAGED_PROVIDER,
+        read_selection,
+        selection_error,
+        selection_exists,
+    )
+
+    selected = read_selection("web")
 
     direct_config = _get_direct_firecrawl_config()
-    if direct_config is not None and not _wt.prefers_gateway("web"):
-        kwargs, client_config = direct_config
-    else:
+
+    def _managed_kwargs():
         managed_gateway = _wt.resolve_managed_tool_gateway(
             "firecrawl", token_reader=_wt._read_nous_access_token
         )
         if managed_gateway is None:
+            return None
+        kwargs = {
+            "api_key": managed_gateway.nous_user_token,
+            "api_url": managed_gateway.gateway_origin,
+        }
+        return kwargs, (
+            "tool-gateway",
+            kwargs["api_url"],
+            managed_gateway.nous_user_token,
+        )
+
+    if selected == NOUS_MANAGED_PROVIDER:
+        managed = _managed_kwargs()
+        if managed is None:
+            logger.error(
+                "Firecrawl client initialization failed: the Nous "
+                "Subscription web selection is stored but the tool gateway "
+                "is unavailable."
+            )
+            raise ValueError(selection_error(
+                "web",
+                NOUS_MANAGED_PROVIDER,
+                "the Nous Tool Gateway is not available (not entitled or "
+                "unreachable)",
+            ))
+        kwargs, client_config = managed
+    elif selected is not None or selection_exists("web"):
+        # Stored vendor selection (or per-capability web keys routing to
+        # firecrawl): direct Firecrawl only.
+        if direct_config is None:
+            logger.error(
+                "Firecrawl client initialization failed: direct Firecrawl "
+                "selected but FIRECRAWL_API_KEY/FIRECRAWL_API_URL is not set."
+            )
+            raise ValueError(selection_error(
+                "web",
+                selected or "firecrawl",
+                "neither FIRECRAWL_API_KEY nor FIRECRAWL_API_URL is set",
+            ))
+        kwargs, client_config = direct_config
+    elif direct_config is not None:
+        kwargs, client_config = direct_config
+    else:
+        # Never-configured web section: legacy managed fallback.
+        managed = _managed_kwargs()
+        if managed is None:
             logger.error(
                 "Firecrawl client initialization failed: "
                 "missing direct config and tool-gateway auth."
             )
             _raise_web_backend_configuration_error()
-
-        kwargs = {
-            "api_key": managed_gateway.nous_user_token,
-            "api_url": managed_gateway.gateway_origin,
-        }
-        client_config = (
-            "tool-gateway",
-            kwargs["api_url"],
-            managed_gateway.nous_user_token,
-        )
+        kwargs, client_config = managed
 
     cached = getattr(_wt, "_firecrawl_client", None)
     cached_config = getattr(_wt, "_firecrawl_client_config", None)

--- a/tests/hermes_cli/test_imagegen_managed_gateway.py
+++ b/tests/hermes_cli/test_imagegen_managed_gateway.py
@@ -1,15 +1,18 @@
-"""Regression tests for image_gen use_gateway persistence (managed FAL clobber).
+"""Regression tests for image_gen provider persistence (managed FAL clobber).
 
-Bug: ``_select_plugin_image_gen_provider`` hardcoded
-``image_gen.use_gateway = False``. When a user picked FAL through the
-Nous-subscription managed flow, ``_write_provider_config`` first set
-``use_gateway = True`` — then the image selector ran and clobbered it back
-to False, silently routing every generation through the user's personal
-FAL_KEY instead of the Nous Tool Gateway (real incident: personal key
-drained to zero while the subscription sat unused).
+Historical bug: ``_select_plugin_image_gen_provider`` hardcoded the direct
+(non-managed) routing. When a user picked FAL through the Nous-subscription
+managed flow, the managed write landed first — then the image selector ran
+and clobbered it back to direct, silently routing every generation through
+the user's personal FAL_KEY instead of the Nous Tool Gateway (real incident:
+personal key drained to zero while the subscription sat unused).
 
-The video twin (``_select_plugin_video_gen_provider``) already accepted a
-``use_gateway`` kwarg; these tests pin the image path to the same contract.
+Current contract (strict provider-string selection): each picker row writes
+exactly ONE provider string per category — ``image_gen.provider: nous`` for
+the managed "Nous Subscription" row, ``image_gen.provider: fal`` for the
+BYOK FAL row — and any legacy ``use_gateway`` key is popped so the
+read-time shim (use_gateway: true ⇒ nous) cannot override the fresh pick.
+The video twin (``_select_plugin_video_gen_provider``) shares the contract.
 """
 
 from hermes_cli.tools_config import (
@@ -28,43 +31,50 @@ def _quiet(monkeypatch):
     monkeypatch.setattr(tc, "_configure_videogen_model_for_plugin", lambda *a, **k: None)
 
 
-def test_image_gen_selector_preserves_managed_gateway_flag(monkeypatch):
-    """Managed pick: use_gateway=True must survive the selector."""
+def test_image_gen_selector_preserves_managed_selection(monkeypatch):
+    """Managed pick: the 'nous' provider string must survive the selector."""
     _quiet(monkeypatch)
     config = {}
 
-    # The managed flow first writes the managed flag...
+    # The managed flow first persists the managed selection...
     _write_provider_config(
         {"image_gen_plugin_name": "fal"}, config, managed_feature="image_gen"
     )
-    assert config["image_gen"]["use_gateway"] is True
+    assert config["image_gen"]["provider"] == "nous"
+    assert "use_gateway" not in config["image_gen"]
 
-    # ...then the selector runs; passing the managed flag must NOT clobber it.
+    # ...then the selector runs; the managed kwarg must NOT clobber it
+    # back onto the vendor name (direct-key routing).
     _select_plugin_image_gen_provider("fal", config, use_gateway=True)
-    assert config["image_gen"]["provider"] == "fal"
-    assert config["image_gen"]["use_gateway"] is True
+    assert config["image_gen"]["provider"] == "nous"
+    assert "use_gateway" not in config["image_gen"]
 
 
-def test_image_gen_selector_direct_key_pick_clears_gateway(monkeypatch):
-    """Non-managed pick keeps the historical default: direct key, no gateway."""
+def test_image_gen_selector_direct_key_pick_writes_vendor(monkeypatch):
+    """Non-managed pick writes the vendor name and pops the legacy flag."""
     _quiet(monkeypatch)
     config = {"image_gen": {"use_gateway": True}}
 
     _select_plugin_image_gen_provider("fal", config)
     assert config["image_gen"]["provider"] == "fal"
-    assert config["image_gen"]["use_gateway"] is False
+    assert "use_gateway" not in config["image_gen"]
 
 
-def test_image_and_video_selectors_share_the_gateway_contract(monkeypatch):
+def test_image_and_video_selectors_share_the_selection_contract(monkeypatch):
     """The two selectors are twins: same kwarg, same persistence behavior."""
     _quiet(monkeypatch)
 
-    for use_gateway in (True, False):
-        config = {}
+    for use_gateway, expected in ((True, "nous"), (False, "fal")):
+        config = {
+            "image_gen": {"use_gateway": not use_gateway},
+            "video_gen": {"use_gateway": not use_gateway},
+        }
         _select_plugin_image_gen_provider("fal", config, use_gateway=use_gateway)
         _select_plugin_video_gen_provider("fal", config, use_gateway=use_gateway)
-        assert config["image_gen"]["use_gateway"] is use_gateway
-        assert config["video_gen"]["use_gateway"] is use_gateway
+        assert config["image_gen"]["provider"] == expected
+        assert config["video_gen"]["provider"] == expected
+        assert "use_gateway" not in config["image_gen"]
+        assert "use_gateway" not in config["video_gen"]
 
 
 def _quiet_reconfigure(monkeypatch):
@@ -82,11 +92,12 @@ def _quiet_reconfigure(monkeypatch):
     monkeypatch.setattr(ns, "ensure_nous_portal_access", lambda **k: True)
 
 
-def test_reconfigure_managed_fal_row_keeps_gateway_flag(monkeypatch):
+def test_reconfigure_managed_fal_row_keeps_managed_selection(monkeypatch):
     """The sibling bug of fe63353cb: the legacy-backend model-pick step in
-    _reconfigure_provider hardcoded use_gateway=False AFTER the managed
-    branch wrote True — a Nous Subscription user re-entering the picker to
-    change models was silently flipped onto their personal FAL_KEY."""
+    _reconfigure_provider hardcoded the direct selection AFTER the managed
+    branch wrote the managed one — a Nous Subscription user re-entering the
+    picker to change models was silently flipped onto their personal
+    FAL_KEY."""
     _quiet_reconfigure(monkeypatch)
     import hermes_cli.tools_config as tc
 
@@ -98,17 +109,17 @@ def test_reconfigure_managed_fal_row_keeps_gateway_flag(monkeypatch):
         "override_env_vars": ["FAL_KEY"],
         "imagegen_backend": "fal",
     }
-    config = {"image_gen": {"model": "fal-ai/gpt-image-2"}}
+    config = {"image_gen": {"model": "fal-ai/gpt-image-2", "use_gateway": True}}
 
     tc._reconfigure_provider(managed_row, config)
 
-    assert config["image_gen"]["provider"] == "fal"
-    assert config["image_gen"]["use_gateway"] is True
+    assert config["image_gen"]["provider"] == "nous"
+    assert "use_gateway" not in config["image_gen"]
 
 
-def test_reconfigure_direct_fal_row_clears_gateway_flag(monkeypatch):
-    """Direct-key FAL reconfig must still clear the flag (historical
-    behavior for genuinely non-managed picks)."""
+def test_reconfigure_direct_fal_row_writes_vendor_selection(monkeypatch):
+    """Direct-key FAL reconfig writes the vendor name and pops any stale
+    legacy use_gateway key so the read-time shim can't resurrect 'nous'."""
     _quiet_reconfigure(monkeypatch)
     import hermes_cli.tools_config as tc
 
@@ -121,4 +132,5 @@ def test_reconfigure_direct_fal_row_clears_gateway_flag(monkeypatch):
 
     tc._reconfigure_provider(direct_row, config)
 
-    assert config["image_gen"]["use_gateway"] is False
+    assert config["image_gen"]["provider"] == "fal"
+    assert "use_gateway" not in config["image_gen"]

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -150,9 +150,8 @@ def test_prompt_enable_tool_gateway_pool_offers_covered_tools_only(monkeypatch):
 
 
 def test_apply_nous_managed_defaults_writes_video_gen_config(monkeypatch):
-    """apply_nous_managed_defaults must write video_gen.provider and
-    video_gen.use_gateway when a Nous subscriber selects video_gen
-    without a direct FAL_KEY."""
+    """apply_nous_managed_defaults must store the managed 'nous' selection
+    when a Nous subscriber selects video_gen without a direct FAL_KEY."""
     monkeypatch.setattr(ns, "managed_nous_tools_enabled", lambda **kw: True)
     monkeypatch.delenv("FAL_KEY", raising=False)
     monkeypatch.setattr(ns, "fal_key_is_configured", lambda: False)
@@ -167,8 +166,8 @@ def test_apply_nous_managed_defaults_writes_video_gen_config(monkeypatch):
     )
 
     assert "video_gen" in changed
-    assert config["video_gen"]["provider"] == "fal"
-    assert config["video_gen"]["use_gateway"] is True
+    assert config["video_gen"]["provider"] == "nous"
+    assert "use_gateway" not in config["video_gen"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_stt_picker.py
+++ b/tests/hermes_cli/test_stt_picker.py
@@ -56,11 +56,12 @@ class TestSttCategory:
 
 class TestConfigWrites:
     def test_write_provider_config_sets_stt_provider(self):
-        config = {}
+        config = {"stt": {"use_gateway": True}}
         prov = _stt_provider_named("Groq")
         _write_provider_config(prov, config, managed_feature=None)
         assert config["stt"]["provider"] == "groq"
-        assert config["stt"]["use_gateway"] is False
+        # Legacy key is popped so the read-time shim can't override the pick.
+        assert "use_gateway" not in config["stt"]
 
 
     def test_apply_provider_selection_stt(self):

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -256,8 +256,8 @@ def test_first_install_nous_auto_configures_video_gen(monkeypatch):
 
     tools_command(first_install=True, config=config)
 
-    assert config["video_gen"]["provider"] == "fal"
-    assert config["video_gen"]["use_gateway"] is True
+    assert config["video_gen"]["provider"] == "nous"
+    assert "use_gateway" not in config["video_gen"]
     # video_gen should NOT appear in the manual configure list — it's auto-configured
     assert "video_gen" not in configured
 

--- a/tests/hermes_cli/test_video_gen_picker.py
+++ b/tests/hermes_cli/test_video_gen_picker.py
@@ -113,7 +113,8 @@ class TestReconfigureWritesProvider:
 
         assert config["video_gen"]["provider"] == "xai_fake"
         assert config["video_gen"]["model"] == "xai_fake-video-v1"
-        assert config["video_gen"]["use_gateway"] is False
+        # Non-managed pick: no legacy use_gateway key is written.
+        assert "use_gateway" not in config["video_gen"]
 
 
 class TestPluginVideoProvidersRow:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2671,9 +2671,12 @@ class TestNewEndpoints:
         assert data["needs_nous_auth"] is True
         assert data["feature"] == "browser"
         # The selection is still persisted — activation is what's gated.
+        # Managed rows store the single 'nous' provider string (the runtime
+        # maps it to the Browser Use cloud through the Nous Tool Gateway).
         from hermes_cli.config import load_config
         cfg = load_config()
-        assert cfg["browser"]["cloud_provider"] == "browser-use"
+        assert cfg["browser"]["cloud_provider"] == "nous"
+        assert "use_gateway" not in cfg["browser"]
 
 
     # -- Web capability split (search vs extract backends) ------------------

--- a/tests/tools/test_managed_media_gateways.py
+++ b/tests/tools/test_managed_media_gateways.py
@@ -247,7 +247,9 @@ def test_transcription_uses_model_specific_response_formats(monkeypatch, tmp_pat
     _install_fake_tools_package()
     _install_fake_openai_module(whisper_capture, transcription_response="hello from whisper")
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    (tmp_path / "config.yaml").write_text("stt:\n  provider: openai\n")
+    # The managed audio route is the stored "nous" selection (strict model);
+    # a stored "openai" selection now means direct credentials only.
+    (tmp_path / "config.yaml").write_text("stt:\n  provider: nous\n")
     monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setenv("TOOL_GATEWAY_DOMAIN", "nousresearch.com")
@@ -257,7 +259,7 @@ def test_transcription_uses_model_specific_response_formats(monkeypatch, tmp_pat
         "tools.transcription_tools",
         "transcription_tools.py",
     )
-    transcription_tools._load_stt_config = lambda: {"provider": "openai"}
+    transcription_tools._load_stt_config = lambda: {"provider": "nous"}
     audio_path = tmp_path / "audio.wav"
     audio_path.write_bytes(b"RIFF0000WAVEfmt ")
 

--- a/tests/tools/test_strict_provider_selection.py
+++ b/tests/tools/test_strict_provider_selection.py
@@ -1,0 +1,357 @@
+"""Strict tool-provider selection: the `hermes tools` choice always wins.
+
+Policy (owner decision): the provider string stored in config.yaml is what
+runs at call time. "nous" → managed Nous Tool Gateway only; a vendor name →
+that vendor direct with the user's own credentials; no key ever written →
+today's credential autodetect. Credential presence must NEVER select or
+reroute; a selected-but-broken provider produces an honest error naming the
+selection and pointing at `hermes tools`.
+
+Per category these tests pin the three strict behaviors:
+  (a) managed selection + direct key present ⇒ managed route (key ignored)
+  (b) vendor selection + key missing ⇒ selection-naming error, NO managed call
+  (c) never-configured ⇒ legacy autodetect unchanged
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tools import tool_backend_helpers as tbh
+
+
+MANAGED = SimpleNamespace(
+    nous_user_token="managed-token",
+    gateway_origin="https://gateway.nousresearch.com",
+)
+
+
+# ---------------------------------------------------------------------------
+# read_selection — the shared helper
+# ---------------------------------------------------------------------------
+
+
+class TestReadSelection:
+    def _with_raw(self, raw):
+        return patch(
+            "hermes_cli.config.read_raw_config_readonly",
+            return_value=raw,
+        )
+
+    def test_never_configured_returns_none(self):
+        with self._with_raw({}):
+            assert tbh.read_selection("image_gen") is None
+
+    def test_vendor_provider_returned(self):
+        with self._with_raw({"image_gen": {"provider": "fal"}}):
+            assert tbh.read_selection("image_gen") == "fal"
+
+    def test_nous_provider_returned(self):
+        with self._with_raw({"image_gen": {"provider": "nous"}}):
+            assert tbh.read_selection("image_gen") == "nous"
+
+    def test_legacy_use_gateway_true_maps_to_nous(self):
+        """Old configs stored use_gateway: true beside a vendor name — only
+        the managed picker row ever wrote it, so it means 'nous'."""
+        with self._with_raw({"video_gen": {"provider": "fal", "use_gateway": True}}):
+            assert tbh.read_selection("video_gen") == "nous"
+
+    def test_legacy_use_gateway_false_keeps_vendor(self):
+        with self._with_raw({"tts": {"provider": "openai", "use_gateway": False}}):
+            assert tbh.read_selection("tts") == "openai"
+
+    def test_empty_string_backend_is_no_selection(self):
+        """DEFAULT_CONFIG's seeded empty strings are not selections."""
+        with self._with_raw({"web": {"backend": ""}}):
+            assert tbh.read_selection("web") is None
+
+    def test_seeded_stt_local_is_no_selection(self):
+        """Legacy DEFAULT_CONFIG seeded stt.provider: local on every
+        install; that value alone must be treated as never-configured."""
+        with self._with_raw({"stt": {"provider": "local"}}):
+            assert tbh.read_selection("stt") is None
+
+    def test_stt_local_with_use_gateway_key_is_a_selection(self):
+        """A picker-written stt section (use_gateway key present) means
+        local was a genuine choice."""
+        with self._with_raw({"stt": {"provider": "local", "use_gateway": False}}):
+            assert tbh.read_selection("stt") == "local"
+
+    def test_browser_backend_key_is_not_the_cloud_selection(self):
+        """browser.backend is the driver choice (browser-use CLI vs built-in
+        tools), not the cloud provider selection."""
+        with self._with_raw({"browser": {"backend": "browser-use"}}):
+            assert tbh.read_selection("browser") is None
+
+    def test_web_per_capability_keys_mark_configured(self):
+        with self._with_raw({"web": {"search_backend": "searxng"}}):
+            assert tbh.read_selection("web") is None
+            assert tbh.selection_exists("web") is True
+
+
+# ---------------------------------------------------------------------------
+# Image generation (FAL)
+# ---------------------------------------------------------------------------
+
+
+class TestImageFalStrictSelection:
+    def test_nous_selection_routes_managed_even_with_fal_key(self):
+        from tools import image_generation_tool as it
+
+        with patch.object(it, "read_selection", return_value="nous"), \
+             patch.object(it, "fal_key_is_configured", return_value=True), \
+             patch.object(it, "resolve_managed_tool_gateway", return_value=MANAGED) as gw:
+            assert it._resolve_managed_fal_gateway() is MANAGED
+        gw.assert_called_once_with("fal-queue")
+
+    def test_nous_selection_unentitled_raises_selection_error(self):
+        from tools import image_generation_tool as it
+
+        with patch.object(it, "read_selection", return_value="nous"), \
+             patch.object(it, "fal_key_is_configured", return_value=True), \
+             patch.object(it, "resolve_managed_tool_gateway", return_value=None):
+            with pytest.raises(ValueError) as exc:
+                it._resolve_managed_fal_gateway()
+        assert "image_gen is configured to use nous" in str(exc.value)
+        assert "hermes tools" in str(exc.value)
+
+    def test_fal_selection_missing_key_errors_without_managed_call(self):
+        from tools import image_generation_tool as it
+
+        with patch.object(it, "read_selection", return_value="fal"), \
+             patch.object(it, "fal_key_is_configured", return_value=False), \
+             patch.object(it, "resolve_managed_tool_gateway") as gw:
+            with pytest.raises(ValueError) as exc:
+                it._resolve_managed_fal_gateway()
+        gw.assert_not_called()
+        assert "FAL_KEY" in str(exc.value)
+        assert "image_gen is configured to use fal" in str(exc.value)
+        assert "hermes tools" in str(exc.value)
+
+    def test_fal_selection_with_key_routes_direct(self):
+        from tools import image_generation_tool as it
+
+        with patch.object(it, "read_selection", return_value="fal"), \
+             patch.object(it, "fal_key_is_configured", return_value=True), \
+             patch.object(it, "resolve_managed_tool_gateway") as gw:
+            assert it._resolve_managed_fal_gateway() is None
+        gw.assert_not_called()
+
+    def test_never_configured_autodetect_direct_when_key_present(self):
+        from tools import image_generation_tool as it
+
+        with patch.object(it, "read_selection", return_value=None), \
+             patch.object(it, "fal_key_is_configured", return_value=True):
+            assert it._resolve_managed_fal_gateway() is None
+
+    def test_never_configured_autodetect_managed_when_no_key(self):
+        from tools import image_generation_tool as it
+
+        with patch.object(it, "read_selection", return_value=None), \
+             patch.object(it, "fal_key_is_configured", return_value=False), \
+             patch.object(it, "resolve_managed_tool_gateway", return_value=MANAGED):
+            assert it._resolve_managed_fal_gateway() is MANAGED
+
+    def test_check_fal_api_key_reflects_selection(self):
+        from tools import image_generation_tool as it
+
+        with patch.object(it, "read_selection", return_value="fal"), \
+             patch.object(it, "fal_key_is_configured", return_value=False), \
+             patch.object(it, "resolve_managed_tool_gateway", return_value=MANAGED):
+            # Broken vendor selection reports unavailable even though the
+            # managed gateway would resolve.
+            assert it.check_fal_api_key() is False
+
+
+# ---------------------------------------------------------------------------
+# Video generation (FAL plugin)
+# ---------------------------------------------------------------------------
+
+
+class TestVideoFalStrictSelection:
+    def test_nous_selection_routes_managed_even_with_fal_key(self):
+        from plugins.video_gen import fal as vf
+
+        with patch("tools.tool_backend_helpers.read_selection", return_value="nous"), \
+             patch("tools.tool_backend_helpers.fal_key_is_configured", return_value=True), \
+             patch("tools.managed_tool_gateway.resolve_managed_tool_gateway", return_value=MANAGED):
+            assert vf._resolve_managed_fal_video_gateway() is MANAGED
+
+    def test_fal_selection_missing_key_errors_without_managed_call(self):
+        from plugins.video_gen import fal as vf
+
+        with patch("tools.tool_backend_helpers.read_selection", return_value="fal"), \
+             patch("tools.tool_backend_helpers.fal_key_is_configured", return_value=False), \
+             patch("tools.managed_tool_gateway.resolve_managed_tool_gateway") as gw:
+            with pytest.raises(ValueError) as exc:
+                vf._resolve_managed_fal_video_gateway()
+        gw.assert_not_called()
+        assert "video_gen is configured to use fal" in str(exc.value)
+        assert "FAL_KEY" in str(exc.value)
+
+    def test_never_configured_autodetect_unchanged(self):
+        from plugins.video_gen import fal as vf
+
+        with patch("tools.tool_backend_helpers.read_selection", return_value=None), \
+             patch("tools.tool_backend_helpers.fal_key_is_configured", return_value=True):
+            assert vf._resolve_managed_fal_video_gateway() is None
+
+
+# ---------------------------------------------------------------------------
+# STT (OpenAI audio resolver — previously ignored the stored intent entirely)
+# ---------------------------------------------------------------------------
+
+
+class TestSttStrictSelection:
+    def test_nous_selection_beats_direct_openai_key(self):
+        from tools import transcription_tools as tt
+
+        with patch.object(tt, "_load_stt_config", return_value={"openai": {"api_key": "sk-direct"}}), \
+             patch("tools.tool_backend_helpers.read_selection", return_value="nous"), \
+             patch.object(tt, "resolve_managed_tool_gateway", return_value=MANAGED):
+            api_key, base_url = tt._resolve_openai_audio_client_config()
+        assert api_key == "managed-token"
+        assert base_url.startswith("https://gateway.nousresearch.com")
+
+    def test_vendor_selection_missing_key_errors_without_managed_call(self):
+        from tools import transcription_tools as tt
+
+        with patch.object(tt, "_load_stt_config", return_value={}), \
+             patch("tools.tool_backend_helpers.read_selection", return_value="openai"), \
+             patch.object(tt, "resolve_openai_audio_api_key", return_value=""), \
+             patch.object(tt, "resolve_managed_tool_gateway") as gw:
+            with pytest.raises(ValueError) as exc:
+                tt._resolve_openai_audio_client_config()
+        gw.assert_not_called()
+        assert "stt is configured to use openai" in str(exc.value)
+        assert "hermes tools" in str(exc.value)
+
+    def test_never_configured_keeps_legacy_ladder(self):
+        from tools import transcription_tools as tt
+
+        with patch.object(tt, "_load_stt_config", return_value={}), \
+             patch("tools.tool_backend_helpers.read_selection", return_value=None), \
+             patch.object(tt, "resolve_openai_audio_api_key", return_value="sk-env"):
+            api_key, base_url = tt._resolve_openai_audio_client_config()
+        assert api_key == "sk-env"
+
+
+# ---------------------------------------------------------------------------
+# Browser Use provider
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserUseStrictSelection:
+    def _provider(self):
+        from plugins.browser.browser_use.provider import BrowserUseBrowserProvider
+
+        return BrowserUseBrowserProvider()
+
+    def test_nous_selection_routes_managed_even_with_direct_key(self):
+        provider = self._provider()
+        with patch("plugins.browser.browser_use.provider.get_secret", return_value="bu-key"), \
+             patch("tools.tool_backend_helpers.read_selection", return_value="nous"), \
+             patch("tools.managed_tool_gateway.resolve_managed_tool_gateway", return_value=MANAGED):
+            config = provider._get_config_or_none()
+        assert config["managed_mode"] is True
+        assert config["api_key"] == "managed-token"
+
+    def test_vendor_selection_missing_key_errors_without_managed_call(self):
+        provider = self._provider()
+        with patch("plugins.browser.browser_use.provider.get_secret", return_value=""), \
+             patch("tools.tool_backend_helpers.read_selection", return_value="browser-use"), \
+             patch("tools.managed_tool_gateway.resolve_managed_tool_gateway") as gw:
+            with pytest.raises(ValueError) as exc:
+                provider._get_config()
+        gw.assert_not_called()
+        assert "browser is configured to use browser-use" in str(exc.value)
+        assert "BROWSER_USE_API_KEY" in str(exc.value)
+
+    def test_never_configured_key_still_routes_direct(self):
+        provider = self._provider()
+        with patch("plugins.browser.browser_use.provider.get_secret", return_value="bu-key"), \
+             patch("tools.tool_backend_helpers.read_selection", return_value=None):
+            config = provider._get_config_or_none()
+        assert config["managed_mode"] is False
+        assert config["api_key"] == "bu-key"
+
+
+# ---------------------------------------------------------------------------
+# Camofox: selection over env var
+# ---------------------------------------------------------------------------
+
+
+class TestCamofoxSelection:
+    def test_camofox_selection_activates_mode(self, monkeypatch):
+        from tools import browser_camofox as bc
+
+        monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+        with patch.object(bc, "_config_cdp_url", return_value=""), \
+             patch("tools.tool_backend_helpers.read_selection", return_value="camofox"):
+            assert bc.is_camofox_mode() is True
+
+    def test_other_selection_beats_camofox_url_env(self, monkeypatch):
+        """CAMOFOX_URL is the ADDRESS, not the choice: an explicit different
+        browser selection wins."""
+        from tools import browser_camofox as bc
+
+        monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+        with patch.object(bc, "_config_cdp_url", return_value=""), \
+             patch.object(bc, "get_camofox_url", return_value="http://localhost:9377"), \
+             patch("tools.tool_backend_helpers.read_selection", return_value="local"):
+            assert bc.is_camofox_mode() is False
+
+    def test_never_configured_env_url_still_activates(self, monkeypatch):
+        from tools import browser_camofox as bc
+
+        monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+        with patch.object(bc, "_config_cdp_url", return_value=""), \
+             patch.object(bc, "get_camofox_url", return_value="http://localhost:9377"), \
+             patch("tools.tool_backend_helpers.read_selection", return_value=None):
+            assert bc.is_camofox_mode() is True
+
+
+# ---------------------------------------------------------------------------
+# tools_config writers: one provider string per row, no use_gateway writes
+# ---------------------------------------------------------------------------
+
+
+class TestWriteProviderConfig:
+    def test_managed_row_writes_nous_and_clears_legacy_flag(self):
+        from hermes_cli.tools_config import _write_provider_config
+
+        config = {"tts": {"provider": "edge", "use_gateway": False}}
+        provider = {"name": "Nous Subscription", "tts_provider": "openai"}
+        _write_provider_config(provider, config, managed_feature="tts")
+        assert config["tts"]["provider"] == "nous"
+        assert "use_gateway" not in config["tts"]
+
+    def test_byok_row_writes_vendor_and_clears_legacy_flag(self):
+        from hermes_cli.tools_config import _write_provider_config
+
+        config = {"web": {"backend": "nous", "use_gateway": True}}
+        provider = {"name": "Tavily", "web_backend": "tavily"}
+        _write_provider_config(provider, config, managed_feature=None)
+        assert config["web"]["backend"] == "tavily"
+        assert "use_gateway" not in config["web"]
+
+    def test_managed_image_row_persists_nous_provider(self):
+        from hermes_cli.tools_config import _write_provider_config
+
+        config = {}
+        provider = {"name": "Nous Subscription", "imagegen_backend": "fal"}
+        _write_provider_config(provider, config, managed_feature="image_gen")
+        assert config["image_gen"]["provider"] == "nous"
+        assert "use_gateway" not in config["image_gen"]
+
+    def test_plugin_injected_byok_row_clears_stale_use_gateway(self):
+        """Plugin-injected rows are not in TOOL_CATEGORIES' hardcoded
+        provider lists; the legacy clear-loop skipped them."""
+        from hermes_cli.tools_config import _write_provider_config
+
+        config = {"stt": {"provider": "nous", "use_gateway": True}}
+        provider = {"name": "Groq Whisper", "stt_provider": "groq"}
+        _write_provider_config(provider, config, managed_feature=None)
+        assert config["stt"]["provider"] == "groq"
+        assert "use_gateway" not in config["stt"]

--- a/tests/tools/test_strict_provider_selection.py
+++ b/tests/tools/test_strict_provider_selection.py
@@ -66,11 +66,14 @@ class TestReadSelection:
         with self._with_raw({"web": {"backend": ""}}):
             assert tbh.read_selection("web") is None
 
-    def test_seeded_stt_local_is_no_selection(self):
-        """Legacy DEFAULT_CONFIG seeded stt.provider: local on every
-        install; that value alone must be treated as never-configured."""
+    def test_raw_stt_local_is_a_selection(self):
+        """A raw config.yaml ``stt.provider: local`` is a genuine pick: the
+        DEFAULT_CONFIG seed never reached disk (save_config strips schema
+        defaults), and the current picker's Local Whisper row writes exactly
+        this shape (provider only, legacy use_gateway popped). Treating it
+        as no-selection would silently discard the user's choice."""
         with self._with_raw({"stt": {"provider": "local"}}):
-            assert tbh.read_selection("stt") is None
+            assert tbh.read_selection("stt") == "local"
 
     def test_stt_local_with_use_gateway_key_is_a_selection(self):
         """A picker-written stt section (use_gateway key present) means

--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -43,7 +43,8 @@ class TestGetProvider:
         monkeypatch.delenv("GROQ_API_KEY", raising=False)
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
              patch("tools.transcription_tools._HAS_OPENAI", True), \
-             patch("tools.transcription_tools._has_local_command", return_value=False):
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.tool_backend_helpers.read_selection", return_value="local"):
             from tools.transcription_tools import _get_provider
             assert _get_provider({"provider": "local"}) == "none"
 

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -131,10 +131,24 @@ class TestExplicitProviderRespected:
         monkeypatch.delenv("GROQ_API_KEY", raising=False)
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
              patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.tool_backend_helpers.read_selection", return_value="local"), \
              patch("tools.transcription_tools._HAS_OPENAI", True):
             from tools.transcription_tools import _get_provider
             result = _get_provider({"provider": "local"})
             assert result == "none", f"Expected 'none' but got {result!r}"
+
+    def test_seeded_local_without_stored_selection_autodetects(self, monkeypatch):
+        """The DEFAULT_CONFIG-seeded stt.provider: local (no raw-config
+        selection) is treated as never-configured: autodetect runs instead of
+        hard-pinning to a missing local backend."""
+        monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.transcription_tools._try_lazy_install_stt", return_value=False), \
+             patch("tools.tool_backend_helpers.read_selection", return_value=None), \
+             patch("tools.transcription_tools._HAS_OPENAI", True):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({"provider": "local"}) == "groq"
 
     def test_explicit_local_uses_local_command_fallback(self, monkeypatch):
         """Local-to-local_command fallback is fine — both are local."""

--- a/tests/tools/test_tts_openai_config.py
+++ b/tests/tools/test_tts_openai_config.py
@@ -25,7 +25,7 @@ class TestResolveOpenaiAudioClientConfig:
         }
 
         with patch.object(tts_tool, "_load_tts_config", return_value=config), \
-             patch.object(tts_tool, "prefers_gateway", return_value=False), \
+             patch.object(tts_tool, "read_selection", return_value="openai"), \
              patch.object(tts_tool, "resolve_openai_audio_api_key", return_value="env-key"), \
              patch.object(tts_tool, "resolve_managed_tool_gateway", return_value=None):
             assert tts_tool._resolve_openai_audio_client_config() == (
@@ -38,7 +38,7 @@ class TestResolveOpenaiAudioClientConfig:
         config = {"openai": {"api_key": "cfg-key"}}
 
         with patch.object(tts_tool, "_load_tts_config", return_value=config), \
-             patch.object(tts_tool, "prefers_gateway", return_value=False):
+             patch.object(tts_tool, "read_selection", return_value=None):
             assert tts_tool._resolve_openai_audio_client_config() == (
                 "cfg-key",
                 tts_tool.DEFAULT_OPENAI_BASE_URL,
@@ -46,7 +46,9 @@ class TestResolveOpenaiAudioClientConfig:
             )
 
 
-    def test_use_gateway_overrides_config_credentials(self):
+    def test_nous_selection_overrides_config_credentials(self):
+        """A stored 'nous' selection (or legacy use_gateway: true) routes
+        managed even when direct credentials are present."""
         config = {"openai": {"api_key": "cfg-key", "base_url": "http://localhost:4003/v1"}}
         managed = SimpleNamespace(
             nous_user_token="managed-token",
@@ -54,7 +56,7 @@ class TestResolveOpenaiAudioClientConfig:
         )
 
         with patch.object(tts_tool, "_load_tts_config", return_value=config), \
-             patch.object(tts_tool, "prefers_gateway", return_value=True), \
+             patch.object(tts_tool, "read_selection", return_value="nous"), \
              patch.object(tts_tool, "resolve_openai_audio_api_key", return_value="env-key"), \
              patch.object(tts_tool, "resolve_managed_tool_gateway", return_value=managed):
             assert tts_tool._resolve_openai_audio_client_config() == (
@@ -63,9 +65,35 @@ class TestResolveOpenaiAudioClientConfig:
                 True,
             )
 
+    def test_nous_selection_unentitled_raises_selection_error(self):
+        """Selected managed route + unavailable gateway = honest error naming
+        the selection, never a silent fall back to direct credentials."""
+        config = {"openai": {"api_key": "cfg-key"}}
+        with patch.object(tts_tool, "_load_tts_config", return_value=config), \
+             patch.object(tts_tool, "read_selection", return_value="nous"), \
+             patch.object(tts_tool, "resolve_openai_audio_api_key", return_value="env-key"), \
+             patch.object(tts_tool, "resolve_managed_tool_gateway", return_value=None):
+            with pytest.raises(ValueError) as exc:
+                tts_tool._resolve_openai_audio_client_config()
+        assert "nous" in str(exc.value)
+        assert "hermes tools" in str(exc.value)
+
+    def test_vendor_selection_missing_key_raises_selection_error(self):
+        """A stored vendor selection with no credentials errors by name —
+        NO managed gateway call is attempted."""
+        with patch.object(tts_tool, "_load_tts_config", return_value={"provider": "openai"}), \
+             patch.object(tts_tool, "read_selection", return_value="openai"), \
+             patch.object(tts_tool, "resolve_openai_audio_api_key", return_value=""), \
+             patch.object(tts_tool, "resolve_managed_tool_gateway") as gateway_mock:
+            with pytest.raises(ValueError) as exc:
+                tts_tool._resolve_openai_audio_client_config()
+        gateway_mock.assert_not_called()
+        assert "openai" in str(exc.value)
+        assert "hermes tools" in str(exc.value)
+
     def test_missing_config_and_env_raises_updated_error(self):
         with patch.object(tts_tool, "_load_tts_config", return_value={}), \
-             patch.object(tts_tool, "prefers_gateway", return_value=False), \
+             patch.object(tts_tool, "read_selection", return_value=None), \
              patch.object(tts_tool, "resolve_openai_audio_api_key", return_value=""), \
              patch.object(tts_tool, "resolve_managed_tool_gateway", return_value=None), \
              patch.object(tts_tool, "managed_nous_tools_enabled", return_value=False):

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -222,12 +222,29 @@ class TestBackendSelection:
              patch("tools.web_tools._ddgs_package_importable", return_value=False):
             assert _get_backend() == "firecrawl"
 
-    def test_invalid_config_falls_through_to_fallback(self):
-        """web.backend=invalid → ignored, uses key-based fallback."""
+    def test_invalid_config_is_returned_verbatim(self):
+        """Strict selection: web.backend=nonexistent is returned as-is so the
+        dispatch path raises the honest selection-naming error — never
+        silently rerouted through the credential ladder."""
         from tools.web_tools import _get_backend
         with patch("tools.web_tools._load_web_config", return_value={"backend": "nonexistent"}), \
              patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):
-            assert _get_backend() == "parallel"
+            assert _get_backend() == "nonexistent"
+
+    def test_stored_backend_wins_over_other_credentials(self):
+        """Strict selection: a stored web.backend beats env keys for other
+        vendors — no availability probe, no credential override."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "firecrawl"}), \
+             patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}):
+            assert _get_backend() == "firecrawl"
+
+    def test_nous_backend_maps_to_firecrawl(self):
+        """The managed 'nous' selection is serviced by the firecrawl
+        provider (whose client resolver routes managed)."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "nous"}):
+            assert _get_backend() == "firecrawl"
 
     def test_managed_gateway_does_not_preempt_explicit_tavily(self):
         """Regression: a Nous OAuth token (managed gateway "ready") must NOT

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -113,20 +113,38 @@ def _config_cdp_url() -> str:
 
 
 def is_camofox_mode() -> bool:
-    """True when Camofox backend is configured and no CDP override is active.
+    """True when the Camofox backend is selected and no CDP override is active.
+
+    Camofox is a selection: ``browser.cloud_provider: camofox`` (set via
+    ``hermes tools``). ``CAMOFOX_URL`` is the server ADDRESS only — its
+    presence no longer selects the backend when a different
+    ``browser.cloud_provider`` is stored. Legacy read-time interpretation:
+    when NO cloud provider selection was ever written, a set ``CAMOFOX_URL``
+    keeps activating Camofox exactly as before (nothing is migrated/written
+    to config).
 
     A CDP override takes priority over Camofox so the browser tools operate on
     the real CDP browser (and a CDP backend is treated as non-local for SSRF
     checks) instead of being silently routed to Camofox. The override may come
     from the ``BROWSER_CDP_URL`` env var (set by ``/browser connect``) OR a
     persistent ``browser.cdp_url`` in config.yaml — both are honored, matching
-    ``browser_tool._get_cdp_override()``'s precedence. (Previously only the env
-    var suppressed Camofox, so ``CAMOFOX_URL`` + a config CDP override still
-    routed navigation through Camofox.)
+    ``browser_tool._get_cdp_override()``'s precedence.
     """
     if os.getenv("BROWSER_CDP_URL", "").strip():
         return False
     if _config_cdp_url():
+        return False
+    try:
+        from tools.tool_backend_helpers import read_selection
+
+        selected = read_selection("browser")
+    except Exception:  # pragma: no cover — helpers are in-repo
+        selected = None
+    if selected == "camofox":
+        return True
+    if selected is not None:
+        # An explicit different browser selection wins: CAMOFOX_URL is just
+        # an address, not a choice.
         return False
     return bool(get_camofox_url())
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -815,19 +815,26 @@ def _resolve_cloud_provider_uncached() -> Optional[CloudBrowserProvider]:
     global _cached_cloud_provider, _cloud_provider_resolved
 
     resolved: Optional[CloudBrowserProvider] = None
+    provider_key = None
     try:
         from hermes_cli.config import read_raw_config
         cfg = read_raw_config()
         browser_cfg = cfg.get("browser", {})
-        provider_key = None
         if isinstance(browser_cfg, dict) and "cloud_provider" in browser_cfg:
             provider_key = normalize_browser_cloud_provider(
                 browser_cfg.get("cloud_provider")
             )
-            if provider_key == "local":
+            if provider_key in ("local", "camofox"):
+                # Camofox runs through the built-in browser tools
+                # (is_camofox_mode() dispatch), not a cloud provider.
                 _cached_cloud_provider = None
                 _cloud_provider_resolved = True
                 return None
+            if provider_key == "nous":
+                # Managed "Nous Subscription" selection is serviced by the
+                # Browser Use provider, whose config resolver routes it
+                # through the managed browser-use gateway.
+                provider_key = "browser-use"
         if provider_key:
             try:
                 if _is_legacy_provider_registry_overridden():
@@ -841,20 +848,20 @@ def _resolve_cloud_provider_uncached() -> Optional[CloudBrowserProvider]:
                     # populated. Idempotent — cheap on subsequent calls.
                     _ensure_browser_plugins_loaded()
                     resolved = _registry_get_browser_provider(provider_key)
-                    if resolved is None:
-                        # Explicit config name unknown to the registry —
-                        # might be a typo, an uninstalled plugin, or a
-                        # registry-population failure. Warn the user
-                        # (legacy code would have surfaced a typed
-                        # credentials error via direct class instantiation;
-                        # post-migration we surface this WARNING instead).
-                        logger.warning(
-                            "browser.cloud_provider=%r is not a registered "
-                            "browser plugin; falling back to auto-detect "
-                            "(install the corresponding plugin or fix the "
-                            "config key spelling).",
-                            provider_key,
-                        )
+                if resolved is None:
+                    # Strict selection: a stored-but-unregistered name is an
+                    # honest error, never a silent reroute to auto-detect.
+                    from tools.tool_backend_helpers import selection_error
+
+                    raise ValueError(selection_error(
+                        "browser",
+                        f"'{provider_key}'",
+                        "no registered browser plugin has that name (install "
+                        "the corresponding plugin or fix the config key "
+                        "spelling)",
+                    ))
+            except ValueError:
+                raise
             except Exception:
                 logger.warning(
                     "Failed to instantiate explicit cloud_provider %r; will retry on next call",
@@ -862,13 +869,16 @@ def _resolve_cloud_provider_uncached() -> Optional[CloudBrowserProvider]:
                     exc_info=True,
                 )
                 return None
+    except ValueError:
+        raise
     except Exception as e:
         # Config file may be temporarily unreadable; still try auto-detect so
         # env-based / managed-gateway credentials can resolve. Don't pin cache.
         logger.debug("Could not read cloud_provider from config: %s", e)
 
-    if resolved is None:
-        # Auto-detect path: Browser Use first (managed Nous gateway or
+    if resolved is None and provider_key is None:
+        # Auto-detect path — permitted ONLY when no cloud_provider selection
+        # was ever written: Browser Use first (managed Nous gateway or
         # direct API key), then Browserbase (direct credentials). Uses
         # the legacy class names imported at the top of this module so
         # tests that ``monkeypatch.setattr(browser_tool, "BrowserUseProvider", ...)``

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -66,10 +66,12 @@ from tools.fal_common import (
 )
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
 from tools.tool_backend_helpers import (
+    NOUS_MANAGED_PROVIDER,
     fal_key_is_configured,
     managed_nous_tools_enabled,
     nous_tool_gateway_unavailable_message,
-    prefers_gateway,
+    read_selection,
+    selection_error,
 )
 
 logger = logging.getLogger(__name__)
@@ -732,9 +734,43 @@ _managed_fal_client_lock = threading.Lock()
 # Managed FAL gateway (Nous Subscription)
 # ---------------------------------------------------------------------------
 def _resolve_managed_fal_gateway():
-    """Return managed fal-queue gateway config when the user prefers the gateway
-    or direct FAL credentials are absent."""
-    if fal_key_is_configured() and not prefers_gateway("image_gen"):
+    """Resolve the FAL route from the stored `hermes tools` selection.
+
+    Dispatch is a plain switch on the stored ``image_gen`` provider string:
+    - ``"nous"`` (or legacy ``use_gateway: true``) → managed fal-queue
+      gateway ONLY; unentitled/unreachable is a selection-naming error
+      (never a silent fall back to FAL_KEY).
+    - any other stored provider (``"fal"``, ...) → direct FAL ONLY; a
+      missing FAL_KEY is an error naming FAL_KEY and the selection (never a
+      silent managed reroute).
+    - no selection ever written → legacy credential autodetect: direct when
+      FAL_KEY is set, else the managed gateway when resolvable, else None.
+
+    Returns the managed gateway config, or ``None`` for the direct route.
+    Raises ``ValueError`` with the honest error contract when the stored
+    selection cannot run.
+    """
+    selected = read_selection("image_gen")
+    if selected == NOUS_MANAGED_PROVIDER:
+        gateway = resolve_managed_tool_gateway("fal-queue")
+        if gateway is None:
+            raise ValueError(selection_error(
+                "image_gen",
+                NOUS_MANAGED_PROVIDER,
+                "the Nous Tool Gateway is not available (not entitled or "
+                "unreachable)",
+            ))
+        return gateway
+    if selected is not None:
+        if not fal_key_is_configured():
+            raise ValueError(selection_error(
+                "image_gen",
+                selected,
+                "FAL_KEY is not set",
+            ))
+        return None
+    # Never-configured category: legacy credential autodetect (do NOT persist).
+    if fal_key_is_configured():
         return None
     return resolve_managed_tool_gateway("fal-queue")
 
@@ -1228,6 +1264,9 @@ def image_generate_tool(
         if not prompt or not isinstance(prompt, str) or len(prompt.strip()) == 0:
             raise ValueError("Prompt is required and must be a non-empty string")
 
+        # Strict selection check: a stored-but-broken selection raises the
+        # honest selection-naming error from _resolve_managed_fal_gateway();
+        # only the never-configured path can report "no backend at all".
         if not (fal_key_is_configured() or _resolve_managed_fal_gateway()):
             raise ValueError(_build_no_backend_setup_message())
 
@@ -1372,8 +1411,19 @@ def image_generate_tool(
 
 
 def check_fal_api_key() -> bool:
-    """True if the FAL.ai API key (direct or managed gateway) is available."""
-    return bool(fal_key_is_configured() or _resolve_managed_fal_gateway())
+    """True if the FAL backend selected via `hermes tools` (or, on a
+    never-configured install, any FAL backend) is available.
+
+    A stored-but-broken selection reports False here (registry gating);
+    the honest selection-naming error surfaces at call time from
+    ``_resolve_managed_fal_gateway``.
+    """
+    selected = read_selection("image_gen")
+    if selected == NOUS_MANAGED_PROVIDER:
+        return bool(resolve_managed_tool_gateway("fal-queue"))
+    if selected is not None:
+        return fal_key_is_configured()
+    return bool(fal_key_is_configured() or resolve_managed_tool_gateway("fal-queue"))
 
 
 def _build_no_backend_setup_message() -> str:
@@ -1431,7 +1481,7 @@ def check_image_generation_requirements() -> bool:
         pass
 
     configured = _read_configured_image_provider()
-    if not configured or configured == "fal":
+    if not configured or configured in ("fal", NOUS_MANAGED_PROVIDER):
         return False
 
     # Probe only the explicitly selected plugin. Merely possessing a cloud
@@ -1629,8 +1679,11 @@ def _dispatch_to_plugin_provider(
     ignore it via their ``**kwargs`` (the ABC contract).
     """
     configured = _read_configured_image_provider()
-    if not configured or configured == "fal":
-        return None  # unset/explicit FAL keeps the legacy FAL path
+    if not configured or configured in ("fal", NOUS_MANAGED_PROVIDER):
+        # Unset/explicit FAL keeps the legacy FAL path; "nous" (managed
+        # Nous Subscription selection) also runs the legacy pipeline, which
+        # routes through the managed fal-queue gateway.
+        return None
 
     # Also read configured model so we can pass it to the plugin
     configured_model = _read_configured_image_model()
@@ -1785,8 +1838,13 @@ def _maybe_route_managed_krea(
 
     Direct/BYO users (no managed gateway) fall through untouched.
     """
-    # ``provider == "krea"`` is already handled by the standard plugin dispatch.
-    if _read_configured_image_provider() == "krea":
+    # Strict selection rule: an explicitly stored ``image_gen.provider``
+    # (other than the managed "nous" selection, which IS a managed-mode
+    # opt-in) disables the model-driven managed interception — the user's
+    # picker choice dispatches normally. Interception is permitted only on
+    # never-configured installs or under the managed selection.
+    configured_provider = _read_configured_image_provider()
+    if configured_provider is not None and configured_provider != NOUS_MANAGED_PROVIDER:
         return None
 
     normalized = _normalize_krea_model(_read_configured_image_model())

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -361,13 +361,13 @@ def read_selection(section: str) -> str | None:
     if "use_gateway" in raw and is_truthy_value(raw.get("use_gateway"), default=False):
         return NOUS_MANAGED_PROVIDER
 
-    # Migration shim: DEFAULT_CONFIG historically seeded ``stt.provider:
-    # local`` on every install, so that exact value with no picker-written
-    # use_gateway key is ambiguous. Treat it as never-configured — the
-    # autodetect ladder prefers local first anyway, and hard-pinning would
-    # error every seeded install that lacks faster-whisper.
-    if section == "stt" and name == "local" and "use_gateway" not in raw:
-        return None
+    # NOTE on the legacy DEFAULT_CONFIG ``stt.provider: local`` seed: it never
+    # reached the raw config.yaml (``save_config`` strips schema defaults),
+    # and the old picker's Local Whisper row always wrote ``use_gateway:
+    # False`` beside it. A raw ``local`` here therefore IS a user selection —
+    # hand-written or picker-written — and is honored like any other vendor
+    # name. The seeded-value ambiguity only exists in DEFAULT_CONFIG-merged
+    # views, which this function never reads.
 
     if name:
         return name

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -290,6 +290,126 @@ def prefers_gateway(config_section: str) -> bool:
     return False
 
 
+# The provider value the managed "Nous Subscription" picker rows write for
+# every category (image_gen.provider: nous, web.backend: nous,
+# browser.cloud_provider: nous, ...). Runtime dispatch is a plain switch on
+# the stored string: "nous" → managed gateway client; any vendor name → that
+# vendor direct with the user's own credentials; no key ever written →
+# legacy credential autodetect.
+NOUS_MANAGED_PROVIDER = "nous"
+
+# Per-capability keys that also count as "this category has been configured".
+_EXTRA_SELECTION_KEYS = {
+    "web": ("search_backend", "extract_backend"),
+}
+
+# Which key(s) carry the category's provider selection. ``browser.backend``
+# is deliberately excluded for the browser section — it is the DRIVER choice
+# ("browser-use" CLI vs built-in tools), not the cloud provider selection.
+_SELECTION_NAME_KEYS = {
+    "browser": ("cloud_provider",),
+    "web": ("backend",),
+}
+_DEFAULT_NAME_KEYS = ("provider", "backend", "cloud_provider")
+
+
+def read_selection(section: str) -> str | None:
+    """Return the stored `hermes tools` provider string for a config section.
+
+    THE single runtime read of the persisted selection. Returns:
+    - ``"nous"`` — the managed Nous Tool Gateway row was selected,
+    - a vendor name (``"fal"``, ``"openai"``, ``"firecrawl"``, ...) — that
+      vendor, direct, with the user's own credentials,
+    - ``None`` — the category has NEVER been configured; the legacy
+      credential autodetect ladder is permitted (and must not be persisted).
+
+    Reads the RAW config.yaml (not the DEFAULT_CONFIG-merged view) so key
+    presence means "a selection was actually written", not "the schema has a
+    default". Never raises; an unreadable config reports ``None``.
+
+    Legacy interpretation (read-time only — nothing is migrated on disk):
+    older picker versions wrote ``<section>.use_gateway`` beside the name
+    key. ``use_gateway: true`` was only ever written by the managed "Nous
+    Subscription" row, so it maps to ``"nous"`` regardless of the name key;
+    ``use_gateway: false`` beside a name key maps to that name.
+    """
+    try:
+        from hermes_cli.config import read_raw_config_readonly
+
+        cfg = read_raw_config_readonly() or {}
+        raw = cfg.get(section) if isinstance(cfg, dict) else None
+    except Exception:
+        raw = None
+    if not isinstance(raw, dict):
+        return None
+
+    def _str_or_none(key: str) -> str | None:
+        value = raw.get(key)
+        if value is None:
+            return None
+        text = str(value).strip().lower()
+        return text or None
+
+    name = None
+    for key in _SELECTION_NAME_KEYS.get(section, _DEFAULT_NAME_KEYS):
+        name = _str_or_none(key)
+        if name:
+            break
+
+    # Legacy shim: a truthy use_gateway means the managed row was picked
+    # (it was the only writer of use_gateway: true).
+    if "use_gateway" in raw and is_truthy_value(raw.get("use_gateway"), default=False):
+        return NOUS_MANAGED_PROVIDER
+
+    # Migration shim: DEFAULT_CONFIG historically seeded ``stt.provider:
+    # local`` on every install, so that exact value with no picker-written
+    # use_gateway key is ambiguous. Treat it as never-configured — the
+    # autodetect ladder prefers local first anyway, and hard-pinning would
+    # error every seeded install that lacks faster-whisper.
+    if section == "stt" and name == "local" and "use_gateway" not in raw:
+        return None
+
+    if name:
+        return name
+
+    # use_gateway: false with no name key is not a usable selection shape;
+    # per-capability web keys still count as configured elsewhere via
+    # selection_exists(). Fall to autodetect.
+    return None
+
+
+def selection_exists(section: str) -> bool:
+    """True when ANY selection signal has ever been written for the section.
+
+    Wider than ``read_selection() is not None``: per-capability web keys
+    (``search_backend``/``extract_backend``) mark the category as configured
+    even when the shared backend name is empty.
+    """
+    if read_selection(section) is not None:
+        return True
+    extra = _EXTRA_SELECTION_KEYS.get(section, ())
+    if not extra:
+        return False
+    try:
+        from hermes_cli.config import read_raw_config_readonly
+
+        cfg = read_raw_config_readonly() or {}
+        raw = cfg.get(section) if isinstance(cfg, dict) else None
+    except Exception:
+        return False
+    if not isinstance(raw, dict):
+        return False
+    return any(str(raw.get(key) or "").strip() for key in extra)
+
+
+def selection_error(section: str, selection_name: str, failure: str) -> str:
+    """The uniform honest-error contract for a selected-but-broken provider."""
+    return (
+        f"{section} is configured to use {selection_name} (set via hermes "
+        f"tools), but {failure}. Run 'hermes tools' to change it."
+    )
+
+
 def fal_key_is_configured() -> bool:
     """Return True when FAL_KEY is set to a non-whitespace value.
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1025,6 +1025,27 @@ def _get_provider(stt_config: dict) -> str:
     explicit = "provider" in stt_config
     provider = stt_config.get("provider", DEFAULT_PROVIDER)
 
+    # The managed "Nous Subscription" selection (stt.provider: nous) is
+    # serviced by the OpenAI provider implementation, routed through the
+    # managed openai-audio gateway by _resolve_openai_audio_client_config.
+    if isinstance(provider, str) and provider.strip().lower() == "nous":
+        provider = "openai"
+
+    if explicit and provider == "local":
+        # Legacy DEFAULT_CONFIG seeded ``stt.provider: local`` on every
+        # install, so a merged-config "local" is not proof of a user pick.
+        # ``read_selection`` reads the raw config.yaml and applies the
+        # seeded-value migration shim; when the raw file holds no stt
+        # selection, take the autodetect branch (which prefers local first
+        # anyway, so a genuine local user is unaffected when it's available).
+        try:
+            from tools.tool_backend_helpers import read_selection
+
+            if read_selection("stt") is None:
+                explicit = False
+        except Exception:  # pragma: no cover — helpers are in-repo
+            pass
+
     # --- Explicit provider: respect the user's choice ----------------------
 
     if explicit:
@@ -3260,11 +3281,61 @@ def transcribe_audio_local_fallback(
 
 
 def _resolve_openai_audio_client_config() -> tuple[str, str]:
-    """Return direct OpenAI audio config or a managed gateway fallback."""
+    """Return ``(api_key, base_url)`` for the OpenAI STT client.
+
+    Strict selection semantics (switch on the stored ``stt`` provider
+    string; previously this resolver never read the stored gateway intent):
+    - ``"nous"`` (or legacy ``use_gateway: true``) → managed gateway ONLY;
+      unentitled/unreachable is a selection-naming error (a direct
+      OPENAI_API_KEY must NOT override it).
+    - any other stored stt provider → direct credentials ONLY; missing
+      credentials is a selection-naming error — no silent managed fallback.
+    - never-configured stt section → legacy ladder: config key → local
+      base_url → env key → managed gateway.
+    """
+    from tools.tool_backend_helpers import (
+        NOUS_MANAGED_PROVIDER,
+        read_selection,
+        selection_error,
+    )
+
     stt_config = _load_stt_config()
     openai_cfg = stt_config.get("openai") or {}
     cfg_api_key = openai_cfg.get("api_key", "")
     cfg_base_url = openai_cfg.get("base_url", "")
+
+    selected = read_selection("stt")
+
+    if selected == NOUS_MANAGED_PROVIDER:
+        managed_gateway = resolve_managed_tool_gateway("openai-audio")
+        if managed_gateway is None:
+            raise ValueError(selection_error(
+                "stt",
+                NOUS_MANAGED_PROVIDER,
+                "the Nous Tool Gateway is not available (not entitled or "
+                "unreachable)",
+            ))
+        return managed_gateway.nous_user_token, urljoin(
+            f"{managed_gateway.gateway_origin.rstrip('/')}/", "v1"
+        )
+
+    if selected is not None:
+        # Stored vendor selection: direct credentials only.
+        if cfg_api_key:
+            return cfg_api_key, (cfg_base_url or OPENAI_BASE_URL)
+        if cfg_base_url and _is_local_or_private_url(cfg_base_url):
+            return "not-needed", cfg_base_url
+        direct_api_key = resolve_openai_audio_api_key()
+        if direct_api_key:
+            return direct_api_key, OPENAI_BASE_URL
+        raise ValueError(selection_error(
+            "stt",
+            selected,
+            "neither stt.openai.api_key in config nor "
+            "VOICE_TOOLS_OPENAI_KEY/OPENAI_API_KEY is set",
+        ))
+
+    # Never-configured stt section: legacy credential ladder.
     if cfg_api_key:
         return cfg_api_key, (cfg_base_url or OPENAI_BASE_URL)
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1034,9 +1034,10 @@ def _get_provider(stt_config: dict) -> str:
     if explicit and provider == "local":
         # Legacy DEFAULT_CONFIG seeded ``stt.provider: local`` on every
         # install, so a merged-config "local" is not proof of a user pick.
-        # ``read_selection`` reads the raw config.yaml and applies the
-        # seeded-value migration shim; when the raw file holds no stt
-        # selection, take the autodetect branch (which prefers local first
+        # ``read_selection`` reads the raw config.yaml: when the raw file
+        # holds an stt selection (picker- or hand-written ``local``) it is
+        # honored; when the merged "local" came only from a legacy default
+        # merge, take the autodetect branch (which prefers local first
         # anyway, so a genuine local user is unaffected when it's available).
         try:
             from tools.tool_backend_helpers import read_selection

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -93,10 +93,12 @@ def _resolve_provider_key(env_var: str, provider_id: str) -> str:
 
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
 from tools.tool_backend_helpers import (
+    NOUS_MANAGED_PROVIDER,
     managed_nous_tools_enabled,
     nous_tool_gateway_unavailable_message,
-    prefers_gateway,
+    read_selection,
     resolve_openai_audio_api_key,
+    selection_error,
 )
 from tools.xai_http import hermes_xai_user_agent
 
@@ -651,8 +653,15 @@ def _get_provider(tts_config: Dict[str, Any]) -> str:
     Inference credentials do not imply consent to paid speech generation.
     Users opt into cloud TTS by setting ``tts.provider`` (normally through
     ``hermes tools``); otherwise the historical Edge backend remains active.
+
+    The managed "Nous Subscription" selection (``tts.provider: nous``) is
+    serviced by the OpenAI provider implementation, routed through the
+    managed openai-audio gateway by ``_resolve_openai_audio_client_config``.
     """
-    return (tts_config.get("provider") or DEFAULT_PROVIDER).lower().strip()
+    provider = (tts_config.get("provider") or DEFAULT_PROVIDER).lower().strip()
+    if provider == NOUS_MANAGED_PROVIDER:
+        return "openai"
+    return provider
 
 
 @dataclass(frozen=True)
@@ -3785,24 +3794,61 @@ def _resolve_openai_audio_client_config() -> tuple[str, str, bool]:
 
     ``is_managed`` is True when the config resolves to the Nous managed audio
     gateway (a restricted proxy), so callers can coerce the request to what the
-    gateway supports. When ``tts.use_gateway`` is set the gateway is preferred
-    even if direct OpenAI credentials are present.
+    gateway supports.
 
-    Resolution order (mirrors the STT resolver):
-    1. ``tts.openai.api_key`` / ``tts.openai.base_url`` from ``config.yaml``
-    2. ``VOICE_TOOLS_OPENAI_KEY`` / ``OPENAI_API_KEY`` environment variables
-       (still honoring ``tts.openai.base_url`` when set)
-    3. Managed OpenAI audio tool gateway
+    Strict selection semantics (switch on the stored ``tts`` provider
+    string):
+    - ``"nous"`` (or legacy ``use_gateway: true``) → managed gateway ONLY;
+      unentitled/unreachable is a selection-naming error.
+    - any other stored tts provider → direct credentials ONLY
+      (``tts.openai.api_key`` then ``VOICE_TOOLS_OPENAI_KEY``/
+      ``OPENAI_API_KEY``); missing credentials is a selection-naming error —
+      no silent managed fallback.
+    - never-configured tts section → legacy ladder: config key → env key →
+      managed gateway.
     """
     tts_config = _load_tts_config()
     openai_cfg = (tts_config.get("openai") if isinstance(tts_config, dict) else None) or {}
     cfg_api_key = openai_cfg.get("api_key") or ""
     cfg_base_url = openai_cfg.get("base_url") or ""
-    if cfg_api_key and not prefers_gateway("tts"):
+
+    selected = read_selection("tts")
+
+    if selected == NOUS_MANAGED_PROVIDER:
+        managed_gateway = resolve_managed_tool_gateway("openai-audio")
+        if managed_gateway is None:
+            raise ValueError(selection_error(
+                "tts",
+                NOUS_MANAGED_PROVIDER,
+                "the Nous Tool Gateway is not available (not entitled or "
+                "unreachable)",
+            ))
+        return (
+            managed_gateway.nous_user_token,
+            urljoin(f"{managed_gateway.gateway_origin.rstrip('/')}/", "v1"),
+            True,
+        )
+
+    if selected is not None:
+        # Stored vendor selection: direct credentials only.
+        if cfg_api_key:
+            return cfg_api_key, (cfg_base_url or DEFAULT_OPENAI_BASE_URL), False
+        direct_api_key = resolve_openai_audio_api_key()
+        if direct_api_key:
+            return direct_api_key, (cfg_base_url or DEFAULT_OPENAI_BASE_URL), False
+        raise ValueError(selection_error(
+            "tts",
+            selected,
+            "neither tts.openai.api_key in config nor "
+            "VOICE_TOOLS_OPENAI_KEY/OPENAI_API_KEY is set",
+        ))
+
+    # Never-configured tts section: legacy credential ladder.
+    if cfg_api_key:
         return cfg_api_key, (cfg_base_url or DEFAULT_OPENAI_BASE_URL), False
 
     direct_api_key = resolve_openai_audio_api_key()
-    if direct_api_key and not prefers_gateway("tts"):
+    if direct_api_key:
         return direct_api_key, (cfg_base_url or DEFAULT_OPENAI_BASE_URL), False
 
     managed_gateway = resolve_managed_tool_gateway("openai-audio")
@@ -3811,7 +3857,7 @@ def _resolve_openai_audio_client_config() -> tuple[str, str, bool]:
             "Neither tts.openai.api_key in config nor "
             "VOICE_TOOLS_OPENAI_KEY/OPENAI_API_KEY is set"
         )
-        if managed_nous_tools_enabled() or prefers_gateway("tts"):
+        if managed_nous_tools_enabled():
             message += (
                 ". "
                 + nous_tool_gateway_unavailable_message(
@@ -3828,11 +3874,12 @@ def _resolve_openai_audio_client_config() -> tuple[str, str, bool]:
 
 
 def _has_openai_audio_backend() -> bool:
-    """Return True when OpenAI audio can use config/env credentials or the managed gateway."""
-    openai_cfg = (_load_tts_config().get("openai") or {})
-    if openai_cfg.get("api_key"):
+    """Return True when the selected OpenAI audio route is usable."""
+    try:
+        _resolve_openai_audio_client_config()
         return True
-    return bool(resolve_openai_audio_api_key() or resolve_managed_tool_gateway("openai-audio"))
+    except ValueError:
+        return False
 
 
 # ===========================================================================

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -223,16 +223,36 @@ def _list_registered_web_providers():
 def _get_backend() -> str:
     """Determine which web backend to use (shared fallback).
 
-    Reads ``web.backend`` from config.yaml (set by ``hermes tools``).
-    Falls back to whichever API key is present for users who configured
-    keys manually without running setup.
+    Reads ``web.backend`` from config.yaml (set by ``hermes tools``). A
+    stored backend name is returned as-is — no availability probe, no
+    fallback — so the vendor path can raise its own honest error when the
+    selection is broken. The credential/entitlement autodetect ladder runs
+    ONLY when no web selection has ever been stored.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in _LEGACY_WEB_BACKENDS or _registered_web_provider(configured) is not None:
+    if configured:
+        # Strict: the stored selection is final, known name or not — an
+        # unknown/typoed name surfaces as the vendor path's honest error
+        # rather than silently rerouting through the credential ladder.
+        # The managed "Nous Subscription" selection ("nous") is serviced by
+        # the firecrawl provider, whose client resolver routes it through
+        # the managed Tool Gateway.
+        from tools.tool_backend_helpers import NOUS_MANAGED_PROVIDER
+
+        if configured == NOUS_MANAGED_PROVIDER:
+            return "firecrawl"
         return configured
 
-    # Fallback for manual / legacy config — pick the highest-priority
-    # available backend. Explicit user credentials (TAVILY_API_KEY etc.)
+    from tools.tool_backend_helpers import selection_exists
+
+    if selection_exists("web"):
+        # A web selection exists (e.g. use_gateway key or per-capability
+        # backends) but the shared backend name is empty — keep the
+        # firecrawl default rather than credential-laddering.
+        return "firecrawl"
+
+    # Never-configured install — pick the highest-priority available
+    # backend. Explicit user credentials (TAVILY_API_KEY etc.)
     # beat the managed-tool-gateway probe so a deliberate setup is not
     # pre-empted by a Nous OAuth token whose subscription tier may not
     # actually grant web-search access (the gateway then fails at runtime
@@ -298,12 +318,16 @@ def _get_extract_backend() -> str:
 def _get_capability_backend(capability: str) -> str:
     """Shared helper for per-capability backend selection.
 
-    Reads ``web.{capability}_backend`` from config; if set and available,
-    uses it. Otherwise falls through to the shared ``_get_backend()``.
+    Reads ``web.{capability}_backend`` from config; a stored value is
+    returned unconditionally (strict selection — no availability probe).
+    A selected-but-broken backend surfaces the vendor path's honest error
+    instead of being silently replaced by whatever the credential ladder
+    finds. Falls through to the shared ``_get_backend()`` only when no
+    per-capability override is stored.
     """
     cfg = _load_web_config()
     specific = (cfg.get(f"{capability}_backend") or "").lower().strip()
-    if specific and _is_backend_available(specific):
+    if specific:
         return specific
     return _get_backend()
 
@@ -692,9 +716,35 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         backend = _get_search_backend()
         provider = _wsp_get_provider(backend) if backend else None
         if provider is None or not provider.supports_search():
-            # Fall back to availability-walked active provider when the
-            # configured backend isn't a registered search provider (typo,
-            # uninstalled plugin, or capability mismatch).
+            from tools.tool_backend_helpers import (
+                selection_error,
+                selection_exists,
+            )
+
+            if provider is None and backend and selection_exists("web"):
+                disabled_key = _disabled_web_plugin_for(capability="search")
+                if disabled_key:
+                    _vendor = disabled_key.split("/", 1)[-1]
+                    error_text = (
+                        f"web.search_backend is set to '{_vendor}', but its "
+                        f"plugin ('{disabled_key}') is disabled in config. "
+                        f"Re-enable it with `hermes plugins enable {disabled_key}` "
+                        "(or remove it from plugins.disabled)."
+                    )
+                else:
+                    error_text = selection_error(
+                        "web",
+                        f"'{backend}'",
+                        "no registered web search provider has that name",
+                    )
+                response_data = {"success": False, "error": error_text}
+                result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+                debug_call_data["error"] = error_text
+                _debug.log_call("web_search_tool", debug_call_data)
+                _debug.save()
+                return result_json
+            # Never-configured install: fall back to the availability-walked
+            # active provider (legacy autodetect behavior).
             provider = get_active_search_provider()
 
         if provider is None:
@@ -896,6 +946,35 @@ async def web_extract_tool(
                                 "tavily, exa, or parallel."
                             ),
                         },
+                        ensure_ascii=False,
+                    )
+                from tools.tool_backend_helpers import (
+                    selection_error,
+                    selection_exists,
+                )
+
+                if backend and selection_exists("web"):
+                    # Strict selection: a stored-but-unregistered backend
+                    # errors by name instead of silently switching to
+                    # whatever the availability walk finds.
+                    disabled_key = _disabled_web_plugin_for(capability="extract")
+                    if disabled_key:
+                        _vendor = disabled_key.split("/", 1)[-1]
+                        error_text = (
+                            f"web.extract_backend is set to '{_vendor}', but "
+                            f"its plugin ('{disabled_key}') is disabled in "
+                            f"config. Re-enable it with `hermes plugins "
+                            f"enable {disabled_key}` (or remove it from "
+                            "plugins.disabled)."
+                        )
+                    else:
+                        error_text = selection_error(
+                            "web",
+                            f"'{backend}'",
+                            "no registered web extract provider has that name",
+                        )
+                    return json.dumps(
+                        {"success": False, "error": error_text},
                         ensure_ascii=False,
                     )
                 provider = get_active_extract_provider()


### PR DESCRIPTION
## Summary
The provider you pick in `hermes tools` (or the desktop GUI) is now what runs — always. Runtime tool dispatch no longer chooses backends by sniffing which API keys or entitlements happen to exist: pick Nous Portal → FAL → gpt-image-2 and it uses the managed gateway even if a `FAL_KEY` sits in `.env`; pick BYOK FAL and it uses your key or fails with an error that names your selection — never a silent reroute to another route or account.

This kills the class behind the repeated "wrong provider ran" incidents (most recently: an exhausted personal `FAL_KEY` hijacking image gen from the managed subscription). A pre-PR audit found the same `if <key present> → direct, else → managed` pattern at 10 call sites across all six tool categories; all are replaced.

**The model (one string, no booleans):** each picker row writes one provider value — `provider: nous` for the managed Nous Subscription row, the vendor name (`fal`, `openai`, `firecrawl`, `browser-use`, `camofox`, …) for BYOK rows. Runtime is a switch on that string. `use_gateway` is never written again; old configs are interpreted at read time (`use_gateway: true` ⇒ `nous`), nothing rewritten on disk. Never-configured categories keep today's autodetect, unchanged.

## Changes
- `tools/tool_backend_helpers.py`: `read_selection()` / `selection_exists()` / `selection_error()` — the one shared resolver (folds in the legacy `use_gateway` shim; treats the previously-seeded `stt.provider: local` as no-selection).
- image (`_resolve_managed_fal_gateway`, krea interception) + video FAL: strict switch on the stored selection; krea model-interception only fires with no stored provider.
- TTS/STT OpenAI-audio resolvers: route on the stored selection (the STT one previously never read the stored intent at all).
- web: `_get_capability_backend` no longer silently swaps an unavailable selected backend; firecrawl client no longer silently falls to the managed gateway.
- browser: unknown stored `cloud_provider` = honest error (was warn + autodetect); `camofox` is now a real selection (`CAMOFOX_URL` is just the address); `nous` routes via the managed browser-use gateway.
- `hermes_cli/tools_config.py`: every row persists its provider string (BYOK image FAL included), legacy `use_gateway` keys popped on write, plugin-row clear-gap fixed.
- `hermes_cli/nous_subscription.py`: status/`hermes status` mirrors + setup writers follow the same strict precedence.
- Error contract everywhere: `<category> is configured to use <selection> (set via hermes tools), but <failure>. Run 'hermes tools' to change it.`

## Validation
| | Result |
|---|---|
| New strict-selection suite (per category: managed-wins-over-key, selection-naming error with no managed call, autodetect-unchanged) | 33/33 |
| Touched suites (strict + image env + managed gateways + tools_config) re-run by reviewer | 91/91 |
| Sabotage check (strict switch reverted → managed-selection tests fail, restored) | verified |
| Real-import E2E vs temp HERMES_HOME: `provider: nous`+FAL_KEY⇒nous · `provider: fal`+no key⇒error naming fal/FAL_KEY/hermes tools · legacy `use_gateway: true`⇒nous · never-configured⇒autodetect | 6/6 |
| ruff on touched files | clean |

## Infographic

_Not included: FAL image account for this box is the exhausted direct key this PR exists to stop silently routing around. Will backfill via `gh pr edit`._
