### PR TITLE
fix(cli): read .env (not os.environ) for deprecated cwd warning

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2228,9 +2228,18 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
 
     These env vars are deprecated — the canonical setting is terminal.cwd
     in config.yaml.  Prints a migration hint to stderr.
+
+    Reads the on-disk .env via load_env() rather than os.environ, so
+    runtime bridges (e.g. the CLI exporting TERMINAL_CWD when restoring a
+    session's working directory, or a gateway restarted from such a
+    session) do not trigger a false positive.
     """
-    messaging_cwd = os.environ.get("MESSAGING_CWD")
-    terminal_cwd_env = os.environ.get("TERMINAL_CWD")
+    try:
+        env_map = load_env()
+    except Exception:
+        env_map = {}
+    messaging_cwd = (env_map.get("MESSAGING_CWD") or "").strip() or None
+    terminal_cwd_env = (env_map.get("TERMINAL_CWD") or "").strip() or None
 
     if config is None:
         try:

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -5,25 +5,42 @@ class TestDeprecatedCwdWarning:
     """Warn when MESSAGING_CWD or TERMINAL_CWD is set in .env."""
 
     def test_messaging_cwd_triggers_warning(self, monkeypatch, capsys):
-        monkeypatch.setenv("MESSAGING_CWD", "/some/path")
-        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        import hermes_cli.config as config_mod
 
-        from hermes_cli.config import warn_deprecated_cwd_env_vars
-        warn_deprecated_cwd_env_vars(config={})
+        monkeypatch.setattr(
+            config_mod, "load_env", lambda: {"MESSAGING_CWD": "/some/path"}
+        )
+
+        config_mod.warn_deprecated_cwd_env_vars(config={})
 
         captured = capsys.readouterr()
         assert "MESSAGING_CWD" in captured.err
         assert "deprecated" in captured.err.lower()
         assert "config.yaml" in captured.err
 
-
     def test_both_deprecated_vars_warn(self, monkeypatch, capsys):
-        monkeypatch.setenv("MESSAGING_CWD", "/msg/path")
-        monkeypatch.setenv("TERMINAL_CWD", "/term/path")
+        import hermes_cli.config as config_mod
 
-        from hermes_cli.config import warn_deprecated_cwd_env_vars
-        warn_deprecated_cwd_env_vars(config={})
+        monkeypatch.setattr(
+            config_mod,
+            "load_env",
+            lambda: {"MESSAGING_CWD": "/msg/path", "TERMINAL_CWD": "/term/path"},
+        )
+
+        config_mod.warn_deprecated_cwd_env_vars(config={})
 
         captured = capsys.readouterr()
         assert "MESSAGING_CWD" in captured.err
         assert "TERMINAL_CWD" in captured.err
+
+    def test_process_env_alone_does_not_warn(self, monkeypatch, capsys):
+        """Runtime-bridged TERMINAL_CWD (not in .env) must not false-positive."""
+        import hermes_cli.config as config_mod
+
+        monkeypatch.setattr(config_mod, "load_env", lambda: {})
+        monkeypatch.setenv("TERMINAL_CWD", "/runtime/bridged/path")
+
+        config_mod.warn_deprecated_cwd_env_vars(config={})
+
+        captured = capsys.readouterr()
+        assert "deprecated" not in captured.err.lower()


### PR DESCRIPTION
## Problem

`warn_deprecated_cwd_env_vars()` reads `TERMINAL_CWD` / `MESSAGING_CWD` from `os.environ`. But the CLI itself exports `TERMINAL_CWD` into the process environment at runtime when restoring a session's working directory (and a gateway restarted from such a session inherits it). This produces a **false-positive** deprecation warning on every startup even when the user has already migrated the setting to `terminal.cwd` in `config.yaml` and there is **no** `TERMINAL_CWD` in `.env` at all.

## Fix

Read the on-disk `.env` via `load_env()` instead of `os.environ`, so only a genuine `.env` entry triggers the warning. Runtime-bridged values no longer false-positive.

## Test

Added a regression test (`test_process_env_alone_does_not_warn`) asserting that a `TERMINAL_CWD` present only in the process environment (not in `.env`) does not warn. Existing tests updated to stub `load_env` instead of `monkeypatch.setenv`.

```
tests/hermes_cli/test_deprecated_cwd_warning.py ...  3 passed
```