### PR TITLE
fix(cli): enable editing in custom model prompt

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7578,6 +7578,7 @@ def _prompt_model_selection(
     If *unavailable_models* is provided, those models are shown grayed out
     and unselectable, with an upgrade link to *portal_url*.
     """
+    from hermes_cli.cli_output import line_input
     from hermes_cli.models import (
         _format_price_per_mtok,
         compute_sale_discount,
@@ -7794,7 +7795,7 @@ def _prompt_model_selection(
             return _confirmed_selection(ordered[idx])
         elif idx == len(ordered):
             try:
-                custom = input("Enter model name: ").strip()
+                custom = line_input("Enter model name: ").strip()
             except (EOFError, KeyboardInterrupt):
                 return None
             return _confirmed_selection(custom) if custom else None
@@ -7838,7 +7839,7 @@ def _prompt_model_selection(
             if 1 <= idx <= n:
                 return _confirmed_selection(ordered[idx - 1])
             elif idx == n + 1:
-                custom = input("Enter model name: ").strip()
+                custom = line_input("Enter model name: ").strip()
                 return _confirmed_selection(custom) if custom else None
             elif idx == n + 2:
                 return None

--- a/hermes_cli/cli_output.py
+++ b/hermes_cli/cli_output.py
@@ -5,6 +5,8 @@ functions previously duplicated across setup.py, tools_config.py,
 mcp_config.py, and memory_setup.py.
 """
 
+import sys
+
 from hermes_cli.colors import Colors, color
 from hermes_cli.secret_prompt import masked_secret_prompt
 
@@ -38,6 +40,26 @@ def print_header(text: str) -> None:
 
 
 # ─── Input Prompts ────────────────────────────────────────────────────────────
+
+
+def line_input(prompt_text: str) -> str:
+    """Read non-secret text with normal cursor-editing keys on a real TTY.
+
+    Setup and model-selection commands run outside the interactive chat's
+    prompt-toolkit application, so they can safely use a short-lived prompt
+    here. Redirected input and output retain the built-in ``input`` behavior
+    used by scripts, tests, and numbered fallbacks.
+    """
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return input(prompt_text)
+
+    try:
+        from prompt_toolkit import prompt as prompt_toolkit_prompt
+        from prompt_toolkit.formatted_text import ANSI
+    except ImportError:
+        return input(prompt_text)
+
+    return prompt_toolkit_prompt(ANSI(prompt_text))
 
 
 def prompt(

--- a/tests/hermes_cli/test_cli_output.py
+++ b/tests/hermes_cli/test_cli_output.py
@@ -1,6 +1,47 @@
 from hermes_cli import cli_output
 
 
+class _TTY:
+    def isatty(self):
+        return True
+
+
+class _NotTTY:
+    def isatty(self):
+        return False
+
+
+def test_line_input_supports_cursor_and_emacs_navigation(monkeypatch):
+    from prompt_toolkit.application.current import create_app_session
+    from prompt_toolkit.input.defaults import create_pipe_input
+    from prompt_toolkit.output import DummyOutput
+
+    monkeypatch.setattr(cli_output.sys, "stdin", _TTY())
+    monkeypatch.setattr(cli_output.sys, "stdout", _TTY())
+
+    with create_pipe_input() as pipe_input:
+        # Type "ac", move left, insert "b", move right, append "d", then
+        # exercise Ctrl+A/Ctrl+E before accepting the line.
+        pipe_input.send_text("ac\x1b[Db\x1b[Cd\x01X\x05Y\r")
+        with create_app_session(input=pipe_input, output=DummyOutput()):
+            assert cli_output.line_input("Enter model name: ") == "XabcdY"
+
+
+def test_line_input_preserves_builtin_input_for_redirected_stdin(monkeypatch):
+    seen = {}
+
+    def fake_input(prompt_text):
+        seen["prompt"] = prompt_text
+        return "piped-model"
+
+    monkeypatch.setattr(cli_output.sys, "stdin", _NotTTY())
+    monkeypatch.setattr(cli_output.sys, "stdout", _TTY())
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    assert cli_output.line_input("Enter model name: ") == "piped-model"
+    assert seen["prompt"] == "Enter model name: "
+
+
 def test_password_prompt_uses_masked_secret_prompt(monkeypatch):
     seen = {}
 

--- a/tests/hermes_cli/test_terminal_menu_fallbacks.py
+++ b/tests/hermes_cli/test_terminal_menu_fallbacks.py
@@ -36,6 +36,40 @@ def test_prompt_model_selection_requires_expensive_confirmation(monkeypatch, cap
     assert "EXPENSIVE MODEL WARNING" in out
 
 
+def test_prompt_model_selection_uses_line_editor_for_custom_model(monkeypatch):
+    from hermes_cli.auth import _prompt_model_selection
+
+    monkeypatch.setattr(
+        "hermes_cli.curses_ui.curses_radiolist",
+        lambda _title, choices, **_kwargs: len(choices) - 2,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.cli_output.line_input",
+        lambda prompt_text: (
+            "vendor/edited-model" if prompt_text == "Enter model name: " else ""
+        ),
+    )
+
+    assert _prompt_model_selection(["vendor/default-model"]) == "vendor/edited-model"
+
+
+def test_prompt_model_selection_fallback_uses_line_editor_for_custom_model(
+    monkeypatch,
+):
+    from hermes_cli.auth import _prompt_model_selection
+
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _raise_menu)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "2")
+    monkeypatch.setattr(
+        "hermes_cli.cli_output.line_input",
+        lambda prompt_text: (
+            "vendor/edited-model" if prompt_text == "Enter model name: " else ""
+        ),
+    )
+
+    assert _prompt_model_selection(["vendor/default-model"]) == "vendor/edited-model"
+
+
 def test_remove_custom_provider_falls_back_on_menu_runtime_error(tmp_path, monkeypatch):
     from hermes_cli.main import _remove_custom_provider
 
@@ -58,5 +92,3 @@ def test_remove_custom_provider_falls_back_on_menu_runtime_error(tmp_path, monke
     assert reloaded["custom_providers"] == [
         {"name": "Local B", "base_url": "http://localhost:8002/v1"},
     ]
-
-


### PR DESCRIPTION
## What does this PR do?

Adds normal line editing to the custom model-name prompt. On an interactive terminal, the prompt now uses Hermes' existing `prompt_toolkit` dependency, so Left/Right and Ctrl+A/Ctrl+E edit the entered model name instead of printing raw escape bytes.

The helper is intentionally narrow: redirected input/output keeps the existing built-in `input()` path, imports stay lazy, and password or masked-secret prompts are unchanged.

The root cause was the transition from the curses model picker to a bare `input("Enter model name: ")` call. A scripted Python process does not initialize a readline-style editor for that call, so affected terminals pass cursor keys through as visible VT sequences.

## Related Issue

Reported in the Discord support thread [arrow keys are not correctly processed by CLI wizard](https://discord.com/channels/1053877538025386074/1539761233195180202).

Related open PRs #83045 and #40458 affect the curses picker itself, but neither changes the subsequent custom model-name prompt covered here.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/cli_output.py`: add a TTY-aware non-secret line-input helper backed by `prompt_toolkit`, with the existing built-in `input()` behavior retained for redirected streams or an unavailable dependency.
- `hermes_cli/auth.py`: use that helper in both custom model-name branches, including the numbered fallback.
- `tests/hermes_cli/test_cli_output.py`: cover Left/Right and Ctrl+A/Ctrl+E editing through a real prompt-toolkit pipe, plus the redirected-input fallback.
- `tests/hermes_cli/test_terminal_menu_fallbacks.py`: verify both model-selector paths use the line editor.

## How to Test

1. Run `hermes model` and select a provider with a model picker.
2. Choose `Enter custom model name`.
3. Type a model name, move with Left/Right, and use Ctrl+A/Ctrl+E. The cursor should move and edits should be inserted at its position without visible escape bytes.
4. Run `tests/hermes_cli/test_cli_output.py` and `tests/hermes_cli/test_terminal_menu_fallbacks.py`.

Local validation:

- `ruff check` on all four changed files: passed
- `ruff format --check` on the newly formatted helper and helper-test files: passed
- `git diff --check`: passed
- Focused Python tests were added but not run locally; GitHub CI is expected to run them.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no documented workflow changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Not applicable. The regression is exercised with prompt-toolkit pipe input so the terminal key sequences remain deterministic in CI.
