### PR TITLE
fix(desktop): support custom handles for the default bot

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3805,17 +3805,56 @@ function mergeMultiSourceRoster(local, union, activeConnectionId, previous = [])
   return { ...local, profiles }
 }
 
+function normalizeMentionHandle(value) {
+  const handle = String(value || '').trim().replace(/^@/, '').toLowerCase()
+
+  return NAME_RE.test(handle) && !['all', 'everyone', 'user', 'default'].includes(handle) ? handle : ''
+}
+
 /** The @handle users tag a bot with. Multi-source rosters precompute the
  *  handle (bare name, or name-device when the profile exists on several
- *  registered sources) — prefer it when present. The primary profile's
- *  callable alias is 'hermes' — the mention middleware resolves it back to
- *  'default' — so the word 'default' never surfaces in the UI. */
+ *  registered sources) — prefer it when present. The primary profile may
+ *  persist a custom mention handle in Bot Mode metadata; @hermes remains the
+ *  fallback and backwards-compatible alias. */
 function botHandle(name, bot) {
+  const profile = (name || '').trim().toLowerCase()
+
+  if (profile === 'default') {
+    const inlineMeta = bot?.ui_meta?.[ID]
+    const localMeta = !bot?.remoteSource && typeof $botMeta !== 'undefined' ? $botMeta.get()?.default : null
+    const custom = normalizeMentionHandle(bot?.mentionHandle || inlineMeta?.mentionHandle || localMeta?.mentionHandle)
+    const routed = String(bot?.handle || '').trim()
+
+    if (custom) {
+      if (!routed || routed === name || routed === 'hermes') {
+        return custom
+      }
+      if (routed.toLowerCase().startsWith('default-')) {
+        return custom + routed.slice('default'.length)
+      }
+    }
+
+    return routed && routed !== name ? routed : 'hermes'
+  }
+
   if (bot?.handle && bot.handle !== name) {
     return bot.handle
   }
 
-  return (name || '').trim().toLowerCase() === 'default' ? 'hermes' : name
+  return name
+}
+
+function mentionHandleTaken(handle, currentBot, roster) {
+  const target = String(handle || '').toLowerCase()
+  const currentKey = botRosterKey(currentBot)
+
+  return (roster || []).some(bot => {
+    if (!bot?.name || bot === currentBot || botRosterKey(bot) === currentKey) {
+      return false
+    }
+    const forms = [bot.name, bot.handle, botHandle(bot.name, bot)]
+    return forms.some(form => String(form || '').toLowerCase() === target)
+  })
 }
 
 /** Taggable @-forms derived from a bot's friendly names — the core profile
@@ -3895,11 +3934,21 @@ function resolveRosterMentions(text, roster, active = {}) {
       continue
     }
 
-    const handle = String(botHandle(bot.name, bot) || '').toLowerCase()
+    const rawHandle = botHandle(bot.name, bot)
+    const handle = normalizeMentionHandle(rawHandle) || String(rawHandle || '').toLowerCase()
     const name = String(bot.name || '').toLowerCase()
-    const forms = new Set([handle, name])
+    const isRemoteDefault = name === 'default' && bot.remoteSource
+    const reservedRemoteHandle = isRemoteDefault && ['default', 'hermes'].includes(handle)
+    const forms = new Set([
+      ...(!reservedRemoteHandle ? [handle] : []),
+      ...(!isRemoteDefault ? [name] : [])
+    ])
 
-    if (bot.handle) {
+    if (name === 'default' && !bot.remoteSource) {
+      forms.add('hermes')
+    }
+
+    if (bot.handle && !reservedRemoteHandle) {
       forms.add(String(bot.handle).toLowerCase())
     }
 
@@ -3917,15 +3966,13 @@ function resolveRosterMentions(text, roster, active = {}) {
         continue
       }
 
-      const existing = byForm.get(form)
-
-      if (existing && existing !== bot) {
-        byForm.set(form, null)
+      if (!byForm.has(form)) {
+        byForm.set(form, bot)
         continue
       }
 
-      if (!existing) {
-        byForm.set(form, bot)
+      if (byForm.get(form) !== bot) {
+        byForm.set(form, null)
       }
     }
   }
@@ -4018,7 +4065,8 @@ function botRosterMeta(bot, metaByName) {
 
 function showsHandle(name, meta, bot) {
   const display = displayName({ name }, meta)
-  return Boolean(name && display.toLowerCase() !== botHandle(name, bot).toLowerCase())
+  const identity = bot || { mentionHandle: meta?.mentionHandle }
+  return Boolean(name && display.toLowerCase() !== botHandle(name, identity).toLowerCase())
 }
 
 // ── canonical bot chat ───────────────────────────────────────────────────────
@@ -4433,16 +4481,20 @@ function groupChatMemberBots(group, roster, metaByName) {
  *  here is what keeps the same room intact across machines. */
 function durableGroupChatMembers(bots) {
   return (bots || []).map(bot => {
-    // Keep the friendly identity on the stored descriptor: after a
-    // connection switch the live roster row may be gone, and renamed-tag
-    // mentions must still resolve against the persisted member.
+    // Keep friendly identity and the custom default handle on the stored
+    // descriptor: after a connection switch the live roster row may be gone.
     const title = String(botRosterMeta(bot, $botMeta.get())?.title || bot.ui_meta?.['hermes-bots']?.title || bot.title || '').trim()
+    const localMeta = !bot.remoteSource ? $botMeta.get()?.[bot.name] : null
+    const mentionHandle = (bot.name || '').toLowerCase() === 'default'
+      ? normalizeMentionHandle(bot?.mentionHandle || bot?.ui_meta?.[ID]?.mentionHandle || localMeta?.mentionHandle)
+      : ''
 
     return {
       name: bot.name,
       handle: bot.handle || bot.name,
       ...(title ? { title } : {}),
       ...(bot.display_name ? { display_name: bot.display_name } : {}),
+      ...(mentionHandle ? { mentionHandle } : {}),
       connectionId: bot.connectionId,
       connectionKind: bot.connectionKind,
       connectionLabel: bot.connectionLabel,
@@ -4508,12 +4560,18 @@ function parseGroupChatMentions(text, members) {
     // Cross-connection members are also addressable by their @name-device
     // handle (the roster's disambiguated form) — same-named agents on two
     // machines resolve to the right one.
-    const handle = String(member.handle || botHandle(member.name, member) || '').trim()
+    const handle = String(botHandle(member.name, member) || '').trim()
+    const normalizedHandle = handle.toLowerCase()
+    const isRemoteDefault = member.name.toLowerCase() === 'default' && member.remoteSource
+    const reservedRemoteHandle = isRemoteDefault && ['default', 'hermes'].includes(normalizedHandle)
     const forms = new Set([
-      member.name.toLowerCase(),
-      member.name.toLowerCase().replace(/[\s_-]+/g, ''),
-      ...(handle ? [handle.toLowerCase(), handle.toLowerCase().replace(/[\s_-]+/g, '')] : []),
-      ...(title
+      ...(!isRemoteDefault
+        ? [member.name.toLowerCase(), member.name.toLowerCase().replace(/[\s_-]+/g, '')]
+        : []),
+      ...(handle && !reservedRemoteHandle
+        ? [normalizedHandle, normalizedHandle.replace(/[\s_-]+/g, '')]
+        : []),
+      ...(title && !isRemoteDefault
         ? [title.toLowerCase(), title.toLowerCase().replace(/[\s_-]+/g, ''), title.split(/\s+/)[0].toLowerCase()]
         : [])
     ])
@@ -4527,9 +4585,21 @@ function parseGroupChatMentions(text, members) {
       }
     }
 
+    if (member.name.toLowerCase() === 'default' && !member.remoteSource) {
+      forms.add('hermes')
+    }
+
+    const memberKey = groupMemberKey(member)
     for (const form of forms) {
-      if (form) {
-        handles.set(form, groupMemberKey(member))
+      if (!form) {
+        continue
+      }
+      if (!handles.has(form)) {
+        handles.set(form, memberKey)
+        continue
+      }
+      if (handles.get(form) !== memberKey) {
+        handles.set(form, null)
       }
     }
   }
@@ -5689,7 +5759,7 @@ function singleFlight(ref, start) {
  *  breaking @mentions for customized bots (@wesleysimplicio, #16). */
 function messagingProtocolSection(name, roster) {
   const teammates = (roster || []).filter(b => b.name !== name)
-  const handle = botHandle(name)
+  const handle = botHandle(name, (roster || []).find(bot => bot.name === name))
 
   return [
     '## Messaging other agents',
@@ -7112,6 +7182,7 @@ function EditProfileDialog({ bot, open, onClose }) {
   const [color, setColor] = useState(appearance.color)
   const [image, setImage] = useState(appearance.image)
   const [title, setTitle] = useState(meta?.title || '')
+  const [mentionHandle, setMentionHandle] = useState(meta?.mentionHandle || '')
   const [description, setDescription] = useState(bot?.description || '')
   const [busy, setBusy] = useState(false)
   const [advanced, setAdvanced] = useState(false)
@@ -7127,6 +7198,7 @@ function EditProfileDialog({ bot, open, onClose }) {
       setColor(appearance.color)
       setImage(appearance.image)
       setTitle(meta?.title || '')
+      setMentionHandle(meta?.mentionHandle || '')
       setDescription(bot.description || '')
       setBusy(false)
       setAdvanced(false)
@@ -7143,6 +7215,18 @@ function EditProfileDialog({ bot, open, onClose }) {
       return
     }
 
+    const normalizedMentionHandle = normalizeMentionHandle(mentionHandle)
+
+    if (bot.name === 'default' && mentionHandle.trim() && !normalizedMentionHandle) {
+      host.notify({ kind: 'error', message: 'Handle must use letters, numbers, hyphens, or underscores.' })
+      return
+    }
+
+    if (bot.name === 'default' && mentionHandleTaken(normalizedMentionHandle, bot, $lastRoster.get())) {
+      host.notify({ kind: 'error', message: `@${normalizedMentionHandle} is already used by another profile.` })
+      return
+    }
+
     setBusy(true)
     let advancedFailed = false
     const persistence = await saveBotMeta(bot.name, {
@@ -7151,6 +7235,7 @@ function EditProfileDialog({ bot, open, onClose }) {
       image,
       imageKind: image ? 'photo' : 'shape',
       title: title.trim(),
+      ...(bot.name === 'default' ? { mentionHandle: normalizedMentionHandle } : {}),
       custom: true
     })
     // Only an explicit remote failure is an error — 'unsupported' is the
@@ -7239,6 +7324,25 @@ function EditProfileDialog({ bot, open, onClose }) {
                 onChange: event => setTitle(event.target.value)
               })
             ),
+            bot.name === 'default'
+              ? labeled(
+                  'Handle',
+                  jsxs('div', {
+                    className: 'grid gap-1',
+                    children: [
+                      jsx(Input, {
+                        placeholder: 'hermes',
+                        value: mentionHandle,
+                        onChange: event => setMentionHandle(event.target.value.replace(/^@/, '').toLowerCase())
+                      }),
+                      jsx('div', {
+                        className: 'text-[0.65rem] text-(--ui-text-quaternary)',
+                        children: 'Uniqueness across connected computers is best-effort.'
+                      })
+                    ]
+                  })
+                )
+              : null,
             labeled(
               'Description',
               jsx(Textarea, {
@@ -8842,7 +8946,7 @@ function RoutinesPane() {
                   showsHandle(bot, meta)
                     ? jsx('span', {
                         className: 'shrink-0 font-mono text-[0.65rem] text-(--ui-text-quaternary)',
-                        children: `@${botHandle(bot)}`
+                        children: `@${botHandle(bot, { mentionHandle: meta?.mentionHandle })}`
                       })
                     : null
                 ]
@@ -9557,7 +9661,7 @@ function GroupMentionInput({ members, onChange, onSubmitDraft, value, ...inputPr
     }
 
     for (const member of members) {
-      const handle = String(member.handle || botHandle(member.name, member) || '').trim()
+      const handle = String(botHandle(member.name, member) || '').trim()
       const display = displayName(member, botRosterMeta(member, allMeta))
       // Renamed members complete on their friendly tag; parser resolves both.
       const tag = String(botMentionTag(member) || handle).trim()

--- a/apps/desktop/src/plugins/hermes-bots/tests/bot-meta-sync.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bot-meta-sync.test.mjs
@@ -70,6 +70,23 @@ test('regression: authoritative server metadata removes stale local canonical ch
   assert.equal(Object.hasOwn(writes.at(-1).value.default, 'chat'), false)
 })
 
+test('regression: clearing a custom mention handle overwrites stale local metadata', () => {
+  const writes = []
+  const sync = load()
+  sync.set({ default: { mentionHandle: 'maia', title: 'Maia' } })
+  sync.setPluginCtx({ storage: { set: (key, value) => writes.push({ key, value }) } })
+
+  sync.mergeServerMeta([
+    {
+      name: 'default',
+      ui_meta: { 'hermes-bots': { mentionHandle: '', title: 'Maia' } }
+    }
+  ])
+
+  assert.equal(sync.get().default.mentionHandle, '')
+  assert.equal(writes.at(-1).value.default.mentionHandle, '')
+})
+
 test('regression: authoritative groups remove a stale local legacy group projection', () => {
   const writes = []
   const sync = load()

--- a/apps/desktop/src/plugins/hermes-bots/tests/bots-search.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bots-search.test.mjs
@@ -6,14 +6,17 @@ import vm from 'node:vm'
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
 function loadFilter() {
-  const start = source.indexOf('function botHandle')
+  const nameReStart = source.indexOf('const NAME_RE')
+  const nameReEnd = source.indexOf('\n', nameReStart) + 1
+  const start = source.indexOf('function normalizeMentionHandle')
   const end = source.indexOf('function slugify')
 
+  assert.ok(nameReStart >= 0 && nameReEnd > nameReStart, 'mention-handle grammar must remain extractable')
   assert.ok(start >= 0 && end > start, 'bot identity helper block must remain extractable')
 
   const context = {}
   vm.runInNewContext(
-    `${source.slice(start, end)}\nglobalThis.__filterBots = filterBots;`,
+    `${source.slice(nameReStart, nameReEnd)}\n${source.slice(start, end)}\nglobalThis.__filterBots = filterBots;`,
     context
   )
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -196,7 +196,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, durableGroupChatMembers, botHandle, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -243,6 +243,61 @@ test('mention routing: display titles resolve to the member and @user never matc
   const parsed = gc.parseGroupChatMentions('@theops please check, then ping @user', MEMBERS)
   assert.equal(parsed.mentioned.has('ops'), true)
   assert.equal(parsed.mentioned.size, 1)
+})
+
+test('mention routing: custom default handle resolves while legacy aliases remain valid', () => {
+  const gc = load(() => '(pass)')
+  const members = [{ name: 'default', handle: 'default', mentionHandle: 'maia', title: 'Maia' }]
+
+  assert.equal(gc.botHandle('default', members[0]), 'maia')
+  for (const alias of ['@maia', '@hermes', '@default']) {
+    const parsed = gc.parseGroupChatMentions(`${alias} please check`, members)
+    assert.equal(parsed.mentioned.has('default'), true, `${alias} should resolve to the default profile`)
+  }
+})
+
+test('mention routing: local metadata survives durable group persistence on older gateways', () => {
+  const gc = load(() => '(pass)')
+  gc.$botMeta.set({ default: { mentionHandle: 'maia', title: 'Maia' } })
+  const members = [{ name: 'default', handle: 'default', connectionId: 'local', title: 'Maia' }]
+
+  assert.equal(gc.botHandle('default', members[0]), 'maia')
+  const persisted = gc.durableGroupChatMembers(members)
+  assert.equal(persisted[0].mentionHandle, 'maia')
+
+  gc.$botMeta.set({})
+  assert.equal(gc.parseGroupChatMentions('@maia please check', persisted).mentioned.size, 1)
+})
+
+test('mention routing: legacy aliases target the local default when a remote default is also seated', () => {
+  const gc = load(() => '(pass)')
+  const members = [
+    { name: 'default', handle: 'default', title: 'Hermes' },
+    { name: 'default', handle: 'hermes', connectionId: 'studio', remoteSource: true, sourceScoped: true }
+  ]
+
+  for (const alias of ['@hermes', '@default']) {
+    const parsed = gc.parseGroupChatMentions(`${alias} please check`, members)
+    assert.equal(parsed.mentioned.size, 1)
+    assert.equal(parsed.mentioned.has('default'), true)
+  }
+})
+
+test('mention routing: duplicate forms fail closed even with three matching members', () => {
+  const gc = load(() => '(pass)')
+  const members = [
+    { name: 'alpha', handle: 'shared' },
+    { name: 'beta', handle: 'shared' },
+    { name: 'gamma', handle: 'shared' }
+  ]
+
+  assert.equal(gc.parseGroupChatMentions('@shared please check', members).mentioned.size, 0)
+})
+
+test('source contract: default handle is editable and persisted in Bot Mode metadata', () => {
+  assert.match(pluginSource, /const \[mentionHandle, setMentionHandle\] = useState/)
+  assert.match(pluginSource, /mentionHandle: normalizedMentionHandle/)
+  assert.match(pluginSource, /'Handle'/)
 })
 
 test('a member @-mentioned by another bot joins the NEXT round', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -32,7 +32,7 @@ function runtime() {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__botRosterKey = botRosterKey;\nglobalThis.__botRosterMeta = botRosterMeta;\nglobalThis.__displayName = displayName;\nglobalThis.__filterBots = filterBots;\nglobalThis.__resolveRosterMentions = resolveRosterMentions;'
+      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__normalizeMentionHandle = normalizeMentionHandle;\nglobalThis.__mentionHandleTaken = mentionHandleTaken;\nglobalThis.__botRosterKey = botRosterKey;\nglobalThis.__botRosterMeta = botRosterMeta;\nglobalThis.__displayName = displayName;\nglobalThis.__filterBots = filterBots;\nglobalThis.__resolveRosterMentions = resolveRosterMentions;'
     )
   vm.runInNewContext(code, context)
   return context
@@ -258,6 +258,46 @@ test('botHandle: precomputed multi-source handle wins; default stays hermes', ()
   assert.equal(botHandle('research', { handle: 'research' }), 'research')
   assert.equal(botHandle('research'), 'research')
   assert.equal(botHandle('default'), 'hermes')
+})
+
+test('botHandle: default profile accepts a durable custom mention handle', () => {
+  const { __botHandle: botHandle, __normalizeMentionHandle: normalizeMentionHandle } = runtime()
+  const profile = {
+    name: 'default',
+    handle: 'default',
+    ui_meta: { 'hermes-bots': { mentionHandle: 'maia' } }
+  }
+
+  assert.equal(normalizeMentionHandle('@Maia'), 'maia')
+  assert.equal(normalizeMentionHandle('not valid'), '')
+  assert.equal(normalizeMentionHandle('everyone'), '')
+  assert.equal(botHandle('default', profile), 'maia')
+  assert.equal(botHandle('default', { mentionHandle: 'maia' }), 'maia')
+  assert.equal(botHandle('default', { mentionHandle: 'not valid' }), 'hermes')
+  assert.equal(botHandle('default', { handle: 'default-studio', mentionHandle: 'maia' }), 'maia-studio')
+  assert.equal(botHandle('default', { handle: 'hermes', mentionHandle: 'maia' }), 'maia')
+})
+
+test('mentionHandleTaken rejects profile, routed, and same-named remote collisions', () => {
+  const { __mentionHandleTaken: taken } = runtime()
+  const current = { name: 'default', handle: 'default' }
+  const roster = [
+    current,
+    { name: 'maia', handle: 'maia' },
+    { name: 'research', handle: 'research-studio' },
+    {
+      name: 'default',
+      handle: 'default',
+      connectionId: 'remote',
+      remoteSource: true,
+      ui_meta: { 'hermes-bots': { mentionHandle: 'remote-main' } }
+    }
+  ]
+
+  assert.equal(taken('maia', current, roster), true)
+  assert.equal(taken('research-studio', current, roster), true)
+  assert.equal(taken('remote-main', current, roster), true)
+  assert.equal(taken('unique', current, roster), false)
 })
 
 test('filterBots: matches the source device name for remote rows', () => {
@@ -633,21 +673,65 @@ test('resolveRosterMentions: @dixie and @bob-mac-mini hit Connections bots, not 
 test('resolveRosterMentions: @hermes in this chat is not a handoff to yourself', () => {
   const { __resolveRosterMentions: resolve } = runtime()
   const roster = [
-    { name: 'default', connectionId: 'local', handle: 'hermes' },
+    { name: 'default', connectionId: 'local', handle: 'default' },
     {
       name: 'default',
       connectionId: 'mac-mini',
-      connectionLabel: 'Mac Mini',
       handle: 'default-mac-mini',
-      remoteSource: true
+      remoteSource: true,
+      sourceScoped: true
     }
   ]
 
-  const hits = resolve('ask @hermes and @default-mac-mini', roster, {
+  const selfAlias = resolve('@hermes', roster, {
+    name: 'default',
+    connectionId: 'local'
+  })
+  assert.equal(selfAlias.length, 0)
+
+  const legacyRemote = resolve('@hermes', [
+    roster[0],
+    { ...roster[1], handle: 'hermes' }
+  ], {
+    name: 'default',
+    connectionId: 'local'
+  })
+  assert.equal(legacyRemote.length, 0)
+
+  const hits = resolve('@default-mac-mini', roster, {
     name: 'default',
     connectionId: 'local'
   })
 
   assert.equal(hits.length, 1)
   assert.equal(hits[0].connectionId, 'mac-mini')
+})
+
+test('resolveRosterMentions: custom default handle and @hermes alias target the same profile', () => {
+  const { __resolveRosterMentions: resolve } = runtime()
+  const roster = [
+    {
+      name: 'default',
+      connectionId: 'local',
+      handle: 'default',
+      ui_meta: { 'hermes-bots': { mentionHandle: 'maia' } }
+    },
+    { name: 'dixie', connectionId: 'local', handle: 'dixie' }
+  ]
+
+  for (const alias of ['@maia', '@hermes', '@default']) {
+    const hits = resolve(`${alias} act`, roster, { name: 'dixie', connectionId: 'local' })
+    assert.equal(JSON.stringify(hits.map(bot => bot.name)), JSON.stringify(['default']))
+  }
+})
+
+test('resolveRosterMentions: three-way handle collisions remain ambiguous', () => {
+  const { __resolveRosterMentions: resolve } = runtime()
+  const roster = [
+    { name: 'alpha', handle: 'shared' },
+    { name: 'beta', handle: 'shared' },
+    { name: 'gamma', handle: 'shared' }
+  ]
+
+  assert.equal(resolve('@shared act', roster, { name: 'other' }).length, 0)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/soul-protocol-backfill.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/soul-protocol-backfill.test.mjs
@@ -6,13 +6,16 @@ import vm from 'node:vm'
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
 function loadSoulHelpers({ serverInjects = false } = {}) {
-  const start = source.indexOf('function botHandle(name')
+  const nameReStart = source.indexOf('const NAME_RE')
+  const nameReEnd = source.indexOf('\n', nameReStart) + 1
+  const start = source.indexOf('function normalizeMentionHandle')
   const end = source.indexOf('// ── human-readable row helpers', start)
-  assert.notEqual(start, -1, 'botHandle is missing')
+  assert.ok(nameReStart >= 0 && nameReEnd > nameReStart, 'mention-handle grammar must remain extractable')
+  assert.notEqual(start, -1, 'mention-handle helper block is missing')
   assert.notEqual(end, -1, 'soul-helper section delimiter is missing')
   const context = { serverInjectsProtocol: serverInjects }
   vm.runInNewContext(
-    `${source.slice(start, end)}\nObject.assign(globalThis, { botHandle, hasMessagingProtocol, ensureMessagingProtocol, composeSoul, messagingProtocolSection })`,
+    `${source.slice(nameReStart, nameReEnd)}\n${source.slice(start, end)}\nObject.assign(globalThis, { botHandle, hasMessagingProtocol, ensureMessagingProtocol, composeSoul, messagingProtocolSection })`,
     context
   )
   return context

--- a/tests/tools/test_bot_mode_probe.py
+++ b/tests/tools/test_bot_mode_probe.py
@@ -94,6 +94,20 @@ def test_roster_lines_carry_roles(tmp_path):
     assert "Deep research and literature review" in section
 
 
+def test_default_protocol_uses_custom_bot_mode_handle(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    _make_bot_profile(home, "researcher", managed=True)
+    (home / "profile.yaml").write_text(
+        "ui_meta:\n  hermes-bots:\n    mentionHandle: maia\n",
+        encoding="utf-8",
+    )
+
+    section = bot_mode_probe.get_bot_mode_protocol_section(home)
+    assert "You are `@maia`." in section
+    assert "You are `@hermes`." not in section
+
+
 def test_silent_when_soul_already_carries_protocol(tmp_path):
     """Legacy plugin-side append — never double the section."""
     home = tmp_path / ".hermes"
@@ -173,7 +187,40 @@ def test_fingerprint_changes_on_each_capability_axis(tmp_path):
 
     # teammate added to the roster
     _make_bot_profile(home, "coder", managed=True)
-    assert bot_mode_probe.capability_fingerprint(home) != after_soul
+    after_roster = bot_mode_probe.capability_fingerprint(home)
+    assert after_roster != after_soul
+
+    # default Bot Mode mention handle changed
+    (home / "profile.yaml").write_text(
+        "ui_meta:\n  hermes-bots:\n    mentionHandle: maia\n",
+        encoding="utf-8",
+    )
+    assert bot_mode_probe.capability_fingerprint(home) != after_roster
+
+
+def test_default_protocol_refreshes_after_handle_epoch_change(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    _make_bot_profile(home, "researcher", managed=True)
+    profile = home / "profile.yaml"
+    profile.write_text(
+        "ui_meta:\n  hermes-bots:\n    mentionHandle: maia\n",
+        encoding="utf-8",
+    )
+
+    first = bot_mode_probe.get_bot_mode_protocol_section(home)
+    stamped = first + "\n\n" + bot_mode_probe.epoch_line(home)
+    assert "You are `@maia`." in first
+
+    profile.write_text(
+        "ui_meta:\n  hermes-bots:\n    mentionHandle: luna\n",
+        encoding="utf-8",
+    )
+    assert bot_mode_probe.stored_prompt_capability_stale(stamped, home)
+
+    rebuilt = bot_mode_probe.get_bot_mode_protocol_section(home)
+    assert "You are `@luna`." in rebuilt
+    assert "You are `@maia`." not in rebuilt
 
 
 def test_stored_prompt_staleness(tmp_path):

--- a/tools/bot_mode_probe.py
+++ b/tools/bot_mode_probe.py
@@ -21,8 +21,9 @@ Silent (returns ``""``) when:
 - the current profile's SOUL.md already contains the protocol heading,
 - anything at all goes wrong (never crash a prompt build).
 
-Deterministic within a process: the result is computed once and cached, so
-compression-triggered prompt rebuilds produce identical bytes.
+Deterministic within a capability epoch: the result is cached, so ordinary
+prompt rebuilds produce identical bytes. A detected user-initiated capability
+change refreshes the cache exactly once before rebuilding the stored prompt.
 
 Toggle via ``agent.bot_mode_protocol`` in config.yaml (default True).
 """
@@ -30,6 +31,7 @@ Toggle via ``agent.bot_mode_protocol`` in config.yaml (default True).
 from __future__ import annotations
 
 import os
+import re
 import threading
 from pathlib import Path
 
@@ -100,9 +102,30 @@ def _soul_has_protocol(profile_dir: Path) -> bool:
         return False
 
 
-def _handle(name: str) -> str:
-    # The mention middleware aliases the default profile as @hermes.
-    return "hermes" if name == "default" else name
+def _handle(name: str, profile_dir: Path | None = None) -> str:
+    """Callable Bot Mode handle; default may override @hermes in profile metadata."""
+    if name != "default":
+        return name
+    try:
+        meta = profile_dir / "profile.yaml" if profile_dir else None
+        if meta and meta.is_file():
+            raw = meta.read_text(encoding="utf-8", errors="replace")
+            if "mentionHandle" in raw:
+                import yaml
+
+                data = yaml.safe_load(raw)
+                ui_meta = data.get("ui_meta") if isinstance(data, dict) else None
+                bots = ui_meta.get("hermes-bots") if isinstance(ui_meta, dict) else None
+                custom = ""
+                if isinstance(bots, dict):
+                    custom = str(bots.get("mentionHandle") or "").strip().lstrip("@").lower()
+                if re.fullmatch(r"[a-z0-9][a-z0-9_-]{0,63}", custom) and custom not in {
+                    "all", "everyone", "user", "default"
+                }:
+                    return custom
+    except Exception:
+        pass
+    return "hermes"
 
 
 def _profile_role(profile_dir: Path) -> str:
@@ -145,7 +168,7 @@ def _roster_lines(root: Path, me: str) -> list[str]:
         if name == me:
             continue
         role = _profile_role(profile_dir)
-        handle = _handle(name)
+        handle = _handle(name, profile_dir)
         lines.append(f"- `@{handle}`" + (f" — {role}" if role else ""))
     return lines
 
@@ -203,7 +226,7 @@ def _build_section(home: Path) -> str:
     if _soul_has_protocol(my_dir):
         return ""
 
-    handle = _handle(me)
+    handle = _handle(me, my_dir)
     roster_block = "\n".join(_roster_lines(root, me)) or "- (no teammates yet)"
 
     return (
@@ -321,14 +344,16 @@ def capability_fingerprint(home: str | os.PathLike | None = None) -> str:
     try:
         root = _hermes_root(resolved)
         surface["roster"] = sorted(n for n, d in _roster(root) if _is_bot_managed(d))
-        # Roles are part of the messaging surface: renaming a bot or editing
-        # a profile description must refresh eternal Bot Chat prompts so the
-        # roster block teammates pick recipients from stays current.
+        # Roles and the callable handle are part of the messaging surface:
+        # rename/description/handle edits refresh eternal Bot Chat prompts.
         surface["roster_roles"] = sorted(
             f"{n}:{_profile_role(d)}" for n, d in _roster(root)
         )
+        surface["bot_handle"] = _handle(_profile_name(resolved), resolved)
     except Exception:
         surface["roster"] = []
+        surface["roster_roles"] = []
+        surface["bot_handle"] = ""
     # Protocol-text version salt: bumping this refreshes every eternal Bot
     # Chat prompt ONCE so existing bots adopt a new protocol section (e.g.
     # the v2 message_agent tool replacing the shellout instructions).
@@ -369,7 +394,13 @@ def stored_prompt_capability_stale(stored_prompt: str, home: str | os.PathLike |
         current = capability_fingerprint(home)
         if current == "unavailable":
             return False
-        return m.group(1) != current
+        stale = m.group(1) != current
+        if stale:
+            # The caller rebuilds the stored Bot Chat prompt immediately after
+            # this check. Refresh the rendered protocol in the same epoch
+            # transition so the rebuild cannot reuse stale roster/handle text.
+            get_bot_mode_protocol_section(home, force_refresh=True)
+        return stale
     except Exception:
         return False
 


### PR DESCRIPTION
## Summary

- let Bot Mode users configure a public mention handle for the canonical `default` profile
- use that handle consistently in autocomplete, group chats, handoffs, routines, and backend-injected Bot Chat protocol text
- retain `@hermes` and `@default` as local compatibility aliases while keeping the canonical profile ID unchanged
- reject conflicting handles and fail closed on ambiguous or cross-source mention forms
- use one shared mention-handle validity rule and disclose that cross-machine uniqueness is best-effort

## Why

The Desktop profile editor can give the primary profile a display title, but its callable identity remains hard-coded as `@hermes` in some paths and leaks as `@default` in others. This separates the public mention handle from the stable internal profile ID.

Fixes #89720.

## Verification

- `node --test src/plugins/*/tests/*.test.mjs` — 372 passed
- `pytest tests/tools/test_bot_mode_probe.py -o addopts= -q` — 16 passed
- `npm run typecheck` in `apps/desktop` — passed
- `npm run build` in `apps/desktop` — passed
- `git diff --check` — passed