### PR TITLE
fix(bot-mode): preserve cross-connection group identity

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -665,6 +665,7 @@ function groupChatSyncSnapshot(all = $groupChats.get(), deleted = {}) {
       ...(typeof room?.roomId === 'string' && room.roomId ? { roomId: String(room.roomId).slice(0, 128) } : {}),
       log,
       revision: Math.max(0, Number(room?.syncRevision ?? room?.revision ?? 0)),
+      ...groupChatMembersSchemaField(room),
       members: (Array.isArray(room.members) ? room.members : []).slice(0, GROUP_CHAT_MAX_MEMBERS).map(member => ({
         name: String(member?.name || '').slice(0, 128),
         ...(member?.handle ? { handle: String(member.handle).slice(0, 128) } : {}),
@@ -801,25 +802,39 @@ function mergeGroupChatSyncSnapshots(
     }
 
     // Identity fields (display name, membership, picture) follow the higher
-    // revision; a tie unions members and prefers the local writer's fields.
+    // revision. Legacy ties union members; once either side explicitly marks
+    // its source-qualified member list complete, that complete roster wins
+    // instead of resurrecting stale legacy descriptors during rollout.
     let identity
     let members
+    let membersComplete
     let image
     if (localRevision > remoteRevision) {
       identity = localRoom
       members = [...(localRoom?.members || [])]
+      membersComplete = groupChatHasCompleteMembers(localRoom)
       image = localRoom?.image
     } else if (remoteRevision > localRevision) {
       identity = remoteRoom
       members = [...(remoteRoom?.members || [])]
+      membersComplete = groupChatHasCompleteMembers(remoteRoom)
       image = remoteRoom?.image
     } else {
       identity = localRoom || remoteRoom
-      const byId = new Map()
-      for (const member of [...(remoteRoom?.members || []), ...(localRoom?.members || [])]) {
-        byId.set(groupChatSyncMemberKey(member), member)
+      const localMembersComplete = groupChatHasCompleteMembers(localRoom)
+      const remoteMembersComplete = groupChatHasCompleteMembers(remoteRoom)
+      membersComplete = localMembersComplete || remoteMembersComplete
+      if (localMembersComplete) {
+        members = [...(localRoom?.members || [])]
+      } else if (remoteMembersComplete) {
+        members = [...(remoteRoom?.members || [])]
+      } else {
+        const byId = new Map()
+        for (const member of [...(remoteRoom?.members || []), ...(localRoom?.members || [])]) {
+          byId.set(groupChatSyncMemberKey(member), member)
+        }
+        members = [...byId.values()]
       }
-      members = [...byId.values()]
       image = Object.prototype.hasOwnProperty.call(localRoom || {}, 'image') ? localRoom.image : remoteRoom?.image
     }
     rooms[key] = {
@@ -832,6 +847,7 @@ function mergeGroupChatSyncSnapshots(
         return byTime || groupChatSyncEntryKey(left).localeCompare(groupChatSyncEntryKey(right))
       }),
       members,
+      ...(membersComplete ? { membersSchema: GROUP_CHAT_MEMBERS_SCHEMA } : {}),
       revision: Math.max(remoteRevision, localRevision),
       ...(typeof image === 'string' && image ? { image } : {})
     }
@@ -936,6 +952,8 @@ function mergeRemoteGroupChatSnapshotIntoRooms(
     const existing = (localName ? rooms[localName] : rooms[displayName]) || {}
     const remoteRevision = Math.max(0, Number(projected.revision || 0))
     const localRevision = Math.max(0, Number(existing.syncRevision || 0))
+    const existingMembersComplete = groupChatHasCompleteMembers(existing)
+    const projectedMembersComplete = groupChatHasCompleteMembers(projected)
     const entries = new Map(
       (Array.isArray(existing.log) ? existing.log : []).map(entry => [groupChatSyncEntryKey(entry), entry])
     )
@@ -954,12 +972,25 @@ function mergeRemoteGroupChatSnapshotIntoRooms(
       }
     }
     const isPreserved = preserved.has(displayName) || (localName && preserved.has(localName))
+    let mergedMembersComplete = existingMembersComplete
     if (!isPreserved) {
       if (remoteRevision > localRevision) {
         members.clear()
+        mergedMembersComplete = projectedMembersComplete
+      } else if (remoteRevision === localRevision && projectedMembersComplete && !existingMembersComplete) {
+        // Equal revisions can meet during a mixed-version rollout. Prefer the
+        // side that explicitly declares a complete source-qualified roster.
+        members.clear()
+        mergedMembersComplete = true
       }
-      for (const member of Array.isArray(projected.members) ? projected.members : []) {
-        members.set(groupChatSyncMemberKey(member), { ...member, remoteSource: true })
+
+      // A complete newer/equal roster is authoritative. Conversely, once the
+      // local side has a complete newer roster, an older legacy projection
+      // must not union stale descriptors back into it.
+      if (remoteRevision >= localRevision || !existingMembersComplete) {
+        for (const member of Array.isArray(projected.members) ? projected.members : []) {
+          members.set(groupChatSyncMemberKey(member), { ...member, remoteSource: true })
+        }
       }
     }
 
@@ -986,6 +1017,7 @@ function mergeRemoteGroupChatSnapshotIntoRooms(
       sessions: existing.sessions && typeof existing.sessions === 'object' ? existing.sessions : {},
       stranded: existing.stranded && typeof existing.stranded === 'object' ? existing.stranded : {},
       members: [...members.values()],
+      ...(mergedMembersComplete ? { membersSchema: GROUP_CHAT_MEMBERS_SCHEMA } : { membersSchema: undefined }),
       ...(projectedRoomId || existing.roomId ? { roomId: existing.roomId || projectedRoomId } : {}),
       image: isPreserved
         ? existing.image || null
@@ -1044,6 +1076,7 @@ function durableGroupChatRooms(all = $groupChats.get()) {
       sessions: room.sessions || {},
       stranded: room.stranded || {},
       members: Array.isArray(room.members) ? room.members : [],
+      ...groupChatMembersSchemaField(room),
       // Immutable room identity: without this, a room merged in via the
       // remote-sync path (the only caller of this function) loses its
       // roomId on the next cold hydrate and falls back to legacy
@@ -1056,6 +1089,32 @@ function durableGroupChatRooms(all = $groupChats.get()) {
   }
 
   return durable
+}
+
+/** Lift one persisted room record into the runtime atom shape. Inverse of
+ *  the durable maps above: shape-guards every persisted field and resets the
+ *  runtime-only flags (epoch/running — a loop can't survive a reload). */
+function hydrateStoredGroupChatRoom(room) {
+  return {
+    // Pre-thread entries get synthetic thread ids on hydrate so every
+    // UI/engine path can assume entry.thread exists.
+    log: assignLegacyThreads(room.log),
+    watermarks: room.watermarks && typeof room.watermarks === 'object' ? room.watermarks : {},
+    sessions: room.sessions && typeof room.sessions === 'object' ? room.sessions : {},
+    sessionOwners: room.sessionOwners && typeof room.sessionOwners === 'object' ? room.sessionOwners : {},
+    stranded: room.stranded && typeof room.stranded === 'object' ? room.stranded : {},
+    // #93129: rehydrate sticky stop holds with the same shape guard as the
+    // other maps — a held bot stays held across window restarts until
+    // explicitly released.
+    holds: room.holds && typeof room.holds === 'object' ? room.holds : {},
+    members: Array.isArray(room.members) ? room.members : [],
+    ...groupChatMembersSchemaField(room),
+    roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
+    image: typeof room.image === 'string' && room.image ? room.image : null,
+    syncRevision: Math.max(0, Number(room.syncRevision || 0)),
+    epoch: 0,
+    running: false
+  }
 }
 
 function persistGroupChatRooms(all = $groupChats.get()) {
@@ -4404,67 +4463,77 @@ function PetTab({ image, onImage }) {
  *  Gates every SOUL.md protocol append below. */
 let serverInjectsProtocol = false
 
+/** Load the active gateway's rich profiles and merge the registered
+ *  connection roster over them. Kept outside the React hook so composer
+ *  middleware can resolve a source-qualified @mention even on a cold start,
+ *  before the Bots pane has populated React Query's per-connection cache.
+ *
+ *  The pane uses the backend's name-keyed canonical Bot Chat registry. The
+ *  mention cold-path passes `{ include_sessions: false }` because it only
+ *  needs identity and routing, not session-rich rows. */
+async function loadMultiSourceRoster(activeConnectionId, params = {}) {
+  // Stamp the ISSUE time on the snapshot: mergeServerMeta compares it
+  // against each bot's last local meta write, and a fetch issued before
+  // a write can only carry pre-write ui_meta. (Issue time is the
+  // conservative bound — the server answered no earlier than this.)
+  const issuedAt = Date.now()
+  // Rich rows (last_session, canonical_session, ui_meta, has_avatar)
+  // come from the ACTIVE gateway's profiles.list — the canonical Bot
+  // Chat is resolved server-side by NAME (the "Bot Chat" registry row),
+  // so the roster never sends session pointers.
+  // Refresh the alias identity index alongside the roster: alias routes
+  // (Desktop profile → remote backend root) are what let a backend row
+  // keep its configured friendly identity after activation (#89131).
+  // Best-effort and feature-detected — a failed read keeps the last
+  // good index rather than dropping identities mid-session.
+  if (typeof host.profileRoutes === 'function') {
+    try {
+      indexAliasRoutes(await host.profileRoutes())
+    } catch {
+      /* keep the previous alias index */
+    }
+  }
+  // Owner routing is ambient in the SDK now (post-#92731): requestForBot
+  // resolves the active owner itself, no captured route needed here.
+  const activeBot = { name: String(host.state.profile?.get?.() || 'default').trim() || 'default' }
+  const local = await requestForBot(activeBot, 'profiles.list', params)
+  // Newer backends inject the teammate-messaging protocol into every
+  // session's system prompt (agent.bot_mode_protocol) — SOUL.md must not
+  // carry a second copy. Older gateways lack the flag: keep appending.
+  serverInjectsProtocol = Boolean(local?.bot_mode_protocol)
+
+  // Multi-source desktops (hermes-agent #86875) also expose the union
+  // agent roster across every registered connection. Merge agents from
+  // OTHER sources in as additional rows. Feature-detected + best-effort:
+  // an older Desktop build (no host.agents) or a roster hiccup leaves
+  // the local list exactly as it was.
+  if (typeof host.agents === 'function') {
+    try {
+      const union = await host.agents()
+      const previous = $lastRoster.get().filter(row => !row?.ghost)
+      const merged = mergeMultiSourceRoster(local, union, activeConnectionId, previous)
+      const sources = Array.isArray(union?.sources) ? union.sources : []
+
+      return {
+        ...merged,
+        profiles: (merged?.profiles || []).map(row => annotateBotSource(row, sources)),
+        sources,
+        fetchedAt: issuedAt
+      }
+    } catch {
+      /* older build or roster failure — single-source list stands */
+    }
+  }
+
+  return { ...(local && typeof local === 'object' ? local : {}), fetchedAt: issuedAt }
+}
+
 function useRoster() {
   const activeConnectionId = useValue(host.state.connectionId)
 
   return useQuery({
     queryKey: [...ROSTER_KEY, activeConnectionId],
-    queryFn: async () => {
-      // Stamp the ISSUE time on the snapshot: mergeServerMeta compares it
-      // against each bot's last local meta write, and a fetch issued before
-      // a write can only carry pre-write ui_meta. (Issue time is the
-      // conservative bound — the server answered no earlier than this.)
-      const issuedAt = Date.now()
-      // Rich rows (last_session, canonical_session, ui_meta, has_avatar)
-      // come from the ACTIVE gateway's profiles.list — the canonical Bot
-      // Chat is resolved server-side by NAME (the "Bot Chat" registry row),
-      // so the roster never sends session pointers.
-      // Refresh the alias identity index alongside the roster: alias routes
-      // (Desktop profile → remote backend root) are what let a backend row
-      // keep its configured friendly identity after activation (#89131).
-      // Best-effort and feature-detected — a failed read keeps the last
-      // good index rather than dropping identities mid-session.
-      if (typeof host.profileRoutes === 'function') {
-        try {
-          indexAliasRoutes(await host.profileRoutes())
-        } catch {
-          /* keep the previous alias index */
-        }
-      }
-      // Owner routing is ambient in the SDK now (post-#92731): requestForBot
-      // resolves the active owner itself, no captured route needed here.
-      const activeBot = { name: String(host.state.profile?.get?.() || 'default').trim() || 'default' }
-      const local = await requestForBot(activeBot, 'profiles.list', {})
-      // Newer backends inject the teammate-messaging protocol into every
-      // session's system prompt (agent.bot_mode_protocol) — SOUL.md must not
-      // carry a second copy. Older gateways lack the flag: keep appending.
-      serverInjectsProtocol = Boolean(local?.bot_mode_protocol)
-
-      // Multi-source desktops (hermes-agent #86875) also expose the union
-      // agent roster across every registered connection. Merge agents from
-      // OTHER sources in as additional rows. Feature-detected + best-effort:
-      // an older Desktop build (no host.agents) or a roster hiccup leaves
-      // the local list exactly as it was.
-      if (typeof host.agents === 'function') {
-        try {
-          const union = await host.agents()
-          const previous = $lastRoster.get().filter(row => !row?.ghost)
-          const merged = mergeMultiSourceRoster(local, union, activeConnectionId, previous)
-          const sources = Array.isArray(union?.sources) ? union.sources : []
-
-          return {
-            ...merged,
-            profiles: (merged?.profiles || []).map(row => annotateBotSource(row, sources)),
-            sources,
-            fetchedAt: issuedAt
-          }
-        } catch {
-          /* older build or roster failure — single-source list stands */
-        }
-      }
-
-      return { ...(local && typeof local === 'object' ? local : {}), fetchedAt: issuedAt }
-    },
+    queryFn: () => loadMultiSourceRoster(activeConnectionId),
     refetchInterval: 5000,
     staleTime: 5000,
     // Remote (SSH) gateways connect slowly and drop on sleep/wake; keep
@@ -6055,21 +6124,37 @@ function groupLastActivity(room) {
   return log.length ? log[log.length - 1].at || 0 : 0
 }
 
-/** Seat a group's member roster: local bots whose meta names the group, plus
- *  the room record's stored descriptors (remote members can't ride bot-meta).
- *  Prefers the LIVE roster row for a stored descriptor when present. */
-function groupChatMemberBots(group, roster, metaByName) {
-  const local = (roster || []).filter(
-    bot => botGroups(botRosterMeta(bot, metaByName)).includes(group)
-  )
-  const stored = ($groupChats.get()[group] || {}).members || []
-  const seated = new Set(local.map(botRosterKey))
-  const remote = []
+/** Seat a group's member roster.
+ *
+ *  membersSchema >= 2 means the stored source-qualified list is complete:
+ *  trust it across gateway switches and ignore leftover name-keyed metadata.
+ *
+ *  Unmarked rooms (created before that marker) may have stored only the
+ *  members that were remote at create time. Keep those descriptors, then
+ *  add current meta members whose (connection, profile) is not already
+ *  seated AND whose profile name is not already claimed by a stored
+ *  member. The name guard is what stops a leaked `default` tag from
+ *  seating Hermo next to Marvin after a gateway switch.
+ *
+ *  Rooms with no stored members still fall back to bot-meta grouping. */
+const GROUP_CHAT_MEMBERS_SCHEMA = 2
 
-  for (const descriptor of stored) {
+function groupChatHasCompleteMembers(room) {
+  return Number(room?.membersSchema) >= GROUP_CHAT_MEMBERS_SCHEMA
+}
+
+function groupChatMembersSchemaField(room) {
+  return groupChatHasCompleteMembers(room) ? { membersSchema: GROUP_CHAT_MEMBERS_SCHEMA } : {}
+}
+
+function seatStoredGroupMembers(stored, roster) {
+  const seated = new Set()
+  const members = []
+
+  for (const descriptor of stored || []) {
     const key = botRosterKey(descriptor)
 
-    if (seated.has(key)) {
+    if (!descriptor?.name || seated.has(key)) {
       continue
     }
 
@@ -6077,10 +6162,51 @@ function groupChatMemberBots(group, roster, metaByName) {
     // A selected-but-offline ghost intentionally carries only enough identity
     // to paint the roster. Never let it replace the room's durable descriptor,
     // which owns the full handle/title used by mentions and remote sync.
-    remote.push((roster || []).find(bot => !bot?.ghost && botRosterKey(bot) === key) || descriptor)
+    members.push((roster || []).find(bot => !bot?.ghost && botRosterKey(bot) === key) || descriptor)
   }
 
-  return [...local, ...remote]
+  return { members, seated }
+}
+
+function groupMetaMembers(group, roster, metaByName) {
+  return (roster || []).filter(
+    bot => botGroups(botRosterMeta(bot, metaByName)).includes(group)
+  )
+}
+
+function groupChatMemberBots(group, roster, metaByName) {
+  const room = $groupChats.get()[group] || {}
+  const stored = Array.isArray(room.members) ? room.members : []
+
+  if (groupChatHasCompleteMembers(room)) {
+    return seatStoredGroupMembers(stored, roster).members
+  }
+
+  if (stored.length) {
+    const { members: storedMembers, seated } = seatStoredGroupMembers(stored, roster)
+    const storedNames = new Set(
+      stored.map(member => String(member?.name || '').trim()).filter(Boolean)
+    )
+    const extras = []
+
+    for (const bot of groupMetaMembers(group, roster, metaByName)) {
+      const key = botRosterKey(bot)
+      const name = String(bot?.name || '').trim()
+
+      if (seated.has(key) || (name && storedNames.has(name))) {
+        continue
+      }
+
+      seated.add(key)
+      extras.push(bot)
+    }
+
+    // Historical meta-then-stored order: do not rotate the first speaker
+    // of a legacy room after upgrade.
+    return [...extras, ...storedMembers]
+  }
+
+  return groupMetaMembers(group, roster, metaByName)
 }
 
 /** Persist source-qualified identities for every selected member. The active
@@ -6107,6 +6233,14 @@ function durableGroupChatMembers(bots) {
       sourceScoped: Boolean(route)
     }
   })
+}
+
+/** Write a room's full member roster and mark it complete: from here on the
+ *  stored source-qualified descriptors are authoritative for seating. */
+function writeCompleteGroupMembers(room, bots) {
+  room.members = durableGroupChatMembers(bots)
+  room.membersSchema = GROUP_CHAT_MEMBERS_SCHEMA
+  return room
 }
 
 /** Existing group names, alphabetical — feeds the Manage-groups dialog. */
@@ -6409,6 +6543,7 @@ function updateGroupChat(group, mutate, { sync = true } = {}) {
         // Source-qualified member descriptors keep the room whole when the
         // active connection changes and today's local members become remote.
         members: Array.isArray(room.members) ? room.members : [],
+        ...groupChatMembersSchemaField(room),
         // Immutable room identity: the member-session title for new rooms.
         roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
         // Room picture (small data URL, same normalization as bot avatars).
@@ -6498,6 +6633,7 @@ async function disbandGroupChat(group, members) {
           sessions: room.sessions || {},
           sessionOwners: room.sessionOwners || {},
           members: Array.isArray(room.members) ? room.members : [],
+          ...groupChatMembersSchemaField(room),
           roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
           image: room.image || null,
           syncRevision: Math.max(0, Number(room.syncRevision || 0))
@@ -7575,10 +7711,7 @@ function sendToGroupChat(group, members, text, thread, images) {
   // Refresh the durable room roster on every send. This backfills rooms made
   // by older Desktop builds and keeps the gateway mirror complete even when
   // members overlap across multiple groups.
-  updateGroupChat(group, room => {
-    room.members = durableGroupChatMembers(members)
-    return room
-  })
+  updateGroupChat(group, room => writeCompleteGroupMembers(room, members))
   const sent = appendGroupChatEntry(group, { kind: 'user', name: 'You' }, trimmed, target, attached)
 
   const wasRunning = ($groupChats.get()[group] || {}).running === true
@@ -11527,6 +11660,7 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
 
     updateGroupChat(groupName, room => {
       room.members = roomMembers
+      room.membersSchema = GROUP_CHAT_MEMBERS_SCHEMA
       room.roomId = roomId
 
       if (image) {
@@ -13698,6 +13832,14 @@ function GatewaySectionHeading({ collapsed, count, onToggle, option }) {
   })
 }
 
+/** Group rooms may span registered connections, so the creation affordance is
+ *  available as soon as the full union roster contains two seatable bots.
+ *  Ghost placeholders only paint an offline owner — the dialog cannot seat
+ *  them, so they do not count. */
+function canCreateGroupChat(roster) {
+  return (Array.isArray(roster) ? roster : []).filter(bot => !bot?.ghost).length >= 2
+}
+
 function BotsPane() {
   const { data, error, isLoading, refetch } = useRoster()
   const gatewayState = useValue(host.state.gateway)
@@ -14100,7 +14242,10 @@ function BotsPane() {
                         children: [jsx(Codicon, { name: 'hubot', className: 'mr-1.5' }), 'New Bot']
                       }),
                       jsxs(DropdownMenuItem, {
-                        disabled: activeSourceRoster.length < 2,
+                        // The creation dialog seats the full union roster, so
+                        // one active bot plus one bot on another registered
+                        // connection is enough to start a room.
+                        disabled: !canCreateGroupChat(roster),
                         onSelect: () => setGroupCreateOpen(true),
                         children: [jsx(Codicon, { name: 'organization', className: 'mr-1.5' }), 'New Group Chat']
                       })
@@ -14618,25 +14763,7 @@ export default {
 
             for (const [name, room] of Object.entries(value)) {
               if (room && Array.isArray(room.log)) {
-                rooms[name] = {
-                  // Pre-thread entries get synthetic thread ids on hydrate so
-                  // every UI/engine path can assume entry.thread exists.
-                  log: assignLegacyThreads(room.log),
-                  watermarks: room.watermarks && typeof room.watermarks === 'object' ? room.watermarks : {},
-                  sessions: room.sessions && typeof room.sessions === 'object' ? room.sessions : {},
-                  sessionOwners: room.sessionOwners && typeof room.sessionOwners === 'object' ? room.sessionOwners : {},
-                  stranded: room.stranded && typeof room.stranded === 'object' ? room.stranded : {},
-                  // #93129: rehydrate sticky stop holds with the same shape
-                  // guard as the other maps — a held bot stays held across
-                  // window restarts until explicitly released.
-                  holds: room.holds && typeof room.holds === 'object' ? room.holds : {},
-                  members: Array.isArray(room.members) ? room.members : [],
-                  roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
-                  image: typeof room.image === 'string' && room.image ? room.image : null,
-                  syncRevision: Math.max(0, Number(room.syncRevision || 0)),
-                  epoch: 0,
-                  running: false
-                }
+                rooms[name] = hydrateStoredGroupChatRoom(room)
               }
             }
 
@@ -14986,7 +15113,21 @@ export default {
             connectionId: String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local')
           }
           const cached = cachedUnionRoster()
-          const roster = Array.isArray(cached?.profiles) ? cached.profiles : null
+          let roster = Array.isArray(cached?.profiles) ? cached.profiles : null
+
+          // The Bots pane owns the normal five-second query. Sessions mode
+          // can submit a mention before that pane has ever mounted (or just
+          // after a gateway switch), so populate the same union on demand.
+          // include_sessions: false is intentional — this path only needs
+          // identity/routing, not the pane's session-rich rows.
+          if (!roster) {
+            try {
+              const loaded = await loadMultiSourceRoster(live.connectionId, { include_sessions: false })
+              roster = Array.isArray(loaded?.profiles) ? loaded.profiles : null
+            } catch {
+              /* active-source fallback below preserves legacy behavior */
+            }
+          }
           let mentionedBots = roster ? resolveRosterMentions(text, roster, live) : []
 
           if (!roster) {

--- a/apps/desktop/src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs
@@ -51,7 +51,7 @@ function runtime() {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__x = { botConnectionRoute, scopedBotParams, botBackendProfileScope, requestForBot, groupMemberKey, parseGroupChatMentions, resolveGroupResponders, formatGroupChatLine, buildGroupChatTurnPrompt };\n'
+      '\nglobalThis.__x = { botConnectionRoute, scopedBotParams, botBackendProfileScope, requestForBot, groupMemberKey, parseGroupChatMentions, resolveGroupResponders, formatGroupChatLine, buildGroupChatTurnPrompt, canCreateGroupChat, loadMultiSourceRoster };\n'
     )
   vm.runInNewContext(code, context, { filename: 'plugin.js' })
   return context
@@ -151,6 +151,63 @@ test('advanced capability scope keeps Desktop identity separate from backend tar
     connectionId: 'remote-a',
     profile: 'backend-worker'
   })
+})
+
+test('group creation is enabled for one active bot plus one bot on another connection', () => {
+  const ctx = runtime()
+
+  assert.equal(
+    ctx.__x.canCreateGroupChat([
+      { name: 'marvin', connectionId: 'house-of-marvin' },
+      { name: 'default', connectionId: 'local', remoteSource: true }
+    ]),
+    true
+  )
+})
+
+test('group creation stays disabled when the union roster has only one bot', () => {
+  const ctx = runtime()
+
+  assert.equal(ctx.__x.canCreateGroupChat([{ name: 'marvin', connectionId: 'house-of-marvin' }]), false)
+})
+
+test('group creation ignores presentation-only ghost rows', () => {
+  const ctx = runtime()
+
+  assert.equal(
+    ctx.__x.canCreateGroupChat([
+      { name: 'marvin', connectionId: 'house-of-marvin' },
+      { name: 'spark', connectionId: 'workshop', remoteSource: true, ghost: true }
+    ]),
+    false
+  )
+})
+
+test('cold Sessions roster merges This device while a remote gateway is active', async () => {
+  const ctx = runtime()
+  ctx.host.request = async (method, params) => {
+    assert.equal(method, 'profiles.list')
+    assert.deepEqual(JSON.parse(JSON.stringify(params)), { include_sessions: false })
+    return { profiles: [{ name: 'default' }] }
+  }
+  ctx.host.agents = async () => ({
+    primaryConnectionId: 'house',
+    agents: [
+      { profile: 'default', connectionId: 'house', connectionKind: 'remote', connectionLabel: 'HouseOfMarvin' },
+      { profile: 'lokay', connectionId: 'local', connectionKind: 'local', connectionLabel: 'This device', handle: 'lokay-this-device' }
+    ]
+  })
+
+  const loaded = await ctx.__x.loadMultiSourceRoster('house', { include_sessions: false })
+  const profiles = JSON.parse(JSON.stringify(loaded.profiles))
+
+  assert.equal(profiles.length, 2)
+  assert.equal(profiles[0].name, 'default')
+  assert.equal(profiles[0].connectionId, 'house')
+  assert.equal(profiles[1].name, 'lokay')
+  assert.equal(profiles[1].connectionId, 'local')
+  assert.equal(profiles[1].remoteSource, true)
+  assert.equal(profiles[1].handle, 'lokay-this-device')
 })
 
 test('groupMemberKey: local members keep bare names (persisted-room compat), remote members are source-qualified', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -2028,6 +2028,95 @@ test('durableGroupChatRooms carries roomId — omitting it drops the durable id 
   assert.equal(durable.Legacy.roomId, null, 'a room with no roomId persists an explicit null, not undefined')
 })
 
+test('complete member schema survives projection, pull-before-push, cold merge, and persistence', () => {
+  const gc = load(() => '(pass)')
+  const source = {
+    Team: {
+      log: [{ id: 'user:1', from: { kind: 'user', name: 'You' }, text: 'hello', at: 1 }],
+      watermarks: {},
+      members: [
+        { name: 'default', connectionId: 'house', sourceScoped: true },
+        { name: 'lokay', connectionId: 'local', sourceScoped: true }
+      ],
+      membersSchema: 2,
+      syncRevision: 4
+    }
+  }
+
+  const localSnapshot = gc.groupChatSyncSnapshot(source)
+  const roomKey = Object.keys(localSnapshot.rooms)[0]
+  const pulled = gc.mergeGroupChatSyncSnapshots(
+    {
+      version: 3,
+      rooms: {
+        [roomKey]: {
+          name: 'Team',
+          log: source.Team.log,
+          members: [{ name: 'stale', connectionId: 'old' }],
+          revision: 3
+        }
+      }
+    },
+    localSnapshot,
+    { changedRooms: ['Team'], writeRevision: 5 }
+  )
+  const projected = pulled.rooms[roomKey]
+  const merged = gc.mergeRemoteGroupChatSnapshotIntoRooms(pulled, {})
+  const durable = gc.durableGroupChatRooms(merged)
+
+  assert.equal(projected.membersSchema, 2)
+  assert.equal(projected.members.some(member => member.name === 'stale'), false)
+  assert.equal(merged.Team.membersSchema, 2)
+  assert.equal(durable.Team.membersSchema, 2)
+  assert.equal(merged.Team.members.length, 2)
+})
+
+test('member schema follows the revision whose member list wins', () => {
+  const gc = load(() => '(pass)')
+  const current = {
+    Team: {
+      log: [{ id: 'user:1', from: { kind: 'user', name: 'You' }, text: 'hello', at: 1 }],
+      watermarks: {},
+      members: [
+        { name: 'default', connectionId: 'house', sourceScoped: true },
+        { name: 'lokay', connectionId: 'local', sourceScoped: true }
+      ],
+      membersSchema: 2,
+      syncRevision: 3
+    }
+  }
+  const olderLegacy = {
+    version: 3,
+    rooms: {
+      'name:Team': {
+        name: 'Team',
+        log: current.Team.log,
+        members: [{ name: 'phantom', connectionId: 'old' }],
+        revision: 2
+      }
+    }
+  }
+  const newerLegacy = {
+    version: 3,
+    rooms: {
+      'name:Team': {
+        name: 'Team',
+        log: current.Team.log,
+        members: [{ name: 'default', connectionId: 'house' }],
+        revision: 4
+      }
+    }
+  }
+
+  const kept = gc.mergeRemoteGroupChatSnapshotIntoRooms(olderLegacy, current)
+  const replaced = gc.mergeRemoteGroupChatSnapshotIntoRooms(newerLegacy, current)
+
+  assert.equal(kept.Team.membersSchema, 2)
+  assert.equal(kept.Team.members.some(member => member.name === 'phantom'), false)
+  assert.equal(replaced.Team.membersSchema, undefined)
+  assert.equal(JSON.stringify(replaced.Team.members.map(member => member.name)), JSON.stringify(['default']))
+})
+
 test('remote-merge reachability: a disband tombstone that survives a merge (gateway has not received the delete yet) is never written to storage', async () => {
   const gc = load(() => '(pass)')
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/mention-identification.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/mention-identification.test.mjs
@@ -15,9 +15,11 @@ const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf
 function load({
   activeProfile = 'research',
   focusedProfile = activeProfile,
+  connectionId = 'local',
   profiles = ['research', 'ops'],
   title = null,
   unionProfiles = null,
+  agents = null,
   requestProfileSpy = null
 } = {}) {
   const values = new Map()
@@ -42,11 +44,12 @@ function load({
         }
         return {}
       },
+      ...(agents ? { agents: async () => agents } : {}),
       ...(requestProfileSpy ? { requestProfile: requestProfileSpy } : {}),
       state: {
         profile: { get: () => activeProfile, listen: () => undefined },
         focusedSessionProfile: { get: () => focusedProfile, listen: () => undefined },
-        connectionId: { get: () => 'local', listen: () => undefined },
+        connectionId: { get: () => connectionId, listen: () => undefined },
         gateway: { listen: () => undefined }
       }
     },
@@ -135,6 +138,38 @@ test('remote mentions: identified with their device, never delivered by the rend
   // The renderer must NOT deliver: no requestProfile traffic at all.
   await new Promise(resolve => setTimeout(resolve, 50))
   assert.equal(delivered.length, 0, 'middleware must never deliver over Connections')
+})
+
+test('cold remote-gateway mention loads the union and identifies This device', async () => {
+  const { handler } = load({
+    activeProfile: 'default',
+    focusedProfile: 'default',
+    connectionId: 'house',
+    profiles: [{ name: 'default' }],
+    agents: {
+      primaryConnectionId: 'house',
+      agents: [
+        {
+          profile: 'default',
+          connectionId: 'house',
+          connectionKind: 'remote',
+          connectionLabel: 'HouseOfMarvin'
+        },
+        {
+          profile: 'lokay',
+          connectionId: 'local',
+          connectionKind: 'local',
+          connectionLabel: 'This device',
+          handle: 'lokay-this-device'
+        }
+      ]
+    }
+  })
+
+  const result = await handler({ text: '@lokay-this-device can you inspect the Mac?' })
+
+  assert.match(result.text, /@lokay-this-device = agent profile "lokay"/)
+  assert.match(result.text, /on This device/)
 })
 
 test('unknown @ and emails pass through untouched', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -665,7 +665,9 @@ test('resolveRosterMentions: @hermes in this chat is not a handoff to yourself',
 test('source contract: active roster queries use the SDK ambient owner route', () => {
   assert.doesNotMatch(source, /activeBotRoute/)
   assert.equal(
-    source.match(/requestForBot\(activeBot, 'profiles\.list', \{\}\)/g)?.length,
+    // Roster hydration forwards the caller's params (the mention cold path
+    // passes { include_sessions: false }); the session sweep needs none.
+    source.match(/requestForBot\(activeBot, 'profiles\.list', (?:\{\}|params)\)/g)?.length,
     2,
     'roster hydration and the session sweep must both use the upstream ambient-owner route'
   )

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-groups.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-groups.test.mjs
@@ -30,7 +30,7 @@ function load() {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__groups = { botGroups, groupMembershipPatch, groupChatNames, groupLastActivity, groupChatMemberBots, durableGroupChatMembers, knownGroups, stripPreviewMarkdown, $groupChats };\n'
+      '\nglobalThis.__groups = { botGroups, groupMembershipPatch, groupChatNames, groupLastActivity, groupChatMemberBots, durableGroupChatMembers, writeCompleteGroupMembers, hydrateStoredGroupChatRoom, GROUP_CHAT_MEMBERS_SCHEMA, knownGroups, stripPreviewMarkdown, $groupChats };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   return context.__groups
@@ -151,6 +151,150 @@ test('groupChatMemberBots: stored descriptors beat presentation-only ghosts', ()
   assert.equal(members.length, 1)
   assert.equal(members[0], stored)
   assert.equal(members[0].handle, 'spark-work')
+})
+
+test('groupChatMemberBots: pre-schema Pi+Mac room keeps the local Mac bot from metadata', () => {
+  const { groupChatMemberBots, $groupChats } = load()
+  const roster = [
+    { name: 'default', handle: 'default-this-device', connectionId: 'local' },
+    { name: 'lokay', handle: 'lokay-this-device', connectionId: 'local' },
+    { name: 'default', handle: 'default-houseofmarvin', remoteSource: true, connectionId: 'houseofmarvin' }
+  ]
+  $groupChats.set({
+    'Marvin, Lokay': {
+      log: [],
+      members: [{ name: 'default', handle: 'default-houseofmarvin', remoteSource: true, connectionId: 'houseofmarvin' }]
+    }
+  })
+
+  const members = groupChatMemberBots('Marvin, Lokay', roster, {
+    lokay: { group: 'Marvin, Lokay' }
+  })
+
+  assert.equal(
+    JSON.stringify(members.map(m => `${m.connectionId}::${m.name}`)),
+    JSON.stringify(['local::lokay', 'houseofmarvin::default'])
+  )
+  assert.equal(members[0], roster[1])
+  assert.equal(members[1], roster[2])
+})
+
+test('groupChatMemberBots: leaked default metadata cannot seat a phantom twin on an unmarked complete room', () => {
+  const { groupChatMemberBots, $groupChats } = load()
+  const roster = [
+    { name: 'default', handle: 'default-this-device', connectionId: 'local' },
+    { name: 'lokay', handle: 'lokay-this-device', connectionId: 'local' },
+    { name: 'default', handle: 'default-houseofmarvin', remoteSource: true, connectionId: 'houseofmarvin' }
+  ]
+  $groupChats.set({
+    'Marvin, Lokay': {
+      log: [],
+      members: [
+        { name: 'default', handle: 'default-houseofmarvin', remoteSource: true, connectionId: 'houseofmarvin' },
+        { name: 'lokay', handle: 'lokay-this-device', remoteSource: true, connectionId: 'local' }
+      ]
+    }
+  })
+
+  const members = groupChatMemberBots('Marvin, Lokay', roster, {
+    default: { group: 'Marvin, Lokay' },
+    lokay: { group: 'Marvin, Lokay' }
+  })
+
+  assert.equal(
+    JSON.stringify(members.map(m => `${m.connectionId}::${m.name}`)),
+    JSON.stringify(['houseofmarvin::default', 'local::lokay'])
+  )
+  assert.equal(members[0], roster[2])
+  assert.equal(members[1], roster[1])
+})
+
+test('groupChatMemberBots: schema-2 rooms treat the stored list as complete', () => {
+  const { groupChatMemberBots, GROUP_CHAT_MEMBERS_SCHEMA, $groupChats } = load()
+  const roster = [
+    { name: 'default', handle: 'default-this-device', connectionId: 'local' },
+    { name: 'lokay', handle: 'lokay-this-device', connectionId: 'local' },
+    { name: 'default', handle: 'default-houseofmarvin', remoteSource: true, connectionId: 'houseofmarvin' }
+  ]
+  $groupChats.set({
+    'Marvin, Lokay': {
+      log: [],
+      membersSchema: GROUP_CHAT_MEMBERS_SCHEMA,
+      members: [
+        { name: 'default', handle: 'default-houseofmarvin', remoteSource: true, connectionId: 'houseofmarvin' },
+        { name: 'lokay', handle: 'lokay-this-device', remoteSource: true, connectionId: 'local' }
+      ]
+    }
+  })
+
+  const members = groupChatMemberBots('Marvin, Lokay', roster, {
+    default: { group: 'Marvin, Lokay' },
+    lokay: { group: 'Marvin, Lokay' }
+  })
+
+  assert.equal(
+    JSON.stringify(members.map(m => `${m.connectionId}::${m.name}`)),
+    JSON.stringify(['houseofmarvin::default', 'local::lokay'])
+  )
+})
+
+test('groupChatMemberBots: a complete empty roster cannot be resurrected from legacy metadata', () => {
+  const { groupChatMemberBots, GROUP_CHAT_MEMBERS_SCHEMA, $groupChats } = load()
+  const roster = [{ name: 'researcher' }, { name: 'builder' }]
+
+  $groupChats.set({
+    Research: { log: [], members: [], membersSchema: GROUP_CHAT_MEMBERS_SCHEMA }
+  })
+
+  const members = groupChatMemberBots('Research', roster, {
+    researcher: { group: 'Research' },
+    builder: { group: 'Research' }
+  })
+
+  assert.equal(members.length, 0)
+})
+
+test('groupChatMemberBots: rooms without durable members still use local bot metadata', () => {
+  const { groupChatMemberBots, $groupChats } = load()
+  const roster = [{ name: 'researcher' }, { name: 'builder' }]
+
+  $groupChats.set({ Research: { log: [], members: [] } })
+
+  const members = groupChatMemberBots('Research', roster, {
+    researcher: { group: 'Research' },
+    builder: { groups: ['Ops', 'Research'], group: 'Ops' }
+  })
+
+  assert.equal(JSON.stringify(members.map(m => m.name)), JSON.stringify(['researcher', 'builder']))
+})
+
+test('writeCompleteGroupMembers: stamps schema 2 onto every selected identity', () => {
+  const { writeCompleteGroupMembers, durableGroupChatMembers, GROUP_CHAT_MEMBERS_SCHEMA } = load()
+  const selected = [
+    { name: 'default', handle: 'default-houseofmarvin', connectionId: 'houseofmarvin', connectionLabel: 'HouseOfMarvin' },
+    { name: 'lokay', handle: 'lokay-this-device', connectionId: 'local', connectionLabel: 'This device' }
+  ]
+  const room = writeCompleteGroupMembers({}, selected)
+
+  assert.equal(room.membersSchema, GROUP_CHAT_MEMBERS_SCHEMA)
+  assert.equal(GROUP_CHAT_MEMBERS_SCHEMA, 2)
+  assert.deepEqual(JSON.parse(JSON.stringify(room.members)), JSON.parse(JSON.stringify(durableGroupChatMembers(selected))))
+})
+
+test('hydrateStoredGroupChatRoom: preserves complete-member schema but leaves legacy rooms unmarked', () => {
+  const { hydrateStoredGroupChatRoom, GROUP_CHAT_MEMBERS_SCHEMA } = load()
+  const base = {
+    log: [{ from: { kind: 'user', name: 'You' }, text: 'hello', at: 1 }],
+    members: [{ name: 'lokay', connectionId: 'local' }]
+  }
+
+  const current = hydrateStoredGroupChatRoom({ ...base, membersSchema: GROUP_CHAT_MEMBERS_SCHEMA })
+  const legacy = hydrateStoredGroupChatRoom(base)
+
+  assert.equal(current.membersSchema, GROUP_CHAT_MEMBERS_SCHEMA)
+  assert.equal(Object.prototype.hasOwnProperty.call(legacy, 'membersSchema'), false)
+  assert.equal(current.running, false)
+  assert.equal(current.epoch, 0)
 })
 
 test('durableGroupChatMembers: retains active and remote source identities', () => {


### PR DESCRIPTION
## Summary

Rebased onto current `main` and hardened the cross-connection identity fix:

- enable **New Group Chat** from the full multi-connection roster, rather than only the active gateway
- route a `This device` member through `{ connectionId: 'local', mode: 'local' }` while a remote gateway is active
- share one multi-source roster loader between the Bots pane and cold Sessions mentions; the cold path intentionally requests identity/routing only with `include_sessions: false`
- preserve current `main` behavior where mention middleware identifies the target and the agent owns messaging
- mark complete source-qualified room rosters with `membersSchema: 2`, and preserve that marker through local hydration, gateway projection, pull-before-push reconciliation, fan-out, and durable persistence
- migrate unmarked legacy rooms by retaining stored remote descriptors plus valid local metadata members, while guarding against a same-name `default` profile being reseated as a phantom after a gateway switch

## Root causes

Three independent routing/identity gaps blocked the documented mixed-gateway room:

1. The group menu checked the active-source roster even though the dialog already received the union roster.
2. `botConnectionRoute` rejected `connectionId === "local"`, so a This-device member could fall back to the active remote gateway.
3. Legacy room seating mixed durable source-qualified descriptors with name-keyed metadata after a gateway switch, which could either lose an old local member or introduce a same-name phantom.

## Compatibility and migration

New rooms and rooms refreshed by a send persist every selected source identity and carry schema 2. Unmarked rooms remain on a compatibility path because older builds may have stored only remote descriptors; they are upgraded on the next send. Revision arbitration keeps the schema marker attached to the member list that actually wins, so mixed-version gateways cannot silently union stale members back into a newer complete roster.

This also addresses the automated review migration finding and documents why the cold loader omits session-rich rows.

## Verification

- `npm run check:test:plugins` — 375/375 passed
- `npm run check:lint` — typecheck and ESLint passed with 0 errors (existing repository warnings only)
- `npm run build` — production desktop build passed
- targeted behavior coverage includes local/remote request routing, union-roster group creation, cold mention lookup, legacy-room migration, phantom prevention, schema persistence, and revision arbitration
