### PR TITLE
fix(desktop): re-arm the project tree root load after a store reset

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
@@ -5,7 +5,12 @@ import type { HermesReadDirResult } from '@/global'
 import { $connection } from '@/store/session'
 
 import { clearProjectDirCache, readProjectDir } from './ipc'
-import { resetProjectTreeState, useProjectTree } from './use-project-tree'
+import {
+  isUnownedProjectTree,
+  readProjectTreeState,
+  resetProjectTreeState,
+  useProjectTree
+} from './use-project-tree'
 
 const readDir = vi.fn<(path: string) => Promise<HermesReadDirResult>>()
 
@@ -347,5 +352,31 @@ describe('useProjectTree', () => {
 
     expect(readDir.mock.calls.length).toBe(settled)
     expect(second.result.current.data.map(n => n.name)).toEqual(['in-/b'])
+  })
+})
+
+describe('the reset contract', () => {
+  // The re-arm effect fires on "the store is unowned". Nothing else in the
+  // module asserts that a reset actually PRODUCES an unowned store, so a
+  // change to how the reset represents that state would disarm the re-arm
+  // and every behavioural test above would still pass: they all reset first,
+  // so they would agree with each other about a broken shape.
+  it('leaves the store unowned', () => {
+    resetProjectTreeState()
+
+    expect(isUnownedProjectTree(readProjectTreeState())).toBe(true)
+  })
+
+  it('does not call a store owned by a live cwd unowned', async () => {
+    readDir.mockResolvedValue(ok([]))
+
+    const view = renderHook(() => useProjectTree('/repo'))
+
+    await waitFor(() => {
+      expect(view.result.current.rootLoading).toBe(false)
+    })
+
+    expect(readProjectTreeState().cwd).toBe('/repo')
+    expect(isUnownedProjectTree(readProjectTreeState())).toBe(false)
   })
 })

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
@@ -269,4 +269,83 @@ describe('useProjectTree', () => {
     await waitFor(() => expect(result.current.rootError).toBe('no-bridge'))
     expect(result.current.data).toEqual([])
   })
+  it('reloads the root after a mid-flight reset instead of sticking on the skeleton', async () => {
+    // #90229. A gateway boot calls resetProjectTreeState() from
+    // useGatewayBoot({ beforeConnectionSwitch }), which can land while the
+    // first root read is still in flight. The completion is then correctly
+    // abandoned -- the store no longer owns this cwd -- but nothing re-armed a
+    // replacement, so the tree waited forever.
+    let release: (result: HermesReadDirResult) => void = () => {}
+
+    readDir.mockImplementationOnce(
+      () =>
+        new Promise<HermesReadDirResult>(resolve => {
+          release = resolve
+        })
+    )
+    readDir.mockResolvedValue(ok([{ name: 'src', path: '/p/src', isDirectory: true }]))
+
+    const { result } = renderHook(() => useProjectTree('/p'))
+
+    await waitFor(() => expect(readDir).toHaveBeenCalledTimes(1))
+    expect(result.current.rootLoading).toBe(true)
+
+    act(() => {
+      resetProjectTreeState()
+    })
+
+    await act(async () => {
+      release(ok([{ name: 'stale', path: '/p/stale', isDirectory: false }]))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(result.current.data.map(n => n.name)).toEqual(['src']))
+    // rootLoading feeds `disabled` on the sidebar's Refresh button, so a stuck
+    // `true` is what left the user with no way out.
+    expect(result.current.rootLoading).toBe(false)
+    expect(result.current.rootError).toBeNull()
+  })
+
+  it('reloads the root after a reset that lands once the tree is already loaded', async () => {
+    // Same defect without the race: the load effect depends only on
+    // [connectionKey, cwd], and a reset changes neither, so a reset at any
+    // moment orphaned the tree until one of those happened to change.
+    readDir.mockResolvedValue(ok([{ name: 'src', path: '/p/src', isDirectory: true }]))
+
+    const { result } = renderHook(() => useProjectTree('/p'))
+
+    await waitFor(() => expect(result.current.data.length).toBe(1))
+
+    act(() => {
+      resetProjectTreeState()
+    })
+
+    await waitFor(() => expect(result.current.data.map(n => n.name)).toEqual(['src']))
+    expect(result.current.rootLoading).toBe(false)
+    expect(readDir).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not re-arm when a different cwd owns the store', async () => {
+    // The re-arm keys on the CLEARED store (cwd: ''), not on any mismatch. The
+    // atom is global, so two mounted consumers with different cwds would
+    // otherwise each keep re-claiming it and loop forever.
+    readDir.mockImplementation(async path => ok([{ name: `in-${path}`, path: `${path}/x`, isDirectory: false }]))
+
+    const first = renderHook(() => useProjectTree('/a'))
+
+    await waitFor(() => expect(first.result.current.data.length).toBe(1))
+
+    const second = renderHook(() => useProjectTree('/b'))
+
+    await waitFor(() => expect(second.result.current.data.length).toBe(1))
+
+    const settled = readDir.mock.calls.length
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 20))
+    })
+
+    expect(readDir.mock.calls.length).toBe(settled)
+    expect(second.result.current.data.map(n => n.name)).toEqual(['in-/b'])
+  })
 })

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
@@ -105,7 +105,7 @@ export interface UseProjectTreeResult {
   setNodeOpen: (id: string, open: boolean) => void
 }
 
-interface ProjectTreeState {
+export interface ProjectTreeState {
   collapseNonce: number
   cwd: string
   data: TreeNode[]
@@ -148,6 +148,27 @@ function clearProjectTree() {
   nextRootRequestId += 1
   inflight.clear()
   $projectTree.set({ ...initialState, requestId: nextRootRequestId })
+}
+
+/** True when the store belongs to no consumer: `clearProjectTree` has wiped
+ *  it and nothing has claimed a cwd since.
+ *
+ *  This is the reset contract, and it lives here rather than at the one place
+ *  that reads it so a caller never has to know *how* "unowned" is spelled.
+ *  Today it is `cwd: ''` straight out of `initialState`, which is also what
+ *  `clearProjectTree` writes -- the two cannot drift because they name the
+ *  same object. If the representation ever becomes a generation counter or an
+ *  explicit null owner, this function changes and the re-arm effect keeps
+ *  working, instead of silently going quiet again (#90229). */
+export function isUnownedProjectTree(state: ProjectTreeState): boolean {
+  return state.cwd === initialState.cwd
+}
+
+/** Read-only view of the store, exported for the reset-contract test.
+ *  The re-arm effect's correctness depends on what a reset LEAVES BEHIND, and
+ *  a test that can only see the hook's rendered output cannot assert that. */
+export function readProjectTreeState(): ProjectTreeState {
+  return $projectTree.get()
 }
 
 /** Sessions record their launch cwd; deleted worktrees and remote-backend
@@ -450,17 +471,20 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
   // `rootLoading: Boolean(cwd)` forever, which also disables the Refresh
   // button, so there is no way back (#90229).
   //
-  // Keyed on the CLEARED store (`cwd: ''`), not on any mismatch: the atom is
-  // global, so a mismatch against a different non-empty cwd means another
-  // consumer owns it, and re-claiming that would ping-pong. Converges because
+  // Keyed on the CLEARED store, not on any mismatch: the atom is global, so a
+  // mismatch against a different non-empty cwd means another consumer owns it,
+  // and re-claiming that would ping-pong. What "cleared" means is
+  // `isUnownedProjectTree`'s to say, not this effect's. Converges because
   // `loadRoot` writes its cwd into the store before its first await.
+  const treeIsUnowned = isUnownedProjectTree(state)
+
   useEffect(() => {
-    if (!cwd || state.cwd !== '') {
+    if (!cwd || !treeIsUnowned) {
       return
     }
 
     void loadRoot(cwd)
-  }, [cwd, state.cwd, state.requestId])
+  }, [cwd, treeIsUnowned, state.requestId])
 
   // Self-heal: an errored root re-probes every few seconds while the tree is
   // mounted. Each attempt bumps requestId, so a persistent error re-arms the

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
@@ -440,6 +440,28 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
     void loadRoot(cwd)
   }, [connectionKey, cwd])
 
+  // Re-arm after the store is reset out from under us. `resetProjectTreeState`
+  // fires on gateway boot / connection switch, and can land while a root read
+  // is in flight: the completion above is then correctly abandoned (the store
+  // no longer owns this cwd), but nothing starts a replacement. The effect
+  // above only depends on [connectionKey, cwd], neither of which a reset
+  // changes, and both self-heal effects below are gated on `state.cwd === cwd`
+  // -- the very condition the reset broke. The tree then reports
+  // `rootLoading: Boolean(cwd)` forever, which also disables the Refresh
+  // button, so there is no way back (#90229).
+  //
+  // Keyed on the CLEARED store (`cwd: ''`), not on any mismatch: the atom is
+  // global, so a mismatch against a different non-empty cwd means another
+  // consumer owns it, and re-claiming that would ping-pong. Converges because
+  // `loadRoot` writes its cwd into the store before its first await.
+  useEffect(() => {
+    if (!cwd || state.cwd !== '') {
+      return
+    }
+
+    void loadRoot(cwd)
+  }, [cwd, state.cwd, state.requestId])
+
   // Self-heal: an errored root re-probes every few seconds while the tree is
   // mounted. Each attempt bumps requestId, so a persistent error re-arms the
   // timer; a success clears rootError and stops it.


### PR DESCRIPTION
## The bug is not a slow filesystem

The tree is not waiting on a directory read. The store has been reset out from under the hook, and nothing re-arms a load.

`resetProjectTreeState()` runs on gateway boot, from `useGatewayBoot({ beforeConnectionSwitch })` in `src/app/contrib/wiring.tsx`. It calls `clearProjectTree()`, which resets the atom to `cwd: ''` and bumps `requestId`. When that lands after the last `loadRoot` for the current cwd - most visibly while the first root read is still in flight - the in-flight completion is correctly abandoned:

```ts
setProjectTree(latest => {
  if (latest.cwd !== cwd || latest.requestId !== requestId) {
    return latest      // abandoned
  }
  ...
```

but nothing starts a replacement. Three things have to be true at once, and they are:

1. **Nothing re-runs the load.** The only effect that starts a root load depends on `[connectionKey, cwd]`. A reset changes neither.
2. **Neither self-heal can see it.** The errored-root re-probe and the fallback re-probe are both gated on `state.cwd === cwd` - the exact condition the reset broke. They are written to heal a tree the store still owns.
3. **The hook then invents a loading state.** `rootLoading: state.cwd === cwd ? state.rootLoading : Boolean(cwd)`. With the store cleared, that is a synthesized `true` that no completion will ever clear.

## Why Refresh is dead rather than the way out

That synthesized `true` is the same value the button is keyed on. `right-sidebar/index.tsx` passes it down as `loading`, and the refresh control is `disabled={loading}`. So the one control that would call `loadRoot(cwd, { force: true })` and fix everything is disabled by the state it would clear. The user is left with the reporter's "restart the app".

## Why one boot in three and not every boot

Whenever the boot sequence happens to change `connectionKey` *after* the reset, the load effect re-runs (`connectionChanged` -> `loadRoot(cwd, { force: true })`) and the tree recovers silently. The stuck case is the ordering where the reset is the last write to the store. Restarting re-rolls that ordering, which is why the reporter sees it intermittently and why restarting sometimes appears to fix it.

## Changes Made

- **`apps/desktop/src/app/right-sidebar/files/use-project-tree.ts`** - one effect that re-arms `loadRoot(cwd)` when the store is in its cleared shape.
- **`apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts`** - two regression tests that reproduce the stuck tree, and one guardrail that pins why the re-arm condition is narrow.

### Why it keys on the cleared store rather than on any mismatch

The obvious version is `if (state.cwd !== cwd) loadRoot(cwd)`. That is wrong, and the third test exists to keep it from being "simplified" back:

`$projectTree` is a module-level atom shared by every consumer. A mismatch against a **different non-empty cwd** means another consumer currently owns the store, and re-claiming it would make two mounted hooks take turns forever. A reset is distinguishable because it always leaves `cwd: ''`, so that is what the effect keys on.

### Why it terminates

`loadRoot` writes its `cwd` into the store synchronously, before its first `await`. So the effect's own action falsifies its guard on the next render, whether the read succeeds, fails, or is abandoned again.

### Why not just stop synthesizing `rootLoading: true`

Reporting `false` there would re-enable the Refresh button, which is a real improvement, but it leaves the tree blank until the user notices and clicks. The state after a reset is genuinely "should be loading and isn't", and the fix for that is to load, not to relabel it. The synthesized value is left alone, and this change makes it honest again by making the load real.

## Related Issue

Fixes #90229

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## How to Test

```
cd apps/desktop
npx vitest run --project ui src/app/right-sidebar/files/use-project-tree.test.ts
```

## Verification

**Both regression tests fail on `main` and pass with the fix.** Measured, not asserted:

```
without the fix   Tests  2 failed | 14 passed (16)
with the fix      Tests  16 passed (16)
```

The failures are the symptom itself - `expected [] to deeply equal [ 'src' ]` with `rootLoading` still `true`.

- `reloads the root after a mid-flight reset instead of sticking on the skeleton` - holds the first `readDir` open, fires `resetProjectTreeState()`, then releases the stale read. Asserts the stale entries never land, a fresh read is armed, and `rootLoading` ends `false`.
- `reloads the root after a reset that lands once the tree is already loaded` - the same defect without the race, which is the simpler half of it: a reset at *any* moment orphans the tree, because `[connectionKey, cwd]` did not change.
- `does not re-arm when a different cwd owns the store` - mounts two consumers with different cwds and asserts the IPC call count stops growing. This is the ping-pong guardrail; it passes both with and without the fix by design, because its job is to constrain the fix, not to prove the bug.

**Mutation proof.** Each mutation applied to `use-project-tree.ts`, suite re-run:

| # | Mutation | Result |
|---|---|---|
| 1 | the re-arm effect is removed entirely (this is `main`) | **caught** - 2 failed \| 14 passed |
| 2 | re-arm on **any** cwd mismatch instead of the cleared store | **caught** - the suite *hangs*, which is the ping-pong itself: two consumers take the store from each other forever |
| 3 | `state.cwd` drops out of the dependency array | **caught** - 2 failed \| 14 passed |
| 4 | the empty-cwd guard is dropped | **caught** - 14 failed \| 2 passed (`loadRoot('')` clears the store, which re-triggers the effect) |
| 5 | the effect fires but loads nothing | **caught** - 2 failed \| 14 passed |

5/5. Mutation 2 is the one worth reading: it is the "simpler" version of this fix, and it does not fail an assertion, it never terminates. That is why the third test measures a call count rather than a value.

**Suite delta, measured rather than assumed.** `vitest run --project ui`, Windows 11:

```
pristine upstream/main   4 failed | 537 passed (541 files)   14 failed | 5047 passed
this branch              3 failed | 538 passed (541 files)   13 failed | 5051 passed
```

This branch's failing set is a strict subset of main's (`gateway-settings`, `skills/index`, `session-unread-tile`; main additionally fails `messaging/index`). All four are `waitFor` timeouts unrelated to the file tree, and all four pass when run in isolation on pristine main - they are load-dependent flakes on this machine, not regressions. `tsc -p tsconfig.json --noEmit` and `eslint` on the changed files are both clean.

**Platform:** Windows 11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the tests and all pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation or N/A: the effect carries the mechanism and the reason its condition is narrow
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A: no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): the issue is labelled `platform/windows` but the defect is not - it is renderer state ordering with no platform-specific code on the path. The fix is platform-neutral and the tests run in jsdom.
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## Note on the `needs-repro` label

This reproduces deterministically in a unit test now, so the label can come off. The two regression tests are the repro.
