### PR TITLE
fix(desktop): keep Win11 chat windows opaque unless glass is on

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -259,6 +259,7 @@ import {
   chatWindowWebPreferences,
   createSessionWindowRegistry,
   instanceWindowBounds,
+  parseSessionWindowUrl,
   SESSION_WINDOW_MIN_HEIGHT,
   SESSION_WINDOW_MIN_WIDTH
 } from './session-windows'
@@ -271,13 +272,15 @@ import { registerTerminalIpc } from './terminal-ipc'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
 import {
   backgroundMaterialFor,
+  chatWindowNeedsSurfaceRecreate,
+  chatWindowSurfaceOptions as chatWindowSurfaceOptionsFor,
   glassActive,
   glassSupportedOn,
   normalizeState as normalizeTranslucency,
   translucencySupportedOn,
   vibrancyFor as vibrancyForTranslucency,
-  windowBackingOptions,
-  windowOpacityFor
+  windowOpacityFor,
+  windowsChatWindowTransparent
 } from './translucency'
 import {
   compareApiUrl,
@@ -890,6 +893,13 @@ function writePersistedTranslucency(state) {
 }
 
 let translucencyState = readPersistedTranslucency()
+let replacingChatSurfaces = false
+
+let chatSurfaceBornTransparent = windowsChatWindowTransparent(
+  process.platform,
+  GLASS_SUPPORTED,
+  translucencyState
+)
 
 // Chat windows whose webContents backing follows translucency (primary,
 // instance peers, session windows). The HUD / pet overlay / quick entry /
@@ -973,24 +983,141 @@ function applyWindowTranslucency(win, changed = { backing: true, material: true,
 // toggle can re-apply. The HUD, pet overlay, quick entry and wake indicator
 // are `transparent: true` windows that own their backgrounds and are
 // deliberately not chat windows.
+//
+// On glass-capable Windows, `transparent: true` is only set while glass is
+// actually on. DWM Snap / FancyZones ignore transparent frames, and Electron
+// cannot flip `transparent` after construction, so a Clear↔Glass crossing
+// recreates these windows (see recreateChatWindowsForSurface).
 function chatWindowSurfaceOptions() {
-  return {
-    vibrancy: IS_MAC ? vibrancyForTranslucency(translucencyState) : undefined,
-    // Pin the material to its ACTIVE appearance: several NSVisualEffectView
-    // materials collapse to a shared inactive look when the window blurs
-    // (measured on macOS 26: sidebar, popover and under-window composited
-    // pixel-identically once unfocused), which would quietly erase the
-    // user's frost choice whenever they click elsewhere. Only observable
-    // under glass — everywhere else the page buries the material.
-    visualEffectState: IS_MAC ? ('active' as const) : undefined,
-    // Win11 DWM materials only reach the client area on a transparent window
-    // (electron#49443). Chat windows on glass-capable Windows are born
-    // transparent so a live Clear→Glass toggle doesn't need a recreate; the
-    // opaque themed backgroundColor covers it while glass is off.
-    ...(IS_WINDOWS && GLASS_SUPPORTED ? { transparent: true } : {}),
-    backgroundMaterial: IS_WINDOWS && GLASS_SUPPORTED ? backgroundMaterialFor(translucencyState) : undefined,
-    opacity: windowOpacity(),
-    ...windowBackingOptions(translucencyState, getWindowBackgroundColor())
+  return chatWindowSurfaceOptionsFor({
+    platform: process.platform,
+    glassSupported: GLASS_SUPPORTED,
+    state: translucencyState,
+    themedColor: getWindowBackgroundColor()
+  })
+}
+
+function applyChatWindowGeometry(win, snapshot) {
+  if (!win || win.isDestroyed() || !snapshot) {
+    return
+  }
+
+  if (snapshot.fullScreen && typeof win.setFullScreen === 'function') {
+    win.setFullScreen(true)
+
+    return
+  }
+
+  if (typeof win.unmaximize === 'function' && typeof win.isMaximized === 'function' && win.isMaximized() && !snapshot.maximized) {
+    win.unmaximize()
+  }
+
+  if (snapshot.maximized && typeof win.maximize === 'function') {
+    win.maximize()
+
+    return
+  }
+
+  if (snapshot.bounds && typeof win.setBounds === 'function') {
+    win.setBounds(snapshot.bounds)
+  }
+}
+
+// `transparent` is constructor-only. When glass crosses the active threshold
+// on Win11, destroy and re-birth every chat surface so Snap works while glass
+// is off and DWM materials can paint while it is on. HUD / pet / quick-entry
+// are not chat surfaces and stay put.
+function recreateChatWindowsForSurface() {
+  const snapshots = []
+
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!translucencyBackedWindows.has(win) || win.isDestroyed()) {
+      continue
+    }
+
+    const url = typeof win.webContents?.getURL === 'function' ? win.webContents.getURL() : ''
+    const session = parseSessionWindowUrl(url)
+
+    snapshots.push({
+      kind: win === mainWindow ? 'main' : session ? 'session' : 'instance',
+      bounds: typeof win.getBounds === 'function' ? win.getBounds() : null,
+      maximized: typeof win.isMaximized === 'function' && win.isMaximized(),
+      fullScreen: typeof win.isFullScreen === 'function' && win.isFullScreen(),
+      visible: typeof win.isVisible === 'function' ? win.isVisible() : true,
+      minimized: typeof win.isMinimized === 'function' && win.isMinimized(),
+      focused: typeof win.isFocused === 'function' && win.isFocused(),
+      url,
+      sessionId: session?.sessionId,
+      watch: session?.watch === true
+    })
+  }
+
+  if (snapshots.length === 0) {
+    return
+  }
+
+  replacingChatSurfaces = true
+
+  try {
+    if (translucencyWriteTimer) {
+      clearTimeout(translucencyWriteTimer)
+      translucencyWriteTimer = null
+    }
+
+    writePersistedTranslucency(translucencyState)
+
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (translucencyBackedWindows.has(win) && !win.isDestroyed()) {
+        win.destroy()
+      }
+    }
+
+    for (const snapshot of snapshots) {
+      const startHidden = snapshot.visible === false
+      const startMinimized = snapshot.minimized === true && snapshot.visible !== false
+      const startFocused = snapshot.focused === true
+
+      if (snapshot.kind === 'main') {
+        createWindow({ startHidden, startMinimized, startFocused, applySavedMaximize: false })
+
+        applyChatWindowGeometry(mainWindow, snapshot)
+
+        if (snapshot.url) {
+          loadWindowUrl(mainWindow, snapshot.url, 'Main window')
+        }
+
+        continue
+      }
+
+      if (snapshot.kind === 'session' && snapshot.sessionId) {
+        const next = createSessionWindow(snapshot.sessionId, {
+          watch: snapshot.watch,
+          startHidden,
+          startMinimized,
+          startFocused
+        })
+
+        applyChatWindowGeometry(next, snapshot)
+
+        continue
+      }
+
+      const next = createInstanceWindow({ startHidden, startMinimized, startFocused })
+
+      applyChatWindowGeometry(next, snapshot)
+
+      if (snapshot.url) {
+        loadWindowUrl(next, snapshot.url, 'Instance window')
+      }
+    }
+
+    chatSurfaceBornTransparent = windowsChatWindowTransparent(
+      process.platform,
+      GLASS_SUPPORTED,
+      translucencyState
+    )
+  } finally {
+    replacingChatSurfaces = false
   }
 }
 
@@ -10730,6 +10857,24 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
 // reveal, then fall back a few seconds after the renderer loads. `show` and
 // `onRevealed` carry the caller's reveal action and post-visible work; whichever
 // path wins runs them exactly once.
+function chatWindowRevealShow(win, { startHidden = false, startMinimized = false, startFocused = false } = {}) {
+  if (startHidden) {
+    return () => {}
+  }
+
+  return () => {
+    if (startFocused || typeof win.showInactive !== 'function') {
+      win.show()
+    } else {
+      win.showInactive()
+    }
+
+    if (startMinimized && typeof win.minimize === 'function') {
+      win.minimize()
+    }
+  }
+}
+
 function wireWindowReveal(win, { show, onRevealed }: { show?: () => void; onRevealed?: () => void } = {}) {
   const controller = createWindowRevealController(
     {
@@ -10770,7 +10915,19 @@ function focusWindow(win) {
   win.focus()
 }
 
-function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?: boolean } = {}) {
+function spawnSecondaryWindow({
+  sessionId,
+  watch,
+  startHidden = false,
+  startMinimized = false,
+  startFocused = true
+}: {
+  sessionId?: string
+  watch?: boolean
+  startHidden?: boolean
+  startMinimized?: boolean
+  startFocused?: boolean
+} = {}) {
   const icon = getAppIconPath()
 
   const win = new BrowserWindow({
@@ -10802,7 +10959,9 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
     win.setWindowButtonPosition?.(WINDOW_BUTTON_POSITION)
   }
 
-  wireWindowReveal(win)
+  wireWindowReveal(win, {
+    show: chatWindowRevealShow(win, { startHidden, startMinimized, startFocused })
+  })
 
   win.on('enter-full-screen', () => sendWindowStateChanged(true))
   win.on('leave-full-screen', () => sendWindowStateChanged(false))
@@ -10842,8 +11001,13 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
 }
 
 // Open (or focus) a standalone window for a single chat session.
-function createSessionWindow(sessionId, { watch = false } = {}) {
-  return sessionWindows.openOrFocus(sessionId, () => spawnSecondaryWindow({ sessionId, watch }))
+function createSessionWindow(
+  sessionId,
+  { watch = false, startHidden = false, startMinimized = false, startFocused = true } = {}
+) {
+  return sessionWindows.openOrFocus(sessionId, () =>
+    spawnSecondaryWindow({ sessionId, watch, startHidden, startMinimized, startFocused })
+  )
 }
 
 // Additional full "instance" windows — peers of the primary that render the
@@ -10873,7 +11037,7 @@ function nextInstanceBounds() {
 // primary: it never overwrites the mainWindow global, doesn't start the backend
 // (the renderer's getConnection() joins the already-running one), and loads the
 // plain renderer URL so the full app renders.
-function createInstanceWindow() {
+function createInstanceWindow({ startHidden = false, startMinimized = false, startFocused = true } = {}) {
   const icon = getAppIconPath()
 
   const win = new BrowserWindow({
@@ -10899,7 +11063,9 @@ function createInstanceWindow() {
     win.setWindowButtonPosition?.(WINDOW_BUTTON_POSITION)
   }
 
-  wireWindowReveal(win)
+  wireWindowReveal(win, {
+    show: chatWindowRevealShow(win, { startHidden, startMinimized, startFocused })
+  })
 
   // Per-window fullscreen chrome: send this window its own titlebar inset so its
   // traffic lights hide/show independently of the primary.
@@ -11729,7 +11895,12 @@ function closeQuickEntryWindow() {
   quickEntryWindow = null
 }
 
-function createWindow() {
+function createWindow({
+  startHidden = false,
+  startMinimized = false,
+  startFocused = true,
+  applySavedMaximize = true
+} = {}) {
   const icon = getAppIconPath()
   const savedWindowState = readWindowState()
   mainWindow = new BrowserWindow({
@@ -11784,11 +11955,12 @@ function createWindow() {
     }
   }
 
-  if (savedWindowState?.isMaximized) {
+  if (applySavedMaximize && savedWindowState?.isMaximized) {
     mainWindow.maximize()
   }
 
   const revealController = wireWindowReveal(createdMainWindow, {
+    show: chatWindowRevealShow(createdMainWindow, { startHidden, startMinimized, startFocused }),
     onRevealed: () => {
       // Persist geometry as soon as the window is visible so a crash before the
       // first clean resize/move/close still captures the restored bounds (#56726).
@@ -11840,8 +12012,10 @@ function createWindow() {
 
   // the closed wrapper remains truthy, so clear only the window this callback owns.
   mainWindow.on('closed', () => {
-    closePetOverlay()
-    wakeIndicatorController.close()
+    if (!replacingChatSurfaces) {
+      closePetOverlay()
+      wakeIndicatorController.close()
+    }
 
     if (mainWindow === createdMainWindow) {
       mainWindow = null
@@ -13835,7 +14009,8 @@ ipcMain.on('hermes:native-theme', (_event, mode) => {
 })
 
 // See-through window translucency. Persist + re-apply to every open window at
-// runtime (no recreation, so caching/sessions are untouched).
+// runtime. Crossing glass-on on Windows recreates chat windows because
+// `transparent` is constructor-only (see recreateChatWindowsForSurface).
 //
 // The intensity slider is a HOT path: ~100 updates per drag. Two things make
 // that cheap. Native work is diffed, so an intensity-only change under glass
@@ -13857,9 +14032,41 @@ function scheduleTranslucencyWrite() {
   }, 250)
 }
 
+// The glass lever crosses `glassActive` on the first notch (0→1). Recreating
+// there unmounts Settings and drops the rest of the drag. Wait for the
+// trailing edge — one remount after the hand leaves the slider.
+let chatSurfaceRecreateTimer = null
+
+function scheduleChatSurfaceRecreate() {
+  if (chatSurfaceRecreateTimer) {
+    clearTimeout(chatSurfaceRecreateTimer)
+  }
+
+  chatSurfaceRecreateTimer = setTimeout(() => {
+    chatSurfaceRecreateTimer = null
+
+    const wantTransparent = windowsChatWindowTransparent(
+      process.platform,
+      GLASS_SUPPORTED,
+      translucencyState
+    )
+
+    if (wantTransparent === chatSurfaceBornTransparent) {
+      return
+    }
+
+    recreateChatWindowsForSurface()
+  }, 200)
+}
+
 // Flush a pending write before the process can exit, so a quit landing inside
-// the debounce window doesn't lose the setting.
+// the debounce window doesn't lose the setting. Do not recreate mid-quit.
 app.on('before-quit', () => {
+  if (chatSurfaceRecreateTimer) {
+    clearTimeout(chatSurfaceRecreateTimer)
+    chatSurfaceRecreateTimer = null
+  }
+
   if (translucencyWriteTimer) {
     clearTimeout(translucencyWriteTimer)
     translucencyWriteTimer = null
@@ -13872,6 +14079,10 @@ app.on('before-quit', () => {
 // itself. Registered at module scope, which runs long before any window.
 ipcMain.on('hermes:translucency:support', event => {
   event.returnValue = { glass: GLASS_SUPPORTED, translucency: TRANSLUCENCY_SUPPORTED }
+})
+
+ipcMain.on('hermes:translucency:current', event => {
+  event.returnValue = translucencyState
 })
 
 ipcMain.on('hermes:translucency', (_event, payload) => {
@@ -13904,8 +14115,20 @@ ipcMain.on('hermes:translucency', (_event, payload) => {
   // The HUD's frost reads the same setting but answers on its own terms (see
   // hudFrostFor) — and it is a transparent window, so it is deliberately not
   // in the chat fan-out below. It self-diffs, so an unrelated change costs
-  // nothing native.
+  // nothing native. Apply even when chat windows remount: the HUD is not in
+  // that recreate set.
   hudIpc.applyHudFrost()
+
+  if (
+    chatWindowNeedsSurfaceRecreate(previous, next, process.platform, GLASS_SUPPORTED) ||
+    chatSurfaceRecreateTimer
+  ) {
+    // Rearm on every later slider tick so the remount waits for pointer-up,
+    // not 200ms after the first 0→1 notch.
+    scheduleChatSurfaceRecreate()
+
+    return
+  }
 
   if (changed.backing || changed.material || changed.opacity) {
     for (const win of BrowserWindow.getAllWindows()) {
@@ -14912,6 +15135,13 @@ app.on('before-quit', event => {
 })
 
 app.on('window-all-closed', () => {
+  // Recreating chat windows for a Windows glass surface swap destroys every
+  // translucency-backed window before the replacements exist. That is not a
+  // user close — do not quit the process in the gap.
+  if (replacingChatSurfaces) {
+    return
+  }
+
   // macOS convention: keep the process alive in the Dock when the user closes
   // the last window. But when we're handing off to a detached updater / swap /
   // uninstall script, the process MUST exit so the script can replace or remove

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -8,10 +8,12 @@ import { contextBridge, ipcRenderer, webFrame, webUtils } from 'electron'
 // "Desktop IPC bridge is unavailable"). No reply means no glass, which degrades
 // to an ordinary opaque window rather than a page thinned over nothing.
 const translucencySupport = ipcRenderer.sendSync('hermes:translucency:support')
+const translucencyCurrent = ipcRenderer.sendSync('hermes:translucency:current')
 
 contextBridge.exposeInMainWorld('hermesDesktop', {
   glassSupported: translucencySupport?.glass === true,
   translucencySupported: translucencySupport?.translucency === true,
+  translucency: translucencyCurrent && typeof translucencyCurrent === 'object' ? translucencyCurrent : undefined,
   getConnection: profile => ipcRenderer.invoke('hermes:connection', profile),
   // Registry-scoped backend resolution: { connectionId, profile } → descriptor.
   getConnectionFor: payload => ipcRenderer.invoke('hermes:connection:for', payload),

--- a/apps/desktop/electron/session-windows.test.ts
+++ b/apps/desktop/electron/session-windows.test.ts
@@ -6,7 +6,8 @@ import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
   createSessionWindowRegistry,
-  instanceWindowBounds
+  instanceWindowBounds,
+  parseSessionWindowUrl
 } from './session-windows'
 
 // A minimal fake BrowserWindow: tracks listeners + destroyed state and lets a
@@ -54,6 +55,24 @@ function makeFakeWindow() {
     calls
   }
 }
+
+test('parseSessionWindowUrl is the inverse of buildSessionWindowUrl', () => {
+  const built = buildSessionWindowUrl('abc123', { devServer: 'http://localhost:5173', watch: true })
+
+  assert.deepEqual(parseSessionWindowUrl(built), { sessionId: 'abc123', watch: true })
+  assert.deepEqual(parseSessionWindowUrl(buildSessionWindowUrl('a b/c', { devServer: 'http://localhost:5173' })), {
+    sessionId: 'a b/c',
+    watch: false
+  })
+  assert.deepEqual(
+    parseSessionWindowUrl(
+      buildSessionWindowUrl('sess-1', { rendererIndexPath: 'C:/Users/app/resources/app.asar/index.html' })
+    ),
+    { sessionId: 'sess-1', watch: false }
+  )
+  assert.equal(parseSessionWindowUrl('http://localhost:5173/#/abc123'), null)
+  assert.equal(parseSessionWindowUrl('not a url'), null)
+})
 
 test('buildSessionWindowUrl puts the secondary flag before the hash route (dev server)', () => {
   const url = buildSessionWindowUrl('abc123', { devServer: 'http://localhost:5173' })

--- a/apps/desktop/electron/session-windows.ts
+++ b/apps/desktop/electron/session-windows.ts
@@ -77,6 +77,31 @@ function buildSessionWindowUrl(sessionId: string, { devServer, rendererIndexPath
   return `${pathToFileURL(rendererIndexPath).toString()}${query}${route}`
 }
 
+function parseSessionWindowUrl(url: string): { sessionId: string; watch: boolean } | null {
+  if (typeof url !== 'string' || !url) {
+    return null
+  }
+
+  try {
+    const parsed = new URL(url)
+
+    if (parsed.searchParams.get('win') !== 'secondary') {
+      return null
+    }
+
+    const hash = parsed.hash.startsWith('#') ? parsed.hash.slice(1) : parsed.hash
+    const sessionId = decodeURIComponent(hash.replace(/^\/+/, '').split('/')[0] || '')
+
+    if (!sessionId) {
+      return null
+    }
+
+    return { sessionId, watch: parsed.searchParams.get('watch') === '1' }
+  } catch {
+    return null
+  }
+}
+
 // Full "instance" windows (⌘⇧N / the "New Window" command) open a complete app
 // peer, not a compact chat. Cascade each one off its source window's bounds so a
 // new window doesn't land exactly on top of the one it was spawned from. Pure so
@@ -164,6 +189,7 @@ export {
   chatWindowWebPreferences,
   createSessionWindowRegistry,
   instanceWindowBounds,
+  parseSessionWindowUrl,
   SESSION_WINDOW_MIN_HEIGHT,
   SESSION_WINDOW_MIN_WIDTH
 }

--- a/apps/desktop/electron/tests/chat-window-surface.test.ts
+++ b/apps/desktop/electron/tests/chat-window-surface.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Windows chat windows must be ordinary opaque DWM windows while glass is off.
+ * `transparent: true` is constructor-only, so turning glass on/off requires a
+ * recreate when that bit would change. These helpers are the contract main
+ * applies at birth and on the Settings toggle.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  chatWindowNeedsSurfaceRecreate,
+  chatWindowSurfaceOptions,
+  DEFAULT_GLASS_MATERIAL,
+  DEFAULT_GLASS_SCOPE,
+  type TranslucencyState,
+  windowsChatWindowTransparent
+} from '../translucency'
+
+const clear = (intensity: number): TranslucencyState => ({
+  intensity,
+  fade: 0,
+  mode: 'clear',
+  material: DEFAULT_GLASS_MATERIAL,
+  scope: DEFAULT_GLASS_SCOPE
+})
+
+const glass = (intensity: number, material = DEFAULT_GLASS_MATERIAL): TranslucencyState => ({
+  intensity,
+  fade: 0,
+  mode: 'glass',
+  material,
+  scope: DEFAULT_GLASS_SCOPE
+})
+
+const themed = '#101014'
+
+describe('windowsChatWindowTransparent', () => {
+  it('is off for the default Win11 profile (glass selected, intensity 0)', () => {
+    expect(windowsChatWindowTransparent('win32', true, glass(0))).toBe(false)
+    expect(windowsChatWindowTransparent('win32', true, clear(0))).toBe(false)
+    expect(windowsChatWindowTransparent('win32', true, clear(60))).toBe(false)
+  })
+
+  it('is on only when glass is actually active on a glass-capable Windows host', () => {
+    expect(windowsChatWindowTransparent('win32', true, glass(60))).toBe(true)
+    expect(windowsChatWindowTransparent('win32', false, glass(60))).toBe(false)
+    expect(windowsChatWindowTransparent('darwin', true, glass(60))).toBe(false)
+    expect(windowsChatWindowTransparent('linux', true, glass(60))).toBe(false)
+  })
+})
+
+describe('chatWindowSurfaceOptions', () => {
+  it('does not birth a Win11 window transparent while glass is off', () => {
+    const off = chatWindowSurfaceOptions({
+      platform: 'win32',
+      glassSupported: true,
+      state: glass(0),
+      themedColor: themed
+    })
+
+    expect(off.transparent).toBeUndefined()
+    expect(off.backgroundMaterial).toBe('none')
+    expect(off.backgroundColor).toBe(themed)
+  })
+
+  it('births a Win11 window transparent only while glass is active', () => {
+    const on = chatWindowSurfaceOptions({
+      platform: 'win32',
+      glassSupported: true,
+      state: glass(60),
+      themedColor: themed
+    })
+
+    expect(on.transparent).toBe(true)
+    expect(on.backgroundMaterial).not.toBe('none')
+    expect(on.backgroundColor).toBeUndefined()
+  })
+
+  it('never sets Windows transparent on macOS or unsupported Windows', () => {
+    expect(
+      chatWindowSurfaceOptions({
+        platform: 'darwin',
+        glassSupported: true,
+        state: glass(60),
+        themedColor: themed
+      }).transparent
+    ).toBeUndefined()
+    expect(
+      chatWindowSurfaceOptions({
+        platform: 'win32',
+        glassSupported: false,
+        state: glass(60),
+        themedColor: themed
+      }).transparent
+    ).toBeUndefined()
+  })
+})
+
+describe('chatWindowNeedsSurfaceRecreate', () => {
+  it('is required on glass-capable Windows when glass crosses the active threshold', () => {
+    expect(chatWindowNeedsSurfaceRecreate(glass(0), glass(1), 'win32', true)).toBe(true)
+    expect(chatWindowNeedsSurfaceRecreate(glass(1), glass(0), 'win32', true)).toBe(true)
+    expect(chatWindowNeedsSurfaceRecreate(clear(60), glass(60), 'win32', true)).toBe(true)
+    expect(chatWindowNeedsSurfaceRecreate(glass(60), clear(60), 'win32', true)).toBe(true)
+    // A 0→1 crossing is the first notch of a drag, not a completed gesture.
+    // Main must trailing-debounce recreate so Settings is not torn down mid-drag.
+    expect(chatWindowNeedsSurfaceRecreate(glass(0), glass(60), 'win32', true)).toBe(true)
+  })
+
+  it('is not required for tint/frost/fade ticks or on platforms that can swap live', () => {
+    expect(chatWindowNeedsSurfaceRecreate(glass(40), glass(41), 'win32', true)).toBe(false)
+    expect(chatWindowNeedsSurfaceRecreate(clear(40), clear(41), 'win32', true)).toBe(false)
+    expect(chatWindowNeedsSurfaceRecreate(glass(0), glass(1), 'darwin', true)).toBe(false)
+    expect(chatWindowNeedsSurfaceRecreate(glass(0), glass(1), 'win32', false)).toBe(false)
+  })
+})

--- a/apps/desktop/electron/translucency.test.ts
+++ b/apps/desktop/electron/translucency.test.ts
@@ -24,6 +24,7 @@ import {
   glassSupportedOn,
   glassSurfaceKeep,
   hudFrostFor,
+  hydrateTranslucencyState,
   normalizeMaterial,
   normalizeMode,
   normalizeScope,
@@ -448,6 +449,16 @@ describe('normalizeState', () => {
       ...base,
       mode: 'clear'
     })
+  })
+})
+
+describe('hydrateTranslucencyState', () => {
+  it('prefers main seed so a remount does not bounce stale localStorage', () => {
+    const stale = glass(0)
+    const live = glass(60)
+
+    expect(hydrateTranslucencyState(live, stale, true)).toEqual(live)
+    expect(hydrateTranslucencyState(undefined, stale, true)).toEqual(stale)
   })
 })
 

--- a/apps/desktop/electron/translucency.ts
+++ b/apps/desktop/electron/translucency.ts
@@ -11,7 +11,14 @@
  * then fail to bundle.
  */
 
-import { glassActive, type TranslucencyState } from '../../shared/src/translucency'
+import {
+  backgroundMaterialFor,
+  glassActive,
+  type TranslucencyState,
+  vibrancyFor,
+  windowOpacityFor,
+  type WindowsBackgroundMaterial
+} from '../../shared/src/translucency'
 
 export {
   backgroundMaterialFor,
@@ -27,6 +34,7 @@ export {
   glassSupportedOn,
   glassSurfaceKeep,
   hudFrostFor,
+  hydrateTranslucencyState,
   normalizeMaterial,
   normalizeMode,
   normalizeScope,
@@ -65,4 +73,62 @@ export {
  */
 export function windowBackingOptions(state: TranslucencyState, themedColor: string): { backgroundColor?: string } {
   return glassActive(state) ? {} : { backgroundColor: themedColor }
+}
+
+/**
+ * Electron only honours `transparent` at BrowserWindow construction. DWM Snap
+ * and FancyZones treat a transparent window as outside normal frame hit-testing,
+ * so a glass-capable Windows chat window must stay opaque until glass is
+ * actually on. Turning glass on later therefore needs a recreate — the live
+ * `setBackgroundMaterial` path cannot add transparency after the fact
+ * (electron#49443).
+ */
+export function windowsChatWindowTransparent(
+  platform: string,
+  glassSupported: boolean,
+  state: TranslucencyState
+): boolean {
+  return platform === 'win32' && glassSupported && glassActive(state)
+}
+
+export function chatWindowNeedsSurfaceRecreate(
+  previous: TranslucencyState,
+  next: TranslucencyState,
+  platform: string,
+  glassSupported: boolean
+): boolean {
+  return (
+    windowsChatWindowTransparent(platform, glassSupported, previous) !==
+    windowsChatWindowTransparent(platform, glassSupported, next)
+  )
+}
+
+export type ChatWindowSurfaceOptions = {
+  vibrancy?: ReturnType<typeof vibrancyFor>
+  visualEffectState?: 'active'
+  transparent?: true
+  backgroundMaterial?: WindowsBackgroundMaterial
+  opacity: number
+  backgroundColor?: string
+}
+
+export function chatWindowSurfaceOptions(input: {
+  platform: string
+  glassSupported: boolean
+  state: TranslucencyState
+  themedColor: string
+}): ChatWindowSurfaceOptions {
+  const { platform, glassSupported, state, themedColor } = input
+  const isMac = platform === 'darwin'
+  const isWindows = platform === 'win32'
+  const transparent = windowsChatWindowTransparent(platform, glassSupported, state)
+
+  return {
+    vibrancy: isMac ? vibrancyFor(state) : undefined,
+    visualEffectState: isMac ? 'active' : undefined,
+    ...(transparent ? { transparent: true as const } : {}),
+    backgroundMaterial: isWindows && glassSupported ? backgroundMaterialFor(state) : undefined,
+    opacity: windowOpacityFor(state),
+    ...windowBackingOptions(state, themedColor)
+  }
 }

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -252,6 +252,9 @@ declare global {
       /** Main-process fact: this OS can do any translucency at all (not Linux). */
       translucencySupported?: boolean
       setTranslucency?: (payload: TranslucencyState) => void
+      /** Main's current translucency, published at preload so a remounted
+       *  renderer does not hydrate from stale localStorage after a surface recreate. */
+      translucency?: TranslucencyState
       setKeepAwake?: (on: boolean) => void
       setDisableF12?: (blocked: boolean) => void
       setPreviewShortcutActive?: (active: boolean) => void

--- a/apps/desktop/src/store/translucency.ts
+++ b/apps/desktop/src/store/translucency.ts
@@ -20,6 +20,7 @@ import {
   glassMaterialsFor,
   type GlassScope,
   glassSurfaceKeep,
+  hydrateTranslucencyState,
   normalizeMaterial,
   normalizeScope,
   normalizeState,
@@ -78,10 +79,16 @@ const KEY = 'hermes.desktop.translucency.v1'
 const read = (): TranslucencyState => {
   const stored = readJson<unknown>(KEY)
 
-  return normalizeState(stored && typeof stored === 'object' ? stored : { intensity: stored }, GLASS_SUPPORTED)
+  return hydrateTranslucencyState(undefined, stored, GLASS_SUPPORTED)
 }
 
-const initial: TranslucencyState = typeof window === 'undefined' ? normalizeState(null, false) : read()
+// Cold start / remount only: prefer main's seed so a Windows glass recreate
+// does not bounce off stale localStorage. Later `storage` events use `read()`
+// so a sibling window's tint still syncs.
+const initial: TranslucencyState =
+  typeof window === 'undefined'
+    ? normalizeState(null, false)
+    : hydrateTranslucencyState(window.hermesDesktop?.translucency, readJson<unknown>(KEY), GLASS_SUPPORTED)
 
 export const $translucency = atom<TranslucencyState>(initial)
 

--- a/apps/shared/src/index.ts
+++ b/apps/shared/src/index.ts
@@ -82,6 +82,7 @@ export {
   type GlassScope,
   glassSupportedOn,
   glassSurfaceKeep,
+  hydrateTranslucencyState,
   normalizeMaterial,
   normalizeMode,
   normalizeScope,

--- a/apps/shared/src/translucency.ts
+++ b/apps/shared/src/translucency.ts
@@ -213,6 +213,24 @@ export function normalizeState(payload: unknown, glassSupported: boolean): Trans
   }
 }
 
+/**
+ * A remounted renderer must prefer main's in-memory state over localStorage.
+ * Windows glass recreate destroys the old webContents before the 120ms
+ * persist debounce (and Electron `destroy()` may skip `pagehide`), so storage
+ * can still hold the pre-toggle value.
+ */
+export function hydrateTranslucencyState(
+  mainPayload: unknown,
+  stored: unknown,
+  glassSupported: boolean
+): TranslucencyState {
+  if (mainPayload && typeof mainPayload === 'object') {
+    return normalizeState(mainPayload, glassSupported)
+  }
+
+  return normalizeState(stored && typeof stored === 'object' ? stored : { intensity: stored }, glassSupported)
+}
+
 /** Lever percent → native window opacity, floored so it stays usable. */
 function opacityRamp(lever: number): number {
   const ratio = clampIntensity(lever) / TRANSLUCENCY_MAX

--- a/contributors/emails/StanleyStetson@users.noreply.github.com
+++ b/contributors/emails/StanleyStetson@users.noreply.github.com
@@ -1,1 +1,1 @@
-StanleyStetson <StanleyStetson@users.noreply.github.com>
+StanleyStetson


### PR DESCRIPTION
## What does this PR do?

Windows 11 chat windows were born with `transparent: true` whenever the OS could back glass, even when glass was off. DWM then skipped normal Snap / FancyZones frame hit-testing.

`transparent` is constructor-only, so the window is now opaque unless glass is actually active. Crossing that threshold on glass-capable Windows recreates chat windows (macOS still swaps vibrancy live). A remounted renderer hydrates from main's current state so it does not bounce the toggle off stale localStorage.

Residual: live Snap/FancyZones were not run on this host (Linux). A session pop-out whose URL is still empty/`about:blank` at recreate time is classified as an instance window.

## Related Issue

Fixes #90237

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/translucency.ts` — `windowsChatWindowTransparent`, `chatWindowNeedsSurfaceRecreate`, `chatWindowSurfaceOptions`.
- `apps/desktop/electron/main.ts` — constructor uses those helpers; Windows glass-on/off recreates chat windows; `replacingChatSurfaces` skips quit and pet/wake teardown in the destroy gap; hidden/minimized main is restored.
- `apps/desktop/electron/session-windows.ts` — `parseSessionWindowUrl` to re-open session windows from their URL.
- `apps/desktop/electron/preload.ts` + store — remount hydrates from `hermes:translucency:current`; later `read()` stays on localStorage for sibling tint sync.
- `apps/shared/src/translucency.ts` — `hydrateTranslucencyState`.
- Tests in `electron/tests/chat-window-surface.test.ts`, `electron/translucency.test.ts`, `electron/session-windows.test.ts`.

## How to Test

1. Constructor class (Linux/CI):

```bash
cd apps/desktop && npx vitest run electron/tests/chat-window-surface.test.ts electron/translucency.test.ts electron/session-windows.test.ts
```

Expected: 78 passed (7 + 53 + 18).

2. On Windows 11 22H2+ with glass **off** (default): open a chat window. Win+Left/Right, drag-to-top snap layouts, and FancyZones should treat it as a normal window.

3. Turn glass **on** in Settings → Appearance. The chat window remounts and shows the DWM material. Turn glass **off** again: Snap should work on the reborn opaque window.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (constructor/unit tests). Live Snap/FancyZones residual: Windows 11 22H2+

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
