### PR TITLE
Reconcile Hermes stack with v0.20.4 provider boundaries

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -556,6 +556,7 @@ class SessionManager:
         # Extract cwd from model_config.
         cwd = "."
         requested_provider = row.get("billing_provider")
+        has_requested_provider = False
         restored_base_url = row.get("billing_base_url")
         restored_api_mode = None
         mc = row.get("model_config")
@@ -565,6 +566,7 @@ class SessionManager:
                 if isinstance(meta, dict):
                     cwd = meta.get("cwd", ".")
                     if "requested_provider" in meta:
+                        has_requested_provider = True
                         requested = meta["requested_provider"]
                         if not isinstance(requested, str) or not requested.strip() or requested.strip().endswith(":"):
                             return None
@@ -575,6 +577,20 @@ class SessionManager:
                     restored_api_mode = meta.get("api_mode") or restored_api_mode
             except (json.JSONDecodeError, TypeError):
                 pass
+
+        # Legacy rows stored only the resolved ``custom`` bucket. Recover a
+        # routable identity from their safe endpoint/model before resolution;
+        # a subsequent normal persistence then heals the durable metadata.
+        if not has_requested_provider and str(requested_provider or "").strip().lower() == "custom":
+            try:
+                from hermes_cli.runtime_provider import canonical_custom_identity
+
+                requested_provider = canonical_custom_identity(
+                    base_url=restored_base_url or None,
+                    model=row.get("model") or None,
+                ) or requested_provider
+            except Exception:
+                logger.debug("ACP legacy custom identity recovery failed", exc_info=True)
 
         model = row.get("model") or None
 
@@ -692,6 +708,11 @@ class SessionManager:
                 }
             )
         except Exception:
+            # A persisted identity is authoritative. Constructing an ambient
+            # agent after it fails resolver validation silently rebinds the
+            # resumed session to the wrong route.
+            if requested_provider:
+                raise
             logger.debug("ACP session falling back to default provider resolution", exc_info=True)
 
         _register_task_cwd(session_id, cwd)

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -18,12 +18,34 @@ import re
 import sys
 import time
 import uuid
+from urllib.parse import urlsplit, urlunsplit
 from datetime import datetime, timezone
 from dataclasses import dataclass, field
 from threading import Lock
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _persistable_runtime_base_url(value: Any) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    try:
+        parsed = urlsplit(raw)
+        scheme = parsed.scheme.lower()
+        hostname = parsed.hostname
+        port = parsed.port
+    except (TypeError, ValueError):
+        return ""
+    if scheme not in {"http", "https"} or not hostname:
+        return ""
+    host = hostname.lower()
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    if port is not None and (scheme, port) not in {("http", 80), ("https", 443)}:
+        host = f"{host}:{port}"
+    return urlunsplit((scheme, host, parsed.path, "", ""))
 
 
 def _translate_acp_cwd(cwd: str) -> str:
@@ -432,14 +454,18 @@ class SessionManager:
 
         # Ensure model is a plain string (not a MagicMock or other proxy).
         model_str = str(state.model) if state.model else None
-        session_meta = {"cwd": state.cwd}
+        session_meta = {"cwd": state.cwd, "model": model_str}
         provider = getattr(state.agent, "provider", None)
+        requested_provider = getattr(state.agent, "requested_provider", None)
         base_url = getattr(state.agent, "base_url", None)
         api_mode = getattr(state.agent, "api_mode", None)
         if isinstance(provider, str) and provider.strip():
             session_meta["provider"] = provider.strip()
-        if isinstance(base_url, str) and base_url.strip():
-            session_meta["base_url"] = base_url.strip()
+        if isinstance(requested_provider, str) and requested_provider.strip():
+            session_meta["requested_provider"] = requested_provider.strip()
+        safe_base_url = _persistable_runtime_base_url(base_url)
+        if safe_base_url:
+            session_meta["base_url"] = safe_base_url
         if isinstance(api_mode, str) and api_mode.strip():
             session_meta["api_mode"] = api_mode.strip()
         cwd_json = json.dumps(session_meta)
@@ -452,7 +478,7 @@ class SessionManager:
                     session_id=state.session_id,
                     source="acp",
                     model=model_str,
-                    model_config={"cwd": state.cwd},
+                    model_config=session_meta,
                 )
             else:
                 # Update model_config (contains cwd) if changed.
@@ -538,7 +564,13 @@ class SessionManager:
                 meta = json.loads(mc)
                 if isinstance(meta, dict):
                     cwd = meta.get("cwd", ".")
-                    requested_provider = meta.get("provider") or requested_provider
+                    if "requested_provider" in meta:
+                        requested = meta["requested_provider"]
+                        if not isinstance(requested, str) or not requested.strip() or requested.strip().endswith(":"):
+                            return None
+                        requested_provider = requested.strip().lower()
+                    else:
+                        requested_provider = meta.get("provider") or requested_provider
                     restored_base_url = meta.get("base_url") or restored_base_url
                     restored_api_mode = meta.get("api_mode") or restored_api_mode
             except (json.JSONDecodeError, TypeError):
@@ -649,11 +681,14 @@ class SessionManager:
             kwargs.update(
                 {
                     "provider": runtime.get("provider"),
+                    "requested_provider": runtime.get("requested_provider"),
                     "api_mode": api_mode or runtime.get("api_mode"),
                     "base_url": base_url or runtime.get("base_url"),
                     "api_key": runtime.get("api_key"),
-                    "command": runtime.get("command"),
-                    "args": list(runtime.get("args") or []),
+                    "acp_command": runtime.get("command"),
+                    "acp_args": list(runtime.get("args") or []),
+                    "credential_pool": runtime.get("credential_pool"),
+                    "provider_request_overrides": copy.deepcopy(runtime.get("request_overrides") or {}),
                 }
             )
         except Exception:

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2376,7 +2376,10 @@ def init_agent(
             _user_providers = _agent_cfg.get("providers")
             _disabled_custom_provider_ids: set[str] = set()
             if isinstance(_user_providers, dict):
-                from hermes_cli.config import is_provider_enabled
+                from hermes_cli.config import (
+                    get_custom_provider_endpoint,
+                    is_provider_enabled,
+                )
 
                 for _provider_key, _provider_entry in _user_providers.items():
                     if not isinstance(_provider_entry, dict):
@@ -2397,9 +2400,7 @@ def init_agent(
                     if _configured_custom_provider not in _entry_provider_ids:
                         continue
                     _configured_base_url = _normalize_route_base_url(
-                        _provider_entry.get("api")
-                        or _provider_entry.get("url")
-                        or _provider_entry.get("base_url")
+                        get_custom_provider_endpoint(_provider_entry)
                     )
                     if _configured_base_url:
                         break

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -26,6 +26,8 @@ import sys
 import threading
 import time
 import uuid
+from collections.abc import Mapping
+from copy import deepcopy
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import parse_qs, urlparse, urlunparse
@@ -37,8 +39,6 @@ from agent.session_activity import ActivityProvenance
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
     fetch_model_metadata,
-    is_local_endpoint,
-    query_ollama_num_ctx,
 )
 from agent.process_bootstrap import _install_safe_stdio
 from agent.subdirectory_hints import SubdirectoryHintTracker
@@ -471,31 +471,31 @@ def _custom_provider_extra_body_for_agent(
     return fallback
 
 
-def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, Any]]) -> None:
+def _provider_request_overrides_for_route(
+    *,
+    requested_provider: str,
+    provider: str,
+    model: str,
+    base_url: str,
+    custom_providers: List[Dict[str, Any]],
+) -> Dict[str, Any]:
     from hermes_cli.runtime_provider import _is_named_loopback_ollama_route
 
     if _is_named_loopback_ollama_route(
-        agent.requested_provider or agent.provider,
-        agent.base_url,
+        requested_provider,
+        base_url,
     ):
-        return
+        return {}
 
     extra_body = _custom_provider_extra_body_for_agent(
-        provider=agent.provider,
-        model=agent.model,
-        base_url=agent.base_url,
+        provider=provider,
+        model=model,
+        base_url=base_url,
         custom_providers=custom_providers,
     )
-    if not extra_body:
-        return
-
-    overrides = dict(getattr(agent, "request_overrides", {}) or {})
-    merged_extra_body = dict(extra_body)
-    existing_extra_body = overrides.get("extra_body")
-    if isinstance(existing_extra_body, dict):
-        merged_extra_body.update(existing_extra_body)
-    overrides["extra_body"] = merged_extra_body
-    agent.request_overrides = overrides
+    if not isinstance(extra_body, Mapping) or not extra_body:
+        return {}
+    return {"extra_body": deepcopy(dict(extra_body))}
 
 
 def init_agent(
@@ -575,6 +575,7 @@ def init_agent(
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
     requested_provider: str = None,
+    provider_request_overrides: dict[str, Any] | None = None,
 ):
     """
     Initialize the AI Agent.
@@ -670,9 +671,9 @@ def init_agent(
     provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
     agent.provider = provider_name or ""
     agent.requested_provider = (
-        requested_provider.strip().lower()
+        requested_provider.strip()
         if isinstance(requested_provider, str) and requested_provider.strip()
-        else agent.provider
+        else str(provider or "").strip()
     )
     agent._credential_pool = credential_pool
     agent.acp_command = acp_command or command
@@ -920,7 +921,10 @@ def init_agent(
     agent.max_tokens = max_tokens  # None = use model default
     agent.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
     agent.service_tier = service_tier
-    agent.request_overrides = dict(request_overrides or {})
+    agent._caller_request_overrides = {}
+    agent._provider_request_overrides = {}
+    agent._request_overrides = {}
+    agent.request_overrides = request_overrides
     agent.prefill_messages = prefill_messages or []  # Prefilled conversation turns
     agent._force_ascii_payload = False
     
@@ -2483,7 +2487,15 @@ def init_agent(
     # Store for reuse by _check_compression_model_feasibility (auxiliary
     # compression model context-length detection needs the same list).
     agent._custom_providers = _custom_providers
-    _merge_custom_provider_extra_body(agent, _custom_providers)
+    if provider_request_overrides is None:
+        provider_request_overrides = _provider_request_overrides_for_route(
+            requested_provider=agent.requested_provider,
+            provider=agent.provider,
+            model=agent.model,
+            base_url=agent.base_url,
+            custom_providers=_custom_providers,
+        )
+    agent._set_provider_request_overrides(provider_request_overrides)
 
     # Check custom_providers per-model context_length
     if _config_context_length is None and _custom_providers:
@@ -2849,18 +2861,6 @@ def init_agent(
             agent._ollama_num_ctx = int(_ollama_num_ctx_override)
         except (TypeError, ValueError):
             _ra().logger.debug("Invalid ollama_num_ctx config value: %r", _ollama_num_ctx_override)
-    if agent._ollama_num_ctx is None and agent.base_url and is_local_endpoint(agent.base_url):
-        try:
-            # ``agent.api_key`` may be a callable (Entra token provider).
-            # Ollama detection makes a manual HTTP request and expects a
-            # string — Azure Foundry isn't a local endpoint so this branch
-            # never fires for Entra, but guard defensively.
-            _key_for_ollama = agent.api_key if isinstance(agent.api_key, str) else ""
-            _detected = query_ollama_num_ctx(agent.model, agent.base_url, api_key=_key_for_ollama or "")
-            if _detected and _detected > 0:
-                agent._ollama_num_ctx = _detected
-        except Exception as exc:
-            _ra().logger.debug("Ollama num_ctx detection failed: %s", exc)
     # Cap auto-detected ollama_num_ctx to the user's explicit context_length.
     # Without this, GGUF metadata can advertise 256K+ which Ollama honours
     # by allocating that much VRAM — blowing up small GPUs even though the
@@ -2956,6 +2956,8 @@ def init_agent(
         "model": agent.model,
         "provider": agent.provider,
         "requested_provider": agent.requested_provider,
+        "caller_request_overrides": deepcopy(agent._caller_request_overrides),
+        "provider_request_overrides": deepcopy(agent._provider_request_overrides),
         "base_url": agent.base_url,
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -472,6 +472,14 @@ def _custom_provider_extra_body_for_agent(
 
 
 def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, Any]]) -> None:
+    from hermes_cli.runtime_provider import _is_named_loopback_ollama_route
+
+    if _is_named_loopback_ollama_route(
+        agent.requested_provider or agent.provider,
+        agent.base_url,
+    ):
+        return
+
     extra_body = _custom_provider_extra_body_for_agent(
         provider=agent.provider,
         model=agent.model,

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1429,11 +1429,15 @@ def init_agent(
             # custom_providers[].extra_headers) — proxies, gateways, custom
             # auth. Applied last so the most specific config level wins.
             # SECURITY: values may carry credentials — never log them.
-            apply_custom_provider_extra_headers_to_client_kwargs(
-                client_kwargs,
-                _cp_base_url,
-                _cp_entries,
-            )
+            from hermes_cli.runtime_provider import _is_named_loopback_ollama_route
+
+            route_provider = agent.requested_provider or agent.provider
+            if not _is_named_loopback_ollama_route(route_provider, _cp_base_url):
+                apply_custom_provider_extra_headers_to_client_kwargs(
+                    client_kwargs,
+                    _cp_base_url,
+                    _cp_entries,
+                )
         except Exception:
             logger.debug("custom-provider TLS resolution skipped", exc_info=True)
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2563,6 +2563,7 @@ def try_activate_fallback(
     http_status: Optional[int] = None,
     _initial_provider: Optional[str] = None,
     _initial_model: Optional[str] = None,
+    _diagnostic_reason: "FailoverReason | None" = None,
 ) -> bool:
     """Switch to the next fallback model/provider in the chain.
 
@@ -2576,16 +2577,18 @@ def try_activate_fallback(
     mappings.
     """
     if _initial_provider is None and _initial_model is None:
-        agent._last_fallback_event = None
         _initial_provider = getattr(agent, "provider", "")
         _initial_model = getattr(agent, "model", "")
+    if _diagnostic_reason is None:
+        _diagnostic_reason = reason
 
     def _try_next_fallback() -> bool:
         return agent._try_activate_fallback(
-            reason,
+            None,
             http_status=http_status,
             _initial_provider=_initial_provider,
             _initial_model=_initial_model,
+            _diagnostic_reason=_diagnostic_reason,
         )
 
     if reason in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit}:
@@ -2991,10 +2994,10 @@ def try_activate_fallback(
                 "initial_model": _initial_model,
                 "selected_fallback_provider": fb_provider,
                 "selected_fallback_model": fb_model,
-                "failure_class": _fallback_failure_class(reason),
+                "failure_class": _fallback_failure_class(_diagnostic_reason),
                 "reason_code": (
-                    reason.value
-                    if isinstance(reason, FailoverReason)
+                    _diagnostic_reason.value
+                    if isinstance(_diagnostic_reason, FailoverReason)
                     else FailoverReason.unknown.value
                 ),
                 "http_status": http_status,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -65,6 +65,138 @@ _PROVIDER_STREAM_ERROR_TEXT_LIMIT = 4096
 # narrower non-rate-limit case.  See issue #24996.
 _FALLBACK_EXHAUSTED_COOLDOWN_S = 5.0
 
+_FALLBACK_EVENT_ROUTE_MAX_CHARS = 120
+_FALLBACK_EVENT_ALLOWED_KEYS = frozenset(
+    {
+        "initial_provider",
+        "initial_model",
+        "selected_fallback_provider",
+        "selected_fallback_model",
+        "failure_class",
+        "reason_code",
+        "http_status",
+    }
+)
+_FALLBACK_FAILURE_CLASSES = frozenset(
+    {
+        "authentication",
+        "quota",
+        "availability",
+        "transport",
+        "capacity",
+        "policy",
+        "request",
+        "provider_protocol",
+        "unknown",
+    }
+)
+
+
+def _normalize_fallback_route_label(value: Any) -> Optional[str]:
+    """Return a bounded provider/model label, never an arbitrary payload."""
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not normalized or len(normalized) > _FALLBACK_EVENT_ROUTE_MAX_CHARS:
+        return None
+    if "://" in normalized:
+        return None
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:+/@-]*", normalized):
+        return None
+    return normalized
+
+
+def _fallback_failure_class(reason: "FailoverReason | None") -> str:
+    if reason in {FailoverReason.auth, FailoverReason.auth_permanent}:
+        return "authentication"
+    if reason in {
+        FailoverReason.billing,
+        FailoverReason.rate_limit,
+        FailoverReason.upstream_rate_limit,
+    }:
+        return "quota"
+    if reason in {FailoverReason.overloaded, FailoverReason.server_error}:
+        return "availability"
+    if reason in {FailoverReason.timeout, FailoverReason.ssl_cert_verification}:
+        return "transport"
+    if reason in {
+        FailoverReason.context_overflow,
+        FailoverReason.payload_too_large,
+        FailoverReason.image_too_large,
+    }:
+        return "capacity"
+    if reason in {
+        FailoverReason.model_not_found,
+        FailoverReason.provider_policy_blocked,
+        FailoverReason.content_policy_blocked,
+    }:
+        return "policy"
+    if reason in {
+        FailoverReason.format_error,
+        FailoverReason.invalid_encrypted_content,
+        FailoverReason.multimodal_tool_content_unsupported,
+    }:
+        return "request"
+    if reason in {
+        FailoverReason.thinking_signature,
+        FailoverReason.long_context_tier,
+        FailoverReason.oauth_long_context_beta_forbidden,
+        FailoverReason.llama_cpp_grammar_pattern,
+    }:
+        return "provider_protocol"
+    return "unknown"
+
+
+def sanitize_fallback_event(event: Any) -> Optional[Dict[str, Any]]:
+    """Copy one fallback event through an exact, bounded allowlist.
+
+    This intentionally accepts no exception object or message. Callers may
+    retain only route labels, enum-derived classification, and a valid HTTP
+    status; response bodies, prompts, headers, URLs, and arbitrary payloads
+    are structurally unreachable from the returned value.
+    """
+    if not isinstance(event, dict):
+        return None
+
+    sanitized: Dict[str, Any] = {}
+    for key in (
+        "initial_provider",
+        "initial_model",
+        "selected_fallback_provider",
+        "selected_fallback_model",
+    ):
+        value = _normalize_fallback_route_label(event.get(key))
+        if value is None:
+            return None
+        sanitized[key] = value
+
+    failure_class = event.get("failure_class")
+    sanitized["failure_class"] = (
+        failure_class
+        if isinstance(failure_class, str)
+        and failure_class in _FALLBACK_FAILURE_CLASSES
+        else "unknown"
+    )
+
+    reason_code = event.get("reason_code")
+    allowed_reasons = {reason.value for reason in FailoverReason}
+    sanitized["reason_code"] = (
+        reason_code
+        if isinstance(reason_code, str) and reason_code in allowed_reasons
+        else FailoverReason.unknown.value
+    )
+
+    http_status = event.get("http_status")
+    sanitized["http_status"] = (
+        http_status
+        if isinstance(http_status, int)
+        and not isinstance(http_status, bool)
+        and 100 <= http_status <= 599
+        else None
+    )
+    assert set(sanitized) == _FALLBACK_EVENT_ALLOWED_KEYS
+    return sanitized
+
 
 def _context_thread_target(callback):
     """Bind a no-argument thread target to the caller's ContextVars."""
@@ -2424,7 +2556,14 @@ def _fallback_entry_unavailable_without_network(agent, fb: dict) -> Optional[str
 
 
 
-def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
+def try_activate_fallback(
+    agent,
+    reason: "FailoverReason | None" = None,
+    *,
+    http_status: Optional[int] = None,
+    _initial_provider: Optional[str] = None,
+    _initial_model: Optional[str] = None,
+) -> bool:
     """Switch to the next fallback model/provider in the chain.
 
     Called when the current model is failing after retries.  Swaps the
@@ -2436,6 +2575,19 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     auth resolution and client construction — no duplicated provider→key
     mappings.
     """
+    if _initial_provider is None and _initial_model is None:
+        agent._last_fallback_event = None
+        _initial_provider = getattr(agent, "provider", "")
+        _initial_model = getattr(agent, "model", "")
+
+    def _try_next_fallback() -> bool:
+        return agent._try_activate_fallback(
+            reason,
+            http_status=http_status,
+            _initial_provider=_initial_provider,
+            _initial_model=_initial_model,
+        )
+
     if reason in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit}:
         # Only start cooldown when leaving the primary provider.  If we're
         # already on a fallback and chain-switching, the primary wasn't the
@@ -2484,11 +2636,11 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         agent._unavailable_fallback_keys = unavailable
     if fb_key in unavailable:
         logger.debug("Fallback skip: %s previously marked unavailable", fb_key)
-        return agent._try_activate_fallback(reason)
+        return _try_next_fallback()
     fb_provider = (fb.get("provider") or "").strip().lower()
     fb_model = (fb.get("model") or "").strip()
     if not fb_provider or not fb_model:
-        return agent._try_activate_fallback(reason)  # skip invalid, try next
+        return _try_next_fallback()  # skip invalid, try next
 
     local_skip_reason = _fallback_entry_unavailable_without_network(agent, fb)
     if local_skip_reason:
@@ -2499,7 +2651,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             fb_model,
             local_skip_reason,
         )
-        return agent._try_activate_fallback(reason)
+        return _try_next_fallback()
 
     # Skip entries that resolve to the same backend that just failed —
     # falling back to it loops the failure. Identity semantics (which axes
@@ -2524,7 +2676,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             "as the current one (%s)",
             fb_provider, fb_model, current_ident.base_url or current_ident.provider,
         )
-        return agent._try_activate_fallback(reason)
+        return _try_next_fallback()
 
     # Use centralized router for client construction.
     # raw_codex=True because the main agent needs direct responses.stream()
@@ -2581,7 +2733,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 "Fallback to %s failed: provider not configured",
                 fb_provider)
             unavailable.add(fb_key)
-            return agent._try_activate_fallback(reason)  # try next in chain
+            return _try_next_fallback()  # try next in chain
         try:
             from hermes_cli.model_normalize import normalize_model_for_provider
 
@@ -2833,12 +2985,27 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # short-circuit the freshly activated fallback before it gets a
         # single stream attempt.
         _reset_stale_streak(agent)
+        agent._last_fallback_event = sanitize_fallback_event(
+            {
+                "initial_provider": _initial_provider,
+                "initial_model": _initial_model,
+                "selected_fallback_provider": fb_provider,
+                "selected_fallback_model": fb_model,
+                "failure_class": _fallback_failure_class(reason),
+                "reason_code": (
+                    reason.value
+                    if isinstance(reason, FailoverReason)
+                    else FailoverReason.unknown.value
+                ),
+                "http_status": http_status,
+            }
+        )
         return True
     except Exception as e:
         if fb_provider == "nous":
             unavailable.add(fb_key)
         logger.error("Failed to activate fallback %s: %s", fb_model, e)
-        return agent._try_activate_fallback(reason)  # try next in chain
+        return _try_next_fallback()  # try next in chain
 
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5267,7 +5267,10 @@ def run_conversation(
                             )
                         else:
                             agent._buffer_status("⚠️ Rate limited — switching to fallback provider...")
-                        if agent._try_activate_fallback(reason=classified.reason):
+                        if agent._try_activate_fallback(
+                            reason=classified.reason,
+                            http_status=classified.status_code,
+                        ):
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)
                             retry_count = 0
@@ -5301,7 +5304,10 @@ def run_conversation(
                         "🔐 Authentication failed and could not be refreshed — "
                         "switching to fallback provider..."
                     )
-                    if agent._try_activate_fallback(reason=classified.reason):
+                    if agent._try_activate_fallback(
+                        reason=classified.reason,
+                        http_status=classified.status_code,
+                    ):
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5915,7 +5915,10 @@ def run_conversation(
                             agent._buffer_status("⚠️ TLS certificate verification failed — trying fallback...")
                         else:
                             agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
-                    if agent._try_activate_fallback():
+                    if agent._try_activate_fallback(
+                        reason=classified.reason,
+                        http_status=classified.status_code,
+                    ):
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
@@ -6129,7 +6132,10 @@ def run_conversation(
                     # Try fallback before giving up entirely
                     if agent._has_pending_fallback():
                         agent._buffer_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
-                    if agent._try_activate_fallback():
+                    if agent._try_activate_fallback(
+                        reason=classified.reason,
+                        http_status=classified.status_code,
+                    ):
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5916,8 +5916,9 @@ def run_conversation(
                         else:
                             agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
                     if agent._try_activate_fallback(
-                        reason=classified.reason,
+                        reason=None,
                         http_status=classified.status_code,
+                        _diagnostic_reason=classified.reason,
                     ):
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
@@ -6133,8 +6134,9 @@ def run_conversation(
                     if agent._has_pending_fallback():
                         agent._buffer_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
                     if agent._try_activate_fallback(
-                        reason=classified.reason,
+                        reason=None,
                         http_status=classified.status_code,
+                        _diagnostic_reason=classified.reason,
                     ):
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)

--- a/cli.py
+++ b/cli.py
@@ -8669,6 +8669,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             stored_provider_for_resolution = stored_provider
         model_changed = stored_model != self.model
         provider_changed = bool(stored_provider_for_resolution) and stored_provider_for_resolution != self.requested_provider
+        resolved_runtime = None
         if not model_changed and not provider_changed:
             return
         self.model = stored_model
@@ -8693,8 +8694,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             try:
                 from hermes_cli.runtime_provider import resolve_runtime_provider
                 resolved = resolve_runtime_provider(requested=stored_provider_for_resolution)
+                resolved_runtime = resolved
                 if resolved.get("provider"):
                     self.provider = resolved["provider"]
+                if resolved.get("requested_provider"):
+                    self.requested_provider = resolved["requested_provider"]
                 if resolved.get("api_key"):
                     self.api_key = resolved["api_key"]
                     self._credential_pool = resolved.get("credential_pool")
@@ -8721,6 +8725,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     base_url=self.base_url or "",
                     api_mode=self.api_mode or "",
                 )
+                if resolved_runtime is not None:
+                    resolved_requested = resolved_runtime.get("requested_provider")
+                    if resolved_requested:
+                        self.agent.requested_provider = resolved_requested
+                    if hasattr(self.agent, "_set_provider_request_overrides"):
+                        self.agent._set_provider_request_overrides(
+                            copy.deepcopy(
+                                resolved_runtime.get("request_overrides") or {}
+                            )
+                        )
+                    primary_runtime = getattr(self.agent, "_primary_runtime", None)
+                    if isinstance(primary_runtime, dict):
+                        primary_runtime = copy.deepcopy(primary_runtime)
+                        primary_runtime["requested_provider"] = (
+                            resolved_requested or self.agent.requested_provider
+                        )
+                        self.agent._primary_runtime = primary_runtime
             except Exception:
                 logger.debug(
                     "In-place agent model swap on resume failed", exc_info=True

--- a/cli.py
+++ b/cli.py
@@ -39,13 +39,34 @@ import time
 import uuid
 import textwrap
 from collections import deque
-from urllib.parse import unquote, urlparse
+from urllib.parse import unquote, urlparse, urlsplit, urlunsplit
 from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime
 from typing import List, Dict, Any, Optional, Mapping
 
 logger = logging.getLogger(__name__)
+
+
+def _persistable_runtime_base_url(value: Any) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    try:
+        parsed = urlsplit(raw)
+        scheme = parsed.scheme.lower()
+        hostname = parsed.hostname
+        port = parsed.port
+    except (TypeError, ValueError):
+        return ""
+    if scheme not in {"http", "https"} or not hostname:
+        return ""
+    host = hostname.lower()
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    if port is not None and (scheme, port) not in {("http", 80), ("https", 443)}:
+        host = f"{host}:{port}"
+    return urlunsplit((scheme, host, parsed.path, "", ""))
 
 # Suppress startup messages for clean CLI experience
 os.environ["HERMES_QUIET"] = "1"  # Our own modules
@@ -8530,7 +8551,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         sid = getattr(self, "session_id", None)
         if not db or not sid:
             return
-        provider = result.target_provider
+        provider = getattr(result, "provider", None) or result.target_provider
+        requested_provider = getattr(result, "requested_provider", None) or result.target_provider
         # Bare "custom" is the resolved billing class, not a routable
         # identity — persisting it verbatim makes a later resume hard-fail
         # when the config default has moved off the custom endpoint
@@ -8538,15 +8560,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # custom while the config provider is still custom-ish). Heal to
         # the durable custom:<name> menu key, else drop the provider —
         # same recovery the TUI gateway applies on its read path.
-        if str(provider or "").strip().lower() == "custom":
-            try:
-                from hermes_cli.runtime_provider import canonical_custom_identity
-                provider = canonical_custom_identity(
-                    base_url=result.base_url or None,
-                    model=result.new_model or None,
-                ) or None
-            except Exception:
-                provider = None
         # Both shapes use the same or-None discipline so stale keys from a
         # previous switch are deleted (not merely omitted) in BOTH the
         # nested gateway_runtime dict (CLI reader) and the top-level keys
@@ -8557,7 +8570,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # stale-key bug (#85261 simplify-code review).
         route = {
             "provider": provider or None,
-            "base_url": result.base_url or None,
+            "requested_provider": requested_provider or None,
+            "base_url": _persistable_runtime_base_url(result.base_url) or None,
             "api_mode": result.api_mode or None,
         }
         try:
@@ -8601,6 +8615,31 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # An explicit -m / --model on the command line overrides resume.
         if getattr(self, "_explicit_model_override", False):
             return
+        # Read raw metadata here because the compatibility reader filters None
+        # values and cannot distinguish an absent requested identity from a
+        # present invalid one.
+        raw_model_config = (session_meta or {}).get("model_config")
+        parsed_model_config = {}
+        if isinstance(raw_model_config, dict):
+            parsed_model_config = raw_model_config
+        elif isinstance(raw_model_config, str) and raw_model_config.strip():
+            try:
+                candidate = json.loads(raw_model_config)
+                if isinstance(candidate, dict):
+                    parsed_model_config = candidate
+            except (TypeError, ValueError):
+                pass
+        nested_runtime = parsed_model_config.get("gateway_runtime")
+        nested_runtime = nested_runtime if isinstance(nested_runtime, dict) else {}
+        identity_container = nested_runtime if "requested_provider" in nested_runtime else parsed_model_config
+        has_requested_identity = "requested_provider" in identity_container
+        if has_requested_identity:
+            candidate = identity_container["requested_provider"]
+            if not isinstance(candidate, str) or not candidate.strip() or candidate.strip().endswith(":"):
+                raise ValueError("invalid persisted requested_provider")
+            stored_requested_provider = candidate.strip().lower()
+        else:
+            stored_requested_provider = None
         # Stored provider/endpoint via the canonical row-level reader
         # (prefers model_config.gateway_runtime, falls back to the TUI
         # gateway's top-level keys).
@@ -8615,7 +8654,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # provider so resume keeps the ambient default. (Stricter than the
         # TUI gateway's recovery, which keeps bare "custom" when a base_url
         # exists — the CLI's resolve path would hard-fail on it, #14676.)
-        if str(stored_provider or "").strip().lower() == "custom":
+        if not has_requested_identity and str(stored_provider or "").strip().lower() == "custom":
             try:
                 from hermes_cli.runtime_provider import canonical_custom_identity
                 stored_provider = canonical_custom_identity(
@@ -8624,14 +8663,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 ) or None
             except Exception:
                 stored_provider = None
+        if has_requested_identity:
+            stored_provider_for_resolution = stored_requested_provider
+        else:
+            stored_provider_for_resolution = stored_provider
         model_changed = stored_model != self.model
-        provider_changed = bool(stored_provider) and stored_provider != self.provider
+        provider_changed = bool(stored_provider_for_resolution) and stored_provider_for_resolution != self.requested_provider
         if not model_changed and not provider_changed:
             return
         self.model = stored_model
-        if stored_provider:
+        if stored_provider_for_resolution:
+            self.requested_provider = stored_provider_for_resolution
             self.provider = stored_provider
-            self.requested_provider = stored_provider
             if stored_base_url:
                 self.base_url = stored_base_url
             if stored_api_mode:
@@ -8649,7 +8692,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # runtime provider resolution owns credentials.
             try:
                 from hermes_cli.runtime_provider import resolve_runtime_provider
-                resolved = resolve_runtime_provider(requested=stored_provider)
+                resolved = resolve_runtime_provider(requested=stored_provider_for_resolution)
+                if resolved.get("provider"):
+                    self.provider = resolved["provider"]
                 if resolved.get("api_key"):
                     self.api_key = resolved["api_key"]
                     self._credential_pool = resolved.get("credential_pool")

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5563,6 +5563,8 @@ def run_job(
             prefill_messages=prefill_messages,
             fallback_model=fallback_model,
             credential_pool=credential_pool,
+            provider_request_overrides=dict(runtime.get("request_overrides") or {}),
+            max_tokens=runtime.get("max_output_tokens"),
             providers_allowed=pr.get("only"),
             providers_ignored=pr.get("ignore"),
             providers_order=pr.get("order"),

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -15,6 +15,7 @@ loaded) so this module never imports ``cli`` at import time -> no import cycle.
 from __future__ import annotations
 
 import sys
+import copy
 
 from rich.markup import escape as _escape
 
@@ -92,6 +93,8 @@ class CLIAgentSetupMixin:
         resolved_acp_command = runtime.get("command")
         resolved_acp_args = list(runtime.get("args") or [])
         resolved_credential_pool = runtime.get("credential_pool")
+        resolved_requested_provider = runtime.get("requested_provider") or self.requested_provider
+        resolved_provider_overrides = copy.deepcopy(runtime.get("request_overrides") or {})
         # A callable api_key is a bearer-token provider (Azure Foundry
         # Entra ID — ``azure_identity_adapter.build_token_provider``).
         # The OpenAI SDK accepts ``Callable[[], str]`` for ``api_key`` and
@@ -138,10 +141,12 @@ class CLIAgentSetupMixin:
             or resolved_acp_args != self.acp_args
         )
         self.provider = resolved_provider
+        self.requested_provider = resolved_requested_provider
         self.api_mode = resolved_api_mode
         self.acp_command = resolved_acp_command
         self.acp_args = resolved_acp_args
         self._credential_pool = resolved_credential_pool
+        self._provider_request_overrides = resolved_provider_overrides
         self._provider_source = runtime.get("source")
         self.api_key = api_key
         self.base_url = base_url
@@ -309,6 +314,9 @@ class CLIAgentSetupMixin:
             "command": self.acp_command,
             "args": list(self.acp_args or []),
             "credential_pool": getattr(self, "_credential_pool", None),
+            "provider_request_overrides": copy.deepcopy(
+                getattr(self, "_provider_request_overrides", {}) or {}
+            ),
         }
         route = {
             "model": self.model,
@@ -321,6 +329,7 @@ class CLIAgentSetupMixin:
                 runtime["api_mode"],
                 runtime["command"],
                 tuple(runtime["args"]),
+                repr(runtime["provider_request_overrides"]),
             ),
         }
 
@@ -486,6 +495,9 @@ class CLIAgentSetupMixin:
                 "command": self.acp_command,
                 "args": list(self.acp_args or []),
                 "credential_pool": getattr(self, "_credential_pool", None),
+                "provider_request_overrides": copy.deepcopy(
+                    getattr(self, "_provider_request_overrides", {}) or {}
+                ),
             }
             effective_model = model_override or self.model
             self.agent = AIAgent(
@@ -498,6 +510,9 @@ class CLIAgentSetupMixin:
                 acp_command=runtime.get("command"),
                 acp_args=runtime.get("args"),
                 credential_pool=runtime.get("credential_pool"),
+                provider_request_overrides=copy.deepcopy(
+                    runtime.get("provider_request_overrides") or {}
+                ),
                 max_tokens=self.max_tokens,
                 max_iterations=self.max_turns,
                 enabled_toolsets=self.enabled_toolsets,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1327,6 +1327,23 @@ def _canonical_api_mode(api_mode: str) -> str:
     return _API_MODE_ALIASES.get(cleaned.lower(), cleaned)
 
 
+def get_custom_provider_endpoint(entry: Any) -> str:
+    """Return a custom provider's canonical endpoint field.
+
+    ``base_url`` is the current schema; ``url`` and ``api`` are compatibility
+    aliases retained in existing configs.  Keeping the precedence here makes
+    runtime, picker, and dashboard consumers agree when an older entry has
+    both a legacy field and a later canonical override.
+    """
+    if not isinstance(entry, dict):
+        return ""
+    for key in ("base_url", "url", "api"):
+        value = entry.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
 def _normalize_custom_provider_entry(
     entry: Any,
     *,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -30,7 +30,7 @@ import time
 import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Any, Optional, List, Tuple, Set
+from typing import Callable, Dict, Any, Optional, List, Tuple, Set
 
 from hermes_cli.route_identity import normalize_route_base_url
 from hermes_cli.secret_prompt import masked_secret_prompt
@@ -1327,20 +1327,39 @@ def _canonical_api_mode(api_mode: str) -> str:
     return _API_MODE_ALIASES.get(cleaned.lower(), cleaned)
 
 
-def get_custom_provider_endpoint(entry: Any) -> str:
+def get_custom_provider_endpoint(
+    entry: Any,
+    *,
+    on_invalid_endpoint: Optional[Callable[[str, str], None]] = None,
+) -> str:
     """Return a custom provider's canonical endpoint field.
 
     ``base_url`` is the current schema; ``url`` and ``api`` are compatibility
     aliases retained in existing configs.  Keeping the precedence here makes
     runtime, picker, and dashboard consumers agree when an older entry has
-    both a legacy field and a later canonical override.
+    both a legacy field and a later canonical override. Invalid higher-priority
+    values fall through just like ``_normalize_custom_provider_entry``.
     """
     if not isinstance(entry, dict):
         return ""
     for key in ("base_url", "url", "api"):
         value = entry.get(key)
+        if key == "base_url" and key not in entry:
+            value = entry.get("baseUrl")
         if isinstance(value, str) and value.strip():
-            return value.strip()
+            candidate = value.strip()
+            # Endpoints can include unresolved environment references or
+            # templated regions. They are expanded at runtime, so retain them
+            # without URL parsing as the normalizer has always done.
+            if re.search(r"\{[^}]+\}", candidate):
+                return candidate
+            from urllib.parse import urlparse
+
+            parsed = urlparse(candidate)
+            if parsed.scheme and parsed.netloc:
+                return candidate
+            if on_invalid_endpoint:
+                on_invalid_endpoint(key, candidate)
     return ""
 
 
@@ -1409,31 +1428,16 @@ def _normalize_custom_provider_entry(
             provider_key or "?", ", ".join(sorted(unknown)),
         )
 
-    from urllib.parse import urlparse
+    def _warn_invalid_endpoint(url_key: str, candidate: str) -> None:
+        logger.warning(
+            "providers.%s: '%s' value '%s' is not a valid URL "
+            "(no scheme or host) — skipped",
+            provider_key or "?", url_key, candidate,
+        )
 
-    base_url = ""
-    for url_key in ("base_url", "url", "api"):
-        raw_url = entry.get(url_key)
-        if isinstance(raw_url, str) and raw_url.strip():
-            candidate = raw_url.strip()
-            # Accept URLs containing unresolved placeholder tokens — both
-            # ``${ENV_VAR}`` env-refs and bare ``{region}``-style templates —
-            # without URL validation. They are expanded at runtime, so a
-            # caller reaching this normalizer with raw (un-expanded) config
-            # would otherwise see the provider silently dropped (#14457).
-            if re.search(r"\{[^}]+\}", candidate):
-                base_url = candidate
-                break
-            parsed = urlparse(candidate)
-            if parsed.scheme and parsed.netloc:
-                base_url = candidate
-                break
-            else:
-                logger.warning(
-                    "providers.%s: '%s' value '%s' is not a valid URL "
-                    "(no scheme or host) — skipped",
-                    provider_key or "?", url_key, candidate,
-                )
+    base_url = get_custom_provider_endpoint(
+        entry, on_invalid_endpoint=_warn_invalid_endpoint
+    )
     if not base_url:
         return None
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1355,9 +1355,15 @@ def get_custom_provider_endpoint(
                 return candidate
             from urllib.parse import urlparse
 
-            parsed = urlparse(candidate)
-            if parsed.scheme and parsed.netloc:
-                return candidate
+            try:
+                parsed = urlparse(candidate)
+                hostname = parsed.hostname
+                _ = parsed.port
+            except ValueError:
+                pass
+            else:
+                if parsed.scheme and hostname:
+                    return candidate
             if on_invalid_endpoint:
                 on_invalid_endpoint(key, candidate)
     return ""

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1434,11 +1434,11 @@ def _normalize_custom_provider_entry(
             provider_key or "?", ", ".join(sorted(unknown)),
         )
 
-    def _warn_invalid_endpoint(url_key: str, candidate: str) -> None:
+    def _warn_invalid_endpoint(url_key: str, _candidate: str) -> None:
         logger.warning(
-            "providers.%s: '%s' value '%s' is not a valid URL "
-            "(no scheme or host) — skipped",
-            provider_key or "?", url_key, candidate,
+            "providers.%s: '%s' value is not a valid URL "
+            "(scheme, host, or port validation failed) — skipped",
+            provider_key or "?", url_key,
         )
 
     base_url = get_custom_provider_endpoint(

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2954,7 +2954,10 @@ def list_authenticated_providers(
         # the wire protocol differs.
         from collections import OrderedDict as _OD3
 
-        from hermes_cli.config import is_provider_enabled
+        from hermes_cli.config import (
+            get_custom_provider_endpoint,
+            is_provider_enabled,
+        )
 
         ep_groups: "_OD3[tuple, dict]" = _OD3()
         for ep_name, ep_cfg in user_providers.items():
@@ -2967,12 +2970,7 @@ def list_authenticated_providers(
             if ep_name.lower() in seen_slugs:
                 continue
             display_name = ep_cfg.get("name", "") or ep_name
-            api_url = (
-                ep_cfg.get("base_url", "")
-                or ep_cfg.get("api", "")
-                or ep_cfg.get("url", "")
-                or ""
-            )
+            api_url = get_custom_provider_endpoint(ep_cfg)
             key_env = str(ep_cfg.get("key_env", "") or "").strip()
             inline_api_key = str(ep_cfg.get("api_key", "") or "").strip()
             api_mode = str(

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -447,6 +447,10 @@ def _run_agent(
             platform="cli",
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
+            provider_request_overrides=dict(runtime.get("request_overrides") or {}),
+            acp_command=runtime.get("command"),
+            acp_args=list(runtime.get("args") or []),
+            max_tokens=runtime.get("max_output_tokens"),
             fallback_model=_fb or None,
             # Interactive callbacks are intentionally NOT wired beyond this
             # one.  In oneshot mode there's no user sitting at a terminal:

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -731,9 +731,11 @@ def resolve_user_provider(name: str, user_config: Dict[str, Any]) -> Optional[Pr
     if not isinstance(entry, dict):
         return None
 
+    from hermes_cli.config import get_custom_provider_endpoint
+
     # Extract fields
     display_name = entry.get("name", "") or name
-    api_url = entry.get("api", "") or entry.get("url", "") or entry.get("base_url", "") or ""
+    api_url = get_custom_provider_endpoint(entry)
     key_env = entry.get("key_env", "") or ""
     transport = entry.get("transport", "openai_chat") or "openai_chat"
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+from ipaddress import ip_address
 from urllib.parse import urlparse
 from typing import Any, Dict, Optional
 
@@ -70,8 +71,15 @@ def _normalize_custom_provider_name(value: str) -> str:
 
 
 def _loopback_hostname(host: str) -> bool:
-    h = (host or "").lower().rstrip(".")
-    return h in {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
+    h = (host or "").lower().rstrip(".").strip("[]")
+    if h in {"localhost", "0.0.0.0"}:
+        # Preserve Hermes' existing wildcard-bind compatibility. A listener
+        # configured this way is still a local Ollama route.
+        return True
+    try:
+        return ip_address(h).is_loopback
+    except ValueError:
+        return False
 
 
 def _is_named_loopback_ollama_route(requested_provider: str, base_url: str) -> bool:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -90,6 +90,17 @@ def _is_named_loopback_ollama_route(requested_provider: str, base_url: str) -> b
     )
 
 
+def _reject_authenticated_named_local_ollama(base_url: str) -> None:
+    parsed = urlparse(base_url)
+    if parsed.username is None and parsed.password is None:
+        return
+    raise AuthError(
+        "Provider 'ollama' local endpoints cannot use embedded authentication; "
+        "use 'custom:ollama' for authenticated local endpoints.",
+        provider="ollama",
+    )
+
+
 def _config_base_url_trustworthy_for_bare_custom(cfg_base_url: str, cfg_provider: str) -> bool:
     """Decide whether ``model.base_url`` may back bare ``custom`` runtime resolution.
 
@@ -1122,6 +1133,7 @@ def _resolve_named_custom_runtime(
     if explicit_base_url and _is_named_loopback_ollama_route(
         requested_provider, explicit_base_url
     ):
+        _reject_authenticated_named_local_ollama(explicit_base_url)
         base_url = explicit_base_url.strip().rstrip("/")
         return {
             "provider": "custom",
@@ -1190,6 +1202,7 @@ def _resolve_named_custom_runtime(
     # boundary. Keep model and output-token overrides, which are nonsecret.
     # Do not apply this to custom:ollama or remote/LAN Ollama endpoints.
     if _is_named_loopback_ollama_route(requested_provider, base_url):
+        _reject_authenticated_named_local_ollama(base_url)
         result = {
             "provider": "custom",
             "api_mode": custom_provider.get("api_mode")

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -41,6 +41,7 @@ from hermes_cli.auth import (
     normalize_actual_base_url,
 )
 from hermes_cli.config import (
+    get_custom_provider_endpoint,
     get_compatible_custom_providers,
     load_config,
     normalize_extra_headers,
@@ -769,7 +770,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 str(ep_name),
             ):
                 # Found match by provider key
-                base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
+                base_url = get_custom_provider_endpoint(entry)
                 if base_url:
                     result = {
                         "name": entry.get("name", ep_name),
@@ -894,9 +895,7 @@ def find_custom_provider_identity(base_url: str) -> Optional[str]:
         for ep_name, entry in providers.items():
             if not isinstance(entry, dict):
                 continue
-            entry_url = (
-                entry.get("api") or entry.get("url") or entry.get("base_url") or ""
-            )
+            entry_url = get_custom_provider_endpoint(entry)
             if _normalize_base_url_for_match(entry_url) == target:
                 return custom_provider_slug(str(ep_name), str(ep_name))
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -74,6 +74,14 @@ def _loopback_hostname(host: str) -> bool:
     return h in {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
 
 
+def _is_named_loopback_ollama_route(requested_provider: str, base_url: str) -> bool:
+    """Whether the exact named Ollama route resolves to a local endpoint."""
+    return (
+        (requested_provider or "").strip().lower() == "ollama"
+        and _loopback_hostname(base_url_hostname(base_url))
+    )
+
+
 def _config_base_url_trustworthy_for_bare_custom(cfg_base_url: str, cfg_provider: str) -> bool:
     """Decide whether ``model.base_url`` may back bare ``custom`` runtime resolution.
 
@@ -1103,6 +1111,18 @@ def _resolve_named_custom_runtime(
     # `provider: ollama` with a LAN/WireGuard `base_url` doesn't silently
     # fall through to OpenRouter.
     requested_norm = (requested_provider or "").strip().lower()
+    if explicit_base_url and _is_named_loopback_ollama_route(
+        requested_provider, explicit_base_url
+    ):
+        base_url = explicit_base_url.strip().rstrip("/")
+        return {
+            "provider": "custom",
+            "api_mode": _detect_api_mode_for_url(base_url) or "chat_completions",
+            "base_url": base_url,
+            "api_key": "no-key-required",
+            "source": "direct-alias",
+            "requested_provider": requested_provider,
+        }
     if requested_norm and requested_norm != "custom":
         try:
             from hermes_cli.auth import resolve_provider as _resolve_provider
@@ -1155,6 +1175,28 @@ def _resolve_named_custom_runtime(
     ).rstrip("/")
     if not base_url:
         return None
+
+    # A literal ``provider: ollama`` targeting loopback is Hermes's local
+    # no-auth route. Old provider entries can retain remote credentials and
+    # auth headers after an endpoint is changed locally; none may cross this
+    # boundary. Keep model and output-token overrides, which are nonsecret.
+    # Do not apply this to custom:ollama or remote/LAN Ollama endpoints.
+    if _is_named_loopback_ollama_route(requested_provider, base_url):
+        result = {
+            "provider": "custom",
+            "api_mode": custom_provider.get("api_mode")
+            or _detect_api_mode_for_url(base_url)
+            or "chat_completions",
+            "base_url": base_url,
+            "api_key": "no-key-required",
+            "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
+            "requested_provider": requested_provider,
+        }
+        if custom_provider.get("model"):
+            result["model"] = custom_provider["model"]
+        if isinstance(custom_provider.get("max_output_tokens"), int):
+            result["max_output_tokens"] = custom_provider["max_output_tokens"]
+        return result
 
     # Check if a credential pool exists for this custom endpoint
     pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"), provider_name=custom_provider.get("name"))

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7912,6 +7912,8 @@ def _config_api_key_is_env_ref(endpoint_id: str) -> bool:
 
 
 def _custom_endpoint_response(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    from hermes_cli.config import get_custom_provider_endpoint
+
     model_cfg = cfg.get("model", {}) if isinstance(cfg.get("model"), dict) else {}
     current_provider = str(model_cfg.get("provider", "") or "")
     current_model = str(model_cfg.get("default", model_cfg.get("name", "")) or "")
@@ -7923,7 +7925,7 @@ def _custom_endpoint_response(cfg: Dict[str, Any]) -> Dict[str, Any]:
         for provider_id, raw_entry in providers.items():
             if not isinstance(raw_entry, dict):
                 continue
-            base_url = str(raw_entry.get("base_url") or raw_entry.get("url") or raw_entry.get("api") or "").strip()
+            base_url = get_custom_provider_endpoint(raw_entry)
             if not base_url:
                 continue
             endpoint_id = str(provider_id)

--- a/run_agent.py
+++ b/run_agent.py
@@ -6989,6 +6989,7 @@ class AIAgent:
         http_status: Optional[int] = None,
         _initial_provider: Optional[str] = None,
         _initial_model: Optional[str] = None,
+        _diagnostic_reason: "FailoverReason | None" = None,
     ) -> bool:
         """Forwarder — see ``agent.chat_completion_helpers.try_activate_fallback``."""
         from agent.chat_completion_helpers import try_activate_fallback
@@ -6998,6 +6999,7 @@ class AIAgent:
             http_status=http_status,
             _initial_provider=_initial_provider,
             _initial_model=_initial_model,
+            _diagnostic_reason=_diagnostic_reason,
         )
 
     def _has_pending_fallback(self) -> bool:

--- a/run_agent.py
+++ b/run_agent.py
@@ -6351,6 +6351,11 @@ class AIAgent:
         """
         if self.api_mode in ("anthropic_messages", "bedrock_converse"):
             return
+        from hermes_cli.runtime_provider import _is_named_loopback_ollama_route
+
+        route_provider = getattr(self, "requested_provider", "") or self.provider
+        if _is_named_loopback_ollama_route(route_provider, self.base_url):
+            return
         from agent.auxiliary_client import (
             _apply_user_default_headers as _merge_user_headers,
         )

--- a/run_agent.py
+++ b/run_agent.py
@@ -6982,10 +6982,23 @@ class AIAgent:
         from agent.chat_completion_helpers import interruptible_streaming_api_call
         return interruptible_streaming_api_call(self, api_kwargs, on_first_delta=on_first_delta)
 
-    def _try_activate_fallback(self, reason: "FailoverReason | None" = None) -> bool:
+    def _try_activate_fallback(
+        self,
+        reason: "FailoverReason | None" = None,
+        *,
+        http_status: Optional[int] = None,
+        _initial_provider: Optional[str] = None,
+        _initial_model: Optional[str] = None,
+    ) -> bool:
         """Forwarder — see ``agent.chat_completion_helpers.try_activate_fallback``."""
         from agent.chat_completion_helpers import try_activate_fallback
-        return try_activate_fallback(self, reason)
+        return try_activate_fallback(
+            self,
+            reason,
+            http_status=http_status,
+            _initial_provider=_initial_provider,
+            _initial_model=_initial_model,
+        )
 
     def _has_pending_fallback(self) -> bool:
         """Whether a fallback provider is actually available to switch to.

--- a/run_agent.py
+++ b/run_agent.py
@@ -6311,10 +6311,20 @@ class AIAgent:
                 from hermes_cli.config import (
                     apply_custom_provider_extra_headers_to_client_kwargs,
                 )
-
-                apply_custom_provider_extra_headers_to_client_kwargs(
-                    self._client_kwargs, base_url,
+                from hermes_cli.runtime_provider import (
+                    _is_named_loopback_ollama_route,
                 )
+
+                # The named loopback Ollama resolver deliberately drops stale
+                # provider auth headers. Do not reconstruct them here from
+                # config after that credential boundary has been applied.
+                route_provider = (
+                    getattr(self, "requested_provider", "") or self.provider
+                )
+                if not _is_named_loopback_ollama_route(route_provider, base_url):
+                    apply_custom_provider_extra_headers_to_client_kwargs(
+                        self._client_kwargs, base_url,
+                    )
             except Exception:
                 logger.debug("custom-provider extra_headers skipped", exc_info=True)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -46,6 +46,7 @@ import time
 import threading
 import uuid
 import warnings
+from collections.abc import Mapping
 from typing import List, Dict, Any, Optional, Callable
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
 # SDK pulls ~240 ms of imports. We expose `OpenAI` as a thin proxy object
@@ -432,6 +433,39 @@ class AIAgent:
         self._base_url_lower = value.lower() if value else ""
         self._base_url_hostname = base_url_hostname(value)
 
+    def _rebuild_effective_request_overrides(self) -> None:
+        provider = copy.deepcopy(self._provider_request_overrides)
+        caller = copy.deepcopy(self._caller_request_overrides)
+        effective = copy.deepcopy(provider)
+        effective.update(copy.deepcopy(caller))
+        provider_body = provider.get("extra_body")
+        caller_body = caller.get("extra_body")
+        if isinstance(provider_body, Mapping) and isinstance(caller_body, Mapping):
+            body = copy.deepcopy(dict(provider_body))
+            body.update(copy.deepcopy(dict(caller_body)))
+            effective["extra_body"] = body
+        self._request_overrides = copy.deepcopy(effective)
+
+    def _set_caller_request_overrides(self, value) -> None:
+        if value is not None and not isinstance(value, Mapping):
+            raise TypeError("caller request overrides must be a mapping")
+        self._caller_request_overrides = copy.deepcopy(dict(value or {}))
+        self._rebuild_effective_request_overrides()
+
+    def _set_provider_request_overrides(self, value) -> None:
+        if value is not None and not isinstance(value, Mapping):
+            raise TypeError("provider request overrides must be a mapping")
+        self._provider_request_overrides = copy.deepcopy(dict(value or {}))
+        self._rebuild_effective_request_overrides()
+
+    @property
+    def request_overrides(self):
+        return self._request_overrides
+
+    @request_overrides.setter
+    def request_overrides(self, value):
+        self._set_caller_request_overrides(value)
+
     def __init__(
         self,
         base_url: str = None,
@@ -510,6 +544,7 @@ class AIAgent:
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
         requested_provider: str = None,
+        provider_request_overrides: dict[str, Any] | None = None,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         if tool_delay is not None:
@@ -597,6 +632,7 @@ class AIAgent:
             checkpoint_max_total_size_mb=checkpoint_max_total_size_mb,
             checkpoint_max_file_size_mb=checkpoint_max_file_size_mb,
             pass_session_id=pass_session_id,
+            provider_request_overrides=provider_request_overrides,
         )
 
     def _get_session_db_for_recall(self):

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -450,3 +450,68 @@ def test_acp_persist_writes_safe_requested_provider_metadata(tmp_path, monkeypat
     SessionManager(db=db)._persist(state)
     config = db.create_session.call_args.kwargs["model_config"]
     assert config == {"cwd": str(tmp_path), "model": "synthetic-model", "provider": "custom", "requested_provider": "custom:remote", "base_url": "https://remote.example/v1", "api_mode": "chat_completions"}
+
+
+def test_acp_legacy_bare_custom_restores_identity_and_heals_on_persist(tmp_path, monkeypatch):
+    """Removing legacy recovery would rebind a stored custom endpoint as bare custom."""
+    db = MagicMock()
+    db.get_session.return_value = {
+        "source": "acp",
+        "model": "legacy-model",
+        "model_config": json.dumps({
+            "cwd": str(tmp_path), "provider": "custom",
+            "base_url": "https://legacy.example/v1", "api_mode": "chat_completions",
+        }),
+    }
+    db.get_messages_as_conversation.return_value = []
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.canonical_custom_identity",
+        lambda **_kwargs: "custom:legacy",
+    )
+    resolved = MagicMock(return_value={
+        "provider": "custom", "requested_provider": "custom:legacy",
+        "api_key": "synthetic-key", "base_url": "https://legacy.example/v1",
+        "api_mode": "chat_completions", "request_overrides": {},
+        "credential_pool": None, "command": None, "args": [],
+    })
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", resolved)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": {"default": "legacy-model"}})
+    monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda *_args: None)
+    agent = SimpleNamespace(
+        model="legacy-model", provider="custom", requested_provider="custom:legacy",
+        base_url="https://legacy.example/v1", api_mode="chat_completions",
+        _session_db=None, _session_db_created=False,
+    )
+
+    with patch("run_agent.AIAgent", return_value=agent):
+        manager = SessionManager(db=db)
+        restored = manager._restore("legacy-acp-row")
+
+    assert restored is not None
+    assert resolved.call_args.kwargs["requested"] == "custom:legacy"
+    manager._persist(restored)
+    healed = json.loads(db.update_session_meta.call_args.args[1])
+    assert healed["requested_provider"] == "custom:legacy"
+
+
+def test_acp_unknown_present_identity_fails_closed_without_agent_construction(tmp_path, monkeypatch):
+    """Removing resolver-failure handling would construct an unbound default agent."""
+    db = MagicMock()
+    db.get_session.return_value = {
+        "source": "acp", "model": "synthetic-model",
+        "model_config": json.dumps({
+            "cwd": str(tmp_path), "provider": "custom", "requested_provider": "unknown:route",
+        }),
+    }
+    db.get_messages_as_conversation.return_value = []
+    resolver = MagicMock(side_effect=ValueError("unknown persisted provider"))
+    constructor = MagicMock()
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", resolver)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": {"default": "synthetic-model"}})
+    monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda *_args: None)
+
+    with patch("run_agent.AIAgent", constructor):
+        assert SessionManager(db=db)._restore("unknown-acp-row") is None
+
+    assert resolver.call_args.kwargs["requested"] == "unknown:route"
+    constructor.assert_not_called()

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -4,13 +4,35 @@ import contextlib
 import io
 import json
 import time
+from copy import deepcopy
 from types import SimpleNamespace
 import pytest
 from unittest.mock import MagicMock, patch
 
+from run_agent import AIAgent as RealAIAgent
+
 from acp_adapter import session as acp_session
 from acp_adapter.session import SessionManager, SessionState
 from hermes_state import SessionDB
+
+
+def _install_real_agent_probe_guards(monkeypatch):
+    context_length = MagicMock(return_value=262144)
+    endpoint_metadata = MagicMock(side_effect=AssertionError("constructor attempted endpoint metadata access"))
+    local_server = MagicMock(side_effect=AssertionError("constructor attempted local-server detection"))
+    monkeypatch.setattr("agent.context_compressor.get_model_context_length", context_length)
+    monkeypatch.setattr("agent.model_metadata.get_model_context_length", context_length)
+    monkeypatch.setattr("agent.model_metadata.fetch_endpoint_model_metadata", endpoint_metadata)
+    monkeypatch.setattr("agent.usage_pricing.fetch_endpoint_model_metadata", MagicMock(return_value={}))
+    monkeypatch.setattr("agent.model_metadata.detect_local_server_type", local_server)
+    return context_length, endpoint_metadata, local_server
+
+
+def _assert_real_agent_probe_guards(probes):
+    context_length, endpoint_metadata, local_server = probes
+    context_length.assert_called()
+    endpoint_metadata.assert_not_called()
+    local_server.assert_not_called()
 
 
 def _mock_agent():
@@ -375,3 +397,56 @@ class TestPersistence:
 
         assert stdout_buf.getvalue() == ""
         assert stderr_buf.getvalue() == "ACP noise\n"
+
+
+@pytest.mark.parametrize("requested", ["custom", "custom:remote"])
+def test_acp_modern_requested_identity_resolves_without_reverse_inference(requested, tmp_path, monkeypatch):
+    import run_agent
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    db = MagicMock()
+    db.get_session.return_value = {
+        "source": "acp", "model": "synthetic-model",
+        "model_config": json.dumps({"cwd": str(tmp_path), "provider": "custom", "requested_provider": requested, "base_url": "https://remote.example/v1", "api_mode": "chat_completions"}),
+    }
+    db.get_messages_as_conversation.return_value = []
+    canonical = MagicMock(side_effect=AssertionError("modern ACP row reverse-inferred"))
+    resolved = MagicMock(return_value={"provider": "custom", "requested_provider": requested, "api_key": "synthetic-key", "base_url": "https://remote.example/v1", "api_mode": "chat_completions", "request_overrides": {"extra_body": {"route": "provider"}}, "credential_pool": None, "command": None, "args": [], "max_output_tokens": None})
+    monkeypatch.setattr("hermes_cli.runtime_provider.canonical_custom_identity", canonical)
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", resolved)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": {"default": "synthetic-model", "provider": requested}})
+    monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda *_a: None)
+    monkeypatch.setattr(run_agent, "OpenAI", MagicMock(return_value=MagicMock()))
+    constructor_probes = _install_real_agent_probe_guards(monkeypatch)
+    captured = {}
+
+    def construct(*args, **kwargs):
+        captured["kwargs"] = deepcopy(kwargs)
+        captured["agent"] = RealAIAgent(*args, **kwargs)
+        return captured["agent"]
+
+    with patch("run_agent.AIAgent", side_effect=construct):
+        restored = SessionManager(db=db)._restore("modern-acp-row")
+    assert restored is not None
+    canonical.assert_not_called()
+    assert resolved.call_args.kwargs["requested"] == requested
+    assert isinstance(restored.agent, RealAIAgent)
+    assert (restored.agent.provider, restored.agent.requested_provider) == ("custom", requested)
+    assert restored.agent._caller_request_overrides == {}
+    assert restored.agent._provider_request_overrides == {"extra_body": {"route": "provider"}}
+    _assert_real_agent_probe_guards(constructor_probes)
+
+
+def test_acp_persist_writes_safe_requested_provider_metadata(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    db = MagicMock()
+    db.get_session.return_value = None
+    agent = SimpleNamespace(
+        provider="custom", requested_provider="custom:remote",
+        base_url="https://" + "synthetic-user" + ":" + "synthetic-pass" + "@remote.example/v1?synthetic_token=value#fragment",
+        api_mode="chat_completions", _session_db=None, _session_db_created=False,
+    )
+    state = SessionState(session_id="safe-acp", agent=agent, cwd=str(tmp_path), model="synthetic-model", history=[], cancel_event=None)
+    SessionManager(db=db)._persist(state)
+    config = db.create_session.call_args.kwargs["model_config"]
+    assert config == {"cwd": str(tmp_path), "model": "synthetic-model", "provider": "custom", "requested_provider": "custom:remote", "base_url": "https://remote.example/v1", "api_mode": "chat_completions"}

--- a/tests/agent/test_custom_provider_extra_body.py
+++ b/tests/agent/test_custom_provider_extra_body.py
@@ -1,26 +1,45 @@
-from types import SimpleNamespace
+from unittest.mock import MagicMock
 
-from agent.agent_init import _merge_custom_provider_extra_body
+import agent.agent_init as agent_init
+from run_agent import AIAgent
+
+
+def _install_task1_constructor_guards(monkeypatch):
+    probes = {
+        "context": MagicMock(return_value=262_144),
+        "endpoint": MagicMock(
+            side_effect=AssertionError("constructor endpoint probe forbidden")
+        ),
+        "local": MagicMock(
+            side_effect=AssertionError("constructor local-service probe forbidden")
+        ),
+    }
+    monkeypatch.setattr(
+        "agent.context_compressor.get_model_context_length", probes["context"],
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.fetch_endpoint_model_metadata", probes["endpoint"],
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.detect_local_server_type", probes["local"],
+    )
+    return probes
+
+
+def _assert_task1_constructor_guards(probes):
+    probes["context"].assert_called_once()
+    probes["endpoint"].assert_not_called()
+    probes["local"].assert_not_called()
 
 
 
-
-def test_custom_provider_extra_body_preserves_caller_override():
-    agent = SimpleNamespace(
+def test_custom_provider_extra_body_preserves_caller_override(tmp_path, monkeypatch):
+    provider_overrides = agent_init._provider_request_overrides_for_route(
+        requested_provider="custom",
         provider="custom",
         model="google/gemma-4-31b-it",
         base_url="https://example.test/v1",
-        request_overrides={
-            "extra_body": {
-                "reasoning_effort": "low",
-                "caller_only": True,
-            }
-        },
-    )
-
-    _merge_custom_provider_extra_body(
-        agent,
-        [
+        custom_providers=[
             {
                 "name": "gemma",
                 "base_url": "https://example.test/v1",
@@ -33,26 +52,44 @@ def test_custom_provider_extra_body_preserves_caller_override():
         ],
     )
 
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("run_agent.OpenAI", MagicMock(return_value=MagicMock()))
+    probes = _install_task1_constructor_guards(monkeypatch)
+    agent = AIAgent(
+        api_key="synthetic-key",
+        base_url="https://example.test/v1",
+        provider="custom",
+        requested_provider="custom",
+        model="google/gemma-4-31b-it",
+        request_overrides={
+            "extra_body": {
+                "reasoning_effort": "low",
+                "caller_only": True,
+            }
+        },
+        provider_request_overrides=provider_overrides,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
     assert agent.request_overrides["extra_body"] == {
         "enable_thinking": True,
         "reasoning_effort": "low",
         "caller_only": True,
     }
+    _assert_task1_constructor_guards(probes)
 
 
 
 
-def test_named_custom_provider_extra_body_matches_provider_key():
-    agent = SimpleNamespace(
+def test_named_custom_provider_extra_body_matches_provider_key(tmp_path, monkeypatch):
+    provider_overrides = agent_init._provider_request_overrides_for_route(
+        requested_provider="custom:zai-coding-plan",
         provider="custom:zai-coding-plan",
         model="glm-5.2",
         base_url="https://api.z.ai/api/coding/paas/v4",
-        request_overrides={},
-    )
-
-    _merge_custom_provider_extra_body(
-        agent,
-        [
+        custom_providers=[
             {
                 "provider_key": "other-provider",
                 "name": "Other Provider",
@@ -70,4 +107,103 @@ def test_named_custom_provider_extra_body_matches_provider_key():
         ],
     )
 
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("run_agent.OpenAI", MagicMock(return_value=MagicMock()))
+    probes = _install_task1_constructor_guards(monkeypatch)
+    agent = AIAgent(
+        api_key="synthetic-key",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        provider="custom:zai-coding-plan",
+        requested_provider="custom:zai-coding-plan",
+        model="glm-5.2",
+        request_overrides={},
+        provider_request_overrides=provider_overrides,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
     assert agent.request_overrides == {"extra_body": {"enable_thinking": False}}
+    _assert_task1_constructor_guards(probes)
+
+
+def test_constructor_separates_layers_deep_copies_and_whole_replacement(
+    tmp_path, monkeypatch
+):
+    provider = {
+        "provider_option": {"marker": "provider"},
+        "extra_body": {
+            "auth": {"provider_marker": "must-disappear", "mode": "provider"},
+            "provider_only": {"value": 1},
+        },
+    }
+    caller = {
+        "caller_option": {"marker": "caller"},
+        "extra_body": {
+            "auth": {"mode": "caller"},
+            "caller_only": {"value": 2},
+        },
+    }
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("run_agent.OpenAI", MagicMock(return_value=MagicMock()))
+    probes = _install_task1_constructor_guards(monkeypatch)
+    agent = AIAgent(
+        api_key="synthetic-key",
+        base_url="https://remote.example/v1",
+        provider="custom",
+        requested_provider="custom:remote",
+        model="synthetic-model",
+        request_overrides=caller,
+        provider_request_overrides=provider,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    provider["extra_body"]["auth"]["provider_marker"] = "mutated-input"
+    caller["extra_body"]["auth"]["mode"] = "mutated-input"
+    assert agent._provider_request_overrides["extra_body"]["auth"]["provider_marker"] == "must-disappear"
+    assert agent._caller_request_overrides["extra_body"]["auth"] == {"mode": "caller"}
+    assert agent.request_overrides["extra_body"] == {
+        "auth": {"mode": "caller"},
+        "provider_only": {"value": 1},
+        "caller_only": {"value": 2},
+    }
+
+    replacement = {"speed": "fast", "extra_body": {"auth": {"mode": "replacement"}}}
+    agent.request_overrides = replacement
+    replacement["extra_body"]["auth"]["mode"] = "mutated-after-assignment"
+    assert agent._caller_request_overrides == {
+        "speed": "fast",
+        "extra_body": {"auth": {"mode": "replacement"}},
+    }
+    assert agent.request_overrides["extra_body"]["auth"] == {"mode": "replacement"}
+    assert "provider_marker" not in agent.request_overrides["extra_body"]["auth"]
+    _assert_task1_constructor_guards(probes)
+
+
+def test_provider_layer_parameter_is_appended_after_requested_provider(monkeypatch):
+    import inspect
+
+    from agent.agent_init import init_agent
+
+    constructor_parameters = list(inspect.signature(AIAgent.__init__).parameters.values())[1:]
+    initializer_parameters = list(inspect.signature(init_agent).parameters.values())[1:]
+    assert [item.name for item in constructor_parameters[-2:]] == [
+        "requested_provider",
+        "provider_request_overrides",
+    ]
+    assert [item.name for item in initializer_parameters[-2:]] == [
+        "requested_provider",
+        "provider_request_overrides",
+    ]
+    assert all(item.default is not inspect.Parameter.empty for item in constructor_parameters)
+
+    old_positional_arguments = [item.default for item in constructor_parameters[:-2]]
+    old_positional_arguments.append("custom:positional-proof")
+    forwarded = MagicMock()
+    monkeypatch.setattr("agent.agent_init.init_agent", forwarded)
+    AIAgent(*old_positional_arguments)
+
+    assert forwarded.call_args.kwargs["requested_provider"] == "custom:positional-proof"
+    assert forwarded.call_args.kwargs["provider_request_overrides"] is None

--- a/tests/cli/test_resume_model_restore.py
+++ b/tests/cli/test_resume_model_restore.py
@@ -7,6 +7,7 @@ used instead of the ambient config default (#57588-class, #79536).
 """
 
 import json
+from copy import deepcopy
 
 import pytest
 
@@ -410,3 +411,55 @@ def test_cli_absent_requested_provider_legacy_heals_on_next_write(monkeypatch):
     assert route["requested_provider"] == "custom:remote"
     assert route["base_url"] == "https://remote.example/v1"
     assert not ({"api_key", "request_overrides", "provider_request_overrides"} & route.keys())
+
+
+def test_cli_in_place_resume_installs_resolved_route_binding(monkeypatch):
+    """Removing the post-swap route install loses the requested identity and provider layer."""
+    class LiveAgent:
+        def __init__(self):
+            self.model = "ambient-model"
+            self.provider = "openrouter"
+            self.requested_provider = "openrouter"
+            self._caller_request_overrides = {"extra_body": {"caller": "keep"}, "caller_only": True}
+            self._provider_request_overrides = {"extra_body": {"old": "drop"}}
+            self._request_overrides = {}
+            self._primary_runtime = {}
+
+        def _set_provider_request_overrides(self, value):
+            self._provider_request_overrides = deepcopy(value)
+            effective = deepcopy(self._provider_request_overrides)
+            effective.update(deepcopy(self._caller_request_overrides))
+            effective["extra_body"] = {
+                **self._provider_request_overrides.get("extra_body", {}),
+                **self._caller_request_overrides.get("extra_body", {}),
+            }
+            self._request_overrides = effective
+
+        def switch_model(self, **kwargs):
+            self.model = kwargs["new_model"]
+            self.provider = kwargs["new_provider"]
+            self.requested_provider = kwargs["new_provider"]
+            self._primary_runtime = {"requested_provider": kwargs["new_provider"]}
+
+    provider_layer = {"extra_body": {"route": "fresh"}, "provider_only": True}
+    runtime = {
+        "provider": "custom", "requested_provider": "ollama",
+        "api_key": "synthetic-key", "base_url": "http://127.0.0.1:11434/v1",
+        "api_mode": "chat_completions", "request_overrides": provider_layer,
+        "credential_pool": None,
+    }
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", lambda **_kwargs: runtime)
+    agent = LiveAgent()
+    stub = _make_stub(agent=agent)
+
+    stub._restore_session_model(_row(model_config={"gateway_runtime": {
+        "provider": "custom", "requested_provider": "ollama",
+        "base_url": "http://127.0.0.1:11434/v1", "api_mode": "chat_completions",
+    }}))
+    provider_layer["extra_body"]["route"] = "mutated-after-resume"
+
+    assert agent.requested_provider == "ollama"
+    assert agent._provider_request_overrides == {"extra_body": {"route": "fresh"}, "provider_only": True}
+    assert agent._caller_request_overrides == {"extra_body": {"caller": "keep"}, "caller_only": True}
+    assert agent._request_overrides == {"extra_body": {"route": "fresh", "caller": "keep"}, "provider_only": True, "caller_only": True}
+    assert agent._primary_runtime["requested_provider"] == "ollama"

--- a/tests/cli/test_resume_model_restore.py
+++ b/tests/cli/test_resume_model_restore.py
@@ -124,6 +124,8 @@ def test_restore_session_model_swaps_running_agent_in_place():
 class _Result:
     new_model = "deepseek-v4-flash-free"
     target_provider = "custom:opencode-zen"
+    provider = "custom"
+    requested_provider = "custom:opencode-zen"
     base_url = "https://oz/v1"
     api_mode = ""
 
@@ -143,9 +145,11 @@ def test_persist_model_switch_writes_model_and_both_route_shapes():
     assert written["model"] == ("s1", "deepseek-v4-flash-free")
     sid, patch = written["patch"]
     # Nested shape for the CLI reader...
-    assert patch["gateway_runtime"]["provider"] == "custom:opencode-zen"
+    assert patch["gateway_runtime"]["provider"] == "custom"
+    assert patch["gateway_runtime"]["requested_provider"] == "custom:opencode-zen"
     # ...and top-level for the TUI gateway's _stored_session_runtime_overrides.
-    assert patch["provider"] == "custom:opencode-zen"
+    assert patch["provider"] == "custom"
+    assert patch["requested_provider"] == "custom:opencode-zen"
     assert patch["base_url"] == "https://oz/v1"
     # Both shapes use or-None so stale keys are deleted (not merely omitted)
     # in BOTH gateway_runtime and top-level — the asymmetry that caused the
@@ -213,8 +217,8 @@ def test_persist_model_switch_swallows_db_errors():
     stub._persist_model_switch_to_session(_Result())  # must not raise
 
 
-def test_persist_model_switch_heals_bare_custom(monkeypatch):
-    """Bare 'custom' is not routable — heal to custom:<name> or drop (C1)."""
+def test_persist_model_switch_keeps_explicit_modern_custom_identity(monkeypatch):
+    """An explicit modern requested identity must not be reverse-inferred."""
     written = {}
 
     class _DB:
@@ -227,24 +231,18 @@ def test_persist_model_switch_heals_bare_custom(monkeypatch):
     class _BareResult:
         new_model = "qwen3.6-plus"
         target_provider = "custom"
+        provider = "custom"
+        requested_provider = "custom"
         base_url = "https://my-endpoint/v1"
         api_mode = ""
 
     import hermes_cli.runtime_provider as rp
-    monkeypatch.setattr(rp, "canonical_custom_identity",
-                        lambda base_url=None, model=None: "custom:myendpoint")
+    monkeypatch.setattr(rp, "canonical_custom_identity", pytest.fail)
     stub = _make_stub(_session_db=_DB(), session_id="s1")
     stub._persist_model_switch_to_session(_BareResult())
-    assert written["patch"]["provider"] == "custom:myendpoint"
-
-    # Healing fails -> provider dropped (explicit None deletes any stale
-    # persisted provider), never persisted bare.
-    monkeypatch.setattr(rp, "canonical_custom_identity",
-                        lambda base_url=None, model=None: None)
-    written.clear()
-    stub._persist_model_switch_to_session(_BareResult())
-    assert written["patch"]["provider"] is None
-    assert written["patch"]["gateway_runtime"]["provider"] is None
+    assert written["patch"]["provider"] == "custom"
+    assert written["patch"]["requested_provider"] == "custom"
+    assert written["patch"]["gateway_runtime"]["provider"] == "custom"
 
 
 def test_restore_session_model_heals_bare_custom_stored_rows(monkeypatch):
@@ -276,7 +274,8 @@ def test_round_trip_persist_then_restore(tmp_path, monkeypatch):
     restored = _make_stub()
     restored._restore_session_model(meta)
     assert restored.model == "deepseek-v4-flash-free"
-    assert restored.provider == "custom:opencode-zen"
+    assert restored.provider == "custom"
+    assert restored.requested_provider == "custom:opencode-zen"
     assert restored.base_url == "https://oz/v1"
 
 
@@ -365,3 +364,49 @@ def test_restore_session_model_restores_billing_provider_fallback():
     })
     assert stub.model == "glm-4.7"
     assert stub.provider == "minimax"
+
+
+@pytest.mark.parametrize("requested", ["custom", "custom:remote"])
+def test_cli_modern_requested_provider_is_authoritative(requested, monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    canonical = pytest.fail
+    monkeypatch.setattr("hermes_cli.runtime_provider.canonical_custom_identity", lambda **_kwargs: canonical("modern rows must not reverse-infer identity"))
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", lambda **_kwargs: {"provider": "custom", "requested_provider": requested, "api_key": "synthetic-key", "base_url": "https://remote.example/v1", "api_mode": "chat_completions", "request_overrides": {}, "credential_pool": None, "command": None, "args": [], "max_output_tokens": None})
+    stub = _make_stub()
+    stub._restore_session_model(_row(model_config={"gateway_runtime": {"provider": "custom", "requested_provider": requested, "base_url": "https://remote.example/v1", "api_mode": "chat_completions"}}))
+    assert stub.provider == "custom"
+    assert stub.requested_provider == requested
+
+
+@pytest.mark.parametrize("invalid", [None, "", "   ", [], {}, "custom:"])
+def test_cli_present_invalid_requested_provider_fails_closed(invalid):
+    stub = _make_stub()
+    with pytest.raises(ValueError, match="requested_provider"):
+        stub._restore_session_model(_row(model_config={"gateway_runtime": {"provider": "custom", "requested_provider": invalid, "base_url": "https://remote.example/v1"}}))
+    assert stub.model == "ambient-model"
+    assert stub.requested_provider == "openrouter"
+
+
+def test_cli_absent_requested_provider_legacy_heals_on_next_write(monkeypatch):
+    monkeypatch.setattr("hermes_cli.runtime_provider.canonical_custom_identity", lambda **_kwargs: "custom:remote")
+    written = {}
+
+    class DB:
+        def update_session_model(self, session_id, model):
+            written["model"] = (session_id, model)
+
+        def patch_session_model_config(self, session_id, patch):
+            written["patch"] = (session_id, patch)
+
+    stub = _make_stub(_session_db=DB(), session_id="synthetic-session")
+    stub._restore_session_model(_row(model_config={"gateway_runtime": {"provider": "custom", "base_url": "https://remote.example/v1", "api_mode": "chat_completions"}}))
+    assert stub.requested_provider == "custom:remote"
+    result = _Result()
+    result.provider = "custom"
+    result.requested_provider = stub.requested_provider
+    result.base_url = "https://" + "synthetic-user" + ":" + "synthetic-pass" + "@remote.example/v1?token=value#fragment"
+    stub._persist_model_switch_to_session(result)
+    route = written["patch"][1]["gateway_runtime"]
+    assert route["requested_provider"] == "custom:remote"
+    assert route["base_url"] == "https://remote.example/v1"
+    assert not ({"api_key", "request_overrides", "provider_request_overrides"} & route.keys())

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -5,9 +5,11 @@ import itertools
 import json
 import logging
 import os
+from copy import deepcopy
 from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
+from run_agent import AIAgent as RealAIAgent
 
 from cron.scheduler import (
     SILENT_MARKER,
@@ -23,6 +25,25 @@ from cron.scheduler import (
 )
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
+
+
+def _install_real_agent_probe_guards(monkeypatch):
+    context_length = MagicMock(return_value=262144)
+    endpoint_metadata = MagicMock(side_effect=AssertionError("constructor attempted endpoint metadata access"))
+    local_server = MagicMock(side_effect=AssertionError("constructor attempted local-server detection"))
+    monkeypatch.setattr("agent.context_compressor.get_model_context_length", context_length)
+    monkeypatch.setattr("agent.model_metadata.get_model_context_length", context_length)
+    monkeypatch.setattr("agent.model_metadata.fetch_endpoint_model_metadata", endpoint_metadata)
+    monkeypatch.setattr("agent.usage_pricing.fetch_endpoint_model_metadata", MagicMock(return_value={}))
+    monkeypatch.setattr("agent.model_metadata.detect_local_server_type", local_server)
+    return context_length, endpoint_metadata, local_server
+
+
+def _assert_real_agent_probe_guards(probes):
+    context_length, endpoint_metadata, local_server = probes
+    context_length.assert_called()
+    endpoint_metadata.assert_not_called()
+    local_server.assert_not_called()
 
 
 class TestSummarizeCronFailureForDelivery:
@@ -563,6 +584,72 @@ class TestRunJobSessionPersistence:
         assert call_args[0][1] == "cron_complete"
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
+
+    def test_run_job_real_agent_forwards_complete_runtime_binding(self, tmp_path, monkeypatch):
+        import run_agent
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        job = {"id": "provider-binding-job", "name": "provider binding job", "prompt": "synthetic cron prompt", "enabled_toolsets": []}
+        config = {"model": {"default": "synthetic-model", "provider": "custom:remote"}, "agent": {"max_turns": 2}, "cron": {"preflight": False}, "fallback_providers": []}
+        runtime = {"provider": "custom", "requested_provider": "custom:remote", "api_key": "synthetic-key", "base_url": "https://remote.example/v1", "api_mode": "chat_completions", "request_overrides": {"extra_body": {"route": "provider-owned"}}, "credential_pool": None, "command": "synthetic-command", "args": ["--synthetic"], "max_output_tokens": 3072}
+        fake_db = MagicMock(name="SyntheticCronSessionDB")
+        fake_db.get_compression_tip.side_effect = lambda session_id: session_id
+        sdk_client = MagicMock(name="SyntheticCronSDKClient")
+        openai_factory = MagicMock(return_value=sdk_client)
+        monkeypatch.setattr(run_agent, "OpenAI", openai_factory)
+        constructor_probes = _install_real_agent_probe_guards(monkeypatch)
+        captured = {}
+
+        def construct(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = dict(kwargs)
+            agent = RealAIAgent(*args, **kwargs)
+            captured["agent"] = agent
+            agent.run_conversation = MagicMock(return_value={"final_response": "synthetic cron response", "messages": [], "api_calls": 0, "completed": True})
+            agent.close = MagicMock()
+            return agent
+
+        empty_pool = MagicMock(name="EmptyCredentialPool")
+        empty_pool.has_credentials.return_value = False
+        with (
+            patch("cron.scheduler._hermes_home", hermes_home),
+            patch("cron.scheduler._resolve_origin", return_value=None),
+            patch("cron.scheduler._preflight_job_config", return_value=None),
+            patch("cron.scheduler.load_config", return_value=deepcopy(config)),
+            patch("hermes_cli.config.load_config", return_value=deepcopy(config)),
+            patch("hermes_cli.env_loader.load_hermes_dotenv"),
+            patch("hermes_cli.env_loader.reset_secret_source_cache"),
+            patch("hermes_state.SessionDB", return_value=fake_db),
+            patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=deepcopy(runtime)),
+            patch("agent.credential_pool.load_pool", return_value=empty_pool),
+            patch("tools.mcp_tool.discover_mcp_tools", return_value=[]),
+            patch("cron.scheduler._resolve_cron_enabled_toolsets", return_value=[]),
+            patch("cron.scheduler._resolve_cron_disabled_toolsets", return_value=[]),
+            patch("run_agent.AIAgent", side_effect=construct),
+        ):
+            success, output, final_response, error = run_job(job)
+
+        assert success is True and error is None
+        assert final_response == "synthetic cron response"
+        assert "synthetic cron response" in output
+        assert isinstance(captured["agent"], RealAIAgent)
+        kwargs = captured["kwargs"]
+        assert (kwargs["provider"], kwargs["requested_provider"]) == ("custom", "custom:remote")
+        assert kwargs["provider_request_overrides"] == {"extra_body": {"route": "provider-owned"}}
+        assert kwargs["acp_command"] == "synthetic-command"
+        assert kwargs["acp_args"] == ["--synthetic"]
+        assert kwargs["max_tokens"] == 3072
+        assert captured["agent"]._caller_request_overrides == {}
+        assert captured["agent"]._provider_request_overrides == {"extra_body": {"route": "provider-owned"}}
+        captured["agent"].run_conversation.assert_called_once()
+        captured["agent"].close.assert_called_once()
+        fake_db.end_session.assert_called_once()
+        fake_db.close.assert_called_once()
+        sdk_client.chat.completions.create.assert_not_called()
+        openai_factory.assert_called_once()
+        _assert_real_agent_probe_guards(constructor_probes)
 
 
     @contextlib.contextmanager

--- a/tests/hermes_cli/test_cli_custom_provider_vision.py
+++ b/tests/hermes_cli/test_cli_custom_provider_vision.py
@@ -7,13 +7,48 @@ and assert that the separate requested identity reaches each capability gate.
 
 from __future__ import annotations
 
+from copy import deepcopy
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
+from run_agent import AIAgent as RealAIAgent
 from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
 
 
 MODEL = "qwen3.8-max-preview"
 REQUESTED_PROVIDER = "custom:qwen-token-plan"
+
+
+def _install_real_agent_probe_guards(monkeypatch):
+    context_length = MagicMock(return_value=262144)
+    endpoint_metadata = MagicMock(side_effect=AssertionError("constructor attempted endpoint metadata access"))
+    local_server = MagicMock(side_effect=AssertionError("constructor attempted local-server detection"))
+    monkeypatch.setattr("agent.context_compressor.get_model_context_length", context_length)
+    monkeypatch.setattr("agent.model_metadata.fetch_endpoint_model_metadata", endpoint_metadata)
+    monkeypatch.setattr("agent.model_metadata.detect_local_server_type", local_server)
+    return context_length, endpoint_metadata, local_server
+
+
+def _assert_real_agent_probe_guards(probes):
+    context_length, endpoint_metadata, local_server = probes
+    context_length.assert_called()
+    endpoint_metadata.assert_not_called()
+    local_server.assert_not_called()
+
+
+def _install_real_agent_factory(monkeypatch, target, captured):
+    captured["constructor_probes"] = _install_real_agent_probe_guards(monkeypatch)
+
+    def construct(*args, **kwargs):
+        captured["args"] = deepcopy(args)
+        captured["kwargs"] = deepcopy(kwargs)
+        agent = RealAIAgent(*args, **kwargs)
+        captured["agent"] = agent
+        agent.run_conversation = MagicMock(return_value={"final_response": "synthetic-response", "messages": []})
+        agent.chat = MagicMock(return_value="synthetic-response")
+        return agent
+
+    monkeypatch.setattr(target, construct)
 
 
 class _RuntimeCLI(CLIAgentSetupMixin):
@@ -123,3 +158,59 @@ def test_named_identity_reaches_agent_and_vision_tool_native_gates():
         assert _should_use_native_vision_fast_path() is True
     finally:
         reset_runtime_main(token)
+
+
+def test_cli_primary_real_agent_keeps_provider_layer(tmp_path, monkeypatch):
+    import cli
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    runtime = {
+        "provider": "custom", "requested_provider": "ollama",
+        "api_key": "synthetic-key", "base_url": "http://127.0.0.1:11434/v1",
+        "api_mode": "chat_completions", "request_overrides": {},
+        "credential_pool": None, "command": "synthetic-command", "args": ["--synthetic"],
+        "max_output_tokens": None,
+    }
+    cli_instance = _RuntimeCLI(model="synthetic-model", provider="ollama")
+    cli_instance.__dict__.update({
+        "max_tokens": 4096, "max_turns": 2, "enabled_toolsets": [],
+        "disabled_toolsets": [], "verbose": False, "tool_progress_mode": "all",
+        "system_prompt": "", "prefill_messages": [], "reasoning_config": None,
+        "_providers_only": None, "_providers_ignore": None, "_providers_order": None,
+        "_provider_sort": None, "_provider_require_params": False,
+        "_provider_data_collection": None, "_openrouter_min_coding_score": None,
+        "session_id": "synthetic-session", "_session_db": MagicMock(),
+        "_resumed": False, "conversation_history": [],
+        "checkpoints_enabled": False, "checkpoint_max_snapshots": 5,
+        "checkpoint_max_total_size_mb": 50, "checkpoint_max_file_size_mb": 10,
+        "pass_session_id": False, "ignore_rules": True, "streaming_enabled": False,
+        "_inline_diffs_enabled": False, "_pending_title": None,
+    })
+    cli_instance._clarify_callback = None
+    cli_instance.finalize_preloaded_skills = lambda: None
+    cli_instance._install_tool_callbacks = lambda: None
+    cli_instance._ensure_tirith_security = lambda: None
+    cli_instance._ensure_runtime_credentials = lambda: True
+    cli_instance._current_reasoning_callback = lambda: None
+    cli_instance._on_thinking = None
+    cli_instance._on_tool_progress = None
+    cli_instance._on_tool_start = None
+    cli_instance._on_tool_complete = None
+    cli_instance._stream_delta = None
+    cli_instance._on_tool_gen_start = None
+    cli_instance._on_notice = None
+    cli_instance._on_notice_clear = None
+    cli_instance._on_reaction = None
+    captured = {}
+    monkeypatch.setattr("run_agent.OpenAI", MagicMock(return_value=MagicMock()))
+    _install_real_agent_factory(monkeypatch, "cli.AIAgent", captured)
+    monkeypatch.setattr("agent.credits_tracker.seed_credits_at_session_start", lambda *_a: None)
+
+    assert cli_instance._init_agent(runtime_override=runtime) is True
+    assert isinstance(captured["agent"], RealAIAgent)
+    assert captured["kwargs"]["requested_provider"] == "ollama"
+    assert captured["kwargs"]["provider_request_overrides"] == {}
+    assert (cli_instance.agent.provider, cli_instance.agent.requested_provider) == ("custom", "ollama")
+    assert cli_instance.agent._caller_request_overrides == {}
+    assert cli_instance.agent._provider_request_overrides == {}
+    _assert_real_agent_probe_guards(captured["constructor_probes"])

--- a/tests/hermes_cli/test_cli_model_once.py
+++ b/tests/hermes_cli/test_cli_model_once.py
@@ -149,3 +149,12 @@ def test_cli_restore_model_runtime_prefers_primary_runtime():
     assert stub.agent.model == "old/model"
     assert stub.agent.provider == "openrouter"
     assert stub.agent.calls == []
+
+
+def test_cli_one_turn_snapshot_retains_requested_provider_identity():
+    import cli as cli_mod
+
+    stub = _StubCLI()
+    stub.agent = _FakeAgent()
+    snapshot = cli_mod.HermesCLI._snapshot_model_runtime(stub)
+    assert snapshot["requested_provider"] == "openrouter"

--- a/tests/hermes_cli/test_custom_provider_identity.py
+++ b/tests/hermes_cli/test_custom_provider_identity.py
@@ -37,6 +37,29 @@ def test_matches_providers_dict_by_key(monkeypatch):
         rp.find_custom_provider_identity("http://127.0.0.1:8000/v1")
         == "custom:local"
     )
+    assert rp.find_custom_provider_identity("http://127.0.0.1:8000") is None
+
+
+def test_matches_canonical_base_url_when_legacy_api_is_retained(monkeypatch):
+    """Session identity must follow the endpoint the runtime will use."""
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "local": {
+                    "api": "http://127.0.0.1:8000",
+                    "base_url": "http://127.0.0.1:8000/v1",
+                }
+            }
+        },
+    )
+
+    assert (
+        rp.find_custom_provider_identity("http://127.0.0.1:8000/v1")
+        == "custom:local"
+    )
+    assert rp.find_custom_provider_identity("http://127.0.0.1:8000") is None
 
 
 def test_matches_providers_dict_by_stable_key_not_display_name(monkeypatch):

--- a/tests/hermes_cli/test_ollama_cloud_auth.py
+++ b/tests/hermes_cli/test_ollama_cloud_auth.py
@@ -10,6 +10,29 @@ Covers:
 """
 
 import os
+from copy import deepcopy
+from unittest.mock import MagicMock
+
+from run_agent import AIAgent as RealAIAgent
+
+
+def _install_real_agent_probe_guards(monkeypatch):
+    context_length = MagicMock(return_value=262144)
+    endpoint_metadata = MagicMock(side_effect=AssertionError("constructor attempted endpoint metadata access"))
+    local_server = MagicMock(side_effect=AssertionError("constructor attempted local-server detection"))
+    monkeypatch.setattr("agent.context_compressor.get_model_context_length", context_length)
+    monkeypatch.setattr("agent.model_metadata.get_model_context_length", context_length)
+    monkeypatch.setattr("agent.model_metadata.fetch_endpoint_model_metadata", endpoint_metadata)
+    monkeypatch.setattr("agent.usage_pricing.fetch_endpoint_model_metadata", MagicMock(return_value={}))
+    monkeypatch.setattr("agent.model_metadata.detect_local_server_type", local_server)
+    return context_length, endpoint_metadata, local_server
+
+
+def _assert_real_agent_probe_guards(probes):
+    context_length, endpoint_metadata, local_server = probes
+    context_length.assert_called()
+    endpoint_metadata.assert_not_called()
+    local_server.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -470,3 +493,57 @@ class TestFallbackEdgeCases:
 
         assert fb_base_url_hint is None
         assert fb_api_key_hint is None
+
+
+def test_oneshot_real_agent_forwards_complete_remote_named_ollama_binding(tmp_path, monkeypatch):
+    import run_agent
+    from hermes_cli import oneshot
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    config = {"model": {"default": "synthetic-model", "provider": "ollama"}, "providers": {"ollama": {"name": "Remote Named Ollama", "base_url": "https://ollama.remote.example/v1", "api_key": "synthetic-key", "transport": "openai_chat", "extra_body": {"route": "remote-named"}}}, "fallback_providers": []}
+    pool = MagicMock(name="SyntheticCredentialPool")
+    runtime = {"provider": "custom", "requested_provider": "ollama", "api_key": "synthetic-key", "base_url": "https://ollama.remote.example/v1", "api_mode": "chat_completions", "request_overrides": {"extra_body": {"route": "remote-named"}}, "credential_pool": pool, "command": "synthetic-command", "args": ["--synthetic"], "max_output_tokens": 4096}
+    sdk_client = MagicMock(name="SyntheticOneShotSDKClient")
+    openai_factory = MagicMock(return_value=sdk_client)
+    monkeypatch.setattr(run_agent, "OpenAI", openai_factory)
+    constructor_probes = _install_real_agent_probe_guards(monkeypatch)
+    captured = {}
+
+    def construct(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = dict(kwargs)
+        agent = RealAIAgent(*args, **kwargs)
+        captured["agent"] = agent
+        agent.run_conversation = MagicMock(return_value={"final_response": "synthetic one-shot response", "messages": [], "api_calls": 0, "completed": True})
+        agent.shutdown_memory_provider = MagicMock()
+        agent.close = MagicMock()
+        return agent
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: deepcopy(config))
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", MagicMock(return_value=runtime))
+    monkeypatch.setattr("hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build", MagicMock(return_value=None))
+    monkeypatch.setattr(oneshot, "_create_session_db_for_oneshot", lambda: None)
+    monkeypatch.setattr(oneshot, "get_fallback_chain", lambda _cfg: [])
+    monkeypatch.setattr(run_agent, "AIAgent", construct)
+
+    final, result = oneshot._run_agent("synthetic prompt", model="synthetic-model", provider="ollama", toolsets=[], use_config_toolsets=False)
+    assert final == "synthetic one-shot response"
+    assert result["completed"] is True
+    assert isinstance(captured["agent"], RealAIAgent)
+    kwargs = captured["kwargs"]
+    assert (kwargs["provider"], kwargs["requested_provider"]) == ("custom", "ollama")
+    assert kwargs["provider_request_overrides"] == {"extra_body": {"route": "remote-named"}}
+    assert kwargs["credential_pool"] is pool
+    assert kwargs["acp_command"] == "synthetic-command"
+    assert kwargs["acp_args"] == ["--synthetic"]
+    assert kwargs["max_tokens"] == 4096
+    assert captured["agent"]._caller_request_overrides == {}
+    assert captured["agent"]._provider_request_overrides == {"extra_body": {"route": "remote-named"}}
+    captured["agent"].run_conversation.assert_called_once_with("synthetic prompt")
+    captured["agent"].shutdown_memory_provider.assert_called_once()
+    captured["agent"].close.assert_called_once()
+    sdk_client.chat.completions.create.assert_not_called()
+    openai_factory.assert_called_once()
+    _assert_real_agent_probe_guards(constructor_probes)

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -11,6 +11,7 @@ import pytest
 from hermes_cli.config import (
     _PROVIDER_NORMALIZE_WARNED,
     _normalize_custom_provider_entry,
+    get_custom_provider_endpoint,
 )
 
 
@@ -25,6 +26,24 @@ class TestNormalizeCustomProviderEntry:
         _PROVIDER_NORMALIZE_WARNED.clear()
         yield
         _PROVIDER_NORMALIZE_WARNED.clear()
+
+    @pytest.mark.parametrize(
+        ("entry", "expected"),
+        [
+            ({"api": "http://127.0.0.1:11434"}, "http://127.0.0.1:11434"),
+            ({"url": "http://127.0.0.1:11434/v1"}, "http://127.0.0.1:11434/v1"),
+            (
+                {
+                    "api": "http://127.0.0.1:11434",
+                    "url": "http://127.0.0.1:11434/legacy",
+                    "base_url": "http://127.0.0.1:11434/v1",
+                },
+                "http://127.0.0.1:11434/v1",
+            ),
+        ],
+    )
+    def test_get_custom_provider_endpoint_uses_canonical_precedence(self, entry, expected):
+        assert get_custom_provider_endpoint(entry) == expected
 
 
 
@@ -66,5 +85,3 @@ class TestNormalizeCustomProviderEntry:
         result = _normalize_custom_provider_entry(entry, provider_key="PROVIDER_A")
         assert result is not None
         assert result["base_url"] == "${PROVIDER_A_BASE_URL}"
-
-

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -46,6 +46,36 @@ class TestNormalizeCustomProviderEntry:
         assert get_custom_provider_endpoint(entry) == expected
 
 
+    def test_endpoint_helper_skips_invalid_canonical_value_like_normalizer(self):
+        """Invalid canonical aliases must fall through consistently everywhere."""
+        entry = {
+            "base_url": "not a URL",
+            "url": "https://valid-url.example/v1",
+            "api": "https://valid-api.example/v1",
+        }
+
+        normalized = _normalize_custom_provider_entry(entry, provider_key="test")
+
+        assert normalized is not None
+        assert get_custom_provider_endpoint(entry) == normalized["base_url"]
+        assert normalized["base_url"] == "https://valid-url.example/v1"
+
+
+    def test_endpoint_helper_accepts_normalizer_camelcase_base_url_alias(self):
+        """Raw consumers must accept the normalizer's baseUrl compatibility alias."""
+        entry = {
+            "baseUrl": "https://camel-base.example/v1",
+            "url": "https://legacy-url.example/v1",
+            "api": "https://legacy-api.example/v1",
+        }
+
+        normalized = _normalize_custom_provider_entry(entry, provider_key="test")
+
+        assert normalized is not None
+        assert get_custom_provider_endpoint(entry) == normalized["base_url"]
+        assert normalized["base_url"] == "https://camel-base.example/v1"
+
+
 
 
 

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -61,6 +61,32 @@ class TestNormalizeCustomProviderEntry:
         assert normalized["base_url"] == "https://valid-url.example/v1"
 
 
+    @pytest.mark.parametrize(
+        "invalid_endpoint",
+        ["http://[::1", "http://localhost:notaport"],
+    )
+    def test_endpoint_helper_falls_through_when_canonical_host_or_port_is_malformed(
+        self, invalid_endpoint
+    ):
+        """Malformed canonical URLs must not raise or block a valid API alias."""
+        entry = {
+            "base_url": invalid_endpoint,
+            "api": "https://valid-api.example/v1",
+        }
+        invalid_fields = []
+
+        endpoint = get_custom_provider_endpoint(
+            entry,
+            on_invalid_endpoint=lambda key, value: invalid_fields.append((key, value)),
+        )
+        normalized = _normalize_custom_provider_entry(entry, provider_key="test")
+
+        assert endpoint == "https://valid-api.example/v1"
+        assert normalized is not None
+        assert normalized["base_url"] == "https://valid-api.example/v1"
+        assert invalid_fields == [("base_url", invalid_endpoint)]
+
+
     def test_endpoint_helper_accepts_normalizer_camelcase_base_url_alias(self):
         """Raw consumers must accept the normalizer's baseUrl compatibility alias."""
         entry = {

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -87,6 +87,39 @@ class TestNormalizeCustomProviderEntry:
         assert invalid_fields == [("base_url", invalid_endpoint)]
 
 
+    def test_invalid_endpoint_warning_omits_candidate_and_reports_validation_scope(
+        self, caplog
+    ):
+        """Rejected endpoint diagnostics must not persist URL authentication."""
+        candidate = (
+            "http://synthetic-user:synthetic-pass@localhost:notaport/v1"
+            "?marker=synthetic-query"
+        )
+        entry = {
+            "base_url": candidate,
+            "api": "https://valid-api.example/v1",
+        }
+
+        with caplog.at_level(logging.WARNING):
+            normalized = _normalize_custom_provider_entry(
+                entry,
+                provider_key="log-safe-provider",
+            )
+
+        assert normalized is not None
+        assert normalized["base_url"] == "https://valid-api.example/v1"
+        messages = [record.getMessage() for record in caplog.records]
+        assert len(messages) == 1
+        message = messages[0]
+        assert "providers.log-safe-provider" in message
+        assert "base_url" in message
+        assert "scheme, host, or port validation failed" in message
+        assert candidate not in message
+        assert "synthetic-user" not in message
+        assert "synthetic-pass" not in message
+        assert "synthetic-query" not in message
+
+
     def test_endpoint_helper_accepts_normalizer_camelcase_base_url_alias(self):
         """Raw consumers must accept the normalizer's baseUrl compatibility alias."""
         entry = {

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -6,6 +6,34 @@ from types import SimpleNamespace
 import pytest
 
 from hermes_cli import runtime_provider as rp
+from hermes_cli.config import set_config_value
+from utils import atomic_yaml_write
+
+
+def _write_v0204_ollama_provider(
+    monkeypatch, tmp_path, *, base_url, key_env
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv(key_env, "synthetic-env-value")
+    atomic_yaml_write(
+        tmp_path / "config.yaml",
+        {
+            "providers": {
+                "ollama": {
+                    "api_key": "synthetic-inline-value",
+                    "key_env": key_env,
+                    "key_cmd": "synthetic-command-never-run",
+                    "extra_headers": {
+                        "Authorization": "synthetic-provider-header",
+                    },
+                    "extra_body": {"gateway_token": "synthetic-body-value"},
+                    "default_model": "unit3-local-model",
+                }
+            }
+        },
+        sort_keys=False,
+    )
+    set_config_value("providers.ollama.base_url", base_url)
 
 
 def test_configured_api_key_provider_without_key_fails_closed(monkeypatch):
@@ -178,6 +206,105 @@ providers:
 
     assert resolved["api_key"] == "remote-credential-sentinel"
     assert resolved["extra_headers"] == {"Authorization": "remote-header-sentinel"}
+
+
+def test_named_loopback_ollama_does_not_build_key_cmd_token_provider(
+    tmp_path, monkeypatch
+):
+    """Exact named local Ollama suppresses the evolved key_cmd source."""
+    base_url = "http://127.0.0.2:11434/v1"
+    _write_v0204_ollama_provider(
+        monkeypatch,
+        tmp_path,
+        base_url=base_url,
+        key_env="UNIT3_LOCAL_OLLAMA_KEY",
+    )
+    command_calls = []
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *_a, **_k: None)
+
+    def build(command, provider_name):
+        command_calls.append((command, provider_name))
+
+        def token_provider():
+            return "synthetic-command-value"
+
+        return token_provider
+
+    monkeypatch.setattr("agent.command_token_source.build_command_token_provider", build)
+
+    resolved = rp.resolve_runtime_provider(requested="ollama")
+
+    assert resolved["base_url"] == base_url
+    assert resolved["api_key"] == "no-key-required"
+    assert "extra_headers" not in resolved
+    assert "request_overrides" not in resolved
+    assert command_calls == []
+
+
+def test_loopback_custom_ollama_preserves_key_cmd_headers_and_body(
+    tmp_path, monkeypatch
+):
+    """custom:ollama remains an authenticated custom-provider route."""
+    base_url = "http://127.0.0.2:11434/v1"
+    _write_v0204_ollama_provider(
+        monkeypatch,
+        tmp_path,
+        base_url=base_url,
+        key_env="UNIT3_CUSTOM_OLLAMA_KEY",
+    )
+
+    def marker():
+        return "synthetic-command-value"
+
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        "agent.command_token_source.build_command_token_provider",
+        lambda *_a, **_k: marker,
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:ollama")
+
+    assert resolved["base_url"] == base_url
+    assert resolved["api_key"] is marker
+    assert resolved["extra_headers"] == {
+        "Authorization": "synthetic-provider-header"
+    }
+    assert resolved["request_overrides"] == {
+        "extra_body": {"gateway_token": "synthetic-body-value"}
+    }
+
+
+def test_named_remote_ollama_preserves_key_cmd_headers_and_body(
+    tmp_path, monkeypatch
+):
+    """Remote named Ollama retains key_cmd and request overrides."""
+    base_url = "https://ollama.remote.example/v1"
+    _write_v0204_ollama_provider(
+        monkeypatch,
+        tmp_path,
+        base_url=base_url,
+        key_env="UNIT3_REMOTE_OLLAMA_KEY",
+    )
+
+    def marker():
+        return "synthetic-command-value"
+
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        "agent.command_token_source.build_command_token_provider",
+        lambda *_a, **_k: marker,
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="ollama")
+
+    assert resolved["base_url"] == base_url
+    assert resolved["api_key"] is marker
+    assert resolved["extra_headers"] == {
+        "Authorization": "synthetic-provider-header"
+    }
+    assert resolved["request_overrides"] == {
+        "extra_body": {"gateway_token": "synthetic-body-value"}
+    }
 
 
 def _fake_invoke_jwt(ttl_seconds=3600):

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -49,6 +49,115 @@ def test_noauth_lmstudio_still_resolves(monkeypatch):
     assert resolved["api_key"]
 
 
+def test_named_loopback_ollama_drops_configured_credentials_and_headers(tmp_path, monkeypatch):
+    """The named local Ollama route cannot inherit stale remote credentials."""
+    (tmp_path / "config.yaml").write_text(
+        """\
+providers:
+  ollama:
+    base_url: http://127.0.0.1:11434/v1
+    api_key: inline-credential-sentinel
+    key_env: LOCAL_OLLAMA_TEST_KEY
+    extra_headers:
+      Authorization: header-credential-sentinel
+    extra_body:
+      gateway_token: body-credential-sentinel
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_OLLAMA_TEST_KEY", "env-credential-sentinel")
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *_a, **_kw: None)
+
+    resolved = rp.resolve_runtime_provider(
+        requested="ollama", explicit_api_key="explicit-credential-sentinel"
+    )
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "http://127.0.0.1:11434/v1"
+    assert resolved["api_key"] == "no-key-required"
+    assert "extra_headers" not in resolved
+    assert "request_overrides" not in resolved
+
+
+def test_named_loopback_ollama_bypasses_pool_credentials(tmp_path, monkeypatch):
+    """Pooled credentials must not follow the exact named local Ollama route."""
+    (tmp_path / "config.yaml").write_text(
+        """\
+providers:
+  ollama:
+    base_url: http://localhost:11434/v1
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    pool_calls = []
+
+    def pool_with_credential(*_args, **_kwargs):
+        pool_calls.append(True)
+        return {
+            "provider": "custom",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "pool-credential-sentinel",
+            "extra_headers": {"Authorization": "pool-header-sentinel"},
+        }
+
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", pool_with_credential)
+
+    resolved = rp.resolve_runtime_provider(requested="ollama")
+
+    assert resolved["api_key"] == "no-key-required"
+    assert "extra_headers" not in resolved
+    assert pool_calls == []
+
+
+def test_named_loopback_ollama_explicit_endpoint_bypasses_pool_credentials(monkeypatch):
+    """An explicit local endpoint keeps the exact named Ollama no-key boundary."""
+    pool_calls = []
+
+    def pool_with_credential(*_args, **_kwargs):
+        pool_calls.append(True)
+        return {
+            "provider": "custom",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "api_key": "pool-credential-sentinel",
+        }
+
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", pool_with_credential)
+
+    resolved = rp.resolve_runtime_provider(
+        requested="ollama",
+        explicit_api_key="explicit-credential-sentinel",
+        explicit_base_url="http://127.0.0.1:11434/v1",
+    )
+
+    assert resolved["api_key"] == "no-key-required"
+    assert resolved["requested_provider"] == "ollama"
+    assert pool_calls == []
+
+
+def test_named_remote_ollama_preserves_configured_credentials_and_headers(tmp_path, monkeypatch):
+    """The local credential boundary does not change remote Ollama routes."""
+    (tmp_path / "config.yaml").write_text(
+        """\
+providers:
+  ollama:
+    base_url: https://ollama.remote.example/v1
+    api_key: remote-credential-sentinel
+    extra_headers:
+      Authorization: remote-header-sentinel
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *_a, **_kw: None)
+
+    resolved = rp.resolve_runtime_provider(requested="ollama")
+
+    assert resolved["api_key"] == "remote-credential-sentinel"
+    assert resolved["extra_headers"] == {"Authorization": "remote-header-sentinel"}
+
+
 def _fake_invoke_jwt(ttl_seconds=3600):
     header = base64.urlsafe_b64encode(b'{"alg":"none","typ":"JWT"}').decode().rstrip("=")
     payload = base64.urlsafe_b64encode(

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -164,6 +164,75 @@ def test_named_loopback_ollama_explicit_endpoint_bypasses_pool_credentials(monke
     assert pool_calls == []
 
 
+@pytest.mark.parametrize("endpoint_source", ["configured", "explicit"])
+def test_named_loopback_ollama_rejects_url_userinfo_without_echoing_it(
+    tmp_path, monkeypatch, endpoint_source
+):
+    """The no-auth route must fail closed on embedded URL authentication."""
+    endpoint = "http://synthetic-user:synthetic-pass@127.0.0.1:11434/v1?marker=synthetic-query"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    if endpoint_source == "configured":
+        atomic_yaml_write(
+            tmp_path / "config.yaml",
+            {"providers": {"ollama": {"base_url": endpoint}}},
+            sort_keys=False,
+        )
+
+    kwargs = {"requested": "ollama"}
+    if endpoint_source == "explicit":
+        kwargs["explicit_base_url"] = endpoint
+
+    with pytest.raises(rp.AuthError) as exc_info:
+        rp.resolve_runtime_provider(**kwargs)
+
+    error = exc_info.value
+    message = str(error)
+    assert error.provider == "ollama"
+    assert "custom:ollama" in message
+    assert endpoint not in message
+    assert "synthetic-user" not in message
+    assert "synthetic-pass" not in message
+    assert "synthetic-query" not in message
+
+
+@pytest.mark.parametrize(
+    ("requested_provider", "base_url"),
+    [
+        (
+            "custom:ollama",
+            "http://synthetic-user:synthetic-pass@127.0.0.1:11434/v1?marker=synthetic-query",
+        ),
+        (
+            "ollama",
+            "https://synthetic-user:synthetic-pass@ollama.remote.example/v1?marker=synthetic-query",
+        ),
+    ],
+)
+def test_authenticated_ollama_routes_preserve_url_userinfo(
+    tmp_path, monkeypatch, requested_provider, base_url
+):
+    """Custom-local and named-remote routes retain authenticated URL behavior."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    atomic_yaml_write(
+        tmp_path / "config.yaml",
+        {
+            "providers": {
+                "ollama": {
+                    "base_url": base_url,
+                    "api_key": "synthetic-auth-value",
+                }
+            }
+        },
+        sort_keys=False,
+    )
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *_a, **_kw: None)
+
+    resolved = rp.resolve_runtime_provider(requested=requested_provider)
+
+    assert resolved["base_url"] == base_url
+    assert resolved["api_key"] == "synthetic-auth-value"
+
+
 @pytest.mark.parametrize(
     ("requested_provider", "base_url", "expected"),
     [

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -136,6 +136,28 @@ def test_named_loopback_ollama_explicit_endpoint_bypasses_pool_credentials(monke
     assert pool_calls == []
 
 
+@pytest.mark.parametrize(
+    ("requested_provider", "base_url", "expected"),
+    [
+        ("ollama", "http://127.0.0.1:11434/v1", True),
+        ("ollama", "http://127.0.0.2:11434/v1", True),
+        ("ollama", "http://127.255.255.254:11434/v1", True),
+        ("ollama", "http://[::1]:11434/v1", True),
+        ("ollama", "http://localhost:11434/v1", True),
+        ("ollama", "http://0.0.0.0:11434/v1", True),
+        ("ollama", "http://[::2]:11434/v1", False),
+        ("ollama", "http://128.0.0.1:11434/v1", False),
+        ("ollama", "https://ollama.remote.example/v1", False),
+        ("custom:ollama", "http://127.0.0.2:11434/v1", False),
+    ],
+)
+def test_named_loopback_ollama_route_uses_parsed_loopback_addresses(
+    requested_provider, base_url, expected
+):
+    """Loopback classification accepts the whole IPv4 range and parsed IPv6."""
+    assert rp._is_named_loopback_ollama_route(requested_provider, base_url) is expected
+
+
 def test_named_remote_ollama_preserves_configured_credentials_and_headers(tmp_path, monkeypatch):
     """The local credential boundary does not change remote Ollama routes."""
     (tmp_path / "config.yaml").write_text(

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -284,5 +284,21 @@ def test_make_tui_argv_dev_prebuilds_hermes_ink(monkeypatch, main_mod, tmp_path)
     assert calls == [(["/usr/bin/npm", "run", "build"], str(ink_dir))]
 
 
+def test_tui_one_turn_snapshot_deep_copies_provider_identity_layers():
+    from tui_gateway import server
+
+    agent = types.SimpleNamespace(
+        model="synthetic-model", provider="custom", requested_provider="custom:remote",
+        api_key="synthetic-key", base_url="https://remote.example/v1", api_mode="chat_completions",
+        _caller_request_overrides={"extra_body": {"caller": "value"}},
+        _provider_request_overrides={"extra_body": {"provider": "value"}},
+    )
+    snapshot = server._snapshot_agent_model_runtime(agent)
+    assert snapshot["requested_provider"] == "custom:remote"
+    assert snapshot["caller_request_overrides"] == {"extra_body": {"caller": "value"}}
+    assert snapshot["provider_request_overrides"] == {"extra_body": {"provider": "value"}}
+    snapshot["caller_request_overrides"]["extra_body"]["caller"] = "changed"
+    assert agent._caller_request_overrides == {"extra_body": {"caller": "value"}}
+
 
 

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -86,6 +86,59 @@ def test_resolve_user_provider_prefers_canonical_base_url_over_legacy_api():
     assert provider.base_url == "http://127.0.0.1:11434/v1"
 
 
+@pytest.mark.parametrize(
+    ("entry", "expected"),
+    [
+        (
+            {
+                "api": "https://picker-api.example/v1",
+                "url": "https://picker-url.example/v1",
+            },
+            "https://picker-url.example/v1",
+        ),
+        (
+            {
+                "api": "https://picker-api.example/v1",
+                "url": "https://picker-url.example/v1",
+                "base_url": "https://picker-base.example/v1",
+            },
+            "https://picker-base.example/v1",
+        ),
+        (
+            {
+                "api": "https://picker-api.example/v1",
+                "url": "https://picker-url.example/v1",
+                "baseUrl": "https://picker-camel-base.example/v1",
+            },
+            "https://picker-camel-base.example/v1",
+        ),
+    ],
+)
+def test_list_authenticated_providers_uses_canonical_endpoint_precedence(
+    monkeypatch, entry, expected
+):
+    """The real picker must agree with canonical provider endpoint resolution."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.get_curated_nous_model_ids", lambda: [])
+
+    providers = list_authenticated_providers(
+        current_provider="other",
+        user_providers={
+            "picker-provider": {
+                "name": "Picker Provider",
+                "model": "picker-model",
+                **entry,
+            }
+        },
+        custom_providers=[],
+        max_models=50,
+    )
+
+    provider = next(p for p in providers if p["slug"] == "picker-provider")
+    assert provider["api_url"] == expected
+
+
 def test_list_authenticated_providers_enumerates_dict_format_models(monkeypatch):
     """providers: dict entries with ``models:`` as a dict keyed by model id
     (canonical Hermes write format) should surface every key in the picker.

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -8,6 +8,7 @@ are exposed in the model picker.
 import pytest
 from hermes_cli.model_switch import list_authenticated_providers, switch_model
 from hermes_cli import runtime_provider as rp
+from hermes_cli.providers import resolve_user_provider
 
 
 @pytest.fixture(autouse=True)
@@ -67,6 +68,22 @@ def test_list_authenticated_providers_includes_full_models_list_from_user_provid
     assert "kimi-k2.5:cloud" in user_prov["models"]
     assert "glm-5.1:cloud" in user_prov["models"]
     assert "qwen3.5:cloud" in user_prov["models"]
+
+
+def test_resolve_user_provider_prefers_canonical_base_url_over_legacy_api():
+    """The picker must advertise the same endpoint as runtime resolution."""
+    provider = resolve_user_provider(
+        "local-ollama",
+        {
+            "local-ollama": {
+                "api": "http://127.0.0.1:11434",
+                "base_url": "http://127.0.0.1:11434/v1",
+            }
+        },
+    )
+
+    assert provider is not None
+    assert provider.base_url == "http://127.0.0.1:11434/v1"
 
 
 def test_list_authenticated_providers_enumerates_dict_format_models(monkeypatch):

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1841,6 +1841,24 @@ class TestWebServerEndpoints:
         assert endpoint["has_api_key"] is True
         assert "sk-in-env" not in (endpoint["api_key_preview"] or "")
 
+    def test_custom_endpoint_response_prefers_canonical_base_url_over_legacy_api(self):
+        """The dashboard must not report a stale compatibility endpoint."""
+        from hermes_cli.web_server import _custom_endpoint_response
+
+        result = _custom_endpoint_response(
+            {
+                "providers": {
+                    "local-ollama": {
+                        "api": "http://127.0.0.1:11434",
+                        "base_url": "http://127.0.0.1:11434/v1",
+                    }
+                }
+            }
+        )
+
+        endpoint = next(e for e in result["endpoints"] if e["id"] == "local-ollama")
+        assert endpoint["base_url"] == "http://127.0.0.1:11434/v1"
+
     def test_activating_an_endpoint_carries_its_credential_either_way(self):
         """Activate must work for both key_env and pre-#69449 plaintext entries."""
         from hermes_cli.config import load_config, save_config

--- a/tests/run_agent/test_nous_fallback_unavailable.py
+++ b/tests/run_agent/test_nous_fallback_unavailable.py
@@ -7,7 +7,7 @@ to the next provider.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from run_agent import AIAgent
 
@@ -95,6 +95,9 @@ class TestNousFallbackLocalAvailability:
         ), patch(
             "agent.auxiliary_client.resolve_provider_client",
             return_value=(_mock_client(api_key="fb"), "anthropic/claude-sonnet-4.6"),
+        ), patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            return_value=MagicMock(),
         ):
             activated = agent._try_activate_fallback(None)
         assert activated is True

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -75,6 +75,66 @@ providers:
     )
 
 
+def _write_ollama_extra_body_config(tmp_path, *, base_url):
+    (tmp_path / "config.yaml").write_text(
+        f"""\
+providers:
+  ollama:
+    base_url: {base_url}
+    extra_body:
+      provider_body_marker: configured
+""",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    ("base_url", "requested_provider", "keeps_provider_body"),
+    [
+        ("http://127.0.0.1:11434/v1", "ollama", False),
+        ("http://127.0.0.1:11434/v1", "custom:ollama", True),
+        ("https://ollama.remote.example/v1", "ollama", True),
+    ],
+)
+def test_full_constructor_and_rebuild_isolate_named_local_ollama_provider_body(
+    tmp_path, monkeypatch, base_url, requested_provider, keeps_provider_body
+):
+    """Provider config must not cross the exact named-local body boundary."""
+    _write_ollama_extra_body_config(tmp_path, base_url=base_url)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("run_agent.OpenAI", MagicMock(return_value=MagicMock()))
+
+    agent = AIAgent(
+        api_key="synthetic-route-key",
+        base_url=base_url,
+        provider="custom",
+        requested_provider=requested_provider,
+        api_mode="chat_completions",
+        model="synthetic-model",
+        request_overrides={
+            "caller_option": "caller-owned-marker",
+            "extra_body": {"caller_body_marker": "retained"},
+        },
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    expected_extra_body = {"caller_body_marker": "retained"}
+    if keeps_provider_body:
+        expected_extra_body["provider_body_marker"] = "configured"
+    assert agent.request_overrides == {
+        "caller_option": "caller-owned-marker",
+        "extra_body": expected_extra_body,
+    }
+
+    assert agent._replace_primary_openai_client(reason="test-provider-body") is True
+    assert agent.request_overrides == {
+        "caller_option": "caller-owned-marker",
+        "extra_body": expected_extra_body,
+    }
+
+
 def test_full_constructor_and_rebuild_keep_authenticated_loopback_custom_ollama_headers(
     tmp_path, monkeypatch
 ):

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -75,6 +75,37 @@ providers:
     )
 
 
+def test_full_constructor_and_rebuild_keep_authenticated_loopback_custom_ollama_headers(
+    tmp_path, monkeypatch
+):
+    base_url = "http://127.0.0.2:11434/v1"
+    _write_ollama_header_config(tmp_path, base_url=base_url)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("run_agent.OpenAI", MagicMock(return_value=MagicMock()))
+
+    agent = AIAgent(
+        api_key="synthetic-authenticated-local-proxy-key",
+        base_url=base_url,
+        provider="custom",
+        requested_provider="custom:ollama",
+        api_mode="chat_completions",
+        model="authenticated-local-model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    expected_headers = {
+        "Authorization": "model-default-header-sentinel",
+        "X-Model-Token": "model-extra-header-sentinel",
+        "X-Provider-Token": "provider-header-sentinel",
+    }
+    assert agent.api_key == "synthetic-authenticated-local-proxy-key"
+    assert agent._client_kwargs["default_headers"] == expected_headers
+    agent._apply_client_headers_for_base_url(base_url)
+    assert agent._client_kwargs["default_headers"] == expected_headers
+
+
 @pytest.mark.parametrize(
     ("provider", "requested_provider"),
     [("custom", "ollama"), ("ollama", None)],

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -6,6 +6,8 @@ referrerUrl / appName / User-Agent flow into gateway analytics.
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from run_agent import AIAgent
 
 
@@ -53,6 +55,84 @@ def test_named_remote_ollama_keeps_configured_provider_headers():
     assert agent._client_kwargs["default_headers"] == {
         "Authorization": "remote-header-sentinel"
     }
+
+
+def _write_ollama_header_config(tmp_path, *, base_url):
+    (tmp_path / "config.yaml").write_text(
+        f"""\
+model:
+  default_headers:
+    Authorization: model-default-header-sentinel
+  extra_headers:
+    X-Model-Token: model-extra-header-sentinel
+providers:
+  ollama:
+    base_url: {base_url}
+    extra_headers:
+      X-Provider-Token: provider-header-sentinel
+""",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider", "requested_provider"),
+    [("custom", "ollama"), ("ollama", None)],
+)
+def test_full_constructor_and_rebuild_drop_all_local_ollama_headers(
+    tmp_path, monkeypatch, provider, requested_provider
+):
+    """Both client creation paths isolate model and provider headers locally."""
+    base_url = "http://127.0.0.1:11434/v1"
+    _write_ollama_header_config(tmp_path, base_url=base_url)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("run_agent.OpenAI", MagicMock(return_value=MagicMock()))
+
+    agent = AIAgent(
+        api_key="no-key-required",
+        base_url=base_url,
+        provider=provider,
+        requested_provider=requested_provider,
+        api_mode="chat_completions",
+        model="local-model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    assert agent._client_kwargs.get("default_headers") is None
+    agent._apply_client_headers_for_base_url(base_url)
+    assert agent._client_kwargs.get("default_headers") is None
+
+
+def test_full_constructor_and_rebuild_keep_remote_ollama_headers(tmp_path, monkeypatch):
+    """Remote Ollama retains configured credentials and header behavior."""
+    base_url = "https://ollama.remote.example/v1"
+    _write_ollama_header_config(tmp_path, base_url=base_url)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("run_agent.OpenAI", MagicMock(return_value=MagicMock()))
+
+    agent = AIAgent(
+        api_key="remote-credential-sentinel",
+        base_url=base_url,
+        provider="custom",
+        requested_provider="ollama",
+        api_mode="chat_completions",
+        model="remote-model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    expected_headers = {
+        "Authorization": "model-default-header-sentinel",
+        "X-Model-Token": "model-extra-header-sentinel",
+        "X-Provider-Token": "provider-header-sentinel",
+    }
+    assert agent.api_key == "remote-credential-sentinel"
+    assert agent._client_kwargs["default_headers"] == expected_headers
+    agent._apply_client_headers_for_base_url(base_url)
+    assert agent._client_kwargs["default_headers"] == expected_headers
 
 
 @patch("run_agent.OpenAI")

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -11,6 +11,34 @@ import pytest
 from run_agent import AIAgent
 
 
+def _install_task1_constructor_guards(monkeypatch):
+    probes = {
+        "context": MagicMock(return_value=262_144),
+        "endpoint": MagicMock(
+            side_effect=AssertionError("constructor endpoint probe forbidden")
+        ),
+        "local": MagicMock(
+            side_effect=AssertionError("constructor local-service probe forbidden")
+        ),
+    }
+    monkeypatch.setattr(
+        "agent.context_compressor.get_model_context_length", probes["context"],
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.fetch_endpoint_model_metadata", probes["endpoint"],
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.detect_local_server_type", probes["local"],
+    )
+    return probes
+
+
+def _assert_task1_constructor_guards(probes):
+    probes["context"].assert_called_once()
+    probes["endpoint"].assert_not_called()
+    probes["local"].assert_not_called()
+
+
 def test_named_loopback_ollama_does_not_apply_configured_provider_headers():
     """Local named Ollama must not reattach headers dropped by its resolver."""
     agent = AIAgent.__new__(AIAgent)
@@ -103,6 +131,12 @@ def test_full_constructor_and_rebuild_isolate_named_local_ollama_provider_body(
     _write_ollama_extra_body_config(tmp_path, base_url=base_url)
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setattr("run_agent.OpenAI", MagicMock(return_value=MagicMock()))
+    probes = _install_task1_constructor_guards(monkeypatch)
+    provider_layer = (
+        {"extra_body": {"provider_body_marker": "configured"}}
+        if keeps_provider_body
+        else {}
+    )
 
     agent = AIAgent(
         api_key="synthetic-route-key",
@@ -112,25 +146,41 @@ def test_full_constructor_and_rebuild_isolate_named_local_ollama_provider_body(
         api_mode="chat_completions",
         model="synthetic-model",
         request_overrides={
-            "caller_option": "caller-owned-marker",
+            "caller_option": "retained",
             "extra_body": {"caller_body_marker": "retained"},
         },
+        provider_request_overrides=provider_layer,
         quiet_mode=True,
         skip_context_files=True,
         skip_memory=True,
     )
 
+    assert agent.requested_provider == requested_provider
+    assert agent._provider_request_overrides == provider_layer
+    assert agent._caller_request_overrides == {
+        "caller_option": "retained",
+        "extra_body": {"caller_body_marker": "retained"},
+    }
     expected_extra_body = {"caller_body_marker": "retained"}
     if keeps_provider_body:
         expected_extra_body["provider_body_marker"] = "configured"
     assert agent.request_overrides == {
-        "caller_option": "caller-owned-marker",
+        "caller_option": "retained",
         "extra_body": expected_extra_body,
     }
+    if not keeps_provider_body:
+        assert agent.request_overrides == agent._caller_request_overrides
+        assert agent._client_kwargs.get("default_headers") is None
+    _assert_task1_constructor_guards(probes)
+
+    if keeps_provider_body:
+        provider_layer["extra_body"]["provider_body_marker"] = "mutated-input"
+        assert agent._provider_request_overrides["extra_body"]["provider_body_marker"] == "configured"
+        assert agent.request_overrides["extra_body"]["provider_body_marker"] == "configured"
 
     assert agent._replace_primary_openai_client(reason="test-provider-body") is True
     assert agent.request_overrides == {
-        "caller_option": "caller-owned-marker",
+        "caller_option": "retained",
         "extra_body": expected_extra_body,
     }
 

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -9,6 +9,52 @@ from unittest.mock import MagicMock, patch
 from run_agent import AIAgent
 
 
+def test_named_loopback_ollama_does_not_apply_configured_provider_headers():
+    """Local named Ollama must not reattach headers dropped by its resolver."""
+    agent = AIAgent.__new__(AIAgent)
+    agent._client_kwargs = {}
+    agent.provider = "custom"
+    agent.requested_provider = "ollama"
+    agent.api_mode = "chat_completions"
+    agent._apply_user_default_headers = lambda: None
+
+    with patch("hermes_cli.config.load_config", return_value={
+        "providers": {
+            "ollama": {
+                "base_url": "http://127.0.0.1:11434/v1",
+                "extra_headers": {"Authorization": "header-credential-sentinel"},
+            }
+        }
+    }):
+        agent._apply_client_headers_for_base_url("http://127.0.0.1:11434/v1")
+
+    assert "default_headers" not in agent._client_kwargs
+
+
+def test_named_remote_ollama_keeps_configured_provider_headers():
+    """The named local boundary does not suppress remote Ollama headers."""
+    agent = AIAgent.__new__(AIAgent)
+    agent._client_kwargs = {}
+    agent.provider = "custom"
+    agent.requested_provider = "ollama"
+    agent.api_mode = "chat_completions"
+    agent._apply_user_default_headers = lambda: None
+
+    with patch("hermes_cli.config.load_config", return_value={
+        "providers": {
+            "ollama": {
+                "base_url": "https://ollama.remote.example/v1",
+                "extra_headers": {"Authorization": "remote-header-sentinel"},
+            }
+        }
+    }):
+        agent._apply_client_headers_for_base_url("https://ollama.remote.example/v1")
+
+    assert agent._client_kwargs["default_headers"] == {
+        "Authorization": "remote-header-sentinel"
+    }
+
+
 @patch("run_agent.OpenAI")
 def test_openrouter_base_url_applies_or_headers(mock_openai):
     mock_openai.return_value = MagicMock()
@@ -279,5 +325,3 @@ def test_openrouter_headers_no_cache_when_disabled(mock_openai):
     assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
     assert "X-OpenRouter-Cache" not in headers
     assert "X-OpenRouter-Cache-TTL" not in headers
-
-

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -153,6 +153,61 @@ class TestFallbackChainAdvancement:
         assert overlong_value not in serialized
         assert len(serialized.encode("utf-8")) <= 768
 
+    def test_recursive_skip_applies_rate_limit_backoff_once(self):
+        """One API failure must arm one cooldown despite skipped candidates."""
+        agent = _make_agent(
+            fallback_model=[
+                {"provider": "unconfigured", "model": "unavailable"},
+                {"provider": "openai", "model": "gpt-4o"},
+            ]
+        )
+        agent.provider = "ollama"
+        agent.model = "nemotron-3.5-lightning:30b-mlx"
+        agent.base_url = "http://localhost:11434/v1"
+        agent._rate_limited_until = 0
+        frozen = 1_000.0
+
+        with (
+            patch("agent.chat_completion_helpers.time.monotonic", return_value=frozen),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                side_effect=[(None, None), (_mock_client(), "gpt-4o")],
+            ),
+        ):
+            assert agent._try_activate_fallback(
+                reason=FailoverReason.rate_limit,
+                http_status=429,
+            ) is True
+
+        assert agent._rate_limit_backoff_count == 1
+        assert agent._rate_limited_until == frozen + 60
+        assert agent._last_fallback_event["reason_code"] == "rate_limit"
+        assert agent._last_fallback_event["http_status"] == 429
+
+    def test_exhausted_attempt_preserves_latest_successful_event(self):
+        """A failed later attempt cannot erase the task's latest transition."""
+        agent = _make_agent(
+            fallback_model=[{"provider": "openai", "model": "gpt-4o"}]
+        )
+        agent.provider = "ollama"
+        agent.model = "nemotron-3.5-lightning:30b-mlx"
+        agent.base_url = "http://localhost:11434/v1"
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "gpt-4o"),
+        ):
+            assert agent._try_activate_fallback(
+                reason=FailoverReason.timeout,
+                http_status=504,
+            ) is True
+
+        latest_event = dict(agent._last_fallback_event)
+        assert agent._try_activate_fallback(
+            reason=FailoverReason.timeout,
+            http_status=504,
+        ) is False
+        assert agent._last_fallback_event == latest_event
+
 
 
     def test_skips_unconfigured_provider_to_next(self):

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -5,8 +5,10 @@ the new list-based ``fallback_providers`` config format and chain
 advancement through multiple providers.
 """
 
+import json
 from unittest.mock import MagicMock, patch
 
+from agent.error_classifier import FailoverReason, classify_api_error
 from run_agent import AIAgent, _pool_may_recover_from_rate_limit
 
 
@@ -85,6 +87,71 @@ class TestFallbackChainAdvancement:
             assert agent._fallback_index == 1
             assert agent.model == "gpt-4o"
             assert agent._fallback_activated is True
+
+    def test_records_bounded_sanitized_failure_event(self):
+        """Fallback diagnostics retain routing facts, never raw failure data."""
+        agent = _make_agent(
+            fallback_model=[
+                {"provider": "unconfigured", "model": "unavailable"},
+                {"provider": "ollama-cloud", "model": "glm-5.2"},
+            ]
+        )
+        agent.provider = "ollama"
+        agent.model = "nemotron-3.5-lightning:30b-mlx"
+        agent.base_url = "http://localhost:11434/v1"
+
+        secret_sentinel = "SENTINEL_SECRET_MUST_NOT_SURVIVE"
+        prompt_sentinel = "SENTINEL_PROMPT_MUST_NOT_SURVIVE"
+        overlong_value = "Z" * 10_000
+        error = RuntimeError(
+            f"provider failure {secret_sentinel} {prompt_sentinel} {overlong_value}"
+        )
+        error.status_code = 503
+        classified = classify_api_error(
+            error,
+            provider=agent.provider,
+            model=agent.model,
+        )
+        assert classified.reason == FailoverReason.overloaded
+        assert secret_sentinel in classified.message
+        assert prompt_sentinel in classified.message
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                side_effect=[
+                    (None, None),
+                    (
+                        _mock_client(base_url="https://ollama.com/v1"),
+                        "glm-5.2",
+                    ),
+                ],
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda model, provider: model,
+            ),
+        ):
+            assert agent._try_activate_fallback(
+                reason=classified.reason,
+                http_status=classified.status_code,
+            ) is True
+
+        event = agent._last_fallback_event
+        assert event == {
+            "initial_provider": "ollama",
+            "initial_model": "nemotron-3.5-lightning:30b-mlx",
+            "selected_fallback_provider": "ollama-cloud",
+            "selected_fallback_model": "glm-5.2",
+            "failure_class": "availability",
+            "reason_code": "overloaded",
+            "http_status": 503,
+        }
+        serialized = json.dumps(event, sort_keys=True)
+        assert secret_sentinel not in serialized
+        assert prompt_sentinel not in serialized
+        assert overlong_value not in serialized
+        assert len(serialized.encode("utf-8")) <= 768
 
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5,9 +5,10 @@ import sys
 import threading
 import time
 import types
+from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -17,6 +18,24 @@ from hermes_cli.browser_connect import ChromeDebugLaunch
 from tools import async_delegation as ad
 from tui_gateway import server
 from tui_gateway.transport import bind_transport, reset_transport
+from run_agent import AIAgent as RealAIAgent
+
+
+def _install_real_agent_probe_guards(monkeypatch):
+    context_length = MagicMock(return_value=262144)
+    endpoint_metadata = MagicMock(side_effect=AssertionError("constructor attempted endpoint metadata access"))
+    local_server = MagicMock(side_effect=AssertionError("constructor attempted local-server detection"))
+    monkeypatch.setattr("agent.context_compressor.get_model_context_length", context_length)
+    monkeypatch.setattr("agent.model_metadata.fetch_endpoint_model_metadata", endpoint_metadata)
+    monkeypatch.setattr("agent.model_metadata.detect_local_server_type", local_server)
+    return context_length, endpoint_metadata, local_server
+
+
+def _assert_real_agent_probe_guards(probes):
+    context_length, endpoint_metadata, local_server = probes
+    context_length.assert_called()
+    endpoint_metadata.assert_not_called()
+    local_server.assert_not_called()
 
 
 def _dispatch_sync(req: dict, transport=None) -> dict | None:
@@ -3624,6 +3643,7 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
     assert captured["model_override"] == {
         "model": "gpt-5.4",
         "provider": "openai-codex",
+        "requested_provider": "openai-codex",
         "base_url": "https://custom.example/v1",
         "api_mode": "chat_completions",
     }
@@ -19830,3 +19850,24 @@ def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):
     assert captured["row_update"] == (target, str(new_cwd))
     assert live["cwd"] == str(new_cwd)
     assert live.get("explicit_cwd") is True
+
+
+def test_background_agent_kwargs_keep_identity_and_private_layers_isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    agent = types.SimpleNamespace(
+        model="synthetic-model", provider="custom", requested_provider="custom:remote",
+        base_url="https://remote.example/v1", api_key="synthetic-key", api_mode="chat_completions",
+        acp_command="synthetic-command", acp_args=["--synthetic"], enabled_toolsets=[],
+        _caller_request_overrides={"extra_body": {"caller": "value"}},
+        _provider_request_overrides={"extra_body": {"provider": "value"}},
+        request_overrides={"extra_body": {"provider": "value", "caller": "value"}},
+    )
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {"max_turns": 2}})
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda *_a, **_k: [])
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    kwargs = server._background_agent_kwargs(agent, "task-id")
+    assert kwargs["requested_provider"] == "custom:remote"
+    assert kwargs["request_overrides"] == {"extra_body": {"caller": "value"}}
+    assert kwargs["provider_request_overrides"] == {"extra_body": {"provider": "value"}}
+    kwargs["request_overrides"]["extra_body"]["caller"] = "changed"
+    assert agent._caller_request_overrides == {"extra_body": {"caller": "value"}}

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -562,6 +562,60 @@ class TestDelegateObservability(unittest.TestCase):
             )
             self.assertEqual(entry["tool_trace"][0]["status"], "ok")
 
+    def test_surfaces_only_allowlisted_child_fallback_event(self):
+        """Delegation preserves one safe fallback event, not raw child data."""
+        parent = _make_mock_parent(depth=0)
+        secret_sentinel = "SENTINEL_SECRET_MUST_NOT_SURVIVE"
+        prompt_sentinel = "SENTINEL_PROMPT_MUST_NOT_SURVIVE"
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "glm-5.2"
+            mock_child.session_prompt_tokens = 10
+            mock_child.session_completion_tokens = 5
+            mock_child._last_fallback_event = {
+                "initial_provider": "ollama",
+                "initial_model": "nemotron-3.5-lightning:30b-mlx",
+                "selected_fallback_provider": "ollama-cloud",
+                "selected_fallback_model": "glm-5.2",
+                "failure_class": "availability",
+                "reason_code": "overloaded",
+                "http_status": 503,
+                "raw_exception": secret_sentinel + ("X" * 10_000),
+                "prompt": prompt_sentinel,
+                "headers": {"authorization": secret_sentinel},
+            }
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 2,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(goal="Test fallback metadata", parent_agent=parent)
+            )
+
+        event = result["results"][0]["fallback_event"]
+        self.assertEqual(
+            set(event),
+            {
+                "initial_provider",
+                "initial_model",
+                "selected_fallback_provider",
+                "selected_fallback_model",
+                "failure_class",
+                "reason_code",
+                "http_status",
+            },
+        )
+        serialized = json.dumps(event, sort_keys=True)
+        self.assertNotIn(secret_sentinel, serialized)
+        self.assertNotIn(prompt_sentinel, serialized)
+        self.assertLessEqual(len(serialized.encode("utf-8")), 768)
+
     def test_tool_trace_handles_list_content_blocks(self):
         """Tool-result content blocks should not crash observability metadata."""
         parent = _make_mock_parent(depth=0)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -573,7 +573,7 @@ class TestDelegateObservability(unittest.TestCase):
             mock_child.model = "glm-5.2"
             mock_child.session_prompt_tokens = 10
             mock_child.session_completion_tokens = 5
-            mock_child._last_fallback_event = {
+            polluted_event = {
                 "initial_provider": "ollama",
                 "initial_model": "nemotron-3.5-lightning:30b-mlx",
                 "selected_fallback_provider": "ollama-cloud",
@@ -585,13 +585,18 @@ class TestDelegateObservability(unittest.TestCase):
                 "prompt": prompt_sentinel,
                 "headers": {"authorization": secret_sentinel},
             }
-            mock_child.run_conversation.return_value = {
-                "final_response": "done",
-                "completed": True,
-                "interrupted": False,
-                "api_calls": 2,
-                "messages": [],
-            }
+
+            def run_with_fallback_event(*args, **kwargs):
+                mock_child._last_fallback_event = polluted_event
+                return {
+                    "final_response": "done",
+                    "completed": True,
+                    "interrupted": False,
+                    "api_calls": 2,
+                    "messages": [],
+                }
+
+            mock_child.run_conversation.side_effect = run_with_fallback_event
             MockAgent.return_value = mock_child
 
             result = json.loads(

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -931,6 +931,86 @@ class TestDelegationCredentialResolution(unittest.TestCase):
             requested="crof.ai", target_model="deepseek-v4-pro-CEER"
         )
 
+
+def test_named_ollama_delegation_uses_configured_local_endpoint_without_cloud_key(
+    tmp_path, monkeypatch
+):
+    """Canonical base_url must win over a retained legacy api field.
+
+    Updating an existing provider entry with ``providers.ollama.base_url``
+    leaves the older ``api`` field in place.  The delegation resolver must
+    consume the canonical endpoint and keep cloud credential sentinels out of
+    the local child.
+    """
+    (tmp_path / "config.yaml").write_text(
+        """\
+providers:
+  ollama:
+    api: http://127.0.0.1:11434
+delegation:
+  provider: ollama
+  model: nemotron-3.5-lightning:30b-mlx
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "parent-openai-sentinel")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "parent-openrouter-sentinel")
+    parent = _make_mock_parent(depth=0)
+    parent.api_key = "parent-cloud-sentinel"
+
+    from hermes_cli.config import load_config, set_config_value
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    set_config_value("providers.ollama.base_url", "http://127.0.0.1:11434/v1")
+    delegation = load_config()["delegation"]
+    runtime = resolve_runtime_provider(
+        requested=delegation["provider"], target_model=delegation["model"]
+    )
+    creds = _resolve_delegation_credentials(delegation, parent)
+
+    assert runtime["provider"] == "custom"
+    assert runtime["base_url"] == "http://127.0.0.1:11434/v1"
+    assert runtime["source"] == "custom_provider:ollama"
+    assert runtime["api_key"] == "no-key-required"
+    assert creds["provider"] == "ollama"
+    assert creds["model"] == "nemotron-3.5-lightning:30b-mlx"
+    assert creds["api_mode"] == "chat_completions"
+    assert creds["base_url"] == "http://127.0.0.1:11434/v1"
+    assert creds["api_key"] == "no-key-required"
+    assert "sentinel" not in creds["api_key"]
+
+
+def test_named_ollama_delegation_preserves_legacy_api_only_endpoint(tmp_path, monkeypatch):
+    """An api-only named provider keeps its established local route."""
+    (tmp_path / "config.yaml").write_text(
+        """\
+providers:
+  ollama:
+    api: http://127.0.0.1:11434
+delegation:
+  provider: ollama
+  model: nemotron-3.5-lightning:30b-mlx
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "parent-openai-sentinel")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "parent-openrouter-sentinel")
+    parent = _make_mock_parent(depth=0)
+    parent.api_key = "parent-cloud-sentinel"
+
+    from hermes_cli.config import load_config
+
+    creds = _resolve_delegation_credentials(load_config()["delegation"], parent)
+
+    assert creds["provider"] == "ollama"
+    assert creds["model"] == "nemotron-3.5-lightning:30b-mlx"
+    assert creds["api_mode"] == "chat_completions"
+    assert creds["base_url"] == "http://127.0.0.1:11434"
+    assert creds["api_key"] == "no-key-required"
+    assert "sentinel" not in creds["api_key"]
+
 class TestDelegationProviderIntegration(unittest.TestCase):
     """Integration tests: delegation config → _run_single_child → AIAgent construction."""
 

--- a/tests/tools/test_delegate_fallback_event_integration.py
+++ b/tests/tools/test_delegate_fallback_event_integration.py
@@ -7,6 +7,9 @@ import threading
 from types import MappingProxyType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import httpx
+from openai import NotFoundError
+
 from agent.chat_completion_helpers import sanitize_fallback_event
 from run_agent import AIAgent
 from tools.delegate_tool import delegate_task
@@ -151,6 +154,181 @@ def test_raw_child_exception_reaches_delegate_as_only_sanitized_fallback_event(
     assert prompt_sentinel not in serialized_payload
     assert overlong_value not in serialized_payload
     assert len(serialized.encode("utf-8")) <= 768
+
+
+def _loop_child(*, base_url: str, model: str, max_iterations: int) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        child = AIAgent(
+            api_key="test-key",
+            base_url=base_url,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            max_iterations=max_iterations,
+            fallback_model=[
+                {
+                    "provider": "ollama-cloud",
+                    "model": "glm-5.2",
+                    "api_mode": "chat_completions",
+                }
+            ],
+        )
+
+    child.provider = "ollama"
+    child.requested_provider = "ollama"
+    child.model = model
+    child.base_url = base_url
+    child._api_max_retries = 3
+    child._primary_runtime["provider"] = "ollama"
+    child._primary_runtime["model"] = child.model
+    return child
+
+
+def _run_loop_with_fallback(child: AIAgent, primary_error: Exception):
+    calls = []
+
+    def fake_api_call(_api_kwargs):
+        calls.append((child.provider, child.model))
+        if child.provider == "ollama":
+            raise primary_error
+        return _completion("done")
+
+    fallback_client = MagicMock()
+    fallback_client.base_url = "https://ollama.com/v1"
+    fallback_client.api_key = "test-key"
+
+    with (
+        patch.object(child, "_interruptible_api_call", side_effect=fake_api_call),
+        patch.object(child, "_persist_session"),
+        patch.object(child, "_save_trajectory"),
+        patch.object(child, "_cleanup_task_resources"),
+        patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fallback_client, "glm-5.2"),
+        ),
+        patch(
+            "hermes_cli.model_normalize.normalize_model_for_provider",
+            side_effect=lambda model, provider: model,
+        ),
+        patch("agent.model_metadata.get_model_context_length", return_value=128_000),
+        patch("agent.conversation_loop.jittered_backoff", return_value=0.0),
+    ):
+        result = child.run_conversation("hello")
+    return result, calls
+
+
+def _assert_sanitized_event(event, expected, sentinels):
+    assert event == expected
+    serialized = json.dumps(event, sort_keys=True)
+    assert set(event) == {
+        "initial_provider",
+        "initial_model",
+        "selected_fallback_provider",
+        "selected_fallback_model",
+        "failure_class",
+        "reason_code",
+        "http_status",
+    }
+    for sentinel in sentinels:
+        assert sentinel not in serialized
+    assert len(serialized.encode("utf-8")) <= 768
+
+
+def test_sdk_not_found_max_retry_fallback_retains_only_safe_http_status(
+    tmp_path, monkeypatch
+):
+    """A retried SDK 404 keeps its safe status when fallback activates."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    secret_sentinel = "SENTINEL_SECRET_MUST_NOT_SURVIVE"
+    prompt_sentinel = "SENTINEL_PROMPT_MUST_NOT_SURVIVE"
+    body_sentinel = "SENTINEL_BODY_MUST_NOT_SURVIVE"
+    primary_error = NotFoundError(
+        message=f"route missing {secret_sentinel} {prompt_sentinel}",
+        response=httpx.Response(
+            404,
+            request=httpx.Request(
+                "POST", "http://localhost:11434/chat/completions"
+            ),
+        ),
+        body={"error": {"message": body_sentinel}},
+    )
+    child = _loop_child(
+        base_url="http://localhost:11434",
+        model="nemotron-3.5-lightning:30b-mlx",
+        max_iterations=4,
+    )
+    result, calls = _run_loop_with_fallback(child, primary_error)
+
+    assert result["completed"] is True
+    assert result["final_response"] == "done"
+    assert calls == [
+        ("ollama", "nemotron-3.5-lightning:30b-mlx"),
+        ("ollama", "nemotron-3.5-lightning:30b-mlx"),
+        ("ollama", "nemotron-3.5-lightning:30b-mlx"),
+        ("ollama-cloud", "glm-5.2"),
+    ]
+    _assert_sanitized_event(
+        child._last_fallback_event,
+        {
+            "initial_provider": "ollama",
+            "initial_model": "nemotron-3.5-lightning:30b-mlx",
+            "selected_fallback_provider": "ollama-cloud",
+            "selected_fallback_model": "glm-5.2",
+            "failure_class": "unknown",
+            "reason_code": "unknown",
+            "http_status": 404,
+        },
+        (secret_sentinel, prompt_sentinel, body_sentinel),
+    )
+
+
+def test_nonretryable_sdk_error_fallback_retains_classification_without_raw_data(
+    tmp_path, monkeypatch
+):
+    """A non-retryable SDK error forwards only classified fallback facts."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    secret_sentinel = "SENTINEL_SECRET_MUST_NOT_SURVIVE"
+    body_sentinel = "SENTINEL_BODY_MUST_NOT_SURVIVE"
+    primary_error = NotFoundError(
+        message=f"model not found {secret_sentinel}",
+        response=httpx.Response(
+            404,
+            request=httpx.Request(
+                "POST", "http://localhost:11434/v1/chat/completions"
+            ),
+        ),
+        body={"error": {"message": f"model not found {body_sentinel}"}},
+    )
+    child = _loop_child(
+        base_url="http://localhost:11434/v1",
+        model="missing-model",
+        max_iterations=2,
+    )
+    result, calls = _run_loop_with_fallback(child, primary_error)
+
+    assert result["completed"] is True
+    assert result["final_response"] == "done"
+    assert calls == [
+        ("ollama", "missing-model"),
+        ("ollama-cloud", "glm-5.2"),
+    ]
+    _assert_sanitized_event(
+        child._last_fallback_event,
+        {
+            "initial_provider": "ollama",
+            "initial_model": "missing-model",
+            "selected_fallback_provider": "ollama-cloud",
+            "selected_fallback_model": "glm-5.2",
+            "failure_class": "policy",
+            "reason_code": "model_not_found",
+            "http_status": 404,
+        },
+        (secret_sentinel, body_sentinel),
+    )
 
 
 def test_fallback_event_rejects_unknown_types_bool_status_and_extra_payloads():

--- a/tests/tools/test_delegate_fallback_event_integration.py
+++ b/tests/tools/test_delegate_fallback_event_integration.py
@@ -8,7 +8,7 @@ from types import MappingProxyType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import httpx
-from openai import NotFoundError
+from openai import APIStatusError, NotFoundError, RateLimitError
 
 from agent.chat_completion_helpers import sanitize_fallback_event
 from run_agent import AIAgent
@@ -238,6 +238,27 @@ def _assert_sanitized_event(event, expected, sentinels):
     assert len(serialized.encode("utf-8")) <= 768
 
 
+def _pool_with_no_successful_rotation():
+    """Keep late fallback reachable without simulating a recovered key."""
+    current = SimpleNamespace(
+        id="credential-1",
+        runtime_api_key="test-key",
+        last_status=None,
+    )
+    alternate = SimpleNamespace(
+        id="credential-2",
+        runtime_api_key="alternate-key",
+        last_status=None,
+    )
+    pool = MagicMock()
+    pool.provider = "ollama"
+    pool.current.return_value = current
+    pool.entries.return_value = [current, alternate]
+    pool.has_available.return_value = True
+    pool.mark_exhausted_and_rotate.return_value = None
+    return pool
+
+
 def test_sdk_not_found_max_retry_fallback_retains_only_safe_http_status(
     tmp_path, monkeypatch
 ):
@@ -328,6 +349,110 @@ def test_nonretryable_sdk_error_fallback_retains_classification_without_raw_data
             "http_status": 404,
         },
         (secret_sentinel, body_sentinel),
+    )
+
+
+def test_max_retry_rate_limit_diagnostic_does_not_start_new_cooldown(
+    tmp_path, monkeypatch
+):
+    """Late diagnostic forwarding cannot add behavioral rate-limit state."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    message_sentinel = "SENTINEL_MESSAGE_MUST_NOT_SURVIVE"
+    body_sentinel = "SENTINEL_BODY_MUST_NOT_SURVIVE"
+    primary_error = RateLimitError(
+        message=f"rate limit {message_sentinel}",
+        response=httpx.Response(
+            429,
+            request=httpx.Request(
+                "POST", "http://localhost:11434/v1/chat/completions"
+            ),
+        ),
+        body={"error": {"message": body_sentinel}},
+    )
+    child = _loop_child(
+        base_url="http://localhost:11434/v1",
+        model="nemotron-3.5-lightning:30b-mlx",
+        max_iterations=4,
+    )
+    child._credential_pool = _pool_with_no_successful_rotation()
+    child._credential_pool_entry_id = "credential-1"
+    child._rate_limit_backoff_count = 0
+    child._rate_limited_until = 0
+
+    result, calls = _run_loop_with_fallback(child, primary_error)
+
+    assert result["completed"] is True
+    assert calls == [
+        ("ollama", "nemotron-3.5-lightning:30b-mlx"),
+        ("ollama", "nemotron-3.5-lightning:30b-mlx"),
+        ("ollama", "nemotron-3.5-lightning:30b-mlx"),
+        ("ollama-cloud", "glm-5.2"),
+    ]
+    assert child._rate_limit_backoff_count == 0
+    assert child._rate_limited_until == 0
+    _assert_sanitized_event(
+        child._last_fallback_event,
+        {
+            "initial_provider": "ollama",
+            "initial_model": "nemotron-3.5-lightning:30b-mlx",
+            "selected_fallback_provider": "ollama-cloud",
+            "selected_fallback_model": "glm-5.2",
+            "failure_class": "quota",
+            "reason_code": "rate_limit",
+            "http_status": 429,
+        },
+        (message_sentinel, body_sentinel),
+    )
+
+
+def test_nonretryable_billing_diagnostic_does_not_start_new_cooldown(
+    tmp_path, monkeypatch
+):
+    """Late billing diagnostics preserve the former no-cooldown behavior."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    message_sentinel = "SENTINEL_MESSAGE_MUST_NOT_SURVIVE"
+    body_sentinel = "SENTINEL_BODY_MUST_NOT_SURVIVE"
+    primary_error = APIStatusError(
+        message=f"credits exhausted {message_sentinel}",
+        response=httpx.Response(
+            402,
+            request=httpx.Request(
+                "POST", "http://localhost:11434/v1/chat/completions"
+            ),
+        ),
+        body={"error": {"message": body_sentinel}},
+    )
+    child = _loop_child(
+        base_url="http://localhost:11434/v1",
+        model="nemotron-3.5-lightning:30b-mlx",
+        max_iterations=2,
+    )
+    child._credential_pool = _pool_with_no_successful_rotation()
+    child._credential_pool_entry_id = "credential-1"
+    child._rate_limit_backoff_count = 0
+    child._rate_limited_until = 0
+
+    result, calls = _run_loop_with_fallback(child, primary_error)
+
+    assert result["completed"] is True
+    assert calls == [
+        ("ollama", "nemotron-3.5-lightning:30b-mlx"),
+        ("ollama-cloud", "glm-5.2"),
+    ]
+    assert child._rate_limit_backoff_count == 0
+    assert child._rate_limited_until == 0
+    _assert_sanitized_event(
+        child._last_fallback_event,
+        {
+            "initial_provider": "ollama",
+            "initial_model": "nemotron-3.5-lightning:30b-mlx",
+            "selected_fallback_provider": "ollama-cloud",
+            "selected_fallback_model": "glm-5.2",
+            "failure_class": "quota",
+            "reason_code": "billing",
+            "http_status": 402,
+        },
+        (message_sentinel, body_sentinel),
     )
 
 

--- a/tests/tools/test_delegate_fallback_event_integration.py
+++ b/tests/tools/test_delegate_fallback_event_integration.py
@@ -1,0 +1,187 @@
+"""Behavior-level coverage for delegated fallback diagnostics."""
+
+from __future__ import annotations
+
+import json
+import threading
+from types import MappingProxyType, SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.chat_completion_helpers import sanitize_fallback_event
+from run_agent import AIAgent
+from tools.delegate_tool import delegate_task
+
+
+def _parent():
+    parent = MagicMock()
+    parent.base_url = "https://primary.invalid/v1"
+    parent.api_key = "test-key"
+    parent.provider = "ollama"
+    parent.api_mode = "chat_completions"
+    parent.model = "nemotron-3.5-lightning:30b-mlx"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent._session_db = None
+    parent._credential_pool = None
+    parent._delegate_depth = 0
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    return parent
+
+
+def _completion(text: str):
+    message = SimpleNamespace(
+        role="assistant",
+        content=text,
+        tool_calls=None,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")],
+        model="glm-5.2",
+        usage=None,
+    )
+
+
+def test_raw_child_exception_reaches_delegate_as_only_sanitized_fallback_event(
+    tmp_path, monkeypatch
+):
+    """Exercise raw exception -> classifier -> fallback -> delegate result."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    secret_sentinel = "SENTINEL_SECRET_MUST_NOT_SURVIVE"
+    prompt_sentinel = "SENTINEL_PROMPT_MUST_NOT_SURVIVE"
+    overlong_value = "Q" * 10_000
+    primary_error = RuntimeError(
+        f"rate limited {secret_sentinel} {prompt_sentinel} {overlong_value}"
+    )
+    primary_error.status_code = 429
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        child = AIAgent(
+            api_key="test-key",
+            base_url="https://primary.invalid/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            max_iterations=4,
+            fallback_model=[
+                {
+                    "provider": "ollama-cloud",
+                    "model": "glm-5.2",
+                    "api_mode": "chat_completions",
+                }
+            ],
+        )
+
+    child.provider = "ollama"
+    child.requested_provider = "ollama"
+    child.model = "nemotron-3.5-lightning:30b-mlx"
+    child.base_url = "http://localhost:11434/v1"
+    child._primary_runtime["provider"] = "ollama"
+    child._primary_runtime["model"] = child.model
+    primary_client = MagicMock()
+    primary_client.chat.completions.create.side_effect = primary_error
+    child.client = primary_client
+
+    fallback_client = MagicMock()
+    fallback_client.base_url = "https://ollama.com/v1"
+    fallback_client.api_key = "test-key"
+    fallback_client.chat.completions.create.return_value = _completion("done")
+
+    with (
+        patch("tools.delegate_tool._load_config", return_value={}),
+        patch("tools.delegate_tool._build_child_agent", return_value=child),
+        patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fallback_client, "glm-5.2"),
+        ),
+        patch(
+            "hermes_cli.model_normalize.normalize_model_for_provider",
+            side_effect=lambda model, provider: model,
+        ),
+        patch("agent.model_metadata.get_model_context_length", return_value=128_000),
+        patch.object(child, "_persist_session"),
+        patch.object(child, "_save_trajectory"),
+        patch.object(child, "_cleanup_task_resources"),
+    ):
+        payload = json.loads(
+            delegate_task(goal="Exercise fallback diagnostics", parent_agent=_parent())
+        )
+
+    entry = payload["results"][0]
+    assert entry["status"] == "completed"
+    assert entry["model"] == "glm-5.2"
+    assert entry["fallback_event"] == {
+        "initial_provider": "ollama",
+        "initial_model": "nemotron-3.5-lightning:30b-mlx",
+        "selected_fallback_provider": "ollama-cloud",
+        "selected_fallback_model": "glm-5.2",
+        "failure_class": "quota",
+        "reason_code": "rate_limit",
+        "http_status": 429,
+    }
+    assert child._last_fallback_event == entry["fallback_event"]
+    serialized = json.dumps(entry["fallback_event"], sort_keys=True)
+    serialized_payload = json.dumps(payload, sort_keys=True)
+    assert set(entry["fallback_event"]) == {
+        "initial_provider",
+        "initial_model",
+        "selected_fallback_provider",
+        "selected_fallback_model",
+        "failure_class",
+        "reason_code",
+        "http_status",
+    }
+    assert secret_sentinel not in serialized
+    assert prompt_sentinel not in serialized
+    assert overlong_value not in serialized
+    assert secret_sentinel not in serialized_payload
+    assert prompt_sentinel not in serialized_payload
+    assert overlong_value not in serialized_payload
+    assert len(serialized.encode("utf-8")) <= 768
+
+
+def test_fallback_event_rejects_unknown_types_bool_status_and_extra_payloads():
+    secret_sentinel = "SENTINEL_SECRET_MUST_NOT_SURVIVE"
+    event = sanitize_fallback_event(
+        {
+            "initial_provider": "ollama",
+            "initial_model": "nemotron-3.5-lightning:30b-mlx",
+            "selected_fallback_provider": "ollama-cloud",
+            "selected_fallback_model": "glm-5.2",
+            "failure_class": ["availability"],
+            "reason_code": {"value": "overloaded"},
+            "http_status": True,
+            "raw_exception": secret_sentinel,
+            "headers": {"authorization": secret_sentinel},
+        }
+    )
+
+    assert event is not None
+    assert event["failure_class"] == "unknown"
+    assert event["reason_code"] == "unknown"
+    assert event["http_status"] is None
+    assert set(event) == {
+        "initial_provider",
+        "initial_model",
+        "selected_fallback_provider",
+        "selected_fallback_model",
+        "failure_class",
+        "reason_code",
+        "http_status",
+    }
+    assert secret_sentinel not in json.dumps(event, sort_keys=True)
+    assert sanitize_fallback_event(MappingProxyType(dict(event))) is None
+    assert sanitize_fallback_event({**event, "initial_model": "M" * 121}) is None

--- a/tests/tools/test_delegate_output_schema.py
+++ b/tests/tools/test_delegate_output_schema.py
@@ -215,6 +215,45 @@ class TestRunSingleChildSchemaValidation:
         # final summary is the retried (valid) answer
         assert json.loads(entry["summary"])["city"] == "Oslo"
 
+    def test_task_boundary_resets_stale_event_but_schema_retry_keeps_fresh_event(self):
+        stale_event = {
+            "initial_provider": "stale-primary",
+            "initial_model": "stale-model",
+            "selected_fallback_provider": "stale-fallback",
+            "selected_fallback_model": "stale-fallback-model",
+            "failure_class": "unknown",
+            "reason_code": "unknown",
+            "http_status": None,
+        }
+        fresh_event = {
+            "initial_provider": "ollama",
+            "initial_model": "nemotron-3.5-lightning:30b-mlx",
+            "selected_fallback_provider": "ollama-cloud",
+            "selected_fallback_model": "glm-5.2",
+            "failure_class": "availability",
+            "reason_code": "overloaded",
+            "http_status": 503,
+        }
+        child = _StubChild(["not json", '{"city": "Oslo"}'])
+        child._delegate_output_schema = ADDRESS_SCHEMA
+        child._last_fallback_event = stale_event
+        observed_before_turn = []
+        original_run = child.run_conversation
+
+        def run_and_activate(user_message, task_id=None, **kwargs):
+            observed_before_turn.append(child._last_fallback_event)
+            result = original_run(user_message, task_id=task_id, **kwargs)
+            if len(observed_before_turn) == 1:
+                child._last_fallback_event = fresh_event
+            return result
+
+        child.run_conversation = run_and_activate
+        entry = _run(child)
+
+        assert observed_before_turn == [None, fresh_event]
+        assert entry["schema_retries"] == 1
+        assert entry["fallback_event"] == fresh_event
+
     def test_invalid_twice_surfaces_errors_and_stops(self):
         child = _StubChild(["nope", "still nope"])
         child._delegate_output_schema = ADDRESS_SCHEMA

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -80,6 +80,7 @@ class TestDirHash:
         cache_dir = cached_skill / "scripts" / "__pycache__"
         cache_dir.mkdir()
         (cache_dir / "main.cpython-311.pyc").write_bytes(b"bytecode")
+        (cache_dir / "cache-metadata.json").write_text('{"format": 1}')
         (cached_skill / "scripts" / "legacy.pyc").write_bytes(b"legacy bytecode")
         (cached_skill / "scripts" / "optimized.pyo").write_bytes(b"optimized bytecode")
 

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -69,6 +69,22 @@ class TestDirHash:
         # A nonexistent dir hashes as empty content rather than raising.
         assert isinstance(_dir_hash(tmp_path / "nope"), str)
 
+    def test_hash_ignores_python_runtime_cache_artifacts(self, tmp_path):
+        clean_skill = tmp_path / "clean-skill"
+        cached_skill = tmp_path / "cached-skill"
+        for skill_dir in (clean_skill, cached_skill):
+            (skill_dir / "scripts").mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text("# Test skill")
+            (skill_dir / "scripts" / "main.py").write_text("print('hello')")
+
+        cache_dir = cached_skill / "scripts" / "__pycache__"
+        cache_dir.mkdir()
+        (cache_dir / "main.cpython-311.pyc").write_bytes(b"bytecode")
+        (cached_skill / "scripts" / "legacy.pyc").write_bytes(b"legacy bytecode")
+        (cached_skill / "scripts" / "optimized.pyo").write_bytes(b"optimized bytecode")
+
+        assert _dir_hash(clean_skill) == _dir_hash(cached_skill)
+
 
 class TestDiscoverBundledSkills:
     def test_finds_skill_dirs_and_ignores_non_skills(self, tmp_path):

--- a/tests/tui_gateway/test_custom_provider_session_persistence.py
+++ b/tests/tui_gateway/test_custom_provider_session_persistence.py
@@ -260,6 +260,24 @@ def test_tui_present_invalid_requested_identity_fails_closed(invalid):
         _stored_session_runtime_overrides(row)
 
 
+def test_tui_unknown_present_identity_failure_never_constructs_agent(monkeypatch):
+    """A resolver grammar error on a stored identity must abort before construction."""
+    import tui_gateway.server as server
+
+    resolver = MagicMock(side_effect=ValueError("persisted identity is not routable"))
+    constructor = MagicMock()
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", resolver)
+
+    with patch("run_agent.AIAgent", constructor):
+        with pytest.raises(ValueError, match="not routable"):
+            server._make_agent(
+                "tui-invalid-route", "synthetic-key",
+                model_override={"model": "stored-model", "provider": "custom", "requested_provider": "unknown:route"},
+            )
+
+    constructor.assert_not_called()
+
+
 # --- Regression: bare "custom" WITHOUT a base_url (GH #44022 / #47714) ------
 #
 # The recurring Desktop/TUI "No LLM provider configured" regression. Every
@@ -430,4 +448,3 @@ class TestModelNameRecoversEntryIdentity:
             rp.find_custom_provider_identity_by_model("hermes-ultra-sft")
             == "custom:hermes-ultra"
         )
-

--- a/tests/tui_gateway/test_custom_provider_session_persistence.py
+++ b/tests/tui_gateway/test_custom_provider_session_persistence.py
@@ -25,9 +25,30 @@ pinning); same family of resolved-vs-requested identity loss.
 
 import json
 import types
+from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
+import pytest
+from run_agent import AIAgent as RealAIAgent
+
 import hermes_cli.runtime_provider as rp
+
+
+def _install_real_agent_probe_guards(monkeypatch):
+    context_length = MagicMock(return_value=262144)
+    endpoint_metadata = MagicMock(side_effect=AssertionError("constructor attempted endpoint metadata access"))
+    local_server = MagicMock(side_effect=AssertionError("constructor attempted local-server detection"))
+    monkeypatch.setattr("agent.context_compressor.get_model_context_length", context_length)
+    monkeypatch.setattr("agent.model_metadata.fetch_endpoint_model_metadata", endpoint_metadata)
+    monkeypatch.setattr("agent.model_metadata.detect_local_server_type", local_server)
+    return context_length, endpoint_metadata, local_server
+
+
+def _assert_real_agent_probe_guards(probes):
+    context_length, endpoint_metadata, local_server = probes
+    context_length.assert_called()
+    endpoint_metadata.assert_not_called()
+    local_server.assert_not_called()
 
 MIMO_URL = "https://token-plan-cn.xiaomimimo.com/v1"
 MIMO_KEY = "sk-mimo-entry-key"
@@ -169,6 +190,74 @@ class TestResumeRoundTrip:
 
         assert kwargs["base_url"] == MIMO_URL
         assert kwargs["api_key"] == MIMO_KEY
+
+
+@pytest.mark.parametrize("requested", ["custom", "custom:remote"])
+def test_tui_modern_requested_identity_resolves_without_reverse_inference(
+    requested, tmp_path, monkeypatch,
+):
+    import run_agent
+    import tui_gateway.server as server
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    config = deepcopy(LEGACY_LIST_CONFIG)
+    captured = {}
+    canonical = MagicMock(side_effect=AssertionError("modern row reverse-inferred"))
+    resolved = MagicMock(return_value={
+        "provider": "custom", "requested_provider": requested,
+        "api_key": "synthetic-key", "base_url": MIMO_URL,
+        "api_mode": "chat_completions",
+        "request_overrides": {"extra_body": {"route": "provider"}},
+        "credential_pool": None, "command": None, "args": [],
+        "max_output_tokens": None,
+    })
+    monkeypatch.setattr(rp, "load_config", lambda: config)
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *_a, **_k: None)
+    monkeypatch.setattr(rp, "canonical_custom_identity", canonical)
+    monkeypatch.setattr(rp, "resolve_runtime_provider", resolved)
+    monkeypatch.setattr(run_agent, "OpenAI", MagicMock(return_value=MagicMock()))
+    constructor_probes = _install_real_agent_probe_guards(monkeypatch)
+
+    def construct(*args, **kwargs):
+        captured["kwargs"] = deepcopy(kwargs)
+        captured["agent"] = RealAIAgent(*args, **kwargs)
+        return captured["agent"]
+
+    row = {"model": "mimo-v2.5-pro", "model_config": json.dumps({
+        "model": "mimo-v2.5-pro", "provider": "custom",
+        "requested_provider": requested, "base_url": MIMO_URL,
+        "api_mode": "chat_completions",
+    })}
+    overrides = server._stored_session_runtime_overrides(row)
+    fake_cfg = {"agent": {"system_prompt": ""}, "model": {"default": "unused"}}
+    with (
+        patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch("tui_gateway.server._load_reasoning_config", return_value=None),
+        patch("tui_gateway.server._load_service_tier", return_value=None),
+        patch("tui_gateway.server._load_enabled_toolsets", return_value=None),
+        patch("run_agent.AIAgent", side_effect=construct),
+    ):
+        agent = server._make_agent("sid-modern", "key-modern", model_override=overrides["model_override"])
+    canonical.assert_not_called()
+    assert resolved.call_args.kwargs["requested"] == requested
+    assert isinstance(agent, RealAIAgent)
+    assert (agent.provider, agent.requested_provider) == ("custom", requested)
+    assert agent._caller_request_overrides == {}
+    assert agent._provider_request_overrides == {"extra_body": {"route": "provider"}}
+    _assert_real_agent_probe_guards(constructor_probes)
+
+
+@pytest.mark.parametrize("invalid", [None, "", "   ", [], {}, "custom:"])
+def test_tui_present_invalid_requested_identity_fails_closed(invalid):
+    from tui_gateway.server import _stored_session_runtime_overrides
+
+    row = {"model": "mimo-v2.5-pro", "model_config": json.dumps({
+        "provider": "custom", "requested_provider": invalid, "base_url": MIMO_URL,
+    })}
+    with pytest.raises(ValueError, match="requested_provider"):
+        _stored_session_runtime_overrides(row)
 
 
 # --- Regression: bare "custom" WITHOUT a base_url (GH #44022 / #47714) ------
@@ -341,5 +430,4 @@ class TestModelNameRecoversEntryIdentity:
             rp.find_custom_provider_identity_by_model("hermes-ultra-sft")
             == "custom:hermes-ultra"
         )
-
 

--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -6,25 +6,76 @@ provider/base_url/api_key empty in AIAgent, causing HTTP 404.
 """
 
 import os
+from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
+from run_agent import AIAgent as RealAIAgent
 
-def test_make_agent_passes_resolved_provider():
+
+def _install_real_agent_probe_guards(monkeypatch):
+    context_length = MagicMock(return_value=262144)
+    endpoint_metadata = MagicMock(
+        side_effect=AssertionError("constructor attempted endpoint metadata access")
+    )
+    local_server = MagicMock(
+        side_effect=AssertionError("constructor attempted local-server detection")
+    )
+    monkeypatch.setattr(
+        "agent.context_compressor.get_model_context_length", context_length,
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.fetch_endpoint_model_metadata", endpoint_metadata,
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.detect_local_server_type", local_server,
+    )
+    return context_length, endpoint_metadata, local_server
+
+
+def _assert_real_agent_probe_guards(probes):
+    context_length, endpoint_metadata, local_server = probes
+    context_length.assert_called()
+    endpoint_metadata.assert_not_called()
+    local_server.assert_not_called()
+
+
+def _install_real_agent_factory(monkeypatch, target, captured):
+    captured["constructor_probes"] = _install_real_agent_probe_guards(monkeypatch)
+
+    def construct(*args, **kwargs):
+        captured["args"] = deepcopy(args)
+        captured["kwargs"] = deepcopy(kwargs)
+        agent = RealAIAgent(*args, **kwargs)
+        captured["agent"] = agent
+        agent.run_conversation = MagicMock(
+            return_value={"final_response": "synthetic-response", "messages": []}
+        )
+        agent.chat = MagicMock(return_value="synthetic-response")
+        return agent
+
+    monkeypatch.setattr(target, construct)
+
+
+def test_make_agent_passes_resolved_provider(tmp_path, monkeypatch):
     """_make_agent forwards provider/base_url/api_key/api_mode from
     resolve_runtime_provider to AIAgent."""
 
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     fake_runtime = {
-        "provider": "anthropic",
-        "base_url": "https://api.anthropic.com",
-        "api_key": "sk-test-key",
-        "api_mode": "anthropic_messages",
+        "provider": "custom",
+        "requested_provider": "ollama",
+        "base_url": "http://127.0.0.1:11434/v1",
+        "api_key": "synthetic-key",
+        "api_mode": "chat_completions",
         "command": None,
         "args": None,
         "credential_pool": None,
+        "request_overrides": {},
+        "max_output_tokens": None,
     }
 
     fake_cfg = {
-        "model": {"default": "claude-opus-4-6", "provider": "anthropic"},
+        "model": {"default": "synthetic-model", "provider": "ollama"},
         "agent": {"system_prompt": "test"},
     }
 
@@ -39,12 +90,15 @@ def test_make_agent_passes_resolved_provider():
             "hermes_cli.runtime_provider.resolve_runtime_provider",
             return_value=fake_runtime,
         ) as mock_resolve,
-        patch("run_agent.AIAgent") as mock_agent,
     ):
-
         from tui_gateway.server import _make_agent
+        import run_agent
 
-        _make_agent("sid-1", "key-1")
+        monkeypatch.setattr(run_agent, "OpenAI", MagicMock(return_value=MagicMock()))
+        captured = {}
+        _install_real_agent_factory(monkeypatch, "run_agent.AIAgent", captured)
+
+        agent = _make_agent("sid-1", "key-1")
 
         # target_model comes from _resolve_startup_runtime() which reads
         # _load_cfg().  Due to module-level caching in tui_gateway.server,
@@ -53,11 +107,18 @@ def test_make_agent_passes_resolved_provider():
         mock_resolve.assert_called_once()
         assert mock_resolve.call_args.kwargs.get("requested") is None
 
-        call_kwargs = mock_agent.call_args
-        assert call_kwargs.kwargs["provider"] == "anthropic"
-        assert call_kwargs.kwargs["base_url"] == "https://api.anthropic.com"
-        assert call_kwargs.kwargs["api_key"] == "sk-test-key"
-        assert call_kwargs.kwargs["api_mode"] == "anthropic_messages"
+        call_kwargs = captured["kwargs"]
+        assert call_kwargs["provider"] == "custom"
+        assert call_kwargs["requested_provider"] == "ollama"
+        assert call_kwargs["provider_request_overrides"] == {}
+        assert call_kwargs["base_url"] == "http://127.0.0.1:11434/v1"
+        assert call_kwargs["api_key"] == "synthetic-key"
+        assert call_kwargs["api_mode"] == "chat_completions"
+        assert isinstance(agent, RealAIAgent)
+        assert (agent.provider, agent.requested_provider) == ("custom", "ollama")
+        assert agent._caller_request_overrides == {}
+        assert agent._provider_request_overrides == {}
+        _assert_real_agent_probe_guards(captured["constructor_probes"])
 
 
 def test_probe_config_health_flags_null_sections():

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2751,6 +2751,12 @@ def _run_single_child(
             list(file_state.known_reads(parent_task_id)) if parent_task_id else []
         )
 
+        # A child object may be reused by an embedding/test harness, but one
+        # delegated task must never inherit a prior task's diagnostic. Reset
+        # exactly once at the task boundary; a same-task schema retry below
+        # intentionally keeps any event produced by the first turn.
+        child._last_fallback_event = None
+
         # Run child with an optional hard timeout (off by default —
         # result(timeout=None) blocks until the child finishes). Stuck-child
         # protection comes from the heartbeat staleness monitor instead.

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3122,6 +3122,13 @@ def _run_single_child(
                 else 0.0
             ),
         }
+        from agent.chat_completion_helpers import sanitize_fallback_event
+
+        fallback_event = sanitize_fallback_event(
+            getattr(child, "_last_fallback_event", None)
+        )
+        if fallback_event is not None:
+            entry["fallback_event"] = fallback_event
         # Per-delegation spend, serialized back to the model alongside
         # tokens/api_calls so the parent can see what each delegation cost.
         # Mirrors _child_cost_usd (which is stripped pre-serialization and

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -252,12 +252,14 @@ def _compute_relative_dest(skill_dir: Path, bundled_dir: Path) -> Path:
 
 
 def _dir_hash(directory: Path) -> str:
-    """Compute a hash of all file contents in a directory for change detection."""
+    """Compute a hash of source files in a directory for change detection."""
     hasher = hashlib.md5()
     try:
         for fpath in sorted(directory.rglob("*")):
             if fpath.is_file():
                 rel = fpath.relative_to(directory)
+                if "__pycache__" in rel.parts or fpath.suffix in {".pyc", ".pyo"}:
+                    continue
                 hasher.update(str(rel).encode("utf-8"))
                 hasher.update(fpath.read_bytes())
     except (OSError, IOError):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -17,6 +17,7 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, NamedTuple, Optional
+from urllib.parse import urlsplit, urlunsplit
 
 from agent.secret_scope import (
     build_profile_secret_scope,
@@ -2956,11 +2957,18 @@ def _ensure_session_db_row(session: dict) -> None:
     for src_key, cfg_key in (
         ("model", "model"),
         ("provider", "provider"),
+        ("requested_provider", "requested_provider"),
         ("base_url", "base_url"),
         ("api_mode", "api_mode"),
     ):
         if val := override.get(src_key):
             model_config[cfg_key] = str(val)
+    if "base_url" in model_config:
+        safe_base_url = _persistable_runtime_base_url(model_config["base_url"])
+        if safe_base_url:
+            model_config["base_url"] = safe_base_url
+        else:
+            model_config.pop("base_url", None)
     # The composer override may carry the RESOLVED provider "custom" for a named
     # ``providers:`` / ``custom_providers:`` entry. Persisting bare "custom" here
     # (the very first DB write for a fresh desktop session, before the agent is
@@ -2969,7 +2977,10 @@ def _ensure_session_db_row(session: dict) -> None:
     # the durable ``custom:<name>`` identity from the override's base_url, else
     # the configured provider, so a routable identity is persisted from the
     # start (matches _runtime_model_config's normalization).
-    if str(model_config.get("provider") or "").strip().lower() == "custom":
+    if (
+        "requested_provider" not in model_config
+        and str(model_config.get("provider") or "").strip().lower() == "custom"
+    ):
         try:
             from hermes_cli.runtime_provider import canonical_custom_identity
 
@@ -4019,7 +4030,14 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
     # regression vector). If none names a real entry,
     # drop the bare provider entirely so resume falls back to the configured
     # default rather than the broken OpenRouter route.
-    if provider.strip().lower() == "custom":
+    if "requested_provider" in model_config:
+        requested = model_config["requested_provider"]
+        if not isinstance(requested, str) or not requested.strip() or requested.strip().endswith(":"):
+            raise ValueError("invalid persisted requested_provider")
+        requested_provider = requested.strip().lower()
+    else:
+        requested_provider = provider
+    if "requested_provider" not in model_config and provider.strip().lower() == "custom":
         healed = None
         try:
             from hermes_cli.runtime_provider import canonical_custom_identity
@@ -4032,6 +4050,7 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
                 "custom provider identity recovery failed", exc_info=True
             )
         provider = healed or ("" if not base_url else provider)
+        requested_provider = provider
 
     if model:
         # Use the same dict-shaped override that live /model switches use so a
@@ -4042,6 +4061,7 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
         overrides["model_override"] = {
             "model": model,
             "provider": provider or None,
+            "requested_provider": requested_provider or None,
             "base_url": base_url or None,
             "api_mode": api_mode or None,
         }
@@ -4059,11 +4079,33 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
     return overrides
 
 
+def _persistable_runtime_base_url(value: Any) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    try:
+        parsed = urlsplit(raw)
+        scheme = parsed.scheme.lower()
+        hostname = parsed.hostname
+        port = parsed.port
+    except (TypeError, ValueError):
+        return ""
+    if scheme not in {"http", "https"} or not hostname:
+        return ""
+    host = hostname.lower()
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    if port is not None and (scheme, port) not in {("http", 80), ("https", 443)}:
+        host = f"{host}:{port}"
+    return urlunsplit((scheme, host, parsed.path, "", ""))
+
+
 def _runtime_model_config(agent, existing: dict | None = None) -> dict:
     config = dict(existing or {})
     model = str(getattr(agent, "model", "") or "").strip()
     provider = str(getattr(agent, "provider", "") or "").strip()
-    base_url = str(getattr(agent, "base_url", "") or "").strip()
+    requested_provider = str(getattr(agent, "requested_provider", "") or "").strip()
+    base_url = _persistable_runtime_base_url(getattr(agent, "base_url", ""))
     api_mode = str(getattr(agent, "api_mode", "") or "").strip()
     reasoning_config = getattr(agent, "reasoning_config", None)
     service_tier = getattr(agent, "service_tier", None)
@@ -4071,7 +4113,7 @@ def _runtime_model_config(agent, existing: dict | None = None) -> dict:
     if model:
         config["model"] = model
     if provider:
-        if provider.strip().lower() == "custom":
+        if provider.strip().lower() == "custom" and not requested_provider:
             # ``agent.provider`` is the RESOLVED provider, and for any named
             # ``providers:`` / ``custom_providers:`` entry that is the literal
             # string "custom" — persisting it loses the entry identity, so a
@@ -4100,6 +4142,10 @@ def _runtime_model_config(agent, existing: dict | None = None) -> dict:
                     "custom provider identity lookup failed", exc_info=True
                 )
         config["provider"] = provider
+    if requested_provider:
+        config["requested_provider"] = requested_provider
+    else:
+        config.pop("requested_provider", None)
     if base_url:
         config["base_url"] = base_url
     else:
@@ -4709,10 +4755,13 @@ def _snapshot_agent_model_runtime(agent) -> dict:
     return {
         "model": getattr(agent, "model", ""),
         "provider": getattr(agent, "provider", ""),
+        "requested_provider": getattr(agent, "requested_provider", ""),
         "api_key": getattr(agent, "api_key", ""),
         "base_url": getattr(agent, "base_url", ""),
         "api_mode": getattr(agent, "api_mode", ""),
         "primary_runtime": copy.deepcopy(getattr(agent, "_primary_runtime", None)),
+        "caller_request_overrides": copy.deepcopy(getattr(agent, "_caller_request_overrides", {}) or {}),
+        "provider_request_overrides": copy.deepcopy(getattr(agent, "_provider_request_overrides", {}) or {}),
     }
 
 
@@ -4720,6 +4769,13 @@ def _restore_agent_model_runtime(agent, snapshot: dict | None) -> None:
     """Restore an agent model runtime captured before a one-turn override."""
     if not snapshot or agent is None:
         return
+    if hasattr(agent, "_set_caller_request_overrides"):
+        agent._set_caller_request_overrides(snapshot.get("caller_request_overrides") or {})
+    if hasattr(agent, "_set_provider_request_overrides"):
+        agent._set_provider_request_overrides(snapshot.get("provider_request_overrides") or {})
+    requested_provider = snapshot.get("requested_provider")
+    if requested_provider:
+        agent.requested_provider = requested_provider
     primary = snapshot.get("primary_runtime")
     if primary and hasattr(agent, "_restore_primary_runtime"):
         try:
@@ -4738,6 +4794,8 @@ def _restore_agent_model_runtime(agent, snapshot: dict | None) -> None:
             base_url=snapshot.get("base_url", ""),
             api_mode=snapshot.get("api_mode", ""),
         )
+        if requested_provider:
+            agent.requested_provider = requested_provider
 
 
 def _apply_model_switch(
@@ -4940,6 +4998,7 @@ def _apply_model_switch(
         session["model_override"] = {
             "model": result.new_model,
             "provider": result.target_provider,
+            "requested_provider": getattr(result, "requested_provider", result.target_provider),
             "base_url": result.base_url,
             "api_key": result.api_key,
             "api_mode": result.api_mode,
@@ -6492,6 +6551,7 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "base_url": getattr(agent, "base_url", None) or None,
         "api_key": getattr(agent, "api_key", None) or None,
         "provider": getattr(agent, "provider", None) or None,
+        "requested_provider": getattr(agent, "requested_provider", None) or None,
         "api_mode": getattr(agent, "api_mode", None) or None,
         "acp_command": getattr(agent, "acp_command", None) or None,
         "acp_args": getattr(agent, "acp_args", None) or None,
@@ -6520,7 +6580,8 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "reasoning_config": getattr(agent, "reasoning_config", None)
         or _load_reasoning_config(str(getattr(agent, "model", "") or "")),
         "service_tier": getattr(agent, "service_tier", None) or _load_service_tier(),
-        "request_overrides": dict(getattr(agent, "request_overrides", {}) or {}),
+        "request_overrides": copy.deepcopy(getattr(agent, "_caller_request_overrides", {}) or {}),
+        "provider_request_overrides": copy.deepcopy(getattr(agent, "_provider_request_overrides", {}) or {}),
         "platform": "tui",
         "session_db": _get_db(),
         "fallback_model": _agent_fallback_model(agent),
@@ -6910,12 +6971,20 @@ def _make_agent(
     # also pass scalar model/provider/runtime knobs from the persisted DB row.
     if isinstance(model_override, dict) and model_override.get("model"):
         model = str(model_override.get("model") or "")
-        requested_provider = model_override.get("provider") or provider_override or None
+        requested_provider = (
+            model_override.get("requested_provider")
+            or model_override.get("provider")
+            or provider_override
+            or None
+        )
         override_base_url = model_override.get("base_url")
         override_api_key = model_override.get("api_key")
         override_api_mode = model_override.get("api_mode")
         resolve_kwargs = {}
-        if str(requested_provider or "").strip().lower() == "custom":
+        if (
+            "requested_provider" not in model_override
+            and str(requested_provider or "").strip().lower() == "custom"
+        ):
             # Session rows persisted before the custom-provider identity fix
             # (see _runtime_model_config) stored the resolved provider
             # "custom", which _get_named_custom_provider cannot match back to
@@ -6976,12 +7045,14 @@ def _make_agent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 500),
         provider=runtime.get("provider"),
+        requested_provider=runtime.get("requested_provider"),
         base_url=runtime.get("base_url"),
         api_key=runtime.get("api_key"),
         api_mode=runtime.get("api_mode"),
         acp_command=runtime.get("command"),
         acp_args=runtime.get("args"),
         credential_pool=runtime.get("credential_pool"),
+        provider_request_overrides=copy.deepcopy(runtime.get("request_overrides") or {}),
         quiet_mode=True,
         # verbose_logging controls DEBUG-level agent logging; it is intentionally
         # independent of tool_progress_mode (which only controls per-tool


### PR DESCRIPTION
## Summary

This draft reconciles the Hermes stack work with the v0.20.4 codebase while preserving the project’s provider, security, and prompt-caching boundaries.

- Ignore Python cache artifacts when hashing bundled skills.
- Preserve bounded, sanitized provider-fallback diagnostics through delegation.
- Prefer canonical custom-provider endpoints while retaining legacy compatibility.
- Enforce the no-key, no-header, no-request-body inheritance boundary for named local Ollama routes.
- Keep the caller-requested provider identity distinct from the resolved transport provider across agent construction, switching, persistence, CLI, TUI, cron, and ACP paths.

## Root cause and impact

Provider identity and provider-derived request metadata were being collapsed or lost across resolution, construction, and persistence boundaries. Mixed legacy/canonical endpoint fields could also select a stale endpoint, while local named Ollama routes could inherit credentials or provider-owned request data.

The changes make route identity durable, preserve safe diagnostic context, select the canonical endpoint consistently, and prevent credentials or request overrides from crossing into local Ollama.

## Validation

- Unit 3 provider-boundary verification: 110 passed in changed files; reconstructed provider-free harness 4 passed; retained suite 432 passed, 1 skipped.
- Unit 3B Task 1: focused and owned suites passed, including 24 final tests; specification and code/security reviews passed with no findings.
- Unit 3B Task 2: final exact ten-file suite passed 795 tests; specification and code/security reviews passed with no Critical or Important findings.
- Ruff, diff, scope, secret-hygiene, and history checks passed at the reviewed commits.
- Worktree is clean at the published head.

## Draft status

This is intentionally a draft. Unit 3B Tasks 3–5 and the final reconciliation gate remain before it is ready for merge. This PR does not deploy, release, or change any live Hermes configuration, credentials, provider state, or services.
