### PR TITLE
fix(a2a): isolate authenticated peer sessions

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1519,6 +1519,30 @@ def init_agent(
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
     )
+    # Optional exact tool-name boundary applied after plugin discovery and
+    # check_fn filtering. Toolset allowlists alone can still widen when a future
+    # plugin registers another tool into an already-approved toolset.
+    try:
+        from hermes_cli.config import load_config_readonly as _load_strict_tool_config
+
+        _strict_tool_cfg = _load_strict_tool_config()
+    except Exception:
+        _strict_tool_cfg = {}
+    _strict_by_platform = _strict_tool_cfg.get("strict_platform_tools") or {}
+    _platform_key = str(platform or "").strip().lower()
+    _strict_names = (
+        _strict_by_platform.get(_platform_key)
+        if isinstance(_strict_by_platform, dict)
+        else None
+    )
+    agent._strict_tool_names = None
+    if isinstance(_strict_names, list):
+        _strict_allow = {str(name) for name in _strict_names if str(name)}
+        agent._strict_tool_names = frozenset(_strict_allow)
+        agent.tools = [
+            tool for tool in agent.tools
+            if tool.get("function", {}).get("name") in _strict_allow
+        ]
     
     # Show tool configuration and store valid tool names for validation
     agent.valid_tool_names = set()
@@ -1755,6 +1779,12 @@ def init_agent(
     # needed later by the startup feasibility check.  Avoid exposing a
     # broad pseudo-public config object on the agent instance.
     agent._aux_compression_context_length_config = None
+
+    # A2A peers are authenticated agents, not the profile owner. Persistent
+    # MEMORY.md / USER.md and external memory providers must never enter their
+    # system prompt, regardless of the profile's human-channel memory settings.
+    if str(platform or "").strip().lower() == "a2a":
+        skip_memory = True
 
     # Persistent memory (MEMORY.md + USER.md) -- loaded from disk
     agent._memory_store = None

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2680,6 +2680,20 @@ def _get_platform_tools(
         }
         enabled_toolsets -= disabled_set
 
+    # Optional fail-closed platform boundary. Normal Hermes behavior discovers
+    # and auto-enables newly shipped/plugin toolsets for convenience. Security
+    # boundaries such as cross-principal A2A need the saved list to remain an
+    # exact allowlist even after an upgrade introduces a new toolset.
+    strict_platforms = config.get("strict_platform_toolsets") or []
+    if isinstance(strict_platforms, list) and platform in {
+        str(name) for name in strict_platforms
+    }:
+        explicit_allow = {
+            str(name) for name in (platform_toolsets.get(platform) or [])
+            if str(name) != "no_mcp"
+        }
+        enabled_toolsets &= explicit_allow
+
     # #38798: if this platform was explicitly configured but every toolset name
     # is invalid (e.g. a migration or hand-edit left `hermes` instead of
     # `hermes-cli`), resolve_toolset() returns [] for each and the platform ends

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -30,6 +30,7 @@ Bind safety: with no token configured, the server binds 127.0.0.1 only.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -302,6 +303,18 @@ class A2ARequestHandler(BaseHTTPRequestHandler):
                 req_id, protocol.ERR_METHOD_NOT_FOUND, f"method not found: {method}"))
             return
 
+        if operation in {"stream", "subscribe"} and not adapter._streaming_enabled:
+            self._json(200, protocol.jsonrpc_error(
+                req_id, protocol.ERR_STREAMING_DISABLED,
+                "streaming disabled for this A2A endpoint"))
+            return
+
+        if operation.startswith("push_") and not adapter._push_notifications_enabled:
+            self._json(200, protocol.jsonrpc_error(
+                req_id, protocol.ERR_PUSH_NOT_SUPPORTED,
+                "push notifications disabled for this A2A endpoint"))
+            return
+
         if operation == "send":
             self._json(200, adapter._rpc_message_send(req_id, params, identity, agent=agent, v1_response=is_v1))
             return
@@ -309,28 +322,28 @@ class A2ARequestHandler(BaseHTTPRequestHandler):
             adapter._rpc_message_stream(self, req_id, params, identity, agent=agent)
             return
         if operation == "get":
-            self._json(200, adapter._rpc_tasks_get(req_id, params, agent=agent))
+            self._json(200, adapter._rpc_tasks_get(req_id, params, agent=agent, peer=identity))
             return
         if operation == "list":
-            self._json(200, adapter._rpc_tasks_list(req_id, params, agent=agent))
+            self._json(200, adapter._rpc_tasks_list(req_id, params, agent=agent, peer=identity))
             return
         if operation == "cancel":
-            self._json(200, adapter._rpc_tasks_cancel(req_id, params, agent=agent))
+            self._json(200, adapter._rpc_tasks_cancel(req_id, params, agent=agent, peer=identity))
             return
         if operation == "subscribe":
-            adapter._rpc_tasks_subscribe(self, req_id, params, agent=agent)
+            adapter._rpc_tasks_subscribe(self, req_id, params, agent=agent, peer=identity)
             return
         if operation == "push_create":
-            self._json(200, adapter._rpc_push_config_create(req_id, params, agent=agent))
+            self._json(200, adapter._rpc_push_config_create(req_id, params, agent=agent, peer=identity))
             return
         if operation == "push_get":
-            self._json(200, adapter._rpc_push_config_get(req_id, params, agent=agent))
+            self._json(200, adapter._rpc_push_config_get(req_id, params, agent=agent, peer=identity))
             return
         if operation == "push_list":
-            self._json(200, adapter._rpc_push_config_list(req_id, params, agent=agent))
+            self._json(200, adapter._rpc_push_config_list(req_id, params, agent=agent, peer=identity))
             return
         if operation == "push_delete":
-            self._json(200, adapter._rpc_push_config_delete(req_id, params, agent=agent))
+            self._json(200, adapter._rpc_push_config_delete(req_id, params, agent=agent, peer=identity))
             return
 
 
@@ -343,6 +356,8 @@ class A2AAdapter(BasePlatformAdapter):
         super().__init__(config=config, platform=platform)
 
         extra = getattr(config, "extra", {}) or {}
+        self._streaming_enabled = bool(extra.get("streaming", True))
+        self._push_notifications_enabled = bool(extra.get("push_notifications", True))
         self.port = int(os.getenv("A2A_PORT") or extra.get("port", _DEFAULT_PORT))
         self.host = security.resolve_bind_host()
         self.agent_name = _default_agent_name()
@@ -386,6 +401,10 @@ class A2AAdapter(BasePlatformAdapter):
     @property
     def name(self) -> str:
         return "A2A"
+
+    def _should_auto_tts_for_chat(self, chat_id: str) -> bool:
+        """A2A's v1.0 result path is text-only; never substitute an audio send."""
+        return False
 
     @property
     def authorization_is_upstream(self) -> bool:
@@ -609,8 +628,8 @@ class A2AAdapter(BasePlatformAdapter):
             url=url,
             description=agent.get("description") or "Hermes Agent — a general-purpose agent reachable over A2A.",
             skills=self._advertised_skills(agent),
-            streaming=bool(agent.get("local", True)),
-            push_notifications=True,
+            streaming=self._streaming_enabled and bool(agent.get("local", True)),
+            push_notifications=self._push_notifications_enabled,
             auth_required=not security.localhost_only(),
             tenant=str(agent.get("tenant") or ""),
         )
@@ -633,6 +652,9 @@ class A2AAdapter(BasePlatformAdapter):
                 for n in names
                 if allowed is None or n in allowed
             }
+            if allowed is not None:
+                for name in configured or []:
+                    mapping.setdefault(name, [])
             if mapping:
                 return protocol.skills_from_toolsets(mapping)
         except Exception:
@@ -683,6 +705,14 @@ class A2AAdapter(BasePlatformAdapter):
         agent = agent or self._agents[""]
         return str(agent.get("slug") or ""), str(agent.get("tenant") or "")
 
+    @staticmethod
+    def _scoped_context_id(peer: str, context_id: str) -> str:
+        """Internal session/persistence key bound to the authenticated peer."""
+        digest = hashlib.sha256(
+            f"{peer}\0{context_id}".encode("utf-8", errors="replace")
+        ).hexdigest()[:24]
+        return f"peer-{digest}"
+
     def _forward_lock(self, key: tuple[str, str, str]) -> threading.Lock:
         with self._profile_session_locks_guard:
             lock = self._profile_session_locks.get(key)
@@ -702,7 +732,8 @@ class A2AAdapter(BasePlatformAdapter):
         """
         agent = agent or self._agents[""]
         text = protocol.extract_text(params)
-        context_id = protocol.extract_context_id(params) or protocol.new_context_id()
+        wire_context_id = protocol.extract_context_id(params) or protocol.new_context_id()
+        context_id = self._scoped_context_id(peer, wire_context_id)
         task_id = protocol.new_task_id()
 
         # Anti-loop ping-pong protection
@@ -711,21 +742,21 @@ class A2AAdapter(BasePlatformAdapter):
             protocol.metrics.anti_loop_triggers += 1
             logger.warning("A2A: anti-loop triggered for context %s (turn %d > %d)",
                            context_id, turn, protocol.max_pingpong_turns())
-            rec = self.tasks.create(task_id, context_id, peer, *self._scope_for_agent(agent))
+            rec = self.tasks.create(task_id, wire_context_id, peer, *self._scope_for_agent(agent))
             self.tasks.complete(task_id, protocol.STATE_REJECTED, "")
             return protocol.build_task(
-                task_id, context_id, protocol.STATE_REJECTED,
-                f"Anti-loop protection: context {context_id} exceeded "
+                task_id, wire_context_id, protocol.STATE_REJECTED,
+                f"Anti-loop protection: context {wire_context_id} exceeded "
                 f"{protocol.max_pingpong_turns()} turns. Start a new context or "
                 f"increase A2A_MAX_PINGPONG_TURNS.",
                 created_at=rec["created_iso"],
             ), None
 
         if not text:
-            rec = self.tasks.create(task_id, context_id, peer, *self._scope_for_agent(agent))
+            rec = self.tasks.create(task_id, wire_context_id, peer, *self._scope_for_agent(agent))
             self.tasks.complete(task_id, protocol.STATE_REJECTED, "")
             return protocol.build_task(
-                task_id, context_id, protocol.STATE_REJECTED,
+                task_id, wire_context_id, protocol.STATE_REJECTED,
                 "Empty task — nothing to do.", created_at=rec["created_iso"],
             ), None
 
@@ -734,7 +765,7 @@ class A2AAdapter(BasePlatformAdapter):
         protocol.persist_message(context_id, "user", text, task_id)
         protocol.metrics.inbound_total += 1
 
-        rec = self.tasks.create(task_id, context_id, peer, *self._scope_for_agent(agent))
+        rec = self.tasks.create(task_id, wire_context_id, peer, *self._scope_for_agent(agent))
         self._register_inline_push(task_id, params, agent=agent)
 
         if not agent.get("local", True):
@@ -747,14 +778,16 @@ class A2AAdapter(BasePlatformAdapter):
                 protocol.metrics.tasks_completed += 1
             else:
                 protocol.metrics.tasks_failed += 1
-            self._send_push_notification(task_id, context_id, reply, state)
-            return protocol.build_task(task_id, context_id, state, reply, created_at=rec["created_iso"]), None
+            self._send_push_notification(task_id, wire_context_id, reply, state)
+            return protocol.build_task(
+                task_id, wire_context_id, state, reply, created_at=rec["created_iso"]
+            ), None
 
         if self._loop is None or self._message_handler is None:
             self.tasks.complete(task_id, protocol.STATE_FAILED, "")
             protocol.metrics.tasks_failed += 1
             return protocol.build_task(
-                task_id, context_id, protocol.STATE_FAILED,
+                task_id, wire_context_id, protocol.STATE_FAILED,
                 "Agent gateway not ready to accept A2A tasks.",
                 created_at=rec["created_iso"],
             ), None
@@ -782,7 +815,7 @@ class A2AAdapter(BasePlatformAdapter):
             self.tasks.complete(task_id, protocol.STATE_FAILED, msg)
             protocol.metrics.tasks_failed += 1
             return protocol.build_task(
-                task_id, context_id, protocol.STATE_FAILED, msg,
+                task_id, wire_context_id, protocol.STATE_FAILED, msg,
                 created_at=rec["created_iso"],
             ), None
 
@@ -790,6 +823,7 @@ class A2AAdapter(BasePlatformAdapter):
         return None, {
             "task_id": task_id,
             "context_id": context_id,
+            "wire_context_id": wire_context_id,
             "peer": peer,
             "future": fut,
             "created_iso": rec["created_iso"],
@@ -898,6 +932,7 @@ class A2AAdapter(BasePlatformAdapter):
         redaction and input-required detection."""
         task_id = pending["task_id"]
         context_id = pending["context_id"]
+        wire_context_id = pending["wire_context_id"]
         peer = pending["peer"]
         self._pop_pending(task_id)
 
@@ -922,7 +957,7 @@ class A2AAdapter(BasePlatformAdapter):
             protocol.metrics.tasks_failed += 1
 
         self.tasks.complete(task_id, state, reply)
-        self._send_push_notification(task_id, context_id, reply, state)
+        self._send_push_notification(task_id, wire_context_id, reply, state)
         return state, reply
 
     def _await_reply(self, pending: dict, keepalive=None) -> tuple[str, str]:
@@ -953,10 +988,11 @@ class A2AAdapter(BasePlatformAdapter):
         if terminal is not None:
             result = protocol.send_message_response(terminal) if v1_response else terminal
             return protocol.jsonrpc_result(req_id, result)
+        assert pending is not None
         state, reply = self._await_reply(pending)
         state, reply = self._finalize_task(pending, state, reply)
         task = protocol.build_task(
-            pending["task_id"], pending["context_id"], state, reply,
+            pending["task_id"], pending["wire_context_id"], state, reply,
             created_at=pending["created_iso"],
         )
         result = protocol.send_message_response(task) if v1_response else task
@@ -1012,7 +1048,8 @@ class A2AAdapter(BasePlatformAdapter):
                 )
                 return
 
-            task_id, context_id = pending["task_id"], pending["context_id"]
+            assert pending is not None
+            task_id, context_id = pending["task_id"], pending["wire_context_id"]
             self._sse_write(handler, protocol.sse_data(protocol.stream_task(
                 protocol.build_task(task_id, context_id, protocol.STATE_SUBMITTED, created_at=pending["created_iso"])),
                 req_id))
@@ -1026,10 +1063,11 @@ class A2AAdapter(BasePlatformAdapter):
         except (BrokenPipeError, ConnectionResetError):
             logger.debug("A2A: stream client disconnected")
 
-    def _rpc_tasks_subscribe(self, handler, req_id: Any, params: dict, agent: Optional[dict] = None) -> None:
+    def _rpc_tasks_subscribe(self, handler, req_id: Any, params: dict,
+                             agent: Optional[dict] = None, peer: str = "") -> None:
         """Reconnect to an existing task's stream (v1.0 SubscribeToTask)."""
         task_id = str(params.get("taskId") or params.get("id") or "")
-        rec = self.tasks.get(task_id, *self._scope_for_agent(agent))
+        rec = self.tasks.get(task_id, *self._scope_for_agent(agent), peer=peer)
         if not rec:
             handler._json(200, protocol.jsonrpc_error(
                 req_id, protocol.ERR_TASK_NOT_FOUND, f"task not found: {task_id}"))
@@ -1037,7 +1075,7 @@ class A2AAdapter(BasePlatformAdapter):
 
         self._sse_headers(handler)
         try:
-            fut = self.tasks.watch(task_id, *self._scope_for_agent(agent))
+            fut = self.tasks.watch(task_id, *self._scope_for_agent(agent), peer=peer)
             if fut is None:
                 self._sse_write(handler, protocol.sse_done())
                 return
@@ -1057,9 +1095,10 @@ class A2AAdapter(BasePlatformAdapter):
 
     # ── Task queries ──────────────────────────────────────────────────────
 
-    def _rpc_tasks_get(self, req_id: Any, params: dict, agent: Optional[dict] = None) -> dict:
+    def _rpc_tasks_get(self, req_id: Any, params: dict,
+                       agent: Optional[dict] = None, peer: str = "") -> dict:
         task_id = str(params.get("taskId") or params.get("id") or "")
-        rec = self.tasks.get(task_id, *self._scope_for_agent(agent))
+        rec = self.tasks.get(task_id, *self._scope_for_agent(agent), peer=peer)
         if not rec:
             return protocol.jsonrpc_error(
                 req_id, protocol.ERR_TASK_NOT_FOUND, f"task not found: {task_id}")
@@ -1070,7 +1109,8 @@ class A2AAdapter(BasePlatformAdapter):
             history_len = None
         return protocol.jsonrpc_result(req_id, protocol.TaskStore.to_task(rec, history_length=history_len))
 
-    def _rpc_tasks_list(self, req_id: Any, params: dict, agent: Optional[dict] = None) -> dict:
+    def _rpc_tasks_list(self, req_id: Any, params: dict,
+                        agent: Optional[dict] = None, peer: str = "") -> dict:
         try:
             offset = int(params.get("pageToken") or 0)
         except (ValueError, TypeError):
@@ -1086,6 +1126,7 @@ class A2AAdapter(BasePlatformAdapter):
             offset=max(0, offset),
             agent_slug=self._scope_for_agent(agent)[0],
             tenant=self._scope_for_agent(agent)[1],
+            peer=peer,
             with_total=True,
         )
         include_artifacts = bool(params.get("includeArtifacts", False))
@@ -1101,9 +1142,10 @@ class A2AAdapter(BasePlatformAdapter):
             "totalSize": total,
         })
 
-    def _rpc_tasks_cancel(self, req_id: Any, params: dict, agent: Optional[dict] = None) -> dict:
+    def _rpc_tasks_cancel(self, req_id: Any, params: dict,
+                          agent: Optional[dict] = None, peer: str = "") -> dict:
         task_id = str(params.get("taskId") or params.get("id") or "")
-        rec = self.tasks.get(task_id, *self._scope_for_agent(agent))
+        rec = self.tasks.get(task_id, *self._scope_for_agent(agent), peer=peer)
         if not rec:
             return protocol.jsonrpc_error(
                 req_id, protocol.ERR_TASK_NOT_FOUND, f"task not found: {task_id}")
@@ -1112,15 +1154,17 @@ class A2AAdapter(BasePlatformAdapter):
                 req_id, protocol.ERR_TASK_NOT_CANCELABLE,
                 f"task {task_id} already {rec['state']}")
         self.tasks.complete(task_id, protocol.STATE_CANCELED, "")
-        self._turns.reset(rec["context_id"])
+        self._turns.reset(self._scoped_context_id(peer, rec["context_id"]))
         self._resolve_task(task_id, protocol.STATE_CANCELED, "")
-        rec = self.tasks.get(task_id, *self._scope_for_agent(agent)) or rec
+        rec = self.tasks.get(task_id, *self._scope_for_agent(agent), peer=peer) or rec
         return protocol.jsonrpc_result(req_id, protocol.TaskStore.to_task(rec))
 
     # ── Push notifications ────────────────────────────────────────────────
 
     def _register_inline_push(self, task_id: str, params: dict, agent: Optional[dict] = None) -> None:
         """v1.0: message/send can carry configuration.taskPushNotificationConfig."""
+        if not self._push_notifications_enabled:
+            return
         cfg = (params.get("configuration") or {}).get("taskPushNotificationConfig") or {}
         if not isinstance(cfg, dict):
             return
@@ -1128,7 +1172,8 @@ class A2AAdapter(BasePlatformAdapter):
         if url:
             self.tasks.set_push_config(task_id, str(url), *self._scope_for_agent(agent))
 
-    def _rpc_push_config_create(self, req_id: Any, params: dict, agent: Optional[dict] = None) -> dict:
+    def _rpc_push_config_create(self, req_id: Any, params: dict,
+                                agent: Optional[dict] = None, peer: str = "") -> dict:
         task_id = str(params.get("taskId") or "")
         cfg = params.get("pushNotificationConfig") or params.get("config") or {}
         url = str((cfg or {}).get("url") or "")
@@ -1136,43 +1181,54 @@ class A2AAdapter(BasePlatformAdapter):
             return protocol.jsonrpc_error(
                 req_id, protocol.ERR_INVALID_PARAMS,
                 "taskId and pushNotificationConfig.url required")
-        stored = self.tasks.set_push_config(task_id, url, *self._scope_for_agent(agent))
+        stored = self.tasks.set_push_config(
+            task_id, url, *self._scope_for_agent(agent), peer=peer
+        )
         if stored is None:
             return protocol.jsonrpc_error(
                 req_id, protocol.ERR_TASK_NOT_FOUND, f"task not found: {task_id}")
         return protocol.jsonrpc_result(req_id, stored)
 
-    def _rpc_push_config_get(self, req_id: Any, params: dict, agent: Optional[dict] = None) -> dict:
+    def _rpc_push_config_get(self, req_id: Any, params: dict,
+                             agent: Optional[dict] = None, peer: str = "") -> dict:
         """GetTaskPushNotificationConfig — retrieve a push config by task id."""
         task_id = str(params.get("taskId") or "")
         config_id = str(params.get("id") or params.get("configId") or "")
         if not task_id:
             return protocol.jsonrpc_error(
                 req_id, protocol.ERR_INVALID_PARAMS, "taskId required")
-        cfg = self.tasks.get_push_config(task_id, config_id, *self._scope_for_agent(agent))
+        cfg = self.tasks.get_push_config(
+            task_id, config_id, *self._scope_for_agent(agent), peer=peer
+        )
         if cfg is None:
             return protocol.jsonrpc_error(
                 req_id, protocol.ERR_TASK_NOT_FOUND,
                 f"push config not found for task: {task_id}")
         return protocol.jsonrpc_result(req_id, cfg)
 
-    def _rpc_push_config_list(self, req_id: Any, params: dict, agent: Optional[dict] = None) -> dict:
+    def _rpc_push_config_list(self, req_id: Any, params: dict,
+                              agent: Optional[dict] = None, peer: str = "") -> dict:
         """ListTaskPushNotificationConfigs — list push configs for a task."""
         task_id = str(params.get("taskId") or "")
         if not task_id:
             return protocol.jsonrpc_error(
                 req_id, protocol.ERR_INVALID_PARAMS, "taskId required")
-        configs = self.tasks.list_push_configs(task_id, *self._scope_for_agent(agent))
+        configs = self.tasks.list_push_configs(
+            task_id, *self._scope_for_agent(agent), peer=peer
+        )
         return protocol.jsonrpc_result(req_id, {"configs": configs, "nextPageToken": ""})
 
-    def _rpc_push_config_delete(self, req_id: Any, params: dict, agent: Optional[dict] = None) -> dict:
+    def _rpc_push_config_delete(self, req_id: Any, params: dict,
+                                agent: Optional[dict] = None, peer: str = "") -> dict:
         """DeleteTaskPushNotificationConfig — remove a push config."""
         task_id = str(params.get("taskId") or "")
         config_id = str(params.get("id") or params.get("configId") or "")
         if not task_id:
             return protocol.jsonrpc_error(
                 req_id, protocol.ERR_INVALID_PARAMS, "taskId required")
-        deleted = self.tasks.delete_push_config(task_id, config_id, *self._scope_for_agent(agent))
+        deleted = self.tasks.delete_push_config(
+            task_id, config_id, *self._scope_for_agent(agent), peer=peer
+        )
         if not deleted:
             return protocol.jsonrpc_error(
                 req_id, protocol.ERR_TASK_NOT_FOUND,
@@ -1186,6 +1242,8 @@ class A2AAdapter(BasePlatformAdapter):
         addresses (169.254.x.x metadata, loopback, RFC1918 private ranges)
         unless we're in localhost-only mode (where internal access is expected).
         """
+        if not self._push_notifications_enabled:
+            return
         callback_url = self.tasks.pop_push_url(task_id)
         if not callback_url:
             return
@@ -1229,9 +1287,11 @@ class A2AAdapter(BasePlatformAdapter):
     ):
         """Fulfil the pending reply Future for this context.
 
-        ``chat_id`` is the A2A context id we set as the source chat_id; the
-        oldest outstanding task for that context receives the reply (the
-        gateway session processes messages in order).
+        ``reply_to`` is the inbound A2A task id supplied by the gateway's
+        normal final-delivery path. Resolve that exact task when present so a
+        late final from a timed-out task can never satisfy a newer task sharing
+        the context. The context-order fallback is retained only for older
+        callers that do not provide a reply anchor.
 
         The gateway marks final user-visible replies with ``metadata['notify']``
         (see ``_mark_notify_metadata`` in gateway.platforms.base — this is the
@@ -1243,17 +1303,29 @@ class A2AAdapter(BasePlatformAdapter):
         if not (metadata or {}).get("notify"):
             logger.debug("A2A: ignoring non-final send for context %s", chat_id)
             return SendResult(success=True, message_id=message_id)
-        if not self._resolve_oldest_for_context(chat_id, protocol.STATE_COMPLETED, content or ""):
-            # No waiter (e.g. a late chunk or out-of-band send) — drop it.
-            logger.debug("A2A: send() for context %s had no pending waiter", chat_id)
+        resolved = (
+            self._resolve_task(str(reply_to), protocol.STATE_COMPLETED, content or "")
+            if reply_to
+            else self._resolve_oldest_for_context(
+                chat_id, protocol.STATE_COMPLETED, content or ""
+            )
+        )
+        if not resolved:
+            # No matching waiter (e.g. a late final after timeout) — drop it.
+            logger.debug(
+                "A2A: send() for context %s task %s had no pending waiter",
+                chat_id,
+                reply_to or "<unanchored>",
+            )
         return SendResult(success=True, message_id=message_id)
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Resolve the task future when processing ends without a reply send.
 
-        The success path resolves via send(); this hook catches failures,
-        cancellations, and empty runs so the HTTP thread returns promptly
-        instead of waiting out the reply timeout.
+        The success path resolves only via a notify-marked final send.
+        This hook catches failures and cancellations, but ignores SUCCESS: the
+        gateway can emit an early SUCCESS before its background agent turn starts,
+        so treating that event as an empty completion loses the later model reply.
         """
         task_id = str(getattr(event, "message_id", "") or "")
         if not task_id:
@@ -1262,8 +1334,6 @@ class A2AAdapter(BasePlatformAdapter):
             self._resolve_task(task_id, protocol.STATE_FAILED, "[agent processing failed]")
         elif outcome == ProcessingOutcome.CANCELLED:
             self._resolve_task(task_id, protocol.STATE_CANCELED, "")
-        else:
-            self._resolve_task(task_id, protocol.STATE_COMPLETED, "")
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         return None

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -68,6 +68,7 @@ ERR_PUSH_NOT_SUPPORTED = -32003    # A2A spec: PushNotificationNotSupportedError
 ERR_UNAUTHORIZED = -32050
 ERR_RATE_LIMITED = -32051
 ERR_UNTRUSTED_PEER = -32052
+ERR_STREAMING_DISABLED = -32053
 
 # Maximum turns an A2A conversation can have before anti-loop kicks in.
 # Default 5, configurable via A2A_MAX_PINGPONG_TURNS env (max 20).
@@ -590,10 +591,13 @@ class TaskStore:
         self._lock = threading.Lock()
 
     @staticmethod
-    def _in_scope(rec: dict, agent_slug: str = "", tenant: str = "") -> bool:
+    def _in_scope(rec: dict, agent_slug: str = "", tenant: str = "",
+                  peer: str = "") -> bool:
         if agent_slug and rec.get("agent_slug", "") != agent_slug:
             return False
         if tenant and rec.get("tenant", "") != tenant:
+            return False
+        if peer and rec.get("peer", "") != peer:
             return False
         return True
 
@@ -623,11 +627,12 @@ class TaskStore:
                 rec["state"] = state
 
     def set_push_config(self, task_id: str, url: str,
-                        agent_slug: str = "", tenant: str = "") -> Optional[dict]:
+                        agent_slug: str = "", tenant: str = "",
+                        peer: str = "") -> Optional[dict]:
         """Attach a push notification config; returns the stored config or None."""
         with self._lock:
             rec = self._tasks.get(task_id)
-            if not rec or not self._in_scope(rec, agent_slug, tenant):
+            if not rec or not self._in_scope(rec, agent_slug, tenant, peer):
                 return None
             rec["push_url"] = url
             rec["push_config_id"] = "cfg-" + uuid.uuid4().hex[:12]
@@ -644,27 +649,30 @@ class TaskStore:
         }
 
     def get_push_config(self, task_id: str, config_id: str = "",
-                        agent_slug: str = "", tenant: str = "") -> Optional[dict]:
+                        agent_slug: str = "", tenant: str = "",
+                        peer: str = "") -> Optional[dict]:
         with self._lock:
             rec = self._tasks.get(task_id)
-            if not rec or not self._in_scope(rec, agent_slug, tenant) or not rec.get("push_url"):
+            if not rec or not self._in_scope(rec, agent_slug, tenant, peer) or not rec.get("push_url"):
                 return None
             if config_id and rec.get("push_config_id") != config_id:
                 return None
             return self._push_config_view(rec)
 
-    def list_push_configs(self, task_id: str, agent_slug: str = "", tenant: str = "") -> list[dict]:
+    def list_push_configs(self, task_id: str, agent_slug: str = "", tenant: str = "",
+                          peer: str = "") -> list[dict]:
         with self._lock:
             rec = self._tasks.get(task_id)
-            if not rec or not self._in_scope(rec, agent_slug, tenant) or not rec.get("push_url"):
+            if not rec or not self._in_scope(rec, agent_slug, tenant, peer) or not rec.get("push_url"):
                 return []
             return [self._push_config_view(rec)]
 
     def delete_push_config(self, task_id: str, config_id: str = "",
-                           agent_slug: str = "", tenant: str = "") -> bool:
+                           agent_slug: str = "", tenant: str = "",
+                           peer: str = "") -> bool:
         with self._lock:
             rec = self._tasks.get(task_id)
-            if not rec or not self._in_scope(rec, agent_slug, tenant) or not rec.get("push_url"):
+            if not rec or not self._in_scope(rec, agent_slug, tenant, peer) or not rec.get("push_url"):
                 return False
             if config_id and rec.get("push_config_id") != config_id:
                 return False
@@ -680,10 +688,11 @@ class TaskStore:
             url, rec["push_url"] = rec["push_url"], ""
             return url
 
-    def get(self, task_id: str, agent_slug: str = "", tenant: str = "") -> Optional[dict]:
+    def get(self, task_id: str, agent_slug: str = "", tenant: str = "",
+            peer: str = "") -> Optional[dict]:
         with self._lock:
             rec = self._tasks.get(task_id)
-            if not rec or not self._in_scope(rec, agent_slug, tenant):
+            if not rec or not self._in_scope(rec, agent_slug, tenant, peer):
                 return None
             return dict(rec)
 
@@ -705,10 +714,11 @@ class TaskStore:
                 fut.set_result((state, reply))
         return out
 
-    def watch(self, task_id: str, agent_slug: str = "", tenant: str = "") -> Optional[Future]:
+    def watch(self, task_id: str, agent_slug: str = "", tenant: str = "",
+              peer: str = "") -> Optional[Future]:
         with self._lock:
             rec = self._tasks.get(task_id)
-            if not rec or not self._in_scope(rec, agent_slug, tenant):
+            if not rec or not self._in_scope(rec, agent_slug, tenant, peer):
                 return None
             fut: Future = Future()
             if rec["state"] in TERMINAL_STATES:
@@ -725,6 +735,7 @@ class TaskStore:
         offset: int = 0,
         agent_slug: str = "",
         tenant: str = "",
+        peer: str = "",
         with_total: bool = False,
     ):
         """Filtered task page (newest first).
@@ -735,8 +746,8 @@ class TaskStore:
         page_size = max(1, min(int(page_size or 50), 100))
         with self._lock:
             recs = [dict(r) for r in reversed(self._tasks.values())]
-        if agent_slug or tenant:
-            recs = [r for r in recs if self._in_scope(r, agent_slug, tenant)]
+        if agent_slug or tenant or peer:
+            recs = [r for r in recs if self._in_scope(r, agent_slug, tenant, peer)]
         if context_id:
             recs = [r for r in recs if r["context_id"] == context_id]
         if state:

--- a/tests/plugins/test_a2a_phase23.py
+++ b/tests/plugins/test_a2a_phase23.py
@@ -453,6 +453,20 @@ class TestTaskStore:
         assert rec["context_id"] == "c1"
         assert rec["peer"] == "peer-1"
 
+    def test_peer_scope_is_fail_closed_across_task_and_push_operations(self):
+        store = protocol.TaskStore()
+        store.create("t-alice", "ctx", "alice")
+        store.create("t-bob", "ctx", "bob")
+        assert store.get("t-alice", peer="alice") is not None
+        assert store.get("t-alice", peer="bob") is None
+        assert store.watch("t-alice", peer="bob") is None
+        assert store.set_push_config(
+            "t-alice", "https://example.com/hook", peer="bob"
+        ) is None
+        recs, _next, total = store.list(peer="alice", with_total=True)
+        assert [rec["task_id"] for rec in recs] == ["t-alice"]
+        assert total == 1
+
     def test_complete_keeps_task_queryable(self):
         store = protocol.TaskStore()
         store.create("t1", "c1", "p")

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -606,6 +606,75 @@ def _bare_adapter():
 
 
 class TestReplyCapture:
+    def test_strict_platform_toolsets_reject_future_plugin_expansion(self, monkeypatch):
+        from hermes_cli import tools_config
+        import toolsets
+
+        monkeypatch.setitem(toolsets.TOOLSETS, "future_privileged_plugin", {
+            "description": "future privileged plugin",
+            "tools": ["future_privileged_tool"],
+            "includes": [],
+        })
+        monkeypatch.setattr(
+            tools_config,
+            "_get_plugin_toolset_keys",
+            lambda: {"future_privileged_plugin"},
+        )
+        config = {
+            "platform_toolsets": {
+                "a2a": ["web", "todo", "clarify", "no_mcp"],
+            },
+            "strict_platform_toolsets": ["a2a"],
+            "known_builtin_toolsets": {"a2a": ["bfl"]},
+        }
+        assert tools_config._get_platform_tools(config, "a2a") == {
+            "web", "todo", "clarify",
+        }
+
+    def test_context_ids_are_namespaced_by_authenticated_peer(self):
+        adapter = _bare_adapter()
+        alice = adapter._scoped_context_id("alice", "shared")
+        bob = adapter._scoped_context_id("bob", "shared")
+        assert alice != bob
+        assert alice == adapter._scoped_context_id("alice", "shared")
+
+    def test_streaming_can_be_disabled_for_hardened_endpoints(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.a2a.adapter import A2AAdapter
+
+        adapter = A2AAdapter(PlatformConfig(
+            enabled=True,
+            extra={"streaming": False, "push_notifications": False},
+        ))
+        assert adapter._streaming_enabled is False
+        assert adapter._build_card()["capabilities"]["streaming"] is False
+        assert adapter._push_notifications_enabled is False
+        assert adapter._build_card()["capabilities"]["pushNotifications"] is False
+
+    def test_late_final_cannot_complete_a_newer_task_in_same_context(self):
+        adapter = _bare_adapter()
+        first = adapter._add_pending("task-1", "ctx")
+        second = adapter._add_pending("task-2", "ctx")
+        adapter._pop_pending("task-1")
+
+        asyncio.run(adapter.send(
+            "ctx", "LATE-FIRST", reply_to="task-1", metadata={"notify": True}
+        ))
+        assert not second.done()
+
+        asyncio.run(adapter.send(
+            "ctx", "SECOND", reply_to="task-2", metadata={"notify": True}
+        ))
+        assert second.result(timeout=0) == (protocol.STATE_COMPLETED, "SECOND")
+        assert not first.done()
+
+    def test_a2a_never_auto_tts_text_replies(self):
+        """A2A is text-only; global voice defaults must not replace RPC text with an audio fallback."""
+        adapter = _bare_adapter()
+        adapter._auto_tts_default = True
+        adapter._auto_tts_enabled_chats.add("ctx-a2a")
+        assert adapter._should_auto_tts_for_chat("ctx-a2a") is False
+
     def test_send_waits_for_notify_marked_final_reply(self):
         """Interim/editable sends must not satisfy the blocked A2A RPC future."""
         adapter = _bare_adapter()
@@ -653,6 +722,43 @@ class TestReplyCapture:
             adapter._pop_pending("task-1")
             adapter._pop_pending("task-2")
 
+    def test_early_success_and_edit_preview_cannot_complete_the_rpc(self):
+        """Only a notify-marked final send may complete a successful A2A RPC."""
+        from gateway.platforms.base import ProcessingOutcome
+
+        adapter = _bare_adapter()
+        setattr(adapter, "_preview_settle_seconds", 0.01)
+        fut = adapter._add_pending("task-preview", "ctx-preview")
+        event = SimpleNamespace(
+            message_id="task-preview",
+            source=SimpleNamespace(chat_id="ctx-preview"),
+        )
+
+        async def run():
+            # The gateway may report SUCCESS before its background agent turn starts.
+            await adapter.on_processing_complete(
+                event, ProcessingOutcome.SUCCESS  # pyright: ignore[reportArgumentType]
+            )
+            assert fut.done() is False
+            # An edit-preview can be partial and must never resolve the RPC.
+            await adapter.send(
+                "ctx-preview", "PARTIAL", metadata={"expect_edits": True}
+            )
+            await asyncio.sleep(0.02)
+            assert fut.done() is False
+            await adapter.send(
+                "ctx-preview", "FINAL_TEXT", metadata={"notify": True}
+            )
+
+        try:
+            asyncio.run(run())
+            assert fut.result(timeout=0) == (
+                protocol.STATE_COMPLETED,
+                "FINAL_TEXT",
+            )
+        finally:
+            adapter._pop_pending("task-preview")
+
     def test_on_processing_complete_resolves_failure(self):
         """A failed run must resolve the future promptly (no reply timeout wait)."""
         from gateway.platforms.base import ProcessingOutcome
@@ -694,6 +800,19 @@ class TestReplyCapture:
 # --------------------------------------------------------------------------
 
 class TestTaskRpcHandlers:
+    def test_task_rpcs_are_scoped_to_authenticated_peer(self):
+        adapter = _bare_adapter()
+        adapter.tasks.create("task-alice", "ctx", "alice")
+        adapter.tasks.complete("task-alice", protocol.STATE_COMPLETED, "private")
+        assert "error" in adapter._rpc_tasks_get(
+            1, {"taskId": "task-alice"}, peer="bob"
+        )
+        listed = adapter._rpc_tasks_list(2, {}, peer="bob")["result"]
+        assert listed["tasks"] == []
+        assert "error" in adapter._rpc_tasks_cancel(
+            3, {"taskId": "task-alice"}, peer="bob"
+        )
+
     def test_tasks_get_unknown_uses_spec_error_code(self):
         adapter = _bare_adapter()
         resp = adapter._rpc_tasks_get(1, {"taskId": "ghost"})
@@ -709,16 +828,15 @@ class TestTaskRpcHandlers:
         assert protocol.extract_text(task["artifacts"][0]) == "answer"
 
     def test_tasks_cancel_resets_turns_for_context(self):
-        """Cancel must reset anti-loop turns for the task's CONTEXT (the old
-        code passed the task_id into a context-keyed map — silent no-op)."""
+        """Cancel resets the authenticated peer's internal anti-loop context."""
         adapter = _bare_adapter()
+        internal_context = adapter._scoped_context_id("peer", "ctx-loopy")
         for _ in range(4):
-            adapter._turns.track("ctx-loopy")
+            adapter._turns.track(internal_context)
         adapter.tasks.create("task-c", "ctx-loopy", "peer")
-        resp = adapter._rpc_tasks_cancel(1, {"taskId": "task-c"})
+        resp = adapter._rpc_tasks_cancel(1, {"taskId": "task-c"}, peer="peer")
         assert resp["result"]["status"]["state"] == "TASK_STATE_CANCELED"
-        # Turn counter went back to zero: next track() is turn 1.
-        assert adapter._turns.track("ctx-loopy") == 1
+        assert adapter._turns.track(internal_context) == 1
 
     def test_cancel_terminal_task_not_cancelable(self):
         adapter = _bare_adapter()
@@ -898,7 +1016,7 @@ class TestTaskRpcHandlers:
 # End-to-end inbound round-trip (real http.server + mocked agent)
 # --------------------------------------------------------------------------
 
-def _make_live_adapter(monkeypatch, reply_fn=None):
+def _make_live_adapter(monkeypatch, reply_fn=None, extra=None):
     """Create an adapter on a free port with a mocked agent handler.
 
     ``reply_fn(event) -> Optional[str]`` returns the agent's reply (None =
@@ -910,7 +1028,7 @@ def _make_live_adapter(monkeypatch, reply_fn=None):
     port = _free_port()
     monkeypatch.setenv("A2A_PORT", str(port))
 
-    adapter = A2AAdapter(PlatformConfig(enabled=True))
+    adapter = A2AAdapter(PlatformConfig(enabled=True, extra=extra or {}))
 
     async def fake_handle_message(event):
         if reply_fn is None:
@@ -950,6 +1068,32 @@ def _send_body(text, ctx="", extra_params=None):
 
 @pytest.mark.integration
 class TestInboundRoundTrip:
+    def test_hardened_endpoint_rejects_streaming_rpc(self, monkeypatch):
+        adapter, base = _make_live_adapter(
+            monkeypatch, extra={"streaming": False, "push_notifications": False}
+        )
+
+        async def run():
+            assert await adapter.connect() is True
+            body = _send_body("hello")
+            body["method"] = "SendStreamingMessage"
+            resp = await asyncio.to_thread(_post_json, base + "/", body)
+            assert resp["error"]["code"] == protocol.ERR_STREAMING_DISABLED
+            push = {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "CreateTaskPushNotificationConfig",
+                "params": {
+                    "taskId": "foreign",
+                    "pushNotificationConfig": {"url": "http://100.64.0.1/hook"},
+                },
+            }
+            push_resp = await asyncio.to_thread(_post_json, base + "/", push)
+            assert push_resp["error"]["code"] == protocol.ERR_PUSH_NOT_SUPPORTED
+            await adapter.disconnect()
+
+        asyncio.run(run())
+
     def test_live_server_card_and_message_send(self, monkeypatch):
         """Start the real adapter server, hit the Agent Card, then send a task
         and verify the mocked agent's reply comes back as a v1.0 Task."""
@@ -1204,19 +1348,22 @@ class TestInboundRoundTrip:
         def reply_fn(event):
             seen["text"] = event.text
             seen["user"] = event.source.user_id
+            seen["chat"] = event.source.chat_id
             return "ok"
 
         adapter, base = _make_live_adapter(monkeypatch, reply_fn=reply_fn)
 
         async def run():
             assert await adapter.connect() is True
-            body = _send_body("do a thing")
+            body = _send_body("do a thing", ctx="shared-context")
             # An attacker-controlled 'peer' field in params must be ignored.
             body["params"]["peer"] = "the-operator"
             resp = await asyncio.to_thread(
                 _post_json, base + "/", body, {"Authorization": "Bearer tok-alice"})
             assert resp["result"]["status"]["state"] == "TASK_STATE_COMPLETED"
             assert seen["user"] == "alice"
+            assert seen["chat"] != "shared-context"
+            assert resp["result"]["contextId"] == "shared-context"
             assert "'alice'" in seen["text"]
             assert "the-operator" not in seen["text"]
             await adapter.disconnect()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -78,6 +78,64 @@ def agent():
         return a
 
 
+def test_a2a_platform_enforces_exact_tool_name_allowlist(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "strict_platform_tools:\n  a2a:\n    - web_search\n"
+    )
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search", "future_privileged_tool"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            platform="a2a",
+            enabled_toolsets=["web"],
+        )
+    assert a.valid_tool_names == {"web_search"}
+
+    from tools.mcp_tool import refresh_agent_mcp_tools
+    with patch(
+        "model_tools.get_tool_definitions",
+        return_value=_make_tool_defs("web_search", "future_privileged_tool"),
+    ):
+        refresh_agent_mcp_tools(a)
+    assert a.valid_tool_names == {"web_search"}
+
+
+def test_a2a_platform_suppresses_persistent_memory_context(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "memory:\n  memory_enabled: true\n  user_profile_enabled: true\n"
+    )
+    (tmp_path / "MEMORY.md").write_text("PRIVATE_MEMORY")
+    (tmp_path / "USER.md").write_text("PRIVATE_USER_PROFILE")
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            platform="a2a",
+            enabled_toolsets=["web"],
+        )
+    assert a._memory_store is None
+    assert a._memory_enabled is False
+    assert a._user_profile_enabled is False
+    assert a._memory_manager is None
+
+
 def test_persist_user_message_override_rewrites_text_turns(agent):
     messages = [{"role": "user", "content": "API-only synthetic prefix\nhello"}]
     agent._persist_user_message_idx = 0

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -7758,6 +7758,18 @@ def refresh_agent_mcp_tools(
     # this rebuild actually appended (matching agent_init's dedup-aware add).
     staged_engine_names = _reinject_post_build_tools(agent, new_defs, new_names)
 
+    # Preserve an exact tool-name security boundary across late MCP/plugin
+    # registry refreshes. The initial agent build applies this after plugin
+    # discovery; every later rebuild must apply the same filter before publish.
+    strict_names = getattr(agent, "_strict_tool_names", None)
+    if isinstance(strict_names, (set, frozenset)):
+        new_defs = [
+            tool for tool in new_defs
+            if tool.get("function", {}).get("name") in strict_names
+        ]
+        new_names = {tool["function"]["name"] for tool in new_defs}
+        staged_engine_names &= new_names
+
     # Single atomic read-diff-publish so the returned ``added`` is consistent
     # with what was actually published, even under concurrent callers, and a
     # stale (older-generation) rebuild can't overwrite a newer published one.


### PR DESCRIPTION
## Summary
- suppress persistent owner memory for A2A sessions
- scope task/query/cancel/push state and internal contexts to the authenticated peer
- support fail-closed exact platform toolsets and tool names across registry refreshes
- disable auto-TTS, protocol streaming and push notifications when configured
- resolve successful replies by exact inbound task anchor and ignore premature SUCCESS hooks

## Verification
- 179 focused A2A/agent tests pass
- late-final, cross-peer, strict-tool-refresh, no-memory, non-streaming and no-push regressions included
- diff checks pass

This was developed from live v0.20.4 fleet canaries and keeps default behavior compatible unless the new strict/disabled config options are selected.