### PR TITLE
fix(cli): arrow keys and Ctrl+A/E now edit text in every wizard prompt (salvage #90327)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3383,8 +3383,10 @@ def _spotify_interactive_setup(redirect_uri_hint: str) -> str:
         except Exception:
             pass
 
+    from hermes_cli.cli_output import line_input
+
     try:
-        raw = input("Spotify Client ID: ").strip()
+        raw = line_input("Spotify Client ID: ").strip()
     except (EOFError, KeyboardInterrupt):
         print()
         raise SystemExit("Spotify setup cancelled.")

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7578,6 +7578,7 @@ def _prompt_model_selection(
     If *unavailable_models* is provided, those models are shown grayed out
     and unselectable, with an upgrade link to *portal_url*.
     """
+    from hermes_cli.cli_output import line_input
     from hermes_cli.models import (
         _format_price_per_mtok,
         compute_sale_discount,
@@ -7794,7 +7795,7 @@ def _prompt_model_selection(
             return _confirmed_selection(ordered[idx])
         elif idx == len(ordered):
             try:
-                custom = input("Enter model name: ").strip()
+                custom = line_input("Enter model name: ").strip()
             except (EOFError, KeyboardInterrupt):
                 return None
             return _confirmed_selection(custom) if custom else None
@@ -7838,7 +7839,7 @@ def _prompt_model_selection(
             if 1 <= idx <= n:
                 return _confirmed_selection(ordered[idx - 1])
             elif idx == n + 1:
-                custom = input("Enter model name: ").strip()
+                custom = line_input("Enter model name: ").strip()
                 return _confirmed_selection(custom) if custom else None
             elif idx == n + 2:
                 return None

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -1,6 +1,7 @@
 """Credential-pool auth subcommands."""
 
 from __future__ import annotations
+from hermes_cli.cli_output import line_input
 
 import math
 import sys
@@ -204,7 +205,7 @@ def auth_add_command(args) -> None:
         label = (getattr(args, "label", None) or "").strip()
         if not label:
             if sys.stdin.isatty():
-                label = input(f"Label (optional, default: {default_label}): ").strip() or default_label
+                label = line_input(f"Label (optional, default: {default_label}): ").strip() or default_label
             else:
                 label = default_label
         entry = PooledCredential(
@@ -663,7 +664,7 @@ def _pick_provider(prompt: str = "Provider") -> str:
     else:
         print(f"\nKnown providers: {', '.join(known)}")
     try:
-        raw = input(f"{prompt}: ").strip()
+        raw = line_input(f"{prompt}: ").strip()
     except (EOFError, KeyboardInterrupt):
         raise SystemExit()
     return _normalize_provider(raw)
@@ -692,7 +693,7 @@ def _interactive_add() -> None:
 
     label = None
     try:
-        typed_label = input("Label / account name (optional): ").strip()
+        typed_label = line_input("Label / account name (optional): ").strip()
     except (EOFError, KeyboardInterrupt):
         return
     if typed_label:
@@ -718,7 +719,7 @@ def _interactive_remove() -> None:
         print(f"  #{i}  {e.label:25s} {e.auth_type:10s} {e.source}{exhausted} [id:{e.id}]")
 
     try:
-        raw = input("Remove #, id, or label (blank to cancel): ").strip()
+        raw = line_input("Remove #, id, or label (blank to cancel): ").strip()
     except (EOFError, KeyboardInterrupt):
         return
     if not raw:

--- a/hermes_cli/bundles.py
+++ b/hermes_cli/bundles.py
@@ -13,6 +13,7 @@ Subcommands:
 """
 
 from __future__ import annotations
+from hermes_cli.cli_output import line_input
 
 import sys
 from typing import List
@@ -100,7 +101,7 @@ def _cmd_create(args) -> None:
         )
         try:
             while True:
-                line = input("skill> ").strip()
+                line = line_input("skill> ").strip()
                 if not line:
                     break
                 skills.append(line)

--- a/hermes_cli/cli_output.py
+++ b/hermes_cli/cli_output.py
@@ -5,6 +5,8 @@ functions previously duplicated across setup.py, tools_config.py,
 mcp_config.py, and memory_setup.py.
 """
 
+import sys
+
 from hermes_cli.colors import Colors, color
 from hermes_cli.secret_prompt import masked_secret_prompt
 
@@ -38,6 +40,26 @@ def print_header(text: str) -> None:
 
 
 # ─── Input Prompts ────────────────────────────────────────────────────────────
+
+
+def line_input(prompt_text: str) -> str:
+    """Read non-secret text with normal cursor-editing keys on a real TTY.
+
+    Setup and model-selection commands run outside the interactive chat's
+    prompt-toolkit application, so they can safely use a short-lived prompt
+    here. Redirected input and output retain the built-in ``input`` behavior
+    used by scripts, tests, and numbered fallbacks.
+    """
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return input(prompt_text)
+
+    try:
+        from prompt_toolkit import prompt as prompt_toolkit_prompt
+        from prompt_toolkit.formatted_text import ANSI
+    except ImportError:
+        return input(prompt_text)
+
+    return prompt_toolkit_prompt(ANSI(prompt_text))
 
 
 def prompt(

--- a/hermes_cli/cli_output.py
+++ b/hermes_cli/cli_output.py
@@ -82,7 +82,7 @@ def prompt(
         if password:
             value = masked_secret_prompt(display)
         else:
-            value = input(display)
+            value = line_input(display)
         value = value.strip()
         return value if value else (default or "")
     except (KeyboardInterrupt, EOFError):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -15,6 +15,7 @@ This module provides:
 """
 
 import copy
+from hermes_cli.cli_output import line_input
 import json
 import logging
 import os
@@ -2438,7 +2439,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             if var.get("password"):
                 value = masked_secret_prompt(f"  {var['prompt']}: ")
             else:
-                value = input(f"  {var['prompt']}: ").strip()
+                value = line_input(f"  {var['prompt']}: ").strip()
             
             if value:
                 save_env_value(var["name"], value)
@@ -2491,7 +2492,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                             f"  {info.get('prompt', name)} (Enter to skip): "
                         )
                     else:
-                        value = input(f"  {info.get('prompt', name)} (Enter to skip): ").strip()
+                        value = line_input(f"  {info.get('prompt', name)} (Enter to skip): ").strip()
                     if value:
                         save_env_value(name, value)
                         results["env_added"].append(name)
@@ -2542,7 +2543,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             for var in missing_skill_config:
                 default = var.get("default", "")
                 default_hint = f" (default: {default})" if default else ""
-                value = input(f"  {var['prompt']}{default_hint}: ").strip()
+                value = line_input(f"  {var['prompt']}{default_hint}: ").strip()
                 if not value and default:
                     value = str(default)
                 if value:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5,6 +5,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 """
 
 import asyncio
+from hermes_cli.cli_output import line_input
 import json
 import logging
 import os
@@ -6812,7 +6813,7 @@ def _setup_signal():
     print_info("  Enter the URL where signal-cli HTTP daemon is running.")
     default_url = existing_url or "http://127.0.0.1:8080"
     try:
-        url = input(f"  HTTP URL [{default_url}]: ").strip() or default_url
+        url = line_input(f"  HTTP URL [{default_url}]: ").strip() or default_url
     except (EOFError, KeyboardInterrupt):
         print("\n  Setup cancelled.")
         return
@@ -6844,7 +6845,7 @@ def _setup_signal():
     print_info("  Example: +15551234567")
     default_account = existing_account or ""
     try:
-        account = input(
+        account = line_input(
             f"  Account number{f' [{default_account}]' if default_account else ''}: "
         ).strip()
         if not account:
@@ -6867,7 +6868,7 @@ def _setup_signal():
     default_allowed = existing_allowed or account
     try:
         allowed = (
-            input(f"  Allowed users [{default_allowed}]: ").strip() or default_allowed
+            line_input(f"  Allowed users [{default_allowed}]: ").strip() or default_allowed
         )
     except (EOFError, KeyboardInterrupt):
         print("\n  Setup cancelled.")
@@ -6885,7 +6886,7 @@ def _setup_signal():
         existing_groups = get_env_value("SIGNAL_GROUP_ALLOWED_USERS") or ""
         try:
             groups = (
-                input(f"  Group IDs [{existing_groups or '*'}]: ").strip()
+                line_input(f"  Group IDs [{existing_groups or '*'}]: ").strip()
                 or existing_groups
                 or "*"
             )

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -67,6 +67,7 @@ except ModuleNotFoundError:
 # visible console when this process is windowless (pythonw gateway + every
 # kanban worker).  No-op on POSIX; never raises.
 from hermes_cli._subprocess_compat import suppress_platform_ver_console
+from hermes_cli.cli_output import line_input
 
 suppress_platform_ver_console()
 
@@ -3337,11 +3338,11 @@ def cmd_whatsapp(args):
             response = "n"
         if response.lower() in {"y", "yes"}:
             if wa_mode == "bot":
-                phone = input(
+                phone = line_input(
                     "  Phone numbers that can message the bot (comma-separated): "
                 ).strip()
             else:
-                phone = input("  Your phone number (e.g. 15551234567): ").strip()
+                phone = line_input("  Your phone number (e.g. 15551234567): ").strip()
             if phone:
                 save_env_value("WHATSAPP_ALLOWED_USERS", phone.replace(" ", ""))
                 print(f"  ✓ Updated to: {phone}")
@@ -3349,11 +3350,11 @@ def cmd_whatsapp(args):
         print()
         if wa_mode == "bot":
             print("  Who should be allowed to message the bot?")
-            phone = input(
+            phone = line_input(
                 "  Phone numbers (comma-separated, or * for anyone): "
             ).strip()
         else:
-            phone = input("  Your phone number (e.g. 15551234567): ").strip()
+            phone = line_input("  Your phone number (e.g. 15551234567): ").strip()
         if phone:
             save_env_value("WHATSAPP_ALLOWED_USERS", phone.replace(" ", ""))
             print(f"  ✓ Allowed users set: {phone}")
@@ -4407,7 +4408,7 @@ def _aux_flow_provider_model(
         print(f"No curated model list for {provider_slug}.")
         print("Enter a model slug manually (blank = use provider default):")
         try:
-            val = input("Model: ").strip()
+            val = line_input("Model: ").strip()
         except (KeyboardInterrupt, EOFError):
             print()
             return
@@ -4448,7 +4449,7 @@ def _aux_flow_custom_endpoint(task: str, task_cfg: dict) -> None:
         url_prompt = (
             f"Base URL [{current_base_url}]: " if current_base_url else "Base URL: "
         )
-        url = input(url_prompt).strip()
+        url = line_input(url_prompt).strip()
     except (KeyboardInterrupt, EOFError):
         print()
         return
@@ -4462,7 +4463,7 @@ def _aux_flow_custom_endpoint(task: str, task_cfg: dict) -> None:
             if current_model
             else "Model slug (optional): "
         )
-        model = input(model_prompt).strip()
+        model = line_input(model_prompt).strip()
     except (KeyboardInterrupt, EOFError):
         print()
         return
@@ -11015,7 +11016,7 @@ def _maybe_setup_dashboard_auth_interactively(args) -> None:
 
     print()
     try:
-        username = input("  Username [admin]: ").strip() or "admin"
+        username = line_input("  Username [admin]: ").strip() or "admin"
         password = getpass.getpass("  Password: ")
         confirm = getpass.getpass("  Confirm password: ")
     except (EOFError, KeyboardInterrupt):

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -19,6 +19,7 @@ call time, when main.py is fully loaded) so this module never imports
 """
 
 from __future__ import annotations
+from hermes_cli.cli_output import line_input
 
 import argparse
 import os
@@ -919,7 +920,7 @@ def _model_flow_custom(config):
     print()
 
     try:
-        base_url = input(
+        base_url = line_input(
             f"API base URL [{current_url or 'e.g. https://api.example.com/v1'}]: "
         ).strip()
         api_key = masked_secret_prompt(
@@ -1020,7 +1021,7 @@ def _model_flow_custom(config):
             if confirm in {"", "y", "yes"}:
                 model_name = detected_models[0]
             else:
-                model_name = input("Model name (e.g. gpt-4, llama-3-70b): ").strip()
+                model_name = line_input("Model name (e.g. gpt-4, llama-3-70b): ").strip()
         elif len(detected_models) > 1:
             print("  Available models:")
             for i, m in enumerate(detected_models, 1):
@@ -1033,15 +1034,15 @@ def _model_flow_custom(config):
             elif pick:
                 model_name = pick
         else:
-            model_name = input("Model name (e.g. gpt-4, llama-3-70b): ").strip()
+            model_name = line_input("Model name (e.g. gpt-4, llama-3-70b): ").strip()
 
-        context_length_str = input(
+        context_length_str = line_input(
             "Context length in tokens [leave blank for auto-detect]: "
         ).strip()
 
         # Prompt for a display name — shown in the provider menu on future runs
         default_name = _auto_provider_name(effective_url)
-        display_name = input(f"Display name [{default_name}]: ").strip() or default_name
+        display_name = line_input(f"Display name [{default_name}]: ").strip() or default_name
     except (KeyboardInterrupt, EOFError):
         print("\nCancelled.")
         return
@@ -1224,7 +1225,7 @@ def _model_flow_azure_foundry(config, current_model=""):
             or "e.g. https://<resource>.openai.azure.com/openai/v1 "
               "or https://<resource>.services.ai.azure.com/anthropic"
         )
-        base_url = input(
+        base_url = line_input(
             f"API endpoint URL [{_placeholder}]: "
         ).strip()
     except (KeyboardInterrupt, EOFError):
@@ -1421,7 +1422,7 @@ def _model_flow_azure_foundry(config, current_model=""):
             effective_model = pick
     else:
         try:
-            model_name = input(
+            model_name = line_input(
                 f"Model / deployment name [{current_model or 'e.g. gpt-5.4, claude-sonnet-4-6'}]: "
             ).strip()
         except (KeyboardInterrupt, EOFError):
@@ -1715,14 +1716,14 @@ def _model_flow_named_custom(config, provider_info):
     elif saved_model and not native_catalog_empty:
         print("Could not fetch models from endpoint.")
         try:
-            model_name = input(f"Model name [{saved_model}]: ").strip() or saved_model
+            model_name = line_input(f"Model name [{saved_model}]: ").strip() or saved_model
         except (KeyboardInterrupt, EOFError):
             print("\nCancelled.")
             return
     else:
         print("Could not fetch models from endpoint. Enter model name manually.")
         try:
-            model_name = input("Model name: ").strip()
+            model_name = line_input("Model name: ").strip()
         except (KeyboardInterrupt, EOFError):
             print("\nCancelled.")
             return
@@ -1939,7 +1940,7 @@ def _model_flow_copilot(config, current_model=""):
         )
     else:
         try:
-            selected = input("Model name: ").strip()
+            selected = line_input("Model name: ").strip()
         except (KeyboardInterrupt, EOFError):
             selected = None
 
@@ -2080,7 +2081,7 @@ def _model_flow_copilot_acp(config, current_model=""):
         )
     else:
         try:
-            selected = input("Model name: ").strip()
+            selected = line_input("Model name: ").strip()
         except (KeyboardInterrupt, EOFError):
             selected = None
 
@@ -2178,7 +2179,7 @@ def _model_flow_kimi(config, current_model=""):
         )
     else:
         try:
-            selected = input("Enter model name: ").strip()
+            selected = line_input("Enter model name: ").strip()
         except (KeyboardInterrupt, EOFError):
             selected = None
 
@@ -2291,7 +2292,7 @@ def _model_flow_stepfun(config, current_model=""):
         )
     else:
         try:
-            selected = input("Model name: ").strip()
+            selected = line_input("Model name: ").strip()
         except (KeyboardInterrupt, EOFError):
             selected = None
 
@@ -2384,7 +2385,7 @@ def _model_flow_bedrock_api_key(config, region, current_model=""):
         )
     else:
         try:
-            selected = input("  Model ID: ").strip()
+            selected = line_input("  Model ID: ").strip()
         except (KeyboardInterrupt, EOFError):
             selected = None
 
@@ -2476,7 +2477,7 @@ def _model_flow_bedrock(config, current_model=""):
     # 2. Region selection
     current_region = resolve_bedrock_region()
     try:
-        region_input = input(f"  AWS Region [{current_region}]: ").strip()
+        region_input = line_input(f"  AWS Region [{current_region}]: ").strip()
     except (KeyboardInterrupt, EOFError):
         print()
         return
@@ -2607,7 +2608,7 @@ def _model_flow_bedrock(config, current_model=""):
         )
     else:
         try:
-            selected = input("  Model ID: ").strip()
+            selected = line_input("  Model ID: ").strip()
         except (KeyboardInterrupt, EOFError):
             selected = None
 
@@ -2677,7 +2678,7 @@ def _model_flow_vertex(config, current_model=""):
     # 2. Project ID (optional — falls back to the project embedded in creds).
     current_project = str(vertex_cfg.get("project_id") or "").strip()
     try:
-        project_input = input(
+        project_input = line_input(
             f"  GCP project ID [{current_project or 'from credentials'}]: "
         ).strip()
     except (KeyboardInterrupt, EOFError):
@@ -2688,7 +2689,7 @@ def _model_flow_vertex(config, current_model=""):
     # 3. Region (default global — required for the Gemini 3.x previews).
     current_region = str(vertex_cfg.get("region") or "global").strip() or "global"
     try:
-        region_input = input(f"  Vertex region [{current_region}]: ").strip()
+        region_input = line_input(f"  Vertex region [{current_region}]: ").strip()
     except (KeyboardInterrupt, EOFError):
         print()
         return
@@ -2785,7 +2786,7 @@ def _select_zai_endpoint(current_base: str) -> str:
     if selected == len(options):
         # Custom proxy URL
         try:
-            override = input(f"Custom base URL [{current_base}]: ").strip()
+            override = line_input(f"Custom base URL [{current_base}]: ").strip()
         except (KeyboardInterrupt, EOFError):
             print()
             return current_base
@@ -2923,7 +2924,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         effective_base = chosen_base
     else:
         try:
-            override = input(f"Base URL [{effective_base}]: ").strip()
+            override = line_input(f"Base URL [{effective_base}]: ").strip()
         except (KeyboardInterrupt, EOFError):
             print()
             override = ""
@@ -3082,7 +3083,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         )
     else:
         try:
-            selected = input("Model name: ").strip()
+            selected = line_input("Model name: ").strip()
         except (KeyboardInterrupt, EOFError):
             selected = None
 
@@ -3237,7 +3238,7 @@ def _model_flow_anthropic(config, current_model=""):
         )
     else:
         try:
-            selected = input("Model name (e.g., claude-sonnet-4-20250514): ").strip()
+            selected = line_input("Model name (e.g., claude-sonnet-4-20250514): ").strip()
         except (KeyboardInterrupt, EOFError):
             selected = None
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -8,6 +8,7 @@ rendered with Rich Markdown.  Otherwise a default confirmation is shown.
 """
 
 from __future__ import annotations
+from hermes_cli.cli_output import line_input
 
 import functools
 import importlib.metadata
@@ -484,7 +485,7 @@ def _prompt_plugin_env_vars(manifest: dict, console) -> None:
             if secret:
                 value = masked_secret_prompt(f"  {name}: ").strip()
             else:
-                value = input(f"  {name}: ").strip()
+                value = line_input(f"  {name}: ").strip()
         except (EOFError, KeyboardInterrupt):
             console.print(f"\n[dim]  Skipped (you can set these later in {display_hermes_home()}/.env)[/dim]")
             return

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -210,7 +210,9 @@ def prompt(question: str, default: str = None, password: bool = False) -> str:
         if password:
             value = masked_secret_prompt(color(display, Colors.YELLOW))
         else:
-            value = input(color(display, Colors.YELLOW))
+            from hermes_cli.cli_output import line_input
+
+            value = line_input(color(display, Colors.YELLOW))
 
         cleaned = _sanitize_pasted_input(value)
         return cleaned.strip() or default or ""

--- a/hermes_cli/setup_whatsapp_cloud.py
+++ b/hermes_cli/setup_whatsapp_cloud.py
@@ -33,6 +33,7 @@ to verify the loop end-to-end once everything's running.
 """
 
 from __future__ import annotations
+from hermes_cli.cli_output import line_input
 
 import re
 import secrets
@@ -180,7 +181,7 @@ def _prompt(message: str, default: Optional[str] = None, secret: bool = False) -
 
             raw = getpass.getpass(f"{message}{suffix} (input hidden): ").strip()
         else:
-            raw = input(f"{message}{suffix}: ").strip()
+            raw = line_input(f"{message}{suffix}: ").strip()
     except (EOFError, KeyboardInterrupt):
         print()
         return ""
@@ -444,7 +445,7 @@ def run_whatsapp_cloud_setup() -> int:
     current_allow = get_env_value("WHATSAPP_CLOUD_ALLOWED_USERS") or None
     allow_default = current_allow if current_allow else None
     try:
-        allowed = input(
+        allowed = line_input(
             f"  → Allowed users{' [' + allow_default + ']' if allow_default else ''}: "
         ).strip() or (allow_default or "")
     except (EOFError, KeyboardInterrupt):

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -252,8 +252,10 @@ def _prompt_for_skill_name(c: Console, url: str, default: str = "") -> Optional[
         f"[bold]Enter a skill name{default_hint}:[/] "
         f"[dim](lowercase letters, digits, hyphens, underscores; starts with a letter)[/]"
     )
+    from hermes_cli.cli_output import line_input
+
     try:
-        answer = input("Name: ").strip()
+        answer = line_input("Name: ").strip()
     except (EOFError, KeyboardInterrupt):
         return None
     if not answer and default:
@@ -277,8 +279,10 @@ def _prompt_for_category(c: Console, existing: List[str]) -> str:
         c.print(
             "[bold]Category[/] [dim](optional — press Enter to install flat at ~/.hermes/skills/<name>/)[/]"
         )
+    from hermes_cli.cli_output import line_input
+
     try:
-        answer = input("Category: ").strip()
+        answer = line_input("Category: ").strip()
     except (EOFError, KeyboardInterrupt):
         return ""
     if not answer:

--- a/tests/hermes_cli/test_cli_output.py
+++ b/tests/hermes_cli/test_cli_output.py
@@ -1,6 +1,47 @@
 from hermes_cli import cli_output
 
 
+class _TTY:
+    def isatty(self):
+        return True
+
+
+class _NotTTY:
+    def isatty(self):
+        return False
+
+
+def test_line_input_supports_cursor_and_emacs_navigation(monkeypatch):
+    from prompt_toolkit.application.current import create_app_session
+    from prompt_toolkit.input.defaults import create_pipe_input
+    from prompt_toolkit.output import DummyOutput
+
+    monkeypatch.setattr(cli_output.sys, "stdin", _TTY())
+    monkeypatch.setattr(cli_output.sys, "stdout", _TTY())
+
+    with create_pipe_input() as pipe_input:
+        # Type "ac", move left, insert "b", move right, append "d", then
+        # exercise Ctrl+A/Ctrl+E before accepting the line.
+        pipe_input.send_text("ac\x1b[Db\x1b[Cd\x01X\x05Y\r")
+        with create_app_session(input=pipe_input, output=DummyOutput()):
+            assert cli_output.line_input("Enter model name: ") == "XabcdY"
+
+
+def test_line_input_preserves_builtin_input_for_redirected_stdin(monkeypatch):
+    seen = {}
+
+    def fake_input(prompt_text):
+        seen["prompt"] = prompt_text
+        return "piped-model"
+
+    monkeypatch.setattr(cli_output.sys, "stdin", _NotTTY())
+    monkeypatch.setattr(cli_output.sys, "stdout", _TTY())
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    assert cli_output.line_input("Enter model name: ") == "piped-model"
+    assert seen["prompt"] == "Enter model name: "
+
+
 def test_password_prompt_uses_masked_secret_prompt(monkeypatch):
     seen = {}
 

--- a/tests/hermes_cli/test_terminal_menu_fallbacks.py
+++ b/tests/hermes_cli/test_terminal_menu_fallbacks.py
@@ -36,6 +36,40 @@ def test_prompt_model_selection_requires_expensive_confirmation(monkeypatch, cap
     assert "EXPENSIVE MODEL WARNING" in out
 
 
+def test_prompt_model_selection_uses_line_editor_for_custom_model(monkeypatch):
+    from hermes_cli.auth import _prompt_model_selection
+
+    monkeypatch.setattr(
+        "hermes_cli.curses_ui.curses_radiolist",
+        lambda _title, choices, **_kwargs: len(choices) - 2,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.cli_output.line_input",
+        lambda prompt_text: (
+            "vendor/edited-model" if prompt_text == "Enter model name: " else ""
+        ),
+    )
+
+    assert _prompt_model_selection(["vendor/default-model"]) == "vendor/edited-model"
+
+
+def test_prompt_model_selection_fallback_uses_line_editor_for_custom_model(
+    monkeypatch,
+):
+    from hermes_cli.auth import _prompt_model_selection
+
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _raise_menu)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "2")
+    monkeypatch.setattr(
+        "hermes_cli.cli_output.line_input",
+        lambda prompt_text: (
+            "vendor/edited-model" if prompt_text == "Enter model name: " else ""
+        ),
+    )
+
+    assert _prompt_model_selection(["vendor/default-model"]) == "vendor/edited-model"
+
+
 def test_remove_custom_provider_falls_back_on_menu_runtime_error(tmp_path, monkeypatch):
     from hermes_cli.main import _remove_custom_provider
 
@@ -58,5 +92,3 @@ def test_remove_custom_provider_falls_back_on_menu_runtime_error(tmp_path, monke
     assert reloaded["custom_providers"] == [
         {"name": "Local B", "base_url": "http://localhost:8002/v1"},
     ]
-
-


### PR DESCRIPTION
## Summary
Arrow keys and Ctrl+A/Ctrl+E now edit text in every CLI wizard free-text prompt — not just the custom model prompt. Previously these prompts used bare `input()`, which on a raw TTY renders cursor keys as literal `^[[D`/`^[[C` escape garbage (reported in Discord for the model selector; the reporter correctly guessed it applied to all wizards).

Salvages #90327 by @helix4u (authorship preserved via cherry-pick) and widens the fix to the whole class.

## Changes
- `hermes_cli/cli_output.py`: @helix4u's `line_input()` — prompt_toolkit line editor on a real TTY, builtin `input()` when stdin/stdout are redirected or prompt_toolkit is unavailable. The shared `prompt()` helper (used by setup.py, tools_config.py, mcp_config.py, memory_setup.py) now routes its non-password branch through it.
- `hermes_cli/setup.py`: setup wizard `prompt()` routes through `line_input()`.
- Class widening: all 46 bare `input()` free-text prompt sites converted across `model_setup_flows.py` (22), `auth.py`, `auth_commands.py`, `bundles.py`, `config.py`, `gateway.py`, `main.py`, `plugins_cmd.py`, `setup_whatsapp_cloud.py`, `skills_hub.py`. Numbered-choice and y/N prompts left on `input()` (single-key, no editing needed).
- Tests: contributor's 4 tests (real pipe-input escape sequences, redirected-stdin fallback, both model-picker paths).

## Validation
| | Before | After |
|---|---|---|
| Custom model prompt, ←/→/Ctrl+A/E | `^[[D` garbage | cursor edits (PTY E2E: `XabcdY`) |
| `cli_output.prompt()` / `setup.prompt()` wizards | no editing | cursor edits (PTY E2E pass) |
| Piped/redirected stdin | builtin `input()` | unchanged (E2E pass) |

Targeted tests: 8/8 pass (`test_cli_output.py`, `test_terminal_menu_fallbacks.py`). Ruff clean. All 12 touched modules import clean in the repo venv.

## Infographic

![arrow keys work in every wizard](https://files.catbox.moe/d7a3va.png)
