### PR TITLE
feat(openrouter): surface live free models in the /model picker

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -794,6 +794,7 @@ from hermes_cli import __version__, __release_date__
 from hermes_cli.model_setup_flows import (
     _prompt_auth_credentials_choice,
     _model_flow_openrouter,
+    _model_flow_openrouter_free,
     _model_flow_nous,
     _model_flow_openai_codex,
     _model_flow_xai_oauth,
@@ -3777,6 +3778,7 @@ def select_provider_and_model(args=None):
     )
 
     provider_labels = dict(_PROVIDER_LABELS)  # derive from canonical list
+    provider_labels["openrouter-free"] = "OpenRouter Free Models"
     if active and active in _custom_provider_map:
         active_label = _custom_provider_map[active]["name"]
     else:
@@ -3795,6 +3797,9 @@ def select_provider_and_model(args=None):
     # resolves back to a concrete slug, so the dispatch chain below is
     # unchanged. Custom providers and the trailing actions stay flat.
     canonical_descs = {p.slug: p.tui_desc for p in CANONICAL_PROVIDERS}
+    canonical_descs["openrouter-free"] = (
+        "OpenRouter Free Models (live zero-priced, tool-capable catalog)"
+    )
     # Honor ``model_catalog.excluded_providers`` so the CLI ``hermes model``
     # picker hides the same providers the gateway/TUI pickers do. A canonical
     # provider is hidden if its slug OR any of its aliases appears in the
@@ -3818,6 +3823,9 @@ def select_provider_and_model(args=None):
         ]
     else:
         _visible_slugs = [p.slug for p in CANONICAL_PROVIDERS]
+    if "openrouter" in _visible_slugs and "openrouter-free" not in _visible_slugs:
+        _or_idx = _visible_slugs.index("openrouter")
+        _visible_slugs.insert(_or_idx + 1, "openrouter-free")
     grouped_rows = group_providers(_visible_slugs)
 
     # The group/slug that should be pre-selected: the active provider's group
@@ -3912,6 +3920,8 @@ def select_provider_and_model(args=None):
     # Step 2: Provider-specific setup + model selection
     if selected_provider == "openrouter":
         _model_flow_openrouter(config, current_model)
+    elif selected_provider == "openrouter-free":
+        _model_flow_openrouter_free(config, current_model)
     elif selected_provider == "moa":
         _model_flow_moa(config, current_model)
     elif selected_provider == "ai-gateway":

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -246,6 +246,72 @@ def _model_flow_openrouter(config, current_model=""):
         print("No change.")
 
 
+def _model_flow_openrouter_free(config, current_model=""):
+    """OpenRouter free-models picker: live zero-priced catalog, runtime OpenRouter."""
+    from hermes_cli.main import _prompt_api_key
+    from hermes_constants import OPENROUTER_BASE_URL
+    from hermes_cli.auth import (
+        ProviderConfig,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+    )
+
+    pconfig = ProviderConfig(
+        id="openrouter",
+        name="OpenRouter",
+        auth_type="api_key",
+        api_key_env_vars=("OPENROUTER_API_KEY",),
+    )
+    existing_key, existing_source = _existing_api_key_for_model_flow("openrouter", pconfig)
+    if not existing_key:
+        print("Get one at: https://openrouter.ai/keys")
+        print()
+    _resolved, abort = _prompt_api_key(
+        pconfig,
+        existing_key,
+        provider_id="openrouter",
+        existing_source=existing_source,
+    )
+    if abort:
+        return
+
+    from hermes_cli.models import fetch_openrouter_free_models, get_pricing_for_provider
+
+    free_model_ids = [mid for mid, _ in fetch_openrouter_free_models(force_refresh=True)]
+    if not free_model_ids:
+        print("No free, tool-capable OpenRouter models are available right now.")
+        return
+
+    pricing = get_pricing_for_provider("openrouter", force_refresh=True)
+    selected = _prompt_model_selection(
+        free_model_ids,
+        current_model=current_model,
+        pricing=pricing,
+        confirm_provider="openrouter",
+        confirm_base_url=OPENROUTER_BASE_URL,
+        confirm_api_key=_resolved or existing_key,
+    )
+    if selected:
+        _save_model_choice(selected)
+        from hermes_cli.config import load_config, save_config
+
+        cfg = load_config()
+        model = cfg.get("model")
+        if not isinstance(model, dict):
+            model = {"default": model} if model else {}
+            cfg["model"] = model
+        model["provider"] = "openrouter"
+        model["base_url"] = OPENROUTER_BASE_URL
+        model["api_mode"] = "chat_completions"
+        clear_model_endpoint_credentials(model, clear_api_mode=False)
+        save_config(cfg)
+        deactivate_provider()
+        print(f"Default model set to: {selected} (via OpenRouter Free Models)")
+    else:
+        print("No change.")
+
+
 def _print_moa_preset(name: str, preset: dict) -> None:
     """Print the full reference-models + aggregator breakdown for a preset."""
     print(f"  Preset: {name}")

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -3111,6 +3111,50 @@ def list_authenticated_providers(
         seen_slugs.add(hermes_slug.lower())
         _record_builtin_endpoint(hermes_slug)
 
+    # --- 2a. OpenRouter live-free picker row ---
+    # Unique display slug so Telegram/Discord can keep the curated OpenRouter
+    # row and a live free-only catalog as two buttons. Runtime switching
+    # still uses provider ``openrouter`` (see picker_runtime_slug).
+    if (
+        "openrouter-free" not in _excluded
+        and "openrouter" not in _excluded
+        and "openrouter-free" not in seen_slugs
+    ):
+        try:
+            from hermes_cli.models import (
+                OPENROUTER_FREE_PICKER_LABEL,
+                OPENROUTER_FREE_PICKER_SLUG,
+                OPENROUTER_FREE_RUNTIME_SLUG,
+                fetch_openrouter_free_models,
+            )
+            _or_cfg = _auth_registry.get("openrouter")
+            _or_has_creds = bool(
+                _or_cfg
+                and _or_cfg.api_key_env_vars
+                and any(os.environ.get(ev) for ev in _or_cfg.api_key_env_vars)
+            )
+            if not _or_has_creds:
+                try:
+                    _or_has_creds = _credential_pool_is_usable("openrouter")
+                except Exception:
+                    _or_has_creds = False
+            if _or_has_creds:
+                free_ids = [mid for mid, _ in fetch_openrouter_free_models()]
+                if free_ids:
+                    results.append({
+                        "slug": OPENROUTER_FREE_PICKER_SLUG,
+                        "runtime_slug": OPENROUTER_FREE_RUNTIME_SLUG,
+                        "name": OPENROUTER_FREE_PICKER_LABEL,
+                        "is_current": False,
+                        "is_user_defined": False,
+                        "models": list(free_ids),
+                        "total_models": len(free_ids),
+                        "source": "hermes",
+                    })
+                    seen_slugs.add(OPENROUTER_FREE_PICKER_SLUG)
+        except Exception:
+            pass
+
     # --- 2b. Cross-check canonical provider list ---
     # Catches providers that are in CANONICAL_PROVIDERS but weren't found
     # in PROVIDER_TO_MODELS_DEV or HERMES_OVERLAYS (keeps /model in sync
@@ -3947,7 +3991,11 @@ def list_picker_providers(
     The typed ``/model <name>`` path is unaffected -- only the interactive
     picker payload is narrowed.
     """
-    from hermes_cli.models import fetch_openrouter_models
+    from hermes_cli.models import (
+        OPENROUTER_FREE_PICKER_SLUG,
+        fetch_openrouter_free_models,
+        fetch_openrouter_models,
+    )
 
     providers = list_authenticated_providers(
         current_provider=current_provider,
@@ -3974,6 +4022,18 @@ def list_picker_providers(
             p = dict(p)
             p["models"] = live_ids[:max_models] if max_models is not None else live_ids
             p["total_models"] = len(live_ids)
+        elif slug == OPENROUTER_FREE_PICKER_SLUG:
+            try:
+                free_live = fetch_openrouter_free_models()
+                free_ids = [mid for mid, _ in free_live]
+            except Exception:
+                free_ids = list(p.get("models", []))
+            p = dict(p)
+            # Live free catalog is the whole point of this row — do not
+            # truncate it with max_models.
+            p["models"] = free_ids
+            p["total_models"] = len(free_ids)
+            p.setdefault("runtime_slug", "openrouter")
 
         has_models = bool(p.get("models"))
         is_custom_endpoint = bool(p.get("is_user_defined")) and bool(p.get("api_url"))

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -132,6 +132,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("sakana/fugu-ultra",                      ""),
     # OpenRouter routers
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
+    ("openrouter/free",                        "auto-routes to a free OpenRouter model"),
     # Free tier
     ("openrouter/elephant-alpha",              "free"),
     ("poolside/laguna-m.1:free",               "free"),
@@ -1842,6 +1843,97 @@ def fetch_openrouter_models(
 def model_ids(*, force_refresh: bool = False) -> list[str]:
     """Return just the OpenRouter model-id strings."""
     return [mid for mid, _ in fetch_openrouter_models(force_refresh=force_refresh)]
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter free-models picker group
+#
+# Display slug is unique so Telegram/Discord can index two OpenRouter rows
+# (curated vs live-free). Runtime switching always uses ``openrouter``.
+# ---------------------------------------------------------------------------
+OPENROUTER_FREE_PICKER_SLUG = "openrouter-free"
+OPENROUTER_FREE_RUNTIME_SLUG = "openrouter"
+OPENROUTER_FREE_PICKER_LABEL = "OpenRouter Free Models"
+OPENROUTER_FREE_PICKER_DESC = (
+    "All zero-priced, tool-capable OpenRouter models (live catalog)"
+)
+
+_openrouter_free_cache: list[tuple[str, str]] | None = None
+_openrouter_free_cache_time: float = 0.0
+_OPENROUTER_FREE_CACHE_TTL = 3600.0
+
+
+def picker_runtime_slug(provider: Any) -> str:
+    """Return the runtime provider slug for a picker row or slug.
+
+    Picker display identifiers (``openrouter-free``) are not runtime
+    providers. Prefer an explicit ``runtime_slug`` field on a row dict.
+    """
+    if isinstance(provider, dict):
+        runtime = str(provider.get("runtime_slug") or "").strip()
+        if runtime:
+            return runtime
+        slug = str(provider.get("slug") or "").strip()
+    else:
+        slug = str(provider or "").strip()
+    if slug == OPENROUTER_FREE_PICKER_SLUG:
+        return OPENROUTER_FREE_RUNTIME_SLUG
+    return slug
+
+
+def fetch_openrouter_free_models(
+    timeout: float = 8.0,
+    *,
+    force_refresh: bool = False,
+) -> list[tuple[str, str]]:
+    """Return every live OpenRouter model that is free and tool-capable.
+
+    Filters ``/api/v1/models`` for zero prompt+completion pricing. Tool
+    support uses :func:`_openrouter_model_supports_tools` (permissive when
+    ``supported_parameters`` is missing). NVIDIA and every other vendor
+    that meets those two rules is kept.
+    """
+    global _openrouter_free_cache, _openrouter_free_cache_time
+
+    now = time.time()
+    if (
+        not force_refresh
+        and _openrouter_free_cache is not None
+        and (now - _openrouter_free_cache_time) < _OPENROUTER_FREE_CACHE_TTL
+    ):
+        return list(_openrouter_free_cache)
+
+    try:
+        req = urllib.request.Request(
+            "https://openrouter.ai/api/v1/models",
+            headers={"Accept": "application/json"},
+        )
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode())
+    except Exception:
+        return list(_openrouter_free_cache or [])
+
+    live_items = payload.get("data", [])
+    if not isinstance(live_items, list):
+        return list(_openrouter_free_cache or [])
+
+    free_models: list[tuple[str, str]] = []
+    for item in live_items:
+        if not isinstance(item, dict):
+            continue
+        mid = str(item.get("id") or "").strip()
+        if not mid:
+            continue
+        if not _openrouter_model_is_free(item.get("pricing")):
+            continue
+        if not _openrouter_model_supports_tools(item):
+            continue
+        free_models.append((mid, "free"))
+
+    free_models.sort(key=lambda row: row[0])
+    _openrouter_free_cache = free_models
+    _openrouter_free_cache_time = now
+    return list(free_models)
 
 
 def get_curated_nous_model_ids() -> list[str]:

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -915,6 +915,12 @@ def resolve_provider_full(
     canonical = normalize_provider(name)
     raw = name.strip().lower()
 
+    # Picker-only display slug. Selecting a free OpenRouter model still
+    # routes through the real OpenRouter provider.
+    if raw == "openrouter-free":
+        canonical = "openrouter"
+        raw = "openrouter"
+
     # 0. User-defined config providers win over the built-in alias table.
     #    A user who declares ``providers.<name>`` in config.yaml has stated
     #    explicit intent for that name — it must not be hijacked by a legacy

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -9314,10 +9314,14 @@ def _define_discord_view_classes() -> None:
                 return
 
             provider_slug = interaction.data["values"][0]
-            self._selected_provider = provider_slug
             provider = next(
                 (p for p in self.providers if p["slug"] == provider_slug), None
             )
+            try:
+                from hermes_cli.models import picker_runtime_slug
+                self._selected_provider = picker_runtime_slug(provider or provider_slug)
+            except Exception:
+                self._selected_provider = provider_slug
             pname = provider.get("name", provider_slug) if provider else provider_slug
 
             self._build_model_select(provider_slug)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6677,6 +6677,11 @@ class TelegramAdapter(BasePlatformAdapter):
 
             models = provider.get("models", [])
             state["selected_provider"] = provider_slug
+            try:
+                from hermes_cli.models import picker_runtime_slug
+                state["selected_runtime_slug"] = picker_runtime_slug(provider)
+            except Exception:
+                state["selected_runtime_slug"] = provider_slug
             state["selected_provider_name"] = provider.get("name", provider_slug)
             state["model_list"] = models
             state["model_page"] = 0
@@ -6783,7 +6788,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 return
 
             model_id = model_list[idx]
-            provider_slug = state.get("selected_provider", "")
+            provider_slug = state.get("selected_runtime_slug") or state.get("selected_provider", "")
             callback = state.get("on_model_selected")
 
             if not callback:
@@ -6832,7 +6837,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 return
 
             model_id = model_list[idx]
-            provider_slug = state.get("selected_provider", "")
+            provider_slug = state.get("selected_runtime_slug") or state.get("selected_provider", "")
             callback = state.get("on_model_selected")
 
             if not callback:

--- a/tests/hermes_cli/test_openrouter_free_model_picker.py
+++ b/tests/hermes_cli/test_openrouter_free_model_picker.py
@@ -1,0 +1,224 @@
+"""OpenRouter live-free picker group.
+
+The curated OpenRouter row stays intact. A second picker row uses a unique
+display slug (``openrouter-free``) and a separate ``runtime_slug`` of
+``openrouter`` so Telegram/Discord can index both rows without switching
+onto a fake provider.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from hermes_cli import model_switch
+from hermes_cli.models import (
+    OPENROUTER_FREE_PICKER_SLUG,
+    OPENROUTER_FREE_RUNTIME_SLUG,
+    _openrouter_model_is_free,
+    _openrouter_model_supports_tools,
+    fetch_openrouter_free_models,
+    picker_runtime_slug,
+)
+import hermes_cli.models as models_mod
+
+
+class _Resp:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self._payload
+
+
+LIVE_FREE_PAYLOAD = (
+    b'{"data":['
+    b'{"id":"nvidia/nemotron-3-ultra-550b-a55b:free",'
+    b'"pricing":{"prompt":"0","completion":"0"},'
+    b'"supported_parameters":["tools","temperature"]},'
+    b'{"id":"openrouter/free",'
+    b'"pricing":{"prompt":"0","completion":"0"},'
+    b'"supported_parameters":["tools"]},'
+    b'{"id":"paid/model",'
+    b'"pricing":{"prompt":"0.001","completion":"0.002"},'
+    b'"supported_parameters":["tools"]},'
+    b'{"id":"free/no-tools",'
+    b'"pricing":{"prompt":"0","completion":"0"},'
+    b'"supported_parameters":["temperature"]},'
+    b'{"id":"free/unknown-tools",'
+    b'"pricing":{"prompt":"0","completion":"0"}}'
+    b"]}"
+)
+
+
+def test_openrouter_free_pricing_requires_both_sides_zero():
+    assert _openrouter_model_is_free({"prompt": "0", "completion": "0"}) is True
+    assert _openrouter_model_is_free({"prompt": "0", "completion": "0.1"}) is False
+    assert _openrouter_model_is_free(None) is False
+
+
+def test_fetch_openrouter_free_models_keeps_nvidia_and_unknown_tools(monkeypatch):
+    monkeypatch.setattr(models_mod, "_openrouter_free_cache", None)
+    monkeypatch.setattr(models_mod, "_openrouter_free_cache_time", 0.0)
+    monkeypatch.setattr(
+        models_mod,
+        "_urlopen_model_catalog_request",
+        lambda *a, **k: _Resp(LIVE_FREE_PAYLOAD),
+    )
+
+    rows = fetch_openrouter_free_models(force_refresh=True)
+    ids = [mid for mid, _ in rows]
+
+    assert "nvidia/nemotron-3-ultra-550b-a55b:free" in ids
+    assert "openrouter/free" in ids
+    assert "free/unknown-tools" in ids
+    assert "paid/model" not in ids
+    assert "free/no-tools" not in ids
+    assert ids == sorted(ids)
+    assert all(desc == "free" for _, desc in rows)
+
+
+def test_picker_runtime_slug_separates_display_from_runtime():
+    assert picker_runtime_slug(OPENROUTER_FREE_PICKER_SLUG) == OPENROUTER_FREE_RUNTIME_SLUG
+    assert picker_runtime_slug({
+        "slug": OPENROUTER_FREE_PICKER_SLUG,
+        "runtime_slug": OPENROUTER_FREE_RUNTIME_SLUG,
+    }) == "openrouter"
+    assert picker_runtime_slug({"slug": "openrouter"}) == "openrouter"
+    assert picker_runtime_slug("anthropic") == "anthropic"
+
+
+def test_list_picker_providers_emits_unique_free_row(monkeypatch):
+    monkeypatch.setattr(
+        model_switch,
+        "list_authenticated_providers",
+        lambda **kw: [
+            {
+                "slug": "openrouter",
+                "name": "OpenRouter",
+                "is_current": True,
+                "is_user_defined": False,
+                "models": ["anthropic/claude-sonnet-5"],
+                "total_models": 1,
+                "source": "built-in",
+            },
+            {
+                "slug": OPENROUTER_FREE_PICKER_SLUG,
+                "runtime_slug": OPENROUTER_FREE_RUNTIME_SLUG,
+                "name": "OpenRouter Free Models",
+                "is_current": False,
+                "is_user_defined": False,
+                "models": ["stale/id:free"],
+                "total_models": 1,
+                "source": "hermes",
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_openrouter_models",
+        lambda *a, **k: [("anthropic/claude-sonnet-5", "")],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_openrouter_free_models",
+        lambda *a, **k: [
+            ("nvidia/nemotron-3-ultra-550b-a55b:free", "free"),
+            ("openrouter/free", "free"),
+        ],
+    )
+
+    rows = model_switch.list_picker_providers(current_provider="openrouter", max_models=1)
+    slugs = [r["slug"] for r in rows]
+    assert slugs.count("openrouter") == 1
+    assert slugs.count(OPENROUTER_FREE_PICKER_SLUG) == 1
+
+    free = next(r for r in rows if r["slug"] == OPENROUTER_FREE_PICKER_SLUG)
+    assert free["runtime_slug"] == "openrouter"
+    assert free["models"] == [
+        "nvidia/nemotron-3-ultra-550b-a55b:free",
+        "openrouter/free",
+    ]
+    assert free["total_models"] == 2
+
+
+def test_resolve_provider_full_maps_picker_slug_to_openrouter():
+    from hermes_cli.providers import resolve_provider_full
+
+    pdef = resolve_provider_full("openrouter-free")
+    assert pdef is not None
+    assert pdef.id == "openrouter"
+
+
+def test_openrouter_free_in_curated_snapshot():
+    from hermes_cli.models import OPENROUTER_MODELS
+
+    ids = [mid for mid, _ in OPENROUTER_MODELS]
+    assert "openrouter/free" in ids
+
+
+def test_telegram_switch_uses_runtime_slug_not_display_slug(monkeypatch):
+    import asyncio
+    import sys
+
+    if "telegram" not in sys.modules or not hasattr(sys.modules["telegram"], "__file__"):
+        mod = MagicMock()
+        mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+        mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+        sys.modules.setdefault("telegram", mod)
+        sys.modules.setdefault("telegram.ext", mod)
+        sys.modules.setdefault("telegram.constants", mod)
+        sys.modules.setdefault("telegram.error", SimpleNamespace(
+            NetworkError=type("NetworkError", (OSError,), {}),
+            TimedOut=type("TimedOut", (OSError,), {}),
+            BadRequest=type("BadRequest", (Exception,), {}),
+        ))
+
+    from gateway.config import PlatformConfig
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = AsyncMock()
+    seen = {}
+
+    async def _cb(_chat_id, model_id, provider_slug):
+        seen["model"] = model_id
+        seen["provider"] = provider_slug
+        return "ok"
+
+    adapter._model_picker_state["1"] = {
+        "providers": [{
+            "slug": OPENROUTER_FREE_PICKER_SLUG,
+            "runtime_slug": OPENROUTER_FREE_RUNTIME_SLUG,
+            "name": "OpenRouter Free Models",
+            "models": ["nvidia/nemotron-3-ultra-550b-a55b:free"],
+        }],
+        "selected_provider": OPENROUTER_FREE_PICKER_SLUG,
+        "selected_runtime_slug": "openrouter",
+        "model_list": ["nvidia/nemotron-3-ultra-550b-a55b:free"],
+        "on_model_selected": _cb,
+        "current_model": "x",
+        "current_provider": "openrouter",
+    }
+
+    query = SimpleNamespace(
+        answer=AsyncMock(),
+        edit_message_text=AsyncMock(),
+        from_user=SimpleNamespace(id=1, first_name="t"),
+        message=SimpleNamespace(chat_id=1, chat=SimpleNamespace(type="private"), message_thread_id=None),
+    )
+    monkeypatch.setattr(adapter, "_is_callback_user_authorized", lambda *a, **k: True)
+    asyncio.run(adapter._handle_model_picker_callback(query, "mm:0", "1"))
+
+    assert seen["model"] == "nvidia/nemotron-3-ultra-550b-a55b:free"
+    assert seen["provider"] == "openrouter"
+
+
+def test_tool_support_helper_still_drops_explicit_empty_list():
+    assert _openrouter_model_supports_tools({"supported_parameters": []}) is False
+    assert _openrouter_model_supports_tools({"supported_parameters": ["tools"]}) is True
+    assert _openrouter_model_supports_tools({}) is True

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -154,6 +154,10 @@
           "description": "auto-routes to cheapest coder meeting openrouter.min_coding_score"
         },
         {
+          "id": "openrouter/free",
+          "description": "auto-routes to a free OpenRouter model"
+        },
+        {
           "id": "openrouter/elephant-alpha",
           "description": "free"
         },


### PR DESCRIPTION
## Summary

- Adds a dedicated **OpenRouter Free Models** picker row that lists every live zero-priced, tool-capable OpenRouter model (including `nvidia/*`).
- Uses a unique display slug (`openrouter-free`) and a separate `runtime_slug` of `openrouter`, so Telegram/Discord can show both the curated OpenRouter list and the live-free catalog without treating the free row as a fake provider.
- Adds `openrouter/free` to the curated OpenRouter snapshot / hosted catalog so the official free router is selectable from the normal OpenRouter list.

## Motivation

Hermes's OpenRouter picker is a curated allowlist. The live `/v1/models` filter only keeps IDs already in that list, so newly free models never appear in `/model` (CLI, Telegram, Discord).

Related:
- #39933 / #40717 (`openrouter/free` missing from curated picker)
- #17923 (broader free-model discoverability)
- Salvages the intent of #15178 against current architecture (plugin Telegram adapter, unique picker id vs runtime slug, no NVIDIA exclusion)

## Changes

- `fetch_openrouter_free_models()` — live catalog, zero prompt+completion price, tool-capable (or unknown tools). Cached 1h. NVIDIA kept.
- `picker_runtime_slug()` — display row → runtime provider.
- `list_authenticated_providers` / `list_picker_providers` emit the extra row when OpenRouter credentials exist.
- Telegram + Discord pass `runtime_slug` into `switch_model`.
- CLI `hermes model` gets the same extra row and `_model_flow_openrouter_free`.
- `resolve_provider_full("openrouter-free")` maps to `openrouter`.
- Curated snapshot + `website/static/api/model-catalog.json` include `openrouter/free`.

## Test Plan

- [x] `pytest tests/hermes_cli/test_openrouter_free_model_picker.py tests/hermes_cli/test_list_picker_providers.py tests/hermes_cli/test_models.py -o addopts=` (91 passed)
- [x] `ruff check` on touched files
- [ ] Manual: `hermes model` → OpenRouter Free Models → pick a `:free` model; confirm `model.provider` stays `openrouter`
- [ ] Manual: Telegram `/model` → both OpenRouter and OpenRouter Free Models selectable

## Notes for Reviewers

This is **not** a fake `free` provider. Selecting a free model still resolves as:

- provider: `openrouter`
- model: the chosen OpenRouter id

The curated OpenRouter picker is unchanged except for adding `openrouter/free`. The live-free group is additive.

Teknium's #15178 review asked for:
1. Unique picker identifier separate from runtime slug — done (`openrouter-free` / `runtime_slug=openrouter`)
2. Telegram tests on the plugin adapter — done
3. Keep all zero-priced tool-capable models including NVIDIA — done