### PR TITLE
fix(discord): track handoff-created threads for replies

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7375,6 +7375,21 @@ class DiscordAdapter(BasePlatformAdapter):
         thread_name = (name or "handoff").strip()[:80] or "handoff"
         reason = "Hermes session handoff"
 
+        def _track_created_thread(thread: Any) -> str:
+            thread_id = str(thread.id)
+            try:
+                self._threads.mark(thread_id)
+            except Exception:
+                logger.warning(
+                    "[%s] Handoff thread %s was created, but participation "
+                    "tracking failed; mention-free continuation may not survive "
+                    "a gateway restart",
+                    self.name,
+                    thread_id,
+                    exc_info=True,
+                )
+            return thread_id
+
         # First try: create a thread directly on the channel.
         try:
             create = getattr(parent, "create_thread", None)
@@ -7384,16 +7399,12 @@ class DiscordAdapter(BasePlatformAdapter):
                     auto_archive_duration=1440,
                     reason=reason,
                 )
-                thread_id = str(thread.id)
+                return _track_created_thread(thread)
         except Exception as direct_error:
             logger.debug(
                 "[%s] Handoff thread: direct create failed (%s); trying seed-message fallback",
                 self.name, direct_error,
             )
-        else:
-            if create is not None:
-                self._threads.mark(thread_id)
-                return thread_id
 
         # Fallback: post a seed message and create the thread from it.
         try:
@@ -7406,16 +7417,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 auto_archive_duration=1440,
                 reason=reason,
             )
-            thread_id = str(thread.id)
+            return _track_created_thread(thread)
         except Exception as fallback_error:
             logger.warning(
                 "[%s] Handoff thread: both create paths failed for parent %s: %s",
                 self.name, parent_chat_id, fallback_error,
             )
             return None
-
-        self._threads.mark(thread_id)
-        return thread_id
 
     def _self_contained_prompt_content(
         self, header: str, body: str, *, code_block: bool = False, tail: str = ""

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7384,12 +7384,16 @@ class DiscordAdapter(BasePlatformAdapter):
                     auto_archive_duration=1440,
                     reason=reason,
                 )
-                return str(thread.id)
+                thread_id = str(thread.id)
         except Exception as direct_error:
             logger.debug(
                 "[%s] Handoff thread: direct create failed (%s); trying seed-message fallback",
                 self.name, direct_error,
             )
+        else:
+            if create is not None:
+                self._threads.mark(thread_id)
+                return thread_id
 
         # Fallback: post a seed message and create the thread from it.
         try:
@@ -7402,13 +7406,16 @@ class DiscordAdapter(BasePlatformAdapter):
                 auto_archive_duration=1440,
                 reason=reason,
             )
-            return str(thread.id)
+            thread_id = str(thread.id)
         except Exception as fallback_error:
             logger.warning(
                 "[%s] Handoff thread: both create paths failed for parent %s: %s",
                 self.name, parent_chat_id, fallback_error,
             )
             return None
+
+        self._threads.mark(thread_id)
+        return thread_id
 
     def _self_contained_prompt_content(
         self, header: str, body: str, *, code_block: bool = False, tail: str = ""

--- a/tests/e2e/test_discord_adapter.py
+++ b/tests/e2e/test_discord_adapter.py
@@ -114,6 +114,26 @@ class TestHandoffThreadContinuation:
         assert thread_id == str(thread.id)
         discord_adapter.handle_message.assert_awaited_once()
 
+    async def test_unmentioned_reply_in_untracked_thread_is_rejected(
+        self, discord_adapter, monkeypatch
+    ):
+        monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+        monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "false")
+        discord_adapter._fetch_channel_context = AsyncMock(return_value="")
+        discord_adapter._text_batch_delay_seconds = 0
+        discord_adapter.handle_message = AsyncMock()
+
+        thread = make_fake_thread(thread_id=90003, name="Untracked thread")
+        msg = make_discord_message(
+            content="Do not continue without a mention",
+            channel=thread,
+            mentions=[],
+        )
+
+        await dispatch(discord_adapter, msg)
+
+        discord_adapter.handle_message.assert_not_awaited()
+
 
 class TestAutoThreadingPreservesCommand:
     async def test_command_detected_after_auto_thread(self, discord_adapter, bot_user, monkeypatch):

--- a/tests/e2e/test_discord_adapter.py
+++ b/tests/e2e/test_discord_adapter.py
@@ -80,6 +80,41 @@ class TestMentionStrippedCommandDispatch:
         assert "/new" in response
 
 
+class TestHandoffThreadContinuation:
+    async def test_unmentioned_reply_in_created_thread_is_admitted(
+        self, discord_adapter, monkeypatch
+    ):
+        monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+        monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "false")
+        discord_adapter._fetch_channel_context = AsyncMock(return_value="")
+        discord_adapter._text_batch_delay_seconds = 0
+        discord_adapter.handle_message = AsyncMock()
+
+        thread = make_fake_thread(thread_id=90002, name="Daily brief")
+        parent = thread.parent
+        parent.create_thread = AsyncMock(return_value=thread)
+        parent.send = AsyncMock()
+        discord_adapter._client = SimpleNamespace(
+            user=discord_adapter._client.user,
+            get_channel=lambda _channel_id: parent,
+            fetch_channel=AsyncMock(),
+        )
+
+        thread_id = await discord_adapter.create_handoff_thread(
+            str(parent.id), "Daily brief"
+        )
+        msg = make_discord_message(
+            content="Continue without a mention",
+            channel=thread,
+            mentions=[],
+        )
+
+        await dispatch(discord_adapter, msg)
+
+        assert thread_id == str(thread.id)
+        discord_adapter.handle_message.assert_awaited_once()
+
+
 class TestAutoThreadingPreservesCommand:
     async def test_command_detected_after_auto_thread(self, discord_adapter, bot_user, monkeypatch):
         """@mention /help in channel with auto-thread → thread created AND command dispatched."""

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -450,6 +450,41 @@ async def test_create_handoff_thread_direct_creation_marks_once(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_create_handoff_thread_direct_mark_failure_returns_thread(
+    caplog, monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    thread = SimpleNamespace(id=9001)
+    parent = SimpleNamespace(
+        create_thread=AsyncMock(return_value=thread),
+        send=AsyncMock(),
+    )
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    monkeypatch.setattr(
+        adapter,
+        "_client",
+        SimpleNamespace(
+            get_channel=lambda _channel_id: parent,
+            fetch_channel=AsyncMock(),
+        ),
+    )
+    save = MagicMock(side_effect=OSError("disk full"))
+    monkeypatch.setattr(adapter._threads, "_save", save)
+
+    with caplog.at_level("WARNING"):
+        thread_id = await adapter.create_handoff_thread("123", "Daily brief")
+
+    assert thread_id == "9001"
+    save.assert_called_once_with()
+    assert "9001" in adapter._threads
+    parent.create_thread.assert_awaited_once()
+    parent.send.assert_not_awaited()
+    assert "Handoff thread 9001 was created" in caplog.text
+    assert "participation tracking failed" in caplog.text
+    assert "OSError: disk full" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_create_handoff_thread_fallback_creation_marks_once(monkeypatch):
     thread = SimpleNamespace(id=9002)
     seed = SimpleNamespace(create_thread=AsyncMock(return_value=thread))
@@ -464,6 +499,31 @@ async def test_create_handoff_thread_fallback_creation_marks_once(monkeypatch):
     assert thread_id == "9002"
     mark.assert_called_once_with("9002")
     seed.create_thread.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_handoff_thread_fallback_mark_failure_returns_thread(
+    caplog, monkeypatch
+):
+    thread = SimpleNamespace(id=9002)
+    seed = SimpleNamespace(create_thread=AsyncMock(return_value=thread))
+    parent = SimpleNamespace(
+        create_thread=AsyncMock(side_effect=RuntimeError("direct denied")),
+        send=AsyncMock(return_value=seed),
+    )
+    adapter, mark = _handoff_adapter(parent, monkeypatch)
+    mark.side_effect = OSError("disk full")
+
+    with caplog.at_level("WARNING"):
+        thread_id = await adapter.create_handoff_thread("123", "Daily brief")
+
+    assert thread_id == "9002"
+    mark.assert_called_once_with("9002")
+    parent.create_thread.assert_awaited_once()
+    parent.send.assert_awaited_once()
+    seed.create_thread.assert_awaited_once()
+    assert "Handoff thread 9002 was created" in caplog.text
+    assert "participation tracking failed" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -418,3 +418,66 @@ async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch
     assert isinstance(thread_kwargs.get("files"), list) and len(thread_kwargs["files"]) == 1
 
 
+def _handoff_adapter(parent, monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    monkeypatch.setattr(
+        adapter,
+        "_client",
+        SimpleNamespace(
+            get_channel=lambda _channel_id: parent,
+            fetch_channel=AsyncMock(),
+        ),
+    )
+    mark = MagicMock()
+    monkeypatch.setattr(adapter._threads, "mark", mark)
+    return adapter, mark
+
+
+@pytest.mark.asyncio
+async def test_create_handoff_thread_direct_creation_marks_once(monkeypatch):
+    thread = SimpleNamespace(id=9001)
+    parent = SimpleNamespace(
+        create_thread=AsyncMock(return_value=thread),
+        send=AsyncMock(),
+    )
+    adapter, mark = _handoff_adapter(parent, monkeypatch)
+
+    thread_id = await adapter.create_handoff_thread("123", "Daily brief")
+
+    assert thread_id == "9001"
+    mark.assert_called_once_with("9001")
+    parent.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_handoff_thread_fallback_creation_marks_once(monkeypatch):
+    thread = SimpleNamespace(id=9002)
+    seed = SimpleNamespace(create_thread=AsyncMock(return_value=thread))
+    parent = SimpleNamespace(
+        create_thread=AsyncMock(side_effect=RuntimeError("direct denied")),
+        send=AsyncMock(return_value=seed),
+    )
+    adapter, mark = _handoff_adapter(parent, monkeypatch)
+
+    thread_id = await adapter.create_handoff_thread("123", "Daily brief")
+
+    assert thread_id == "9002"
+    mark.assert_called_once_with("9002")
+    seed.create_thread.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_handoff_thread_failure_does_not_mark(monkeypatch):
+    seed = SimpleNamespace(
+        create_thread=AsyncMock(side_effect=RuntimeError("fallback denied"))
+    )
+    parent = SimpleNamespace(
+        create_thread=AsyncMock(side_effect=RuntimeError("direct denied")),
+        send=AsyncMock(return_value=seed),
+    )
+    adapter, mark = _handoff_adapter(parent, monkeypatch)
+
+    thread_id = await adapter.create_handoff_thread("123", "Daily brief")
+
+    assert thread_id is None
+    mark.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

`DiscordAdapter.create_handoff_thread()` did not register successfully created Discord threads in the existing `ThreadParticipationTracker`.

With `require_mention=true` and `thread_require_mention=false`, the first ordinary, unmentioned message in a handoff-created thread could therefore be rejected. This change records both direct-created and seed-fallback-created threads before returning them.

Thread creation remains authoritative over bookkeeping: if participation-tracker persistence fails after Discord creates the thread, Hermes logs a warning (including the thread ID, traceback, and restart-durability consequence) and still returns the real thread ID. It does not report a false creation failure or attempt a duplicate fallback thread.

Failed and unsupported creation attempts remain untracked. No configuration change is required.

## Related Issue

Related PR: #63459

Based on work by @SEStarkman in #63459, especially commit [9d269402d5](https://github.com/NousResearch/hermes-agent/commit/9d269402d5183cab3f5f4fe8857d7aa1d9c651e8). This PR ports the tracking behavior onto current main's direct-first/fallback implementation.

It intentionally does **not** change creation order, stale-seed cleanup, Discord public/private thread behavior, or thread discoverability. Those broader changes remain separate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `plugins/platforms/discord/adapter.py`
  - Track successful direct and seed-fallback handoff-thread creation.
  - Catch tracker failures, warn, and return the successfully created Discord thread ID.
- `tests/gateway/test_discord_send.py`
  - Cover successful direct/fallback tracking, failed creation, and tracker failures after both creation paths without duplicate creation.
  - Exercise a real tracker `_save()` failure and verify the in-memory mark remains usable.
- `tests/e2e/test_discord_adapter.py`
  - Verify an unmentioned message in a tracked handoff thread is admitted.
  - Verify the same message in an untracked thread remains rejected.

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_discord_send.py tests/e2e/test_discord_adapter.py -q
scripts/run_tests.sh tests/gateway tests/e2e/test_discord_adapter.py -q
scripts/run_tests.sh
ruff check .
python scripts/check-windows-footguns.py --all
git diff --check upstream/main...HEAD
python3 scripts/audit_pr_attribution.py
```

Automated evidence:

- PR head: `8fcbb1374fbd68b7340bfa0b0c44cfade98a0bfd`.
- Current upstream/main: `13f4cfebfafbce8ac9d1bf29f66731858ed638b5`.
- Local current-main integration tested: `6a46804520d589656972812e750ca88f10bd2851`.
- GitHub merge result: `05243f87a727a7bedd3c072865c6f7cb801fdc1c`; it has the two SHAs above as parents and the same tree as the tested local integration.
- Focused regressions: **25 passed**.
- Relevant Discord/gateway suite: **6,112 passed, 4 failed, 30 skipped**. All four failures reproduce unchanged on the exact current upstream/main SHA in this macOS environment.
- Complete repository suite: **36,688 passed, 43 failed, 307 skipped** across 3,181 files; one additional file failed once and passed on the runner's retry.
  - 41 of the 43 final failures reproduce unchanged on exact current upstream/main.
  - The other two are timing-sensitive under full-suite load and pass in isolated reruns on both current main and the integration commit (**12/12 passed** on each).
  - The failures are outside this PR's three changed files and cover macOS/Linux path or socket assumptions, missing optional lazy-installed SDKs under the installed policy, host-specific command behavior, active-service discovery, and unrelated timing/config-state tests.
- `ruff check .`: passed (with two pre-existing invalid-`noqa` warnings).
- Windows-footgun scan: passed (**1,003 files scanned**).
- PR-only `git diff --check`: passed.
- Contributor-attribution audit: passed.

Manual Discord evidence:

- Tested through the standard installed gateway with the current-main integration SHA above.
- With `require_mention=true` and `thread_require_mention=false`, the first message sent in the handoff-created thread—without a mention and without replying to the bot—received a response and correctly recalled `BLUE-COMET-90348`.
- Discord required the direct thread link to locate the created thread. Discoverability and public/private-thread behavior are unchanged by this PR and intentionally out of scope.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs; #63459 is credited and the narrower scope is explained above.
- [x] My PR contains only changes related to this fix.
- [x] I've run the complete repository suite; all PR-relevant tests pass, with baseline/transient failures documented above.
- [x] I've added tests for the bug and both reviewer-requested edge cases.
- [x] I've tested on macOS.

### Documentation & Housekeeping

- [x] Documentation changes are not required for this runtime-only bug fix.
- [x] No configuration keys were added or changed.
- [x] No architecture or workflow documentation changes are required.
- [x] Cross-platform checks were considered and the Windows-footgun scan passed.
- [x] No tool descriptions or schemas changed.

## Screenshots / Logs

Not applicable. Automated regressions and a live Discord test are summarized above.