### PR TITLE
feat(security): add Jarvis Phase 1 capability boundary

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1092,6 +1092,11 @@ def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
 
     Returns dict with {accessToken, refreshToken?, expiresAt?, source} or None.
     """
+    from hermes_cli.phase1_capability import (
+        require_persistent_credential_expansion_allowed,
+    )
+
+    require_persistent_credential_expansion_allowed("Claude Code credentials")
     kc_creds = _read_claude_code_credentials_from_keychain()
     file_creds = _read_claude_code_credentials_from_file()
 
@@ -1664,6 +1669,11 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
 
 def read_hermes_oauth_credentials() -> Optional[Dict[str, Any]]:
     """Read Hermes-managed OAuth credentials from ~/.hermes/.anthropic_oauth.json."""
+    from hermes_cli.phase1_capability import (
+        require_persistent_credential_expansion_allowed,
+    )
+
+    require_persistent_credential_expansion_allowed("Anthropic OAuth credentials")
     oauth_file = _get_hermes_oauth_file()
     if oauth_file.exists():
         try:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2448,6 +2448,11 @@ def _read_nous_auth() -> Optional[dict]:
     Returns the provider state dict if Nous is active with tokens,
     otherwise None.
     """
+    from hermes_cli.phase1_capability import phase1_capability_mode_enabled
+
+    if phase1_capability_mode_enabled():
+        return None
+
     pool_present, entry = _select_pool_entry("nous")
     if pool_present:
         if entry is None:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -3130,6 +3130,11 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
 
 
 def load_pool(provider: str) -> CredentialPool:
+    from hermes_cli.phase1_capability import (
+        require_persistent_credential_expansion_allowed,
+    )
+
+    require_persistent_credential_expansion_allowed("credential pool")
     provider = (provider or "").strip().lower()
     raw_entries = read_credential_pool(provider)
     disk_ids = {

--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -28,6 +28,11 @@ from contextvars import ContextVar, Token
 from pathlib import Path
 from typing import Dict, Mapping, Optional
 
+from hermes_cli.phase1_capability import (
+    phase1_capability_mode_enabled,
+    require_persistent_credential_expansion_allowed,
+)
+
 
 # ── multiplex-active flag ────────────────────────────────────────────────
 # Process-global: set once at gateway startup when gateway.multiplex_profiles
@@ -238,6 +243,7 @@ def load_env_file(env_path: Path) -> Dict[str, str]:
     PowerShell ``Set-Content -Encoding UTF8``) does not prefix the first
     key as ``\\ufeffNAME`` and make ``get_secret('NAME')`` miss under scope.
     """
+    require_persistent_credential_expansion_allowed("profile dotenv")
     secrets: Dict[str, str] = {}
     try:
         text = env_path.read_text(encoding="utf-8-sig")
@@ -276,6 +282,9 @@ def build_profile_secret_scope(hermes_home: Path) -> Dict[str, str]:
     global vars are intentionally NOT copied in — ``get_secret`` reads those
     from ``os.environ`` directly, so the scope holds only profile secrets.
     """
+    if phase1_capability_mode_enabled():
+        return dict(os.environ)
+
     home = Path(hermes_home)
     secrets = load_env_file(home / ".env")
 

--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -449,6 +449,11 @@ def apply_all(secrets_cfg: dict, home_path: Path,
     preserve / claimed / override guards and is disabled with
     ``secrets.profile_alias: false``.
     """
+    from hermes_cli.phase1_capability import (
+        require_persistent_credential_expansion_allowed,
+    )
+
+    require_persistent_credential_expansion_allowed("external secret sources")
     import os as _os
 
     env = environ if environ is not None else _os.environ

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -47,6 +47,8 @@ from pathlib import Path
 from datetime import datetime, timedelta, timezone
 from typing import Awaitable, Callable, Dict, Optional, Any, List, Tuple, Union, cast
 
+from hermes_cli import phase1_capability as _phase1_capability  # noqa: F401
+
 from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
 from agent.conversation_compression import (
     COMPACTION_STATUS,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -678,6 +678,17 @@ def _resolve_api_key_provider_secret(
     provider_id: str, pconfig: ProviderConfig
 ) -> tuple[str, str]:
     """Resolve an API-key provider's token and indicate where it came from."""
+    from hermes_cli.phase1_capability import phase1_capability_mode_enabled
+
+    if phase1_capability_mode_enabled():
+        from agent.secret_scope import get_secret
+
+        for env_var in pconfig.api_key_env_vars:
+            val = (get_secret(env_var) or "").strip()
+            if has_usable_secret(val):
+                return val, env_var
+        return "", ""
+
     if provider_id == "copilot":
         # Use the dedicated copilot auth module for proper token validation
         try:
@@ -1278,6 +1289,11 @@ def _auth_store_lock(
 
 
 def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
+    from hermes_cli.phase1_capability import (
+        require_persistent_credential_expansion_allowed,
+    )
+
+    require_persistent_credential_expansion_allowed("auth store")
     auth_file = auth_file or _auth_file_path()
     if not auth_file.exists():
         return {"version": AUTH_STORE_VERSION, "providers": {}}
@@ -2204,6 +2220,23 @@ def resolve_provider(
         _scoped_key_env("OPENROUTER_API_KEY")
     ):
         return "openrouter"
+
+    from hermes_cli.phase1_capability import phase1_capability_mode_enabled
+
+    if phase1_capability_mode_enabled():
+        for pid, pconfig in PROVIDER_REGISTRY.items():
+            if pconfig.auth_type != "api_key" or pid in {"copilot", "lmstudio"}:
+                continue
+            if any(
+                has_usable_secret(_scoped_key_env(env_var))
+                for env_var in pconfig.api_key_env_vars
+            ):
+                return pid
+        raise AuthError(
+            "No inherited inference credential is available in Jarvis Phase 1 "
+            "capability mode",
+            code="phase1_capability_boundary",
+        )
 
     # Auto-detect an OpenRouter credential added via `hermes auth add openrouter`
     # (manual pool entry, no env var). Without this, a key that only lives in

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3924,6 +3924,11 @@ def load_env() -> Dict[str, str]:
     menu paint on top of the OAuth-refresh slowness. The mtime check
     invalidates the cache when the user edits .env mid-process.
     """
+    from hermes_cli.phase1_capability import (
+        require_persistent_credential_expansion_allowed,
+    )
+
+    require_persistent_credential_expansion_allowed("user dotenv")
     global _env_cache
     env_path = get_env_path()
 
@@ -4360,6 +4365,10 @@ def reload_env() -> int:
     the .env file (but only vars known to Hermes — OPTIONAL_ENV_VARS and
     _EXTRA_ENV_KEYS — to avoid clobbering unrelated environment).
     """
+    from hermes_cli.phase1_capability import phase1_capability_mode_enabled
+
+    if phase1_capability_mode_enabled():
+        return 0
     env_vars = load_env()
     known_keys = set(OPTIONAL_ENV_VARS.keys()) | _EXTRA_ENV_KEYS
     count = 0
@@ -4407,6 +4416,11 @@ def get_env_value(key: str) -> Optional[str]:
     if val is not None:
         return val
 
+    from hermes_cli.phase1_capability import phase1_capability_mode_enabled
+
+    if phase1_capability_mode_enabled():
+        return None
+
     # Then check .env file
     env_vars = load_env()
     return env_vars.get(key)
@@ -4426,6 +4440,16 @@ def get_env_value_prefer_dotenv(key: str) -> Optional[str]:
     is scope-checked rather than leaking another profile's raw ``os.environ``
     value — matching the credential-pool seeding path's behaviour.
     """
+    from hermes_cli.phase1_capability import phase1_capability_mode_enabled
+
+    if phase1_capability_mode_enabled():
+        try:
+            from agent.secret_scope import get_secret as _get_secret
+
+            return _get_secret(key)
+        except Exception:
+            return os.environ.get(key)
+
     env_vars = load_env()
     val = env_vars.get(key)
     if val:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -9,6 +9,10 @@ import sys
 import threading
 from pathlib import Path
 
+from hermes_cli.phase1_capability import (
+    phase1_capability_mode_enabled,
+    require_persistent_credential_expansion_allowed,
+)
 from dotenv import load_dotenv
 from utils import atomic_replace, fast_safe_load
 
@@ -181,12 +185,15 @@ def hydrate_profile_secret_sources(
     values actually contributed by external sources, never the profile's
     plaintext ``.env`` entries.
     """
+    if phase1_capability_mode_enabled():
+        return {}
     with _SECRET_SOURCE_CACHE_LOCK:
         return _hydrate_profile_secret_sources(Path(hermes_home))
 
 
 def _hydrate_profile_secret_sources(home: Path) -> dict[str, str]:
     """Locked implementation for :func:`hydrate_profile_secret_sources`."""
+    require_persistent_credential_expansion_allowed("profile secret sources")
     home_key = str(home.resolve())
     if home_key in _APPLIED_HOMES:
         return get_secret_source_values(home)
@@ -484,6 +491,9 @@ def load_hermes_dotenv(
       ``load_external_secrets=False`` to avoid loading optional secret-manager
       dependencies into the process that replaces that same environment.
     """
+    if phase1_capability_mode_enabled():
+        return []
+
     loaded: list[Path] = []
 
     home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
@@ -599,6 +609,7 @@ def _apply_managed_env() -> None:
     Fail-open: a missing managed dir or .env is the common case and a no-op; any
     error here is swallowed so managed scope can never block startup.
     """
+    require_persistent_credential_expansion_allowed("managed-scope environment")
     try:
         from hermes_cli import managed_scope
 
@@ -637,6 +648,7 @@ def _apply_external_secret_sources(home_path: Path) -> None:
     ``reset_secret_source_cache()`` if you need to force a re-pull
     (tests, long-running processes after a config change).
     """
+    require_persistent_credential_expansion_allowed("external secret sources")
     home_key = str(Path(home_path).resolve())
     if home_key in _APPLIED_HOMES:
         return

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -80,6 +80,7 @@ import sys
 _bootstrap_root = os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir))
 if _bootstrap_root not in sys.path:
     sys.path.insert(0, _bootstrap_root)
+from hermes_cli import phase1_capability as _phase1_capability  # noqa: E402, F401
 from hermes_cli import _startup_fast  # noqa: E402
 
 # Early venv self-heal — MUST run before any third-party import below.  When
@@ -1013,6 +1014,14 @@ def _has_any_provider_configured() -> bool:
             provider_env_vars.update(pconfig.api_key_env_vars)
     if any(os.getenv(v) for v in provider_env_vars):
         return True
+
+    if _phase1_capability.phase1_capability_mode_enabled():
+        if not isinstance(model_cfg, dict):
+            return False
+        return bool(
+            str(model_cfg.get("provider") or "").strip()
+            or str(model_cfg.get("base_url") or "").strip()
+        )
 
     # Check .env file for keys
     env_file = get_env_path()

--- a/hermes_cli/phase1_capability.py
+++ b/hermes_cli/phase1_capability.py
@@ -1,0 +1,48 @@
+"""Jarvis Phase 1 inherited-environment credential boundary.
+
+This module is deliberately stdlib-only and safe to import before dotenv,
+configuration, plugin, provider, or credential-store modules. The decision is
+snapshotted once at import time so a later dotenv load or in-process mutation
+cannot change the boundary after startup.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+PHASE1_CAPABILITY_MODE_ENV = "HERMES_PHASE1_CAPABILITY_MODE"
+
+
+class Phase1CapabilityModeError(RuntimeError):
+    """Raised when the Phase 1 boundary is invalid or would be crossed."""
+
+
+def _parse_phase1_capability_mode(raw: str | None) -> bool:
+    if raw is None or raw.strip().lower() in {"", "0", "false", "no", "off"}:
+        return False
+    if raw.strip() == "1":
+        return True
+    raise Phase1CapabilityModeError(
+        f"{PHASE1_CAPABILITY_MODE_ENV} must be 1 when enabled "
+        "(or unset/0/false/no/off when disabled)"
+    )
+
+
+_PHASE1_CAPABILITY_MODE = _parse_phase1_capability_mode(
+    os.environ.get(PHASE1_CAPABILITY_MODE_ENV)
+)
+
+
+def phase1_capability_mode_enabled() -> bool:
+    """Return the immutable startup decision for this process."""
+    return _PHASE1_CAPABILITY_MODE
+
+
+def require_persistent_credential_expansion_allowed(source: str) -> None:
+    """Fail closed if *source* would expand inherited capabilities."""
+    if _PHASE1_CAPABILITY_MODE:
+        raise Phase1CapabilityModeError(
+            "Jarvis Phase 1 capability mode forbids persistent credential "
+            f"expansion from {source}"
+        )

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -639,6 +639,10 @@ def _try_resolve_from_custom_pool(
     provider_name: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Check if a credential pool exists for a custom endpoint and return a runtime dict if so."""
+    from hermes_cli.phase1_capability import phase1_capability_mode_enabled
+
+    if phase1_capability_mode_enabled():
+        return None
     pool_key = get_custom_provider_pool_key(base_url, provider_name=provider_name)
     if not pool_key:
         return None
@@ -697,12 +701,19 @@ def _lift_extra_headers(entry: Dict[str, Any], result: Dict[str, Any]) -> None:
     SECURITY: header values routinely carry credentials (Cloudflare Access
     service tokens, proxy auth, custom bearer schemes). Never log them.
     """
+    from hermes_cli.phase1_capability import phase1_capability_mode_enabled
+
+    if phase1_capability_mode_enabled():
+        return
     extra_headers = normalize_extra_headers(entry.get("extra_headers"))
     if extra_headers:
         result["extra_headers"] = extra_headers
 
 
 def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, Any]]:
+    from hermes_cli.phase1_capability import phase1_capability_mode_enabled
+
+    phase1_mode = phase1_capability_mode_enabled()
     requested_norm = _normalize_custom_provider_name(requested_provider or "")
     if not requested_norm:
         return None
@@ -762,7 +773,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             ).strip()
             resolved_api_key = _getenv(key_env, "").strip() if key_env else ""
             # Fall back to inline api_key when key_env is absent or unresolvable
-            if not resolved_api_key:
+            if not resolved_api_key and not phase1_mode:
                 resolved_api_key = str(entry.get("api_key", "") or "").strip()
 
             display_name = entry.get("name", "")
@@ -779,6 +790,8 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                         "api_key": resolved_api_key,
                         "model": entry.get("default_model", ""),
                     }
+                    if key_env:
+                        result["key_env"] = key_env
                     extra_body = entry.get("extra_body")
                     if isinstance(extra_body, dict):
                         result["extra_body"] = dict(extra_body)
@@ -787,7 +800,11 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     # short-lived bearers instead of static keys. Propagated
                     # raw; wrapped in a per-request token provider at
                     # resolution.
-                    key_cmd = str(entry.get("key_cmd", "") or "").strip()
+                    key_cmd = (
+                        ""
+                        if phase1_mode
+                        else str(entry.get("key_cmd", "") or "").strip()
+                    )
                     if key_cmd:
                         result["key_cmd"] = key_cmd
                     # The v11→v12 migration writes the API mode under the new
@@ -830,7 +847,11 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         result = {
             "name": name.strip(),
             "base_url": base_url.strip(),
-            "api_key": str(entry.get("api_key", "") or "").strip(),
+            "api_key": (
+                ""
+                if phase1_mode
+                else str(entry.get("api_key", "") or "").strip()
+            ),
         }
         key_env = str(entry.get("key_env", "") or "").strip()
         if key_env:
@@ -1097,6 +1118,9 @@ def _resolve_named_custom_runtime(
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
+    from hermes_cli.phase1_capability import phase1_capability_mode_enabled
+
+    phase1_mode = phase1_capability_mode_enabled()
     # Bare `provider="custom"` with an explicit base_url (e.g. propagated
     # from a `model_aliases:` direct-alias resolution) — build a runtime
     # directly so the alias's base_url actually takes effect.
@@ -1186,7 +1210,11 @@ def _resolve_named_custom_runtime(
     _cp_is_openrouter   = base_url_host_matches(base_url, "openrouter.ai")
     api_key_candidates = [
         (explicit_api_key or "").strip(),
-        str(custom_provider.get("api_key", "") or "").strip(),
+        (
+            ""
+            if phase1_mode
+            else str(custom_provider.get("api_key", "") or "").strip()
+        ),
         _getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
         # Gate provider env keys on their authoritative hosts — sending
         # OPENAI_API_KEY to a local-llm endpoint leaks credentials (#28660).
@@ -1203,7 +1231,9 @@ def _resolve_named_custom_runtime(
     # mid-session and 401. Both wire clients already accept a callable api_key
     # (the Entra ID contract) and invoke it per request. An explicit --api-key
     # still wins — it is the one-off recovery escape hatch.
-    key_cmd = str(custom_provider.get("key_cmd", "") or "").strip()
+    key_cmd = (
+        "" if phase1_mode else str(custom_provider.get("key_cmd", "") or "").strip()
+    )
     if key_cmd and not has_usable_secret((explicit_api_key or "").strip()):
         from agent.command_token_source import build_command_token_provider
 
@@ -1231,7 +1261,7 @@ def _resolve_named_custom_runtime(
         result["max_output_tokens"] = custom_provider["max_output_tokens"]
     # Per-provider extra HTTP headers (proxies, gateways, custom auth).
     # Values may carry credentials — NEVER log them.
-    if custom_provider.get("extra_headers"):
+    if custom_provider.get("extra_headers") and not phase1_mode:
         result["extra_headers"] = dict(custom_provider["extra_headers"])
     request_overrides = _custom_provider_request_overrides(custom_provider)
     if request_overrides:
@@ -1248,12 +1278,15 @@ def _resolve_openrouter_runtime(
     model_cfg = _get_model_config()
     cfg_base_url = model_cfg.get("base_url") if isinstance(model_cfg.get("base_url"), str) else ""
     cfg_provider = model_cfg.get("provider") if isinstance(model_cfg.get("provider"), str) else ""
+    from hermes_cli.phase1_capability import phase1_capability_mode_enabled
+
     cfg_api_key = ""
-    for k in ("api_key", "api"):
-        v = model_cfg.get(k)
-        if isinstance(v, str) and v.strip():
-            cfg_api_key = v.strip()
-            break
+    if not phase1_capability_mode_enabled():
+        for k in ("api_key", "api"):
+            v = model_cfg.get(k)
+            if isinstance(v, str) and v.strip():
+                cfg_api_key = v.strip()
+                break
     requested_norm = (requested_provider or "").strip().lower()
     cfg_provider = cfg_provider.strip().lower()
     # GitHub #27132: provider aliases that resolve to "custom" (ollama,
@@ -1467,6 +1500,15 @@ def _resolve_azure_foundry_runtime(
     # are identical — return the callable api_key and let the
     # downstream SDK wrapper handle the contract difference.
     if cfg_auth_mode == "entra_id":
+        from hermes_cli.phase1_capability import phase1_capability_mode_enabled
+
+        if phase1_capability_mode_enabled() and not explicit_api_key:
+            raise AuthError(
+                "Azure Foundry Entra ID credential expansion is disabled in "
+                "Jarvis Phase 1 capability mode",
+                provider="azure-foundry",
+                code="phase1_capability_boundary",
+            )
         if explicit_api_key:
             # User passed --api-key on the CLI while config says entra_id —
             # honour the explicit string (escape hatch for one-off testing).
@@ -1740,6 +1782,8 @@ def resolve_runtime_provider(
     persisted default. Other callers can leave it None to preserve existing
     behavior (api_mode derived from config).
     """
+    from hermes_cli.phase1_capability import phase1_capability_mode_enabled
+
     requested_provider = resolve_requested_provider(requested)
 
     # Honour ``providers.<name>.enabled: false`` for BOTH user-defined
@@ -1762,6 +1806,30 @@ def resolve_runtime_provider(
                 f"provider {requested_provider!r} is disabled in config "
                 f"(providers.{requested_provider}.enabled: false)"
             )
+
+    if phase1_capability_mode_enabled() and requested_provider in {
+        "vertex",
+        "google-vertex",
+        "vertex-ai",
+        "gcp-vertex",
+        "vertexai",
+        "bedrock",
+        "aws",
+        "aws-bedrock",
+        "amazon-bedrock",
+        "amazon",
+        "openai-codex",
+        "xai-oauth",
+        "qwen-oauth",
+        "minimax-oauth",
+        "copilot-acp",
+    }:
+        raise AuthError(
+            f"Provider '{requested_provider}' requires credential expansion "
+            "that is disabled in Jarvis Phase 1 capability mode",
+            provider=requested_provider,
+            code="phase1_capability_boundary",
+        )
 
     if requested_provider == "moa":
         return {
@@ -1924,10 +1992,13 @@ def resolve_runtime_provider(
             and not has_runtime_override
         )
 
-    try:
-        pool = load_pool(provider) if should_use_pool else None
-    except Exception:
+    if phase1_capability_mode_enabled():
         pool = None
+    else:
+        try:
+            pool = load_pool(provider) if should_use_pool else None
+        except Exception:
+            pool = None
     if pool and pool.has_credentials():
         entry = pool.select()
         pool_api_key = ""
@@ -2137,7 +2208,7 @@ def resolve_runtime_provider(
                         break
             # Next: an inline api_key on the model config (useful in multi-profile
             # setups that want to avoid env-var juggling).
-            if not token:
+            if not token and not phase1_capability_mode_enabled():
                 token = str(model_cfg.get("api_key") or "").strip()
             # Finally fall back to the historical fixed names.
             if not token:
@@ -2152,13 +2223,29 @@ def resolve_runtime_provider(
                     "config.yaml model section at a custom env var."
                 )
         else:
-            from agent.anthropic_adapter import resolve_anthropic_token
-            token = resolve_anthropic_token()
-            if not token:
-                raise AuthError(
-                    "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
-                    "run 'claude setup-token', or authenticate with 'claude /login'."
+            if phase1_capability_mode_enabled():
+                token = (
+                    _getenv("ANTHROPIC_TOKEN", "").strip()
+                    or _getenv("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
+                    or _getenv("ANTHROPIC_API_KEY", "").strip()
                 )
+                if not token:
+                    raise AuthError(
+                        "No inherited Anthropic credential is available in "
+                        "Jarvis Phase 1 capability mode",
+                        provider="anthropic",
+                        code="missing_api_key",
+                    )
+            else:
+                from agent.anthropic_adapter import resolve_anthropic_token
+
+                token = resolve_anthropic_token()
+                if not token:
+                    raise AuthError(
+                        "No Anthropic credentials found. Set ANTHROPIC_TOKEN or "
+                        "ANTHROPIC_API_KEY, run 'claude setup-token', or "
+                        "authenticate with 'claude /login'."
+                    )
         return {
             "provider": "anthropic",
             "api_mode": "anthropic_messages",

--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -248,11 +248,15 @@ def _load_hermes_env() -> None:
     intentionally reimplement the minimum needed here so ``hermes send``
     doesn't pull in the full gateway module just to resolve a home channel.
     """
+    from hermes_cli.phase1_capability import phase1_capability_mode_enabled
+
     # Step 1: dotenv
-    try:
-        from dotenv import load_dotenv
-    except Exception:
-        load_dotenv = None  # type: ignore[assignment]
+    load_dotenv = None
+    if not phase1_capability_mode_enabled():
+        try:
+            from dotenv import load_dotenv
+        except Exception:
+            load_dotenv = None  # type: ignore[assignment]
 
     try:
         from hermes_cli.config import get_hermes_home

--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -33,11 +33,13 @@ from datetime import datetime
 from typing import List, Dict, Any, Optional
 
 import fire
+from hermes_cli.phase1_capability import phase1_capability_mode_enabled
 from dotenv import load_dotenv
 from agent.tool_dispatch_helpers import make_tool_result_message
 
 # Load environment variables
-load_dotenv()
+if not phase1_capability_mode_enabled():
+    load_dotenv()
 
 
 def _effective_temperature_for_model(

--- a/scripts/sample_and_compress.py
+++ b/scripts/sample_and_compress.py
@@ -22,8 +22,11 @@ from typing import List, Dict, Any, Tuple
 import fire
 
 # Load environment variables
+from hermes_cli.phase1_capability import phase1_capability_mode_enabled
 from dotenv import load_dotenv
-load_dotenv()
+
+if not phase1_capability_mode_enabled():
+    load_dotenv()
 
 
 # Default datasets to sample from

--- a/tests/hermes_cli/test_phase1_capability_mode.py
+++ b/tests/hermes_cli/test_phase1_capability_mode.py
@@ -1,0 +1,285 @@
+"""Jarvis Phase 1 inherited-environment capability boundary tests."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_isolated(
+    code: str,
+    *,
+    mode: str,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HERMES_PHASE1_CAPABILITY_MODE"] = mode
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_phase1_uses_only_inherited_capabilities_and_opens_no_persistent_sources(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    managed = tmp_path / "managed"
+    for directory in (home, project, managed):
+        directory.mkdir()
+
+    (home / ".env").write_text(
+        "OPENROUTER_API_KEY=jarvis-file-provider-sentinel\n"
+        "JARVIS_FILE_ONLY_SENTINEL=jarvis-file-only-sentinel\n",
+        encoding="utf-8",
+    )
+    (project / ".env").write_text(
+        "JARVIS_PROJECT_SENTINEL=jarvis-project-sentinel\n",
+        encoding="utf-8",
+    )
+    (home / ".op.env").write_text(
+        "OP_SERVICE_ACCOUNT_TOKEN=jarvis-op-sentinel\n",
+        encoding="utf-8",
+    )
+    (managed / ".env").write_text(
+        "JARVIS_MANAGED_SENTINEL=jarvis-managed-sentinel\n",
+        encoding="utf-8",
+    )
+    (home / "auth.json").write_text(
+        '{"credential_pool":{"openrouter":[{"access_token":"jarvis-pool-sentinel"}]}}',
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: openrouter\n"
+        "providers:\n"
+        "  jarvis-sentinel-custom:\n"
+        "    name: jarvis-sentinel-custom\n"
+        "    base_url: https://jarvis-sentinel.invalid/v1\n"
+        "    key_env: JARVIS_CUSTOM_PROVIDER_KEY\n"
+        "    api_key: jarvis-config-provider-sentinel\n"
+        "    extra_headers:\n"
+        "      Authorization: jarvis-config-header-sentinel\n"
+        "secrets:\n"
+        "  sentinel_source:\n"
+        "    enabled: true\n",
+        encoding="utf-8",
+    )
+
+    result = _run_isolated(
+        """
+        import builtins
+        import os
+        from pathlib import Path
+        import subprocess
+        import sys
+
+        home = Path(os.environ["JARVIS_TEST_HOME"])
+        project_env = Path(os.environ["JARVIS_TEST_PROJECT_ENV"])
+        managed_env = Path(os.environ["JARVIS_TEST_MANAGED_ENV"])
+        blocked = {
+            (home / ".env").resolve(),
+            project_env.resolve(),
+            (home / ".op.env").resolve(),
+            managed_env.resolve(),
+            (home / "auth.json").resolve(),
+        }
+
+        original_open = builtins.open
+        original_path_open = Path.open
+
+        def _blocked_path(value):
+            try:
+                return Path(value).resolve() in blocked
+            except (OSError, TypeError, ValueError):
+                return False
+
+        def guarded_open(file, *args, **kwargs):
+            if _blocked_path(file):
+                raise AssertionError(f"persistent credential path opened: {Path(file).name}")
+            return original_open(file, *args, **kwargs)
+
+        def guarded_path_open(self, *args, **kwargs):
+            if _blocked_path(self):
+                raise AssertionError(f"persistent credential path opened: {self.name}")
+            return original_path_open(self, *args, **kwargs)
+
+        builtins.open = guarded_open
+        Path.open = guarded_path_open
+
+        from hermes_cli.phase1_capability import (
+            Phase1CapabilityModeError,
+            phase1_capability_mode_enabled,
+        )
+        assert phase1_capability_mode_enabled()
+
+        import hermes_cli.env_loader as env_loader
+        env_loader._apply_external_secret_sources = lambda *_a, **_kw: (_ for _ in ()).throw(
+            AssertionError("external source applied")
+        )
+        env_loader._apply_managed_env = lambda: (_ for _ in ()).throw(
+            AssertionError("managed environment applied")
+        )
+
+        assert env_loader.load_hermes_dotenv(
+            hermes_home=home,
+            project_env=project_env,
+        ) == []
+        assert env_loader.hydrate_profile_secret_sources(home) == {}
+
+        from agent.secret_scope import build_profile_secret_scope, get_secret
+        scope = build_profile_secret_scope(home)
+        assert scope["OPENROUTER_API_KEY"] == os.environ["OPENROUTER_API_KEY"]
+        assert scope["JARVIS_APPROVED_TOOL_TOKEN"] == os.environ["JARVIS_APPROVED_TOOL_TOKEN"]
+        assert "JARVIS_FILE_ONLY_SENTINEL" not in scope
+        assert get_secret("OPENROUTER_API_KEY") == os.environ["OPENROUTER_API_KEY"]
+
+        from hermes_cli.config import reload_env
+        assert reload_env() == 0
+        assert env_loader.load_hermes_dotenv(
+            hermes_home=home,
+            project_env=project_env,
+        ) == []
+
+        import hermes_cli.runtime_provider as runtime_provider
+        runtime_provider.load_pool = lambda *_a, **_kw: (_ for _ in ()).throw(
+            AssertionError("credential pool consulted")
+        )
+        runtime = runtime_provider.resolve_runtime_provider(requested="openrouter")
+        assert runtime["api_key"] == os.environ["OPENROUTER_API_KEY"]
+        custom_runtime = runtime_provider.resolve_runtime_provider(
+            requested="jarvis-sentinel-custom"
+        )
+        assert custom_runtime["api_key"] == os.environ["JARVIS_CUSTOM_PROVIDER_KEY"]
+        assert "extra_headers" not in custom_runtime
+
+        import hermes_cli.main as cli_main
+        assert cli_main._has_any_provider_configured()
+
+        import gateway.run as gateway_run
+        gateway_run._reload_runtime_env_preserving_config_authority()
+
+        from agent.credential_pool import load_pool
+        try:
+            load_pool("openrouter")
+        except Phase1CapabilityModeError:
+            pass
+        else:
+            raise AssertionError("direct credential-pool expansion did not fail closed")
+
+        from hermes_cli.auth import _load_auth_store
+        try:
+            _load_auth_store()
+        except Phase1CapabilityModeError:
+            pass
+        else:
+            raise AssertionError("direct auth-store expansion did not fail closed")
+
+        from agent.secret_sources.registry import apply_all
+        try:
+            apply_all({}, home)
+        except Phase1CapabilityModeError:
+            pass
+        else:
+            raise AssertionError("direct external-source expansion did not fail closed")
+
+        child = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from hermes_cli.phase1_capability import "
+                "phase1_capability_mode_enabled; "
+                "raise SystemExit(0 if phase1_capability_mode_enabled() else 1)",
+            ],
+            cwd=os.getcwd(),
+            env=os.environ.copy(),
+            check=False,
+        )
+        assert child.returncode == 0
+        """,
+        mode="1",
+        extra_env={
+            "HERMES_HOME": str(home),
+            "HERMES_MANAGED_DIR": str(managed),
+            "JARVIS_TEST_HOME": str(home),
+            "JARVIS_TEST_PROJECT_ENV": str(project / ".env"),
+            "JARVIS_TEST_MANAGED_ENV": str(managed / ".env"),
+            "OPENROUTER_API_KEY": "jarvis-inherited-provider-sentinel",
+            "JARVIS_CUSTOM_PROVIDER_KEY": "jarvis-inherited-custom-sentinel",
+            "JARVIS_APPROVED_TOOL_TOKEN": "jarvis-inherited-tool-sentinel",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("invalid_value", ["yes", "2"])
+def test_invalid_truthy_mode_fails_before_dotenv_import(invalid_value: str) -> None:
+    result = _run_isolated(
+        """
+        import importlib.abc
+        import sys
+
+        class RejectDotenv(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path, target=None):
+                if fullname == "dotenv" or fullname.startswith("dotenv."):
+                    raise AssertionError("dotenv imported before Phase 1 validation")
+                return None
+
+        sys.meta_path.insert(0, RejectDotenv())
+        try:
+            import hermes_cli.env_loader  # noqa: F401
+        except Exception as exc:
+            if (
+                type(exc).__name__ != "Phase1CapabilityModeError"
+                or type(exc).__module__ != "hermes_cli.phase1_capability"
+            ):
+                raise
+        else:
+            raise AssertionError("invalid truthy Phase 1 value was accepted")
+        """,
+        mode=invalid_value,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_disabled_mode_preserves_normal_dotenv_behavior(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".env").write_text(
+        "JARVIS_NORMAL_MODE_SENTINEL=jarvis-normal-mode-sentinel\n",
+        encoding="utf-8",
+    )
+
+    result = _run_isolated(
+        """
+        import os
+        from pathlib import Path
+        from hermes_cli.env_loader import load_hermes_dotenv
+        from hermes_cli.phase1_capability import phase1_capability_mode_enabled
+
+        home = Path(os.environ["JARVIS_TEST_HOME"])
+        assert not phase1_capability_mode_enabled()
+        assert load_hermes_dotenv(hermes_home=home) == [home / ".env"]
+        assert os.environ["JARVIS_NORMAL_MODE_SENTINEL"] == "jarvis-normal-mode-sentinel"
+        """,
+        mode="0",
+        extra_env={"HERMES_HOME": str(home), "JARVIS_TEST_HOME": str(home)},
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -44,6 +44,10 @@ def has_xai_credentials() -> bool:
     else:
         if (get_secret("XAI_API_KEY", "") or "").strip():
             return True
+    from hermes_cli.phase1_capability import phase1_capability_mode_enabled
+
+    if phase1_capability_mode_enabled():
+        return False
     try:
         from hermes_constants import get_hermes_home
 


### PR DESCRIPTION
## Summary

Jarvis Phase 1 prerequisite. Adds `HERMES_PHASE1_CAPABILITY_MODE=1` as an immutable, early-startup credential-capability boundary. In this mode Hermes uses only the inherited process environment, skips dotenv/managed/external-secret hydration and credential pools, and fails closed when a persistent credential source is reached. Normal behavior is unchanged when the mode is absent or disabled.

## Safety

- No live activation, service restart, provider call, audio, firmware, profile, secret, or user-data mutation was performed.
- No ElevenLabs-specific capability crosses this boundary.
- This PR does not merge or activate Phase 1.

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_phase1_capability_mode.py tests/hermes_cli/test_env_loader.py tests/test_env_loader_applied_homes.py tests/test_env_loader_op_bootstrap.py tests/test_env_loader_secret_sources.py tests/agent/test_secret_scope.py tests/agent/test_secret_scope_tier1_migration.py tests/test_secret_scope_plugin_families.py tests/agent/test_credential_pool.py tests/hermes_cli/test_runtime_provider_resolution.py tests/gateway/test_adapter_startup_secret_scope.py tests/gateway/test_allowlist_startup_check.py tests/gateway/test_own_policy_startup_gate.py tests/gateway/test_runner_startup_failures.py tests/gateway/test_startup_connect_parallel.py tests/gateway/test_startup_no_eager_platform_install.py tests/gateway/test_startup_restart_race.py tests/agent/test_anthropic_adapter.py tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_client_anthropic_custom.py tests/agent/test_auxiliary_client_azure_foundry.py tests/agent/test_auxiliary_client_xai_oauth_recovery.py tests/tools/test_xai_http_credentials.py tests/tools/test_xai_http_storage.py -q` — 623 passed, 0 failed, 2 skipped.
- `ruff check` on all changed Python files — passed.
- `ruff format --check hermes_cli/phase1_capability.py tests/hermes_cli/test_phase1_capability_mode.py` — passed.
- `git diff --check` — passed.