### PR TITLE
fix(desktop): terminal pane no longer traps the window when you switch tabs

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
@@ -365,4 +365,41 @@ describe('PersistentTerminal rect tracking', () => {
     expect(overlay.style.pointerEvents).toBe('auto')
     expect(mount.container!.querySelector('[data-testid="terminal-workspace"]')).toBe(workspace)
   })
+
+  it('hides the overlay on a tab switch that happens while the window is unfocused', () => {
+    // The trap: the terminal is a tab in the main zone and the user clicks
+    // another tab without the window being focused (or right as it blurs).
+    // The rect chase is paused then — but visibility is correctness, not perf,
+    // so the overlay must still stand down instead of covering the chat with
+    // an opaque, pointer-interactive surface until something refocuses.
+    installRaf()
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(rect(10, 20, 200, 100))
+    $terminalTakeover.set(true)
+
+    mount.render(<HiddenPaneHarness hidden={false} />)
+
+    const overlay = mount.container!.lastElementChild as HTMLElement
+
+    expect(overlay.style.visibility).toBe('visible')
+    expect(overlay.style.pointerEvents).toBe('auto')
+
+    act(() => {
+      vi.mocked(document.hasFocus).mockReturnValue(false)
+      window.dispatchEvent(new Event('blur'))
+    })
+
+    act(() => {
+      mount.root!.render(<HiddenPaneHarness hidden />)
+    })
+
+    act(() => {
+      mutationObserverCallback?.([], {} as MutationObserver)
+    })
+
+    expect(overlay.style.visibility).toBe('hidden')
+    expect(overlay.style.opacity).toBe('0')
+    expect(overlay.style.pointerEvents).toBe('none')
+    // The PTY survives — only the overlay stands down.
+    expect(mount.container!.querySelector('[data-testid="terminal-workspace"]')).not.toBeNull()
+  })
 })

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
@@ -103,8 +103,25 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
       }
     }
 
+    // Visibility is CORRECTNESS, not perf. The rect chase below forces layout,
+    // so it stays gated on the renderer pause — but `hidden` is a cheap
+    // attribute walk, and skipping it while paused strands the overlay over a
+    // tab the user has already switched away from: the terminal keeps covering
+    // the chat, opaque and pointer-interactive, until something refocuses the
+    // window. Sample it on every wake, paused or not.
+    const syncHidden = () => {
+      const hidden = isElementInHiddenPane(slot)
+
+      if (prev && prev.hidden !== hidden) {
+        prev = { ...prev, hidden }
+        setRect(prev)
+      }
+    }
+
     const measure = (reason: string): boolean => {
       if (rendererPaused()) {
+        syncHidden()
+
         return false
       }
 
@@ -140,7 +157,20 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
     }
 
     const scheduleMeasure = (reason = 'unknown') => {
-      if (stopped || rendererPaused() || frame !== 0) {
+      if (stopped) {
+        return
+      }
+
+      // Paused: no frame is coming (and none is wanted — the rect chase is the
+      // expensive half). Still settle visibility synchronously so a tab switch
+      // while the window is unfocused can't leave the overlay stranded.
+      if (rendererPaused()) {
+        syncHidden()
+
+        return
+      }
+
+      if (frame !== 0) {
         return
       }
 
@@ -158,6 +188,7 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
     const handleVisibilityChange = () => {
       if (rendererPaused()) {
         cancelFrame()
+        syncHidden()
 
         return
       }


### PR DESCRIPTION
Opening the terminal and then clicking another tab could leave you stuck: the tab switch registered, but the terminal kept covering the pane and swallowing clicks, so the chat was unreachable until the app was restarted.

The persistent terminal is a `position: fixed` overlay that chases its slot's rect instead of moving in the DOM (moving it detaches xterm's WebGL renderer). That tracker is paused while the renderer is idle — sensible for the rect chase, which forces layout, but visibility was gated behind the same check. Switch tabs while the window is unfocused, or right as it blurs, and the overlay never learns its slot went inactive: it stays parked over the zone at full opacity with `pointer-events: auto`.

The `hidden` flag is a cheap attribute walk and it is correctness, not perf, so it is now sampled on every wake — paused or not — while the measurement half stays gated. The PTY is untouched: only the overlay stands down.

Verified against a live build over CDP. With the terminal stacked as a tab in the main zone, switching away while unfocused previously left `active: workspace` with the overlay still hit-testing over the pane; it now reports hidden with the chat reachable, and the terminal workspace stays mounted. The regression test fails on `main` and passes here.

This is scoped to the terminal overlay. It does not address the Bot Mode open failures tracked in #89617 / #90111 / #89556 / #89834, which are backend hydration and workspace-tab problems rather than occlusion.

Closes #82315
Closes #72590