### PR TITLE
fix(compression): salvage grown candidates before refusal

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -350,6 +350,102 @@ _SUMMARY_END_MARKER = (
 _MERGED_PRIOR_CONTEXT_HEADER = "[PRIOR CONTEXT — for reference only; not a new message]"
 _MERGED_SUMMARY_DELIMITER = "[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]"
 
+_SALVAGE_TOOL_PLACEHOLDER = "[Old tool output cleared to save context space]"
+_SALVAGE_SUMMARY_MAX_CHARS = 8_000
+_SALVAGE_KEEP_RECENT_TOOLS = 2
+_SALVAGE_REASONING_KEYS = ("reasoning", "reasoning_content", "reasoning_details")
+
+
+def _looks_like_compaction_summary(msg: Dict[str, Any], content: str) -> bool:
+    # Only cap a standalone handoff. Merged carriers preserve a real tail ask
+    # in the same content string; truncating those could delete live user text.
+    if not content.rstrip().endswith(_SUMMARY_END_MARKER):
+        return False
+    if content.startswith(_MERGED_PRIOR_CONTEXT_HEADER):
+        return False
+    # Content heuristics alone must never authorize mutating a live user turn.
+    # Compressor-generated user-role summaries carry this private marker;
+    # ordinary user input does not.
+    if (
+        msg.get("role") == "user"
+        and not msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
+    ):
+        return False
+    head = content[:280]
+    return (
+        bool(msg.get(COMPRESSED_SUMMARY_METADATA_KEY))
+        or "CONTEXT COMPACTION" in head
+        or "[CONTEXT COMPACTION]" in head
+        or "Conversation Summary" in head
+    )
+
+
+def salvage_grown_transcript(
+    original: List[Dict[str, Any]],
+    candidate: List[Dict[str, Any]],
+) -> Optional[List[Dict[str, Any]]]:
+    """Mechanically shrink a compression candidate, or return ``None``.
+
+    Already-compacted middles can be summarized slightly larger while retained
+    tool bodies, stale reasoning, or a synthetic todo snapshot tip the final
+    candidate over the input size. Work on copies and admit the salvage only
+    when the same rough estimator proves it is strictly smaller than the input.
+    """
+    if not candidate or not original:
+        return None
+    budget = estimate_messages_tokens_rough(original)
+    if budget <= 0:
+        return None
+
+    out: List[Dict[str, Any]] = []
+    tool_indices: List[int] = []
+    last_assistant_idx = -1
+    for msg in candidate:
+        if not isinstance(msg, dict):
+            out.append(msg)
+            continue
+        if msg.get("_todo_snapshot_synthetic") and msg.get("role") == "user":
+            continue
+        copied = dict(msg)
+        out.append(copied)
+        role = copied.get("role")
+        if role == "tool":
+            tool_indices.append(len(out) - 1)
+        elif role == "assistant":
+            last_assistant_idx = len(out) - 1
+
+    keep_tools = set(tool_indices[-_SALVAGE_KEEP_RECENT_TOOLS:])
+    for index, msg in enumerate(out):
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") == "assistant" and index != last_assistant_idx:
+            for key in _SALVAGE_REASONING_KEYS:
+                msg.pop(key, None)
+        if msg.get("role") == "tool" and index not in keep_tools:
+            content = msg.get("content")
+            if isinstance(content, str) and len(content) > 200:
+                msg["content"] = _SALVAGE_TOOL_PLACEHOLDER
+        content = msg.get("content")
+        if (
+            isinstance(content, str)
+            and len(content) > _SALVAGE_SUMMARY_MAX_CHARS
+            and _looks_like_compaction_summary(msg, content)
+        ):
+            msg["content"] = (
+                content[:_SALVAGE_SUMMARY_MAX_CHARS].rstrip()
+                + "\n…[summary truncated so compaction can shrink]\n\n"
+                + _SUMMARY_END_MARKER
+            )
+
+    if not any(
+        isinstance(message, dict) and message.get("role") == "user"
+        for message in out
+    ):
+        return None
+    if estimate_messages_tokens_rough(out) < budget:
+        return out
+    return None
+
 # Handoff prefixes that shipped in earlier releases. A summary persisted under
 # one of these can be inherited into a resumed lineage (#35344); when it is
 # re-normalized on re-compaction we must strip the OLD prefix too, otherwise the

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3387,6 +3387,25 @@ def compress_context(
                 _rough_in = estimate_messages_tokens_rough(messages)
                 _rough_out = estimate_messages_tokens_rough(compressed)
                 if _rough_out > _rough_in:
+                    # Todo refresh and user-turn anchoring happen after the
+                    # compressor's own size check, so they can tip a break-even
+                    # candidate over. Give it one mechanical salvage pass.
+                    from agent.context_compressor import salvage_grown_transcript
+
+                    _salvaged = salvage_grown_transcript(messages, compressed)
+                    if _salvaged is not None:
+                        _salv_est = estimate_messages_tokens_rough(_salvaged)
+                        if _salv_est < _rough_in:
+                            logger.info(
+                                "Compression salvage recovered a shrinking "
+                                "transcript (session=%s, ~%s -> ~%s tokens)",
+                                agent.session_id or "none",
+                                f"{_rough_in:,}",
+                                f"{_salv_est:,}",
+                            )
+                            compressed = _salvaged
+                            _rough_out = _salv_est
+                if _rough_out > _rough_in:
                     logger.warning(
                         "Compression refused: compressed transcript would be "
                         "larger than the original (session=%s, ~%s -> ~%s "

--- a/tests/agent/test_salvage_grown_transcript.py
+++ b/tests/agent/test_salvage_grown_transcript.py
@@ -1,0 +1,119 @@
+"""Mechanical salvage for compression candidates that would grow."""
+
+from agent.context_compressor import (
+    COMPRESSED_SUMMARY_METADATA_KEY,
+    _SUMMARY_END_MARKER,
+    salvage_grown_transcript,
+)
+from agent.model_metadata import estimate_messages_tokens_rough
+
+
+def test_salvage_stubs_old_tools_and_drops_todo():
+    original = [
+        {"role": "user", "content": "go"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "tool", "tool_call_id": "a", "content": "A" * 4000},
+        {"role": "tool", "tool_call_id": "b", "content": "B" * 4000},
+        {"role": "tool", "tool_call_id": "c", "content": "keep-latest"},
+    ]
+    grown = original + [
+        {
+            "role": "user",
+            "content": "Current todos:\n- [ ] x",
+            "_todo_snapshot_synthetic": True,
+        }
+    ]
+    assert estimate_messages_tokens_rough(grown) > estimate_messages_tokens_rough(original)
+
+    out = salvage_grown_transcript(original, grown)
+
+    assert out is not None
+    assert estimate_messages_tokens_rough(out) < estimate_messages_tokens_rough(original)
+    assert not any(m.get("_todo_snapshot_synthetic") for m in out)
+    tools = [m["content"] for m in out if m.get("role") == "tool"]
+    assert tools[-1] == "keep-latest"
+    assert any("cleared to save context space" in t for t in tools)
+
+
+def test_salvage_returns_none_when_nothing_can_shrink():
+    original = [{"role": "user", "content": "tiny"}]
+    huge = [{"role": "user", "content": "X" * 200_000}]
+
+    assert salvage_grown_transcript(original, huge) is None
+
+
+def test_salvage_caps_oversized_summary():
+    original = [
+        {"role": "user", "content": "ask " + ("o" * 12_000)},
+        {"role": "assistant", "content": "short reply"},
+    ]
+    grown = [
+        {
+            "role": "user",
+            "content": (
+                "[CONTEXT COMPACTION] "
+                + ("S" * 20_000)
+                + "\n\n"
+                + _SUMMARY_END_MARKER
+            ),
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        },
+        {"role": "assistant", "content": "short reply"},
+    ]
+    assert estimate_messages_tokens_rough(grown) > estimate_messages_tokens_rough(original)
+
+    out = salvage_grown_transcript(original, grown)
+
+    assert out is not None
+    assert len(out[0]["content"]) < 12_000
+    assert "truncated so compaction can shrink" in out[0]["content"]
+    assert out[0]["content"].endswith(_SUMMARY_END_MARKER)
+
+
+def test_salvage_never_truncates_merged_summary_with_live_user_tail():
+    original = [{"role": "user", "content": "O" * 12_000}]
+    merged = [
+        {
+            "role": "user",
+            "content": (
+                "[CONTEXT COMPACTION] "
+                + ("S" * 20_000)
+                + "\n\n"
+                + _SUMMARY_END_MARKER
+                + "\n\nLIVE USER REQUEST"
+            ),
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        }
+    ]
+
+    assert salvage_grown_transcript(original, merged) is None
+    assert merged[0]["content"].endswith("LIVE USER REQUEST")
+
+
+def test_salvage_does_not_cap_plain_user_text_quoting_summary_marker():
+    original = [{"role": "user", "content": "O" * 20_000}]
+    quoted = "ordinary user text " + ("Q" * 12_000) + "\n\n" + _SUMMARY_END_MARKER
+    candidate = [{"role": "user", "content": quoted}]
+
+    out = salvage_grown_transcript(original, candidate)
+
+    assert out is not None
+    assert out[0]["content"] == quoted
+    assert "truncated so compaction can shrink" not in out[0]["content"]
+
+
+def test_salvage_never_caps_unmarked_summary_shaped_live_user_text():
+    original = [{"role": "user", "content": "O" * 20_000}]
+    live_user_text = (
+        "[CONTEXT COMPACTION] "
+        + ("U" * 12_000)
+        + "\n\n"
+        + _SUMMARY_END_MARKER
+    )
+    candidate = [{"role": "user", "content": live_user_text}]
+
+    out = salvage_grown_transcript(original, candidate)
+
+    assert out is not None
+    assert out[0]["content"] == live_user_text
+    assert "truncated so compaction can shrink" not in out[0]["content"]

--- a/tests/run_agent/test_in_place_compaction.py
+++ b/tests/run_agent/test_in_place_compaction.py
@@ -293,6 +293,60 @@ class TestInPlaceAntiGrowthGuard:
             assert agent.session_id == sid
             assert db.get_session(sid)["end_reason"] is None
 
+    def test_in_place_salvages_near_break_even_growth(self):
+        """Fat retained tool output + todo state should be salvaged and committed."""
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+        from agent.model_metadata import estimate_messages_tokens_rough
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260819_salvage"
+            _seed(db, sid, "salvage")
+            agent = _make_agent(db, sid, in_place=True)
+            agent._last_flushed_db_idx = 5
+
+            tool_calls = [
+                {"id": call_id, "function": {"name": "terminal", "arguments": "{}"}}
+                for call_id in ("c1", "c2", "c3")
+            ]
+            original = [
+                {"role": "user", "content": "do the work"},
+                {"role": "assistant", "content": "calling tools", "tool_calls": tool_calls},
+                {"role": "tool", "tool_call_id": "c1", "content": "OLD1 " + ("x" * 8000)},
+                {"role": "tool", "tool_call_id": "c2", "content": "OLD2 " + ("y" * 8000)},
+                {"role": "tool", "tool_call_id": "c3", "content": "keep-me " + ("z" * 100)},
+                {"role": "user", "content": "thanks"},
+            ]
+            grown = [
+                {"role": "user", "content": "[CONTEXT COMPACTION] " + ("S" * 200)},
+                {"role": "assistant", "content": "calling tools", "tool_calls": tool_calls},
+                {"role": "tool", "tool_call_id": "c1", "content": "OLD1 " + ("x" * 8000)},
+                {"role": "tool", "tool_call_id": "c2", "content": "OLD2 " + ("y" * 8000)},
+                {"role": "tool", "tool_call_id": "c3", "content": "keep-me " + ("z" * 100)},
+                {
+                    "role": "user",
+                    "content": "Current todos:\n- [ ] leftover",
+                    "_todo_snapshot_synthetic": True,
+                },
+            ]
+            assert estimate_messages_tokens_rough(grown) > estimate_messages_tokens_rough(original)
+            compressor = getattr(agent, "context_compressor")
+            compressor.compress = (
+                lambda messages, current_tokens=None, focus_topic=None, force=False: grown
+            )
+
+            compressed, _sp = compress_context(
+                agent, original, approx_tokens=100_000, system_message="sys"
+            )
+
+            assert getattr(agent, "_last_compaction_in_place") is True
+            assert estimate_messages_tokens_rough(compressed) < estimate_messages_tokens_rough(original)
+            tool_bodies = [m.get("content") for m in compressed if m.get("role") == "tool"]
+            assert any(isinstance(body, str) and body.startswith("keep-me") for body in tool_bodies)
+            assert any("cleared to save context space" in (body or "") for body in tool_bodies)
+            assert not any(m.get("_todo_snapshot_synthetic") for m in compressed)
+
     def test_in_place_still_commits_shrinking_compression(self):
         """The guard must not block legitimate compressions — a result SMALLER
         than the input still commits in place (regression net for #83339)."""


### PR DESCRIPTION
## What does this PR do?

The commit-site anti-growth guard can reject an otherwise useful compression after todo refresh or user-turn anchoring tips a near-break-even candidate just over the original size.

Before refusing that candidate, this PR performs one fail-closed mechanical salvage pass:

- drops only regenerable `_todo_snapshot_synthetic` user messages
- replaces older oversized tool bodies while retaining the newest two
- removes stale reasoning sidecars from older assistant messages
- caps only compressor-marked standalone summaries
- never caps merged summary carriers or unmarked live user text

The salvaged transcript is admitted only when the same rough-token estimator proves it is strictly smaller than the original. Otherwise the existing refusal path remains unchanged.

This complements #88593; it does not duplicate or alter that PR's anti-thrash strike accounting.

## Related Issue

Related to #88568 and #88593.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_compressor.py`: add strict mechanical salvage with live-user and merged-carrier guards.
- `agent/conversation_compression.py`: attempt salvage once before the existing `would_grow` refusal.
- `tests/agent/test_salvage_grown_transcript.py`: cover tool/todo cleanup, strict size admission, summary capping, and user-content safety.
- `tests/run_agent/test_in_place_compaction.py`: prove a near-break-even candidate is salvaged and committed through the real in-place path.

## How to Test

1. `python -m pytest tests/agent/test_salvage_grown_transcript.py tests/run_agent/test_in_place_compaction.py -o addopts= -q --tb=short` — 17 passed.
2. `python -m pytest tests/agent/test_context_compressor.py -o addopts= -q --tb=short` — 136 passed.
3. `python -m py_compile agent/context_compressor.py agent/conversation_compression.py tests/agent/test_salvage_grown_transcript.py tests/run_agent/test_in_place_compaction.py`
4. `ruff check agent/context_compressor.py agent/conversation_compression.py tests/agent/test_salvage_grown_transcript.py tests/run_agent/test_in_place_compaction.py`
5. `python scripts/check-windows-footguns.py --diff origin/main` — no findings across the four changed files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted affected suites pass (153 tests); full repository suite was not run locally
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: N/A; internal recovery behavior is documented in code
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure message transformation; Windows lint clean
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A: N/A

## Screenshots / Logs

N/A — covered by the in-place persistence regression test.
