### PR TITLE
fix(config): recognize memory nudge interval

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -820,11 +820,6 @@ memory:
   # every N user turns. Set to 0 to disable. Only active when memory is enabled.
   nudge_interval: 10        # Nudge every 10 user turns (0 = disabled)
 
-  # Memory flush: give the agent one turn to save memories before context is
-  # lost (compression, /new, /reset, exit). Set to 0 to disable.
-  # For exit/reset, only fires if the session had at least this many user turns.
-  flush_min_turns: 6        # Min user turns to trigger flush on exit/reset (0 = disabled)
-
 # =============================================================================
 # Session Reset Policy (Messaging Platforms)
 # =============================================================================

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1838,6 +1838,10 @@ DEFAULT_CONFIG = {
         "write_approval": False,
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        # Periodic built-in memory review. External providers with automatic
+        # turn/session extraction can set this to 0 and keep the small local
+        # store reserved for explicit high-frequency operational facts.
+        "nudge_interval": 10,
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -111,6 +111,13 @@ class TestConfigYamlRouting:
         assert "not a recognized config key" not in capsys.readouterr().out
         assert "script_timeout_seconds: 600" in _read_config(_isolated_hermes_home)
 
+    def test_memory_nudge_interval_is_recognized(self, _isolated_hermes_home, capsys):
+        """The documented background-memory review interval is runtime config."""
+        set_config_value("memory.nudge_interval", "0")
+
+        assert "not a recognized config key" not in capsys.readouterr().out
+        assert "nudge_interval: 0" in _read_config(_isolated_hermes_home)
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)


### PR DESCRIPTION
## What does this PR do?

`memory.nudge_interval` is read at runtime by `agent/agent_init.py` and documented in `cli-config.yaml.example`, but it is absent from `hermes_cli.config_defaults.DEFAULT_CONFIG`. As a result, `hermes config set memory.nudge_interval 0` warns that the live setting is unrecognized.

This PR adds the runtime-backed key to the config schema and removes the stale `flush_min_turns` example block. The latter no longer has a runtime consumer, so keeping it documented tells users to configure a dead setting.

## Related Issue

N/A — exact issue/PR searches for the schema mismatch found no duplicate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config_defaults.py`: recognize `memory.nudge_interval` with the existing runtime default of `10`.
- `cli-config.yaml.example`: remove the stale `memory.flush_min_turns` block.
- `tests/hermes_cli/test_set_config_value.py`: prove `hermes config set memory.nudge_interval 0` persists without the unknown-key warning.

## How to Test

1. `python -m pytest tests/hermes_cli/test_set_config_value.py -o addopts= -q --tb=short` — 85 passed.
2. `python -m py_compile hermes_cli/config_defaults.py tests/hermes_cli/test_set_config_value.py`
3. `ruff check hermes_cli/config_defaults.py tests/hermes_cli/test_set_config_value.py`
4. `git grep -n 'flush_min_turns'` — zero matches.

The Windows-footgun checker reports eight pre-existing encoding findings in untouched lines of `tests/hermes_cli/test_set_config_value.py`; this PR adds no file I/O, subprocess, signal, or platform-specific behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the complete affected config-routing file passes (85 tests); full repository suite was not run locally
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: removed the stale example block
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — updated
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — config-only change; no platform-sensitive code added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A: N/A

## Screenshots / Logs

N/A — the regression is asserted through the real config setter and persisted YAML.
