### PR TITLE
fix(desktop): sidebar search results no longer show raw >>>term<<< FTS markers

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -257,6 +257,16 @@ const HEADER_NAV_BTN =
 // FTS results cover sessions that aren't in the loaded page; synthesize a
 // minimal SessionInfo so they render in the same row component (resume works
 // by id; the snippet stands in for the preview).
+
+// The backend's FTS layer wraps matched terms in literal '>>>' / '<<<'
+// highlight markers (sqlite snippet() delimiters — see hermes_state_search.py).
+// The sidebar renders the snippet as plain text, so the markers must be
+// stripped or a search for "foo" paints rows titled ">>>foo<<<".
+// Exported for tests.
+export function stripFtsMarkers(snippet: string): string {
+  return snippet.replaceAll('>>>', '').replaceAll('<<<', '')
+}
+
 function searchResultToSession(result: SessionSearchResult): SessionInfo {
   const ts = result.session_started ?? Date.now() / 1000
 
@@ -272,7 +282,7 @@ function searchResultToSession(result: SessionSearchResult): SessionInfo {
     message_count: 0,
     model: result.model ?? null,
     output_tokens: 0,
-    preview: result.snippet?.trim() || null,
+    preview: stripFtsMarkers(result.snippet ?? '').trim() || null,
     source: result.source ?? null,
     started_at: ts,
     title: null,

--- a/apps/desktop/src/app/chat/sidebar/strip-fts-markers.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/strip-fts-markers.test.ts
@@ -1,0 +1,27 @@
+// Regression: the backend's session-search FTS layer wraps matched terms in
+// literal '>>>' / '<<<' snippet() delimiters (hermes_state_search.py). The
+// sidebar paints the snippet as plain text, so an unstripped marker renders
+// rows titled ">>>foo<<<" (Aug 2026 desktop audit).
+import { describe, expect, it } from 'vitest'
+
+import { stripFtsMarkers } from './index'
+
+describe('stripFtsMarkers', () => {
+  it('strips highlight markers around the matched term', () => {
+    expect(stripFtsMarkers('...replied with >>>MARCO<<< and nothing else...')).toBe(
+      '...replied with MARCO and nothing else...'
+    )
+  })
+
+  it('strips multiple marked terms', () => {
+    expect(stripFtsMarkers('>>>alpha<<< then >>>beta<<<')).toBe('alpha then beta')
+  })
+
+  it('leaves marker-free snippets untouched', () => {
+    expect(stripFtsMarkers('plain snippet text')).toBe('plain snippet text')
+  })
+
+  it('handles empty string', () => {
+    expect(stripFtsMarkers('')).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

Desktop sidebar session-search results no longer render raw FTS highlight markers — searching "MARCO" showed a row literally titled `>>>MARCO<<<`.

Root cause: the backend's session search wraps matched terms in sqlite `snippet()` delimiters `>>>`/`<<<` (hermes_state_search.py), and `searchResultToSession()` passed the snippet straight into the row preview/title as plain text.

## Changes

- `apps/desktop/src/app/chat/sidebar/index.tsx`: new `stripFtsMarkers()` strips the delimiters before the snippet becomes the row preview.
- `strip-fts-markers.test.ts`: 4 tests (single term, multiple terms, marker-free, empty).

## Validation

| | Result |
|---|---|
| vitest strip-fts-markers.test.ts | 4/4 pass |
| Live: search "MARCO" in the running desktop app | row reads clean snippet (verified post-fix rebuild) |

Found during the full-desktop feature audit (Aug 19).

## Infographic

![Search snippets markers stripped](https://files.catbox.moe/pj77ei.png)
