### PR TITLE
fix(acp): isolate shell probes from protocol stdin

### DIFF
--- a/tests/tools/test_find_shell.py
+++ b/tests/tools/test_find_shell.py
@@ -153,6 +153,23 @@ class TestGitBashExternalProgramProbe:
 
         assert local_mod._bash_starts(r"C:\Git\bin\bash.exe") is True
         assert calls[0][0][-1] == "/usr/bin/true; /usr/bin/cat --version >/dev/null"
+        assert calls[0][1]["stdin"] is subprocess.DEVNULL
+
+    def test_aslr_probe_does_not_inherit_protocol_stdin(self, monkeypatch):
+        import tools.environments.local as local_mod
+
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append((argv, kwargs))
+            return subprocess.CompletedProcess(argv, 0, stdout="OFF", stderr="")
+
+        monkeypatch.setattr(local_mod, "_mandatory_aslr_enabled_cache", None)
+        monkeypatch.setattr(local_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(local_mod.shutil, "which", lambda _name: "powershell.exe")
+
+        assert local_mod._mandatory_aslr_enabled() is False
+        assert calls[0][1]["stdin"] is subprocess.DEVNULL
 
     @pytest.mark.windows_only
     def test_aslr_failure_surfaces_targeted_windows_command(

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -859,6 +859,7 @@ def _mandatory_aslr_enabled() -> "bool | None":
                 "-Command",
                 "(Get-ProcessMitigation -System).Aslr.ForceRelocateImages.ToString()",
             ],
+            stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
             timeout=10,
@@ -925,6 +926,7 @@ def _bash_starts(bash: str) -> bool:
     try:
         result = subprocess.run(
             [bash, "--noprofile", "--norc", "-c", _BASH_EXTERNAL_PROGRAM_PROBE],
+            stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
             timeout=15,


### PR DESCRIPTION
## Summary

- prevent the Windows mandatory-ASLR PowerShell probe from inheriting ACP protocol stdin
- prevent the Git Bash external-program probe from inheriting ACP protocol stdin
- add regression assertions for both subprocess boundaries

## Why

Hermes ACP uses stdin as its JSON-RPC transport. On Windows, these discovery probes could inherit that same pipe during tool execution and compete for protocol input. A captured failure stopped immediately after an approved `write_file`: Hermes emitted no tool result, assistant chunk, or `session/prompt` response, and later exited normally when the client tore down the stalled session.

Redirecting these non-interactive probes to `subprocess.DEVNULL` gives them the correct ownership boundary without changing ACP behavior, tool execution, profiles, providers, or shell selection.

## Validation

- focused upstream regression class: 3 passed
- fork focused file after the patch: 12 passed, 2 environment-dependent skips
- captured live ACP acceptance after the patch: conversation, parallel research, Builder, Reviewer, approval, persistence, cleanup, and provider-failure gates all passed
- direct `hermes-acp` acceptance without the capture proxy: complete pass

The broader upstream test file currently has two unrelated Windows expectation failures because those tests expect `$SHELL` to win while `_find_shell()` intentionally falls back to Git Bash on Windows; the changed regression class passes independently.