### PR TITLE
fix(web): noindex the docs search page

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -15,6 +15,11 @@ const config: Config = {
 
   onBrokenLinks: 'warn',
 
+  // The local search page answers queries only via JS; it has no indexable
+  // content and only wastes crawl budget and dilutes SERP quality signals.
+  // The sitemap plugin honors noIndex automatically.
+  noIndex: ['/search'],
+
   markdown: {
     mermaid: true,
     hooks: {


### PR DESCRIPTION
## Problem

`/docs/search` is indexed and listed in the docs sitemap, but it is a JS-only query surface with zero indexable content. It wastes crawl budget and puts a low-quality entry into the SERP for hermes-agent.nousresearch.com.

## Fix

`noIndex: ['/search']` in the website config (Docusaurus 3.10 supports the route-level noIndex field). The sitemap plugin honors noIndex metadata and drops the URL automatically, so no sitemap change is needed.

## Verification

- Config-level change only, no user-visible behavior (search page still works for visitors).
- Local deps were not installed in this worktree, so `website` typecheck was not run; the field is standard config API for the pinned Docusaurus 3.10.2.

Done by Hermes Agent (deepseek-v4-pro via nous), Nous Research.