### PR TITLE
fix(gateway): resolve context_max from model config when compressor is stale

### DIFF
--- a/agent/context_breakdown.py
+++ b/agent/context_breakdown.py
@@ -34,6 +34,31 @@ def _chars_to_tokens(text: str) -> int:
     return (len(text) + 3) // 4
 
 
+def _resolve_model_context_length(agent: Any) -> int:
+    """Resolve the model's context window when the context compressor is
+    absent or hasn't resolved yet.
+
+    Uses the same ``get_model_context_length`` resolver the compressor itself
+    uses on first access, reading the agent's model/provider/base_url and the
+    explicit ``_config_context_length`` / ``_custom_providers`` attributes that
+    ``agent_init`` sets. Returns 0 if resolution fails — the caller treats 0
+    as "unknown" and omits the gauge rather than fabricating a number.
+    """
+    try:
+        from agent.model_metadata import get_model_context_length
+
+        return get_model_context_length(
+            model=str(getattr(agent, "model", "") or ""),
+            base_url=str(getattr(agent, "base_url", "") or ""),
+            api_key=str(getattr(agent, "api_key", "") or ""),
+            config_context_length=getattr(agent, "_config_context_length", None),
+            provider=str(getattr(agent, "provider", "") or ""),
+            custom_providers=getattr(agent, "_custom_providers", None),
+        )
+    except Exception:
+        return 0
+
+
 def _json_tokens(value: Any) -> int:
     if not value:
         return 0
@@ -129,6 +154,12 @@ def compute_session_context_breakdown(
 
     comp = getattr(agent, "context_compressor", None)
     context_max = int(getattr(comp, "context_length", 0) or 0) if comp else 0
+    # Fall back to the model's configured context_length when the compressor
+    # is absent (resumed session) or hasn't resolved yet. Without this, a
+    # resumed or freshly-opened session reports context_max=0 and the desktop
+    # panel shows "0/0 tokens, No context data yet" until a turn runs.
+    if not context_max:
+        context_max = _resolve_model_context_length(agent)
     measured_used = int(getattr(comp, "last_prompt_tokens", 0) or 0) if comp else 0
     context_used = measured_used if measured_used > 0 else estimated_total
     context_percent = (

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5533,6 +5533,35 @@ def _get_usage(agent) -> dict:
             usage["context_max"] = ctx_max
             usage["context_percent"] = max(0, min(100, round(last_prompt / ctx_max * 100)))
         usage["compressions"] = getattr(comp, "compression_count", 0) or 0
+    # Always resolve context_max from the model's configured context_length.
+    # This covers three cases the compressor block above misses:
+    #   1. Compressor absent (resumed session) — context_max was never set.
+    #   2. No turn has run yet — last_prompt_tokens is 0, so the block above
+    #      intentionally omits context_max. We fill in only the denominator
+    #      so the bar shows "0/262K" instead of the cumulative fallback.
+    #   3. Model switched mid-session but no turn has run on the new model yet
+    #      — the compressor still holds the OLD model's context_length. We
+    #      override with the NEW model's resolved context_length so the bar
+    #      doesn't show impossible readings like "167K/131K 100%".
+    # context_used/percent stay omitted until a real measurement exists — we
+    # only fill in (or correct) the denominator.
+    try:
+        from agent.context_breakdown import _resolve_model_context_length
+
+        _resolved_max = _resolve_model_context_length(agent)
+        if _resolved_max:
+            _existing_max = usage.get("context_max", 0) or 0
+            # Override when there's no context_max yet, or when the compressor's
+            # stale value doesn't match the current model's resolved window
+            # (model switch with no turn on the new model yet).
+            if not _existing_max or _existing_max != _resolved_max:
+                usage["context_max"] = _resolved_max
+                # Recalculate percent if we have a real context_used
+                _ctx_used = usage.get("context_used", 0) or 0
+                if _ctx_used:
+                    usage["context_percent"] = max(0, min(100, round(_ctx_used / _resolved_max * 100)))
+    except Exception:
+        pass
     # Live count of background/async subagents still running (delegate_task
     # batches + background single delegations). Mirrors the classic CLI status
     # bar's ⛓ indicator; sourced from the same async_delegation registry.


### PR DESCRIPTION
## What

The desktop statusbar context meter showed wrong or empty readings for:
- **Resumed sessions**: "0/0 tokens, No context data yet" (compressor absent)
- **Fresh sessions before first turn**: bar fell back to cumulative "3.4M tok"
- **Model switch mid-session**: "167K/131K 100%" (stale compressor context_length)

## Root cause

`_get_usage()` in `tui_gateway/server.py` and `compute_session_context_breakdown()` in `agent/context_breakdown.py` both read `context_max` exclusively from `agent.context_compressor.context_length`. When the compressor is absent (resumed session), hasn't run yet (no turn), or holds a stale value (model switched but no turn on new model yet), `context_max` is 0 or wrong.

## Fix

Add `_resolve_model_context_length(agent)` — a shared helper that calls the same `get_model_context_length()` resolver the compressor uses on first access, reading `agent.model`, `agent.provider`, `agent.base_url`, `agent._config_context_length`, and `agent._custom_providers`.

- `context_breakdown.py`: falls back to the helper when the compressor's `context_length` is 0
- `server.py`: always resolves `context_max` from the helper, overriding the compressor's stale value when they disagree (model switch case); recalculates `context_percent` if `context_used` exists

`context_used` and `context_percent` stay omitted until a real measurement exists — only the denominator is filled in or corrected. No fabrication.

## Testing

- 4/4 existing tests pass (`tests/agent/test_context_breakdown.py`)
- Python syntax verified
- Verified on Hermes Desktop v0.20.4:
  - MiniMax-M3 (1M window): bar shows `38K/1M` ✅
  - Qwen3.8-27B-4bit (262K window): bar shows `0/262K` ✅
  - Model switch from 131K → 1M mid-session: no longer shows `167K/131K 100%` ✅
