### PR TITLE
fix(sessions): redact every session field on export --redact, not just messages

### DIFF
--- a/hermes_cli/session_export_md.py
+++ b/hermes_cli/session_export_md.py
@@ -237,7 +237,10 @@ def redact_session_data(session: dict[str, Any]) -> dict[str, Any]:
         if isinstance(value, list):
             return [_clean(v) for v in value]
         if isinstance(value, dict):
-            return {k: _clean(v) for k, v in value.items()}
+            # Keys are strings too — a credential-shaped key (a misbehaving
+            # JSON emitter writing {"sk-...": value}) must not pass through
+            # verbatim when the user asked for --redact (review on #90361).
+            return {_clean(k) if isinstance(k, str) else k: _clean(v) for k, v in value.items()}
         return value
 
     return _clean(session)

--- a/hermes_cli/session_export_md.py
+++ b/hermes_cli/session_export_md.py
@@ -219,12 +219,15 @@ def verify_export_file(path: Path | str, session: dict[str, Any]) -> tuple[bool,
 def redact_session_data(session: dict[str, Any]) -> dict[str, Any]:
     """Return a deep copy of a session export dict with secrets redacted.
 
-    Runs every message's content and tool-call arguments through the
-    force-mode redaction pass (``agent.redact.redact_sensitive_text``), so
-    API keys, tokens, and credentials that appeared in tool output never
-    land in plaintext export files. Force mode ignores the user's global
-    ``security.redact_secrets`` preference — an explicit ``--redact`` export
-    must never emit raw secrets.
+    Runs every string in the export through the force-mode redaction pass
+    (``agent.redact.redact_sensitive_text``) — message content, tool-call
+    arguments, AND session-level fields outside ``messages``/``segments``.
+    The auto-generated session title quotes the first user message, so a
+    credential pasted into that message rides into the title and, before
+    this walked the whole dict, straight into the export header in
+    plaintext despite ``--redact`` (#90361). Force mode ignores the user's
+    global ``security.redact_secrets`` preference — an explicit ``--redact``
+    export must never emit raw secrets anywhere in the file.
     """
     from agent.redact import redact_sensitive_text
 
@@ -237,11 +240,7 @@ def redact_session_data(session: dict[str, Any]) -> dict[str, Any]:
             return {k: _clean(v) for k, v in value.items()}
         return value
 
-    redacted = dict(session)
-    for key in ("messages", "segments"):
-        if key in redacted and redacted[key] is not None:
-            redacted[key] = _clean(redacted[key])
-    return redacted
+    return _clean(session)
 
 
 def write_session_markdown(

--- a/tests/hermes_cli/test_session_export_redaction.py
+++ b/tests/hermes_cli/test_session_export_redaction.py
@@ -83,6 +83,18 @@ class TestRedactSessionData:
         out = redact_session_data(session)
         assert _fake_api_key() not in out["summary"]
 
+    def test_credential_shaped_dict_key_redacted(self):
+        """Dict KEYS are strings too — a misbehaving emitter writing the
+        credential as a key must not pass through verbatim (review #90361)."""
+        from hermes_cli.session_export_md import redact_session_data
+
+        session = _session_fixture()
+        key = _fake_api_key()
+        session["tool_result"] = {key: "payload"}
+        out = redact_session_data(session)
+        assert key not in str(out["tool_result"]), out["tool_result"]
+        assert "payload" in str(out["tool_result"])
+
     def test_original_session_not_mutated(self):
         from hermes_cli.session_export_md import redact_session_data
 

--- a/tests/hermes_cli/test_session_export_redaction.py
+++ b/tests/hermes_cli/test_session_export_redaction.py
@@ -1,0 +1,106 @@
+"""Fail-closed redaction tests for sessions export --redact (#90361).
+
+``redact_session_data`` used to walk only the ``messages``/``segments``
+keys, so session-level string fields — most importantly the auto-generated
+title, which quotes the first user message — escaped redaction and rendered
+into the export header in plaintext despite an explicit ``--redact``. The
+walk now covers every string in the export dict.
+"""
+
+
+def _fake_botfather_token() -> str:
+    # BotFather shape: <10-digit id>:<35-char base64url-ish>, assembled to
+    # avoid a credential-shaped literal in source.
+    digits = "8" * 10
+    tail = ("A" * 34) + "h"
+    return digits + ":" + tail
+
+
+def _fake_api_key() -> str:
+    return "-".join(("sk", "probe" * 3, "key9")) + "XYZabcd"
+
+
+def _session_fixture() -> dict:
+    token = _fake_botfather_token()
+    return {
+        "id": "s1",
+        "title": f"telegram setup with {token}",
+        "cwd": "/tmp/x",
+        "message_count": 3,
+        "started_at": 1710000000,
+        "messages": [
+            {"role": "user", "content": f"use {token} please"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc1",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": f'{{"token": "{token}"}}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "content": f"sent via {token}"},
+        ],
+    }
+
+
+class TestRedactSessionData:
+    def test_title_token_is_redacted(self):
+        """The title quotes the first user message — a credential there must
+        not ride into the export header in plaintext (#90361)."""
+        from hermes_cli.session_export_md import redact_session_data
+
+        token = _fake_botfather_token()
+        out = redact_session_data(_session_fixture())
+        assert token not in out["title"]
+
+    def test_message_content_and_tool_args_still_redacted(self):
+        from hermes_cli.session_export_md import redact_session_data
+
+        token = _fake_botfather_token()
+        out = redact_session_data(_session_fixture())
+        assert token not in out["messages"][0]["content"]
+        assert token not in out["messages"][1]["tool_calls"][0]["function"]["arguments"]
+        assert token not in out["messages"][2]["content"]
+
+    def test_non_string_scalars_preserved(self):
+        from hermes_cli.session_export_md import redact_session_data
+
+        out = redact_session_data(_session_fixture())
+        assert out["id"] == "s1"
+        assert out["message_count"] == 3
+        assert out["started_at"] == 1710000000
+
+    def test_api_key_in_top_level_field_redacted(self):
+        from hermes_cli.session_export_md import redact_session_data
+
+        session = _session_fixture()
+        session["summary"] = f"rotated to {_fake_api_key()} today"
+        out = redact_session_data(session)
+        assert _fake_api_key() not in out["summary"]
+
+    def test_original_session_not_mutated(self):
+        from hermes_cli.session_export_md import redact_session_data
+
+        session = _session_fixture()
+        token = _fake_botfather_token()
+        redact_session_data(session)
+        assert token in session["title"], "redaction must return a copy"
+
+
+class TestRenderedExportIsClean:
+    def test_markdown_render_contains_no_token(self):
+        """End-to-end: --redact output file must not contain the token
+        anywhere — header included."""
+        from hermes_cli.session_export_md import (
+            redact_session_data,
+            render_session_markdown,
+        )
+
+        token = _fake_botfather_token()
+        md = render_session_markdown(redact_session_data(_session_fixture()), fmt="md")
+        assert token not in md


### PR DESCRIPTION
## What does this PR do?

Makes `hermes sessions export --redact` redact **every** string in the exported session, not just `messages`/`segments`. `redact_session_data` walked only those two keys, so session-level string fields escaped the force-mode redaction pass — most importantly the auto-generated title, which quotes the first user message: a credential pasted there rode into the export header in plaintext despite an explicit `--redact` (#90361 reported Telegram bot tokens surviving; I verified the redactor's `_TELEGRAM_RE` masks tokens inside message content correctly on both v0.20.0 and current `main` — the pattern was never the gap, the walk scope was. The title escape is demonstrated end-to-end on current `main`: a token in `title` survives `redact_session_data` and appears in the rendered markdown header).

The walk now covers the entire export dict — message content, tool-call arguments, and every session-level string — through `redact_sensitive_text(force=True)`. Non-string scalars pass through unchanged and the input session is not mutated. Fail-closed: an explicit `--redact` export must never emit raw secrets anywhere in the file.

## Related Issue

Fixes #90361

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/session_export_md.py` — `redact_session_data` returns `_clean(session)` over the whole dict instead of only the `messages`/`segments` keys; docstring documents the title-escape mechanism.
- `tests/hermes_cli/test_session_export_redaction.py` — new fail-closed suite: title token redacted, message content/tool args still redacted, non-string scalars preserved, arbitrary top-level field (`summary`) redacted, input not mutated, and an end-to-end `render_session_markdown` check that the output file contains no token.

## How to Test

1. `uv run --python 3.11 --with pytest --with pyyaml --with python-dotenv --with rich python -m pytest -q -o 'addopts=' tests/hermes_cli/test_session_export_redaction.py`
2. Observed result: 6 passed on this branch; on unmodified `main` the three escape proofs fail (title token, top-level `summary` field, and the rendered-markdown end-to-end check) while the message-walk companions pass — confirming the regression tests pin exactly the walk-scope gap.
3. Baseline: `tests/hermes_cli/test_session_export_md.py` — 2 passed, unchanged.
4. Live check (optional): export a session whose first message contained a bot token with `--format md --redact` and `grep` the header — the title is now masked.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring documents the escape mechanism)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
