### PR TITLE
fix(desktop): deleting an archived session no longer leaves a ghost row that spins forever

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -16,6 +16,7 @@ import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue
 import { $gatewaySwitching } from '@/store/gateway-switch'
 import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
+import { $archivedSessions } from '@/store/sidebar-archive'
 import {
   $activeGatewayProfile,
   $gatewaySwapTarget,
@@ -1713,17 +1714,30 @@ export function useSessionActions({
     async (storedSessionId: string) => {
       clearNotifications()
 
-      const removed = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+      // The row may live in the main list OR the archived view's own store
+      // (archived rows are excluded from $sessions by design). Resolve from
+      // both so deleting from the Archived filter evicts the row instead of
+      // leaving a ghost that resumes into a dead id (infinite spinner).
+      const removedFromMain = $sessions
+        .get()
+        .find(session => sessionMatchesStoredId(session, storedSessionId))
+      const removed =
+        removedFromMain ??
+        $archivedSessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
       const wasSelected = selectedStoredSessionId === storedSessionId
       const closingRuntimeId = wasSelected ? activeSessionId : null
       const previousMessages = $messages.get()
       const previousPinned = $pinnedSessionIds.get()
+      const previousArchived = $archivedSessions.get()
       // Pins are keyed on the durable lineage-root id; the stored id may be the
       // live tip after compression. Drop both so the pin can't linger.
       const removedPinId = removed ? sessionPinId(removed) : storedSessionId
       const removedIds = [storedSessionId, removed?.id, removed?._lineage_root_id]
 
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
+      $archivedSessions.set(
+        previousArchived.filter(session => !sessionMatchesStoredId(session, storedSessionId))
+      )
       // Evict from the project tree's optimistic layer too (the backend snapshot
       // still lists it until its next refresh), so grouped + flat views drop the
       // row in lockstep. Pin the tombstone against the projects.tree prune while
@@ -1767,9 +1781,12 @@ export function useSessionActions({
           dropSessionState(tiledRuntimeId)
         }
       } catch (err) {
-        if (removed) {
-          setSessions(prev => [removed, ...prev])
+        if (removedFromMain) {
+          setSessions(prev => [removedFromMain, ...prev])
         }
+
+        // Restore the archived-view row too (no-op when it wasn't archived).
+        $archivedSessions.set(previousArchived)
 
         untombstoneSessions(removedIds)
         $pinnedSessionIds.set(previousPinned)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -16,7 +16,6 @@ import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue
 import { $gatewaySwitching } from '@/store/gateway-switch'
 import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
-import { $archivedSessions } from '@/store/sidebar-archive'
 import {
   $activeGatewayProfile,
   $gatewaySwapTarget,
@@ -81,6 +80,7 @@ import {
 } from '@/store/session-states'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { forgetSessionUnread } from '@/store/session-unread'
+import { $archivedSessions } from '@/store/sidebar-archive'
 import { dropTranscriptTail, loadTranscriptTail, saveTranscriptTail } from '@/store/transcript-tail-cache'
 import { isWatchWindow } from '@/store/windows'
 import type { SessionCreateResponse, SessionMessage, SessionResumeResponse, UsageStats } from '@/types/hermes'

--- a/apps/desktop/src/app/session/hooks/use-session-actions/remove-archived-session.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/remove-archived-session.test.tsx
@@ -1,0 +1,141 @@
+// Regression: deleting a session from the Archived filter view left a ghost
+// row. Archived rows live in $archivedSessions (their own capped store —
+// they're excluded from $sessions by design), and removeSession only pruned
+// $sessions. The ghost row then resumed into a hard-deleted id: resume 404 →
+// goneSessionVerdict saw the row still listed → 'retry' → an unrecoverable
+// spinner (Aug 2026 desktop audit, F8).
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import type { MutableRefObject } from 'react'
+import { useEffect } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { deleteSession, type SessionInfo } from '@/hermes'
+import { setSessions } from '@/store/session'
+import { $archivedSessions } from '@/store/sidebar-archive'
+
+import type { ClientSessionState } from '../../../types'
+
+import { useSessionActions } from './index'
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  deleteSession: vi.fn(),
+  getSession: vi.fn(),
+  getAllSessionMessages: vi.fn(),
+  getLatestSessionMessages: vi.fn(),
+  listAllProfileSessions: vi.fn(),
+  setApiRequestProfile: vi.fn(),
+  setSessionArchived: vi.fn()
+}))
+
+vi.mock('@/store/profile', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ensureGatewayProfile: vi.fn().mockResolvedValue(undefined)
+}))
+
+function archivedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    archived: true,
+    ended_at: null,
+    id: 'arch-1',
+    input_tokens: 0,
+    is_active: false,
+    last_active: 1,
+    message_count: 2,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    source: 'desktop',
+    started_at: 1,
+    title: 'archived ghost',
+    tool_call_count: 0,
+    ...overrides
+  } as SessionInfo
+}
+
+type Handle = Pick<ReturnType<typeof useSessionActions>, 'removeSession'>
+
+function Harness({ onReady }: { onReady: (handle: Handle) => void }) {
+  const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
+
+  const actions = useSessionActions({
+    activeSessionId: null,
+    activeSessionIdRef: ref<string | null>(null),
+    busyRef: ref(false),
+    creatingSessionRef: ref(false),
+    ensureSessionState: () => ({}) as ClientSessionState,
+    getRouteToken: () => 'token',
+    getRoutedStoredSessionId: () => null,
+    navigate: vi.fn() as never,
+    requestGateway: vi.fn().mockResolvedValue(undefined),
+    resetViewSync: vi.fn(),
+    runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
+    selectedStoredSessionId: null,
+    selectedStoredSessionIdRef: ref<string | null>(null),
+    sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
+    syncSessionStateToView: vi.fn(),
+    updateSessionState: () => ({}) as ClientSessionState
+  })
+
+  useEffect(() => {
+    onReady({ removeSession: actions.removeSession })
+  }, [actions, onReady])
+
+  return null
+}
+
+async function mountHarness(): Promise<Handle> {
+  let handle: Handle | undefined
+  render(<Harness onReady={h => (handle = h)} />)
+  await waitFor(() => expect(handle).toBeDefined())
+
+  return handle as Handle
+}
+
+describe('removeSession × archived view store', () => {
+  beforeEach(() => {
+    setSessions([])
+    $archivedSessions.set([])
+    vi.mocked(deleteSession).mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+    setSessions([])
+    $archivedSessions.set([])
+  })
+
+  it('evicts the row from $archivedSessions on successful delete', async () => {
+    $archivedSessions.set([archivedSession(), archivedSession({ id: 'arch-2', title: 'keep me' })])
+    vi.mocked(deleteSession).mockResolvedValue({ ok: true })
+
+    const handle = await mountHarness()
+
+    await act(() => handle.removeSession('arch-1'))
+
+    expect(vi.mocked(deleteSession)).toHaveBeenCalledWith('arch-1', undefined)
+    expect($archivedSessions.get().map(session => session.id)).toEqual(['arch-2'])
+  })
+
+  it('restores the archived row when the delete RPC fails', async () => {
+    $archivedSessions.set([archivedSession()])
+    vi.mocked(deleteSession).mockRejectedValue(new Error('backend down'))
+
+    const handle = await mountHarness()
+
+    await act(() => handle.removeSession('arch-1'))
+
+    expect($archivedSessions.get().map(session => session.id)).toEqual(['arch-1'])
+  })
+
+  it('passes the archived row profile to deleteSession', async () => {
+    $archivedSessions.set([archivedSession({ profile: 'sage' } as Partial<SessionInfo>)])
+    vi.mocked(deleteSession).mockResolvedValue({ ok: true })
+
+    const handle = await mountHarness()
+
+    await act(() => handle.removeSession('arch-1'))
+
+    expect(vi.mocked(deleteSession)).toHaveBeenCalledWith('arch-1', 'sage')
+  })
+})


### PR DESCRIPTION
## Summary

Deleting a session from the sidebar's Archived filter no longer leaves a ghost row whose click spins forever.

Root cause: archived rows render from `$archivedSessions` — a separate capped store (archived rows are excluded from `$sessions` by design) — but `removeSession` only pruned `$sessions`. The surviving ghost row then resumed into a hard-deleted id: resume 404 → `goneSessionVerdict` saw the row still listed (`stillListed=true`) → verdict `retry` → an unrecoverable spinner with the composer unmounted.

## Changes

- `use-session-actions/index.ts`: `removeSession` resolves the row from `$sessions` OR `$archivedSessions`, evicts it from both stores optimistically, and restores the archived row on RPC failure (rollback parity with the main list). Resolving from the archived store also means `deleteSession` now receives the row's owning `profile` for archived rows.
- `remove-archived-session.test.tsx`: 3 tests — eviction on success, restore on failure, profile forwarding.

## Validation

| | Result |
|---|---|
| New tests | 3/3 pass |
| Sabotage run (fix stashed) | 2/3 fail as intended |
| Sibling use-session-actions suites | 182/182 pass |
| Live desktop: archive → Archived filter → delete | row gone from view + state.db, no spinner |

Found during the full-desktop feature audit (Aug 19): deterministic repro was archive session → enable Archived filter → delete → click remaining row.

## Infographic

![Archived delete no more ghost row](https://files.catbox.moe/m4rytk.png)
