### PR TITLE
test(update): Windows progress self-test no longer flakes on publish/hold timing

### DIFF
--- a/tests/test_desktop_update_windows_progress.py
+++ b/tests/test_desktop_update_windows_progress.py
@@ -39,7 +39,11 @@ def test_progress_advances_while_the_orchestrator_blocks(tmp_path: Path) -> None
     env = os.environ.copy()
     env["TEMP"] = str(tmp_path)
     env["TMP"] = str(tmp_path)
-    env["HERMES_SELFTEST_HOLD_SECONDS"] = "4"
+    # Generous hold: the assertions below must both land INSIDE it. 4s was
+    # too tight for a slow runner — the second sample slid past the hold,
+    # caught the cleared terminal state, and failed '' == 'Testing quiet
+    # update' (PR #90358 rerun, Aug 2026).
+    env["HERMES_SELFTEST_HOLD_SECONDS"] = "10"
 
     with output_path.open("wb") as output:
         process = subprocess.Popen(
@@ -72,7 +76,20 @@ def test_progress_advances_while_the_orchestrator_blocks(tmp_path: Path) -> None
             time.sleep(0.1)
 
         assert shim_url, output_path.read_text(encoding="utf-8", errors="replace")
+
+        # The URL prints BEFORE the orchestrator publishes its held stage —
+        # sampling immediately races the publish and can catch the page's
+        # boot default instead ('Hermes will open once done.' ==
+        # 'Testing quiet update', PR #90358 first run). Wait for the held
+        # stage to actually land, THEN start the stability window.
+        held_stage = "Testing quiet update"
+        publish_deadline = time.monotonic() + 10
         first = _read_progress(shim_url)
+        while first.get("message") != held_stage and time.monotonic() < publish_deadline:
+            time.sleep(0.1)
+            first = _read_progress(shim_url)
+        assert first["message"] == held_stage, first
+
         time.sleep(1.5)
         second = _read_progress(shim_url)
 


### PR DESCRIPTION
## Summary

`test_progress_advances_while_the_orchestrator_blocks` no longer flakes — it raced its subject on BOTH edges within one hour of PR CI on #90358, failing two unrelated Windows runs in a row.

- Run 1: sampled right after the shim URL printed, before the orchestrator published its stage → caught the page boot default (`'Hermes will open once done.' != 'Testing quiet update'`).
- Run 2 (rerun): with `HOLD=4s` on a slow runner, the second sample slid past the hold → caught the cleared terminal state (`'' != 'Testing quiet update'`).

## Changes

- `tests/test_desktop_update_windows_progress.py`: wait (≤10s) for the published stage to actually land before starting the 1.5s stability window; raise `HERMES_SELFTEST_HOLD_SECONDS` from 4 to 10 so both samples land inside the hold. Same assertions, same contract — anchored to the event under test instead of wall-clock luck. No production code touched.

## Validation

| | Evidence |
|---|---|
| Flake direction 1 | [run 96264743282](https://github.com/NousResearch/hermes-agent/actions/runs/32314778795/job/96264743282) — boot default caught |
| Flake direction 2 | [run 96266489358](https://github.com/NousResearch/hermes-agent/actions/runs/32314778795/job/96266489358) — cleared state caught |
| Test is `windows_only` | verified on this PR's Windows CI job |

## Infographic

![Race-free self-test](https://files.catbox.moe/wu39qu.png)
