### PR TITLE
feat(hindsight): forward prefer_observations and pin client 0.9.1

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -846,6 +846,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._auto_recall = True
         self._recall_sync = False
         self._recall_max_tokens = 4096
+        self._prefer_observations = False
         # Default to observation-only recall. Observations are Hindsight's
         # consolidated knowledge layer — deduplicated, evidence-grounded
         # beliefs built from many raw facts, with proof counts and
@@ -1714,6 +1715,11 @@ class HindsightMemoryProvider(MemoryProvider):
         else:
             self._recall_types = list(configured_types) or ["observation"]
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
+        # When True and recalling observations together with raw types
+        # (world/experience), drop raw facts that an observation was
+        # consolidated from so observations supersede their sources.
+        # Requires hindsight-client 0.8+ (0.6.1 silently drops the kwarg).
+        self._prefer_observations = bool(self._config.get("prefer_observations", False))
         # On-by-default deterministic indicator: when auto-recall injects memory,
         # Hermes emits a "👁️ Hindsight — recalled N memories" status line so the
         # user SEES memory working, independent of whether the model mentions it.
@@ -1873,6 +1879,7 @@ class HindsightMemoryProvider(MemoryProvider):
             recall_kwargs: dict = {
                 "bank_id": self._bank_id, "query": query,
                 "budget": self._budget, "max_tokens": self._recall_max_tokens,
+                "prefer_observations": self._prefer_observations,
             }
             if self._recall_tags:
                 recall_kwargs["tags"] = self._recall_tags
@@ -2206,6 +2213,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 recall_kwargs: dict = {
                     "bank_id": self._bank_id, "query": query, "budget": self._budget,
                     "max_tokens": self._recall_max_tokens,
+                    "prefer_observations": self._prefer_observations,
                 }
                 if self._recall_tags:
                     recall_kwargs["tags"] = self._recall_tags

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,7 +180,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
-hindsight = ["hindsight-client==0.6.1"]
+hindsight = ["hindsight-client==0.9.1"]
 dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
 messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.1", "slack-bolt==1.30.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
@@ -414,7 +414,7 @@ exclude-newer = "14 days"
 # cutoff can still brick installs. Exempting exact pins is pure brick-risk
 # removal at no supply-chain cost. Guarded by
 # tests/test_packaging_metadata.py::test_build_system_requires_exempt_from_exclude_newer.
-exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false }
+exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false, hindsight-client = false }
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -267,6 +267,7 @@ class TestConfig:
         # aggregate facts that often crowd out concrete-event signal during
         # auto-recall. Users opt back in via the recall_types config key.
         assert provider._recall_types == ["observation"]
+        assert provider._prefer_observations is False
         assert provider._bank_mission == ""
         assert provider._bank_retain_mission is None
         assert provider._retain_context == "conversation between Hermes Agent and the User"
@@ -296,6 +297,7 @@ class TestConfig:
             bank_retain_mission="Extract key facts",
             recall_max_tokens=2048,
             recall_types=["world", "experience"],
+            prefer_observations=True,
             recall_prompt_preamble="Custom preamble:",
             recall_max_input_chars=500,
             bank_mission="Test agent mission",
@@ -314,6 +316,7 @@ class TestConfig:
         assert p._bank_retain_mission == "Extract key facts"
         assert p._recall_max_tokens == 2048
         assert p._recall_types == ["world", "experience"]
+        assert p._prefer_observations is True
         assert p._recall_prompt_preamble == "Custom preamble:"
         assert p._recall_max_input_chars == 500
         assert p._bank_mission == "Test agent mission"
@@ -462,6 +465,12 @@ class TestToolHandlers:
         assert "Memory 1" in result["result"]
         assert "Memory 2" in result["result"]
 
+    def test_recall_tool_forwards_prefer_observations(self, provider_with_config):
+        p = provider_with_config(prefer_observations=True)
+        p.handle_tool_call("hindsight_recall", {"query": "dark mode"})
+        kwargs = p._client.arecall.call_args.kwargs
+        assert kwargs["prefer_observations"] is True
+
 
     def test_reflect_success(self, provider):
         result = json.loads(provider.handle_tool_call(
@@ -532,6 +541,19 @@ class TestPrefetch:
         assert captured["query"] == "fix tests"       # current query, not ignored
         assert "fresh memory" in result
         p._client.arecall.assert_called_once()
+
+    def test_sync_recall_forwards_prefer_observations(self, provider_with_config):
+        p = provider_with_config(recall_sync=True, prefer_observations=True)
+        captured = {}
+
+        def _capture_recall(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(results=[SimpleNamespace(text="fresh memory")])
+
+        p._client.arecall = AsyncMock(side_effect=_capture_recall)
+        result = p.prefetch("fix tests")
+        assert "fresh memory" in result
+        assert captured["prefer_observations"] is True
 
     def test_recall_sync_skips_background_queue(self, provider_with_config):
         # With sync recall there's nothing to prime in the background.

--- a/uv.lock
+++ b/uv.lock
@@ -8,22 +8,23 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-04T07:06:16.774262776Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
 setuptools = false
-h2 = false
+huggingface-hub = false
 vercel = false
 pillow = false
 unpaddedbase64 = false
+h2 = false
 defusedxml = false
 aiohttp = false
 cryptography = false
-mcp = false
+hindsight-client = false
 python-olm = false
+mcp = false
 nemo-relay = false
-huggingface-hub = false
 
 [manifest]
 overrides = [
@@ -1868,7 +1869,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
-    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.6.1" },
+    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.9.1" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.2.0" },
     { name = "httplib2", marker = "extra == 'google'", specifier = "==0.32.0" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
@@ -1966,7 +1967,7 @@ wheels = [
 
 [[package]]
 name = "hindsight-client"
-version = "0.6.1"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1976,9 +1977,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/26/8b8efa4be21fc3ba12ade3b1353d87f9837ec0d3ec2607e8adbf85bc9c63/hindsight_client-0.6.1.tar.gz", hash = "sha256:314d0bb9e13622e15586ba1586a799726d405b27bc20d78872474b5d6d96cd51", size = 99833, upload-time = "2026-05-08T13:01:23.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/78/0f341cbf4ddb4ca04c43e255c03620354390f62bb39c425ddeda58d6e1c7/hindsight_client-0.9.1.tar.gz", hash = "sha256:1949a22d2c2493ae6ca69cf90f2ecf936d5ed9e39645b00cab343978864d4738", size = 146220, upload-time = "2026-08-14T08:46:45.441Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/4f/a1d0bc33ef933ecc52e76dc1514163594d25836a5d303c256a61bb61445d/hindsight_client-0.6.1-py3-none-any.whl", hash = "sha256:9fdda176ab50f7cec8d7339c6608c148f0cd9ad7e65d9d76192f2db730bc330a", size = 249379, upload-time = "2026-05-08T13:01:22.035Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a1/1e16036d01c5e7d0e4a4514214af798625f84d7de0ddb61885d73a53fcf7/hindsight_client-0.9.1-py3-none-any.whl", hash = "sha256:95183c7dc8eebdc34ef4d5afdb4927cd2511b7e7fe71805879ce0e0d0f42546a", size = 349681, upload-time = "2026-08-14T08:46:43.895Z" },
 ]
 
 [[package]]
@@ -4050,7 +4051,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4105,7 +4106,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -4744,11 +4745,11 @@ name = "vercel-workers"
 version = "0.0.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.12'" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
-    { name = "vercel", marker = "python_full_version >= '3.12'" },
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "vercel" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/df/04d37021ad7ca53b7599c313e411d91623c7a005c741f491d1eefb7a9f0c/vercel_workers-0.0.25.tar.gz", hash = "sha256:212ded01400b524be51d251df49f801caf115ad7d48cca7eb168cbeceda3def3", size = 64149, upload-time = "2026-06-20T19:26:27.177Z" }
 wheels = [


### PR DESCRIPTION
## Problem

Hindsight server 0.9.1 supports `prefer_observations` on recall: when recalling observations together with raw `world`/`experience` facts, it drops raw facts that a returned observation already supersedes and backfills the budget.

Hermes still pins `hindsight-client==0.6.1`. That client builds a fixed `RecallRequest` and **silently drops** unknown kwargs. Setting `"prefer_observations": true` in `~/.hermes/hindsight/config.json` is therefore inert.

## Fix

- Pin the `hindsight` extra to `hindsight-client==0.9.1` (current PyPI latest; published 2026-08-14).
- Add `hindsight-client = false` to `[tool.uv].exclude-newer-package` so the 14-day cutoff cannot hide a freshly-pinned exact version.
- Plugin reads `prefer_observations` from config (default `false`) and forwards it on **both** recall sites: `_do_recall` (prefetch / auto-recall) and the `hindsight_recall` tool.

Default stays off. Existing observation-only configs do not change behavior.

## Verification

- New tests fail on unpatched `origin/main` (`AttributeError` / missing kwarg) and pass with the patch.
- `tests/plugins/memory/test_hindsight_*.py` + packaging metadata: **121 passed**.

## Notes

`_MIN_CLIENT_VERSION` stays `0.6.1`. Older clients still initialize; they just cannot forward the flag until the extra is installed.
