### PR TITLE
fix(desktop): cron panel empty states stop suggesting a broader search when no search is active

### DIFF
--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -682,7 +682,9 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
               />
             ))}
             {visibleJobs.length === 0 && (
-              <p className="px-2 py-4 text-center text-xs text-muted-foreground">{c.emptyTitleSearch}</p>
+              <p className="px-2 py-4 text-center text-xs text-muted-foreground">
+                {query.trim() ? c.emptyTitleSearch : c.emptyTitleNew}
+              </p>
             )}
             <PanelAddButton label={c.newCron} onClick={() => setEditor({ mode: 'create' })} />
             {visibleBlueprints.length > 0 && (
@@ -711,8 +713,13 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
               onPauseResume={() => void handlePauseResume(selectedJob)}
               onTrigger={() => void handleTrigger(selectedJob)}
             />
-          ) : (
+          ) : query.trim() ? (
+            // A search with no selected job: search-flavored copy is right.
             <PanelEmpty description={c.emptyDescSearch} icon="search" />
+          ) : (
+            // No selection and no search — "Try a broader search query" here
+            // just confused people staring at an empty panel with zero jobs.
+            <PanelEmpty description={c.emptyDescNew} icon="watch" title={jobs.length === 0 ? c.emptyTitleNew : undefined} />
           )}
         </PanelBody>
       )}


### PR DESCRIPTION
## Summary

The Scheduled jobs panel no longer tells users to "Try a broader search query" when they haven't searched for anything.

Both cron empty states used search-flavored copy unconditionally: the list's zero-rows row always said "No matches", and the detail pane always said "Try a broader search query" — including on a fresh panel with zero jobs and no query, where it reads as a non sequitur.

## Changes

- `apps/desktop/src/app/cron/index.tsx`: both empty states now follow the query state — with a query: existing "No matches" / "Try a broader search query"; without: "No scheduled jobs yet" / the schedule-a-prompt description (existing i18n keys, no new locale strings).

## Validation

| | Result |
|---|---|
| vitest src/app/cron/ | 32/32 pass |
| Live desktop, 1 job + no query | search copy gone, schedule copy shown in detail pane |

Found during the full-desktop feature audit (Aug 19).

## Infographic

![Cron panel honest empty states](https://files.catbox.moe/6fk8w8.png)
