### PR TITLE
fix(config): desktop launches no longer log a false TERMINAL_CWD .env deprecation warning (salvage #85703)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2227,10 +2227,17 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
     """Warn if MESSAGING_CWD or TERMINAL_CWD is set in .env instead of config.yaml.
 
     These env vars are deprecated — the canonical setting is terminal.cwd
-    in config.yaml.  Prints a migration hint to stderr.
+    in config.yaml.  Read the file rather than ``os.environ`` because runtime
+    config bridges and session restoration legitimately set ``TERMINAL_CWD``.
+    Prints a migration hint to stderr.
     """
-    messaging_cwd = os.environ.get("MESSAGING_CWD")
-    terminal_cwd_env = os.environ.get("TERMINAL_CWD")
+    try:
+        env_map = load_env()
+    except Exception:
+        return
+
+    messaging_cwd = str(env_map.get("MESSAGING_CWD") or "").strip()
+    terminal_cwd_env = str(env_map.get("TERMINAL_CWD") or "").strip()
 
     if config is None:
         try:
@@ -2250,7 +2257,6 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
             f"this is deprecated."
         )
     if terminal_cwd_env and not config_has_explicit_cwd:
-        # TERMINAL_CWD in env but not from config bridge — likely from .env
         lines.append(
             f"  \033[33m⚠\033[0m TERMINAL_CWD={terminal_cwd_env} found in .env — "
             f"this is deprecated."

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2239,24 +2239,13 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
     messaging_cwd = str(env_map.get("MESSAGING_CWD") or "").strip()
     terminal_cwd_env = str(env_map.get("TERMINAL_CWD") or "").strip()
 
-    if config is None:
-        try:
-            config = load_config()
-        except Exception:
-            return
-
-    terminal_cfg = config.get("terminal", {})
-    config_cwd = terminal_cfg.get("cwd", ".") if isinstance(terminal_cfg, dict) else "."
-    # Only warn if config.yaml doesn't have an explicit path
-    config_has_explicit_cwd = config_cwd not in {".", "auto", "cwd", ""}
-
     lines: list[str] = []
     if messaging_cwd:
         lines.append(
             f"  \033[33m⚠\033[0m MESSAGING_CWD={messaging_cwd} found in .env — "
             f"this is deprecated."
         )
-    if terminal_cwd_env and not config_has_explicit_cwd:
+    if terminal_cwd_env:
         lines.append(
             f"  \033[33m⚠\033[0m TERMINAL_CWD={terminal_cwd_env} found in .env — "
             f"this is deprecated."

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2223,7 +2223,7 @@ def print_config_warnings(config: Optional[Dict[str, Any]] = None) -> None:
     sys.stderr.write("\n".join(lines) + "\n\n")
 
 
-def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> None:
+def warn_deprecated_cwd_env_vars() -> None:
     """Warn if MESSAGING_CWD or TERMINAL_CWD is set in .env instead of config.yaml.
 
     These env vars are deprecated — the canonical setting is terminal.cwd

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -46,6 +46,17 @@ class TestDeprecatedCwdWarning:
         assert "deprecated" in captured.err.lower()
         assert "config.yaml" in captured.err
 
+    def test_dotenv_terminal_cwd_warns_with_explicit_config(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        _write_env(monkeypatch, tmp_path, "TERMINAL_CWD=/legacy/path\n")
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+
+        warn_deprecated_cwd_env_vars(config={"terminal": {"cwd": "/current/path"}})
+
+        assert "TERMINAL_CWD=/legacy/path" in capsys.readouterr().err
+
     def test_commented_and_empty_dotenv_values_do_not_warn(
         self, monkeypatch, tmp_path, capsys
     ):

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -1,29 +1,63 @@
 """Tests for warn_deprecated_cwd_env_vars() migration warning."""
 
 
+def _write_env(monkeypatch, tmp_path, content):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_text(content, encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return hermes_home
+
+
 class TestDeprecatedCwdWarning:
     """Warn when MESSAGING_CWD or TERMINAL_CWD is set in .env."""
 
-    def test_messaging_cwd_triggers_warning(self, monkeypatch, capsys):
-        monkeypatch.setenv("MESSAGING_CWD", "/some/path")
+    def test_process_environment_does_not_trigger_warning(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        _write_env(monkeypatch, tmp_path, "# TERMINAL_CWD=.\n")
+        monkeypatch.setenv("MESSAGING_CWD", "/process/message-path")
+        monkeypatch.setenv("TERMINAL_CWD", "/process/terminal-path")
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+
+        warn_deprecated_cwd_env_vars(config={})
+
+        assert capsys.readouterr().err == ""
+
+    def test_both_deprecated_vars_in_dotenv_warn(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        _write_env(
+            monkeypatch,
+            tmp_path,
+            "MESSAGING_CWD=/msg/path\nTERMINAL_CWD=/term/path\n",
+        )
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
         monkeypatch.delenv("TERMINAL_CWD", raising=False)
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
-        warn_deprecated_cwd_env_vars(config={})
 
-        captured = capsys.readouterr()
-        assert "MESSAGING_CWD" in captured.err
-        assert "deprecated" in captured.err.lower()
-        assert "config.yaml" in captured.err
-
-
-    def test_both_deprecated_vars_warn(self, monkeypatch, capsys):
-        monkeypatch.setenv("MESSAGING_CWD", "/msg/path")
-        monkeypatch.setenv("TERMINAL_CWD", "/term/path")
-
-        from hermes_cli.config import warn_deprecated_cwd_env_vars
         warn_deprecated_cwd_env_vars(config={})
 
         captured = capsys.readouterr()
         assert "MESSAGING_CWD" in captured.err
         assert "TERMINAL_CWD" in captured.err
+        assert "deprecated" in captured.err.lower()
+        assert "config.yaml" in captured.err
+
+    def test_commented_and_empty_dotenv_values_do_not_warn(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        _write_env(
+            monkeypatch,
+            tmp_path,
+            "# MESSAGING_CWD=/commented\nTERMINAL_CWD=\n",
+        )
+        monkeypatch.setenv("TERMINAL_CWD", "/process/bridge")
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+
+        warn_deprecated_cwd_env_vars(config={})
+
+        assert capsys.readouterr().err == ""

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -21,7 +21,7 @@ class TestDeprecatedCwdWarning:
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
 
-        warn_deprecated_cwd_env_vars(config={})
+        warn_deprecated_cwd_env_vars()
 
         assert capsys.readouterr().err == ""
 
@@ -38,7 +38,7 @@ class TestDeprecatedCwdWarning:
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
 
-        warn_deprecated_cwd_env_vars(config={})
+        warn_deprecated_cwd_env_vars()
 
         captured = capsys.readouterr()
         assert "MESSAGING_CWD" in captured.err
@@ -49,11 +49,16 @@ class TestDeprecatedCwdWarning:
     def test_dotenv_terminal_cwd_warns_with_explicit_config(
         self, monkeypatch, tmp_path, capsys
     ):
-        _write_env(monkeypatch, tmp_path, "TERMINAL_CWD=/legacy/path\n")
+        hermes_home = _write_env(
+            monkeypatch, tmp_path, "TERMINAL_CWD=/legacy/path\n"
+        )
+        (hermes_home / "config.yaml").write_text(
+            "terminal:\n  cwd: /current/path\n", encoding="utf-8"
+        )
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
 
-        warn_deprecated_cwd_env_vars(config={"terminal": {"cwd": "/current/path"}})
+        warn_deprecated_cwd_env_vars()
 
         assert "TERMINAL_CWD=/legacy/path" in capsys.readouterr().err
 
@@ -69,7 +74,7 @@ class TestDeprecatedCwdWarning:
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
 
-        warn_deprecated_cwd_env_vars(config={})
+        warn_deprecated_cwd_env_vars()
 
         assert capsys.readouterr().err == ""
 
@@ -81,6 +86,6 @@ class TestDeprecatedCwdWarning:
 
         monkeypatch.setattr(config_module, "load_env", raise_read_error)
 
-        config_module.warn_deprecated_cwd_env_vars(config={})
+        config_module.warn_deprecated_cwd_env_vars()
 
         assert capsys.readouterr().err == ""

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -72,3 +72,15 @@ class TestDeprecatedCwdWarning:
         warn_deprecated_cwd_env_vars(config={})
 
         assert capsys.readouterr().err == ""
+
+    def test_dotenv_read_failure_is_silent(self, monkeypatch, capsys):
+        import hermes_cli.config as config_module
+
+        def raise_read_error():
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(config_module, "load_env", raise_read_error)
+
+        config_module.warn_deprecated_cwd_env_vars(config={})
+
+        assert capsys.readouterr().err == ""


### PR DESCRIPTION
## Summary

The "⚠ Deprecated .env settings detected: TERMINAL_CWD found in .env" warning no longer fires when the variable was injected into the process environment rather than actually written in `.env` — which is what the Desktop app does on every backend spawn (electron/main.ts pins `TERMINAL_CWD` in the child env), so every desktop user saw a false deprecation warning on every launch.

Salvage of PR #85703 by @fangliquanflq (earliest of a 5-PR cluster: #85703 → #87034 → #88533 → #89124 → #90320, all the same fix) cherry-picked onto current main with authorship preserved.

## Changes

- `hermes_cli/config.py`: `warn_deprecated_cwd_env_vars()` reads MESSAGING_CWD / TERMINAL_CWD from `load_env()` (the actual `.env` file) instead of `os.environ`; the config-cwd heuristic parameter is gone (no longer needed — file entries are ground truth, so a real `.env` entry now warns even when config.yaml also sets terminal.cwd, which the old heuristic wrongly suppressed).
- `tests/hermes_cli/test_deprecated_cwd_warning.py`: rewritten against the file-based contract (process-env silent, .env entries warn, unreadable .env silent).

## Validation

| | Result |
|---|---|
| tests/hermes_cli/test_deprecated_cwd_warning.py | 5/5 pass |
| E2E: TERMINAL_CWD in process env, clean .env | silent |
| E2E: TERMINAL_CWD written in .env | warns |
| Desktop launch scenario (audit repro) | false warning gone |

Fixes #85695, #88829, #89016, #89389, #90299 (reported five times). Found again live during the full-desktop feature audit (Aug 19): a scratch-home desktop launch with only OPENROUTER_API_KEY in .env logged the warning.

## Infographic

![Warn from the file not the env](https://files.catbox.moe/109gk7.png)
