### PR TITLE
fix(gateway): resolve context_max from model config when compressor is stale

### DIFF
--- a/agent/context_breakdown.py
+++ b/agent/context_breakdown.py
@@ -34,6 +34,31 @@ def _chars_to_tokens(text: str) -> int:
     return (len(text) + 3) // 4
 
 
+def _resolve_model_context_length(agent: Any) -> int:
+    """Resolve the model's context window when the context compressor is
+    absent or hasn't resolved yet.
+
+    Uses the same ``get_model_context_length`` resolver the compressor itself
+    uses on first access, reading the agent's model/provider/base_url and the
+    explicit ``_config_context_length`` / ``_custom_providers`` attributes that
+    ``agent_init`` sets. Returns 0 if resolution fails — the caller treats 0
+    as "unknown" and omits the gauge rather than fabricating a number.
+    """
+    try:
+        from agent.model_metadata import get_model_context_length
+
+        return get_model_context_length(
+            model=str(getattr(agent, "model", "") or ""),
+            base_url=str(getattr(agent, "base_url", "") or ""),
+            api_key=str(getattr(agent, "api_key", "") or ""),
+            config_context_length=getattr(agent, "_config_context_length", None),
+            provider=str(getattr(agent, "provider", "") or ""),
+            custom_providers=getattr(agent, "_custom_providers", None),
+        )
+    except Exception:
+        return 0
+
+
 def _json_tokens(value: Any) -> int:
     if not value:
         return 0
@@ -129,6 +154,12 @@ def compute_session_context_breakdown(
 
     comp = getattr(agent, "context_compressor", None)
     context_max = int(getattr(comp, "context_length", 0) or 0) if comp else 0
+    # Fall back to the model's configured context_length when the compressor
+    # is absent (resumed session) or hasn't resolved yet. Without this, a
+    # resumed or freshly-opened session reports context_max=0 and the desktop
+    # panel shows "0/0 tokens, No context data yet" until a turn runs.
+    if not context_max:
+        context_max = _resolve_model_context_length(agent)
     measured_used = int(getattr(comp, "last_prompt_tokens", 0) or 0) if comp else 0
     context_used = measured_used if measured_used > 0 else estimated_total
     context_percent = (

--- a/tests/agent/test_context_breakdown.py
+++ b/tests/agent/test_context_breakdown.py
@@ -126,3 +126,43 @@ def test_details_lines_caps_listing():
     assert any("… and 5 more" in line for line in lines)
 
 
+# ── Fallback when compressor is absent or has context_length=0 ──────────────
+
+
+def test_breakdown_falls_back_when_compressor_absent():
+    """A resumed session has no context_compressor; the breakdown should
+    still report a real context_max resolved from the model config."""
+    agent, parts = _make_agent()
+    agent.context_compressor = None  # simulate resumed session
+
+    with (
+        patch("agent.system_prompt.build_system_prompt_parts", return_value=parts),
+        patch(
+            "agent.context_breakdown._resolve_model_context_length",
+            return_value=262_144,
+        ),
+    ):
+        data = compute_session_context_breakdown(agent, [])
+
+    assert data["context_max"] == 262_144
+    assert data["context_percent"] >= 0
+
+
+def test_breakdown_falls_back_when_compressor_context_length_is_zero():
+    """A freshly-built compressor may report context_length=0 before its
+    first lazy resolution; the breakdown should fall back to the model
+    config rather than showing 0/0."""
+    agent, parts = _make_agent(context_length=0)
+
+    with (
+        patch("agent.system_prompt.build_system_prompt_parts", return_value=parts),
+        patch(
+            "agent.context_breakdown._resolve_model_context_length",
+            return_value=131_072,
+        ),
+    ):
+        data = compute_session_context_breakdown(agent, [])
+
+    assert data["context_max"] == 131_072
+
+

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17798,6 +17798,46 @@ def test_get_usage_reports_real_current_occupancy():
     assert usage["context_percent"] == 50
 
 
+def test_get_usage_overrides_stale_context_max_after_model_switch():
+    """After a model switch with no turn run yet, the compressor still holds
+    the PREVIOUS model's context_length. The resolver should override it with
+    the current model's resolved context_length, and NOT fabricate a percent
+    from the previous model's context_used."""
+    agent = types.SimpleNamespace(
+        model="new-model-1m",
+        session_total_tokens=1_900_000,
+        context_compressor=types.SimpleNamespace(
+            model="old-model-131k",
+            last_prompt_tokens=167_000,
+            context_length=131_072,
+            compression_count=2,
+        ),
+    )
+    usage = server._get_usage(agent)
+    assert usage["context_used"] == 167_000
+    assert usage["context_max"] != 131_072  # overridden to the new model's window
+    assert "context_percent" not in usage  # stale percent dropped
+
+
+def test_get_usage_keeps_current_model_compressor_context_max():
+    """A legitimate compressor context_max for the CURRENT model is
+    authoritative and must not be replaced by the resolver's generic default
+    for an unrelated model string."""
+    agent = types.SimpleNamespace(
+        model="120k-model",
+        session_total_tokens=1_900_000,
+        context_compressor=types.SimpleNamespace(
+            model="120k-model",
+            last_prompt_tokens=60_000,
+            context_length=120_000,
+            compression_count=2,
+        ),
+    )
+    usage = server._get_usage(agent)
+    assert usage["context_max"] == 120_000
+    assert usage["context_percent"] == 50
+
+
 def test_get_usage_clamps_post_compression_sentinel():
     """Right after a compression, last_prompt_tokens is the -1 sentinel
     (conversation_compression sets it until the next real usage report). It is

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5533,6 +5533,59 @@ def _get_usage(agent) -> dict:
             usage["context_max"] = ctx_max
             usage["context_percent"] = max(0, min(100, round(last_prompt / ctx_max * 100)))
         usage["compressions"] = getattr(comp, "compression_count", 0) or 0
+    # Resolve context_max from the model's configured context_length.
+    # This covers three cases the compressor block above misses:
+    #   1. Compressor absent (resumed session) — context_max was never set.
+    #   2. No turn has run yet — last_prompt_tokens is 0, so the block above
+    #      intentionally omits context_max. We fill in only the denominator
+    #      so the bar shows "0/262K" instead of the cumulative fallback.
+    #   3. Model switched mid-session but no turn has run on the new model yet
+    #      — the compressor still holds the OLD model's context_length. We
+    #      override with the NEW model's resolved context_length so the bar
+    #      doesn't show impossible readings like "167K/131K 100%".
+    #
+    # We NEVER override a context_max the compressor reported for the CURRENT
+    # model — a legitimate reading (e.g. 120K for a 120K-window model) must
+    # not be replaced by the resolver's generic default for an unrelated
+    # model string. Override only when there is no context_max yet, or when
+    # the compressor is holding the previous model's value after a switch.
+    #
+    # Cache the resolved value on the agent so the per-tick polling path
+    # doesn't re-resolve (and potentially block on an unreachable endpoint)
+    # every few seconds. Re-resolve only when the model changes.
+    try:
+        from agent.context_breakdown import _resolve_model_context_length
+
+        _cache_key = getattr(agent, "model", "") or ""
+        _cached = getattr(agent, "_cached_context_max", None)
+        _cached_key = getattr(agent, "_cached_context_max_key", None)
+        if _cached is not None and _cached_key == _cache_key and _cached > 0:
+            _resolved_max = _cached
+        else:
+            _resolved_max = _resolve_model_context_length(agent)
+            if _resolved_max:
+                agent._cached_context_max = _resolved_max
+                agent._cached_context_max_key = _cache_key
+
+        if _resolved_max:
+            _existing_max = usage.get("context_max", 0) or 0
+            _compressor_model = (
+                str(getattr(comp, "model", "") or "") if comp else ""
+            )
+            _agent_model = str(getattr(agent, "model", "") or "")
+            # Override only when the compressor is absent, hasn't reported a
+            # context_max, or is holding the PREVIOUS model's value after a
+            # switch. A current-model compressor value is authoritative.
+            if not _existing_max or (
+                _compressor_model and _compressor_model != _agent_model
+            ):
+                usage["context_max"] = _resolved_max
+                # Do NOT recalculate context_percent here: context_used may
+                # be stale from the previous model. Omit percent until a real
+                # measurement on the current model arrives via the compressor.
+                usage.pop("context_percent", None)
+    except Exception:
+        pass
     # Live count of background/async subagents still running (delegate_task
     # batches + background single delegations). Mirrors the classic CLI status
     # bar's ⛓ indicator; sourced from the same async_delegation registry.


### PR DESCRIPTION
## What

The desktop statusbar context meter was completely missing — it didn't show at all. When manually enabled via localStorage, it showed wrong or empty readings:
- **Resumed sessions**: "0/0 tokens, No context data yet" (compressor absent)
- **Fresh sessions before first turn**: bar fell back to cumulative "3.4M tok"
- **Model switch mid-session**: "167K/131K 100%" (stale compressor context_length)

## Root cause

Commit `25d1c8d740` (Aug 14, 2026) refactored the context usage popover from fetching its own breakdown on mount to reading from a new `useContextBreakdown` hook in the statusbar. The hook calls `session.context_breakdown` RPC, but the backend's `compute_session_context_breakdown()` reads `context_max` exclusively from `agent.context_compressor.context_length` — which is 0 when the compressor is absent (resumed session), hasn't run yet (no turn), or holds a stale value (model switched but no turn on the new model yet). The panel became presentational and lost its own fetch path, so it had no fallback when the hook's data was empty.

The CLI doesn't have this problem because `/context` runs `compute_session_context_breakdown` synchronously in the agent's own process where the compressor is always attached.

## Fix

Add `_resolve_model_context_length(agent)` — a shared helper that calls the same `get_model_context_length()` resolver the compressor uses on first access, reading `agent.model`, `agent.provider`, `agent.base_url`, `agent._config_context_length`, and `agent._custom_providers`.

- `context_breakdown.py`: falls back to the helper when the compressor's `context_length` is 0
- `server.py`: resolves `context_max` from the helper, cached on the agent keyed by model name (re-resolves only on model switch, not every tick). Overrides the compressor's stale value when they disagree. `context_percent` is popped (not recalculated from stale `context_used`) when `context_max` is corrected. Only positive results are cached so a failed resolution retries on the next tick.

`context_used` and `context_percent` stay omitted until a real measurement exists — only the denominator is filled in or corrected. No fabrication.

## Security audit

Audited by `cyber` (adversarial code security review). Three issues found and fixed:
1. **HIGH**: synchronous resolver on per-tick polling path could block on unreachable endpoints → fixed with agent-level cache keyed by model name
2. **MED**: stale `context_percent` recalculated from old model's `context_used` after model switch → fixed by omitting percent when denominator is corrected
3. **MED**: zero-result cached permanently blocking retry → fixed by only caching positive results

No security issues (no new input validation surfaces, no secrets handling, no injection vectors).

## Testing

- 6/6 tests pass (`tests/agent/test_context_breakdown.py`), including 2 new tests for the fallback behavior
- Python syntax verified
- Verified on Hermes Desktop v0.20.4:
  - MiniMax-M3 (1M window): bar shows `38K/1M` ✅
  - Qwen3.8-27B-4bit (262K window): bar shows `0/262K` ✅
  - Model switch from 131K → 1M mid-session: no longer shows `167K/131K 100%` ✅
