### PR TITLE
fix(cli): /whoami no longer reports Unknown command in the classic CLI (salvage #26047)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9212,6 +9212,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         print()
     
 
+    def _handle_whoami_command(self):
+        """Display slash-command access for the local CLI surface."""
+        import getpass
+
+        try:
+            user_name = getpass.getuser() or "?"
+        except Exception:
+            user_name = "?"
+
+        print()
+        print("  You:            cli (local terminal)")
+        print(f"  User:           {user_name}")
+        print("  Tier:           unrestricted")
+        print("  Slash commands: all available")
+        print()
+
     def show_config(self):
         """Display current configuration with kawaii ASCII art."""
         # Get terminal config from environment (which was set from cli-config.yaml)
@@ -11381,6 +11397,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return False
         elif canonical == "help":
             self.show_help()
+        elif canonical == "whoami":
+            self._handle_whoami_command()
         elif canonical == "profile":
             self._handle_profile_command()
         elif canonical == "tools":

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -443,6 +443,24 @@ class TestNestedDictModelDefaultPairing:
         assert cli.requested_provider == "anthropic"
         assert cli.provider == "anthropic"
 
+    def test_whoami_command_is_dispatched_and_prints_cli_access(self, capsys):
+        """/whoami is advertised in classic CLI help and must not fall through.
+
+        Regression test: the command existed in the shared registry, so it
+        appeared in /help and completion, but classic CLI dispatch lacked a
+        matching branch and printed `Unknown command: /whoami`.
+        """
+        cli = _make_cli()
+
+        cli.process_command("/whoami")
+        output = capsys.readouterr().out
+
+        assert "Unknown command" not in output
+        assert "cli (local terminal)" in output
+        assert "Tier:" in output
+        assert "unrestricted" in output
+        assert "Slash commands: all available" in output
+
 
 class TestRootLevelProviderOverride:
     """Root-level provider/base_url in config.yaml must NOT override model.provider."""


### PR DESCRIPTION
## Summary
`/whoami` now dispatches in the classic CLI instead of printing `Unknown command: /whoami`.

Salvage of #26047 by @kronexoi (earliest of 4 independent fixes for this bug), cherry-picked onto current main with authorship preserved.

Root cause: the command exists in the shared `COMMAND_REGISTRY` (so it appears in `/help` and autocomplete on every surface), but `cli.py`'s `process_command()` never had a dispatch branch for it. Refs #74594, #35892.

## Changes
- `cli.py`: `_handle_whoami_command()` + dispatch branch in `process_command()`
- `tests/cli/test_cli_init.py`: regression test — `/whoami` must not fall through to Unknown command

## Validation
| | Before | After |
|---|---|---|
| `/whoami` in `hermes` chat | `Unknown command: /whoami` | prints access summary (verified live in tmux sandbox) |
| targeted test | n/a | `tests/cli/test_cli_init.py -k whoami` → 1 passed |

Duplicate cluster to close on merge: #26047 (salvaged, credit), #52170 (also fixed `/indicator` — already fixed on main), #61416, #77920.

## Infographic

![whoami fix infographic](https://files.catbox.moe/lfa42o.png)
