### PR TITLE
fix(cli): /yolo no longer claims approvals are re-enabled under process-frozen YOLO

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12654,10 +12654,27 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         """
         from hermes_cli.colors import Colors as _Colors
         from tools.approval import (
+            _YOLO_MODE_FROZEN,
             disable_session_yolo,
             enable_session_yolo,
             is_session_yolo_enabled,
         )
+
+        # Process-level YOLO (--yolo flag / HERMES_YOLO_MODE at startup) is
+        # frozen into tools.approval at import time and cannot be disabled by
+        # the session toggle. Before this guard, /yolo printed "YOLO mode OFF —
+        # dangerous commands will require approval" while every command kept
+        # auto-approving (the frozen flag short-circuits the approval gate
+        # ahead of the session check) — a false safety claim. Say the truth
+        # instead of toggling a bypass that has no effect.
+        if _YOLO_MODE_FROZEN:
+            _cprint(
+                f"  ⚡ YOLO is {_Colors.BOLD}{_Colors.RED}locked ON{_Colors.RESET}"
+                " for this process (started with --yolo / HERMES_YOLO_MODE)."
+                " /yolo cannot disable it — restart without the flag to"
+                " re-enable approvals."
+            )
+            return
 
         session_key = self.session_id or "default"
         # ``getattr`` guard: tests exercise this method unbound against a

--- a/tests/cli/test_cli_yolo_toggle.py
+++ b/tests/cli/test_cli_yolo_toggle.py
@@ -138,6 +138,27 @@ class TestIsSessionYoloActiveHelper:
         with patch.object(approval_module, "_YOLO_MODE_FROZEN", True):
             assert HermesCLI._is_session_yolo_active(stand_in) is True
 
+    def test_toggle_under_frozen_yolo_reports_locked_and_stays_on(self):
+        """With process-level YOLO frozen ON, /yolo must NOT claim approvals
+        are back. Pre-fix, the second toggle printed "YOLO mode OFF —
+        dangerous commands will require approval" while the frozen flag kept
+        auto-approving everything — a false safety claim."""
+        stand_in = _make_stand_in()
+
+        printed = []
+        with patch.object(approval_module, "_YOLO_MODE_FROZEN", True):
+            with patch("cli._cprint", side_effect=lambda msg: printed.append(msg)):
+                HermesCLI._toggle_yolo(stand_in)
+                HermesCLI._toggle_yolo(stand_in)
+
+            # Still effectively ON, and no session-level state was flipped.
+            assert HermesCLI._is_session_yolo_active(stand_in) is True
+            assert not approval_module.is_session_yolo_enabled(SESSION_KEY)
+
+        joined = "\n".join(printed)
+        assert "locked ON" in joined
+        assert "will require approval" not in joined
+
 
 class TestToggleYoloEndToEnd:
     """End-to-end: a dangerous command must auto-approve through the same


### PR DESCRIPTION
## Summary
`/yolo` no longer prints "YOLO mode OFF — dangerous commands will require approval" while process-frozen YOLO keeps auto-approving everything.

Found during a full-surface live QA sweep of the CLI: launch with `--yolo` (or `HERMES_YOLO_MODE=1`), then `/yolo` twice — the toggle claimed approvals were re-enabled, but `_YOLO_MODE_FROZEN` short-circuits `check_all_command_guards()` ahead of the session check, so `rm -rf` etc. still auto-approved. A false safety claim, and the status-bar `⚠ YOLO` badge (correctly) stayed on, contradicting the message.

Root cause: `_toggle_yolo()` only flips session-level bypass; process-level YOLO is intentionally frozen at import time (anti prompt-injection hardening) and unreachable from the toggle.

## Changes
- `cli.py` `_toggle_yolo()`: when `_YOLO_MODE_FROZEN` is set, print "YOLO is locked ON for this process… restart without the flag" and change nothing, instead of toggling dead session state with a misleading OFF message
- `tests/cli/test_cli_yolo_toggle.py`: regression test — frozen mode reports locked-ON, never claims approvals are back, session state untouched

## Validation
| | Before | After |
|---|---|---|
| `HERMES_YOLO_MODE=1` + `/yolo` | "YOLO mode OFF — will require approval" (untrue) | "YOLO is locked ON for this process…" (live-verified in tmux sandbox) |
| `tests/cli/test_cli_yolo_toggle.py` | 8 passed | 9 passed |

## Infographic

![yolo toggle fix infographic](https://files.catbox.moe/xl6ucp.png)
