### PR TITLE
fix(cli): /config no longer shows another vendor's API key on non-OpenAI providers

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9230,10 +9230,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # ``self.api_key`` may be a callable (Azure Foundry Entra ID bearer
         # provider). Never invoke it; just identify the auth surface.
         from agent.azure_identity_adapter import is_token_provider
-        if is_token_provider(self.api_key):
+
+        # Prefer the LIVE agent's credential when one exists: HermesCLI's
+        # constructor seeds self.api_key from OPENAI/OPENROUTER env vars
+        # before provider resolution runs, so on non-OpenAI providers (Nous,
+        # Anthropic, ...) the constructor value is a different vendor's key
+        # than the one actually authenticating requests. /config displaying
+        # an sk-proj-... OpenAI key next to a Nous base URL was the visible
+        # symptom (full-surface CLI QA sweep, Aug 2026).
+        display_key = self.api_key
+        agent = getattr(self, "agent", None)
+        if agent is not None and getattr(agent, "api_key", None):
+            display_key = agent.api_key
+        if is_token_provider(display_key):
             api_key_display = "Microsoft Entra ID"
-        elif isinstance(self.api_key, str) and len(self.api_key) > 12:
-            api_key_display = f"{self.api_key[:8]}...{self.api_key[-4:]}"
+        elif isinstance(display_key, str) and len(display_key) > 12:
+            api_key_display = f"{display_key[:8]}...{display_key[-4:]}"
         else:
             api_key_display = "Not set!"
         

--- a/tests/cli/test_show_config_credential.py
+++ b/tests/cli/test_show_config_credential.py
@@ -1,0 +1,51 @@
+"""Regression test: /config must show the LIVE agent credential.
+
+HermesCLI.__init__ seeds ``self.api_key`` from OPENAI_API_KEY /
+OPENROUTER_API_KEY env vars before provider resolution runs. On any
+non-OpenAI provider (Nous, Anthropic, ...) the constructor value is a
+different vendor's key than the one actually used for requests, so
+``/config`` displayed e.g. an ``sk-proj-...`` OpenAI key next to a Nous
+base URL. ``show_config`` must prefer ``self.agent.api_key`` when an
+agent exists.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+
+from cli import HermesCLI
+
+
+def _run_show_config(stand_in, capsys):
+    HermesCLI.show_config(stand_in)
+    return capsys.readouterr().out
+
+
+def _make_stand_in(cli_key, agent_key):
+    agent = SimpleNamespace(api_key=agent_key) if agent_key is not None else None
+    return SimpleNamespace(
+        api_key=cli_key,
+        agent=agent,
+        model="test/model",
+        base_url="https://example.invalid/v1",
+        enabled_toolsets=[],
+        max_turns=5,
+        verbose=False,
+        session_start=datetime(2026, 8, 19, 12, 0, 0),
+    )
+
+
+class TestShowConfigCredentialSource:
+    def test_prefers_live_agent_key(self, capsys):
+        out = _run_show_config(
+            _make_stand_in(cli_key="sk-proj-WRONGVENDORKEY1234", agent_key="nous-REALKEY-abcdef9876"),
+            capsys,
+        )
+        assert "nous-REA" in out
+        assert "sk-proj-" not in out
+
+    def test_falls_back_to_cli_key_without_agent(self, capsys):
+        out = _run_show_config(
+            _make_stand_in(cli_key="sk-proj-CONSTRUCTORKEY5678", agent_key=None),
+            capsys,
+        )
+        assert "sk-proj-" in out

--- a/tests/run_agent/test_callable_api_key.py
+++ b/tests/run_agent/test_callable_api_key.py
@@ -302,8 +302,8 @@ class TestInlinedDisplayMasks:
         from pathlib import Path
         src = (Path(__file__).resolve().parent.parent.parent
                / "cli.py").read_text()
-        assert "is_token_provider(self.api_key)" in src, (
-            "cli.HermesCLI.show_config must guard self.api_key via "
+        assert "is_token_provider(display_key)" in src, (
+            "cli.HermesCLI.show_config must guard the displayed key via "
             "is_token_provider so callable Entra ID providers don't "
             "crash /config."
         )


### PR DESCRIPTION
## Summary
`/config` now masks and displays the credential the live agent actually uses, not a constructor fallback from a different vendor.

Found during a full-surface live QA sweep: on a Nous Portal session, `/config` printed `API Key: sk-proj-...f8EA` (an OpenAI key) next to `Base URL: https://inference-api.nousresearch.com/v1` — confusing at best, and it makes users think the wrong key is authenticating their requests.

Root cause: `HermesCLI.__init__` seeds `self.api_key` from `OPENAI_API_KEY`/`OPENROUTER_API_KEY` env vars before provider resolution runs; `show_config()` displayed that seed. The resolved credential lives on `self.agent.api_key` once the agent is built.

## Changes
- `cli.py` `show_config()`: prefer `self.agent.api_key` when an agent exists; constructor value remains the fallback pre-agent; Entra ID callable guard preserved
- `tests/cli/test_show_config_credential.py`: new — live-agent key preferred, constructor fallback without agent
- `tests/run_agent/test_callable_api_key.py`: source-contract assertion updated to the new guarded symbol

## Validation
| | Before | After |
|---|---|---|
| `/config` on a Nous session | `API Key: sk-proj-...f8EA` (OpenAI env key) | `API Key: eyJhbGci...NnfA` (live Nous token, live-verified in tmux) |
| targeted tests | — | 14 passed |

## Infographic

![config credential fix infographic](https://files.catbox.moe/yjjjyr.png)
