### PR TITLE
feat(cron): preserve native routine and execution identity

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -12,6 +12,7 @@ import sqlite3
 import threading
 import uuid
 from contextlib import contextmanager
+from datetime import datetime
 from typing import Any, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
@@ -159,25 +160,23 @@ def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:
 
 
 def get_execution(execution_id: str) -> Optional[Dict[str, Any]]:
-    if not isinstance(execution_id, str) or not execution_id:
-        return None
+    if not isinstance(execution_id, str) or not execution_id: return None
     with _transaction() as conn:
-        row = conn.execute(
-            "SELECT * FROM executions WHERE id=?", (execution_id,)
-        ).fetchone()
-    return _record(row)
+        return _record(conn.execute("SELECT * FROM executions WHERE id=?", (execution_id,)).fetchone())
+
+def execution_identity(record: Optional[Dict[str, Any]]) -> Optional[Dict[str, str]]:
+    return None if not record else {key: str(record.get(key) or ("unknown" if key == "status" else "")) for key in ("id", "job_id", "source", "status")}
 
 
-def execution_identity(record: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
-    if not record:
-        return None
-    return {
-        "id": str(record.get("id") or ""),
-        "job_id": str(record.get("job_id") or ""),
-        "source": str(record.get("source") or ""),
-        "status": str(record.get("status") or "unknown"),
-    }
-
+def execution_projection(
+    execution_id: Optional[str] = None,
+    *,
+    job_id: Optional[str] = None,
+    source: str = "",
+    status: str = "unknown",
+) -> Optional[Dict[str, str]]:
+    record = get_execution(execution_id) if execution_id else None
+    return execution_identity(record) or ({"id": str(execution_id), "job_id": str(job_id or ""), "source": str(source), "status": str(status)} if execution_id else None)
 
 def mark_execution_running(execution_id: str) -> Optional[Dict[str, Any]]:
     """Transition one claimed attempt to running exactly once."""
@@ -269,15 +268,21 @@ def list_executions(
         clauses.append("job_id=?")
         params.append(str(job_id))
     if before_claimed_at is not None:
-        if "|" in str(before_claimed_at):
-            claimed_at, execution_id = str(before_claimed_at).rsplit("|", 1)
+        cursor = str(before_claimed_at)
+        if "|" in cursor:
+            try:
+                claimed_at, execution_id = cursor.split("|")
+                if not claimed_at or not execution_id: raise ValueError
+                datetime.fromisoformat(claimed_at.replace("Z", "+00:00"))
+            except ValueError as exc:
+                raise ValueError("malformed execution cursor") from exc
             clauses.append("(claimed_at < ? OR (claimed_at = ? AND id < ?))")
             params.extend((claimed_at, claimed_at, execution_id))
         else:
             clauses.append("claimed_at < ?")
             params.append(str(before_claimed_at))
     where = " WHERE " + " AND ".join(clauses) if clauses else ""
-    params.append(max(1, min(int(limit), 500)))
+    params.append(max(1, min(int(limit), 501)))
     with _transaction() as conn:
         rows = conn.execute(
             "SELECT * FROM executions" + where
@@ -285,6 +290,18 @@ def list_executions(
             params,
         ).fetchall()
     return [dict(row) for row in rows]
+
+
+def list_execution_page(
+    job_id: str, *, limit: int = 50, before_claimed_at: Optional[str] = None
+) -> tuple[List[Dict[str, Any]], Optional[str], bool]:
+    page_limit = min(max(1, int(limit)), 500)
+    rows = list_executions(job_id=job_id, limit=page_limit + 1,
+                           before_claimed_at=before_claimed_at)
+    has_more = len(rows) > page_limit
+    last = rows[page_limit - 1] if has_more else None
+    return rows[:page_limit], (f"{last['claimed_at']}|{last['id']}"
+                  if last and last.get("claimed_at") and last.get("id") else None), has_more
 
 
 def latest_execution(job_id: str) -> Optional[Dict[str, Any]]:

--- a/cron/executions.py
+++ b/cron/executions.py
@@ -279,6 +279,7 @@ def list_executions(
             clauses.append("(claimed_at < ? OR (claimed_at = ? AND id < ?))")
             params.extend((claimed_at, claimed_at, execution_id))
         else:
+            datetime.fromisoformat(cursor.replace("Z", "+00:00"))
             clauses.append("claimed_at < ?")
             params.append(str(before_claimed_at))
     where = " WHERE " + " AND ".join(clauses) if clauses else ""

--- a/cron/executions.py
+++ b/cron/executions.py
@@ -158,6 +158,27 @@ def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:
     return record  # type: ignore[return-value]
 
 
+def get_execution(execution_id: str) -> Optional[Dict[str, Any]]:
+    if not isinstance(execution_id, str) or not execution_id:
+        return None
+    with _transaction() as conn:
+        row = conn.execute(
+            "SELECT * FROM executions WHERE id=?", (execution_id,)
+        ).fetchone()
+    return _record(row)
+
+
+def execution_identity(record: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if not record:
+        return None
+    return {
+        "id": str(record.get("id") or ""),
+        "job_id": str(record.get("job_id") or ""),
+        "source": str(record.get("source") or ""),
+        "status": str(record.get("status") or "unknown"),
+    }
+
+
 def mark_execution_running(execution_id: str) -> Optional[Dict[str, Any]]:
     """Transition one claimed attempt to running exactly once."""
     now = _hermes_now().isoformat()
@@ -248,8 +269,13 @@ def list_executions(
         clauses.append("job_id=?")
         params.append(str(job_id))
     if before_claimed_at is not None:
-        clauses.append("claimed_at < ?")
-        params.append(str(before_claimed_at))
+        if "|" in str(before_claimed_at):
+            claimed_at, execution_id = str(before_claimed_at).rsplit("|", 1)
+            clauses.append("(claimed_at < ? OR (claimed_at = ? AND id < ?))")
+            params.extend((claimed_at, claimed_at, execution_id))
+        else:
+            clauses.append("claimed_at < ?")
+            params.append(str(before_claimed_at))
     where = " WHERE " + " AND ".join(clauses) if clauses else ""
     params.append(max(1, min(int(limit), 500)))
     with _transaction() as conn:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -341,10 +341,24 @@ def _jobs_lock(*, require_cross_process: bool = False):
                         except (OSError, IOError):
                             if time.monotonic() >= _deadline:
                                 if require_cross_process:
+                                    logger.error(
+                                        "Timed out after %.0fs waiting for the cron "
+                                        "jobs lock (%s) — durable keyed create "
+                                        "fails closed",
+                                        _JOBS_LOCK_TIMEOUT_SECONDS,
+                                        _jobs_lock_file(),
+                                    )
                                     raise CronStoreLockUnavailable(
                                         "timed out acquiring the durable cron store lock; "
                                         "retry the keyed create"
                                     )
+                                logger.error(
+                                    "Timed out after %.0fs waiting for the cron "
+                                    "jobs lock (%s) — proceeding with "
+                                    "in-process locking only",
+                                    _JOBS_LOCK_TIMEOUT_SECONDS,
+                                    _jobs_lock_file(),
+                                )
                                 lock_fd.close()
                                 lock_fd = None
                                 break
@@ -371,7 +385,14 @@ def _jobs_lock(*, require_cross_process: bool = False):
                         pass
                     finally:
                         lock_fd.close()
+                        lock_fd = None
         finally:
+            if lock_fd is not None and require_cross_process:
+                try:
+                    lock_fd.close()
+                except OSError:
+                    pass
+                lock_fd = None
             _jobs_lock_state.depth = 0
             _jobs_lock_state.load_stamp = None
 
@@ -1783,7 +1804,7 @@ def _validate_job_mode_invariants(
         )
 
 
-def create_job(
+def _create_job(
     prompt: Optional[str],
     schedule: str,
     name: Optional[str] = None,
@@ -1804,7 +1825,8 @@ def create_job(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     dedup_key: Optional[str] = None,
-) -> Dict[str, Any]:
+    _return_creation: bool = False,
+) -> Union[Dict[str, Any], Tuple[Dict[str, Any], bool]]:
     """
     Create a new cron job.
 
@@ -2006,16 +2028,28 @@ def create_job(
     if normalized_attach is not None:
         job["attach_to_session"] = normalized_attach
 
-    with _jobs_lock(require_cross_process=normalized_dedup_key is not None):
+    lock = (
+        _jobs_lock(require_cross_process=True)
+        if normalized_dedup_key is not None
+        else _jobs_lock()
+    )
+    with lock:
         jobs = load_jobs()
         if normalized_dedup_key is not None:
             for existing in jobs:
                 if _normalize_dedup_key(existing.get("dedup_key")) == normalized_dedup_key:
-                    return _normalize_job_record(existing)
+                    replay = _normalize_job_record(existing)
+                    return (replay, False) if _return_creation else replay
         jobs.append(job)
         save_jobs(jobs)
 
-    return job
+    return (job, True) if _return_creation else job
+
+
+def create_job(*args, **kwargs) -> Dict[str, Any]:
+    """Create one job and always return its public dict record."""
+    kwargs.pop("_return_creation", None)
+    return _create_job(*args, **kwargs)
 
 
 def get_job(job_id: str) -> Optional[Dict[str, Any]]:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -120,6 +120,9 @@ ONESHOT_GRACE_SECONDS = 120
 
 
 class CronStoreLockUnavailable(RuntimeError): retryable = True
+class CronDedupKeyInvalid(ValueError): pass
+class CronDedupConflict(ValueError):
+    def __init__(self, job_id: str): self.job_id = job_id; super().__init__("dedup_key conflicts with an existing job")
 @dataclass(frozen=True)
 class _CronStorePaths:
     cron_dir: Path
@@ -484,7 +487,17 @@ _IMMUTABLE_JOB_FIELDS = frozenset({"id", "dedup_key"})
 
 
 def _normalize_dedup_key(value: Any) -> Optional[str]:
-    return str(value).strip() or None if value is not None else None
+    if value is None: return None
+    if not isinstance(value, str) or re.fullmatch(r"[!-~]{1,128}", value) is None:
+        raise CronDedupKeyInvalid("dedup_key must be 1-128 printable ASCII characters without spaces")
+    return value
+
+
+_DEDUP_SEMANTIC_FIELDS = ("name", "prompt", "skills", "model", "provider", "base_url", "script", "no_agent", "monitor_script", "monitor_url", "context_from", "schedule", "repeat", "deliver", "enabled_toolsets", "workdir", "attach_to_session")
+def _dedup_fingerprint(job: Dict[str, Any], schedule: Optional[str] = None) -> str:
+    payload = {key: job.get(key) for key in _DEDUP_SEMANTIC_FIELDS}
+    payload["schedule"] = schedule.strip() if schedule is not None else payload["schedule"]
+    return uuid.uuid5(uuid.NAMESPACE_URL, json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)).hex
 
 
 def _job_output_dir(job_id: str) -> Path:
@@ -561,6 +574,7 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
     ensure consumers never crash while formatting or running those records.
     """
     normalized = _apply_skill_fields(job)
+    normalized.pop("_dedup_fingerprint", None)
     job_id = _coerce_job_text(normalized.get("id"), "unknown")
     prompt = _coerce_job_text(normalized.get("prompt"))
     normalized["id"] = job_id
@@ -2027,6 +2041,8 @@ def _create_job(
     # global cron.mirror_delivery config, default off).
     if normalized_attach is not None:
         job["attach_to_session"] = normalized_attach
+    if normalized_dedup_key is not None:
+        job["_dedup_fingerprint"] = _dedup_fingerprint(job, schedule)
 
     lock = (
         _jobs_lock(require_cross_process=True)
@@ -2038,16 +2054,16 @@ def _create_job(
         if normalized_dedup_key is not None:
             for existing in jobs:
                 if _normalize_dedup_key(existing.get("dedup_key")) == normalized_dedup_key:
+                    if existing.get("_dedup_fingerprint") != job["_dedup_fingerprint"]: raise CronDedupConflict(str(existing.get("id") or ""))
                     replay = _normalize_job_record(existing)
                     return (replay, False) if _return_creation else replay
         jobs.append(job)
         save_jobs(jobs)
 
-    return (job, True) if _return_creation else job
+    return (_normalize_job_record(job), True) if _return_creation else _normalize_job_record(job)
 
 
 def create_job(*args, **kwargs) -> Dict[str, Any]:
-    """Create one job and always return its public dict record."""
     kwargs.pop("_return_creation", None)
     return _create_job(*args, **kwargs)
 

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2242,7 +2242,6 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
 
 
 def _resolve_job_mutation(job_id: str, *, exact: bool = False) -> Optional[Dict[str, Any]]:
-    exact = exact or (isinstance(job_id, str) and re.fullmatch(r"[a-f0-9]{12}", job_id) is not None)
     return get_job(job_id) if exact else resolve_job_ref(job_id)
 
 

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -18,6 +18,7 @@ import time
 import os
 import re
 import uuid
+from functools import partial
 
 # Cross-process advisory file locking for jobs.json critical sections.
 # fcntl is Unix-only; on Windows fall back to msvcrt. Either may be absent,
@@ -118,6 +119,7 @@ OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
 
 
+class CronStoreLockUnavailable(RuntimeError): retryable = True
 @dataclass(frozen=True)
 class _CronStorePaths:
     cron_dir: Path
@@ -270,7 +272,7 @@ def _jobs_lock_file() -> Path:
 
 
 @contextlib.contextmanager
-def _jobs_lock():
+def _jobs_lock(*, require_cross_process: bool = False):
     """Serialize a load_jobs→modify→save_jobs critical section.
 
     Combines the in-process threading lock (cheap mutual exclusion between
@@ -308,6 +310,10 @@ def _jobs_lock():
         _jobs_lock_state.load_stamp = None
         lock_fd = None
         try:
+            if require_cross_process and not any((callable(getattr(fcntl, "flock", None)), callable(getattr(msvcrt, "locking", None)))):
+                raise CronStoreLockUnavailable(
+                    "durable cron store locking is unavailable; retry the keyed create"
+                )
             try:
                 ensure_dirs()
                 lock_fd = open(_jobs_lock_file(), "a+", encoding="utf-8")
@@ -334,24 +340,20 @@ def _jobs_lock():
                             break
                         except (OSError, IOError):
                             if time.monotonic() >= _deadline:
-                                logger.error(
-                                    "Timed out after %.0fs waiting for the cron "
-                                    "jobs lock (%s) — another process is holding "
-                                    "it. Proceeding with in-process locking only "
-                                    "so the scheduler stays alive (#60703).",
-                                    _JOBS_LOCK_TIMEOUT_SECONDS,
-                                    _jobs_lock_file(),
-                                )
-                                try:
-                                    lock_fd.close()
-                                except OSError:
-                                    pass
+                                if require_cross_process:
+                                    raise CronStoreLockUnavailable(
+                                        "timed out acquiring the durable cron store lock; "
+                                        "retry the keyed create"
+                                    )
+                                lock_fd.close()
                                 lock_fd = None
                                 break
                             time.sleep(0.1)
                 elif msvcrt is not None:
                     getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_LOCK"), 1)
             except (OSError, IOError) as e:
+                if require_cross_process:
+                    raise CronStoreLockUnavailable(f"durable cron store lock unavailable; retry the keyed create: {e}") from e
                 # Never let a locking failure take down cron writes — fall back to
                 # in-process-only protection (still held via _jobs_file_lock).
                 logger.warning("jobs.json cross-process lock unavailable (%s); "
@@ -461,19 +463,7 @@ _IMMUTABLE_JOB_FIELDS = frozenset({"id", "dedup_key"})
 
 
 def _normalize_dedup_key(value: Any) -> Optional[str]:
-    if value is None:
-        return None
-    text = str(value).strip()
-    return text or None
-
-
-def _find_job_exact_unlocked(job_id: str) -> Optional[Dict[str, Any]]:
-    if not isinstance(job_id, str) or not job_id:
-        return None
-    for job in load_jobs():
-        if job.get("id") == job_id:
-            return _normalize_job_record(job)
-    return None
+    return str(value).strip() or None if value is not None else None
 
 
 def _job_output_dir(job_id: str) -> Path:
@@ -1871,9 +1861,6 @@ def create_job(
         monitor_url: Optional http(s) URL used as the monitor source instead
                 of a script — fetched with a bounded GET each tick. Same
                 hash-suppression semantics as ``monitor_script``.
-        dedup_key: Optional profile-local idempotency key. A valid repeated
-                create with the same non-empty key returns the existing job;
-                malformed retries are rejected before idempotent lookup.
 
     Returns:
         The created job dict
@@ -2019,7 +2006,7 @@ def create_job(
     if normalized_attach is not None:
         job["attach_to_session"] = normalized_attach
 
-    with _jobs_lock():
+    with _jobs_lock(require_cross_process=normalized_dedup_key is not None):
         jobs = load_jobs()
         if normalized_dedup_key is not None:
             for existing in jobs:
@@ -2033,10 +2020,11 @@ def create_job(
 
 def get_job(job_id: str) -> Optional[Dict[str, Any]]:
     """Get a job by ID."""
-    return _find_job_exact_unlocked(job_id)
-
-
-get_job_exact = get_job
+    jobs = load_jobs()
+    for job in jobs:
+        if job["id"] == job_id:
+            return _normalize_job_record(job)
+    return None
 
 
 class AmbiguousJobReference(LookupError):
@@ -2219,11 +2207,9 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
     return None
 
 
-update_job_exact = update_job
-
-
 def _resolve_job_mutation(job_id: str, *, exact: bool = False) -> Optional[Dict[str, Any]]:
-    return get_job_exact(job_id) if exact else resolve_job_ref(job_id)
+    exact = exact or (isinstance(job_id, str) and re.fullmatch(r"[a-f0-9]{12}", job_id) is not None)
+    return get_job(job_id) if exact else resolve_job_ref(job_id)
 
 
 def pause_job(
@@ -2242,10 +2228,6 @@ def pause_job(
             "paused_reason": reason,
         },
     )
-
-
-def pause_job_exact(job_id: str, reason: Optional[str] = None) -> Optional[Dict[str, Any]]:
-    return pause_job(job_id, reason, exact=True)
 
 
 def resume_job(job_id: str, *, exact: bool = False) -> Optional[Dict[str, Any]]:
@@ -2273,10 +2255,6 @@ def resume_job(job_id: str, *, exact: bool = False) -> Optional[Dict[str, Any]]:
     )
 
 
-def resume_job_exact(job_id: str) -> Optional[Dict[str, Any]]:
-    return resume_job(job_id, exact=True)
-
-
 def trigger_job(job_id: str, *, exact: bool = False) -> Optional[Dict[str, Any]]:
     """Schedule a job to run on the next scheduler tick. Accepts a job ID or name."""
     job = _resolve_job_mutation(job_id, exact=exact)
@@ -2292,10 +2270,6 @@ def trigger_job(job_id: str, *, exact: bool = False) -> Optional[Dict[str, Any]]
             "next_run_at": _hermes_now().isoformat(),
         },
     )
-
-
-def trigger_job_exact(job_id: str) -> Optional[Dict[str, Any]]:
-    return trigger_job(job_id, exact=True)
 
 
 def remove_job(job_id: str, *, exact: bool = False) -> bool:
@@ -2337,10 +2311,10 @@ def remove_job(job_id: str, *, exact: bool = False) -> bool:
     return False
 
 
-def remove_job_exact(job_id: str) -> bool:
-    return remove_job(job_id, exact=True)
-
-
+pause_job_exact = partial(pause_job, exact=True)
+resume_job_exact = partial(resume_job, exact=True)
+trigger_job_exact = partial(trigger_job, exact=True)
+remove_job_exact = partial(remove_job, exact=True)
 def mark_job_run(
     job_id: str,
     success: bool,

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -457,7 +457,23 @@ def fire_claim_fence(job_id: str, *, expected_owner: str):
 # as a filesystem path component under ``OUTPUT_DIR``; allowing it to be
 # updated lets an unsafe value (``../escape``, absolute path, nested) leak
 # into output writes/deletes.
-_IMMUTABLE_JOB_FIELDS = frozenset({"id"})
+_IMMUTABLE_JOB_FIELDS = frozenset({"id", "dedup_key"})
+
+
+def _normalize_dedup_key(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _find_job_exact_unlocked(job_id: str) -> Optional[Dict[str, Any]]:
+    if not isinstance(job_id, str) or not job_id:
+        return None
+    for job in load_jobs():
+        if job.get("id") == job_id:
+            return _normalize_job_record(job)
+    return None
 
 
 def _job_output_dir(job_id: str) -> Path:
@@ -1797,6 +1813,7 @@ def create_job(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    dedup_key: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1854,10 +1871,14 @@ def create_job(
         monitor_url: Optional http(s) URL used as the monitor source instead
                 of a script — fetched with a bounded GET each tick. Same
                 hash-suppression semantics as ``monitor_script``.
+        dedup_key: Optional profile-local idempotency key. A valid repeated
+                create with the same non-empty key returns the existing job;
+                malformed retries are rejected before idempotent lookup.
 
     Returns:
         The created job dict
     """
+    normalized_dedup_key = _normalize_dedup_key(dedup_key)
     parsed_schedule = parse_schedule(schedule)
 
     # Normalize repeat: treat 0 or negative values as None (infinite)
@@ -1990,6 +2011,8 @@ def create_job(
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
     }
+    if normalized_dedup_key is not None:
+        job["dedup_key"] = normalized_dedup_key
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
     # global cron.mirror_delivery config, default off).
@@ -1998,6 +2021,10 @@ def create_job(
 
     with _jobs_lock():
         jobs = load_jobs()
+        if normalized_dedup_key is not None:
+            for existing in jobs:
+                if _normalize_dedup_key(existing.get("dedup_key")) == normalized_dedup_key:
+                    return _normalize_job_record(existing)
         jobs.append(job)
         save_jobs(jobs)
 
@@ -2006,11 +2033,10 @@ def create_job(
 
 def get_job(job_id: str) -> Optional[Dict[str, Any]]:
     """Get a job by ID."""
-    jobs = load_jobs()
-    for job in jobs:
-        if job["id"] == job_id:
-            return _normalize_job_record(job)
-    return None
+    return _find_job_exact_unlocked(job_id)
+
+
+get_job_exact = get_job
 
 
 class AmbiguousJobReference(LookupError):
@@ -2193,9 +2219,18 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
     return None
 
 
-def pause_job(job_id: str, reason: Optional[str] = None) -> Optional[Dict[str, Any]]:
+update_job_exact = update_job
+
+
+def _resolve_job_mutation(job_id: str, *, exact: bool = False) -> Optional[Dict[str, Any]]:
+    return get_job_exact(job_id) if exact else resolve_job_ref(job_id)
+
+
+def pause_job(
+    job_id: str, reason: Optional[str] = None, *, exact: bool = False
+) -> Optional[Dict[str, Any]]:
     """Pause a job without deleting it. Accepts a job ID or name."""
-    job = resolve_job_ref(job_id)
+    job = _resolve_job_mutation(job_id, exact=exact)
     if not job:
         return None
     return update_job(
@@ -2209,9 +2244,13 @@ def pause_job(job_id: str, reason: Optional[str] = None) -> Optional[Dict[str, A
     )
 
 
-def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
+def pause_job_exact(job_id: str, reason: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    return pause_job(job_id, reason, exact=True)
+
+
+def resume_job(job_id: str, *, exact: bool = False) -> Optional[Dict[str, Any]]:
     """Resume a paused job and compute the next future run from now. Accepts a job ID or name."""
-    job = resolve_job_ref(job_id)
+    job = _resolve_job_mutation(job_id, exact=exact)
     if not job:
         return None
 
@@ -2234,9 +2273,13 @@ def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
     )
 
 
-def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
+def resume_job_exact(job_id: str) -> Optional[Dict[str, Any]]:
+    return resume_job(job_id, exact=True)
+
+
+def trigger_job(job_id: str, *, exact: bool = False) -> Optional[Dict[str, Any]]:
     """Schedule a job to run on the next scheduler tick. Accepts a job ID or name."""
-    job = resolve_job_ref(job_id)
+    job = _resolve_job_mutation(job_id, exact=exact)
     if not job:
         return None
     return update_job(
@@ -2251,9 +2294,13 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
     )
 
 
-def remove_job(job_id: str) -> bool:
+def trigger_job_exact(job_id: str) -> Optional[Dict[str, Any]]:
+    return trigger_job(job_id, exact=True)
+
+
+def remove_job(job_id: str, *, exact: bool = False) -> bool:
     """Remove a job by ID or name."""
-    job = resolve_job_ref(job_id)
+    job = _resolve_job_mutation(job_id, exact=exact)
     if not job:
         return False
     canonical_id = job["id"]
@@ -2288,6 +2335,10 @@ def remove_job(job_id: str) -> bool:
                 _fire_fence_locks.pop(_fence_key, None)
             return True
     return False
+
+
+def remove_job_exact(job_id: str) -> bool:
+    return remove_job(job_id, exact=True)
 
 
 def mark_job_run(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6711,9 +6711,7 @@ def create_job_with_scheduler_registration(**kwargs) -> dict:
     from cron.jobs import _create_job
     from cron.scheduler_provider import resolve_cron_scheduler
 
-    # Preserve the durable dedup result so replaying an idempotent create does
-    # not register a second external trigger.  The public create_job wrapper
-    # intentionally keeps its historical dict-only return shape.
+    # An idempotent replay must not register a second external trigger.
     job, created = _create_job(_return_creation=True, **kwargs)
     if not created:
         return job

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6708,10 +6708,15 @@ class CronSchedulerRegistrationError(RuntimeError):
 
 def create_job_with_scheduler_registration(**kwargs) -> dict:
     """Persist one job and register its first trigger with the active provider."""
-    from cron.jobs import create_job
+    from cron.jobs import _create_job
     from cron.scheduler_provider import resolve_cron_scheduler
 
-    job = create_job(**kwargs)
+    # Preserve the durable dedup result so replaying an idempotent create does
+    # not register a second external trigger.  The public create_job wrapper
+    # intentionally keeps its historical dict-only return shape.
+    job, created = _create_job(_return_creation=True, **kwargs)
+    if not created:
+        return job
     try:
         resolve_cron_scheduler().register_job(job)
     except Exception as exc:

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -501,14 +501,22 @@ def fire_overdue_jobs(
             claimed = provider.claim_fire(job_id)
             if claimed is None:
                 continue
-            threading.Thread(
-                target=provider.fire_claimed,
-                args=(claimed,),
-                kwargs={"adapters": adapters, "loop": loop},
-                daemon=True,
-                name=f"cron-misfire-{job_id[:12]}",
-            ).start()
-            fired += 1
+            def _submit(worker):
+                threading.Thread(
+                    target=worker,
+                    daemon=True,
+                    name=f"cron-misfire-{job_id[:12]}",
+                ).start()
+                return True
+
+            dispatched = provider.dispatch_claimed_fire(
+                claimed,
+                adapters=adapters,
+                loop=loop,
+                submit=_submit,
+            )
+            if dispatched:
+                fired += 1
         except Exception as exc:
             logger.warning(
                 "Misfire catch-up failed for job %s: %s: %s",
@@ -517,17 +525,32 @@ def fire_overdue_jobs(
     return fired
 
 
-def resolve_cron_scheduler() -> "CronScheduler":
+def resolve_cron_scheduler(
+    *, multiplex_profiles: bool | None = None,
+) -> "CronScheduler":
     """Return the active cron scheduler provider.
 
-    Reads ``cron.provider`` from config. Empty/absent → built-in. A named
+    Reads ``cron.provider`` from the active profile config. Empty/absent →
+    built-in. A named
     provider that is missing, fails to load, or reports ``is_available() ==
     False`` falls back to the built-in with a warning — cron must never be left
-    without a trigger.
+    without a trigger. In multiplex mode, the same safe built-in fallback used
+    by gateway startup is applied to every profile-scoped caller, including
+    API routes and manual tools. ``None`` follows the process's active
+    multiplex mode; callers that already own an explicit gateway config may
+    pass it directly.
     """
     import logging
 
     logger = logging.getLogger("cron.scheduler_provider")
+
+    if multiplex_profiles is None:
+        try:
+            from agent.secret_scope import is_multiplex_active
+
+            multiplex_profiles = is_multiplex_active()
+        except Exception:
+            multiplex_profiles = False
 
     name = ""
     try:
@@ -548,6 +571,9 @@ def resolve_cron_scheduler() -> "CronScheduler":
         if not provider.is_available():
             logger.warning("cron.provider '%s' not available; using built-in ticker", name)
             return InProcessCronScheduler()
+        provider = scheduler_for_profile_mode(
+            provider, multiplex_profiles=bool(multiplex_profiles)
+        )
         logger.info("Using cron scheduler provider: %s", provider.name)
         return provider
     except Exception as e:

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -222,13 +222,93 @@ class CronScheduler(ABC):
         """
         from cron.scheduler import run_one_job
 
-        run_one_job(
-            claimed_job,
-            adapters=adapters,
-            loop=loop,
-            cancel_event=cancel_event,
-        )
+        kwargs = {
+            "adapters": adapters,
+            "loop": loop,
+            "extra_prompt": claimed_job.get("_cron_extra_prompt"),
+        }
+        if cancel_event is not None:
+            kwargs["cancel_event"] = cancel_event
+        run_one_job(claimed_job, **kwargs)
         return True
+
+    def dispatch_claimed_fire(
+        self, claimed_job: dict, *, adapters=None, loop=None,
+        submit=None, cancel_event=None, extra_prompt=None,
+    ) -> bool:
+        """Run or hand off one already-admitted fire; callers own the rail."""
+        if extra_prompt:
+            claimed_job = dict(claimed_job, _cron_extra_prompt=extra_prompt)
+
+        def _run():
+            from cron.scheduler import release_running_job, try_register_running_job
+            if not try_register_running_job(claimed_job["id"]):
+                self.abort_claimed_fire(
+                    claimed_job,
+                    "Job is already running; execution was not started.",
+                )
+                return False
+            kwargs = {"adapters": adapters, "loop": loop}
+            if cancel_event is not None and provider_supports_fire_cancel(self):
+                kwargs["cancel_event"] = cancel_event
+            try:
+                try:
+                    result = self.fire_claimed(claimed_job, **kwargs)
+                except BaseException as exc:
+                    # The provider's fire hook is the first code that can
+                    # fail after admission. Close this exact owner-fenced
+                    # claim/attempt before returning a worker failure (or
+                    # propagating process-control signals). The abort is
+                    # deliberately idempotent: a provider that already wrote
+                    # a terminal row cannot be rewritten by this cleanup.
+                    self.abort_claimed_fire(
+                        claimed_job, str(exc) or type(exc).__name__
+                    )
+                    if not isinstance(exc, Exception):
+                        raise
+                    return False
+                if result is False:
+                    self.abort_claimed_fire(
+                        claimed_job, "Provider did not process the claimed fire."
+                    )
+                return result
+            finally:
+                release_running_job(claimed_job["id"])
+
+        if submit is None:
+            return bool(_run())
+        try:
+            handed_off = submit(_run)
+        except BaseException as exc:
+            self.abort_claimed_fire(claimed_job, str(exc) or type(exc).__name__)
+            if not isinstance(exc, Exception):
+                raise
+            return False
+        if handed_off is False:
+            self.abort_claimed_fire(
+                claimed_job, "Provider dispatch rail rejected the claimed fire."
+            )
+            return False
+        return True
+
+    @staticmethod
+    def abort_claimed_fire(claimed_job: dict, error: str) -> None:
+        """Close a claim when setup or submission fails before the worker."""
+        claim = claimed_job.get("fire_claim")
+        owner = claim.get("by") if isinstance(claim, dict) else None
+        try:
+            from cron.jobs import mark_job_run
+            kwargs = {"expected_fire_owner": owner} if owner else {}
+            mark_job_run(claimed_job["id"], False, error, **kwargs)
+        except Exception:
+            pass
+        execution_id = claimed_job.get("execution_id")
+        if execution_id:
+            try:
+                from cron.executions import finish_execution
+                finish_execution(str(execution_id), success=False, error=error)
+            except Exception:
+                pass
 
     def reconcile(self) -> None:
         """Converge the external registry toward jobs.json (the desired state):
@@ -241,7 +321,7 @@ def provider_supports_force_fire(provider: Any) -> bool:
     """Return whether a provider can safely receive ``fire_due(force=...)``."""
     try:
         parameters = inspect.signature(provider.fire_due).parameters.values()
-    except (TypeError, ValueError):
+    except (AttributeError, TypeError, ValueError):
         return False
     return any(
         parameter.kind is inspect.Parameter.VAR_KEYWORD
@@ -297,7 +377,7 @@ def provider_supports_fire_cancel(provider: Any) -> bool:
     """Return whether ``fire_claimed`` accepts a ``cancel_event`` kwarg."""
     try:
         parameters = inspect.signature(provider.fire_claimed).parameters.values()
-    except (TypeError, ValueError):
+    except (AttributeError, TypeError, ValueError):
         return False
     return any(
         parameter.kind is inspect.Parameter.VAR_KEYWORD

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -254,6 +254,17 @@ def provider_supports_force_fire(provider: Any) -> bool:
     )
 
 
+def provider_supports_claim_force(provider: Any) -> bool:
+    try:
+        parameters = inspect.signature(provider.claim_fire).parameters.values()
+    except (AttributeError, TypeError, ValueError):
+        return False
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD or
+               (p.name == "force" and p.kind in (
+                   inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                   inspect.Parameter.KEYWORD_ONLY)) for p in parameters)
+
+
 def provider_supports_split_fire(provider: Any) -> bool:
     """Return whether a provider implements the two-phase fire contract.
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1284,12 +1284,11 @@ _CRON_AVAILABLE = False
 try:
     from cron.jobs import (
         list_jobs as _cron_list,
-        get_job as _cron_get,
-        update_job as _cron_update,
-        remove_job as _cron_remove,
-        pause_job as _cron_pause,
-        resume_job as _cron_resume,
-        trigger_job as _cron_trigger,
+        get_job_exact as _cron_get,
+        update_job_exact as _cron_update,
+        remove_job_exact as _cron_remove,
+        pause_job_exact as _cron_pause,
+        resume_job_exact as _cron_resume,
     )
     from cron.scheduler import (
         CronSchedulerRegistrationError as _CronSchedulerRegistrationError,
@@ -1304,7 +1303,6 @@ except ImportError:
     _cron_remove = None
     _cron_pause = None
     _cron_resume = None
-    _cron_trigger = None
 
     class _CronSchedulerRegistrationError(RuntimeError):
         pass
@@ -1319,6 +1317,29 @@ def _notify_cron_provider_jobs_changed() -> None:
     except Exception:
         pass
 
+
+def _cron_execution_identity(
+    execution_id: Optional[str],
+    *,
+    job_id: str,
+    source: str = "",
+    status: str = "claimed",
+) -> Optional[Dict[str, str]]:
+    if not execution_id:
+        return None
+    try:
+        from cron.executions import execution_identity, get_execution
+        projected = execution_identity(get_execution(str(execution_id)))
+    except Exception:
+        projected = None
+    if projected:
+        return projected
+    return {
+        "id": str(execution_id),
+        "job_id": str(job_id),
+        "source": str(source),
+        "status": str(status),
+    }
 # Defense-in-depth: mirror the agent-facing cronjob tool, which scans the
 # user-supplied prompt for exfiltration/injection payloads at create/update
 # time (tools/cronjob_tools.py).  The REST cron endpoints are authenticated
@@ -2091,6 +2112,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("POST", "/api/jobs/{job_id}/pause", self._handle_pause_job),
             ("POST", "/api/jobs/{job_id}/resume", self._handle_resume_job),
             ("POST", "/api/jobs/{job_id}/run", self._handle_run_job),
+            ("GET", "/api/jobs/{job_id}/runs", self._handle_list_job_runs),
             ("POST", "/v1/runs", self._handle_runs),
             ("GET", "/v1/runs/{run_id}", self._handle_get_run),
             ("GET", "/v1/runs/{run_id}/events", self._handle_run_events),
@@ -5742,6 +5764,7 @@ class APIServerAdapter(BasePlatformAdapter):
             deliver = body.get("deliver", "local")
             skills = body.get("skills")
             repeat = body.get("repeat")
+            dedup_key = body.get("dedup_key")
 
             if not name:
                 return web.json_response({"error": "Name is required"}, status=400)
@@ -5761,7 +5784,6 @@ class APIServerAdapter(BasePlatformAdapter):
                     return web.json_response({"error": scan_error}, status=400)
             if repeat is not None and (not isinstance(repeat, int) or repeat < 1):
                 return web.json_response({"error": "Repeat must be a positive integer"}, status=400)
-
             kwargs = {
                 "prompt": prompt,
                 "schedule": schedule,
@@ -5773,6 +5795,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 kwargs["skills"] = skills
             if repeat is not None:
                 kwargs["repeat"] = repeat
+            if dedup_key is not None:
+                kwargs["dedup_key"] = str(dedup_key).strip()
 
             job = _cron_create(**kwargs)
             return web.json_response({"job": job})
@@ -5899,7 +5923,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
     async def _handle_run_job(self, request: "web.Request") -> "web.Response":
-        """POST /api/jobs/{job_id}/run — trigger immediate execution."""
+        """POST /api/jobs/{job_id}/run — admit and dispatch one native run."""
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
@@ -5912,11 +5936,140 @@ class APIServerAdapter(BasePlatformAdapter):
         job_id, id_err = self._check_job_id(request)
         if id_err:
             return id_err
+        with _reserve_pending_api_work(self) as reservation:
+            try:
+                job = _cron_get(job_id)
+                if not job:
+                    return web.json_response({"error": "Job not found"}, status=404)
+
+                from cron.scheduler_provider import resolve_cron_scheduler
+                provider = resolve_cron_scheduler()
+                provider_source = str(getattr(provider, "name", "provider"))
+                try:
+                    claimed_job = await asyncio.to_thread(
+                        provider.claim_fire, job_id, force=True
+                    )
+                except TypeError:
+                    claimed_job = await asyncio.to_thread(provider.claim_fire, job_id)
+                except Exception as admission_error:
+                    logger.error(
+                        "cron API run admission failed for %s: %s",
+                        job_id,
+                        admission_error,
+                    )
+                    return web.json_response(
+                        {"error": "cron run admission failed", "job_id": job_id},
+                        status=503,
+                    )
+                execution_id = (
+                    claimed_job.get("execution_id") or (claimed_job.get("execution") or {}).get("id")
+                    if isinstance(claimed_job, dict)
+                    else None
+                )
+                if claimed_job is None:
+                    from cron.executions import latest_execution
+                    latest = latest_execution(job_id)
+                    execution = _cron_execution_identity(
+                        latest.get("id") if latest else None,
+                        job_id=job_id,
+                        source=provider_source,
+                        status=latest.get("status", "unknown") if latest else "unknown",
+                    )
+                    return web.json_response(
+                        {
+                            "job": job,
+                            "execution": execution,
+                            "session_id": None,
+                            "status": "duplicate" if execution else "not_admitted",
+                        },
+                        status=200,
+                    )
+
+                job = _cron_get(job_id) or job
+                loop = asyncio.get_running_loop()
+                runner = self.gateway_runner or request.app.get("gateway_runner")
+                adapters = getattr(runner, "adapters", None) or None
+                task = asyncio.create_task(
+                    asyncio.to_thread(
+                        provider.fire_claimed,
+                        claimed_job,
+                        adapters=adapters,
+                        loop=loop,
+                    )
+                )
+                reservation["detached"] = True
+                task.add_done_callback(
+                    lambda _task: _release_pending_api_work(self, reservation)
+                )
+                try:
+                    self._background_tasks.add(task)
+                    task.add_done_callback(self._background_tasks.discard)
+                except (TypeError, AttributeError):
+                    pass
+                execution = _cron_execution_identity(
+                    execution_id,
+                    job_id=job_id,
+                    source=provider_source,
+                    status="claimed",
+                )
+                return web.json_response(
+                    {
+                        "job": job,
+                        "execution": execution,
+                        "session_id": (
+                            claimed_job.get("session_id")
+                            if isinstance(claimed_job, dict)
+                            else None
+                        ),
+                    },
+                    status=202,
+                )
+            except Exception as e:
+                return web.json_response({"error": _redact_api_error_text(e)}, status=500)
+
+    async def _handle_list_job_runs(self, request: "web.Request") -> "web.Response":
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        cron_err = self._check_jobs_available()
+        if cron_err:
+            return cron_err
+        job_id, id_err = self._check_job_id(request)
+        if id_err:
+            return id_err
+        raw_limit = request.query.get("limit", "50")
         try:
-            job = _cron_trigger(job_id)
-            if not job:
+            limit = int(raw_limit)
+        except (TypeError, ValueError):
+            return web.json_response({"error": "limit must be an integer"}, status=400)
+        if limit < 1:
+            return web.json_response({"error": "limit must be positive"}, status=400)
+        cursor = request.query.get("before_claimed_at") or None
+        try:
+            if not _cron_get(job_id):
                 return web.json_response({"error": "Job not found"}, status=404)
-            return web.json_response({"job": job})
+            from cron.executions import list_executions
+
+            runs = list_executions(
+                job_id=job_id,
+                limit=limit,
+                before_claimed_at=cursor,
+            )
+            next_cursor = (
+                f"{runs[-1].get('claimed_at')}|{runs[-1].get('id')}"
+                if len(runs) >= min(limit, 500)
+                and runs[-1].get("claimed_at") and runs[-1].get("id")
+                else None
+            )
+            return web.json_response(
+                {
+                    "job_id": job_id,
+                    "runs": runs,
+                    "next_before_claimed_at": next_cursor,
+                    "next_cursor": next_cursor,
+                    "has_more": next_cursor is not None,
+                }
+            )
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1342,7 +1342,6 @@ try:
         resume_job_exact as _cron_resume,
     )
     from cron.scheduler import (
-        CronSchedulerRegistrationError as _CronSchedulerRegistrationError,
         create_job_with_scheduler_registration as _cron_create,
     )
     _CRON_AVAILABLE = True
@@ -1354,10 +1353,6 @@ except ImportError:
     _cron_remove = None
     _cron_pause = None
     _cron_resume = None
-
-    class _CronSchedulerRegistrationError(RuntimeError):
-        pass
-
 
 def _notify_cron_provider_jobs_changed() -> None:
     """Tell the active cron scheduler provider the job set changed after a REST
@@ -5785,6 +5780,8 @@ class APIServerAdapter(BasePlatformAdapter):
         cron_err = self._check_jobs_available()
         if cron_err:
             return cron_err
+        from cron.jobs import CronDedupConflict, CronDedupKeyInvalid
+        from cron.scheduler import CronSchedulerRegistrationError
         try:
             body = await request.json()
             name = (body.get("name") or "").strip()
@@ -5825,11 +5822,13 @@ class APIServerAdapter(BasePlatformAdapter):
             if repeat is not None:
                 kwargs["repeat"] = repeat
             if dedup_key is not None:
-                kwargs["dedup_key"] = str(dedup_key).strip()
+                kwargs["dedup_key"] = dedup_key
 
             job = _cron_create(**kwargs)
             return web.json_response({"job": job})
-        except _CronSchedulerRegistrationError as e:
+        except CronDedupKeyInvalid as e: return web.json_response({"error": str(e)}, status=400)
+        except CronDedupConflict as e: return web.json_response({"error": str(e), "job_id": e.job_id}, status=409)
+        except CronSchedulerRegistrationError as e:
             return web.json_response(e.to_dict(), status=424)
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
@@ -5972,9 +5971,10 @@ class APIServerAdapter(BasePlatformAdapter):
                     return web.json_response({"error": "Job not found"}, status=404)
 
                 from cron.executions import execution_projection, latest_execution
-                from cron.scheduler_provider import provider_supports_claim_force, resolve_cron_scheduler
+                from cron.scheduler_provider import provider_supports_claim_force, provider_supports_split_fire, resolve_cron_scheduler
                 provider = resolve_cron_scheduler()
                 provider_source = str(getattr(provider, "name", "provider"))
+                if not provider_supports_split_fire(provider): return web.json_response({"error": "cron provider does not support typed run identity", "job_id": job_id}, status=409)
                 previous_execution = latest_execution(job_id)
                 claim_kwargs = {"force": True} if provider_supports_claim_force(provider) else {}
                 try:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1172,6 +1172,29 @@ def _fire_claim_kwargs(provider, adapters, loop):
     return kwargs, cancel_event
 
 
+def _dispatch_claimed_api_fire(provider, claimed_job, adapter, reservation, adapters, loop):
+    fire_kwargs, cancel_event = _fire_claim_kwargs(provider, adapters, loop)
+
+    def submit(worker):
+        _detach_api_task(
+            adapter,
+            reservation,
+            _run_thread_until_terminal(worker, abort_event=cancel_event),
+        )
+
+    dispatch = getattr(provider, "dispatch_claimed_fire", None)
+    if callable(dispatch):
+        return dispatch(claimed_job, **fire_kwargs, submit=submit)
+    submit(lambda: provider.fire_claimed(claimed_job, **fire_kwargs))
+    return True
+
+
+def _abort_claimed_api_fire(provider, claimed_job, error):
+    abort = getattr(provider, "abort_claimed_fire", None)
+    if callable(abort):
+        abort(claimed_job, error)
+
+
 @contextmanager
 def _reserve_pending_api_work(adapter):
     """Keep externally-triggered background work visible across awaits.
@@ -5979,13 +6002,24 @@ class APIServerAdapter(BasePlatformAdapter):
                          "status": "duplicate" if fresh_execution else "not_admitted"}, status=200,
                     )
 
-                loop = asyncio.get_running_loop()
-                runner = self.gateway_runner or request.app.get("gateway_runner")
-                adapters = getattr(runner, "adapters", None) or None
-                fire_kwargs, cancel_event = _fire_claim_kwargs(provider, adapters, loop)
-                _detach_api_task(self, reservation, _run_thread_until_terminal(
-                    provider.fire_claimed, claimed_job, abort_event=cancel_event, **fire_kwargs
-                ))
+                try:
+                    loop = asyncio.get_running_loop()
+                    runner = self.gateway_runner or request.app.get("gateway_runner")
+                    adapters = getattr(runner, "adapters", None) or None
+                    dispatched = _dispatch_claimed_api_fire(
+                        provider, claimed_job, self, reservation, adapters, loop
+                    )
+                except BaseException as setup_error:
+                    _abort_claimed_api_fire(
+                        provider,
+                        claimed_job, str(setup_error) or type(setup_error).__name__
+                    )
+                    raise
+                if not dispatched:
+                    return web.json_response(
+                        {"error": "cron run dispatch failed", "job_id": job_id},
+                        status=503,
+                    )
                 execution = execution_projection(execution_id, job_id=job_id,
                                                   source=provider_source, status="claimed")
                 return web.json_response(
@@ -6139,10 +6173,27 @@ class APIServerAdapter(BasePlatformAdapter):
                     status=200,
                 )
 
-            fire_kwargs, cancel_event = _fire_claim_kwargs(provider, adapters, loop)
-            _detach_api_task(self, reservation, _run_thread_until_terminal(
-                provider.fire_claimed, claimed_job, abort_event=cancel_event, **fire_kwargs
-            ))
+            try:
+                dispatched = _dispatch_claimed_api_fire(
+                    provider, claimed_job, self, reservation, adapters, loop
+                )
+            except BaseException as dispatch_error:
+                _abort_claimed_api_fire(
+                    provider,
+                    claimed_job, str(dispatch_error) or type(dispatch_error).__name__
+                )
+                if not isinstance(dispatch_error, Exception):
+                    raise
+                logger.error("cron fire dispatch failed for %s: %s", job_id, dispatch_error)
+                return web.json_response(
+                    {"error": "cron fire dispatch failed", "job_id": job_id},
+                    status=503,
+                )
+            if not dispatched:
+                return web.json_response(
+                    {"error": "cron fire dispatch failed", "job_id": job_id},
+                    status=503,
+                )
 
             return web.json_response({"status": "accepted", "job_id": job_id}, status=202)
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1144,6 +1144,34 @@ def _release_pending_api_work(adapter, reservation: dict[str, bool]) -> None:
         adapter._pending_agent_requests = max(0, adapter._pending_agent_requests - 1)
 
 
+async def _run_thread_until_terminal(target, *args, abort_event: Optional[threading.Event] = None, **kwargs):
+    worker = asyncio.create_task(asyncio.to_thread(target, *args, **kwargs))
+    try:
+        return await asyncio.shield(worker)
+    except asyncio.CancelledError:
+        if abort_event: abort_event.set()
+        try:
+            await worker
+        except BaseException:
+            pass
+        raise
+
+
+def _detach_api_task(adapter, reservation, awaitable):
+    task = asyncio.create_task(awaitable)
+    reservation["detached"] = True
+    task.add_done_callback(lambda _task: _release_pending_api_work(adapter, reservation))
+    adapter._background_tasks.add(task); task.add_done_callback(adapter._background_tasks.discard)
+
+
+def _fire_claim_kwargs(provider, adapters, loop):
+    cancel_event = threading.Event()
+    kwargs = {"adapters": adapters, "loop": loop}
+    from cron.scheduler_provider import provider_supports_fire_cancel
+    if provider_supports_fire_cancel(provider): kwargs["cancel_event"] = cancel_event
+    return kwargs, cancel_event
+
+
 @contextmanager
 def _reserve_pending_api_work(adapter):
     """Keep externally-triggered background work visible across awaits.
@@ -1284,8 +1312,8 @@ _CRON_AVAILABLE = False
 try:
     from cron.jobs import (
         list_jobs as _cron_list,
-        get_job_exact as _cron_get,
-        update_job_exact as _cron_update,
+        get_job as _cron_get,
+        update_job as _cron_update,
         remove_job_exact as _cron_remove,
         pause_job_exact as _cron_pause,
         resume_job_exact as _cron_resume,
@@ -1318,28 +1346,6 @@ def _notify_cron_provider_jobs_changed() -> None:
         pass
 
 
-def _cron_execution_identity(
-    execution_id: Optional[str],
-    *,
-    job_id: str,
-    source: str = "",
-    status: str = "claimed",
-) -> Optional[Dict[str, str]]:
-    if not execution_id:
-        return None
-    try:
-        from cron.executions import execution_identity, get_execution
-        projected = execution_identity(get_execution(str(execution_id)))
-    except Exception:
-        projected = None
-    if projected:
-        return projected
-    return {
-        "id": str(execution_id),
-        "job_id": str(job_id),
-        "source": str(source),
-        "status": str(status),
-    }
 # Defense-in-depth: mirror the agent-facing cronjob tool, which scans the
 # user-supplied prompt for exfiltration/injection payloads at create/update
 # time (tools/cronjob_tools.py).  The REST cron endpoints are authenticated
@@ -5923,7 +5929,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
     async def _handle_run_job(self, request: "web.Request") -> "web.Response":
-        """POST /api/jobs/{job_id}/run — admit and dispatch one native run."""
+        """POST /api/jobs/{job_id}/run — trigger immediate execution."""
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
@@ -5942,86 +5948,48 @@ class APIServerAdapter(BasePlatformAdapter):
                 if not job:
                     return web.json_response({"error": "Job not found"}, status=404)
 
-                from cron.scheduler_provider import resolve_cron_scheduler
+                from cron.executions import execution_projection, latest_execution
+                from cron.scheduler_provider import provider_supports_claim_force, resolve_cron_scheduler
                 provider = resolve_cron_scheduler()
                 provider_source = str(getattr(provider, "name", "provider"))
+                previous_execution = latest_execution(job_id)
+                claim_kwargs = {"force": True} if provider_supports_claim_force(provider) else {}
                 try:
-                    claimed_job = await asyncio.to_thread(
-                        provider.claim_fire, job_id, force=True
-                    )
-                except TypeError:
-                    claimed_job = await asyncio.to_thread(provider.claim_fire, job_id)
+                    claimed_job = await asyncio.to_thread(provider.claim_fire, job_id, **claim_kwargs)
                 except Exception as admission_error:
-                    logger.error(
-                        "cron API run admission failed for %s: %s",
-                        job_id,
-                        admission_error,
-                    )
-                    return web.json_response(
-                        {"error": "cron run admission failed", "job_id": job_id},
-                        status=503,
-                    )
-                execution_id = (
-                    claimed_job.get("execution_id") or (claimed_job.get("execution") or {}).get("id")
-                    if isinstance(claimed_job, dict)
-                    else None
-                )
+                    logger.error("cron API run admission failed for %s: %s", job_id, admission_error)
+                    return web.json_response({"error": "cron run admission failed", "job_id": job_id}, status=503)
+                execution_id = (claimed_job.get("execution_id") or
+                                (claimed_job.get("execution") or {}).get("id")) if isinstance(claimed_job, dict) else None
                 if claimed_job is None:
-                    from cron.executions import latest_execution
+                    job = _cron_get(job_id)
+                    if not job:
+                        return web.json_response({"error": "Job not found"}, status=404)
                     latest = latest_execution(job_id)
-                    execution = _cron_execution_identity(
-                        latest.get("id") if latest else None,
+                    previous_id = previous_execution.get("id") if isinstance(previous_execution, dict) else None
+                    fresh_execution = bool(isinstance(latest, dict) and latest.get("id") and latest.get("id") != previous_id)
+                    execution = execution_projection(
+                        latest.get("id") if fresh_execution else None,
                         job_id=job_id,
                         source=provider_source,
                         status=latest.get("status", "unknown") if latest else "unknown",
                     )
                     return web.json_response(
-                        {
-                            "job": job,
-                            "execution": execution,
-                            "session_id": None,
-                            "status": "duplicate" if execution else "not_admitted",
-                        },
-                        status=200,
+                        {"job": job, "execution": execution,
+                         "status": "duplicate" if fresh_execution else "not_admitted"}, status=200,
                     )
 
-                job = _cron_get(job_id) or job
                 loop = asyncio.get_running_loop()
                 runner = self.gateway_runner or request.app.get("gateway_runner")
                 adapters = getattr(runner, "adapters", None) or None
-                task = asyncio.create_task(
-                    asyncio.to_thread(
-                        provider.fire_claimed,
-                        claimed_job,
-                        adapters=adapters,
-                        loop=loop,
-                    )
-                )
-                reservation["detached"] = True
-                task.add_done_callback(
-                    lambda _task: _release_pending_api_work(self, reservation)
-                )
-                try:
-                    self._background_tasks.add(task)
-                    task.add_done_callback(self._background_tasks.discard)
-                except (TypeError, AttributeError):
-                    pass
-                execution = _cron_execution_identity(
-                    execution_id,
-                    job_id=job_id,
-                    source=provider_source,
-                    status="claimed",
-                )
+                fire_kwargs, cancel_event = _fire_claim_kwargs(provider, adapters, loop)
+                _detach_api_task(self, reservation, _run_thread_until_terminal(
+                    provider.fire_claimed, claimed_job, abort_event=cancel_event, **fire_kwargs
+                ))
+                execution = execution_projection(execution_id, job_id=job_id,
+                                                  source=provider_source, status="claimed")
                 return web.json_response(
-                    {
-                        "job": job,
-                        "execution": execution,
-                        "session_id": (
-                            claimed_job.get("session_id")
-                            if isinstance(claimed_job, dict)
-                            else None
-                        ),
-                    },
+                    {"job": job, "execution": execution},
                     status=202,
                 )
             except Exception as e:
@@ -6048,28 +6016,12 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             if not _cron_get(job_id):
                 return web.json_response({"error": "Job not found"}, status=404)
-            from cron.executions import list_executions
-
-            runs = list_executions(
-                job_id=job_id,
-                limit=limit,
-                before_claimed_at=cursor,
-            )
-            next_cursor = (
-                f"{runs[-1].get('claimed_at')}|{runs[-1].get('id')}"
-                if len(runs) >= min(limit, 500)
-                and runs[-1].get("claimed_at") and runs[-1].get("id")
-                else None
-            )
-            return web.json_response(
-                {
-                    "job_id": job_id,
-                    "runs": runs,
-                    "next_before_claimed_at": next_cursor,
-                    "next_cursor": next_cursor,
-                    "has_more": next_cursor is not None,
-                }
-            )
+            from cron.executions import list_execution_page
+            runs, next_cursor, has_more = list_execution_page(job_id, limit=limit, before_claimed_at=cursor)
+            return web.json_response({"job_id": job_id, "runs": runs,
+                                      "next_cursor": next_cursor, "has_more": has_more})
+        except ValueError:
+            return web.json_response({"error": "Malformed execution cursor"}, status=400)
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
@@ -6164,23 +6116,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 # ``fire_due`` hook (custom claim/re-arm/telemetry) but
                 # inherits the base ``claim_fire`` — driving it through the
                 # split claim path would silently bypass that override.
-                task = asyncio.create_task(
-                    asyncio.to_thread(
-                        provider.fire_due,
-                        job_id,
-                        adapters=adapters,
-                        loop=loop,
-                    )
-                )
-                reservation["detached"] = True
-                task.add_done_callback(
-                    lambda _task: _release_pending_api_work(self, reservation)
-                )
-                try:
-                    self._background_tasks.add(task)
-                    task.add_done_callback(self._background_tasks.discard)
-                except (TypeError, AttributeError):
-                    pass
+                _detach_api_task(self, reservation, _run_thread_until_terminal(
+                    provider.fire_due, job_id, adapters=adapters, loop=loop
+                ))
                 return web.json_response(
                     {"status": "accepted", "job_id": job_id}, status=202
                 )
@@ -6201,23 +6139,10 @@ class APIServerAdapter(BasePlatformAdapter):
                     status=200,
                 )
 
-            task = asyncio.create_task(
-                asyncio.to_thread(
-                    provider.fire_claimed,
-                    claimed_job,
-                    adapters=adapters,
-                    loop=loop,
-                )
-            )
-            reservation["detached"] = True
-            task.add_done_callback(
-                lambda _task: _release_pending_api_work(self, reservation)
-            )
-            try:
-                self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
-            except (TypeError, AttributeError):
-                pass
+            fire_kwargs, cancel_event = _fire_claim_kwargs(provider, adapters, loop)
+            _detach_api_task(self, reservation, _run_thread_until_terminal(
+                provider.fire_claimed, claimed_job, abort_event=cancel_event, **fire_kwargs
+            ))
 
             return web.json_response({"status": "accepted", "job_id": job_id}, status=202)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30477,14 +30477,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     from cron.scheduler_provider import (
         InProcessCronScheduler,
         resolve_cron_scheduler,
-        scheduler_for_profile_mode,
     )
     cron_stop = threading.Event()
     multiplex_cron = bool(getattr(runner.config, "multiplex_profiles", False))
-    cron_provider = scheduler_for_profile_mode(
-        resolve_cron_scheduler(),
-        multiplex_profiles=multiplex_cron,
-    )
+    cron_provider = resolve_cron_scheduler(multiplex_profiles=multiplex_cron)
     cron_start_kwargs: Dict[str, Any] = {"adapters": runner.adapters, "loop": asyncio.get_running_loop()}
 
     # Multiplex profiles: tell the built-in ticker which profile homes to

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -107,6 +107,22 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     assert "RAM 92% on host" in doc
 
 
+def test_run_one_job_no_agent_persists_direct_execution_identity(hermes_env):
+    from cron.executions import list_executions
+    from cron.jobs import create_job
+    from cron.scheduler import run_one_job
+
+    (hermes_env / "scripts" / "identity.sh").write_text("echo identity\n")
+    job = create_job(
+        prompt=None, schedule="every 5m", script="identity.sh", no_agent=True, deliver="local"
+    )
+    assert run_one_job(job) is True
+    rows = list_executions(job_id=job["id"])
+    assert len(rows) == 1
+    assert rows[0]["source"] == "direct"
+    assert rows[0]["status"] == "completed"
+
+
 def test_run_job_no_agent_reloads_dotenv_before_script(hermes_env, monkeypatch):
     """Regression: a standalone cron tick process starts without home-channel
     vars in its environment, and the agent path's per-run dotenv reload never

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -22,6 +22,9 @@ def test_execution_transitions_are_durable(monkeypatch, tmp_path):
 
     claimed = executions.create_execution("job-1", source="builtin")
     assert claimed["status"] == "claimed"
+    assert executions.execution_identity(claimed) == {
+        "id": claimed["id"], "job_id": "job-1", "source": "builtin", "status": "claimed"
+    }
     assert claimed["claimed_at"]
     assert claimed["started_at"] is None
     assert claimed["finished_at"] is None
@@ -81,6 +84,25 @@ def test_retention_bounds_terminal_history_but_preserves_inflight(monkeypatch, t
     records = executions.list_executions(limit=100)
     assert len([row for row in records if row["status"] == "completed"]) == 3
     assert executions.latest_execution("live")["status"] == "running"
+
+
+def test_history_cursor_keeps_same_timestamp_rows(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    from datetime import datetime, timezone
+
+    monkeypatch.setattr(
+        executions,
+        "_hermes_now",
+        lambda: datetime(2026, 8, 20, tzinfo=timezone.utc),
+    )
+    rows = [executions.create_execution("cursor-job", source="builtin") for _ in range(3)]
+    first = executions.list_executions(job_id="cursor-job", limit=2)
+    cursor = f"{first[-1]['claimed_at']}|{first[-1]['id']}"
+    second = executions.list_executions(
+        job_id="cursor-job", limit=2, before_claimed_at=cursor
+    )
+    assert {row["id"] for row in first + second} == {row["id"] for row in rows}
+    assert not ({row["id"] for row in first} & {row["id"] for row in second})
 
 
 def test_corrupt_store_fails_closed_without_overwrite(monkeypatch, tmp_path):

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -105,6 +105,15 @@ def test_history_cursor_keeps_same_timestamp_rows(monkeypatch, tmp_path):
     assert not ({row["id"] for row in first} & {row["id"] for row in second})
 
 
+def test_history_cursor_rejects_malformed_compound_values(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    import pytest
+
+    for cursor in ("bad|", "|execution", "not-a-time|execution", "a|b|c"):
+        with pytest.raises(ValueError):
+            executions.list_executions(before_claimed_at=cursor)
+
+
 def test_corrupt_store_fails_closed_without_overwrite(monkeypatch, tmp_path):
     executions = _point_ledger(monkeypatch, tmp_path)
     executions.EXECUTIONS_FILE.parent.mkdir(parents=True)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -216,6 +216,16 @@ class TestJobCRUD:
         assert len({job["id"] for job in results}) == 1
         assert len(load_jobs()) == 1
 
+    def test_keyed_create_fails_closed_without_durable_lock(self, tmp_cron_dir, monkeypatch):
+        """A keyed retry must not mint a process-local duplicate."""
+        import cron.jobs as jobs_mod
+
+        monkeypatch.setattr(jobs_mod, "fcntl", None)
+        monkeypatch.setattr(jobs_mod, "msvcrt", None)
+        with pytest.raises(jobs_mod.CronStoreLockUnavailable):
+            create_job(prompt="one", schedule="30m", dedup_key="no-lock")
+        assert load_jobs() == []
+
     def test_create_dedup_key_replays_across_processes_and_profiles(self, tmp_path):
         repo = Path(__file__).resolve().parents[2]
         code = (

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -196,12 +196,24 @@ def tmp_cron_dir(tmp_path, monkeypatch):
 
 class TestJobCRUD:
     def test_create_dedup_key_returns_existing_job(self, tmp_cron_dir):
-        first = create_job(prompt="one", schedule="30m", dedup_key="routine-1")
-        with pytest.raises(ValueError):
-            create_job(prompt="changed", schedule="not-a-schedule", dedup_key="routine-1")
-        second = create_job(prompt="changed", schedule="30m", dedup_key="routine-1")
+        import cron.jobs as jobs_mod
+        first = create_job(prompt="one", schedule="30m", dedup_key="routine-1", attach_to_session=True)
+        second = create_job(prompt="one", schedule="30m", dedup_key="routine-1", attach_to_session=True)
         assert second["id"] == first["id"]
+        assert "_dedup_fingerprint" not in second
+        for changed in ({"prompt": "changed", "schedule": "30m"},
+                        {"prompt": "one", "schedule": "31m"},
+                        {"prompt": "one", "schedule": "30m", "attach_to_session": False}):
+            with pytest.raises(jobs_mod.CronDedupConflict) as conflict:
+                create_job(**changed, dedup_key="routine-1")
+            assert conflict.value.job_id == first["id"]
         assert len(load_jobs()) == 1
+
+    @pytest.mark.parametrize("key", ["", "space key", "\n", "x" * 129, 7])
+    def test_create_rejects_invalid_dedup_key(self, tmp_cron_dir, key):
+        import cron.jobs as jobs_mod
+        with pytest.raises(jobs_mod.CronDedupKeyInvalid):
+            create_job(prompt="one", schedule="30m", dedup_key=key)
 
     def test_create_dedup_key_is_atomic_across_threads(self, tmp_cron_dir):
         results = []

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1,6 +1,10 @@
 """Tests for cron/jobs.py — schedule parsing, job CRUD, and due-job detection."""
 
 import threading
+import os
+import subprocess
+import sys
+from pathlib import Path
 import pytest
 from datetime import datetime, timedelta, timezone
 
@@ -190,6 +194,62 @@ def tmp_cron_dir(tmp_path, monkeypatch):
 
 
 class TestJobCRUD:
+    def test_create_dedup_key_returns_existing_job(self, tmp_cron_dir):
+        first = create_job(prompt="one", schedule="30m", dedup_key="routine-1")
+        with pytest.raises(ValueError):
+            create_job(prompt="changed", schedule="not-a-schedule", dedup_key="routine-1")
+        second = create_job(prompt="changed", schedule="30m", dedup_key="routine-1")
+        assert second["id"] == first["id"]
+        assert len(load_jobs()) == 1
+
+    def test_create_dedup_key_is_atomic_across_threads(self, tmp_cron_dir):
+        results = []
+
+        def create():
+            results.append(create_job(prompt="one", schedule="30m", dedup_key="routine-race"))
+
+        threads = [threading.Thread(target=create) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        assert len({job["id"] for job in results}) == 1
+        assert len(load_jobs()) == 1
+
+    def test_create_dedup_key_replays_across_processes_and_profiles(self, tmp_path):
+        repo = Path(__file__).resolve().parents[2]
+        code = (
+            "from cron.jobs import create_job; "
+            "print(create_job(prompt='one', schedule='every 5m', "
+            "dedup_key='process-key')['id'])"
+        )
+
+        def child(home, *, capture=True):
+            env = os.environ.copy()
+            env["HERMES_HOME"] = str(home)
+            env["PYTHONPATH"] = str(repo)
+            return subprocess.run(
+                [sys.executable, "-c", code],
+                cwd=repo,
+                env=env,
+                text=True,
+                capture_output=capture,
+                check=True,
+            )
+
+        first_home = tmp_path / "first"
+        second_home = tmp_path / "second"
+        first = child(first_home).stdout.strip()
+        # Simulate a successful create whose response was lost before the
+        # caller observed it; the retry must return the durable same ID.
+        child(first_home, capture=False)
+        replay = child(first_home).stdout.strip()
+        other_profile = child(second_home).stdout.strip()
+        assert replay == first
+        assert other_profile != first
+        assert len(__import__("json").loads((first_home / "cron" / "jobs.json").read_text())["jobs"]) == 1
+        assert len(__import__("json").loads((second_home / "cron" / "jobs.json").read_text())["jobs"]) == 1
+
     def test_cjk_and_emoji_round_trip_readable_in_jobs_json(self, tmp_cron_dir):
         """CJK/emoji job text must round-trip AND stay human-readable on disk.
 
@@ -405,6 +465,10 @@ class TestResolveJobRef:
         job = create_job(prompt="A", schedule="1h", name="alpha")
         assert resolve_job_ref(job["id"])["id"] == job["id"]
 
+    def test_cli_mutation_still_resolves_friendly_name(self, tmp_cron_dir):
+        job = create_job(prompt="A", schedule="1h", name="friendly")
+        assert pause_job("friendly")["id"] == job["id"]
+
 
     def test_mutations_refuse_ambiguous_name(self, tmp_cron_dir):
         """pause/resume/trigger/remove must refuse to act on an ambiguous name."""
@@ -417,6 +481,14 @@ class TestResolveJobRef:
                 fn("dup")
         with pytest.raises(AmbiguousJobReference):
             remove_job("dup")
+
+    def test_exact_lifecycle_helpers_do_not_resolve_names(self, tmp_cron_dir):
+        from cron.jobs import pause_job_exact, trigger_job_exact
+
+        job = create_job(prompt="A", schedule="1h", name="friendly")
+        assert pause_job_exact("friendly") is None
+        assert trigger_job_exact("friendly") is None
+        assert pause_job_exact(job["id"])["id"] == job["id"]
 
 
 class TestMarkJobRun:

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -25,6 +25,7 @@ from cron.jobs import (
     advance_next_run,
     claim_dispatch,
     claim_job_for_fire,
+    trigger_job,
     heartbeat_run_claim,
     get_due_jobs,
     save_job_output,
@@ -478,6 +479,15 @@ class TestResolveJobRef:
     def test_cli_mutation_still_resolves_friendly_name(self, tmp_cron_dir):
         job = create_job(prompt="A", schedule="1h", name="friendly")
         assert pause_job("friendly")["id"] == job["id"]
+
+    def test_cli_mutations_resolve_hex_name_without_exact_id(self, tmp_cron_dir):
+        """CLI/tool mutations keep name lookup even for ID-shaped names."""
+        job = create_job(prompt="A", schedule="1h", name="deadbeefdead")
+
+        assert pause_job("deadbeefdead")["id"] == job["id"]
+        assert resume_job("deadbeefdead")["id"] == job["id"]
+        assert trigger_job("deadbeefdead")["id"] == job["id"]
+        assert remove_job("deadbeefdead") is True
 
 
     def test_mutations_refuse_ambiguous_name(self, tmp_cron_dir):

--- a/tests/cron/test_jobs_changed_notify.py
+++ b/tests/cron/test_jobs_changed_notify.py
@@ -71,6 +71,34 @@ def test_create_registers_first_trigger_with_active_provider(
     assert registered == [job]
 
 
+def test_dedup_replay_does_not_register_provider_again(
+    temp_home, monkeypatch, make_cron_provider
+):
+    """An idempotent create replay returns the durable job without rearming."""
+    import cron.scheduler as sched
+    import cron.scheduler_provider as sp
+
+    registered = []
+    provider = make_cron_provider(register_job=registered.append)
+    monkeypatch.setattr(sp, "resolve_cron_scheduler", lambda: provider)
+
+    first = sched.create_job_with_scheduler_registration(
+        prompt="echo hi",
+        schedule="every 5m",
+        name="w",
+        dedup_key="accept:w",
+    )
+    replay = sched.create_job_with_scheduler_registration(
+        prompt="echo hi",
+        schedule="every 5m",
+        name="w",
+        dedup_key="accept:w",
+    )
+
+    assert replay == first
+    assert registered == [first]
+
+
 def test_create_failure_preserves_job_and_hides_provider_details(
     temp_home, monkeypatch, make_cron_provider
 ):

--- a/tests/cron/test_misfire_catchup.py
+++ b/tests/cron/test_misfire_catchup.py
@@ -161,3 +161,33 @@ class TestFireOverdueJobs:
         assert time.monotonic() - start < 1.0  # returned before the run
         assert provider.wait_fired(timeout=10)
         assert provider.fired == [job["id"]]
+
+    def test_worker_failure_closes_claim_and_execution(self, tmp_cron_dir):
+        """A misfire worker exception cannot strand either durable record."""
+        from cron.executions import list_executions
+
+        class FailingProvider(RecordingProvider):
+            def fire_claimed(self, claimed_job, **_kwargs):
+                self._done.set()
+                raise RuntimeError("misfire worker failed")
+
+        job = create_job(prompt="p", schedule="every 1h")
+        _park_in_past(job["id"], minutes=30)
+        provider = FailingProvider()
+
+        assert fire_overdue_jobs(provider) == 1
+        assert provider.wait_fired()
+
+        # The sweep deliberately returns as soon as the worker is submitted;
+        # wait for its owner-fenced failure cleanup after the provider hook
+        # signals that it started.
+        deadline = time.monotonic() + 5.0
+        stored = get_job(job["id"])
+        while stored.get("fire_claim") is not None and time.monotonic() < deadline:
+            time.sleep(0.01)
+            stored = get_job(job["id"])
+        assert stored.get("fire_claim") is None
+        records = list_executions(job_id=job["id"])
+        assert len(records) == 1
+        assert records[0]["status"] == "failed"
+        assert "misfire worker failed" in records[0]["error"]

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -20,6 +20,8 @@ import threading
 import time
 from unittest.mock import patch
 
+import pytest
+
 
 def _wait_until(predicate, timeout=10.0, interval=0.005):
     """Block until ``predicate()`` is truthy or ``timeout`` elapses.
@@ -420,6 +422,88 @@ def test_claim_fire_persists_attempt_before_fire_claimed(monkeypatch):
     assert claimed["execution_id"] == "exec-1"
     assert provider.fire_claimed(claimed) is True
     assert events == ["ledger", "claim", ("run", "exec-1")]
+
+
+def test_dispatch_claimed_fire_aborts_provider_exception(monkeypatch):
+    """A provider failure after admission closes both durable records."""
+    import cron.executions as executions
+    import cron.jobs as jobs
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    marked = []
+    finished = []
+    monkeypatch.setattr(
+        jobs,
+        "mark_job_run",
+        lambda *args, **kwargs: marked.append((args, kwargs)) or True,
+    )
+    monkeypatch.setattr(
+        executions,
+        "finish_execution",
+        lambda *args, **kwargs: finished.append((args, kwargs)) or {},
+    )
+
+    provider = InProcessCronScheduler()
+
+    def fail_fire(_job, **_kwargs):
+        raise RuntimeError("provider fire failed")
+
+    monkeypatch.setattr(provider, "fire_claimed", fail_fire)
+    claimed = {
+        "id": "provider-failure",
+        "fire_claim": {"by": "owner-1"},
+        "execution_id": "execution-1",
+    }
+
+    assert provider.dispatch_claimed_fire(claimed) is False
+    assert marked == [
+        (
+            ("provider-failure", False, "provider fire failed"),
+            {"expected_fire_owner": "owner-1"},
+        )
+    ]
+    assert finished == [
+        (
+            ("execution-1",),
+            {"success": False, "error": "provider fire failed"},
+        )
+    ]
+
+
+def test_dispatch_claimed_fire_aborts_process_control_and_reraises(monkeypatch):
+    """Control-flow interrupts close the attempt before propagating."""
+    import cron.executions as executions
+    import cron.jobs as jobs
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    marked = []
+    finished = []
+    monkeypatch.setattr(
+        jobs,
+        "mark_job_run",
+        lambda *args, **kwargs: marked.append((args, kwargs)) or True,
+    )
+    monkeypatch.setattr(
+        executions,
+        "finish_execution",
+        lambda *args, **kwargs: finished.append((args, kwargs)) or {},
+    )
+    provider = InProcessCronScheduler()
+
+    def stop_fire(_job, **_kwargs):
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(provider, "fire_claimed", stop_fire)
+    claimed = {
+        "id": "provider-interrupt",
+        "fire_claim": {"by": "owner-2"},
+        "execution_id": "execution-2",
+    }
+
+    with pytest.raises(KeyboardInterrupt):
+        provider.dispatch_claimed_fire(claimed)
+    assert marked and marked[0][0] == ("provider-interrupt", False, "KeyboardInterrupt")
+    assert finished and finished[0][0] == ("execution-2",)
 
 
 def test_claim_fire_replay_does_not_dispatch_twice():

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -317,6 +317,31 @@ def test_resolve_available_provider_is_used(monkeypatch):
     assert prov.name == "fake"
 
 
+def test_resolve_available_provider_falls_back_in_active_multiplex(monkeypatch):
+    """Profile-scoped callers share startup's safe multiplex provider choice."""
+    import hermes_cli.config as cfg
+    import plugins.cron_providers as pc
+    from agent.secret_scope import set_multiplex_active
+    from cron import scheduler_provider as sp
+    from cron.scheduler_provider import CronScheduler
+
+    class Fake(CronScheduler):
+        @property
+        def name(self):
+            return "fake"
+
+        def start(self, stop_event, **kw):
+            pass
+
+    monkeypatch.setattr(cfg, "load_config", lambda: {"cron": {"provider": "fake"}})
+    monkeypatch.setattr(pc, "load_cron_scheduler", lambda n: Fake())
+    set_multiplex_active(True)
+    try:
+        assert sp.resolve_cron_scheduler().name == "builtin"
+    finally:
+        set_multiplex_active(False)
+
+
 def test_external_provider_falls_back_to_builtin_under_multiplex():
     from cron.scheduler_provider import (
         CronScheduler,

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -422,6 +422,24 @@ def test_claim_fire_persists_attempt_before_fire_claimed(monkeypatch):
     assert events == ["ledger", "claim", ("run", "exec-1")]
 
 
+def test_claim_fire_replay_does_not_dispatch_twice():
+    from cron.executions import list_executions
+    from cron.jobs import create_job
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    job = create_job(prompt="x", schedule="every 1h")
+    provider = InProcessCronScheduler()
+    first = provider.claim_fire(job["id"])
+    replay = provider.claim_fire(job["id"])
+    assert first and first["execution_id"]
+    assert replay is None
+    rows = list_executions(job_id=job["id"])
+    assert len(rows) == 2
+    assert rows[0]["status"] == "failed"
+    assert rows[1]["status"] == "claimed"
+    assert {row["source"] for row in rows} == {"builtin"}
+
+
 def test_fire_due_forwards_manual_force_to_store_claim(monkeypatch):
     import cron.jobs as jobs
     import cron.scheduler as sched
@@ -638,5 +656,3 @@ def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
     # With 2 profiles and multiple iterations, we should have seen at least 2 calls.
     assert len(tick_count) >= len(profile_homes), \
         f"Expected >= {len(profile_homes)} tick calls, got {len(tick_count)}"
-
-

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -458,6 +458,21 @@ def test_fire_due_forwards_manual_force_to_store_claim(monkeypatch):
     assert claims == [("j1", {"force": True, "return_job": True})]
 
 
+def test_claim_force_capability_is_inspected_before_dispatch():
+    from cron.scheduler_provider import provider_supports_claim_force
+
+    class SupportsForce:
+        def claim_fire(self, job_id, *, force=False):
+            return None
+
+    class Legacy:
+        def claim_fire(self, job_id):
+            return None
+
+    assert provider_supports_claim_force(SupportsForce()) is True
+    assert provider_supports_claim_force(Legacy()) is False
+
+
 def test_fire_due_lost_claim_does_not_run(monkeypatch):
     """If the CAS claim is lost (another machine/retry won), fire_due returns
     False and never runs the job."""

--- a/tests/cron/test_suggestions.py
+++ b/tests/cron/test_suggestions.py
@@ -93,7 +93,7 @@ class TestStore:
             created.update(kwargs)
             return {"id": "job123", "name": kwargs.get("name"), **kwargs}
 
-        with patch("cron.jobs.create_job", fake_create_job):
+        with patch("cron.scheduler.create_job_with_scheduler_registration", fake_create_job):
             job = store.accept_suggestion("1", origin={"platform": "telegram", "chat_id": "5"})
 
         assert job is not None

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -141,6 +141,20 @@ class TestCreateJob:
                 assert call_kwargs["origin"]["forwarded_for"] == "203.0.113.11"
                 assert call_kwargs["origin"]["user_agent"] == "cron-client"
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("failure,status", [("invalid", 400), ("conflict", 409)])
+    async def test_create_job_maps_dedup_errors(self, adapter, failure, status):
+        from cron.jobs import CronDedupConflict, CronDedupKeyInvalid
+        error = (CronDedupKeyInvalid("invalid") if failure == "invalid"
+                 else CronDedupConflict(VALID_JOB_ID))
+        app = _create_app(adapter)
+        with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+            f"{_MOD}._cron_create", side_effect=error
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post("/api/jobs", json={"name": "n", "schedule": "30m"})
+        assert response.status == status
+
 
     @pytest.mark.asyncio
     async def test_create_job_reports_saved_but_unregistered(self, adapter):
@@ -382,6 +396,25 @@ class TestRunJob:
         assert fired == ["exec-native"]
 
     @pytest.mark.asyncio
+    async def test_run_job_rejects_legacy_single_phase_provider(self, adapter):
+        from cron.scheduler_provider import CronScheduler
+        calls = []
+
+        class Legacy(CronScheduler):
+            name = "legacy"
+            def start(self, stop_event, **kwargs): pass
+            def fire_due(self, job_id, **kwargs): calls.append(job_id)
+
+        app = _create_app(adapter)
+        with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+            f"{_MOD}._cron_get", return_value=SAMPLE_JOB
+        ), patch("cron.scheduler_provider.resolve_cron_scheduler", return_value=Legacy()):
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(f"/api/jobs/{VALID_JOB_ID}/run")
+        assert response.status == 409
+        assert calls == []
+
+    @pytest.mark.asyncio
     async def test_run_job_setup_failure_aborts_claim_once(self, adapter):
         app = _create_app(adapter)
         claimed = {
@@ -557,16 +590,17 @@ class TestRunJob:
                     assert response.status == 400
 
     @pytest.mark.asyncio
-    async def test_list_job_runs_rejects_malformed_compound_cursor(self, adapter):
+    async def test_list_job_runs_rejects_malformed_cursor(self, adapter):
         app = _create_app(adapter)
         with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
             f"{_MOD}._cron_get", return_value=SAMPLE_JOB
         ):
             async with TestClient(TestServer(app)) as cli:
-                response = await cli.get(
-                    f"/api/jobs/{VALID_JOB_ID}/runs?before_claimed_at=bad|cursor"
-                )
-        assert response.status == 400
+                for cursor in ("bad|cursor", "not-a-timestamp"):
+                    response = await cli.get(
+                        f"/api/jobs/{VALID_JOB_ID}/runs?before_claimed_at={cursor}"
+                    )
+                    assert response.status == 400
 
     @pytest.mark.asyncio
     async def test_list_job_runs_uses_extra_row_for_has_more(self, adapter):

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -609,6 +609,10 @@ class TestRunJob:
             ("post", f"/api/jobs/{VALID_JOB_ID}/pause"),
             ("post", f"/api/jobs/{VALID_JOB_ID}/resume"),
             ("post", f"/api/jobs/{VALID_JOB_ID}/run"),
+            ("delete", "/api/jobs/deadbeefdead"),
+            ("post", "/api/jobs/deadbeefdead/pause"),
+            ("post", "/api/jobs/deadbeefdead/resume"),
+            ("post", "/api/jobs/deadbeefdead/run"),
         ]
         with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
             "cron.jobs.resolve_job_ref", return_value=SAMPLE_JOB

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -10,6 +10,7 @@ Covers:
 - Cron module unavailability (501 when _CRON_AVAILABLE is False)
 """
 
+import asyncio
 import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -63,6 +64,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/api/jobs/{job_id}/pause", adapter._handle_pause_job)
     app.router.add_post("/api/jobs/{job_id}/resume", adapter._handle_resume_job)
     app.router.add_post("/api/jobs/{job_id}/run", adapter._handle_run_job)
+    app.router.add_get("/api/jobs/{job_id}/runs", adapter._handle_list_job_runs)
     return app
 
 
@@ -325,18 +327,131 @@ class TestRunJob:
         """POST /api/jobs/{id}/run returns triggered job."""
         app = _create_app(adapter)
         triggered_job = {**SAMPLE_JOB, "last_run": "2025-01-01T00:00:00Z"}
-        mock_trigger = MagicMock(return_value=triggered_job)
+        mock_get = MagicMock(return_value=triggered_job)
         async with TestClient(TestServer(app)) as cli:
             with patch(
                 f"{_MOD}._CRON_AVAILABLE", True
             ), patch(
-                f"{_MOD}._cron_trigger", mock_trigger
+                f"{_MOD}._cron_get", mock_get
             ):
                 resp = await cli.post(f"/api/jobs/{VALID_JOB_ID}/run")
                 assert resp.status == 200
                 data = await resp.json()
                 assert data["job"] == triggered_job
-                mock_trigger.assert_called_once_with(VALID_JOB_ID)
+                mock_get.assert_called_once_with(VALID_JOB_ID)
+
+    @pytest.mark.asyncio
+    async def test_run_job_admits_native_execution(self, adapter):
+        app = _create_app(adapter)
+        fired = []
+
+        class Provider:
+            name = "builtin"
+
+            def claim_fire(self, job_id, *, force=False):
+                return {"id": job_id, "execution_id": "exec-native"}
+
+            def fire_claimed(self, job, *, adapters=None, loop=None):
+                fired.append(job["execution_id"])
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_get", return_value=SAMPLE_JOB
+            ), patch(
+                "cron.scheduler_provider.resolve_cron_scheduler",
+                return_value=Provider(),
+            ):
+                resp = await cli.post(f"/api/jobs/{VALID_JOB_ID}/run")
+                assert resp.status == 202
+                data = await resp.json()
+                assert data["execution"] == {
+                    "id": "exec-native",
+                    "job_id": VALID_JOB_ID,
+                    "source": "builtin",
+                    "status": "claimed",
+                }
+        for _ in range(50):
+            if fired:
+                break
+            await asyncio.sleep(0.01)
+        assert fired == ["exec-native"]
+
+    @pytest.mark.asyncio
+    async def test_list_job_runs_uses_exact_id_and_cursor(self, adapter):
+        app = _create_app(adapter)
+        rows = [{
+            "id": "exec-1", "job_id": VALID_JOB_ID,
+            "claimed_at": "2026-08-20T00:00:00+00:00", "status": "completed",
+        }]
+        with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+            f"{_MOD}._cron_get", return_value=SAMPLE_JOB
+        ), patch("cron.executions.list_executions", return_value=rows) as listed:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get(
+                    f"/api/jobs/{VALID_JOB_ID}/runs?limit=1&before_claimed_at=cursor"
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["runs"] == rows
+                assert data["next_cursor"] == "2026-08-20T00:00:00+00:00|exec-1"
+        listed.assert_called_once_with(
+            job_id=VALID_JOB_ID, limit=1, before_claimed_at="cursor"
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_job_runs_rejects_unbounded_or_invalid_limit(self, adapter):
+        app = _create_app(adapter)
+        with patch(f"{_MOD}._CRON_AVAILABLE", True):
+            async with TestClient(TestServer(app)) as cli:
+                for query in ("limit=0", "limit=nope"):
+                    response = await cli.get(
+                        f"/api/jobs/{VALID_JOB_ID}/runs?{query}"
+                    )
+                    assert response.status == 400
+
+    @pytest.mark.asyncio
+    async def test_list_job_runs_requires_api_auth(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        with patch(f"{_MOD}._CRON_AVAILABLE", True):
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.get(f"/api/jobs/{VALID_JOB_ID}/runs")
+                assert response.status == 401
+
+    @pytest.mark.asyncio
+    async def test_gateway_lifecycle_ids_never_fall_back_to_names(self, adapter):
+        app = _create_app(adapter)
+        routes = [
+            ("delete", f"/api/jobs/{VALID_JOB_ID}"),
+            ("post", f"/api/jobs/{VALID_JOB_ID}/pause"),
+            ("post", f"/api/jobs/{VALID_JOB_ID}/resume"),
+            ("post", f"/api/jobs/{VALID_JOB_ID}/run"),
+        ]
+        with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+            "cron.jobs.resolve_job_ref", return_value=SAMPLE_JOB
+        ) as resolver:
+            async with TestClient(TestServer(app)) as cli:
+                for method, path in routes:
+                    response = await getattr(cli, method)(path)
+                    assert response.status == 404
+        resolver.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_gateway_lifecycle_malformed_ids_are_400(self, adapter):
+        app = _create_app(adapter)
+        with patch(f"{_MOD}._CRON_AVAILABLE", True):
+            async with TestClient(TestServer(app)) as cli:
+                for path in (
+                    "/api/jobs/not-an-id",
+                    "/api/jobs/not-an-id/pause",
+                    "/api/jobs/not-an-id/resume",
+                    "/api/jobs/not-an-id/run",
+                    "/api/jobs/not-an-id/runs",
+                ):
+                    method = cli.get if path.endswith("runs") else cli.post
+                    if path == "/api/jobs/not-an-id":
+                        method = cli.delete
+                    response = await method(path)
+                    assert response.status == 400
 
 
 # ---------------------------------------------------------------------------
@@ -497,4 +612,3 @@ class TestCronPromptScanParity:
                 data = await resp.json()
                 assert "Blocked" in data["error"] or "threat" in data["error"].lower()
                 mock_create.assert_not_called()
-

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -382,6 +382,40 @@ class TestRunJob:
         assert fired == ["exec-native"]
 
     @pytest.mark.asyncio
+    async def test_run_job_setup_failure_aborts_claim_once(self, adapter):
+        app = _create_app(adapter)
+        claimed = {
+            "id": VALID_JOB_ID,
+            "fire_claim": {"by": "api-owner"},
+            "execution_id": "exec-api-failure",
+        }
+        aborted = []
+
+        class Provider:
+            name = "builtin"
+
+            def claim_fire(self, job_id, *, force=False):
+                return dict(claimed)
+
+            def dispatch_claimed_fire(self, job, **kwargs):
+                raise RuntimeError("api dispatch setup failed")
+
+            def abort_claimed_fire(self, job, error):
+                aborted.append((job, error))
+
+        with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+            f"{_MOD}._cron_get", return_value=SAMPLE_JOB
+        ), patch(
+            "cron.scheduler_provider.resolve_cron_scheduler",
+            return_value=Provider(),
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(f"/api/jobs/{VALID_JOB_ID}/run")
+
+        assert response.status == 500
+        assert aborted == [(claimed, "api dispatch setup failed")]
+
+    @pytest.mark.asyncio
     async def test_run_job_claim_loss_rechecks_deleted_job(self, adapter):
         app = _create_app(adapter)
 

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -338,7 +338,12 @@ class TestRunJob:
                 assert resp.status == 200
                 data = await resp.json()
                 assert data["job"] == triggered_job
-                mock_get.assert_called_once_with(VALID_JOB_ID)
+                # A lost claim requires an exact re-read to distinguish a
+                # deleted job from a duplicate admission.
+                assert mock_get.call_args_list == [
+                    ((VALID_JOB_ID,), {}),
+                    ((VALID_JOB_ID,), {}),
+                ]
 
     @pytest.mark.asyncio
     async def test_run_job_admits_native_execution(self, adapter):
@@ -377,6 +382,113 @@ class TestRunJob:
         assert fired == ["exec-native"]
 
     @pytest.mark.asyncio
+    async def test_run_job_claim_loss_rechecks_deleted_job(self, adapter):
+        app = _create_app(adapter)
+
+        class Provider:
+            name = "builtin"
+
+            def claim_fire(self, job_id):
+                return None
+
+        with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+            f"{_MOD}._cron_get", side_effect=[SAMPLE_JOB, None]
+        ), patch(
+            "cron.scheduler_provider.resolve_cron_scheduler",
+            return_value=Provider(),
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(f"/api/jobs/{VALID_JOB_ID}/run")
+        assert response.status == 404
+
+    @pytest.mark.asyncio
+    async def test_run_job_claim_loss_distinguishes_stale_execution(self, adapter):
+        app = _create_app(adapter)
+
+        class Provider:
+            name = "builtin"
+
+            def claim_fire(self, job_id):
+                return None
+
+        stale = {
+            "id": "exec-old", "job_id": VALID_JOB_ID,
+            "status": "completed", "claimed_at": "2026-08-20T00:00:00+00:00",
+        }
+        with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+            f"{_MOD}._cron_get", return_value=SAMPLE_JOB
+        ), patch(
+            "cron.executions.latest_execution", side_effect=[stale, stale]
+        ), patch(
+            "cron.scheduler_provider.resolve_cron_scheduler",
+            return_value=Provider(),
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(f"/api/jobs/{VALID_JOB_ID}/run")
+                data = await response.json()
+        assert response.status == 200
+        assert data["status"] == "not_admitted"
+        assert data["execution"] is None
+
+    @pytest.mark.asyncio
+    async def test_run_job_claim_loss_reports_fresh_duplicate_execution(self, adapter):
+        app = _create_app(adapter)
+
+        class Provider:
+            name = "builtin"
+
+            def claim_fire(self, job_id):
+                return None
+
+        previous = {
+            "id": "exec-old", "job_id": VALID_JOB_ID,
+            "status": "completed", "claimed_at": "2026-08-20T00:00:00+00:00",
+        }
+        fresh = {
+            "id": "exec-new", "job_id": VALID_JOB_ID,
+            "status": "failed", "claimed_at": "2026-08-20T00:00:01+00:00",
+        }
+        with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+            f"{_MOD}._cron_get", return_value=SAMPLE_JOB
+        ), patch(
+            "cron.executions.latest_execution", side_effect=[previous, fresh]
+        ), patch(
+            "cron.executions.get_execution", return_value=fresh
+        ), patch(
+            "cron.scheduler_provider.resolve_cron_scheduler",
+            return_value=Provider(),
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(f"/api/jobs/{VALID_JOB_ID}/run")
+                data = await response.json()
+        assert response.status == 200
+        assert data["status"] == "duplicate"
+        assert data["execution"]["id"] == "exec-new"
+
+    @pytest.mark.asyncio
+    async def test_run_job_internal_type_error_is_not_retried(self, adapter):
+        app = _create_app(adapter)
+        calls = []
+
+        class Provider:
+            name = "builtin"
+
+            def claim_fire(self, job_id):
+                calls.append(job_id)
+                raise TypeError("provider implementation failure")
+
+        with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+            f"{_MOD}._cron_get", return_value=SAMPLE_JOB
+        ), patch(
+            "cron.scheduler_provider.resolve_cron_scheduler",
+            return_value=Provider(),
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(f"/api/jobs/{VALID_JOB_ID}/run")
+        assert response.status == 503
+        assert calls == [VALID_JOB_ID]
+
+    @pytest.mark.asyncio
     async def test_list_job_runs_uses_exact_id_and_cursor(self, adapter):
         app = _create_app(adapter)
         rows = [{
@@ -393,9 +505,10 @@ class TestRunJob:
                 assert resp.status == 200
                 data = await resp.json()
                 assert data["runs"] == rows
-                assert data["next_cursor"] == "2026-08-20T00:00:00+00:00|exec-1"
+                assert data["next_cursor"] is None
+                assert data["has_more"] is False
         listed.assert_called_once_with(
-            job_id=VALID_JOB_ID, limit=1, before_claimed_at="cursor"
+            job_id=VALID_JOB_ID, limit=2, before_claimed_at="cursor"
         )
 
     @pytest.mark.asyncio
@@ -408,6 +521,43 @@ class TestRunJob:
                         f"/api/jobs/{VALID_JOB_ID}/runs?{query}"
                     )
                     assert response.status == 400
+
+    @pytest.mark.asyncio
+    async def test_list_job_runs_rejects_malformed_compound_cursor(self, adapter):
+        app = _create_app(adapter)
+        with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+            f"{_MOD}._cron_get", return_value=SAMPLE_JOB
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.get(
+                    f"/api/jobs/{VALID_JOB_ID}/runs?before_claimed_at=bad|cursor"
+                )
+        assert response.status == 400
+
+    @pytest.mark.asyncio
+    async def test_list_job_runs_uses_extra_row_for_has_more(self, adapter):
+        app = _create_app(adapter)
+        rows = [
+            {"id": "exec-2", "job_id": VALID_JOB_ID,
+             "claimed_at": "2026-08-20T00:00:02+00:00"},
+            {"id": "exec-1", "job_id": VALID_JOB_ID,
+             "claimed_at": "2026-08-20T00:00:01+00:00"},
+        ]
+        with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+            f"{_MOD}._cron_get", return_value=SAMPLE_JOB
+        ), patch("cron.executions.list_executions", return_value=rows) as listed:
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.get(
+                    f"/api/jobs/{VALID_JOB_ID}/runs?limit=1"
+                )
+                data = await response.json()
+        assert response.status == 200
+        assert data["runs"] == rows[:1]
+        assert data["has_more"] is True
+        assert data["next_cursor"] == "2026-08-20T00:00:02+00:00|exec-2"
+        listed.assert_called_once_with(
+            job_id=VALID_JOB_ID, limit=2, before_claimed_at=None
+        )
 
     @pytest.mark.asyncio
     async def test_list_job_runs_requires_api_auth(self, auth_adapter):

--- a/tests/gateway/test_cron_fire_webhook.py
+++ b/tests/gateway/test_cron_fire_webhook.py
@@ -408,3 +408,54 @@ async def test_fire_without_runner_passes_none_adapters(adapter, monkeypatch):
 
     assert seen.get("job_id") == "no-runner"
     assert seen.get("adapters") is None
+
+
+@pytest.mark.asyncio
+async def test_cancelled_fire_wrapper_keeps_reservation_until_worker_finishes(
+    adapter, monkeypatch
+):
+    started = threading.Event()
+    release = threading.Event()
+    observed = {}
+
+    class BlockingProvider:
+        def claim_fire(self, job_id):
+            return {"id": job_id, "execution_id": "exec-cancel"}
+
+        def fire_claimed(self, job, *, adapters=None, loop=None, cancel_event=None):
+            observed["cancel_event"] = cancel_event
+            started.set()
+            release.wait(timeout=2)
+            return True
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: BlockingProvider(),
+    )
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: (lambda **kw: {"purpose": "cron_fire"}),
+    )
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.post(
+            "/api/cron/fire",
+            headers={"Authorization": "Bearer good"},
+            json={"job_id": "cancel-me"},
+        )
+        assert response.status == 202
+        assert await asyncio.to_thread(started.wait, 2)
+        assert adapter._background_tasks
+        worker_wrapper = next(iter(adapter._background_tasks))
+        worker_wrapper.cancel()
+        await asyncio.sleep(0.05)
+        assert observed["cancel_event"].is_set()
+        assert adapter.active_agent_work_count() == 1
+        release.set()
+        for _ in range(100):
+            if adapter.active_agent_work_count() == 0:
+                break
+            await asyncio.sleep(0.01)
+
+    assert adapter.active_agent_work_count() == 0

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -237,6 +237,24 @@ class TestInFlightDedupe:
         assert seen_during_run["registered"] is True
         assert "job-bg-09" not in sched.get_running_job_ids()   # released after
 
+    def test_manual_projection_carries_native_execution_identity(self):
+        from cron.executions import create_execution
+        from tools.cronjob_tools import _run_claimed_job
+
+        row = create_execution("job-bg-identity", source="direct")
+        job = {**_job("job-bg-identity"), "execution_id": row["id"]}
+        with patch("cron.scheduler.run_one_job", return_value=True), patch(
+            "tools.cronjob_tools.get_job",
+            return_value={"last_status": "ok", "last_error": None},
+        ):
+            result = _run_claimed_job(job)
+        assert result["execution"] == {
+            "id": row["id"],
+            "job_id": "job-bg-identity",
+            "source": "direct",
+            "status": "claimed",
+        }
+
     def test_background_dispatch_reports_running_job_immediately(self):
         """The dispatch path pre-checks the running set so a mid-run job
         reports in the tool response, not as a delayed completion event."""

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -67,7 +67,7 @@ class TestBackgroundDispatch:
             return True
 
         with _bound_session_key():
-            with patch("tools.cronjob_tools.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}) as m_claim, \
+            with patch("cron.jobs.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}) as m_claim, \
                  patch("cron.scheduler.run_one_job", side_effect=slow_run_one_job), \
                  patch("tools.cronjob_tools.get_job",
                        return_value={"last_status": "ok", "last_error": None}):
@@ -95,7 +95,7 @@ class TestBackgroundDispatch:
         # The runner executes on a daemon thread — the patches must stay
         # active until the completion event lands, so poll INSIDE the blocks.
         with _bound_session_key("agent:main:telegram:dm:777"):
-            with patch("tools.cronjob_tools.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}), \
+            with patch("cron.jobs.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}), \
                  patch("cron.scheduler.run_one_job", return_value=True), \
                  patch("tools.cronjob_tools.get_job",
                        return_value={"last_status": "ok", "last_error": None,
@@ -128,7 +128,7 @@ class TestBackgroundDispatch:
         from tools.process_registry import process_registry
 
         with _bound_session_key("agent:main:telegram:dm:778"):
-            with patch("tools.cronjob_tools.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}), \
+            with patch("cron.jobs.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}), \
                  patch("cron.scheduler.run_one_job", return_value=True), \
                  patch("tools.cronjob_tools.get_job",
                        return_value={"last_status": "error",
@@ -156,7 +156,7 @@ class TestBackgroundDispatch:
         """Paused/already-firing jobs report in the tool response, not as a
         delayed completion event."""
         with _bound_session_key():
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
+            with patch("cron.jobs.claim_job_for_fire", return_value=False), \
                  patch("tools.cronjob_tools.get_job",
                        return_value={**_JOB, "enabled": False}), \
                  patch("tools.async_delegation.dispatch_async_delegation") as m_disp:
@@ -171,7 +171,7 @@ class TestBackgroundDispatch:
         from cron.executions import get_execution
 
         with _bound_session_key():
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
+            with patch("cron.jobs.claim_job_for_fire", return_value=False), \
                  patch("tools.cronjob_tools.get_job", return_value=_job("job-bg-04b")), \
                  patch("tools.async_delegation.dispatch_async_delegation"):
                 res = _try_dispatch_background_run(_job("job-bg-04b"))
@@ -197,7 +197,7 @@ class TestSyncFallbacks:
     def test_pool_at_capacity_runs_inline(self):
         """A rejected dispatch must not strand the already-taken claim."""
         with _bound_session_key():
-            with patch("tools.cronjob_tools.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}), \
+            with patch("cron.jobs.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}), \
                  patch("tools.async_delegation.dispatch_async_delegation",
                        return_value={"status": "rejected", "error": "capacity"}), \
                  patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
@@ -211,7 +211,7 @@ class TestSyncFallbacks:
     def test_dispatch_exception_closes_execution(self):
         with _bound_session_key():
             with patch(
-                "tools.cronjob_tools.claim_job_for_fire",
+                "cron.jobs.claim_job_for_fire",
                 side_effect=lambda jid, **kw: {
                     **_job(jid), "fire_claim": {"by": "bg-owner"}
                 },
@@ -222,6 +222,28 @@ class TestSyncFallbacks:
                 result = _try_dispatch_background_run(_job("job-bg-07b"))
         assert result["dispatched"] is False
         assert result["execution"]["status"] == "failed"
+
+    def test_setup_exception_after_claim_aborts_once(self):
+        """A pre-dispatch setup failure cannot strand the provider claim."""
+        from cron.scheduler_provider import InProcessCronScheduler
+        from tools.cronjob_tools import _run_claimed_job
+
+        provider = InProcessCronScheduler()
+        claimed = {
+            **_job("job-bg-setup-failure"),
+            "fire_claim": {"by": "setup-owner"},
+            "execution_id": "setup-execution",
+        }
+        with patch(
+            "gateway.run._gateway_runner_ref",
+            side_effect=RuntimeError("gateway setup failed"),
+        ), patch.object(provider, "abort_claimed_fire") as abort:
+            result = _run_claimed_job(provider, claimed)
+
+        assert result["claimed"] is True
+        assert result["success"] is False
+        assert "gateway setup failed" in result["error"]
+        abort.assert_called_once_with(claimed, "gateway setup failed")
 
 
 class TestInFlightDedupe:
@@ -292,7 +314,7 @@ class TestInFlightDedupe:
         assert sched.try_register_running_job("job-bg-10")
         try:
             with _bound_session_key():
-                with patch("tools.cronjob_tools.claim_job_for_fire") as m_claim, \
+                with patch("cron.jobs.claim_job_for_fire") as m_claim, \
                      patch("tools.async_delegation.dispatch_async_delegation") as m_disp:
                     res = _try_dispatch_background_run(_job('job-bg-10'))
             assert res["claimed"] is False
@@ -325,7 +347,7 @@ class TestCronjobRunToolIntegration:
         """cronjob(action='run') surfaces the handle + do-not-wait note."""
         with _bound_session_key():
             with patch("tools.cronjob_tools.resolve_job_ref", return_value=_job('job-bg-12')), \
-                 patch("tools.cronjob_tools.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}), \
+                 patch("cron.jobs.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}), \
                  patch("cron.scheduler.run_one_job", return_value=True), \
                  patch("tools.cronjob_tools.get_job",
                        return_value={"id": "job-bg-12", "name": "bg run",
@@ -343,7 +365,7 @@ class TestCronjobRunToolIntegration:
         execution_success populated from the completed run)."""
         ran = {"job": "after-run", "last_status": "ok", "last_error": None}
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=_job('job-bg-13')), \
-             patch("tools.cronjob_tools.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}) as m_claim, \
+             patch("cron.jobs.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}) as m_claim, \
              patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=ran):
             out = json.loads(cronjob(action="run", job_id="job-bg-13"))

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -163,7 +163,21 @@ class TestBackgroundDispatch:
                 res = _try_dispatch_background_run(_job('job-bg-04'))
         assert res["claimed"] is False
         assert "paused/disabled" in res["error"]
+        assert res["execution"]["status"] == "failed"
         m_disp.assert_not_called()
+
+    def test_claim_refusal_closes_pre_dispatch_execution(self):
+        """A refused manual claim leaves no open ledger attempt."""
+        from cron.executions import get_execution
+
+        with _bound_session_key():
+            with patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
+                 patch("tools.cronjob_tools.get_job", return_value=_job("job-bg-04b")), \
+                 patch("tools.async_delegation.dispatch_async_delegation"):
+                res = _try_dispatch_background_run(_job("job-bg-04b"))
+        assert res["claimed"] is False
+        assert res["execution"]["status"] == "failed"
+        assert get_execution(res["execution"]["id"])["status"] == "failed"
 
 
 class TestSyncFallbacks:
@@ -193,6 +207,21 @@ class TestSyncFallbacks:
         assert res["dispatched"] is False
         assert res["success"] is True
         m_run.assert_called_once()   # ran inline on this thread
+
+    def test_dispatch_exception_closes_execution(self):
+        with _bound_session_key():
+            with patch(
+                "tools.cronjob_tools.claim_job_for_fire",
+                side_effect=lambda jid, **kw: {
+                    **_job(jid), "fire_claim": {"by": "bg-owner"}
+                },
+            ), patch(
+                "tools.async_delegation.dispatch_async_delegation",
+                side_effect=RuntimeError("submit failed"),
+            ):
+                result = _try_dispatch_background_run(_job("job-bg-07b"))
+        assert result["dispatched"] is False
+        assert result["execution"]["status"] == "failed"
 
 
 class TestInFlightDedupe:

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -223,6 +223,105 @@ class TestSyncFallbacks:
         assert result["dispatched"] is False
         assert result["execution"]["status"] == "failed"
 
+    def test_legacy_provider_background_uses_fire_due_without_claim(self):
+        """A legacy provider is dispatched through its single-phase hook."""
+        seen = {}
+        adapters = {"relay": object()}
+        gateway_loop = object()
+
+        class LegacyProvider:
+            name = "legacy"
+
+            def fire_due(self, job_id, *, adapters=None, loop=None):
+                seen.update(job_id=job_id, adapters=adapters, loop=loop)
+                return True
+
+        def dispatch(**kwargs):
+            seen["result"] = kwargs["runner"]()
+            return {"status": "dispatched", "delegation_id": "legacy-run-1"}
+
+        runner = type(
+            "Runner",
+            (),
+            {"adapters": adapters, "_gateway_loop": gateway_loop},
+        )()
+        with _bound_session_key():
+            with patch(
+                "cron.scheduler_provider.resolve_cron_scheduler",
+                return_value=LegacyProvider(),
+            ), patch("gateway.run._gateway_runner_ref", return_value=runner), patch(
+                "tools.async_delegation.dispatch_async_delegation",
+                side_effect=dispatch,
+            ), patch("cron.scheduler.run_one_job") as m_run:
+                result = _try_dispatch_background_run(
+                    _job("job-bg-legacy"), extra_prompt="transient context"
+                )
+
+        assert result == {
+            "claimed": True,
+            "dispatched": True,
+            "delegation_id": "legacy-run-1",
+            "execution": None,
+        }
+        assert seen["job_id"] == "job-bg-legacy"
+        assert seen["adapters"] is adapters
+        assert seen["loop"] is gateway_loop
+        assert seen["result"]["status"] == "completed"
+        assert seen["result"]["error"] is None
+        assert seen["result"]["execution"] is None
+        m_run.assert_not_called()
+
+    def test_legacy_provider_pool_rejection_runs_inline(self):
+        class LegacyProvider:
+            name = "legacy"
+
+            def __init__(self):
+                self.calls = 0
+
+            def fire_due(self, job_id, *, adapters=None, loop=None):
+                self.calls += 1
+                return True
+
+        provider = LegacyProvider()
+        with _bound_session_key():
+            with patch(
+                "cron.scheduler_provider.resolve_cron_scheduler",
+                return_value=provider,
+            ), patch(
+                "tools.async_delegation.dispatch_async_delegation",
+                return_value={"status": "rejected", "error": "capacity"},
+            ), patch("cron.scheduler.run_one_job") as m_run:
+                result = _try_dispatch_background_run(_job("job-bg-legacy-inline"))
+
+        assert result["claimed"] is True
+        assert result["success"] is True
+        assert result["dispatched"] is False
+        assert result["execution"] is None
+        assert provider.calls == 1
+        m_run.assert_not_called()
+
+    def test_legacy_provider_dispatch_exception_has_no_execution(self):
+        class LegacyProvider:
+            name = "legacy"
+
+            def fire_due(self, job_id, *, adapters=None, loop=None):
+                raise AssertionError("fire_due must not run after dispatch failure")
+
+        with _bound_session_key():
+            with patch(
+                "cron.scheduler_provider.resolve_cron_scheduler",
+                return_value=LegacyProvider(),
+            ), patch(
+                "tools.async_delegation.dispatch_async_delegation",
+                side_effect=RuntimeError("legacy submit failed"),
+            ):
+                result = _try_dispatch_background_run(_job("job-bg-legacy-error"))
+
+        assert result["claimed"] is False
+        assert result["dispatched"] is False
+        assert result["execution"] is None
+        assert result["error"] == "legacy submit failed"
+
     def test_setup_exception_after_claim_aborts_once(self):
         """A pre-dispatch setup failure cannot strand the provider claim."""
         from cron.scheduler_provider import InProcessCronScheduler

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -31,7 +31,7 @@ class TestCronjobRunExecutesImmediately:
         ran = {"job": "after-run", "last_status": "ok", "last_error": None}
         claimed = {**_JOB, "fire_claim": {"by": "manual-owner"}}
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=claimed) as m_claim, \
+             patch("cron.jobs.claim_job_for_fire", return_value=claimed) as m_claim, \
              patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=ran):
             out = json.loads(cronjob(action="run", job_id="job-run-1"))
@@ -40,7 +40,9 @@ class TestCronjobRunExecutesImmediately:
         assert out["job"]["executed"] is True
         assert out["job"]["execution_success"] is True
         m_claim.assert_called_once_with("job-run-1", return_job=True)
-        m_run.assert_called_once_with(claimed, adapters=None, loop=None, extra_prompt=None)
+        m_run.assert_called_once_with(
+            claimed, adapters=None, loop=None, extra_prompt=None,
+        )
 
     def test_run_reconciles_external_provider_after_claimed_execution(self):
         """A direct run must re-arm Chronos after it advances next_run_at.
@@ -53,7 +55,7 @@ class TestCronjobRunExecutesImmediately:
         ran = {"id": "job-run-1", "last_status": "ok", "last_error": None}
         claimed = {**_JOB, "fire_claim": {"by": "manual-owner"}}
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=claimed), \
+             patch("cron.jobs.claim_job_for_fire", return_value=claimed), \
              patch("cron.scheduler.run_one_job",
                    side_effect=lambda *a, **kw: order.append("run") or True), \
              patch("tools.cronjob_tools.get_job", return_value=ran), \
@@ -73,9 +75,8 @@ class TestCronjobRunExecutesImmediately:
         failed = {"id": "job-run-1", "last_status": "error", "last_error": "provider 500"}
         claimed = {**_JOB, "fire_claim": {"by": "manual-owner"}}
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=claimed), \
+             patch("cron.jobs.claim_job_for_fire", return_value=claimed), \
              patch("cron.scheduler.run_one_job", side_effect=RuntimeError("boom")), \
-             patch("tools.cronjob_tools.mark_job_run"), \
              patch("tools.cronjob_tools.get_job", return_value=failed), \
              patch("tools.cronjob_tools._notify_provider_jobs_changed_safe") as m_notify:
             out = json.loads(cronjob(action="run", job_id="job-run-1"))
@@ -87,7 +88,7 @@ class TestCronjobRunExecutesImmediately:
     def test_run_skips_when_claim_lost(self):
         """If the scheduler already holds the fire claim, do NOT double-run."""
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
+             patch("cron.jobs.claim_job_for_fire", return_value=False), \
              patch("cron.scheduler.run_one_job") as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)), \
              patch("tools.cronjob_tools._notify_provider_jobs_changed_safe") as m_notify:
@@ -105,7 +106,7 @@ class TestCronjobRunExecutesImmediately:
         failed = {"id": "job-run-1", "last_status": "error", "last_error": "provider 500"}
         claimed = {**_JOB, "fire_claim": {"by": "manual-owner"}}
         with patch("tools.cronjob_tools.resolve_job_ref", return_value=dict(_JOB)), \
-             patch("tools.cronjob_tools.claim_job_for_fire", return_value=claimed), \
+             patch("cron.jobs.claim_job_for_fire", return_value=claimed), \
              patch("cron.scheduler.run_one_job", return_value=True), \
              patch("tools.cronjob_tools.get_job", return_value=failed):
             out = json.loads(cronjob(action="run", job_id="job-run-1"))
@@ -116,7 +117,7 @@ class TestCronjobRunExecutesImmediately:
 
     def test_execute_job_now_bails_without_claim(self):
         """_execute_job_now never calls run_one_job when the claim is lost."""
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=False), \
+        with patch("cron.jobs.claim_job_for_fire", return_value=False), \
              patch("cron.scheduler.run_one_job") as m_run:
             res = _execute_job_now(dict(_JOB))
         assert res["claimed"] is False
@@ -130,45 +131,45 @@ class TestCronjobRunExecutesImmediately:
         runner = SimpleNamespace(adapters=adapters, _gateway_loop=gateway_loop)
         completed = {"id": "job-run-1", "last_status": "ok", "last_error": None}
 
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
+        with patch("cron.jobs.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
              patch("gateway.run._gateway_runner_ref", return_value=runner), \
              patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=completed):
             res = _execute_job_now(dict(_JOB))
 
         assert res["success"] is True
-        m_run.assert_called_once_with(
-            {**_JOB, "fire_claim": {"by": "manual-owner"}},
-            adapters=adapters,
-            loop=gateway_loop,
-            extra_prompt=None,
-        )
+        m_run.assert_called_once()
+        assert m_run.call_args.args[0]["fire_claim"] == {"by": "manual-owner"}
+        assert m_run.call_args.kwargs == {
+            "adapters": adapters, "loop": gateway_loop, "extra_prompt": None,
+        }
 
     def test_execute_job_now_remains_standalone_without_gateway(self):
         """CLI-only runs retain the standalone delivery path."""
         completed = {"id": "job-run-1", "last_status": "ok", "last_error": None}
 
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
+        with patch("cron.jobs.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
              patch.dict(sys.modules, {"gateway.run": None}), \
              patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
              patch("tools.cronjob_tools.get_job", return_value=completed):
             res = _execute_job_now(dict(_JOB))
 
         assert res["success"] is True
-        m_run.assert_called_once_with(
-            {**_JOB, "fire_claim": {"by": "manual-owner"}},
-            adapters=None,
-            loop=None,
-            extra_prompt=None,
-        )
+        m_run.assert_called_once()
+        assert m_run.call_args.args[0]["fire_claim"] == {"by": "manual-owner"}
+        assert m_run.call_args.kwargs == {
+            "adapters": None, "loop": None, "extra_prompt": None,
+        }
 
     def test_execute_job_now_marks_failure_on_exception(self):
         """An exception during fire is captured, marked failed, not propagated."""
         claimed = {**_JOB, "fire_claim": {"by": "manual-owner"}}
-        with patch("tools.cronjob_tools.claim_job_for_fire", return_value=claimed), \
+        with patch("cron.jobs.claim_job_for_fire", return_value=claimed), \
              patch("cron.scheduler.run_one_job", side_effect=RuntimeError("boom")), \
-             patch("tools.cronjob_tools.mark_job_run") as m_mark, \
-             patch("tools.cronjob_tools.get_job", return_value=dict(_JOB)):
+             patch("cron.jobs.mark_job_run") as m_mark, \
+             patch("tools.cronjob_tools.get_job", return_value={
+                 **_JOB, "last_status": "error", "last_error": "boom",
+             }):
             res = _execute_job_now(dict(_JOB))
         assert res["claimed"] is True
         assert res["success"] is False
@@ -199,7 +200,7 @@ class TestCronjobRunExecutesImmediately:
                 assert heartbeat_seen.wait(timeout=5.0), "no heartbeat within 5s"
                 return True
 
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
+            with patch("cron.jobs.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
                  patch("tools.cronjob_tools._CRON_RUN_HEARTBEAT_INTERVAL", 0.05), \
                  patch("cron.scheduler.run_one_job", side_effect=slow_run) as m_run, \
                  patch("tools.cronjob_tools.get_job",
@@ -217,7 +218,7 @@ class TestCronjobRunExecutesImmediately:
         heartbeat thread is never started and behavior is unchanged."""
         set_activity_callback(None)
         try:
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
+            with patch("cron.jobs.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
                  patch("cron.scheduler.run_one_job", return_value=True) as m_run, \
                  patch("tools.cronjob_tools.get_job",
                        return_value={"last_status": "ok", "last_error": None}), \
@@ -248,7 +249,7 @@ class TestCronjobRunExecutesImmediately:
                 time.sleep(0.2)
                 return True
 
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
+            with patch("cron.jobs.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
                  patch("tools.cronjob_tools._CRON_RUN_HEARTBEAT_INTERVAL", 0.05), \
                  patch("tools.cronjob_tools._CRON_RUN_HEARTBEAT_CEILING", 0.0), \
                  patch("cron.scheduler.run_one_job", side_effect=slow_run), \
@@ -281,7 +282,7 @@ class TestCronjobRunExecutesImmediately:
                     "heartbeat stopped after one callback exception"
                 return True
 
-            with patch("tools.cronjob_tools.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
+            with patch("cron.jobs.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
                  patch("tools.cronjob_tools._CRON_RUN_HEARTBEAT_INTERVAL", 0.05), \
                  patch("cron.scheduler.run_one_job", side_effect=slow_run), \
                  patch("tools.cronjob_tools.get_job",

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -161,6 +161,86 @@ class TestCronjobRunExecutesImmediately:
             "adapters": None, "loop": None, "extra_prompt": None,
         }
 
+    def test_execute_job_now_preserves_legacy_provider_fire_due(self):
+        """Legacy providers keep ownership of their single-phase fire hook."""
+        seen = {}
+
+        class LegacyProvider:
+            name = "legacy"
+
+            def fire_due(self, job_id, *, adapters=None, loop=None):
+                from cron.scheduler import release_running_job, try_register_running_job
+
+                # Legacy fire_due owns admission. The wrapper must not occupy
+                # the shared running set before this hook gets control.
+                assert try_register_running_job(job_id)
+                try:
+                    seen.update(job_id=job_id, adapters=adapters, loop=loop)
+                    return True
+                finally:
+                    release_running_job(job_id)
+
+        adapters = {"telegram": object()}
+        gateway_loop = object()
+        runner = SimpleNamespace(adapters=adapters, _gateway_loop=gateway_loop)
+        with patch(
+            "cron.scheduler_provider.resolve_cron_scheduler",
+            return_value=LegacyProvider(),
+        ), patch("gateway.run._gateway_runner_ref", return_value=runner), patch(
+            "cron.scheduler.run_one_job"
+        ) as m_run:
+            result = _execute_job_now(dict(_JOB), extra_prompt="one-off context")
+
+        assert result == {
+            "claimed": True,
+            "success": True,
+            "error": None,
+            "execution": None,
+        }
+        assert seen == {
+            "job_id": "job-run-1",
+            "adapters": adapters,
+            "loop": gateway_loop,
+        }
+        m_run.assert_not_called()
+
+    def test_execute_job_now_reports_legacy_provider_failure(self):
+        class LegacyProvider:
+            name = "legacy"
+
+            def fire_due(self, job_id, *, adapters=None, loop=None):
+                raise RuntimeError("legacy fire failed")
+
+        with patch(
+            "cron.scheduler_provider.resolve_cron_scheduler",
+            return_value=LegacyProvider(),
+        ), patch("cron.scheduler.run_one_job") as m_run:
+            result = _execute_job_now(dict(_JOB))
+
+        assert result["claimed"] is True
+        assert result["success"] is False
+        assert result["error"] == "legacy fire failed"
+        assert result["execution"] is None
+        m_run.assert_not_called()
+
+    def test_execute_job_now_treats_legacy_lost_fire_as_unclaimed(self):
+        class LegacyProvider:
+            name = "legacy"
+
+            def fire_due(self, job_id, *, adapters=None, loop=None):
+                return False
+
+        with patch(
+            "cron.scheduler_provider.resolve_cron_scheduler",
+            return_value=LegacyProvider(),
+        ):
+            result = _execute_job_now(dict(_JOB))
+
+        assert result["claimed"] is False
+        assert result["success"] is False
+        assert result["error"] == "Legacy provider did not process the fire."
+        assert result["execution"] is None
+
     def test_execute_job_now_marks_failure_on_exception(self):
         """An exception during fire is captured, marked failed, not propagated."""
         claimed = {**_JOB, "fire_claim": {"by": "manual-owner"}}

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -39,12 +39,12 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from cron.jobs import (
     AmbiguousJobReference,
-    claim_job_for_fire,
+    claim_job_for_fire,  # noqa: F401 - legacy direct-call test seam
     effective_job_state,
     get_job,
     is_job_runnable,
     list_jobs,
-    mark_job_run,
+    mark_job_run,  # noqa: F401 - legacy direct-call test seam
     parse_schedule,
     pause_job,
     remove_job,
@@ -52,7 +52,7 @@ from cron.jobs import (
     resume_job,
     update_job,
 )
-from cron.executions import execution_projection
+from cron.executions import execution_projection, latest_execution
 
 
 def _notify_provider_jobs_changed_safe() -> None:
@@ -61,16 +61,6 @@ def _notify_provider_jobs_changed_safe() -> None:
     try:
         from cron.scheduler import _notify_provider_jobs_changed
         _notify_provider_jobs_changed()
-    except Exception:
-        pass
-
-
-def _finish_execution(execution_id: Optional[str], error: str) -> None:
-    if not execution_id:
-        return
-    try:
-        from cron.executions import finish_execution
-        finish_execution(str(execution_id), success=False, error=error)
     except Exception:
         pass
 
@@ -90,22 +80,18 @@ def _manual_result(
     return result
 
 
-def _claim_manual_execution(job_id: str):
-    from cron.executions import create_execution
-
-    execution_id = create_execution(job_id, source="direct").get("id")
+def _newest_execution_id(job_id: str, previous_id: Optional[str]) -> Optional[str]:
+    """Return the attempt created by a provider admission, if one is new."""
     try:
-        claimed_job = claim_job_for_fire(job_id, return_job=True)
-    except Exception as exc:
-        _finish_execution(execution_id, f"Manual fire claim failed before dispatch: {type(exc).__name__}: {exc}")
-        return None, execution_id, exc
-    if not isinstance(claimed_job, dict):
-        _finish_execution(execution_id, "Manual fire claim was not acquired.")
-        return None, execution_id, None
-    claimed_job = dict(claimed_job)
-    if execution_id:
-        claimed_job["execution_id"] = execution_id
-    return claimed_job, execution_id, None
+        latest = latest_execution(job_id)
+    except Exception:
+        return None
+    if not isinstance(latest, dict):
+        return None
+    execution_id = latest.get("id")
+    if execution_id and execution_id != previous_id:
+        return str(execution_id)
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -738,16 +724,24 @@ def _execute_job_now(
     Returns {"claimed": bool, "success": bool, "error": str|None}.
     """
     job_id = job["id"]
-    claimed_job = None
     execution_id = None
+    previous_execution_id = None
+    try:
+        previous = latest_execution(job_id)
+        if isinstance(previous, dict):
+            previous_execution_id = previous.get("id")
+    except Exception:
+        pass
     try:
         # At-most-once claim: bail without running if a tick/other fire owns it.
-        claimed_job, execution_id, claim_error = _claim_manual_execution(job_id)
-        if claim_error is not None:
-            raise claim_error
+        from cron.scheduler_provider import resolve_cron_scheduler
+        provider = resolve_cron_scheduler()
+        claimed_job = provider.claim_fire(job_id)
+        execution_id = claimed_job.get("execution_id") if isinstance(claimed_job, dict) else None
         if not isinstance(claimed_job, dict):
-            # claim_job_for_fire returns False for paused/disabled/missing
-            # jobs too — don't mislabel those as "already being fired"
+            execution_id = _newest_execution_id(job_id, previous_execution_id)
+            # claim_fire returns None for paused/disabled/missing jobs too —
+            # don't mislabel those as "already being fired"
             # (#60703): that message sends the user chasing a phantom
             # in-flight run when the job simply isn't runnable.
             refreshed = get_job(job_id)
@@ -760,17 +754,14 @@ def _execute_job_now(
             return _manual_result(job_id, execution_id, claimed=False, error=reason)
     except Exception as e:
         logger.error("Failed to claim cron job %s for immediate run: %s", job_id, e)
-        try:
-            mark_job_run(job_id, False, str(e))
-        except Exception:
-            pass
         return _manual_result(job_id, execution_id, claimed=True, error=str(e))
 
-    return _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
+    return _run_claimed_job(provider, claimed_job, extra_prompt=extra_prompt)
 
 
 def _run_claimed_job(
-    job: Dict[str, Any], extra_prompt: Optional[str] = None
+    provider, job: Optional[Dict[str, Any]] = None,
+    extra_prompt: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Fire an already-claimed job through the shared ``run_one_job`` body.
 
@@ -781,35 +772,15 @@ def _run_claimed_job(
 
     Returns {"claimed": True, "success": bool, "error": str|None}.
     """
+    if job is None:
+        job = provider
+        from cron.scheduler_provider import resolve_cron_scheduler
+        provider = resolve_cron_scheduler()
     job_id = job["id"]
-    _registered = False
-    fire_owner = None
+    dispatch_started = False
+    _heartbeat_stop = threading.Event()
+    _heartbeat_thread = None
     try:
-        from cron.scheduler import (
-            release_running_job,
-            run_one_job,
-            try_register_running_job,
-        )
-
-        # In-flight dedupe (idea from #53395 by @izumi0uu): the fire claim's
-        # TTL (300s) is routinely outlived by real jobs, so it alone cannot
-        # stop a manual run from double-firing a job the ticker (or another
-        # manual run) is still executing. Register in the scheduler's shared
-        # running set — the same guard _submit_with_guard uses — which also
-        # makes this run visible to the gateway shutdown drain
-        # (get_running_job_ids, #60432) and mark_running_jobs_interrupted.
-        if not try_register_running_job(job_id):
-            execution_id = job.get("execution_id")
-            _finish_execution(execution_id, "Job is already running; execution was not started.")
-            return _manual_result(
-                job_id, execution_id, claimed=True,
-                error="Job is already running (a scheduler tick or another manual run is executing it); not started again.",
-            )
-        _registered = True
-
-        claim = job.get("fire_claim")
-        fire_owner = str(claim.get("by") or "") if isinstance(claim, dict) else None
-
         # run_one_job records last_run_at/last_status via mark_job_run (which
         # also clears the fire claim) and returns True iff it processed the job.
         # ``job`` here is the exact claimed snapshot (owner-bearing), so the
@@ -834,9 +805,6 @@ def _run_claimed_job(
             activity_cb = get_activity_callback()
         except Exception:
             activity_cb = None
-
-        _heartbeat_stop = threading.Event()
-        _heartbeat_thread = None
 
         if activity_cb is not None:
             job_name = str(job.get("name") or job_id)
@@ -886,53 +854,52 @@ def _run_claimed_job(
         adapters = getattr(runner, "adapters", None) if runner is not None else None
         gateway_loop = getattr(runner, "_gateway_loop", None) if runner is not None else None
 
-        try:
-            try:
-                processed = run_one_job(
-                    job, adapters=adapters, loop=gateway_loop,
-                    extra_prompt=extra_prompt,
-                )
-            finally:
-                _heartbeat_stop.set()
-                if _heartbeat_thread is not None:
-                    _heartbeat_thread.join(timeout=_CRON_RUN_HEARTBEAT_INTERVAL + 1)
-        finally:
-            _registered = False
-            release_running_job(job_id)
+        dispatch = getattr(provider, "dispatch_claimed_fire", None)
+        if not callable(dispatch):
+            raise RuntimeError("Cron scheduler provider cannot dispatch a claimed fire")
+        dispatch_started = True
+        processed = dispatch(
+            job,
+            adapters=adapters,
+            loop=gateway_loop,
+            extra_prompt=extra_prompt,
+        )
         refreshed = get_job(job_id) or {}
         ok = refreshed.get("last_status") == "ok"
+        error = refreshed.get("last_error")
+        if not processed and not error:
+            error = "Job is already running; execution was not started."
         return {
             "claimed": True,
             "success": bool(processed and ok),
-            "error": refreshed.get("last_error"),
+            "error": error,
             "execution": execution_projection(job.get("execution_id"), job_id=job_id),
         }
 
-    except Exception as e:
+    except BaseException as e:
         logger.error("Failed to execute cron job %s immediately: %s", job_id, e)
-        if _registered:
-            # Registration succeeded but we raised before the run's own
-            # release ran (e.g. heartbeat setup) — don't leave the job
-            # permanently marked in-flight. Only release registrations WE
-            # took: a bare discard here could erase a ticker-owned entry.
+        if not dispatch_started:
             try:
-                from cron.scheduler import release_running_job as _release
-
-                _release(job_id)
+                provider.abort_claimed_fire(job, str(e) or type(e).__name__)
             except Exception:
-                pass
+                logger.debug(
+                    "Failed to abort claimed cron job %s after setup failure",
+                    job_id,
+                    exc_info=True,
+                )
+        if not isinstance(e, Exception):
+            raise
         execution_id = job.get("execution_id")
-        _finish_execution(execution_id, str(e))
-        try:
-            mark_job_run(
-                job_id,
-                False,
-                str(e),
-                expected_fire_owner=fire_owner,
-            )
-        except Exception:
-            pass
         return _manual_result(job_id, execution_id, claimed=True, error=str(e))
+    finally:
+        _heartbeat_stop.set()
+        if _heartbeat_thread is not None:
+            try:
+                _heartbeat_thread.join(timeout=_CRON_RUN_HEARTBEAT_INTERVAL + 1)
+            except RuntimeError:
+                # Thread.start() can fail during interpreter teardown; there
+                # is no running heartbeat to join in that case.
+                pass
 
 
 def _latest_job_output_excerpt(job_id: str, max_chars: int = 2000) -> Optional[str]:
@@ -1060,33 +1027,29 @@ def _try_dispatch_background_run(
         # the tool returns. Run synchronously.
         return None
 
-    # ---- synchronous claim (same semantics as _execute_job_now) ----
+    # ---- synchronous admission; execution stays provider-owned ----
+    previous_execution_id = None
+    execution_id = None
     try:
-        # Best-effort early dedupe so a mid-run job reports in THIS tool
-        # response instead of as a delayed error completion event. The
-        # authoritative (atomic) check is try_register_running_job inside
-        # _run_claimed_job on the worker.
-        try:
-            from cron.scheduler import get_running_job_ids
-
-            if job_id in get_running_job_ids():
-                return {
-                    "claimed": False,
-                    "success": False,
-                    "error": (
-                        "Job is already running (a scheduler tick or another "
-                        "manual run is executing it); not started again."
-                    ),
-                }
-        except Exception:
-            pass
-
-        # Same snapshot claim as _execute_job_now: carry the owner-bearing
-        # record into the run so terminal writes stay fenced by this owner.
-        claimed_job, execution_id, claim_error = _claim_manual_execution(job_id)
-        if claim_error is not None:
-            raise claim_error
+        previous = latest_execution(job_id)
+        if isinstance(previous, dict):
+            previous_execution_id = previous.get("id")
+        from cron.scheduler import get_running_job_ids
+        if job_id in get_running_job_ids():
+            return {
+                "claimed": False,
+                "success": False,
+                "error": (
+                    "Job is already running (a scheduler tick or another "
+                    "manual run is executing it); not started again."
+                ),
+            }
+        from cron.scheduler_provider import resolve_cron_scheduler
+        provider = resolve_cron_scheduler()
+        claimed_job = provider.claim_fire(job_id)
+        execution_id = claimed_job.get("execution_id") if isinstance(claimed_job, dict) else None
         if not isinstance(claimed_job, dict):
+            execution_id = _newest_execution_id(job_id, previous_execution_id)
             refreshed = get_job(job_id)
             if refreshed is None:
                 reason = "Job no longer exists; nothing to run."
@@ -1097,10 +1060,6 @@ def _try_dispatch_background_run(
             return _manual_result(job_id, execution_id, claimed=False, error=reason)
     except Exception as e:
         logger.error("Failed to claim cron job %s for background run: %s", job_id, e)
-        try:
-            mark_job_run(job_id, False, str(e))
-        except Exception:
-            pass
         return _manual_result(
             job_id, execution_id, claimed=True, error=str(e), dispatched=False
         )
@@ -1125,7 +1084,7 @@ def _try_dispatch_background_run(
             "cronjob run: async delegation registry unavailable (%s); "
             "running job '%s' inline.", e, job_name,
         )
-        result = _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
+        result = _run_claimed_job(provider, claimed_job, extra_prompt=extra_prompt)
         result["dispatched"] = False
         return result
 
@@ -1140,7 +1099,7 @@ def _try_dispatch_background_run(
     deliver = job.get("deliver", "local")
 
     def _runner() -> Dict[str, Any]:
-        res = _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
+        res = _run_claimed_job(provider, claimed_job, extra_prompt=extra_prompt)
         duration = round(time.time() - started_at, 2)
         refreshed = get_job(job_id) or {}
         lines = [
@@ -1181,7 +1140,7 @@ def _try_dispatch_background_run(
         )
     except Exception as dispatch_error:
         execution_id = claimed_job.get("execution_id")
-        _finish_execution(execution_id, f"Background dispatch failed: {dispatch_error}")
+        provider.abort_claimed_fire(claimed_job, str(dispatch_error))
         return _manual_result(job_id, execution_id, claimed=True,
                               error=str(dispatch_error), dispatched=False)
 
@@ -1200,7 +1159,7 @@ def _try_dispatch_background_run(
         "cronjob run: background pool unavailable (%s); running job '%s' inline.",
         dispatch.get("error", "rejected"), job_name,
     )
-    result = _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
+    result = _run_claimed_job(provider, claimed_job, extra_prompt=extra_prompt)
     result["dispatched"] = False
     return result
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1250,6 +1250,7 @@ def cronjob(
                 CronSchedulerRegistrationError,
                 create_job_with_scheduler_registration,
             )
+            from cron.jobs import CronDedupConflict, CronDedupKeyInvalid
 
             try:
                 job = create_job_with_scheduler_registration(
@@ -1278,6 +1279,7 @@ def cronjob(
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
                 return tool_error(_partial.pop("error"), success=False, **_partial)
+            except (CronDedupConflict, CronDedupKeyInvalid) as exc: return tool_error(str(exc), success=False)
             _create_message = f"Cron job '{job['name']}' created."
             _local_notice = _local_delivery_notice(job, _normalize_deliver_param(deliver))
             if _local_notice:

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -64,6 +64,33 @@ def _notify_provider_jobs_changed_safe() -> None:
         pass
 
 
+def _execution_identity_for_job(
+    job_id: str,
+    *,
+    execution_id: Optional[str] = None,
+    fallback_source: str = "direct",
+    fallback_status: str = "unknown",
+) -> Optional[Dict[str, str]]:
+    """Return the stable native execution projection for a job's latest run."""
+    try:
+        from cron.executions import execution_identity, get_execution, latest_execution
+
+        record = get_execution(execution_id) if execution_id else latest_execution(job_id)
+        projected = execution_identity(record)
+        if projected:
+            return projected
+    except Exception:
+        pass
+    if not execution_id:
+        return None
+    return {
+        "id": str(execution_id),
+        "job_id": str(job_id),
+        "source": fallback_source,
+        "status": fallback_status,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Cron prompt scanning
 # ---------------------------------------------------------------------------
@@ -645,6 +672,14 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "paused_at": job.get("paused_at"),
         "paused_reason": job.get("paused_reason"),
     }
+    latest_execution = job.get("latest_execution")
+    if isinstance(latest_execution, dict):
+        result["latest_execution"] = _execution_identity_for_job(
+            job_id,
+            execution_id=latest_execution.get("id"),
+            fallback_source=str(latest_execution.get("source") or ""),
+            fallback_status=str(latest_execution.get("status") or "unknown"),
+        )
     if job.get("script"):
         result["script"] = job["script"]
     if job.get("monitor_script"):
@@ -659,6 +694,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("dedup_key"):
+        result["dedup_key"] = job["dedup_key"]
     stored_refs = job.get("context_from") or []
     if isinstance(stored_refs, str):
         stored_refs = [stored_refs]
@@ -750,12 +787,27 @@ def _run_claimed_job(
         # makes this run visible to the gateway shutdown drain
         # (get_running_job_ids, #60432) and mark_running_jobs_interrupted.
         if not try_register_running_job(job_id):
+            execution_id = job.get("execution_id")
+            if execution_id:
+                try:
+                    from cron.executions import finish_execution
+
+                    finish_execution(
+                        str(execution_id),
+                        success=False,
+                        error="Job is already running; execution was not started.",
+                    )
+                except Exception:
+                    pass
             return {
                 "claimed": True,
                 "success": False,
                 "error": (
                     "Job is already running (a scheduler tick or another "
                     "manual run is executing it); not started again."
+                ),
+                "execution": _execution_identity_for_job(
+                    job_id, execution_id=execution_id, fallback_status="failed"
                 ),
             }
         _registered = True
@@ -858,6 +910,7 @@ def _run_claimed_job(
             "claimed": True,
             "success": bool(processed and ok),
             "error": refreshed.get("last_error"),
+            "execution": _execution_identity_for_job(job_id, execution_id=job.get("execution_id")),
         }
 
     except Exception as e:
@@ -886,6 +939,7 @@ def _run_claimed_job(
             "claimed": True,
             "success": False,
             "error": str(e),
+            "execution": _execution_identity_for_job(job_id, execution_id=job.get("execution_id")),
         }
 
 
@@ -1114,6 +1168,7 @@ def _try_dispatch_background_run(
             "status": "completed" if res.get("success") else "error",
             "summary": "\n".join(lines),
             "error": res.get("error"),
+            "execution": res.get("execution") or _execution_identity_for_job(job_id),
             "api_calls": 0,
             "duration_seconds": duration,
         }
@@ -1201,6 +1256,7 @@ def cronjob(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    dedup_key: Optional[str] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1301,6 +1357,7 @@ def cronjob(
                     attach_to_session=attach_to_session,
                     monitor_script=_normalize_optional_job_value(monitor_script),
                     monitor_url=_normalize_optional_job_value(monitor_url),
+                    dedup_key=_normalize_optional_job_value(dedup_key),
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
@@ -1452,6 +1509,8 @@ def cronjob(
             result = _format_job(get_job(job_id) or {"id": job_id})
             result["executed"] = exec_result.get("claimed", False)
             result["execution_success"] = exec_result.get("success", False)
+            if exec_result.get("execution"):
+                result["execution"] = exec_result["execution"]
             if not exec_result.get("claimed", False):
                 result["execution_skipped"] = exec_result.get("error") or (
                     "Already being fired by the scheduler; not run again."

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -708,21 +708,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
 def _execute_job_now(
     job: Dict[str, Any], extra_prompt: Optional[str] = None
 ) -> Dict[str, Any]:
-    """Execute a cron job immediately, outside the scheduler tick.
-
-    Atomically claims the job first via ``claim_job_for_fire`` — the same
-    at-most-once CAS the scheduler/external-provider fire path uses — so a
-    concurrently-running gateway ticker cannot also fire it (the claim both
-    blocks a duplicate fire and advances ``next_run_at`` for recurring jobs).
-    If the claim is lost (another fire is in flight), this is a no-op.
-
-    The actual firing is delegated to ``run_one_job`` — the single shared
-    execute→save→deliver→mark body the ticker and external providers use — so
-    failure delivery, ``[SILENT]`` handling, and live-adapter delivery stay
-    identical across paths and can't drift.
-
-    Returns {"claimed": bool, "success": bool, "error": str|None}.
-    """
+    """Execute a job now through the selected provider's fire contract."""
     job_id = job["id"]
     execution_id = None
     previous_execution_id = None
@@ -734,8 +720,18 @@ def _execute_job_now(
         pass
     try:
         # At-most-once claim: bail without running if a tick/other fire owns it.
-        from cron.scheduler_provider import resolve_cron_scheduler
+        from cron.scheduler_provider import (
+            provider_supports_split_fire,
+            resolve_cron_scheduler,
+        )
         provider = resolve_cron_scheduler()
+        if not provider_supports_split_fire(provider):
+            # Providers written against the original single-phase hook own
+            # admission/re-arm/telemetry inside fire_due. Calling the inherited
+            # claim + fire_claimed path would silently bypass that contract.
+            return _run_claimed_job(
+                provider, job, extra_prompt=extra_prompt
+            )
         claimed_job = provider.claim_fire(job_id)
         execution_id = claimed_job.get("execution_id") if isinstance(claimed_job, dict) else None
         if not isinstance(claimed_job, dict):
@@ -763,15 +759,7 @@ def _run_claimed_job(
     provider, job: Optional[Dict[str, Any]] = None,
     extra_prompt: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Fire an already-claimed job through the shared ``run_one_job`` body.
-
-    Split out of ``_execute_job_now`` so the background dispatch path
-    (``_try_dispatch_background_run``) can take the claim synchronously — so
-    the tool response can report "paused"/"already firing" immediately — and
-    hand the actual run to a daemon worker.
-
-    Returns {"claimed": True, "success": bool, "error": str|None}.
-    """
+    """Fire one job through the provider seam and return its tool result."""
     if job is None:
         job = provider
         from cron.scheduler_provider import resolve_cron_scheduler
@@ -781,27 +769,10 @@ def _run_claimed_job(
     _heartbeat_stop = threading.Event()
     _heartbeat_thread = None
     try:
-        # run_one_job records last_run_at/last_status via mark_job_run (which
-        # also clears the fire claim) and returns True iff it processed the job.
-        # ``job`` here is the exact claimed snapshot (owner-bearing), so the
-        # shared body fences every terminal write by that owner.
-        #
-        # A manual `run` executes the job synchronously on the caller's thread,
-        # and a cron job is itself a full agent run that routinely takes
-        # minutes. The calling turn emits no tool activity for that entire
-        # window, so the gateway inactivity watchdog concludes the agent is
-        # hung and kills the parent turn (#76502). Fire a heartbeat into the
-        # caller's activity tracker (the same signal tool progress uses) while
-        # the job runs, so the watchdog sees a working tool instead of a
-        # silent one — mirrors the delegate_task heartbeat pattern. Best-effort:
-        # if no activity callback is registered (direct Python callers, tests),
-        # behavior is unchanged.
+        # Keep the parent watchdog alive during long synchronous fires.
         try:
             from tools.environments.base import get_activity_callback
 
-            # Capture on THIS thread: the callback is thread-local (installed
-            # by the tool executor as the calling agent's _touch_activity), so
-            # a freshly spawned thread cannot read it back.
             activity_cb = get_activity_callback()
         except Exception:
             activity_cb = None
@@ -814,8 +785,6 @@ def _run_claimed_job(
                 while not _heartbeat_stop.wait(_CRON_RUN_HEARTBEAT_INTERVAL):
                     elapsed = time.monotonic() - started
                     if elapsed > _CRON_RUN_HEARTBEAT_CEILING:
-                        # Stop masking the gateway watchdog — a run this long
-                        # with an unlimited child watchdog is likely wedged.
                         logger.warning(
                             "cronjob run heartbeat ceiling reached for job "
                             "'%s' (%.0fs) — stopping heartbeat; gateway "
@@ -828,9 +797,6 @@ def _run_claimed_job(
                             f"cronjob: running job '{job_name}' ({int(elapsed)}s elapsed)"
                         )
                     except Exception:
-                        # Never break the job run; keep heartbeating — one
-                        # transient callback error must not silently drop
-                        # watchdog protection for the rest of a long job.
                         continue
 
             _heartbeat_thread = threading.Thread(
@@ -840,19 +806,28 @@ def _run_claimed_job(
             )
             _heartbeat_thread.start()
 
-        # Manual runs invoked from a gateway agent execute outside the scheduler
-        # ticker, but they still share the process with the live platform
-        # adapters. Pass the gateway-owned adapter map and event loop through
-        # to run_one_job so delivery is scheduled on the loop that owns clients
-        # such as Matrix/aiohttp. Calling those clients from run_one_job's
-        # standalone asyncio.run() loop raises errors like "Timeout context
-        # manager should be used inside a task" and can break encrypted Matrix
-        # delivery (#61495 — salvaged from #63586 by @Fly-onlyone).
+        # Reuse the gateway-owned adapters and loop for delivery.
         gateway_module = sys.modules.get("gateway.run")
         runner_ref = getattr(gateway_module, "_gateway_runner_ref", None)
         runner = runner_ref() if callable(runner_ref) else None
         adapters = getattr(runner, "adapters", None) if runner is not None else None
         gateway_loop = getattr(runner, "_gateway_loop", None) if runner is not None else None
+
+        from cron.scheduler_provider import provider_supports_split_fire
+
+        if not provider_supports_split_fire(provider):
+            # Legacy providers own their historical single-phase admission.
+            # Keep this call on the same adapter/loop and heartbeat rail.
+            dispatch_started = True
+            processed = provider.fire_due(
+                job_id, adapters=adapters, loop=gateway_loop
+            )
+            return {
+                "claimed": bool(processed),
+                "success": bool(processed),
+                "error": None if processed else "Legacy provider did not process the fire.",
+                "execution": None,
+            }
 
         dispatch = getattr(provider, "dispatch_claimed_fire", None)
         if not callable(dispatch):
@@ -930,41 +905,7 @@ def _try_dispatch_background_run(
     job: Dict[str, Any], session_id: Optional[str] = None,
     extra_prompt: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
-    """Claim ``job`` now, then fire it on the async-delegation daemon executor.
-
-    A manual ``cronjob(action='run')`` used to execute the job synchronously
-    on the calling agent's tool thread. A cron job is a full agent run that
-    routinely takes minutes-to-hours, so the parent turn sat inside ONE tool
-    call the whole time: uninterruptible (the interrupt flag is only checked
-    between loop iterations) and serial (a batch of runs executed one by one).
-
-    This dispatches the run like ``delegate_task``'s background mode: the tool
-    returns immediately with a handle, the run executes on the shared async
-    daemon executor, and a ``type="async_delegation"`` completion event
-    re-enters the conversation as a fresh turn when the job finishes — riding
-    the existing completion-queue rail (CLI drain + gateway watcher), which
-    keeps message-role alternation legal and the prompt cache intact.
-
-    The at-most-once claim is taken SYNCHRONOUSLY before dispatch so
-    unrunnable jobs (paused / missing / already firing) report in the tool
-    response immediately instead of as a delayed completion event.
-
-    Returns
-    -------
-    None
-        Background delivery unavailable on this session runtime (one-shot
-        ``hermes -z``, stateless HTTP, Kanban worker, nested cron run).
-        Caller falls back to the synchronous path unchanged.
-    dict
-        ``{"claimed": False, "success": False, "error": ...}`` — claim lost;
-        same shape as ``_execute_job_now`` so the caller's existing response
-        formatting applies.
-        ``{"claimed": True, "dispatched": True, "delegation_id": ...}`` —
-        run is executing in the background.
-        ``{"claimed": True, "dispatched": False, "success": ..., "error": ...}``
-        — dispatch pool was at capacity; the run executed inline (the claim
-        was already taken and must not be stranded).
-    """
+    """Admit a manual run, then dispatch it when the session supports it."""
     # Finite sessions cannot route a detached result back after the turn
     # ends — mirror delegate_task's gate and fall back to sync execution.
     try:
@@ -1044,11 +985,17 @@ def _try_dispatch_background_run(
                     "manual run is executing it); not started again."
                 ),
             }
-        from cron.scheduler_provider import resolve_cron_scheduler
+        from cron.scheduler_provider import (
+            provider_supports_split_fire,
+            resolve_cron_scheduler,
+        )
         provider = resolve_cron_scheduler()
-        claimed_job = provider.claim_fire(job_id)
+        legacy_provider = not provider_supports_split_fire(provider)
+        claimed_job = None
+        if not legacy_provider:
+            claimed_job = provider.claim_fire(job_id)
         execution_id = claimed_job.get("execution_id") if isinstance(claimed_job, dict) else None
-        if not isinstance(claimed_job, dict):
+        if not legacy_provider and not isinstance(claimed_job, dict):
             execution_id = _newest_execution_id(job_id, previous_execution_id)
             refreshed = get_job(job_id)
             if refreshed is None:
@@ -1084,7 +1031,9 @@ def _try_dispatch_background_run(
             "cronjob run: async delegation registry unavailable (%s); "
             "running job '%s' inline.", e, job_name,
         )
-        result = _run_claimed_job(provider, claimed_job, extra_prompt=extra_prompt)
+        result = _run_claimed_job(
+            provider, job if legacy_provider else claimed_job, extra_prompt=extra_prompt
+        )
         result["dispatched"] = False
         return result
 
@@ -1097,9 +1046,10 @@ def _try_dispatch_background_run(
 
     started_at = time.time()
     deliver = job.get("deliver", "local")
+    fire_job = job if legacy_provider else claimed_job
 
     def _runner() -> Dict[str, Any]:
-        res = _run_claimed_job(provider, claimed_job, extra_prompt=extra_prompt)
+        res = _run_claimed_job(provider, fire_job, extra_prompt=extra_prompt)
         duration = round(time.time() - started_at, 2)
         refreshed = get_job(job_id) or {}
         lines = [
@@ -1139,9 +1089,11 @@ def _try_dispatch_background_run(
             origin_session_id=origin_session_id, max_async_children=max_async,
         )
     except Exception as dispatch_error:
-        execution_id = claimed_job.get("execution_id")
-        provider.abort_claimed_fire(claimed_job, str(dispatch_error))
-        return _manual_result(job_id, execution_id, claimed=True,
+        if not legacy_provider:
+            execution_id = claimed_job.get("execution_id")
+            provider.abort_claimed_fire(claimed_job, str(dispatch_error))
+        return _manual_result(
+            job_id, execution_id, claimed=not legacy_provider,
                               error=str(dispatch_error), dispatched=False)
 
     if dispatch.get("status") == "dispatched":
@@ -1149,17 +1101,25 @@ def _try_dispatch_background_run(
             "claimed": True,
             "dispatched": True,
             "delegation_id": dispatch.get("delegation_id"),
-            "execution": execution_projection(claimed_job.get("execution_id"),
-                                                job_id=job_id, status="claimed"),
+            "execution": (
+                execution_projection(
+                    claimed_job.get("execution_id"),
+                    job_id=job_id,
+                    status="claimed",
+                )
+                if isinstance(claimed_job, dict)
+                else None
+            ),
         }
 
-    # Pool at capacity (or submit failure): the claim is already taken and
-    # must not be stranded — run inline exactly as the legacy path did.
+    # Pool at capacity (or submit failure): split-aware claims are already
+    # taken and must not be stranded; legacy providers have not admitted a
+    # fire yet. Run either provider path inline.
     logger.info(
         "cronjob run: background pool unavailable (%s); running job '%s' inline.",
         dispatch.get("error", "rejected"), job_name,
     )
-    result = _run_claimed_job(provider, claimed_job, extra_prompt=extra_prompt)
+    result = _run_claimed_job(provider, fire_job, extra_prompt=extra_prompt)
     result["dispatched"] = False
     return result
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -52,6 +52,7 @@ from cron.jobs import (
     resume_job,
     update_job,
 )
+from cron.executions import execution_projection
 
 
 def _notify_provider_jobs_changed_safe() -> None:
@@ -64,31 +65,47 @@ def _notify_provider_jobs_changed_safe() -> None:
         pass
 
 
-def _execution_identity_for_job(
-    job_id: str,
-    *,
-    execution_id: Optional[str] = None,
-    fallback_source: str = "direct",
-    fallback_status: str = "unknown",
-) -> Optional[Dict[str, str]]:
-    """Return the stable native execution projection for a job's latest run."""
+def _finish_execution(execution_id: Optional[str], error: str) -> None:
+    if not execution_id:
+        return
     try:
-        from cron.executions import execution_identity, get_execution, latest_execution
-
-        record = get_execution(execution_id) if execution_id else latest_execution(job_id)
-        projected = execution_identity(record)
-        if projected:
-            return projected
+        from cron.executions import finish_execution
+        finish_execution(str(execution_id), success=False, error=error)
     except Exception:
         pass
-    if not execution_id:
-        return None
-    return {
-        "id": str(execution_id),
-        "job_id": str(job_id),
-        "source": fallback_source,
-        "status": fallback_status,
+
+
+def _manual_result(
+    job_id: str, execution_id: Optional[str], *, claimed: bool, error: str,
+    dispatched: Optional[bool] = None,
+) -> Dict[str, Any]:
+    result = {
+        "claimed": claimed,
+        "success": False,
+        "error": error,
+        "execution": execution_projection(execution_id, job_id=job_id, status="failed"),
     }
+    if dispatched is not None:
+        result["dispatched"] = dispatched
+    return result
+
+
+def _claim_manual_execution(job_id: str):
+    from cron.executions import create_execution
+
+    execution_id = create_execution(job_id, source="direct").get("id")
+    try:
+        claimed_job = claim_job_for_fire(job_id, return_job=True)
+    except Exception as exc:
+        _finish_execution(execution_id, f"Manual fire claim failed before dispatch: {type(exc).__name__}: {exc}")
+        return None, execution_id, exc
+    if not isinstance(claimed_job, dict):
+        _finish_execution(execution_id, "Manual fire claim was not acquired.")
+        return None, execution_id, None
+    claimed_job = dict(claimed_job)
+    if execution_id:
+        claimed_job["execution_id"] = execution_id
+    return claimed_job, execution_id, None
 
 
 # ---------------------------------------------------------------------------
@@ -672,14 +689,6 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "paused_at": job.get("paused_at"),
         "paused_reason": job.get("paused_reason"),
     }
-    latest_execution = job.get("latest_execution")
-    if isinstance(latest_execution, dict):
-        result["latest_execution"] = _execution_identity_for_job(
-            job_id,
-            execution_id=latest_execution.get("id"),
-            fallback_source=str(latest_execution.get("source") or ""),
-            fallback_status=str(latest_execution.get("status") or "unknown"),
-        )
     if job.get("script"):
         result["script"] = job["script"]
     if job.get("monitor_script"):
@@ -730,9 +739,12 @@ def _execute_job_now(
     """
     job_id = job["id"]
     claimed_job = None
+    execution_id = None
     try:
         # At-most-once claim: bail without running if a tick/other fire owns it.
-        claimed_job = claim_job_for_fire(job_id, return_job=True)
+        claimed_job, execution_id, claim_error = _claim_manual_execution(job_id)
+        if claim_error is not None:
+            raise claim_error
         if not isinstance(claimed_job, dict):
             # claim_job_for_fire returns False for paused/disabled/missing
             # jobs too — don't mislabel those as "already being fired"
@@ -745,14 +757,14 @@ def _execute_job_now(
                 reason = "Job is paused/disabled; resume it before running."
             else:
                 reason = "Job is already being fired by the scheduler; not run again."
-            return {"claimed": False, "success": False, "error": reason}
+            return _manual_result(job_id, execution_id, claimed=False, error=reason)
     except Exception as e:
         logger.error("Failed to claim cron job %s for immediate run: %s", job_id, e)
         try:
             mark_job_run(job_id, False, str(e))
         except Exception:
             pass
-        return {"claimed": True, "success": False, "error": str(e)}
+        return _manual_result(job_id, execution_id, claimed=True, error=str(e))
 
     return _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
 
@@ -788,28 +800,11 @@ def _run_claimed_job(
         # (get_running_job_ids, #60432) and mark_running_jobs_interrupted.
         if not try_register_running_job(job_id):
             execution_id = job.get("execution_id")
-            if execution_id:
-                try:
-                    from cron.executions import finish_execution
-
-                    finish_execution(
-                        str(execution_id),
-                        success=False,
-                        error="Job is already running; execution was not started.",
-                    )
-                except Exception:
-                    pass
-            return {
-                "claimed": True,
-                "success": False,
-                "error": (
-                    "Job is already running (a scheduler tick or another "
-                    "manual run is executing it); not started again."
-                ),
-                "execution": _execution_identity_for_job(
-                    job_id, execution_id=execution_id, fallback_status="failed"
-                ),
-            }
+            _finish_execution(execution_id, "Job is already running; execution was not started.")
+            return _manual_result(
+                job_id, execution_id, claimed=True,
+                error="Job is already running (a scheduler tick or another manual run is executing it); not started again.",
+            )
         _registered = True
 
         claim = job.get("fire_claim")
@@ -910,7 +905,7 @@ def _run_claimed_job(
             "claimed": True,
             "success": bool(processed and ok),
             "error": refreshed.get("last_error"),
-            "execution": _execution_identity_for_job(job_id, execution_id=job.get("execution_id")),
+            "execution": execution_projection(job.get("execution_id"), job_id=job_id),
         }
 
     except Exception as e:
@@ -926,6 +921,8 @@ def _run_claimed_job(
                 _release(job_id)
             except Exception:
                 pass
+        execution_id = job.get("execution_id")
+        _finish_execution(execution_id, str(e))
         try:
             mark_job_run(
                 job_id,
@@ -935,12 +932,7 @@ def _run_claimed_job(
             )
         except Exception:
             pass
-        return {
-            "claimed": True,
-            "success": False,
-            "error": str(e),
-            "execution": _execution_identity_for_job(job_id, execution_id=job.get("execution_id")),
-        }
+        return _manual_result(job_id, execution_id, claimed=True, error=str(e))
 
 
 def _latest_job_output_excerpt(job_id: str, max_chars: int = 2000) -> Optional[str]:
@@ -1091,7 +1083,9 @@ def _try_dispatch_background_run(
 
         # Same snapshot claim as _execute_job_now: carry the owner-bearing
         # record into the run so terminal writes stay fenced by this owner.
-        claimed_job = claim_job_for_fire(job_id, return_job=True)
+        claimed_job, execution_id, claim_error = _claim_manual_execution(job_id)
+        if claim_error is not None:
+            raise claim_error
         if not isinstance(claimed_job, dict):
             refreshed = get_job(job_id)
             if refreshed is None:
@@ -1100,14 +1094,16 @@ def _try_dispatch_background_run(
                 reason = "Job is paused/disabled; resume it before running."
             else:
                 reason = "Job is already being fired by the scheduler; not run again."
-            return {"claimed": False, "success": False, "error": reason}
+            return _manual_result(job_id, execution_id, claimed=False, error=reason)
     except Exception as e:
         logger.error("Failed to claim cron job %s for background run: %s", job_id, e)
         try:
             mark_job_run(job_id, False, str(e))
         except Exception:
             pass
-        return {"claimed": True, "dispatched": False, "success": False, "error": str(e)}
+        return _manual_result(
+            job_id, execution_id, claimed=True, error=str(e), dispatched=False
+        )
 
     origin_ui_session_id = ""
     try:
@@ -1168,33 +1164,34 @@ def _try_dispatch_background_run(
             "status": "completed" if res.get("success") else "error",
             "summary": "\n".join(lines),
             "error": res.get("error"),
-            "execution": res.get("execution") or _execution_identity_for_job(job_id),
+            "execution": res.get("execution") or execution_projection(job_id=job_id),
             "api_calls": 0,
             "duration_seconds": duration,
         }
 
-    dispatch = dispatch_async_delegation(
-        goal=f"Manual run of cron job '{job_name}' ({job_id})",
-        context=(
-            "Triggered via cronjob(action='run'). The job executed in its own "
-            "fresh cron session; this block reports its outcome."
-        ),
-        toolsets=None,
-        role="cron_run",
-        model=job.get("model"),
-        session_key=session_key,
-        parent_session_id=str(session_id) if session_id else None,
-        runner=_runner,
-        origin_ui_session_id=origin_ui_session_id,
-        origin_session_id=origin_session_id,
-        max_async_children=max_async,
-    )
+    try:
+        dispatch = dispatch_async_delegation(
+            goal=f"Manual run of cron job '{job_name}' ({job_id})",
+            context="Triggered via cronjob(action='run'). The job executed in its own fresh cron session; this block reports its outcome.",
+            toolsets=None, role="cron_run", model=job.get("model"),
+            session_key=session_key,
+            parent_session_id=str(session_id) if session_id else None,
+            runner=_runner, origin_ui_session_id=origin_ui_session_id,
+            origin_session_id=origin_session_id, max_async_children=max_async,
+        )
+    except Exception as dispatch_error:
+        execution_id = claimed_job.get("execution_id")
+        _finish_execution(execution_id, f"Background dispatch failed: {dispatch_error}")
+        return _manual_result(job_id, execution_id, claimed=True,
+                              error=str(dispatch_error), dispatched=False)
 
     if dispatch.get("status") == "dispatched":
         return {
             "claimed": True,
             "dispatched": True,
             "delegation_id": dispatch.get("delegation_id"),
+            "execution": execution_projection(claimed_job.get("execution_id"),
+                                                job_id=job_id, status="claimed"),
         }
 
     # Pool at capacity (or submit failure): the claim is already taken and
@@ -1203,7 +1200,7 @@ def _try_dispatch_background_run(
         "cronjob run: background pool unavailable (%s); running job '%s' inline.",
         dispatch.get("error", "rejected"), job_name,
     )
-    result = _run_claimed_job(job, extra_prompt=extra_prompt)
+    result = _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
     result["dispatched"] = False
     return result
 
@@ -1479,6 +1476,8 @@ def cronjob(
                 result["executed"] = True
                 result["execution_mode"] = "background"
                 result["delegation_id"] = bg.get("delegation_id")
+                if bg.get("execution"):
+                    result["execution"] = bg["execution"]
                 return json.dumps(
                     {
                         "success": True,


### PR DESCRIPTION
## Summary
- add exact-ID cron API mutation paths while preserving name-friendly CLI behavior
- add durable execution identities, claim cleanup, pagination cursors, and typed manual-run responses
- add atomic bounded create idempotency with semantic conflict detection
- preserve legacy provider ownership by failing closed on typed runs when split-fire identity is unavailable

## Verification
- 272 changed-surface tests passed
- ruff, compile, and diff checks passed
- hosted linux/x86_64 proof covered restart persistence, idempotent replay/conflict, exact-ID behavior, execution cleanup, and multiplex fallback
- independent review CLEAR; exact-SHA verification VERIFIED

No dependency changes.