### PR TITLE
fix(build): replace __dirname with import.meta.dirname in vite configs

### DIFF
--- a/apps/bootstrap-installer/vite.config.ts
+++ b/apps/bootstrap-installer/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src')
+      '@': path.resolve(import.meta.dirname, './src')
     }
   },
   clearScreen: false,

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -19,9 +19,9 @@ const real = (p: string): string | null => {
 const fsAllow = [
   ...new Set(
     [
-      path.resolve(__dirname, '../..'),
-      real(path.resolve(__dirname, 'node_modules')),
-      real(path.resolve(__dirname, '../../node_modules'))
+      path.resolve(import.meta.dirname, '../..'),
+      real(path.resolve(import.meta.dirname, 'node_modules')),
+      real(path.resolve(import.meta.dirname, '../../node_modules'))
     ].filter((p): p is string => p !== null)
   )
 ]
@@ -36,7 +36,7 @@ const fsAllow = [
 // warns. Resolving from this workspace instead of a hardcoded root path yields
 // the versions declared here — npm nests a copy under the workspace exactly
 // when the hoisted one differs, so the pair can only ever match.
-const requireFromApp = createRequire(path.join(__dirname, 'vite.config.ts'))
+const requireFromApp = createRequire(path.join(import.meta.dirname, 'vite.config.ts'))
 const reactDir = path.dirname(requireFromApp.resolve('react/package.json'))
 const reactDomDir = path.dirname(requireFromApp.resolve('react-dom/package.json'))
 
@@ -48,16 +48,16 @@ const reactDomDir = path.dirname(requireFromApp.resolve('react-dom/package.json'
 // the perf harness opts a production build back in with VITE_PERF_PROBE=1.
 const debugEntry = (command: string, env: Record<string, string>) =>
   command === 'serve' || env.VITE_PERF_PROBE === '1'
-    ? path.resolve(__dirname, './src/debug/dev-only.ts')
-    : path.resolve(__dirname, './src/debug/dev-only.noop.ts')
+    ? path.resolve(import.meta.dirname, './src/debug/dev-only.ts')
+    : path.resolve(import.meta.dirname, './src/debug/dev-only.noop.ts')
 
 // The emoji picker (frimousse) fetches `<emojibaseUrl>/<locale>/data.json` at
 // runtime. Its default is a CDN; Electron must work offline, so serve the
 // bundled emojibase-data package at a stable local path instead — middleware
 // in dev, emitted assets in the build. Only the files a locale actually needs.
 const emojibaseDir =
-  real(path.resolve(__dirname, 'node_modules/emojibase-data')) ??
-  real(path.resolve(__dirname, '../../node_modules/emojibase-data'))
+  real(path.resolve(import.meta.dirname, 'node_modules/emojibase-data')) ??
+  real(path.resolve(import.meta.dirname, '../../node_modules/emojibase-data'))
 
 const EMOJIBASE_PATH = /^[a-z-]+\/(data|messages|shortcodes\/emojibase)\.json$/
 
@@ -174,10 +174,10 @@ export default defineConfig(({ command }) => ({
   resolve: {
     alias: {
       '@/debug/dev-only': debugEntry(command, process.env as Record<string, string>),
-      '@': path.resolve(__dirname, './src'),
-      '@hermes/plugin-sdk': path.resolve(__dirname, './src/sdk/index.ts'),
-      '@hermes/shared/billing': path.resolve(__dirname, '../shared/src/billing-types.ts'),
-      '@hermes/shared': path.resolve(__dirname, '../shared/src'),
+      '@': path.resolve(import.meta.dirname, './src'),
+      '@hermes/plugin-sdk': path.resolve(import.meta.dirname, './src/sdk/index.ts'),
+      '@hermes/shared/billing': path.resolve(import.meta.dirname, '../shared/src/billing-types.ts'),
+      '@hermes/shared': path.resolve(import.meta.dirname, '../shared/src'),
       // The tour tool's preview surface injects driver.js's prebuilt IIFE into
       // the pane's guest page as raw source; the package's exports map doesn't
       // expose that dist file (nor ./package.json), so resolve the main entry

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -61,8 +61,8 @@ export default defineConfig({
   plugins: [react(), tailwindcss(), hermesDevToken()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "@hermes/shared": path.resolve(__dirname, "../apps/shared/src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
+      "@hermes/shared": path.resolve(import.meta.dirname, "../apps/shared/src"),
     },
     // When @nous-research/ui is symlinked via `file:../../design-language`,
     // Node's module resolution would pick up shared deps from


### PR DESCRIPTION
## What does this PR do?

Vite 8.2 warns on every build that uses `__dirname` in a vite config:

```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`,
    which is planned to become the default in a future major version of Vite:
      - `__dirname` (web/vite.config.ts:64). Use `import.meta.dirname` instead
```

The configs currently work only because the default config loader bundles the config and shims the CJS global. The native config loader — planned as the default in a future Vite major — will not support `__dirname` at all, so every `hermes update` / `hermes doctor` web build prints this warning today and will break once the default flips.

This PR mechanically replaces `__dirname` with `import.meta.dirname` in all three vite configs:

- `web/vite.config.ts` — 2 `resolve.alias` entries
- `apps/desktop/vite.config.ts` — 12 path resolutions + the `createRequire` base path
- `apps/bootstrap-installer/vite.config.ts` — 1 `resolve.alias` entry

The repo's node engine floor is `>=22.22.0` (root and `apps/desktop` `package.json`), so `import.meta.dirname` (available since Node 20.11) is always defined.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/vite.config.ts`: `path.resolve(__dirname, ...)` → `path.resolve(import.meta.dirname, ...)` in `resolve.alias`
- `apps/desktop/vite.config.ts`: same replacement for `server.fs.allow`, `createRequire` base, debug-entry selection, `emojibase-data` resolution and `resolve.alias`
- `apps/bootstrap-installer/vite.config.ts`: same replacement in `resolve.alias`

## How to Test

1. `cd web && npm run build` — before: warning banner printed above `vite v8.2.0 building client environment...`; after: banner gone, build succeeds (2220 modules transformed on my machine)
2. `cd apps/bootstrap-installer && npx vite build` and `cd apps/desktop && npx vite build` — configs load and bundle identically before/after this change (my machine lacks some workspace deps, so both fail at the same pre-existing spot on both the patched and unpatched configs — no behavior change introduced)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: TypeScript build-config-only change, no Python touched
- [ ] I've added tests for my changes — N/A: config-file replacement, verified by real builds
- [x] I've tested on my platform: macOS (Darwin 25.6.0, arm64), Node v24.19.0

### Documentation & Housekeeping

- [ ] N/A — no docs, config keys, architecture or tool-schema changes

## Screenshots / Logs

Build output with the patch applied (warning banner gone):

```
vite v8.2.0 building client environment for production...
✓ 2220 modules transformed.
```