### PR TITLE
fix(desktop): keep Bot Mode group chats in one workspace

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -204,8 +204,8 @@ const $sessionsGatewayGeneration = atom(0)
 /** Group-chat rooms: { [group]: { log: [{from:{kind,name},text,at}], watermarks:{[member]:idx}, epoch, running } }.
  *  Log + watermarks persist via plugin storage; epoch/running are runtime-only. */
 const $groupChats = atom({})
-/** Group whose room view is open in the Bots pane (secondary navigation,
- *  same pattern as $botSessionsWorkspace). */
+/** Selected group chat. Modern hosts render it in the main workspace; older
+ *  hosts fall back to the Bots pane. */
 const $groupChatWorkspace = atom(null)
 /** Groups whose latest room activity mentions @user — the needs-you badge. */
 const $groupNeedsYou = atom({})
@@ -9367,6 +9367,10 @@ function GroupChatWorkspace({ group, members, onBack }) {
  *  disband (or the room view's own Back) can retire the tab it opened. */
 const groupChatMainTabs = new Map()
 
+function shouldRenderGroupChatInPane(group) {
+  return Boolean(group && !groupChatMainTabs.has(group))
+}
+
 function closeGroupChatMainTab(group) {
   const close = groupChatMainTabs.get(group)
 
@@ -9403,7 +9407,6 @@ function GroupChatMainView({ group }) {
  *  view on desktops whose SDK predates the main-area door. */
 function openGroupChat(group) {
   $groupNeedsYou.set({ ...$groupNeedsYou.get(), [group]: false })
-  $groupChatWorkspace.set(group)
 
   if (typeof host.openWorkspace === 'function') {
     try {
@@ -9421,6 +9424,7 @@ function openGroupChat(group) {
       })
 
       groupChatMainTabs.set(group, close)
+      $groupChatWorkspace.set(group)
 
       return
     } catch {
@@ -9428,8 +9432,7 @@ function openGroupChat(group) {
     }
   }
 
-  // The selected-group atom was set before trying the main-window door, so
-  // older desktops naturally render the in-panel room as the fallback.
+  $groupChatWorkspace.set(group)
 }
 
 /** One group chat as ONE roster row — the Discord shape: stacked member
@@ -9656,7 +9659,7 @@ function BotsPane() {
 
   const groupChatMembers = groupChatName ? groupChatMemberBots(groupChatName, roster, allMeta) : []
 
-  if (groupChatName && groupChatMembers.length) {
+  if (shouldRenderGroupChatInPane(groupChatName) && groupChatMembers.length) {
     return jsx(GroupChatWorkspace, { group: groupChatName, members: groupChatMembers })
   }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -104,7 +104,7 @@ function load(turnScript, { busyUntilResumeCall } = {}) {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, disbandGroupChat, updateGroupChat, openGroupChat, closeGroupChatMainTab, $groupChats, $groupNeedsYou, $groupChatWorkspace, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, disbandGroupChat, updateGroupChat, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, $groupChats, $groupNeedsYou, $groupChatWorkspace, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -355,7 +355,7 @@ test('source contract: workspace + main-window door + prompt rules are wired', (
   assert.match(pluginSource, /\[Group chat: "\$\{groupName\}"\]/)
 })
 
-test('group selection follows main-window open and close', () => {
+test('modern hosts render a selected group only in the main workspace', () => {
   const gc = load(() => '(pass)')
   let onClose
 
@@ -366,9 +366,27 @@ test('group selection follows main-window open and close', () => {
 
   gc.openGroupChat('Core')
   assert.equal(gc.$groupChatWorkspace.get(), 'Core')
+  assert.equal(gc.shouldRenderGroupChatInPane('Core'), false)
 
   onClose()
   assert.equal(gc.$groupChatWorkspace.get(), null)
+})
+
+test('older and failed workspace hosts keep the in-pane group fallback', () => {
+  const older = load(() => '(pass)')
+
+  older.openGroupChat('Core')
+  assert.equal(older.$groupChatWorkspace.get(), 'Core')
+  assert.equal(older.shouldRenderGroupChatInPane('Core'), true)
+
+  const failed = load(() => '(pass)')
+  failed.host.openWorkspace = () => {
+    throw new Error('workspace unavailable')
+  }
+
+  failed.openGroupChat('Ops')
+  assert.equal(failed.$groupChatWorkspace.get(), 'Ops')
+  assert.equal(failed.shouldRenderGroupChatInPane('Ops'), true)
 })
 
 test('closing an older selected group does not clear the newer selection', () => {


### PR DESCRIPTION
## What does this PR do?

Prevents Bot Mode group chats from rendering in both the narrow Bots pane and the main workspace after a group row is selected.

The selected-group state now records the main workspace before notifying the pane, and the pane renders its compatibility fallback only when no main group-chat tab exists. Desktops without `host.openWorkspace`, or hosts where that call fails, still use the existing in-pane room.

## Related Issue

Discord report: https://discord.com/channels/1053877538025386074/1539779952776318976

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Gate the legacy Bots-pane group room on the absence of a registered main workspace tab in `apps/desktop/src/plugins/hermes-bots/plugin.js`.
- Register the main workspace before publishing the selected group, avoiding a transient duplicate render.
- Add behavioral coverage for modern, missing, and failed `openWorkspace` hosts in `apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs`.

## How to Test

1. Open Desktop Bot Mode and select a group chat.
2. Confirm the group chat appears in the main workspace while the narrow Bots pane keeps the roster visible.
3. Run the group-chat tests and confirm older hosts without a working `openWorkspace` capability still render the room in the Bots pane.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - platform-independent renderer logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Automated verification:

- `node --test apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs` (41 passed)
- `npm run check:test:plugins` (316 passed)
- `npm run check:lint` (passed; 0 errors, 119 existing warnings outside this change)