### PR TITLE
fix(cli): first-run banner no longer claims "No skills installed" while 69 skills seed

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3111,22 +3111,50 @@ def cmd_chat(args):
         except Exception:
             pass
 
-    # Sync bundled skills on every CLI launch. Runs in a background daemon
-    # thread: the sync is idempotent, hash-gated (unchanged skills are
+    # Sync bundled skills on every CLI launch. Normally runs in a background
+    # daemon thread: the sync is idempotent, hash-gated (unchanged skills are
     # skipped), and nothing on the banner path depends on it, yet the scan
     # alone costs ~120-170ms of rglob/hashing on the startup path. Skill
     # loading happens at agent init (first message), by which point the
-    # sync has long finished; a same-instant race would only matter in the
-    # rare launch right after `hermes update` changed a bundled skill.
+    # sync has long finished.
+    #
+    # FIRST RUN is the exception: with an empty ~/.hermes/skills the banner
+    # prefetch races the background sync, caches an empty skills index, and
+    # the very first launch greets the user with "No skills installed ·
+    # 0 skills" while 69 bundled skills land milliseconds later (full-surface
+    # CLI QA sweep, Aug 2026). Run the sync in the foreground exactly once —
+    # only when the skills dir has no SKILL.md yet — so the first impression
+    # matches reality; every later launch keeps the background path.
+    def _skills_dir_is_unseeded() -> bool:
+        try:
+            from hermes_cli.config import get_hermes_home
+            skills_dir = Path(get_hermes_home()) / "skills"
+            if not skills_dir.is_dir():
+                return True
+            return next(skills_dir.rglob("SKILL.md"), None) is None
+        except Exception:
+            return False
+
     def _skills_sync_bg() -> None:
         try:
             _sync_bundled_skills_for_startup()
         except Exception:
             pass
 
-    threading.Thread(
-        target=_skills_sync_bg, name="bundled-skills-sync", daemon=True
-    ).start()
+    if _skills_dir_is_unseeded():
+        _skills_sync_bg()
+        # The banner prefetch thread (started above) may have scanned the
+        # still-empty dir and cached an empty skills index — drop it so the
+        # banner recomputes against the freshly seeded tree.
+        try:
+            import hermes_cli.banner as _banner_mod
+            _banner_mod._available_skills_cache = None
+        except Exception:
+            pass
+    else:
+        threading.Thread(
+            target=_skills_sync_bg, name="bundled-skills-sync", daemon=True
+        ).start()
 
     # --yolo: bypass all dangerous command approvals.
     # Also set in main() before _prepare_agent_startup() — that is the


### PR DESCRIPTION
## Summary
A brand-new install's first launch now shows the real skill catalog ("27 tools · 69 skills") instead of "No skills installed · 0 skills".

Found during a full-surface live QA sweep, reproduced deterministically with a fresh `HERMES_HOME`: the welcome-banner prefetch scans the still-empty `~/.hermes/skills` while `sync_skills()` seeds the 69 bundled skills in a background daemon thread. The banner caches the empty index and greets the user with an empty catalog on the one launch where first impressions matter most; `/help` (which scans later) simultaneously lists all 69, contradicting the banner.

## Changes
- `hermes_cli/main.py`: when the skills dir has no `SKILL.md` yet (first run only), run the bundled-skill sync in the foreground before the banner renders and drop the banner's possibly-empty prefetch cache; every subsequent launch keeps the existing background-thread path (zero startup-cost change)

## Validation
| | Before | After |
|---|---|---|
| fresh HERMES_HOME, first `hermes` launch | banner: "No skills installed · 0 skills" (69 seeded ms later) | banner: "27 tools · 69 skills" + category list (live-verified in tmux, fresh home) |
| subsequent launches | background sync | unchanged (background sync) |

## Infographic

![first-run banner fix infographic](https://files.catbox.moe/n331bs.png)
