### PR TITLE
fix(mcp): skip waiter-task cleanup when the event loop is already closed

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2939,6 +2939,12 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
+                    try:
+                        loop = asyncio.get_event_loop()
+                        if loop.is_closed():
+                            continue
+                    except RuntimeError:
+                        continue
                     t.cancel()
                     try:
                         await t
@@ -2983,6 +2989,12 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
+                    try:
+                        loop = asyncio.get_event_loop()
+                        if loop.is_closed():
+                            continue
+                    except RuntimeError:
+                        continue
                     t.cancel()
                     try:
                         await t


### PR DESCRIPTION
## What does this PR do?

`MCPServerTask` parks each connection on two asyncio waiter tasks and cleans them up in `finally` blocks (`t.cancel()` + `await t`), in two places:

- the park loop in `MCPServerTask` (around line 2939)
- `_wait_for_reconnect_or_shutdown` (around line 2989)

During MCP server shutdown I hit failures where the surrounding event loop is already closed by the time this cleanup runs. Touching the pending waiters at that point raises `RuntimeError` (event loop closed / no running event loop, message varies by Python version) and derails the shutdown sequence instead of letting it finish quietly.

This PR probes the loop before touching each waiter: if no loop is retrievable, or it reports itself closed, the `cancel`/`await` is skipped. A waiter whose loop is gone can never run again, so the cleanup is both impossible and unnecessary — skipping it is strictly safer.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: guard the two waiter-cleanup `finally` blocks with a loop liveness probe (`asyncio.get_event_loop()` → `is_closed()` check, `RuntimeError` treated as closed)

## How to Test

1. Configure an MCP server (e.g. a stdio one) and let Hermes connect and park it
2. Shut Hermes down; on affected setups the shutdown path raises `RuntimeError` from the cleanup block without this patch
3. With this patch, shutdown completes without the exception; waiters on a live loop are still cancelled and awaited exactly as before

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not run locally (live-install environment); happy to iterate if CI flags anything
- [ ] I've added tests for my changes — open to adding one if maintainers point at the test seam they prefer for closed-loop cleanup
- [x] I've tested on my platform: macOS (Darwin 25.6.0, arm64), Python 3.14 venv

### Documentation & Housekeeping

- [ ] N/A — no docs, config keys, architecture or tool-schema changes
