### PR TITLE
fix(agent): honour fallback entry context_length on failover activation

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2646,7 +2646,18 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # Clear the per-config context_length override so the fallback
         # model's actual context window is resolved instead of inheriting
         # the stale value from the previous model.  See #22387.
+        # However, if the fallback chain entry itself has an explicit
+        # context_length, restore it so get_model_context_length() honours
+        # the user's per-fallback config instead of falling through to the
+        # 256K hardcoded default (custom models like xopdeepseekv4pro are
+        # not in any known catalog). See local fix for #22387.
+        _fb_entry_ctx_len = fb.get("context_length")
         agent._config_context_length = None
+        if _fb_entry_ctx_len is not None:
+            try:
+                agent._config_context_length = int(_fb_entry_ctx_len)
+            except (TypeError, ValueError):
+                pass
         agent.model = fb_model
         agent.provider = fb_provider
         agent.requested_provider = fb_provider


### PR DESCRIPTION
## What does this PR do?

`try_activate_fallback` clears the per-config `context_length` override before switching models, so the fallback model resolves its **real** context window instead of inheriting the stale value from the previous model (#22387).

However, the clear is unconditional. When the fallback chain entry itself carries an explicit `context_length` (a user-configured per-fallback value), that value is dropped as well, and `get_model_context_length()` falls through to the hardcoded 256K default. Explicit per-fallback `context_length` is most commonly set for custom/self-hosted models that are not in any known catalog — exactly the models that cannot fall back to catalog resolution — so after a failover their context window is silently mis-reported as 256K.

This PR keeps the #22387 clearing behaviour but first captures the fallback entry's own `context_length` and restores it after the clear:

- fallback entry has explicit `context_length` → honoured (user config wins)
- fallback entry has none → cleared override, catalog resolution proceeds as designed

## Related Issue

Follow-up to #22387

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` (`try_activate_fallback`): capture `fb.get("context_length")` before clearing `agent._config_context_length`, restore it afterwards when present and parseable

## How to Test

1. Configure a model with a fallback chain entry that sets an explicit `context_length` (e.g. a custom endpoint model with a 128K window) whose primary model uses a different `context_length`
2. Trigger the failover (fail the primary)
3. Before: the fallback model's context window resolves to the 256K default, ignoring the per-fallback value
4. After: the fallback model honours the entry's `context_length`; entries without one behave exactly as before

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not run locally (live-install environment); happy to iterate if CI flags anything
- [ ] I've added tests for my changes — open to adding one for `try_activate_fallback` if maintainers point at the preferred seam
- [x] I've tested on my platform: macOS (Darwin 25.6.0, arm64)

### Documentation & Housekeeping

- [ ] N/A — no docs, config keys, architecture or tool-schema changes
