### PR TITLE
fix(desktop): opening a Bot Chat wakes reliably instead of hanging, stranding, or emptying Sessions

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -62,12 +62,14 @@ import {
   $selectedStoredSessionId,
   $sessionResumeRequest,
   $sessions,
+  rememberedSessionProfile,
   sessionMatchesStoredId,
   sessionPinId,
   setAwaitingResponse,
   setBusy,
   setMessages
 } from '@/store/session'
+import { requestForSessionProfile } from '@/store/session-request-router'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord, stopClientCapture } from '@/store/wake-word'
 import { isAuxiliaryWindow, isHudWindow } from '@/store/windows'
@@ -279,7 +281,22 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     setMessages
   })
 
-  const { connectionRef, gateway, gatewayRef, requestGateway } = useGatewayRequest()
+  const { connectionRef, gateway, gatewayRef, requestGateway: ambientRequestGateway } = useGatewayRequest()
+
+  // When chrome stays on the launch backend (Bot Mode / all-profiles
+  // navigation), session-owned RPCs still have to hit the session's backend.
+  const requestGateway = useCallback(
+    <T,>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal) => {
+      const owner = rememberedSessionProfile(
+        $sessions.get(),
+        selectedStoredSessionIdRef.current,
+        $activeGatewayProfile.get()
+      )
+
+      return requestForSessionProfile<T>(owner, ambientRequestGateway, method, params ?? {}, timeoutMs, signal)
+    },
+    [ambientRequestGateway]
+  )
 
   const { loadMoreMessagingForPlatform, loadMoreSessions, refreshCronJobs, refreshMessagingSessions, refreshSessions } =
     useSessionListActions({ profileScope })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -13,6 +13,7 @@ import { setSessionYolo } from '@/lib/yolo-session'
 import { normalizeChoices, setClarifyRequest } from '@/store/clarify'
 import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
+import { openGatewayForAgent, openGatewayForProfile } from '@/store/gateway'
 import { $gatewaySwitching } from '@/store/gateway-switch'
 import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
@@ -20,6 +21,7 @@ import {
   $activeGatewayProfile,
   $gatewaySwapTarget,
   $newChatProfile,
+  $showAllProfiles,
   ensureGatewayAgent,
   ensureGatewayProfile,
   normalizeProfileKey
@@ -740,7 +742,15 @@ export function useSessionActions({
       // A row spliced from a CONNECTED registry gateway (#88880) carries its
       // owning connection — activate THAT gateway, not a same-named local
       // profile. Rows without the tag keep the legacy profile path.
-      if (storedForProfile?.connection_id) {
+      // All-profiles / plugin navigation must not steal chrome API-home:
+      // dial the owning backend without moving $activeGatewayProfile.
+      if ($showAllProfiles.get()) {
+        if (storedForProfile?.connection_id) {
+          await openGatewayForAgent(storedForProfile.connection_id, sessionProfile || 'default')
+        } else if (sessionProfile) {
+          await openGatewayForProfile(normalizeProfileKey(sessionProfile))
+        }
+      } else if (storedForProfile?.connection_id) {
         await ensureGatewayAgent(storedForProfile.connection_id, sessionProfile || 'default')
       } else {
         await ensureGatewayProfile(sessionProfile)

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3287,7 +3287,7 @@ async function openStoredBotChat(name, storedId, summary) {
     intent: 'main',
     awaitHydration: true,
     expectHistory,
-    keepAllProfilesScope: false,
+    keepAllProfilesScope: true,
     retryHydrationTimeoutOnce: true
   })
 
@@ -3328,7 +3328,7 @@ function createCanonicalChat(name) {
 
     if (sid && typeof host.openSession === 'function') {
       try {
-        await host.openSession(sid, { profile: name, intent: 'main', keepAllProfilesScope: false })
+        await host.openSession(sid, { profile: name, intent: 'main', keepAllProfilesScope: true })
         opened = true
       } catch {
         // The stored row may not exist until the kickoff persists it. Retry
@@ -3343,7 +3343,7 @@ function createCanonicalChat(name) {
         await host.request('prompt.submit', { session_id: runtime, text: 'Hey, tell me about yourself!' })
 
         if (!opened && sid && typeof host.openSession === 'function') {
-          await host.openSession(sid, { profile: name, intent: 'main', keepAllProfilesScope: false })
+          await host.openSession(sid, { profile: name, intent: 'main', keepAllProfilesScope: true })
         }
       } catch {
         // The chat already exists. Keep the pin so the next click
@@ -7852,7 +7852,7 @@ async function openProfileSession(botName, session, gatewayGeneration) {
     typeof session?.message_count === 'number' && Number.isFinite(session.message_count)
   const expectHistory = hasAuthoritativeCount ? session.message_count > 0 : Boolean(session?.preview)
 
-  await host.openSession(id, { profile, awaitHydration: true, expectHistory, keepAllProfilesScope: false })
+  await host.openSession(id, { profile, awaitHydration: true, expectHistory, keepAllProfilesScope: true })
   if (gatewayGeneration !== $sessionsGatewayGeneration.get()) return
   $botSelectedSessions.set({ ...$botSelectedSessions.get(), [profile]: id })
 }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3276,12 +3276,19 @@ async function openStoredBotChat(name, storedId, summary) {
     typeof summary?.message_count === 'number' && Number.isFinite(summary.message_count)
   const expectHistory = hasAuthoritativeCount ? summary.message_count > 0 : true
 
+  // A profile backend that just woke up can lose the hydration-timeout race
+  // even though the session is fine (hermes-agent#89617) — clicking Retry
+  // succeeds because the backend is warm by then. retryHydrationTimeoutOnce
+  // asks the SDK layer to retry that same wait internally, BEFORE it arms the
+  // core stranded-session overlay: a plugin-side retry can't do this because
+  // only host.openSession sees the resume-exhausted latch that overlay reads.
   await host.openSession(storedId, {
     profile: name,
     intent: 'main',
     awaitHydration: true,
     expectHistory,
-    keepAllProfilesScope: false
+    keepAllProfilesScope: false,
+    retryHydrationTimeoutOnce: true
   })
 
   return storedId

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-identity.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-identity.test.mjs
@@ -112,7 +112,8 @@ test('pin: preferred_session present opens the resolved session and keeps the pi
       intent: 'main',
       awaitHydration: true,
       expectHistory: true,
-      keepAllProfilesScope: false
+      keepAllProfilesScope: false,
+      retryHydrationTimeoutOnce: true
     }
   }])
   assert.equal(runtime.saved.length, 0, 'a live pin must not be rewritten')
@@ -212,6 +213,63 @@ test('pin: precise hit but failed hydration keeps the pin and surfaces the failu
   assert.equal(runtime.saved.length, 0, 'a confirmed-live pin must survive a transient open failure')
   assert.equal(runtime.requests.some(r => r.method === 'session.create'), false,
     'must not fork the forever-chat on a hiccup')
+})
+
+test('pin: a waking-backend hydration timeout asks the SDK to retry internally', async () => {
+  // The internal retry-and-succeed behavior lives in host.openSession itself
+  // (apps/desktop/src/sdk/index.ts) now, because only that layer sees the
+  // $resumeExhaustedSessionId latch that the core stranded-session overlay
+  // reads — a plugin-side retry can silently resolve while that overlay stays
+  // latched (hermes-agent#89617). This harness stubs host.openSession with a
+  // bare mock, so it can only prove the plugin ASKS for the retry, not that
+  // the overlay never appears; see profile-routing.test.ts for that.
+  const opts = []
+  const runtime = loadOpenPath({
+    openSession: async (id, options) => { opts.push(options) },
+    request: async method => {
+      if (method === 'profiles.list') {
+        return {
+          profiles: [{
+            name: 'ops',
+            preferred_session: {
+              id: 'pin-1', resolved_id: 'pin-1', title: 'Bot Chat',
+              preview: 'latest', started_at: 1, last_active: 2, message_count: 3
+            }
+          }]
+        }
+      }
+      return {}
+    }
+  })
+
+  const result = await runtime.openBotCanonicalChat('ops', 'pin-1', HISTORY)
+
+  assert.equal(result, 'pin-1')
+  assert.equal(opts.length, 1)
+  assert.equal(opts[0].retryHydrationTimeoutOnce, true, 'the SDK must own the hydration-timeout retry')
+})
+
+test('pin: a persistent hydration timeout still surfaces the failure', async () => {
+  const runtime = loadOpenPath({
+    openSession: async () => { throw new Error("Timed out loading ops's session history.") },
+    request: async method => {
+      if (method === 'profiles.list') {
+        return {
+          profiles: [{
+            name: 'ops',
+            preferred_session: {
+              id: 'pin-1', resolved_id: 'pin-1', title: 'Bot Chat',
+              preview: 'latest', started_at: 1, last_active: 2, message_count: 3
+            }
+          }]
+        }
+      }
+      return {}
+    }
+  })
+
+  await assert.rejects(runtime.openBotCanonicalChat('ops', 'pin-1', HISTORY), /Timed out loading/)
+  assert.equal(runtime.saved.length, 0, 'a confirmed-live pin must survive a persistent hydration timeout')
 })
 
 // ── transient failures must never destroy the pin ──────────────────────────

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-identity.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-identity.test.mjs
@@ -112,7 +112,7 @@ test('pin: preferred_session present opens the resolved session and keeps the pi
       intent: 'main',
       awaitHydration: true,
       expectHistory: true,
-      keepAllProfilesScope: false,
+      keepAllProfilesScope: true,
       retryHydrationTimeoutOnce: true
     }
   }])

--- a/apps/desktop/src/plugins/hermes-bots/tests/session-workspace.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/session-workspace.test.mjs
@@ -90,7 +90,7 @@ test('sessions workspace: opening a stored row uses profile-aware navigation and
   const runtime = load({ profile: 'default' })
   await runtime.__sessions.openProfileSession('ops', { id: 'stored-123', message_count: 4 }, 0)
   assert.deepEqual(plain(runtime.calls), [
-    ['openSession', 'stored-123', { profile: 'ops', awaitHydration: true, expectHistory: true, keepAllProfilesScope: false }]
+    ['openSession', 'stored-123', { profile: 'ops', awaitHydration: true, expectHistory: true, keepAllProfilesScope: true }]
   ])
   assert.equal(runtime.__sessions.$botSelectedSessions.get().ops, 'stored-123')
 })
@@ -117,7 +117,7 @@ test('sessions workspace: an empty session with no preview does not demand histo
   const runtime = load()
   await runtime.__sessions.openProfileSession('ops', { id: 'stored-empty', message_count: 0 }, 0)
   assert.deepEqual(plain(runtime.calls), [
-    ['openSession', 'stored-empty', { profile: 'ops', awaitHydration: true, expectHistory: false, keepAllProfilesScope: false }]
+    ['openSession', 'stored-empty', { profile: 'ops', awaitHydration: true, expectHistory: false, keepAllProfilesScope: true }]
   ])
 })
 

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -226,6 +226,12 @@ interface PluginOpenSessionOptions {
   intent?: OpenSessionIntent
   keepAllProfilesScope?: boolean
   profile?: null | string
+  /** A cold profile backend can lose the hydration-timeout race once and still
+   *  be fine on a second try. When set, a hydration timeout is retried
+   *  internally before it reaches the caller or arms the core stranded-session
+   *  overlay ($resumeExhaustedSessionId) — a caller-side retry can't do this
+   *  itself because only this SDK layer sees $resumeExhaustedSessionId. */
+  retryHydrationTimeoutOnce?: boolean
 }
 
 function waitForFocusedSessionHydration({
@@ -567,6 +573,11 @@ export const host = {
     // is a gateway problem, a slow transcript is a backend-warmup one.
     let wakePhase: 'activation' | 'hydration' = 'activation'
 
+    // Bounded to 2 attempts (never more): a cold profile backend can lose the
+    // hydration-timeout race once and still be fine moments later, but this is
+    // a caller-opt-in retry of the SAME wait, not a backoff loop.
+    const maxAttempts = options.awaitHydration && options.retryHydrationTimeoutOnce ? 2 : 1
+
     try {
       if (profile && profile !== $activeGatewayProfile.get()) {
         // Bounded only on the hydration contract, which is where a budget and a
@@ -595,47 +606,76 @@ export const host = {
         $gatewaySwapTarget.set(targetProfile)
       }
 
-      openSession(
-          storedSessionId,
-          (to: string, opts?: { replace?: boolean }) => {
-            const target = to.startsWith('#') ? to : `#${to}`
+      // Only the HYDRATION half retries. Activation already failed its own
+      // bounded wait above, and a wedged dial does not get better by dialling
+      // again inside the same wake — that is the Retry surface's job.
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+          openSession(
+            storedSessionId,
+            (to: string, opts?: { replace?: boolean }) => {
+              const target = to.startsWith('#') ? to : `#${to}`
 
-            if (opts?.replace) {
-              window.location.replace(target)
-            } else {
-              window.location.hash = target
-            }
-          },
-          options.intent ?? 'in-place'
-        )
+              if (opts?.replace) {
+                window.location.replace(target)
+              } else {
+                window.location.hash = target
+              }
+            },
+            options.intent ?? 'in-place'
+          )
 
-      // Judge the main surface AFTER the open: on a cold start the persisted
-      // route can already point at this session while selection has not
-      // settled, so a pre-open "already selected" precondition skips the
-      // resume exactly when it is needed (#89206 — blank Bot Chat with the
-      // roster preview intact). The surface is healthy only when this stored
-      // session is selected, a runtime is bound, and the expected transcript
-      // is present; anything less gets an explicit sequenced resume request.
-      // The route-resume effect only honors the request while the route
-      // points at this session, and consumes it alongside any resume the
-      // navigation itself triggers, so a redundant request is a no-op.
-      const surfaceHealthy =
-        $selectedStoredSessionId.get() === storedSessionId &&
-        Boolean($activeSessionId.get()) &&
-        (!expectHistory || $messages.get().length > 0)
+          // Judge the main surface AFTER the open: on a cold start the persisted
+          // route can already point at this session while selection has not
+          // settled, so a pre-open "already selected" precondition skips the
+          // resume exactly when it is needed (#89206 — blank Bot Chat with the
+          // roster preview intact). The surface is healthy only when this stored
+          // session is selected, a runtime is bound, and the expected transcript
+          // is present; anything less gets an explicit sequenced resume request.
+          // The route-resume effect only honors the request while the route
+          // points at this session, and consumes it alongside any resume the
+          // navigation itself triggers, so a redundant request is a no-op.
+          const surfaceHealthy =
+            $selectedStoredSessionId.get() === storedSessionId &&
+            Boolean($activeSessionId.get()) &&
+            (!expectHistory || $messages.get().length > 0)
 
-      if (options.awaitHydration && !surfaceHealthy) {
-        requestSessionResume(storedSessionId)
-      }
+          if (options.awaitHydration && !surfaceHealthy) {
+            requestSessionResume(storedSessionId)
+          }
 
-      if (options.awaitHydration) {
-        await waitForFocusedSessionHydration({
-          expectHistory,
-          generation,
-          profile: targetProfile,
-          storedSessionId,
-          timeoutMs: hydrationTimeoutMs
-        })
+          if (options.awaitHydration) {
+            await waitForFocusedSessionHydration({
+              expectHistory,
+              generation,
+              profile: targetProfile,
+              storedSessionId,
+              timeoutMs: hydrationTimeoutMs
+            })
+          }
+
+          break
+        } catch (error) {
+          const retryable =
+            options.awaitHydration &&
+            generation === openSessionGeneration &&
+            attempt < maxAttempts &&
+            error instanceof Error &&
+            error.message.startsWith('Timed out loading ')
+
+          if (!retryable) {
+            throw error
+          }
+
+          // Logged per attempt so a support bundle shows the retry happened at
+          // all; the terminal failure is reported once by the catch below.
+          console.warn('[bot-wake] hydration timed out, retrying', {
+            attempt,
+            hydrationWaitMs: Date.now() - profileActiveAt,
+            profile: targetProfile,
+            storedSessionId
+          })
+        }
       }
     } catch (error) {
       if (
@@ -647,6 +687,7 @@ export const host = {
         const timedOutAt = Date.now()
 
         console.warn('[bot-wake] hydration timed out', {
+          attempts: wakePhase === 'hydration' ? maxAttempts : 1,
           hydrationWaitMs: wakePhase === 'hydration' ? timedOutAt - profileActiveAt : 0,
           phase: wakePhase,
           profile: targetProfile,

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -79,6 +79,8 @@ import {
 import { runGatewayRestart } from '@/store/system-actions'
 import type { UsageStats } from '@/types/hermes'
 
+import { planPluginOpenSession } from './plugin-open-session-plan'
+
 // -- state: readonly views over the app's live atoms -------------------------
 
 const readonlyAtom = <T>(atomLike: ReadableAtom<T>): ReadableAtom<T> => atomLike
@@ -238,12 +240,14 @@ function waitForFocusedSessionHydration({
   expectHistory,
   generation,
   profile,
+  requireActiveProfile,
   storedSessionId,
   timeoutMs
 }: {
   expectHistory: boolean
   generation: number
   profile: string
+  requireActiveProfile: boolean
   storedSessionId: string
   timeoutMs: number
 }): Promise<void> {
@@ -281,7 +285,8 @@ function waitForFocusedSessionHydration({
         return
       }
 
-      const profileMatches = normalizeProfileKey($activeGatewayProfile.get()) === profile
+      const profileMatches =
+        !requireActiveProfile || normalizeProfileKey($activeGatewayProfile.get()) === profile
       const sessionMatches = $selectedStoredSessionId.get() === storedSessionId
       const runtimeReady = Boolean($activeSessionId.get())
       const historyPainted = Boolean($messages.get().length)
@@ -336,8 +341,16 @@ function waitForFocusedSessionHydration({
 // regression. The trade is that a wake that is slow in BOTH phases can now take
 // up to twice the budget before it surfaces; that is a maintainer call and is
 // called out in the PR rather than buried here.
-async function awaitProfileActivation(profile: string, targetProfile: string, timeoutMs: number): Promise<void> {
-  const activation = ensureGatewayProfile(profile)
+// The caller supplies the dial itself, because WHICH backend to open is a
+// routing decision (a workspace switch moves chrome; a plain bot navigation
+// only opens the gateway) while the deadline enforced here is the same either
+// way.
+async function awaitProfileActivation(
+  dial: () => Promise<void>,
+  targetProfile: string,
+  timeoutMs: number
+): Promise<void> {
+  const activation = dial()
   let timer: number | undefined
 
   try {
@@ -548,14 +561,22 @@ export const host = {
     ensureGatewayAgent(connectionId, (profile ?? '').trim() || 'default'),
 
   /** Open a stored session the way core surfaces do. A plugin/Bot Mode open
-   *  is navigation, not a workspace switch — keepAllProfilesScope defaults
-   *  true so Sessions stays on the unified list (the bot forever-chat is
-   *  hidden and would otherwise look like every session disappeared). */
+   *  is navigation, not a workspace or chrome API-home switch —
+   *  keepAllProfilesScope defaults true so `$activeGatewayProfile` /
+   *  Sessions REST stay on the previous (usually launch) backend while the
+   *  bot backend is dialed in the background. The bot forever-chat is hidden
+   *  and would otherwise look like every session disappeared. Pass false to
+   *  also scope chrome onto that profile and collapse the sidebar. */
   openSession: async (storedSessionId: string, options: PluginOpenSessionOptions = {}): Promise<void> => {
     const generation = ++openSessionGeneration
     const profile = (options.profile ?? '').trim()
     const targetProfile = normalizeProfileKey(profile || $activeGatewayProfile.get())
     const expectHistory = options.expectHistory ?? false
+    const plan = planPluginOpenSession({
+      activeProfile: $activeGatewayProfile.get(),
+      keepAllProfilesScope: options.keepAllProfilesScope,
+      profile
+    })
     // Wake-path phase timings. Logged ONLY on a hydration timeout (bridged
     // into desktop.log via the renderer-console tap), so a support bundle
     // pinpoints WHERE the budget went — profile activation vs hydration —
@@ -574,23 +595,27 @@ export const host = {
     const maxAttempts = options.awaitHydration && options.retryHydrationTimeoutOnce ? 2 : 1
 
     try {
-      if (profile && profile !== $activeGatewayProfile.get()) {
+      // WHICH backend to dial is the plan's call; HOW LONG to wait is the wake
+      // budget's. A workspace switch moves $activeGatewayProfile / chrome REST;
+      // a plain navigation only opens the bot's gateway so session.resume can
+      // hydrate, leaving chrome on the launch backend.
+      const dial = plan.switchWorkspace
+        ? () => ensureGatewayProfile(plan.switchWorkspace as string)
+        : plan.dialWithoutSwitching
+          ? () => openGatewayForProfile(plan.dialWithoutSwitching as string)
+          : null
+
+      if (dial) {
         // Bounded only on the hydration contract, which is where a budget and a
         // Retry surface both already exist. A plain open never asked for a
         // deadline and has nowhere to render one, so it keeps today's
         // behaviour rather than gaining a rejection its callers cannot handle.
-        await (options.awaitHydration
-          ? awaitProfileActivation(profile, targetProfile, hydrationTimeoutMs)
-          : ensureGatewayProfile(profile))
+        await (options.awaitHydration ? awaitProfileActivation(dial, targetProfile, hydrationTimeoutMs) : dial())
         profileActiveAt = Date.now()
       }
 
-      // Outside the dial branch on purpose: re-opening a bot whose profile is
-      // ALREADY active still has to restore the unified list. Scoped inside,
-      // the second open of the same bot left Sessions collapsed onto a profile
-      // whose forever-chat is hidden — an empty sidebar and no roster.
-      if (profile && options.keepAllProfilesScope !== false) {
-        setShowAllProfiles(true)
+      if (plan.showAllProfiles !== null) {
+        setShowAllProfiles(plan.showAllProfiles)
       }
 
       wakePhase = 'hydration'
@@ -648,6 +673,9 @@ export const host = {
               expectHistory,
               generation,
               profile: targetProfile,
+              // A background dial never moves $activeGatewayProfile, so gating
+              // hydration on it would wait for something that is not coming.
+              requireActiveProfile: plan.requireActiveProfileForHydration,
               storedSessionId,
               timeoutMs: hydrationTimeoutMs
             })

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -312,6 +312,56 @@ function waitForFocusedSessionHydration({
   })
 }
 
+// Wait for a profile switch, but never longer than the wake budget.
+//
+// ensureGatewayProfile awaits the store's dial, and HermesGateway.connect() has
+// no dial timeout of its own: a backend that accepts the socket and then never
+// completes the handshake leaves this promise pending for the life of the
+// window. That is not merely a slow open. waitForFocusedSessionHydration arms
+// the only timer on this path, and it is armed AFTER this await returns - so an
+// unbounded activation means the wake never settles at all, and the pane wedges
+// with no error, no Retry and no timeout (#89556: `ws accepted` in the gateway
+// log with no matching `ws closed`).
+//
+// The activation gets its OWN budget rather than sharing the hydration one. A
+// cold profile backend can legitimately spend most of the hydration budget
+// painting a large transcript - that race is already tight enough to lose
+// (#89617) - so charging activation to the same clock would turn a wedge into a
+// regression. The trade is that a wake that is slow in BOTH phases can now take
+// up to twice the budget before it surfaces; that is a maintainer call and is
+// called out in the PR rather than buried here.
+async function awaitProfileActivation(profile: string, targetProfile: string, timeoutMs: number): Promise<void> {
+  const activation = ensureGatewayProfile(profile)
+  let timer: number | undefined
+
+  try {
+    await Promise.race([
+      activation,
+      new Promise<never>((_resolve, reject) => {
+        // Same message shape as the hydration timeout on purpose: openSession's
+        // catch keys the core stranded-session surface off this prefix, and a
+        // wedged dial wants exactly that surface. The phase is distinguished in
+        // the [bot-wake] support log, not in the user-facing string.
+        timer = window.setTimeout(
+          () => reject(new Error(`Timed out loading ${targetProfile}'s session history.`)),
+          timeoutMs
+        )
+      })
+    ])
+  } finally {
+    if (timer !== undefined) {
+      window.clearTimeout(timer)
+    }
+  }
+
+  // No extra catch on the abandoned dial: an in-flight activation has no
+  // cancellation handle and keeps running after the budget expires, but
+  // Promise.race subscribes to every input, so a rejection that lands after the
+  // race has settled is already handled and cannot escape as an unhandled
+  // rejection. An explicit `activation.catch()` here was dead code - verified
+  // by mutation: removing it changed no test outcome.
+}
+
 export const host = {
   state: {
     /** Runtime id of the active chat session (null on a fresh draft). */
@@ -511,40 +561,53 @@ export const host = {
     // instead of leaving us to infer it from process spawn timestamps.
     const wakeStartedAt = Date.now()
     let profileActiveAt = wakeStartedAt
-
-    if (profile && profile !== $activeGatewayProfile.get()) {
-      await ensureGatewayProfile(profile)
-      profileActiveAt = Date.now()
-
-      if (options.keepAllProfilesScope !== false) {
-        setShowAllProfiles(true)
-      }
-    }
-
-    if (generation !== openSessionGeneration) {
-      throw new Error('Session open was superseded by a newer selection.')
-    }
-
-    if (options.awaitHydration) {
-      // Keep the target-specific overlay visible through transcript hydration,
-      // not merely through the gateway/profile activation that precedes it.
-      $gatewaySwapTarget.set(targetProfile)
-    }
+    const hydrationTimeoutMs = Math.max(1, options.hydrationTimeoutMs ?? DEFAULT_SESSION_HYDRATION_TIMEOUT_MS)
+    // Which half of the wake a timeout landed in. Only meaningful on the
+    // failure path, where the two phases have different remedies: a stuck dial
+    // is a gateway problem, a slow transcript is a backend-warmup one.
+    let wakePhase: 'activation' | 'hydration' = 'activation'
 
     try {
-      openSession(
-        storedSessionId,
-        (to: string, opts?: { replace?: boolean }) => {
-          const target = to.startsWith('#') ? to : `#${to}`
+      if (profile && profile !== $activeGatewayProfile.get()) {
+        // Bounded only on the hydration contract, which is where a budget and a
+        // Retry surface both already exist. A plain open never asked for a
+        // deadline and has nowhere to render one, so it keeps today's
+        // behaviour rather than gaining a rejection its callers cannot handle.
+        await (options.awaitHydration
+          ? awaitProfileActivation(profile, targetProfile, hydrationTimeoutMs)
+          : ensureGatewayProfile(profile))
+        profileActiveAt = Date.now()
 
-          if (opts?.replace) {
-            window.location.replace(target)
-          } else {
-            window.location.hash = target
-          }
-        },
-        options.intent ?? 'in-place'
-      )
+        if (options.keepAllProfilesScope !== false) {
+          setShowAllProfiles(true)
+        }
+      }
+
+      wakePhase = 'hydration'
+
+      if (generation !== openSessionGeneration) {
+        throw new Error('Session open was superseded by a newer selection.')
+      }
+
+      if (options.awaitHydration) {
+        // Keep the target-specific overlay visible through transcript hydration,
+        // not merely through the gateway/profile activation that precedes it.
+        $gatewaySwapTarget.set(targetProfile)
+      }
+
+      openSession(
+          storedSessionId,
+          (to: string, opts?: { replace?: boolean }) => {
+            const target = to.startsWith('#') ? to : `#${to}`
+
+            if (opts?.replace) {
+              window.location.replace(target)
+            } else {
+              window.location.hash = target
+            }
+          },
+          options.intent ?? 'in-place'
+        )
 
       // Judge the main surface AFTER the open: on a cold start the persisted
       // route can already point at this session while selection has not
@@ -571,7 +634,7 @@ export const host = {
           generation,
           profile: targetProfile,
           storedSessionId,
-          timeoutMs: Math.max(1, options.hydrationTimeoutMs ?? DEFAULT_SESSION_HYDRATION_TIMEOUT_MS)
+          timeoutMs: hydrationTimeoutMs
         })
       }
     } catch (error) {
@@ -581,10 +644,13 @@ export const host = {
         error instanceof Error &&
         error.message.startsWith('Timed out loading ')
       ) {
+        const timedOutAt = Date.now()
+
         console.warn('[bot-wake] hydration timed out', {
-          hydrationWaitMs: Date.now() - profileActiveAt,
+          hydrationWaitMs: wakePhase === 'hydration' ? timedOutAt - profileActiveAt : 0,
+          phase: wakePhase,
           profile: targetProfile,
-          profileActivationMs: profileActiveAt - wakeStartedAt,
+          profileActivationMs: (wakePhase === 'activation' ? timedOutAt : profileActiveAt) - wakeStartedAt,
           runtimeBound: Boolean($activeSessionId.get()),
           selectionSettled: $selectedStoredSessionId.get() === storedSessionId,
           storedSessionId,

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -285,8 +285,7 @@ function waitForFocusedSessionHydration({
         return
       }
 
-      const profileMatches =
-        !requireActiveProfile || normalizeProfileKey($activeGatewayProfile.get()) === profile
+      const profileMatches = !requireActiveProfile || normalizeProfileKey($activeGatewayProfile.get()) === profile
       const sessionMatches = $selectedStoredSessionId.get() === storedSessionId
       const runtimeReady = Boolean($activeSessionId.get())
       const historyPainted = Boolean($messages.get().length)

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -431,14 +431,6 @@ export const host = {
     window.location.hash = path.startsWith('#') ? path : `#${path}`
   },
 
-  /** Open a stored session the way core surfaces do (focus an existing
-   *  tile/main, else load into main). When `profile` names a non-active
-   *  profile, its backend is activated first so the resume routes to the
-   *  right state.db — the same soft profile swap the unified sidebar does.
-   *  `keepAllProfilesScope` (default true) keeps the Sessions sidebar in the
-   *  unified all-profiles view instead of narrowing it to the target
-   *  profile's sessions — a cross-profile open from a plugin surface is a
-   *  navigation, not a scope choice; pass false to also scope the sidebar. */
   /** Pre-dial a profile's gateway socket in the background — pool-only, no
    *  activation, no navigation, no scope change (openGatewayForProfile; it
    *  already no-ops for shared-remote routes and the primary). Roster UIs
@@ -555,7 +547,10 @@ export const host = {
   ensureAgent: async (connectionId: null | string, profile: string): Promise<void> =>
     ensureGatewayAgent(connectionId, (profile ?? '').trim() || 'default'),
 
-  /** Open a stored session — optionally pre-activating its profile first. */
+  /** Open a stored session the way core surfaces do. A plugin/Bot Mode open
+   *  is navigation, not a workspace switch — keepAllProfilesScope defaults
+   *  true so Sessions stays on the unified list (the bot forever-chat is
+   *  hidden and would otherwise look like every session disappeared). */
   openSession: async (storedSessionId: string, options: PluginOpenSessionOptions = {}): Promise<void> => {
     const generation = ++openSessionGeneration
     const profile = (options.profile ?? '').trim()
@@ -588,10 +583,14 @@ export const host = {
           ? awaitProfileActivation(profile, targetProfile, hydrationTimeoutMs)
           : ensureGatewayProfile(profile))
         profileActiveAt = Date.now()
+      }
 
-        if (options.keepAllProfilesScope !== false) {
-          setShowAllProfiles(true)
-        }
+      // Outside the dial branch on purpose: re-opening a bot whose profile is
+      // ALREADY active still has to restore the unified list. Scoped inside,
+      // the second open of the same bot left Sessions collapsed onto a profile
+      // whose forever-chat is hidden — an empty sidebar and no roster.
+      if (profile && options.keepAllProfilesScope !== false) {
+        setShowAllProfiles(true)
       }
 
       wakePhase = 'hydration'

--- a/apps/desktop/src/sdk/plugin-open-session-plan.test.ts
+++ b/apps/desktop/src/sdk/plugin-open-session-plan.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { planPluginOpenSession } from './plugin-open-session-plan'
+
+describe('planPluginOpenSession', () => {
+  it('defaults to navigation: dial the worker, do not steal chrome', () => {
+    const plan = planPluginOpenSession({
+      activeProfile: 'default',
+      profile: 'worker'
+    })
+
+    expect(plan.switchWorkspace).toBeNull()
+    expect(plan.dialWithoutSwitching).toBe('worker')
+    expect(plan.showAllProfiles).toBe(true)
+    expect(plan.requireActiveProfileForHydration).toBe(false)
+  })
+
+  it('does not steal chrome even when keepAllProfilesScope is explicitly true', () => {
+    const plan = planPluginOpenSession({
+      activeProfile: 'default',
+      keepAllProfilesScope: true,
+      profile: 'worker'
+    })
+
+    expect(plan.switchWorkspace).toBeNull()
+    expect(plan.dialWithoutSwitching).toBe('worker')
+    expect(plan.showAllProfiles).toBe(true)
+    expect(plan.requireActiveProfileForHydration).toBe(false)
+  })
+
+  it('does not re-dial when chrome is already on that profile', () => {
+    const plan = planPluginOpenSession({
+      activeProfile: 'worker',
+      keepAllProfilesScope: true,
+      profile: 'worker'
+    })
+
+    expect(plan.switchWorkspace).toBeNull()
+    expect(plan.dialWithoutSwitching).toBeNull()
+    // Still restores the unified list: re-opening an already-live bot must not
+    // leave Sessions collapsed onto a profile whose forever-chat is hidden.
+    expect(plan.showAllProfiles).toBe(true)
+  })
+
+  it('treats keepAllProfilesScope:false as an explicit workspace switch', () => {
+    const plan = planPluginOpenSession({
+      activeProfile: 'default',
+      keepAllProfilesScope: false,
+      profile: 'worker'
+    })
+
+    expect(plan.switchWorkspace).toBe('worker')
+    expect(plan.dialWithoutSwitching).toBeNull()
+    expect(plan.showAllProfiles).toBe(false)
+    expect(plan.requireActiveProfileForHydration).toBe(true)
+  })
+
+  it('treats an empty profile as neither a dial nor a workspace switch', () => {
+    const plan = planPluginOpenSession({
+      activeProfile: 'default',
+      keepAllProfilesScope: true,
+      profile: '  '
+    })
+
+    expect(plan.switchWorkspace).toBeNull()
+    expect(plan.dialWithoutSwitching).toBeNull()
+    expect(plan.showAllProfiles).toBeNull()
+  })
+})

--- a/apps/desktop/src/sdk/plugin-open-session-plan.ts
+++ b/apps/desktop/src/sdk/plugin-open-session-plan.ts
@@ -1,0 +1,50 @@
+/** How `host.openSession` should treat a named profile.
+
+A plugin/Bot Mode open is navigation, not a workspace or chrome API-home
+switch. `keepAllProfilesScope` defaults true (undefined counts as true).
+Pass false for an explicit profile workspace switch. */
+export interface PluginOpenSessionPlan {
+  /** Dial this profile's backend without making it chrome-home. */
+  dialWithoutSwitching: null | string
+  /** Hydration may wait until `$activeGatewayProfile` matches the target. */
+  requireActiveProfileForHydration: boolean
+  /** Unified Sessions list vs collapse onto the switched profile. Null = leave. */
+  showAllProfiles: boolean | null
+  /** Activate this profile as the workspace/API home. Null = do not steal chrome. */
+  switchWorkspace: null | string
+}
+
+export function planPluginOpenSession(input: {
+  activeProfile: string
+  keepAllProfilesScope?: boolean
+  profile: string
+}): PluginOpenSessionPlan {
+  const profile = (input.profile ?? '').trim()
+  const activeProfile = (input.activeProfile ?? '').trim()
+  const keepWorkspace = input.keepAllProfilesScope !== false
+
+  if (!profile) {
+    return {
+      dialWithoutSwitching: null,
+      requireActiveProfileForHydration: false,
+      showAllProfiles: null,
+      switchWorkspace: null
+    }
+  }
+
+  if (keepWorkspace) {
+    return {
+      dialWithoutSwitching: profile !== activeProfile ? profile : null,
+      requireActiveProfileForHydration: false,
+      showAllProfiles: true,
+      switchWorkspace: null
+    }
+  }
+
+  return {
+    dialWithoutSwitching: null,
+    requireActiveProfileForHydration: true,
+    showAllProfiles: false,
+    switchWorkspace: profile
+  }
+}

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -471,6 +471,57 @@ describe('profile-aware plugin session opens', () => {
     expect($gatewaySwapTarget.get()).toBeNull()
   })
 
+  it('retries a Bot Chat hydration timeout once without ever arming the Retry surface (#89617)', async () => {
+    $activeGatewayProfile.set('hyoseob')
+
+    // First attempt: leave the surface unhealthy so the hydration wait below
+    // times out, exactly like a profile backend still waking up. Second
+    // attempt: the backend is warm now — hydrate immediately. Queued as two
+    // one-shots (not a standing mockImplementation) so this doesn't leak into
+    // later tests via the shared afterEach's vi.clearAllMocks(), which clears
+    // call history but not a standing implementation.
+    vi.mocked(openSessionCore).mockImplementationOnce(() => undefined).mockImplementationOnce(() => {
+      setMockAtom($selectedStoredSessionId, 'waking-bot-chat')
+      setMockAtom($activeSessionId, 'runtime-waking')
+      setMockAtom($messages, [{ id: 'history-waking', parts: [], role: 'assistant' }] as never)
+    })
+
+    await host.openSession('waking-bot-chat', {
+      profile: 'hyoseob',
+      awaitHydration: true,
+      expectHistory: true,
+      hydrationTimeoutMs: 1,
+      retryHydrationTimeoutOnce: true
+    })
+
+    expect(openSessionCore).toHaveBeenCalledTimes(2)
+    // The overlay in apps/desktop/src/app/chat/index.tsx is gated purely on
+    // this atom equalling the routed session id — if it were ever set here,
+    // the user would land on "Couldn't load this session" even though the
+    // retry above succeeded underneath, since only a manual resumeSession()
+    // call clears it for the currently-routed session.
+    expect(setResumeExhaustedSessionId).not.toHaveBeenCalled()
+    expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
+  it('still arms the Retry surface when a retried Bot Chat hydration times out twice', async () => {
+    $activeGatewayProfile.set('hyoseob')
+
+    await expect(
+      host.openSession('stranded-bot-chat', {
+        profile: 'hyoseob',
+        awaitHydration: true,
+        expectHistory: true,
+        hydrationTimeoutMs: 1,
+        retryHydrationTimeoutOnce: true
+      })
+    ).rejects.toThrow(/timed out loading/i)
+
+    expect(openSessionCore).toHaveBeenCalledTimes(2)
+    expect(setResumeExhaustedSessionId).toHaveBeenCalledWith('stranded-bot-chat')
+    expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
   it('lets the latest rapid bot selection win and cancels the older hydration wait', async () => {
     vi.mocked(ensureGatewayProfile).mockImplementation(async (target: null | string | undefined) => {
       $activeGatewayProfile.set(target || 'default')

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -307,8 +307,12 @@ describe('profile-aware plugin session opens', () => {
         resolved = true
       })
 
-    await Promise.resolve()
-    await Promise.resolve()
+    // Flush a macrotask rather than counting microtask ticks: the profile
+    // activation is now a bounded race, so the number of awaits between the
+    // call and the core open is an implementation detail, and `resolved`
+    // staying false through a full turn of the event loop is the stronger
+    // assertion anyway.
+    await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(openSessionCore).toHaveBeenCalledWith('bot-chat', expect.any(Function), 'in-place')
     expect(resolved).toBe(false)
@@ -356,8 +360,7 @@ describe('profile-aware plugin session opens', () => {
       hydrationTimeoutMs: 1_000
     })
 
-    await Promise.resolve()
-    await Promise.resolve()
+    await new Promise(resolve => setTimeout(resolve, 0))
 
     // The old pre-open "already selected" precondition skipped this request,
     // stranding the pane blank until timeout. It must fire now.
@@ -503,5 +506,168 @@ describe('profile-aware plugin session opens', () => {
     expect($activeGatewayProfile.get()).toBe('hyoseob')
     expect($selectedStoredSessionId.get()).toBe('chat-b')
     expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
+
+  it('surfaces a wedged profile activation instead of waiting on it forever (#89556)', async () => {
+    // The dial the store is waiting on never settles - a backend that accepts
+    // the socket and then never completes the handshake. Before this was
+    // bounded, openSession's await sat here for the life of the window and the
+    // hydration timer, which is armed downstream, never got a chance to fire:
+    // the pane wedged with no error and no Retry rather than timing out.
+    vi.mocked(ensureGatewayProfile).mockImplementationOnce(() => new Promise<void>(() => undefined))
+
+    setMockAtom($selectedStoredSessionId, 'wedged-chat')
+    setMockAtom($activeSessionId, 'runtime-wedged')
+    setMockAtom($messages, [{ id: 'history-1', parts: [], role: 'user' }] as never)
+
+    await expect(
+      host.openSession('wedged-chat', {
+        profile: 'medicina',
+        intent: 'main',
+        awaitHydration: true,
+        expectHistory: true,
+        hydrationTimeoutMs: 60
+      })
+    ).rejects.toThrow("Timed out loading medicina's session history.")
+
+    // The stranded-session surface is the point: a bounded failure the user can
+    // retry, not a frozen pane.
+    expect(setResumeExhaustedSessionId).toHaveBeenCalledWith('wedged-chat')
+    expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
+  it('names the phase in the wake log so a stuck dial is not read as a slow transcript', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    vi.mocked(ensureGatewayProfile).mockImplementationOnce(() => new Promise<void>(() => undefined))
+
+    await expect(
+      host.openSession('wedged-chat', {
+        profile: 'medicina',
+        intent: 'main',
+        awaitHydration: true,
+        expectHistory: true,
+        hydrationTimeoutMs: 60
+      })
+    ).rejects.toThrow('Timed out loading ')
+
+    expect(warn).toHaveBeenCalledWith('[bot-wake] hydration timed out', expect.objectContaining({ phase: 'activation' }))
+
+    const payload = warn.mock.calls.at(-1)?.[1] as { hydrationWaitMs: number; profileActivationMs: number }
+
+    // The whole budget went to activation. Reporting it as hydration wait time
+    // would send a support bundle reader looking at transcript size.
+    expect(payload.profileActivationMs).toBeGreaterThan(0)
+    expect(payload.hydrationWaitMs).toBe(0)
+
+    warn.mockRestore()
+  })
+
+  it('gives hydration its own full budget after a slow but successful activation', async () => {
+    // Guards the choice of a SEPARATE budget per phase over one shared clock.
+    // A cold profile backend can legitimately spend most of the budget getting
+    // its socket up; if hydration then inherited what was left, this wake would
+    // fail even though the transcript painted well inside the documented
+    // 20s-equivalent window.
+    vi.mocked(ensureGatewayProfile).mockImplementationOnce(
+      async (target: null | string | undefined) =>
+        new Promise<void>(resolve => {
+          setTimeout(() => {
+            $activeGatewayProfile.set(target || 'default')
+            resolve()
+          }, 150)
+        })
+    )
+
+    const opening = host.openSession('slow-dial-chat', {
+      profile: 'medicina',
+      intent: 'main',
+      awaitHydration: true,
+      expectHistory: true,
+      hydrationTimeoutMs: 200
+    })
+
+    // 300ms total is past a single shared 200ms budget and inside hydration's
+    // own one, which only starts once the profile is actually active.
+    await new Promise(resolve => setTimeout(resolve, 300))
+    setMockAtom($selectedStoredSessionId, 'slow-dial-chat')
+    setMockAtom($activeSessionId, 'runtime-medicina')
+    setMockAtom($messages, [{ id: 'history-1', parts: [], role: 'user' }] as never)
+
+    await expect(opening).resolves.toBeUndefined()
+    expect(setResumeExhaustedSessionId).not.toHaveBeenCalled()
+  })
+
+  it('absorbs an activation that rejects after its budget has already expired', async () => {
+    // The abandoned race loser keeps running - there is no cancellation handle
+    // for an in-flight dial - so a late rejection must not escape as an
+    // unhandled promise rejection long after the caller gave up.
+    // Node's process-level hook, not window's: under jsdom a rejection that
+    // escapes lands on the runner's process, which is where vitest turns it
+    // into an "Unhandled Rejection" run failure.
+    const unhandled: unknown[] = []
+
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason)
+    }
+
+    const existing = process.listeners('unhandledRejection')
+
+    for (const listener of existing) {
+      process.off('unhandledRejection', listener)
+    }
+
+    process.on('unhandledRejection', onUnhandled)
+
+    vi.mocked(ensureGatewayProfile).mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          setTimeout(() => reject(new Error('dial failed after the caller gave up')), 120)
+        })
+    )
+
+    await expect(
+      host.openSession('late-failure-chat', {
+        profile: 'medicina',
+        intent: 'main',
+        awaitHydration: true,
+        expectHistory: true,
+        hydrationTimeoutMs: 40
+      })
+    ).rejects.toThrow('Timed out loading ')
+
+    await new Promise(resolve => setTimeout(resolve, 200))
+    process.off('unhandledRejection', onUnhandled)
+
+    for (const listener of existing) {
+      process.on('unhandledRejection', listener)
+    }
+
+    expect(unhandled).toEqual([])
+  })
+
+  it('leaves a plain open unbounded, because it has no budget and no Retry surface', async () => {
+    // Deliberate scope line, not an oversight: the activation deadline rides on
+    // the same contract as the hydration one. A caller that never passed
+    // awaitHydration gets exactly the behaviour it had before, since a
+    // rejection here would surface to code with nowhere to render it.
+    vi.mocked(ensureGatewayProfile).mockImplementationOnce(() => new Promise<void>(() => undefined))
+
+    let settled = 'pending'
+
+    void host.openSession('plain-chat', { profile: 'medicina', intent: 'main', hydrationTimeoutMs: 40 }).then(
+      () => {
+        settled = 'resolved'
+      },
+      () => {
+        settled = 'rejected'
+      }
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 200))
+
+    expect(settled).toBe('pending')
+    expect(setResumeExhaustedSessionId).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -102,7 +102,8 @@ vi.mock('@/store/gateway', async () => {
 const { host } = await import('./index')
 const { openSession: openSessionCore } = await import('@/app/open-session')
 const { deleteProfile } = await import('@/hermes')
-const { requestGatewayForAgent, requestGatewayForProfile, retireLocalProfileGateways } = await import('@/store/gateway')
+const { openGatewayForProfile, requestGatewayForAgent, requestGatewayForProfile, retireLocalProfileGateways } =
+  await import('@/store/gateway')
 
 const { $activeGatewayProfile, $gatewaySwapTarget, $profiles, ensureGatewayProfile, refreshProfiles, setShowAllProfiles } =
   await import('@/store/profile')
@@ -290,9 +291,7 @@ describe('connection-aware plugin host APIs', () => {
 
 describe('profile-aware plugin session opens', () => {
   it('waits until the target Bot Chat runtime and history are on main before resolving', async () => {
-    vi.mocked(ensureGatewayProfile).mockImplementationOnce(async (target: null | string | undefined) => {
-      $activeGatewayProfile.set(target || 'default')
-    })
+    vi.mocked(openGatewayForProfile).mockImplementationOnce(async () => undefined)
 
     let resolved = false
 
@@ -343,9 +342,7 @@ describe('profile-aware plugin session opens', () => {
   })
 
   it('requests an explicit resume on a cold open where selection has not settled (#89206)', async () => {
-    vi.mocked(ensureGatewayProfile).mockImplementationOnce(async (target: null | string | undefined) => {
-      $activeGatewayProfile.set(target || 'default')
-    })
+    vi.mocked(openGatewayForProfile).mockImplementationOnce(async () => undefined)
 
     // Cold-start shape from the field: the persisted route already points at
     // the bot's stored session, but no selection, no runtime, no transcript.
@@ -398,9 +395,7 @@ describe('profile-aware plugin session opens', () => {
   })
 
   it('resolves a history-bearing wake on transcript paint without waiting for the runtime (paint-first)', async () => {
-    vi.mocked(ensureGatewayProfile).mockImplementationOnce(async (target: null | string | undefined) => {
-      $activeGatewayProfile.set(target || 'default')
-    })
+    vi.mocked(openGatewayForProfile).mockImplementationOnce(async () => undefined)
 
     setMockAtom($selectedStoredSessionId, null)
     setMockAtom($activeSessionId, null)
@@ -554,9 +549,49 @@ describe('profile-aware plugin session opens', () => {
 
     await second
     expect(await firstOutcome).toMatch(/superseded/i)
-    expect($activeGatewayProfile.get()).toBe('hyoseob')
+    expect($activeGatewayProfile.get()).toBe('remote-worker')
     expect($selectedStoredSessionId.get()).toBe('chat-b')
     expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
+  it('keeps chrome API home on the previous profile when opening a Bot Chat', async () => {
+    $activeGatewayProfile.set('default')
+
+    await host.openSession('bot-chat', {
+      profile: 'worker',
+      keepAllProfilesScope: true
+    })
+
+    expect(ensureGatewayProfile).not.toHaveBeenCalled()
+    expect(openGatewayForProfile).toHaveBeenCalledWith('worker')
+    expect(setShowAllProfiles).toHaveBeenCalledWith(true)
+    expect($activeGatewayProfile.get()).toBe('default')
+  })
+
+  it('defaults keepAllProfilesScope to navigation instead of a workspace switch', async () => {
+    $activeGatewayProfile.set('default')
+
+    await host.openSession('bot-chat', { profile: 'worker' })
+
+    expect(ensureGatewayProfile).not.toHaveBeenCalled()
+    expect(openGatewayForProfile).toHaveBeenCalledWith('worker')
+    expect(setShowAllProfiles).toHaveBeenCalledWith(true)
+    expect($activeGatewayProfile.get()).toBe('default')
+  })
+
+  it('still switches workspace when keepAllProfilesScope is false', async () => {
+    $activeGatewayProfile.set('default')
+    vi.mocked(openGatewayForProfile).mockImplementationOnce(async () => undefined)
+
+    await host.openSession('stored-worker', {
+      profile: 'worker',
+      keepAllProfilesScope: false
+    })
+
+    expect(ensureGatewayProfile).toHaveBeenCalledWith('worker')
+    expect(openGatewayForProfile).not.toHaveBeenCalled()
+    expect(setShowAllProfiles).toHaveBeenCalledWith(false)
+    expect($activeGatewayProfile.get()).toBe('worker')
   })
 
   it('keeps the Sessions sidebar in all-profiles even when the bot is already live', async () => {
@@ -593,6 +628,7 @@ describe('profile-aware plugin session opens', () => {
         intent: 'main',
         awaitHydration: true,
         expectHistory: true,
+        keepAllProfilesScope: false,
         hydrationTimeoutMs: 60
       })
     ).rejects.toThrow("Timed out loading medicina's session history.")
@@ -614,6 +650,7 @@ describe('profile-aware plugin session opens', () => {
         intent: 'main',
         awaitHydration: true,
         expectHistory: true,
+        keepAllProfilesScope: false,
         hydrationTimeoutMs: 60
       })
     ).rejects.toThrow('Timed out loading ')
@@ -651,7 +688,8 @@ describe('profile-aware plugin session opens', () => {
       intent: 'main',
       awaitHydration: true,
       expectHistory: true,
-      hydrationTimeoutMs: 200
+      keepAllProfilesScope: false,
+        hydrationTimeoutMs: 200
     })
 
     // 300ms total is past a single shared 200ms budget and inside hydration's
@@ -699,6 +737,7 @@ describe('profile-aware plugin session opens', () => {
         intent: 'main',
         awaitHydration: true,
         expectHistory: true,
+        keepAllProfilesScope: false,
         hydrationTimeoutMs: 40
       })
     ).rejects.toThrow('Timed out loading ')
@@ -722,7 +761,8 @@ describe('profile-aware plugin session opens', () => {
 
     let settled = 'pending'
 
-    void host.openSession('plain-chat', { profile: 'medicina', intent: 'main', hydrationTimeoutMs: 40 }).then(
+    void host.openSession('plain-chat', { profile: 'medicina', intent: 'main', keepAllProfilesScope: false,
+        hydrationTimeoutMs: 40 }).then(
       () => {
         settled = 'resolved'
       },

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -105,8 +105,14 @@ const { deleteProfile } = await import('@/hermes')
 const { openGatewayForProfile, requestGatewayForAgent, requestGatewayForProfile, retireLocalProfileGateways } =
   await import('@/store/gateway')
 
-const { $activeGatewayProfile, $gatewaySwapTarget, $profiles, ensureGatewayProfile, refreshProfiles, setShowAllProfiles } =
-  await import('@/store/profile')
+const {
+  $activeGatewayProfile,
+  $gatewaySwapTarget,
+  $profiles,
+  ensureGatewayProfile,
+  refreshProfiles,
+  setShowAllProfiles
+} = await import('@/store/profile')
 
 const { $focusedRuntimeId, $focusedSessionState, $focusedStoredSessionId } = await import('@/store/session-states')
 
@@ -475,11 +481,13 @@ describe('profile-aware plugin session opens', () => {
     // one-shots (not a standing mockImplementation) so this doesn't leak into
     // later tests via the shared afterEach's vi.clearAllMocks(), which clears
     // call history but not a standing implementation.
-    vi.mocked(openSessionCore).mockImplementationOnce(() => undefined).mockImplementationOnce(() => {
-      setMockAtom($selectedStoredSessionId, 'waking-bot-chat')
-      setMockAtom($activeSessionId, 'runtime-waking')
-      setMockAtom($messages, [{ id: 'history-waking', parts: [], role: 'assistant' }] as never)
-    })
+    vi.mocked(openSessionCore)
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        setMockAtom($selectedStoredSessionId, 'waking-bot-chat')
+        setMockAtom($activeSessionId, 'runtime-waking')
+        setMockAtom($messages, [{ id: 'history-waking', parts: [], role: 'assistant' }] as never)
+      })
 
     await host.openSession('waking-bot-chat', {
       profile: 'hyoseob',
@@ -655,7 +663,10 @@ describe('profile-aware plugin session opens', () => {
       })
     ).rejects.toThrow('Timed out loading ')
 
-    expect(warn).toHaveBeenCalledWith('[bot-wake] hydration timed out', expect.objectContaining({ phase: 'activation' }))
+    expect(warn).toHaveBeenCalledWith(
+      '[bot-wake] hydration timed out',
+      expect.objectContaining({ phase: 'activation' })
+    )
 
     const payload = warn.mock.calls.at(-1)?.[1] as { hydrationWaitMs: number; profileActivationMs: number }
 
@@ -689,7 +700,7 @@ describe('profile-aware plugin session opens', () => {
       awaitHydration: true,
       expectHistory: true,
       keepAllProfilesScope: false,
-        hydrationTimeoutMs: 200
+      hydrationTimeoutMs: 200
     })
 
     // 300ms total is past a single shared 200ms budget and inside hydration's
@@ -761,15 +772,21 @@ describe('profile-aware plugin session opens', () => {
 
     let settled = 'pending'
 
-    void host.openSession('plain-chat', { profile: 'medicina', intent: 'main', keepAllProfilesScope: false,
-        hydrationTimeoutMs: 40 }).then(
-      () => {
-        settled = 'resolved'
-      },
-      () => {
-        settled = 'rejected'
-      }
-    )
+    void host
+      .openSession('plain-chat', {
+        profile: 'medicina',
+        intent: 'main',
+        keepAllProfilesScope: false,
+        hydrationTimeoutMs: 40
+      })
+      .then(
+        () => {
+          settled = 'resolved'
+        },
+        () => {
+          settled = 'rejected'
+        }
+      )
 
     await new Promise(resolve => setTimeout(resolve, 200))
 

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -104,7 +104,7 @@ const { openSession: openSessionCore } = await import('@/app/open-session')
 const { deleteProfile } = await import('@/hermes')
 const { requestGatewayForAgent, requestGatewayForProfile, retireLocalProfileGateways } = await import('@/store/gateway')
 
-const { $activeGatewayProfile, $gatewaySwapTarget, $profiles, ensureGatewayProfile, refreshProfiles } =
+const { $activeGatewayProfile, $gatewaySwapTarget, $profiles, ensureGatewayProfile, refreshProfiles, setShowAllProfiles } =
   await import('@/store/profile')
 
 const { $focusedRuntimeId, $focusedSessionState, $focusedStoredSessionId } = await import('@/store/session-states')
@@ -559,6 +559,21 @@ describe('profile-aware plugin session opens', () => {
     expect($gatewaySwapTarget.get()).toBeNull()
   })
 
+  it('keeps the Sessions sidebar in all-profiles even when the bot is already live', async () => {
+    $activeGatewayProfile.set('hyoseob')
+    setMockAtom($selectedStoredSessionId, 'bot-chat')
+    setMockAtom($activeSessionId, 'runtime-live')
+    setMockAtom($messages, [{ id: 'history', parts: [], role: 'assistant' }] as never)
+
+    await host.openSession('bot-chat', {
+      profile: 'hyoseob',
+      awaitHydration: true,
+      expectHistory: true,
+      hydrationTimeoutMs: 1_000
+    })
+
+    expect(setShowAllProfiles).toHaveBeenCalledWith(true)
+  })
 
   it('surfaces a wedged profile activation instead of waiting on it forever (#89556)', async () => {
     // The dial the store is waiting on never settles - a backend that accepts

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -573,7 +573,9 @@ async function gatewayForProfile(
 export async function requestGatewayForProfile<T>(
   profile: string,
   method: string,
-  params: Record<string, unknown> = {}
+  params: Record<string, unknown> = {},
+  timeoutMs?: number,
+  signal?: AbortSignal
 ): Promise<T> {
   const route = await gatewayForProfile(profile, true)
 
@@ -584,7 +586,7 @@ export async function requestGatewayForProfile<T>(
 
     const routedParams = route.scopeProfile ? { ...params, profile: route.key } : params
 
-    return await route.gateway.request<T>(method, routedParams)
+    return await route.gateway.request<T>(method, routedParams, timeoutMs, signal)
   } finally {
     route.release()
   }

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -586,7 +586,12 @@ export async function requestGatewayForProfile<T>(
 
     const routedParams = route.scopeProfile ? { ...params, profile: route.key } : params
 
-    return await route.gateway.request<T>(method, routedParams, timeoutMs, signal)
+    // Same arity contract as the ambient path in session-request-router: only
+    // pass the deadline args through when the caller set them, so a plain
+    // profile-routed RPC keeps its two-argument call shape.
+    return await (timeoutMs === undefined && signal === undefined
+      ? route.gateway.request<T>(method, routedParams)
+      : route.gateway.request<T>(method, routedParams, timeoutMs, signal))
   } finally {
     route.release()
   }

--- a/apps/desktop/src/store/session-request-router.test.ts
+++ b/apps/desktop/src/store/session-request-router.test.ts
@@ -167,6 +167,37 @@ describe('requestForSessionProfile', () => {
     expect(secondaryGateways[0].request).toHaveBeenCalledWith('session.resume', { session_id: 'stored-loki-chat' })
   })
 
+  it('forwards timeout and abort signal onto the owning profile socket', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    installDesktop()
+    await ensureGatewayForProfile('default')
+
+    const ambient = vi.fn(async (method: string, params?: Record<string, unknown>) => ({
+      ambient: true,
+      method,
+      params
+    }))
+    const controller = new AbortController()
+
+    await requestForSessionProfile(
+      'loki',
+      ambient as never,
+      'prompt.submit',
+      { session_id: 'stored-loki-chat', text: 'hi' },
+      1_800_000,
+      controller.signal
+    )
+
+    expect(ambient).not.toHaveBeenCalled()
+    expect(secondaryGateways[0].request).toHaveBeenCalledWith(
+      'prompt.submit',
+      { session_id: 'stored-loki-chat', text: 'hi' },
+      1_800_000,
+      controller.signal
+    )
+  })
+
   it('keeps the ambient dispatcher when the active route already serves the owner', async () => {
     const primary = makePrimary()
     setPrimaryGateway(primary as never, 'default')

--- a/apps/desktop/src/store/session-request-router.ts
+++ b/apps/desktop/src/store/session-request-router.ts
@@ -40,13 +40,20 @@ export function sessionRpcNeedsProfileRoute(
  */
 export function requestForSessionProfile<T>(
   ownerProfile: null | string | undefined,
-  ambientRequest: <R>(method: string, params?: Record<string, unknown>) => Promise<R>,
+  ambientRequest: <R>(
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+    signal?: AbortSignal
+  ) => Promise<R>,
   method: string,
-  params: Record<string, unknown> = {}
+  params: Record<string, unknown> = {},
+  timeoutMs?: number,
+  signal?: AbortSignal
 ): Promise<T> {
   if (!sessionRpcNeedsProfileRoute(ownerProfile)) {
-    return ambientRequest<T>(method, params)
+    return ambientRequest<T>(method, params, timeoutMs, signal)
   }
 
-  return requestGatewayForProfile<T>(normKey(ownerProfile), method, params)
+  return requestGatewayForProfile<T>(normKey(ownerProfile), method, params, timeoutMs, signal)
 }

--- a/apps/desktop/src/store/session-request-router.ts
+++ b/apps/desktop/src/store/session-request-router.ts
@@ -52,7 +52,15 @@ export function requestForSessionProfile<T>(
   signal?: AbortSignal
 ): Promise<T> {
   if (!sessionRpcNeedsProfileRoute(ownerProfile)) {
-    return ambientRequest<T>(method, params, timeoutMs, signal)
+    // Forward the extra args only when the caller actually supplied them. The
+    // ambient dispatcher is a plain gateway request whose arity callers assert
+    // on; handing it a trailing `undefined, undefined` on every session RPC
+    // changes the observed call shape for the many callers that never asked
+    // for a deadline (the plugin host bridge in contrib/wiring is the only one
+    // that does).
+    return timeoutMs === undefined && signal === undefined
+      ? ambientRequest<T>(method, params)
+      : ambientRequest<T>(method, params, timeoutMs, signal)
   }
 
   return requestGatewayForProfile<T>(normKey(ownerProfile), method, params, timeoutMs, signal)


### PR DESCRIPTION
Opening a Bot from the roster had three separate ways to fail, and they all live in the same function — `host.openSession`. Three contributors each fixed one phase; every pair conflicts with every other pair in the same ~15 lines, so this lands them together rather than resolving the same merge three times.

**The wake never settled.** `ensureGatewayProfile` awaits a dial that `HermesGateway.connect()` never bounds, and the hydration timer is armed downstream of that await. A backend that accepts the socket and never finishes the handshake left the pane frozen with no error, no Retry, and no timeout — a bug that hangs past its own deadline. Activation now gets its own copy of the wake budget.

**A cold backend that lost the race got stranded.** On a hydration timeout `openSession` arms `$resumeExhaustedSessionId` before rethrowing, which latches the full-screen "Couldn't load this session" overlay until the user clicks Retry — and Retry usually worked, because the backend was warm by then. The timeout is now retried once internally, before the latch is ever armed.

**Opening a bot emptied the Sessions list.** The open was treated as a workspace switch, scoping chrome REST onto the bot profile whose forever-chat is hidden — so the sidebar looked empty and the roster vanished. A plugin open is navigation now: dial the bot backend in the background, leave `$activeGatewayProfile` alone. `keepAllProfilesScope: false` remains the explicit workspace switch.

Two follow-ups were needed to make the three coexist. `awaitProfileActivation` takes the dial as a thunk, so the routing plan chooses *which* backend and the budget bounds *how long*. And threading `timeoutMs`/`signal` through the session-RPC router handed every call a trailing `undefined, undefined`; only the plugin host bridge supplies them, so they are forwarded only when set.

## Verification

- `src/sdk/`, session-request-router, gateway-profile-request: 64 passed
- plugin tests: 317 passed
- full `ui` project: 5043 passed, 1 failure in `turn-gap-indicator` — a timer test this branch does not touch. Clean `main` fails 2 different tests under the same full-suite load (`markdown-blocks`, `gateway-settings`), and the file passes 3/3 in isolation here.
- Reverting `sdk/index.ts` to `main` turns 13 tests in `profile-routing.test.ts` red.

`plugin-open-session-plan.test.ts` arrived written against `node:test` while sitting in vitest's `src/sdk/**` glob, so vitest collected zero tests and hard-failed the suite. Converted to `describe`/`it`; the five assertions now actually run in CI.

Co-authored-by: Jack Lau <72348727+jackulau@users.noreply.github.com>
Co-authored-by: chelsealong <chelsealong@126.com>
Co-authored-by: EndeavorYen <endeavorisforever@gmail.com>

Supersedes #89832, #89638, #90203
Closes #89617
Refs #89556