### PR TITLE
fix(mattermost): accept (path, is_voice) media tuples in the standalone sender

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -1088,7 +1088,19 @@ async def _standalone_send(
             # 1. Upload media (if any) and collect file_ids.
             file_ids: List[str] = []
             for media in media_files:
-                file_path = media.get("path") if isinstance(media, dict) else media
+                # The shared media extraction path (send_message_tool) yields
+                # ``(file_path, is_voice)`` tuples — the shape every other
+                # standalone sender unpacks directly. Dict items (legacy
+                # ``{"path": ...}`` form) and bare path strings are also
+                # accepted. Without the tuple branch the whole item reached
+                # ``os.path.exists`` and raised TypeError, dropping the
+                # attachment (#90403).
+                if isinstance(media, dict):
+                    file_path = media.get("path")
+                elif isinstance(media, (tuple, list)) and media:
+                    file_path = media[0]
+                else:
+                    file_path = media
                 if not file_path or not os.path.exists(file_path):
                     continue
                 form = aiohttp.FormData()

--- a/tests/tools/test_mattermost_standalone_media.py
+++ b/tests/tools/test_mattermost_standalone_media.py
@@ -1,0 +1,137 @@
+"""Regression tests for Mattermost standalone media item shapes (#90403).
+
+The shared media extraction path (``send_message_tool``) yields
+``(file_path, is_voice)`` tuples — the shape every other standalone sender
+unpacks directly. The Mattermost sender treated every non-dict item as a
+bare path, so a tuple reached ``os.path.exists`` and raised ``TypeError``,
+dropping the attachment instead of uploading it.
+"""
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_aiohttp_resp(status, json_data=None):
+    resp = AsyncMock()
+    resp.status = status
+    resp.json = AsyncMock(return_value=json_data or {})
+    resp.text = AsyncMock(return_value="")
+    return resp
+
+
+def _make_aiohttp_session(resp):
+    request_ctx = MagicMock()
+    request_ctx.__aenter__ = AsyncMock(return_value=resp)
+    request_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    session = MagicMock()
+    session.post = MagicMock(return_value=request_ctx)
+
+    session_ctx = MagicMock()
+    session_ctx.__aenter__ = AsyncMock(return_value=session)
+    session_ctx.__aexit__ = AsyncMock(return_value=False)
+    return session_ctx, session
+
+
+async def _send_media(media_files):
+    from plugins.platforms.mattermost.adapter import _standalone_send
+
+    pconfig = SimpleNamespace(
+        token="tok-abc", extra={"url": "https://mm.example.com"}
+    )
+    return await _standalone_send(
+        pconfig, "channel1", "see attachment", media_files=media_files
+    )
+
+
+class TestStandaloneSendMediaShapes:
+    def test_upload_accepts_media_path_voice_flag_tuple(self, tmp_path):
+        """The shared-extraction shape ``(path, is_voice)`` uploads and the
+        returned file_id rides on the post payload."""
+        target = tmp_path / "report.html"
+        target.write_text("<html>report</html>", encoding="utf-8")
+
+        # One resp serves both the upload POST and the final post POST.
+        resp = _make_aiohttp_resp(
+            201, json_data={"id": "post123", "file_infos": [{"id": "file9"}]}
+        )
+        session_ctx, session = _make_aiohttp_session(resp)
+
+        with patch("aiohttp.ClientSession", return_value=session_ctx), \
+             patch.dict(os.environ, {"MATTERMOST_URL": "", "MATTERMOST_TOKEN": ""}, clear=False):
+            result = asyncio.run(_send_media([(str(target), False)]))
+
+        assert result.get("success") is True
+        assert session.post.call_count == 2
+        upload_url = session.post.call_args_list[0][0][0]
+        post_url = session.post.call_args_list[1][0][0]
+        assert upload_url.endswith("/api/v4/files")
+        assert post_url.endswith("/api/v4/posts")
+        post_payload = session.post.call_args_list[1][1]["json"]
+        assert post_payload["file_ids"] == ["file9"]
+
+    def test_bare_path_string_still_uploads(self, tmp_path):
+        target = tmp_path / "plain.txt"
+        target.write_text("hello", encoding="utf-8")
+        resp = _make_aiohttp_resp(
+            201, json_data={"id": "post124", "file_infos": [{"id": "file10"}]}
+        )
+        session_ctx, session = _make_aiohttp_session(resp)
+
+        with patch("aiohttp.ClientSession", return_value=session_ctx), \
+             patch.dict(os.environ, {"MATTERMOST_URL": "", "MATTERMOST_TOKEN": ""}, clear=False):
+            result = asyncio.run(_send_media([str(target)]))
+
+        assert result.get("success") is True
+        assert session.post.call_count == 2
+
+    def test_legacy_dict_item_still_uploads(self, tmp_path):
+        target = tmp_path / "dict_item.txt"
+        target.write_text("hello", encoding="utf-8")
+        resp = _make_aiohttp_resp(
+            201, json_data={"id": "post125", "file_infos": [{"id": "file11"}]}
+        )
+        session_ctx, session = _make_aiohttp_session(resp)
+
+        with patch("aiohttp.ClientSession", return_value=session_ctx), \
+             patch.dict(os.environ, {"MATTERMOST_URL": "", "MATTERMOST_TOKEN": ""}, clear=False):
+            result = asyncio.run(_send_media([{"path": str(target)}]))
+
+        assert result.get("success") is True
+        assert session.post.call_count == 2
+
+    def test_voice_flagged_tuple_still_uploads_as_attachment(self, tmp_path):
+        """Mattermost has no native voice bubble distinction (uploads are
+        generic attachments), so the flag is ignored — the file must still
+        be delivered rather than crash."""
+        target = tmp_path / "note.ogg"
+        target.write_bytes(b"\x4f\x67\x67\x53")
+        resp = _make_aiohttp_resp(
+            201, json_data={"id": "post126", "file_infos": [{"id": "file12"}]}
+        )
+        session_ctx, session = _make_aiohttp_session(resp)
+
+        with patch("aiohttp.ClientSession", return_value=session_ctx), \
+             patch.dict(os.environ, {"MATTERMOST_URL": "", "MATTERMOST_TOKEN": ""}, clear=False):
+            result = asyncio.run(_send_media([(str(target), True)]))
+
+        assert result.get("success") is True
+        assert session.post.call_count == 2
+
+    def test_missing_tuple_path_is_skipped_not_fatal(self):
+        """An unresolvable path is skipped silently (pre-existing behavior);
+        the send must still deliver the text."""
+        resp = _make_aiohttp_resp(201, json_data={"id": "post127"})
+        session_ctx, session = _make_aiohttp_session(resp)
+
+        with patch("aiohttp.ClientSession", return_value=session_ctx), \
+             patch.dict(os.environ, {"MATTERMOST_URL": "", "MATTERMOST_TOKEN": ""}, clear=False):
+            result = asyncio.run(_send_media([("/nonexistent/path.png", False)]))
+
+        assert result.get("success") is True
+        assert session.post.call_count == 1
+        assert "file_ids" not in session.post.call_args[1]["json"]


### PR DESCRIPTION
## What does this PR do?

Makes the Mattermost standalone sender accept the shared media extraction shape. `send_message_tool`'s media extraction yields `(file_path, is_voice)` tuples — the shape every other standalone sender unpacks directly (Discord: `for media_path, _is_voice in media_files`). The Mattermost sender treated every non-dict item as a bare path, so a tuple reached `os.path.exists` and raised `TypeError` (`stat: path should be string, bytes, os.PathLike or integer, not tuple`), dropping the attachment instead of uploading it (#90403; verified still present on current `main`).

The fix normalizes the established media item shapes before the path check: dict items keep their legacy `{"path": ...}` lookup, tuple/list items take their first element, bare strings pass through unchanged. The voice flag is ignored — Mattermost uploads are generic attachments, matching `force_document`'s documented no-distinction behavior.

## Related Issue

Fixes #90403

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/mattermost/adapter.py` — `_standalone_send` media loop: tuple/list items resolve to their first element before the `os.path.exists` check; comment documents the shared-extraction shape and why the flag is ignored.
- `tests/tools/test_mattermost_standalone_media.py` — new: `(path, False)` tuple uploads and the returned `file_id` rides on the post payload, voice-flagged tuple still delivers, bare path string and legacy dict item still work, and an unresolvable tuple path is skipped without failing the send.

## How to Test

1. `uv run --python 3.11 --with pytest --with pytest-asyncio --with pyyaml --with python-dotenv --with httpx --with pillow --with requests --with rich --with prompt_toolkit --with aiohttp python -m pytest -q -o 'addopts=' tests/tools/test_mattermost_standalone_media.py`
2. Observed result: 5 passed on this branch; on unmodified `main` the three tuple-shape tests fail with the TypeError from the issue, while the bare-string and dict companions pass — confirming the regression tests pin exactly the tuple gap.
3. Baseline: `tests/tools/test_send_message_missing_platforms.py` + `tests/gateway/test_mattermost.py` — 32 passed, unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (in-code comment documents the shape contract)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
