### PR TITLE
fix(nous): honor "thinking off" on Portal models that can honor it

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -458,6 +458,7 @@ export function ModelCatalogMenu({
                           ) : null}
                         </DropdownMenuSubTrigger>
                         <ModelEditSubmenu
+                          canDisableReasoning={caps?.can_disable_reasoning}
                           defaultEffort={defaultEffort}
                           effort={effEffort}
                           fastControl={fastControl}

--- a/apps/desktop/src/app/shell/model-edit-submenu.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.tsx
@@ -59,6 +59,10 @@ export function resolveFastControl(
 }
 
 interface ModelEditSubmenuProps {
+  /** Whether this model can turn thinking off. False on reasoning-mandatory
+   *  routes, whose upstream rejects a disable — the toggle is hidden rather
+   *  than offered as a control that silently does nothing. */
+  canDisableReasoning?: boolean
   /** The profile's configured default effort — what an unset row inherits.
    *  Passed in (not read from a store) so this submenu stays pure. */
   defaultEffort: string
@@ -98,6 +102,7 @@ export function ModelEditSubmenu(props: ModelEditSubmenuProps) {
 }
 
 function ModelEditSubmenuBody({
+  canDisableReasoning,
   defaultEffort,
   effort,
   fastControl,
@@ -111,6 +116,7 @@ function ModelEditSubmenuBody({
 
   const effortValue = resolveReasoningEffort(effort, defaultEffort)
   const thinkingOn = isThinkingEnabled(effort, defaultEffort)
+  const showThinkingToggle = reasoning && canDisableReasoning !== false
 
   const setFast = (enabled: boolean) => {
     if (fastControl.kind === 'variant') {
@@ -139,7 +145,7 @@ function ModelEditSubmenuBody({
   ) : (
     <>
       <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.options}</DropdownMenuLabel>
-      {reasoning ? (
+      {showThinkingToggle ? (
         <DropdownMenuItem className={dropdownMenuRow} onSelect={event => event.preventDefault()}>
           {copy.thinking}
           <Switch

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -427,6 +427,10 @@ export interface ModelOptionProvider {
 }
 
 export interface ModelCapabilities {
+  /** False when the route rejects a reasoning disable ("mandatory" in the
+   *  provider catalog), so the Thinking toggle must not be offered. Absent
+   *  when the catalog doesn't say. */
+  can_disable_reasoning?: boolean
   fast: boolean
   reasoning: boolean
 }

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -34,7 +34,7 @@ Substrate facts (verified May 2026):
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import Optional
+from typing import Any, Optional
 
 
 # ─── Public types ───────────────────────────────────────────────────────
@@ -402,14 +402,51 @@ def format_aux_picker_entries(
     return entries
 
 
+def _reasoning_catalog_reader(slug: str):
+    """Per-model reasoning-capability reader for aggregators that publish one.
+
+    Cache-only — building the picker payload must never block on HTTP. A cold
+    cache warms in the background so the next open is accurate; until then the
+    model reports no restriction and the UI offers the full scale.
+    """
+    try:
+        from hermes_cli.models import (
+            nous_model_reasoning_capabilities,
+            openrouter_model_reasoning_capabilities,
+            warm_nous_reasoning_caps_async,
+            warm_openrouter_reasoning_caps_async,
+        )
+    except Exception:
+        return None
+
+    if slug == "nous":
+        warm_nous_reasoning_caps_async()
+        return nous_model_reasoning_capabilities
+    if slug == "openrouter":
+        warm_openrouter_reasoning_caps_async()
+        return openrouter_model_reasoning_capabilities
+    return None
+
+
 def _apply_capabilities(rows: list[dict]) -> None:
-    """Attach a ``{model: {fast, reasoning}}`` map to each provider row.
+    """Attach a ``{model: {fast, reasoning, ...}}`` map to each provider row.
 
     `fast` mirrors ``model_supports_fast_mode`` (the same gate the runtime
     enforces). `reasoning` comes from the models.dev catalog when known and
     defaults to True otherwise — the effort dial is broadly accepted and a
     no-op on models that ignore it, whereas hiding it from a capable-but-
     uncatalogued model is the worse failure.
+
+    Aggregators that publish per-model reasoning detail add
+    `can_disable_reasoning`, False on reasoning-mandatory routes whose upstream
+    answers a disable with HTTP 400. Omitted when the catalog doesn't say,
+    which the UI reads as "no restriction known".
+
+    The catalog's `supported_efforts` list is deliberately NOT forwarded: it
+    under-reports. The Portal accepts and honors levels a route doesn't
+    advertise (``z-ai/glm-5.3`` publishes ``max, high, low`` yet serves
+    ``minimal`` at its lowest thinking), so filtering the picker by that list
+    would hide levels that demonstrably work.
     """
     from hermes_cli.models import model_supports_fast_mode
 
@@ -420,7 +457,8 @@ def _apply_capabilities(rows: list[dict]) -> None:
 
     for row in rows:
         slug = row.get("slug") or ""
-        caps: dict[str, dict[str, bool]] = {}
+        caps: dict[str, dict[str, Any]] = {}
+        read_reasoning_catalog = _reasoning_catalog_reader(slug.lower())
 
         for model in row.get("models") or []:
             reasoning = True
@@ -432,10 +470,20 @@ def _apply_capabilities(rows: list[dict]) -> None:
                 except Exception:
                     reasoning = True
 
-            caps[model] = {
+            entry: dict[str, Any] = {
                 "fast": bool(model_supports_fast_mode(model)),
                 "reasoning": reasoning,
             }
+
+            if reasoning and read_reasoning_catalog is not None:
+                try:
+                    detail = read_reasoning_catalog(model)
+                except Exception:
+                    detail = None
+                if detail:
+                    entry["can_disable_reasoning"] = not detail.get("mandatory")
+
+            caps[model] = entry
 
         row["capabilities"] = caps
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1600,6 +1600,39 @@ _openrouter_reasoning_caps_cache: dict[str, Optional[dict[str, Any]]] | None = N
 _openrouter_reasoning_caps_failed_at: float | None = None
 
 
+def _fetch_reasoning_caps_catalog(
+    url: str, timeout: float
+) -> Optional[dict[str, Optional[dict[str, Any]]]]:
+    """Fetch one OpenRouter-shaped ``/v1/models`` catalog → per-model caps.
+
+    Shared by every aggregator that serves OpenRouter's catalog schema
+    (OpenRouter itself, Nous Portal). Returns None when the catalog is
+    unreachable or carries no usable entries, so callers can remember the
+    failure and fall back rather than caching an empty result.
+
+    Sends a User-Agent because the Portal 403s anonymous catalog reads.
+    """
+    headers = {"Accept": "application/json", "User-Agent": _HERMES_USER_AGENT}
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode())
+    except Exception:
+        return None
+    items = payload.get("data")
+    if not isinstance(items, list):
+        return None
+    caps_by_id: dict[str, Optional[dict[str, Any]]] = {}
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        mid = str(item.get("id") or "").strip()
+        if not mid:
+            continue
+        caps_by_id[mid] = parse_openrouter_reasoning_capabilities(item)
+    return caps_by_id or None
+
+
 def _fetch_openrouter_reasoning_caps(timeout: float = 6.0) -> Optional[dict[str, Optional[dict[str, Any]]]]:
     """Fetch + cache per-model reasoning capabilities from the live catalog.
 
@@ -1616,29 +1649,10 @@ def _fetch_openrouter_reasoning_caps(timeout: float = 6.0) -> Optional[dict[str,
         and (time.monotonic() - _openrouter_reasoning_caps_failed_at) < 60
     ):
         return None
-    try:
-        req = urllib.request.Request(
-            "https://openrouter.ai/api/v1/models",
-            headers={"Accept": "application/json"},
-        )
-        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
-            payload = json.loads(resp.read().decode())
-    except Exception:
-        _openrouter_reasoning_caps_failed_at = time.monotonic()
-        return None
-    items = payload.get("data")
-    if not isinstance(items, list):
-        _openrouter_reasoning_caps_failed_at = time.monotonic()
-        return None
-    caps_by_id: dict[str, Optional[dict[str, Any]]] = {}
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        mid = str(item.get("id") or "").strip()
-        if not mid:
-            continue
-        caps_by_id[mid] = parse_openrouter_reasoning_capabilities(item)
-    if not caps_by_id:
+    caps_by_id = _fetch_reasoning_caps_catalog(
+        "https://openrouter.ai/api/v1/models", timeout
+    )
+    if caps_by_id is None:
         _openrouter_reasoning_caps_failed_at = time.monotonic()
         return None
     _openrouter_reasoning_caps_cache = caps_by_id
@@ -1701,6 +1715,72 @@ def warm_openrouter_reasoning_caps_async() -> None:
     threading.Thread(
         target=_fetch_openrouter_reasoning_caps,
         name="openrouter-reasoning-caps-warm",
+        daemon=True,
+    ).start()
+
+
+# Nous Portal serves OpenRouter's catalog schema, so the same parser and
+# tri-state contract apply. Kept in its own cache because the two catalogs
+# list different models (and different capabilities for shared ids).
+_nous_reasoning_caps_cache: dict[str, Optional[dict[str, Any]]] | None = None
+_nous_reasoning_caps_failed_at: float | None = None
+_nous_caps_warm_started = False
+
+
+def _fetch_nous_reasoning_caps(timeout: float = 6.0) -> Optional[dict[str, Optional[dict[str, Any]]]]:
+    """Nous Portal counterpart of :func:`_fetch_openrouter_reasoning_caps`."""
+    global _nous_reasoning_caps_cache, _nous_reasoning_caps_failed_at
+    if _nous_reasoning_caps_cache is not None:
+        return _nous_reasoning_caps_cache
+    if (
+        _nous_reasoning_caps_failed_at is not None
+        and (time.monotonic() - _nous_reasoning_caps_failed_at) < 60
+    ):
+        return None
+    caps_by_id = _fetch_reasoning_caps_catalog(
+        f"{_DEFAULT_NOUS_INFERENCE_BASE}/v1/models", timeout
+    )
+    if caps_by_id is None:
+        _nous_reasoning_caps_failed_at = time.monotonic()
+        return None
+    _nous_reasoning_caps_cache = caps_by_id
+    return caps_by_id
+
+
+def nous_model_reasoning_capabilities(
+    model_id: Optional[str],
+    *,
+    timeout: float = 6.0,
+    allow_fetch: bool = False,
+) -> Optional[dict[str, Any]]:
+    """Return live-catalog reasoning capabilities for a Nous Portal model.
+
+    Same tri-state contract and cache-only default as
+    :func:`openrouter_model_reasoning_capabilities`; warm the cache with
+    :func:`warm_nous_reasoning_caps_async` from hot paths.
+    """
+    model = str(model_id or "").strip()
+    if not model:
+        return None
+    caps_by_id = _nous_reasoning_caps_cache
+    if caps_by_id is None and allow_fetch:
+        caps_by_id = _fetch_nous_reasoning_caps(timeout=timeout)
+    if caps_by_id is None:
+        return None
+    return caps_by_id.get(model)
+
+
+def warm_nous_reasoning_caps_async() -> None:
+    """Nous Portal counterpart of :func:`warm_openrouter_reasoning_caps_async`."""
+    global _nous_caps_warm_started
+    if _nous_caps_warm_started or _nous_reasoning_caps_cache is not None:
+        return
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return
+    _nous_caps_warm_started = True
+    threading.Thread(
+        target=_fetch_nous_reasoning_caps,
+        name="nous-reasoning-caps-warm",
         daemon=True,
     ).start()
 

--- a/plugins/model-providers/nous/__init__.py
+++ b/plugins/model-providers/nous/__init__.py
@@ -65,20 +65,53 @@ class NousProfile(ProviderProfile):
             body["provider"] = provider_preferences
         return body
 
+    @staticmethod
+    def _cannot_disable_reasoning(model: str | None) -> bool:
+        """True when a disable can't safely be sent for *model*.
+
+        Reasoning-mandatory routes answer ``reasoning: {enabled: false}``
+        with HTTP 400 ("Reasoning is mandatory for this model"), so the
+        catalog's ``mandatory`` flag decides. Cache-only, and an unknown
+        model (catalog cold, unlisted, or unreachable) also answers True:
+        a cold first turn errs toward the old omit-everything behavior
+        rather than risking a 400.
+        """
+        try:
+            from hermes_cli.models import (
+                nous_model_reasoning_capabilities,
+                warm_nous_reasoning_caps_async,
+            )
+
+            caps = nous_model_reasoning_capabilities(model)
+            if caps is None:
+                warm_nous_reasoning_caps_async()
+                return True
+        except Exception:
+            return True
+        return bool(caps.get("mandatory"))
+
     def build_api_kwargs_extras(
         self,
         *,
         reasoning_config: dict | None = None,
         supports_reasoning: bool = False,
+        model: str | None = None,
         **context,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
-        """Nous: passes full reasoning_config, but OMITS when disabled."""
+        """Nous: passes the full reasoning_config, disable included.
+
+        The Portal honors ``reasoning: {enabled: false}`` — it is the only
+        wire shape that does. Sending nothing means the *upstream* default,
+        which for a thinking-first model like ``deepseek/deepseek-v4-pro``
+        (catalog: ``default_effort: high``) is thinking ON, so omitting a
+        disable silently ignored the user's "thinking off".
+        """
         extra_body = {}
         if supports_reasoning:
             if reasoning_config is not None:
                 rc = dict(reasoning_config)
-                if rc.get("enabled") is False:
-                    pass  # Nous omits reasoning when disabled
+                if rc.get("enabled") is False and self._cannot_disable_reasoning(model):
+                    pass  # route rejects a disable — let the model think
                 else:
                     extra_body["reasoning"] = rc
             else:

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -262,7 +262,7 @@ class TestChatCompletionsBuildKwargs:
         )
         assert kw["extra_body"]["reasoning"] == {"enabled": True, "effort": "medium"}
 
-    def test_nous_omits_disabled_reasoning(self, transport):
+    def test_nous_omits_disabled_reasoning_for_unknown_model(self, transport):
         from providers import get_provider_profile
         profile = get_provider_profile("nous")
         msgs = [{"role": "user", "content": "Hi"}]
@@ -272,7 +272,10 @@ class TestChatCompletionsBuildKwargs:
             supports_reasoning=True,
             reasoning_config={"enabled": False},
         )
-        # Nous rejects enabled=false; reasoning omitted entirely
+        # Not a Portal model id, so the catalog can't rule out a
+        # reasoning-mandatory route (which 400s on a disable) — omit.
+        # tests/plugins/model_providers/test_nous_profile.py covers the
+        # catalog-known cases where the disable IS forwarded.
         assert "reasoning" not in kw.get("extra_body", {})
 
     def test_ollama_num_ctx(self, transport):

--- a/tests/hermes_cli/test_inventory_reasoning_caps.py
+++ b/tests/hermes_cli/test_inventory_reasoning_caps.py
@@ -1,0 +1,141 @@
+"""Tests for the reasoning detail inventory._apply_capabilities puts on the
+
+picker payload. The desktop model picker hides its Thinking toggle from this,
+so a route that can't disable reasoning must be describable here — otherwise
+the UI offers an off switch whose setting the upstream rejects.
+
+The catalog's `supported_efforts` is intentionally absent from the payload:
+the Portal honors levels a route doesn't advertise, so publishing it would
+invite a picker filter that hides working levels.
+"""
+
+import hermes_cli.inventory as inv
+import hermes_cli.models as models_mod
+
+
+def _patch_catalog(monkeypatch, caps_by_model, *, provider="nous"):
+    """Point the Nous/OpenRouter catalog readers at a fixed capability map."""
+    monkeypatch.setattr(models_mod, "model_supports_fast_mode", lambda model: False)
+    monkeypatch.setattr(
+        models_mod, "warm_nous_reasoning_caps_async", lambda: None, raising=False
+    )
+    monkeypatch.setattr(
+        models_mod, "warm_openrouter_reasoning_caps_async", lambda: None, raising=False
+    )
+    reader = f"{provider}_model_reasoning_capabilities"
+    monkeypatch.setattr(
+        models_mod, reader, lambda model, **kw: caps_by_model.get(model), raising=False
+    )
+
+
+def test_optional_reasoning_route_can_disable(monkeypatch):
+    """A route that accepts a disable says so."""
+    _patch_catalog(monkeypatch, {
+        "deepseek/deepseek-v4-pro": {
+            "supports_reasoning": True,
+            "supported_efforts": ["xhigh", "high"],
+            "mandatory": False,
+        },
+    })
+    rows = [{"slug": "nous", "models": ["deepseek/deepseek-v4-pro"]}]
+    inv._apply_capabilities(rows)
+
+    assert rows[0]["capabilities"]["deepseek/deepseek-v4-pro"]["can_disable_reasoning"] is True
+
+
+def test_advertised_efforts_never_reach_the_picker(monkeypatch):
+    """The catalog's level list stays off the wire even when it is published.
+
+    It under-reports what the Portal serves, so forwarding it would let the
+    picker hide levels that work. Only the disable verdict crosses.
+    """
+    _patch_catalog(monkeypatch, {
+        "deepseek/deepseek-v4-pro": {
+            "supports_reasoning": True,
+            "supported_efforts": ["xhigh", "high"],
+            "mandatory": False,
+        },
+    })
+    rows = [{"slug": "nous", "models": ["deepseek/deepseek-v4-pro"]}]
+    inv._apply_capabilities(rows)
+
+    assert "supported_efforts" not in rows[0]["capabilities"]["deepseek/deepseek-v4-pro"]
+
+
+def test_reasoning_mandatory_route_cannot_disable(monkeypatch):
+    """`mandatory` inverts into the flag the Thinking toggle keys off.
+
+    The Portal answers a disable on these routes with HTTP 400, so offering
+    the toggle would be offering a control that cannot work.
+    """
+    _patch_catalog(monkeypatch, {
+        "z-ai/glm-5.3": {
+            "supports_reasoning": True,
+            "supported_efforts": ["max", "high", "low"],
+            "mandatory": True,
+        },
+    })
+    rows = [{"slug": "nous", "models": ["z-ai/glm-5.3"]}]
+    inv._apply_capabilities(rows)
+
+    assert rows[0]["capabilities"]["z-ai/glm-5.3"]["can_disable_reasoning"] is False
+
+
+def test_unlisted_model_states_no_restriction(monkeypatch):
+    """A model the catalog doesn't cover omits both keys rather than guessing.
+
+    The UI reads "absent" as no known restriction and offers the full scale,
+    which is the right failure: over-offering beats hiding levels a model
+    actually accepts.
+    """
+    _patch_catalog(monkeypatch, {})
+    rows = [{"slug": "nous", "models": ["mystery/model"]}]
+    inv._apply_capabilities(rows)
+
+    caps = rows[0]["capabilities"]["mystery/model"]
+    assert "supported_efforts" not in caps
+    assert "can_disable_reasoning" not in caps
+    assert caps["reasoning"] is True
+
+
+def test_providers_without_a_reasoning_catalog_are_untouched(monkeypatch):
+    """Only aggregators that publish per-model detail gain the extra keys."""
+    _patch_catalog(monkeypatch, {
+        "gpt-5.6": {"supports_reasoning": True, "supported_efforts": ["high"], "mandatory": True},
+    })
+    rows = [{"slug": "openai-api", "models": ["gpt-5.6"]}]
+    inv._apply_capabilities(rows)
+
+    caps = rows[0]["capabilities"]["gpt-5.6"]
+    assert "supported_efforts" not in caps
+    assert "can_disable_reasoning" not in caps
+
+
+def test_openrouter_uses_its_own_catalog(monkeypatch):
+    """The reader is chosen per provider row, not hardcoded to one aggregator."""
+    _patch_catalog(
+        monkeypatch,
+        {"x-ai/grok-5": {"supports_reasoning": True, "mandatory": True}},
+        provider="openrouter",
+    )
+    rows = [{"slug": "openrouter", "models": ["x-ai/grok-5"]}]
+    inv._apply_capabilities(rows)
+
+    assert rows[0]["capabilities"]["x-ai/grok-5"]["can_disable_reasoning"] is False
+
+
+def test_catalog_failure_never_breaks_the_picker(monkeypatch):
+    """A raising catalog reader degrades to "unknown", not to a broken payload."""
+    monkeypatch.setattr(models_mod, "model_supports_fast_mode", lambda model: False)
+    monkeypatch.setattr(models_mod, "warm_nous_reasoning_caps_async", lambda: None, raising=False)
+
+    def _boom(model, **kw):
+        raise RuntimeError("catalog exploded")
+
+    monkeypatch.setattr(models_mod, "nous_model_reasoning_capabilities", _boom, raising=False)
+    rows = [{"slug": "nous", "models": ["deepseek/deepseek-v4-pro"]}]
+    inv._apply_capabilities(rows)
+
+    caps = rows[0]["capabilities"]["deepseek/deepseek-v4-pro"]
+    assert "supported_efforts" not in caps
+    assert caps["reasoning"] is True

--- a/tests/hermes_cli/test_nous_reasoning_metadata.py
+++ b/tests/hermes_cli/test_nous_reasoning_metadata.py
@@ -1,0 +1,132 @@
+"""Tests for Nous Portal reasoning-capability metadata.
+
+The Portal serves OpenRouter's catalog schema, so it reuses
+``parse_openrouter_reasoning_capabilities`` and the same cache-only tri-state
+contract. What is Portal-specific: it 403s a catalog read that arrives
+without a User-Agent, and its ``reasoning.mandatory`` flag is what decides
+whether a disable can be sent at all.
+"""
+
+import pytest
+
+
+def _mock_response(body: bytes):
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return body
+
+    return _Resp()
+
+
+_CATALOG = (
+    b'{"data": ['
+    b'{"id": "deepseek/deepseek-v4-pro", "supported_parameters": ["reasoning", "tools"],'
+    b' "reasoning": {"mandatory": false, "supported_efforts": ["xhigh", "high"]}},'
+    b'{"id": "arcee-ai/trinity-large-thinking", "supported_parameters": ["reasoning"],'
+    b' "reasoning": {"mandatory": true}}'
+    b']}'
+)
+
+
+@pytest.fixture
+def cold_cache(monkeypatch):
+    import hermes_cli.models as models_mod
+
+    monkeypatch.setattr(models_mod, "_nous_reasoning_caps_cache", None)
+    monkeypatch.setattr(models_mod, "_nous_reasoning_caps_failed_at", None)
+    return models_mod
+
+
+class TestNousModelReasoningCapabilities:
+    def test_fetch_parses_mandatory_flag(self, cold_cache, monkeypatch):
+        from hermes_cli.models import nous_model_reasoning_capabilities
+
+        monkeypatch.setattr(
+            cold_cache, "_urlopen_model_catalog_request",
+            lambda req, *, timeout: _mock_response(_CATALOG),
+        )
+        optional = nous_model_reasoning_capabilities(
+            "deepseek/deepseek-v4-pro", allow_fetch=True
+        )
+        assert optional["supports_reasoning"] is True
+        assert optional["mandatory"] is False
+        assert optional["supported_efforts"] == ["xhigh", "high"]
+
+        mandatory = nous_model_reasoning_capabilities("arcee-ai/trinity-large-thinking")
+        assert mandatory["mandatory"] is True
+
+    def test_catalog_read_sends_user_agent(self, cold_cache, monkeypatch):
+        """The Portal 403s an anonymous catalog read."""
+        from hermes_cli.models import nous_model_reasoning_capabilities
+
+        seen = []
+
+        def _capture(req, *, timeout):
+            seen.append(req)
+            return _mock_response(_CATALOG)
+
+        monkeypatch.setattr(cold_cache, "_urlopen_model_catalog_request", _capture)
+        nous_model_reasoning_capabilities("deepseek/deepseek-v4-pro", allow_fetch=True)
+
+        # urllib title-cases header names.
+        assert seen[0].get_header("User-agent")
+        assert "nousresearch.com" in seen[0].full_url
+
+    def test_unlisted_and_empty_models_return_none(self, cold_cache, monkeypatch):
+        from hermes_cli.models import nous_model_reasoning_capabilities
+
+        monkeypatch.setattr(
+            cold_cache, "_urlopen_model_catalog_request",
+            lambda req, *, timeout: _mock_response(_CATALOG),
+        )
+        assert nous_model_reasoning_capabilities("private/route", allow_fetch=True) is None
+        assert nous_model_reasoning_capabilities("") is None
+        assert nous_model_reasoning_capabilities(None) is None
+
+    def test_cache_only_by_default_never_fetches(self, cold_cache, monkeypatch):
+        from hermes_cli.models import nous_model_reasoning_capabilities
+
+        def _boom(req, *, timeout):
+            raise AssertionError("hot path must not fetch")
+
+        monkeypatch.setattr(cold_cache, "_urlopen_model_catalog_request", _boom)
+        assert nous_model_reasoning_capabilities("deepseek/deepseek-v4-pro") is None
+
+    def test_unreachable_catalog_rate_limits_refetch(self, cold_cache, monkeypatch):
+        from hermes_cli.models import nous_model_reasoning_capabilities
+
+        calls = {"n": 0}
+
+        def _boom(req, *, timeout):
+            calls["n"] += 1
+            raise OSError("offline")
+
+        monkeypatch.setattr(cold_cache, "_urlopen_model_catalog_request", _boom)
+        assert nous_model_reasoning_capabilities("a/b", allow_fetch=True) is None
+        assert nous_model_reasoning_capabilities("a/b", allow_fetch=True) is None
+        # Second call inside the failure TTL must not re-fetch.
+        assert calls["n"] == 1
+
+    def test_openrouter_cache_is_independent(self, cold_cache, monkeypatch):
+        """Two catalogs, two caches — a Portal fetch must not answer for OpenRouter."""
+        from hermes_cli.models import (
+            nous_model_reasoning_capabilities,
+            openrouter_model_reasoning_capabilities,
+        )
+
+        monkeypatch.setattr(cold_cache, "_openrouter_reasoning_caps_cache", None)
+        monkeypatch.setattr(cold_cache, "_openrouter_reasoning_caps_failed_at", None)
+        monkeypatch.setattr(
+            cold_cache, "_urlopen_model_catalog_request",
+            lambda req, *, timeout: _mock_response(_CATALOG),
+        )
+        assert nous_model_reasoning_capabilities(
+            "deepseek/deepseek-v4-pro", allow_fetch=True
+        ) is not None
+        assert openrouter_model_reasoning_capabilities("deepseek/deepseek-v4-pro") is None

--- a/tests/plugins/model_providers/test_nous_profile.py
+++ b/tests/plugins/model_providers/test_nous_profile.py
@@ -1,0 +1,123 @@
+"""Unit tests for the Nous Portal profile's reasoning wiring.
+
+The Portal honors ``reasoning: {enabled: false}`` — it is the only wire shape
+that does, and ``extra_body.thinking`` is not forwarded upstream. The profile
+used to drop a disable for every model, which on a thinking-first route like
+``deepseek/deepseek-v4-pro`` (catalog: ``default_effort: high``) meant the
+upstream default applied and "thinking off" burned reasoning tokens anyway.
+
+A disable is still dropped for reasoning-mandatory routes, which answer
+``reasoning: {enabled: false}`` with HTTP 400, and for models the catalog
+can't speak to — an unknown model errs toward the old behavior rather than
+risking a 400 on a cold first turn.
+
+These tests pin that contract without going live.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def nous_profile():
+    """Resolve the registered Nous profile through the real discovery path."""
+    # ``model_tools`` triggers plugin discovery on import, which is what
+    # registers the Nous profile in the global provider registry.
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("nous")
+    assert profile is not None, "nous provider profile must be registered"
+    return profile
+
+
+@pytest.fixture
+def portal_catalog(monkeypatch):
+    """Prime the Portal reasoning-capability cache with known entries."""
+    import hermes_cli.models as models_mod
+
+    monkeypatch.setattr(models_mod, "_nous_reasoning_caps_failed_at", None)
+    monkeypatch.setattr(models_mod, "_nous_reasoning_caps_cache", {
+        "deepseek/deepseek-v4-pro": {
+            "supports_reasoning": True,
+            "supported_efforts": ["xhigh", "high"],
+            "mandatory": False,
+        },
+        "arcee-ai/trinity-large-thinking": {
+            "supports_reasoning": True,
+            "supported_efforts": None,
+            "mandatory": True,
+        },
+    })
+
+
+class TestNousReasoningWireShape:
+    """``build_api_kwargs_extras`` produces the Portal's wire format."""
+
+    def test_disable_reaches_optional_reasoning_model(self, nous_profile, portal_catalog):
+        """The knob the user set is the knob the Portal receives."""
+        extra_body, top_level = nous_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            supports_reasoning=True,
+            model="deepseek/deepseek-v4-pro",
+        )
+        assert extra_body == {"reasoning": {"enabled": False}}
+        assert top_level == {}
+
+    def test_disable_dropped_for_mandatory_reasoning_model(self, nous_profile, portal_catalog):
+        """Mandatory routes 400 on a disable — send nothing instead."""
+        extra_body, _ = nous_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            supports_reasoning=True,
+            model="arcee-ai/trinity-large-thinking",
+        )
+        assert "reasoning" not in extra_body
+
+    def test_disable_dropped_for_unknown_model(self, nous_profile, portal_catalog):
+        """Unlisted / cold catalog → fail safe, never risk the 400."""
+        extra_body, _ = nous_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            supports_reasoning=True,
+            model="private/unlisted-route",
+        )
+        assert "reasoning" not in extra_body
+
+    @pytest.mark.parametrize(
+        "model",
+        ["deepseek/deepseek-v4-pro", "arcee-ai/trinity-large-thinking", "private/unlisted-route"],
+    )
+    def test_enabled_config_always_forwarded(self, nous_profile, portal_catalog, model):
+        """Mandatory-ness only gates the disable; an enable always ships."""
+        extra_body, _ = nous_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            supports_reasoning=True,
+            model=model,
+        )
+        assert extra_body["reasoning"] == {"enabled": True, "effort": "high"}
+
+    def test_no_config_defaults_to_medium(self, nous_profile, portal_catalog):
+        extra_body, _ = nous_profile.build_api_kwargs_extras(
+            reasoning_config=None,
+            supports_reasoning=True,
+            model="deepseek/deepseek-v4-pro",
+        )
+        assert extra_body["reasoning"] == {"enabled": True, "effort": "medium"}
+
+    def test_nothing_emitted_without_reasoning_support(self, nous_profile, portal_catalog):
+        extra_body, top_level = nous_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            supports_reasoning=False,
+            model="deepseek/deepseek-v4-pro",
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_caller_config_not_mutated(self, nous_profile, portal_catalog):
+        cfg = {"enabled": False}
+        nous_profile.build_api_kwargs_extras(
+            reasoning_config=cfg,
+            supports_reasoning=True,
+            model="deepseek/deepseek-v4-pro",
+        )
+        assert cfg == {"enabled": False}

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -105,7 +105,7 @@ class TestOpenRouterParity:
 
 
 class TestNousParity:
-    """Nous: product tags, reasoning, omit when disabled."""
+    """Nous: product tags, reasoning passthrough (disable included)."""
 
     def test_tags(self, transport):
         from agent.portal_tags import nous_portal_tags


### PR DESCRIPTION
Turning thinking off did nothing on the Nous Portal. The profile refused to send `reasoning: {enabled: false}` for any model, and sending nothing means the *upstream* default applies — which on a thinking-first route like `deepseek/deepseek-v4-pro` is thinking ON. Users who disabled thinking kept paying for it on every turn.

Reported against a real session: `deepseek/deepseek-v4-pro` via `nous` with `reasoning_config: {"enabled": false}`, 2,193 reasoning tokens against 3,766 output tokens.

## What the Portal actually accepts

Probed live against `deepseek/deepseek-v4-pro`, `deepseek-v4-flash`, and `arcee-ai/trinity-large-thinking` (reasoning tokens on an identical prompt):

| sent | v4-pro | v4-flash | trinity |
|---|---|---|---|
| nothing (previous behavior) | 1500 | 204 | 1342 |
| `extra_body.thinking: {type: disabled}` | 525 | 1194 | 1266 |
| `reasoning: {enabled: false}` | **0** | **0** | HTTP 400 |

`reasoning: {enabled: false}` is the only shape that works. DeepSeek's own `extra_body.thinking` is not forwarded upstream by the Portal, so the direct-DeepSeek translation is not an option on this route.

The blanket omission was over-broad rather than wrong: the Portal rejects a disable only on **reasoning-mandatory** routes, with `Reasoning is mandatory for this model`. Its catalog flags those per model (`reasoning.mandatory`), so that flag now gates the omission instead of the model list being empty.

Independently corroborated by #70058, where the Portal's parameter-validation 400 enumerates the efforts it accepts as `"max"|"xhigh"|"high"|"medium"|"low"|"minimal"|"none"` — a disable has been in the accepted set all along.

## Don't offer the control where it can't work

Fixing the wire still leaves reasoning-mandatory routes, where a disable is
rejected and "thinking off" therefore cannot be honored at all. The desktop
picker offered the toggle there anyway, so it stayed a control that silently
did nothing.

`model.options` now carries `can_disable_reasoning` per model and the picker
hides the Thinking toggle when it is false. Omitted when the catalog is
silent, which reads as no known restriction.

Effort levels are deliberately left alone. The catalog's `supported_efforts`
under-reports what the Portal actually serves — `z-ai/glm-5.3` publishes
`max, high, low` yet accepts `minimal` and honors it at its lowest thinking
(83 reasoning tokens vs 944 at `max`) — so filtering the scale by that list
would hide levels that demonstrably work.

## How

The Portal serves OpenRouter's catalog schema, so `parse_openrouter_reasoning_capabilities` and the existing cache-only tri-state contract carry over unchanged. Only the HTTP fetch is generalized across the two catalogs; each keeps its own cache since they list different models. The Portal 403s a catalog read with no User-Agent, so the shared fetch sends one.

A model the catalog can't speak to — cold cache, unlisted route, catalog unreachable — keeps the old omit-everything behavior. A silently-ignored disable is a much better failure than a 400 that kills the turn.

## Verification

End-to-end against the live Portal, with `{"enabled": false}` and the fix in place:

```
deepseek/deepseek-v4-pro           reasoning_tokens=0     (was 1500)
deepseek/deepseek-v4-flash         reasoning_tokens=0     (was 204)
arcee-ai/trinity-large-thinking    reasoning_tokens=3956  no 400
```

Two stale tests encoded the old premise (`Nous rejects enabled=false`) and are corrected. New coverage pins the profile's wire shape per catalog verdict, the Portal capability lookup, and the picker payload's disable verdict — including that `supported_efforts` stays off the wire — all offline.
