### PR TITLE
fix(desktop): keep peer windows on shared gateway

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -255,6 +255,7 @@ import {
 import { missingRendererAssets } from './renderer-bundle'
 import { attachRendererConsoleCapture, formatRendererBoundaryReport } from './renderer-log'
 import {
+  buildInstanceWindowUrl,
   buildSessionWindowUrl,
   chatWindowWebPreferences,
   createSessionWindowRegistry,
@@ -10849,8 +10850,10 @@ function createSessionWindow(sessionId, { watch = false } = {}) {
 // Additional full "instance" windows — peers of the primary that render the
 // COMPLETE app (sidebar, routing, its own draft) against the shared backend, so
 // a user can run multiple GUI windows at once (⌘⇧N / the "New Window" palette
-// command). Unlike the compact session windows they carry no `?win` flag. The
-// primary mainWindow stays the notification / deep-link / pet-overlay anchor and
+// command). Unlike the compact session windows they carry no `?win` flag; a
+// separate `peer=1` marker prevents them from replaying app-launch source
+// restoration after joining that shared backend. The primary mainWindow stays
+// the notification / deep-link / pet-overlay anchor and
 // is NOT tracked here. The set holds a strong reference so an open peer isn't
 // garbage-collected, and drops it on close.
 const instanceWindows = new Set<any>()
@@ -10930,7 +10933,14 @@ function createInstanceWindow() {
   })
 
   attachRendererConsoleCapture(win, 'instance', rememberLog)
-  loadWindowUrl(win, DEV_SERVER || pathToFileURL(resolveRendererIndex()).toString(), 'Instance window')
+  loadWindowUrl(
+    win,
+    buildInstanceWindowUrl({
+      devServer: DEV_SERVER,
+      rendererIndexPath: DEV_SERVER ? undefined : resolveRendererIndex()
+    }),
+    'Instance window'
+  )
 
   return win
 }

--- a/apps/desktop/electron/session-windows.test.ts
+++ b/apps/desktop/electron/session-windows.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
 import {
+  buildInstanceWindowUrl,
   buildSessionWindowUrl,
   chatWindowWebPreferences,
   createSessionWindowRegistry,
@@ -86,6 +87,19 @@ test('buildSessionWindowUrl adds the watch flag for spectator windows, before th
   const url = buildSessionWindowUrl('abc', { devServer: 'http://localhost:5173', watch: true })
 
   assert.equal(url, 'http://localhost:5173/?win=secondary&watch=1#/abc')
+})
+
+test('buildInstanceWindowUrl marks a full peer without selecting a specialized renderer', () => {
+  const url = buildInstanceWindowUrl({ devServer: 'http://localhost:5173/' })
+
+  assert.equal(url, 'http://localhost:5173/?peer=1')
+  assert.ok(!url.includes('win='))
+})
+
+test('buildInstanceWindowUrl marks a packaged full peer', () => {
+  const url = buildInstanceWindowUrl({ rendererIndexPath: '/opt/app/index.html' })
+
+  assert.match(url, /^file:\/\/.*index\.html\?peer=1$/)
 })
 
 test('instanceWindowBounds cascades a new window off its source bounds', () => {

--- a/apps/desktop/electron/session-windows.ts
+++ b/apps/desktop/electron/session-windows.ts
@@ -77,6 +77,23 @@ function buildSessionWindowUrl(sessionId: string, { devServer, rendererIndexPath
   return `${pathToFileURL(rendererIndexPath).toString()}${query}${route}`
 }
 
+// Full peer windows render the ordinary app shell, so they deliberately do
+// not use the `win` query parameter that selects a specialized renderer. The
+// separate marker lets the renderer distinguish a peer from the one primary
+// app window: app-launch source restoration belongs to the primary only, while
+// a peer keeps the already-running backend it joined during boot.
+function buildInstanceWindowUrl({ devServer, rendererIndexPath }: any = {}) {
+  const query = '?peer=1'
+
+  if (devServer) {
+    const base = devServer.endsWith('/') ? devServer.slice(0, -1) : devServer
+
+    return `${base}/${query}`
+  }
+
+  return `${pathToFileURL(rendererIndexPath).toString()}${query}`
+}
+
 // Full "instance" windows (⌘⇧N / the "New Window" command) open a complete app
 // peer, not a compact chat. Cascade each one off its source window's bounds so a
 // new window doesn't land exactly on top of the one it was spawned from. Pure so
@@ -160,6 +177,7 @@ function createSessionWindowRegistry() {
 }
 
 export {
+  buildInstanceWindowUrl,
   buildSessionWindowUrl,
   chatWindowWebPreferences,
   createSessionWindowRegistry,

--- a/apps/desktop/src/app/chat/sidebar/connection-switcher.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/connection-switcher.test.tsx
@@ -40,6 +40,10 @@ vi.mock('@/store/boot', () => ({
   })
 }))
 
+vi.mock('@/store/windows', () => ({
+  isPeerInstanceWindow: vi.fn(() => false)
+}))
+
 vi.mock('@/i18n', () => ({
   useI18n: () => ({
     t: {
@@ -65,6 +69,7 @@ vi.mock('@/i18n', () => ({
 
 const connectionStore = await import('@/store/connections')
 const bootStore = await import('@/store/boot')
+const windowStore = await import('@/store/windows')
 const $activeConnectionId = connectionStore.$activeConnectionId as ReturnType<typeof atom<null | string>>
 const $connectionsRegistry = connectionStore.$connectionsRegistry
 const $desktopBoot = bootStore.$desktopBoot
@@ -72,6 +77,7 @@ const $pendingConnectionId = connectionStore.$pendingConnectionId
 const initializeConnectionsRegistry = vi.mocked(connectionStore.initializeConnectionsRegistry)
 const refreshConnectionsRegistry = vi.mocked(connectionStore.refreshConnectionsRegistry)
 const selectConnection = vi.mocked(connectionStore.selectConnection)
+const isPeerInstanceWindow = vi.mocked(windowStore.isPeerInstanceWindow)
 const onConnect = vi.fn()
 
 const connection = (id: string, label: string, kind: 'local' | 'remote' = 'remote') => ({
@@ -106,6 +112,7 @@ afterEach(() => {
   })
   $pendingConnectionId.set(null)
   $findInPage.set({ active: false, query: '', matchOrdinal: 0, matchCount: 0 })
+  isPeerInstanceWindow.mockReturnValue(false)
 })
 
 describe('ConnectionSwitcher', () => {
@@ -125,6 +132,22 @@ describe('ConnectionSwitcher', () => {
     })
 
     await waitFor(() => expect(initializeConnectionsRegistry).toHaveBeenCalledTimes(1))
+  })
+
+  it('keeps a full peer on the shared backend instead of replaying app-launch source restoration', async () => {
+    isPeerInstanceWindow.mockReturnValue(true)
+    $desktopBoot.set({
+      ...$desktopBoot.get(),
+      phase: 'renderer.ready',
+      progress: 100,
+      running: false,
+      visible: false
+    })
+
+    render(<ConnectionSwitcher onConnect={onConnect} />)
+
+    await waitFor(() => expect(refreshConnectionsRegistry).toHaveBeenCalledTimes(1))
+    expect(initializeConnectionsRegistry).not.toHaveBeenCalled()
   })
 
   it('adds no source chrome for a local-only setup', () => {

--- a/apps/desktop/src/app/chat/sidebar/connection-switcher.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/connection-switcher.test.tsx
@@ -41,6 +41,7 @@ vi.mock('@/store/boot', () => ({
 }))
 
 vi.mock('@/store/windows', () => ({
+  isAuxiliaryWindow: vi.fn(() => false),
   isPeerInstanceWindow: vi.fn(() => false)
 }))
 
@@ -77,6 +78,7 @@ const $pendingConnectionId = connectionStore.$pendingConnectionId
 const initializeConnectionsRegistry = vi.mocked(connectionStore.initializeConnectionsRegistry)
 const refreshConnectionsRegistry = vi.mocked(connectionStore.refreshConnectionsRegistry)
 const selectConnection = vi.mocked(connectionStore.selectConnection)
+const isAuxiliaryWindow = vi.mocked(windowStore.isAuxiliaryWindow)
 const isPeerInstanceWindow = vi.mocked(windowStore.isPeerInstanceWindow)
 const onConnect = vi.fn()
 
@@ -112,6 +114,7 @@ afterEach(() => {
   })
   $pendingConnectionId.set(null)
   $findInPage.set({ active: false, query: '', matchOrdinal: 0, matchCount: 0 })
+  isAuxiliaryWindow.mockReturnValue(false)
   isPeerInstanceWindow.mockReturnValue(false)
 })
 
@@ -136,6 +139,22 @@ describe('ConnectionSwitcher', () => {
 
   it('keeps a full peer on the shared backend instead of replaying app-launch source restoration', async () => {
     isPeerInstanceWindow.mockReturnValue(true)
+    $desktopBoot.set({
+      ...$desktopBoot.get(),
+      phase: 'renderer.ready',
+      progress: 100,
+      running: false,
+      visible: false
+    })
+
+    render(<ConnectionSwitcher onConnect={onConnect} />)
+
+    await waitFor(() => expect(refreshConnectionsRegistry).toHaveBeenCalledTimes(1))
+    expect(initializeConnectionsRegistry).not.toHaveBeenCalled()
+  })
+
+  it('keeps a secondary session window from replaying app-launch source restoration', async () => {
+    isAuxiliaryWindow.mockReturnValue(true)
     $desktopBoot.set({
       ...$desktopBoot.get(),
       phase: 'renderer.ready',

--- a/apps/desktop/src/app/chat/sidebar/connection-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/connection-switcher.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/store/connections'
 import { closeFindBar } from '@/store/find-in-page'
 import { notifyError } from '@/store/notifications'
+import { isPeerInstanceWindow } from '@/store/windows'
 
 export function ConnectionSwitcher({ compact = false, onConnect }: { compact?: boolean; onConnect: () => void }) {
   const { t } = useI18n()
@@ -64,8 +65,10 @@ export function ConnectionSwitcher({ compact = false, onConnect }: { compact?: b
     // The primary boot owns its initial config/session fetches. Restoring a
     // different source before those settle lets a late primary response repaint
     // the sidebar under the new source label. Switch only after boot completes,
-    // then the normal source reset/refetch remains the final writer.
-    if (!boot.running) {
+    // then the normal source reset/refetch remains the final writer. Full peer
+    // windows already joined the shared backend during their own boot; replaying
+    // this app-launch preference there would move them away from that backend.
+    if (!boot.running && !isPeerInstanceWindow()) {
       void initializeConnectionsRegistry().catch(() => undefined)
     }
   }, [boot.running])

--- a/apps/desktop/src/app/chat/sidebar/connection-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/connection-switcher.tsx
@@ -36,7 +36,7 @@ import {
 } from '@/store/connections'
 import { closeFindBar } from '@/store/find-in-page'
 import { notifyError } from '@/store/notifications'
-import { isPeerInstanceWindow } from '@/store/windows'
+import { isAuxiliaryWindow, isPeerInstanceWindow } from '@/store/windows'
 
 export function ConnectionSwitcher({ compact = false, onConnect }: { compact?: boolean; onConnect: () => void }) {
   const { t } = useI18n()
@@ -65,10 +65,10 @@ export function ConnectionSwitcher({ compact = false, onConnect }: { compact?: b
     // The primary boot owns its initial config/session fetches. Restoring a
     // different source before those settle lets a late primary response repaint
     // the sidebar under the new source label. Switch only after boot completes,
-    // then the normal source reset/refetch remains the final writer. Full peer
-    // windows already joined the shared backend during their own boot; replaying
-    // this app-launch preference there would move them away from that backend.
-    if (!boot.running && !isPeerInstanceWindow()) {
+    // then the normal source reset/refetch remains the final writer. Peer and
+    // auxiliary windows already boot into their intended runtime; replaying the
+    // primary window's app-launch preference would move them away from it.
+    if (!boot.running && !isAuxiliaryWindow() && !isPeerInstanceWindow()) {
       void initializeConnectionsRegistry().catch(() => undefined)
     }
   }, [boot.running])

--- a/apps/desktop/src/store/windows.test.ts
+++ b/apps/desktop/src/store/windows.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { canOpenNewWindow, canOpenSessionWindow, openNewWindow, openSessionInNewWindow } from './windows'
+import {
+  canOpenNewWindow,
+  canOpenSessionWindow,
+  isPeerInstanceWindow,
+  openNewWindow,
+  openSessionInNewWindow
+} from './windows'
 
 const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
 const initialHermesDesktop = desktopWindow.hermesDesktop
@@ -47,6 +53,15 @@ describe('canOpenSessionWindow', () => {
   it('is true when the bridge exposes openSessionWindow', () => {
     installBridge(vi.fn().mockResolvedValue({ ok: true }))
     expect(canOpenSessionWindow()).toBe(true)
+  })
+})
+
+describe('isPeerInstanceWindow', () => {
+  it('recognizes only the full peer marker', () => {
+    expect(isPeerInstanceWindow('?peer=1')).toBe(true)
+    expect(isPeerInstanceWindow('?peer=0')).toBe(false)
+    expect(isPeerInstanceWindow('?win=secondary')).toBe(false)
+    expect(isPeerInstanceWindow('')).toBe(false)
   })
 })
 

--- a/apps/desktop/src/store/windows.ts
+++ b/apps/desktop/src/store/windows.ts
@@ -83,6 +83,18 @@ export function isWatchWindow(): boolean {
 // keystroke into N prompts, and a HUD is the last place to paint onboarding.
 export const isAuxiliaryWindow = (): boolean => isSecondaryWindow() || isHudWindow()
 
+// A full peer window renders the ordinary app shell against the backend that
+// Electron already has running. It is not an auxiliary/specialized renderer,
+// but it must not replay the primary window's app-launch source restoration
+// after boot and silently re-home itself to another registered gateway.
+export function isPeerInstanceWindow(search = typeof window === 'undefined' ? '' : window.location.search): boolean {
+  try {
+    return new URLSearchParams(search).get('peer') === '1'
+  } catch {
+    return false
+  }
+}
+
 // The profile a helper window (the HUD) was asked to boot against, carried in
 // the query string by the main process (see hudUrl). The HUD is a full app
 // renderer that otherwise adopts the PRIMARY backend's profile — wrong the


### PR DESCRIPTION
## What does this PR do?

Fixes a Desktop regression where a full peer window opened through File -> New Window, the command palette, or Ctrl/Cmd+Shift+N briefly joined the running remote gateway and then switched itself to the registry Primary, often local.

Full peer windows now carry a renderer-neutral `peer=1` marker. They still render the ordinary app shell and refresh the registered-gateway list, but they do not replay the primary window's app-launch source restoration after joining the shared backend. The primary window continues to honor Primary vs last-used launch behavior unchanged.

This is intentionally narrower than the draft per-window backend work in #83219: it restores the existing shared-backend peer-window contract and fixes the current-main regression at `initializeConnectionsRegistry()`.

## Related Issue

Discord report: https://discord.com/channels/1053877538025386074/1539789563109834812

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/session-windows.ts` builds full peer URLs with a `peer=1` marker while preserving the ordinary renderer.
- `apps/desktop/electron/main.ts` uses that URL for every full peer-window entry point.
- `apps/desktop/src/store/windows.ts` identifies full peer renderers without classifying them as auxiliary windows.
- `apps/desktop/src/app/chat/sidebar/connection-switcher.tsx` keeps registry refresh in peers but limits app-launch source restoration to the primary window.
- Added Electron and renderer regressions for dev and packaged URLs, marker parsing, and source-restore suppression.

## How to Test

1. Set Desktop's running backend to a remote gateway while the registered-gateway Primary is local.
2. Open a full peer through File -> New Window, the command palette, or Ctrl/Cmd+Shift+N.
3. Confirm the peer remains on the shared remote backend after boot while the primary app window still honors its configured launch-source preference.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not run: Desktop-only TypeScript change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 with focused Electron and renderer tests, typechecks, ESLint, and formatting checks

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - URL/query and renderer logic only
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Focused validation on Windows 11:

- `vitest run --project electron electron/session-windows.test.ts`: 19 passed
- `vitest run --project ui src/store/windows.test.ts src/app/chat/sidebar/connection-switcher.test.tsx`: 29 passed
- Both Desktop TypeScript projects passed `tsc --noEmit`.
- Touched-file ESLint, Prettier, and `git diff --check` passed.

Not run: the full Python suite or a packaged Desktop runtime smoke test.
