### PR TITLE
fix(agent): recover inline reasoning stripped by the think scrubber

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4034,6 +4034,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
         def _relay_final_response() -> dict[str, Any]:
             tool_calls = [tool_calls_acc[index] for index in sorted(tool_calls_acc)]
+            reasoning_text = "".join(reasoning_parts)
+            if not reasoning_text:
+                # Providers that inline reasoning (MiniMax-M3 streams
+                # <think>…</think> in content) never send a reasoning
+                # delta — recover what the think scrubber stripped so the
+                # structured reasoning_content field stays populated
+                # (#89647).
+                _think_scrubber = getattr(agent, "_stream_think_scrubber", None)
+                if _think_scrubber is not None:
+                    reasoning_text = _think_scrubber.reasoning()
             return {
                 "model": model_name,
                 "choices": [
@@ -4041,7 +4051,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         "message": {
                             "role": role,
                             "content": "".join(content_parts) or None,
-                            "reasoning_content": "".join(reasoning_parts) or None,
+                            "reasoning_content": reasoning_text or None,
                             "tool_calls": tool_calls or None,
                         },
                         "finish_reason": finish_reason or "stop",

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4037,13 +4037,22 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             reasoning_text = "".join(reasoning_parts)
             if not reasoning_text:
                 # Providers that inline reasoning (MiniMax-M3 streams
-                # <think>…</think> in content) never send a reasoning
+                #  thinking… response in content) never send a reasoning
                 # delta — recover what the think scrubber stripped so the
                 # structured reasoning_content field stays populated
                 # (#89647).
                 _think_scrubber = getattr(agent, "_stream_think_scrubber", None)
                 if _think_scrubber is not None:
                     reasoning_text = _think_scrubber.reasoning()
+            # Heal the pool entry after a successful served request (#95166)
+            pool = getattr(agent, "_credential_pool", None)
+            if pool is not None:
+                api_key = getattr(agent, "api_key", None)
+                if api_key:
+                    from agent.credential_pool import STATUS_EXHAUSTED, STATUS_DEAD
+                    for entry in pool.entries():
+                        if entry.runtime_api_key == api_key and entry.last_status in (STATUS_EXHAUSTED, STATUS_DEAD):
+                            pool._mark_healthy(entry)
             return {
                 "model": model_name,
                 "choices": [

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -915,6 +915,24 @@ class CredentialPool:
             self._persist()
         return updated
 
+    def _mark_healthy(self, entry: PooledCredential, *, persist: bool = True) -> PooledCredential:
+        """Clear a stale exhausted/dead verdict after a served request succeeds (#95166)."""
+        if entry.last_status is None:
+            return entry
+        updated = replace(
+            entry,
+            last_status=STATUS_OK,
+            last_status_at=None,
+            last_error_code=None,
+            last_error_reason=None,
+            last_error_message=None,
+            last_error_reset_at=None,
+        )
+        self._replace_entry(entry, updated)
+        if persist:
+            self._persist()
+        return updated
+
     def _sync_anthropic_entry_from_credentials_file(self, entry: PooledCredential) -> PooledCredential:
         """Sync a claude_code pool entry from ~/.claude/.credentials.json if tokens differ.
 

--- a/agent/think_scrubber.py
+++ b/agent/think_scrubber.py
@@ -56,9 +56,17 @@ intentional, bounded construct.
 
 from __future__ import annotations
 
+import re
 from typing import Tuple
 
 __all__ = ["StreamingThinkScrubber"]
+
+# Tag markup stripped by reasoning(); matches every variant the scrubber
+# recognizes (open, close, self-closing, case-insensitive).
+_THINK_TAG_RE = re.compile(
+    r"<\s*/?\s*(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)\s*>",
+    re.IGNORECASE,
+)
 
 
 class StreamingThinkScrubber:
@@ -96,12 +104,14 @@ class StreamingThinkScrubber:
         self._in_block: bool = False
         self._buf: str = ""
         self._last_emitted_ended_newline: bool = True
+        self._reasoning_parts: list[str] = []
 
     def reset(self) -> None:
         """Reset all state.  Call at the top of every new turn."""
         self._in_block = False
         self._buf = ""
         self._last_emitted_ended_newline = True
+        self._reasoning_parts = []
 
     def feed(self, text: str) -> str:
         """Feed one delta; return the scrubbed visible portion.
@@ -124,11 +134,18 @@ class StreamingThinkScrubber:
                 )
                 if close_idx == -1:
                     # No close yet — hold back a potential partial
-                    # close-tag prefix; discard everything else.
+                    # close-tag prefix; collect everything else as
+                    # reasoning (#89647).
                     held = self._max_partial_suffix(buf, self._CLOSE_TAGS)
+                    discard = buf[:-held] if held else buf
+                    if discard:
+                        self._reasoning_parts.append(discard)
                     self._buf = buf[-held:] if held else ""
                     return "".join(out)
-                # Found close: discard block content + tag, continue.
+                # Found close: collect block content as reasoning, then
+                # continue scanning after the close tag (#89647).
+                if buf[:close_idx]:
+                    self._reasoning_parts.append(buf[:close_idx])
                 buf = buf[close_idx + close_len:]
                 self._in_block = False
             else:
@@ -150,6 +167,10 @@ class StreamingThinkScrubber:
                     open_idx == -1 or pair[0] <= open_idx
                 ):
                     start_idx, end_idx = pair
+                    # Collect the stripped pair (tags removed later by
+                    # reasoning()) so inline reasoning is not lost (#89647).
+                    if end_idx > start_idx:
+                        self._reasoning_parts.append(buf[start_idx:end_idx])
                     preceding = buf[:start_idx]
                     if preceding:
                         preceding = self._strip_orphan_close_tags(preceding)
@@ -217,6 +238,8 @@ class StreamingThinkScrubber:
         visible reply.
         """
         if self._in_block:
+            if self._buf:
+                self._reasoning_parts.append(self._buf)
             self._buf = ""
             self._in_block = False
             # Next feed() is a new stream — start-of-stream is a boundary.
@@ -231,6 +254,25 @@ class StreamingThinkScrubber:
         if not tail:
             return ""
         return self._strip_orphan_close_tags(tail)
+
+    def reasoning(self) -> str:
+        """Return reasoning text stripped from streamed content so far.
+
+        Collects everything the scrubber suppressed (block content and
+        closed pairs) and removes the tag markup. Empty when no
+        reasoning blocks were seen — callers can use this to populate
+        a structured ``reasoning_content`` field for providers (e.g.
+        MiniMax-M3) that inline reasoning instead of returning a
+        reasoning delta (#89647).
+        """
+        if not self._reasoning_parts:
+            return ""
+        cleaned: list[str] = []
+        for part in self._reasoning_parts:
+            text = _THINK_TAG_RE.sub("", part).strip()
+            if text:
+                cleaned.append(text)
+        return "\n".join(cleaned)
 
     # ── internal helpers ───────────────────────────────────────────────
 

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2079,3 +2079,48 @@ class TestCredentialPoolQueryLocking:
             inner.release()
 
         assert done.wait(timeout=2.0), f"{method}() did not complete after lock release"
+
+
+class TestMarkHealthy:
+    """_mark_healthy clears a transient failure verdict (#95166)."""
+
+    def test_clears_exhausted_status(self, tmp_path, monkeypatch):
+        from agent.credential_pool import CredentialPool, PooledCredential, STATUS_EXHAUSTED, STATUS_OK
+
+        entry = PooledCredential(
+            provider="test", id="e1", label="", auth_type="api_key", priority=0,
+            source="env", access_token="sk-test",
+            last_status=STATUS_EXHAUSTED, last_status_at=1000.0,
+            last_error_code=429, last_error_reason="rate_limit",
+        )
+        pool = CredentialPool(provider="test", entries=[entry])
+        healed = pool._mark_healthy(entry)
+        assert healed.last_status == STATUS_OK
+        assert healed.last_status_at is None
+        assert healed.last_error_code is None
+
+    def test_skips_already_healthy_entry(self, tmp_path, monkeypatch):
+        from agent.credential_pool import CredentialPool, PooledCredential, STATUS_OK
+
+        entry = PooledCredential(
+            provider="test", id="e1", label="", auth_type="api_key", priority=0,
+            source="env", access_token="sk-test",
+            last_status=STATUS_OK,
+        )
+        pool = CredentialPool(provider="test", entries=[entry])
+        healed = pool._mark_healthy(entry)
+        assert healed.last_status == STATUS_OK
+
+    def test_clears_dead_status(self, tmp_path, monkeypatch):
+        from agent.credential_pool import CredentialPool, PooledCredential, STATUS_OK, STATUS_DEAD
+
+        entry = PooledCredential(
+            provider="test", id="e1", label="", auth_type="api_key", priority=0,
+            source="test", access_token="sk-test",
+            last_status=STATUS_DEAD, last_status_at=1000.0,
+            last_error_code=401, last_error_reason="token_invalidated",
+        )
+        pool = CredentialPool(provider="test", entries=[entry])
+        healed = pool._mark_healthy(entry)
+        assert healed.last_status == STATUS_OK
+        assert healed.last_error_code is None

--- a/tests/agent/test_think_scrubber.py
+++ b/tests/agent/test_think_scrubber.py
@@ -189,3 +189,36 @@ class TestRealisticStreaming:
         s = StreamingThinkScrubber()
         deltas = ["Hello ", "world ", "how ", "are ", "you?"]
         assert _drive(s, deltas) == "Hello world how are you?"
+
+
+class TestReasoningCollection:
+    """The scrubber collects stripped reasoning for structured fields (#89647)."""
+
+    def test_collects_split_block_across_deltas(self) -> None:
+        s = StreamingThinkScrubber()
+        visible = _drive(s, ["<think>", "Let me check", " their config", "</think>", "Done."])
+        assert visible == "Done."
+        assert s.reasoning() == "Let me check\ntheir config"
+
+    def test_collects_closed_pair_in_single_delta(self) -> None:
+        s = StreamingThinkScrubber()
+        visible = _drive(s, ["<think>inline reasoning</think>Hello"])
+        assert visible == "Hello"
+        assert s.reasoning() == "inline reasoning"
+
+    def test_empty_when_no_reasoning(self) -> None:
+        s = StreamingThinkScrubber()
+        _drive(s, ["Just visible text"])
+        assert s.reasoning() == ""
+
+    def test_strips_tag_markup_from_collected_text(self) -> None:
+        s = StreamingThinkScrubber()
+        _drive(s, ["<thinking>plan</thinking>ok"])
+        assert s.reasoning() == "plan"
+
+    def test_reset_clears_collected_reasoning(self) -> None:
+        s = StreamingThinkScrubber()
+        _drive(s, ["<think>a</think>x"])
+        assert s.reasoning() == "a"
+        s.reset()
+        assert s.reasoning() == ""


### PR DESCRIPTION
## Summary

Fixes #89647: providers that inline reasoning (MiniMax-M3 streams `<think>…</think>` inside content) never send a `reasoning_content` delta, so the desktop reasoning pane stays dead even though reasoning happened.

## Approach

- `StreamingThinkScrubber` (agent/think_scrubber.py, #17924) already strips inline think blocks from streamed content but discarded the text. It now **collects** the stripped text (block content, closed pairs, end-of-stream tail) with a `reasoning()` accessor that removes tag markup.
- `_relay_final_response` (agent/chat_completion_helpers.py) populates `reasoning_content` from the scrubber when the provider returned no reasoning delta.

## Relation to #43827 / #43836

- This fixes the **structured-field extraction** side of the MiniMax-M3 reasoning family. The English `<think>` blocks are already suppressed from visible output by the scrubber (#17924) — this PR recovers them into `reasoning_content` so the desktop reasoning pane populates.
- The **Chinese reasoning tags** (思考/反思/推理/推敲) leak reported in #43827 (still open; #43836 closed without merge) is a separate symptom in the same family: those tags are not in the scrubber's tag set, so they are neither suppressed nor collected here. Out of scope for this PR.

## Test Plan

- 5 new tests in `TestReasoningCollection` (tests/agent/test_think_scrubber.py): split block across deltas / closed pair in one delta / no-reasoning empty / tag markup stripped / reset clears.
- Full file: 25/25 pass. `ruff check` clean.

## Risk / Exclusions

- Scrubber behavior for visible output is unchanged (collection only); reasoning() is additive.
- Only fills reasoning_content when the provider gave none — native reasoning deltas still take precedence.
- No changes to streaming delivery, prompts, the content scrubber, or the Chinese-tag path (#43827).

References #89647

---

**Update (2026-08-29):** This PR now also carries the credential-pool heal fix (formerly #95351, closed). Both changes edit `_relay_final_response`'s success path, so they were merged into one branch to avoid a merge conflict between overlapping edits of the same function:
1. Recover inline reasoning stripped by the think scrubber (#89647)
2. Heal credential-pool `last_status` after a successful served request (#95166)

Combined branch: `fix/minimax-reasoning-extraction` (2 commits). 87/87 tests pass.