### PR TITLE
fix(desktop): include unread flag in session signatures

### DIFF
--- a/apps/desktop/src/lib/session-signatures.test.ts
+++ b/apps/desktop/src/lib/session-signatures.test.ts
@@ -51,6 +51,23 @@ describe('sameCronSignature', () => {
     const b = [session('a', 't', { archived: false, pinned: true })]
     expect(sameCronSignature(a, b)).toBe(true)
   })
+
+  // Read-state-only pages must swap in: opening a session clears `unread`
+  // backend-side, and the refresh page whose only delta is that flag is the
+  // one that clears the emerald dot. Gating it out froze the stale `unread:
+  // true` row, and the dot survived navigation until some content field
+  // moved too (mirror of the #76919 pin-signature fix).
+  it('is false when only the unread flag changed', () => {
+    const a = [session('a', 't', { unread: true })]
+    const b = [session('a', 't', { unread: false })]
+    expect(sameCronSignature(a, b)).toBe(false)
+  })
+
+  it('is true when the unread flag matches', () => {
+    const a = [session('a', 't', { unread: true })]
+    const b = [session('a', 't', { unread: true })]
+    expect(sameCronSignature(a, b)).toBe(true)
+  })
 })
 
 describe('sessionMessagesSignature', () => {

--- a/apps/desktop/src/lib/session-signatures.ts
+++ b/apps/desktop/src/lib/session-signatures.ts
@@ -29,8 +29,13 @@ export function sameCronSignature(a: SessionInfo[], b: SessionInfo[]): boolean {
       // whose only delta is a flag has to swap in or the reconciler reads a
       // frozen copy forever. An idle conversation never moves any of the
       // fields above again, which is exactly when a pin gets toggled (#76919).
+      // `unread` is the backend read-state watermark: opening a session
+      // clears it backend-side, and only a read-state-only page delivers the
+      // false — if the signature misses it, the stale emerald dot survives
+      // navigation until some content field moves too.
       session.pinned === other.pinned &&
-      session.archived === other.archived
+      session.archived === other.archived &&
+      session.unread === other.unread
     )
   })
 }


### PR DESCRIPTION
## Problem

The sidebar's session list signature (`sameCronSignature`) compares row content plus the `pinned`/`archived` flags, but not the backend read-state flag `unread`. When a session is opened, the backend clears `unread` (PATCH → `SessionDB.set_session_read`), and the next list refresh's only delta is that flag. The signature reports "unchanged", the stale array (with `unread: true`) is kept, and the emerald "finished — unread" dot survives navigation until some content field (title, message_count, last_active) moves too.

## Fix

Compare `session.unread === other.unread` in `sameCronSignature`, so a read-state-only page swaps in and the dot clears. Same class of fix as the `pinned`/`archived` comparison added for #76919 — row STATE flags must be part of the signature, not just row content.

## Tests

- `is false when only the unread flag changed` — the regression case: a page whose only delta is `unread: true → false` must swap in.
- `is true when the unread flag matches` — no spurious swaps when read state is stable.

Verified: targeted suite 12/12, full `--project ui` suite 5,057/5,057, typecheck + eslint clean.