### PR TITLE
fix(api): require API_SERVER_KEY on GET /health

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2988,7 +2988,17 @@ class APIServerAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def _handle_health(self, request: "web.Request") -> "web.Response":
-        """GET /health — simple health check."""
+        """GET /health — simple health check.
+
+        Requires the same Bearer auth as the other API routes (and
+        /health/detailed): API_SERVER_KEY is documented as required for
+        every deployment, and an unauthenticated 200 made status checks
+        treat the API as open while chat was actually gated (#90315).
+        The no-key branch of _check_auth keeps loopback testing working.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
         return web.json_response(
             {"status": "ok", "platform": "hermes-agent", "version": _hermes_version()}
         )

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -691,6 +691,38 @@ class TestHealthEndpoint:
             assert isinstance(data["version"], str)
             assert data["version"] != ""
 
+    @pytest.mark.asyncio
+    async def test_health_requires_auth_when_key_set(self):
+        """GET /health must enforce API_SERVER_KEY like the other API routes
+        (#90315) — an unauthenticated 200 made clients treat the API as open
+        while chat was gated."""
+        app = _create_app(_make_adapter(api_key="secret-key"))
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/health")
+            assert resp.status == 401
+            data = await resp.json()
+            assert data["error"]["type"] == "gateway_auth_error"
+
+    @pytest.mark.asyncio
+    async def test_health_allows_valid_bearer(self):
+        app = _create_app(_make_adapter(api_key="secret-key"))
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(
+                "/health", headers={"Authorization": "Bearer secret-key"}
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["status"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_health_without_key_stays_public(self):
+        """No-key deployments (tests / manual wiring) keep the open probe —
+        _check_auth's no-key branch is deliberately permissive."""
+        app = _create_app(_make_adapter(api_key=""))
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/health")
+            assert resp.status == 200
+
 
 # ---------------------------------------------------------------------------
 # /health/detailed endpoint


### PR DESCRIPTION
## Summary

Fixes #90315: `GET /health` returned HTTP 200 without an `Authorization` header while every other route on the same listener (and `/health/detailed`) enforced `API_SERVER_KEY`. Docs require the key for every deployment, so an unauthenticated 200 made clients/status checks treat the API as open while chat was gated.

## Approach

- `_handle_health` now runs `_check_auth` (same 401 `gateway_auth_error` as the other routes).
- The no-key branch of `_check_auth` keeps loopback testing / manual wiring working (existing behavior preserved).
- Desktop health probes use `/api/health` (different route) — unaffected.

## Test Plan

- 3 new tests in `TestHealthEndpoint`: with key → 401 without bearer / 200 with valid bearer; without key → still 200.
- `pytest tests/gateway/test_api_server.py -k Health`: 7 passed; 1 pre-existing failure (`test_health_detailed_returns_ok`, readiness reports 'degraded' locally — confirmed identical with the change stashed) unrelated to this change.
- `ruff check` clean.

## Risk / Exclusions

- Only the simple health handler changes; detailed health, model routes, and no-key deployments are untouched.

References #90315