### PR TITLE
fix(profiles): find alias collisions without shelling out to where

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -407,28 +407,32 @@ def check_alias_collision(name: str) -> Optional[str]:
     if canon in _HERMES_SUBCOMMANDS:
         return f"'{canon}' conflicts with a hermes subcommand"
 
-    # Check existing commands in PATH
+    # Check existing commands in PATH.
+    #
+    # Resolved in-process with shutil.which() rather than by shelling out to
+    # ``where``/``which``. Those are native console programs: on Windows their
+    # stdout carries the machine code page, and the decoded text was compared
+    # against a path this function builds from the filesystem. A CP932 lead
+    # byte followed by a 0x5C trail byte survives a UTF-8 decode as a literal
+    # backslash, so the comparison sees extra path separators and can never
+    # match. shutil.which() reads PATH and PATHEXT directly and never crosses
+    # a byte boundary, so no codepage enters into it.
     wrapper_dir = _get_wrapper_dir()
     is_windows = sys.platform == "win32"
-    try:
-        result = subprocess.run(
-            ["where" if is_windows else "which", canon],
-            capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=5,
-        )
-        if result.returncode == 0:
-            existing_path = result.stdout.strip().splitlines()[0]
-            # Allow overwriting our own wrappers
-            expected = wrapper_dir / (f"{canon}.bat" if is_windows else canon)
-            if existing_path == str(expected):
-                try:
-                    content = expected.read_text(encoding="utf-8")
-                    if "hermes -p" in content:
-                        return None  # it's our wrapper, safe to overwrite
-                except Exception:
-                    pass
-            return f"'{canon}' conflicts with an existing command ({existing_path})"
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        pass
+    existing_path = shutil.which(canon)
+    if existing_path:
+        # Allow overwriting our own wrappers. normcase() folds the Windows
+        # separator and case so a PATH entry written with forward slashes
+        # still matches; it is a no-op on POSIX.
+        expected = wrapper_dir / (f"{canon}.bat" if is_windows else canon)
+        if os.path.normcase(existing_path) == os.path.normcase(str(expected)):
+            try:
+                content = expected.read_text(encoding="utf-8")
+                if "hermes -p" in content:
+                    return None  # it's our wrapper, safe to overwrite
+            except Exception:
+                pass
+        return f"'{canon}' conflicts with an existing command ({existing_path})"
 
     return None  # safe
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -547,20 +547,95 @@ class TestAliasCollision:
         wrapper_dir.mkdir(parents=True, exist_ok=True)
         bat_path = wrapper_dir / "mybot.bat"
         bat_path.write_text("@echo off\r\nhermes -p mybot %*\r\n")
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=0, stdout=str(bat_path),
-            )
+        with patch("hermes_cli.profiles.shutil.which", return_value=str(bat_path)):
             result = check_alias_collision("mybot")
         assert result is None  # our own wrapper, safe to overwrite
 
     def test_traversal_alias_rejected_before_path_lookup(self, profile_env):
-        """A path-traversal alias is rejected without ever shelling out to which/where."""
-        with patch("subprocess.run") as mock_run:
+        """A path-traversal alias is rejected without ever looking up PATH."""
+        with patch("hermes_cli.profiles.shutil.which") as mock_which:
             result = check_alias_collision("../../.bashrc")
         assert result is not None
         assert "invalid alias name" in result.lower()
+        mock_which.assert_not_called()
+
+    def test_path_lookup_does_not_spawn_a_child_process(self, profile_env):
+        """PATH resolution happens in-process.
+
+        ``where``/``which`` are native console programs whose stdout carries
+        the machine code page. Decoding that as UTF-8 corrupted the path this
+        function then compares against, so the lookup must not shell out at
+        all. Fails before the fix: ``subprocess.run`` was called.
+        """
+        with patch("hermes_cli.profiles.subprocess.run") as mock_run:
+            with patch("hermes_cli.profiles.shutil.which", return_value=None):
+                assert check_alias_collision("mybot") is None
         mock_run.assert_not_called()
+
+    def test_wrapper_recognised_when_its_path_is_not_ascii(self, profile_env, monkeypatch):
+        """A wrapper under a non-ASCII directory is still recognised as ours.
+
+        A real PATH lookup \u2014 nothing is mocked, so on a CP932 host this
+        exercises the actual decode. The three directory characters are
+        U+5341 U+80FD U+4E88; in CP932 each is a two-byte sequence whose
+        trail byte is 0x5C, so a UTF-8 decode of the native ``where`` output
+        turned every one of them into an extra path separator and the
+        comparison below could never hold.
+
+        Passes either way on a UTF-8 host: there is no decode to get wrong
+        there. It is a genuine regression test only on native Windows.
+        """
+        wrapper_dir = profile_env / "\u5341\u80fd\u4e88" / "bin"
+        wrapper_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(
+            "hermes_cli.profiles._get_wrapper_dir", lambda: wrapper_dir
+        )
+        is_windows = sys.platform == "win32"
+        wrapper = wrapper_dir / ("mybot.bat" if is_windows else "mybot")
+        wrapper.write_text("hermes -p mybot\n", encoding="utf-8")
+        wrapper.chmod(0o755)
+        monkeypatch.setenv(
+            "PATH", str(wrapper_dir) + os.pathsep + os.environ.get("PATH", "")
+        )
+
+        assert check_alias_collision("mybot") is None
+
+    def test_wrapper_match_tolerates_forward_slashes_in_path_entry(
+        self, profile_env, monkeypatch
+    ):
+        """A PATH entry written with ``/`` still resolves to our own wrapper.
+
+        ``shutil.which`` joins onto the PATH entry verbatim, so a Windows PATH
+        carrying ``C:/tools`` yields ``C:/tools\\mybot.bat``. ``where`` used to
+        normalise that for us; ``os.path.normcase`` now does, and is a no-op
+        off Windows.
+        """
+        wrapper_dir = profile_env / ".local" / "bin"
+        wrapper_dir.mkdir(parents=True, exist_ok=True)
+        is_windows = sys.platform == "win32"
+        wrapper = wrapper_dir / ("mybot.bat" if is_windows else "mybot")
+        wrapper.write_text("hermes -p mybot\n", encoding="utf-8")
+
+        as_posix_style = str(wrapper).replace("\\", "/")
+        with patch(
+            "hermes_cli.profiles.shutil.which", return_value=as_posix_style
+        ):
+            assert check_alias_collision("mybot") is None
+
+    def test_cp932_trail_byte_becomes_a_path_separator_under_utf8(self):
+        """Pin the stdlib behaviour this change exists to avoid.
+
+        Independent of hermes: asserts what a CP932 path does when decoded as
+        UTF-8 with replacement, which is what the removed ``where`` call did.
+        """
+        path = "C:\\\u5341\u80fd\u4e88\\mybot.bat"
+        raw = path.encode("cp932")
+        assert raw.startswith(b"C:\\\x8f\x5c\x94\x5c\x97\x5c\\")
+        assert raw.decode("cp932") == path
+        mangled = raw.decode("utf-8", errors="replace")
+        assert mangled.count("\\") == 5
+        assert path.count("\\") == 2
+        assert mangled != path
 
 
 # ===================================================================


### PR DESCRIPTION
## What does this PR do?

`check_alias_collision()` shells out to `where` (Windows) / `which` (POSIX) and compares the decoded first line against a path it builds itself:

```python
result = subprocess.run(
    ["where" if is_windows else "which", canon],
    capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=5,
)
existing_path = result.stdout.strip().splitlines()[0]
expected = wrapper_dir / (f"{canon}.bat" if is_windows else canon)
if existing_path == str(expected):
    ...  # our own wrapper, safe to overwrite
return f"'{canon}' conflicts with an existing command ({existing_path})"
```

`expected` comes from the filesystem and is correct. `existing_path` comes from a native console program decoded as UTF-8. `where.exe` writes the machine code page, so on a CJK host the two can never be compared meaningfully.

`_get_wrapper_dir()` is `Path.home() / ".local" / "bin"`, so the wrapper path contains the user profile name. An account named in kana or kanji puts non-ASCII on both sides of that comparison.

**Measured on ja-JP Windows 11 (ACP=932), Python 3.12.10.** A directory named 十能予 on PATH, holding `hermesprobe.bat`, then the same `where` call captured as bytes:

```
raw bytes  27
raw hex    43 3a 5c  8f 5c  94 5c  97 5c  5c  6865726d657370726f62652e626174  0d 0a
             C  :  \    十     能     予    \        hermesprobe.bat          CRLF

cp932            'C:\\\u5341\u80fd\u4e88\\hermesprobe.bat\r\n'
utf-8 + replace  'C:\\\ufffd\\\ufffd\\\ufffd\\\\hermesprobe.bat\r\n'

backslashes  expected 2   cp932 2   utf-8 5
match cp932  True
match utf8   False
```

This is not the usual replacement-character story. All three characters have `0x5C` as their CP932 trail byte, and `0x5C` is the path separator, so the decode does not lose the path — it **adds three separators to it**. There are 52 such characters in CPython's CP932 double-byte table and they are ordinary ones: 表 十 能 予 構 貼.

**What it costs.** `check_alias_collision` is called from eight places (`main.py` ×3, `web_routers/profiles.py` ×2, `cli_commands_mixin.py`, `backup.py` ×2), including profile import and backup restore. With the comparison unable to hold, the "this is our own wrapper, safe to overwrite" branch is unreachable, so re-creating an alias you already own fails with:

```
'hermesprobe' conflicts with an existing command (C:\<?>\<?>\<?>\\hermesprobe.bat)
```

`errors='replace'` means nothing raises, so this surfaces only as that message.

**The fix.** `shutil.which()` instead of the subprocess. It reads `PATH` and `PATHEXT` in-process and returns the first match — the same value `.splitlines()[0]` was taking — so no byte boundary exists to get the codepage wrong. `shutil` was already imported. The net change removes a spawn, a 5-second timeout, and two exception arms.

One behaviour difference this introduces and then closes: `shutil.which` joins onto the PATH entry verbatim, so a Windows `PATH` carrying `C:/tools` yields `C:/tools\mybot.bat`, where `where` normalised the separator. `os.path.normcase` on both sides folds separator and case on Windows and is a no-op on POSIX.

**The alternative I did not take.** Keeping the subprocess and passing `encoding=locale.getencoding()` is a one-line diff and matches #89907 / #90017. I preferred deleting the boundary: this lookup never needed a child process, `check-windows-footguns.py` already lists `shutil.which(` among its guard hints, and the diff comes out smaller. Happy to switch to the minimal form if you would rather keep the change surface at one line.

## Related Issue

No separate issue — reporting it here with the measurement. Same family as #89878 / #89907 / #90017 / #90046, but this site does not merely mangle text for display: the corrupted string is an operand in an equality test against a correct path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/profiles.py` — `check_alias_collision()` resolves PATH with `shutil.which()` instead of `subprocess.run(["where"|"which", ...])`, and compares through `os.path.normcase`.
- `tests/hermes_cli/test_profiles.py` — `test_windows_checks_bat_extension` and `test_traversal_alias_rejected_before_path_lookup` now patch `shutil.which` rather than `subprocess.run`.
- `tests/hermes_cli/test_profiles.py` — four tests added: no child process is spawned for the lookup; a wrapper under a non-ASCII directory is recognised through a real PATH lookup; a PATH entry written with forward slashes still matches; and a byte-level assertion pinning what CP932 does under a UTF-8 decode.

## How to Test

1. On a CP932 host, reproduce the decode against the same call:

```powershell
mkdir C:\十能予 -Force
"@echo off" | Out-File -Encoding ascii C:\十能予\hermesprobe.bat
$env:PATH = "C:\十能予;$env:PATH"
```

```python
import subprocess
raw = subprocess.run(["where", "hermesprobe"], capture_output=True).stdout
print(raw.hex())
print(ascii(raw.decode("cp932")))
print(ascii(raw.decode("utf-8", errors="replace")))
```

The backslash count goes from 2 to 5. Output above is from that run.

2. `python -m pytest tests/hermes_cli/test_profiles.py -q` on that same host, against `upstream/main` and against this branch:

```
upstream/main    8 failed, 48 passed
this branch      8 failed, 52 passed
```

The same eight fail on both, and none of them are in `TestAliasCollision`. They are pre-existing Windows failures in this file, four distinct causes:

- two `assert 438 == 384` — a byte count that assumes LF line endings
- two asserting a POSIX wrapper name against the `.bat` one Windows actually writes (`assert 'mybot.bat' == 'mybot'`)
- two needing the symlink privilege (`OSError: [WinError 1314]`)
- two `Path.read_text()` without `encoding=` raising `UnicodeDecodeError: 'cp932' codec can't decode byte 0x94` inside the test file itself

The four extra passes are the four tests this PR adds.

3. Against the pre-patch source with the new tests kept, `-k AliasCollision` gives 1 failed / 4 passed. Only `test_path_lookup_does_not_spawn_a_child_process` is a genuine regression test off Windows — the others cannot fail on a UTF-8 host because there is no decode to get wrong there, and I would rather say that than imply four-way coverage. `test_wrapper_recognised_when_its_path_is_not_ascii` does a real PATH lookup with nothing mocked, so it is a real regression test on native Windows and a no-op assertion elsewhere. That pre-patch comparison was run in a Linux checkout of the same commit, not on the Windows host.

Note on the checklist below: I ran `tests/hermes_cli/test_profiles.py` and the before/after comparison above, not the full `pytest tests/ -q`, so I left that box unchecked rather than claiming it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, ja-JP (ACP=932), Python 3.12.10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

I have a ja-JP (ACP=932) Windows host and can measure anything else on that locale.

*(Measured on my host. Drafted with Claude.)*
