### PR TITLE
fix(desktop): stop decoding the HERMES_HOME registry read as utf-8

### DIFF
--- a/apps/desktop/electron/windows-user-env.test.ts
+++ b/apps/desktop/electron/windows-user-env.test.ts
@@ -85,3 +85,107 @@ test('readWindowsUserEnvVar returns null for an empty value', () => {
   const exec = () => '    HERMES_HOME    REG_SZ    \r\n'
   assert.equal(readWindowsUserEnvVar('HERMES_HOME', { platform: 'win32', exec }), null)
 })
+
+// ── code page: the reg.exe stdout boundary ─────────────────────────────────
+
+test('an ASCII reg value is decoded without spawning anything else', () => {
+  const calls = []
+
+  const exec = (cmd, args) => {
+    calls.push(cmd)
+
+    return Buffer.from(
+      'HKEY_CURRENT_USER\\Environment\r\n    HERMES_HOME    REG_SZ    F:\\Hermes\r\n',
+      'utf8'
+    )
+  }
+
+  const value = readWindowsUserEnvVar('HERMES_HOME', { platform: 'win32', env: {}, exec })
+
+  assert.equal(value, 'F:\\Hermes')
+  assert.deepEqual(calls, ['reg'])
+})
+
+test('a non-ASCII reg value is re-read as base64 instead of guessed at', () => {
+  // C:\<U+5341 U+80FD U+4E88>\hermes in CP932. Each of the three characters
+  // has 0x5C as its trail byte, so a UTF-8 decode of these bytes yields three
+  // extra path separators rather than three replacement characters.
+  const cp932Value = Buffer.from([
+    0x43, 0x3a, 0x5c, 0x8f, 0x5c, 0x94, 0x5c, 0x97, 0x5c, 0x5c,
+    0x68, 0x65, 0x72, 0x6d, 0x65, 0x73
+  ])
+  const regOutput = Buffer.concat([
+    Buffer.from('HKEY_CURRENT_USER\\Environment\r\n    HERMES_HOME    REG_SZ    ', 'utf8'),
+    cp932Value,
+    Buffer.from('\r\n', 'utf8')
+  ])
+  const expected = 'C:\\\u5341\u80fd\u4e88\\hermes'
+
+  // What the old code returned, kept as an assertion so the failure mode is
+  // pinned rather than described.
+  const mangled = regOutput.toString('utf8').split('REG_SZ    ')[1].trim()
+
+  assert.notEqual(mangled, expected)
+  assert.equal((mangled.match(/\\/g) || []).length, 5)
+  assert.equal((expected.match(/\\/g) || []).length, 2)
+
+  const calls = []
+
+  const exec = (cmd, args) => {
+    calls.push(cmd)
+
+    if (cmd === 'reg') {
+      return regOutput
+    }
+
+    assert.equal(cmd, 'powershell')
+    assert.ok(String(args[args.length - 1]).includes('ToBase64String'))
+    assert.ok(String(args[args.length - 1]).includes("'HERMES_HOME','User'"))
+
+    return Buffer.from(expected, 'utf8').toString('base64') + '\r\n'
+  }
+
+  const value = readWindowsUserEnvVar('HERMES_HOME', { platform: 'win32', env: {}, exec })
+
+  assert.equal(value, expected)
+  assert.deepEqual(calls, ['reg', 'powershell'])
+})
+
+test('a non-ASCII value returns null when the base64 re-read fails', () => {
+  const exec = (cmd) => {
+    if (cmd === 'reg') {
+      return Buffer.from([
+        0x20, 0x48, 0x45, 0x52, 0x4d, 0x45, 0x53, 0x5f, 0x48, 0x4f, 0x4d, 0x45,
+        0x20, 0x52, 0x45, 0x47, 0x5f, 0x53, 0x5a, 0x20, 0x8f, 0x5c, 0x0d, 0x0a
+      ])
+    }
+
+    throw new Error('powershell missing')
+  }
+
+  assert.equal(readWindowsUserEnvVar('HERMES_HOME', { platform: 'win32', env: {}, exec }), null)
+})
+
+test('a name that is not a plain identifier is never interpolated into PowerShell', () => {
+  const calls = []
+
+  const exec = (cmd, args) => {
+    calls.push(cmd)
+
+    if (cmd === 'reg') {
+      return Buffer.from([0x20, 0x52, 0x45, 0x47, 0x5f, 0x53, 0x5a, 0x20, 0x8f, 0x5c, 0x0d, 0x0a])
+    }
+
+    return ''
+  }
+
+  assert.equal(
+    readWindowsUserEnvVar("X'; Remove-Item C:\\ -Recurse; '", {
+      platform: 'win32',
+      env: {},
+      exec
+    }),
+    null
+  )
+  assert.deepEqual(calls, ['reg'])
+})

--- a/apps/desktop/electron/windows-user-env.ts
+++ b/apps/desktop/electron/windows-user-env.ts
@@ -53,6 +53,64 @@ function expandWindowsEnvRefs(value, env = process.env) {
   })
 }
 
+// True when every byte is below 0x80.
+//
+// `reg.exe` is a native console program: its stdout carries the machine code
+// page, not UTF-8. While the bytes are pure ASCII the two agree and decoding as
+// UTF-8 is exact. Once any byte is >= 0x80 they do not, and Node exposes no API
+// for the host code page — so rather than guess, we re-read the value through a
+// channel that carries its own encoding (below). On CP932 the guess would not
+// merely be lossy: a two-byte character whose trail byte is 0x5C survives a
+// UTF-8 decode as a literal backslash, so `C:\<kanji>\hermes` comes back with
+// MORE path separators than it started with, and the caller treats that
+// non-empty string as a valid HERMES_HOME instead of falling back (#45471).
+function isAsciiBytes(buf) {
+  for (let i = 0; i < buf.length; i += 1) {
+    if (buf[i] >= 0x80) {
+      return false
+    }
+  }
+
+  return true
+}
+
+const SAFE_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+// Re-read the value via PowerShell, base64-encoded from UTF-8 inside the child
+// so the bytes on the wire are ASCII and no code page is involved. Mirrors the
+// approach already used for clipboard text in ui-tui/src/lib/clipboard.ts.
+function readUserEnvVarAsBase64(name, exec) {
+  if (!SAFE_ENV_NAME.test(name)) {
+    return null
+  }
+
+  const script =
+    '[Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(' +
+    "[Environment]::GetEnvironmentVariable('" +
+    name +
+    "','User')))"
+
+  let out
+
+  try {
+    out = exec('powershell', ['-NoProfile', '-NonInteractive', '-Command', script], {
+      encoding: 'utf8',
+      windowsHide: true,
+      timeout: 5000
+    })
+  } catch {
+    return null
+  }
+
+  const b64 = String(out == null ? '' : out).trim()
+
+  if (!b64) {
+    return null
+  }
+
+  return Buffer.from(b64, 'base64').toString('utf8') || null
+}
+
 // Read a User-scoped env var from HKCU\Environment. Windows-only: returns null
 // off-Windows (without spawning), on any spawn error, when `reg` exits non-zero
 // (the value doesn't exist), or when the value is empty.
@@ -75,11 +133,24 @@ function readWindowsUserEnvVar(
   let stdout
 
   try {
-    stdout = exec('reg', ['query', 'HKCU\\Environment', '/v', name], {
-      encoding: 'utf8',
+    // No `encoding` — take the bytes, decide how to read them below.
+    const out = exec('reg', ['query', 'HKCU\\Environment', '/v', name], {
       windowsHide: true,
       timeout: 5000
     })
+    const buf = Buffer.isBuffer(out) ? out : Buffer.from(String(out == null ? '' : out), 'utf8')
+
+    if (!isAsciiBytes(buf)) {
+      const viaBase64 = readUserEnvVarAsBase64(name, exec)
+
+      if (viaBase64 == null) {
+        return null
+      }
+
+      return expandWindowsEnvRefs(viaBase64, env).trim() || null
+    }
+
+    stdout = buf.toString('utf8')
   } catch {
     // `reg` missing, or value absent (reg exits 1) — caller falls back.
     return null


### PR DESCRIPTION
## What does this PR do?

`readWindowsUserEnvVar()` reads `HERMES_HOME` out of `HKCU\Environment` and decodes `reg.exe`'s stdout as UTF-8:

```ts
stdout = exec('reg', ['query', 'HKCU\\Environment', '/v', name], {
  encoding: 'utf8',
  windowsHide: true,
  timeout: 5000
})
```

`reg.exe` is a native console program; its stdout carries the machine code page. The value being read is a filesystem path.

**Measured on ja-JP Windows 11 (ACP=932), Node v24.17.0.** `setx HERMES_PROBE "C:\十能予\hermes"`, then the same `reg query` captured as bytes:

```
raw bytes  83
value hex  43 3a 5c  8f 5c  94 5c  97 5c  5c  6865726d6573
             C  :  \    十     能     予    \      hermes

parsed, utf8   "C:\\\ufffd\\\ufffd\\\ufffd\\\\hermes"
parsed, sjis   "C:\\\u5341\u80fd\u4e88\\hermes"

backslashes    utf8 5    sjis 2
values equal   false

parent exists, utf8   false
parent exists, sjis   true
```

The three characters each have `0x5C` as their CP932 trail byte, and `0x5C` is the path separator. So the UTF-8 decode does not shorten the path, it **lengthens** it by three segments. There are 52 such characters in CPython's CP932 double-byte table, and they are ordinary ones: 表 十 能 予 構 貼.

**What it costs.** `parseRegQueryValue` matches on `\S+` for the name and takes the rest of the line as the value, so a mangled value parses cleanly. The caller in `main.ts` is:

```ts
const fromRegistry = readWindowsUserEnvVar('HERMES_HOME')

if (fromRegistry) {
  return normalizeHermesHomeRoot(fromRegistry)
}
// LOCALAPPDATA fallback below is never reached
```

A corrupted string is still truthy, so the desktop resolves `HERMES_HOME` to a directory that does not exist rather than falling through to `%LOCALAPPDATA%\hermes`. That is worse than the stale-snapshot gap this function was added to close (#45471): the fallback that would have produced a working home is skipped by a value that only looks valid. `parent exists utf8 = false` above is that outcome on a real host.

**The fix.** Node exposes no API for the host ANSI or OEM code page, so rather than guess at one:

- Take `reg`'s stdout as bytes (drop `encoding: 'utf8'`).
- If every byte is `< 0x80`, the code page and UTF-8 agree by definition — decode and return, unchanged behaviour and no extra spawn. This is the path essentially every host takes.
- If any byte is `>= 0x80`, the value is in a code page we cannot name. Re-read it through PowerShell base64-encoded from UTF-8 inside the child, so the bytes on the wire are ASCII and no code page is involved:

```
[Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(
  [Environment]::GetEnvironmentVariable('HERMES_HOME','User')))
```

That is the same trick `ui-tui/src/lib/clipboard.ts` and `hermes_cli/clipboard.py` already use for clipboard text, for the same reason.

The trigger is a fact about the bytes, not a judgement about damage. I deliberately did not detect this by looking for `U+FFFD`: I measured on #89468 that the replacement output is not stable across runtimes (29 replacements on .NET Framework 4.8, 30 on .NET 8 and CPython 3.11 for identical input), so replacement characters are not a sound signal.

The name is checked against `/^[A-Za-z_][A-Za-z0-9_]*$/` before it is interpolated into the PowerShell string. Today the only caller passes a literal, but the function is exported.

**Note on the linter.** `scripts/check-windows-footguns.py` cannot see this file: `should_scan_file()` returns `True` only for `.py`, `.pyw`, `.pyi`. Every `.ts` under `apps/desktop/electron/` is outside the gate that exists to catch exactly this class of bug.

## Related Issue

No separate issue — reporting it here with the measurement. Same class as #89878 / #89907 / #90017 / #90046, on the Electron side of the same seam. The Python half of `bounded_probe_run` is #90046; this is the TypeScript half, and it is independent of that PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/windows-user-env.ts` — added `isAsciiBytes()`; `readWindowsUserEnvVar()` now captures `reg` stdout as bytes and only decodes it as UTF-8 when it is pure ASCII.
- `apps/desktop/electron/windows-user-env.ts` — added `readUserEnvVarAsBase64()`, a PowerShell re-read that base64-encodes the UTF-8 bytes inside the child, used only on the non-ASCII path. Env-var names are validated before interpolation.
- `apps/desktop/electron/windows-user-env.test.ts` — four tests added: the ASCII fast path spawns only `reg`; a CP932 value is re-read as base64 and returns the correct path, with the old five-backslash result pinned as an assertion; a failed re-read returns `null`; a name that is not a plain identifier never reaches PowerShell.

## How to Test

1. On a CP932 host:

```powershell
mkdir C:\十能予 -Force
setx HERMES_PROBE "C:\十能予\hermes"
```

Then, in a new shell:

```js
const { execFileSync } = require('node:child_process')
const raw = execFileSync('reg', ['query','HKCU\\Environment','/v','HERMES_PROBE'], { windowsHide: true })
console.log(raw.toString('hex'))
console.log(JSON.stringify(raw.toString('utf8')))
console.log(JSON.stringify(new TextDecoder('shift_jis').decode(raw)))
```

The backslash count goes from 2 to 5, and `fs.statSync` on the parent of the UTF-8 result throws. Output above is from that run.

2. The test file, run directly under `node --test` with the type annotations stripped — 14 pass (10 pre-existing, unchanged). I did not run it through the repo's vitest runner: the desktop workspace's dependencies are not installed on my host, so `npm test -w apps/desktop` is not something I can honestly claim to have run.

3. Against the pre-patch source, keeping the new tests: 2 failed / 12 passed. The other two pass either way on purpose — one pins that the ASCII path still spawns only `reg` so the common case cannot regress, the other pins the name-validation guard, which is new but not what the bug was.

Note on the checklist below: I left the full-suite box unchecked for the reason in 2.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, ja-JP (ACP=932), Node v24.17.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

I have a ja-JP (ACP=932) Windows host and can measure anything else on that locale.

*(Measured on my host. Drafted with Claude.)*
