### PR TITLE
fix(windows): resolve memory provider command shims

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -11,6 +11,7 @@ import os
 import re
 import sys
 import shlex
+import shutil
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
@@ -193,8 +194,18 @@ def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
         install_cmd = dep.get("install", "")
         if check_cmd:
             try:
+                argv = shlex.split(check_cmd, posix=os.name != "nt")
+
+                if argv and os.name == "nt":
+                    resolved = shutil.which(argv[0])
+                    if resolved:
+                        argv[0] = resolved
+
                 subprocess.run(
-                    shlex.split(check_cmd), check=True, capture_output=True, timeout=5
+                    argv,
+                    check=True,
+                    capture_output=True,
+                    timeout=5,
                 )
             except Exception:
                 if install_cmd:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6095,6 +6095,22 @@ def _run_setup_command(
     )
 
 
+def _memory_provider_command_argv(command: str) -> List[str]:
+    """Split an external dependency command and resolve Windows npm shims.
+
+    On Windows, CreateProcess cannot execute a bare npm-generated command such
+    as ``brv`` when the actual executable is ``brv.cmd``. Resolve argv[0]
+    through PATH first so commands such as ``brv --version`` work correctly.
+    """
+    argv = shlex.split(command, posix=os.name != "nt")
+
+    if argv and os.name == "nt":
+        resolved = shutil.which(argv[0])
+        if resolved:
+            argv[0] = resolved
+
+    return argv
+
 def _memory_provider_dependencies_installed(setup: Dict[str, Any]) -> bool:
     pip_dependencies = _string_list(setup.get("pip_dependencies"))
     external_dependencies = setup.get("external_dependencies") or []
@@ -6112,7 +6128,7 @@ def _memory_provider_dependencies_installed(setup: Dict[str, Any]) -> bool:
             continue
         try:
             completed = _run_setup_command(
-                shlex.split(check_cmd),
+                _memory_provider_command_argv(check_cmd),
                 display=check_cmd,
                 timeout=20,
             )
@@ -6197,7 +6213,7 @@ def _install_memory_provider_external_dependencies(
         if check_cmd:
             try:
                 check = _run_setup_command(
-                    shlex.split(check_cmd),
+                    _memory_provider_command_argv(check_cmd),
                     display=check_cmd,
                     timeout=20,
                 )
@@ -6269,7 +6285,7 @@ def _install_memory_provider_external_dependencies(
             if check_cmd and install.returncode == 0:
                 try:
                     post_check = _run_setup_command(
-                        shlex.split(check_cmd),
+                        _memory_provider_command_argv(check_cmd),
                         display=check_cmd,
                         timeout=20,
                     )

--- a/tests/hermes_cli/test_memory_provider_windows_cmd_shims.py
+++ b/tests/hermes_cli/test_memory_provider_windows_cmd_shims.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+import subprocess
+
+import hermes_cli.memory_setup as memory_setup
+import hermes_cli.web_server as web_server
+
+
+BRV_CMD = r"C:\nvm4w\nodejs\brv.CMD"
+
+
+def test_dashboard_memory_provider_check_resolves_windows_cmd_shim(monkeypatch):
+    """Dashboard dependency checks must resolve npm .cmd shims on Windows.
+
+    Native Windows CreateProcess cannot launch a bare npm shim name such as
+    ``brv`` from a subprocess argv list. ``shutil.which`` resolves the command
+    through PATHEXT to the actual ``brv.CMD`` launcher.
+    """
+    monkeypatch.setattr(web_server, "os", SimpleNamespace(name="nt"))
+    monkeypatch.setattr(
+        web_server.shutil,
+        "which",
+        lambda name: BRV_CMD if name == "brv" else None,
+    )
+
+    assert web_server._memory_provider_command_argv("brv --version") == [
+        BRV_CMD,
+        "--version",
+    ]
+
+
+def test_dashboard_memory_provider_check_preserves_unresolved_command(monkeypatch):
+    monkeypatch.setattr(web_server, "os", SimpleNamespace(name="nt"))
+    monkeypatch.setattr(web_server.shutil, "which", lambda _name: None)
+
+    assert web_server._memory_provider_command_argv("missing-tool --version") == [
+        "missing-tool",
+        "--version",
+    ]
+
+
+def test_cli_memory_setup_resolves_windows_cmd_shim(tmp_path, monkeypatch):
+    """The CLI setup path must use the resolved .cmd launcher too."""
+    plugin_dir = tmp_path / "byterover"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.yaml").write_text(
+        """\
+pip_dependencies:\n  - sys\nexternal_dependencies:\n  - name: brv\n    check: brv --version\n    install: npm install -g byterover-cli\n""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "plugins.memory.find_provider_dir",
+        lambda _name: plugin_dir,
+    )
+    monkeypatch.setattr(memory_setup, "os", SimpleNamespace(name="nt"))
+    monkeypatch.setattr(
+        memory_setup.shutil,
+        "which",
+        lambda name: BRV_CMD if name == "brv" else None,
+    )
+
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    memory_setup._install_dependencies("byterover")
+
+    assert calls
+    assert calls[-1][0] == [BRV_CMD, "--version"]
+    assert calls[-1][1]["check"] is True


### PR DESCRIPTION
## Summary

Fix native-Windows memory-provider dependency checks for CLI tools installed through npm shims such as ByteRover's `brv.cmd`.

On Windows, the dashboard and `hermes memory setup` were passing a bare command like `brv` directly to `subprocess.run([...])`. Python ultimately calls `CreateProcessW`, which does not perform PATHEXT resolution for this argv form, so a valid npm-installed CLI could fail with:

```text
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

This caused the Plugins page to report ByteRover as missing even while:

```text
where.exe brv
C:\nvm4w\nodejs\brv
C:\nvm4w\nodejs\brv.cmd

brv --version
byterover-cli/3.16.1 win32-x64 node-v22.23.2

hermes memory status
Plugin: installed
Status: available
```

## Fix

- split external dependency check commands with Windows-aware `shlex` behavior
- resolve argv[0] with `shutil.which()` on Windows before calling `subprocess.run`
- apply the same fix to:
  - CLI memory-provider setup
  - dashboard dependency-installed checks
  - dashboard pre-install checks
  - dashboard post-install verification
- preserve the existing behavior when the executable cannot be resolved

For an npm-installed ByteRover CLI this turns:

```text
brv --version
```

into an argv beginning with the actual launcher, e.g.:

```text
C:\nvm4w\nodejs\brv.CMD
```

## Regression coverage

Adds tests covering:

- `.cmd` shim resolution in the dashboard path
- unresolved-command fallback behavior
- `.cmd` shim resolution in the CLI memory setup path

The tests mock Windows behavior so they can run on non-Windows CI as well.

## Reproduction / validation

Reproduced on native Windows 11 with NVM for Windows, Node 22.23.2, and `byterover-cli` 3.16.1. Before the fix, the Plugins page returned `missing brv` / `[WinError 2]`; after resolving the shim path and restarting the dashboard, ByteRover showed `ready` and `active` and the dependency warning disappeared.

This PR is intentionally scoped to executable resolution. The ByteRover manifest's Unix-oriented install command is a separate portability concern.