### PR TITLE
feat(desktop): Space stages clarify choices from the keyboard

### DIFF
--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -367,6 +367,48 @@ describe('ClarifyTool keyboard navigation', () => {
     expect(fireEvent.keyDown(window, { key: 'ArrowDown' })).toBe(true)
     expect(request).not.toHaveBeenCalled()
   })
+
+  it('stages the highlighted choice with Space without submitting', async () => {
+    const request = renderLiveClarify()
+    const production = screen.getByRole('button', { name: /production/ })
+
+    fireEvent.keyDown(window, { key: 'ArrowDown' })
+    fireEvent.keyDown(window, { key: ' ' })
+
+    expect(production.getAttribute('aria-pressed')).toBe('true')
+    expect(request).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: 'production',
+        request_id: 'request-1'
+      })
+    })
+  })
+
+  it('Space toggles the highlighted multi-select choice', () => {
+    const request = renderLiveClarify({ multiSelect: true })
+    const staging = screen.getByRole('button', { name: /staging/ })
+
+    fireEvent.keyDown(window, { key: ' ' })
+    expect(staging.getAttribute('aria-pressed')).toBe('true')
+
+    fireEvent.keyDown(window, { key: ' ' })
+    expect(staging.getAttribute('aria-pressed')).toBe('false')
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('Space on the Other row focuses the free-text field', () => {
+    renderLiveClarify()
+
+    const other = screen.getByPlaceholderText(/Other/)
+
+    fireEvent.keyDown(window, { key: 'ArrowUp' })
+    fireEvent.keyDown(window, { key: ' ' })
+    expect(document.activeElement).toBe(other)
+  })
 })
 
 describe('ClarifyTool recommended option', () => {

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -582,11 +582,12 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
     [submitAnswer]
   )
 
-  // Arrow keys move a visual cursor, 1-9 and A/B/C… pick directly, and Enter
-  // confirms the current answer (or acts on the highlighted row). Stands down
-  // whenever a focusable control (a field, a choice button, the action bar) is
-  // focused, so it never eats keystrokes meant for the composer, the Other box,
-  // or a button the user tabbed to.
+  // Arrow keys move a visual cursor, 1-9 and A/B/C… pick directly, Space
+  // stages/toggles the highlighted row without submitting, and Enter confirms
+  // the current answer (or acts on the highlighted row). Stands down whenever
+  // a focusable control (a field, a choice button, the action bar) is focused,
+  // so it never eats keystrokes meant for the composer, the Other box, or a
+  // button the user tabbed to.
   useEffect(() => {
     if (!ready || !hasChoices || submitting) {
       return
@@ -609,6 +610,23 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
       if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
         event.preventDefault()
         moveActive(event.key === 'ArrowDown' ? 1 : -1)
+
+        return
+      }
+
+      // Space stages (or, multi-select, toggles) the highlighted row without
+      // submitting — Enter stays the confirm key. On the "Other" row it just
+      // focuses the free-text field.
+      if (event.key === ' ') {
+        event.preventDefault()
+
+        const choice = choices[activeIndex]
+
+        if (choice) {
+          selectChoice(choice, activeIndex)
+        } else {
+          textareaRef.current?.focus()
+        }
 
         return
       }
@@ -658,7 +676,7 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
     window.addEventListener('keydown', onKeyDown)
 
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [activateActive, choices, hasChoices, moveActive, ready, selectChoice, submitting])
+  }, [activateActive, activeIndex, choices, hasChoices, moveActive, ready, selectChoice, submitting])
 
   if (loading) {
     return (

--- a/apps/desktop/src/lib/keybinds/composer-focus-keys.test.ts
+++ b/apps/desktop/src/lib/keybinds/composer-focus-keys.test.ts
@@ -186,7 +186,9 @@ describe('composerFocusKeysAllowed', () => {
     expect(allowed('z', 'type')).toBe(true)
     expect(allowed('4', 'type')).toBe(true)
     expect(allowed('?', 'type')).toBe(true)
-    expect(allowed(' ', 'type')).toBe(true)
+
+    // Space stages the highlighted row; a real message never starts with one.
+    expect(allowed(' ', 'type')).toBe(false)
   })
 
   it('leaves every key alone for a clarify card in a background tab', () => {

--- a/apps/desktop/src/lib/keybinds/composer-focus-keys.ts
+++ b/apps/desktop/src/lib/keybinds/composer-focus-keys.ts
@@ -80,6 +80,12 @@ export function clarifyCardOwnsKey(event: KeyboardEvent): boolean {
     return true
   }
 
+  // Space stages/toggles the highlighted row on the card — a leading space is
+  // never how a real composer message starts, so yielding it costs nothing.
+  if (event.key === ' ') {
+    return true
+  }
+
   // "Other" is the row past the last choice, hence the +1.
   const rows = Number(card.getAttribute('data-clarify-choices')) + 1
 


### PR DESCRIPTION
## Summary

The desktop clarify card can now be driven fully from the keyboard: **Space stages/toggles the highlighted choice without submitting**, matching the standard option-list convention. Enter stays the confirm key.

Inspired by Factory Droid v0.199 ("Question prompt keyboard controls" — answers pickable with Space or number keys). Hermes already had arrow/letter/number navigation on the clarify card; Space was the gap — it did nothing on the card and fell through to the global type-to-focus listener, which yanked focus into the composer with a leading space, silently killing the staged selection.

## Changes

- `clarify-tool.tsx`: Space stages the highlighted choice (single-select) or toggles it (multi-select) without submitting; on the "Other" row it focuses the free-text field.
- `composer-focus-keys.ts`: a live clarify card now owns the Space key (`clarifyCardOwnsKey`) so type-to-focus yields it — a real composer message never starts with a leading space, so this costs nothing.
- Tests: 3 new clarify-tool cases (stage-then-confirm, multi-select toggle, Other-row focus) + updated the composer-focus-keys ownership pin.

## Validation

| | Before | After |
|---|---|---|
| Space on highlighted choice | focus jumps to composer, " " typed | choice staged, card keeps focus |
| Space on multi-select choice | same composer steal | toggles the choice in the staged set |
| `vitest run` clarify-tool + composer-focus-keys | 41 tests | 44/44 pass |

Source: [Droid v0.199 release notes](https://docs.factory.ai/changelog/release-notes) (Aug 18, 2026).

Their mechanism: Space/number pick answers, Tab moves between questions. Our adaptation: Space maps onto Hermes' existing stage-then-confirm model (Droid picks immediately; we deliberately keep Enter as the explicit confirm, consistent with the card's Continue button). Tab-between-questions was not ported — the batch card stages all questions in one form and native Tab traversal already walks its fields.

## Infographic

![Space stages your choice — keyboard controls for clarify cards](https://files.catbox.moe/70rzd3.png)
