### PR TITLE
feat(sdk): add host.preview(url) for plugin-driven preview pane opens

### DIFF
--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -26,6 +26,7 @@ import { getLogs, getStatus } from '@/hermes'
 import { $gateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile } from '@/store/profile'
+import { openPreview } from '@/store/preview'
 import { $activeSessionId, $currentCwd, $currentModel, $gatewayState } from '@/store/session'
 import { runGatewayRestart } from '@/store/system-actions'
 
@@ -94,6 +95,17 @@ export const host = {
 
   /** Restart the backend gateway (progress surfaces in the core statusbar). */
   restartGateway: async () => runGatewayRestart(),
+
+  /** Open a URL in the desktop preview pane (the right-rail tab the chat
+   *  preview uses — same UX as a tool-result / file-browser preview). Use
+   *  this when a plugin wants to surface a server UI, dev tool, or web
+   *  page to the user without leaving the app. Mirrors `openPreview(target,
+   *  'manual')` from `@/store/preview`; the URL becomes a fresh tab and
+   *  the right rail focuses it. */
+  preview: (url: string) => {
+    if (typeof url !== 'string' || !url.trim()) return
+    openPreview({ kind: 'url', label: url, source: 'plugin', url }, 'manual')
+  },
 
   /** One-shot system status snapshot (platforms, versions, …). */
   status: async () => getStatus(),


### PR DESCRIPTION
## What does this PR do?

Add a one-line `host.preview(url)` entry to the desktop plugin SDK so a plugin can surface a URL in the right-rail preview pane — the same UX chat uses for tool-result / file-browser / artifact previews.

## Why?

The runtime loader (`contrib/runtime-loader.ts`) restricts disk-loaded plugins to `@hermes/plugin-sdk` and `react`; plugins can't import `@/store/preview` directly. Until now there was no first-class SDK door into the preview store, so plugins had no way to hand the user a server UI, dev tool, or web page without leaving the app (e.g. `window.open` to a system browser, or `target=_blank`).

Concrete motivator: the DSH settings plugin (`<hermes home>/desktop-plugins/dsh-settings/`) wants a "Open DSH Web UI" button that pops the DSH chat workspace into the right-rail preview pane — same host, same UX as a tool-result preview.

## How

`apps/desktop/src/sdk/index.ts` — add `host.preview(url)`:

```ts
import { openPreview } from '@/store/preview'
…
preview: (url: string) => {
  if (typeof url !== 'string' || !url.trim()) return
  openPreview({ kind: 'url', label: url, source: 'plugin', url }, 'manual')
}
```

`source: 'plugin'` is a free-form discriminator (the type is `string`) — it's recorded so future telemetry / "close all plugin tabs" affordances can find plugin-opened tabs without conflating them with chat / file-browser / artifact previews. `PreviewRecordSource` (`'manual'` here) is the second arg to `openPreview` and only affects HTML file rendering — for URL targets the rendering path is identical to any other `kind: 'url'` target.

The `sdkImportMap` in `src/sdk/runtime.ts` re-exports every named export of `./index` as a shim blob, so the new method is automatically available to runtime-loaded disk plugins with zero loader changes.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## How to Test

1. Open the desktop app, install a disk plugin that calls `host.preview('https://example.com')` (e.g. a debug plugin).
3. Click the button.
4. Right rail focuses the new preview tab showing example.com — same UX as the chat preview on a tool-result.
5. With a file target (e.g. `/tmp/index.html`) loaded via chat preview, verify the new `host.preview` tab is independent (different `source` discriminator, separate tab id).

For the DSH settings plugin (the original motivator): once a desktop release with this PR ships, `dsh-settings`'s "Open DSH Web UI" button can be re-pointed from `<a target="_blank">` to `host.preview('http://127.0.0.1:8080/')`.

## Checklist

### Code
- [x] Conventional commit message (`feat(sdk): ...`)
- [x] Single-file change, no unrelated commits
- [x] Diff is +12 lines (1 import + 11 lines incl. doc-comment)
