### PR TITLE
fix: 'max' effort no longer 400s on pre-5.6 Codex Responses models (#68365 verified live)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1552,14 +1552,15 @@ class _CodexCompletionsAdapter:
                     # with a 400.
                     effort = reasoning_cfg.get("effort") or "medium"
                     # Same declared vocabulary + shared clamp as the main
-                    # Codex transport (agent.reasoning_effort): the backend
-                    # rejects "minimal" and the internal "ultra" level.
+                    # Codex transport (agent.reasoning_effort): per-model —
+                    # "max" is gpt-5.6-only, "minimal"/"ultra" always
+                    # rejected (live-verified, #68365).
                     from agent.reasoning_effort import (
-                        CODEX_RESPONSES_EFFORTS,
                         clamp_effort,
+                        codex_supported_efforts,
                     )
 
-                    effort = clamp_effort(effort, CODEX_RESPONSES_EFFORTS)
+                    effort = clamp_effort(effort, codex_supported_efforts(model))
                     resp_kwargs["reasoning"] = {
                         "effort": effort,
                         "summary": "auto",

--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -55,10 +55,27 @@ OPENAI_COMPAT_WIRE_EFFORTS: tuple[str, ...] = (
     "none", "minimal", "low", "medium", "high", "xhigh", "max",
 )
 
-#: OpenAI/Codex Responses backend (``minimal`` is rejected → clamps to low).
-CODEX_RESPONSES_EFFORTS: tuple[str, ...] = (
-    "low", "medium", "high", "xhigh", "max",
+#: OpenAI/Codex Responses backend — per-model vocabulary, live-verified
+#: (Aug 2026): ``minimal`` is rejected by both generations (clamps to low);
+#: ``max`` is gpt-5.6-only — gpt-5.5 rejects it with "Supported values are:
+#: 'none', 'low', 'medium', 'high', 'xhigh'" (#68365's premise, confirmed).
+CODEX_GPT56_EFFORTS: tuple[str, ...] = (
+    "none", "low", "medium", "high", "xhigh", "max",
 )
+CODEX_LEGACY_EFFORTS: tuple[str, ...] = (
+    "none", "low", "medium", "high", "xhigh",
+)
+
+
+def codex_supported_efforts(model: Optional[str]) -> tuple[str, ...]:
+    """Supported effort set for an OpenAI/Codex Responses model."""
+    if "gpt-5.6" in (model or "").lower():
+        return CODEX_GPT56_EFFORTS
+    return CODEX_LEGACY_EFFORTS
+
+
+#: Backward-compat alias (pre-#68365-verification name).
+CODEX_RESPONSES_EFFORTS: tuple[str, ...] = CODEX_GPT56_EFFORTS
 
 #: xAI Responses — Grok 4.6+ accepts xhigh; older Grok tops out at high.
 XAI_GROK46_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh")

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -29,10 +29,10 @@ def _cache_scope_from_session_id(session_id: Optional[str]) -> str:
 
 from agent.reasoning_effort import (
     ACTUAL_RELAY_EFFORTS,
-    CODEX_RESPONSES_EFFORTS,
     XAI_GROK46_EFFORTS,
     XAI_LEGACY_EFFORTS,
     clamp_effort,
+    codex_supported_efforts,
 )
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
@@ -459,9 +459,10 @@ class ResponsesApiTransport(ProviderTransport):
             # none/low/medium/high/max.
             _supported = ACTUAL_RELAY_EFFORTS
         else:
-            # OpenAI/Codex Responses backend rejects "minimal" and the
-            # internal "ultra" level.
-            _supported = CODEX_RESPONSES_EFFORTS
+            # OpenAI/Codex Responses backend — per-model vocabulary
+            # (live-verified: "max" is gpt-5.6-only, "minimal" always
+            # rejected). #68365 premise confirmed.
+            _supported = codex_supported_efforts(model)
         reasoning_effort = clamp_effort(reasoning_effort, _supported)
 
         response_tools = _responses_tools(tools)

--- a/tests/agent/test_reasoning_effort_module.py
+++ b/tests/agent/test_reasoning_effort_module.py
@@ -138,6 +138,26 @@ class TestCodexVocabulary:
         assert clamp_effort("minimal", CODEX_RESPONSES_EFFORTS) == "low"
         assert clamp_effort("ultra", CODEX_RESPONSES_EFFORTS) == "max"
 
+    def test_per_model_max_support(self):
+        """Live-verified (Aug 2026, #68365): 'max' is gpt-5.6-only — gpt-5.5
+        rejects it ("Supported values are: 'none','low','medium','high',
+        'xhigh'"); 'minimal' is rejected by both generations."""
+        from agent.reasoning_effort import (
+            CODEX_GPT56_EFFORTS,
+            CODEX_LEGACY_EFFORTS,
+            codex_supported_efforts,
+        )
+
+        assert codex_supported_efforts("gpt-5.6") is CODEX_GPT56_EFFORTS
+        assert codex_supported_efforts("gpt-5.6-codex") is CODEX_GPT56_EFFORTS
+        assert codex_supported_efforts("gpt-5.5") is CODEX_LEGACY_EFFORTS
+        assert codex_supported_efforts("o5-pro") is CODEX_LEGACY_EFFORTS
+        # The consequential clamps:
+        assert clamp_effort("max", CODEX_GPT56_EFFORTS) == "max"
+        assert clamp_effort("max", CODEX_LEGACY_EFFORTS) == "xhigh"
+        assert clamp_effort("ultra", CODEX_LEGACY_EFFORTS) == "xhigh"
+        assert clamp_effort("minimal", CODEX_LEGACY_EFFORTS) == "low"
+
 
 class TestRequestedEffort:
     def test_extracts_effort(self):

--- a/tests/agent/transports/test_reasoning_effort_sibling_sites.py
+++ b/tests/agent/transports/test_reasoning_effort_sibling_sites.py
@@ -109,13 +109,22 @@ class TestTokenHubEffortVocabulary:
 
 
 class TestCodexUltraForEveryModel:
-    def test_ultra_maps_to_max_for_non_gpt56_models(self):
+    def test_ultra_never_leaks_and_respects_per_model_ceiling(self):
+        """'ultra' must never reach the Codex wire. Live-verified vocabulary
+        (#68365): gpt-5.6 accepts max (its ceiling), gpt-5.5/o5 do not —
+        their ceiling is xhigh."""
         transport = get_transport("codex_responses")
-        for model in ("gpt-5.6-codex", "o5-pro", "some-responses-model"):
+        expected = {
+            "gpt-5.6-codex": "max",
+            "o5-pro": "xhigh",
+            "gpt-5.5": "xhigh",
+            "some-responses-model": "xhigh",
+        }
+        for model, wire in expected.items():
             kw = transport.build_kwargs(
                 model=model,
                 messages=[{"role": "user", "content": "hi"}],
                 tools=[],
                 reasoning_config={"enabled": True, "effort": "ultra"},
             )
-            assert kw["reasoning"]["effort"] == "max", model
+            assert kw["reasoning"]["effort"] == wire, model


### PR DESCRIPTION
## Summary
`reasoning_effort: max` no longer 400s on pre-5.6 OpenAI Responses models — the Codex wire vocabulary is now per-model, verified by live probes (#68365's premise confirmed).

Live results against `api.openai.com/v1/responses` (Aug 2026):
| Model | Accepts | Rejects |
|---|---|---|
| gpt-5.6 | none, low, medium, high, xhigh, **max** | minimal, ultra |
| gpt-5.5 | none, low, medium, high, xhigh | **max** ("Unsupported value"), minimal, ultra |

So @joelbrilliant's #68365 was half right: `max` does 400 — but only on pre-5.6 models. Its blanket `max → xhigh` clamp would have capped gpt-5.6, the one model that supports `max`. The declared-vocabulary architecture (#90350) absorbs the truth as data instead.

## Changes
- `agent/reasoning_effort.py`: `CODEX_GPT56_EFFORTS` / `CODEX_LEGACY_EFFORTS` + `codex_supported_efforts(model)` (old `CODEX_RESPONSES_EFFORTS` kept as alias)
- `agent/transports/codex.py` + `agent/auxiliary_client.py`: both Responses paths pick the per-model set; the shared clamp does the rest

Wire outcomes: `ultra → max` on gpt-5.6; `ultra`/`max → xhigh` on gpt-5.5/o5; `minimal → low` everywhere.

## Validation
509 targeted tests green (reasoning-effort module, both transports, aux client). New test pins the per-model sets and the consequential clamps, quoting the live error strings.

Resolves #68365 (premise verified live; credit to @joelbrilliant for the report and observation).

## Infographic

![per-model effort ceilings](https://files.catbox.moe/xr2e64.png)
