### PR TITLE
fix(desktop): restore the status-bar right-click customize menu

### DIFF
--- a/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
@@ -354,6 +354,19 @@ describe('AppContextMenu', () => {
     expect($contextMenu.get()).toBeNull()
   })
 
+  // The statusbar <footer> carries data-slot="statusbar" (the pet's perch),
+  // not the radix context-menu-trigger marker, but it owns a context menu too.
+  // Regression: right-clicking the bar must NOT fall through to the app menu.
+  it('leaves the statusbar surface alone (data-slot="statusbar")', () => {
+    installBridge()
+    mountMenu()
+    const host = attach('<div data-slot="statusbar"><span>gateway pill</span></div>')
+
+    fireEvent.contextMenu(host.querySelector('span')!)
+
+    expect($contextMenu.get()).toBeNull()
+  })
+
   it('shows the terminal menu through a registered handle', async () => {
     installBridge()
     mountMenu()

--- a/apps/desktop/src/app/context-menu/app-context-menu.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.tsx
@@ -609,7 +609,12 @@ export function AppContextMenu() {
       const element = event.target instanceof Element ? event.target : null
 
       // Surfaces with their own Radix context menu keep the whole gesture.
-      if (element?.closest('[data-slot="context-menu-trigger"]')) {
+      // `data-slot="statusbar"` (the statusbar <footer>) is ALSO an owned
+      // surface: its footer carries that data-slot for the pet's perch (not
+      // `context-menu-trigger`, which a plain data-slot on the same node
+      // would collide with), so exempt it here or right-clicking the bar
+      // falls through to this app menu instead of the statusbar customize menu.
+      if (element?.closest('[data-slot="context-menu-trigger"], [data-slot="statusbar"]')) {
         return
       }
 


### PR DESCRIPTION
## Problem

After the recent Desktop updates, **right-clicking the status bar opens the app context menu** (New Chat ...), not the status-bar customize menu ("显示" / show-in-statusbar menu). Since that menu is the only way to re-show status-bar items that ship hidden by default (`context-usage`, `running-timer`, `session-timer`, `cron`, `agents`, `webhooks`, `terminal`, `approval-mode` all start in `STATUSBAR_HIDDEN_BY_DEFAULT`), the bug made it impossible to restore fields like context usage via the UI.

## Root cause

The status-bar `<footer data-slot="statusbar">` is wrapped in the Radix `ContextMenuTrigger`, which injects `data-slot="context-menu-trigger"` through its Slot. The two data-slots collide on the same node — the footer keeps `data-slot="statusbar"` (needed by the pet's perch in `components/pet/roam-geometry.ts` via `'[data-slot="statusbar"]'`), so it never resolves as `[data-slot="context-menu-trigger"]`. The app-level capture-phase context-menu resolver (`app-context-menu.tsx`) only exempts `[data-slot="context-menu-trigger"]`, so the status-bar right-click falls through to the app menu.

## Fix

Treat `data-slot="statusbar"` as another owned surface in the resolver's `closest()` exemption — a one-line selector addition. This lets the status bar's own Radix context menu open while leaving the app context menu and every other surface untouched.

## Test

Adds a regression test mirroring the existing `leaves surfaces with their own radix menu alone` case, asserting a `data-slot="statusbar"` surface is exempt. The full `app-context-menu` suite passes (34 tests).
