### PR TITLE
fix(file): coalesce read_file backend probes

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -303,17 +303,24 @@ class TestShellFileOpsHelpers:
 
         def side_effect(command, **kwargs):
             commands.append(command)
-            # The size probe gates `wc -c` behind `[ -f ]` so a FIFO or device
-            # cannot block the read; it still reports a plain byte count.
-            if command.startswith("if [ -f ") or command.startswith("wc -c"):
-                return {"output": "5\n", "returncode": 0}
+            # The probe gates every file-opening operation behind `[ -f ]`,
+            # then returns size and a base64 byte sample together.
+            if command.startswith("if [ -f "):
+                import base64 as b64
+                return {
+                    "output": "__hermes_read_probe__5\n" + b64.b64encode(b"hello").decode(),
+                    "returncode": 0,
+                }
             if command.startswith("head -c") and "| base64" in command:
                 import base64 as b64
                 return {"output": b64.b64encode(b"hello").decode(), "returncode": 0}
             if command.startswith("head -c"):
                 return {"output": "hello", "returncode": 0}
             if command.startswith("sed -n"):
-                return {"output": "hello\n", "returncode": 0}
+                return {
+                    "output": "hello\n__hermes_read_page__1:1\n",
+                    "returncode": 0,
+                }
             if command.startswith("wc -l"):
                 return {"output": "1\n", "returncode": 0}
             return {"output": "", "returncode": 0}
@@ -323,16 +330,15 @@ class TestShellFileOpsHelpers:
         result = ops.read_file(r"C:\Users\alice\notes.txt")
 
         assert result.error is None
-        assert commands[0] == (
-            "if [ -f '/c/Users/alice/notes.txt' ]; "
-            "then wc -c < '/c/Users/alice/notes.txt' 2>/dev/null; "
-            "elif [ -e '/c/Users/alice/notes.txt' ]; "
-            "then echo __hermes_not_regular__; "
-            "else exit 1; fi"
+        assert commands[0].startswith("if [ -f '/c/Users/alice/notes.txt' ]; then ")
+        assert "wc -c < '/c/Users/alice/notes.txt'" in commands[0]
+        assert "elif [ -e '/c/Users/alice/notes.txt' ]" in commands[0]
+        assert "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null | base64" in commands[0]
+        assert commands[1].startswith(
+            "sed -n '1,2000p' '/c/Users/alice/notes.txt' | cut -b1-8001"
         )
-        assert commands[1] == "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null | base64"
-        assert commands[2] == "sed -n '1,2000p' '/c/Users/alice/notes.txt' | cut -b1-8001"
-        assert commands[3] == "wc -l < '/c/Users/alice/notes.txt'"
+        assert "wc -l < '/c/Users/alice/notes.txt'" in commands[1]
+        assert len(commands) == 2
 
     def test_is_likely_binary_by_extension(self, file_ops):
         assert file_ops._is_likely_binary("photo.png") is True
@@ -355,12 +361,19 @@ class TestShellFileOpsHelpers:
         )
 
         def side_effect(command, **kwargs):
-            if command.startswith("if [ -f ") or command.startswith("wc -c"):
-                return {"output": "12\n", "returncode": 0}
+            if command.startswith("if [ -f "):
+                import base64 as b64
+                return {
+                    "output": "__hermes_read_probe__12\n" + b64.b64encode(b"print('ok')\n").decode(),
+                    "returncode": 0,
+                }
             if command.startswith("head -c"):
                 return {"output": "print('ok')\n", "returncode": 0}
             if command.startswith("sed -n"):
-                return {"output": leaked, "returncode": 0}
+                return {
+                    "output": leaked + "__hermes_read_page__1:1\n",
+                    "returncode": 0,
+                }
             if command.startswith("wc -l"):
                 return {"output": "1\n", "returncode": 0}
             return {"output": "", "returncode": 0}
@@ -776,12 +789,24 @@ class TestByteLayerBinaryDetection:
         import base64 as b64
 
         def side_effect(command, **kwargs):
-            if command.startswith("if [ -f ") or command.startswith("wc -c"):
-                return {"output": f"{len(cjk_bytes)}\n", "returncode": 0}
+            if command.startswith("if [ -f "):
+                return {
+                    "output": (
+                        f"__hermes_read_probe__{len(cjk_bytes)}\n"
+                        + b64.b64encode(cjk_bytes[:1000]).decode()
+                    ),
+                    "returncode": 0,
+                }
             if command.startswith("head -c") and "| base64" in command:
                 return {"output": b64.b64encode(cjk_bytes[:1000]).decode(), "returncode": 0}
             if command.startswith("sed -n"):
-                return {"output": cjk_bytes.decode("utf-8", errors="replace"), "returncode": 0}
+                return {
+                    "output": (
+                        cjk_bytes.decode("utf-8", errors="replace")
+                        + "\n__hermes_read_page__1:0\n"
+                    ),
+                    "returncode": 0,
+                }
             if command.startswith("wc -l"):
                 return {"output": "1\n", "returncode": 0}
             return {"output": "", "returncode": 0}

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -205,12 +205,18 @@ class TestPaginationBounds:
 
         def fake_exec(command, *args, **kwargs):
             commands.append(command)
-            if command.startswith("if [ -f ") or command.startswith("wc -c"):
-                return MagicMock(exit_code=0, stdout="12")
+            if command.startswith("if [ -f "):
+                return MagicMock(
+                    exit_code=0,
+                    stdout="__hermes_read_probe__12\nbGluZTEKbGluZTIK",
+                )
             if command.startswith("head -c"):
                 return MagicMock(exit_code=0, stdout="line1\nline2\n")
             if command.startswith("sed -n"):
-                return MagicMock(exit_code=0, stdout="line1\n")
+                return MagicMock(
+                    exit_code=0,
+                    stdout="line1\n__hermes_read_page__2:x\n",
+                )
             if command.startswith("wc -l"):
                 return MagicMock(exit_code=0, stdout="2")
             return MagicMock(exit_code=0, stdout="")
@@ -221,7 +227,11 @@ class TestPaginationBounds:
         assert result.error is None
         assert "1|line1" in result.content
         sed_commands = [cmd for cmd in commands if cmd.startswith("sed -n")]
-        assert sed_commands == ["sed -n '1,1p' 'notes.txt' | cut -b1-8001"]
+        assert len(sed_commands) == 1
+        assert sed_commands[0].startswith(
+            "sed -n '1,1p' 'notes.txt' | cut -b1-8001"
+        )
+        assert "wc -l < 'notes.txt'" in sed_commands[0]
 
     def test_search_clamps_offset_and_limit_before_building_head_pipeline(self):
         env = MagicMock()

--- a/tests/tools/test_read_shell_line_clamp.py
+++ b/tests/tools/test_read_shell_line_clamp.py
@@ -72,6 +72,28 @@ def test_normal_multiline_read_unchanged(tmp_path, ops):
     assert result.content.startswith("1|alpha\n2|beta\n3|gamma")
 
 
+def test_text_read_uses_two_backend_executions(tmp_path):
+    """The regular-file probe and page metadata each use one shell call."""
+    p = tmp_path / "plain.txt"
+    p.write_text("alpha\nbeta\n", encoding="utf-8")
+    env = LocalEnvironment()
+    calls = []
+    execute = env.execute
+
+    def recording_execute(command, **kwargs):
+        calls.append(command)
+        return execute(command, **kwargs)
+
+    env.execute = recording_execute
+    result = ShellFileOperations(env).read_file(str(p))
+
+    assert result.error is None
+    assert result.content.startswith("1|alpha\n2|beta")
+    assert len(calls) == 2
+    assert calls[0].startswith("if [ -f ")
+    assert calls[1].startswith("sed -n ")
+
+
 def test_no_trailing_newline_preserved(tmp_path, ops):
     """cut newline-terminates its output; read_file must strip the artifact."""
     p = tmp_path / "nonl.txt"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -800,6 +800,8 @@ DEFAULT_SEARCH_LIMIT = 50
 # Echoed by the size probe when the path exists but is not a regular file.
 # `wc -c` prints only digits, so this can never collide with a real size.
 NOT_REGULAR_SENTINEL = "__hermes_not_regular__"
+_READ_PROBE_MARKER = "__hermes_read_probe__"
+_READ_PAGE_MARKER = "__hermes_read_page__"
 
 
 def _coerce_int(value: Any, default: int) -> int:
@@ -1341,6 +1343,78 @@ class ShellFileOperations(FileOperations):
             f"else exit 1; fi"
         )
 
+    def _read_probe_cmd(self, path: str, sample_length: int = 1000) -> str:
+        """Build the regular-file gate, size probe, and byte sample command.
+
+        Keeping these operations in one backend execution avoids two extra
+        process starts (or remote round trips) while preserving the important
+        ordering: ``[ -f ]`` gates every operation that opens the path.
+        """
+        arg = self._escape_shell_arg(path)
+        return (
+            f"if [ -f {arg} ]; then "
+            f"size=$(wc -c < {arg} 2>/dev/null) || exit 1; "
+            f"printf '{_READ_PROBE_MARKER}%s\\n' \"$size\"; "
+            f"head -c {sample_length} {arg} 2>/dev/null | base64; "
+            f"elif [ -e {arg} ]; then echo {NOT_REGULAR_SENTINEL}; "
+            f"else exit 1; fi"
+        )
+
+    @staticmethod
+    def _parse_read_probe(output: str) -> tuple[Optional[int], Optional[bytes]]:
+        """Parse ``_read_probe_cmd`` output without trusting terminal wrappers."""
+        cleaned = _strip_terminal_fence_leaks(output or "")
+        match = re.search(
+            rf"(?:^|\n){re.escape(_READ_PROBE_MARKER)}(\d+)\r?\n",
+            cleaned,
+        )
+        if match is None:
+            return None, None
+        encoded = "".join(cleaned[match.end():].split())
+        if not encoded:
+            return int(match.group(1)), b""
+        if not re.fullmatch(r"[A-Za-z0-9+/]+={0,2}", encoded):
+            return int(match.group(1)), None
+        try:
+            return int(match.group(1)), base64.b64decode(encoded, validate=True)
+        except (binascii.Error, ValueError):
+            return int(match.group(1)), None
+
+    def _read_page_cmd(
+        self,
+        path: str,
+        offset: int,
+        end_line: int,
+        line_clamp_bytes: int,
+    ) -> str:
+        """Build one command for page content and its line metadata."""
+        arg = self._escape_shell_arg(path)
+        return (
+            f"sed -n '{offset},{end_line}p' {arg} | cut -b1-{line_clamp_bytes}; "
+            f"total=$(wc -l < {arg}) || exit 1; tail_nl=x; "
+            f"if [ \"$total\" -le {end_line} ]; then "
+            f"tail_nl=$(tail -c 1 {arg} | wc -l) || exit 1; fi; "
+            f"printf '{_READ_PAGE_MARKER}%s:%s\\n' \"$total\" \"$tail_nl\""
+        )
+
+    @staticmethod
+    def _parse_read_page(output: str) -> tuple[Optional[str], int, Optional[bool]]:
+        """Return page text, total lines, and final-newline state."""
+        cleaned = _strip_terminal_fence_leaks(output or "")
+        matches = list(re.finditer(
+            rf"(?:^|\n){re.escape(_READ_PAGE_MARKER)}(\d+):([01x])\r?\n?",
+            cleaned,
+        ))
+        if not matches:
+            return None, 0, None
+        match = matches[-1]
+        content_end = match.start()
+        if cleaned[content_end:content_end + 1] == "\n":
+            content_end += 1
+        tail_state = match.group(2)
+        has_final_newline = None if tail_state == "x" else tail_state == "1"
+        return cleaned[:content_end], int(match.group(1)), has_final_newline
+
     @staticmethod
     def _not_regular_error(path: str) -> ReadResult:
         """Error for a path that exists but would block if read."""
@@ -1474,10 +1548,16 @@ class ShellFileOperations(FileOperations):
         
         offset, limit = normalize_read_pagination(offset, limit)
         
-        # Check if file exists and get size (POSIX, works on Linux + macOS)
-        stat_result = self._exec(self._size_probe_cmd(path))
+        # Gate regular files, get the byte size, and sample raw bytes in one
+        # backend execution. This ordering must remain intact: image/binary
+        # decisions happen only after the non-blocking ``[ -f ]`` gate.
+        probe_result = self._exec(self._read_probe_cmd(path))
 
-        if stat_result.exit_code != 0:
+        probe_output = _strip_terminal_fence_leaks(probe_result.stdout or "")
+        file_size, sample_bytes = self._parse_read_probe(probe_result.stdout)
+        if file_size is None and probe_output.strip() == NOT_REGULAR_SENTINEL:
+            return self._not_regular_error(path)
+        if file_size is None:
             # File not found. Before failing, try unicode-equivalent
             # spellings — NFC/NFD, narrow no-break space, curly quotes
             # render identically in a terminal, so the model retyping a
@@ -1497,14 +1577,6 @@ class ShellFileOperations(FileOperations):
             # No equivalent spelling — suggest similar files
             return self._suggest_similar_files(path)
 
-        stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
-        if stat_output.strip() == NOT_REGULAR_SENTINEL:
-            return self._not_regular_error(path)
-        try:
-            file_size = int(stat_output.strip())
-        except ValueError:
-            file_size = 0
-        
         # Check if file is too large
         if file_size > MAX_FILE_SIZE:
             # Still try to read, but warn
@@ -1524,7 +1596,6 @@ class ShellFileOperations(FileOperations):
         
         # Read a sample to check for binary content — at the byte layer when
         # the transport allows, falling back to the legacy text heuristic.
-        sample_bytes = self._sample_file_bytes(path)
         if sample_bytes is not None:
             ext_binary = os.path.splitext(path)[1].lower() in BINARY_EXTENSIONS
             is_binary = ext_binary or self._is_likely_binary_bytes(sample_bytes)
@@ -1578,29 +1649,23 @@ class ShellFileOperations(FileOperations):
         from tools.tool_output_limits import get_max_line_length
         line_clamp_bytes = 4 * get_max_line_length() + 1
         end_line = offset + limit - 1
-        read_cmd = (
-            f"sed -n '{offset},{end_line}p' {self._escape_shell_arg(path)}"
-            f" | cut -b1-{line_clamp_bytes}"
+        read_cmd = self._read_page_cmd(
+            path, offset, end_line, line_clamp_bytes,
         )
         read_result = self._exec(read_cmd)
         
         if read_result.exit_code != 0:
             return ReadResult(error=f"Failed to read file: {read_result.stdout}")
-        read_output = _strip_terminal_fence_leaks(read_result.stdout)
+        read_output, total_lines, has_final_newline = self._parse_read_page(
+            read_result.stdout
+        )
+        if read_output is None:
+            return ReadResult(error=f"Failed to parse file metadata: {path}")
         # Strip a leading UTF-8 BOM so the model never sees a phantom U+FEFF
         # before the first real character. Only meaningful on the first
         # chunk (the marker lives at byte 0); later pages can't carry it.
         if offset == 1:
             read_output, _ = _strip_bom(read_output)
-        
-        # Get total line count
-        wc_cmd = f"wc -l < {self._escape_shell_arg(path)}"
-        wc_result = self._exec(wc_cmd)
-        wc_output = _strip_terminal_fence_leaks(wc_result.stdout)
-        try:
-            total_lines = int(wc_output.strip())
-        except ValueError:
-            total_lines = 0
         
         # Check if truncated
         truncated = total_lines > end_line
@@ -1612,12 +1677,8 @@ class ShellFileOperations(FileOperations):
         # so a file whose final line has no trailing newline would grow a
         # phantom empty last line. Only possible when this page reaches the
         # file's final line; probe the last byte and strip the artifact.
-        if not truncated and read_output.endswith('\n'):
-            tail_cmd = f"tail -c 1 {self._escape_shell_arg(path)} | wc -l"
-            tail_result = self._exec(tail_cmd)
-            tail_output = _strip_terminal_fence_leaks(tail_result.stdout)
-            if tail_result.exit_code == 0 and tail_output.strip() == "0":
-                read_output = read_output[:-1]
+        if not truncated and has_final_newline is False and read_output.endswith('\n'):
+            read_output = read_output[:-1]
 
         # Ambiguous-silence guards: an empty content string is
         # indistinguishable, from inside the model, from a broken tool —


### PR DESCRIPTION
## What does this PR do?

Coalesces `ShellFileOperations.read_file` backend work into two ordered executions for normal text files: one regular-file/size/sample probe and one page/line-count/final-newline probe. This removes 2–3 Git Bash process starts on Windows and equivalent remote-backend round trips without moving image or binary decisions ahead of the regular-file safety gate.

## Related Issue

Fixes #90039

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a framed probe protocol in `tools/file_operations.py` for regular-file validation, byte size, and base64 sample retrieval in one backend call.
- Combine `sed`, `wc -l`, and conditional final-byte inspection into one page call while preserving existing pagination and trailing-newline semantics.
- Update mocked terminal contracts and add a real-path regression test asserting a normal text read performs exactly two backend executions.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_read_shell_line_clamp.py -k 'not read_file_raw_not_clamped' -q`.
2. Run the affected `read_file` cases in `tests/tools/test_file_operations.py` and the pagination case in `tests/tools/test_file_operations_edge_cases.py`.
3. On Windows, observe that a normal text read invokes the terminal backend twice rather than 4–5 times.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the full `pytest tests/ -q` suite
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Git Bash

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A
- [x] I've considered cross-platform impact
- [x] Tool descriptions/schemas update: N/A; observable tool behavior is unchanged

## Screenshots / Logs

Affected regression runs passed: 7 real-path line/pagination tests, 4 mocked `read_file` behavior tests, and 1 pagination-boundary test. Ruff and `git diff --check` also passed.