### PR TITLE
fix(gateway): heal a dead reconnect watcher when the platform is already queued

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13323,11 +13323,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # live task even when _spawn_supervised's own backoff respawns it — so
         # _ensure_reconnect_watcher_running never mistakes a superseded handle
         # for a dead watcher and spawns a duplicate.
-        self._reconnect_watcher_task = self._spawn_supervised(
-            self._platform_reconnect_watcher,
-            "platform_reconnect_watcher",
-            on_spawn=lambda t: setattr(self, "_reconnect_watcher_task", t),
-        )
+        self._spawn_reconnect_watcher()
 
         # Start background handoff watcher — picks up CLI sessions marked
         # handoff_state='pending' in state.db and re-binds them to the
@@ -13392,7 +13388,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # handoff for the rest of the process life).
     _SUPERVISED_HEALTHY_SECS = 300
 
-    def _spawn_supervised(self, coro_factory, name, *, restart=True, _attempt=0, on_spawn=None):
+    @staticmethod
+    def _supervised_backoff(attempt: int) -> float:
+        """Delay before the supervisor's next respawn, in seconds.
+
+        Capped exponential. A method rather than an inline expression so the
+        schedule has one name, and so a test can collapse it -- the ordering
+        of crash / give-up / slow-tier is what the exhaustion tests assert,
+        and sleeping through the real curve to observe it would make them
+        take minutes.
+        """
+        return min(60, 2 ** min(attempt, 6))
+
+    def _spawn_supervised(
+        self, coro_factory, name, *, restart=True, _attempt=0, on_spawn=None,
+        on_give_up=None,
+    ):
         """Launch a long-lived background task with task-level supervision.
 
         Complements upstream's per-iteration inner-loop try/except (which only
@@ -13415,6 +13426,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         supervisor's own respawn creates a new task without updating that
         external handle, so ``_ensure_...`` later sees the stale/done handle
         and spawns a SECOND concurrent watcher (double reconnect attempts).
+
+        ``on_give_up`` (optional) is invoked with ``name`` when supervision is
+        abandoned — the restart budget is spent and this task will never be
+        respawned by the supervisor again. Supervision being finite is correct;
+        having no owner of the invariant afterwards is not. A task that still
+        has queued work depending on it needs somewhere to hand that fact to,
+        and before this hook existed the only thing standing between budget
+        exhaustion and a permanent silent outage was a *later, unrelated
+        event* happening to call ``_ensure_...`` (#90386). This is the
+        supervisor telling its caller "I am done; the invariant is yours now",
+        which is a thing only the supervisor knows.
         """
         if getattr(self, "_background_tasks", None) is None:
             self._background_tasks = set()
@@ -13473,8 +13495,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         effective_attempt,
                         self._SUPERVISED_HEALTHY_SECS,
                     )
+                    if on_give_up is not None:
+                        try:
+                            on_give_up(name)
+                        except Exception:  # pragma: no cover - defensive
+                            logger.debug(
+                                "on_give_up callback for %s raised",
+                                name, exc_info=True,
+                            )
                     return
-                backoff = min(60, 2 ** min(effective_attempt, 6))
+                backoff = self._supervised_backoff(effective_attempt)
 
                 async def _respawn():
                     await asyncio.sleep(backoff)
@@ -13485,6 +13515,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             restart=restart,
                             _attempt=effective_attempt + 1,
                             on_spawn=on_spawn,
+                            # Must be threaded through the recursion for the
+                            # same reason on_spawn is: the give-up that
+                            # matters is the LAST respawn's, and a callback
+                            # dropped here would leave the exhaustion branch
+                            # with no owner at exactly the moment it needs one.
+                            on_give_up=on_give_up,
                         )
 
                 respawn_task = asyncio.create_task(_respawn())
@@ -14204,6 +14240,117 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # self state, so inheriting the mixin keeps every self._kanban_* call site
     # working unchanged while lifting ~1,000 LOC out of this file.
 
+    #: Interval of the slow respawn tier that takes over once the reconnect
+    #: watcher has exhausted its supervised restart budget. Long on purpose:
+    #: the budget is spent precisely when the watcher is crashing on contact,
+    #: so the useful cadence is "check back later", not "try again now". A
+    #: tight loop here would be worse than the outage it is healing.
+    _RECONNECT_WATCHER_SLOW_RETRY_SECS = 300
+
+    #: How many slow-tier respawns to attempt while work is still queued.
+    #: Bounded, not infinite: if half an hour of five-minute retries cannot
+    #: keep a watcher alive, the fault is not transient and a louder failure
+    #: is more useful than a quieter one that never stops.
+    _MAX_SLOW_WATCHER_RESPAWNS = 6
+
+    def _on_reconnect_watcher_gave_up(self, name: str = "") -> None:
+        """Own the reconnect invariant once supervision has abandoned it.
+
+        The invariant this closes: **while the gateway is running and
+        ``_failed_platforms`` is non-empty, either a reconnect watcher is live
+        or a bounded respawn is scheduled.**
+
+        Before this, the only thing that noticed a dead watcher was a *later
+        fatal error from some other platform* reaching
+        ``_queue_retryable_fatal_platform``. That is event-coupled recovery: it
+        needs an event that, by construction, may never come. #81036 moved
+        queue publication ahead of disconnect and drops the failed adapter from
+        the live map, so once the watcher's budget is spent there may be no
+        adapter left that can emit the event recovery was waiting on. The
+        platform stays queued, nothing retries it, and the stranded check in
+        ``_handle_adapter_fatal_error_detached`` treats a queued platform as
+        safe — so the process is never restarted either.
+
+        Deliberately NOT done here: requesting a supervisor/process restart
+        when the slow tier is also exhausted. That is a policy decision about
+        blast radius (a gateway serving healthy platforms would be taken down
+        to heal a sick one) and it belongs to a maintainer, not to this patch.
+        What happens instead is a single loud error naming the still-queued
+        platforms, which is the state an operator or an external supervisor can
+        act on.
+        """
+        if not getattr(self, "_running", False):
+            return
+        if not getattr(self, "_failed_platforms", None):
+            # No queued work depends on the watcher. Letting it stay dead is
+            # correct -- the enqueue path spawns a fresh one the moment a
+            # platform is queued again.
+            logger.warning(
+                "Reconnect watcher supervision exhausted with an empty retry "
+                "queue — leaving it down until a platform is queued."
+            )
+            return
+        self._schedule_slow_reconnect_watcher_respawn(attempt=0)
+
+    def _schedule_slow_reconnect_watcher_respawn(self, *, attempt: int) -> None:
+        """Bounded slow-tier respawn of the reconnect watcher."""
+        if attempt >= self._MAX_SLOW_WATCHER_RESPAWNS:
+            logger.error(
+                "Reconnect watcher could not be kept alive after %d slow "
+                "respawns; %d platform(s) remain queued and unattended: %s. "
+                "Manual intervention or a gateway restart is required.",
+                attempt,
+                len(self._failed_platforms),
+                ", ".join(str(p) for p in self._failed_platforms),
+            )
+            return
+
+        async def _slow_respawn() -> None:
+            await asyncio.sleep(self._RECONNECT_WATCHER_SLOW_RETRY_SECS)
+            if not getattr(self, "_running", False):
+                return
+            if not getattr(self, "_failed_platforms", None):
+                # The queue drained while we waited -- something else healed
+                # it. Nothing to own any more.
+                return
+            task = getattr(self, "_reconnect_watcher_task", None)
+            if task is not None and not task.done():
+                return  # a watcher came back on its own; stand down
+            logger.warning(
+                "Reconnect watcher still down with %d platform(s) queued — "
+                "slow respawn %d/%d",
+                len(self._failed_platforms),
+                attempt + 1,
+                self._MAX_SLOW_WATCHER_RESPAWNS,
+            )
+            self._spawn_reconnect_watcher(
+                on_give_up=lambda _name: self._schedule_slow_reconnect_watcher_respawn(
+                    attempt=attempt + 1
+                )
+            )
+
+        respawn_task = asyncio.create_task(_slow_respawn())
+        if getattr(self, "_background_tasks", None) is None:
+            self._background_tasks = set()
+        self._background_tasks.add(respawn_task)
+        respawn_task.add_done_callback(self._background_tasks.discard)
+
+    def _spawn_reconnect_watcher(self, *, on_give_up=None):
+        """Single place that knows how to launch the reconnect watcher.
+
+        Three call sites used to repeat this triple (factory, name, on_spawn),
+        and the ``on_spawn`` half of it is load-bearing: without it the
+        supervisor's own respawn leaves ``_reconnect_watcher_task`` pointing at
+        a dead handle and ``_ensure_...`` spawns a second concurrent watcher.
+        """
+        self._reconnect_watcher_task = self._spawn_supervised(
+            self._platform_reconnect_watcher,
+            "platform_reconnect_watcher",
+            on_spawn=lambda t: setattr(self, "_reconnect_watcher_task", t),
+            on_give_up=on_give_up or self._on_reconnect_watcher_gave_up,
+        )
+        return self._reconnect_watcher_task
+
     def _ensure_reconnect_watcher_running(self) -> None:
         """Ensure the platform reconnect watcher background task is alive.
 
@@ -14225,11 +14372,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "Reconnect watcher task is dead (done=%s) — respawning",
             task.done() if task is not None else "N/A",
         )
-        self._reconnect_watcher_task = self._spawn_supervised(
-            self._platform_reconnect_watcher,
-            "platform_reconnect_watcher",
-            on_spawn=lambda t: setattr(self, "_reconnect_watcher_task", t),
-        )
+        self._spawn_reconnect_watcher()
 
     async def _platform_reconnect_watcher(self) -> None:
         """Background task that periodically retries connecting failed platforms.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8339,7 +8339,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not adapter.fatal_error_retryable:
             return False
         platform_config = self.config.platforms.get(adapter.platform)
-        if not platform_config or adapter.platform in self._failed_platforms:
+        if not platform_config:
+            return False
+        if adapter.platform in self._failed_platforms:
+            # Nothing to enqueue -- but "already queued" is precisely the state
+            # in which the watcher has had time to die, and the enqueue branch
+            # below holds the ONLY call to _ensure_reconnect_watcher_running().
+            #
+            # _spawn_supervised auto-restarts the watcher after a crash (#71758),
+            # but only _MAX_SUPERVISED_RESTARTS times in rapid succession; past
+            # that it logs "giving up restarts" and the watcher stays dead
+            # forever. _ensure_reconnect_watcher_running is the documented
+            # backstop for exactly that budget exhaustion (#70344) -- and it was
+            # unreachable for a platform already in the queue, which is the only
+            # kind of platform the watcher can have been retrying long enough to
+            # exhaust it on.
+            #
+            # The result is a silent permanent outage: nothing retries, and the
+            # stranded check in _handle_adapter_fatal_error_detached deliberately
+            # treats a queued platform as safe, so the process never restarts
+            # either (#90386).
+            self._ensure_reconnect_watcher_running()
             return False
         self._failed_platforms[adapter.platform] = {
             "config": platform_config,
@@ -14190,8 +14210,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         If the tracked reconnect watcher task has died (e.g. from exhausting
         its restart budget, or a terminal exception that _spawn_supervised
         could not recover), respawns it so platforms queued for reconnection
-        are not permanently stranded. Called after queueing a retryable fatal
-        error in _handle_adapter_fatal_error (#70344).
+        are not permanently stranded. Called from
+        _queue_retryable_fatal_platform on BOTH paths (#70344, #90386): after a
+        new enqueue, and after a re-fatal for a platform that is already queued
+        -- the latter being the only case in which the watcher can have been
+        retrying long enough to exhaust its supervised restart budget.
         """
         if not getattr(self, "_running", False):
             return

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -853,3 +853,148 @@ class TestVoiceInputCallbackWiring:
             "startup must wire _voice_input_callback"
         )
 
+
+
+class TestRequeueHealsDeadReconnectWatcher:
+    """Regression for #90386: a second retryable fatal error for a platform that
+    is ALREADY queued must still check that the reconnect watcher is alive.
+
+    ``_ensure_reconnect_watcher_running()`` is the documented backstop for the
+    watcher exhausting ``_MAX_SUPERVISED_RESTARTS`` (#70344) -- ``_spawn_supervised``
+    stops respawning after that and logs "giving up restarts". Its only call site
+    sat behind the newly-queued branch of ``_queue_retryable_fatal_platform``,
+    so it could never fire for a platform already in ``_failed_platforms`` --
+    which is the only kind of platform the watcher can have been retrying long
+    enough to exhaust the budget on.
+
+    The observable result is a silent permanent outage: the queue holds the
+    platform, nothing retries it, and the stranded check in
+    ``_handle_adapter_fatal_error_detached`` deliberately treats a queued
+    platform as safe, so the process is never restarted either.
+    """
+
+    @staticmethod
+    def _runner_with_dead_watcher(spawned):
+        runner = _make_runner()
+        runner._running = True
+        runner._background_tasks = set()
+
+        def _fake_spawn(coro_factory, name, **kwargs):
+            spawned.append(name)
+            handle = MagicMock()
+            handle.done.return_value = False
+            on_spawn = kwargs.get("on_spawn")
+            if on_spawn is not None:
+                on_spawn(handle)
+            return handle
+
+        runner._spawn_supervised = _fake_spawn
+        return runner
+
+    @staticmethod
+    def _already_queued(runner, *, attempts=7):
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": runner.config.platforms[Platform.TELEGRAM],
+            "attempts": attempts,
+            "next_retry": time.monotonic() + 300,
+            "queued_at": time.monotonic() - 3600,
+            "credential_claim": None,
+            "listener_claim": None,
+        }
+
+    @staticmethod
+    def _fatal_adapter():
+        adapter = StubAdapter()
+        adapter._set_fatal_error(
+            "telegram_network_error",
+            "Telegram polling could not reconnect after 10 network error retries.",
+            retryable=True,
+        )
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_requeue_respawns_a_watcher_that_gave_up_restarting(self):
+        """The core #90386 regression.
+
+        Telegram is queued and the watcher has exhausted its restart budget, so
+        the task is done and ``_spawn_supervised`` will never bring it back on
+        its own. A fresh retryable fatal error arrives for that same platform.
+        Nothing is enqueued (it is already there), but the watcher MUST be
+        respawned -- otherwise the queue entry is retried by nobody, forever.
+        """
+        spawned: list[str] = []
+        runner = self._runner_with_dead_watcher(spawned)
+        self._already_queued(runner)
+
+        async def _died():
+            return None
+
+        dead = asyncio.create_task(_died())
+        await dead
+        runner._reconnect_watcher_task = dead
+
+        queued = runner._queue_retryable_fatal_platform(self._fatal_adapter())
+
+        assert queued is False, "already-queued platform must not be re-enqueued"
+        assert spawned == ["platform_reconnect_watcher"], (
+            "a re-fatal on an already-queued platform must still heal a dead "
+            "reconnect watcher -- it is the only remaining path back to the "
+            "queue once _spawn_supervised has given up restarting (#90386)"
+        )
+        assert not runner._reconnect_watcher_task.done(), (
+            "the tracked handle must point at the newly spawned watcher"
+        )
+
+    @pytest.mark.asyncio
+    async def test_requeue_does_not_disturb_the_existing_queue_entry(self):
+        """Guardrail on the fix: healing the watcher must not become a re-enqueue.
+
+        Overwriting the entry would reset ``attempts`` and ``next_retry``, so a
+        platform that fails repeatedly would restart its backoff ladder on every
+        fatal error and hammer a provider that is already refusing it.
+        """
+        spawned: list[str] = []
+        runner = self._runner_with_dead_watcher(spawned)
+        self._already_queued(runner, attempts=7)
+        before = dict(runner._failed_platforms[Platform.TELEGRAM])
+
+        async def _died():
+            return None
+
+        dead = asyncio.create_task(_died())
+        await dead
+        runner._reconnect_watcher_task = dead
+
+        assert runner._queue_retryable_fatal_platform(self._fatal_adapter()) is False
+        assert runner._failed_platforms[Platform.TELEGRAM] == before, (
+            "the existing queue entry, including its attempt count and backoff "
+            "deadline, must survive the watcher heal untouched"
+        )
+
+    @pytest.mark.asyncio
+    async def test_requeue_with_a_live_watcher_spawns_nothing(self):
+        """Guardrail on the fix: a live watcher must not be duplicated.
+
+        Two concurrent watchers would double every reconnect attempt, which is
+        the failure ``_spawn_supervised``'s ``on_spawn`` handle-tracking exists
+        to prevent.
+        """
+        spawned: list[str] = []
+        runner = self._runner_with_dead_watcher(spawned)
+        self._already_queued(runner)
+
+        async def _alive():
+            await asyncio.sleep(5)
+
+        live = asyncio.create_task(_alive())
+        runner._reconnect_watcher_task = live
+        try:
+            assert runner._queue_retryable_fatal_platform(self._fatal_adapter()) is False
+            assert spawned == [], "a live watcher must never be respawned"
+            assert runner._reconnect_watcher_task is live
+        finally:
+            live.cancel()
+            try:
+                await live
+            except asyncio.CancelledError:
+                pass

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -998,3 +998,192 @@ class TestRequeueHealsDeadReconnectWatcher:
                 await live
             except asyncio.CancelledError:
                 pass
+
+
+class TestSupervisionExhaustionHasAnOwner:
+    """The witness @andrexibiza asked for on #90448: recovery with NO new event.
+
+    The predecessor architecture (#72366, salvage of #71867 by @ygd58)
+    established that a reconnect watcher which dies while work is queued must
+    be respawned by something *autonomous*, because the only other trigger --
+    a fresh fatal error from another platform -- may never arrive. Supervised
+    restart closed that, but supervision is finite: after
+    ``_MAX_SUPERVISED_RESTARTS`` rapid crashes it logs "giving up restarts" and
+    stops.
+
+    Past that point the system is back in exactly the state #72366 described.
+    And #81036 (salvage of #80700, preserving @HexLab98) makes the missing
+    event less likely rather than more: it publishes the queue *before*
+    disconnect and drops the failed adapter from the live map, so there may be
+    no adapter left to emit the callback recovery was waiting on.
+
+    These tests exercise that state directly. They queue a platform, let the
+    watcher burn its whole budget, and then emit **no further fatal
+    callbacks at all** -- the thing the branch-level regression tests below
+    cannot prove, because they manufacture the event.
+    """
+
+    @staticmethod
+    def _runner(monkeypatch, *, crashes):
+        """A runner whose reconnect watcher crashes `crashes` times, then lives."""
+        runner = _make_runner()
+        runner._background_tasks = set()
+        runner._reconnect_watcher_task = None
+        runner.state = {"live": 0, "spawns": 0}
+
+        # Collapse every real-time delay: the point is the ORDER of events, not
+        # their spacing. Left as class attributes in production precisely so a
+        # test can do this without sleeping for half an hour.
+        monkeypatch.setattr(GatewayRunner, "_MAX_SUPERVISED_RESTARTS", 2)
+        monkeypatch.setattr(GatewayRunner, "_SUPERVISED_HEALTHY_SECS", 3600)
+        monkeypatch.setattr(GatewayRunner, "_RECONNECT_WATCHER_SLOW_RETRY_SECS", 0)
+        monkeypatch.setattr(GatewayRunner, "_supervised_backoff", staticmethod(lambda _a: 0))
+
+        remaining = {"n": crashes}
+
+        async def _watcher():
+            runner.state["spawns"] += 1
+            if remaining["n"] > 0:
+                remaining["n"] -= 1
+                raise RuntimeError("watcher crashed on contact")
+            # Healthy: stay alive so `task.done()` is False.
+            runner.state["live"] += 1
+            await asyncio.Event().wait()
+
+        runner._platform_reconnect_watcher = _watcher
+        return runner
+
+    @staticmethod
+    def _queue_telegram(runner):
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": runner.config.platforms[Platform.TELEGRAM],
+            "attempts": 9,
+            "next_retry": time.monotonic() + 300,
+            "queued_at": time.monotonic() - 7200,
+            "credential_claim": None,
+            "listener_claim": None,
+        }
+
+    @staticmethod
+    async def _settle(times=40):
+        """Let the supervisor's done-callbacks and respawn tasks drain."""
+        for _ in range(times):
+            await asyncio.sleep(0)
+
+    @pytest.mark.asyncio
+    async def test_watcher_recovers_after_budget_exhaustion_with_no_new_event(
+        self, monkeypatch
+    ):
+        """The whole review gate in one test.
+
+        Queue a platform, crash the watcher past its supervised budget, then do
+        nothing at all -- no fatal callback, no enqueue, no external poke. The
+        watcher must come back on its own once it stops crashing.
+        """
+        # One crash more than supervision will tolerate, so the give-up branch
+        # is genuinely reached and the slow tier is what recovers it.
+        runner = self._runner(monkeypatch, crashes=3)
+        self._queue_telegram(runner)
+
+        runner._spawn_reconnect_watcher()
+        await self._settle(300)
+
+        assert runner.state["live"] == 1, (
+            "with no new fatal event, only the slow tier can have brought the "
+            "watcher back after supervision gave up"
+        )
+        assert runner._reconnect_watcher_task is not None
+        assert not runner._reconnect_watcher_task.done()
+
+        runner._running = False
+        for task in list(runner._background_tasks):
+            task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_the_slow_tier_is_bounded_not_a_restart_loop(self, monkeypatch):
+        """A watcher that never recovers must stop being respawned, and say so."""
+        runner = self._runner(monkeypatch, crashes=10_000)
+        self._queue_telegram(runner)
+        monkeypatch.setattr(GatewayRunner, "_MAX_SLOW_WATCHER_RESPAWNS", 3)
+
+        runner._spawn_reconnect_watcher()
+        await self._settle(400)
+
+        assert runner.state["live"] == 0
+        # Bounded, and the arithmetic is worth stating because it is the
+        # whole safety argument. Each slow-tier attempt hands the watcher a
+        # FRESH supervised budget -- that is deliberate, since a slow retry is
+        # a new bet that conditions have changed -- so the ceiling is
+        # (1 + _MAX_SUPERVISED_RESTARTS) x (1 + _MAX_SLOW_WATCHER_RESPAWNS):
+        # here (1+2) x (1+3) = 12. With production values that is 6 x 7 = 42
+        # spawns spread across at least half an hour, which is a ladder, not
+        # a restart loop. A tight loop here would be worse than the outage it
+        # is healing.
+        assert runner.state["spawns"] == 12, (
+            f"expected a finite spawn ladder, got {runner.state['spawns']}"
+        )
+        assert runner._reconnect_watcher_task.done()
+
+        # And it stays stopped: no further spawns once the ladder is spent.
+        await self._settle(400)
+        assert runner.state["spawns"] == 12
+
+        runner._running = False
+        for task in list(runner._background_tasks):
+            task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_an_empty_queue_leaves_the_watcher_down(self, monkeypatch):
+        """No queued work, no invariant to own.
+
+        Respawning a crash-looping watcher that nothing depends on would burn
+        the process for no one. The enqueue path spawns a fresh one the moment
+        a platform is actually queued.
+        """
+        runner = self._runner(monkeypatch, crashes=10_000)
+        assert not runner._failed_platforms
+
+        runner._spawn_reconnect_watcher()
+        await self._settle(200)
+
+        assert runner.state["live"] == 0
+        assert runner._reconnect_watcher_task.done()
+
+        runner._running = False
+        for task in list(runner._background_tasks):
+            task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_the_slow_tier_stands_down_when_the_queue_drains(self, monkeypatch):
+        """Something else healed the platform -- stop respawning for it."""
+        runner = self._runner(monkeypatch, crashes=10_000)
+        self._queue_telegram(runner)
+
+        runner._spawn_reconnect_watcher()
+        # Let supervision give up, then drain the queue before the slow tier
+        # gets its turn.
+        await self._settle(6)
+        runner._failed_platforms.clear()
+        await self._settle(200)
+
+        assert runner.state["live"] == 0, (
+            "with nothing queued, the slow tier has no invariant left to own"
+        )
+
+        runner._running = False
+        for task in list(runner._background_tasks):
+            task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_give_up_does_nothing_once_the_gateway_is_shutting_down(
+        self, monkeypatch
+    ):
+        runner = self._runner(monkeypatch, crashes=10_000)
+        self._queue_telegram(runner)
+        runner._running = False
+
+        runner._on_reconnect_watcher_gave_up("platform_reconnect_watcher")
+        await self._settle()
+
+        assert runner.state["live"] == 0
+        assert not runner._background_tasks


### PR DESCRIPTION
## What does this PR do?

`_ensure_reconnect_watcher_running()` exists for exactly one situation: the reconnect watcher has exhausted `_MAX_SUPERVISED_RESTARTS`, so `_spawn_supervised` has logged `giving up restarts` and will never bring it back on its own. That is what #70344 added it for, and it is the gap `_spawn_supervised`'s own auto-restart (the #71758 fix) explicitly does **not** cover, because the budget is finite.

It had exactly one call site:

```py
def _queue_retryable_fatal_platform(self, adapter) -> bool:
    if not adapter.fatal_error_retryable:
        return False
    platform_config = self.config.platforms.get(adapter.platform)
    if not platform_config or adapter.platform in self._failed_platforms:
        return False          # <- silent return, before the ensure
    ...
    logger.info("%s queued for background reconnection", ...)
    self._ensure_reconnect_watcher_running()   # <- only here
    return True
```

The `already in _failed_platforms` early return skips it. But a platform that is already queued is **the only kind of platform the watcher can have been retrying long enough to burn five rapid restarts on**. The backstop could not fire in the one state it was written for.

### Why the outage is silent rather than loud

This is the part that makes it expensive to diagnose. Every other guard in the fatal path is deliberately satisfied:

| guard | why it does not fire |
|---|---|
| `logger.info("... queued for background reconnection")` | after the early return |
| `stranded` check in `_handle_adapter_fatal_error_detached` | requires `platform not in self._failed_platforms`; it **is** in there, so the platform reads as safe and the gateway never exits for the service manager |
| `No connected messaging platforms remain ...` | needs `not self.adapters`; with a second platform still connected, non-empty |
| `... gateway staying alive, watcher will retry in background` | same condition, same reason |

So a retryable fatal error can produce a single `ERROR` line and then **nothing at all**, while the platform sits in a queue nobody is draining. #90386 reports 4h17m of exactly that shape, with the cron scheduler running normally the whole time and recovery requiring a manual `systemctl --user restart`.

### The change

Call the ensure on the already-queued path too. It is already idempotent and already cheap - it returns immediately unless the tracked task is `done()`, and it spawns through the same `on_spawn` handle tracking, so a live watcher is never duplicated.

The queue entry is deliberately **not** touched. Re-enqueueing would reset `attempts` and `next_retry`, restarting the backoff ladder on every fatal error and hammering a provider that is already refusing the connection. There is a test that fails if someone later "simplifies" it that way.

### On the reported issue

This closes a real, reachable hole on that path, and it matches #90386's log signature exactly (one `Fatal telegram adapter error` line, then silence, gateway alive, cron unaffected). I want to be straight about what I have and have not proven: I do not have the reporter's `_failed_platforms` contents at 04:02:31, so I cannot prove from their logs alone that this is the *only* thing that went wrong in that outage. The report's own suggestion 3 (a state-file watchdog) would be a broader belt-and-braces change and is not attempted here. What I can show is that this branch is reachable, silent, terminal, and now covered.

## Related Issue

Refs #90386

**Not `Fixes`, deliberately.** Per @andrexibiza's review: the #90386 reporter is
on Hermes **v0.19.0 (2026.7.20)**, and #81036 (which moved queue publication
ahead of disconnect, added the outer fatal-handling deadline, and
best-effort-queues on cancellation) merged **2026-08-07**, three weeks later.
Their log silence therefore cannot distinguish "the already-queued branch
stranded them" from "the pre-queue disconnect wedge that #81036 already fixed".
The incident stays open until a current-main witness exists; this PR is
hardening plus the supervision-exhaustion owner, not a P1 closure.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` - `_queue_retryable_fatal_platform`: split the combined early return so the `already queued` case calls `_ensure_reconnect_watcher_running()` before returning `False`. The `no platform_config` case still returns immediately, since there is nothing to reconnect to.
- `gateway/run.py` - `_ensure_reconnect_watcher_running` docstring: it is now called from both paths, and the docstring says which and why.
- `tests/gateway/test_platform_reconnect.py` - new `TestRequeueHealsDeadReconnectWatcher` with three tests.

## How to Test

1. `pytest tests/gateway/test_platform_reconnect.py -q` - 24 passed.
2. Sabotage proof. Revert only the `gateway/run.py` hunk and re-run:

   ```
   E  assert [] == ['platform_reconnect_watcher']
   E  a re-fatal on an already-queued platform must still heal a dead reconnect
      watcher -- it is the only remaining path back to the queue once
      _spawn_supervised has given up restarting (#90386)
   ```

   `test_requeue_respawns_a_watcher_that_gave_up_restarting` fails; the other two pass unpatched **by design** - they constrain the shape of the fix rather than detect the bug:
   - `test_requeue_does_not_disturb_the_existing_queue_entry` fails any fix that re-enqueues,
   - `test_requeue_with_a_live_watcher_spawns_nothing` fails any fix that spawns unconditionally.
3. `ruff check gateway/run.py tests/gateway/test_platform_reconnect.py` - clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.12, repo dev venv)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring updated; no user-facing docs describe this internal path
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure asyncio bookkeeping, no paths, processes, or platform APIs; identical on all three

### Duplicate check

Ran before writing any code, since this seam has been fixed several times:

- issue #90386 timeline cross-references: none
- `gh search prs --repo NousResearch/hermes-agent "_ensure_reconnect_watcher_running" --state open`: no results
- `gh search prs ... "reconnect watcher respawn" --state open`: no results
- open PRs touching `gateway/run.py` at this seam: #54041 bounds the disconnect inside the fatal handler, #71646 shields secondary-profile fatal reconnect, #88305 clears stale platform status on adapter-creation failure. None of them touch `_queue_retryable_fatal_platform`'s early return or the watcher-liveness call.
- merged prior art at the same seam, all distinct: #81036 and #69112 (cancellation-proofing the handoff), #68447 (preserving the handoff from self-cancellation), #71758 (supervised auto-restart, whose finite budget is precisely what leaves this gap).

