### PR TITLE
fix(kanban): retain review-delivered worktrees

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -988,7 +988,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
 
     # --- gc ---
     p_gc = sub.add_parser(
-        "gc", help="Garbage-collect archived-task workspaces, old events, and old logs",
+        "gc", help="Garbage-collect completed/archived workspaces, old events, and old logs",
     )
     p_gc.add_argument("--event-retention-days", type=int, default=30,
                       help="Delete task_events older than N days for terminal tasks (default: 30)")
@@ -3214,7 +3214,7 @@ def _cmd_decompose(args: argparse.Namespace) -> int:
 
 
 def _cmd_gc(args: argparse.Namespace) -> int:
-    """Remove scratch workspaces of archived tasks, prune old events, and
+    """Remove completed/archived task workspaces, prune old events, and
     delete old worker logs."""
     import shutil
     scratch_root = kb.workspaces_root()
@@ -3222,7 +3222,7 @@ def _cmd_gc(args: argparse.Namespace) -> int:
     with kb.connect_closing() as conn:
         rows = conn.execute(
             "SELECT id, workspace_kind, workspace_path, branch_name FROM tasks "
-            "WHERE status = 'archived'"
+            "WHERE status IN ('done', 'archived')"
         ).fetchall()
     for row in rows:
         if row["workspace_kind"] == "worktree":

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5393,6 +5393,26 @@ def complete_task(
     and never blocks.
     """
     now = int(time.time())
+    # A reviewer claim transitions ``review -> running``, so the task row no
+    # longer says ``review`` by the time the reviewer approves it. Preserve
+    # the source phase from the claim event for the retention decision below.
+    current_run = conn.execute(
+        "SELECT current_run_id FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    current_run_id = current_run["current_run_id"] if current_run else None
+    latest_claim = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'claimed' "
+        "AND run_id = ? ORDER BY id DESC LIMIT 1",
+        (task_id, current_run_id),
+    ).fetchone() if current_run_id is not None else None
+    review_delivery = False
+    if latest_claim and latest_claim["payload"]:
+        try:
+            claimed_payload = json.loads(latest_claim["payload"])
+            if isinstance(claimed_payload, dict):
+                review_delivery = claimed_payload.get("source_status") == "review"
+        except (TypeError, ValueError):
+            pass
     # Fail before validating cards or staging artifacts; re-check inside the
     # final write transaction below to close the parent-reopen race.
     if not _parents_satisfied(conn, task_id):
@@ -5527,6 +5547,14 @@ def complete_task(
         completed_payload: dict = {
             "result_len": len(result) if result else 0,
             "summary": ev_summary or None,
+            # A review approval is a delivery boundary, not just another
+            # successful worker exit.  Keep this provenance on the event so
+            # deferred parent cleanup and explicit GC can make the same
+            # retention decision after this call returns.
+            "source_status": (
+                "review" if (prior_status == "review" or review_delivery)
+                else prior_status
+            ),
         }
         if verified_cards:
             completed_payload["verified_cards"] = verified_cards
@@ -5578,7 +5606,15 @@ def complete_task(
     # Recompute ready status for dependents (separate txn so children see done).
     recompute_ready(conn)
     # Clean up the scratch workspace and any stale tmux session for the worker.
-    _cleanup_workspace(conn, task_id)
+    # A source-changing task that is approved from the review lane is still
+    # useful evidence for the person inspecting the delivered PR.  Preserve
+    # that task-owned worktree until an explicit archive/GC action. Scratch
+    # workspaces and ordinary completions retain their existing lifecycle.
+    _cleanup_workspace(
+        conn,
+        task_id,
+        retain_completed_worktree=(prior_status == "review" or review_delivery),
+    )
     _done_task = get_task(conn, task_id)
     if fire_lifecycle_hook:
         _fire_kanban_lifecycle_hook(
@@ -5875,14 +5911,21 @@ def _is_managed_scratch_path(p: Path) -> bool:
     return is_managed
 
 
-def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
+def _cleanup_workspace(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    retain_completed_worktree: bool = False,
+) -> None:
     """Remove a task's scratch workspace dir and kill its stale tmux session.
 
     Called from :func:`complete_task` after the DB transaction commits.
     Best-effort — any error is swallowed so cleanup never blocks task completion.
     ``scratch`` workspaces are removed; ``worktree`` workspaces are removed only
     when provably free of work (clean tree, every commit reachable from a
-    remote-tracking ref); ``dir`` workspaces are intentionally preserved.
+    remote-tracking ref), unless this is a review-approved completion, where
+    the worktree is retained for inspection until explicit cleanup;
+    ``dir`` workspaces are intentionally preserved.
     """
     try:
         row = conn.execute(
@@ -5921,6 +5964,14 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
             # worktree so a lingering worker never has its cwd deleted out
             # from under it. Both steps stay best-effort.
             _cleanup_worker_tmux(conn, task_id)
+            if retain_completed_worktree:
+                _log.info(
+                    "Preserving review-delivered worktree for task %s: %s",
+                    task_id,
+                    path,
+                )
+                _try_cleanup_parent_workspaces(conn, task_id)
+                return
             _cleanup_worktree_workspace(task_id, path, row["branch_name"])
             _try_cleanup_parent_workspaces(conn, task_id)
             return
@@ -5958,7 +6009,10 @@ def _cleanup_worktree_workspace(
 ) -> None:
     """Remove a finished task's linked git worktree when it holds no work.
 
-    Mirrors the safety judgment of the CLI startup pruner
+    Only removes the canonical task-owned checkout at
+    ``<repo>/.worktrees/<task-id>``. Explicit custom worktree targets and
+    existing user worktrees are never owned by Kanban. It then mirrors the
+    safety judgment of the CLI startup pruner
     (``cli._prune_stale_worktrees``): removal requires a clean working tree
     AND every commit reachable from a remote-tracking ref. Any doubt — dirty
     files, unpushed commits, unresolvable repo, failing git — preserves the
@@ -5979,6 +6033,14 @@ def _cleanup_worktree_workspace(
         repo_root = common.parent
         if wp.resolve(strict=False) == repo_root.resolve(strict=False):
             return  # never remove the main checkout
+        expected = (repo_root / ".worktrees" / task_id).resolve(strict=False)
+        if wp.resolve(strict=False) != expected:
+            _log.info(
+                "Preserving non-canonical worktree for task %s at %s "
+                "(expected %s)",
+                task_id, wp, expected,
+            )
+            return
         if _worktree_is_dirty(str(wp)) or _worktree_has_unpushed_commits(str(wp)):
             _log.info(
                 "Preserving worktree for task %s: dirty or unpushed work at %s",
@@ -6031,7 +6093,7 @@ def _try_cleanup_parent_workspaces(conn: sqlite3.Connection, task_id: str) -> No
         ).fetchall()
         for (parent_id,) in parents:
             row = conn.execute(
-                "SELECT workspace_kind, workspace_path, branch_name FROM tasks WHERE id = ?",
+                "SELECT status, workspace_kind, workspace_path, branch_name FROM tasks WHERE id = ?",
                 (parent_id,),
             ).fetchone()
             if (
@@ -6050,6 +6112,35 @@ def _try_cleanup_parent_workspaces(conn: sqlite3.Connection, task_id: str) -> No
             ).fetchone()
             if active:
                 continue  # still has active children
+            # Review-approved source work is deliberately retained until an
+            # explicit archive/GC action, including when the last child later
+            # completes and revisits this deferred-parent path.
+            # Explicit archive is the authoritative cleanup decision. It may
+            # have been deferred while children were active, but a later child
+            # completion must finish that cleanup rather than let historical
+            # review provenance retain the archived worktree forever.
+            if row["status"] == "archived":
+                pass
+            elif row["workspace_kind"] == "worktree":
+                latest_completion = conn.execute(
+                    "SELECT payload FROM task_events "
+                    "WHERE task_id = ? AND kind = 'completed' "
+                    "ORDER BY id DESC LIMIT 1",
+                    (parent_id,),
+                ).fetchone()
+                try:
+                    latest_payload = (
+                        json.loads(latest_completion["payload"])
+                        if latest_completion and latest_completion["payload"]
+                        else {}
+                    )
+                except (json.JSONDecodeError, TypeError):
+                    latest_payload = {}
+                if (
+                    isinstance(latest_payload, dict)
+                    and latest_payload.get("source_status") == "review"
+                ):
+                    continue
             # All children done — safe to clean up parent workspace
             if row["workspace_kind"] == "worktree":
                 _cleanup_worktree_workspace(

--- a/tests/hermes_cli/test_kanban_worktree_teardown.py
+++ b/tests/hermes_cli/test_kanban_worktree_teardown.py
@@ -1,21 +1,19 @@
-"""Tests for worktree workspace teardown at task completion/archive.
+"""Tests for worktree workspace retention and teardown at task completion/archive.
 
-Covers the ownership gap where kanban ``worktree`` workspaces were never
-reaped by anything: ``_cleanup_workspace`` preserved them by design, the CLI
-startup pruner explicitly skips ``t_*`` worktrees ("dispatcher-driven
-lifecycle"), and ``kanban gc`` only swept scratch. A completed or archived
-task's linked worktree is now removed when — and only when — it provably
-holds no work: clean working tree and every commit reachable from a
-remote-tracking ref. Any doubt preserves the worktree.
+Review-delivered source work remains inspectable after completion; archive or
+explicit GC removes it only when it is provably disposable. Scratch cleanup
+and all dirty/unpushed/user-tree safety guards remain intact.
 """
 
 from __future__ import annotations
 
+import argparse
 import subprocess
 from pathlib import Path
 
 import pytest
 
+from hermes_cli import kanban as kanban_cli
 from hermes_cli import kanban_db as kb
 
 
@@ -115,6 +113,14 @@ def test_custom_branch_survives_worktree_removal(repo: Path) -> None:
     assert _branch_exists(repo, "feature/custom")
 
 
+def test_custom_existing_worktree_is_not_task_owned(repo: Path) -> None:
+    target = repo / "user-worktree"
+    kb._ensure_git_worktree(repo, target, "feature/user-worktree")
+    kb._cleanup_worktree_workspace("t_ownercase", str(target), "feature/user-worktree")
+    assert target.is_dir()
+    assert _branch_exists(repo, "feature/user-worktree")
+
+
 def test_main_checkout_never_removed(repo: Path) -> None:
     kb._cleanup_worktree_workspace("t_eeee5555", str(repo))
     assert repo.is_dir()
@@ -178,6 +184,174 @@ def test_complete_task_reaps_clean_worktree(kanban_home: Path, repo: Path) -> No
     assert not _branch_exists(repo, f"wt/{tid}")
 
 
+def test_review_delivered_completion_retains_clean_worktree_until_archive(
+    kanban_home: Path, repo: Path
+) -> None:
+    with kb.connect_closing() as conn:
+        tid, wt = _worktree_task(conn, repo)
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        implementation = kb.claim_task(conn, tid, claimer="worker")
+        assert implementation is not None
+        assert kb.request_review(
+            conn, tid, summary="PR delivered", reviewer="reviewer",
+            expected_run_id=implementation.current_run_id,
+        )
+        review = kb.claim_review_task(conn, tid, claimer="reviewer")
+        assert review is not None
+        assert kb.complete_task(
+            conn, tid, summary="Approved", expected_run_id=review.current_run_id
+        )
+        assert wt.is_dir(), "review delivery must leave source work inspectable"
+        assert _branch_exists(repo, f"wt/{tid}"), (
+            "review delivery must retain the local task branch until archive"
+        )
+        assert kb.archive_task(conn, tid)
+    assert not wt.exists(), "archive is an explicit cleanup action"
+
+
+def test_review_delivered_worktree_gc_is_explicit_cleanup(
+    kanban_home: Path, repo: Path
+) -> None:
+    with kb.connect_closing() as conn:
+        tid, wt = _worktree_task(conn, repo)
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='review' WHERE id=?", (tid,))
+        assert kb.complete_task(conn, tid, summary="Approved")
+        assert wt.is_dir()
+    # GC's backstop covers retained done tasks from the review-only path.
+    assert kanban_cli._cmd_gc(
+        argparse.Namespace(event_retention_days=30, log_retention_days=30)
+    ) == 0
+    assert not wt.exists()
+
+
+def test_corrupt_review_claim_payload_keeps_completion_cleanup_safe(
+    kanban_home: Path, repo: Path
+) -> None:
+    """A non-object claimed payload is non-review provenance, not an error."""
+    with kb.connect_closing() as conn:
+        tid, wt = _worktree_task(conn, repo)
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        implementation = kb.claim_task(conn, tid, claimer="worker")
+        assert implementation is not None
+        assert kb.request_review(
+            conn, tid, summary="PR delivered", reviewer="reviewer",
+            expected_run_id=implementation.current_run_id,
+        )
+        review = kb.claim_review_task(conn, tid, claimer="reviewer")
+        assert review is not None
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE task_events SET payload='[]' "
+                "WHERE task_id=? AND kind='claimed' AND run_id=?",
+                (tid, review.current_run_id),
+            )
+        assert kb.complete_task(
+            conn, tid, summary="Approved", expected_run_id=review.current_run_id
+        )
+        assert kb.get_task(conn, tid).status == "done"
+    assert not wt.exists(), "corrupt provenance must retain ordinary cleanup"
+    assert not _branch_exists(repo, f"wt/{tid}")
+
+
+def test_review_delivered_gc_preserves_dirty_worktree(
+    kanban_home: Path, repo: Path
+) -> None:
+    with kb.connect_closing() as conn:
+        tid, wt = _worktree_task(conn, repo)
+        (wt / "wip.txt").write_text("review evidence\n", encoding="utf-8")
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='review' WHERE id=?", (tid,))
+        assert kb.complete_task(conn, tid, summary="Approved")
+        assert wt.is_dir()
+    assert kanban_cli._cmd_gc(
+        argparse.Namespace(event_retention_days=30, log_retention_days=30)
+    ) == 0
+    assert wt.is_dir(), "GC must preserve dirty review-delivered work"
+    assert (wt / "wip.txt").read_text(encoding="utf-8") == "review evidence\n"
+
+
+def test_reopened_review_then_ordinary_completion_does_not_retain_worktree(
+    kanban_home: Path, repo: Path
+) -> None:
+    with kb.connect_closing() as conn:
+        tid, wt = _worktree_task(conn, repo)
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        implementation = kb.claim_task(conn, tid, claimer="worker")
+        assert implementation is not None
+        assert kb.request_review(
+            conn, tid, summary="needs changes", reviewer="reviewer",
+            expected_run_id=implementation.current_run_id,
+        )
+        assert kb.reopen_review_task(conn, tid)
+        rerun = kb.claim_task(conn, tid, claimer="worker")
+        assert rerun is not None
+        assert kb.complete_task(
+            conn, tid, summary="fixed", expected_run_id=rerun.current_run_id
+        )
+    assert not wt.exists(), "ordinary completion after reopen must clean up"
+
+
+def test_reopened_review_deferred_parent_uses_latest_completion(
+    kanban_home: Path, repo: Path
+) -> None:
+    with kb.connect_closing() as conn:
+        parent, parent_wt = _worktree_task(conn, repo, title="review parent")
+        child = kb.create_task(conn, title="child", assignee="worker")
+        kb.link_tasks(conn, parent, child)
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (parent,))
+        implementation = kb.claim_task(conn, parent, claimer="worker")
+        assert implementation is not None
+        assert kb.request_review(
+            conn, parent, summary="needs changes", reviewer="reviewer",
+            expected_run_id=implementation.current_run_id,
+        )
+        assert kb.reopen_review_task(conn, parent)
+        rerun = kb.claim_task(conn, parent, claimer="worker")
+        assert rerun is not None
+        assert kb.complete_task(
+            conn, parent, summary="fixed", expected_run_id=rerun.current_run_id
+        )
+        assert parent_wt.is_dir(), "active child should defer parent cleanup"
+
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (child,))
+        assert kb.claim_task(conn, child, claimer="worker") is not None
+        assert kb.complete_task(conn, child, summary="child done")
+    assert not parent_wt.exists(), "deferred cleanup must use latest provenance"
+
+
+def test_scratch_completion_and_abandoned_archive_still_clean_up(
+    kanban_home: Path,
+) -> None:
+    with kb.connect_closing() as conn:
+        completed = kb.create_task(conn, title="scratch", assignee="worker")
+        completed_path = kanban_home / "kanban" / "workspaces" / completed
+        completed_path.mkdir(parents=True)
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET workspace_path=? WHERE id=?",
+                (str(completed_path), completed),
+            )
+        assert kb.complete_task(conn, completed, summary="done")
+        assert not completed_path.exists()
+
+        abandoned = kb.create_task(conn, title="abandoned", assignee="worker")
+        abandoned_path = kanban_home / "kanban" / "workspaces" / abandoned
+        abandoned_path.mkdir(parents=True)
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET workspace_path=? WHERE id=?",
+                (str(abandoned_path), abandoned),
+            )
+        assert kb.archive_task(conn, abandoned)
+        assert not abandoned_path.exists()
+
+
 def test_complete_task_preserves_dirty_worktree(kanban_home: Path, repo: Path) -> None:
     with kb.connect_closing() as conn:
         tid, wt = _worktree_task(conn, repo)
@@ -218,3 +392,21 @@ def test_parent_worktree_deferred_until_children_done(
         assert kb.complete_task(conn, child, summary="child done")
     # last child terminal -> deferred parent worktree reaped
     assert not parent_wt.exists()
+
+
+def test_archived_parent_cleanup_wins_after_active_child_finishes(
+    kanban_home: Path, repo: Path
+) -> None:
+    with kb.connect_closing() as conn:
+        parent, parent_wt = _worktree_task(conn, repo, title="archived parent")
+        child = kb.create_task(conn, title="child", assignee="worker")
+        kb.link_tasks(conn, parent, child)
+
+        assert kb.archive_task(conn, parent)
+        assert parent_wt.is_dir(), "active child should defer physical removal"
+
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (child,))
+        assert kb.claim_task(conn, child, claimer="worker") is not None
+        assert kb.complete_task(conn, child, summary="child done")
+    assert not parent_wt.exists(), "archive must remain authoritative after deferral"

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -65,9 +65,31 @@ They coexist: a kanban worker may call `delegate_task` internally during its run
 - **Workspace** — the directory a worker operates in. Three kinds:
   - `scratch` (default) — fresh tmp dir under `~/.hermes/kanban/workspaces/<id>/` (or `~/.hermes/kanban/boards/<slug>/workspaces/<id>/` on non-default boards). **Deleted when the task completes** — scratch is ephemeral by design. Files explicitly declared through `kanban_complete(artifacts=[...])` are copied into durable per-task attachment storage before cleanup; existing deliverable paths in legacy completion summaries receive the same treatment. Other scratch files are removed. A missing declared scratch artifact keeps the task in-flight so the worker can correct the path and retry. Use `worktree:` or `dir:<path>` when the whole workspace should remain available. The first time a scratch workspace is created on an install, the dispatcher logs a warning and emits a `tip_scratch_workspace` event on the task (visible via `hermes kanban show <id>`).
   - `dir:<path>` — an existing shared directory (Obsidian vault, mail ops dir, per-account folder). **Must be an absolute path.** Relative paths like `dir:../tenants/foo/` are rejected at dispatch because they'd resolve against whatever CWD the dispatcher happens to be in, which is ambiguous and a confused-deputy escape vector. The path is otherwise trusted — it's your box, your filesystem, the worker runs with your uid. This is the trusted-local-user threat model; kanban is single-host by design. **Preserved on completion.**
-  - `worktree` — a git worktree under `.worktrees/<id>/` for coding tasks. Use `worktree:<path>` to pin the exact target path. Worker-side `git worktree add` creates it, using `--branch` when provided. **Preserved on completion.**
+  - `worktree` — a git worktree under `.worktrees/<id>/` for coding tasks. Use `worktree:<path>` to pin the exact target path. Worker-side `git worktree add` creates it, using `--branch` when provided. Ordinary completions clean up a provably disposable tree; a source-changing task approved from the `review` lane is **preserved after completion for inspection**.
 - **Dispatcher** — a long-lived loop that, every N seconds (default 60): reclaims stale claims, reclaims crashed workers (PID gone but TTL not yet expired), promotes ready tasks, atomically claims, spawns assigned profiles. Runs **inside the gateway** by default (`kanban.dispatch_in_gateway: true`). One dispatcher sweeps all boards per tick; workers are spawned with `HERMES_KANBAN_BOARD` pinned so they can't see other boards. After `kanban.failure_limit` consecutive spawn failures on the same task (default: 2) the dispatcher auto-blocks it with the last error as the reason — prevents thrashing on tasks whose profile doesn't exist, workspace can't mount, etc.
 - **Tenant** — optional string namespace *within* a board. One specialist fleet can serve multiple businesses (`--tenant business-a`) with data isolation by workspace path and memory key prefix. Tenants are a soft filter; boards are the hard isolation boundary.
+
+### Worktree lifecycle and explicit cleanup
+
+Kanban owns only the task worktrees it creates under
+`.worktrees/t_<task-id>/`. The CLI startup stale-worktree pruner skips these
+task-owned trees, so it cannot accidentally remove a user's named worktree.
+When a coding task is delivered through the review lane and approved, its
+completed worktree and branch remain available for inspection.
+
+Use an explicit cleanup action when it is no longer needed:
+
+```bash
+hermes kanban archive <task-id>   # archive and clean its workspace
+hermes kanban gc                  # clean eligible done/archived workspaces
+```
+
+Cleanup is fail-safe: removal requires the canonical task-owned linked
+checkout at `<repo>/.worktrees/<task-id>`, with a clean tree and commits
+reachable from a remote-tracking ref. Dirty, unpushed, and explicitly custom
+worktree targets are retained. Scratch workspaces still disappear on normal
+completion, and abandoned tasks can be archived or collected without
+affecting the main checkout or user-created worktrees.
 
 ## Boards (multi-project)
 


### PR DESCRIPTION
## Summary
- Preserve Kanban worktrees and task branches after review-only delivery until explicit archive or GC.
- Keep scratch/abandoned cleanup and dirty/unpushed safety behavior intact.
- Restrict automatic linked-worktree deletion to canonical task-owned `.worktrees/<task-id>` paths.
- Document lifecycle and add regression coverage for review, archive/GC, deferred parents, ownership, and malformed provenance.

## Verification
- `pytest -q tests/hermes_cli/test_kanban_worktree_teardown.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_db.py` — 91 passed, 1 skipped
- `python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_worktree_teardown.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py` — passed
- `git diff --check` — passed
- Independent Codex review — APPROVE

Review-only draft PR; do not merge without maintainer approval.