### PR TITLE
fix(gateway): respect tool_preview_length=0 as no-limit in progress bubbles

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3372,7 +3372,13 @@ class BasePlatformAdapter(ABC):
         if preview:
             from agent.display import prepare_tool_preview
 
-            cap = preview_max_len if preview_max_len > 0 else 40
+            # cap semantics: 0 means "no limit" (config_defaults + tips both
+            # document 0 = show full paths/commands); only fall back to 40 when
+            # the value is missing entirely (None).  Local patch 2026-08-20.
+            if preview_max_len is None:
+                cap = 40
+            else:
+                cap = preview_max_len
             prepared = prepare_tool_preview(
                 event.tool_name,
                 event.args,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4324,11 +4324,16 @@ class TurnRunner:
             _code_block_full = f"{_block_header}```\n{_cmd_full}\n```"
             # Single-line, capped preview for non-verbose modes.
             _pl = get_tool_preview_max_len()
-            _cap = _pl if _pl > 0 else 40
+            # 0 = no limit (per config docs); only fall back to 40 when
+            # unset. Local patch 2026-08-20 (upstream treated 0 as falsy).
+            _cap = 40 if _pl is None else _pl
             _lines = _cmd_full.splitlines()
             _cmd_short = _lines[0] if _lines else _cmd_full
             _multiline = len(_lines) > 1
-            if len(_cmd_short) > _cap:
+            # _cap == 0 means unlimited — skip truncation entirely
+            # (guard added in local patch 2026-08-20: `len > 0` is always
+            # true, so an unguarded branch would cut len-3 chars off).
+            if _cap > 0 and len(_cmd_short) > _cap:
                 _cmd_short = _cmd_short[:_cap - 3] + "..."
             elif _multiline:
                 _cmd_short = _cmd_short + " ..."
@@ -4375,7 +4380,8 @@ class TurnRunner:
                 verb_drops_preview,
             )
             _pl = get_tool_preview_max_len()
-            _cap = _pl if _pl > 0 else 40
+            # 0 = no limit; fall back only when unset. Local patch 2026-08-20.
+            _cap = 40 if _pl is None else _pl
             _prepared_preview = prepare_tool_preview(
                 tool_name,
                 args,


### PR DESCRIPTION
## Problem

`display.tool_preview_length: 0` is documented as **no limit** (config_defaults comment: *"0 = no limit, show full paths/commands"*; tips.py says the same). The CLI spinner path honors it. But three gateway paths use the pattern:

```python
cap = preview_max_len if preview_max_len > 0 else 40
```

which treats 0 as falsy and silently falls back to a hardcoded 40-char cap:

- `gateway/platforms/base.py` — `format_tool_progress_event`
- `gateway/run.py` — terminal code-block preview (~line 4327)
- `gateway/run.py` — generic tool preview (~line 4380)

On messaging platforms (reproduced on Feishu) this makes tool-progress bubbles show truncated commands like `⚙️ terminal: sed -n '3800,3830p' ~/.hermes/hermes-...` with no way to see the full command, even though the user explicitly configured 0 = unlimited.

## Fix

- All three sites: fall back to 40 **only when the value is unset** (`None`), pass 0 through.
- Guard the inline truncation with `_cap > 0` so a 0 cap skips truncation entirely — without the guard, `len > 0` is always true and `[:0-3]` becomes `[:-3]`, chopping the last 3 chars instead of disabling truncation (a subtle regression I hit while patching).

## Verification

- `_cap=0`: 43-char and 184-char commands render in full in the progress bubble (tested live on Feishu after gateway restart).
- `_cap=40`: behavior unchanged (single-line preview capped at 40).
- Multi-line commands: unchanged (first line + ` ...` continuation marker).