### PR TITLE
fix(plugins): let installer accept manifest_version 2

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -141,7 +141,7 @@ def _scan_plugin_tree(plugin_dir: Path, identifier: str, *, force: bool, scan_de
 # Minimum manifest version this installer understands.
 # Plugins may declare ``manifest_version: 1`` in plugin.yaml;
 # future breaking changes to the manifest schema bump this.
-_SUPPORTED_MANIFEST_VERSION = 1
+_SUPPORTED_MANIFEST_VERSION = 2
 
 
 def _plugins_dir() -> Path:


### PR DESCRIPTION
## Summary
The plugin loader (`hermes_cli/plugins.py`) supports `manifest_version 2`, but the installer (`hermes_cli/plugins_cmd.py`) still checked `_SUPPORTED_MANIFEST_VERSION = 1`, hard-blocking any v2 plugin at install time. Since the loader tolerates v2 (ignoring unknown fields), the installer should accept it too.

One-line change: bump `_SUPPORTED_MANIFEST_VERSION` to 2 to match the loader.

## Repro
`hermes plugins install ADWilkinson/usdctofiat-hermes-plugin` (declares `manifest_version: 2`) fails with:
```
Error: Plugin 'usdctofiat' requires manifest_version 2, but this installer only supports up to 1.
```

## Test Plan
- [x] Applied the change locally; the v2 plugin then installs and enables cleanly
- [x] Loader already tolerates v2 (plugins.py:701-706 'loading anyway and ignoring unknown fields')

Closes #90451