### PR TITLE
fix(desktop): let worktree checkout hooks finish

### DIFF
--- a/apps/desktop/electron/git-worktree-ops.test.ts
+++ b/apps/desktop/electron/git-worktree-ops.test.ts
@@ -9,12 +9,77 @@ import { test } from 'vitest'
 import {
   addWorktree,
   ensureGitRepo,
+  gitTimeoutFor,
   listBaseBranches,
   listBranches,
   parseWorktrees,
   sanitizeBranch,
   switchBranch
 } from './git-worktree-ops'
+
+test('checkout-like git commands allow repository hooks to finish', () => {
+  const probeTimeout = gitTimeoutFor(['status', '--short'])
+
+  assert.ok(gitTimeoutFor(['worktree', 'add', '/tmp/tree', 'main']) > probeTimeout)
+  assert.ok(gitTimeoutFor(['switch', 'feature']) > probeTimeout)
+  assert.ok(gitTimeoutFor(['checkout', 'feature']) > probeTimeout)
+  assert.ok(
+    gitTimeoutFor([
+      '-c',
+      'user.email=hermes@localhost',
+      '-c',
+      'user.name=Hermes',
+      'commit',
+      '--allow-empty',
+      '-m',
+      'Initial commit'
+    ]) > probeTimeout
+  )
+  assert.equal(gitTimeoutFor(['status', '--', 'commit']), probeTimeout)
+  assert.equal(gitTimeoutFor(['diff', '--', 'commit']), probeTimeout)
+})
+
+test.skipIf(process.platform === 'win32')(
+  'addWorktree reports partial success when a post-checkout hook fails after creation',
+  async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-wt-hook-failure-'))
+
+    try {
+      await ensureGitRepo('git', dir)
+      const hook = path.join(dir, '.git', 'hooks', 'post-checkout')
+
+      fs.writeFileSync(hook, '#!/bin/sh\nprintf "project setup failed\\n" >&2\nexit 42\n')
+      fs.chmodSync(hook, 0o755)
+
+      const result = await addWorktree(dir, { branch: 'hook-failure', name: 'hook-failure' }, 'git')
+
+      assert.equal(result.setupIncomplete, true)
+      assert.match(result.warning, /post-checkout/i)
+      assert.equal(
+        execFileSync('git', ['branch', '--show-current'], { cwd: result.path }).toString().trim(),
+        'hook-failure'
+      )
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  }
+)
+
+test('addWorktree does not treat stale metadata for a missing directory as partial success', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-wt-stale-metadata-'))
+  const stalePath = path.join(dir, '.worktrees', 'stale-feature')
+
+  try {
+    await ensureGitRepo('git', dir)
+    execFileSync('git', ['worktree', 'add', '-b', 'stale-feature', stalePath], { cwd: dir })
+    fs.rmSync(stalePath, { recursive: true, force: true })
+
+    await assert.rejects(() => addWorktree(dir, { branch: 'stale-feature', name: 'stale-feature' }, 'git'))
+    assert.equal(fs.existsSync(stalePath), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
 
 test('sanitizeBranch: spaces → hyphens, forbidden chars dropped, edges trimmed', () => {
   assert.equal(sanitizeBranch('beach vibes'), 'beach-vibes')

--- a/apps/desktop/electron/git-worktree-ops.ts
+++ b/apps/desktop/electron/git-worktree-ops.ts
@@ -8,12 +8,48 @@ import path from 'node:path'
 
 import { resolveRequestedPathForIpc } from './hardening'
 
+const DEFAULT_GIT_TIMEOUT_MS = 30_000
+const HOOK_CAPABLE_GIT_TIMEOUT_MS = 15 * 60_000
+const GIT_GLOBAL_OPTIONS_WITH_VALUE = new Set(['-c', '-C', '--config-env', '--git-dir', '--namespace', '--work-tree'])
+
+function gitSubcommand(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = String(args[index] || '')
+
+    if (arg === '--') {
+      break
+    }
+
+    if (GIT_GLOBAL_OPTIONS_WITH_VALUE.has(arg)) {
+      index += 1
+    } else if (!arg.startsWith('-')) {
+      return { index, name: arg }
+    }
+  }
+
+  return { index: -1, name: '' }
+}
+
+// Checkout-like mutations synchronously run repository hooks. A single global
+// 30-second budget kills legitimate post-checkout setup (dependency installs,
+// code generation, Git LFS) after the worktree has already been created.
+// Keep probes bounded tightly while giving commands that can run hooks a real
+// interactive-operation budget.
+function gitTimeoutFor(args) {
+  const command = gitSubcommand(args)
+  const addsWorktree = command.name === 'worktree' && args[command.index + 1] === 'add'
+
+  return addsWorktree || command.name === 'checkout' || command.name === 'commit' || command.name === 'switch'
+    ? HOOK_CAPABLE_GIT_TIMEOUT_MS
+    : DEFAULT_GIT_TIMEOUT_MS
+}
+
 function runGit(gitBin, args, cwd): Promise<string> {
   return new Promise((resolve, reject) => {
     execFile(
       gitBin,
       args,
-      { cwd, windowsHide: true, timeout: 30_000, maxBuffer: 8 * 1024 * 1024 },
+      { cwd, windowsHide: true, timeout: gitTimeoutFor(args), maxBuffer: 8 * 1024 * 1024 },
       (err, stdout, stderr) => {
         if (err) {
           err.stderr = String(stderr || '')
@@ -242,6 +278,65 @@ function uniqueDir(base) {
   return dir
 }
 
+function canonicalPath(value) {
+  try {
+    return fs.realpathSync(value)
+  } catch {
+    return path.resolve(value)
+  }
+}
+
+async function worktreeWasCreated(gitBin, root, dir, branch) {
+  try {
+    if (!fs.statSync(dir).isDirectory()) {
+      return false
+    }
+  } catch {
+    return false
+  }
+
+  const expectedPath = canonicalPath(dir)
+  const trees = await listWorktrees(root, gitBin)
+  const listed = trees.some(tree => !tree.locked && tree.branch === branch && canonicalPath(tree.path) === expectedPath)
+
+  if (!listed) {
+    return false
+  }
+
+  try {
+    const inside = (await runGit(gitBin, ['-C', dir, 'rev-parse', '--is-inside-work-tree'], root)).trim()
+    const currentBranch = (await runGit(gitBin, ['-C', dir, 'branch', '--show-current'], root)).trim()
+
+    return inside === 'true' && currentBranch === branch
+  } catch {
+    return false
+  }
+}
+
+async function runWorktreeAdd(gitBin, root, args, result) {
+  try {
+    await runGit(gitBin, args, root)
+
+    return result
+  } catch (err) {
+    // `git worktree add` is not atomic with respect to post-checkout hooks: the
+    // checkout and branch can be complete before a hook exits nonzero or the
+    // parent process times out. Reconcile against git's authoritative worktree
+    // list so the renderer does not tell the user creation failed and then
+    // poison a retry with an already-checked-out branch.
+    if (await worktreeWasCreated(gitBin, root, result.path, result.branch)) {
+      return {
+        ...result,
+        setupIncomplete: true,
+        warning:
+          'Worktree created, but its post-checkout setup did not finish. Dependency installation or code generation may be incomplete; rerun the repository setup command in the worktree.'
+      }
+    }
+
+    throw err
+  }
+}
+
 async function addExistingBranchWorktree(gitBin, root, name) {
   const requested = sanitizeBranch(name)
 
@@ -275,14 +370,18 @@ async function addExistingBranchWorktree(gitBin, root, name) {
       // that the repo already has.
     }
 
-    await runGit(gitBin, ['worktree', 'add', '--track', '-b', branch, dir, requested], root)
-
-    return { path: dir, branch, repoRoot: root }
+    return runWorktreeAdd(gitBin, root, ['worktree', 'add', '--track', '-b', branch, dir, requested], {
+      path: dir,
+      branch,
+      repoRoot: root
+    })
   }
 
-  await runGit(gitBin, ['worktree', 'add', dir, branch], root)
-
-  return { path: dir, branch, repoRoot: root }
+  return runWorktreeAdd(gitBin, root, ['worktree', 'add', dir, branch], {
+    path: dir,
+    branch,
+    repoRoot: root
+  })
 }
 
 async function addWorktree(repoPath, options, gitBin) {
@@ -333,18 +432,20 @@ async function addWorktree(repoPath, options, gitBin) {
   }
 
   try {
-    await runGit(gitBin, args, root)
+    return await runWorktreeAdd(gitBin, root, args, { path: dir, branch, repoRoot: root })
   } catch (err) {
     // Branch name may already exist — retry checking out the existing branch
     // into a fresh worktree dir instead of failing the whole flow.
     if (/already exists/i.test(err.stderr || '')) {
-      await runGit(gitBin, ['worktree', 'add', dir, branch], root)
+      return runWorktreeAdd(gitBin, root, ['worktree', 'add', dir, branch], {
+        path: dir,
+        branch,
+        repoRoot: root
+      })
     } else {
       throw err
     }
   }
-
-  return { path: dir, branch, repoRoot: root }
 }
 
 async function removeWorktree(repoPath, worktreePath, options, gitBin) {
@@ -527,6 +628,7 @@ async function listBaseBranches(repoPath, gitBin) {
 export {
   addWorktree,
   ensureGitRepo,
+  gitTimeoutFor,
   listBaseBranches,
   listBranches,
   listWorktrees,

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -307,7 +307,7 @@ declare global {
         worktreeAdd: (
           repoPath: string,
           options?: { name?: string; branch?: string; base?: string; existingBranch?: string }
-        ) => Promise<{ path: string; branch: string; repoRoot: string }>
+        ) => Promise<HermesGitWorktreeAddResult>
         worktreeRemove: (
           repoPath: string,
           worktreePath: string,
@@ -1154,6 +1154,15 @@ export interface HermesGitWorktree {
   isMain: boolean
   detached: boolean
   locked: boolean
+}
+
+export interface HermesGitWorktreeAddResult {
+  path: string
+  branch: string
+  repoRoot: string
+  /** The checkout exists, but a repository post-checkout hook failed or timed out. */
+  setupIncomplete?: boolean
+  warning?: string
 }
 
 // A branch that the "convert a branch into a worktree" picker offers: the local

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -280,6 +280,29 @@ describe('worktree refresh', () => {
 })
 
 describe('startWorkInRepo remote capability gate (#81724)', () => {
+  it('warns when git created the worktree but repository setup did not finish', async () => {
+    isDesktopFsRemoteMode.mockReturnValue(false)
+    desktopGit.mockReturnValue({
+      worktreeAdd: vi.fn(async () => ({
+        branch: 'feature',
+        path: '/repo/.worktrees/feature',
+        repoRoot: '/repo',
+        setupIncomplete: true,
+        warning: 'Worktree created, but its post-checkout setup did not finish.'
+      }))
+    } as never)
+    notify.mockClear()
+
+    await expect(startWorkInRepo('/repo', { branch: 'feature' })).resolves.toEqual({
+      branch: 'feature',
+      path: '/repo/.worktrees/feature'
+    })
+    expect(notify).toHaveBeenCalledWith({
+      kind: 'warning',
+      message: 'Worktree created, but its post-checkout setup did not finish.'
+    })
+  })
+
   it('names the stale-backend remedy when a remote gateway lacks the worktree route', async () => {
     isDesktopFsRemoteMode.mockReturnValue(true)
     desktopGit.mockReturnValue({

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -1106,6 +1106,10 @@ export async function startWorkInRepo(
 
   bumpWorktrees()
 
+  if (result.setupIncomplete && result.warning) {
+    notify({ kind: 'warning', message: result.warning })
+  }
+
   return { branch: result.branch, path: result.path }
 }
 

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from hermes_cli._subprocess_compat import noninteractive_git_env
 
 _GIT_TIMEOUT = 30
+_GIT_HOOK_TIMEOUT = 15 * 60
 _GH_TIMEOUT = 30
 _MAX_BUFFER = 32 * 1024 * 1024
 _UNTRACKED_LINE_MAX_BYTES = 1024 * 1024
@@ -29,9 +30,47 @@ _UNTRACKED_SCAN_CAP = 500
 _COMMIT_CONTEXT_DIFF_MAX_CHARS = 120_000
 _COMMIT_CONTEXT_UNTRACKED_MAX = 80
 _TRUNK_BRANCHES = ("main", "master")
+_GIT_GLOBAL_OPTIONS_WITH_VALUE = {
+    "-c",
+    "-C",
+    "--config-env",
+    "--git-dir",
+    "--namespace",
+    "--work-tree",
+}
 
 
-def _git(cwd: str, args: list[str], *, timeout: int = _GIT_TIMEOUT) -> tuple[int, str, str]:
+def _git_subcommand(args: list[str]) -> tuple[int, str]:
+    index = 0
+    while index < len(args):
+        arg = str(args[index] or "")
+        if arg == "--":
+            break
+        if arg in _GIT_GLOBAL_OPTIONS_WITH_VALUE:
+            index += 2
+            continue
+        if not arg.startswith("-"):
+            return index, arg
+        index += 1
+    return -1, ""
+
+
+def _git_timeout_for(args: list[str]) -> int:
+    """Return a hook-safe budget for checkout-like mutations."""
+    command_index, command = _git_subcommand(args)
+    adds_worktree = (
+        command == "worktree"
+        and command_index + 1 < len(args)
+        and args[command_index + 1] == "add"
+    )
+    return (
+        _GIT_HOOK_TIMEOUT
+        if adds_worktree or command in {"checkout", "commit", "switch"}
+        else _GIT_TIMEOUT
+    )
+
+
+def _git(cwd: str, args: list[str], *, timeout: int | None = None) -> tuple[int, str, str]:
     """Run ``git`` in ``cwd``. Returns (returncode, stdout, stderr); never raises
     on a non-zero exit (callers decide what an error means).
 
@@ -39,7 +78,12 @@ def _git(cwd: str, args: list[str], *, timeout: int = _GIT_TIMEOUT) -> tuple[int
     calls serve authenticated REST requests from the dashboard/desktop, so a
     credential prompt from ``fetch``/``push``/``pull`` could never be answered
     — it would just hang the request until the timeout. Failing fast surfaces
-    the real auth error in the toast instead."""
+    the real auth error in the toast instead. Checkout-like mutations receive a
+    longer budget because they synchronously run repository hooks.
+    """
+    if timeout is None:
+        timeout = _git_timeout_for(args)
+
     try:
         proc = subprocess.run(
             ["git", *args],
@@ -682,6 +726,51 @@ def _unique_dir(base: str) -> str:
     return candidate
 
 
+_WORKTREE_SETUP_WARNING = (
+    "Worktree created, but its post-checkout setup did not finish. "
+    "Dependency installation or code generation may be incomplete; rerun the "
+    "repository setup command in the worktree."
+)
+
+
+def _worktree_was_created(root: str, target: str, branch: str) -> bool:
+    target_path = Path(target)
+    if not target_path.is_dir():
+        return False
+
+    expected = target_path.resolve()
+    listed = any(
+        not tree["locked"]
+        and tree["branch"] == branch
+        and Path(tree["path"]).resolve() == expected
+        for tree in worktree_list(root)
+    )
+    if not listed:
+        return False
+
+    inside_code, inside, _ = _git(target, ["rev-parse", "--is-inside-work-tree"])
+    branch_code, current_branch, _ = _git(target, ["branch", "--show-current"])
+    return (
+        inside_code == 0
+        and inside.strip() == "true"
+        and branch_code == 0
+        and current_branch.strip() == branch
+    )
+
+
+def _run_worktree_add(root: str, args: list[str], result: dict) -> dict:
+    code, _, err = _git(root, args)
+    if code == 0:
+        return result
+    if _worktree_was_created(root, result["path"], result["branch"]):
+        return {
+            **result,
+            "setupIncomplete": True,
+            "warning": _WORKTREE_SETUP_WARNING,
+        }
+    raise RuntimeError(err.strip() or "git worktree add failed")
+
+
 def _remote_of_ref(cwd: str, name: str) -> str:
     """The remote a ref belongs to ("origin" for "origin/main"), or "" when the
     name is not a remote-tracking ref in this repo. Asks git rather than
@@ -720,10 +809,16 @@ def worktree_add(cwd: str, options: dict) -> dict:
             # user did not fetch recently. On failure (offline, branch gone)
             # the last known ref is still there to branch from.
             _git(root, ["fetch", remote, existing])
-            _git_ok(root, ["worktree", "add", "--track", "-b", existing, target, requested])
-            return {"path": target, "branch": existing, "repoRoot": root}
-        _git_ok(root, ["worktree", "add", target, existing])
-        return {"path": target, "branch": existing, "repoRoot": root}
+            return _run_worktree_add(
+                root,
+                ["worktree", "add", "--track", "-b", existing, target, requested],
+                {"path": target, "branch": existing, "repoRoot": root},
+            )
+        return _run_worktree_add(
+            root,
+            ["worktree", "add", target, existing],
+            {"path": target, "branch": existing, "repoRoot": root},
+        )
 
     slug = _slugify(options.get("name") or f"work-{os.urandom(4).hex()}")
     branch = _sanitize_branch(options.get("branch") or "") or f"hermes/{slug}"
@@ -744,13 +839,13 @@ def worktree_add(cwd: str, options: dict) -> dict:
             # checkout -b new` — so suppress it (parity with the Electron op).
             args.append("--no-track")
         args.append(base)
-    code, _, err = _git(root, args)
-    if code != 0:
-        if "already exists" in (err or "").lower():
-            _git_ok(root, ["worktree", "add", target, branch])
-        else:
-            raise RuntimeError(err.strip() or "git worktree add failed")
-    return {"path": target, "branch": branch, "repoRoot": root}
+    result = {"path": target, "branch": branch, "repoRoot": root}
+    try:
+        return _run_worktree_add(root, args, result)
+    except RuntimeError as exc:
+        if "already exists" in str(exc).lower():
+            return _run_worktree_add(root, ["worktree", "add", target, branch], result)
+        raise
 
 
 def worktree_remove(cwd: str, worktree_path: str, force: bool) -> dict:

--- a/tests/hermes_cli/test_web_server_git.py
+++ b/tests/hermes_cli/test_web_server_git.py
@@ -1,9 +1,11 @@
+import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
-from hermes_cli import web_server
+from hermes_cli import web_git, web_server
 
 pytest.importorskip("starlette.testclient")
 from starlette.testclient import TestClient
@@ -29,6 +31,17 @@ def client():
 
 def _git(repo: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+def test_checkout_like_git_commands_allow_repository_hooks_to_finish():
+    probe_timeout = web_git._git_timeout_for(["status", "--short"])
+
+    assert web_git._git_timeout_for(["worktree", "add", "/tmp/tree", "main"]) > probe_timeout
+    assert web_git._git_timeout_for(["switch", "feature"]) > probe_timeout
+    assert web_git._git_timeout_for(["checkout", "feature"]) > probe_timeout
+    assert web_git._git_timeout_for(["commit", "--allow-empty", "-m", "Initial commit"]) > probe_timeout
+    assert web_git._git_timeout_for(["status", "--", "commit"]) == probe_timeout
+    assert web_git._git_timeout_for(["diff", "--", "commit"]) == probe_timeout
 
 
 @pytest.fixture
@@ -94,6 +107,41 @@ def test_worktree_add_initializes_plain_folder(client, tmp_path):
     assert status["branch"]
     # Existing files are not silently committed by repo initialization.
     assert any(file["path"] == "notes.txt" and file["untracked"] for file in status["files"])
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell hook fixture")
+def test_worktree_add_reports_partial_success_after_post_checkout_failure(client, repo):
+    hook = repo / ".git" / "hooks" / "post-checkout"
+    hook.write_text(
+        '#!/bin/sh\nprintf "project setup failed\\n" >&2\nexit 42\n',
+        encoding="utf-8",
+    )
+    hook.chmod(0o755)
+
+    response = client.post(
+        "/api/git/worktree/add",
+        json={"path": str(repo), "branch": "hook-failure", "name": "hook-failure"},
+    )
+
+    assert response.status_code == 200
+    added = response.json()
+    assert added["setupIncomplete"] is True
+    assert "post-checkout" in added["warning"]
+    assert Path(added["path"]).is_dir()
+
+
+def test_worktree_add_rejects_stale_metadata_for_a_missing_directory(client, repo):
+    stale_path = repo / ".worktrees" / "stale-feature"
+    _git(repo, "worktree", "add", "-b", "stale-feature", str(stale_path))
+    shutil.rmtree(stale_path)
+
+    response = client.post(
+        "/api/git/worktree/add",
+        json={"path": str(repo), "branch": "stale-feature", "name": "stale-feature"},
+    )
+
+    assert response.status_code == 400
+    assert not stale_path.exists()
 
 
 


### PR DESCRIPTION
## Bug Description

Hermes Desktop reported `git worktree add` as failed for repositories whose synchronous `post-checkout` setup took longer than 30 seconds. Git had already created the branch and worktree, so retrying then failed against the leftover checkout. This reproduced in a large pnpm workspace whose hook installs dependencies and generates Prisma clients.

## Root Cause

The Electron Git bridge and remote dashboard Git mirror applied the same 30-second timeout to quick probes and checkout-like mutations. `git worktree add`, `git switch`, `git checkout`, and `git commit` can synchronously run repository hooks, so the timeout could kill a legitimate operation after its Git state mutation had completed.

The add-worktree error paths also assumed a nonzero exit meant no worktree existed and did not reconcile against Git's authoritative worktree list.

## Fix

- Keep quick Git probes on the existing 30-second budget while allowing hook-capable mutations up to 15 minutes.
- Apply the same timeout policy in Electron and the remote REST Git mirror.
- Reconcile a failed `worktree add` against the expected unlocked path and branch, then verify the directory is a live Git worktree on that branch.
- Return partial success when Git created the worktree but post-checkout setup failed or timed out.
- Surface a persistent warning that dependency installation or code generation may need to be rerun.
- Preserve existing-branch retry behavior.

## How to Verify

1. Configure a repository `post-checkout` hook that exits nonzero after checkout.
2. Create a worktree through Desktop.
3. Confirm the worktree lane/session opens once and Desktop warns that setup did not finish instead of reporting creation failed.
4. Confirm quick Git probes retain their 30-second timeout while checkout-like commands receive the longer budget.

## Test Plan

- [x] Added Electron regression coverage for timeout selection and post-checkout partial success.
- [x] Added remote REST regression coverage for timeout parity and partial success.
- [x] Added renderer coverage for the warning notification.
- [x] `npm run test:desktop:platforms` — 1,481 passed, 2 skipped.
- [x] `npm run test:ui` — 5,096 passed.
- [x] `scripts/run_tests.sh tests/hermes_cli/test_web_server_git.py -v` — 9 passed.
- [x] `npm run typecheck`.
- [x] Targeted ESLint and Prettier checks.
- [x] `npm run build`.

## Risk Assessment

Low to medium — only checkout-like Git mutations receive a longer timeout, and the operation remains bounded. Partial success requires an unlocked worktree matching both the internally generated target path and expected branch; all other errors continue to surface normally.
