### PR TITLE
fix(checkpoints): /rollback no longer reports "No checkpoints found" while other projects have them (#10505)

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -88,8 +88,19 @@ class CLICommandsMixin:
         args = filtered
 
         if not args:
-            # List checkpoints
+            # List checkpoints — fall back to the cross-project view when the
+            # current directory has none (#10505, reapply of PR #10633 by
+            # @nightq). The Aug 2026 QA sweep hit this live: writes landed
+            # checkpoints under the session cwd (/tmp/qa-repo) while bare
+            # /rollback searched only TERMINAL_CWD's project and reported
+            # "No checkpoints found" despite fresh checkpoints existing.
             checkpoints = mgr.list_checkpoints(cwd)
+            if not checkpoints:
+                all_checkpoints = mgr.list_all_checkpoints()
+                if all_checkpoints:
+                    print(f"  No checkpoints for {cwd} — showing all directories.")
+                    print(format_checkpoint_list(all_checkpoints, "all directories"))
+                    return
             print(format_checkpoint_list(checkpoints, cwd))
             return
 

--- a/tests/tools/test_rollback_all_directories.py
+++ b/tests/tools/test_rollback_all_directories.py
@@ -1,0 +1,70 @@
+"""Regression tests for the /rollback all-directories fallback (#10505).
+
+Bare /rollback searched only TERMINAL_CWD's project; checkpoints created
+under a different session cwd were invisible ("No checkpoints found for
+/home/user" while checkpoints existed seconds earlier). Reapply of PR
+#10633 by @nightq onto the v2 single-store layout.
+"""
+
+import json
+
+import tools.checkpoint_manager as cm
+from tools.checkpoint_manager import CheckpointManager, format_checkpoint_list
+
+
+def _make_store_with_project(tmp_path, workdir: str):
+    store = tmp_path / "store"
+    (store / cm._PROJECTS_DIRNAME).mkdir(parents=True)
+    (store / "HEAD").write_text("ref: refs/heads/main\n")
+    dir_hash = cm._project_hash(workdir)
+    meta = {"workdir": workdir, "created_at": 1, "last_touch": 2}
+    (store / cm._PROJECTS_DIRNAME / f"{dir_hash}.json").write_text(json.dumps(meta))
+    return store
+
+
+class TestListAllCheckpoints:
+    def test_aggregates_projects_and_labels_workdir(self, tmp_path, monkeypatch):
+        workdir = str(tmp_path / "proj")
+        store = _make_store_with_project(tmp_path, workdir)
+        monkeypatch.setattr(cm, "CHECKPOINT_BASE", tmp_path)
+        monkeypatch.setattr(cm, "_store_path", lambda base=None: store)
+
+        mgr = CheckpointManager(enabled=True)
+        fake_entries = [
+            {"hash": "a" * 40, "short_hash": "aaaaaaa", "timestamp": "2026-08-19T10:00:00",
+             "reason": "before write_file", "files_changed": 1, "insertions": 2, "deletions": 0},
+        ]
+        monkeypatch.setattr(
+            CheckpointManager, "list_checkpoints", lambda self, wd: list(fake_entries)
+        )
+
+        results = mgr.list_all_checkpoints()
+        assert len(results) == 1
+        assert results[0]["workdir"] == workdir
+
+    def test_empty_store_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(cm, "CHECKPOINT_BASE", tmp_path)
+        monkeypatch.setattr(cm, "_store_path", lambda base=None: tmp_path / "missing")
+        assert CheckpointManager(enabled=True).list_all_checkpoints() == []
+
+
+class TestFormatAllDirectories:
+    def test_workdir_label_shown_in_all_directories_view(self):
+        cps = [{
+            "hash": "b" * 40, "short_hash": "bbbbbbb",
+            "timestamp": "2026-08-19T10:00:00", "reason": "before patch",
+            "files_changed": 0, "insertions": 0, "deletions": 0,
+            "workdir": "/tmp/qa-repo",
+        }]
+        out = format_checkpoint_list(cps, "all directories")
+        assert "[qa-repo]" in out
+
+    def test_single_directory_view_unchanged(self):
+        cps = [{
+            "hash": "c" * 40, "short_hash": "ccccccc",
+            "timestamp": "2026-08-19T10:00:00", "reason": "before patch",
+            "files_changed": 0, "insertions": 0, "deletions": 0,
+        }]
+        out = format_checkpoint_list(cps, "/tmp/qa-repo")
+        assert "[qa-repo]" not in out
+        assert "ccccccc" in out

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -968,6 +968,29 @@ class CheckpointManager:
                 results.append(entry)
         return results
 
+    def list_all_checkpoints(self) -> List[Dict]:
+        """List checkpoints across every registered project (most recent first).
+
+        Surgical reapply of PR #10633 by @nightq (#10505) onto the v2
+        single-store layout: iterate ``projects/<hash>.json`` metadata via
+        ``_list_projects`` instead of the pre-v2 per-shadow-dir scan. Each
+        entry carries the extra ``workdir`` key so callers can label which
+        project a checkpoint belongs to.
+        """
+        store = _store_path(CHECKPOINT_BASE)
+        if not (store / "HEAD").exists():
+            return []
+        results: List[Dict] = []
+        for meta in _list_projects(store):
+            workdir = meta.get("workdir") or ""
+            if not workdir:
+                continue
+            for entry in self.list_checkpoints(workdir):
+                entry["workdir"] = workdir
+                results.append(entry)
+        results.sort(key=lambda x: x.get("timestamp", ""), reverse=True)
+        return results
+
     @staticmethod
     def _parse_shortstat(stat_line: str, entry: Dict) -> None:
         """Parse git --shortstat output into entry dict."""
@@ -1563,7 +1586,16 @@ def format_checkpoint_list(checkpoints: List[Dict], directory: str) -> str:
         else:
             stat = ""
 
-        lines.append(f"  {i}. {cp['short_hash']}  {ts}  {cp['reason']}{stat}")
+        # Label per-project entries when showing the cross-project view
+        # (workdir key only present on list_all_checkpoints results).
+        workdir = cp.get("workdir", "")
+        if workdir and directory == "all directories":
+            workdir_short = Path(workdir).name or workdir
+            lines.append(
+                f"  {i}. {cp['short_hash']}  {ts}  [{workdir_short}]  {cp['reason']}{stat}"
+            )
+        else:
+            lines.append(f"  {i}. {cp['short_hash']}  {ts}  {cp['reason']}{stat}")
 
     lines.append("\n  /rollback <N>             restore to checkpoint N")
     lines.append("  /rollback diff <N>        preview changes since checkpoint N")


### PR DESCRIPTION
## Summary
Bare `/rollback` now falls back to a labeled cross-project checkpoint list instead of reporting "No checkpoints found" while checkpoints exist under another directory.

Surgical reapply of PR #10633 by @nightq (fixes #10505) onto the v2 single-store checkpoint layout — the original targeted the pre-v2 per-shadow-dir scan and no longer applied.

Reproduced live in the round-2 QA sweep: the agent's writes checkpointed the session cwd (`/tmp/qa-repo`, 2 fresh checkpoints), but bare `/rollback` searched only `TERMINAL_CWD` (`/home/teknium`) and printed "No checkpoints found for /home/teknium" — the user's undo path looked empty seconds after a write.

## Changes
- `tools/checkpoint_manager.py`: `list_all_checkpoints()` — aggregates every registered project via `projects/*.json`, most-recent-first, each entry carrying `workdir`; `format_checkpoint_list()` shows a `[dirname]` label in the all-directories view
- `hermes_cli/cli_commands_mixin.py`: bare `/rollback` falls back to the cross-project view (with an explicit "showing all directories" notice) when the cwd project has none
- `tests/tools/test_rollback_all_directories.py`: aggregation, empty-store, and label/no-label formatting contracts

## Validation
| | Before | After |
|---|---|---|
| bare `/rollback` from a cwd without checkpoints | "No checkpoints found for /home/teknium" | "showing all directories" + `[qa-repo]`-labeled list (live-verified in tmux) |
| targeted tests | — | 4 passed |

Original PR to close on merge: #10633 (credited author; commit reapplied rather than cherry-picked because the v2 store rewrite obsoleted the original patch base).

## Infographic

![rollback fallback fix infographic](https://files.catbox.moe/fwn2un.png)
