### PR TITLE
fix(display): stop misclassifying web_extract/web_search successes as failures

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1370,6 +1370,17 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
         if err and (data.get("success") is False or "error" in data):
             return True, f" [{_trim_error(str(err))}]"
 
+    # Tools whose normal result contract includes an "error" key per item
+    # (value is null on success). The string-literal heuristic below would
+    # false-positive on them on every successful call, so they are judged
+    # by the structured branches here instead.
+    if tool_name in {"web_extract", "web_search"}:
+        if isinstance(data, dict):
+            for item in data.get("results", []) or []:
+                if isinstance(item, dict) and item.get("error"):
+                    return True, f" [{_trim_error(str(item['error']))}]"
+        return False, ""
+
     # Generic heuristic for non-terminal tools
     # Multimodal tool results (dicts with _multimodal=True) are not strings —
     # treat them as successes since failures would be JSON-encoded strings.


### PR DESCRIPTION
## Problem

`_detect_tool_failure()` ends with a string heuristic:

```python
lower = result[:500].lower()
if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):
    return True, " [error]"
```

`web_extract` and `web_search` have a result contract where **every** item carries an `"error": null` key on success:

```json
{"results": [{"url": "https://example.com", "title": "ok", "content": "...", "error": null}]}
```

So the substring `\"error\"` is always present in a *successful* result → every successful call is tagged `[error]`, polluting per-session tool success/failure stats.

## Fix

Structured branch for these two tools, placed after the JSON-level `data.get("error")` check and before the generic heuristic:

```python
if tool_name in {"web_extract", "web_search"}:
    if isinstance(data, dict):
        for item in data.get("results", []) or []:
            if isinstance(item, dict) and item.get("error"):
                return True, f" [{_trim_error(str(item['error']))}]"
    return False, ""
```

- An item-level non-null error still reports failure (with the real message).
- All-null errors → success, and the generic heuristic is never reached.

## Verification

10/10 cases tested: all-success, single-item failure, mixed results, top-level error, plus regression on the generic string heuristic for other tools.