### PR TITLE
feat(models): add glm-5.2-highspeed to the zai provider catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -366,6 +366,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "zai": [
         "glm-5.2",
+        "glm-5.2-highspeed",
         "glm-5.1",
         "glm-5",
         "glm-5v-turbo",


### PR DESCRIPTION
Z.ai ships `glm-5.2-highspeed` (the coding-plan tier of the GLM 5.2 family), but it is absent from `_PROVIDER_MODELS["zai"]`. Selecting it currently works only via the curated-catalog tolerance path and prints a warning on every model switch.

One-line addition to the catalog list.