### PR TITLE
fix(tui): log 4001 session-not-found rejections for diagnosability

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import subprocess
 import sys
@@ -339,6 +340,38 @@ def test_compute_host_explicit_images_do_not_clear_later_attachment(monkeypatch)
 
     assert response["result"]["status"] == "streaming"
     assert session["attached_images"] == ["/tmp/c.png"]
+
+
+def test_prompt_submit_unknown_session_logs_warning(caplog):
+    """A submit against a reaped runtime id must leave a diagnosable trace.
+
+    Regression for #90428: messages sent into a session whose in-memory
+    runtime was detached on WS disconnect and orphan-reaped vanished
+    silently — the 4001 was never logged, so "request arrived and was
+    rejected" was indistinguishable from "request never arrived".
+    """
+    for session in list(server._sessions.values()):
+        server._teardown_session(session)
+    server._sessions.clear()
+
+    with caplog.at_level(logging.WARNING, logger="tui_gateway.server"):
+        resp = _dispatch_sync(
+            {
+                "id": "r1",
+                "method": "prompt.submit",
+                "params": {"session_id": "gone-sid", "text": "hello"},
+            }
+        )
+
+    assert resp == {
+        "jsonrpc": "2.0",
+        "id": "r1",
+        "error": {"code": 4001, "message": "session not found"},
+    }
+    assert any(
+        "session-scoped RPC rejected" in rec.message and "gone-sid" in rec.message
+        for rec in caplog.records
+    )
 
 
 def test_prompt_submit_fails_open_inline_when_compute_host_dispatch_breaks(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2516,8 +2516,25 @@ def _start_agent_build(sid: str, session: dict) -> None:
 
 
 def _sess_nowait(params, rid):
-    s = _sessions.get(params.get("session_id") or "")
-    return (s, None) if s else (None, _err(rid, 4001, "session not found"))
+    sid = params.get("session_id") or ""
+    s = _sessions.get(sid)
+    if s:
+        return (s, None)
+    # A session-scoped RPC hit a runtime id the gateway no longer holds
+    # (detached on WS disconnect and orphan-reaped, LRU-evicted, or torn down
+    # after an idle TTL). The client is expected to recover via
+    # session.resume on the STORED session id, but a plain stale-id send
+    # leaves no trace anywhere when the resume never fires — every RPC in
+    # this class returned a silent 4001. Log it so a "message vanished"
+    # report is diagnosable as "request arrived and was rejected" instead of
+    # "request never arrived" (see #90428).
+    logger.warning(
+        "session-scoped RPC rejected: session_id=%r not in memory "
+        "(detached/reaped runtime; client should resume the stored session), rid=%r",
+        sid,
+        rid,
+    )
+    return (None, _err(rid, 4001, "session not found"))
 
 
 def _sess(params, rid):


### PR DESCRIPTION
## Summary

Fixes the diagnosability gap in #90428: messages sent into a session whose in-memory runtime was detached on WS disconnect and orphan-reaped vanished **silently** — `_sess_nowait` returned `4001 "session not found"` with **no log line**, so "request arrived and was rejected" was indistinguishable from "request never arrived" when a user reported a vanished message.

This PR adds a `WARNING` log line on every session-scoped RPC rejected against an unknown runtime id, recording the session id and request id. It does not change any response payload or behavior — the 4001 is still returned as before.

## Changes

- `tui_gateway/server.py` — `_sess_nowait` logs a warning (session id + rid) before returning the existing 4001 error.
- `tests/test_tui_gateway_server.py` — new regression test `test_prompt_submit_unknown_session_logs_warning` asserting both the 4001 response and the warning line.

## Test plan

- New test passes.
- Full `tests/test_tui_gateway_server.py` run: 584 passed, 2 failed — both failures (`test_load_enabled_toolsets_falls_back_when_tui_env_invalid`, `test_load_enabled_toolsets_rejects_disabled_mcp_env`) are **pre-existing on `main`** (verified by stashing the change and re-running) and unrelated to this PR.

## Update: scope after community root-cause analysis

The community root-cause analysis in #90428 (comment by luigigiunta) pins the reproduced path to a frontend abort between a successful `session.resume` and `prompt.submit` — a request that never reaches the backend. This PR's server-side log may therefore not fire for that exact path, but it remains the diagnostic layer for stale-runtime sends that DO reach the gateway (where a silent 4001 was previously indistinguishable from a request that never arrived). Relinking from `Closes` to `Part of` to avoid auto-closing the issue on merge.

Part of #90428
