### PR TITLE
fix(desktop): stop Bot Chat click-spam reminting into the launch store

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3404,15 +3404,19 @@ const lastCanonicalPins = new Map()
 let botOpenGeneration = 0
 
 function canonicalChatKey(name, bot) {
-  if (bot && typeof bot === 'object') {
-    return `${bot.connectionId || 'legacy'}::${bot.name || name || 'default'}`
-  }
-  return `legacy::${name || 'default'}`
+  const row = bot && typeof bot === 'object' ? bot : null
+  return botRosterKey({
+    connectionId: row?.connectionId,
+    name: row?.name || name
+  })
 }
 
 function isMissingCanonicalChat(error) {
   const msg = String(error?.message || error || '')
-  return /not found|vanished|unknown session|no such session|does not exist|session not found/i.test(msg)
+  // Session-scoped only. Bare "not found" / "does not exist" match RPC and
+  // filesystem failures. "session not found" is a reconnect/cross-profile
+  // false positive on bot-pane opens (isSessionGoneError).
+  return /unknown session|no such session|session vanished/i.test(msg)
 }
 
 async function openStoredBotChat(name, storedId, summary) {
@@ -6974,7 +6978,10 @@ function CreateAgentDialog({ open, onClose, roster }) {
       // the first thing the user sees, and the pin exists from minute one.
       try {
         // Creates, pins, opens, and kicks off the intro in one flow.
-        const sid = await createCanonicalChat(slug)
+        const sid = await createCanonicalChat(slug, {
+          name: slug,
+          connectionId: String(host.state?.connectionId?.get?.() || host.activeConnectionId?.() || '').trim() || undefined
+        })
 
         if (!sid && typeof host.newChat === 'function') {
           host.newChat(slug)

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3395,7 +3395,16 @@ const canonicalCreations = new Map()
 /** Upper bound for per-profile session.list scans (hide sweep, canonical-chat
  *  adoption, stored-session lookups). */
 const PROFILE_SESSION_LIST_LIMIT = 200
+// Last successful canonical pin per bot. Extra clicks often still snapshot
+// meta.chat as null (React has not re-rendered) or as a launch-store id
+// that profiles.list cannot see in the bot profile store (#90458).
+const lastCanonicalPins = new Map()
 let botOpenGeneration = 0
+
+function isMissingCanonicalChat(error) {
+  const msg = String(error?.message || error || '')
+  return /not found|vanished|unknown session|no such session|does not exist|session not found/i.test(msg)
+}
 
 async function openStoredBotChat(name, storedId, summary) {
   if (!storedId || typeof host.openSession !== 'function') {
@@ -3496,6 +3505,7 @@ function createCanonicalChat(name) {
     const runtime = res?.session_id
 
     if (sid) {
+      lastCanonicalPins.set(name, sid)
       saveBotMeta(name, { chat: sid })
     }
 
@@ -3548,6 +3558,9 @@ function createCanonicalChat(name) {
  *    resolver (hidden rows still resolve; compression lineages resolve to
  *    the live tip) — never inferred from a paginated, hidden-excluding
  *    session.list window, which misjudged real hidden pins as gone;
+ *  - preferred_session=null means the pin is not in this profile store,
+ *    not that it is gone: try the stored id as-is and remint only after
+ *    the opener proves the session is missing (hermes-agent#90458);
  *  - transient lookup failures keep the pin: try the stored id as-is, and
  *    only a rejected open enters recovery. */
 function isCanonicalBotChatHistory(history) {
@@ -3558,12 +3571,17 @@ function isCanonicalBotChatHistory(history) {
 
 async function openBotCanonicalChat(name, pinned, history) {
   if (!pinned) {
+    pinned = lastCanonicalPins.get(name) || null
+  }
+
+  if (!pinned) {
     // Grandfather only an actual Bot Chat. `last_session` is merely the most
     // recent row for the profile; adopting it blindly can claim an unrelated
     // user conversation and the hide sweep would then hide that conversation.
     const adoptId = isCanonicalBotChatHistory(history) ? history.id : null
     if (adoptId && typeof host.openSession === 'function') {
       await openStoredBotChat(name, adoptId, history)
+      lastCanonicalPins.set(name, adoptId)
       saveBotMeta(name, { chat: adoptId })
       return adoptId
     }
@@ -3594,12 +3612,14 @@ async function openBotCanonicalChat(name, pinned, history) {
     // until proven guilty — try it as-is. A rejected open is still ambiguous:
     // it can be the same reconnect/hydration outage that broke this lookup, so
     // preserve the forever-chat pin and surface Retry instead of forking it.
+    lastCanonicalPins.set(name, pinned)
     return openStoredBotChat(name, pinned, history)
   }
 
   if (preferred && isCanonicalBotChatHistory(preferred)) {
     try {
       await openStoredBotChat(name, preferred.resolved_id || preferred.id, preferred)
+      lastCanonicalPins.set(name, pinned)
       return pinned
     } catch (error) {
       // The precise lookup JUST confirmed this session exists, so a failed
@@ -3632,23 +3652,39 @@ async function openBotCanonicalChat(name, pinned, history) {
 
     if (messageCount > 0) {
       await openStoredBotChat(name, preferred.resolved_id || preferred.id, preferred)
+      lastCanonicalPins.set(name, pinned)
       return pinned
     }
 
+    lastCanonicalPins.delete(name)
     await saveBotMeta(name, { chat: null })
     return createCanonicalChat(name)
   }
 
-  // Definitively gone (db reset, or the lineage was rewritten past
-  // recovery): re-anchor on the previewed session when there is one.
-  // A previewed row is safe to re-anchor only when it is Bot Mode plumbing.
-  // Otherwise a stale pin must not steal the profile's ordinary latest chat.
+  // preferred_session=null is "not in this profile store", not "gone".
+  // A kickoff minted against the launch/default TUI lands in
+  // ~/.hermes/state.db while this lookup reads profiles/<bot>/state.db
+  // (#90458). Try the existing pin before reminting or overwriting it.
+  try {
+    await openStoredBotChat(name, pinned, history)
+    lastCanonicalPins.set(name, pinned)
+    return pinned
+  } catch (error) {
+    if (!isMissingCanonicalChat(error)) {
+      throw error
+    }
+  }
+
+  // Proven missing from the opener too: re-anchor on a previewed Bot Chat
+  // when there is one. Ordinary latest chats are never adopted.
   const recoveryId = isCanonicalBotChatHistory(history) ? history.id : null
   if (recoveryId && typeof host.openSession === 'function') {
     await openStoredBotChat(name, recoveryId, history)
+    lastCanonicalPins.set(name, recoveryId)
     saveBotMeta(name, { chat: recoveryId })
     return recoveryId
   }
+  lastCanonicalPins.delete(name)
   saveBotMeta(name, { chat: null })
   return createCanonicalChat(name)
 }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3388,18 +3388,27 @@ function showsHandle(name, meta, bot) {
 //   - recovery: if the pinned id vanishes from the DB (compaction rewrote
 //     the lineage), re-pin the newest session carrying the canonical title.
 
-// In-flight creations, keyed by bot name — double-clicking a row must not
-// mint two canonical chats.
+// In-flight creations, keyed by source-qualified identity — double-clicking
+// a row must not mint two canonical chats, and same-named bots on different
+// connections must not share one inflight create.
 const canonicalCreations = new Map()
 
 /** Upper bound for per-profile session.list scans (hide sweep, canonical-chat
  *  adoption, stored-session lookups). */
 const PROFILE_SESSION_LIST_LIMIT = 200
-// Last successful canonical pin per bot. Extra clicks often still snapshot
-// meta.chat as null (React has not re-rendered) or as a launch-store id
-// that profiles.list cannot see in the bot profile store (#90458).
+// Last successful canonical pin per source-qualified bot. Extra clicks often
+// still snapshot meta.chat as null (React has not re-rendered) or as a
+// launch-store id that profiles.list cannot see in the bot profile store
+// (#90458). Keyed like botRosterKey: names alone are not identity.
 const lastCanonicalPins = new Map()
 let botOpenGeneration = 0
+
+function canonicalChatKey(name, bot) {
+  if (bot && typeof bot === 'object') {
+    return `${bot.connectionId || 'legacy'}::${bot.name || name || 'default'}`
+  }
+  return `legacy::${name || 'default'}`
+}
 
 function isMissingCanonicalChat(error) {
   const msg = String(error?.message || error || '')
@@ -3469,8 +3478,9 @@ async function findExistingCanonicalChat(name) {
  *  with the bot introducing itself). Pins the stored id in bot meta and
  *  returns it. Adopts an existing "Bot Chat" row instead of creating when
  *  the profile already has one (see findExistingCanonicalChat). */
-function createCanonicalChat(name) {
-  const inflight = canonicalCreations.get(name)
+function createCanonicalChat(name, bot) {
+  const key = canonicalChatKey(name, bot)
+  const inflight = canonicalCreations.get(key)
 
   if (inflight) {
     return inflight
@@ -3480,6 +3490,7 @@ function createCanonicalChat(name) {
     const existing = await findExistingCanonicalChat(name)
 
     if (existing?.id) {
+      lastCanonicalPins.set(key, existing.id)
       saveBotMeta(name, { chat: existing.id })
 
       if (typeof host.openSession === 'function') {
@@ -3505,7 +3516,7 @@ function createCanonicalChat(name) {
     const runtime = res?.session_id
 
     if (sid) {
-      lastCanonicalPins.set(name, sid)
+      lastCanonicalPins.set(key, sid)
       saveBotMeta(name, { chat: sid })
     }
 
@@ -3539,9 +3550,9 @@ function createCanonicalChat(name) {
     }
 
     return sid || null
-  })().finally(() => canonicalCreations.delete(name))
+  })().finally(() => canonicalCreations.delete(key))
 
-  canonicalCreations.set(name, run)
+  canonicalCreations.set(key, run)
 
   return run
 }
@@ -3569,9 +3580,10 @@ function isCanonicalBotChatHistory(history) {
   return rootTitle === 'Bot Chat' || (!rootTitle && title === 'Bot Chat')
 }
 
-async function openBotCanonicalChat(name, pinned, history) {
+async function openBotCanonicalChat(name, pinned, history, bot) {
+  const key = canonicalChatKey(name, bot)
   if (!pinned) {
-    pinned = lastCanonicalPins.get(name) || null
+    pinned = lastCanonicalPins.get(key) || null
   }
 
   if (!pinned) {
@@ -3581,11 +3593,11 @@ async function openBotCanonicalChat(name, pinned, history) {
     const adoptId = isCanonicalBotChatHistory(history) ? history.id : null
     if (adoptId && typeof host.openSession === 'function') {
       await openStoredBotChat(name, adoptId, history)
-      lastCanonicalPins.set(name, adoptId)
+      lastCanonicalPins.set(key, adoptId)
       saveBotMeta(name, { chat: adoptId })
       return adoptId
     }
-    return createCanonicalChat(name)
+    return createCanonicalChat(name, bot)
   }
 
   // Precise verification. An older gateway ignores the unknown param and
@@ -3612,14 +3624,14 @@ async function openBotCanonicalChat(name, pinned, history) {
     // until proven guilty — try it as-is. A rejected open is still ambiguous:
     // it can be the same reconnect/hydration outage that broke this lookup, so
     // preserve the forever-chat pin and surface Retry instead of forking it.
-    lastCanonicalPins.set(name, pinned)
+    lastCanonicalPins.set(key, pinned)
     return openStoredBotChat(name, pinned, history)
   }
 
   if (preferred && isCanonicalBotChatHistory(preferred)) {
     try {
       await openStoredBotChat(name, preferred.resolved_id || preferred.id, preferred)
-      lastCanonicalPins.set(name, pinned)
+      lastCanonicalPins.set(key, pinned)
       return pinned
     } catch (error) {
       // The precise lookup JUST confirmed this session exists, so a failed
@@ -3652,13 +3664,13 @@ async function openBotCanonicalChat(name, pinned, history) {
 
     if (messageCount > 0) {
       await openStoredBotChat(name, preferred.resolved_id || preferred.id, preferred)
-      lastCanonicalPins.set(name, pinned)
+      lastCanonicalPins.set(key, pinned)
       return pinned
     }
 
-    lastCanonicalPins.delete(name)
+    lastCanonicalPins.delete(key)
     await saveBotMeta(name, { chat: null })
-    return createCanonicalChat(name)
+    return createCanonicalChat(name, bot)
   }
 
   // preferred_session=null is "not in this profile store", not "gone".
@@ -3667,7 +3679,7 @@ async function openBotCanonicalChat(name, pinned, history) {
   // (#90458). Try the existing pin before reminting or overwriting it.
   try {
     await openStoredBotChat(name, pinned, history)
-    lastCanonicalPins.set(name, pinned)
+    lastCanonicalPins.set(key, pinned)
     return pinned
   } catch (error) {
     if (!isMissingCanonicalChat(error)) {
@@ -3678,7 +3690,7 @@ async function openBotCanonicalChat(name, pinned, history) {
   // Extra clicks still pass the dead pin (React has not re-rendered).
   // A prior remint already lives in lastCanonicalPins — reuse it instead
   // of minting another launch-store kickoff.
-  const remembered = lastCanonicalPins.get(name)
+  const remembered = lastCanonicalPins.get(key)
   if (remembered && remembered !== pinned) {
     try {
       await openStoredBotChat(name, remembered, history)
@@ -3695,13 +3707,13 @@ async function openBotCanonicalChat(name, pinned, history) {
   const recoveryId = isCanonicalBotChatHistory(history) ? history.id : null
   if (recoveryId && typeof host.openSession === 'function') {
     await openStoredBotChat(name, recoveryId, history)
-    lastCanonicalPins.set(name, recoveryId)
+    lastCanonicalPins.set(key, recoveryId)
     saveBotMeta(name, { chat: recoveryId })
     return recoveryId
   }
-  lastCanonicalPins.delete(name)
+  lastCanonicalPins.delete(key)
   saveBotMeta(name, { chat: null })
-  return createCanonicalChat(name)
+  return createCanonicalChat(name, bot)
 }
 
 async function prepareBotSource(bot, pinnedChat) {
@@ -5400,7 +5412,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
     }
 
     try {
-      const id = await openBotCanonicalChat(bot.name, pinnedChat, previewSession)
+      const id = await openBotCanonicalChat(bot.name, pinnedChat, previewSession, bot)
 
       if (generation === botOpenGeneration && id) {
         return
@@ -10347,7 +10359,8 @@ function BotsPane() {
               const id = await openBotCanonicalChat(
                 bot.name,
                 pinnedChat,
-                bot.preferred_session || bot.last_session
+                bot.preferred_session || bot.last_session,
+                bot
               )
 
               if (generation === botOpenGeneration && id) {

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3675,6 +3675,21 @@ async function openBotCanonicalChat(name, pinned, history) {
     }
   }
 
+  // Extra clicks still pass the dead pin (React has not re-rendered).
+  // A prior remint already lives in lastCanonicalPins — reuse it instead
+  // of minting another launch-store kickoff.
+  const remembered = lastCanonicalPins.get(name)
+  if (remembered && remembered !== pinned) {
+    try {
+      await openStoredBotChat(name, remembered, history)
+      return remembered
+    } catch (error) {
+      if (!isMissingCanonicalChat(error)) {
+        throw error
+      }
+    }
+  }
+
   // Proven missing from the opener too: re-anchor on a previewed Bot Chat
   // when there is one. Ordinary latest chats are never adopted.
   const recoveryId = isCanonicalBotChatHistory(history) ? history.id : null

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-adopt-before-mint.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-adopt-before-mint.test.mjs
@@ -16,7 +16,7 @@ import vm from 'node:vm'
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
 function loadOpenPath({ openSession, request }) {
-  const start = source.indexOf('const canonicalCreations = new Map()')
+  const start = source.indexOf('function botRosterKey(bot)')
   const end = source.indexOf('function displayName(', start)
   const saved = []
   const requests = []

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-click-spam.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-click-spam.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// #90458 — blank Bot Chat click-spam mints kickoffs into the launch/default
+// ~/.hermes/state.db and overwrites profiles/<bot>/profile.yaml
+// ui_meta.hermes-bots.chat. profiles.list looks the pin up in the *bot*
+// profile store, so a launch-store kickoff comes back as preferred_session=null
+// and used to be treated as "pin is dead" → another mint → another overwrite.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadOpenPath({ openSession, request }) {
+  const start = source.indexOf('const canonicalCreations = new Map()')
+  const end = source.indexOf('function displayName(', start)
+  const saved = []
+  const requests = []
+  const context = {
+    host: {
+      openSession,
+      request: async (method, params) => {
+        requests.push({ method, params })
+        return request(method, params)
+      }
+    },
+    saveBotMeta: (name, patch) => saved.push({ name, patch: JSON.parse(JSON.stringify(patch)) }),
+    $hideBotChats: { get: () => false },
+    window: { setTimeout: callback => callback() }
+  }
+  const exportLine = [
+    '',
+    'globalThis.__open = { openBotCanonicalChat };',
+    ''
+  ].join('\n')
+  const section = source.slice(start, end).concat(exportLine)
+
+  assert.notEqual(start, -1, 'canonical chat section is missing')
+  assert.notEqual(end, -1, 'canonical chat section delimiter is missing')
+  vm.runInNewContext(section, context, { filename: 'canonical-click-spam.js' })
+  return { ...context.__open, saved, requests }
+}
+
+test('click-spam: extra clicks do not mint a new pin in the launch/default store', async () => {
+  const opened = []
+  let creates = 0
+  const runtime = loadOpenPath({
+    openSession: async id => {
+      opened.push(id)
+    },
+    request: async method => {
+      if (method === 'profiles.list') {
+        // Launch-store kickoff is invisible in profiles/<bot>/state.db.
+        return { profiles: [{ name: 'ops', preferred_session: null }] }
+      }
+      if (method === 'session.create') {
+        creates += 1
+        return { stored_session_id: `launch-kickoff-${creates}`, session_id: `rt-${creates}` }
+      }
+      return {}
+    }
+  })
+
+  const first = await runtime.openBotCanonicalChat('ops', 'bot-profile-chat', null)
+  const second = await runtime.openBotCanonicalChat('ops', 'bot-profile-chat', null)
+
+  assert.equal(first, 'bot-profile-chat')
+  assert.equal(second, 'bot-profile-chat')
+  assert.deepEqual(opened, ['bot-profile-chat', 'bot-profile-chat'])
+  assert.equal(creates, 0, 'extra clicks must not session.create into the launch store')
+  assert.deepEqual(runtime.saved, [], 'the bot-profile Bot Chat pin must stay put')
+})
+
+test('click-spam: a just-minted chat is reused when the next click still has no pin snapshot', async () => {
+  let creates = 0
+  const runtime = loadOpenPath({
+    openSession: async () => undefined,
+    request: async method => {
+      if (method === 'session.create') {
+        creates += 1
+        return { stored_session_id: `launch-kickoff-${creates}`, session_id: `rt-${creates}` }
+      }
+      return {}
+    }
+  })
+
+  const first = await runtime.openBotCanonicalChat('ops', null, null)
+  const second = await runtime.openBotCanonicalChat('ops', null, null)
+
+  assert.equal(first, 'launch-kickoff-1')
+  assert.equal(second, 'launch-kickoff-1')
+  assert.equal(creates, 1, 'the second click must not mint another launch-store kickoff')
+  assert.deepEqual(runtime.saved.filter(entry => entry.patch?.chat), [
+    { name: 'ops', patch: { chat: 'launch-kickoff-1' } }
+  ])
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-click-spam.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-click-spam.test.mjs
@@ -94,3 +94,75 @@ test('click-spam: a just-minted chat is reused when the next click still has no 
     { name: 'ops', patch: { chat: 'launch-kickoff-1' } }
   ])
 })
+
+test('click-spam: openSession not-found remints once', async () => {
+  // preferred_session=null + opener "not found" is the only proven-missing
+  // path. Extra clicks still pass the dead pin (React has not re-rendered);
+  // lastCanonicalPins must stop a second launch-store kickoff.
+  const opened = []
+  let creates = 0
+  const runtime = loadOpenPath({
+    openSession: async id => {
+      if (id === 'dead-pin') throw new Error('session not found')
+      opened.push(id)
+    },
+    request: async method => {
+      if (method === 'profiles.list') {
+        return { profiles: [{ name: 'ops', preferred_session: null }] }
+      }
+      if (method === 'session.create') {
+        creates += 1
+        return { stored_session_id: `remint-${creates}`, session_id: `rt-${creates}` }
+      }
+      return {}
+    }
+  })
+
+  const first = await runtime.openBotCanonicalChat('ops', 'dead-pin', null)
+  const second = await runtime.openBotCanonicalChat('ops', 'dead-pin', null)
+
+  assert.equal(first, 'remint-1')
+  assert.equal(second, 'remint-1')
+  assert.equal(creates, 1, 'a proven-missing pin remints once, not on every extra click')
+  assert.deepEqual(opened, ['remint-1', 'remint-1'])
+  assert.deepEqual(runtime.saved, [
+    { name: 'ops', patch: { chat: null } },
+    { name: 'ops', patch: { chat: 'remint-1' } }
+  ])
+})
+
+test('click-spam: openSession timeout does not remint or overwrite the pin', async () => {
+  // Hydration/timeout is not proof the pin is gone. Pass the same pin on
+  // every click so this cannot accidentally pass via lastCanonicalPins.
+  const opened = []
+  let creates = 0
+  const runtime = loadOpenPath({
+    openSession: async id => {
+      opened.push(id)
+      throw new Error("Timed out loading ops's session history.")
+    },
+    request: async method => {
+      if (method === 'profiles.list') {
+        return { profiles: [{ name: 'ops', preferred_session: null }] }
+      }
+      if (method === 'session.create') {
+        creates += 1
+        return { stored_session_id: `timeout-kickoff-${creates}`, session_id: `rt-${creates}` }
+      }
+      return {}
+    }
+  })
+
+  await assert.rejects(
+    runtime.openBotCanonicalChat('ops', 'bot-profile-chat', null),
+    /Timed out loading/
+  )
+  await assert.rejects(
+    runtime.openBotCanonicalChat('ops', 'bot-profile-chat', null),
+    /Timed out loading/
+  )
+
+  assert.deepEqual(opened, ['bot-profile-chat', 'bot-profile-chat'])
+  assert.equal(creates, 0, 'timeout must not session.create into the launch store')
+  assert.deepEqual(runtime.saved, [], 'timeout must not overwrite the bot-profile pin')
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-click-spam.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-click-spam.test.mjs
@@ -12,7 +12,7 @@ import vm from 'node:vm'
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
 function loadOpenPath({ openSession, request }) {
-  const start = source.indexOf('const canonicalCreations = new Map()')
+  const start = source.indexOf('function botRosterKey(bot)')
   const end = source.indexOf('function displayName(', start)
   const saved = []
   const requests = []
@@ -30,7 +30,7 @@ function loadOpenPath({ openSession, request }) {
   }
   const exportLine = [
     '',
-    'globalThis.__open = { openBotCanonicalChat, createCanonicalChat };',
+    'globalThis.__open = { openBotCanonicalChat, createCanonicalChat, canonicalChatKey, botRosterKey };',
     ''
   ].join('\n')
   const section = source.slice(start, end).concat(exportLine)
@@ -95,7 +95,7 @@ test('click-spam: a just-minted chat is reused when the next click still has no 
   ])
 })
 
-test('click-spam: openSession not-found remints once', async () => {
+test('click-spam: openSession vanished remints once', async () => {
   // preferred_session=null + opener "not found" is the only proven-missing
   // path. Extra clicks still pass the dead pin (React has not re-rendered);
   // lastCanonicalPins must stop a second launch-store kickoff.
@@ -103,7 +103,7 @@ test('click-spam: openSession not-found remints once', async () => {
   let creates = 0
   const runtime = loadOpenPath({
     openSession: async id => {
-      if (id === 'dead-pin') throw new Error('session not found')
+      if (id === 'dead-pin') throw new Error('session vanished')
       opened.push(id)
     },
     request: async method => {
@@ -240,4 +240,99 @@ test('overlapping creates for same-named bots on different sources do not share 
 
   assert.equal(await pendingA, 'mint-1')
   assert.equal(await pendingB, 'mint-2')
+})
+
+test('click-spam: Method not found / profile not found do not remint', async () => {
+  for (const message of ['Method not found', 'profile not found']) {
+    let creates = 0
+    const runtime = loadOpenPath({
+      openSession: async () => {
+        throw new Error(message)
+      },
+      request: async method => {
+        if (method === 'profiles.list') {
+          return { profiles: [{ name: 'ops', preferred_session: null }] }
+        }
+        if (method === 'session.create') {
+          creates += 1
+          return { stored_session_id: `bad-${creates}`, session_id: `rt-${creates}` }
+        }
+        return {}
+      }
+    })
+
+    await assert.rejects(
+      runtime.openBotCanonicalChat('ops', 'bot-profile-chat', null),
+      new RegExp(message.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    )
+    assert.equal(creates, 0, `${message} must not be treated as a missing session`)
+    assert.deepEqual(runtime.saved, [])
+  }
+})
+
+test('click-spam: reconnect-shaped session not found does not remint', async () => {
+  let creates = 0
+  const runtime = loadOpenPath({
+    openSession: async () => {
+      throw new Error('session not found')
+    },
+    request: async method => {
+      if (method === 'profiles.list') {
+        return { profiles: [{ name: 'ops', preferred_session: null }] }
+      }
+      if (method === 'session.create') {
+        creates += 1
+        return { stored_session_id: `reconnect-${creates}`, session_id: `rt-${creates}` }
+      }
+      return {}
+    }
+  })
+
+  await assert.rejects(
+    runtime.openBotCanonicalChat('ops', 'bot-profile-chat', null),
+    /session not found/
+  )
+  assert.equal(creates, 0, 'session not found is a reconnect false positive, not proven missing')
+  assert.deepEqual(runtime.saved, [])
+})
+
+test('canonicalChatKey delegates to botRosterKey', () => {
+  const runtime = loadOpenPath({
+    openSession: async () => undefined,
+    request: async () => ({})
+  })
+  const bot = { name: 'ops', connectionId: 'gw-1' }
+  assert.equal(runtime.canonicalChatKey('ops', bot), runtime.botRosterKey(bot))
+  assert.equal(runtime.canonicalChatKey('ops'), runtime.botRosterKey({ name: 'ops' }))
+})
+
+test('production open handlers pass the roster bot into openBotCanonicalChat', () => {
+  assert.match(
+    source,
+    /openBotCanonicalChat\(\s*bot\.name,\s*pinnedChat,\s*previewSession,\s*bot\s*\)/
+  )
+  assert.match(
+    source,
+    /openBotCanonicalChat\(\s*bot\.name,\s*pinnedChat,\s*bot\.preferred_session \|\| bot\.last_session,\s*bot\s*\)/
+  )
+  assert.match(source, /createCanonicalChat\(slug, \{/)
+})
+
+test('create then null-snapshot click shares the source-qualified pin', async () => {
+  let creates = 0
+  const runtime = loadOpenPath({
+    openSession: async () => undefined,
+    request: async method => {
+      if (method === 'session.create') {
+        creates += 1
+        return { stored_session_id: `birth-${creates}`, session_id: `rt-${creates}` }
+      }
+      return {}
+    }
+  })
+  const bot = { name: 'ops', connectionId: 'gw-1' }
+
+  assert.equal(await runtime.createCanonicalChat('ops', bot), 'birth-1')
+  assert.equal(await runtime.openBotCanonicalChat('ops', null, null, bot), 'birth-1')
+  assert.equal(creates, 1)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-click-spam.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-click-spam.test.mjs
@@ -30,7 +30,7 @@ function loadOpenPath({ openSession, request }) {
   }
   const exportLine = [
     '',
-    'globalThis.__open = { openBotCanonicalChat };',
+    'globalThis.__open = { openBotCanonicalChat, createCanonicalChat };',
     ''
   ].join('\n')
   const section = source.slice(start, end).concat(exportLine)
@@ -165,4 +165,79 @@ test('click-spam: openSession timeout does not remint or overwrite the pin', asy
   assert.deepEqual(opened, ['bot-profile-chat', 'bot-profile-chat'])
   assert.equal(creates, 0, 'timeout must not session.create into the launch store')
   assert.deepEqual(runtime.saved, [], 'timeout must not overwrite the bot-profile pin')
+})
+
+test('same-named bots on different connections never reuse the other source pin', async () => {
+  const opened = []
+  const created = []
+  const runtime = loadOpenPath({
+    openSession: async id => {
+      opened.push(id)
+    },
+    request: async method => {
+      if (method === 'profiles.list') {
+        return { profiles: [{ name: 'ops', preferred_session: null }] }
+      }
+      if (method === 'session.create') {
+        created.push(method)
+        return { stored_session_id: `mint-${created.length}`, session_id: `rt-${created.length}` }
+      }
+      return {}
+    }
+  })
+
+  const sourceA = { name: 'ops', connectionId: 'conn-a' }
+  const sourceB = { name: 'ops', connectionId: 'conn-b' }
+
+  const firstA = await runtime.openBotCanonicalChat('ops', 'pin-a', null, sourceA)
+  const firstB = await runtime.openBotCanonicalChat('ops', null, null, sourceB)
+  const againA = await runtime.openBotCanonicalChat('ops', null, null, sourceA)
+
+  assert.equal(firstA, 'pin-a')
+  assert.notEqual(firstB, 'pin-a', 'source B must not open source A pin')
+  assert.equal(againA, 'pin-a', 'returning to source A must reuse its own pin')
+  assert.equal(opened.includes('pin-a'), true)
+  assert.equal(created.length, 1, 'only the null-pin source mints')
+  assert.deepEqual(
+    runtime.saved.filter(entry => entry.patch?.chat === 'pin-a'),
+    [],
+    'source B must not save source A pin'
+  )
+})
+
+test('overlapping creates for same-named bots on different sources do not share inflight', async () => {
+  let createStarted = 0
+  let releaseFirst
+  const firstGate = new Promise(resolve => {
+    releaseFirst = resolve
+  })
+  const runtime = loadOpenPath({
+    openSession: async () => undefined,
+    request: async method => {
+      if (method === 'session.create') {
+        createStarted += 1
+        const n = createStarted
+        if (n === 1) await firstGate
+        return { stored_session_id: `mint-${n}`, session_id: `rt-${n}` }
+      }
+      return {}
+    }
+  })
+
+  const sourceA = { name: 'ops', connectionId: 'conn-a' }
+  const sourceB = { name: 'ops', connectionId: 'conn-b' }
+  const pendingA = runtime.createCanonicalChat('ops', sourceA)
+  for (let i = 0; i < 20 && createStarted < 1; i += 1) {
+    await Promise.resolve()
+  }
+  assert.equal(createStarted, 1, 'source A create should start first')
+  const pendingB = runtime.createCanonicalChat('ops', sourceB)
+  for (let i = 0; i < 20 && createStarted < 2; i += 1) {
+    await Promise.resolve()
+  }
+  assert.equal(createStarted, 2, 'same name on different sources must not share one inflight create')
+  releaseFirst()
+
+  assert.equal(await pendingA, 'mint-1')
+  assert.equal(await pendingB, 'mint-2')
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-creation.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-creation.test.mjs
@@ -6,7 +6,7 @@ import vm from 'node:vm'
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
 function loadCanonicalCreation({ openSession, request }) {
-  const start = source.indexOf('const canonicalCreations = new Map()')
+  const start = source.indexOf('function botRosterKey(bot)')
   const end = source.indexOf('function displayName(', start)
   const saved = []
   const context = {

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-empty-recovery.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-empty-recovery.test.mjs
@@ -6,7 +6,7 @@ import vm from 'node:vm'
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
 function loadCanonicalRecovery({ openSession, request }) {
-  const start = source.indexOf('const canonicalCreations = new Map()')
+  const start = source.indexOf('function botRosterKey(bot)')
   const end = source.indexOf('function displayName(', start)
   const saved = []
   const requests = []

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-empty-recovery.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-empty-recovery.test.mjs
@@ -31,14 +31,15 @@ function loadCanonicalRecovery({ openSession, request }) {
 }
 
 test('regression: a definitively-gone pin with no history clears and creates a replacement', async () => {
-  // New contract (hermes-agent#88200): the pin is verified through the
-  // backend's precise preferred_session resolver — NOT a paginated,
-  // hidden-excluding session.list window. preferred_session=null is the
-  // definitive "this session is gone"; with no previewed history to
-  // re-anchor on, recovery clears the pin and creates a fresh chat.
+  // New contract (hermes-agent#88200 + #90458): preferred_session=null
+  // means the pin is not in this profile store. Recovery remints only after
+  // the opener also reports the session missing.
   const opened = []
   const runtime = loadCanonicalRecovery({
-    openSession: async id => opened.push(id),
+    openSession: async id => {
+      if (id === 'stale-pin') throw new Error('session vanished')
+      opened.push(id)
+    },
     request: async method => {
       if (method === 'profiles.list') return { profiles: [{ name: 'ops', preferred_session: null }] }
       if (method === 'session.create') return { stored_session_id: 'replacement', session_id: 'replacement-runtime' }
@@ -81,7 +82,10 @@ test('regression: a dead pin re-anchors on the previewed chat instead of the new
   // previewed history row when one exists — session.create never fires.
   const opened = []
   const runtime = loadCanonicalRecovery({
-    openSession: async id => opened.push(id),
+    openSession: async id => {
+      if (id === 'old-pin') throw new Error('session vanished')
+      opened.push(id)
+    },
     request: async method => {
       if (method === 'profiles.list') return { profiles: [{ name: 'ops', preferred_session: null }] }
       if (method === 'session.create') throw new Error('must not create')

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-identity.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-identity.test.mjs
@@ -194,7 +194,9 @@ test('pin: compression-rotated pin opens the live tip, keeps the durable pin', a
 
 test('pin: definitively gone pin re-pins to the previewed session, not rows[0]', async () => {
   const runtime = loadOpenPath({
-    openSession: async () => undefined,
+    openSession: async id => {
+      if (id === 'dead-pin') throw new Error('session vanished')
+    },
     request: async method => {
       if (method === 'profiles.list') {
         return { profiles: [{ name: 'ops', preferred_session: null }] }
@@ -212,7 +214,9 @@ test('pin: definitively gone pin re-pins to the previewed session, not rows[0]',
 
 test('safety: a dead pin does not re-anchor on an ordinary latest session', async () => {
   const runtime = loadOpenPath({
-    openSession: async () => undefined,
+    openSession: async id => {
+      if (id === 'dead-pin') throw new Error('session vanished')
+    },
     request: async method => {
       if (method === 'profiles.list') return { profiles: [{ name: 'ops', preferred_session: null }] }
       if (method === 'session.create') return { stored_session_id: 'safe-replacement', session_id: 'safe-replacement-runtime' }
@@ -233,7 +237,9 @@ test('safety: a dead pin does not re-anchor on an ordinary latest session', asyn
 
 test('pin: gone pin + no history clears the pin and creates', async () => {
   const runtime = loadOpenPath({
-    openSession: async () => undefined,
+    openSession: async id => {
+      if (id === 'dead-pin') throw new Error('session vanished')
+    },
     request: async method => {
       if (method === 'profiles.list') {
         return { profiles: [{ name: 'ops', preferred_session: null }] }

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-identity.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-identity.test.mjs
@@ -7,7 +7,7 @@ const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
 // ── canonical open-path harness (slice: createCanonicalChat + openBotCanonicalChat)
 function loadOpenPath({ openSession, request }) {
-  const start = source.indexOf('const canonicalCreations = new Map()')
+  const start = source.indexOf('function botRosterKey(bot)')
   const end = source.indexOf('function displayName(', start)
   const saved = []
   const requests = []

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-pin.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-pin.test.mjs
@@ -69,7 +69,9 @@ test('regression: a live pinned canonical chat is opened as-is, never replaced',
 
 test('regression: only an actually-missing pin triggers recovery', async () => {
   const runtime = loadOpenPath({
-    openSession: async () => undefined,
+    openSession: async id => {
+      if (id === 'dead-pin') throw new Error('session vanished')
+    },
     request: async method => {
       if (method === 'profiles.list') {
         return { profiles: [{ name: 'ops', preferred_session: null }] }

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-pin.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-pin.test.mjs
@@ -14,7 +14,7 @@ import vm from 'node:vm'
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
 function loadOpenPath({ openSession, request }) {
-  const start = source.indexOf('const canonicalCreations = new Map()')
+  const start = source.indexOf('function botRosterKey(bot)')
   const end = source.indexOf('function displayName(', start)
   const saved = []
   const requests = []

--- a/apps/desktop/src/plugins/hermes-bots/tests/hide-bot-chats.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/hide-bot-chats.test.mjs
@@ -13,7 +13,7 @@ import vm from 'node:vm'
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
 function loadCreate() {
-  const start = source.indexOf('const canonicalCreations = new Map()')
+  const start = source.indexOf('function botRosterKey(bot)')
   const end = source.indexOf('function displayName(', start)
   const created = []
   const context = {


### PR DESCRIPTION
## Bug Description

Desktop Bot Mode: a blank Bot Chat plus extra clicks minted kickoff sessions into the **launch/default** `~/.hermes/state.db`, overwrote `profiles/<bot>/profile.yaml` `ui_meta.hermes-bots.chat`, then the next open against the bot store was blank again.

Fixes #90458

Related but not this bug: #90219 (named-profile writes into the launch `state.db`) does not cover mint+pin overwrite. Do not close #90458 as a duplicate of #90219.

## Root Cause

`profiles.list` `preferred_session` looks the pin up in the **bot profile** `state.db`. A kickoff that landed in the launch/default store comes back as `preferred_session=null`. The open path treated that as "pin is dead", minted another kickoff, and rewrote the pin. Extra clicks while the pane was still blank repeated the loop. A stale `meta.chat === null` snapshot (React had not re-rendered) could mint a second time even after the first create saved a pin.

## Fix

- Treat `preferred_session=null` as "not in this profile store", not "gone".
- Open the existing pin first. Remint only after the opener proves the session is missing (not on hydration/timeout hiccups).
- Remember the last successful canonical pin so a stale null snapshot cannot mint another launch-store kickoff.
- After a proven-missing remint, extra clicks that still pass the dead pin reuse that remembered id instead of minting again.

## How to Verify

1. Open a named-profile bot whose Bot Chat pane is blank.
2. Click the roster row several times.
3. Confirm `~/.hermes/state.db` does not gain extra "Tell about yourself" / "Learn about AI" kickoffs, and `profiles/<bot>/profile.yaml` `ui_meta.hermes-bots.chat` is not overwritten onto a default-store session.

## Test Plan

- [x] Added `canonical-chat-click-spam.test.mjs` (extra clicks do not `session.create` into the launch store; pin stays)
- [x] `openSession` "not found" remints **once**; extra clicks still passing the dead pin do not mint again
- [x] `openSession` timeout / hydration error does **not** remint and does **not** overwrite the pin (test passes the pin on every click so `lastCanonicalPins` cannot hide a remint)
- [x] Watched remint-once fail, then pass after the remembered-pin reuse
- [x] Existing canonical-chat / hermes-bots plugin tests still pass

```text
cd apps/desktop
node --test src/plugins/hermes-bots/tests/canonical-chat-click-spam.test.mjs
# 4 passed
node --test src/plugins/hermes-bots/tests/*.test.mjs
# 327 passed, exit 0
```

## Risk Assessment

Low — desktop Bot Mode open path only. Ordinary-session safety remint is unchanged (still requires a proven-missing pin). Does not rewrite Bot Mode, does not change #90219's backend store bind, does not touch npm/release.

## Exclusions

Does not fix named-profile `session.create` persisting into the launch `state.db` (#90219). Still excluded; this PR does not bind `session.create` to the bot store.
