### PR TITLE
fix(memory): gate update_mode='append' on features.store_document_text

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -233,18 +233,19 @@ def _meets_minimum_version(actual: str | None, required: str) -> bool:
         return False
 
 
-def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
-                                 timeout: float = 5.0) -> str | None:
-    """GET ``<api_url>/version`` and return the version string (or None on failure).
+def _fetch_hindsight_api_meta(api_url: str, api_key: str | None = None,
+                              timeout: float = 5.0) -> tuple[str | None, dict | None]:
+    """GET ``<api_url>/version`` and return (version, features) on success.
 
-    Hindsight's `/version` endpoint returns ``{"version": "0.5.6", ...}``.
-    Any failure (timeout, 404, malformed JSON, missing key) → None, which
-    the caller treats as "legacy API, no update_mode support".
+    Hindsight's `/version` endpoint returns ``{"version": "0.5.6",
+    "features": {"store_document_text": false, ...}, ...}``. Any failure
+    (timeout, 404, malformed JSON, missing key) → (None, None), which the
+    caller treats as "legacy API, no update_mode support".
     """
     import urllib.error
     import urllib.request
     if not api_url:
-        return None
+        return None, None
     url = api_url.rstrip("/") + "/version"
     req = urllib.request.Request(url)
     if api_key:
@@ -255,11 +256,26 @@ def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
         data = json.loads(payload)
     except Exception as exc:
         logger.debug("Hindsight /version probe failed for %s: %s", url, exc)
-        return None
+        return None, None
     if not isinstance(data, dict):
-        return None
+        return None, None
     version = data.get("version") or data.get("api_version")
-    return str(version) if version else None
+    features = data.get("features")
+    if not isinstance(features, dict):
+        features = None
+    return (str(version) if version else None), features
+
+
+def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
+                                 timeout: float = 5.0) -> str | None:
+    """GET ``<api_url>/version`` and return the version string (or None on failure).
+
+    Hindsight's `/version` endpoint returns ``{"version": "0.5.6", ...}``.
+    Any failure (timeout, 404, malformed JSON, missing key) → None, which
+    the caller treats as "legacy API, no update_mode support".
+    """
+    version, _ = _fetch_hindsight_api_meta(api_url, api_key, timeout)
+    return version
 
 
 def _check_api_supports_update_mode_append(api_url: str,
@@ -269,14 +285,25 @@ def _check_api_supports_update_mode_append(api_url: str,
     Probes once per URL per process. Returns False on any probe failure —
     that's the safe default: a per-process unique ``document_id`` and no
     ``update_mode`` keeps the resume-overwrite fix (#6654) intact.
+
+    ``update_mode='append'`` also requires the server to actually store
+    document text: when the API reports ``features.store_document_text ==
+    false``, appends are rejected even on recent versions, so we must fall
+    back to per-process document IDs there too (mirrors the original
+    feature-aware behavior before #932 version-only gating).
     """
     if not api_url:
         return False
     with _append_capability_lock:
         if api_url in _append_capability_cache:
             return _append_capability_cache[api_url]
-    version = _fetch_hindsight_api_version(api_url, api_key)
+    version, features = _fetch_hindsight_api_meta(api_url, api_key)
     supported = _meets_minimum_version(version, _MIN_VERSION_FOR_UPDATE_MODE_APPEND)
+    if supported and features is not None:
+        # A server that reports store_document_text=false rejects append
+        # retains regardless of version.
+        if features.get("store_document_text") is False:
+            supported = False
     with _append_capability_lock:
         # Re-check after acquiring the lock in case a concurrent probe filled it.
         cached = _append_capability_cache.get(api_url)
@@ -285,15 +312,26 @@ def _check_api_supports_update_mode_append(api_url: str,
         else:
             supported = cached
     if not supported:
-        logger.warning(
-            "Hindsight API at %s reports version %r, older than %s. "
-            "Falling back to per-process document_id — retains across "
-            "processes/sessions create separate documents instead of "
-            "appending to a session-scoped one. Upgrade Hindsight to "
-            "%s+ to enable update_mode='append' deduplication.",
-            api_url, version, _MIN_VERSION_FOR_UPDATE_MODE_APPEND,
-            _MIN_VERSION_FOR_UPDATE_MODE_APPEND,
-        )
+        if (version is not None
+                and _meets_minimum_version(version, _MIN_VERSION_FOR_UPDATE_MODE_APPEND)):
+            logger.warning(
+                "Hindsight API at %s (version %r) reports "
+                "features.store_document_text=false. Falling back to "
+                "per-process document_id without update_mode='append' — "
+                "Hindsight rejects append retains when document text storage "
+                "is disabled.",
+                api_url, version,
+            )
+        else:
+            logger.warning(
+                "Hindsight API at %s reports version %r, older than %s. "
+                "Falling back to per-process document_id — retains across "
+                "processes/sessions create separate documents instead of "
+                "appending to a session-scoped one. Upgrade Hindsight to "
+                "%s+ to enable update_mode='append' deduplication.",
+                api_url, version, _MIN_VERSION_FOR_UPDATE_MODE_APPEND,
+                _MIN_VERSION_FOR_UPDATE_MODE_APPEND,
+            )
     else:
         logger.debug("Hindsight API %s version %s supports update_mode='append'",
                      api_url, version)

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1159,8 +1159,8 @@ class TestUpdateModeAppendCapability:
         per-process unique doc_id and NOT pass update_mode."""
         self._clear_capability_cache()
         monkeypatch.setattr(
-            "plugins.memory.hindsight._fetch_hindsight_api_version",
-            lambda *a, **kw: None,
+            "plugins.memory.hindsight._fetch_hindsight_api_meta",
+            lambda *a, **kw: (None, None),
         )
         old_doc = provider._document_id
         provider.sync_turn("hello", "hi")
@@ -1173,11 +1173,12 @@ class TestUpdateModeAppendCapability:
         assert "update_mode" not in item
 
     def test_modern_api_uses_stable_doc_id_with_append(self, provider, monkeypatch):
-        """API on >=0.5.0 — retain uses stable session_id and sets update_mode='append'."""
+        """API on >=0.5.0 with text storage enabled — retain uses stable
+        session_id and sets update_mode='append'."""
         self._clear_capability_cache()
         monkeypatch.setattr(
-            "plugins.memory.hindsight._fetch_hindsight_api_version",
-            lambda *a, **kw: "0.5.6",
+            "plugins.memory.hindsight._fetch_hindsight_api_meta",
+            lambda *a, **kw: ("0.5.6", {"store_document_text": True}),
         )
         provider.sync_turn("hello", "hi")
         provider._retain_queue.join()
@@ -1188,6 +1189,26 @@ class TestUpdateModeAppendCapability:
         item = kw["items"][0]
         assert item["update_mode"] == "append"
 
+    def test_modern_api_with_text_storage_disabled_falls_back(self, provider, monkeypatch):
+        """API >=0.5.0 but reports features.store_document_text=false —
+        appends are rejected server-side, so sync_turn must fall back to the
+        per-process doc_id without update_mode (regression: version-only
+        capability gating broke retains against store_document_text=false
+        servers)."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_meta",
+            lambda *a, **kw: ("0.9.0", {"store_document_text": False}),
+        )
+        old_doc = provider._document_id
+        provider.sync_turn("hello", "hi")
+        provider._retain_queue.join()
+
+        kw = provider._client.aretain_batch.call_args.kwargs
+        assert kw["document_id"] == old_doc
+        assert kw["document_id"].startswith("test-session-")
+        item = kw["items"][0]
+        assert "update_mode" not in item
 
     def test_session_switch_flush_picks_capability_against_old_session(
         self, provider_with_config, monkeypatch
@@ -1196,8 +1217,8 @@ class TestUpdateModeAppendCapability:
         in the OLD session's stable document, not a per-process id."""
         self._clear_capability_cache()
         monkeypatch.setattr(
-            "plugins.memory.hindsight._fetch_hindsight_api_version",
-            lambda *a, **kw: "0.5.6",
+            "plugins.memory.hindsight._fetch_hindsight_api_meta",
+            lambda *a, **kw: ("0.5.6", {"store_document_text": True}),
         )
         p = provider_with_config(retain_every_n_turns=3, retain_async=False)
         p.sync_turn("turn1-user", "turn1-asst")


### PR DESCRIPTION
## Problem

The Hindsight memory plugin gates `update_mode='append'` on **version number only** (`_MIN_VERSION_FOR_UPDATE_MODE_APPEND = 0.5.0`). A server at >=0.5.0 that has **document text storage disabled** (`features.store_document_text=false`) still rejects appends:

```
update_mode='append' is not supported when document text storage
(store_document_text / HINDSIGHT_API_STORE_DOCUMENT_TEXT) is disabled
```

Result: every retain fails, `last_memory_write_at` goes permanently stale, and the bank accumulates failed retain/batch_retain operations — with only a "Prefetch: server retain visibility timed out" WARNING on the agent side (no ERROR), so the outage is easy to miss.

## Root cause

`_check_api_supports_update_mode_append()` probes `/version` and reads only the version string, ignoring the `features.store_document_text` field the server already reports. The plugin used to be feature-aware (falling back to per-process `document_id` without `update_mode`); the version-only gate regressed that behavior.

## Fix

- Probe `/version` once per process via new `_fetch_hindsight_api_meta()`, parsing both version and `features`.
- Treat `features.store_document_text=false` as **no append support**: fall back to the per-process unique `document_id` with no `update_mode`, matching the legacy-server path.

## Tests

- Updated the three capability tests to mock the new probe (`_fetch_hindsight_api_meta`).
- Added a regression test: >=0.5.0 server with `store_document_text=false` must fall back to per-process doc_id without `update_mode`.

Verified live against a Hindsight 0.9.0 server with `store_document_text=false`: probe now returns "append not supported" and retain falls back correctly. 108 hindsight-related tests pass.