### PR TITLE
fix(memory): treat serialized-empty content as unset for the new_text alias

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -322,6 +322,28 @@ class TestMemoryToolDispatcher:
         assert result["success"] is True
         assert "added via new_text" in store.memory_entries
 
+    def test_new_text_alias_used_when_content_serialized_empty(self, store):
+        # Runtimes that materialize an omitted optional string as "" (#90468)
+        # used to bypass the alias and fail 'content is required'.
+        store.add("memory", "fact A")
+        result = json.loads(
+            memory_tool(
+                action="replace",
+                old_text="fact A",
+                content="",
+                new_text="fact A refined",
+                store=store,
+            )
+        )
+        assert result["success"] is True
+        assert "fact A refined" in store.memory_entries
+
+        result_add = json.loads(
+            memory_tool(action="add", content="", new_text="added despite empty", store=store)
+        )
+        assert result_add["success"] is True
+        assert "added despite empty" in store.memory_entries
+
     def test_content_wins_when_both_content_and_new_text_set(self, store):
         result = json.loads(
             memory_tool(action="add", content="the real one", new_text="ignored", store=store)

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1083,7 +1083,12 @@ def memory_tool(
         return tool_error("Memory is not available. It may be disabled in config or this environment.", success=False)
 
     # Accept new_text as an alias for content (single-op path). See docstring.
-    if content is None and new_text is not None:
+    # ``content == ""`` counts as unset too: runtimes that materialize an
+    # omitted optional string field as "" (#90468) would otherwise bypass the
+    # alias and fail validation — the batch ops below already coalesce with
+    # ``or``, and #86642 documented the single-op shape as
+    # ``content = content or new_text``.
+    if (content is None or content == "") and new_text is not None:
         content = new_text
 
     # Some strict providers fill optional schema fields with JSON null rather


### PR DESCRIPTION
## What does this PR do?

Makes the memory tool's `new_text` alias work when a runtime materializes an omitted optional string field as `""`. PR #86642 documented the single-op coalescing as `content = content or new_text`, but the implementation only fell back when `content` was `None` — providers that fill optional schema fields with an empty string (rather than omitting them) bypassed the alias, and `replace`/`add` calls carrying a genuine `new_text` failed with `content is required for 'replace' action.` (#90468). Verified still present on current `main` (`tools/memory_tool.py`, single-op alias guard).

The single-op alias guard now treats `content == ""` like `None`, matching the coalescing the batch operations below it already use (`op.get("content") or op.get("new_text")`). A non-empty `content` still wins when both are set.

## Related Issue

Fixes #90468

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/memory_tool.py` — `memory_tool` single-op alias guard widened from `content is None` to `content is None or content == ""`, with a comment referencing the runtime-serialization shape and the #86642 documented coalescing.
- `tests/tools/test_memory_tool.py` — new `test_new_text_alias_used_when_content_serialized_empty`: `replace` with `content=""` + `new_text` succeeds and stores the aliased text, and `add` with the same shape succeeds too.

## How to Test

1. `uv run --python 3.11 --with pytest --with pytest-asyncio --with pyyaml --with python-dotenv --with httpx --with pillow --with requests --with rich --with prompt_toolkit python -m pytest -q -o 'addopts=' tests/tools/test_memory_tool.py`
2. Observed result: 42 passed on this branch; the new test fails on unmodified `main` with `content is required for 'replace' action.` — confirming the regression test pins the fix. The pre-existing alias tests (`new_text` alone, `content` wins when both set) still pass.
3. Baseline: `tests/tools/test_memory_tool_schema.py` + `tests/tools/test_memory_tool_import_fallback.py` — 3 passed, unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (in-code comment documents the shape)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (schema already documents the alias)
