### PR TITLE
fix(desktop): Enter confirms an open confirmation dialog

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -190,6 +190,15 @@ Notes:
 - **Empty:** `EmptyState` for plain page bodies; `PanelEmpty` for overlay
   master/detail empties with an icon and action. Don't hand-roll a third
   centered empty.
+- **Confirmation:** `ConfirmDialog` is the only way we ask "are you sure". It
+  opens focused on Confirm, so `Enter` confirms and `Esc` cancels, and it owns
+  the pending → done → close beat and the inline error — a call site passes an
+  async `onConfirm` and nothing else. A third way out (e.g. "Remove from
+  sidebar" beside "Delete worktree") goes in the one `secondaryAction` slot.
+  Never `window.confirm`: it's an unstyled blocking Chromium modal. A handler
+  that wants the answer inline instead of a mounted dialog calls `confirm()`
+  from `src/store/confirm.ts`, which renders this same primitive through the
+  single `ConfirmHost` at the shell — the way `notify()` backs notifications.
 
 ## Chat, tools & boot surfaces
 
@@ -315,7 +324,8 @@ The detailed state contract lives in the scoped
 ## Before you add something — checklist
 
 - [ ] Reuse a primitive (`Button`, `SearchField`, `SegmentedControl`,
-      `ListRow`, `Loader`, `ErrorState`, `LogView`) instead of forking one?
+      `ListRow`, `Loader`, `ErrorState`, `LogView`, `ConfirmDialog`) instead of
+      forking one?
 - [ ] Tokens (`--ui-*`, `shadow-nous`, `--stroke-nous`) — zero raw colors /
       one-off shadows?
 - [ ] No `className` overriding a primitive's padding / size / radius / chrome?

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -13,6 +13,7 @@ import { deleteCronJob, getCronJobRuns, pauseCronJob, resumeCronJob, type Sessio
 import { useI18n } from '@/i18n'
 import { fmtDayTime, relativeTime } from '@/lib/time'
 import { cn } from '@/lib/utils'
+import { confirm } from '@/store/confirm'
 import { updateCronJobs } from '@/store/cron'
 import { $changeEventsAvailable, $cronChangeTick } from '@/store/live-sync'
 import { notify, notifyError } from '@/store/notifications'
@@ -259,7 +260,14 @@ function CronJobSidebarRow({
   }
 
   const remove = async () => {
-    if (!window.confirm(`${c.deleteDescPrefix}${label}${c.deleteDescSuffix}`)) {
+    const ok = await confirm({
+      confirmLabel: t.common.delete,
+      description: `${c.deleteDescPrefix}${label}${c.deleteDescSuffix}`,
+      destructive: true,
+      title: c.deleteTitle
+    })
+
+    if (!ok) {
       return
     }
 

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -2,16 +2,8 @@ import { useStore } from '@nanostores/react'
 import type * as React from 'react'
 import { useMemo, useState } from 'react'
 
-import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle
-} from '@/components/ui/dialog'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import type { HermesGitWorktree } from '@/global'
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -190,43 +182,26 @@ function RepoFlatSection({
     destructiveLabel: string,
     onDestructive: (group: SidebarSessionGroup) => void
   ) => (
-    <Dialog onOpenChange={isOpen => !isOpen && setTarget(null)} open={Boolean(target)}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{`${s.projects.removeWorktree} "${target?.label ?? ''}"?`}</DialogTitle>
-          <DialogDescription>{description}</DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button onClick={() => setTarget(null)} variant="ghost">
-            {t.common.cancel}
-          </Button>
-          <Button
-            onClick={() => {
-              if (target) {
-                dismissWorktree(target.id)
-              }
-
-              setTarget(null)
-            }}
-            variant="secondary"
-          >
-            {s.projects.removeFromSidebar}
-          </Button>
-          <Button
-            onClick={() => {
-              setTarget(null)
-
-              if (target) {
-                onDestructive(target)
-              }
-            }}
-            variant="destructive"
-          >
-            {destructiveLabel}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <ConfirmDialog
+      confirmLabel={destructiveLabel}
+      description={description}
+      destructive
+      // removeViaGit finishes on its own: it either dismisses the lane, escalates
+      // to the force prompt, or toasts. Nothing left for the dialog to wait on.
+      dismissOnConfirm
+      onClose={() => setTarget(null)}
+      onConfirm={() => {
+        if (target) {
+          onDestructive(target)
+        }
+      }}
+      open={Boolean(target)}
+      secondaryAction={{
+        label: s.projects.removeFromSidebar,
+        onClick: () => target && dismissWorktree(target.id)
+      }}
+      title={`${s.projects.removeWorktree} "${target?.label ?? ''}"?`}
+    />
   )
 
   const removeDialog = (

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -247,12 +247,19 @@ describe('SessionActionsMenu', () => {
     expect(await screen.queryByRole('dialog')).toBeNull()
     expect(onDelete).not.toHaveBeenCalled()
 
-    // Re-open and confirm with Enter: the delete call fires.
+    // Re-open and confirm with Enter at wherever focus actually is. Firing on
+    // the dialog node would pass even when the menu leaves focus on the row
+    // trigger — where Enter re-activates the row instead of confirming.
     fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
     fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
     fireEvent.click(trigger)
     fireEvent.click(await screen.findByRole('menuitem', { name: /delete/i }))
-    fireEvent.keyDown(await screen.findByRole('dialog'), { key: 'Enter' })
+
+    const reopened = await screen.findByRole('dialog')
+    // eslint-disable-next-line no-restricted-globals -- asserting real focus requires the live document
+    await waitFor(() => expect(reopened.contains(document.activeElement)).toBe(true))
+    // eslint-disable-next-line no-restricted-globals -- asserting real focus requires the live document
+    fireEvent.keyDown(document.activeElement!, { key: 'Enter' })
 
     expect(await screen.findByText('Session deleted')).toBeTruthy()
     expect(onDelete).toHaveBeenCalledTimes(1)

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -22,14 +22,7 @@ import { Codicon } from '@/components/ui/codicon'
 import { ColorSwatches } from '@/components/ui/color-swatches'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { CopyButton } from '@/components/ui/copy-button'
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  preventCloseButtonAutoFocus
-} from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { renameSession } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -580,7 +573,6 @@ function DeleteSessionDialog({ open, onOpenChange, onConfirm, sessionTitle }: De
       doneLabel={r.deleted}
       onClose={() => onOpenChange(false)}
       onConfirm={onConfirm}
-      onOpenAutoFocus={preventCloseButtonAutoFocus}
       open={open}
       title={r.deleteTitle}
     />

--- a/apps/desktop/src/app/command-center/maintenance.tsx
+++ b/apps/desktop/src/app/command-center/maintenance.tsx
@@ -23,6 +23,7 @@ import { useI18n } from '@/i18n'
 import { AlertCircle } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { upsertDesktopActionTask } from '@/store/activity'
+import { confirm } from '@/store/confirm'
 import { notify, notifyError } from '@/store/notifications'
 import type { ActionStatusResponse } from '@/types/hermes'
 
@@ -169,7 +170,7 @@ export function MaintenancePanel() {
 
   const doResetMemory = useCallback(
     async (target: 'all' | 'memory' | 'user', label: string) => {
-      if (!window.confirm(mm.resetConfirm(label))) {
+      if (!(await confirm({ destructive: true, title: mm.resetConfirm(label) }))) {
         return
       }
 

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -16,6 +16,7 @@ import { useLocation, useNavigate } from 'react-router'
 import { graftRefreshedTailOntoBackfill } from '@/app/chat/transcript-backfill'
 import { formatRefValue } from '@/components/assistant-ui/directive-text'
 import { BootFailureOverlay } from '@/components/boot-failure-overlay'
+import { ConfirmHost } from '@/components/confirm-host'
 import { DesktopInstallOverlay } from '@/components/desktop-install-overlay'
 import { FindBar } from '@/components/find-bar'
 import { GatewayConnectingOverlay } from '@/components/gateway-connecting-overlay'
@@ -1176,6 +1177,9 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
       {/* Toasts above everything. */}
       <NotificationStack />
+
+      {/* Backs confirm() from @/store/confirm — renders only while one is open. */}
+      <ConfirmHost />
 
       {/* Petdex floating mascot — renders nothing unless installed + enabled.
           Never in the HUD: that window is the chat bar and nothing else. */}

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -8,6 +8,7 @@ import { PageLoader } from '@/components/page-loader'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Codicon } from '@/components/ui/codicon'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import {
   Dialog,
   DialogContent,
@@ -343,7 +344,6 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
 
   const [editor, setEditor] = useState<EditorState>({ mode: 'closed' })
   const [pendingDelete, setPendingDelete] = useState<CronJob | null>(null)
-  const [deleting, setDeleting] = useState(false)
 
   // Jobs live per-profile on disk and the list endpoint aggregates 'all' by
   // default — scope the fetch to the sidebar's profile scope so this overlay
@@ -533,31 +533,23 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
     }
   }
 
+  // Throws on failure — ConfirmDialog reports it inline and stays open.
   async function handleConfirmDelete() {
     if (!pendingDelete) {
       return
     }
 
-    setDeleting(true)
+    const { refreshError, stale } = await mutateAndRefreshCronJobs(profile, () => deleteCronJob(pendingDelete.id))
 
-    try {
-      const { refreshError, stale } = await mutateAndRefreshCronJobs(profile, () => deleteCronJob(pendingDelete.id))
-
-      if (stale) {
-        return
-      }
-
-      if (refreshError) {
-        notifyError(refreshError, c.failedLoad)
-      }
-
-      notify({ kind: 'success', title: c.deleted, message: truncate(jobTitle(pendingDelete), 60) })
-      setPendingDelete(null)
-    } catch (err) {
-      notifyError(err, c.failedDelete)
-    } finally {
-      setDeleting(false)
+    if (stale) {
+      return
     }
+
+    if (refreshError) {
+      notifyError(refreshError, c.failedLoad)
+    }
+
+    notify({ kind: 'success', title: c.deleted, message: truncate(jobTitle(pendingDelete), 60) })
   }
 
   async function handleEditorSave(values: EditorValues) {
@@ -735,30 +727,24 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
         onSave={handleEditorSave}
       />
 
-      <Dialog onOpenChange={open => !open && !deleting && setPendingDelete(null)} open={pendingDelete !== null}>
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle>{c.deleteTitle}</DialogTitle>
-            <DialogDescription>
-              {pendingDelete ? (
-                <>
-                  {c.deleteDescPrefix}
-                  <span className="font-medium text-foreground">{truncate(jobTitle(pendingDelete), 60)}</span>
-                  {c.deleteDescSuffix}
-                </>
-              ) : null}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button disabled={deleting} onClick={() => setPendingDelete(null)} variant="outline">
-              {t.common.cancel}
-            </Button>
-            <Button disabled={deleting} onClick={() => void handleConfirmDelete()} variant="destructive">
-              {deleting ? c.deleting : t.common.delete}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ConfirmDialog
+        busyLabel={c.deleting}
+        confirmLabel={t.common.delete}
+        description={
+          pendingDelete ? (
+            <>
+              {c.deleteDescPrefix}
+              <span className="font-medium text-foreground">{truncate(jobTitle(pendingDelete), 60)}</span>
+              {c.deleteDescSuffix}
+            </>
+          ) : null
+        }
+        destructive
+        onClose={() => setPendingDelete(null)}
+        onConfirm={handleConfirmDelete}
+        open={pendingDelete !== null}
+        title={c.deleteTitle}
+      />
     </Panel>
   )
 }

--- a/apps/desktop/src/app/right-sidebar/review/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/index.tsx
@@ -4,14 +4,7 @@ import { FileDiffPanel } from '@/components/chat/diff-lines'
 import { DiffSkeleton, TreeSkeleton } from '@/components/chat/skeletons'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle
-} from '@/components/ui/dialog'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { DiffCount } from '@/components/ui/diff-count'
 import { Tip } from '@/components/ui/tooltip'
 import { useDelayedTrue } from '@/hooks/use-delayed-true'
@@ -209,32 +202,30 @@ export function ReviewPane() {
 
       <ReviewShipBar />
 
-      <Dialog onOpenChange={open => !open && cancelRevert()} open={revertTarget !== undefined}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{revertingAll ? c.revertAll : c.revert}</DialogTitle>
-            <DialogDescription>
-              {revertingAll ? c.revertAllConfirm : c.revertConfirm}
-              {!revertingAll && revertTarget?.path && (
-                <span
-                  className="mt-2 block truncate font-mono text-[0.7rem] text-(--ui-text-secondary)"
-                  title={displayPath(revertTarget.path)}
-                >
-                  {displayPath(revertTarget.path)}
-                </span>
-              )}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button onClick={cancelRevert} variant="ghost">
-              {t.common.cancel}
-            </Button>
-            <Button onClick={() => void confirmRevert().catch(err => notifyError(err, c.revert))} variant="destructive">
-              {revertingAll ? c.revertAll : c.revert}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ConfirmDialog
+        confirmLabel={revertingAll ? c.revertAll : c.revert}
+        description={
+          <>
+            {revertingAll ? c.revertAllConfirm : c.revertConfirm}
+            {!revertingAll && revertTarget?.path && (
+              <span
+                className="mt-2 block truncate font-mono text-[0.7rem] text-(--ui-text-secondary)"
+                title={displayPath(revertTarget.path)}
+              >
+                {displayPath(revertTarget.path)}
+              </span>
+            )}
+          </>
+        }
+        destructive
+        // confirmRevert closes the dialog itself, then reverts in the
+        // background — so the failure lands in a toast, not inline.
+        dismissOnConfirm
+        onClose={cancelRevert}
+        onConfirm={() => confirmRevert().catch(err => void notifyError(err, c.revert))}
+        open={revertTarget !== undefined}
+        title={revertingAll ? c.revertAll : c.revert}
+      />
     </aside>
   )
 }

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input'
 import { getElevenLabsVoices, getHermesConfigSchema, saveHermesConfig } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
+import { confirm } from '@/store/confirm'
 import {
   $dataUrlReadMaxMb,
   clampDataUrlReadMaxMb,
@@ -213,19 +214,29 @@ function ConfigSettingsInner({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- copy is stable; avoid re-scheduling autosave on locale change
   }, [config, onConfigSaved, saveVersion])
 
+  const applyConfig = (next: HermesConfigRecord) => {
+    saveVersionRef.current += 1
+    setConfig(next)
+    setSaveVersion(saveVersionRef.current)
+  }
+
   const updateConfig = (next: HermesConfigRecord) => {
     // Guard the single most destructive config edit: clearing the entire
     // "Enabled Toolsets" list silently disables memory, terminal, web search,
     // delegation, and most tools, and a stray select-all + Backspace can do it.
     // Auto-save is debounced with no undo, so confirm a non-empty → empty
     // transition before applying it. Every other edit passes through untouched.
-    if (config && clearsEnabledToolsets(config, next) && !window.confirm(c.toolsetsWipeConfirm)) {
+    if (config && clearsEnabledToolsets(config, next)) {
+      void confirm({ destructive: true, title: c.toolsetsWipeConfirm }).then(ok => {
+        if (ok) {
+          applyConfig(next)
+        }
+      })
+
       return
     }
 
-    saveVersionRef.current += 1
-    setConfig(next)
-    setSaveVersion(saveVersionRef.current)
+    applyConfig(next)
   }
 
   const sectionFields = useMemo(() => {

--- a/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
+++ b/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
@@ -13,6 +13,7 @@ import {
 import { triggerHaptic } from '@/lib/haptics'
 import { Check, Globe, Loader2, Plus, Save, Trash2, Zap } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { confirm } from '@/store/confirm'
 import { notify, notifyError } from '@/store/notifications'
 import type { CustomEndpoint, CustomEndpointUpdate } from '@/types/hermes'
 
@@ -195,7 +196,8 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
   }
 
   async function handleDelete(endpoint: CustomEndpoint) {
-    if (!window.confirm(`Delete ${endpoint.name}?`)) {
+    // This panel is not internationalized at all — keep the literal it had.
+    if (!(await confirm({ destructive: true, title: `Delete ${endpoint.name}?` }))) {
       return
     }
 

--- a/apps/desktop/src/app/settings/env-credentials.tsx
+++ b/apps/desktop/src/app/settings/env-credentials.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { deleteEnvVar, getEnvVars, revealEnvVar, setEnvVar } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { type IconComponent } from '@/lib/icons'
+import { confirm } from '@/store/confirm'
 import { notify, notifyError } from '@/store/notifications'
 import type { EnvVarInfo } from '@/types/hermes'
 
@@ -142,7 +143,7 @@ export function useEnvCredentials(profile: null | string = null): UseEnvCredenti
   }
 
   async function handleClear(key: string) {
-    if (!window.confirm(toolsets.removeConfirm(key))) {
+    if (!(await confirm({ destructive: true, title: toolsets.removeConfirm(key) }))) {
       return
     }
 

--- a/apps/desktop/src/app/settings/index.tsx
+++ b/apps/desktop/src/app/settings/index.tsx
@@ -29,6 +29,7 @@ import { isEditableTarget } from '@/lib/keybinds/combo'
 import { typeToFocusChar } from '@/lib/keybinds/composer-focus-keys'
 import { cn } from '@/lib/utils'
 import { $commandPaletteOpen, openCommandPalettePage } from '@/store/command-palette'
+import { confirm } from '@/store/confirm'
 import { bindingsFor } from '@/store/keybinds'
 import { notifyError } from '@/store/notifications'
 
@@ -147,7 +148,13 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
   }
 
   const resetConfig = async () => {
-    if (!window.confirm(t.settings.resetConfirm)) {
+    const ok = await confirm({
+      confirmLabel: t.settings.resetToDefaults,
+      destructive: true,
+      title: t.settings.resetConfirm
+    })
+
+    if (!ok) {
       return
     }
 

--- a/apps/desktop/src/app/settings/providers-settings.test.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.test.tsx
@@ -2,6 +2,8 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { atom } from 'nanostores'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ConfirmHost } from '@/components/confirm-host'
+import { $confirmRequest } from '@/store/confirm'
 import type { EnvVarInfo, OAuthProvider } from '@/types/hermes'
 
 const listOAuthProviders = vi.fn()
@@ -64,20 +66,27 @@ beforeEach(() => {
   listOAuthProviders.mockResolvedValue({
     providers: [provider('nous', true), provider('minimax-oauth', false)]
   })
-  vi.spyOn(window, 'confirm').mockReturnValue(true)
 })
 
 afterEach(() => {
   cleanup()
+  $confirmRequest.set(null)
   vi.restoreAllMocks()
   vi.clearAllMocks()
 })
 
+// Removal goes through confirm() from @/store/confirm, so the host has to be
+// mounted for the prompt to render — same as in the real app shell.
 async function renderProvidersSettings() {
   const { ProvidersSettings } = await import('./providers-settings')
   let result: ReturnType<typeof render>
   await act(async () => {
-    result = render(<ProvidersSettings onClose={vi.fn()} onViewChange={vi.fn()} view="accounts" />)
+    result = render(
+      <>
+        <ProvidersSettings onClose={vi.fn()} onViewChange={vi.fn()} view="accounts" />
+        <ConfirmHost />
+      </>
+    )
   })
 
   return result!
@@ -92,8 +101,30 @@ describe('ProvidersSettings', () => {
       fireEvent.click(remove)
     })
 
+    // Removal is confirmed first — nothing has been disconnected yet.
+    expect(await screen.findByRole('dialog')).toBeTruthy()
+    expect(disconnectOAuthProvider).not.toHaveBeenCalled()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }))
+    })
+
     await waitFor(() => expect(disconnectOAuthProvider).toHaveBeenCalledWith('nous'))
     expect(listOAuthProviders).toHaveBeenCalledTimes(2)
+  })
+
+  it('leaves the account connected when the removal prompt is dismissed', async () => {
+    await renderProvidersSettings()
+
+    await act(async () => {
+      fireEvent.click(await screen.findByRole('button', { name: 'Remove Nous Portal' }))
+    })
+
+    await act(async () => {
+      fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }))
+    })
+
+    expect(disconnectOAuthProvider).not.toHaveBeenCalled()
   })
 
   it('keeps provider selection separate from account removal', async () => {

--- a/apps/desktop/src/app/settings/providers-settings.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.tsx
@@ -20,6 +20,7 @@ import { useI18n } from '@/i18n'
 import { Check, ChevronDown, ChevronRight, KeyRound, Loader2, Terminal, Trash2 } from '@/lib/icons'
 import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
+import { confirm } from '@/store/confirm'
 import { notify, notifyError } from '@/store/notifications'
 import { $desktopOnboarding, startManualLocalEndpoint, startManualProviderOAuth } from '@/store/onboarding'
 import type { EnvVarInfo, OAuthProvider } from '@/types/hermes'
@@ -382,7 +383,7 @@ export function ProvidersSettings({
   // Hermes never deletes creds another tool owns behind a silent API call.
   // Instead we run the documented removal command in the embedded terminal so
   // the user sees exactly what executes, then return them to chat to watch it.
-  function handleTerminalDisconnect(provider: OAuthProvider) {
+  async function handleTerminalDisconnect(provider: OAuthProvider) {
     const command = provider.disconnect_command
 
     if (!command) {
@@ -391,7 +392,13 @@ export function ProvidersSettings({
 
     const name = providerTitle(provider)
 
-    if (!window.confirm(t.settings.providers.removeTerminalConfirm(name, command))) {
+    const ok = await confirm({
+      confirmLabel: t.settings.providers.disconnect,
+      destructive: true,
+      title: t.settings.providers.removeTerminalConfirm(name, command)
+    })
+
+    if (!ok) {
       return
     }
 
@@ -408,7 +415,13 @@ export function ProvidersSettings({
   async function handleDisconnect(provider: OAuthProvider) {
     const name = providerTitle(provider)
 
-    if (!window.confirm(t.settings.providers.removeConfirm(name))) {
+    const ok = await confirm({
+      confirmLabel: t.settings.providers.disconnect,
+      destructive: true,
+      title: t.settings.providers.removeConfirm(name)
+    })
+
+    if (!ok) {
       return
     }
 
@@ -499,7 +512,7 @@ export function ProvidersSettings({
       <OAuthPicker
         disconnecting={disconnecting}
         onDisconnect={provider => void handleDisconnect(provider)}
-        onTerminalDisconnect={handleTerminalDisconnect}
+        onTerminalDisconnect={provider => void handleTerminalDisconnect(provider)}
         onWantApiKey={() => onViewChange('keys')}
         providers={oauthProviders}
       />

--- a/apps/desktop/src/app/settings/sessions-settings.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings.tsx
@@ -15,6 +15,7 @@ import { sessionTitle } from '@/lib/chat-runtime'
 import { pathLeaf } from '@/lib/display-path'
 import { triggerHaptic } from '@/lib/haptics'
 import { Archive, ArchiveOff, FolderOpen, Loader2, Trash2 } from '@/lib/icons'
+import { confirm } from '@/store/confirm'
 import { notify, notifyError } from '@/store/notifications'
 import { untombstoneSessions } from '@/store/projects'
 import { applyConfiguredDefaultProjectDir, ensureDefaultWorkspaceCwd, setSessions } from '@/store/session'
@@ -76,7 +77,13 @@ export function SessionsSettings() {
 
   const remove = useCallback(
     async (session: SessionInfo) => {
-      if (!window.confirm(s.deleteConfirm(sessionTitle(session)))) {
+      const ok = await confirm({
+        confirmLabel: s.deletePermanently,
+        destructive: true,
+        title: s.deleteConfirm(sessionTitle(session))
+      })
+
+      if (!ok) {
         return
       }
 

--- a/apps/desktop/src/app/settings/toolset-config-panel.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.tsx
@@ -22,6 +22,7 @@ import { useI18n } from '@/i18n'
 import { Check, Loader2, Save, Terminal } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { upsertDesktopActionTask } from '@/store/activity'
+import { confirm } from '@/store/confirm'
 import { notify, notifyError } from '@/store/notifications'
 import type {
   ActionStatusResponse,
@@ -141,7 +142,7 @@ function EnvVarField({ envVar, isSet, onSaved, onCleared, profile }: EnvVarField
   }
 
   async function handleClear() {
-    if (!window.confirm(copy.removeConfirm(envVar.key))) {
+    if (!(await confirm({ destructive: true, title: copy.removeConfirm(envVar.key) }))) {
       return
     }
 

--- a/apps/desktop/src/components/confirm-host.test.tsx
+++ b/apps/desktop/src/components/confirm-host.test.tsx
@@ -1,0 +1,81 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { $confirmRequest, confirm } from '@/store/confirm'
+
+import { ConfirmHost } from './confirm-host'
+
+afterEach(() => {
+  cleanup()
+  $confirmRequest.set(null)
+})
+
+/** Open a confirm and wait for the dialog, without awaiting the answer. */
+async function ask(title = 'Delete it?') {
+  let answer: boolean | undefined
+  const pending = confirm({ title }).then(ok => (answer = ok))
+
+  const dialog = await screen.findByRole('dialog')
+
+  return { dialog, pending, read: () => answer }
+}
+
+describe('confirm()', () => {
+  it('renders nothing until something asks', () => {
+    render(<ConfirmHost />)
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('resolves true when confirmed and false when cancelled', async () => {
+    render(<ConfirmHost />)
+
+    const yes = await ask()
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }))
+    await yes.pending
+    expect(yes.read()).toBe(true)
+
+    const no = await ask()
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    await no.pending
+    expect(no.read()).toBe(false)
+  })
+
+  it('confirms on Enter from wherever focus landed', async () => {
+    render(<ConfirmHost />)
+
+    const { dialog, pending, read } = await ask()
+
+    // eslint-disable-next-line no-restricted-globals -- asserting real focus requires the live document
+    await waitFor(() => expect(dialog.contains(document.activeElement)).toBe(true))
+    // eslint-disable-next-line no-restricted-globals -- asserting real focus requires the live document
+    fireEvent.keyDown(document.activeElement!, { key: 'Enter' })
+
+    await pending
+    expect(read()).toBe(true)
+  })
+
+  it('answers no to Escape', async () => {
+    render(<ConfirmHost />)
+
+    const { pending, read } = await ask()
+    fireEvent.keyDown(window.document, { key: 'Escape' })
+
+    await pending
+    expect(read()).toBe(false)
+  })
+
+  it('supersedes an open request, answering the one it replaces no', async () => {
+    render(<ConfirmHost />)
+
+    const first = await ask('First?')
+    const second = await act(async () => ask('Second?'))
+
+    await first.pending
+    expect(first.read()).toBe(false)
+    expect(screen.getByText('Second?')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }))
+    await second.pending
+    expect(second.read()).toBe(true)
+  })
+})

--- a/apps/desktop/src/components/confirm-host.tsx
+++ b/apps/desktop/src/components/confirm-host.tsx
@@ -1,0 +1,40 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useState } from 'react'
+
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { $confirmRequest, type PendingConfirm, settleConfirm } from '@/store/confirm'
+
+// The one mount point for `confirm()` from @/store/confirm. Mounted once at the
+// shell, the way NotificationStack backs notify().
+export function ConfirmHost() {
+  const request = useStore($confirmRequest)
+  // The atom clears the moment the question is answered, but Radix still has a
+  // close animation to play — hold the copy so the dialog doesn't blank mid-fade.
+  const [shown, setShown] = useState<null | PendingConfirm>(request)
+
+  useEffect(() => {
+    if (request) {
+      setShown(request)
+    }
+  }, [request])
+
+  if (!shown) {
+    return null
+  }
+
+  return (
+    <ConfirmDialog
+      cancelLabel={shown.cancelLabel}
+      confirmLabel={shown.confirmLabel}
+      description={shown.description}
+      destructive={shown.destructive}
+      // The caller does the work once it has its answer, so there is nothing
+      // here to keep the dialog open for.
+      dismissOnConfirm
+      onClose={() => settleConfirm(false)}
+      onConfirm={() => settleConfirm(true)}
+      open={request !== null}
+      title={shown.title}
+    />
+  )
+}

--- a/apps/desktop/src/components/ui/confirm-dialog.test.tsx
+++ b/apps/desktop/src/components/ui/confirm-dialog.test.tsx
@@ -1,0 +1,50 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ConfirmDialog } from './confirm-dialog'
+
+afterEach(cleanup)
+
+describe('ConfirmDialog secondary action', () => {
+  function renderWithSecondary() {
+    const onConfirm = vi.fn()
+    const onClose = vi.fn()
+    const onSecondary = vi.fn()
+
+    render(
+      <ConfirmDialog
+        onClose={onClose}
+        onConfirm={onConfirm}
+        open
+        secondaryAction={{ label: 'Remove from sidebar', onClick: onSecondary }}
+        title="Remove worktree?"
+      />
+    )
+
+    return { onClose, onConfirm, onSecondary }
+  }
+
+  it('runs the secondary action and closes without confirming', async () => {
+    const { onClose, onConfirm, onSecondary } = renderWithSecondary()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove from sidebar' }))
+
+    expect(onSecondary).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('still opens focused on Confirm, so Enter confirms rather than picking the secondary', async () => {
+    const { onConfirm, onSecondary } = renderWithSecondary()
+
+    const dialog = await screen.findByRole('dialog')
+
+    // eslint-disable-next-line no-restricted-globals -- asserting real focus requires the live document
+    await waitFor(() => expect(dialog.contains(document.activeElement)).toBe(true))
+    // eslint-disable-next-line no-restricted-globals -- asserting real focus requires the live document
+    fireEvent.keyDown(document.activeElement!, { key: 'Enter' })
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1))
+    expect(onSecondary).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/components/ui/confirm-dialog.tsx
+++ b/apps/desktop/src/components/ui/confirm-dialog.tsx
@@ -28,6 +28,14 @@ interface ConfirmDialogProps {
   destructive?: boolean
   /** Close as soon as onConfirm resolves — for optimistic actions that finish in the background. */
   dismissOnConfirm?: boolean
+  /** A third, non-destructive way out, shown between Cancel and Confirm (e.g.
+   *  "Remove from sidebar" beside "Delete worktree"). Closes on click. */
+  secondaryAction?: ConfirmSecondaryAction
+}
+
+interface ConfirmSecondaryAction {
+  label: string
+  onClick: () => void
 }
 
 // Shared confirmation dialog: opens focused on Confirm, Enter confirms (from
@@ -45,7 +53,8 @@ export function ConfirmDialog({
   doneLabel,
   cancelLabel,
   destructive = false,
-  dismissOnConfirm = false
+  dismissOnConfirm = false,
+  secondaryAction
 }: ConfirmDialogProps) {
   const { t } = useI18n()
   const confirmRef = useRef<HTMLButtonElement>(null)
@@ -131,6 +140,19 @@ export function ConfirmDialog({
           <Button disabled={busy} onClick={onClose} type="button" variant="ghost">
             {resolvedCancelLabel}
           </Button>
+          {secondaryAction && (
+            <Button
+              disabled={busy}
+              onClick={() => {
+                secondaryAction.onClick()
+                onClose()
+              }}
+              type="button"
+              variant="secondary"
+            >
+              {secondaryAction.label}
+            </Button>
+          )}
           <Button
             disabled={busy}
             onClick={() => void run()}

--- a/apps/desktop/src/components/ui/confirm-dialog.tsx
+++ b/apps/desktop/src/components/ui/confirm-dialog.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { ActionStatus } from '@/components/ui/action-status'
 import { Button } from '@/components/ui/button'
@@ -28,15 +28,12 @@ interface ConfirmDialogProps {
   destructive?: boolean
   /** Close as soon as onConfirm resolves — for optimistic actions that finish in the background. */
   dismissOnConfirm?: boolean
-  /** Focus control for dialogs with no input. Pass `preventCloseButtonAutoFocus`
-   *  so opening doesn't land focus on the close/cancel button (which would pop
-   *  its tooltip with no pointer near it). */
-  onOpenAutoFocus?: (event: Event) => void
 }
 
-// Shared confirmation dialog: Enter confirms (from anywhere in the dialog),
-// Esc/Cancel/backdrop dismiss. Owns the pending → done → close beat and inline
-// error, so callers pass only an async onConfirm that does the work.
+// Shared confirmation dialog: opens focused on Confirm, Enter confirms (from
+// anywhere in the dialog), Esc/Cancel/backdrop dismiss. Owns the pending → done
+// → close beat and inline error, so callers pass only an async onConfirm that
+// does the work.
 export function ConfirmDialog({
   open,
   onClose,
@@ -48,10 +45,10 @@ export function ConfirmDialog({
   doneLabel,
   cancelLabel,
   destructive = false,
-  dismissOnConfirm = false,
-  onOpenAutoFocus
+  dismissOnConfirm = false
 }: ConfirmDialogProps) {
   const { t } = useI18n()
+  const confirmRef = useRef<HTMLButtonElement>(null)
   const [status, setStatus] = useState<'done' | 'idle' | 'saving'>('idle')
   const [error, setError] = useState<null | string>(null)
   const busy = status === 'saving' || status === 'done'
@@ -109,7 +106,14 @@ export function ConfirmDialog({
             void run()
           }
         }}
-        onOpenAutoFocus={onOpenAutoFocus}
+        onOpenAutoFocus={event => {
+          // Focus must land inside the dialog or the handler above never sees
+          // the key: it stays on whatever opened the dialog (a menu item, a
+          // sidebar row) and Enter re-triggers that instead. Radix's default
+          // would take the X — confirm is the button Enter maps to.
+          event.preventDefault()
+          confirmRef.current?.focus()
+        }}
       >
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
@@ -127,7 +131,12 @@ export function ConfirmDialog({
           <Button disabled={busy} onClick={onClose} type="button" variant="ghost">
             {resolvedCancelLabel}
           </Button>
-          <Button disabled={busy} onClick={() => void run()} variant={destructive ? 'destructive' : 'default'}>
+          <Button
+            disabled={busy}
+            onClick={() => void run()}
+            ref={confirmRef}
+            variant={destructive ? 'destructive' : 'default'}
+          >
             <ActionStatus
               busy={resolvedBusyLabel}
               done={resolvedDoneLabel}

--- a/apps/desktop/src/components/ui/dialog.tsx
+++ b/apps/desktop/src/components/ui/dialog.tsx
@@ -55,7 +55,9 @@ const DIALOG_BANNER_TONES: Record<DialogBannerTone, string> = {
 // element ends up being the close button, and since Tip shows on focus as well
 // as hover, that autofocus makes the "Close" tip appear immediately with no
 // pointer ever near the button. Dialogs like that should pass this in
-// explicitly as `onOpenAutoFocus={preventCloseButtonAutoFocus}`.
+// explicitly as `onOpenAutoFocus={preventCloseButtonAutoFocus}`. Note it leaves
+// focus wherever it was — outside the dialog — so a dialog that answers keys
+// (Enter to confirm) must focus something of its own instead.
 export function preventCloseButtonAutoFocus(event: Event) {
   event.preventDefault()
 }

--- a/apps/desktop/src/store/confirm.ts
+++ b/apps/desktop/src/store/confirm.ts
@@ -1,0 +1,40 @@
+import { atom } from 'nanostores'
+
+export interface ConfirmRequest {
+  title: string
+  description?: string
+  confirmLabel?: string
+  cancelLabel?: string
+  destructive?: boolean
+}
+
+export interface PendingConfirm extends ConfirmRequest {
+  resolve: (confirmed: boolean) => void
+}
+
+export const $confirmRequest = atom<null | PendingConfirm>(null)
+
+// Imperative front door to ConfirmDialog, for handlers that want the answer
+// inline the way window.confirm gave it — `if (!ok) return`. A surface that
+// wants the busy → done beat or an inline error should mount <ConfirmDialog>
+// itself and hand it the async onConfirm.
+export function confirm(request: ConfirmRequest): Promise<boolean> {
+  // One modal at a time: a second ask supersedes the first, which answers no.
+  settleConfirm(false)
+
+  return new Promise<boolean>(resolve => {
+    $confirmRequest.set({ ...request, resolve })
+  })
+}
+
+/** Answer the open request, if there still is one. Idempotent. */
+export function settleConfirm(confirmed: boolean): void {
+  const pending = $confirmRequest.get()
+
+  if (!pending) {
+    return
+  }
+
+  $confirmRequest.set(null)
+  pending.resolve(confirmed)
+}


### PR DESCRIPTION
Pressing Enter with a confirmation dialog open did nothing — most visibly on delete session, where the key went to the sidebar row behind the dialog and re-opened the session instead.

`ConfirmDialog` has always handled Enter, but only for keys that bubble up from inside it. The delete-session wrapper passed `preventCloseButtonAutoFocus`, so nothing in the dialog ever took focus: it stayed on the row that opened the menu. `ConfirmDialog` now focuses its own Confirm button on open, which makes Enter work natively and gives keyboard users a sensible landing spot. Mouse users see no focus ring — the button styles on `focus-visible`.

Chasing that turned up the wider problem: most confirmations in the app weren't using the shared dialog at all. Cron delete and review revert were hand-rolled copies of it, and ten more prompts were raw `window.confirm` — unstyled blocking Chromium modals. All of them now go through `ConfirmDialog`, so every confirmation looks the same and answers Enter.

Two pieces were needed to get there:

- **A secondary action slot.** The worktree removal prompt offers a third way out (hide the lane, leave the worktree on disk), which is why it resisted the primitive. One optional button between Cancel and Confirm covers it, and Confirm keeps the focus so Enter still means the destructive action.
- **`confirm()` from `@/store/confirm`.** Handlers that want the answer inline — the shape `window.confirm` had — otherwise have to hoist a `pending` state and a JSX mount into their component, which is why ten of them reached for the native one. This mirrors `notify()`: a store action carries the question, and a single `<ConfirmHost>` at the shell renders the real `ConfirmDialog`. It is not a second implementation — the primitive still owns all UI and behavior. `DESIGN.md` now names `ConfirmDialog` as the confirmation primitive alongside the other named contracts, so the next person doesn't reach for the native one.

Copy is unchanged at every converted site, so there are no new i18n keys.

## Test plan

- [x] `session-actions-menu.test.tsx` fires Enter at whatever actually holds focus rather than at the dialog node, which is why the old test passed over this bug.
- [x] New `confirm-host.test.tsx`: resolves true/false, Enter confirms, Escape declines, a second ask supersedes the first.
- [x] New `confirm-dialog.test.tsx`: the secondary action runs without confirming, and doesn't steal Enter.
- [x] `providers-settings.test.tsx` drives the real dialog instead of stubbing `window.confirm`, and now covers the dismiss path.
- [x] Full desktop UI suite: 5103 passed. `tsc --noEmit`, eslint, prettier clean.
- [ ] Manual: Enter confirms and Esc cancels on delete session, delete cron job (sidebar and cron page), revert file, worktree removal, and the settings prompts.
