### PR TITLE
fix(mcp): preserve refresh token on refresh

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -80,6 +80,53 @@ class TestHermesTokenStorage:
         data = json.loads(token_path.read_text())
         assert data["access_token"] == "abc123"
 
+    def test_refresh_preserves_existing_refresh_token_when_omitted(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("test-server")
+
+        initial_token = MagicMock()
+        initial_token.model_dump.return_value = {
+            "access_token": "old-access",
+            "token_type": "Bearer",
+            "refresh_token": "durable-refresh",
+        }
+        refreshed_token = MagicMock()
+        refreshed_token.model_dump.return_value = {
+            "access_token": "new-access",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        }
+
+        asyncio.run(storage.set_tokens(initial_token))
+        asyncio.run(storage.set_tokens(refreshed_token))
+
+        data = json.loads((tmp_path / "mcp-tokens" / "test-server.json").read_text())
+        assert data["access_token"] == "new-access"
+        assert data["refresh_token"] == "durable-refresh"
+
+    def test_refresh_uses_explicit_new_refresh_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("test-server")
+
+        initial_token = MagicMock()
+        initial_token.model_dump.return_value = {
+            "access_token": "old-access",
+            "token_type": "Bearer",
+            "refresh_token": "old-refresh",
+        }
+        refreshed_token = MagicMock()
+        refreshed_token.model_dump.return_value = {
+            "access_token": "new-access",
+            "token_type": "Bearer",
+            "refresh_token": "rotated-refresh",
+        }
+
+        asyncio.run(storage.set_tokens(initial_token))
+        asyncio.run(storage.set_tokens(refreshed_token))
+
+        data = json.loads((tmp_path / "mcp-tokens" / "test-server.json").read_text())
+        assert data["refresh_token"] == "rotated-refresh"
+
     @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
     def test_token_file_created_with_0o600(self, tmp_path, monkeypatch):
         """Tokens must land on disk at 0o600 with no umask-default exposure window.

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -525,6 +525,10 @@ class HermesTokenStorage:
 
     async def set_tokens(self, tokens: "OAuthToken") -> None:
         payload = tokens.model_dump(mode="json", exclude_none=True)
+        if "refresh_token" not in payload:
+            existing_payload = _read_json(self._tokens_path())
+            if existing_payload and "refresh_token" in existing_payload:
+                payload["refresh_token"] = existing_payload["refresh_token"]
         # Persist an absolute ``expires_at`` so a process restart can
         # reconstruct the correct remaining TTL. Without this the MCP SDK's
         # ``_initialize`` reloads a relative ``expires_in`` which has no


### PR DESCRIPTION
## What

Preserve the prior OAuth refresh token when a provider returns a refresh response containing only a new access token.

## Why

OAuth providers may rotate or omit `refresh_token` during refresh. Replacing stored credentials wholesale makes the next refresh require an interactive browser login, which breaks headless gateways. The failure reproduces on current `main` in `HermesTokenStorage.set_tokens`.

## Validation

- `scripts/run_tests.sh tests/tools/test_mcp_oauth.py`
- 60 passed, 0 failed on macOS arm64

The regression tests cover both preservation when the response omits a refresh token and replacement when the provider explicitly returns a new one.