### PR TITLE
fix(webhook): restore provider contracts and readiness

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -736,8 +736,10 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Check event type filter
         event_type = (
-            request.headers.get("X-GitHub-Event", "")
+            request.headers.get("Linear-Event", "")
+            or request.headers.get("X-GitHub-Event", "")
             or request.headers.get("X-GitLab-Event", "")
+            or request.headers.get("X-Event-Type", "")
             or payload.get("event_type", "")
             or payload.get("type", "")
             or "unknown"
@@ -1119,23 +1121,11 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Generic V2: X-Webhook-Signature-V2 = <hex HMAC-SHA256 of "<timestamp>.<body>">
         #             X-Webhook-Timestamp = <unix seconds> (required for V2)
-        # Checked independently of (and before) legacy V1 below — a sender
-        # that only ever sends V2 headers must still validate here; nesting
-        # this inside `if generic_sig:` would silently skip V2-only senders.
-        #
-        # The presence of X-Webhook-Signature-V2 alone selects V2 mode and
-        # commits to it — it must NOT fall through to the V1 branch just
-        # because the timestamp is missing/malformed/expired. A sender
-        # migrating to V2 typically sends both V1 and V2 headers together
-        # for compatibility; if incomplete V2 fell through to V1, an
-        # attacker who captured one such mixed request could strip the
-        # X-Webhook-Timestamp header from a replay and have it validate
-        # against the still-present, still-unprotected V1 signature instead
-        # — silently downgrading a V2-protected request back to the replay
-        # hole V2 exists to close.
-        v2_sig = request.headers.get("X-Webhook-Signature-V2", "")
+        # Checked before legacy/provider body-only signatures; the presence of
+        # V2 commits to V2 validation and must not downgrade to V1 if malformed.
+        v2_sig = _header("X-Webhook-Signature-V2")
         if v2_sig:
-            v2_timestamp = request.headers.get("X-Webhook-Timestamp", "")
+            v2_timestamp = _header("X-Webhook-Timestamp")
             if not v2_timestamp:
                 logger.warning(
                     "[webhook] Route '%s' sent X-Webhook-Signature-V2 with "
@@ -1158,21 +1148,24 @@ class WebhookAdapter(BasePlatformAdapter):
             expected_v2 = hmac.new(
                 secret.encode(), signed_content, hashlib.sha256
             ).hexdigest()
-            return _hmac_str_equal(v2_sig, expected_v2)
+            return _hmac_str_equal(v2_sig.removeprefix("sha256="), expected_v2)
 
-        # Generic V1 (legacy): X-Webhook-Signature = <hex HMAC-SHA256 of body>
-        # (deprecated — no replay protection, since the signature only
-        # covers the body: a captured (body, signature) pair replays
-        # indefinitely with no timestamp binding it to a specific delivery.)
-        # Only reachable when X-Webhook-Signature-V2 was not sent at all —
-        # see the guard above.
-        generic_sig = request.headers.get("X-Webhook-Signature", "")
-        if generic_sig:
-            expected = hmac.new(
-                secret.encode(), body, hashlib.sha256
-            ).hexdigest()
+        # Generic/provider HMAC-SHA256 signatures (legacy body-only; no replay
+        # protection). Providers differ mostly by header name and whether they
+        # prefix the hex digest with "sha256=".
+        expected_hex = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        for header_name in (
+            "X-Webhook-Signature",
+            "Linear-Signature",
+            "Attio-Signature",
+            "X-Attio-Signature",
+            "X-Signature",
+        ):
+            signature = _header(header_name)
+            if not signature:
+                continue
             route_name = request.match_info.get("route_name", "")
-            if route_name not in self._v1_signature_warned:
+            if header_name == "X-Webhook-Signature" and route_name not in self._v1_signature_warned:
                 self._v1_signature_warned.add(route_name)
                 logger.warning(
                     "[webhook] Route '%s' uses legacy body-only HMAC (no "
@@ -1182,7 +1175,8 @@ class WebhookAdapter(BasePlatformAdapter):
                     "'<timestamp>.<body>').",
                     route_name,
                 )
-            return _hmac_str_equal(generic_sig, expected)
+            normalized = signature.removeprefix("sha256=")
+            return _hmac_str_equal(normalized, expected_hex)
 
         # No recognised signature header but secret is configured → reject
         logger.debug(

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -68,6 +68,25 @@ from gateway.response_filters import is_autonomous_silence_response
 logger = logging.getLogger(__name__)
 
 
+def _payload_delivery_id(route_name: str, payload: Any) -> Optional[str]:
+    """Return a route-scoped delivery ID for a safe top-level payload ID.
+
+    Some providers do not send a delivery header but do retry the same object
+    with a stable top-level ``id``.  Only scalar string/integer IDs are safe to
+    use here; otherwise the caller retains the timestamp fallback.
+    """
+    if not isinstance(payload, dict):
+        return None
+    payload_id = payload.get("id")
+    if isinstance(payload_id, bool) or not isinstance(payload_id, (str, int)):
+        return None
+    if isinstance(payload_id, str) and not payload_id:
+        return None
+    return "payload-id:" + json.dumps(
+        [route_name, payload_id], separators=(",", ":"), ensure_ascii=True
+    )
+
+
 def _is_webhook_silence_response(content: Any) -> bool:
     """Whether an agent response means "deliberately say nothing".
 
@@ -288,6 +307,7 @@ class WebhookAdapter(BasePlatformAdapter):
         # Content-Length and would otherwise bypass the header check below.
         app = web.Application(client_max_size=self._max_body_bytes)
         app.router.add_get("/health", self._handle_health)
+        app.router.add_get("/webhooks/{route_name}", self._handle_webhook_readiness)
         app.router.add_post("/webhooks/{route_name}", self._handle_webhook)
         # Multi-profile multiplexing: a /p/<profile>/webhooks/<route> prefix
         # routes the inbound event to that profile. Same handler; the profile is
@@ -296,6 +316,9 @@ class WebhookAdapter(BasePlatformAdapter):
         # when gateway.multiplex_profiles is on (the handler validates).
         app.router.add_post(
             "/p/{profile}/webhooks/{route_name}", self._handle_webhook
+        )
+        app.router.add_get(
+            "/p/{profile}/webhooks/{route_name}", self._handle_webhook_readiness
         )
 
         self._runner = web.AppRunner(app)
@@ -500,6 +523,28 @@ class WebhookAdapter(BasePlatformAdapter):
     async def _handle_health(self, request: "web.Request") -> "web.Response":
         """GET /health — simple health check."""
         return web.json_response({"status": "ok", "platform": "webhook"})
+
+    async def _handle_webhook_readiness(
+        self, request: "web.Request"
+    ) -> "web.Response":
+        """Confirm that a webhook route is registered without processing an event."""
+        # Keep readiness entirely separate from the POST pipeline: do not read a
+        # body, authenticate, rate-limit, deduplicate, or invoke the agent.
+        self._reload_dynamic_routes()
+
+        profile = self._resolve_request_profile(request)
+        if profile is _PROFILE_REJECTED:
+            return web.json_response(
+                {"error": "Unknown or unconfigured profile"}, status=404
+            )
+
+        route_name = request.match_info.get("route_name", "")
+        if route_name not in self._routes:
+            return web.json_response({"error": "Unknown webhook route"}, status=404)
+
+        # Intentionally omit the route name and all route configuration. This
+        # endpoint proves only that the URL is ready to receive webhook POSTs.
+        return web.json_response({"status": "ready"})
 
     def _reload_dynamic_routes(self) -> None:
         """Reload agent-created subscriptions from disk if the file changed."""
@@ -734,6 +779,10 @@ class WebhookAdapter(BasePlatformAdapter):
                     {"error": "Cannot parse body"}, status=400
                 )
 
+        # Capture the provider's signed top-level ID before any route script
+        # can transform the payload used for prompting.
+        payload_delivery_id = _payload_delivery_id(route_name, payload)
+
         # Check event type filter
         event_type = (
             request.headers.get("Linear-Event", "")
@@ -830,12 +879,17 @@ class WebhookAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[webhook] Skill loading failed: %s", e)
 
-        # Build a unique delivery ID
+        # Build a unique delivery ID.  Trusted provider delivery headers keep
+        # their existing priority; a stable top-level payload ID is only a
+        # fallback for providers (such as Circleback) that omit them.
         delivery_id = request.headers.get(
             "X-GitHub-Delivery",
             request.headers.get(
                 "svix-id",
-                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
+                request.headers.get(
+                    "X-Request-ID",
+                    payload_delivery_id or str(int(time.time() * 1000)),
+                ),
             ),
         )
 

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -19,6 +19,7 @@ import base64
 import hashlib
 import hmac
 import json
+import logging
 import socket
 import time
 from collections import deque
@@ -73,7 +74,11 @@ def _create_app(adapter: WebhookAdapter) -> web.Application:
     # Mirror connect(): client_max_size enforces the cap on chunked bodies.
     app = web.Application(client_max_size=adapter._max_body_bytes)
     app.router.add_get("/health", adapter._handle_health)
+    app.router.add_get("/webhooks/{route_name}", adapter._handle_webhook_readiness)
     app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    app.router.add_get(
+        "/p/{profile}/webhooks/{route_name}", adapter._handle_webhook_readiness
+    )
     return app
 
 
@@ -487,6 +492,68 @@ class TestPayloadFilters:
 class TestHTTPHandling:
 
     @pytest.mark.asyncio
+    async def test_registered_route_get_returns_readiness_without_post_side_effects(self):
+        """GET validates only route registration and never enters POST processing."""
+        routes = {
+            "circleback": {
+                "secret": "super-secret",
+                "prompt": "private prompt {payload}",
+                "skills": ["private-skill"],
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+        adapter._rate_counts["circleback"] = deque([123.0])
+        adapter._seen_deliveries["existing"] = 456.0
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(
+                "/webhooks/circleback",
+                data=b"this is not a webhook payload",
+                headers={"X-Webhook-Signature": "invalid"},
+            )
+            assert resp.status == 200
+            assert await resp.json() == {"status": "ready"}
+
+        adapter.handle_message.assert_not_called()
+        assert list(adapter._rate_counts["circleback"]) == [123.0]
+        assert adapter._seen_deliveries == {"existing": 456.0}
+
+    @pytest.mark.asyncio
+    async def test_unknown_route_get_returns_404_without_disclosing_routes(self):
+        adapter = _make_adapter(
+            routes={"real": {"secret": "super-secret", "prompt": "private"}}
+        )
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/webhooks/nonexistent")
+            assert resp.status == 404
+            assert await resp.json() == {"error": "Unknown webhook route"}
+
+    @pytest.mark.asyncio
+    async def test_profile_route_get_preserves_profile_validation(self, monkeypatch):
+        routes = {"circleback": {"secret": "secret", "prompt": "private"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.gateway_runner = MagicMock()
+        adapter.gateway_runner.config.multiplex_profiles = True
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex, profile_allowlist=None: [("default", None)],
+        )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            known = await cli.get("/p/default/webhooks/circleback")
+            unknown = await cli.get("/p/ghost/webhooks/circleback")
+            assert known.status == 200
+            assert await known.json() == {"status": "ready"}
+            assert unknown.status == 404
+            assert await unknown.json() == {
+                "error": "Unknown or unconfigured profile"
+            }
+
+    @pytest.mark.asyncio
     async def test_unknown_route_returns_404(self):
         """POST to an unknown route returns 404."""
         adapter = _make_adapter(routes={"real": {"secret": _INSECURE_NO_AUTH, "prompt": "x"}})
@@ -519,6 +586,99 @@ class TestHTTPHandling:
 
 
 class TestIdempotency:
+
+    @pytest.mark.asyncio
+    async def test_signed_retries_without_delivery_header_use_top_level_payload_id(self):
+        """Circleback-style retries with the same meeting ID invoke the agent once."""
+        secret = "circleback-webhook-secret"
+        routes = {"circleback": {"secret": secret, "prompt": "meeting {id}"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+        body = json.dumps(
+            {"id": "a4doyWdskaVjMqRgU4GK8", "name": "private meeting"}
+        ).encode()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            headers = {"X-Webhook-Signature": _generic_signature(body, secret)}
+            first = await cli.post("/webhooks/circleback", data=body, headers=headers)
+            retry = await cli.post("/webhooks/circleback", data=body, headers=headers)
+            await asyncio.sleep(0)
+
+            assert first.status == 202
+            assert retry.status == 200
+            assert (await retry.json())["status"] == "duplicate"
+            adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_distinct_top_level_payload_ids_invoke_separate_runs(self):
+        secret = "circleback-webhook-secret"
+        routes = {"circleback": {"secret": secret, "prompt": "meeting {id}"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            for payload_id in ("meeting-one", "meeting-two"):
+                body = json.dumps({"id": payload_id}).encode()
+                response = await cli.post(
+                    "/webhooks/circleback",
+                    data=body,
+                    headers={"X-Webhook-Signature": _generic_signature(body, secret)},
+                )
+                assert response.status == 202
+            await asyncio.sleep(0)
+
+            assert adapter.handle_message.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_delivery_header_keeps_priority_over_payload_id(self):
+        routes = {"idem": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post(
+                "/webhooks/idem",
+                json={"id": "same-payload-id"},
+                headers={"X-GitHub-Delivery": "header-one"},
+            )
+            second = await cli.post(
+                "/webhooks/idem",
+                json={"id": "same-payload-id"},
+                headers={"X-GitHub-Delivery": "header-two"},
+            )
+            await asyncio.sleep(0)
+
+            assert first.status == second.status == 202
+            assert (await first.json())["delivery_id"] == "header-one"
+            assert (await second.json())["delivery_id"] == "header-two"
+            assert adapter.handle_message.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_payload_id_fallback_does_not_leak_payload_or_secret(self, caplog):
+        secret = "do-not-log-this-secret"
+        private_value = "do-not-log-this-payload"
+        routes = {"circleback": {"secret": secret, "prompt": "meeting"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+        body = json.dumps({"id": "meeting-id", "notes": private_value}).encode()
+        headers = {"X-Webhook-Signature": _generic_signature(body, secret)}
+
+        app = _create_app(adapter)
+        with caplog.at_level(logging.INFO, logger="gateway.platforms.webhook"):
+            async with TestClient(TestServer(app)) as cli:
+                await cli.post("/webhooks/circleback", data=body, headers=headers)
+                duplicate = await cli.post(
+                    "/webhooks/circleback", data=body, headers=headers
+                )
+                response_text = await duplicate.text()
+
+        assert duplicate.status == 200
+        evidence = response_text + caplog.text
+        assert secret not in evidence
+        assert private_value not in evidence
 
     @pytest.mark.asyncio
     async def test_duplicate_delivery_id_returns_200(self):


### PR DESCRIPTION
## What

- Restore provider-specific signature verification for configured webhook routes.
- Add authenticated GET readiness for known routes.
- Deduplicate repeated provider payloads by stable delivery identifiers.
- Preserve multiplex-profile validation on readiness routes.

## Why

Generic HMAC-only handling rejects valid provider callbacks whose documented signature formats differ, while missing readiness and payload-level deduplication make production subscriptions hard to verify and allow provider retries to enqueue the same event twice.

## Validation

- `scripts/run_tests.sh tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_session_close.py tests/gateway/test_webhook_route_toolsets.py tests/gateway/test_webhook_deliver_only.py tests/gateway/test_webhook_signature_rate_limit.py tests/gateway/test_webhook_integration.py tests/gateway/test_webhook_dynamic_routes.py`
- 71 passed, 0 failed on macOS arm64
- Production acceptance separately confirmed public readiness returns 200 and unsigned POSTs return 401; no production payload contents are included here.