### PR TITLE
fix(gateway): isolate external correspondents

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3498,6 +3498,34 @@ def _platform_config_key(platform: "Platform") -> str:
     return "cli" if platform == Platform.LOCAL else platform.value
 
 
+def _is_external_correspondent(user_config: Dict[str, Any], source: SessionSource) -> bool:
+    """Return whether this authenticated peer is a correspondent, not an operator."""
+    platform_key = _platform_config_key(source.platform)
+    platform_cfg = (user_config.get("platforms") or {}).get(platform_key) or {}
+    extra = platform_cfg.get("extra") or {} if isinstance(platform_cfg, dict) else {}
+    configured = extra.get("external_correspondents", [])
+    if isinstance(configured, str):
+        configured = configured.split(",")
+    allowed = {
+        str(value).strip().lower()
+        for value in configured
+        if str(value).strip()
+    }
+    return str(source.user_id or "").strip().lower() in allowed
+
+
+def _external_agent_isolation_kwargs(
+    user_config: Dict[str, Any], source: SessionSource
+) -> Dict[str, bool]:
+    """Single construction contract for untrusted external correspondents."""
+    isolated = _is_external_correspondent(user_config, source)
+    return {
+        "skip_memory": isolated,
+        "skip_context_files": isolated,
+        "load_soul_identity": not isolated,
+    }
+
+
 def _teams_pipeline_plugin_enabled() -> bool:
     """Return True when the standalone Teams pipeline plugin is enabled."""
     config = _load_gateway_config()
@@ -5604,6 +5632,9 @@ class TurnRunner:
 
         if agent is None:
             # Config changed or first message — create fresh agent
+            isolation_kwargs = _external_agent_isolation_kwargs(
+                ctx.user_config, ctx.source
+            )
             agent = ctx.AIAgent(
                 model=turn_route["model"],
                 **turn_route["runtime"],
@@ -5637,10 +5668,11 @@ class TurnRunner:
                 session_db=getattr(self._runner._session_db, "_db", self._runner._session_db),
                 # Reload from disk — do not reuse the startup snapshot (#60955).
                 fallback_model=self._runner._refresh_fallback_model(),
-                skip_context_files=skip_context_files,
-                # Keep the persona even with minimal context: soul identity is
-                # a single small file, not part of the expensive walk.
-                load_soul_identity=True,
+                skip_memory=isolation_kwargs["skip_memory"],
+                skip_context_files=(
+                    skip_context_files or isolation_kwargs["skip_context_files"]
+                ),
+                load_soul_identity=isolation_kwargs["load_soul_identity"],
             )
             if _cache_lock and _cache is not None:
                 with _cache_lock:
@@ -22157,6 +22189,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         from hermes_cli.tools_config import _get_platform_tools
 
+        if _is_external_correspondent(user_config, source):
+            return []
+
         override = None
         try:
             adapter = self._adapter_for_source(source)
@@ -22215,6 +22250,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             enabled_toolsets = self._resolve_enabled_toolsets_for_source(
                 user_config, source, platform_key
             )
+            isolation_kwargs = _external_agent_isolation_kwargs(user_config, source)
             agent_cfg = user_config.get("agent") or {}
             from agent.skill_utils import parse_config_string_list
 
@@ -22254,6 +22290,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     max_iterations=max_iterations,
                     quiet_mode=True,
                     verbose_logging=False,
+                    **isolation_kwargs,
                     enabled_toolsets=enabled_toolsets,
                     disabled_toolsets=disabled_toolsets,
                     reasoning_config=reasoning_config,
@@ -27822,10 +27859,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         user_config = _load_gateway_config()
         platform_key = _platform_config_key(source.platform)
+        external_correspondent = _is_external_correspondent(user_config, source)
 
         enabled_toolsets = self._resolve_enabled_toolsets_for_source(
             user_config, source, platform_key
         )
+        if external_correspondent:
+            history = []
+            context_prompt = ""
+            channel_prompt = ""
         agent_cfg_local = user_config.get("agent") or {}
         from agent.skill_utils import parse_config_string_list
 

--- a/tests/gateway/test_external_correspondent_isolation.py
+++ b/tests/gateway/test_external_correspondent_isolation.py
@@ -1,0 +1,88 @@
+"""Regression coverage for per-correspondent gateway isolation."""
+
+from gateway.config import Platform
+from gateway.run import (
+    GatewayRunner,
+    _external_agent_isolation_kwargs,
+    _is_external_correspondent,
+)
+from gateway.session import SessionSource
+
+
+def _email_source(user_id: str) -> SessionSource:
+    return SessionSource(
+        platform=Platform.EMAIL,
+        user_id=user_id,
+        chat_id=user_id,
+        chat_type="dm",
+    )
+
+
+def test_external_correspondent_match_is_case_insensitive():
+    config = {
+        "platforms": {
+            "email": {
+                "extra": {"external_correspondents": ["Boardy@Boardy.AI"]}
+            }
+        }
+    }
+
+    assert _is_external_correspondent(config, _email_source("boardy@boardy.ai"))
+
+
+def test_external_correspondent_string_config_is_supported():
+    config = {
+        "platforms": {
+            "email": {
+                "extra": {
+                    "external_correspondents": "first@example.com, second@example.com"
+                }
+            }
+        }
+    }
+
+    assert _is_external_correspondent(config, _email_source("second@example.com"))
+
+
+def test_isolation_kwargs_disable_private_context_only_for_correspondents():
+    config = {
+        "platforms": {
+            "email": {"extra": {"external_correspondents": ["outside@example.com"]}}
+        }
+    }
+
+    assert _external_agent_isolation_kwargs(
+        config, _email_source("outside@example.com")
+    ) == {
+        "skip_memory": True,
+        "skip_context_files": True,
+        "load_soul_identity": False,
+    }
+    assert _external_agent_isolation_kwargs(
+        config, _email_source("operator@example.com")
+    ) == {
+        "skip_memory": False,
+        "skip_context_files": False,
+        "load_soul_identity": True,
+    }
+
+
+def test_external_correspondent_gets_no_model_toolsets(monkeypatch):
+    config = {
+        "platforms": {
+            "email": {"extra": {"external_correspondents": ["outside@example.com"]}}
+        }
+    }
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("toolset resolution must be bypassed")
+        ),
+    )
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    assert runner._resolve_enabled_toolsets_for_source(
+        config,
+        _email_source("outside@example.com"),
+        "email",
+    ) == []

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -153,6 +153,24 @@ Email access is stricter by default than chat-style platforms:
 **Use a dedicated inbox and configure `EMAIL_ALLOWED_USERS` for normal operation.** Email pairing is opt-in because shared inboxes often contain unrelated unread messages, and Hermes should not reply to those contacts by default.
 :::
 
+### Isolating external correspondents
+
+Allowed operators normally share the gateway's configured tools, memory, persona, and
+conversation context. For an address that should be able to correspond with the agent
+without receiving those private operator surfaces, list it as an external correspondent:
+
+```yaml
+platforms:
+  email:
+    extra:
+      external_correspondents:
+        - outside@example.com
+```
+
+Matching is case-insensitive. These correspondents receive a fresh-context turn with no
+model tools, memory, context files, channel prompt, persona, or prior transcript. They
+must still pass the normal Email allowlist or pairing policy.
+
 ---
 
 ## Troubleshooting


### PR DESCRIPTION
## What

Add an opt-in `platforms.<platform>.extra.external_correspondents` boundary for authenticated peers who may correspond with an agent but are not trusted operators.

For a matching peer, every gateway construction path now supplies a fresh turn with:

- no model toolsets
- no memory provider/context files/persona
- no channel prompt or prior transcript

Normal platform admission still applies; this setting does not authorize a sender.

## Why

An Email allowlist answers who may contact the agent, but not whether that person should inherit the operator-facing tools, memory, persona, and conversation context. Existing plugin hooks run after agent construction, too late to prevent those private surfaces from entering the prompt.

## Validation

- `scripts/run_tests.sh tests/gateway/test_external_correspondent_isolation.py tests/gateway/test_skip_context_files_wiring.py`
- 17 passed, 0 failed on macOS arm64
- Tests cover case-insensitive matching, scalar/list config, private-context constructor flags, the non-correspondent path, and bypass of model-toolset resolution.

The Email guide documents the opt-in config and its interaction with the normal allowlist.