### PR TITLE
fix(desktop): model assignment no longer copies a resolved API key into config.yaml in plaintext (#88990)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7342,7 +7342,36 @@ def _apply_model_assignment_sync(
             cfg.get("model", {}), provider, model, base_url, api_key
         )
         if isinstance(provider_entry, dict) and provider_entry.get("api_key"):
-            model_cfg["api_key"] = provider_entry["api_key"]
+            # `cfg` is the env-EXPANDED document: when the raw yaml holds
+            # `api_key: ${MY_KEY}` (or the entry carries `key_env`), copying
+            # `provider_entry["api_key"]` verbatim writes the resolved secret
+            # in plaintext under `model:` in config.yaml (#88990) — and
+            # `_preserve_env_ref_templates` can't save it because no template
+            # ever lived at `model.api_key`. Prefer the credential POINTER:
+            # key_env when present, else the raw `${VAR}` template, and only
+            # fall back to the expanded value when the raw yaml itself stores
+            # the key as a literal (no new exposure in that case).
+            raw_providers = read_raw_config().get("providers")
+            raw_entry = (
+                raw_providers.get(provider) if isinstance(raw_providers, dict) else None
+            )
+            raw_key = (
+                str(raw_entry.get("api_key") or "").strip()
+                if isinstance(raw_entry, dict)
+                else ""
+            )
+            key_env = (
+                str(raw_entry.get("key_env") or "").strip()
+                if isinstance(raw_entry, dict)
+                else ""
+            )
+            if key_env:
+                model_cfg["key_env"] = key_env
+                model_cfg.pop("api_key", None)
+            elif raw_key.startswith("${") and raw_key.endswith("}"):
+                model_cfg["api_key"] = raw_key
+            else:
+                model_cfg["api_key"] = provider_entry["api_key"]
         cfg["model"] = model_cfg
 
         # When switching the main provider to Nous, mirror the CLI's
@@ -8260,7 +8289,24 @@ def activate_custom_endpoint(endpoint_id: str, profile: Optional[str] = None):
                 model_cfg["key_env"] = entry["key_env"]
                 model_cfg.pop("api_key", None)
             elif entry.get("api_key"):
-                model_cfg["api_key"] = entry["api_key"]
+                # Same #88990 shape as /api/model/set: `cfg` is env-expanded,
+                # so a raw `${VAR}` api_key would land as plaintext. Copy the
+                # raw template when that's what's on disk.
+                raw_providers = read_raw_config().get("providers")
+                raw_entry = (
+                    raw_providers.get(provider_key)
+                    if isinstance(raw_providers, dict)
+                    else None
+                )
+                raw_key = (
+                    str(raw_entry.get("api_key") or "").strip()
+                    if isinstance(raw_entry, dict)
+                    else ""
+                )
+                if raw_key.startswith("${") and raw_key.endswith("}"):
+                    model_cfg["api_key"] = raw_key
+                else:
+                    model_cfg["api_key"] = entry["api_key"]
             cfg["model"] = model_cfg
             save_config(cfg)
         return {"ok": True, "provider": provider_key, "model": model}

--- a/tests/hermes_cli/test_model_set_secret_copy.py
+++ b/tests/hermes_cli/test_model_set_secret_copy.py
@@ -1,0 +1,94 @@
+"""POST /api/model/set must never copy an env-expanded secret into config.yaml.
+
+Regression for #88990: ``_apply_model_assignment_sync`` ran on the
+env-EXPANDED config, so a provider entry whose raw yaml held
+``api_key: ${MY_KEY}`` (or a ``key_env`` pointer) got its RESOLVED plaintext
+key copied under ``model.api_key`` and persisted. ``_preserve_env_ref_templates``
+cannot rescue it — no template ever lived at ``model.api_key``.
+
+The fix prefers the credential pointer: ``key_env`` when the raw entry has
+one, else the raw ``${VAR}`` template, and only falls back to the expanded
+value when the key is stored as a literal on disk (no new exposure).
+"""
+
+import importlib
+import sys
+
+import pytest
+
+
+SECRET = "sk-SUPERSECRET-e2e-12345"
+
+
+@pytest.fixture()
+def isolated_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("MY_SECRET_KEY", SECRET)
+    # Config caches are keyed per-path, but reload the config module state so
+    # nothing from a previous test's HERMES_HOME bleeds in.
+    for mod in ("hermes_cli.config",):
+        if mod in sys.modules:
+            importlib.reload(sys.modules[mod])
+    return home
+
+
+def _write_config(home, body: str) -> None:
+    (home / "config.yaml").write_text(body, encoding="utf-8")
+
+
+def _apply(provider="myprov", model="test-model"):
+    from hermes_cli.web_server import _apply_model_assignment_sync
+
+    return _apply_model_assignment_sync("main", provider, model, "", "")
+
+
+def _model_block(home) -> str:
+    text = (home / "config.yaml").read_text(encoding="utf-8")
+    return text.split("providers:")[0]
+
+
+class TestModelSetSecretHandling:
+    def test_env_template_key_is_copied_as_template_not_plaintext(self, isolated_home):
+        _write_config(
+            isolated_home,
+            "model:\n  provider: openrouter\n  default: some/model\n"
+            "providers:\n  myprov:\n    base_url: https://api.example.com/v1\n"
+            "    api_key: ${MY_SECRET_KEY}\n    model: test-model\n",
+        )
+
+        _apply()
+
+        text = (isolated_home / "config.yaml").read_text(encoding="utf-8")
+        assert SECRET not in text
+        assert "api_key: ${MY_SECRET_KEY}" in _model_block(isolated_home)
+
+    def test_key_env_pointer_is_preferred_over_api_key(self, isolated_home, monkeypatch):
+        monkeypatch.setenv("MYPROV_KEY", SECRET)
+        _write_config(
+            isolated_home,
+            "model:\n  provider: openrouter\n  default: some/model\n"
+            "providers:\n  myprov:\n    base_url: https://api.example.com/v1\n"
+            "    key_env: MYPROV_KEY\n    api_key: ${MYPROV_KEY}\n    model: test-model\n",
+        )
+
+        _apply()
+
+        text = (isolated_home / "config.yaml").read_text(encoding="utf-8")
+        block = _model_block(isolated_home)
+        assert SECRET not in text
+        assert "key_env: MYPROV_KEY" in block
+        assert "api_key" not in block
+
+    def test_literal_on_disk_key_keeps_legacy_copy_behavior(self, isolated_home):
+        _write_config(
+            isolated_home,
+            "model:\n  provider: openrouter\n  default: some/model\n"
+            "providers:\n  myprov:\n    base_url: https://api.example.com/v1\n"
+            "    api_key: sk-literal-on-disk\n    model: test-model\n",
+        )
+
+        _apply()
+
+        assert "api_key: sk-literal-on-disk" in _model_block(isolated_home)


### PR DESCRIPTION
## Summary

Assigning a model in Desktop Settings no longer writes the provider's resolved API key in plaintext into `config.yaml` (#88990).

Root cause: `_apply_model_assignment_sync` runs on the env-EXPANDED config document. When a provider entry's raw yaml holds `api_key: ${MY_KEY}` (or a `key_env` pointer), the handler copied the resolved plaintext secret into `model.api_key` and persisted it. `_preserve_env_ref_templates` can't rescue it — no template ever lived at the `model.api_key` path. Same shape existed in the custom-endpoint activate path.

## Changes

- `hermes_cli/web_server.py`:
  - `/api/model/set` (main scope): the api_key copy now prefers the credential POINTER — raw entry's `key_env` when present, else the raw `${VAR}` template — and only falls back to the expanded value when the key is stored as a literal on disk (no new exposure in that case).
  - `/api/providers/custom-endpoints/{id}/activate`: same template-preserving guard on its legacy `api_key` branch (sibling site).
- `tests/hermes_cli/test_model_set_secret_copy.py`: 3 tests — `${VAR}` template preserved (secret absent from file), `key_env` pointer preferred (api_key dropped), literal-on-disk key keeps legacy behavior.

## Validation

| | Result |
|---|---|
| New tests | 3/3 pass |
| Sabotage (handler reverted to origin/main) | the 2 exposure tests fail; literal test passes both ways |
| E2E temp HERMES_HOME, real handler + real env | `sk-SUPERSECRET…` absent from config.yaml; `${MY_SECRET_KEY}` template written |

## Infographic

![Model switch keeps secrets out of config](https://files.catbox.moe/izve53.png)
