### PR TITLE
fix(desktop): send User-Agent when loading pet sprites

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2538,7 +2538,10 @@ function petFrameIcon(spriteUrl) {
       new Promise(resolve => {
         petFetchQueue.push(async () => {
           try {
-            const resp = await fetch(spriteUrl, { signal: AbortSignal.timeout(15000) })
+            const resp = await fetch(spriteUrl, {
+              signal: AbortSignal.timeout(15000),
+              headers: { 'User-Agent': 'hermes-agent-petdex' }
+            })
             const blob = await resp.blob()
             // Crop frame 0 during decode — never materialize the full sheet.
             const bitmap = await createImageBitmap(blob, 0, 0, PET_FRAME_W, PET_FRAME_H)

--- a/apps/desktop/src/plugins/hermes-bots/tests/pet-fetch.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/pet-fetch.test.mjs
@@ -47,6 +47,12 @@ function load(fetchImpl) {
   return { context, fetches }
 }
 
+test('regression: pet sprites send the Petdex user agent', async () => {
+  const { context, fetches } = load(async () => ({ blob: async () => new Blob() }))
+  await context.__api.petFrameIcon('https://pets.example/user-agent.webp')
+  assert.equal(fetches[0].opts.headers['User-Agent'], 'hermes-agent-petdex')
+})
+
 test('unit: a failed pet fetch is not stuck in the cache', async () => {
   let n = 0
   const { context, fetches } = load(async () => {


### PR DESCRIPTION
## Summary

- send the same `hermes-agent-petdex` User-Agent used by the manifest client when fetching Petdex spritesheets
- add a regression test that checks the spritesheet fetch options

## Testing

- `node --test apps/desktop/src/plugins/hermes-bots/tests/pet-fetch.test.mjs` (3/3 passing)
- `git diff --check`

Fixes #90465