### PR TITLE
fix(a2a): expose schemas through tool describe

### DIFF
--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -585,11 +585,12 @@ _HANDLERS = {
 def register_tools(ctx) -> None:
     """Register the client tools in the ``a2a`` toolset."""
     for name, schema in _SCHEMAS.items():
+        function_schema = schema["function"]
         ctx.register_tool(
             name=name,
             toolset="a2a",
-            schema=schema,
+            schema=function_schema,
             handler=_HANDLERS[name],
-            description=schema["function"]["description"],
+            description=function_schema["description"],
             emoji="\U0001f9e9",  # puzzle piece
         )

--- a/tests/plugins/test_a2a_schema_registration.py
+++ b/tests/plugins/test_a2a_schema_registration.py
@@ -1,0 +1,46 @@
+"""Regression tests for A2A client-tool schema registration."""
+
+from __future__ import annotations
+
+import json
+
+from plugins.platforms.a2a import tools as a2a_tools
+from tools import tool_search
+from tools.registry import ToolRegistry
+
+
+def test_a2a_call_schema_round_trips_through_tool_describe(monkeypatch):
+    registry = ToolRegistry()
+
+    class _Context:
+        def register_tool(self, name, toolset, schema, handler, **kwargs):
+            registry.register(
+                name=name,
+                toolset=toolset,
+                schema=schema,
+                handler=handler,
+                **kwargs,
+            )
+
+    a2a_tools.register_tools(_Context())
+    definitions = registry.get_definitions({"a2a_call"})
+    monkeypatch.setattr(
+        tool_search,
+        "is_deferrable_tool_name",
+        lambda name: name == "a2a_call",
+    )
+
+    described = json.loads(
+        tool_search.dispatch_tool_describe(
+            {"name": "a2a_call"},
+            current_tool_defs=definitions,
+        )
+    )
+
+    assert described["description"]
+    assert described["parameters"]["required"] == ["agent", "message"]
+    assert set(described["parameters"]["properties"]) == {
+        "agent",
+        "message",
+        "context_id",
+    }


### PR DESCRIPTION
## What does this PR do?

A2A client tools registered complete OpenAI function wrappers through the plugin API, but that API expects the inner function schema and adds the wrapper itself. The resulting double wrapper left `tool_describe` with a blank description and empty `properties`, even though the real schema was still available to argument validation at call time.

This registers the inner A2A function schema and adds an isolated regression that sends `a2a_call` through `ToolRegistry.get_definitions()` and `dispatch_tool_describe()`.

## Related Issue

No GitHub issue. Reported through support from both CLI and Telegram sessions.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/a2a/tools.py`: pass each schema's inner `function` object to the plugin registration API.
- `tests/plugins/test_a2a_schema_registration.py`: verify `tool_describe("a2a_call")` exposes the description, required arguments, and properties after registry wrapping.

## How to Test

1. Run `scripts/run_tests.sh tests/plugins/test_a2a_schema_registration.py -j 4 -q`.
2. Enable the A2A toolset in a session where plugin tools are deferred.
3. Call `tool_describe` for `a2a_call` and confirm it returns `agent`, `message`, and optional `context_id` instead of an empty schema.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused verification:

```text
scripts/run_tests.sh tests/plugins/test_a2a_schema_registration.py -j 4 -q
1 passed, 0 failed

python -m ruff check plugins/platforms/a2a/tools.py tests/plugins/test_a2a_schema_registration.py
All checks passed!

python -m py_compile plugins/platforms/a2a/tools.py tests/plugins/test_a2a_schema_registration.py
passed

python scripts/check-windows-footguns.py --diff origin/main
No Windows footguns found

git diff --check origin/main
passed
```

A broader Windows run of `tests/plugins/test_a2a_plugin.py` reached 105 passes and one unrelated existing failure: its extensionless fake `hermes` executable is not selected on native Windows, so the test reaches the current session database and rejects its old fixture schema because `parent_session_id` is absent. The new isolated regression is clean.