### PR TITLE
openviking: add OPENVIKING_SKIP_TOOL_OUTPUTS to drop tool result text from sync

### DIFF
--- a/contributors/emails/Backroads4Me@users.noreply.github.com
+++ b/contributors/emails/Backroads4Me@users.noreply.github.com
@@ -1,0 +1,1 @@
+Backroads4Me

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -4445,6 +4445,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 payload_messages.append(payload_message("assistant", pending_tool_parts))
                 pending_tool_parts = []
 
+        skip_tool_outputs = _skip_tool_outputs()
+
         for message in messages:
             if not isinstance(message, dict):
                 continue
@@ -4464,7 +4466,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
                     "tool_id": tool_id,
                     "tool_name": tool_name,
                     "tool_input": prior_call.get("tool_input", {}),
-                    "tool_output": "" if _skip_tool_outputs() else cls._message_text(message.get("content")),
+                    "tool_output": "" if skip_tool_outputs else cls._message_text(message.get("content")),
                     "tool_status": cls._tool_result_status(message),
                 }
                 pending_tool_parts.append(tool_part)

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -14,6 +14,9 @@ or a linked OpenViking CLI config:
   OPENVIKING_ACCOUNT   — Tenant account for local/trusted mode (default: default)
   OPENVIKING_USER      — Tenant user for local/trusted mode (default: default)
   OPENVIKING_AGENT     — Hermes peer ID in OpenViking (default: hermes)
+  OPENVIKING_SKIP_TOOL_OUTPUTS — Set to a truthy value to send empty tool_output
+    strings in the sync payload (keeps tool_name/tool_input/tool_status for
+    context but drops potentially large/multi-KB tool result text)
 
 Capabilities:
   - Automatic memory extraction on session commit (6 categories)
@@ -82,6 +85,7 @@ _DEFERRED_COMMIT_TIMEOUT = (_TIMEOUT * 2) + 5.0
 _SESSION_MESSAGE_BATCH_LIMIT = 100
 _REMOTE_RESOURCE_PREFIXES = ("http://", "https://", "git@", "ssh://", "git://")
 _SYNC_TRACE_ENV = "HERMES_OPENVIKING_SYNC_TRACE"
+_SKIP_TOOL_OUTPUTS_ENV = "OPENVIKING_SKIP_TOOL_OUTPUTS"
 _DEFAULT_RECALL_LIMIT = 6
 _DEFAULT_RECALL_SCORE_THRESHOLD = 0.15
 _DEFAULT_RECALL_MAX_INJECTED_CHARS = 4000
@@ -232,6 +236,16 @@ def _derive_openviking_user_text(content: Any) -> str:
 
 def _sync_trace_enabled() -> bool:
     return env_var_enabled(_SYNC_TRACE_ENV)
+
+
+def _skip_tool_outputs() -> bool:
+    """When true, sync tool parts carry an empty tool_output string.
+
+    Tool result text can be large (terminal output, file reads) and is rarely
+    useful to memory extraction relative to which tool ran and with what input.
+    Kept as an opt-in so default behaviour is unchanged.
+    """
+    return env_var_enabled(_SKIP_TOOL_OUTPUTS_ENV)
 
 
 def _preview(value: Any, limit: int = 160) -> str:
@@ -4450,7 +4464,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
                     "tool_id": tool_id,
                     "tool_name": tool_name,
                     "tool_input": prior_call.get("tool_input", {}),
-                    "tool_output": cls._message_text(message.get("content")),
+                    "tool_output": "" if _skip_tool_outputs() else cls._message_text(message.get("content")),
                     "tool_status": cls._tool_result_status(message),
                 }
                 pending_tool_parts.append(tool_part)

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -544,6 +544,56 @@ class TestOpenVikingTurnConversion:
             {"type": "text", "text": "The current main does not expose assemble."}
         ]
 
+    def test_messages_to_openviking_batch_keeps_tool_output_by_default(self, monkeypatch):
+        monkeypatch.delenv("OPENVIKING_SKIP_TOOL_OUTPUTS", raising=False)
+        turn = [
+            {"role": "user", "content": "Run the tests."},
+            {
+                "role": "assistant",
+                "content": "Running.",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "shell_command", "arguments": json.dumps({"command": "pytest"})},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "name": "shell_command", "content": "12 passed in 3.2s"},
+            {"role": "assistant", "content": "All green."},
+        ]
+
+        batch = OpenVikingMemoryProvider._messages_to_openviking_batch(turn)
+        tool_part = batch[2]["parts"][0]
+        assert tool_part["tool_output"] == "12 passed in 3.2s"
+
+    def test_messages_to_openviking_batch_drops_tool_output_when_skipped(self, monkeypatch):
+        monkeypatch.setenv("OPENVIKING_SKIP_TOOL_OUTPUTS", "1")
+        turn = [
+            {"role": "user", "content": "Run the tests."},
+            {
+                "role": "assistant",
+                "content": "Running.",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "shell_command", "arguments": json.dumps({"command": "pytest"})},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "name": "shell_command", "content": "12 passed in 3.2s"},
+            {"role": "assistant", "content": "All green."},
+        ]
+
+        batch = OpenVikingMemoryProvider._messages_to_openviking_batch(turn)
+        tool_part = batch[2]["parts"][0]
+        assert tool_part["tool_output"] == ""
+        # tool_name/input/status are preserved
+        assert tool_part["tool_name"] == "shell_command"
+        assert tool_part["tool_input"] == {"command": "pytest"}
+        assert tool_part["tool_status"] == "completed"
+
 
 class TestOpenVikingRead:
     def test_overview_read_normalizes_uri_and_unwraps_result(self):


### PR DESCRIPTION
## What

Adds an opt-in `OPENVIKING_SKIP_TOOL_OUTPUTS` flag to the OpenViking memory provider. When enabled, turn-sync payloads carry empty `tool_output` strings while still preserving `tool_name`, `tool_input`, and `tool_status` — so OpenViking's extraction still sees *which* tool ran with *what* arguments, just not the (often multi-KB) result blob.

## Why

Tool result text (terminal stdout, file reads, web extracts) is frequently large and low-signal for long-term memory extraction relative to the fact that a tool was called and with what input. This lets users trim the sync payload without losing the call context.

## Behavior

- **Opt-in, default off** — no behavior change unless the env var is set.
- Truthy values honored via the existing `env_var_enabled()` helper: `1`, `true`, `yes`, `on` (case-insensitive). Unset / `0` / `false` / empty → off.
- Gated at the single `tool_output` assignment site in `_messages_to_openviking_batch`; no change to the flat-text path or to how user/assistant content is handled.

## Design

Mirrors the file's existing convention: a new `_SKIP_TOOL_OUTPUTS_ENV` constant + `_skip_tool_outputs()` helper, modeled on `_SYNC_TRACE_ENV` / `_sync_trace_enabled()`, reusing the already-imported `env_var_enabled`. Documented in the module env-var header block.

The flag is read once per batch (hoisted above the message loop) rather than per tool part, so the env lookup does not repeat across a turn.

## Verification

`python3 -m pytest tests/openviking_plugin/` — 36 passed, including two new tests:

- `test_messages_to_openviking_batch_keeps_tool_output_by_default`
- `test_messages_to_openviking_batch_drops_tool_output_when_skipped`

Both paths are covered, so the default-off behavior is asserted, not assumed.

## Usage (after merge)

Add to a profile's `.env`:

```
OPENVIKING_SKIP_TOOL_OUTPUTS=1
```
