### PR TITLE
fix(cli): Linux hermes.desktop entry launches instead of silently dying on system python (#90292)

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -68,10 +68,46 @@ def resolve_exec_command() -> str:
 
     bin_path = resolve_hermes_bin()
     if bin_path:
-        argv = [str(Path(bin_path).resolve()), "desktop"]
+        resolved = Path(bin_path).resolve()
+        if _needs_interpreter(resolved):
+            # The resolved launcher is a Python script whose shebang points at
+            # a NON-venv interpreter (e.g. the repo's `hermes` script with
+            # `#!/usr/bin/env python3` when argv[0] came from the shell
+            # installer's bash wrapper). Launched from the .desktop entry that
+            # shebang resolves to the SYSTEM python and dies on the first
+            # third-party import (#90292) — silently, since Terminal=false.
+            # sys.executable is the interpreter actually running Hermes (the
+            # venv one), so prefix it explicitly.
+            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+        else:
+            argv = [str(resolved), "desktop"]
     else:
         argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
+
+
+def _needs_interpreter(bin_path: Path) -> bool:
+    """Whether ``bin_path`` is a Python script that must run under
+    ``sys.executable`` to see Hermes' venv (rather than its own shebang)."""
+    try:
+        with open(bin_path, "rb") as fh:
+            head = fh.readline(256)
+    except OSError:
+        return False
+    if not head.startswith(b"#!"):
+        # Native binary (uv tool shim, PyInstaller, distro package) — its own
+        # loader is self-sufficient.
+        return False
+    shebang = head.decode("utf-8", errors="replace").strip().lower()
+    if "python" not in shebang:
+        # A shell wrapper (e.g. the installer's bash launcher) execs the venv
+        # python itself — leave it alone.
+        return False
+    # A python shebang pointing INSIDE the running interpreter's environment
+    # already resolves correctly; anything else (``/usr/bin/env python3``,
+    # a system path) would escape the venv when spawned by the DE.
+    exe_dir = str(Path(sys.executable).resolve().parent)
+    return exe_dir not in shebang
 
 
 def _quote_exec_arg(arg: str) -> str:

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -88,6 +88,67 @@ def test_exec_falls_back_to_interpreter_module(tmp_path, xdg_home, monkeypatch):
     assert Path(exec_line.split(" ")[0]).is_absolute()
 
 
+# #90292: the shell installer's bash wrapper makes argv[0] the repo `hermes`
+# python script whose `#!/usr/bin/env python3` shebang resolves to the SYSTEM
+# interpreter when the DE spawns the .desktop entry → ModuleNotFoundError,
+# silent (Terminal=false). The Exec line must prefix sys.executable for any
+# resolved bin that is a python script escaping the running venv.
+def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_home, monkeypatch):
+    import sys
+
+    root = _make_project(tmp_path)
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir()
+    hermes_bin.write_text("#!/usr/bin/env python3\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    interpreter = str(Path(sys.executable).resolve())
+    assert exec_line.split(" ")[0].strip('"') == interpreter
+    assert str(hermes_bin) in exec_line
+    assert exec_line.endswith("desktop")
+
+
+def test_exec_leaves_shell_wrapper_launchers_alone(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir()
+    hermes_bin.write_text('#!/bin/bash\nexec /opt/hermes/venv/bin/python "$@"\n', encoding="utf-8")
+    hermes_bin.chmod(0o755)
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    # A bash wrapper execs the venv python itself — no interpreter prefix.
+    assert exec_line == f"{hermes_bin} desktop"
+
+
+def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch):
+    import sys
+
+    root = _make_project(tmp_path)
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir()
+    interpreter = str(Path(sys.executable).resolve())
+    hermes_bin.write_text(f"#!{interpreter}\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    # Console-script with the venv's own interpreter in the shebang: correct
+    # as-is, prefixing would only add noise.
+    assert exec_line == f"{hermes_bin} desktop"
+
+
 def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/usr/bin/hermes")


### PR DESCRIPTION
## Summary

The auto-generated Linux `hermes.desktop` launcher actually launches now (#90292). On shell-installer setups (bash wrapper → repo `hermes` script), the icon silently did nothing on every click.

Root cause: `resolve_exec_command()` wrote `Exec=<repo>/hermes desktop` — a Python script whose `#!/usr/bin/env python3` shebang resolves to the SYSTEM interpreter when the DE spawns it, dying on the first third-party import (`ModuleNotFoundError: dotenv`). `Terminal=false` made the failure invisible, and the entry is rewritten on every launch so hand-fixes didn't stick. The `_is_python_script` guard in relaunch.py is Windows-only and extension-keyed, so it never fired.

## Changes

- `hermes_cli/linux_desktop_entry.py`: new `_needs_interpreter()` reads the resolved launcher's shebang — a Python shebang pointing OUTSIDE the running interpreter's environment (env-resolver or system path) gets `Exec={sys.executable} {script} desktop`. Native binaries, bash wrappers (which exec the venv python themselves), and venv-shebang console scripts are untouched.
- `tests/hermes_cli/test_linux_desktop_entry.py`: 3 new tests — env-shebang script gets the interpreter prefix; bash wrapper untouched; venv-shebang script untouched.

## Validation

| | Result |
|---|---|
| test_linux_desktop_entry.py | 15 pass / 2 platform-skips |
| Sabotage (module reverted) | new prefix test fails as intended |
| E2E: generated Exec line executed exactly as a DE would (no shell) | exit 0, script runs under the venv interpreter |

## Infographic

![App icon launch fixed on Linux](https://files.catbox.moe/x9tlk0.png)
