### PR TITLE
fix(file): honour the byte-boundary contract on the text-sample fallback

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -804,6 +804,77 @@ class TestByteLayerBinaryDetection:
         result = ops.read_file("/tmp/a.out")
         assert result.is_binary is True
 
+    # --- fallback: legacy text heuristic ----------------------------------
+    #
+    # _sample_file_bytes returns None on backends whose shell has no
+    # `base64` (see test_sample_falls_back_on_* above), and read_file then
+    # classifies from the replace-decoded `head -c 1000` sample. That
+    # fallback must honour the same boundary contract as the byte layer, or
+    # the #80308 misclassification simply moves to base64-less backends.
+
+    def test_fallback_cjk_cut_mid_character_is_text(self, file_ops):
+        # What `head -c 1000` on a CJK file looks like after the transport
+        # decodes it with errors="replace": one trailing U+FFFD.
+        sample = ("汉字" * 400).encode("utf-8")[:1000].decode("utf-8", errors="replace")
+        assert sample.count("\ufffd") == 1 and sample.endswith("\ufffd")
+        assert file_ops._is_likely_binary("notes.txt", sample) is False
+
+    def test_fallback_emoji_cut_at_boundary_is_text(self, file_ops):
+        sample = (b"x" * 998 + "🎉".encode("utf-8"))[:1000].decode("utf-8", errors="replace")
+        assert file_ops._is_likely_binary("notes.txt", sample) is False
+
+    def test_fallback_midstream_damage_still_binary(self, file_ops):
+        # latin-1 body: U+FFFD before the end means the file really is not
+        # UTF-8, so it stays read-only even though the sample also ends on a
+        # cut character.
+        assert file_ops._is_likely_binary("notes.txt", "caf\ufffd au lait\ufffd") is True
+
+    def test_fallback_all_replacement_chars_is_binary(self, file_ops):
+        assert file_ops._is_likely_binary("blob.xyz", "\ufffd" * 64) is True
+
+    def test_fallback_nonprintable_ratio_still_applies(self, file_ops):
+        # 301/1000 control characters — binary by the ratio rule, unchanged.
+        assert file_ops._is_likely_binary("data.xyz", "\x01" * 301 + "a" * 699) is True
+
+    def _dispatch_without_base64(self, cjk_bytes):
+        """Terminal that has no `base64`, forcing the text-sample fallback."""
+
+        def side_effect(command, **kwargs):
+            if command.startswith("if [ -f ") or command.startswith("wc -c"):
+                return {"output": f"{len(cjk_bytes)}\n", "returncode": 0}
+            if command.startswith("head -c") and "| base64" in command:
+                return {"output": "sh: base64: not found", "returncode": 127}
+            if command.startswith("head -c"):
+                # Raw byte slice, decoded by the transport with errors="replace".
+                return {
+                    "output": cjk_bytes[:1000].decode("utf-8", errors="replace"),
+                    "returncode": 0,
+                }
+            if command.startswith("sed -n"):
+                return {"output": cjk_bytes.decode("utf-8", errors="replace"), "returncode": 0}
+            if command.startswith("wc -l"):
+                return {"output": "1\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        return side_effect
+
+    def test_read_file_returns_cjk_content_when_base64_missing(self, mock_env):
+        content = ("汉字测试" * 300).encode("utf-8")  # > 1000 bytes, cut mid-char
+        mock_env.execute.side_effect = self._dispatch_without_base64(content)
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file("/tmp/notes-中文.txt")
+        assert result.is_binary is False
+        assert result.error is None
+        assert "汉字测试" in (result.content or "")
+
+    def test_read_file_without_base64_still_blocks_latin1(self, mock_env):
+        # Mid-stream invalid UTF-8 must stay read-only on the fallback too.
+        content = b"caf\xe9 au lait " * 100
+        mock_env.execute.side_effect = self._dispatch_without_base64(content)
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file("/tmp/menu.txt")
+        assert result.is_binary is True
+
 
 
 class TestEscapeNativeToolArg:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1050,13 +1050,29 @@ class ShellFileOperations(FileOperations):
             # lossy text would let a read→edit→write round-trip silently
             # overwrite the original bytes with mojibake. Treat a file whose
             # sample carries the replacement char as binary (read-only) so the
-            # agent can't corrupt it. Legitimate UTF-8 text effectively never
-            # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            # agent can't corrupt it.
+            #
+            # A TRAILING run of U+FFFD is the one exception. This heuristic
+            # only runs when ``_sample_file_bytes`` could not use its base64
+            # transport, and the sample is then a fixed BYTE slice
+            # (``head -c 1000``) — so a multibyte character straddling the cut
+            # always decodes to replacement chars at the very end. That is an
+            # artifact of where we cut, not a property of the file. Counting
+            # it made every CJK/emoji document read as binary on backends
+            # without ``base64`` — the same #80308 misclassification that
+            # ``_is_likely_binary_bytes`` fixes for the byte-layer path, still
+            # live on this fallback. Honour the same boundary contract here:
+            # allow one cut-off sequence at the end, keep flagging mid-stream
+            # damage.
+            sample = content_sample[:1000].rstrip("\ufffd")
+            if not sample:
+                # Nothing but replacement chars — no text to salvage.
                 return True
-            non_printable = sum(1 for c in content_sample[:1000]
+            if "\ufffd" in sample:
+                return True
+            non_printable = sum(1 for c in sample
                                if ord(c) < 32 and c not in '\n\r\t')
-            return non_printable / min(len(content_sample), 1000) > 0.30
+            return non_printable / len(sample) > 0.30
         
         return False
     


### PR DESCRIPTION
## Summary

`_is_likely_binary_bytes` (#80308) fixed the CJK/multibyte misclassification for the byte-layer path, but the legacy text heuristic it falls back to still treats **any** U+FFFD in the sample as proof of a binary file. This closes the remaining member of that class.

The fallback is reachable, not theoretical. `_sample_file_bytes` returns `None` whenever the backend's shell can't produce clean base64 — a case the suite already asserts (`test_sample_falls_back_on_non_base64_output`, `test_sample_falls_back_on_nonzero_exit`) and the docstring already documents ("exotic shells without `base64`; callers fall back to the legacy text-sample heuristic"). `read_file` then classifies from a replace-decoded `head -c 1000` sample.

Because that cut lands on a **byte** boundary rather than a character boundary, a multibyte character straddling it always decodes to a trailing U+FFFD. So on a base64-less backend, valid UTF-8 text still comes back as:

```json
{"is_binary": true, "error": "Binary file - cannot display as text. Use appropriate tools to handle this file type."}
```

For 3-byte CJK prose the cut splits a character whenever `1000 % 3 != 0` relative to the leading bytes — roughly two files in three. The agent then has no way to read the file at all through `read_file`.

## What changed

`_is_likely_binary` now ignores a **trailing** U+FFFD run before deciding, matching the boundary contract `_is_likely_binary_bytes` already documents: *text = valid UTF-8, allowing one incomplete multibyte sequence at the sample's end.*

Deliberately unchanged, so the anti-mojibake guarantee on `read → edit → write` still holds:

- U+FFFD anywhere before the tail → still binary (latin-1 and friends).
- A sample that is nothing but U+FFFD → still binary.
- The >30% non-printable ratio → unchanged.

One limitation worth stating explicitly: a file that *legitimately stores* U+FFFD reads as text at the byte layer but is still flagged on this fallback. That is inherent — once the transport has replace-decoded the sample, a stored replacement character and a manufactured one are the same character. This PR does not pretend to fix that; it only stops the boundary cut from manufacturing one.

## Test plan

Added to `TestByteLayerBinaryDetection` under a `--- fallback: legacy text heuristic ---` subsection, mirroring the existing byte-layer cases:

- [x] `test_fallback_cjk_cut_mid_character_is_text` — the reported symptom, at the unit level
- [x] `test_fallback_emoji_cut_at_boundary_is_text` — 4-byte sequence cut after 2 bytes
- [x] `test_fallback_midstream_damage_still_binary` — latin-1 body stays read-only
- [x] `test_fallback_all_replacement_chars_is_binary`
- [x] `test_fallback_nonprintable_ratio_still_applies`
- [x] `test_read_file_returns_cjk_content_when_base64_missing` — integration through `read_file` with a terminal whose `base64` exits 127
- [x] `test_read_file_without_base64_still_blocks_latin1` — same path, negative case

Verified the tests actually guard the fix: reverting `tools/file_operations.py` alone fails exactly the three boundary-cut tests (`test_fallback_cjk_cut_mid_character_is_text`, `test_fallback_emoji_cut_at_boundary_is_text`, `test_read_file_returns_cjk_content_when_base64_missing`) while the five behaviour-preserving assertions keep passing.

```
scripts/run_tests.sh tests/tools/test_file_operations.py tests/tools/test_file_operations_edge_cases.py
=== Summary: 2 files, 94 tests passed, 0 failed, 2 skipped ===
```
