### PR TITLE
fix(desktop): corrupt backend-ownership.json no longer erases records of live backends (#89298)

### DIFF
--- a/apps/desktop/electron/backend-ownership.test.ts
+++ b/apps/desktop/electron/backend-ownership.test.ts
@@ -284,3 +284,71 @@ test('shutdown coordinator returns one promise and awaits teardown exactly once'
   assert.equal(finished, true)
   assert.equal(coordinator.run(), first)
 })
+
+
+// #89298: a corrupt ownership file must never be silently rewritten as [] —
+// that permanently erases the only record of still-running backends. The reap
+// sweep quarantines the file and skips; a later healthy write recreates it.
+test('reapOrphans on a corrupt file quarantines and does not rewrite', async () => {
+  let contents = '{ this is not json'
+  let quarantined = 0
+  const writes: string[] = []
+  const stopped: number[] = []
+
+  const store = {
+    read: () => contents,
+    value: () => contents,
+    write: (next: string) => {
+      writes.push(next)
+      contents = next
+    },
+    quarantine: () => {
+      quarantined += 1
+    }
+  }
+
+  const ownership = createOwnership(store, {
+    stop: identityArg => {
+      stopped.push(identityArg.pid)
+    }
+  })
+
+  assert.deepEqual(await ownership.reapOrphans(), [])
+  assert.equal(quarantined, 1)
+  assert.deepEqual(writes, [])
+  assert.deepEqual(stopped, [])
+})
+
+test('reapOrphans on a corrupt file without a quarantine hook still skips the rewrite', async () => {
+  const writes: string[] = []
+  const store = {
+    read: () => 'garbage{{{',
+    value: () => 'garbage{{{',
+    write: (next: string) => {
+      writes.push(next)
+    }
+  }
+
+  const ownership = createOwnership(store)
+
+  assert.deepEqual(await ownership.reapOrphans(), [])
+  assert.deepEqual(writes, [])
+})
+
+test('an empty or missing ownership file is NOT corrupt — reap sweeps normally', async () => {
+  const writes: string[] = []
+  const store = {
+    read: () => '',
+    value: () => '',
+    write: (next: string) => {
+      writes.push(next)
+    },
+    quarantine: () => assert.fail('empty file must not be quarantined')
+  }
+
+  const ownership = createOwnership(store)
+
+  assert.deepEqual(await ownership.reapOrphans(), [])
+  // Empty roster: rewriting [] is harmless and keeps the legacy behavior.
+  assert.equal(writes.length, 1)
+})

--- a/apps/desktop/electron/backend-ownership.ts
+++ b/apps/desktop/electron/backend-ownership.ts
@@ -16,6 +16,10 @@ export interface BackendOwnershipEntry extends BackendIdentity {
 export interface BackendOwnershipStore {
   read: () => string | null
   write: (contents: string) => void
+  /** Move an unreadable ownership file aside (e.g. rename to `.corrupt`) so
+   *  its contents survive for inspection instead of being rewritten away.
+   *  Optional: stores that can't quarantine simply skip the sweep. */
+  quarantine?: () => void
 }
 
 export interface BackendOwnershipDeps {
@@ -62,12 +66,30 @@ function identitiesMatch(left: BackendIdentity, right: BackendIdentity): boolean
 }
 
 export function parseBackendOwnership(contents: unknown): BackendOwnershipEntry[] {
+  return parseBackendOwnershipDetailed(contents).entries
+}
+
+/** Parse result that distinguishes "empty/valid" from "unreadable". A corrupt
+ *  ownership file must NOT read as an empty roster: `reapOrphans` rewrites the
+ *  file with its survivors, so treating garbage as `[]` permanently erased the
+ *  records of still-running backends — the exact shape of the #89298 report
+ *  (ownership file gone, 28 leaked serve processes nothing will ever reap). */
+export function parseBackendOwnershipDetailed(contents: unknown): {
+  corrupt: boolean
+  entries: BackendOwnershipEntry[]
+} {
+  const text = String(contents ?? '')
+
+  if (!text.trim()) {
+    return { corrupt: false, entries: [] }
+  }
+
   let parsed: unknown
 
   try {
-    parsed = JSON.parse(String(contents ?? ''))
+    parsed = JSON.parse(text)
   } catch {
-    return []
+    return { corrupt: true, entries: [] }
   }
 
   const values = Array.isArray(parsed)
@@ -109,7 +131,7 @@ export function parseBackendOwnership(contents: unknown): BackendOwnershipEntry[
     }
   }
 
-  return entries
+  return { corrupt: false, entries }
 }
 
 export function serializeBackendOwnership(entries: BackendOwnershipEntry[]): string {
@@ -123,7 +145,8 @@ export function serializeBackendOwnership(entries: BackendOwnershipEntry[]): str
  * cleanup before reporting failure to the caller.
  */
 export function createBackendOwnership(deps: BackendOwnershipDeps) {
-  const read = () => parseBackendOwnership(deps.store.read())
+  const readDetailed = () => parseBackendOwnershipDetailed(deps.store.read())
+  const read = () => readDetailed().entries
   const write = (entries: BackendOwnershipEntry[]) => deps.store.write(serializeBackendOwnership(entries))
 
   return {
@@ -181,7 +204,22 @@ export function createBackendOwnership(deps: BackendOwnershipDeps) {
     },
 
     async reapOrphans(): Promise<number[]> {
-      const entries = read()
+      const { corrupt, entries } = readDetailed()
+
+      // An unreadable ownership file yields zero parsed entries — rewriting
+      // survivors ([]) here would DESTROY the only record of any backends the
+      // corrupt file described, guaranteeing they leak forever (#89298).
+      // Preserve the evidence for inspection and skip the sweep.
+      if (corrupt) {
+        try {
+          deps.store.quarantine?.()
+        } catch {
+          // Quarantine is best-effort; the important part is not rewriting.
+        }
+
+        return []
+      }
+
       const survivors: BackendOwnershipEntry[] = []
       const reaped: number[] = []
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3259,7 +3259,20 @@ const backendOwnership = createBackendOwnership({
         return null
       }
     },
-    write: writeBackendOwnership
+    write: writeBackendOwnership,
+    // A corrupt ownership file is moved aside instead of being rewritten
+    // away by the reap sweep — its records are the only pointer to any
+    // still-running backends it described (#89298).
+    quarantine: () => {
+      const parked = `${DESKTOP_BACKEND_OWNERSHIP_PATH}.corrupt`
+
+      try {
+        fs.renameSync(DESKTOP_BACKEND_OWNERSHIP_PATH, parked)
+        rememberLog(`Backend ownership file was unreadable; moved to ${parked}`)
+      } catch {
+        // Nothing to move (or no permission) — the sweep already skipped.
+      }
+    }
   }
 })
 


### PR DESCRIPTION
## Summary

A corrupt `backend-ownership.json` no longer erases the only record of still-running desktop backends — the leak amplifier inside #89298 (reporter: ownership file gone, 28 leaked `hermes serve` processes nothing will ever reap).

Root cause: `parseBackendOwnership()` returned `[]` for unreadable JSON, and `reapOrphans()` unconditionally rewrote the file with its survivors — so one corrupt read permanently replaced the roster with `[]`, orphaning every backend it described.

## Changes

- `apps/desktop/electron/backend-ownership.ts`: new `parseBackendOwnershipDetailed()` distinguishes empty/missing (valid, `corrupt:false`) from unparseable (`corrupt:true`). `reapOrphans()` on a corrupt read quarantines the file via an optional `store.quarantine()` hook and skips the sweep — never rewrites. Empty/missing files keep the exact legacy sweep behavior.
- `apps/desktop/electron/main.ts`: the real store's `quarantine` renames the file to `backend-ownership.json.corrupt` and logs it.
- `backend-ownership.test.ts`: 3 new tests (corrupt → quarantined + zero writes + zero stops; corrupt without hook → still no rewrite; empty file → NOT corrupt, sweeps normally).

## Validation

| | Result |
|---|---|
| backend-ownership tests | 17/17 pass |
| Sabotage (module reverted) | 2 new tests fail as intended |
| tsc electron + app build | clean |

Scope note: this closes the record-destruction half of #89298. The process-scan fallback (reap by cmdline when no ownership file exists at all) is larger and left for a follow-up.

## Infographic

![Corrupt ledger preserve never erase](https://files.catbox.moe/6j5ohv.png)
