### PR TITLE
fix(tui): harden composer bursts and Alt+Backspace

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -284,6 +284,37 @@ function inputToString(input: Buffer | string): string {
   }
 }
 
+/**
+ * Preserve Alt/Option+Backspace when ESC and DEL/BS cross stdin read
+ * boundaries. The tokenizer buffers the trailing ESC, then emits the completed
+ * pair as one text token on the next feed; the generic text splitter would
+ * otherwise turn it into standalone Escape + unmodified Backspace keys.
+ */
+function parseTextWithMetaBackspace(text: string): ParsedKey[] {
+  const keys: ParsedKey[] = []
+  let plainStart = 0
+
+  for (let index = 0; index + 1 < text.length; index++) {
+    if (text[index] !== '\x1b' || (text[index + 1] !== '\x7f' && text[index + 1] !== '\b')) {
+      continue
+    }
+
+    if (index > plainStart) {
+      keys.push(...parseTextKeypresses(text.slice(plainStart, index)))
+    }
+
+    keys.push(parseKeypress(text.slice(index, index + 2)))
+    index += 1
+    plainStart = index + 1
+  }
+
+  if (plainStart < text.length) {
+    keys.push(...parseTextKeypresses(text.slice(plainStart)))
+  }
+
+  return keys
+}
+
 export function parseMultipleKeypresses(
   prevState: KeyParseState,
   input: Buffer | string | null = ''
@@ -346,7 +377,7 @@ export function parseMultipleKeypresses(
         const resynthesized = '\x1b' + token.value
         keys.push(parseKeypress(resynthesized))
       } else {
-        keys.push(...parseTextKeypresses(token.value))
+        keys.push(...parseTextWithMetaBackspace(token.value))
       }
     }
   }

--- a/ui-tui/src/__tests__/textInputBurstInput.test.ts
+++ b/ui-tui/src/__tests__/textInputBurstInput.test.ts
@@ -1,6 +1,48 @@
 import { describe, expect, it } from 'vitest'
 
-import { applyPrintableInsert, shouldRouteMultiCharInputAsPaste } from '../components/textInput.js'
+import {
+  advancePrintableBurst,
+  applyPrintableInsert,
+  type PrintableBurstState,
+  shouldRouteMultiCharInputAsPaste
+} from '../components/textInput.js'
+
+describe('advancePrintableBurst', () => {
+  it('switches to frame batching for a sustained 2ms key stream', () => {
+    let state: PrintableBurstState | null = null
+    const decisions: boolean[] = []
+
+    for (let index = 0; index < 20; index++) {
+      const sample = advancePrintableBurst(state, index * 2)
+      state = sample.state
+      decisions.push(sample.rapid)
+    }
+
+    expect(decisions.slice(0, 7)).toEqual(Array.from({ length: 7 }, () => false))
+    expect(decisions.slice(7)).toEqual(Array.from({ length: 13 }, () => true))
+  })
+
+  it('resets to normal echo after an idle gap', () => {
+    let state: PrintableBurstState | null = null
+
+    for (let index = 0; index < 8; index++) {
+      state = advancePrintableBurst(state, index * 2).state
+    }
+
+    expect(state.rapid).toBe(true)
+    expect(advancePrintableBurst(state, 100).rapid).toBe(false)
+  })
+
+  it('does not classify ordinary typing as machine-speed input', () => {
+    let state: PrintableBurstState | null = null
+
+    for (let index = 0; index < 20; index++) {
+      const sample = advancePrintableBurst(state, index * 20)
+      state = sample.state
+      expect(sample.rapid).toBe(false)
+    }
+  })
+})
 
 describe('applyPrintableInsert', () => {
   it('applies non-bracketed multi-character bursts immediately', () => {

--- a/ui-tui/src/__tests__/textInputSttBurst.test.tsx
+++ b/ui-tui/src/__tests__/textInputSttBurst.test.tsx
@@ -1,0 +1,409 @@
+import { EventEmitter } from 'events'
+
+import { renderSync } from '@hermes/ink'
+import React, { useEffect, useState } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { TextInput } from '../components/textInput.js'
+
+class FakeTty extends EventEmitter {
+  chunks: string[] = []
+  columns = 80
+  rows = 24
+  isTTY = true
+  isRaw = false
+  private pendingReads: string[] = []
+
+  ref(): void {}
+  unref(): void {}
+  read(): string | null {
+    return this.pendingReads.shift() ?? null
+  }
+  send(chunk: string): void {
+    this.pendingReads.push(chunk)
+    this.emit('readable')
+  }
+  setEncoding(): this {
+    return this
+  }
+  setRawMode(mode: boolean): this {
+    this.isRaw = mode
+
+    return this
+  }
+  write(chunk: string | Uint8Array, cb?: (err?: Error | null) => void): boolean {
+    this.chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'))
+    cb?.()
+
+    return true
+  }
+}
+
+const tick = () => new Promise<void>(resolve => setImmediate(resolve))
+
+function Harness({
+  externalValue,
+  initial = '',
+  onValue,
+  rerenderEveryMs = 0
+}: {
+  externalValue?: string
+  initial?: string
+  onValue: (value: string) => void
+  rerenderEveryMs?: number
+}) {
+  const [value, setValue] = useState(initial)
+  const [, setPulse] = useState(0)
+
+  useEffect(() => {
+    if (!rerenderEveryMs) {
+      return
+    }
+
+    const timer = setInterval(() => setPulse(current => current + 1), rerenderEveryMs)
+
+    return () => clearInterval(timer)
+  }, [rerenderEveryMs])
+
+  useEffect(() => {
+    if (externalValue !== undefined) {
+      setValue(externalValue)
+    }
+  }, [externalValue])
+
+  return React.createElement(TextInput, {
+    accentColor: '#00aaff',
+    color: '#ffffff',
+    onChange: (next: string) => {
+      setValue(next)
+      onValue(next)
+    },
+    value
+  })
+}
+
+describe('TextInput sustained STT bursts', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'setInterval', 'Date'] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('drains a 2ms single-key stream with line breaks without stalling', async () => {
+    const stdout = new FakeTty()
+    const stdin = new FakeTty()
+    const stderr = new FakeTty()
+    const values: string[] = []
+    const line = 'speech to text keeps typing into the main composer without pausing '
+    const expected = Array.from({ length: 16 }, () => line).join('\n')
+    const reads = expected.split('').map(ch => (ch === '\n' ? '\x1b[13;2u' : ch))
+
+    const instance = renderSync(React.createElement(Harness, { onValue: value => values.push(value) }), {
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream
+    })
+
+    try {
+      await tick()
+
+      for (const read of reads) {
+        stdin.send(read)
+        vi.advanceTimersByTime(2)
+        await tick()
+      }
+
+      vi.advanceTimersByTime(100)
+      await tick()
+
+      expect(values.at(-1)).toBe(expected)
+      // Sustained injected typing must switch away from one raw stdout write
+      // per key; otherwise the composer can outrun the terminal/Ink renderer
+      // and appear permanently frozen while its output queue drains.
+      expect(stdout.chunks.length).toBeLessThan(400)
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
+  }, 15_000)
+
+  it('does not roll the input back during unrelated parent renders', async () => {
+    const stdout = new FakeTty()
+    const stdin = new FakeTty()
+    const stderr = new FakeTty()
+    const values: string[] = []
+    const expected = 'continuous dictation remains intact '.repeat(12)
+
+    const instance = renderSync(
+      React.createElement(Harness, { onValue: value => values.push(value), rerenderEveryMs: 1 }),
+      {
+        patchConsole: false,
+        stderr: stderr as unknown as NodeJS.WriteStream,
+        stdin: stdin as unknown as NodeJS.ReadStream,
+        stdout: stdout as unknown as NodeJS.WriteStream
+      }
+    )
+
+    try {
+      await tick()
+
+      for (const read of expected) {
+        stdin.send(read)
+        vi.advanceTimersByTime(2)
+        await tick()
+      }
+
+      vi.advanceTimersByTime(100)
+      await tick()
+
+      expect(values.at(-1)).toBe(expected)
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
+  })
+
+  it('lets an external reset cancel a queued local frame', async () => {
+    const stdout = new FakeTty()
+    const stdin = new FakeTty()
+    const stderr = new FakeTty()
+    const values: string[] = []
+    const onValue = (value: string) => values.push(value)
+    const mount = (externalValue?: string) => React.createElement(Harness, { externalValue, onValue })
+
+    const instance = renderSync(mount(), {
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream
+    })
+
+    try {
+      await tick()
+
+      for (const read of 'abcdefgh') {
+        stdin.send(read)
+      }
+
+      // The eighth 0ms key arms the frame-batched local update, but its 16ms
+      // parent timer has not fired. An external reset must cancel that timer.
+      instance.rerender(mount('RESET'))
+      await tick()
+      vi.advanceTimersByTime(20)
+      await tick()
+
+      stdin.send('z')
+      vi.advanceTimersByTime(20)
+      await tick()
+
+      expect(values.at(-1)).toBe('RESETz')
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
+  })
+
+  it('ignores delayed out-of-order echoes of its own earlier values', async () => {
+    const stdout = new FakeTty()
+    const stdin = new FakeTty()
+    const stderr = new FakeTty()
+    const emitted: string[] = []
+
+    const input = (value: string) =>
+      React.createElement(TextInput, {
+        accentColor: '#00aaff',
+        color: '#ffffff',
+        onChange: (next: string) => emitted.push(next),
+        value
+      })
+
+    const instance = renderSync(input(''), {
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream
+    })
+
+    try {
+      await tick()
+
+      for (const read of 'abcdefghijklmnop') {
+        stdin.send(read)
+        vi.advanceTimersByTime(2)
+        await tick()
+      }
+
+      vi.advanceTimersByTime(20)
+      await tick()
+
+      const first = emitted[0]!
+      const latest = emitted.at(-1)!
+      expect(first).not.toBe(latest)
+      expect(latest).toBe('abcdefghijklmnop')
+
+      // Echo the newest value first, then an older value. The old echo is not
+      // an external reset and must not roll the live refs/cursor backward.
+      instance.rerender(input(latest))
+      await tick()
+      instance.rerender(input(first))
+      await tick()
+
+      stdin.send('z')
+      vi.advanceTimersByTime(20)
+      await tick()
+
+      expect(emitted.at(-1)).toBe('abcdefghijklmnopz')
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
+  })
+
+  it('accepts an intentional reset to a previously acknowledged value', async () => {
+    const stdout = new FakeTty()
+    const stdin = new FakeTty()
+    const stderr = new FakeTty()
+    const emitted: string[] = []
+
+    const input = (value: string) =>
+      React.createElement(TextInput, {
+        accentColor: '#00aaff',
+        color: '#ffffff',
+        onChange: (next: string) => emitted.push(next),
+        value
+      })
+
+    const instance = renderSync(input(''), {
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream
+    })
+
+    try {
+      await tick()
+
+      stdin.send('a')
+      vi.advanceTimersByTime(20)
+      await tick()
+      const acknowledged = emitted.at(-1)!
+      instance.rerender(input(acknowledged))
+      await tick()
+
+      stdin.send('b')
+      vi.advanceTimersByTime(20)
+      await tick()
+      const latest = emitted.at(-1)!
+      instance.rerender(input(latest))
+      await tick()
+
+      // Queue another local frame, then intentionally restore the already
+      // acknowledged value A. A is no longer an outstanding echo, so it must
+      // cancel the queued local value rather than be mistaken for stale input.
+      for (const read of '12345678') {
+        stdin.send(read)
+      }
+
+      instance.rerender(input(acknowledged))
+      await tick()
+      vi.advanceTimersByTime(20)
+      await tick()
+
+      stdin.send('z')
+      vi.advanceTimersByTime(20)
+      await tick()
+
+      expect(emitted.at(-1)).toBe('az')
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
+  })
+
+  it('drops superseded echoes when duplicate values are coalesced', async () => {
+    const stdout = new FakeTty()
+    const stdin = new FakeTty()
+    const stderr = new FakeTty()
+    const emitted: string[] = []
+
+    const input = (value: string) =>
+      React.createElement(TextInput, {
+        accentColor: '#00aaff',
+        color: '#ffffff',
+        onChange: (next: string) => emitted.push(next),
+        value
+      })
+
+    const instance = renderSync(input(''), {
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream
+    })
+
+    try {
+      await tick()
+
+      stdin.send('a')
+      vi.advanceTimersByTime(20)
+      await tick()
+      stdin.send('b')
+      vi.advanceTimersByTime(20)
+      await tick()
+      stdin.send('\x7f')
+      vi.advanceTimersByTime(20)
+      await tick()
+
+      expect(emitted).toEqual(['a', 'ab', 'a'])
+
+      // React may coalesce A → B → A into one final A prop. Acknowledging that
+      // newest duplicate must also retire the superseded B expectation.
+      instance.rerender(input('a'))
+      await tick()
+      instance.rerender(input('ab'))
+      await tick()
+
+      stdin.send('z')
+      vi.advanceTimersByTime(20)
+      await tick()
+
+      expect(emitted.at(-1)).toBe('abz')
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
+  })
+
+  it('deletes a word when Alt and Backspace arrive in separate reads', async () => {
+    const stdout = new FakeTty()
+    const stdin = new FakeTty()
+    const stderr = new FakeTty()
+    const values: string[] = []
+
+    const instance = renderSync(
+      React.createElement(Harness, { initial: 'alpha beta', onValue: value => values.push(value) }),
+      {
+        patchConsole: false,
+        stderr: stderr as unknown as NodeJS.WriteStream,
+        stdin: stdin as unknown as NodeJS.ReadStream,
+        stdout: stdout as unknown as NodeJS.WriteStream
+      }
+    )
+
+    try {
+      await tick()
+      stdin.send('\x1b')
+      await tick()
+      stdin.send('\x7f')
+      await tick()
+
+      expect(values.at(-1)).toBe('alpha ')
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
+  })
+})

--- a/ui-tui/src/__tests__/textInputWordDelete.test.ts
+++ b/ui-tui/src/__tests__/textInputWordDelete.test.ts
@@ -11,6 +11,17 @@ function parseOne(sequence: string) {
   return keys[0]!
 }
 
+describe('Alt+Backspace decode contract', () => {
+  it('keeps meta when ESC and backspace arrive in separate stdin reads', () => {
+    const [prefixKeys, pending] = parseMultipleKeypresses(INITIAL_STATE, '\x1b')
+    const [keys] = parseMultipleKeypresses(pending, '\x7f')
+
+    expect(prefixKeys).toEqual([])
+    expect(keys).toHaveLength(1)
+    expect(keys[0]).toMatchObject({ kind: 'key', meta: true, name: 'backspace' })
+  })
+})
+
 // The web dashboard maps Ctrl+Delete to ESC d (see
 // web/src/lib/pty-keyboard-shortcuts.ts). hermes-ink decodes that bare
 // meta-letter form via META_KEY_CODE_RE. If this contract ever changes the

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -48,7 +48,47 @@ const PRINTABLE = /^[ -~\u00a0-\uffff]+$/
 const BRACKET_PASTE = new RegExp(`${ESC}?\\[20[01]~`, 'g')
 const FRAME_BATCH_MS = 16
 const MULTI_CLICK_MS = 500
+const RAPID_INPUT_WINDOW_MS = 32
+const RAPID_INPUT_THRESHOLD = 8
+const RAPID_INPUT_IDLE_RESET_MS = 50
+const OUTSTANDING_PARENT_ECHOES_MAX = 64
 type MinimalEnv = Record<string, string | undefined>
+
+export interface PrintableBurstState {
+  count: number
+  lastAt: number
+  rapid: boolean
+  startedAt: number
+}
+
+export function advancePrintableBurst(
+  previous: PrintableBurstState | null,
+  now: number
+): { rapid: boolean; state: PrintableBurstState } {
+  if (!previous || now - previous.lastAt > RAPID_INPUT_IDLE_RESET_MS) {
+    const state = { count: 1, lastAt: now, rapid: false, startedAt: now }
+
+    return { rapid: false, state }
+  }
+
+  if (previous.rapid) {
+    const state = { ...previous, lastAt: now }
+
+    return { rapid: true, state }
+  }
+
+  if (now - previous.startedAt > RAPID_INPUT_WINDOW_MS) {
+    const state = { count: 1, lastAt: now, rapid: false, startedAt: now }
+
+    return { rapid: false, state }
+  }
+
+  const count = previous.count + 1
+  const rapid = count >= RAPID_INPUT_THRESHOLD
+  const state = { count, lastAt: now, rapid, startedAt: previous.startedAt }
+
+  return { rapid, state }
+}
 
 const invert = (s: string) => INV + s + INV_OFF
 
@@ -799,8 +839,9 @@ export function TextInput({
   const curRef = useRef(cur)
   const selRef = useRef<null | { end: number; start: number }>(null)
   const vRef = useRef(value)
-  const self = useRef(false)
+  const outstandingParentEchoesRef = useRef<string[]>([])
   const keyBurstTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const printableBurstRef = useRef<PrintableBurstState | null>(null)
   const editVersionRef = useRef(0)
   const parentChangeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const pendingParentValue = useRef<string | null>(null)
@@ -827,7 +868,9 @@ export function TextInput({
   cbSubmit.current = onSubmit
   cbPaste.current = onPaste
 
-  const raw = self.current ? vRef.current : value
+  const raw =
+    pendingParentValue.current !== null || outstandingParentEchoesRef.current.includes(value) ? vRef.current : value
+
   const display = mask ? raw.replace(/[^\n]/g, mask[0] ?? '*') : raw
 
   const selected = useMemo(
@@ -919,11 +962,46 @@ export function TextInput({
   }, [accentOpen, cur, display, focus, highlights, nativeCursor, placeholder, placeholderColor, selected])
 
   useEffect(() => {
-    const ownEcho = self.current && value === vRef.current
-    self.current = false
+    const echoes = outstandingParentEchoesRef.current
+    const echoIndex = echoes.indexOf(value)
 
-    if (ownEcho) {
+    if (echoIndex >= 0) {
+      const lastEchoIndex = echoes.lastIndexOf(value)
+
+      if (lastEchoIndex > echoIndex) {
+        // A → B → A followed by one coalesced A acknowledgement means the
+        // newer A superseded every emission before it; remove that whole
+        // prefix so stale B cannot later mask an intentional external reset.
+        echoes.splice(0, lastEchoIndex + 1)
+      } else {
+        // A unique occurrence may still arrive out of order (B before A), so
+        // consume only that exact expected echo and leave the others pending.
+        echoes.splice(echoIndex, 1)
+      }
+
       return
+    }
+
+    // A value not emitted by this TextInput is an external reset/update. It
+    // wins over any queued local frame: otherwise that timer fires after the
+    // reset and sends stale pre-reset text back to the parent.
+    outstandingParentEchoesRef.current = []
+    pendingParentValue.current = null
+    printableBurstRef.current = null
+
+    if (parentChangeTimer.current) {
+      clearTimeout(parentChangeTimer.current)
+      parentChangeTimer.current = null
+    }
+
+    if (keyBurstTimer.current) {
+      clearTimeout(keyBurstTimer.current)
+      keyBurstTimer.current = null
+    }
+
+    if (localRenderTimer.current) {
+      clearTimeout(localRenderTimer.current)
+      localRenderTimer.current = null
     }
 
     setCur(value.length)
@@ -1029,8 +1107,17 @@ export function TextInput({
     pendingParentValue.current = null
 
     if (next !== null) {
-      self.current = true
+      rememberParentEmission(next)
       cbChange.current(next)
+    }
+  }
+
+  const rememberParentEmission = (next: string) => {
+    const outstanding = outstandingParentEchoesRef.current
+    outstanding.push(next)
+
+    if (outstanding.length > OUTSTANDING_PARENT_ECHOES_MAX) {
+      outstanding.splice(0, outstanding.length - OUTSTANDING_PARENT_ECHOES_MAX)
     }
   }
 
@@ -1122,7 +1209,7 @@ export function TextInput({
     if (next !== prev) {
       if (syncParent) {
         flushParentChange()
-        self.current = true
+        rememberParentEmission(next)
         cbChange.current(next)
         // A full Ink repaint just happened. Mark it so any fast-echo backspace
         // later in this IME recompose burst is suppressed (it would write
@@ -1143,7 +1230,6 @@ export function TextInput({
           inkRepaintedRef.current = false
         }, 60)
       } else {
-        self.current = true
         scheduleParentChange(next)
       }
     }
@@ -1408,6 +1494,7 @@ export function TextInput({
       }
 
       if (k.return) {
+        printableBurstRef.current = null
         flushKeyBurst()
 
         const range = selRange()
@@ -1438,6 +1525,16 @@ export function TextInput({
 
       const isPrintableInput =
         (event.keypress.isPasted || inp.length > 0) && PRINTABLE.test(inp.replace(BRACKET_PASTE, ''))
+
+      let batchRapidPrintable = false
+
+      if (isPrintableInput && !event.keypress.isPasted && inp.length === 1) {
+        const sample = advancePrintableBurst(printableBurstRef.current, Date.now())
+        printableBurstRef.current = sample.state
+        batchRapidPrintable = sample.rapid
+      } else if (!isPrintableInput) {
+        printableBurstRef.current = null
+      }
 
       if (!isPrintableInput) {
         flushKeyBurst()
@@ -1642,7 +1739,7 @@ export function TextInput({
             v = inserted.value
             c = inserted.cursor
 
-            if (simpleAppend) {
+            if (simpleAppend && !batchRapidPrintable) {
               const effect = fastAppendEffect(preInsertValue, preInsertCursor, text)
               // Same explicit fg as the Ink render (see the <Text color>) —
               // the bypass cell must not flash the terminal-default color. A
@@ -1668,6 +1765,18 @@ export function TextInput({
               // too far right (#cursor-drift).
               noteCursorAdvance(effect.advanceDelta)
               commit(v, c, true, false, false, lineWidthRef.current + stringWidth(text))
+
+              return
+            }
+
+            if (batchRapidPrintable) {
+              // Speech-to-text/uinput tools can deliver hundreds of discrete
+              // key events per second. One direct stdout write per key outruns
+              // the terminal and Ink renderer until their output queues appear
+              // frozen. Reuse the existing frame-batched commit path once a
+              // sustained machine-speed burst is detected: refs still advance
+              // for every key, while screen + parent updates coalesce at 16ms.
+              scheduleKeyBurstCommit(v, c)
 
               return
             }


### PR DESCRIPTION
## Summary

Fixes two regressions in the main TUI composer:

1. Sustained machine-speed input, such as speech-to-text tools injecting individual keystrokes every 2 ms, could overwhelm the composer's fast-echo path and make the terminal appear frozen.
2. Alt+Backspace could lose its Meta modifier when ESC and Backspace arrived in separate stdin reads, reducing word deletion to a normal single-character Backspace.

---

## Symptom

A long STT/uinput transcript could generate one direct `stdout.write` for every injected key while Ink and the controlled parent state were also rendering. The terminal output queue could fall progressively behind the input stream until the TUI appeared permanently unresponsive.

The deferred parent synchronization also used a single boolean to distinguish the composer's own echoes from external controlled-value updates. Under sustained input, delayed, coalesced, or reordered parent renders could consume that marker at the wrong time and roll the live composer value back to stale text.

For Alt+Backspace, xterm-style terminals encode the chord as `ESC DEL` or `ESC BS`. When those bytes crossed stdin read boundaries, the tokenizer retained the ESC but emitted the completed pair as a text token. The generic text parser then split it into standalone Escape and unmodified Backspace events, so the composer's existing `key.meta` word-delete branch was never reached.

---

## Fix

- Detect a sustained machine-speed stream after 8 single-character key events arrive within 32 ms.
- Switch that stream from per-key raw fast-echo writes to the existing 16 ms frame-batched commit path.
- Return to normal low-latency fast echo after a 50 ms idle gap.
- Keep refs advancing for every key so no input is lost while parent/render updates are coalesced.
- Replace the single parent-echo boolean with a bounded queue of consumable expected echo occurrences.
- Cancel queued parent, key-burst, and local-render timers when a genuine external controlled-value update arrives.
- Preserve unique delayed/out-of-order echoes without rolling the live value backward.
- Correctly retire superseded expectations when duplicate values are coalesced, such as A → B → A.
- Recombine `ESC DEL` and `ESC BS` text-token pairs into one meta+backspace event before generic key decoding.
- Leave bracketed paste mode and unrelated escape/control sequences unchanged.

The normal human-typing path is unchanged: ordinary input rates never cross the burst threshold and retain the existing fast-echo behavior.

---

## Changes Made

**`ui-tui/src/components/textInput.tsx`**
- Add machine-speed printable-input detection.
- Route sustained input through frame-batched commits.
- Replace the fragile boolean parent-echo marker with consumable echo tracking.
- Cancel stale local timers when an external controlled-value update wins.
- Preserve delayed/out-of-order echoes and handle duplicate/coalesced values safely.

**`ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts`**
- Preserve Alt/Option+Backspace when ESC and DEL/BS cross stdin read boundaries.
- Keep paste-mode handling and unrelated key parsing unchanged.

**`ui-tui/src/tests/textInputBurstInput.test.ts`**
- Verify 2 ms streams enter frame batching.
- Verify ordinary human-rate typing remains on the normal path.
- Verify the burst state resets after an idle gap.

**`ui-tui/src/tests/textInputWordDelete.test.ts`**
- Verify split-read ESC + DEL produces one meta+backspace event.

**`ui-tui/src/tests/textInputSttBurst.test.tsx`**
- Replay a sustained ~1,000-character, 2 ms key stream with line breaks.
- Verify the complete transcript survives.
- Verify raw stdout writes remain bounded.
- Verify unrelated parent renders do not roll input backward.
- Verify external resets cancel queued local frames.
- Verify delayed and out-of-order own echoes remain safe.
- Verify intentional resets to previously acknowledged values work.
- Verify duplicate/coalesced A → B → A echoes do not leave stale expectations.
- Verify split-read Alt+Backspace deletes the preceding word end-to-end.

---

## How to Test

1. Start the TUI in an xterm-style Linux terminal.
2. Focus the main chat composer.
3. Use an STT/uinput tool to inject a long transcript at approximately 2 ms per key, including line breaks.
4. Verify the composer remains responsive and preserves the complete transcript.
5. Pause for more than 50 ms and type normally; verify normal fast-echo behavior resumes.
6. Type `alpha beta`, then press Alt+Backspace.
7. Verify the composer becomes `alpha ` rather than deleting only one character.

**Full TUI test suite:**

```bash
cd ui-tui
npm run build:ink
npm test
```

✅ Test Files: 160 passed (160)
✅ Tests: 1709 passed | 1 skipped (1710)

**TypeScript validation:**

```bash
npm run typecheck
```

✅ Passed

**Formatting and lint on affected files:**

```bash
npx prettier --check \
  packages/hermes-ink/src/ink/parse-keypress.ts \
  src/components/textInput.tsx \
  src/tests/textInputBurstInput.test.ts \
  src/tests/textInputWordDelete.test.ts \
  src/tests/textInputSttBurst.test.tsx

npx eslint \
  packages/hermes-ink/src/ink/parse-keypress.ts \
  src/components/textInput.tsx \
  src/tests/textInputBurstInput.test.ts \
  src/tests/textInputWordDelete.test.ts \
  src/tests/textInputSttBurst.test.tsx
```

✅ Prettier: passed
✅ ESLint: 0 errors

ESLint reports one pre-existing `react-hooks/exhaustive-deps` warning in the unchanged selection-registration