### PR TITLE
fix(desktop): status bar keeps its own right-click menu

### DIFF
--- a/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
@@ -3,6 +3,11 @@ import { MemoryRouter } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { registerTerminalContextMenu } from '@/app/right-sidebar/terminal/terminal-context-menu'
+import {
+  ContextMenu,
+  ContextMenuTrigger,
+  HERMES_CONTEXT_MENU_TRIGGER_ATTR
+} from '@/components/ui/context-menu'
 import { formatCombo } from '@/lib/keybinds/combo'
 import { $previewTabs, closeRightRail } from '@/store/preview'
 import { $connection } from '@/store/session'
@@ -354,6 +359,22 @@ describe('AppContextMenu', () => {
     expect($contextMenu.get()).toBeNull()
   })
 
+  it('leaves asChild radix triggers alone when the child overwrites data-slot', () => {
+    installBridge()
+    mountMenu()
+    // Status bar: ContextMenuTrigger asChild over a footer whose data-slot
+    // is "statusbar". The coordinator must still recognize the dedicated
+    // marker — otherwise the window-verbs fallback eats the gesture.
+    const host = attach(
+      '<footer data-slot="statusbar" data-hermes-context-menu-trigger=""><span>meter</span></footer>'
+    )
+
+    fireEvent.contextMenu(host.querySelector('span')!)
+
+    expect($contextMenu.get()).toBeNull()
+    expect(screen.queryByText('Settings')).toBeNull()
+  })
+
   it('shows the terminal menu through a registered handle', async () => {
     installBridge()
     mountMenu()
@@ -565,5 +586,22 @@ describe('AppContextMenu guest (in-app browser)', () => {
 
     expect(guest.replaceMisspelling).toHaveBeenCalledWith('the')
     expect(screen.queryByText('Add to dictionary')).toBeNull()
+  })
+})
+
+describe('ContextMenuTrigger asChild', () => {
+  it('keeps the coordinator marker when the child overwrites data-slot', () => {
+    render(
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <footer data-slot="statusbar">bar</footer>
+        </ContextMenuTrigger>
+      </ContextMenu>
+    )
+
+    const footer = screen.getByText('bar')
+
+    expect(footer.getAttribute('data-slot')).toBe('statusbar')
+    expect(footer.hasAttribute(HERMES_CONTEXT_MENU_TRIGGER_ATTR)).toBe(true)
   })
 })

--- a/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
@@ -359,22 +359,6 @@ describe('AppContextMenu', () => {
     expect($contextMenu.get()).toBeNull()
   })
 
-  it('leaves asChild radix triggers alone when the child overwrites data-slot', () => {
-    installBridge()
-    mountMenu()
-    // Status bar: ContextMenuTrigger asChild over a footer whose data-slot
-    // is "statusbar". The coordinator must still recognize the dedicated
-    // marker — otherwise the window-verbs fallback eats the gesture.
-    const host = attach(
-      '<footer data-slot="statusbar" data-hermes-context-menu-trigger=""><span>meter</span></footer>'
-    )
-
-    fireEvent.contextMenu(host.querySelector('span')!)
-
-    expect($contextMenu.get()).toBeNull()
-    expect(screen.queryByText('Settings')).toBeNull()
-  })
-
   it('shows the terminal menu through a registered handle', async () => {
     installBridge()
     mountMenu()

--- a/apps/desktop/src/app/context-menu/app-context-menu.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router'
 
 import { terminalMenuHandleFor } from '@/app/right-sidebar/terminal/terminal-context-menu'
 import { Codicon } from '@/components/ui/codicon'
+import { HERMES_CONTEXT_MENU_TRIGGER_ATTR } from '@/components/ui/context-menu'
 import { writeClipboardText } from '@/components/ui/copy-button'
 import {
   DropdownMenu,
@@ -609,7 +610,13 @@ export function AppContextMenu() {
       const element = event.target instanceof Element ? event.target : null
 
       // Surfaces with their own Radix context menu keep the whole gesture.
-      if (element?.closest('[data-slot="context-menu-trigger"]')) {
+      // Guard the dedicated marker first: Radix `asChild` Slot merges
+      // `mergeProps(slotProps, childProps)` so the child's `data-slot` wins
+      // (status bar footer is `data-slot="statusbar"`). The marker is stamped
+      // after `{...props}` on ContextMenuTrigger and is not overwritten.
+      if (
+        element?.closest(`[${HERMES_CONTEXT_MENU_TRIGGER_ATTR}], [data-slot="context-menu-trigger"]`)
+      ) {
         return
       }
 

--- a/apps/desktop/src/app/shell/statusbar-context-menu.test.tsx
+++ b/apps/desktop/src/app/shell/statusbar-context-menu.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { AppContextMenu } from '@/app/context-menu/app-context-menu'
+import { $contextMenu } from '@/app/context-menu/store'
+import { StatusbarControls } from '@/app/shell/statusbar-controls'
+import { $statusbarHiddenIds, STATUSBAR_HIDDEN_BY_DEFAULT } from '@/store/statusbar-prefs'
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+  Element.prototype.hasPointerCapture ??= () => false
+  Element.prototype.setPointerCapture ??= () => undefined
+  Element.prototype.releasePointerCapture ??= () => undefined
+  HTMLElement.prototype.scrollIntoView ??= () => undefined
+})
+
+afterEach(() => {
+  cleanup()
+  $contextMenu.set(null)
+  $statusbarHiddenIds.set([...STATUSBAR_HIDDEN_BY_DEFAULT])
+})
+
+// End-to-end companion to the ContextMenuTrigger unit test: that one proves
+// the marker survives the Slot merge, this one proves the real status bar and
+// the real coordinator agree, so the default-hidden items stay reachable.
+describe('statusbar context menu coordination', () => {
+  it('lets the statusbar Radix menu handle right-clicks instead of the app fallback (#89953)', async () => {
+    render(
+      <MemoryRouter>
+        <AppContextMenu />
+        <StatusbarControls
+          items={[
+            {
+              id: 'context-usage',
+              label: 'Context meter',
+              toggleLabel: 'Context meter',
+              variant: 'menu'
+            }
+          ]}
+        />
+      </MemoryRouter>
+    )
+
+    const statusbar = screen.getByRole('contentinfo')
+
+    fireEvent.pointerDown(statusbar, { button: 2, ctrlKey: false, pointerType: 'mouse' })
+    fireEvent.contextMenu(statusbar, { button: 2 })
+
+    expect(await screen.findByRole('menuitemcheckbox', { name: 'Context meter' })).toBeTruthy()
+    expect(screen.queryByText('Settings')).toBeNull()
+    expect($contextMenu.get()).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/ui/context-menu.tsx
+++ b/apps/desktop/src/components/ui/context-menu.tsx
@@ -12,8 +12,19 @@ function ContextMenuPortal({ ...props }: React.ComponentProps<typeof ContextMenu
   return <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />
 }
 
+/** Coordinator marker that survives Radix `asChild` Slot merges.
+ * `data-slot` is overwritten when the child sets its own `data-slot`
+ * (status bar footer); this attribute is not. */
+export const HERMES_CONTEXT_MENU_TRIGGER_ATTR = 'data-hermes-context-menu-trigger'
+
 function ContextMenuTrigger({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
-  return <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />
+  return (
+    <ContextMenuPrimitive.Trigger
+      data-slot="context-menu-trigger"
+      {...props}
+      data-hermes-context-menu-trigger=""
+    />
+  )
 }
 
 function ContextMenuGroup({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Group>) {


### PR DESCRIPTION
Right-clicking the desktop status bar opened the window-verbs fallback menu instead of the status bar's own **Show in status bar** list. That list is the only UI path to the items that ship hidden by default — the context meter, turn and session timers, cron, agents, webhooks, terminal, approval mode — so all of them became unreachable after the context-menu coordinator landed.

## Root cause

`ContextMenuTrigger` marks Radix-owned surfaces with `data-slot="context-menu-trigger"`, and the app-wide capture-phase coordinator in `app-context-menu.tsx` uses that marker to decide whether to keep its hands off a gesture. Radix `asChild` merges as `mergeProps(slotProps, childProps)`, so a child that sets its own `data-slot` wins. The status bar renders the trigger over `<footer data-slot="statusbar">`, the marker never reaches the DOM, the coordinator's guard misses, and `stopPropagation()` eats the Radix menu.

The fix is at the primitive, not the call site: `ContextMenuTrigger` also stamps a dedicated `data-hermes-context-menu-trigger` after `{...props}`, and the coordinator bails on that. Every `asChild` surface with its own `data-slot` is covered, including ones not written yet.

The status bar is the only call site broken today — I swept all ten `ContextMenuTrigger` usages, and `context-menu-trigger` is the only Slot-stamped `data-slot` that production code uses as a runtime gate. The sibling triggers (tooltip, dropdown, dialog, sheet, popover) have no such consumer, so they are deliberately left alone.

## Tests

Two halves of one contract:

- `app-context-menu.test.tsx` renders `ContextMenuTrigger asChild` over a child that sets `data-slot`, and asserts the marker survives the Slot merge.
- `statusbar-context-menu.test.tsx` mounts the real coordinator beside the real `StatusbarControls`, right-clicks the bar, and asserts the customize menu opens while the app fallback stays shut.

Both fail with the marker removed. Full `src/app` + `src/components` suite is green at 2910 tests across 329 files; typecheck and eslint clean on the changed files.

## Credit

Consolidates three independent fixes for the same bug. The primitive-layer approach is @aydnOktay's, cherry-picked with authorship intact. The end-to-end regression test is @huklaa's. @Jeffgithub0029 independently root-caused the same Slot collision.

Supersedes #89979, #89977, #90442

Fixes #89953