### PR TITLE
chore(models): add GLM 5.3 to OpenRouter catalog

### DIFF
--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -117,6 +117,10 @@
           "description": ""
         },
         {
+          "id": "z-ai/glm-5.3",
+          "description": ""
+        },
+        {
           "id": "z-ai/glm-5.2",
           "description": "default",
           "default": true


### PR DESCRIPTION
Adds z-ai/glm-5.3 to the curated OpenRouter model catalog so it appears in Hermes model pickers. GLM 5.2 remains the silent default.