### PR TITLE
fix(billing): scope credential cache by profile

### DIFF
--- a/hermes_cli/nous_billing.py
+++ b/hermes_cli/nous_billing.py
@@ -27,10 +27,13 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 import urllib.error
 import urllib.parse
 import urllib.request
 from typing import Any, Optional
+
+from hermes_constants import get_hermes_home
 
 DEFAULT_PORTAL_BASE_URL = "https://portal.nousresearch.com"
 
@@ -210,12 +213,16 @@ def _absolutize_portal_url(portal_url: Optional[str]) -> Optional[str]:
 # only ever returns a token with >=120s of life (its refresh skew), so a 30s
 # cache can never hand back an about-to-expire token. A 401 still surfaces
 # normally (the cache holds a valid token, not the HTTP outcome).
+# Key by the resolved Hermes home: multiplex gateways switch profiles through
+# a context-local home override, and a process-global entry would let one
+# profile receive another profile's bearer token and portal base for the TTL.
 _TOKEN_CACHE_TTL_SECONDS = 30.0
-_token_cache: tuple[float, str, str] | None = None  # (cached_at, token, base)
+_token_cache_lock = threading.Lock()
+_token_cache: dict[str, tuple[float, str, str]] = {}
 
 
 def invalidate_cached_token() -> None:
-    """Bust the 30s token cache so post-step-up replays use the freshly-scoped token.
+    """Bust this profile's cache so replays use the freshly-scoped token.
 
     ``_request`` only self-busts the cache on a 401 (an expired/invalid
     token), not on a 403 scope denial — so after a step-up grant, the
@@ -224,8 +231,9 @@ def invalidate_cached_token() -> None:
     (e.g. the CLI's scope step-up flow) call this instead of poking
     the private ``_token_cache`` global directly.
     """
-    global _token_cache
-    _token_cache = None
+    cache_key = str(get_hermes_home())
+    with _token_cache_lock:
+        _token_cache.pop(cache_key, None)
 
 
 def _billing_not_logged_in(exc: Optional[BaseException] = None) -> "BillingAuthError":
@@ -253,13 +261,16 @@ def _resolve_token_and_base(*, use_cache: bool = True) -> tuple[str, str]:
     loop from re-locking + re-reading the auth store on every 2s tick. Pass
     ``use_cache=False`` to force a fresh resolution (e.g. after a 401).
     """
-    global _token_cache
     import time as _time
 
-    if use_cache and _token_cache is not None:
-        cached_at, token, base = _token_cache
-        if (_time.time() - cached_at) < _TOKEN_CACHE_TTL_SECONDS:
-            return token, base
+    cache_key = str(get_hermes_home())
+    if use_cache:
+        with _token_cache_lock:
+            cached = _token_cache.get(cache_key)
+        if cached is not None:
+            cached_at, token, base = cached
+            if (_time.time() - cached_at) < _TOKEN_CACHE_TTL_SECONDS:
+                return token, base
 
     try:
         from hermes_cli.auth import get_provider_auth_state
@@ -277,7 +288,8 @@ def _resolve_token_and_base(*, use_cache: bool = True) -> tuple[str, str]:
         token = state.get("access_token")
         if isinstance(token, str) and token.strip():
             resolved = (token.strip(), base)
-            _token_cache = (_time.time(), *resolved)
+            with _token_cache_lock:
+                _token_cache[cache_key] = (_time.time(), *resolved)
             return resolved
         raise _billing_not_logged_in()
 
@@ -286,7 +298,8 @@ def _resolve_token_and_base(*, use_cache: bool = True) -> tuple[str, str]:
     except AuthError as exc:
         raise _billing_not_logged_in(exc) from exc
     resolved = (token.strip(), base)
-    _token_cache = (_time.time(), *resolved)
+    with _token_cache_lock:
+        _token_cache[cache_key] = (_time.time(), *resolved)
     return resolved
 
 
@@ -433,8 +446,7 @@ def _request(
         # A 401 on a cached token → drop the cache and retry once with a fresh
         # (refresh-aware) resolve before surfacing the auth error.
         if exc.code == 401 and not _retried_auth:
-            global _token_cache
-            _token_cache = None
+            invalidate_cached_token()
             return _request(
                 method,
                 path,

--- a/hermes_cli/nous_billing.py
+++ b/hermes_cli/nous_billing.py
@@ -33,7 +33,7 @@ import urllib.parse
 import urllib.request
 from typing import Any, Optional
 
-from hermes_constants import get_hermes_home
+from hermes_constants import hermes_home_key
 
 DEFAULT_PORTAL_BASE_URL = "https://portal.nousresearch.com"
 
@@ -231,7 +231,7 @@ def invalidate_cached_token() -> None:
     (e.g. the CLI's scope step-up flow) call this instead of poking
     the private ``_token_cache`` global directly.
     """
-    cache_key = str(get_hermes_home())
+    cache_key = hermes_home_key()
     with _token_cache_lock:
         _token_cache.pop(cache_key, None)
 
@@ -263,7 +263,7 @@ def _resolve_token_and_base(*, use_cache: bool = True) -> tuple[str, str]:
     """
     import time as _time
 
-    cache_key = str(get_hermes_home())
+    cache_key = hermes_home_key()
     if use_cache:
         with _token_cache_lock:
             cached = _token_cache.get(cache_key)

--- a/tests/hermes_cli/test_nous_billing_profile_cache.py
+++ b/tests/hermes_cli/test_nous_billing_profile_cache.py
@@ -1,0 +1,91 @@
+"""Profile-isolation regression tests for the Nous billing credential cache."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import hermes_constants
+import hermes_cli.auth as auth
+from hermes_cli import nous_billing as billing
+
+
+def _write_auth(home: Path, *, token: str, portal_base_url: str) -> None:
+    (home / "auth.json").write_text(
+        json.dumps({
+            "version": 1,
+            "active_provider": "nous",
+            "providers": {
+                "nous": {
+                    "access_token": token,
+                    "refresh_token": "refresh-token",
+                    "client_id": "hermes-cli-vps",
+                    "expires_at": "2999-01-01T00:00:00+00:00",
+                    "portal_base_url": portal_base_url,
+                }
+            },
+        }),
+        encoding="utf-8",
+    )
+
+
+def _resolve_under_profile(home: Path) -> tuple[str, str]:
+    reset_token = hermes_constants.set_hermes_home_override(str(home))
+    try:
+        return billing._resolve_token_and_base()
+    finally:
+        hermes_constants.reset_hermes_home_override(reset_token)
+
+
+def test_token_cache_does_not_leak_across_multiplex_profile_contexts(
+    monkeypatch, tmp_path
+):
+    """A profile must never receive a sibling profile's cached credentials."""
+    profile_a = tmp_path / "profile-a"
+    profile_b = tmp_path / "profile-b"
+    profile_a.mkdir()
+    profile_b.mkdir()
+    _write_auth(
+        profile_a,
+        token="token-for-profile-a",
+        portal_base_url="https://profile-a.example.invalid",
+    )
+    _write_auth(
+        profile_b,
+        token="token-for-profile-b",
+        portal_base_url="https://profile-b.example.invalid",
+    )
+
+    monkeypatch.delenv("HERMES_PORTAL_BASE_URL", raising=False)
+    monkeypatch.delenv("NOUS_PORTAL_BASE_URL", raising=False)
+    billing.invalidate_cached_token()
+
+    # Bypass auth.py's separate startup memo so this test isolates the billing
+    # cache while retaining real profile-scoped auth.json resolution.
+    real_resolver = auth.resolve_nous_access_token
+    resolved_profiles: list[str] = []
+
+    def _resolve_from_profile_auth() -> str:
+        resolved_profiles.append(hermes_constants.get_hermes_home().name)
+        return real_resolver(insecure=True)
+
+    monkeypatch.setattr(
+        auth,
+        "resolve_nous_access_token",
+        _resolve_from_profile_auth,
+    )
+
+    result_a = _resolve_under_profile(profile_a)
+    cached_result_a = _resolve_under_profile(profile_a)
+    result_b = _resolve_under_profile(profile_b)
+
+    assert result_a == (
+        "token-for-profile-a",
+        "https://profile-a.example.invalid",
+    )
+    assert cached_result_a == result_a
+    assert result_b == (
+        "token-for-profile-b",
+        "https://profile-b.example.invalid",
+    ), "profile B must not receive profile A's cached billing credentials"
+    assert resolved_profiles == ["profile-a", "profile-b"]

--- a/tests/hermes_cli/test_nous_billing_profile_cache.py
+++ b/tests/hermes_cli/test_nous_billing_profile_cache.py
@@ -77,6 +77,7 @@ def test_token_cache_does_not_leak_across_multiplex_profile_contexts(
 
     result_a = _resolve_under_profile(profile_a)
     cached_result_a = _resolve_under_profile(profile_a)
+    aliased_result_a = _resolve_under_profile(profile_a / ".." / "profile-a")
     result_b = _resolve_under_profile(profile_b)
 
     assert result_a == (
@@ -84,6 +85,7 @@ def test_token_cache_does_not_leak_across_multiplex_profile_contexts(
         "https://profile-a.example.invalid",
     )
     assert cached_result_a == result_a
+    assert aliased_result_a == result_a
     assert result_b == (
         "token-for-profile-b",
         "https://profile-b.example.invalid",

--- a/tests/hermes_cli/test_nous_billing_profile_cache.py
+++ b/tests/hermes_cli/test_nous_billing_profile_cache.py
@@ -89,3 +89,13 @@ def test_token_cache_does_not_leak_across_multiplex_profile_contexts(
         "https://profile-b.example.invalid",
     ), "profile B must not receive profile A's cached billing credentials"
     assert resolved_profiles == ["profile-a", "profile-b"]
+
+    reset_token = hermes_constants.set_hermes_home_override(str(profile_a))
+    try:
+        billing.invalidate_cached_token()
+    finally:
+        hermes_constants.reset_hermes_home_override(reset_token)
+
+    assert _resolve_under_profile(profile_b) == result_b
+    assert _resolve_under_profile(profile_a) == result_a
+    assert resolved_profiles == ["profile-a", "profile-b", "profile-a"]

--- a/tests/hermes_cli/test_nous_billing_request.py
+++ b/tests/hermes_cli/test_nous_billing_request.py
@@ -48,7 +48,7 @@ def _http_error(status: int, body: bytes | dict[str, object] = b"{}", headers=No
 def _sequence(monkeypatch, *outcomes, resolver=None):
     """Stub urlopen with ordered outcomes and record each Request."""
     seen: list[dict[str, object]] = []
-    monkeypatch.setattr(nb, "_token_cache", None, raising=False)
+    monkeypatch.setattr(nb, "_token_cache", {}, raising=False)
     monkeypatch.setattr(
         nb,
         "_resolve_token_and_base",
@@ -77,7 +77,7 @@ def _sequence(monkeypatch, *outcomes, resolver=None):
 def _stub(monkeypatch, body: bytes, status: int = 200):
     # Bypass auth/token resolution entirely — we only exercise response parsing.
     monkeypatch.setattr(nb, "_resolve_token_and_base", lambda **kw: ("tok", "https://portal.example"))
-    monkeypatch.setattr(nb, "_token_cache", None, raising=False)
+    monkeypatch.setattr(nb, "_token_cache", {}, raising=False)
     monkeypatch.setattr(nb.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp(body, status))
     yield
 


### PR DESCRIPTION
## Summary

- Scope the short-lived Nous billing credential cache to the resolved Hermes profile home.
- Preserve the existing 30-second same-profile cache while preventing this billing-layer cache from reusing another profile's bearer token or portal base.
- Keep 401 and post-step-up invalidation local to the active profile.

## Security posture

Hermes profiles have independent `auth.json` stores and may intentionally authenticate to different Nous accounts. The billing client previously cached `(token, portal_base_url)` in one process-global slot. In a multiplex process, if profile A populated that slot and profile B made a billing request within 30 seconds, B received A's cached billing credentials.

This is a cross-profile credential-isolation concern inside a shared Hermes process. It does not rely on the dashboard being a multi-tenant boundary, and this PR does not change dashboard profile-management permissions.

The separate five-second startup memo in `auth.py` has the same bug class and is addressed by #77865. This PR removes the independent 30-second billing-layer exposure; complete end-to-end profile isolation requires both cache fixes.

## Root cause

`hermes_cli.nous_billing._resolve_token_and_base()` returned the global `_token_cache` entry before consulting the active context-local Hermes home. The underlying auth lookup was profile-aware, but the billing-layer fast path was not.

## Fix

- Replace the single cache slot with a cache keyed by the canonical `hermes_home_key()`, so path aliases of the same profile share one entry.
- Guard cache reads, writes, and invalidation with a lock.
- Invalidate only the active profile's entry after a 401 or billing-scope step-up.
- Add a regression test using two real temporary `auth.json` stores and `set_hermes_home_override()` contexts. It bypasses the separate `auth.py` memo to isolate the billing cache, confirms repeat calls and path aliases share one profile entry, and confirms invalidating one profile leaves the sibling cache intact.

## Relationship to existing work

This is a complementary sibling fix to #77865, which scopes the separate `auth.py` startup memo to the active profile. This PR deliberately does not duplicate that contributor's change and is limited to the independent 30-second cache in `nous_billing.py`; both fixes are needed to close the complete token-resolution path. Treat #77865 as an integration prerequisite and merge this alongside or after it.

Credit to @pierrenode for the analysis and implementation direction in #77865. The same profile-keyed cache pattern applies here at the billing layer.

## Test plan

- [x] Regression test observed failing on the pre-fix implementation because profile B received profile A's cached token and portal base.
- [x] `scripts/run_tests.sh tests/hermes_cli/test_nous_billing_profile_cache.py tests/hermes_cli/test_nous_billing_request.py tests/hermes_cli/test_billing_portal_url.py tests/hermes_cli/test_billing_scope_stepup.py tests/hermes_cli/test_billing_cli.py tests/tui_gateway/test_billing_rpc.py tests/agent/test_anthropic_billing_guidance.py tests/agent/test_billing_unverified_carrythrough.py tests/agent/test_billing_usage.py tests/agent/test_billing_view.py tests/agent/test_billing_links.py` — 65 passed
- [x] `uv run --with ruff ruff check hermes_cli/nous_billing.py tests/hermes_cli/test_nous_billing_profile_cache.py tests/hermes_cli/test_nous_billing_request.py`
- [x] `git diff origin/main...HEAD --check`
