### PR TITLE
fix(install): read native child logs with an explicit UTF-8 codec

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -600,7 +600,10 @@ function Write-NpmDebugLogTail {
     }
     $tail = $null
     try {
-        $tail = Get-Content -LiteralPath $logPath -Tail $TailLines -ErrorAction Stop
+        # npm writes this log itself, as UTF-8 with no BOM. Get-Content has no
+        # BOM to sniff and falls back to the ANSI code page, so the codec has to
+        # be stated. See the note above _Invoke-NativeWithTimeout.
+        $tail = Get-Content -LiteralPath $logPath -Tail $TailLines -Encoding UTF8 -ErrorAction Stop
     } catch {
         Write-Warn "Could not read npm debug log ${logPath}: $($_.Exception.Message)"
         return
@@ -3299,13 +3302,21 @@ function Install-NodeDeps {
         [string]$exePath, [string]$argLine, [string]$workDir,
         [string]$logPath, [int]$timeoutSec
     ) {
+        # cmd.exe redirects the child's bytes into $logPath verbatim: no
+        # PowerShell decode happens on the way in, so the file carries the
+        # child's own encoding and no BOM.  Node-based children (npm, npx,
+        # playwright) write UTF-8.  Every Get-Content that reads this file
+        # therefore has to say -Encoding UTF8 -- without a BOM to sniff it
+        # would otherwise decode with the machine ANSI code page, which is
+        # the one thing the [Console]::OutputEncoding line near the top of
+        # this script cannot help with (that only fixes the display side).
         $cmdLine = "/d /s /c "" ""$exePath"" $argLine > ""$logPath"" 2>&1 """
         $proc = Start-Process -FilePath $env:ComSpec -ArgumentList $cmdLine `
             -WorkingDirectory $workDir -NoNewWindow -PassThru
         $deadline = [DateTime]::UtcNow.AddSeconds($timeoutSec)
         $shown = 0
         function _Drain-NewLines([string]$path, [ref]$count) {
-            $lines = @(Get-Content $path -ErrorAction SilentlyContinue)
+            $lines = @(Get-Content $path -Encoding UTF8 -ErrorAction SilentlyContinue)
             if ($lines.Count -gt $count.Value) {
                 $lines[$count.Value..($lines.Count - 1)] | ForEach-Object {
                     Write-Host "    $_" -ForegroundColor DarkGray
@@ -3364,7 +3375,7 @@ function Install-NodeDeps {
                 Write-Warn "$label npm install failed -- exit code $code"
             }
             if (Test-Path $logPath) {
-                $errText = (Get-Content $logPath -Raw -ErrorAction SilentlyContinue)
+                $errText = (Get-Content $logPath -Raw -Encoding UTF8 -ErrorAction SilentlyContinue)
                 if ($errText) {
                     $snippet = if ($errText.Length -gt 1200) { $errText.Substring(0, 1200) + "..." } else { $errText }
                     Write-Info "  npm output:"
@@ -3472,7 +3483,7 @@ function Install-NodeDeps {
                         Write-Warn "Playwright Chromium install failed -- exit code $pwCode"
                         Write-Warn "Browser tools will not work until Chromium is installed."
                         if (Test-Path $pwLog) {
-                            $pwErr = Get-Content $pwLog -Raw -ErrorAction SilentlyContinue
+                            $pwErr = Get-Content $pwLog -Raw -Encoding UTF8 -ErrorAction SilentlyContinue
                             if ($pwErr) {
                                 $snippet = if ($pwErr.Length -gt 1200) { $pwErr.Substring(0, 1200) + "..." } else { $pwErr }
                                 Write-Info "  playwright output:"

--- a/tests/test_install_ps1_native_log_encoding.py
+++ b/tests/test_install_ps1_native_log_encoding.py
@@ -1,0 +1,91 @@
+"""Regression tests: install.ps1 must state the codec when reading native logs.
+
+``_Invoke-NativeWithTimeout`` has cmd.exe redirect a child's stdout+stderr into
+a log file.  No PowerShell decode happens on the way in, so the file holds the
+child's own bytes and carries no BOM.  The children here are Node-based (npm,
+npx, playwright) and write UTF-8.
+
+Windows PowerShell 5.1's ``Get-Content`` sniffs a BOM and otherwise falls back
+to the machine ANSI code page, so a bare read of one of those logs decodes
+UTF-8 as cp932/cp936/cp1252.  Measured on ja-JP (ACP=932), PS 5.1.26100.9168::
+
+    no BOM  + bare Get-Content        -> error: 綢輔ぃ 經、綢ォ縺瑚九九▽縺九...
+    no BOM  + Get-Content -Encoding UTF8 -> error: ファイルが見つかりません
+    with BOM + bare Get-Content       -> error: ファイルが見つかりません
+
+The ``[Console]::OutputEncoding`` assignment near the top of install.ps1 does
+not cover this: its own comment says it is "a DISPLAY-only fix".
+
+Logs written through ``Tee-Object -FilePath`` are deliberately NOT in scope.
+PS 5.1 writes those as UTF-16LE **with** a BOM (measured: ``FF FE 42 30 ...``
+for a single "あ"), which Get-Content detects, so those reads are correct
+as they stand.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+
+def _install_ps1() -> str:
+    return INSTALL_PS1.read_text(encoding="utf-8")
+
+
+# The four reads whose file is written by a native child, not by PowerShell.
+_NATIVE_LOG_READS = (
+    r"Get-Content\s+-LiteralPath\s+\$logPath\s+-Tail\s+\$TailLines[^\r\n]*",
+    r"Get-Content\s+\$path[^\r\n]*",
+    r"Get-Content\s+\$logPath\s+-Raw[^\r\n]*",
+    r"Get-Content\s+\$pwLog\s+-Raw[^\r\n]*",
+)
+
+
+def test_native_child_log_reads_state_the_codec() -> None:
+    text = _install_ps1()
+    for pattern in _NATIVE_LOG_READS:
+        matches = re.findall(pattern, text)
+        assert matches, f"expected a Get-Content matching {pattern!r}"
+        for line in matches:
+            assert "-Encoding" in line, (
+                "a log written by a native child has no BOM, so this read "
+                f"decodes with the machine ANSI code page: {line.strip()!r}"
+            )
+
+
+def test_cmd_redirect_helper_documents_why_the_codec_is_needed() -> None:
+    """The helper that creates the BOM-less logs explains the constraint."""
+    text = _install_ps1()
+    assert re.search(
+        r"cmd\.exe redirects the child's bytes[\s\S]{0,700}?"
+        r"\$cmdLine = \"/d /s /c ",
+        text,
+    ), "_Invoke-NativeWithTimeout must say why its log needs an explicit codec"
+
+
+def test_console_outputencoding_is_still_display_only() -> None:
+    """Pin the premise: the console fix does not reach Get-Content.
+
+    If a future change makes install.ps1 set a default read codec globally,
+    this test should be revisited rather than silently kept passing.
+    """
+    text = _install_ps1()
+    assert "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()" in text
+    assert "DISPLAY-only fix" in text
+
+
+def test_tee_object_reads_are_left_alone() -> None:
+    """Tee-Object writes UTF-16LE with a BOM on 5.1; those reads are fine.
+
+    Kept as an explicit statement of scope so the next person does not
+    "finish the job" by adding -Encoding UTF8 to reads that would then
+    misdecode a UTF-16 file.
+    """
+    text = _install_ps1()
+    for var in ("$npmLog", "$buildLog"):
+        assert re.search(
+            r"Tee-Object\s+-FilePath\s+" + re.escape(var), text
+        ), f"{var} is expected to be written through Tee-Object -FilePath"


### PR DESCRIPTION
## What does this PR do?

`_Invoke-NativeWithTimeout` has cmd.exe redirect a child's stdout+stderr into a log file:

```powershell
$cmdLine = "/d /s /c "" ""$exePath"" $argLine > ""$logPath"" 2>&1 """
$proc = Start-Process -FilePath $env:ComSpec -ArgumentList $cmdLine ...
```

No PowerShell decode happens on the way in, so that file holds the child's own bytes and carries no BOM. The children here are Node-based — npm, npx, playwright — and Node writes UTF-8.

Four reads of those logs do not state a codec:

```powershell
$lines   = @(Get-Content $path -ErrorAction SilentlyContinue)                  # live tail
$errText = (Get-Content $logPath -Raw -ErrorAction SilentlyContinue)           # failure output
$pwErr   = Get-Content $pwLog -Raw -ErrorAction SilentlyContinue               # playwright
$tail    = Get-Content -LiteralPath $logPath -Tail $TailLines -ErrorAction Stop  # npm debug log
```

Windows PowerShell 5.1's `Get-Content` sniffs a BOM, and falls back to the machine ANSI code page when there isn't one.

**Measured on ja-JP Windows 11 (ACP=932), Windows PowerShell 5.1.26100.9168.** The same string written both ways, then read back:

```
no BOM  + bare Get-Content            error: 綢輔ぃ 經、綢ォ縺瑚九九▽縺九 j 縺セ縺帙 s
no BOM  + Get-Content -Encoding UTF8  error: ファイルが見つかりません
with BOM + bare Get-Content           error: ファイルが見つかりません
```

The BOM is the whole difference. Logs this script writes itself go through `Out-File -Encoding utf8` and carry one, so they read back correctly. Logs a child writes do not.

**Where it lands.** `_Drain-NewLines` is the live-tail helper — it reads the log and prints it:

```powershell
$lines = @(Get-Content $path -ErrorAction SilentlyContinue)
...
Write-Host "    $_" -ForegroundColor DarkGray
```

Near the top of the script there is `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()`, whose own comment calls it "a DISPLAY-only fix ... only what the user sees in their terminal". Those two are on the same path and the read runs first, so on a CJK host that display fix never receives intact text from this stream — the one `_Invoke-NativeWithTimeout` exists to preserve, because "on a fresh VM the install is 1-3 minutes; total silence is indistinguishable from a hang".

`$errText` at the failure branch is the same file. That is the text a user is shown, and told to copy, at the moment an install fails.

**Scope — two reads deliberately left alone.** `$npmLog` and `$buildLog` are written through `Tee-Object -FilePath`, which on 5.1 writes UTF-16LE **with** a BOM. Measured: a single `"あ"` teed to a file gives `FF FE 42 30 0D 00 0A 00`. `Get-Content` detects that BOM, so those reads are already correct and adding `-Encoding UTF8` to them would break them. The four changed here are exactly the ones whose file was written by a native child.

**Note on the linter.** `scripts/check-windows-footguns.py` never sees this file: `should_scan_file()` returns `True` only for `.py`, `.pyw`, `.pyi`. No `.ps1` in the repository is scanned, including the Windows installer itself.

## Related Issue

No separate issue — reporting it here with the measurement. Same class as #89442 / #89468 ("Affected Windows users lose diagnostic text from native commands"), one layer out: this is the installer, before the agent exists to lose anything.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/install.ps1` — the four `Get-Content` reads of a natively-written log pass `-Encoding UTF8`: the live tail and the failure output in `_Invoke-NativeWithTimeout`'s consumers, the playwright log, and the npm debug-log tail.
- `scripts/install.ps1` — a comment on the `cmd.exe` redirect in `_Invoke-NativeWithTimeout` recording why any reader of that file has to state a codec, and that `[Console]::OutputEncoding` does not cover it.
- `tests/test_install_ps1_native_log_encoding.py` — four tests: every natively-written log read states a codec; the redirect helper documents the constraint; the console fix is still display-only (so this is revisited rather than silently kept passing if that changes); and the `Tee-Object` sites stay out of scope so nobody "finishes the job" onto a UTF-16 file.

## How to Test

1. On a CP932 host, reproduce the decode directly:

```powershell
[IO.File]::WriteAllBytes("$env:TEMP\nobom.log",[Text.Encoding]::UTF8.GetBytes("error: ファイルが見つかりません`r`n"))
"error: ファイルが見つかりません" | Out-File "$env:TEMP\bom.log" -Encoding utf8

Get-Content "$env:TEMP\nobom.log" -Raw                    # mojibake
Get-Content "$env:TEMP\nobom.log" -Raw -Encoding UTF8     # correct
Get-Content "$env:TEMP\bom.log"   -Raw                    # correct (BOM sniffed)
$PSVersionTable.PSVersion.ToString()
```

Output above is from that run.

2. The scope check, on the same host:

```powershell
"あ" | Tee-Object -FilePath "$env:TEMP\tee.log" | Out-Null
Format-Hex "$env:TEMP\tee.log" | Select-Object -First 1
```

`FF FE 42 30 0D 00 0A 00` — UTF-16LE with a BOM, which is why the two `Tee-Object` reads are not touched.

3. `python -m pytest tests/test_install_ps1_*.py -q` across all fourteen install.ps1 test files, including the four added here:

```
ja-JP Windows host   1 failed, 45 passed
Linux checkout       45 passed, 1 skipped
```

The one Windows failure is `test_install_ps1_venv_process_tree.py::test_venv_sweep_stops_managed_runtime_children_but_not_unrelated_processes`, which runs `install.ps1 -Stage venv` for real and stops on the installer's own precondition — `{"ok":false,"reason":"uv is not installed. Run install.ps1 -Stage uv first."}`. That host has no `uv`; the same test is skipped off-Windows. Nothing in this change touches that path.

4. Against the pre-patch `install.ps1` with the new tests kept: 2 failed / 2 passed. The two that pass either way are the scope statements — they assert facts about `[Console]::OutputEncoding` and `Tee-Object` that this PR does not change, and exist so a later edit cannot quietly invalidate the premise.

Note on the checklist below: I ran the install.ps1 test files and the comparison above, not the full `pytest tests/ -q`, so I left that box unchecked rather than claiming it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, ja-JP (ACP=932), Windows PowerShell 5.1.26100.9168

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

I have a ja-JP (ACP=932) Windows host and can measure anything else on that locale.

*(Measured on my host. Drafted with Claude.)*
