### PR TITLE
fix(desktop): extend bot image generation timeout

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2187,12 +2187,26 @@ function probeImagen() {
 
 async function generateAvatarImage(bot, title, description) {
   const who = [title || bot, description].filter(Boolean).join(' — ')
-  const res = await host.request('image.generate', {
-    prompt:
-      `Cute minimal robot avatar for an AI agent named "${who}". ` +
-      'Friendly simple mascot face, bold flat vector style, solid color background, centered, no text.',
-    aspect_ratio: 'square'
-  })
+  return requestGeneratedImage(
+    `Cute minimal robot avatar for an AI agent named "${who}". ` +
+      'Friendly simple mascot face, bold flat vector style, solid color background, centered, no text.'
+  )
+}
+
+// Image models can legitimately take longer than the gateway's generic 30s
+// interactive deadline. Give observed 40s-class renders and result inlining
+// enough headroom while keeping this interactive wait bounded.
+const IMAGE_GENERATE_REQUEST_TIMEOUT_MS = 90_000
+
+async function requestGeneratedImage(prompt) {
+  const res = await host.request(
+    'image.generate',
+    {
+      prompt,
+      aspect_ratio: 'square'
+    },
+    IMAGE_GENERATE_REQUEST_TIMEOUT_MS
+  )
 
   if (!res?.success) {
     throw new Error(res?.error || 'generation failed')
@@ -2247,18 +2261,9 @@ function AvatarPicker({ shape, color, image, onShape, onColor, onImage, generate
     try {
       const custom = describe.trim()
       const img = custom
-        ? await (async () => {
-            const res = await host.request('image.generate', {
-              prompt: `${custom}. Avatar for an AI agent: centered, bold flat vector style, solid color background, no text.`,
-              aspect_ratio: 'square'
-            })
-
-            if (!res?.success) {
-              throw new Error(res?.error || 'generation failed')
-            }
-
-            return res.image_data || res.image
-          })()
+        ? await requestGeneratedImage(
+            `${custom}. Avatar for an AI agent: centered, bold flat vector style, solid color background, no text.`
+          )
         : await generateAvatarImage(generateSeed?.name || 'agent', generateSeed?.title, generateSeed?.description)
 
       if (img) {
@@ -8219,18 +8224,10 @@ function GroupImageControls({ image, onImage, seedName, seedMembers }) {
       const who = [seedName, seedMembers?.length ? `a team of ${seedMembers.join(', ')}` : '']
         .filter(Boolean)
         .join(' — ')
-      const res = await host.request('image.generate', {
-        prompt:
-          `Group chat icon for an AI agent team called "${who || 'a bot team'}". ` +
-          'Friendly minimal emblem, bold flat vector style, solid color background, centered, no text.',
-        aspect_ratio: 'square'
-      })
-
-      if (!res?.success) {
-        throw new Error(res?.error || 'generation failed')
-      }
-
-      const img = res.image_data || res.image
+      const img = await requestGeneratedImage(
+        `Group chat icon for an AI agent team called "${who || 'a bot team'}". ` +
+          'Friendly minimal emblem, bold flat vector style, solid color background, centered, no text.'
+      )
 
       if (img) {
         onImage(await normalizeAvatarImage(img))

--- a/apps/desktop/src/plugins/hermes-bots/tests/avatar-generation-timeout.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/avatar-generation-timeout.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadGenerateAvatarImage() {
+  const start = source.indexOf('async function generateAvatarImage(')
+  const end = source.indexOf('/** Shape grid + color swatches', start)
+
+  assert.notEqual(start, -1, 'generateAvatarImage is missing')
+  assert.notEqual(end, -1, 'avatar helper boundary is missing')
+
+  const calls = []
+  const context = {
+    host: {
+      request: async (...args) => {
+        calls.push(args)
+
+        return { success: true, image_data: 'data:image/png;base64,avatar' }
+      }
+    }
+  }
+
+  vm.runInNewContext(`${source.slice(start, end)}\nglobalThis.generateAvatarImage = generateAvatarImage`, context, {
+    filename: 'plugin.js'
+  })
+
+  return { calls, generateAvatarImage: context.generateAvatarImage }
+}
+
+test('avatar generation gives the image RPC a 90-second deadline', async () => {
+  const { calls, generateAvatarImage } = loadGenerateAvatarImage()
+
+  const image = await generateAvatarImage('health', 'Health', 'Private health intelligence agent')
+
+  assert.equal(image, 'data:image/png;base64,avatar')
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0][0], 'image.generate')
+  assert.equal(calls[0][2], 90_000)
+})

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -852,14 +852,21 @@ export const host = {
 
   /** Gateway JSON-RPC — sessions, config, skills, cron, kanban, everything
    *  the app itself uses. Lazy: resolves the LIVE socket per call. */
-  request: async <T>(method: string, params: Record<string, unknown> = {}): Promise<T> => {
+  request: async <T>(
+    method: string,
+    params: Record<string, unknown> = {},
+    timeoutMs?: number,
+    signal?: AbortSignal
+  ): Promise<T> => {
     const gateway = $gateway.get()
 
     if (!gateway) {
       throw new Error('Hermes gateway unavailable')
     }
 
-    return gateway.request<T>(method, params)
+    return timeoutMs === undefined && signal === undefined
+      ? gateway.request<T>(method, params)
+      : gateway.request<T>(method, params, timeoutMs, signal)
   },
 
   /** The LIVE gateway instance for the active profile (null before the first

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -103,8 +103,13 @@ const { host } = await import('./index')
 const { openSession: openSessionCore } = await import('@/app/open-session')
 const { deleteProfile } = await import('@/hermes')
 
-const { openGatewayForProfile, requestGatewayForAgent, requestGatewayForProfile, retireLocalProfileGateways } =
-  await import('@/store/gateway')
+const {
+  $gateway,
+  openGatewayForProfile,
+  requestGatewayForAgent,
+  requestGatewayForProfile,
+  retireLocalProfileGateways
+} = await import('@/store/gateway')
 
 const {
   $activeGatewayProfile,
@@ -134,6 +139,7 @@ const profile = (name: string): ProfileInfo => ({
 
 afterEach(() => {
   vi.clearAllMocks()
+  $gateway.set(null)
   $activeGatewayProfile.set('remote-worker')
   $gatewaySwapTarget.set(null)
   setMockAtom($focusedRuntimeId, null)
@@ -147,6 +153,34 @@ afterEach(() => {
 })
 
 describe('connection-aware plugin host APIs', () => {
+  it('forwards an explicit plugin RPC deadline to the live gateway', async () => {
+    const request = vi.fn(async () => ({ success: true }))
+    const signal = new AbortController().signal
+
+    const pluginRequest = host.request as <T>(
+      method: string,
+      params?: Record<string, unknown>,
+      timeoutMs?: number,
+      signal?: AbortSignal
+    ) => Promise<T>
+
+    $gateway.set({ request } as never)
+
+    await pluginRequest('image.generate', { prompt: 'health agent avatar' }, 90_000, signal)
+
+    expect(request).toHaveBeenCalledWith('image.generate', { prompt: 'health agent avatar' }, 90_000, signal)
+  })
+
+  it('keeps the two-argument gateway call shape when no plugin deadline is set', async () => {
+    const request = vi.fn(async () => ({ profiles: [] }))
+
+    $gateway.set({ request } as never)
+
+    await host.request('profiles.list', { include_sessions: true })
+
+    expect(request.mock.calls[0]).toEqual(['profiles.list', { include_sessions: true }])
+  })
+
   it('retires a profile gateway before deleting it', async () => {
     const order: string[] = []
 


### PR DESCRIPTION
## Bug Description

Desktop Bot Mode avatar and group-picture generation can exceed the generic 30-second gateway request deadline. The UI then reports `request timed out after 30s: image.generate` even when the backend is healthy and completes later.

Closes #86161.

This builds on the approach in #85692 while incorporating its review feedback: the timeout remains caller-owned at the plugin edge, uses the issue's 90-second bound, and has regression coverage.

## Root Cause

The plugin SDK exposed `host.request(method, params)` only, so plugin-owned long operations could not supply a per-call deadline. Bot Mode called `image.generate` through that two-argument API and inherited the desktop gateway's generic 30-second timeout.

## Fix

- Let `host.request` optionally forward `timeoutMs` and `AbortSignal` to the live gateway.
- Preserve the existing two-argument gateway call shape when no deadline is supplied, so ordinary RPCs retain the 30-second default.
- Route avatar, custom-prompt avatar, and group-picture generation through one helper with a bounded 90-second deadline.
- Add regression tests for explicit deadline forwarding, ordinary-call compatibility, and the Bot Mode avatar path.

## How to Verify

1. Configure an image backend that takes longer than 30 seconds.
2. Open Bot Mode, edit a profile, select Avatar -> Generate, and submit a prompt.
3. Confirm generation remains pending past 30 seconds and completes within the 90-second bound.
4. Confirm ordinary plugin RPCs still use the gateway default.

## Test Plan

- [x] Added regression tests for this bug
- [x] `vitest run --project ui src/sdk/profile-routing.test.ts` - 28 passed
- [x] `npm run check:test:plugins` - 325 passed
- [x] `npm run typecheck`
- [x] ESLint and `git diff --check`
- [x] Confirmed the configured image backend returns a valid 1024 x 1024 PNG

## Risk Assessment

Low - the SDK change is additive, ordinary requests preserve their existing two-argument call shape, and the longer deadline is applied only by Bot Mode's image-generation helper.
