### PR TITLE
fix(telegram): redact polling-callback errors instead of pasting the helper name

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4707,12 +4707,21 @@ class TelegramAdapter(BasePlatformAdapter):
                         self._background_tasks.add(self._polling_error_task)
                         self._polling_error_task.add_done_callback(self._background_tasks.discard)
                     elif self._looks_like_network_error(error):
-                        logger.warning("[%s] Telegram network _redact_telegram_error_text(error), scheduling reconnect: %s", self.name, error)
+                        logger.warning(
+                            "[%s] Telegram network %s, scheduling reconnect",
+                            self.name,
+                            _redact_telegram_error_text(error),
+                        )
                         self._polling_error_task = loop.create_task(self._handle_polling_network_error(error))
                         self._background_tasks.add(self._polling_error_task)
                         self._polling_error_task.add_done_callback(self._background_tasks.discard)
                     else:
-                        logger.error("[%s] Telegram polling _redact_telegram_error_text(error): %s", self.name, error, exc_info=True)
+                        logger.error(
+                            "[%s] Telegram polling %s",
+                            self.name,
+                            _redact_telegram_error_text(error),
+                            exc_info=True,
+                        )
 
                 # Store reference for retry use in _handle_polling_conflict
                 self._polling_error_callback_ref = _polling_error_callback

--- a/tests/gateway/test_telegram_polling_callback_redaction.py
+++ b/tests/gateway/test_telegram_polling_callback_redaction.py
@@ -1,0 +1,197 @@
+"""Callback-level regression tests for Telegram polling-error redaction (#72668).
+
+``_polling_error_callback``'s network-error and fallback branches embedded
+``_redact_telegram_error_text(error)`` in the *format string* — the helper's
+name appeared as literal message text and the raw exception was passed as the
+``%s`` argument, so the redaction pass never ran on those two paths. These
+tests drive the real ``connect()``, capture the ``error_callback`` handed to
+``_start_polling_resilient``, and invoke it with an error that embeds the
+bot-token URL, asserting the emitted log is both well-formed and redacted.
+"""
+import asyncio
+import logging
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+    telegram_mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    telegram_mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+    sys.modules.setdefault("telegram.error", telegram_mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig  # noqa: E402
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+_FAKE_TOKEN_PARTS = ("123456789", "AAFakeSecretTelegramBotTokenXYZ")
+
+
+def _fake_token() -> str:
+    return ":".join(_FAKE_TOKEN_PARTS)
+
+
+@pytest.fixture(autouse=True)
+def _no_auto_discovery(monkeypatch):
+    async def _noop():
+        return []
+
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.discover_fallback_ips", _noop
+    )
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.HTTPXRequest", lambda **kwargs: MagicMock()
+    )
+
+
+async def _cancel_heartbeat(adapter):
+    task = getattr(adapter, "_polling_heartbeat_task", None)
+    if task and not task.done():
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+    adapter._polling_heartbeat_task = None
+
+
+async def _connected_adapter_with_callback(monkeypatch, adapter):
+    """Run the real connect() with a mocked PTB; return the captured
+    ``error_callback`` handed to ``_start_polling_resilient``."""
+
+    async def fake_start_polling(**kwargs):
+        adapter._record_polling_progress(adapter._polling_generation)
+        return True
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(side_effect=fake_start_polling),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(set_my_commands=AsyncMock(), delete_webhook=AsyncMock())
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    ok = await adapter.connect()
+    assert ok is True
+    # connect() never awaits the callback-captured kwargs, so pull the
+    # registered reference the adapter stores for retry use.
+    callback = adapter._polling_error_callback_ref
+    assert callable(callback)
+    return callback
+
+
+class TestPollingCallbackRedaction:
+    @pytest.mark.asyncio
+    async def test_network_branch_redacts_and_is_not_garbled(
+        self, monkeypatch, caplog
+    ):
+        """The network-error branch must run the redactor over the exception
+        and emit a well-formed message (#72668): the helper name never
+        appears as literal text, and the raw token never appears at all."""
+        token = _fake_token()
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token=token))
+        monkeypatch.setattr(
+            "gateway.status.acquire_scoped_lock",
+            lambda scope, identity, metadata=None: (True, None),
+        )
+        monkeypatch.setattr(
+            "gateway.status.release_scoped_lock", lambda scope, identity: None
+        )
+        callback = await _connected_adapter_with_callback(monkeypatch, adapter)
+        try:
+            url = f"https://api.telegram.org/bot{token}/getUpdates"
+            with caplog.at_level(logging.WARNING, logger="plugins.platforms.telegram.adapter"):
+                callback(ConnectionError(f"Network error during getUpdates: {url}"))
+            rendered = " | ".join(rec.getMessage() for rec in caplog.records)
+            assert "_redact_telegram_error_text" not in rendered, (
+                "helper name pasted into the format string (the #72668 garble)"
+            )
+            assert token not in rendered, "raw bot token leaked into the log"
+            assert "network" in rendered.lower()
+            assert "scheduling reconnect" in rendered
+        finally:
+            await _cancel_heartbeat(adapter)
+
+    @pytest.mark.asyncio
+    async def test_fallback_branch_redacts_and_is_not_garbled(
+        self, monkeypatch, caplog
+    ):
+        """The generic fallback (logger.error) branch has the same fix."""
+        token = _fake_token()
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token=token))
+        monkeypatch.setattr(
+            "gateway.status.acquire_scoped_lock",
+            lambda scope, identity, metadata=None: (True, None),
+        )
+        monkeypatch.setattr(
+            "gateway.status.release_scoped_lock", lambda scope, identity: None
+        )
+        callback = await _connected_adapter_with_callback(monkeypatch, adapter)
+        try:
+            url = f"https://api.telegram.org/bot{token}/getUpdates"
+            with caplog.at_level(logging.ERROR, logger="plugins.platforms.telegram.adapter"):
+                callback(ValueError(f"Unexpected polling failure via {url}"))
+            rendered = " | ".join(rec.getMessage() for rec in caplog.records)
+            assert "_redact_telegram_error_text" not in rendered
+            assert token not in rendered
+            assert "polling" in rendered.lower()
+        finally:
+            await _cancel_heartbeat(adapter)
+
+    @pytest.mark.asyncio
+    async def test_callback_no_longer_formats_raw_error_argument(
+        self, monkeypatch, caplog
+    ):
+        """On main (pre-fix) the raw exception is the %s argument of a format
+        string that also garbles the helper name; assert the emitted record
+        carries the *redacted* text, not the raw error string."""
+        token = _fake_token()
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token=token))
+        monkeypatch.setattr(
+            "gateway.status.acquire_scoped_lock",
+            lambda scope, identity, metadata=None: (True, None),
+        )
+        monkeypatch.setattr(
+            "gateway.status.release_scoped_lock", lambda scope, identity: None
+        )
+        callback = await _connected_adapter_with_callback(monkeypatch, adapter)
+        try:
+            raw_error = f"boom at https://api.telegram.org/bot{token}/getMe"
+            with caplog.at_level(logging.WARNING, logger="plugins.platforms.telegram.adapter"):
+                callback(ConnectionError(raw_error))
+            rendered = " | ".join(rec.getMessage() for rec in caplog.records)
+            assert rendered, "no log record emitted by the callback"
+            assert raw_error not in rendered, "unredacted raw error text emitted"
+        finally:
+            await _cancel_heartbeat(adapter)


### PR DESCRIPTION
## What does this PR do?

Fixes the two `_polling_error_callback` logger calls in the Telegram adapter where `_redact_telegram_error_text(error)` was pasted into the **format string** instead of wrapping the **argument** (`plugins/platforms/telegram/adapter.py`, network-error branch and generic fallback — a find-and-replace that landed on the wrong side of the call). Consequences on current `main`: the helper's name is emitted as literal message text, and the raw exception is passed as the `%s` argument, so the redaction pass never runs on those two paths — transport errors embedding the bot-token URL reach the log unredacted (#72668; last confirmed on main at v2026.8.18).

This resubmits the fix from the timed-out #72687 (closed after 14 days with no maintainer decision despite positive reviews, with "should be easy to resubmit" in the closing note) and adds the callback-level regression coverage that its review flagged as missing.

## Related Issue

Fixes #72668

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py` — both callback branches now pass `_redact_telegram_error_text(error)` as the log argument: `logger.warning("[%s] Telegram network %s, scheduling reconnect", self.name, _redact_telegram_error_text(error))` and `logger.error("[%s] Telegram polling %s", self.name, _redact_telegram_error_text(error), exc_info=True)`.
- `tests/gateway/test_telegram_polling_callback_redaction.py` — new callback-level suite (the coverage #72687's review asked for): drives the real `connect()` with a mocked PTB builder, captures the `error_callback` registered via `_start_polling_resilient`, and invokes it with errors embedding a bot-token URL. Asserts the emitted record is well-formed (no literal `_redact_telegram_error_text` text), redacted (no raw token, no raw error string), and still carries the branch context ("scheduling reconnect" / "polling").

## How to Test

1. `uv run --python 3.11 --with pytest --with pytest-asyncio --with pyyaml --with python-dotenv --with httpx --with pillow --with requests --with rich --with prompt_toolkit python -m pytest -q -o 'addopts=' tests/gateway/test_telegram_polling_callback_redaction.py`
2. Observed result: 3 passed on this branch; all 3 fail on unmodified `main` (the log contains the literal helper name and the raw token) — confirming the tests pin the fix.
3. Baseline: `tests/gateway/test_telegram_error_redaction.py` + `tests/gateway/test_telegram_conflict.py` — 17 passed, unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (the prior #72687 is closed unmerged with an explicit resubmit note)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
