### PR TITLE
fix(gateway): handle pairing path I/O errors

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -328,13 +328,13 @@ def _sync_allowlist_remove(platform: str, user_id: str) -> None:
 
 
 def _load_json_file(path: Path) -> dict:
-    if path.exists():
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            return data if isinstance(data, dict) else {}
-        except (json.JSONDecodeError, OSError):
+    try:
+        if not path.exists():
             return {}
-    return {}
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
 
 
 def _merge_pairing_dir(active_dir: Path, alternate_dir: Path) -> None:
@@ -465,36 +465,36 @@ class PairingStore:
         return self._dir / "_rate_limits.json"
 
     def _load_json(self, path: Path) -> dict:
-        if path.exists():
+        try:
+            if not path.exists():
+                return {}
+            return json.loads(path.read_text(encoding="utf-8"))
+        except PermissionError as e:
+            # Surface this loudly: a 0600 file owned by a different user
+            # (classic Docker symptom: `docker exec` runs as root and writes
+            # the file, then the gateway process — running as `hermes` after
+            # gosu drop — can't read it) would otherwise be swallowed by
+            # the generic OSError branch below, silently leaving the user
+            # marked unauthorized. See issue #10270.
             try:
-                return json.loads(path.read_text(encoding="utf-8"))
-            except PermissionError as e:
-                # Surface this loudly: a 0600 file owned by a different user
-                # (classic Docker symptom: `docker exec` runs as root and writes
-                # the file, then the gateway process — running as `hermes` after
-                # gosu drop — can't read it) would otherwise be swallowed by
-                # the generic OSError branch below, silently leaving the user
-                # marked unauthorized. See issue #10270.
-                try:
-                    st = path.stat()
-                    owner_info = f"owner_uid={st.st_uid} mode={oct(st.st_mode)[-4:]}"
-                except OSError:
-                    owner_info = "<stat failed>"
-                # os.geteuid doesn't exist on Windows; the Docker scenario is
-                # POSIX-only, but the gateway (and this fallback) runs anywhere.
-                euid = os.geteuid() if hasattr(os, "geteuid") else "n/a"
-                logger.warning(
-                    "Pairing file %s exists but is not readable as uid=%s (%s; %s). "
-                    "If you ran `docker exec <container> hermes pairing approve ...` as root, "
-                    "re-run with `docker exec -u hermes <container> ...` and "
-                    "chown the existing file to the hermes user, or restart the "
-                    "container so the entrypoint can fix ownership.",
-                    path, euid, owner_info, e,
-                )
-                return {}
-            except (json.JSONDecodeError, OSError):
-                return {}
-        return {}
+                st = path.stat()
+                owner_info = f"owner_uid={st.st_uid} mode={oct(st.st_mode)[-4:]}"
+            except OSError:
+                owner_info = "<stat failed>"
+            # os.geteuid doesn't exist on Windows; the Docker scenario is
+            # POSIX-only, but the gateway (and this fallback) runs anywhere.
+            euid = os.geteuid() if hasattr(os, "geteuid") else "n/a"
+            logger.warning(
+                "Pairing file %s exists but is not readable as uid=%s (%s; %s). "
+                "If you ran `docker exec <container> hermes pairing approve ...` as root, "
+                "re-run with `docker exec -u hermes <container> ...` and "
+                "chown the existing file to the hermes user, or restart the "
+                "container so the entrypoint can fix ownership.",
+                path, euid, owner_info, e,
+            )
+            return {}
+        except (json.JSONDecodeError, OSError):
+            return {}
 
     def _save_json(self, path: Path, data: dict) -> None:
         _secure_write(path, json.dumps(data, indent=2, ensure_ascii=False))

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -17,6 +17,7 @@ from gateway.pairing import (
     RATE_LIMIT_SECONDS,
     MAX_PENDING_PER_PLATFORM,
     MAX_FAILED_ATTEMPTS,
+    _load_json_file,
     _secure_write,
 )
 
@@ -25,6 +26,21 @@ def _make_store(tmp_path):
     """Create a PairingStore with PAIRING_DIR pointed to tmp_path."""
     with patch("gateway.pairing.PAIRING_DIR", tmp_path):
         return PairingStore()
+
+
+class TestPairingJsonReadFailures:
+    @pytest.mark.parametrize("loader_name", ["module", "store"])
+    def test_exists_io_error_is_treated_as_unavailable_pairing_data(self, tmp_path, loader_name):
+        path = tmp_path / "telegram-approved.json"
+        store = _make_store(tmp_path)
+
+        with patch.object(Path, "exists", side_effect=OSError(5, "Input/output error")):
+            if loader_name == "module":
+                result = _load_json_file(path)
+            else:
+                result = store._load_json(path)
+
+        assert result == {}
 
 
 class TestSplitPairingDirMigration:


### PR DESCRIPTION
## Summary
- catch `OSError` raised by `Path.exists()` when loading pairing JSON
- cover both split-directory migration and `PairingStore` reads
- preserve the existing permission-error diagnostics

## Problem
A transient filesystem EIO while checking `<platform>-approved.json` currently escapes before the existing read error handler because `path.exists()` runs outside the `try` block. This can surface as:

```text
OSError: [Errno 5] Input/output error: telegram-approved.json
```

## Tests
- `pytest tests/gateway/test_pairing.py -o addopts= -q` (31 passed)
- pairing-related gateway suite (49 passed)