### PR TITLE
test(web): run the dashboard test project in development mode

### DIFF
--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -12,5 +12,16 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.{ts,tsx}"],
+    // React 19 ships `act` only in its development build, and the jsdom suites
+    // here drive components through `act()`. A shell that already exports
+    // NODE_ENV=production (the one that launched the app, a packaged CI step,
+    // an editor terminal) is inherited by vitest, `React.act` resolves to
+    // undefined, and every `createRoot` test in this project fails with
+    // "act is not a function". Pin the worker to development so the suite is
+    // independent of the ambient environment; app runtime and production
+    // builds are untouched.
+    env: {
+      NODE_ENV: "development",
+    },
   },
 });


### PR DESCRIPTION
## Summary

React 19 only ships `act` in its development build. The jsdom suites in `web/` drive components through `act()`, so when vitest inherits an ambient `NODE_ENV=production` — the shell that launched the app, a packaged CI step, an editor terminal — `React.act` resolves to `undefined` and every `createRoot` test in the project dies with `TypeError: act is not a function`.

I hit this on Windows while trying to run the dashboard suite before touching `ChatPage`: the whole file was red and it looked like I had broken something, when the only difference was the `NODE_ENV` my terminal happened to export.

## Root cause

`web/vitest.config.ts` never pins the worker's environment, so `NODE_ENV` leaks in from whatever launched vitest. `@testing-library`-style `act()` resolution is `React.act ?? reactDomTestUtils.act`, and `react-dom/test-utils.act` forwards to `React.act` as well — under `production` both are `undefined`, so there is no fallback. The failure is entirely environmental: the same commit passes or fails depending on the shell.

This is the same failure class as #77409, one workspace over. That issue (and @derekm's #77421) covers `apps/desktop/vitest.config.ts`; `web/vitest.config.ts` has no equivalent guard, so the dashboard project is still exposed. I deliberately left `apps/desktop` alone to avoid overlapping with that PR.

## Changes

- `web/vitest.config.ts`: set `test.env.NODE_ENV = "development"` for the project, plus a comment recording *why* it has to be pinned so it does not get "simplified" away later.

Only the vitest worker is affected — app runtime, `vite build`, and the production bundle all keep their own `NODE_ENV`.

## Test plan

Both runs below are `web/`, on this branch, with the ambient production env that triggers the bug:

- [x] `NODE_ENV=production npm run check` → typecheck clean, **36 files / 275 tests passed**, lint 0 errors (26 pre-existing warnings, unchanged)
- [x] Reverted just this diff and re-ran the same command → **3 files / 43 tests fail** with `act is not a function`, confirming the config is what fixes it
- [x] `npm run check` with no `NODE_ENV` set at all → 275 passed (no regression for the normal case)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Related Issue

Relates to #77409 — same root cause, different workspace. Complements #77421 rather than replacing it.
