### PR TITLE
fix(desktop): scope native setOpacity to registered chat windows

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -932,8 +932,12 @@ function applyWindowTranslucency(win, changed = { backing: true, material: true,
   }
 
   try {
-    // Backing swap + material are scoped to registered chat windows (see
-    // translucencyBackedWindows above).
+    // Backing swap, material, and opacity are all scoped to registered chat
+    // windows (see translucencyBackedWindows above) — the HUD / pet overlay /
+    // quick entry / wake indicator are `transparent: true` windows that own
+    // their backgrounds, and `setOpacity` fades the whole window (not just a
+    // themed backing), so an unregistered window is just as wrong a target
+    // for it as it is for setBackgroundColor/setVibrancy.
     if (translucencyBackedWindows.has(win)) {
       if (changed.backing && typeof win.setBackgroundColor === 'function') {
         win.setBackgroundColor(glassActive(translucencyState) ? '#00000000' : getWindowBackgroundColor())
@@ -952,10 +956,10 @@ function applyWindowTranslucency(win, changed = { backing: true, material: true,
           win.setBackgroundMaterial(backgroundMaterialFor(translucencyState))
         }
       }
-    }
 
-    if (changed.opacity && typeof win.setOpacity === 'function') {
-      win.setOpacity(windowOpacity())
+      if (changed.opacity && typeof win.setOpacity === 'function') {
+        win.setOpacity(windowOpacity())
+      }
     }
   } catch (error) {
     rememberLog(`[translucency] apply failed: ${error.message}`)

--- a/apps/desktop/electron/translucency.test.ts
+++ b/apps/desktop/electron/translucency.test.ts
@@ -8,6 +8,10 @@
  * across the upgrade that curved the middle of the lever.
  */
 
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -546,5 +550,62 @@ describe('what an update actually changes natively', () => {
 
   it('is everything when switching between the two modes', () => {
     expect(nativeDiff(clear(60), glass(60))).toEqual({ backing: true, material: true, opacity: true })
+  })
+})
+
+// applyWindowTranslucency has no module.exports (it lives in main.ts, which has
+// none at all), so this pins its shape via the repo's source-assertion pattern
+// (see hardening.test.ts).
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+function readMain() {
+  return fs.readFileSync(path.join(__dirname, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+}
+
+describe('applyWindowTranslucency scopes every native call to registered chat windows', () => {
+  // The HUD, pet overlay, quick entry, and wake indicator are `transparent:
+  // true` windows that own their own background — they never register in
+  // translucencyBackedWindows (see the constant's own comment in main.ts) and
+  // are deliberately excluded from setBackgroundColor/setVibrancy/
+  // setBackgroundMaterial for exactly that reason. setOpacity fades the whole
+  // window, not just a themed backing, so an unregistered window is just as
+  // wrong a target for it: applying it turns a HUD band or a floating pet
+  // sprite translucent along with the desktop showing through, every time the
+  // user drags the intensity/fade slider. The bug shipped with setOpacity as a
+  // sibling of the registration gate instead of nested inside it, so it ran
+  // unconditionally over BrowserWindow.getAllWindows() regardless of
+  // registration.
+  it('nests the setOpacity call inside the translucencyBackedWindows.has(win) gate', () => {
+    const source = readMain()
+    const fnStart = source.indexOf('function applyWindowTranslucency(')
+    expect(fnStart, 'applyWindowTranslucency must exist in main.ts').not.toBe(-1)
+    const fnEnd = source.indexOf('\nfunction ', fnStart + 1)
+    const body = source.slice(fnStart, fnEnd === -1 ? undefined : fnEnd)
+
+    const gateIndex = body.indexOf('if (translucencyBackedWindows.has(win))')
+    expect(gateIndex, 'the chat-window registration gate must exist').not.toBe(-1)
+
+    const opacityIndex = body.indexOf("win.setOpacity(windowOpacity())")
+    expect(opacityIndex, 'the native setOpacity call must still exist').not.toBe(-1)
+    expect(opacityIndex, 'setOpacity must appear after the registration gate opens').toBeGreaterThan(gateIndex)
+
+    // Brace-depth between the gate opening and the opacity check's OWN `if`
+    // (not the setOpacity call itself, which would count the opacity `if`'s
+    // own opening brace and read as "nested" regardless of the gate). If
+    // depth is still positive here, the gate's block has not closed yet, so
+    // the opacity check sits inside it. A depth of 0 (or negative) means the
+    // gate already closed — the opacity check is a sibling, unconditional
+    // over every open window.
+    const opacityIfIndex = body.indexOf('if (changed.opacity')
+    expect(opacityIfIndex, 'the opacity change-guard must still exist').not.toBe(-1)
+    let depth = 0
+    for (const ch of body.slice(gateIndex, opacityIfIndex)) {
+      if (ch === '{') depth += 1
+      if (ch === '}') depth -= 1
+    }
+    expect(
+      depth,
+      'the opacity change-guard must be nested inside the translucencyBackedWindows.has(win) block, not a sibling of it'
+    ).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## What does this PR do?

`applyWindowTranslucency()` gates `setBackgroundColor`/`setVibrancy`/`setBackgroundMaterial` behind `translucencyBackedWindows.has(win)` — the comment above that `WeakSet` says explicitly that the HUD, pet overlay, quick entry, and wake indicator are `transparent: true` windows that own their own backgrounds, and painting a themed backing onto them "would turn them into opaque rectangles." `setOpacity` sat as a **sibling** of that gate instead of nested inside it, so it ran unconditionally over every window returned by `BrowserWindow.getAllWindows()` in the `hermes:translucency` IPC handler.

```js
if (translucencyBackedWindows.has(win)) {
  // setBackgroundColor / setVibrancy / setBackgroundMaterial — correctly gated
}

if (changed.opacity && typeof win.setOpacity === 'function') {
  win.setOpacity(windowOpacity())   // NOT gated — ran on every window
}
```

`setOpacity` fades the whole window, not just a themed backing — the same class of corruption the gate exists to prevent, just via a different native call. Dragging the intensity or fade slider (or switching between Clear/Glass) fades the HUD band, a floating pet overlay, the quick-entry composer, and the wake indicator right along with the desktop showing through, even though none of them ever register for translucency treatment and their own constructors never set an `opacity` option (all four are `transparent: true`, relying on Electron's default opacity of `1`).

## Root cause

Traced to `1eb9cbdb7a`, the commit that introduced `translucencyBackedWindows`: it gated the backing swap it was fixing but left the pre-existing unconditional `setOpacity` call as-is. Three later refactors of this function (perf pass, surface-helper consolidation, shared-mapping extraction) preserved the asymmetry without revisiting it.

Worth noting: a same-day sibling commit (`7f9e79b2e1`, "back the HUD band with the same window material the app uses") reinforces the exact same architectural boundary from the other direction — it gives the HUD its own dedicated `applyHudFrost()` for `setVibrancy`/`setBackgroundMaterial` specifically because, per its own comment, the HUD "is deliberately not in the chat fan-out below." That commit doesn't touch `setOpacity` at all, so the leak this PR fixes was still live in the generic fan-out afterward.

## Fix

Move the `changed.opacity` check inside the same `translucencyBackedWindows.has(win)` block the backing/material checks already use — no new gate, just closing the existing one around all three native calls consistently.

## Regression test

`main.ts` has no `module.exports` (nothing in it does), so this pins the fix via the repo's established source-assertion pattern (see `hardening.test.ts`'s `readMain()`/function-body-slice tests): it extracts `applyWindowTranslucency`'s body and brace-counts between the registration gate's opening and the opacity change-guard's own `if` — the guard must be nested inside the gate rather than a sibling of it.

Verified with mutation-verify: `git stash`'d the `main.ts` change and confirmed the new test fails against the pre-fix shape (`expected 0 to be greater than 0`), then restored the fix and confirmed it passes.

## Test plan

- [x] `npx vitest run apps/desktop/electron/translucency.test.ts` — 58/58 pass (57 existing + 1 new)
- [x] Mutation-verify: new test fails against pre-fix `main.ts`, passes against the fix
- [x] `npx tsc -p tsconfig.electron.json --noEmit` — clean
- [x] Full `apps/desktop/electron/` suite (105 files, 1424 tests): 2 pre-existing failures (`find-in-page-native.test.mjs` — Electron `app` module unavailable in this sandbox; `remote-lifecycle.test.ts` — an unrelated installer-wrapper subprocess timing test), both reproduced identically with this change reverted, confirming they're pre-existing and unrelated
- [ ] ESLint not run — this workspace-scoped install is missing the root-only `globals` peer dependency (`eslint.config.mjs` fails to resolve it); `tsc --noEmit` + the full vitest suite were used instead