### PR TITLE
feat(gateway): let a deployment tune the loop-watchdog budget

### DIFF
--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -49,6 +49,64 @@ DEFAULT_LOOP_FLOOR_TIMER_INTERVAL_S = 5.0
 DEFAULT_LOOP_WATCHDOG_INTERVAL_S = 30.0
 DEFAULT_LOOP_WATCHDOG_TIMEOUT_S = 10.0
 DEFAULT_LOOP_WATCHDOG_MAX_STRIKES = 3
+
+
+def _env_number(name: str, default: float, *, minimum: float, integer: bool = False):
+    """Read a positive numeric override from the environment, or return default.
+
+    A malformed or out-of-range value is ignored rather than raising: this runs on
+    the gateway boot path, and refusing to start because of a typo in an optional
+    tuning variable would trade a slow watchdog for no gateway at all.
+    """
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not a number; using the default %s", name, raw, default
+        )
+        return default
+    if value < minimum:
+        logger.warning(
+            "%s=%s is below the %s floor; using the default %s",
+            name, value, minimum, default,
+        )
+        return default
+    return int(value) if integer else value
+
+
+def loop_watchdog_settings() -> tuple[float, float, int]:
+    """(interval, timeout, strikes) for the loop-liveness watchdog.
+
+    Overridable per deployment because the right budget is a property of the
+    HOST's filesystem, not of Hermes. The probe stats a few files and fsyncs a
+    heartbeat; on a WSL2 VHDX under io pressure that was measured taking p99 31s
+    and max 112s, which is longer than the whole default budget (10s x 3), so the
+    watchdog killed a loop that was merely waiting on the disk. A deployment on
+    such a host needs a bigger leash; one on an NVMe box wants the tight default,
+    because the other half of the trade is how fast a genuinely wedged loop dies.
+
+    Defaults are unchanged, so nothing moves unless an operator opts in.
+    """
+    interval = _env_number(
+        "HERMES_LOOP_WATCHDOG_INTERVAL_S",
+        DEFAULT_LOOP_WATCHDOG_INTERVAL_S,
+        minimum=1.0,
+    )
+    timeout = _env_number(
+        "HERMES_LOOP_WATCHDOG_TIMEOUT_S",
+        DEFAULT_LOOP_WATCHDOG_TIMEOUT_S,
+        minimum=1.0,
+    )
+    strikes = _env_number(
+        "HERMES_LOOP_WATCHDOG_MAX_STRIKES",
+        DEFAULT_LOOP_WATCHDOG_MAX_STRIKES,
+        minimum=1,
+        integer=True,
+    )
+    return interval, timeout, int(strikes)
 _HEARTBEAT_RELATIVE = ("state", "gateway.heartbeat")
 _WATCHDOG_DUMP_RELATIVE = ("logs", "gateway-shutdown-watchdog.log")
 
@@ -110,9 +168,9 @@ def _arm_loop_floor_timer(
 def start_loop_liveness_watchdog(
     loop: asyncio.AbstractEventLoop,
     *,
-    probe_interval: float = DEFAULT_LOOP_WATCHDOG_INTERVAL_S,
-    probe_timeout: float = DEFAULT_LOOP_WATCHDOG_TIMEOUT_S,
-    max_strikes: int = DEFAULT_LOOP_WATCHDOG_MAX_STRIKES,
+    probe_interval: Optional[float] = None,
+    probe_timeout: Optional[float] = None,
+    max_strikes: Optional[int] = None,
     exit_code: int = GATEWAY_SERVICE_RESTART_EXIT_CODE,
 ) -> Optional[_LoopLivenessWatchdogHandle]:
     """Start an out-of-loop watchdog that hard-exits after missed probes.
@@ -122,9 +180,14 @@ def start_loop_liveness_watchdog(
     ``GatewayRunner._start_loop_liveness_guards`` — this module stays
     config-agnostic so bare-loop tests can drive it directly).
     """
-    interval = probe_interval
-    timeout = probe_timeout
-    strikes_limit = max_strikes
+    # An explicit argument always wins: the tests drive this function directly
+    # with bare loops and must not inherit an operator's environment. Only the
+    # unset case consults it, which keeps this module config-agnostic as the
+    # docstring above requires — an env read, never a config.yaml read.
+    env_interval, env_timeout, env_strikes = loop_watchdog_settings()
+    interval = env_interval if probe_interval is None else probe_interval
+    timeout = env_timeout if probe_timeout is None else probe_timeout
+    strikes_limit = env_strikes if max_strikes is None else max_strikes
     stop_event = threading.Event()
 
     def _wait_for_probe(probe_event: threading.Event) -> Optional[bool]:

--- a/tests/gateway/test_loop_liveness_watchdog.py
+++ b/tests/gateway/test_loop_liveness_watchdog.py
@@ -198,3 +198,70 @@ def test_gateway_runner_liveness_guards_start_and_stop():
     floor_timer.cancel.assert_called_once_with()
     assert runner._loop_liveness_watchdog is None
     assert runner._loop_floor_timer_handle is None
+def test_loop_watchdog_budget_is_tunable_per_host(monkeypatch):
+    """The right budget is a property of the HOST, so it has to be settable.
+
+    The probe stats a few files and fsyncs a heartbeat. On a WSL2 VHDX under io
+    pressure that was measured at p99 31s and max 112s — longer than the entire
+    default budget of 10s x 3 strikes — so the watchdog killed loops that were
+    only waiting on the disk. On an NVMe box the tight default is the right
+    answer, because the other half of the trade is how fast a wedged loop dies.
+    Nothing about that is knowable from inside Hermes.
+    """
+    from gateway import shutdown_watchdog as sw
+
+    for name in (
+        "HERMES_LOOP_WATCHDOG_INTERVAL_S",
+        "HERMES_LOOP_WATCHDOG_TIMEOUT_S",
+        "HERMES_LOOP_WATCHDOG_MAX_STRIKES",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    assert sw.loop_watchdog_settings() == (
+        sw.DEFAULT_LOOP_WATCHDOG_INTERVAL_S,
+        sw.DEFAULT_LOOP_WATCHDOG_TIMEOUT_S,
+        sw.DEFAULT_LOOP_WATCHDOG_MAX_STRIKES,
+    ), "defaults moved; this change is supposed to leave them alone"
+
+    monkeypatch.setenv("HERMES_LOOP_WATCHDOG_TIMEOUT_S", "35")
+    monkeypatch.setenv("HERMES_LOOP_WATCHDOG_MAX_STRIKES", "5")
+    monkeypatch.setenv("HERMES_LOOP_WATCHDOG_INTERVAL_S", "20")
+    assert sw.loop_watchdog_settings() == (20.0, 35.0, 5)
+
+
+def test_a_malformed_budget_override_does_not_stop_the_gateway(monkeypatch):
+    """This runs on the boot path. Refusing to start over a typo in an optional
+    tuning variable would trade a slow watchdog for no gateway at all, so a bad
+    value falls back to the default instead of raising."""
+    from gateway import shutdown_watchdog as sw
+
+    monkeypatch.setenv("HERMES_LOOP_WATCHDOG_TIMEOUT_S", "not-a-number")
+    assert sw.loop_watchdog_settings()[1] == sw.DEFAULT_LOOP_WATCHDOG_TIMEOUT_S
+
+    # And a value that would disable the guard in practice is refused too: a
+    # sub-second probe timeout makes every probe a strike.
+    monkeypatch.setenv("HERMES_LOOP_WATCHDOG_TIMEOUT_S", "0.05")
+    assert sw.loop_watchdog_settings()[1] == sw.DEFAULT_LOOP_WATCHDOG_TIMEOUT_S
+
+
+def test_an_explicit_argument_still_beats_the_environment(monkeypatch):
+    """The existing tests drive this function directly with bare loops. They must
+    not inherit an operator's environment, or a tuned host would silently change
+    what the suite is asserting."""
+    from gateway import shutdown_watchdog as sw
+
+    monkeypatch.setenv("HERMES_LOOP_WATCHDOG_TIMEOUT_S", "35")
+    captured = {}
+
+    real_thread = threading.Thread
+
+    def capture(*args, **kwargs):
+        captured["started"] = True
+        return real_thread(target=lambda: None, daemon=True)
+
+    with patch.object(threading, "Thread", capture):
+        handle = sw.start_loop_liveness_watchdog(
+            _immediate_loop(), probe_timeout=2.0, probe_interval=1.0, max_strikes=1
+        )
+    assert captured.get("started") is True
+    if handle is not None:
+        handle.stop()


### PR DESCRIPTION
## Problem

The right budget for the loop-liveness watchdog is a property of the **host's filesystem**, not of Hermes — and there was no way to say so. The three constants were module-level defaults, `gateway/run.py` calls `start_loop_liveness_watchdog(loop)` with no arguments, and no environment or config path reached them. Not a bad default; simply not a knob.

The probe stats a few files and fsyncs a heartbeat. On the WSL2 VHDX that prompted this:

| what | value |
|---|---|
| `/proc/pressure/io` full avg300 | 7.60 |
| stat-and-fsync probe, p99 | 31.5s |
| the same probe, max | 112.6s |
| default budget (`10s` × `3` strikes) | ~90–120s |

So a single filesystem stall could consume the whole strike budget, and the watchdog hard-exited a loop that was only waiting on the disk. On an NVMe host the tight default is the *correct* answer, because the other half of the trade is how quickly a genuinely wedged loop dies. Neither number is knowable from inside the process.

## Change

`HERMES_LOOP_WATCHDOG_{INTERVAL_S,TIMEOUT_S,MAX_STRIKES}` now override. **The defaults are unchanged**, so nothing moves for anyone who does not opt in.

Environment rather than `config.yaml`, deliberately: the docstring on this function states that the module stays config-agnostic so bare-loop tests can drive it directly, and reading config here would break that.

An explicit keyword argument still beats the environment. That is what keeps the existing suite honest on a tuned host — otherwise a box with these set would silently change what the tests assert.

A malformed or too-small value logs and falls back rather than raising. This runs on the boot path; refusing to start over a typo in an optional tuning variable would trade a slow watchdog for no gateway at all. The `1.0` floor also refuses a sub-second timeout, which would make every probe a strike and effectively invert the guard.

## Verification

3 new tests:

- defaults unmoved when nothing is set (so this PR cannot be the thing that changes behaviour for existing installs)
- all three overrides applied together
- malformed and below-floor values falling back
- an explicit argument beating the environment

`pytest tests/gateway/test_loop_liveness_watchdog.py` → **8 passed** on a clean `main` worktree. `ruff` clean.

Posting the local run because this repo does not run checks on PRs from forks.

## Relationship to #90502

Companion, not a duplicate, and independent in the source — different functions, and this branch is one commit on top of `main` with `#90502`'s change deliberately excluded. #90502 removes the most frequent *cause* of the loop being blocked (the watchdog's own heartbeat write). This one lets an operator size the budget for whatever the host does to the rest of the distribution. Either can land without the other.
