### PR TITLE
fix(telegram): log the first confirmed getUpdates progress per generation

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2517,6 +2517,19 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         if generation != self._polling_generation:
             return
+        if not self._polling_progress_event.is_set():
+            # The first confirmed getUpdates round-trip of this generation
+            # resolves the "health pending getUpdates progress" line both
+            # reconnect paths end on. Without it the log stream for
+            # "reconnected and healthy" is byte-identical to "reconnected
+            # and hung" — a wedged long-poll is invisible until a user
+            # notices silence (#90504).
+            logger.info(
+                "[%s] Telegram polling confirmed healthy: getUpdates progressing "
+                "(generation %d)",
+                self.name,
+                generation,
+            )
         self._polling_progress_event.set()
         self._polling_network_error_count = 0
         if generation == self._polling_conflict_recovery_generation:

--- a/tests/gateway/test_telegram_polling_health_confirmation.py
+++ b/tests/gateway/test_telegram_polling_health_confirmation.py
@@ -1,0 +1,110 @@
+"""Regression tests for the Telegram polling health-confirmation log (#90504).
+
+Both reconnect paths end on ``health pending getUpdates progress`` and
+``_record_polling_progress`` used to complete silently, so the log stream for
+"reconnected and healthy" was byte-identical to "reconnected and hung". The
+first confirmed getUpdates round-trip of each generation now emits an INFO
+line, turning the pending line into a resolvable pair whose *absence* after a
+reconnect is a reliable hung-poll signature.
+"""
+
+import asyncio
+import logging
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+    telegram_mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    telegram_mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+    sys.modules.setdefault("telegram.error", telegram_mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import Platform  # noqa: E402
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+def _bare_adapter():
+    a = TelegramAdapter.__new__(TelegramAdapter)
+    a.platform = Platform.TELEGRAM
+    a._fatal_error_code = None
+    a._fatal_error_message = None
+    a._fatal_error_retryable = True
+    a._polling_teardown_started = False
+    a._polling_progress_accepting = True
+    a._polling_generation = 1
+    a._polling_progress_event = asyncio.Event()
+    a._polling_network_error_count = 2
+    a._polling_conflict_count = 3
+    a._polling_conflict_recovery_generation = None
+    a._send_path_degraded = True
+    return a
+
+
+class TestPollingHealthConfirmation:
+    def test_first_progress_emits_confirmed_healthy(self, caplog):
+        a = _bare_adapter()
+        with caplog.at_level(logging.INFO, logger="plugins.platforms.telegram.adapter"):
+            a._record_polling_progress(1)
+        rendered = " | ".join(rec.getMessage() for rec in caplog.records)
+        assert "confirmed healthy" in rendered
+        assert "generation 1" in rendered
+        assert a._polling_progress_event.is_set()
+
+    def test_subsequent_progress_is_silent(self, caplog):
+        """Only the FIRST round-trip of a generation logs — a quiet evening
+        must not spam one INFO per getUpdates poll."""
+        a = _bare_adapter()
+        a._record_polling_progress(1)  # first — logs
+        with caplog.at_level(logging.INFO, logger="plugins.platforms.telegram.adapter"):
+            a._record_polling_progress(1)  # second — silent
+            a._record_polling_progress(1)  # third — silent
+        assert not [
+            rec for rec in caplog.records if "confirmed healthy" in rec.getMessage()
+        ]
+
+    def test_new_generation_logs_again(self, caplog):
+        """A reconnect starts a new generation with a fresh event; its first
+        progress must re-emit the confirmation so the pending line of THAT
+        reconnect also resolves."""
+        a = _bare_adapter()
+        a._record_polling_progress(1)
+        # reconnect: new generation, event reset, counters possibly nonzero
+        a._polling_generation = 2
+        a._polling_progress_event = asyncio.Event()
+        a._polling_network_error_count = 1
+        a._send_path_degraded = True
+        with caplog.at_level(logging.INFO, logger="plugins.platforms.telegram.adapter"):
+            a._record_polling_progress(2)
+        rendered = " | ".join(rec.getMessage() for rec in caplog.records)
+        assert "confirmed healthy" in rendered
+        assert "generation 2" in rendered
+
+    def test_stale_generation_progress_stays_silent(self, caplog):
+        """Progress from an abandoned generation must neither log nor set the
+        current event (pre-existing guard, pinned here because the log line
+        must inherit the same generation-scoping)."""
+        a = _bare_adapter()
+        a._polling_generation = 2
+        a._polling_progress_event = asyncio.Event()
+        with caplog.at_level(logging.INFO, logger="plugins.platforms.telegram.adapter"):
+            a._record_polling_progress(1)
+        assert not [
+            rec for rec in caplog.records if "confirmed healthy" in rec.getMessage()
+        ]
+        assert not a._polling_progress_event.is_set()


### PR DESCRIPTION
## What does this PR do?

Makes a Telegram polling recovery positively confirmable in the log. Both reconnect paths (network-error and conflict-retry) end on the same `health pending getUpdates progress` line, and `_record_polling_progress()` completed silently — so the log stream for "reconnected and healthy" was byte-identical to "reconnected and hung". A wedged long-poll (the #87057 / #69314 / #71239 failure class) stayed invisible until a user noticed silence; the only detection method was sending the bot a test message (#90504; verified still present on current `main`).

The fix implements the issue's suggested option 1: emit one INFO on the **first** confirmed getUpdates round-trip of each generation, placed inside the existing `not event.is_set()` branch so steady-state polling adds no log volume. This turns the pending line into a resolvable pair — `health pending getUpdates progress` → `confirmed healthy` — whose *absence* after a reconnect becomes a reliable hung-poll signature. (Option 2, exposing progress age in the health endpoint, is deliberately out of scope — it is a larger surface change.)

## Related Issue

Fixes #90504

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py` — `_record_polling_progress`: when the generation's progress event transitions unset → set, log `[<name>] Telegram polling confirmed healthy: getUpdates progressing (generation N)`. No behavior change beyond the log line; counters/degraded-flag resets are untouched.
- `tests/gateway/test_telegram_polling_health_confirmation.py` — new: first progress emits the confirmation (with generation number), subsequent progress in the same generation is silent (no per-poll spam), a new generation re-emits after a reconnect, and progress from a stale generation neither logs nor sets the current event (the generation guard, pinned so the log inherits the same scoping).

## How to Test

1. `uv run --python 3.11 --with pytest --with pytest-asyncio --with pyyaml --with python-dotenv --with httpx --with pillow --with requests --with rich --with prompt_toolkit python -m pytest -q -o 'addopts=' tests/gateway/test_telegram_polling_health_confirmation.py`
2. Observed result: 4 passed on this branch; the two emission tests fail on unmodified `main` (no record is ever emitted) while the silence/scoping companions pass — confirming the tests pin exactly the new log contract.
3. Baseline: `tests/gateway/test_telegram_conflict.py` + `test_telegram_start_polling_timeout.py` + `test_telegram_error_redaction.py` — 20 passed, unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (in-code comment documents the contract)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
