### PR TITLE
feat(mcp): trusted generic MCP client access and host capability descriptor for desktop plugins

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -30,6 +30,7 @@ import { setSessionCompacting } from '@/store/compaction'
 import { refreshBackgroundProcesses } from '@/store/composer-status'
 import { $gateway, activeGatewayConnectionId } from '@/store/gateway'
 import { applyGoalStatusText } from '@/store/goals'
+import { hostCapabilityScope, ingestHostCapabilities } from '@/store/host-capabilities'
 import {
   notifyCronChanged,
   notifyPairingChanged,
@@ -431,6 +432,10 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // Backends with the change watcher broadcast pet/cron/sessions change
         // events; consumers demote their legacy polls to slow backstops.
         setChangeEventsAvailable(Boolean((payload as { change_events?: boolean } | undefined)?.change_events))
+        ingestHostCapabilities(
+          (payload as { capabilities?: unknown } | undefined)?.capabilities,
+          hostCapabilityScope(event.connectionId, event.profile ?? (fromActiveSource() ? $activeGatewayProfile.get() : null))
+        )
 
         return
       } else if (event.type === 'skin.changed') {

--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { host } from '@/sdk'
+import { $hostCapabilities, ingestHostCapabilities, resetHostCapabilities } from '@/store/host-capabilities'
 import { setActiveSessionId, setAwaitingResponse, setBusy } from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
 
@@ -105,5 +106,24 @@ describe('host.state turn flags', () => {
     expect(host.state.awaitingResponse.get()).toBe(false)
 
     $sessionTiles.set([])
+  })
+})
+
+describe('host.state capabilities', () => {
+  afterEach(resetHostCapabilities)
+
+  it('exposes the validated active-backend capability atom to plugins', () => {
+    ingestHostCapabilities({
+      'mcp-client-access': {
+        endpoints: ['mcp.client.status', 'mcp.client.tools', 'mcp.client.call'],
+        version: { major: 1, minor: 0 }
+      }
+    })
+
+    expect(host.state.capabilities).toBe($hostCapabilities)
+    expect(host.state.capabilities.get()['mcp-client-access']).toEqual({
+      endpoints: ['mcp.client.status', 'mcp.client.tools', 'mcp.client.call'],
+      version: { major: 1, minor: 0 }
+    })
   })
 })

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -43,6 +43,7 @@ import {
   requestGatewayForProfile,
   retireLocalProfileGateways
 } from '@/store/gateway'
+import { $hostCapabilities, type HostCapabilities } from '@/store/host-capabilities'
 import { notify, notifyError } from '@/store/notifications'
 import {
   $activeGatewayProfile,
@@ -198,6 +199,10 @@ export const host = {
   state: {
     /** Runtime id of the active chat session (null on a fresh draft). */
     activeSessionId: readonlyAtom<null | string>($activeSessionId),
+    /** Versioned contracts advertised by the active backend at gateway.ready.
+     * Missing/malformed descriptors are absent; plugins must check before a
+     * capability-specific request and fail closed when unsupported. */
+    capabilities: readonlyAtom<HostCapabilities>($hostCapabilities),
     /** True from send until the first assistant payload on the focused chat. */
     awaitingResponse: readonlyAtom<boolean>($focusedAwaitingResponse),
     /**

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -4,6 +4,7 @@ import { atom } from 'nanostores'
 import type { HermesConnection } from '@/global'
 import { HermesGateway, setApiRequestConnection } from '@/hermes'
 import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
+import { activateHostCapabilities, clearHostCapabilities, hostCapabilityScope } from '@/store/host-capabilities'
 import { markNativeNotifyBaseline } from '@/store/notify-baseline'
 import { setConnection, setGatewayState } from '@/store/session'
 
@@ -182,6 +183,8 @@ function reportGatewayState(profile: string, state: ConnectionState): void {
   // launch/reconnect doesn't alert about state that already existed.
   if (state === 'open') {
     markNativeNotifyBaseline()
+  } else {
+    clearHostCapabilities(profile)
   }
 
   if (normKey(profile) === g.activeKey) {
@@ -210,6 +213,7 @@ function applyActive(profile: string, activationEpoch: number): boolean {
   }
 
   g.activeKey = normKey(profile)
+  activateHostCapabilities(hostCapabilityScope(activeGatewayConnectionId(), profile))
   const gateway = activeGateway()
   g.$gateway.set(gateway)
   setGatewayState(gateway?.connectionState ?? 'closed')

--- a/apps/desktop/src/store/host-capabilities.test.ts
+++ b/apps/desktop/src/store/host-capabilities.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  $hostCapabilities,
+  activateHostCapabilities,
+  clearHostCapabilities,
+  hostCapabilityScope,
+  ingestHostCapabilities,
+  resetHostCapabilities
+} from './host-capabilities'
+
+const descriptor = {
+  'mcp-client-access': {
+    endpoints: ['mcp.client.status', 'mcp.client.tools', 'mcp.client.call'],
+    version: { major: 1, minor: 0 }
+  }
+}
+
+describe('host capability handshake state', () => {
+  afterEach(resetHostCapabilities)
+
+  it('accepts a bounded versioned descriptor from gateway.ready', () => {
+    ingestHostCapabilities(descriptor)
+
+    expect($hostCapabilities.get()).toEqual(descriptor)
+    expect($hostCapabilities.get()).not.toBe(descriptor)
+  })
+
+  it('isolates cached descriptors by connection and profile on backend switches', () => {
+    const sourceA = hostCapabilityScope('source-a', 'researcher')
+    const sourceB = hostCapabilityScope('source-b', 'researcher')
+
+    ingestHostCapabilities(descriptor, sourceA)
+    activateHostCapabilities(sourceA)
+    expect($hostCapabilities.get()).toEqual(descriptor)
+
+    activateHostCapabilities(sourceB)
+    expect($hostCapabilities.get()).toEqual({})
+
+    ingestHostCapabilities(
+      {
+        'mcp-client-access': {
+          endpoints: ['mcp.client.status', 'mcp.client.tools', 'mcp.client.call'],
+          version: { major: 1, minor: 1 }
+        }
+      },
+      sourceB
+    )
+    expect($hostCapabilities.get()['mcp-client-access']?.version.minor).toBe(1)
+  })
+
+  it.each([
+    null,
+    [],
+    { 'mcp-client-access': { endpoints: ['mcp.client.status'], version: { major: 1, minor: '0' } } },
+    { 'mcp-client-access': { endpoints: ['mcp.client.status', 'mcp.client.status'], version: { major: 1, minor: 0 } } },
+    { 'mcp-client-access': { endpoints: ['bad endpoint'], version: { major: 1, minor: 0 } } },
+    { 'mcp-client-access': { endpoints: ['mcp.client.status'], extra: true, version: { major: 1, minor: 0 } } }
+  ])('drops malformed capability payloads fail-closed', payload => {
+    ingestHostCapabilities(payload)
+
+    expect($hostCapabilities.get()).toEqual({})
+  })
+
+  it('clears backend capabilities before a reconnect can advertise replacements', () => {
+    const scope = hostCapabilityScope('source-a', 'researcher')
+    ingestHostCapabilities(descriptor, scope)
+    activateHostCapabilities(scope)
+    clearHostCapabilities(scope)
+
+    expect($hostCapabilities.get()).toEqual({})
+  })
+})

--- a/apps/desktop/src/store/host-capabilities.ts
+++ b/apps/desktop/src/store/host-capabilities.ts
@@ -1,0 +1,141 @@
+import { registryBackendScopeKey } from '@hermes/shared'
+import { atom } from 'nanostores'
+
+export interface HostCapabilityVersion {
+  major: number
+  minor: number
+}
+
+export interface HostCapabilityDescriptor {
+  endpoints: string[]
+  version: HostCapabilityVersion
+}
+
+export type HostCapabilities = Record<string, HostCapabilityDescriptor>
+
+const CAPABILITY_NAME = /^[a-z][a-z0-9-]{0,63}$/
+const ENDPOINT_NAME = /^[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)+$/
+const MAX_CAPABILITIES = 64
+const MAX_ENDPOINTS = 32
+const MAX_ENDPOINT_LENGTH = 128
+const MAX_VERSION = 1_000
+
+const cachedByScope = new Map<string, HostCapabilities>()
+let activeScope = 'default'
+
+export const $hostCapabilities = atom<HostCapabilities>({})
+
+const plainObject = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+
+function normalizeDescriptor(value: unknown): HostCapabilityDescriptor | null {
+  if (!plainObject(value) || Object.keys(value).some(key => key !== 'endpoints' && key !== 'version')) {
+    return null
+  }
+
+  const version = value.version
+  const endpoints = value.endpoints
+
+  if (
+    !plainObject(version) ||
+    Object.keys(version).some(key => key !== 'major' && key !== 'minor') ||
+    !Number.isSafeInteger(version.major) ||
+    !Number.isSafeInteger(version.minor) ||
+    Number(version.major) < 1 ||
+    Number(version.major) > MAX_VERSION ||
+    Number(version.minor) < 0 ||
+    Number(version.minor) > MAX_VERSION ||
+    !Array.isArray(endpoints) ||
+    endpoints.length === 0 ||
+    endpoints.length > MAX_ENDPOINTS
+  ) {
+    return null
+  }
+
+  const normalizedEndpoints: string[] = []
+  const unique = new Set<string>()
+
+  for (const endpoint of endpoints) {
+    if (
+      typeof endpoint !== 'string' ||
+      endpoint.length > MAX_ENDPOINT_LENGTH ||
+      !ENDPOINT_NAME.test(endpoint) ||
+      unique.has(endpoint)
+    ) {
+      return null
+    }
+
+    unique.add(endpoint)
+    normalizedEndpoints.push(endpoint)
+  }
+
+  return {
+    endpoints: normalizedEndpoints,
+    version: { major: Number(version.major), minor: Number(version.minor) }
+  }
+}
+
+export function normalizeHostCapabilities(value: unknown): HostCapabilities {
+  if (!plainObject(value)) {
+    return {}
+  }
+
+  const entries = Object.entries(value)
+
+  if (entries.length > MAX_CAPABILITIES) {
+    return {}
+  }
+
+  const normalized: HostCapabilities = {}
+
+  for (const [name, descriptor] of entries) {
+    if (!CAPABILITY_NAME.test(name)) {
+      continue
+    }
+
+    const accepted = normalizeDescriptor(descriptor)
+
+    if (accepted) {
+      normalized[name] = accepted
+    }
+  }
+
+  return normalized
+}
+
+export function hostCapabilityScope(
+  connectionId: null | string | undefined,
+  profile: null | string | undefined
+): string {
+  const normalizedProfile = profile?.trim() || 'default'
+
+  return connectionId ? registryBackendScopeKey(connectionId, normalizedProfile) : normalizedProfile
+}
+
+export function ingestHostCapabilities(value: unknown, scope = activeScope): void {
+  const normalized = normalizeHostCapabilities(value)
+
+  cachedByScope.set(scope, normalized)
+
+  if (scope === activeScope) {
+    $hostCapabilities.set(normalized)
+  }
+}
+
+export function activateHostCapabilities(scope: string): void {
+  activeScope = scope
+  $hostCapabilities.set(cachedByScope.get(scope) ?? {})
+}
+
+export function clearHostCapabilities(scope: string): void {
+  cachedByScope.delete(scope)
+
+  if (scope === activeScope) {
+    $hostCapabilities.set({})
+  }
+}
+
+export function resetHostCapabilities(): void {
+  cachedByScope.clear()
+  $hostCapabilities.set({})
+}

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -127,6 +127,7 @@ def test_ws_starts_mcp_discovery_before_ready(monkeypatch):
 
     calls = []
     events = []
+    ready_frames = []
 
     monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0)
     monkeypatch.setattr(entry, "ensure_mcp_discovery_started", lambda: calls.append("mcp"))
@@ -138,6 +139,7 @@ def test_ws_starts_mcp_discovery_before_ready(monkeypatch):
         async def send_text(self, line):
             if '"gateway.ready"' in line:
                 events.append(f"ready_after_{len(calls)}")
+                ready_frames.append(json.loads(line))
 
         async def receive_text(self):
             raise ws_mod._WebSocketDisconnect()
@@ -151,6 +153,7 @@ def test_ws_starts_mcp_discovery_before_ready(monkeypatch):
     # should not start MCP discovery before a profile has been bound.
     assert calls == []
     assert events == ["accept", "ready_after_0"]
+    assert ready_frames[0]["params"]["payload"]["capabilities"] == server.gateway_capabilities()
 
 
 def test_ws_transport_serializes_concurrent_sends():

--- a/tests/tools/test_mcp_client_access.py
+++ b/tests/tools/test_mcp_client_access.py
@@ -1,0 +1,377 @@
+"""Behavioral tests for the default-off MCP client access policy."""
+
+import json
+import logging
+import threading
+
+from unittest.mock import patch
+
+import pytest
+
+from tools.mcp_client_access import (
+    MCPClientAccessError,
+    MCPClientAccessPolicy,
+    _is_mcp_client_runtime_noninteractive,
+    call_mcp_client_tool,
+    list_mcp_client_tools,
+    load_mcp_client_access_policy,
+)
+from tools.mcp_tool import MCPToolProvenance
+from tools.registry import registry
+
+
+def _config(client_access=None):
+    server = {} if client_access is None else {"client_access": client_access}
+    return {"mcp_servers": {"convexopps": server}}
+
+
+@pytest.mark.parametrize(
+    "block",
+    [None, {}, {"enabled": False, "tools": ["whoami"]}, {"enabled": 1, "tools": ["whoami"]}],
+)
+def test_policy_is_default_off(block):
+    with patch("hermes_cli.config.load_config", return_value=_config(block)):
+        policy = load_mcp_client_access_policy("convexopps")
+    assert policy.enabled is False
+    assert policy.ordered_tools == ()
+    assert policy.allows("whoami") is False
+
+
+def test_valid_policy_preserves_order_and_deduplicates_first_occurrence():
+    block = {"enabled": True, "tools": ["search_companies", "whoami", "search_companies"]}
+    with patch("hermes_cli.config.load_config", return_value=_config(block)):
+        policy = load_mcp_client_access_policy("convexopps")
+    assert policy.enabled is True
+    assert policy.ordered_tools == ("search_companies", "whoami")
+    assert policy.allows("whoami") is True
+    assert policy.allows("WhoAmI") is False
+
+
+@pytest.mark.parametrize("tools", ["whoami", {}, None, 42])
+def test_invalid_tools_container_fails_closed(tools):
+    block = {"enabled": True, "tools": tools}
+    with patch("hermes_cli.config.load_config", return_value=_config(block)):
+        policy = load_mcp_client_access_policy("convexopps")
+    assert policy.enabled is True
+    assert policy.ordered_tools == ()
+
+
+def test_invalid_entries_are_rejected_without_affecting_valid_entries():
+    block = {
+        "enabled": True,
+        "tools": ["whoami", "", "   ", 7, "search*", "search?", "tool[name]", "x" * 129],
+    }
+    with patch("hermes_cli.config.load_config", return_value=_config(block)):
+        policy = load_mcp_client_access_policy("convexopps")
+    assert policy.ordered_tools == ("whoami",)
+
+
+def test_reads_current_launch_profile_config_without_override(monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", "/launch-profile-home")
+    observed = {}
+
+    def fake_load_config(*args, **kwargs):
+        observed["args"] = args
+        observed["kwargs"] = kwargs
+        observed["home"] = __import__("os").environ.get("HERMES_HOME")
+        return _config({"enabled": True, "tools": ["whoami"]})
+
+    with patch("hermes_cli.config.load_config", side_effect=fake_load_config):
+        policy = load_mcp_client_access_policy("convexopps")
+    assert policy.ordered_tools == ("whoami",)
+    assert observed == {"args": (), "kwargs": {}, "home": "/launch-profile-home"}
+
+
+def test_catalog_is_policy_ordered_exact_provenance_read_only_intersection():
+    names = ["test_mcp_console_whoami", "test_mcp_console_search", "test_mcp_console_utility"]
+    schemas = {
+        names[0]: {"name": names[0], "description": "Identity", "parameters": {"type": "object"}},
+        names[1]: {"name": names[1], "description": "Search", "parameters": {"type": "object"}},
+        names[2]: {"name": names[2], "description": "Utility", "parameters": {"type": "object"}},
+    }
+    for name in names:
+        registry.register(name=name, toolset="mcp-convexopps", schema=schemas[name], handler=lambda args: "ok")
+    provenance = {
+        names[0]: MCPToolProvenance("convexopps", "whoami"),
+        names[1]: MCPToolProvenance("other-server", "search_companies"),
+        # Generated utility intentionally has no raw provenance.
+    }
+    block = {"enabled": True, "tools": ["search_companies", "whoami", "missing"]}
+    try:
+        with (
+            patch("hermes_cli.config.load_config", return_value=_config(block)),
+            patch("tools.mcp_tool.get_mcp_tool_provenance", side_effect=provenance.get),
+            patch("tools.mcp_tool.is_mcp_tool_read_only", side_effect=lambda server, tool: tool == "whoami"),
+        ):
+            catalog = list_mcp_client_tools("convexopps")
+    finally:
+        for name in names:
+            registry.deregister(name)
+    assert catalog == [{"name": "whoami", "description": "Identity", "input_schema": {"type": "object"}}]
+
+
+def test_catalog_rejects_oversized_server_controlled_input_schema():
+    name = "test_mcp_console_oversized_schema"
+    registry.register(
+        name=name,
+        toolset="mcp-convexopps",
+        schema={
+            "name": name,
+            "description": "Identity",
+            "parameters": {"type": "object", "description": "x" * 70_000},
+        },
+        handler=lambda args: "ok",
+    )
+    block = {"enabled": True, "tools": ["whoami"]}
+    try:
+        with (
+            patch("hermes_cli.config.load_config", return_value=_config(block)),
+            patch(
+                "tools.mcp_tool.get_mcp_tool_provenance",
+                side_effect=lambda registry_name: MCPToolProvenance("convexopps", "whoami")
+                if registry_name == name else None,
+            ),
+            patch("tools.mcp_tool.is_mcp_tool_read_only", return_value=True),
+        ):
+            with pytest.raises(MCPClientAccessError) as exc:
+                list_mcp_client_tools("convexopps")
+    finally:
+        registry.deregister(name)
+    assert exc.value.code == "MCP_CLIENT_RESULT_CONTRACT"
+    assert "input schema" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "sampling,elicitation",
+    [({}, {"enabled": False}), ({"enabled": True}, {"enabled": False}),
+     ({"enabled": False}, {}), ({"enabled": False}, {"enabled": True})],
+)
+def test_noninteractive_requires_explicit_false_false(sampling, elicitation):
+    config = _config({"enabled": True, "tools": ["whoami"]})
+    config["mcp_servers"]["convexopps"].update(
+        {"sampling": sampling, "elicitation": elicitation}
+    )
+    with (
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch("tools.mcp_tool.get_mcp_client_runtime_state", return_value={"live": False}),
+    ):
+        assert _is_mcp_client_runtime_noninteractive("convexopps") is False
+
+
+def test_noninteractive_rejects_stale_live_handlers_but_allows_lazy_server():
+    config = _config({"enabled": True, "tools": ["whoami"]})
+    config["mcp_servers"]["convexopps"].update(
+        {"sampling": {"enabled": False}, "elicitation": {"enabled": False}}
+    )
+    with patch("hermes_cli.config.load_config", return_value=config):
+        with patch(
+            "tools.mcp_tool.get_mcp_client_runtime_state",
+            return_value={"live": True, "sampling_handler": True, "elicitation_handler": False},
+        ):
+            assert _is_mcp_client_runtime_noninteractive("convexopps") is False
+        with patch("tools.mcp_tool.get_mcp_client_runtime_state", return_value={"live": False}):
+            assert _is_mcp_client_runtime_noninteractive("convexopps") is True
+
+
+def _call_patches(registry_name, raw_name="whoami", *, read_only=True, interactive=False):
+    config = _config({"enabled": True, "tools": [raw_name]})
+    config["mcp_servers"]["convexopps"].update(
+        {"sampling": {"enabled": False}, "elicitation": {"enabled": False}}
+    )
+    return (
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch(
+            "tools.mcp_tool.get_mcp_tool_provenance",
+            side_effect=lambda name: MCPToolProvenance("convexopps", raw_name)
+            if name == registry_name else None,
+        ),
+        patch("tools.mcp_tool.is_mcp_tool_read_only", return_value=read_only),
+        patch(
+            "tools.mcp_tool.get_mcp_client_runtime_state",
+            return_value={"live": True, "sampling_handler": interactive, "elicitation_handler": False},
+        ),
+    )
+
+
+def test_call_dispatches_exact_registry_handler_and_normalizes_result():
+    name = "test_mcp_client_call_whoami"
+    calls = []
+    registry.register(
+        name=name, toolset="mcp-convexopps",
+        schema={"name": name, "description": "Identity", "parameters": {"type": "object"}},
+        handler=lambda args: calls.append(args) or json.dumps({"result": "ok"}),
+    )
+    try:
+        patches = _call_patches(name)
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = call_mcp_client_tool("convexopps", "whoami", {"include_email": False})
+    finally:
+        registry.deregister(name)
+    assert calls == [{"include_email": False}]
+    assert result.ok is True
+    assert result.result_text == '{"result": "ok"}'
+    assert result.truncated is False
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [[], "bad", None, {"value": float("nan")}, {"value": "x" * 65_537}],
+)
+def test_invalid_or_oversized_arguments_never_dispatch(arguments):
+    with pytest.raises(MCPClientAccessError) as exc:
+        call_mcp_client_tool("convexopps", "whoami", arguments)
+    assert exc.value.code == "MCP_CLIENT_INVALID_PARAMS"
+
+
+def test_policy_readonly_and_interactive_denials_never_dispatch():
+    name = "test_mcp_client_denial"
+    called = []
+    registry.register(
+        name=name, toolset="mcp-convexopps", schema={"name": name, "parameters": {}},
+        handler=lambda args: called.append(args) or "ok",
+    )
+    try:
+        patches = _call_patches(name, read_only=False)
+        with patches[0], patches[1], patches[2], patches[3]:
+            with pytest.raises(MCPClientAccessError) as exc:
+                call_mcp_client_tool("convexopps", "whoami", {})
+        assert exc.value.code == "MCP_CLIENT_NOT_READ_ONLY"
+        patches = _call_patches(name, interactive=True)
+        with patches[0], patches[1], patches[2], patches[3]:
+            with pytest.raises(MCPClientAccessError) as exc:
+                call_mcp_client_tool("convexopps", "whoami", {})
+        assert exc.value.code == "MCP_CLIENT_INTERACTIVE_RUNTIME"
+    finally:
+        registry.deregister(name)
+    assert called == []
+
+
+def test_policy_revocation_is_rechecked_immediately_before_dispatch():
+    name = "test_mcp_client_policy_revoked"
+    called = []
+    registry.register(
+        name=name,
+        toolset="mcp-convexopps",
+        schema={"name": name, "parameters": {}},
+        handler=lambda args: called.append(args) or "ok",
+    )
+    try:
+        with (
+            patch(
+                "tools.mcp_client_access.load_mcp_client_access_policy",
+                side_effect=[
+                    MCPClientAccessPolicy(True, ("whoami",)),
+                    MCPClientAccessPolicy(False, ()),
+                ],
+            ),
+            patch("tools.mcp_client_access._find_registry_tool", return_value=name),
+            patch("tools.mcp_tool.is_mcp_tool_read_only", return_value=True),
+            patch("tools.mcp_client_access._is_mcp_client_runtime_noninteractive", return_value=True),
+        ):
+            with pytest.raises(MCPClientAccessError) as exc:
+                call_mcp_client_tool("convexopps", "whoami", {})
+    finally:
+        registry.deregister(name)
+    assert exc.value.code == "MCP_CLIENT_DISABLED"
+    assert called == []
+
+
+def test_concurrent_second_call_is_busy_without_queueing():
+    name = "test_mcp_client_busy"
+    entered = threading.Event()
+    release = threading.Event()
+
+    def handler(args):
+        entered.set()
+        assert release.wait(5)
+        return '{"result":"ok"}'
+
+    registry.register(name=name, toolset="mcp-convexopps", schema={"name": name, "parameters": {}}, handler=handler)
+    patches = _call_patches(name)
+    first = []
+    try:
+        with patches[0], patches[1], patches[2], patches[3]:
+            thread = threading.Thread(target=lambda: first.append(call_mcp_client_tool("convexopps", "whoami", {})))
+            thread.start()
+            assert entered.wait(2)
+            with pytest.raises(MCPClientAccessError) as exc:
+                call_mcp_client_tool("convexopps", "whoami", {})
+            assert exc.value.code == "MCP_CLIENT_BUSY"
+            release.set()
+            thread.join(5)
+    finally:
+        release.set()
+        registry.deregister(name)
+    assert len(first) == 1
+
+
+def test_result_is_utf8_safely_truncated_to_one_mibibyte():
+    name = "test_mcp_client_large_result"
+    payload = "🙂" * 300_000
+    registry.register(name=name, toolset="mcp-convexopps", schema={"name": name, "parameters": {}}, handler=lambda args: payload)
+    try:
+        patches = _call_patches(name)
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = call_mcp_client_tool("convexopps", "whoami", {})
+    finally:
+        registry.deregister(name)
+    assert result.truncated is True
+    assert result.result_text.endswith("\n… [truncated]")
+    assert len(result.result_text.encode("utf-8")) <= 1_048_576
+
+
+def test_result_strips_backend_session_credential_metadata():
+    name = "test_mcp_client_session_metadata"
+    payload = {
+        "result": {"company": "NOKIA"},
+        "structuredContent": {
+            "company": "NOKIA",
+            "_meta": {
+                "schema_version": "5",
+                "session": {
+                    "token_expires_at": "2030-01-01T00:00:00Z",
+                    "refresh_required_before": "2029-12-31T23:00:00Z",
+                    "state": "ok",
+                },
+            },
+        },
+    }
+    registry.register(
+        name=name,
+        toolset="mcp-convexopps",
+        schema={"name": name, "parameters": {}},
+        handler=lambda args: json.dumps(payload),
+    )
+    try:
+        patches = _call_patches(name)
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = call_mcp_client_tool("convexopps", "whoami", {})
+    finally:
+        registry.deregister(name)
+    decoded = json.loads(result.result_text)
+    assert decoded["result"] == {"company": "NOKIA"}
+    assert decoded["structuredContent"]["company"] == "NOKIA"
+    assert decoded["structuredContent"]["_meta"] == {"schema_version": "5"}
+    assert "token_expires_at" not in result.result_text
+    assert "refresh_required_before" not in result.result_text
+
+
+def test_exception_credentials_are_redacted_and_audit_log_omits_arguments(caplog):
+    name = "test_mcp_client_secret_error"
+    canary = "mcp-client-canary-7d3f9a1c5e"
+
+    def handler(args):
+        raise RuntimeError(f"upstream failed Bearer {canary} token={canary}")
+
+    registry.register(name=name, toolset="mcp-convexopps", schema={"name": name, "parameters": {}}, handler=handler)
+    try:
+        patches = _call_patches(name)
+        with caplog.at_level(logging.INFO), patches[0], patches[1], patches[2], patches[3]:
+            result = call_mcp_client_tool("convexopps", "whoami", {"private_argument": canary})
+    finally:
+        registry.deregister(name)
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert canary not in result.result_text
+    assert canary not in logged
+    assert "private_argument" not in logged
+    assert result.ok is False

--- a/tests/tools/test_mcp_client_access.py
+++ b/tests/tools/test_mcp_client_access.py
@@ -21,6 +21,8 @@ from tools.registry import registry
 
 
 def _config(client_access=None):
+    if isinstance(client_access, dict) and client_access.get("enabled") is True and "tools" in client_access and "operator_read_only" not in client_access:
+        client_access = {**client_access, "operator_read_only": True}
     server = {} if client_access is None else {"client_access": client_access}
     return {"mcp_servers": {"convexopps": server}}
 
@@ -45,6 +47,14 @@ def test_valid_policy_preserves_order_and_deduplicates_first_occurrence():
     assert policy.ordered_tools == ("search_companies", "whoami")
     assert policy.allows("whoami") is True
     assert policy.allows("WhoAmI") is False
+
+
+def test_policy_requires_explicit_operator_read_only_declaration():
+    config = {"mcp_servers": {"convexopps": {"client_access": {"enabled": True, "tools": ["whoami"]}}}}
+    with patch("hermes_cli.config.load_config", return_value=config):
+        policy = load_mcp_client_access_policy("convexopps")
+    assert policy.enabled is True
+    assert policy.ordered_tools == ()
 
 
 @pytest.mark.parametrize("tools", ["whoami", {}, None, 42])
@@ -178,6 +188,11 @@ def _call_patches(registry_name, raw_name="whoami", *, read_only=True, interacti
     config["mcp_servers"]["convexopps"].update(
         {"sampling": {"enabled": False}, "elicitation": {"enabled": False}}
     )
+    entry = registry.get_entry(registry_name)
+    if entry is not None:
+        setattr(entry.handler, "_hermes_mcp_client_server", "convexopps")
+        setattr(entry.handler, "_hermes_mcp_client_raw_tool", raw_name)
+        setattr(entry.handler, "_hermes_mcp_client_read_only_hint", read_only)
     return (
         patch("hermes_cli.config.load_config", return_value=config),
         patch(
@@ -255,6 +270,11 @@ def test_policy_revocation_is_rechecked_immediately_before_dispatch():
         schema={"name": name, "parameters": {}},
         handler=lambda args: called.append(args) or "ok",
     )
+    entry = registry.get_entry(name)
+    assert entry is not None
+    setattr(entry.handler, "_hermes_mcp_client_server", "convexopps")
+    setattr(entry.handler, "_hermes_mcp_client_raw_tool", "whoami")
+    setattr(entry.handler, "_hermes_mcp_client_read_only_hint", True)
     try:
         with (
             patch(
@@ -264,8 +284,7 @@ def test_policy_revocation_is_rechecked_immediately_before_dispatch():
                     MCPClientAccessPolicy(False, ()),
                 ],
             ),
-            patch("tools.mcp_client_access._find_registry_tool", return_value=name),
-            patch("tools.mcp_tool.is_mcp_tool_read_only", return_value=True),
+            patch("tools.mcp_client_access._find_registry_entry", return_value=entry),
             patch("tools.mcp_client_access._is_mcp_client_runtime_noninteractive", return_value=True),
         ):
             with pytest.raises(MCPClientAccessError) as exc:
@@ -274,6 +293,45 @@ def test_policy_revocation_is_rechecked_immediately_before_dispatch():
         registry.deregister(name)
     assert exc.value.code == "MCP_CLIENT_DISABLED"
     assert called == []
+
+
+def test_notification_refresh_cannot_swap_the_authorized_handler_before_dispatch():
+    name = "test_mcp_client_refresh_swap"
+    old_calls = []
+    new_calls = []
+
+    def old_handler(args):
+        old_calls.append(args)
+        return '{"result":"old"}'
+
+    registry.register(name=name, toolset="mcp-convexopps", schema={"name": name, "parameters": {}}, handler=old_handler)
+    patches = _call_patches(name)
+    checks = 0
+
+    def noninteractive(_server):
+        nonlocal checks
+        checks += 1
+        if checks == 2:
+            def new_handler(args):
+                new_calls.append(args)
+                return '{"result":"new"}'
+            setattr(new_handler, "_hermes_mcp_client_server", "convexopps")
+            setattr(new_handler, "_hermes_mcp_client_raw_tool", "whoami")
+            setattr(new_handler, "_hermes_mcp_client_read_only_hint", True)
+            registry.register(name=name, toolset="mcp-convexopps", schema={"name": name, "parameters": {}}, handler=new_handler)
+        return True
+
+    try:
+        with patches[0], patches[1], patches[2], patch(
+            "tools.mcp_client_access._is_mcp_client_runtime_noninteractive",
+            side_effect=noninteractive,
+        ):
+            result = call_mcp_client_tool("convexopps", "whoami", {})
+    finally:
+        registry.deregister(name)
+    assert result.result_text == '{"result":"old"}'
+    assert old_calls == [{}]
+    assert new_calls == []
 
 
 def test_concurrent_second_call_is_busy_without_queueing():
@@ -354,6 +412,23 @@ def test_result_strips_backend_session_credential_metadata():
     assert decoded["structuredContent"]["_meta"] == {"schema_version": "5"}
     assert "token_expires_at" not in result.result_text
     assert "refresh_required_before" not in result.result_text
+
+
+def test_structured_error_envelope_is_never_reported_as_ok():
+    name = "test_mcp_client_structured_error"
+    registry.register(
+        name=name,
+        toolset="mcp-convexopps",
+        schema={"name": name, "parameters": {}},
+        handler=lambda args: json.dumps({"error": {"code": "upstream_failed"}}),
+    )
+    try:
+        patches = _call_patches(name)
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = call_mcp_client_tool("convexopps", "whoami", {})
+    finally:
+        registry.deregister(name)
+    assert result.ok is False
 
 
 def test_exception_credentials_are_redacted_and_audit_log_omits_arguments(caplog):

--- a/tests/tools/test_mcp_lazy_start.py
+++ b/tests/tools/test_mcp_lazy_start.py
@@ -43,6 +43,7 @@ def _fake_cache_entry():
                 "name": "browser_navigate",
                 "description": "Navigate",
                 "inputSchema": {"type": "object", "properties": {}},
+                "annotations": {"readOnlyHint": True},
             }
         ],
         "utility_tools": [],
@@ -318,6 +319,25 @@ class TestCacheLoadDescriptionScan:
             mcp._register_from_cache_sync("playwright", config, entry)
 
         mock_scan.assert_called_once_with("playwright", "browser_navigate", "Navigate")
+
+    def test_lazy_handler_binds_client_identity_and_read_only_hint(self):
+        from tools.registry import registry
+
+        names = mcp._register_from_cache_sync(
+            "playwright",
+            {"command": "npx", "args": [], "lazy": True},
+            _fake_cache_entry(),
+        )
+        try:
+            assert len(names) == 1
+            entry = registry.get_entry(names[0])
+            assert entry is not None
+            assert getattr(entry.handler, "_hermes_mcp_client_server") == "playwright"
+            assert getattr(entry.handler, "_hermes_mcp_client_raw_tool") == "browser_navigate"
+            assert getattr(entry.handler, "_hermes_mcp_client_read_only_hint") is True
+        finally:
+            for registry_name in names:
+                registry.deregister(registry_name)
 
 
 class TestResolveServerLazy:

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -16,6 +16,56 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+def test_exact_mcp_tool_provenance_and_read_only_accessors():
+    from tools import mcp_tool
+
+    registry_name = "mcp__foo_bar__read_file"
+    saved_server = mcp_tool._mcp_tool_server_names.get(registry_name)
+    saved_provenance = mcp_tool._mcp_tool_provenance.get(registry_name)
+    saved_hints = dict(mcp_tool._tool_read_only_hints.get("foo-bar", {}))
+    try:
+        mcp_tool._track_mcp_tool_server(registry_name, "foo-bar", "read-file")
+        mcp_tool._tool_read_only_hints["foo-bar"] = {"read-file": True, "write": False}
+        assert mcp_tool.get_mcp_tool_provenance(registry_name) == mcp_tool.MCPToolProvenance(
+            server_name="foo-bar", raw_tool_name="read-file"
+        )
+        assert mcp_tool.is_mcp_tool_read_only("foo-bar", "read-file") is True
+        assert mcp_tool.is_mcp_tool_read_only("foo-bar", "write") is False
+        assert mcp_tool.is_mcp_tool_read_only("foo-bar", "missing") is False
+        mcp_tool._forget_mcp_tool_server(registry_name)
+        assert mcp_tool.get_mcp_tool_provenance(registry_name) is None
+    finally:
+        if saved_server is not None:
+            mcp_tool._mcp_tool_server_names[registry_name] = saved_server
+        else:
+            mcp_tool._mcp_tool_server_names.pop(registry_name, None)
+        if saved_provenance is not None:
+            mcp_tool._mcp_tool_provenance[registry_name] = saved_provenance
+        else:
+            mcp_tool._mcp_tool_provenance.pop(registry_name, None)
+        mcp_tool._tool_read_only_hints["foo-bar"] = saved_hints
+
+
+def test_mcp_client_runtime_state_reports_handlers_without_exposing_server():
+    from tools import mcp_tool
+
+    server = SimpleNamespace(_sampling=object(), _elicitation=None)
+    saved = mcp_tool._servers.get("runtime-test")
+    try:
+        mcp_tool._servers["runtime-test"] = server
+        assert mcp_tool.get_mcp_client_runtime_state("runtime-test") == {
+            "live": True,
+            "sampling_handler": True,
+            "elicitation_handler": False,
+        }
+        assert mcp_tool.get_mcp_client_runtime_state("lazy-runtime-test") == {"live": False}
+    finally:
+        if saved is None:
+            mcp_tool._servers.pop("runtime-test", None)
+        else:
+            mcp_tool._servers["runtime-test"] = saved
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -291,6 +291,30 @@ class TestToolsetAvailability:
         assert "error" in result
         assert "RuntimeError" in result["error"]
 
+    def test_handler_exception_redacts_credentials_before_logging_and_return(self, caplog):
+        reg = ToolRegistry()
+        canary = "registry-canary-4f8d2a9c7b6e5d1f"
+
+        def bad_handler(args, **kw):
+            raise RuntimeError(
+                f"upstream unavailable Bearer {canary} "
+                f"token={canary} secret={canary}; retry later"
+            )
+
+        reg.register(
+            name="bad-secret", toolset="s", schema=_make_schema(), handler=bad_handler
+        )
+        with caplog.at_level(logging.ERROR, logger="tools.registry"):
+            result = json.loads(reg.dispatch("bad-secret", {}))
+
+        logged = "\n".join(record.getMessage() for record in caplog.records)
+        assert canary not in logged
+        assert canary not in result["error"]
+        assert "upstream unavailable" in result["error"]
+        assert "retry later" in result["error"]
+        assert len(result["error"]) <= _MAX_TOOL_ERROR_CHARS + 200
+        assert all(len(record.getMessage()) < _MAX_LOGGED_ERROR_CHARS + 200 for record in caplog.records)
+
 
 class TestCheckFnExceptionHandling:
     """Verify that a raising check_fn is caught rather than crashing."""

--- a/tests/tui_gateway/test_mcp_client_access_rpc.py
+++ b/tests/tui_gateway/test_mcp_client_access_rpc.py
@@ -1,0 +1,130 @@
+"""Gateway contract for launch-profile-only MCP client RPCs."""
+
+from dataclasses import asdict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.mcp_client_access import MCPClientAccessError, MCPClientCallResult
+
+
+@pytest.fixture()
+def server():
+    with patch.dict("sys.modules", {
+        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
+        "hermes_cli.env_loader": MagicMock(), "hermes_cli.banner": MagicMock(),
+        "hermes_state": MagicMock(),
+    }):
+        import tui_gateway.server as mod
+    return mod
+
+
+@pytest.mark.parametrize("method", ["mcp.client.status", "mcp.client.tools", "mcp.client.call"])
+def test_mcp_client_methods_are_registered_and_pool_routed(server, method):
+    assert method in server._methods
+    assert method in server._LONG_HANDLERS
+
+
+def test_profile_mismatch_fails_before_service_lookup(server):
+    with (
+        patch("hermes_cli.profiles.get_active_profile_name", return_value="researcher"),
+        patch("tools.mcp_client_access.load_mcp_client_access_policy") as policy,
+        patch("tools.mcp_client_access.call_mcp_client_tool") as call,
+    ):
+        response = server._methods["mcp.client.call"](
+            "1", {"server": "convexopps", "tool": "whoami", "arguments": {}, "profile": "other"}
+        )
+    assert response["error"]["code"] == 4601
+    policy.assert_not_called()
+    call.assert_not_called()
+
+
+def test_call_returns_exact_contract(server):
+    result = MCPClientCallResult("mcpui_1", "convexopps", "whoami", True, 12, '{"result":"ok"}', False)
+    with (
+        patch("hermes_cli.profiles.get_active_profile_name", return_value="researcher"),
+        patch("tools.mcp_client_access.call_mcp_client_tool", return_value=result) as call,
+    ):
+        response = server._methods["mcp.client.call"](
+            "1", {"server": "convexopps", "tool": "whoami", "arguments": {}, "profile": "researcher"}
+        )
+    assert response["result"] == asdict(result)
+    call.assert_called_once_with("convexopps", "whoami", {})
+
+
+def test_call_holds_reload_lock_through_policy_and_dispatch(server):
+    result = MCPClientCallResult("mcpui_1", "convexopps", "whoami", True, 12, "ok", False)
+
+    def assert_reload_stable(*_args):
+        assert server._mcp_reload_lock.locked()
+        return result
+
+    with (
+        patch("hermes_cli.profiles.get_active_profile_name", return_value="researcher"),
+        patch("tools.mcp_client_access.call_mcp_client_tool", side_effect=assert_reload_stable),
+    ):
+        response = server._methods["mcp.client.call"](
+            "1", {"server": "convexopps", "tool": "whoami", "arguments": {}, "profile": "researcher"}
+        )
+    assert response["result"] == asdict(result)
+
+
+@pytest.mark.parametrize(
+    "method,params",
+    [
+        ("mcp.client.status", {"server": "x" * 129, "profile": "researcher"}),
+        ("mcp.client.tools", {"server": "convex*", "profile": "researcher"}),
+        (
+            "mcp.client.call",
+            {"server": "convexopps", "tool": "who?ami", "arguments": {}, "profile": "researcher"},
+        ),
+    ],
+)
+def test_invalid_exact_names_fail_before_service_lookup(server, method, params):
+    with (
+        patch("hermes_cli.profiles.get_active_profile_name", return_value="researcher"),
+        patch("tools.mcp_client_access.get_mcp_client_status") as status,
+        patch("tools.mcp_client_access.list_mcp_client_tools") as tools,
+        patch("tools.mcp_client_access.call_mcp_client_tool") as call,
+    ):
+        response = server._methods[method]("1", params)
+    assert response["error"]["code"] == 4600
+    status.assert_not_called()
+    tools.assert_not_called()
+    call.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "symbol,numeric",
+    [("MCP_CLIENT_INVALID_PARAMS", 4600), ("MCP_CLIENT_DISABLED", 4602),
+     ("MCP_CLIENT_SERVER_UNAVAILABLE", 4603), ("MCP_CLIENT_TOOL_DENIED", 4604),
+     ("MCP_CLIENT_NOT_READ_ONLY", 4605), ("MCP_CLIENT_INTERACTIVE_RUNTIME", 4606),
+     ("MCP_CLIENT_BUSY", 4607), ("MCP_CLIENT_RESULT_CONTRACT", 4608)],
+)
+def test_call_maps_stable_service_errors(server, symbol, numeric):
+    with (
+        patch("hermes_cli.profiles.get_active_profile_name", return_value="researcher"),
+        patch("tools.mcp_client_access.call_mcp_client_tool", side_effect=MCPClientAccessError(symbol, "safe")),
+    ):
+        response = server._methods["mcp.client.call"](
+            "1", {"server": "convexopps", "tool": "whoami", "arguments": {}, "profile": "researcher"}
+        )
+    assert response["error"] == {"code": numeric, "message": "safe"}
+
+
+def test_status_and_tools_are_introspection_only(server):
+    status = {"server": "convexopps", "configured": True, "connected": True}
+    tools = [{"name": "whoami", "description": "Identity", "input_schema": {}}]
+    with (
+        patch("hermes_cli.profiles.get_active_profile_name", return_value="researcher"),
+        patch("tools.mcp_client_access.get_mcp_client_status", return_value=status) as get_status,
+        patch("tools.mcp_client_access.list_mcp_client_tools", return_value=tools) as get_tools,
+        patch("tools.mcp_client_access.call_mcp_client_tool") as call,
+    ):
+        status_response = server._methods["mcp.client.status"]("1", {"server": "convexopps", "profile": "researcher"})
+        tools_response = server._methods["mcp.client.tools"]("2", {"server": "convexopps", "profile": "researcher"})
+    assert status_response["result"] == status
+    assert tools_response["result"] == {"server": "convexopps", "tools": tools}
+    get_status.assert_called_once_with("convexopps")
+    get_tools.assert_called_once_with("convexopps")
+    call.assert_not_called()

--- a/tests/tui_gateway/test_mcp_client_access_rpc.py
+++ b/tests/tui_gateway/test_mcp_client_access_rpc.py
@@ -25,6 +25,19 @@ def test_mcp_client_methods_are_registered_and_pool_routed(server, method):
     assert method in server._LONG_HANDLERS
 
 
+def test_gateway_capabilities_advertise_versioned_mcp_client_access(server):
+    assert server.gateway_capabilities() == {
+        "mcp-client-access": {
+            "version": {"major": 1, "minor": 0},
+            "endpoints": [
+                "mcp.client.status",
+                "mcp.client.tools",
+                "mcp.client.call",
+            ],
+        }
+    }
+
+
 def test_profile_mismatch_fails_before_service_lookup(server):
     with (
         patch("hermes_cli.profiles.get_active_profile_name", return_value="researcher"),

--- a/tools/mcp_client_access.py
+++ b/tools/mcp_client_access.py
@@ -69,6 +69,8 @@ def load_mcp_client_access_policy(server_name: str) -> MCPClientAccessPolicy:
     block = server.get("client_access") if isinstance(server, dict) else None
     if not isinstance(block, dict) or block.get("enabled") is not True:
         return MCPClientAccessPolicy(enabled=False, ordered_tools=())
+    if block.get("operator_read_only") is not True:
+        return MCPClientAccessPolicy(enabled=True, ordered_tools=())
 
     configured_tools = block.get("tools")
     if not isinstance(configured_tools, list):
@@ -200,18 +202,19 @@ def get_mcp_client_status(server_name: str) -> dict:
     }
 
 
-def _find_registry_tool(server_name: str, raw_tool_name: str) -> str | None:
-    from tools.mcp_tool import get_mcp_tool_provenance
+def _find_registry_entry(server_name: str, raw_tool_name: str):
+    """Resolve one immutable handler entry carrying registration-time MCP identity."""
     from tools.registry import registry
 
-    for registry_name in registry.get_all_tool_names():
-        provenance = get_mcp_tool_provenance(registry_name)
+    expected_toolset = f"mcp-{server_name}"
+    for entry in registry.get_all_entries():
+        handler = entry.handler
         if (
-            provenance is not None
-            and provenance.server_name == server_name
-            and provenance.raw_tool_name == raw_tool_name
+            entry.toolset == expected_toolset
+            and getattr(handler, "_hermes_mcp_client_server", None) == server_name
+            and getattr(handler, "_hermes_mcp_client_raw_tool", None) == raw_tool_name
         ):
-            return registry_name
+            return entry
     return None
 
 
@@ -284,13 +287,11 @@ def call_mcp_client_tool(
     if not policy.allows(tool_name):
         raise MCPClientAccessError("MCP_CLIENT_TOOL_DENIED", "MCP tool is not allowlisted")
 
-    registry_name = _find_registry_tool(server_name, tool_name)
-    if registry_name is None:
+    registry_entry = _find_registry_entry(server_name, tool_name)
+    if registry_entry is None:
         raise MCPClientAccessError("MCP_CLIENT_SERVER_UNAVAILABLE", "MCP tool is unavailable")
 
-    from tools.mcp_tool import is_mcp_tool_read_only
-
-    if not is_mcp_tool_read_only(server_name, tool_name):
+    if getattr(registry_entry.handler, "_hermes_mcp_client_read_only_hint", None) is not True:
         raise MCPClientAccessError("MCP_CLIENT_NOT_READ_ONLY", "MCP tool is not marked read-only")
     if not _is_mcp_client_runtime_noninteractive(server_name):
         raise MCPClientAccessError(
@@ -318,23 +319,21 @@ def call_mcp_client_tool(
             raise MCPClientAccessError("MCP_CLIENT_DISABLED", "MCP client access is disabled")
         if not current_policy.allows(tool_name):
             raise MCPClientAccessError("MCP_CLIENT_TOOL_DENIED", "MCP tool is not allowlisted")
-        if not is_mcp_tool_read_only(server_name, tool_name):
+        if getattr(registry_entry.handler, "_hermes_mcp_client_read_only_hint", None) is not True:
             raise MCPClientAccessError("MCP_CLIENT_NOT_READ_ONLY", "MCP tool is not marked read-only")
         if not _is_mcp_client_runtime_noninteractive(server_name):
             raise MCPClientAccessError(
                 "MCP_CLIENT_INTERACTIVE_RUNTIME", "MCP runtime must be reloaded as non-interactive"
             )
 
-        dispatched = registry.dispatch(registry_name, arguments)
+        dispatched = registry.dispatch_entry(registry_entry, arguments)
         if not isinstance(dispatched, str):
             raise MCPClientAccessError(
                 "MCP_CLIENT_RESULT_CONTRACT", "MCP tool returned an unsupported result"
             )
         safe_dispatched, envelope = _strip_session_credential_metadata(dispatched)
         result_text, truncated = _bounded_result_text(safe_dispatched)
-        ok = not (
-            isinstance(envelope, dict) and isinstance(envelope.get("error"), str)
-        )
+        ok = not (isinstance(envelope, dict) and ("error" in envelope or envelope.get("isError") is True))
         duration_ms = max(0, int((time.monotonic() - started) * 1000))
         return MCPClientCallResult(
             request_id=request_id,

--- a/tools/mcp_client_access.py
+++ b/tools/mcp_client_access.py
@@ -1,0 +1,354 @@
+"""Default-off policy for trusted local MCP client surfaces.
+
+This module grants a narrow execution capability over Hermes's existing MCP
+registry.  It does not create or own an MCP transport or OAuth client.
+"""
+
+from dataclasses import dataclass
+import json
+import logging
+import threading
+import time
+import uuid
+
+
+_MAX_NAME_CHARS = 128
+_GLOB_CHARS = frozenset("*?[")
+_MAX_DESCRIPTION_CHARS = 4096
+_MAX_INPUT_SCHEMA_BYTES = 65_536
+_MAX_ARGUMENT_BYTES = 65_536
+_MAX_RESULT_BYTES = 1_048_576
+_RESULT_TRUNCATION_MARKER = "\n… [truncated]"
+logger = logging.getLogger(__name__)
+_client_locks_guard = threading.Lock()
+_client_locks: dict[str, threading.Lock] = {}
+
+
+class MCPClientAccessError(Exception):
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class MCPClientCallResult:
+    request_id: str
+    server: str
+    tool: str
+    ok: bool
+    duration_ms: int
+    result_text: str
+    truncated: bool
+
+
+@dataclass(frozen=True)
+class MCPClientAccessPolicy:
+    enabled: bool
+    ordered_tools: tuple[str, ...]
+
+    def allows(self, raw_tool_name: str) -> bool:
+        return self.enabled and raw_tool_name in self.ordered_tools
+
+
+def _valid_exact_name(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and bool(value.strip())
+        and len(value) <= _MAX_NAME_CHARS
+        and not any(char in value for char in _GLOB_CHARS)
+    )
+
+
+def load_mcp_client_access_policy(server_name: str) -> MCPClientAccessPolicy:
+    """Load one server's exact ordered allowlist from launch-profile config."""
+    from hermes_cli.config import load_config
+
+    config = load_config()
+    servers = config.get("mcp_servers") if isinstance(config, dict) else None
+    server = servers.get(server_name) if isinstance(servers, dict) else None
+    block = server.get("client_access") if isinstance(server, dict) else None
+    if not isinstance(block, dict) or block.get("enabled") is not True:
+        return MCPClientAccessPolicy(enabled=False, ordered_tools=())
+
+    configured_tools = block.get("tools")
+    if not isinstance(configured_tools, list):
+        return MCPClientAccessPolicy(enabled=True, ordered_tools=())
+
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for raw_name in configured_tools:
+        if _valid_exact_name(raw_name) and raw_name not in seen:
+            ordered.append(raw_name)
+            seen.add(raw_name)
+    return MCPClientAccessPolicy(enabled=True, ordered_tools=tuple(ordered))
+
+
+def _is_mcp_client_runtime_noninteractive(server_name: str) -> bool:
+    """Require explicit false/false config and no stale live handlers."""
+    from hermes_cli.config import load_config
+    from tools.mcp_tool import get_mcp_client_runtime_state
+
+    config = load_config()
+    servers = config.get("mcp_servers") if isinstance(config, dict) else None
+    server = servers.get(server_name) if isinstance(servers, dict) else None
+    if not isinstance(server, dict):
+        return False
+    sampling = server.get("sampling")
+    elicitation = server.get("elicitation")
+    if not isinstance(sampling, dict) or sampling.get("enabled") is not False:
+        return False
+    if not isinstance(elicitation, dict) or elicitation.get("enabled") is not False:
+        return False
+
+    runtime = get_mcp_client_runtime_state(server_name)
+    if runtime.get("live") is True:
+        return (
+            runtime.get("sampling_handler") is False
+            and runtime.get("elicitation_handler") is False
+        )
+    return True
+
+
+def list_mcp_client_tools(server_name: str) -> list[dict]:
+    """Return the policy-ordered, exact-provenance, read-only catalog."""
+    from tools.mcp_tool import get_mcp_tool_provenance, is_mcp_tool_read_only
+    from tools.registry import registry
+
+    policy = load_mcp_client_access_policy(server_name)
+    if not policy.enabled:
+        return []
+
+    entries_by_raw_name: dict[str, str] = {}
+    for registry_name in registry.get_all_tool_names():
+        provenance = get_mcp_tool_provenance(registry_name)
+        if provenance is None or provenance.server_name != server_name:
+            continue
+        if provenance.raw_tool_name not in policy.ordered_tools:
+            continue
+        entries_by_raw_name[provenance.raw_tool_name] = registry_name
+
+    tools: list[dict] = []
+    for raw_name in policy.ordered_tools:
+        registry_name = entries_by_raw_name.get(raw_name)
+        if registry_name is None or not is_mcp_tool_read_only(server_name, raw_name):
+            continue
+        schema = registry.get_schema(registry_name)
+        if not isinstance(schema, dict):
+            continue
+        description = schema.get("description")
+        parameters = schema.get("parameters")
+        input_schema = parameters if isinstance(parameters, dict) else {}
+        try:
+            serialized_schema = json.dumps(
+                input_schema,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            )
+        except (TypeError, ValueError, RecursionError):
+            raise MCPClientAccessError(
+                "MCP_CLIENT_RESULT_CONTRACT", "MCP input schema is not finite JSON"
+            ) from None
+        if len(serialized_schema.encode("utf-8")) > _MAX_INPUT_SCHEMA_BYTES:
+            raise MCPClientAccessError(
+                "MCP_CLIENT_RESULT_CONTRACT", "MCP input schema exceeds 64 KiB"
+            )
+        tools.append(
+            {
+                "name": raw_name,
+                "description": (
+                    description[:_MAX_DESCRIPTION_CHARS]
+                    if isinstance(description, str)
+                    else ""
+                ),
+                "input_schema": json.loads(serialized_schema),
+            }
+        )
+    return tools
+
+
+def get_mcp_client_status(server_name: str) -> dict:
+    """Return a credential-free snapshot without connecting the server."""
+    from hermes_cli.config import load_config
+    from tools.mcp_tool import get_mcp_status
+
+    config = load_config()
+    servers = config.get("mcp_servers") if isinstance(config, dict) else None
+    configured = isinstance(servers, dict) and isinstance(servers.get(server_name), dict)
+    policy = load_mcp_client_access_policy(server_name)
+    noninteractive = _is_mcp_client_runtime_noninteractive(server_name) if configured else False
+    rows = get_mcp_status() if configured else []
+    row = next((item for item in rows if item.get("name") == server_name), None)
+    connected = bool(row and row.get("connected") is True)
+    if row and row.get("status") in {"connected", "connecting", "failed", "disabled", "configured"}:
+        status = row["status"]
+    elif configured:
+        status = "configured"
+    else:
+        status = "disabled"
+    available = len(list_mcp_client_tools(server_name)) if policy.enabled else 0
+    return {
+        "server": server_name,
+        "configured": configured,
+        "client_access_enabled": policy.enabled,
+        "noninteractive": noninteractive,
+        "status": status,
+        "connected": connected,
+        "allowed_tool_count": len(policy.ordered_tools),
+        "available_tool_count": available,
+    }
+
+
+def _find_registry_tool(server_name: str, raw_tool_name: str) -> str | None:
+    from tools.mcp_tool import get_mcp_tool_provenance
+    from tools.registry import registry
+
+    for registry_name in registry.get_all_tool_names():
+        provenance = get_mcp_tool_provenance(registry_name)
+        if (
+            provenance is not None
+            and provenance.server_name == server_name
+            and provenance.raw_tool_name == raw_tool_name
+        ):
+            return registry_name
+    return None
+
+
+def _bounded_result_text(value: str) -> tuple[str, bool]:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= _MAX_RESULT_BYTES:
+        return value, False
+    marker = _RESULT_TRUNCATION_MARKER.encode("utf-8")
+    prefix = encoded[: _MAX_RESULT_BYTES - len(marker)]
+    while True:
+        try:
+            return prefix.decode("utf-8") + _RESULT_TRUNCATION_MARKER, True
+        except UnicodeDecodeError:
+            prefix = prefix[:-1]
+
+
+def _strip_session_credential_metadata(value: str) -> tuple[str, object]:
+    """Remove backend session/OAuth timing hints from a JSON result envelope."""
+    try:
+        envelope = json.loads(value)
+    except (TypeError, ValueError):
+        return value, None
+    changed = False
+
+    def sanitize(node: object, *, metadata: bool = False) -> object:
+        nonlocal changed
+        if isinstance(node, dict):
+            clean = {}
+            for key, child in node.items():
+                if metadata and key == "session":
+                    changed = True
+                    continue
+                clean[key] = sanitize(child, metadata=key == "_meta")
+            return clean
+        if isinstance(node, list):
+            return [sanitize(child) for child in node]
+        return node
+
+    sanitized = sanitize(envelope)
+    if not changed:
+        return value, envelope
+    return (
+        json.dumps(sanitized, ensure_ascii=False, separators=(",", ":"), allow_nan=False),
+        sanitized,
+    )
+
+
+def call_mcp_client_tool(
+    server_name: str, tool_name: str, arguments: dict
+) -> MCPClientCallResult:
+    """Dispatch one bounded call through the canonical tool registry."""
+    if not _valid_exact_name(server_name) or not _valid_exact_name(tool_name):
+        raise MCPClientAccessError("MCP_CLIENT_INVALID_PARAMS", "Invalid MCP server or tool name")
+    if not isinstance(arguments, dict):
+        raise MCPClientAccessError("MCP_CLIENT_INVALID_PARAMS", "arguments must be a JSON object")
+    try:
+        serialized_arguments = json.dumps(
+            arguments, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False
+        )
+    except (TypeError, ValueError):
+        raise MCPClientAccessError(
+            "MCP_CLIENT_INVALID_PARAMS", "arguments must contain finite JSON values"
+        ) from None
+    if len(serialized_arguments.encode("utf-8")) > _MAX_ARGUMENT_BYTES:
+        raise MCPClientAccessError("MCP_CLIENT_INVALID_PARAMS", "arguments exceed 64 KiB")
+
+    policy = load_mcp_client_access_policy(server_name)
+    if not policy.enabled:
+        raise MCPClientAccessError("MCP_CLIENT_DISABLED", "MCP client access is disabled")
+    if not policy.allows(tool_name):
+        raise MCPClientAccessError("MCP_CLIENT_TOOL_DENIED", "MCP tool is not allowlisted")
+
+    registry_name = _find_registry_tool(server_name, tool_name)
+    if registry_name is None:
+        raise MCPClientAccessError("MCP_CLIENT_SERVER_UNAVAILABLE", "MCP tool is unavailable")
+
+    from tools.mcp_tool import is_mcp_tool_read_only
+
+    if not is_mcp_tool_read_only(server_name, tool_name):
+        raise MCPClientAccessError("MCP_CLIENT_NOT_READ_ONLY", "MCP tool is not marked read-only")
+    if not _is_mcp_client_runtime_noninteractive(server_name):
+        raise MCPClientAccessError(
+            "MCP_CLIENT_INTERACTIVE_RUNTIME", "MCP runtime must be reloaded as non-interactive"
+        )
+
+    with _client_locks_guard:
+        client_lock = _client_locks.setdefault(server_name, threading.Lock())
+    if not client_lock.acquire(blocking=False):
+        raise MCPClientAccessError("MCP_CLIENT_BUSY", "Another MCP client call is already running")
+
+    request_id = f"mcpui_{uuid.uuid4().hex}"
+    started = time.monotonic()
+    truncated = False
+    ok = False
+    try:
+        from tools.registry import registry
+
+        # Re-read revocable policy/config at the final pre-transport boundary.
+        # The gateway holds its MCP reload lock across this block, so registry
+        # provenance and runtime handlers cannot change between this check and
+        # dispatch. A revocation observed here always wins.
+        current_policy = load_mcp_client_access_policy(server_name)
+        if not current_policy.enabled:
+            raise MCPClientAccessError("MCP_CLIENT_DISABLED", "MCP client access is disabled")
+        if not current_policy.allows(tool_name):
+            raise MCPClientAccessError("MCP_CLIENT_TOOL_DENIED", "MCP tool is not allowlisted")
+        if not is_mcp_tool_read_only(server_name, tool_name):
+            raise MCPClientAccessError("MCP_CLIENT_NOT_READ_ONLY", "MCP tool is not marked read-only")
+        if not _is_mcp_client_runtime_noninteractive(server_name):
+            raise MCPClientAccessError(
+                "MCP_CLIENT_INTERACTIVE_RUNTIME", "MCP runtime must be reloaded as non-interactive"
+            )
+
+        dispatched = registry.dispatch(registry_name, arguments)
+        if not isinstance(dispatched, str):
+            raise MCPClientAccessError(
+                "MCP_CLIENT_RESULT_CONTRACT", "MCP tool returned an unsupported result"
+            )
+        safe_dispatched, envelope = _strip_session_credential_metadata(dispatched)
+        result_text, truncated = _bounded_result_text(safe_dispatched)
+        ok = not (
+            isinstance(envelope, dict) and isinstance(envelope.get("error"), str)
+        )
+        duration_ms = max(0, int((time.monotonic() - started) * 1000))
+        return MCPClientCallResult(
+            request_id=request_id,
+            server=server_name,
+            tool=tool_name,
+            ok=ok,
+            duration_ms=duration_ms,
+            result_text=result_text,
+            truncated=truncated,
+        )
+    finally:
+        duration_ms = max(0, int((time.monotonic() - started) * 1000))
+        logger.info(
+            "MCP client call request_id=%s server=%s tool=%s status=%s duration_ms=%d truncated=%s",
+            request_id, server_name, tool_name, "ok" if ok else "error", duration_ms, truncated,
+        )
+        client_lock.release()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -95,6 +95,7 @@ Thread safety:
 """
 
 import asyncio
+from dataclasses import dataclass
 import contextvars
 import concurrent.futures
 import errno
@@ -4944,6 +4945,15 @@ _parallel_safe_servers: set = set()
 # on parsing or re-sanitizing the generated name.
 _mcp_tool_server_names: Dict[str, str] = {}
 
+
+@dataclass(frozen=True)
+class MCPToolProvenance:
+    server_name: str
+    raw_tool_name: str
+
+
+_mcp_tool_provenance: Dict[str, MCPToolProvenance] = {}
+
 # Dedicated event loop running in a background daemon thread.
 _mcp_loop: Optional[asyncio.AbstractEventLoop] = None
 _mcp_thread: Optional[threading.Thread] = None
@@ -6603,16 +6613,46 @@ _UTILITY_CAPABILITY_ATTRS = {
 }
 
 
-def _track_mcp_tool_server(tool_name: str, server_name: str) -> None:
-    """Remember the exact raw MCP server that registered *tool_name*."""
+def _track_mcp_tool_server(
+    tool_name: str, server_name: str, raw_tool_name: Optional[str] = None
+) -> None:
+    """Remember exact registration-time MCP identity for *tool_name*."""
     with _lock:
         _mcp_tool_server_names[tool_name] = server_name
+        if raw_tool_name is not None:
+            _mcp_tool_provenance[tool_name] = MCPToolProvenance(
+                server_name=server_name, raw_tool_name=raw_tool_name
+            )
+
+
+def get_mcp_tool_provenance(tool_name: str) -> Optional[MCPToolProvenance]:
+    with _lock:
+        return _mcp_tool_provenance.get(tool_name)
+
+
+def is_mcp_tool_read_only(server_name: str, raw_tool_name: str) -> bool:
+    with _lock:
+        return _tool_read_only_hints.get(server_name, {}).get(raw_tool_name) is True
+
+
+def get_mcp_client_runtime_state(server_name: str) -> dict:
+    """Return only handler-presence state needed by the client safety gate."""
+    with _lock:
+        server = _servers.get(server_name)
+        if server is None:
+            return {"live": False}
+        return {
+            "live": True,
+            "sampling_handler": getattr(server, "_sampling", None) is not None,
+            "elicitation_handler": getattr(server, "_elicitation", None) is not None,
+        }
 
 
 def _forget_mcp_tool_server(tool_name: str) -> None:
     """Forget MCP server provenance for a deregistered tool."""
     with _lock:
         _mcp_tool_server_names.pop(tool_name, None)
+        _mcp_tool_provenance.pop(tool_name, None)
 
 
 def _select_utility_schemas(server_name: str, server: MCPServerTask, config: dict) -> List[dict]:
@@ -6762,6 +6802,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
         candidates.append(
             {
                 "registry_name": schema["name"],
+                "raw_tool_name": mcp_tool.name,
                 "origin": f"tool {mcp_tool.name!r}",
                 "schema": schema,
                 "handler": _make_tool_handler(
@@ -6912,7 +6953,9 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             )
             continue
 
-        _track_mcp_tool_server(registry_name, name)
+        _track_mcp_tool_server(
+            registry_name, name, candidate.get("raw_tool_name")
+        )
         registered_names.append(registry_name)
 
     if registered_names:
@@ -7054,7 +7097,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
         )
         if registry.get_toolset_for_tool(registry_name) != toolset_name:
             continue
-        _track_mcp_tool_server(registry_name, name)
+        _track_mcp_tool_server(registry_name, name, raw_name)
         registered_names.append(registry_name)
 
     handler_factories = {

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6799,15 +6799,21 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
 
         _scan_mcp_description(name, mcp_tool.name, mcp_tool.description or "")
         schema = _convert_mcp_schema(name, mcp_tool)
+        handler = _make_tool_handler(name, mcp_tool.name, server.tool_timeout)
+        setattr(handler, "_hermes_mcp_client_server", name)
+        setattr(handler, "_hermes_mcp_client_raw_tool", mcp_tool.name)
+        setattr(
+            handler,
+            "_hermes_mcp_client_read_only_hint",
+            _annotation_read_only_hint(mcp_tool),
+        )
         candidates.append(
             {
                 "registry_name": schema["name"],
                 "raw_tool_name": mcp_tool.name,
                 "origin": f"tool {mcp_tool.name!r}",
                 "schema": schema,
-                "handler": _make_tool_handler(
-                    name, mcp_tool.name, server.tool_timeout
-                ),
+                "handler": handler,
                 "check_fn": check_fn,
             }
         )
@@ -7086,11 +7092,21 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
                 name, registry_name, existing_toolset,
             )
             continue
+        handler = _make_tool_handler(name, raw_name, tool_timeout)
+        raw_annotations = raw.get("annotations")
+        annotations = raw_annotations if isinstance(raw_annotations, dict) else {}
+        setattr(handler, "_hermes_mcp_client_server", name)
+        setattr(handler, "_hermes_mcp_client_raw_tool", raw_name)
+        setattr(
+            handler,
+            "_hermes_mcp_client_read_only_hint",
+            annotations.get("readOnlyHint") is True,
+        )
         registry.register(
             name=registry_name,
             toolset=toolset_name,
             schema=schema,
-            handler=_make_tool_handler(name, raw_name, tool_timeout),
+            handler=handler,
             check_fn=check_fn,
             is_async=False,
             description=schema["description"],

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -19,6 +19,7 @@ import functools
 import importlib
 import json
 import logging
+import re
 import sys
 import threading
 import time
@@ -34,6 +35,28 @@ _MAX_TOOL_ERROR_CHARS = 2048
 _TOOL_ERROR_TRUNCATION_MARKER = "… [truncated]"
 # Logs keep more of the body than the model sees, but still a bounded amount.
 _MAX_LOGGED_ERROR_CHARS = 8192
+_DISPATCH_BEARER_RE = re.compile(r"(?i)(\bBearer\s+)[^\s,;]+")
+_DISPATCH_SECRET_ASSIGN_RE = re.compile(
+    r"(?i)(\b(?:access[_-]?token|auth[_-]?token|token|secret|api[_-]?key)\s*=\s*)[^\s,;]+"
+)
+
+
+def _redact_dispatch_exception(exc: BaseException) -> str:
+    """Return bounded, force-redacted exception text for logs and responses.
+
+    This is a credential-egress boundary.  Fail closed if the shared redactor
+    is unavailable; attaching ``exc_info`` to the eventual log record would
+    bypass this boundary by formatting the original exception again.
+    """
+    try:
+        from agent.redact import redact_sensitive_text
+
+        redacted = redact_sensitive_text(str(exc), force=True)
+        redacted = _DISPATCH_BEARER_RE.sub(r"\1***", redacted)
+        redacted = _DISPATCH_SECRET_ASSIGN_RE.sub(r"\1***", redacted)
+    except Exception:
+        redacted = "exception details unavailable"
+    return _bound_error_text(redacted)
 
 
 def _bound_error_text(text: str) -> str:
@@ -1126,19 +1149,17 @@ class ToolRegistry:
                 result = entry.handler(args, **kwargs)
             return self._normalize_handler_result(name, result)
         except Exception as e:
-            # exc_info already renders the exception, so keep the message copy bounded.
-            logger.exception(
-                "Tool %s dispatch error: %s", name, _bound_error_text(str(e))
-            )
+            safe_error = _redact_dispatch_exception(e)
+            logger.error("Tool %s dispatch error: %s", name, safe_error)
             # Route through the sanitizer so framing tokens / CDATA / fences
             # in exception strings don't reach the model as structural noise.
             # See model_tools._sanitize_tool_error for rationale.
-            raw = f"Tool execution failed: {type(e).__name__}: {e}"
+            raw = f"Tool execution failed: {type(e).__name__}: {safe_error}"
             try:
                 from model_tools import _sanitize_tool_error
                 sanitized = _sanitize_tool_error(raw)
             except Exception:
-                sanitized = raw  # defensive: never let the sanitizer block error propagation
+                sanitized = "Tool execution failed: exception details unavailable"
             return tool_error(sanitized)
 
     # ------------------------------------------------------------------

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -1141,6 +1141,13 @@ class ToolRegistry:
         entry = self.get_entry(name, scope=scope)
         if not entry:
             return tool_error(f"Unknown tool: {name}")
+        return self.dispatch_entry(entry, args, **kwargs)
+
+    def dispatch_entry(self, entry: ToolEntry, args: dict, **kwargs) -> str | dict:
+        """Execute the exact captured entry instead of re-resolving a mutable name."""
+        if not isinstance(entry, ToolEntry):
+            return tool_error("Unknown tool entry")
+        name = entry.name
         try:
             if entry.is_async:
                 from model_tools import _run_async

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -437,7 +437,11 @@ def main():
         "params": {
             "type": "gateway.ready",
             # change_events: see tui_gateway/ws.py — clients demote legacy polls.
-            "payload": {"skin": resolve_skin(), "change_events": True},
+            "payload": {
+                "skin": resolve_skin(),
+                "change_events": True,
+                "capabilities": server.gateway_capabilities(),
+            },
         },
     }):
         _log_exit("startup write failed (broken stdout pipe before first event)")

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -4,11 +4,106 @@ Handler bodies are byte-identical to their pre-split server.py form; they
 are rebound onto server.py's globals at install time — see method_ctx.py.
 """
 
+import types
+
 from .method_ctx import HandlerRegistry
 
 _registry = HandlerRegistry()
 method = _registry.method
 _profile_scoped = _registry.profile_scoped
+
+_MCP_CLIENT_ERROR_CODES = {
+    "MCP_CLIENT_INVALID_PARAMS": 4600,
+    "MCP_CLIENT_PROFILE_UNSUPPORTED": 4601,
+    "MCP_CLIENT_DISABLED": 4602,
+    "MCP_CLIENT_SERVER_UNAVAILABLE": 4603,
+    "MCP_CLIENT_TOOL_DENIED": 4604,
+    "MCP_CLIENT_NOT_READ_ONLY": 4605,
+    "MCP_CLIENT_INTERACTIVE_RUNTIME": 4606,
+    "MCP_CLIENT_BUSY": 4607,
+    "MCP_CLIENT_RESULT_CONTRACT": 4608,
+}
+
+
+def _mcp_client_profile_guard(rid, params):
+    """Fail before config/registry access when the process-global profile differs."""
+    requested = params.get("profile") if isinstance(params, dict) else None
+    if not isinstance(requested, str) or not requested.strip():
+        return _err(rid, 4600, "profile is required")
+    try:
+        from hermes_cli.profiles import normalize_profile_name
+
+        requested_name = normalize_profile_name(requested)
+        launch_name = normalize_profile_name(_current_profile_name())
+    except Exception:
+        return _err(rid, 4600, "invalid profile")
+    if requested_name != launch_name:
+        return _err(rid, 4601, "MCP client access supports only the gateway launch profile")
+    return None
+
+
+def _mcp_client_params(rid, params, *, require_tool=False):
+    profile_error = _mcp_client_profile_guard(rid, params)
+    if profile_error:
+        return None, profile_error
+    server_name = params.get("server")
+    tool_name = params.get("tool") if require_tool else None
+    from tools.mcp_client_access import _valid_exact_name
+
+    if not _valid_exact_name(server_name):
+        return None, _err(rid, 4600, "invalid server name")
+    if require_tool and not _valid_exact_name(tool_name):
+        return None, _err(rid, 4600, "invalid tool name")
+    return (server_name, tool_name), None
+
+
+@method("mcp.client.status")
+def _(rid, params: dict) -> dict:
+    parsed, error = _mcp_client_params(rid, params)
+    if error:
+        return error
+    from tools.mcp_client_access import MCPClientAccessError, get_mcp_client_status
+
+    try:
+        with _mcp_reload_lock:
+            result = get_mcp_client_status(parsed[0])
+    except MCPClientAccessError as exc:
+        return _err(rid, _MCP_CLIENT_ERROR_CODES.get(exc.code, 4608), str(exc))
+    return _ok(rid, result)
+
+
+@method("mcp.client.tools")
+def _(rid, params: dict) -> dict:
+    parsed, error = _mcp_client_params(rid, params)
+    if error:
+        return error
+    from tools.mcp_client_access import MCPClientAccessError, list_mcp_client_tools
+
+    try:
+        with _mcp_reload_lock:
+            tools = list_mcp_client_tools(parsed[0])
+    except MCPClientAccessError as exc:
+        return _err(rid, _MCP_CLIENT_ERROR_CODES.get(exc.code, 4608), str(exc))
+    return _ok(rid, {"server": parsed[0], "tools": tools})
+
+
+@method("mcp.client.call")
+def _(rid, params: dict) -> dict:
+    parsed, error = _mcp_client_params(rid, params, require_tool=True)
+    if error:
+        return error
+    from dataclasses import asdict
+    from tools.mcp_client_access import MCPClientAccessError, call_mcp_client_tool
+
+    try:
+        # Stabilize registry provenance, read-only metadata, and interactive
+        # handlers across authorization and dispatch. MCP reload uses this same
+        # lock for shutdown+discovery.
+        with _mcp_reload_lock:
+            result = call_mcp_client_tool(parsed[0], parsed[1], params.get("arguments"))
+    except MCPClientAccessError as exc:
+        return _err(rid, _MCP_CLIENT_ERROR_CODES.get(exc.code, 4608), str(exc))
+    return _ok(rid, asdict(result))
 
 
 @method("system.battery")
@@ -2534,4 +2629,13 @@ def _(rid, params: dict) -> dict:
 
 def register(server) -> None:
     """Bind this module's handlers onto ``server``'s globals and registry."""
+    server._MCP_CLIENT_ERROR_CODES = _MCP_CLIENT_ERROR_CODES
+    server._mcp_client_profile_guard = types.FunctionType(
+        _mcp_client_profile_guard.__code__, vars(server), _mcp_client_profile_guard.__name__
+    )
+    server._mcp_client_params = types.FunctionType(
+        _mcp_client_params.__code__, vars(server), _mcp_client_params.__name__,
+        _mcp_client_params.__defaults__, _mcp_client_params.__closure__,
+    )
+    server._mcp_client_params.__kwdefaults__ = _mcp_client_params.__kwdefaults__
     _registry.install(server)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -197,6 +197,9 @@ _LONG_HANDLERS = frozenset(
         # is two serial round-trips); keep them off the main stdin loop so a slow
         # portal can't stall approval.respond / session.interrupt / other RPCs.
         "billing.state",
+        "mcp.client.status",
+        "mcp.client.tools",
+        "mcp.client.call",
         "subscription.state",
         # Subscription change (V3): preview + the pending-change mutations + upgrade
         # each do a blocking portal round-trip (preview + upgrade also hit Stripe,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -148,6 +148,22 @@ _answers: dict[str, str] = {}
 _db = None
 _db_error: str | None = None
 _stdout_lock = threading.Lock()
+
+_GATEWAY_CAPABILITIES = {
+    "mcp-client-access": {
+        "version": {"major": 1, "minor": 0},
+        "endpoints": [
+            "mcp.client.status",
+            "mcp.client.tools",
+            "mcp.client.call",
+        ],
+    }
+}
+
+
+def gateway_capabilities() -> dict[str, dict]:
+    """Return the bounded, service-neutral contract advertised at handshake."""
+    return copy.deepcopy(_GATEWAY_CAPABILITIES)
 _cfg_lock = threading.Lock()
 _sessions_lock = threading.RLock()  # reentrant: _close_session_by_id may run under callers that already hold it
 _prompt_lock = threading.Lock()

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -320,7 +320,11 @@ async def handle_ws(ws: Any) -> None:
                     # change_events: this backend broadcasts pet.changed /
                     # cron.changed / sessions.changed, so clients can demote
                     # their legacy polls to slow backstops.
-                    "payload": {"skin": skin_payload, "change_events": True},
+                    "payload": {
+                        "skin": skin_payload,
+                        "change_events": True,
+                        "capabilities": server.gateway_capabilities(),
+                    },
                 },
             }
         )

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -550,6 +550,24 @@ listener can't affect app dispatch. Every `host` door is async-safe: a sync thro
 from an internal helper (e.g. no desktop bridge in a plain browser) becomes a
 rejection your `.catch()` sees, never an error-boundary crash.
 
+For an operator-allowlisted, read-only MCP tool, a trusted local plugin can use
+the launch-profile-only client surface without receiving OAuth credentials:
+
+```javascript
+const profile = host.state.profile.get()
+const status = await host.request('mcp.client.status', { server: 'example', profile })
+const catalog = await host.request('mcp.client.tools', { server: 'example', profile })
+const result = await host.request('mcp.client.call', {
+  server: 'example', tool: catalog.tools[0].name, arguments: {}, profile
+})
+```
+
+The server must have default-off `client_access` configured with exact raw tool
+names, explicit `sampling.enabled: false` and `elicitation.enabled: false`, and
+an exact server-supplied `readOnlyHint: true` annotation. Hermes alone owns MCP
+transport, OAuth refresh, and reconnect. The RPC never returns tokens,
+Authorization headers, token paths, expiry, or OAuth metadata.
+
 `ctx.os` is the curated OS door — every way a plugin reaches outside the app
 window, in one namespace attributed to your plugin. `ctx.os.notify` posts a
 **native OS notification** — the same Electron pipeline the app's own
@@ -783,6 +801,12 @@ agent) wrote. The optional `integrity` (`sha256-…`) check only proves the byte
 match a hash; it does **not** sandbox. A future remote-source door will need a
 real boundary (iframe/worker + CSP + capability gating) before it can land; do
 not treat this pipeline as a trust boundary.
+
+An MCP `client_access` allowlist is likewise a safety policy for trusted local
+UI code, not a sandbox against a malicious Desktop plugin with full app
+authority. `readOnlyHint` is supplied by the MCP server and is defense-in-depth,
+not proof of harmless behavior. Do not expose write-capable tools through this
+contract.
 
 ## Pitfalls
 

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -40,7 +40,8 @@ plugin, and fail to resolve in a disk plugin). Capability comes in tiers:
 
 - **`host.state.*`** — readonly views over the app's live state (nanostore
   atoms): active session, per-session turn-busy, cwd, gateway socket status,
-  model, profile, viewport. `gateway` is the WebSocket, not turn-busy.
+  model, profile, viewport, and versioned backend capabilities. `gateway` is
+  the WebSocket, not turn-busy.
 - **`host.*` actions** — curated safe verbs: toast, navigate, tail logs,
   restart the gateway, subscribe to the gateway event stream.
 - **`host.request`** — the gateway JSON-RPC door: sessions, config, skills,
@@ -430,6 +431,7 @@ components.
 
 ```ts
 host.state.activeSessionId  // ReadableAtom<string | null>
+host.state.capabilities     // ReadableAtom<Record<string, { version: { major, minor }, endpoints: string[] }>>
 host.state.awaitingResponse // ReadableAtom<boolean>  true until the first assistant payload
 host.state.busy             // ReadableAtom<boolean>  focused chat is working after a send
 host.state.busyBySession    // ReadableAtom<Record<string, boolean>>  runtime id → mid-turn
@@ -441,6 +443,26 @@ host.state.gateway          // ReadableAtom<string>  socket state ('idle' | 'con
 host.state.model            // ReadableAtom<string>
 host.state.profile          // ReadableAtom<string>
 host.state.viewport         // ReadableAtom<{ width, height, narrow }>
+```
+
+`host.state.capabilities` comes from the active backend's `gateway.ready`
+handshake and is validated before plugins see it. Read it before a
+capability-specific RPC. Missing, malformed, or unsupported-major metadata
+means the capability is unavailable; do not probe an endpoint just to discover
+whether it exists. Capability state is isolated by registry source + profile
+and switches with the active gateway. For example, MCP client access v1.0 is:
+
+```ts
+const capability = host.state.capabilities.get()['mcp-client-access']
+
+if (
+  capability?.version.major === 1 &&
+  capability.endpoints.includes('mcp.client.status') &&
+  capability.endpoints.includes('mcp.client.tools') &&
+  capability.endpoints.includes('mcp.client.call')
+) {
+  // The released host advertises the complete v1 contract.
+}
 ```
 
 `host.state.gateway` is the WebSocket connection, not whether a chat turn is
@@ -483,6 +505,9 @@ cron, kanban, …). `host.requestProfile` accepts a descriptor from
 profile without changing the active chat or gateway. The profile-only overload is
 retained only for the sole-local/legacy topology; registry-aware plugins should pass
 the descriptor so two sources exposing the same profile name cannot collide.
+Runtime plugins are trusted local code: `host.request` is not a sandbox or a
+per-plugin authorization boundary. Backend policy still validates every RPC,
+but operators must not install untrusted plugin source.
 
 `host.openWorkspace(id, { render, title?, minWidth?, onClose? })` docks a
 plugin-rendered view into the **main workspace zone** — the same center area

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -39,6 +39,9 @@ mcp_servers:
       exclude: []
       resources: true
       prompts: true
+    client_access:
+      enabled: false
+      tools: []
 ```
 
 ## Server keys
@@ -68,6 +71,7 @@ mcp_servers:
 | `sampling` | mapping | both | Server-initiated LLM request policy (see MCP guide) |
 | `elicitation` | mapping | both | Server-initiated user-input requests. `enabled` (default `true`) and `timeout` in seconds (default `300`). Form-mode requests route through the approval surface; URL-mode is declined (see MCP guide) |
 | `trust` | string | both | Trust tier: `full` (default) or `untrusted`. On an `untrusted` server, every write-capable tool call (any tool without a `readOnlyHint: true` annotation) requires user approval through the standard approval surface before it runs. `readOnlyHint` is a server-supplied *hint* — a lying server can at most skip approval for tools it claims are read-only, never gain extra access — so mark any server you don't fully control as `untrusted`. Unrecognized values are treated as `untrusted` (fail-closed) |
+| `client_access` | mapping | both | Default-off exact allowlist for trusted local clients using the `mcp.client.*` gateway RPCs. Separate from `tools.include`; globs are rejected. |
 
 ## Environment variable references
 
@@ -114,6 +118,44 @@ Any other `${...}` reference falls through to the env-var lookup above.
 | `exclude` | string or list | Blacklist server-native MCP tools. Same exact-name / glob semantics as `include` |
 | `resources` | bool-like | Enable/disable `list_resources` + `read_resource` |
 | `prompts` | bool-like | Enable/disable `list_prompts` + `get_prompt` |
+
+## Trusted local client access
+
+`client_access` exposes a narrow execution capability to trusted local UI code
+while Hermes continues to own OAuth tokens, refresh, reconnect, and MCP
+transport. It is disabled unless `enabled` is exactly `true`.
+
+```yaml
+mcp_servers:
+  example:
+    sampling:
+      enabled: false
+    elicitation:
+      enabled: false
+    client_access:
+      enabled: true
+      tools:
+        - whoami
+        - search_companies
+```
+
+Tool names are exact, case-sensitive raw MCP names. Blank values, globs,
+malformed lists, and names without exact registration-time provenance fail
+closed. `client_access.tools` does not replace `tools.include`: the latter
+controls normal registry exposure and supports globs, while the former is an
+additional exact allowlist for `mcp.client.call`.
+
+Client calls also require the exact tool's server-supplied `readOnlyHint` to be
+`true` and require both sampling and elicitation to be explicitly disabled.
+After changing those settings, reload MCP or restart the gateway so stale live
+handlers cannot remain active. This surface supports only the profile with
+which the gateway process launched; it does not switch profile homes around a
+process-global MCP runtime.
+
+OAuth tokens, authorization headers, token paths, expiry, and OAuth metadata
+remain backend-only. Write-capable tools are outside this contract. A server's
+`readOnlyHint` is defense-in-depth supplied by that server, not proof that the
+server or tool is harmless.
 
 ## Filtering semantics
 

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -41,6 +41,7 @@ mcp_servers:
       prompts: true
     client_access:
       enabled: false
+      operator_read_only: false
       tools: []
 ```
 
@@ -134,10 +135,16 @@ mcp_servers:
       enabled: false
     client_access:
       enabled: true
+      operator_read_only: true
       tools:
         - whoami
         - search_companies
 ```
+
+`operator_read_only` must be exactly `true`: it is the operator's explicit
+declaration that every listed tool has been reviewed as non-mutating. The
+server's `readOnlyHint=true` remains an additional required signal but cannot
+replace this operator-owned declaration.
 
 Tool names are exact, case-sensitive raw MCP names. Blank values, globs,
 malformed lists, and names without exact registration-time provenance fail
@@ -156,6 +163,19 @@ OAuth tokens, authorization headers, token paths, expiry, and OAuth metadata
 remain backend-only. Write-capable tools are outside this contract. A server's
 `readOnlyHint` is defense-in-depth supplied by that server, not proof that the
 server or tool is harmless.
+
+This is a trusted-local plugin surface. Runtime Desktop plugins execute with
+the app's authority and `host.request` is not a plugin sandbox. Do not install
+untrusted plugin code; per-plugin capability isolation is outside this API.
+
+Desktop plugins must preflight the active backend's versioned
+`host.state.capabilities['mcp-client-access']` descriptor before calling these
+RPCs. Contract v1.0 advertises exactly `mcp.client.status`,
+`mcp.client.tools`, and `mcp.client.call` in `gateway.ready`. Missing,
+malformed, or unsupported-major metadata means the host is incompatible and
+must cause zero client-access calls. The descriptor is a compiled host
+contract, not permission: server policy, profile isolation, read-only
+intersection, and non-interactive checks still run on every request.
 
 ## Filtering semantics
 


### PR DESCRIPTION
## Summary

This PR adds a generic, service-neutral MCP client access RPC contract and versioned host-capability descriptor for Hermes Desktop plugins and integrations.

### Key Innovations & Features:
1. **Generic RPC Endpoints**:
   - `mcp.client.status`: Returns credential-free connection status and active servers.
   - `mcp.client.tools`: Returns available tools filtered by explicit security allowlists and read-only intersections.
   - `mcp.client.call`: Generic bounded execution of trusted MCP tools with runtime policy enforcement.
2. **Versioned Host Capability Handshake**:
   - Adds `mcp-client-access` versioned host capability descriptor (`major: 1`, `minor: 0`) in Desktop SDK/loader.
   - Allows plugins to perform fail-closed capability preflight before invoking MCP transports.
3. **Security & Profile Isolation**:
   - Exact profile isolation, read-only policy gating, argument bounding, non-interactive execution constraints, and content-free audit logging.

## Verification & Test Plan
- [x] Backend pytest suite: 215/215 passed (`tests/tools/test_mcp_client_access.py`, `tests/tui_gateway/test_mcp_client_access_rpc.py`, etc.)
- [x] Desktop frontend tests: Vitest suite passed (`apps/desktop/src/store/host-capabilities.test.ts`, `apps/desktop/src/sdk/index.test.ts`)
- [x] Linting & TypeScript typecheck verified.