### PR TITLE
fix(bot-mode): group-room UX — Shift+Enter newlines, open at latest, late replies harvested

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4555,8 +4555,56 @@ async function runGroupChatRounds(group, members, thread) {
         r.turn = null
         return r
       })
+
+      // #89545: the loop's harvest pass only ran at the top of each round of
+      // an ACTIVE loop — a member whose turn timed out after the final round
+      // stayed stranded until the user's NEXT send. Poll for the late reply
+      // in the background (bounded) so long work is late, never lost.
+      // (window feature-detect: the engine also runs under node in tests.)
+      const strandedLeft = Object.keys(($groupChats.get()[group] || {}).stranded || {})
+
+      if (strandedLeft.length && typeof window !== 'undefined') {
+        void harvestStrandedUntilSettled(group, members, thread)
+      }
     }
   }
+}
+
+/** Bounded background harvest for members whose replies outlived the turn
+ *  loop. Polls every 5s for up to 5 minutes; stops early when nothing is
+ *  stranded, a new loop takes the room over (it harvests on its own), or the
+ *  room record disappears (disband). */
+async function harvestStrandedUntilSettled(group, members, thread) {
+  const HARVEST_INTERVAL_MS = 5000
+  const HARVEST_MAX_TRIES = 60
+
+  for (let attempt = 0; attempt < HARVEST_MAX_TRIES; attempt++) {
+    await new Promise(resolve => window.setTimeout(resolve, HARVEST_INTERVAL_MS))
+
+    const room = $groupChats.get()[group]
+
+    if (!room || room.running) {
+      return
+    }
+
+    const stranded = room.stranded || {}
+
+    if (!Object.keys(stranded).length) {
+      return
+    }
+
+    for (const member of members) {
+      if (Object.prototype.hasOwnProperty.call(stranded, groupMemberKey(member))) {
+        try {
+          await harvestStrandedGroupReply(group, member)
+        } catch {
+          // Best-effort: the next tick retries; the bound stops runaways.
+        }
+      }
+    }
+  }
+
+  recordGroupActivity(group, { kind: 'failed', member: null, thread })
 }
 
 /** User send into a group room. `thread` continues that thread (its reply
@@ -8641,7 +8689,7 @@ function mentionTokenAt(text, caret) {
  *  the strings parseGroupChatMentions resolves. Keyboard: Up/Down navigate,
  *  Enter/Tab insert (Enter falls through to submit when the popover is
  *  closed), Escape dismisses. */
-function GroupMentionInput({ members, onChange, value, ...inputProps }) {
+function GroupMentionInput({ members, onChange, onSubmitDraft, value, ...inputProps }) {
   const allMeta = useValue($botMeta)
   const inputRef = useRef(null)
   const [token, setToken] = useState(null)
@@ -8732,32 +8780,55 @@ function GroupMentionInput({ members, onChange, value, ...inputProps }) {
             )
           })
         : null,
-      jsx(Input, {
+      jsx(Textarea, {
         ...inputProps,
         ref: inputRef,
         value,
+        rows: 1,
+        // Multi-line room prompts (#89884): the composer was a single-line
+        // Input whose form submitted on every Enter — newlines were
+        // impossible. Enter (no Shift) still submits via onSubmitDraft;
+        // Shift+Enter falls through to the textarea's native newline.
+        className: cn('max-h-40 min-h-9 resize-none', inputProps.className),
         onChange: event => {
           onChange(event.target.value)
           refreshToken(event.target)
         },
         onClick: event => refreshToken(event.target),
         onKeyDown: event => {
-          if (!open) {
-            return
+          if (open) {
+            if (event.key === 'ArrowDown') {
+              event.preventDefault()
+              setSelected((active + 1) % options.length)
+
+              return
+            }
+
+            if (event.key === 'ArrowUp') {
+              event.preventDefault()
+              setSelected((active - 1 + options.length) % options.length)
+
+              return
+            }
+
+            if (event.key === 'Enter' || event.key === 'Tab') {
+              event.preventDefault()
+              insert(options[active].handle)
+
+              return
+            }
+
+            if (event.key === 'Escape') {
+              event.preventDefault()
+              setToken(null)
+
+              return
+            }
           }
 
-          if (event.key === 'ArrowDown') {
+          if (event.key === 'Enter' && !event.shiftKey) {
             event.preventDefault()
-            setSelected((active + 1) % options.length)
-          } else if (event.key === 'ArrowUp') {
-            event.preventDefault()
-            setSelected((active - 1 + options.length) % options.length)
-          } else if (event.key === 'Enter' || event.key === 'Tab') {
-            event.preventDefault()
-            insert(options[active].handle)
-          } else if (event.key === 'Escape') {
-            event.preventDefault()
-            setToken(null)
+            onSubmitDraft?.()
           }
         },
         onBlur: () => setToken(null)
@@ -8789,6 +8860,39 @@ function GroupChatWorkspace({ group, members, onBack }) {
   // composer, otherwise the reply box of that thread. Data URLs, already
   // downscaled — they ride the send into every responding member's session.
   const [pendingImages, setPendingImages] = useState({})
+
+  // Scroll anchoring (#89835): rooms used to open at scroll position 0 and
+  // stay there while replies streamed in. Scroll the bottom sentinel into
+  // view on mount and whenever the log grows — but only when the user is
+  // already near the bottom, so reading history is never yanked away.
+  const bottomSentinelRef = useRef(null)
+  const stickToBottomRef = useRef(true)
+
+  useEffect(() => {
+    const sentinel = bottomSentinelRef.current
+
+    if (!sentinel) {
+      return
+    }
+
+    const viewport = sentinel.closest('[data-slot="scroll-area-viewport"]')
+
+    if (viewport) {
+      const onScroll = () => {
+        stickToBottomRef.current = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight < 80
+      }
+
+      viewport.addEventListener('scroll', onScroll, { passive: true })
+
+      return () => viewport.removeEventListener('scroll', onScroll)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (stickToBottomRef.current) {
+      bottomSentinelRef.current?.scrollIntoView({ block: 'end' })
+    }
+  }, [room.log.length, room.running])
 
   const imagesFor = thread => pendingImages[thread ?? 'main'] || []
 
@@ -9297,6 +9401,7 @@ function GroupChatWorkspace({ group, members, onBack }) {
                     members,
                     value: replyDrafts[id] || '',
                     onChange: text => setReplyDrafts(prev => ({ ...prev, [id]: text })),
+                    onSubmitDraft: () => submitReply(id),
                     onPaste: event => pasteImages(id, event)
                   }),
                   attachButton(id),
@@ -9373,7 +9478,11 @@ function GroupChatWorkspace({ group, members, onBack }) {
                     ? `${groupSpeakerLabel(room.turn)} is thinking…`
                     : 'The room is working…'
                 }, 'working')
-              : null
+              : null,
+            // Scroll anchor (#89835): rooms opened at scroll position 0, mid-
+            // history. The effect below scrolls this sentinel into view on
+            // mount and on log growth — unless the user has scrolled up.
+            jsx('div', { ref: bottomSentinelRef, 'aria-hidden': true }, 'bottom-sentinel')
           ]
         })
       }),
@@ -9396,6 +9505,7 @@ function GroupChatWorkspace({ group, members, onBack }) {
                   members,
                   value: draft,
                   onChange: setDraft,
+                  onSubmitDraft: submit,
                   onPaste: event => pasteImages(null, event)
                 }),
                 attachButton(null),

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-mention-composer.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-mention-composer.test.mjs
@@ -21,8 +21,9 @@ test('group room composers mount GroupMentionInput, not bare Input', () => {
   assert.ok(!/jsx\(Input, \{\s*'aria-label': `Message \$\{group\}`/.test(source))
   assert.ok(!/jsx\(Input, \{\s*'aria-label': 'Reply in thread'/.test(source))
 
-  // Both receive the seated members for the popover scope.
-  assert.ok(/GroupMentionInput\(\{ members, onChange, value/.test(source))
+  // Both receive the seated members for the popover scope (onSubmitDraft
+  // rides along so Enter submits from the multi-line textarea, #89884).
+  assert.ok(/GroupMentionInput\(\{ members, onChange, onSubmitDraft, value/.test(source))
 })
 
 test('popover offers @everyone/@all and inserts parser-compatible strings', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-room-ux.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-room-ux.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+// Room UX cluster (Aug 2026 desktop audit): three confirmed defects in the
+// group-chat surface, fixed together.
+//
+//   #89884 — the composer was a single-line Input; Enter always submitted and
+//            multi-line prompts were impossible.
+//   #89835 — rooms opened at scroll position 0 with no anchoring; new replies
+//            streamed in below the fold.
+//   #89545 — a member whose reply outlived the turn loop stayed stranded
+//            until the user's NEXT send (harvest only ran inside the loop).
+
+test('room composer is a textarea with Enter=submit, Shift+Enter=newline (#89884)', () => {
+  const component = source.slice(
+    source.indexOf('function GroupMentionInput'),
+    source.indexOf('function GroupChatWorkspace')
+  )
+
+  // The control is the SDK Textarea, not the single-line Input.
+  assert.match(component, /jsx\(Textarea, \{/)
+  assert.doesNotMatch(component, /jsx\(Input, \{/)
+  // Enter (no Shift) submits through the injected handler...
+  assert.match(component, /event\.key === 'Enter' && !event\.shiftKey/)
+  assert.match(component, /onSubmitDraft\?\.\(\)/)
+  // ...and the popover branch still owns Enter while it is open.
+  assert.match(component, /insert\(options\[active\]\.handle\)/)
+})
+
+test('both room composers wire onSubmitDraft (#89884)', () => {
+  assert.match(source, /onSubmitDraft: submit,/)
+  assert.match(source, /onSubmitDraft: \(\) => submitReply\(id\),/)
+})
+
+test('room log anchors to the bottom with a user-scroll guard (#89835)', () => {
+  const workspace = source.slice(source.indexOf('function GroupChatWorkspace'))
+  assert.match(workspace, /bottomSentinelRef/)
+  assert.match(workspace, /stickToBottomRef/)
+  // Effect keys on log growth; the guard keeps history reading stable.
+  assert.match(workspace, /\[room\.log\.length, room\.running\]/)
+  assert.match(workspace, /scrollIntoView/)
+})
+
+test('stranded replies get a bounded background harvest after the loop settles (#89545)', () => {
+  assert.match(source, /function harvestStrandedUntilSettled\(/)
+  // The loop's finally block kicks it off only when members remain stranded.
+  assert.match(source, /strandedLeft\.length/)
+  // Bounded: interval + max tries, and it yields to a live loop.
+  const harvester = source.slice(source.indexOf('async function harvestStrandedUntilSettled'))
+  assert.match(harvester.slice(0, 1600), /HARVEST_MAX_TRIES/)
+  assert.match(harvester.slice(0, 1600), /room\.running/)
+})


### PR DESCRIPTION
## Summary

Three audit-confirmed group-room UX defects fixed together (same surface, one PR):

1. **Multi-line prompts now possible (#89884):** the room composer and thread reply boxes were single-line `Input`s inside a form — Enter always submitted, newlines were impossible. `GroupMentionInput` now renders the SDK `Textarea`: Enter (no Shift) submits via an injected `onSubmitDraft`, Shift+Enter inserts a newline, and the @mention popover keeps first priority on Enter/Tab/arrows while open.
2. **Rooms open at the latest message (#89835):** the room `ScrollArea` had no anchoring — rooms opened at scroll position 0 and replies streamed in below the fold. A bottom sentinel + effect scrolls to the end on mount and on log growth, with a near-bottom guard (80px) so reading history is never yanked away.
3. **Late replies land without another user send (#89545):** the stranded-reply harvest only ran at the top of each round of an ACTIVE loop — a member whose turn timed out after the final round stayed stranded until the user's next message. The loop's settle path now kicks off a bounded background harvest (5s interval, 5 min cap; yields to a new live loop, stops on disband).

## Changes

- `apps/desktop/src/plugins/hermes-bots/plugin.js`: Textarea composer + submit wiring, scroll sentinel + anchor effect, `harvestStrandedUntilSettled()`.
- `tests/group-room-ux.test.mjs`: 4 source-contract tests; `group-mention-composer.test.mjs` signature contract updated.

## Validation

| | Result |
|---|---|
| hermes-bots suite | 328/328 pass |
| Sabotage (plugin reverted, tests kept) | 4/4 new tests fail |
| Live desktop: room open | scrolled to bottom (was position 0) |
| Live desktop: composer | textarea; Shift+Enter not intercepted (newline), plain Enter submits — "line one" became a thread |

Note: this branch textually overlaps #90474/#90475 in plugin.js; whichever merges later needs a trivial rebase (disjoint hunks).

## Infographic

![Group room three fixes](https://files.catbox.moe/roli47.png)
