### PR TITLE
fix(model-metadata): GLM-5.3 context window is 1M, not the 202K glm catch-all

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -503,11 +503,14 @@ DEFAULT_CONTEXT_LENGTHS = {
     "minimax": 204800,
     # GLM — GLM-5.2 ships with a 1M context window (verified empirically:
     # needle-in-a-haystack retrieval at 789K prompt tokens succeeded with
-    # zero errors on api.z.ai/api/coding/paas/v4).  Older GLM models
+    # zero errors on api.z.ai/api/coding/paas/v4).  GLM-5.3 (preview,
+    # released 2026-08-14) is also 1M per models.dev catalog metadata
+    # (limit.context = 1,048,576; output 131,072).  Older GLM models
     # (5, 5.1, 5-turbo) are ~202K.  Longest-key-first substring matching
-    # ensures "glm-5.2" resolves to 1M while older variants still hit the
-    # generic 202K fallback.
+    # ensures "glm-5.2"/"glm-5.3" resolve to 1M while older variants still
+    # hit the generic 202K fallback.
     "glm-5.2": 1_048_576,
+    "glm-5.3": 1_048_576,
     "glm": 202752,
     # xAI Grok — xAI /v1/models does not return context_length metadata,
     # so these hardcoded fallbacks prevent Hermes from probing-down to

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -371,6 +371,46 @@ class TestDefaultContextLengths:
                     f"{model_id}: expected {expected_ctx}, got {actual}"
                 )
 
+    def test_glm_5_3_resolves_to_1m_not_glm_catchall(self):
+        """GLM-5.3 must resolve to 1M, not the generic ``glm`` 202,752 fallback.
+
+        GLM-5.3 (preview, 2026-08-14) ships with a 1M context window per
+        models.dev catalog metadata (limit.context = 1,048,576; output
+        131,072). Before the dedicated ``glm-5.3`` entry existed, the slug
+        fell through longest-key-first substring matching to the generic
+        ``glm`` catch-all (202,752), silently capping the window at ~202K
+        on endpoints that don't self-report (e.g. the BigModel
+        Anthropic-compatible gateway serving ``glm-5.3``).
+        """
+        from agent.model_metadata import get_model_context_length
+        from unittest.mock import patch as mock_patch
+
+        assert "glm-5.3" in DEFAULT_CONTEXT_LENGTHS
+        assert DEFAULT_CONTEXT_LENGTHS["glm-5.3"] == 1_048_576
+
+        # Longest-first substring matching must resolve the bare slug,
+        # vendor-prefixed OpenRouter forms, and :thinking variants to 1M —
+        # and must NOT touch the legacy ~202K ``glm`` catch-all.
+        with mock_patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             mock_patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata._query_ollama_api_show", return_value=None), \
+             mock_patch("agent.models_dev.lookup_models_dev_context", return_value=None):
+            for model in (
+                "glm-5.3",
+                "zai-org/glm-5.3",
+                "glm-5.3:thinking",
+            ):
+                assert get_model_context_length(model) == 1_048_576, (
+                    f"{model} should resolve to 1M"
+                )
+
+            # Older GLM generations stay on the ~202K catch-all.
+            for model in ("glm-5.1", "glm-4.7"):
+                assert get_model_context_length(model) == 202_752, (
+                    f"{model} should stay on the glm catch-all"
+                )
+
 
 
 


### PR DESCRIPTION
## Summary

- GLM-5.3 (preview, released 2026-08-14) ships with a **1M context window** (models.dev catalog: `limit.context = 1,048,576`, output 131,072).
- Without a dedicated `DEFAULT_CONTEXT_LENGTHS` entry, the `glm-5.3` slug fell through longest-key-first substring matching to the generic `glm` catch-all (**202,752**), silently capping the window at ~202K on endpoints that don't self-report context — e.g. the BigModel Anthropic-compatible gateway (`open.bigmodel.cn/api/anthropic`) serving `glm-5.3`.
- Same class as the existing `glm-5.2` entry: adds `"glm-5.3": 1_048_576` next to it, older GLM generations (5, 5.1, 5-turbo) stay on the ~202K catch-all.

## Testing

- New regression test `test_glm_5_3_resolves_to_1m_not_glm_catchall` covers:
  - bare slug `glm-5.3`, vendor-prefixed `zai-org/glm-5.3`, and `glm-5.3:thinking` → all resolve to 1,048,576
  - `glm-5.1` / `glm-4.7` stay on the 202,752 catch-all
- Full `tests/agent/test_model_metadata.py` passes: **92 passed** on current `main` + this patch.

## Repro (before fix)

```
get_model_context_length("glm-5.3", base_url="https://open.bigmodel.cn/api/anthropic", provider="anthropic")
# → 202,752  (wrong: fell to "glm" catch-all)
```

## After

```
# → 1,048,576
```