### PR TITLE
fix(a2a): expose schemas through tool describe

### DIFF
--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -585,11 +585,12 @@ _HANDLERS = {
 def register_tools(ctx) -> None:
     """Register the client tools in the ``a2a`` toolset."""
     for name, schema in _SCHEMAS.items():
+        function_schema = schema["function"]
         ctx.register_tool(
             name=name,
             toolset="a2a",
-            schema=schema,
+            schema=function_schema,
             handler=_HANDLERS[name],
-            description=schema["function"]["description"],
+            description=function_schema["description"],
             emoji="\U0001f9e9",  # puzzle piece
         )

--- a/tests/plugins/test_a2a_schema_registration.py
+++ b/tests/plugins/test_a2a_schema_registration.py
@@ -1,0 +1,46 @@
+"""Regression tests for A2A client-tool schema registration."""
+
+from __future__ import annotations
+
+import json
+
+from plugins.platforms.a2a import tools as a2a_tools
+from tools import tool_search
+from tools.registry import ToolRegistry
+
+
+def test_a2a_call_schema_round_trips_through_tool_describe(monkeypatch):
+    registry = ToolRegistry()
+
+    class _Context:
+        def register_tool(self, name, toolset, schema, handler, **kwargs):
+            registry.register(
+                name=name,
+                toolset=toolset,
+                schema=schema,
+                handler=handler,
+                **kwargs,
+            )
+
+    a2a_tools.register_tools(_Context())
+    definitions = registry.get_definitions({"a2a_call"})
+    monkeypatch.setattr(
+        tool_search,
+        "is_deferrable_tool_name",
+        lambda name: name == "a2a_call",
+    )
+
+    described = json.loads(
+        tool_search.dispatch_tool_describe(
+            {"name": "a2a_call"},
+            current_tool_defs=definitions,
+        )
+    )
+
+    assert described["description"]
+    assert described["parameters"]["required"] == ["agent", "message"]
+    assert set(described["parameters"]["properties"]) == {
+        "agent",
+        "message",
+        "context_id",
+    }


### PR DESCRIPTION
## Summary
Fixes a double-wrapping bug where A2A client tools passed the full OpenAI function wrapper to `ctx.register_tool()` instead of the inner function schema, leaving `tool_describe` with an empty description and empty parameters for all 5 A2A tools.

## Root cause
`register_tools()` in `plugins/platforms/a2a/tools.py` passed `schema` (the full `{"type":"function","function":{...}}` dict) to `ctx.register_tool()`. But the plugin API expects the inner function schema and `registry.get_definitions()` adds the outer wrapper itself — producing a double-wrapped schema that broke `dispatch_tool_describe()`.

## Changes
- `plugins/platforms/a2a/tools.py`: pass `schema["function"]` (the inner dict) to `ctx.register_tool()` instead of the full wrapper.
- `tests/plugins/test_a2a_schema_registration.py`: regression test verifying `tool_describe("a2a_call")` returns the correct description, required args, and properties after registry wrapping.

## Validation
| | Before (main) | After (this PR) |
|---|---|---|
| `tool_describe("a2a_call")` description | `""` (empty) | Full description (227 chars) |
| `tool_describe("a2a_call")` required | `[]` | `["agent", "message"]` |
| `tool_describe("a2a_call")` properties | `{}` | `{"agent", "message", "context_id"}` |
| PR regression test | N/A | 1 passed |
| Full a2a plugin suite | 106 passed | 106 passed |
| Sibling plugin audit | N/A | spotify + google_meet already correct — no sibling bug |

Closes #90487
