### PR TITLE
fix(model_metadata): add Daybreak Codex 900K context

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -656,7 +656,9 @@ def _is_codex_gpt54_or_gpt55(model: Optional[str], provider: Optional[str] = Non
     via prefix so the override tracks every 272K-capped family (5.4, 5.5,
     5.6 sol/terra/luna incl. their ``-pro`` modes) without re-listing every
     variant. (Name kept for backward compatibility with the
-    ``compression.codex_gpt55_autoraise`` config key.)
+    ``compression.codex_gpt55_autoraise`` config key.) The exact
+    ``gpt-daybreak-blue-latest`` Codex slug is also a verified Sol-family
+    alias and receives the same autoraise.
     """
     prov = (provider or "").strip().lower()
     if prov != "openai-codex":
@@ -672,6 +674,7 @@ def _is_codex_gpt54_or_gpt55(model: Optional[str], provider: Optional[str] = Non
         or bare == "gpt-5.6"
         or bare.startswith("gpt-5.6-")
         or bare.startswith("gpt-5.6.")
+        or bare == "gpt-daybreak-blue-latest"
     )
 
 
@@ -726,7 +729,8 @@ def _compression_threshold_for_model(
 
     Per-model/route overrides:
       - Arcee Trinity Large Thinking → 0.75 (preserve reasoning context).
-      - gpt-5.4 / gpt-5.5 / gpt-5.6 on the Codex OAuth route → 0.85, because
+      - gpt-5.4 / gpt-5.5 / gpt-5.6 and the exact Daybreak Sol alias on the
+        Codex OAuth route → 0.85, because
         Codex caps all three families at 272K and the default 50% trigger
         would compact at ~136K. Gated by ``allow_codex_gpt55_autoraise``
         (historical config-key name kept for backward compatibility) so the

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2341,6 +2341,7 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
     "gpt-5.6-sol": 272_000,
     "gpt-5.6-terra": 272_000,
     "gpt-5.6-luna": 272_000,
+    "gpt-daybreak-blue-latest": 272_000,
     "gpt-5.5": 272_000,
     "gpt-5.4": 272_000,
     "gpt-5.2": 272_000,
@@ -2374,6 +2375,7 @@ _CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_PREFIXES: Dict[str, int] = {
 }
 _CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_EXACT: Dict[str, int] = {
     "gpt-5.4": 900_000,   # verified live at 900K; gpt-5.4-mini rejected 500K — excluded
+    "gpt-daybreak-blue-latest": 900_000,  # exact Daybreak/Sol alias verified at 911,276
 }
 
 # The advertised value the verified-above table is allowed to override.

--- a/tests/agent/test_arcee_trinity_overrides.py
+++ b/tests/agent/test_arcee_trinity_overrides.py
@@ -74,7 +74,10 @@ def test_compression_threshold_default_none_for_other_models() -> None:
 
 @pytest.mark.parametrize(
     "model",
-    ["gpt-5", "gpt-5.55", "gpt-5.50", "gpt-5.45", "gpt-5.40", "", None],
+    [
+        "gpt-5", "gpt-5.55", "gpt-5.50", "gpt-5.45", "gpt-5.40",
+        "gpt-daybreak-blue-latest-mini", "", None,
+    ],
 )
 def test_is_codex_gpt54_or_gpt55_rejects_non_54_55_models(model) -> None:
     # Close numeric neighbours must NOT match — the prefix guards require a
@@ -89,6 +92,8 @@ def test_compression_threshold_for_codex_gpt55() -> None:
     assert _compression_threshold_for_model("gpt-5.5", "openai-codex") == 0.85
     assert _compression_threshold_for_model("gpt-5.5-pro", "openai-codex") == 0.85
     assert _compression_threshold_for_model("openai/gpt-5.5", "openai-codex") == 0.85
+    assert _is_codex_gpt54_or_gpt55("gpt-daybreak-blue-latest", "openai-codex") is True
+    assert _compression_threshold_for_model("gpt-daybreak-blue-latest", "openai-codex") == 0.85
 
 
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -518,6 +518,7 @@ class TestCodexOAuthContextLength:
             "gpt-5.6-luna",
             "gpt-5.6-sol-2026-07-09",  # dated snapshot via gpt-5.6 family prefix
             "gpt-5.4",
+            "gpt-daybreak-blue-latest",  # Sol alias; exact verified slug
         ],
     )
     def test_stale_272k_advertisement_bumped_to_live_verified_900k(self, slug):
@@ -590,7 +591,8 @@ class TestCodexOAuthContextLength:
             )
         assert ctx == 272_000
 
-    def test_fallback_table_resolution_also_bumped(self):
+    @pytest.mark.parametrize("slug", ["gpt-5.6-sol", "gpt-daybreak-blue-latest"])
+    def test_fallback_table_resolution_also_bumped(self, slug):
         """When the live probe fails, the 272K fallback-table value for a
         verified slug is bumped the same way (same enforcement applies)."""
         from agent.model_metadata import get_model_context_length
@@ -602,7 +604,7 @@ class TestCodexOAuthContextLength:
              patch("agent.model_metadata.get_cached_context_length", return_value=None), \
              patch("agent.model_metadata.save_context_length"):
             ctx = get_model_context_length(
-                model="gpt-5.6-sol",
+                model=slug,
                 base_url="https://chatgpt.com/backend-api/codex",
                 api_key="expired-token",
                 provider="openai-codex",


### PR DESCRIPTION
## What does this PR do?

Adds Codex context metadata for the exact `gpt-daybreak-blue-latest` slug. A live Codex Responses probe confirmed that Daybreak accepts the same large-context allocation as its Sol backend, completing with exactly 911,276 input tokens. It also opts Daybreak into the existing Codex 85% compaction autoraise used by Sol/Luna.

The change follows the existing stale-catalog safeguard from #88056: only the exact 272,000-token advertisement is raised to the verified 900,000-token value. Other Daybreak-like or future slugs are not over-matched.

## Related PR

Builds on the merged Codex large-context override in #88056.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

- `agent/model_metadata.py`
  - Adds `gpt-daybreak-blue-latest` to the conservative 272K Codex fallback table.
  - Adds an exact 900K verified-above-advertised override.
- `agent/auxiliary_client.py`
  - Adds the exact Daybreak slug to the existing Codex 85% compaction autoraise matcher.
- `tests/agent/test_arcee_trinity_overrides.py`
  - Covers Daybreak's 85% threshold and rejects similarly suffixed lookalikes.
- `tests/agent/test_model_metadata.py`
  - Covers Daybreak through both the live-catalogue and probe-fallback paths.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_model_metadata.py` — **93 passed**.
2. Run `scripts/run_tests.sh tests/agent/test_arcee_trinity_overrides.py` — **22 passed**.
3. Run `uv run --extra dev ruff check agent/model_metadata.py agent/auxiliary_client.py tests/agent/test_model_metadata.py tests/agent/test_arcee_trinity_overrides.py` — **passed**.
4. Live-probe `gpt-daybreak-blue-latest` through the ChatGPT Codex Responses endpoint with 911,276 input tokens — **HTTP 200 / completed**, effective backend model `gpt-5.6-sol`.

## Verification Note

The full repository suite was run with `scripts/run_tests.sh tests/`, the repository's canonical full-test wrapper. It completed with **164 failed tests across 53 files**, and **44 files did not run** because of collection/import or timeout issues. The failures were outside this PR's two changed files and include missing optional dependencies, disabled optional-install paths, and unrelated test/environment regressions. The focused model-metadata suite and lint checks remain clean.

## Checklist

- [x] I've read the repository contribution guidance.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs.
- [x] This PR contains only related changes.
- [x] I've added tests for the change.
- [x] I've considered cross-platform impact — metadata and tests are platform-independent.
- [ ] I've run the full `pytest tests/ -q` suite — 164 unrelated failures and 44 files not run are documented above.
