### PR TITLE
Spend colour on the pane you're in: focus dimming, one theme list, grey scrollbars

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -23,6 +23,7 @@ import type { ChatMessage } from '@/lib/chat-messages'
 import { NEW_SESSION_TITLE, quickModelOptions, sessionTitle } from '@/lib/chat-runtime'
 import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
 import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
+import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
 import { migrateSessionDraft } from '@/store/composer'
 import { migrateQueuedPrompts, parkQueuedPrompts } from '@/store/composer-queue'
@@ -44,7 +45,7 @@ import {
   sessionPinId,
   shouldMigrateComposerScope
 } from '@/store/session'
-import { sessionTileDelegate } from '@/store/session-states'
+import { $focusedStoredSessionId, sessionTileDelegate } from '@/store/session-states'
 import { $transcriptTailBySessionId } from '@/store/transcript-tail'
 import { isAuxiliaryWindow, isWatchWindow } from '@/store/windows'
 import type { ModelOptionsResponse } from '@/types/hermes'
@@ -371,6 +372,13 @@ const ChatViewContent = memo(function ChatViewContent({
   const isPrimary = view.kind === 'primary'
   const activeSessionId = useStore(view.$runtimeId)
   const storedId = useStore(view.$storedId)
+  // Multi-pane dimming: only the focused surface paints at full strength, so
+  // two sessions side by side read as "this one, and that one over there".
+  // A selector, not a plain useStore — the focused id changes on click, and a
+  // boolean bails every other surface out of the re-render. Sole surface ⇒
+  // always focused (the atom falls back to the primary's selection), so a
+  // single-pane workspace never dims.
+  const surfaceFocused = useStoreSelector($focusedStoredSessionId, focused => focused === storedId)
   // Dock anchor for a session drop onto this surface: the workspace pane for the
   // primary, this tile's pane id for a tile. Read by the session-drop bridge.
   const sessionAnchor = isPrimary ? 'workspace' : `session-tile:${storedId ?? ''}`
@@ -575,6 +583,7 @@ const ChatViewContent = memo(function ChatViewContent({
         className
       )}
       data-chat-surface=""
+      data-chat-unfocused={surfaceFocused ? undefined : ''}
       data-composer-surface-id={composerSurfaceId}
       data-composer-target={composerScope.target}
       data-session-anchor={sessionAnchor}

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -30,6 +30,7 @@ import { $projects } from '@/store/projects'
 import { $pullRequestsByBranch, sessionPrKey } from '@/store/pull-requests'
 import { $sessionDotStateById, hasLiveTurn, showsRunningArc } from '@/store/session-dot-state'
 import { $sessionListDensity } from '@/store/session-list-density'
+import { $openStoredSessionIds } from '@/store/session-states'
 import { sessionCostUsd } from '@/store/sidebar-archive'
 import { $todoProgressBySession } from '@/store/todos'
 
@@ -173,6 +174,10 @@ function SidebarSessionRowImpl({
   // those branches should repaint.
   const prKey = sessionPrKey(session)
   const pr = useStoreSelector($pullRequestsByBranch, prs => (rowMeta.includes('pr') && prKey ? prs[prKey] : undefined))
+  // Open in a pane, but not the focused one. A selector rather than a prop:
+  // it reaches all four row render paths at once, the set only changes when a
+  // tile opens or closes, and the boolean bails every unaffected row out.
+  const openUnfocused = useStoreSelector($openStoredSessionIds, open => !isSelected && open.has(session.id))
   const totalTokens = session.input_tokens + session.output_tokens
   const cost = sessionCostUsd(session)
 
@@ -352,6 +357,10 @@ function SidebarSessionRowImpl({
           !card && density !== 'compact' && 'min-h-[2.75rem]',
           !card && density === 'detailed' && 'min-h-[3.875rem]',
           isSelected && 'bg-(--ui-row-active-background)',
+          // Open in another pane: the SAME band, just weaker. Its own mixed
+          // token rather than row opacity — dimming the whole row would take
+          // the title and the status dot down with it.
+          openUnfocused && 'bg-(--ui-row-open-background)',
           liveTurn && 'text-foreground',
           // Opaque surface while lifted so the dragged row erases what's under
           // it (translucency let the rows below bleed through). data-glass-opaque

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -18,6 +18,7 @@ import { Command, CommandGroup, CommandInput, CommandItem, CommandList } from '@
 import { HighlightMatches } from '@/components/ui/highlight-matches'
 import { KbdCombo } from '@/components/ui/kbd'
 import { getHermesConfigRecord, listAllProfileSessions } from '@/hermes'
+import { useMediaQuery } from '@/hooks/use-media-query'
 import { useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
 import {
@@ -248,8 +249,8 @@ const rankGroups = (groups: PaletteGroup[], search: string): PaletteGroup[] => {
     .map(entry => entry.group)
 }
 
-// cmdk selection values must be unique; labels alone can repeat (the same
-// theme lists under both Light and Dark). The id suffix disambiguates.
+// cmdk selection values must be unique; labels alone can repeat (a settings
+// field and a session can share a title). The id suffix disambiguates.
 const paletteValue = (item: PaletteItem): string => `${item.label}\u0001${item.id}`
 
 const EMPTY_GROUPS: PaletteGroup[] = []
@@ -558,6 +559,15 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
 
   const { availableThemes, clearThemePreview, mode, previewTheme, resolvedMode, setMode, setTheme, themeName } =
     useTheme()
+
+  // Mode rows preview like theme rows do: paint the committed skin at the
+  // highlighted brightness. `system` has to be resolved here — previewTheme
+  // paints a concrete light/dark.
+  const systemDark = useMediaQuery('(prefers-color-scheme: dark)')
+  const resolveThemeMode = useCallback(
+    (target: ThemeMode): 'light' | 'dark' => (target === 'system' ? (systemDark ? 'dark' : 'light') : target),
+    [systemDark]
+  )
 
   const [search, setSearch] = useState('')
   const [page, setPage] = useState<string | null>(null)
@@ -1148,6 +1158,7 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
         keepOpen: true,
         keywords: ['appearance', 'color mode', 'brightness', entry.mode, t.settings.modeOptions[entry.mode].label],
         label: t.settings.modeOptions[entry.mode].label,
+        onHighlight: () => previewTheme(themeName, resolveThemeMode(entry.mode)),
         run: () => setMode(entry.mode)
       }))
     })
@@ -1232,6 +1243,7 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
     mode,
     previewTheme,
     resolvedMode,
+    resolveThemeMode,
     search,
     sessions,
     setMode,
@@ -1325,27 +1337,51 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
               }
             ]
           },
-          // Built-ins and imported families list under the mode(s) they support;
-          // picking sets skin + mode at once. A multi-variant import (GitHub,
-          // Solarized) appears in both groups and switches variants with the mode.
-          ...(['light', 'dark'] as const).map(groupMode => ({
-            heading: groupMode === 'light' ? t.settings.modeOptions.light.label : t.settings.modeOptions.dark.label,
-            items: availableThemes
-              .filter(theme => themeSupportsMode(theme.name, groupMode))
-              .map(theme => ({
-                active: themeName === theme.name && resolvedMode === groupMode,
-                icon: groupMode === 'light' ? Sun : Moon,
-                id: `theme-${theme.name}-${groupMode}`,
+          // Brightness lives with the palettes: one mode toggle for the whole
+          // list instead of splitting every theme across a Light and a Dark group.
+          {
+            heading: t.settings.appearance.colorMode,
+            items: THEME_MODES.map(entry => ({
+              active: mode === entry.mode,
+              icon: entry.icon,
+              id: `theme-mode-${entry.mode}`,
+              keepOpen: true,
+              keywords: ['appearance', 'brightness', 'color mode', t.settings.modeOptions[entry.mode].label],
+              label: t.settings.modeOptions[entry.mode].label,
+              onHighlight: () => previewTheme(themeName, resolveThemeMode(entry.mode)),
+              run: () => setMode(entry.mode)
+            }))
+          },
+          // Every palette once, applied on top of the selected mode. An import
+          // that only ships one variant (Dracula) flips the mode to the side it
+          // can actually render.
+          {
+            heading: t.settings.appearance.themeTitle,
+            items: availableThemes.map(theme => {
+              const previewMode = themeSupportsMode(theme.name, resolvedMode)
+                ? resolvedMode
+                : resolvedMode === 'dark'
+                  ? 'light'
+                  : 'dark'
+
+              return {
+                active: themeName === theme.name,
+                icon: Palette,
+                id: `theme-${theme.name}`,
                 keepOpen: true,
-                keywords: ['theme', 'appearance', 'palette', groupMode, theme.label, theme.description ?? ''],
+                keywords: ['theme', 'appearance', 'palette', theme.label, theme.description ?? ''],
                 label: theme.label,
-                onHighlight: () => previewTheme(theme.name, groupMode),
+                onHighlight: () => previewTheme(theme.name, previewMode),
                 run: () => {
                   setTheme(theme.name)
-                  setMode(groupMode)
+
+                  if (previewMode !== resolvedMode) {
+                    setMode(previewMode)
+                  }
                 }
-              }))
-          }))
+              }
+            })
+          }
         ]
       },
       'color-mode': {
@@ -1361,6 +1397,7 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
               keepOpen: true,
               keywords: ['appearance', 'brightness', t.settings.modeOptions[entry.mode].label],
               label: t.settings.modeOptions[entry.mode].label,
+              onHighlight: () => previewTheme(themeName, resolveThemeMode(entry.mode)),
               run: () => setMode(entry.mode)
             }))
           }
@@ -1387,7 +1424,18 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
         groups: settingsPageGroups
       }
     }),
-    [availableThemes, mode, previewTheme, resolvedMode, setMode, setTheme, settingsPageGroups, t, themeName]
+    [
+      availableThemes,
+      mode,
+      previewTheme,
+      resolvedMode,
+      resolveThemeMode,
+      setMode,
+      setTheme,
+      settingsPageGroups,
+      t,
+      themeName
+    ]
   )
 
   const activePage = page ? subPages[page] : null

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -997,6 +997,15 @@ export const $focusedStoredSessionId = computed(
   }
 )
 
+/** Every session currently OPEN as a surface: the primary's selection plus
+ *  every tile's stored id. The sidebar highlights all of them (the focused one
+ *  at full strength, the rest dimmed) so a multi-pane workspace shows which
+ *  chats are on screen, not just the one being typed into. */
+export const $openStoredSessionIds = computed(
+  [$selectedStoredSessionId, $sessionTiles],
+  (selected, tiles) => new Set([...(selected ? [selected] : []), ...tiles.map(t => t.storedSessionId)])
+)
+
 /** Live runtime id of the focused session (a tile's bound runtime, else the
  *  primary's active session). */
 export const $focusedRuntimeId = computed(

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -300,6 +300,10 @@
       var(--ui-accent) var(--theme-row-active-accent-mix),
       color-mix(in srgb, var(--ui-base) 5%, transparent)
     );
+    /* Open in a pane, but not the FOCUSED one: the active band at reduced
+       strength, so every session on screen is marked and the one you're in
+       still wins. Mixed from the active token so a theme tunes both at once. */
+    --ui-row-open-background: color-mix(in srgb, var(--ui-row-active-background) 28%, transparent);
     --ui-control-hover-background: color-mix(
       in srgb,
       var(--ui-accent) var(--theme-control-hover-accent-mix),
@@ -1652,10 +1656,32 @@ body.guest-pointer-lock :is(webview, iframe) {
    much stronger over a light backdrop), full strength in dark mode. */
 :root {
   --dock-glow-scale: 0.55;
+  /* Unfocused chat surface (multi-pane): a pane the user isn't in recedes so
+     the focused conversation reads as the one being worked in. Light needs a
+     deeper cut — a dim over a bright surface loses contrast far more slowly
+     than the same dim over a dark one. Pairs with a grayscale pass on the same
+     element — one treatment for the whole pane, not per-part tuning. */
+  --chat-unfocused-opacity: 0.62;
 }
 
 .dark {
   --dock-glow-scale: 1;
+  --chat-unfocused-opacity: 0.72;
+}
+
+/* The whole surface recedes as ONE layer — thread, timeline rail, composer,
+   header — fading and desaturating together rather than each part taking its
+   own treatment. Both properties on the surface root also composite the
+   already-painted layer instead of repainting descendants. */
+[data-chat-surface][data-chat-unfocused] {
+  opacity: var(--chat-unfocused-opacity);
+  filter: grayscale(1);
+}
+
+[data-chat-surface] {
+  transition:
+    opacity 75ms ease-out,
+    filter 75ms ease-out;
 }
 
 /* Drag-region hatch — a diagonal ///// pattern (Photoshop-style) that fades into

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -399,6 +399,11 @@
     --ui-tab-hover-darken: 2.5%;
     --dt-ring: var(--ui-stroke-primary);
     --dt-midground: var(--theme-midground);
+    /* Scrollbars carry no theme colour: the accent-tinted thumb read as a
+       coloured element in the corner of every list. Same lightness as the
+       midground so each theme still gets a thumb that sits right against its
+       own surfaces — chroma 0 is the only thing removed. */
+    --dt-scrollbar-thumb: oklch(from var(--dt-midground) l 0 h);
     --dt-composer-ring: var(--ui-base);
     --dt-destructive: #cf2d56;
     --dt-destructive-foreground: #ffffff;
@@ -1300,14 +1305,14 @@ body.guest-pointer-lock :is(webview, iframe) {
 
   .scrollbar-dt::-webkit-scrollbar-thumb,
   .scrollbar-dt *:not(.scrollbar-overlay)::-webkit-scrollbar-thumb {
-    background: color-mix(in srgb, var(--dt-midground) 18%, transparent);
+    background: color-mix(in srgb, var(--dt-scrollbar-thumb) 18%, transparent);
     border-radius: 9999rem;
     background-clip: padding-box;
   }
 
   .scrollbar-dt::-webkit-scrollbar-thumb:hover,
   .scrollbar-dt *:not(.scrollbar-overlay)::-webkit-scrollbar-thumb:hover {
-    background: color-mix(in srgb, var(--dt-midground) 40%, transparent);
+    background: color-mix(in srgb, var(--dt-scrollbar-thumb) 40%, transparent);
     background-clip: padding-box;
   }
 
@@ -1328,12 +1333,12 @@ body.guest-pointer-lock :is(webview, iframe) {
 
   .scrollbar-fade:hover::-webkit-scrollbar-thumb,
   .scrollbar-dt .scrollbar-fade:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--dt-midground) 18%, transparent);
+    background-color: color-mix(in srgb, var(--dt-scrollbar-thumb) 18%, transparent);
   }
 
   .scrollbar-fade:hover::-webkit-scrollbar-thumb:hover,
   .scrollbar-dt .scrollbar-fade:hover::-webkit-scrollbar-thumb:hover {
-    background-color: color-mix(in srgb, var(--dt-midground) 40%, transparent);
+    background-color: color-mix(in srgb, var(--dt-scrollbar-thumb) 40%, transparent);
   }
 
   /* Hover marquee: a truncated line that scrolls its overflow into view while
@@ -1380,13 +1385,13 @@ body.guest-pointer-lock :is(webview, iframe) {
   }
 
   .dt-portal-scrollbar::-webkit-scrollbar-thumb {
-    background: color-mix(in srgb, var(--dt-midground) 28%, transparent);
+    background: color-mix(in srgb, var(--dt-scrollbar-thumb) 28%, transparent);
     border-radius: 9999rem;
     background-clip: padding-box;
   }
 
   .dt-portal-scrollbar::-webkit-scrollbar-thumb:hover {
-    background: color-mix(in srgb, var(--dt-midground) 50%, transparent);
+    background: color-mix(in srgb, var(--dt-scrollbar-thumb) 50%, transparent);
     background-clip: padding-box;
   }
 
@@ -1398,19 +1403,19 @@ body.guest-pointer-lock :is(webview, iframe) {
     .scrollbar-dt,
     .scrollbar-dt *:not(.scrollbar-overlay) {
       scrollbar-width: thin;
-      scrollbar-color: color-mix(in srgb, var(--dt-midground) 18%, transparent) transparent;
+      scrollbar-color: color-mix(in srgb, var(--dt-scrollbar-thumb) 18%, transparent) transparent;
     }
 
     .dt-portal-scrollbar {
       scrollbar-width: thin;
-      scrollbar-color: color-mix(in srgb, var(--dt-midground) 28%, transparent) transparent;
+      scrollbar-color: color-mix(in srgb, var(--dt-scrollbar-thumb) 28%, transparent) transparent;
     }
 
     /* Firefox has no real overlay mode; thin + transparent track is the closest
        match to the Chromium overlay opt-out above. */
     .scrollbar-overlay {
       scrollbar-width: thin;
-      scrollbar-color: color-mix(in srgb, var(--dt-midground) 28%, transparent) transparent;
+      scrollbar-color: color-mix(in srgb, var(--dt-scrollbar-thumb) 28%, transparent) transparent;
     }
 
     /* No transition — Firefox doesn't animate scrollbar-color. */
@@ -1419,7 +1424,7 @@ body.guest-pointer-lock :is(webview, iframe) {
     }
 
     .scrollbar-fade:hover {
-      scrollbar-color: color-mix(in srgb, var(--dt-midground) 18%, transparent) transparent;
+      scrollbar-color: color-mix(in srgb, var(--dt-scrollbar-thumb) 18%, transparent) transparent;
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Four appearance changes to the desktop, all of the same kind: colour and
contrast were being spent on things that weren't the thing you were looking at.

Tiling two sessions side by side didn't say which one you were in — both panes
painted at full strength, both composers looked live, and the sidebar
highlighted only one of the two chats actually on screen. ⌘K's theme picker
listed every built-in twice, once under Light and once under Dark, and picking
one silently changed your mode. Scrollbar thumbs carried the theme accent, so
every list had a small tinted bar in its corner.

| Area | Before | After |
|---|---|---|
| Tiled panes | Both at full strength | Unfocused pane fades + desaturates as one layer |
| Sidebar | Only the focused session banded | Every open session banded, unfocused ones weaker |
| ⌘K theme picker | Light group + Dark group, every built-in twice | Mode toggle (light/dark/system), then each theme once |
| ⌘K mode rows | Commit-only | Preview live on highlight, like theme rows |
| Scrollbars | Accent-tinted thumb | Same lightness, zero chroma |

A single-pane workspace is unaffected: focus falls back to the primary's
selection, so there is nothing to dim.

## Related Issue

N/A — desktop UI.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

**Focus state for tiled sessions**

- `store/session-states.ts` — `$openStoredSessionIds`: the primary's selection
  plus every tile's stored id, so the sidebar can tell *open* from *focused*.
  Sits beside the existing `$focusedStoredSessionId`, same derivation style.
- `app/chat/index.tsx` — the surface root carries `data-chat-unfocused` when
  another surface holds focus, from a `useStoreSelector` over
  `$focusedStoredSessionId`. A boolean, so a focus change elsewhere bails every
  other surface out of the re-render instead of repainting its transcript.
- `styles.css` — one rule on the surface root: `opacity` (0.62 light / 0.72
  dark, each a var) plus `grayscale(1)`, 75ms ease-out. Deliberately one layer
  rather than per-part treatment — an earlier pass gave the composer and the
  timeline rail their own compounding opacity and it read as broken. Both
  properties composite the painted layer instead of repainting descendants.
- `app/chat/sidebar/session-row.tsx` — open-but-unfocused rows paint
  `--ui-row-open-background`, the active token mixed to 28%. A colour rather
  than row opacity: dimming the row would take the title and the status dot
  with it. Read through a selector so it reaches all four row render paths
  (static, sortable, virtual, virtual-sortable) without a prop threaded through
  each.

**⌘K theme picker**

- `app/command-palette/index.tsx` — the theme page now mirrors Appearance
  settings: a Color Mode group (light/dark/system) then every palette once,
  applied on top of whichever mode is selected. Row ids drop their `-light` /
  `-dark` suffix, and `themeSupportsMode` now only handles the edge case it
  exists for: an import that ships a single variant (Dracula) flips the mode to
  the side it can actually render.
- Mode rows preview on highlight in all three places they appear — the theme
  page, the standalone Change Color Mode page, and root-search hits for
  "dark"/"light". `system` resolves through a live `prefers-color-scheme` query,
  so it previews what committing it would actually give you rather than a
  guess.

**Scrollbars**

- `styles.css` — new `--dt-scrollbar-thumb` derives from `--dt-midground` with
  chroma forced to zero, keeping each theme's lightness so the thumb still sits
  correctly against its own surfaces. Applied to all ten thumb declarations:
  `.scrollbar-dt`, `.scrollbar-fade`, `.dt-portal-scrollbar` (rest + hover
  each), and the four Firefox `scrollbar-color` fallbacks. Alpha steps are
  unchanged, so density reads exactly as before. `--dt-midground` itself is
  untouched — the running arc and activity timer still get the real accent.

## How to Test

1. Open a second session as a tile beside the main thread (drag a sidebar row
   onto the chat, or ⌘T). Click between the two panes: the one you're not in
   fades and goes greyscale, the other returns to full colour.
2. Check both light and dark — each carries its own opacity.
3. Close the tile. The remaining pane never dims.
4. In the sidebar, both open sessions carry the active band; the focused one is
   stronger.
5. ⌘K → Change Theme: one Color Mode group (light/dark/system, system default),
   then every theme listed once — no duplicates across two groups. Arrow through
   both groups; each row previews live and reverts on Esc.
6. ⌘K and type "dark": the mode row previews on highlight there too.
7. Scroll any list on any theme: the thumb is grey, same weight as before.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — desktop-only change, no Python touched
- [ ] I've added tests for my changes — presentation only: a CSS attribute, a derived atom, and a palette group rebuild
- [x] I've tested on my platform: macOS 15.7.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
