### PR TITLE
fix(desktop): config autosave sends only session-edited keys — stale drafts stop reverting newer changes

### DIFF
--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -33,6 +33,7 @@ import { PanelEmpty } from '../overlays/panel'
 
 import { ConfigField } from './config-field'
 import {
+  buildSparseRecord,
   clearsEnabledToolsets,
   enumOptionsFor,
   getNested,
@@ -118,6 +119,13 @@ function ConfigSettingsInner({
   const saveVersionRef = useRef(0)
   const savedDiscoverySignatureRef = useRef<string | undefined>(undefined)
   const [saveVersion, setSaveVersion] = useState(0)
+  // Sparse-save bookkeeping: the exact schema keys the user edited in THIS
+  // page session. The autosave payload is built from these alone (see the
+  // save effect) so stale unedited draft keys can never clobber changes made
+  // elsewhere while the page sat open. fullSaveRef flips on whole-record
+  // intents (JSON import) where sending everything IS the point.
+  const editedKeysRef = useRef<Set<string>>(new Set())
+  const fullSaveRef = useRef(false)
 
   // Seed the local draft once, the first time the shared record lands.
   // Background refetches thereafter must not clobber in-progress edits.
@@ -178,7 +186,20 @@ function ConfigSettingsInner({
     const t = window.setTimeout(() => {
       void (async () => {
         try {
-          const result = await saveHermesConfig(config, scopeProfile ?? undefined)
+          // Sparse save (#89184 residual): PUT only the paths edited THIS
+          // session, not the whole seeded draft. The draft is seeded ONCE and
+          // never refreshed (deliberately — background refetches must not
+          // clobber edits), so any key changed elsewhere after seeding
+          // (composer /model, Model page Apply, CLI) is stale in `config`;
+          // a whole-record PUT re-asserted it and the backend's model
+          // re-detection dutifully reverted the user's newer choice. The
+          // backend deep-merges, so keys absent from the payload are safe by
+          // construction. A JSON import is an explicit whole-record replace
+          // and keeps sending everything.
+          const payload = fullSaveRef.current
+            ? config
+            : buildSparseRecord(config, [...editedKeysRef.current])
+          const result = await saveHermesConfig(payload, scopeProfile ?? undefined)
 
           if (!result.ok) {
             throw new Error(c.autosaveFailed)
@@ -214,13 +235,21 @@ function ConfigSettingsInner({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- copy is stable; avoid re-scheduling autosave on locale change
   }, [config, onConfigSaved, saveVersion])
 
-  const applyConfig = (next: HermesConfigRecord) => {
+  const applyConfig = (next: HermesConfigRecord, editedKey?: string) => {
+    if (editedKey) {
+      editedKeysRef.current.add(editedKey)
+    } else {
+      // No key = whole-record intent (JSON import, toolsets-wipe confirm on
+      // an imported record): every subsequent autosave sends the full draft.
+      fullSaveRef.current = true
+    }
+
     saveVersionRef.current += 1
     setConfig(next)
     setSaveVersion(saveVersionRef.current)
   }
 
-  const updateConfig = (next: HermesConfigRecord) => {
+  const updateConfig = (next: HermesConfigRecord, editedKey?: string) => {
     // Guard the single most destructive config edit: clearing the entire
     // "Enabled Toolsets" list silently disables memory, terminal, web search,
     // delegation, and most tools, and a stray select-all + Backspace can do it.
@@ -229,14 +258,14 @@ function ConfigSettingsInner({
     if (config && clearsEnabledToolsets(config, next)) {
       void confirm({ destructive: true, title: c.toolsetsWipeConfirm }).then(ok => {
         if (ok) {
-          applyConfig(next)
+          applyConfig(next, editedKey)
         }
       })
 
       return
     }
 
-    applyConfig(next)
+    applyConfig(next, editedKey)
   }
 
   const sectionFields = useMemo(() => {
@@ -404,7 +433,7 @@ function ConfigSettingsInner({
                     ? enumOptionsFor(key, getNested(config, key), config, elevenLabsVoiceOptions ?? undefined)
                     : enumOptionsFor(key, getNested(config, key), config)
                 }
-                onChange={value => updateConfig(setNested(config, key, value))}
+                onChange={value => updateConfig(setNested(config, key, value), key)}
                 optionLabels={key === 'tts.elevenlabs.voice_id' ? elevenLabsVoiceLabels : undefined}
                 schema={field}
                 schemaKey={key}

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -5,6 +5,7 @@ import type { HermesConfigRecord } from '@/types/hermes'
 import { FIELD_DESCRIPTIONS, FIELD_LABELS, SECTIONS } from './constants'
 import { defineFieldCopy, fieldCopyForSchemaKey, schemaKeyToFieldCopyKey } from './field-copy'
 import {
+  buildSparseRecord,
   clearsEnabledToolsets,
   enumOptionsFor,
   getNested,
@@ -403,5 +404,50 @@ describe('settings helpers', () => {
 
       expect(clearsEnabledToolsets(prev, next)).toBe(false)
     })
+  })
+})
+
+describe('buildSparseRecord', () => {
+  // #89184 residual: the config page seeds its draft ONCE and autosaved the
+  // WHOLE record — any key changed elsewhere while the page sat open (composer
+  // /model, Model page Apply, CLI) was stale in the draft and got re-asserted,
+  // reverting the newer change. The sparse payload contains ONLY session-edited
+  // paths, so unedited staleness can never ride a save.
+
+  it('contains only the edited paths at their nested positions', () => {
+    const config: HermesConfigRecord = {
+      model: 'stale/model-a',
+      display: { personality: 'fresh', show_reasoning: true },
+      agent: { max_turns: 500 }
+    }
+
+    const sparse = buildSparseRecord(config, ['display.personality'])
+
+    expect(sparse).toEqual({ display: { personality: 'fresh' } })
+    // The stale flattened model — the revert vector — is absent by construction.
+    expect('model' in sparse).toBe(false)
+    expect('agent' in sparse).toBe(false)
+  })
+
+  it('bundles model_context_length whenever model is edited (backend pair)', () => {
+    const config: HermesConfigRecord = { model: 'x/y', model_context_length: 32000 }
+
+    const sparse = buildSparseRecord(config, ['model'])
+
+    expect(sparse).toEqual({ model: 'x/y', model_context_length: 32000 })
+  })
+
+  it('skips undefined values and deep-copies edited subtrees', () => {
+    const config: HermesConfigRecord = { toolsets: ['memory', 'terminal'] }
+
+    const sparse = buildSparseRecord(config, ['toolsets', 'missing.path'])
+
+    expect(sparse).toEqual({ toolsets: ['memory', 'terminal'] })
+    ;(sparse.toolsets as string[]).push('mutated')
+    expect((config.toolsets as string[]).length).toBe(2)
+  })
+
+  it('returns an empty record when nothing was edited', () => {
+    expect(buildSparseRecord({ model: 'a' }, [])).toEqual({})
   })
 })

--- a/apps/desktop/src/app/settings/helpers.ts
+++ b/apps/desktop/src/app/settings/helpers.ts
@@ -200,6 +200,51 @@ export function setNested(obj: HermesConfigRecord, path: string, value: unknown)
   return clone
 }
 
+/** Build the sparse autosave payload: only the schema paths in `keys`, each
+ *  copied from `config` at its full nested position. The backend deep-merges
+ *  PUT /api/config, so a payload that omits everything the user did NOT edit
+ *  is the whole fix for the stale-draft revert class (#89184 residual): keys
+ *  changed elsewhere while the page sat open simply never appear.
+ *  `model_context_length` rides along whenever `model` is edited — the
+ *  backend's denormalizer treats the pair as one field. */
+export function buildSparseRecord(config: HermesConfigRecord, keys: string[]): HermesConfigRecord {
+  const sparse: HermesConfigRecord = {}
+  const expanded = new Set(keys)
+
+  if (expanded.has('model')) {
+    expanded.add('model_context_length')
+  }
+
+  for (const key of expanded) {
+    const value = getNested(config, key)
+
+    if (value === undefined) {
+      continue
+    }
+
+    const parts = configPathParts(key)
+    let cur: Record<string, unknown> = sparse
+
+    for (let i = 0; i < parts.length - 1; i += 1) {
+      const part = parts[i]
+
+      if (!isSafePart(part)) {
+        throw new Error(`Unsafe config path part: ${part}`)
+      }
+
+      if (cur[part] == null || typeof cur[part] !== 'object') {
+        safeSet(cur, part, {})
+      }
+
+      cur = cur[part] as Record<string, unknown>
+    }
+
+    safeSet(cur, parts[parts.length - 1], structuredClone(value))
+  }
+
+  return sparse
+}
+
 function personalityOptions(config: HermesConfigRecord): string[] {
   const custom = getNested(config, 'agent.personalities')
 


### PR DESCRIPTION
## Summary

The Settings config page's autosave now PUTs only the keys the user edited this session — a model (or any setting) changed elsewhere while the page sits open is no longer reverted by the page's stale seeded draft. This was the remaining live half of the #89184/#89597 class (settings-pipeline audit Bug 2, HIGH).

Mechanism: the page seeds its local draft ONCE (deliberately — background refetches must not clobber in-progress edits) and autosaved the ENTIRE record on any field change. The backend deep-merge only protects keys ABSENT from the payload, and the flattened `model` string is always present — so: open Settings → switch model via composer `/model` or Model page → toggle any unrelated checkbox → the stale draft's `model` re-asserts, and `_denormalize_config_from_web` dutifully re-detects the provider and reverts the user's newer choice.

## Changes

- `apps/desktop/src/app/settings/helpers.ts`: `buildSparseRecord(config, keys)` — copies only the named schema paths at their nested positions (deep-cloned); bundles `model_context_length` with `model` (the backend denormalizer treats them as one field).
- `apps/desktop/src/app/settings/config-settings.tsx`: `updateConfig`/`applyConfig` track the edited schema key per change (`editedKeysRef`); the autosave payload is the sparse record. A JSON import keeps whole-record semantics (`fullSaveRef`) — sending everything is the point there.
- `helpers.test.ts`: 4 new cases (only-edited-paths, model+context bundling, deep-copy isolation, empty set).

## Validation

| | Result |
|---|---|
| helpers tests | 40/40 pass |
| Sabotage (helpers.ts reverted) | 4/4 new tests fail |
| tsc + eslint + app build | clean |
| Live E2E (the exact revert repro) | Settings open w/ seeded draft (model=fable-5) → `/api/model/set` → sonnet-5 → toggle unrelated switch on the seeded page → autosave fires → **model stays sonnet-5** (previously reverted); the toggled key (`display.show_reasoning`) persisted |

Also hardens the same class for the future: any key edited on ANOTHER surface (aux models, MoA, approvals) can no longer be clobbered by this page's autosave, because it's simply never sent.

## Infographic

![Autosave sends only what you edited](https://files.catbox.moe/jbzhdv.png)
