### PR TITLE
docs(computer-use): correct cua-driver onboarding guidance

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3639,7 +3639,7 @@ function Install-CuaDriver {
             Remove-Job $job -Force -ErrorAction SilentlyContinue
             $installedCuaDriver = Get-Command cua-driver -ErrorAction SilentlyContinue
             if ($installedCuaDriver -and (Test-CuaDriverRuntimeContract -DriverPath $installedCuaDriver.Source)) {
-                Write-Success "Computer Use driver installed (enable via 'hermes tools' -> Computer Use)"
+                Write-Success "Computer Use driver installed (manage via 'hermes tools' -> Computer Use)"
             } else {
                 Write-Warn "Computer Use driver install did not produce a compatible runtime -- repair it before enabling the tool."
                 Write-Info "Install later with: hermes computer-use install"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2574,7 +2574,7 @@ install_computer_use_driver() {
     if run_with_timeout 660 /bin/bash -c \
         'curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh | /bin/bash' \
         >"$cua_log" 2>&1; then
-        log_success "Computer Use driver installed (enable via 'hermes tools' → Computer Use)"
+        log_success "Computer Use driver installed (manage via 'hermes tools' → Computer Use)"
     else
         log_warn "Computer Use driver install failed — it will install on demand when you enable the tool."
         log_info "Install later with: hermes computer-use install"

--- a/skills/autonomous-ai-agents/computer-use/SKILL.md
+++ b/skills/autonomous-ai-agents/computer-use/SKILL.md
@@ -28,9 +28,8 @@ Hermes drives [cua-driver](https://github.com/trycua/cua) under the hood.
 This wrapper skill teaches the Hermes `computer_use` workflow and action
 vocabulary. Call the actions documented below instead of raw cua-driver MCP
 tools. For driver internals and platform-specific behavior, follow the Cua
-skill installed by `cua-driver skills install`. Hermes autodetection is a
-planned cua-driver follow-up, so currently point Hermes at the resulting
-`~/.cua-driver/skills/cua-driver` directory or symlink it into your skill space.
+skill installed by `cua-driver skills install`. The command links the pack into
+the standard Hermes skill directory at `~/.hermes/skills/cua-driver`.
 
 ## The canonical workflow
 
@@ -383,6 +382,7 @@ These are platform deep dives, not duplicates — when the user reports
 `WINDOWS.md` for the UIA / UWP context that explains why and what to
 do differently.
 
-Hermes autodetection is a planned follow-up in trycua/cua. For now, the command
-installs the pack under `~/.cua-driver/skills/cua-driver`; point Hermes at that
-directory or symlink it into the user's skill space.
+The command installs the pack under `~/.cua-driver/skills/cua-driver` and links
+it into the standard Hermes skill directory at
+`~/.hermes/skills/cua-driver`. Start a new Hermes session after installation so
+it loads the linked guidance.

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -72,12 +72,11 @@ under your control, so Hermes reports the incompatibility and leaves it
 unchanged.
 
 If you install Cua Driver first, `cua-driver skills install` installs Cua's
-skill pack under `~/.cua-driver/skills/cua-driver`. Hermes autodetection is a
-planned cua-driver follow-up, so currently point Hermes at that directory or
-symlink it into your skill space. You can also register raw Cua MCP tools as a
-custom MCP server, but that is an alternative for users who need the low-level
-interface. The built-in toolset provides Hermes actions, configuration,
-approvals, and diagnostics.
+skill pack under `~/.cua-driver/skills/cua-driver` and links it into the
+standard Hermes skill directory at `~/.hermes/skills/cua-driver`. You can also
+register raw Cua MCP tools as a custom MCP server, but that is an alternative
+for users who need the low-level interface. The built-in toolset provides
+Hermes actions, configuration, approvals, and diagnostics.
 
 After installing, regardless of which path you took, grant the
 platform-appropriate prereqs:
@@ -236,11 +235,10 @@ maintains directly:
 cua-driver skills install
 ```
 
-The command installs the pack under `~/.cua-driver/skills/cua-driver`. Hermes
-autodetection is a planned cua-driver follow-up, so currently point Hermes at
-that directory or symlink it into your skill space. The wrapper remains the
-workflow layer and points to Cua's installed skill for driver behavior. The
-pack contains:
+The command installs the pack under `~/.cua-driver/skills/cua-driver` and
+links it into the standard Hermes skill directory at
+`~/.hermes/skills/cua-driver`. The wrapper remains the workflow layer and
+points to Cua's installed skill for driver behavior. The pack contains:
 
 | File | Topic |
 |---|---|
@@ -259,11 +257,9 @@ explains why and what to do differently.
 
 `cua-driver skills status` shows what's installed and which agent
 harnesses it's linked into. Today the autodetect list covers Claude
-Code, Codex, OpenCode, OpenClaw, and Antigravity; **Hermes
-autodetection is planned as a follow-up in `trycua/cua`** — until
-then, run `cua-driver skills install` once and point your harness at
-the resulting `~/.cua-driver/skills/cua-driver` directory (or symlink
-it into your usual skill space).
+Code, Codex, Prime Agent, OpenClaw, OpenCode, Antigravity, and Hermes.
+Run `cua-driver skills install` once, then start a new Hermes session so it
+loads the linked guidance.
 
 ## Quick example
 
@@ -561,9 +557,8 @@ autostart pattern — see
   (macOS no-foreground contract, Windows UIA + Session 0, Linux AT-SPI
   + X11/Wayland, recording, browser pages), run
   `cua-driver skills install` and read `MACOS.md` / `WINDOWS.md` /
-  `LINUX.md` / `RECORDING.md` / `WEB_APPS.md`. Hermes autodetection is a
-  planned follow-up; currently point Hermes at the installed pack directory
-  or symlink it into your skill space.
+  `LINUX.md` / `RECORDING.md` / `WEB_APPS.md`. The command links the pack
+  into the standard Hermes skill directory automatically.
 - **cua.ai/docs** — the cua-driver project's documentation:
   - [What is computer use?](https://cua.ai/docs/explanation/what-is-computer-use) — concept intro
   - [The no-foreground contract](https://cua.ai/docs/explanation/the-no-foreground-contract) — *why* background mode matters

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-computer-use.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-computer-use.md
@@ -44,9 +44,8 @@ Hermes drives [cua-driver](https://github.com/trycua/cua) under the hood.
 This wrapper skill teaches the Hermes `computer_use` workflow and action
 vocabulary. Call the actions documented below instead of raw cua-driver MCP
 tools. For driver internals and platform-specific behavior, follow the Cua
-skill installed by `cua-driver skills install`. Hermes autodetection is a
-planned cua-driver follow-up, so currently point Hermes at the resulting
-`~/.cua-driver/skills/cua-driver` directory or symlink it into your skill space.
+skill installed by `cua-driver skills install`. The command links the pack into
+the standard Hermes skill directory at `~/.hermes/skills/cua-driver`.
 
 ## The canonical workflow
 
@@ -388,6 +387,7 @@ These are platform deep dives, not duplicates — when the user reports
 `WINDOWS.md` for the UIA / UWP context that explains why and what to
 do differently.
 
-Hermes autodetection is a planned follow-up in trycua/cua. For now, the command
-installs the pack under `~/.cua-driver/skills/cua-driver`; point Hermes at that
-directory or symlink it into the user's skill space.
+The command installs the pack under `~/.cua-driver/skills/cua-driver` and links
+it into the standard Hermes skill directory at
+`~/.hermes/skills/cua-driver`. Start a new Hermes session after installation so
+it loads the linked guidance.


### PR DESCRIPTION
## What does this PR do?

Correct Hermes's Cua Driver onboarding guidance so it matches the integration that ships today. `cua-driver skills install` already links its maintained skill pack into the standard Hermes skill directory, and fresh Hermes CLI profiles already include the `computer_use` toolset.

The change removes manual-symlink instructions from the canonical Computer Use guide and bundled wrapper skill, updates the generated skill page, and changes the POSIX and Windows installer success messages from “enable” to “manage.” Runtime behavior is unchanged.

## Related Issue

No issue; searches across open issues and open/all-state pull requests found no duplicate for this documentation drift.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Replace stale “Hermes autodetection is planned” guidance with the shipped standard-directory auto-link behavior.
- Keep the bundled skill source and generated skill page aligned.
- Correct installer success text that tells fresh users to enable an already-default toolset.
- Keep `install.sh` and `install.ps1` messages aligned.

## How to Test

1. `scripts/run_tests.sh tests/test_install_scripts_computer_use.py -q`
2. `bash -n scripts/install.sh`
3. Confirm `scripts/install.ps1` remains ASCII-only.
4. `cd website && npm ci && npm run build:fast`
5. `git diff --check`

Validated on macOS 26.5.2. The English Docusaurus build succeeds; it reports the existing `/docs/llms.txt` and `/docs/llms-full.txt` broken-link warnings.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this correction.
- [x] I've run the applicable focused checks (10 tests pass).
- [x] I've tested on macOS 26.5.2.

### Documentation & Housekeeping

- [x] I've updated relevant documentation.
- [x] Config examples are not affected.
- [x] Architecture and contributor workflows are not affected.
- [x] Cross-platform installer wording stays aligned.
- [x] Tool behavior and schemas are not affected.
