### PR TITLE
fix(gateway): probe compute-host pids without signalling them

### DIFF
--- a/scripts/check-windows-footguns.py
+++ b/scripts/check-windows-footguns.py
@@ -759,8 +759,13 @@ def main(argv: list[str]) -> int:
             REPO_ROOT / "plugins",
             REPO_ROOT / "scripts",
             REPO_ROOT / "acp_adapter",
+            REPO_ROOT / "tui_gateway",
         ]
         roots = [r for r in roots if r.exists()]
+        # Top-level modules (cli.py, hermes_state.py, hermes_bootstrap.py, ...)
+        # sit at the repository root and are inside no package directory above,
+        # so a directory-only root list never reaches them.
+        roots += sorted(REPO_ROOT.glob("*.py"))
     elif args.diff:
         roots = get_diff_files(args.diff)
     elif args.paths:

--- a/tests/test_host_supervisor_pid_probe.py
+++ b/tests/test_host_supervisor_pid_probe.py
@@ -1,0 +1,122 @@
+"""Regression tests for the compute-host supervisor's pid handling.
+
+``os.kill(pid, 0)`` is not a no-op on Windows.  ``signal.CTRL_C_EVENT`` is 0,
+so that call reaches ``GenerateConsoleCtrlEvent``, whose second argument is a
+process *group*.  A child started without ``CREATE_NEW_PROCESS_GROUP`` shares
+its parent's group, so the Ctrl-C lands on everything attached to the same
+console.  Measured on Windows 11, Python 3.12.10 — a parent that spawns a
+sleeping child and then probes it with ``os.kill(child_pid, 0)``::
+
+    alive before   : True
+    os.kill(pid,0) : returned, no exception
+    Traceback ... <string>, line 1        <- the child died
+    Traceback ... probe.py, line 10       <- the parent died too
+    KeyboardInterrupt
+
+``KeyboardInterrupt`` is a ``BaseException``, so it also sails through the
+``except Exception`` arms the probe is wrapped in.
+
+``signal.SIGKILL`` does not exist on Windows at all; referencing it raises
+``AttributeError``, which the surrounding blanket except swallows at debug
+level and leaves the process running.
+
+Both are flagged by ``scripts/check-windows-footguns.py``'s own rules.  Neither
+was ever reported, because ``--all`` did not scan ``tui_gateway/``.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOST_SUPERVISOR = REPO_ROOT / "tui_gateway" / "host_supervisor.py"
+FOOTGUN_SCRIPT = REPO_ROOT / "scripts" / "check-windows-footguns.py"
+
+
+def _source() -> str:
+    return HOST_SUPERVISOR.read_text(encoding="utf-8")
+
+
+def test_liveness_probe_does_not_signal_the_process() -> None:
+    """No executable ``os.kill(pid, 0)`` — signal 0 is CTRL_C_EVENT on Windows.
+
+    Parsed rather than grepped: the explanation of why this is wrong lives in
+    a docstring in the same file and would match a textual search.
+    """
+    tree = ast.parse(_source())
+    offenders = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "kill"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "os"
+        and len(node.args) == 2
+        and isinstance(node.args[1], ast.Constant)
+        and node.args[1].value == 0
+    ]
+    assert not offenders, [n.lineno for n in offenders]
+
+
+def test_hard_kill_signal_is_resolved_defensively() -> None:
+    """``signal.SIGKILL`` is absent on Windows; it must not be referenced bare."""
+    source = _source()
+    assert "signal.SIGKILL" not in source or 'getattr(signal, "SIGKILL"' in source
+    assert 'getattr(signal, "SIGKILL", signal.SIGTERM)' in source
+
+
+def test_liveness_probe_uses_the_shared_cross_platform_helper() -> None:
+    assert "from gateway.status import _pid_exists" in _source()
+
+
+def test_pid_alive_answers_correctly_for_a_live_and_a_dead_pid() -> None:
+    """Behavioural check, no mocks — and it does not signal anything.
+
+    On the pre-fix source this test still passes on POSIX (``os.kill(pid, 0)``
+    really is a no-op there); it is the Windows run that separates them.
+    """
+    from tui_gateway.host_supervisor import _pid_alive
+
+    assert _pid_alive(os.getpid()) is True
+    assert _pid_alive(0) is False
+    assert _pid_alive(-1) is False
+
+    child = subprocess.Popen([sys.executable, "-c", "pass"])
+    child.wait()
+    # A reaped child's pid is gone on POSIX; on Windows the handle is closed
+    # by Popen.__del__/wait, so this is the "definitely not running" case.
+    assert _pid_alive(child.pid) in (False, True)  # value is OS-dependent
+    # What must hold everywhere: probing did not raise and did not kill us.
+    assert _pid_alive(os.getpid()) is True
+
+
+def test_footgun_scan_covers_tui_gateway_and_top_level_modules() -> None:
+    """``--all`` has to reach the code these rules are about.
+
+    Before this change the root list held eight package directories; neither
+    ``tui_gateway/`` nor the modules at the repository root were among them,
+    so the CI gate reported success across a strict subset of the tree.
+    """
+    script = FOOTGUN_SCRIPT.read_text(encoding="utf-8")
+    assert 'REPO_ROOT / "tui_gateway"' in script
+    assert 'REPO_ROOT.glob("*.py")' in script
+
+
+def test_footgun_scan_is_clean_on_the_widened_scope() -> None:
+    """The widened gate stays green — that is what makes it mergeable."""
+    result = subprocess.run(
+        [sys.executable, str(FOOTGUN_SCRIPT), "--all"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        cwd=str(REPO_ROOT),
+        timeout=300,
+    )
+    assert result.returncode == 0, (result.stdout or "") + (result.stderr or "")

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -86,15 +86,26 @@ def _default_registry_path() -> Path:
 
 
 def _pid_alive(pid: int) -> bool:
+    """Liveness probe for a compute-host pid.
+
+    ``os.kill(pid, 0)`` is not a no-op on Windows: ``signal.CTRL_C_EVENT``
+    is 0, so that call reaches ``GenerateConsoleCtrlEvent`` and delivers a
+    console Ctrl-C.  The second argument there is a process *group*, and a
+    child started without ``CREATE_NEW_PROCESS_GROUP`` shares its parent's
+    group, so the signal lands on everything attached to the same console
+    -- including this process.  ``KeyboardInterrupt`` is a ``BaseException``
+    and would sail straight through the ``except Exception`` arms below.
+
+    ``gateway.status._pid_exists`` is the repository's cross-platform
+    answer (psutil, with a ctypes ``OpenProcess`` fallback) and reports
+    zombies as dead, which the ``_terminate_pid`` wait loop wants.
+    """
     if pid <= 0:
         return False
     try:
-        os.kill(pid, 0)
-        return True
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
+        from gateway.status import _pid_exists
+
+        return bool(_pid_exists(pid))
     except Exception:
         return False
 
@@ -543,12 +554,16 @@ class HostSupervisor:
             if not _pid_alive(pid):
                 return
             time.sleep(0.05)
+        # signal.SIGKILL does not exist on Windows; referencing it raises
+        # AttributeError, which the blanket except swallows at debug level
+        # and leaves the process running.
+        hard_kill = getattr(signal, "SIGKILL", signal.SIGTERM)
         try:
-            os.kill(pid, signal.SIGKILL)
+            os.kill(pid, hard_kill)
         except ProcessLookupError:
             return
         except Exception:
-            logger.debug("failed to SIGKILL compute host pid=%s", pid, exc_info=True)
+            logger.debug("failed to hard-kill compute host pid=%s", pid, exc_info=True)
 
     def _terminate_process(self, proc: subprocess.Popen[str]) -> None:
         if proc.poll() is not None:


### PR DESCRIPTION
## What does this PR do?

`tui_gateway/host_supervisor.py` has two of the patterns `scripts/check-windows-footguns.py` exists to catch. The file contains no platform guard of any kind — no `sys.platform`, no `os.name`, no `IS_WINDOWS`.

```python
def _pid_alive(pid: int) -> bool:
    if pid <= 0:
        return False
    try:
        os.kill(pid, 0)          # liveness probe
        return True
    except ProcessLookupError:
        return False
    except PermissionError:
        return True
    except Exception:
        return False
```

**`signal.CTRL_C_EVENT` is 0 on Windows**, so `os.kill(pid, 0)` *is* `os.kill(pid, CTRL_C_EVENT)` and reaches `GenerateConsoleCtrlEvent`. That API's second argument is a process **group**, and a child started without `CREATE_NEW_PROCESS_GROUP` shares its parent's group — so the Ctrl-C is delivered to everything attached to the same console.

**Measured on Windows 11, Python 3.12.10.** A parent spawns a sleeping child, then probes it:

```
alive before   : True
os.kill(pid,0) : returned, no exception
Traceback (most recent call last):
  File "<string>", line 1, in <module>          <- the child
Traceback (most recent call last):
  File "...\probe.py", line 10, in <module>     <- the parent, at time.sleep(1)
    time.sleep(1)
KeyboardInterrupt
```

The call returns first and the signal arrives asynchronously, so the failure does not look like it came from the probe. And `KeyboardInterrupt` is a `BaseException`: none of the `except Exception` arms above catch it, so it propagates out of `_pid_alive`, out of its caller, and up.

Its caller is the graceful-shutdown wait loop:

```python
os.kill(pid, signal.SIGTERM)
deadline = time.monotonic() + timeout
while time.monotonic() < deadline:
    if not _pid_alive(pid):      # <- signals the console group each 50ms tick
        return
    time.sleep(0.05)
try:
    os.kill(pid, signal.SIGKILL)  # <- AttributeError on Windows
```

`signal.SIGKILL` does not exist on Windows. Referencing it raises `AttributeError`, the blanket `except Exception` logs it at debug level, and the process is never hard-killed — the branch that exists precisely for a child that ignored SIGTERM does nothing.

`_pid_alive` is reached from `HostSupervisor`'s shutdown path, which `tui_gateway/server.py` instantiates lazily and `methods_tools.py` / `methods_session.py` drive.

**Why nobody saw it.** `.github/workflows/lint.yml` runs `scripts/check-windows-footguns.py --all`, whose `os.kill(pid, 0)` and `bare signal.SIGKILL` rules both match these lines exactly. But `--all` builds its root list from eight package directories:

```python
roots = [
    REPO_ROOT / "hermes_cli", "gateway", "tools", "cron",
    "agent", "plugins", "scripts", "acp_adapter",
]
```

`tui_gateway/` is not one of them, and neither is the repository root, where `cli.py`, `hermes_state.py`, `hermes_bootstrap.py` and eighteen other modules live. Measured: `--all` scanned **986** files against **4,395** tracked `.py` files, and reported ✓.

**The fix.**

- `_pid_alive` delegates to `gateway.status._pid_exists`, which is what the footgun rule's own `Fix:` text names ("Or `gateway.status._pid_exists(pid)` for the hermes wrapper with a stdlib fallback"). It is psutil-backed with a ctypes `OpenProcess` fallback, and reports zombies as dead — which is what this wait loop wants. `psutil==7.2.2` is already a hard dependency in `pyproject.toml`.
- The hard-kill signal becomes `getattr(signal, "SIGKILL", signal.SIGTERM)`. On Windows `os.kill` with a signal other than 0 or 1 routes to `TerminateProcess`, so SIGTERM there is a real kill rather than a no-op.
- `--all` gains `tui_gateway/` and the repository-root modules: **986 → 1,036 files scanned, and it stays green.** That is the point — the widened gate does not import a backlog.

**Scope — what I did not add, and why.** `tests/` (3,185 files), `evals/`, and `apps/` are left out. Each currently has findings — 23 in `tests/`, one each in `evals/readtool/report.py:31` and `apps/desktop/scripts/perf/gateway_attach_bench.py:117`, all `Path.read_text()` without `encoding=`. Adding them would turn CI red, which is a separate call for you to make rather than something to smuggle into a bug fix. This PR widens the gate only as far as it can go while staying green.

## Related Issue

No separate issue — reporting it here with the measurement. Related in kind to #89614 (`[Windows] Hermes kills svchost.exe via stale-PID taskkill /F /PID → repeated 0xEF blue screens`, P1): both are an unguarded kill against a pid on Windows. I am not claiming this is that bug's cause — different call site, different mechanism, and I have not reproduced the BSOD.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/host_supervisor.py` — `_pid_alive()` delegates to `gateway.status._pid_exists` instead of `os.kill(pid, 0)`, with a docstring recording why signal 0 is not a probe on Windows.
- `tui_gateway/host_supervisor.py` — `_terminate_pid()` resolves the hard-kill signal through `getattr(signal, "SIGKILL", signal.SIGTERM)`.
- `scripts/check-windows-footguns.py` — `--all` adds `tui_gateway/` and the repository-root `*.py` modules to its root list.
- `tests/test_host_supervisor_pid_probe.py` — six tests: no executable `os.kill(x, 0)` remains (parsed with `ast`, since the explanation of the bug lives in a docstring in the same file and would match a grep); the hard-kill signal is resolved defensively; the probe uses the shared helper; `_pid_alive` answers correctly for live and dead pids with nothing mocked; `--all` reaches both new roots; and `--all` still exits 0.

## How to Test

1. On Windows, reproduce the probe's behaviour directly:

```python
import os, subprocess, sys, time
p = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
time.sleep(1)
print("alive before :", p.poll() is None)
os.kill(p.pid, 0)
time.sleep(1)
print("alive after  :", p.poll() is None)
```

Both this script and its child end in `KeyboardInterrupt`. Output above is from that run.

The same thing happens without any synthetic setup: run this PR's test file against the pre-fix source on Windows and the probe takes down pytest itself. See step 3.

2. `python -m pytest tests/test_host_supervisor_pid_probe.py -q` — 6 passed, on the Windows host and on Linux.

3. Against the pre-patch source with the new tests kept, run on the same Windows host:

```
FFF
FAILED test_liveness_probe_does_not_signal_the_process
FAILED test_hard_kill_signal_is_resolved_defensively
FAILED test_liveness_probe_uses_the_shared_cross_platform_helper
!!!!!!!!!!!!!!!!!!!!!!!! KeyboardInterrupt !!!!!!!!!!!!!!!!!!!!!!!!
C:\...\Lib\subprocess.py:1590: KeyboardInterrupt
3 failed in 0.79s
```

The session does not finish. `test_pid_alive_answers_correctly_for_a_live_and_a_dead_pid` calls `_pid_alive(os.getpid())`, the pre-fix body reaches `os.kill(self_pid, 0)`, and the resulting console Ctrl-C takes down pytest — it lands a moment later, inside the `subprocess` call on the next line, so the traceback does not point at the probe. Three tests report as failures and the last two never run.

The same comparison in a Linux checkout of this commit gives 4 failed / 2 passed, because `os.kill(pid, 0)` genuinely is a no-op there. Only the Windows run shows what the probe does.

4. `python scripts/check-windows-footguns.py --all` — `✓ No Windows footguns found (1036 file(s) scanned)`, up from 986. Same count on Windows and Linux.

Note on the checklist below: I ran the test file above, the pre-patch comparison, and the footgun scan, not the full `pytest tests/ -q`, so I left that box unchecked rather than claiming it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, ja-JP (ACP=932), Python 3.12.10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

I have a ja-JP (ACP=932) Windows host and can measure anything else on that locale.

*(Measured on my host. Drafted with Claude.)*
