### PR TITLE
fix(desktop): Windows chat windows opaque unless glass is on — Snap/FancyZones work again (#90237)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -277,7 +277,8 @@ import {
   translucencySupportedOn,
   vibrancyFor as vibrancyForTranslucency,
   windowBackingOptions,
-  windowOpacityFor
+  windowOpacityFor,
+  windowsGlassTransparency
 } from './translucency'
 import {
   compareApiUrl,
@@ -948,7 +949,10 @@ function applyWindowTranslucency(win, changed = { backing: true, material: true,
           win.setVibrancy(vibrancyForTranslucency(translucencyState), { animationDuration: 150 })
         }
 
-        if (IS_WINDOWS && GLASS_SUPPORTED && typeof win.setBackgroundMaterial === 'function') {
+        if (
+          typeof win.setBackgroundMaterial === 'function' &&
+          windowsGlassTransparency(IS_WINDOWS && GLASS_SUPPORTED, translucencyState)
+        ) {
           win.setBackgroundMaterial(backgroundMaterialFor(translucencyState))
         }
       }
@@ -984,11 +988,18 @@ function chatWindowSurfaceOptions() {
     // under glass — everywhere else the page buries the material.
     visualEffectState: IS_MAC ? ('active' as const) : undefined,
     // Win11 DWM materials only reach the client area on a transparent window
-    // (electron#49443). Chat windows on glass-capable Windows are born
-    // transparent so a live Clear→Glass toggle doesn't need a recreate; the
-    // opaque themed backgroundColor covers it while glass is off.
-    ...(IS_WINDOWS && GLASS_SUPPORTED ? { transparent: true } : {}),
-    backgroundMaterial: IS_WINDOWS && GLASS_SUPPORTED ? backgroundMaterialFor(translucencyState) : undefined,
+    // (electron#49443). Chat windows used to be born transparent whenever the
+    // OS COULD do glass so a live Clear→Glass toggle needed no recreate — but
+    // transparent windows change DWM hit-testing and break Snap/FancyZones
+    // (#90237) for EVERY Win11-22H2+ user, glass on or off. Gate on the glass
+    // setting actually being ACTIVE (windowsGlassTransparency): the default
+    // (glass off) gets a normal opaque window that snaps correctly. Trade-off,
+    // made consciously: a window born opaque shows the glass material only
+    // after the next window recreation/app relaunch.
+    ...(windowsGlassTransparency(IS_WINDOWS && GLASS_SUPPORTED, translucencyState) ? { transparent: true } : {}),
+    backgroundMaterial: windowsGlassTransparency(IS_WINDOWS && GLASS_SUPPORTED, translucencyState)
+      ? backgroundMaterialFor(translucencyState)
+      : undefined,
     opacity: windowOpacity(),
     ...windowBackingOptions(translucencyState, getWindowBackgroundColor())
   }

--- a/apps/desktop/electron/translucency.ts
+++ b/apps/desktop/electron/translucency.ts
@@ -66,3 +66,19 @@ export {
 export function windowBackingOptions(state: TranslucencyState, themedColor: string): { backgroundColor?: string } {
   return glassActive(state) ? {} : { backgroundColor: themedColor }
 }
+
+/**
+ * Whether a Windows chat window should be created `transparent: true`.
+ *
+ * `transparent` changes DWM hit-testing and breaks Snap layouts / FancyZones
+ * (#90237), so it must be paid ONLY when the user actually runs glass — never
+ * on bare OS capability. `capable` is the platform gate (IS_WINDOWS &&
+ * GLASS_SUPPORTED); the state gate is the user's live translucency mode.
+ *
+ * Consequence, on purpose: flipping glass ON with opaque-born windows shows
+ * the material after the next window recreation/relaunch instead of breaking
+ * snapping for everyone by default.
+ */
+export function windowsGlassTransparency(capable: boolean, state: TranslucencyState): boolean {
+  return capable && glassActive(state)
+}

--- a/apps/desktop/electron/windows-glass-transparency.test.ts
+++ b/apps/desktop/electron/windows-glass-transparency.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { normalizeState, windowsGlassTransparency } from './translucency'
+
+// #90237: `transparent: true` changes DWM hit-testing and breaks Snap/
+// FancyZones. It must be paid only when the user actually RUNS glass —
+// never on bare OS capability (the old gate made every Win11-22H2+ chat
+// window transparent with glass OFF, the default).
+
+const glassOn = normalizeState({ mode: 'glass', intensity: 50 }, true)
+const clear = normalizeState({ mode: 'clear', intensity: 50 }, true)
+const off = normalizeState({ mode: 'off', intensity: 50 }, true)
+
+test('transparent only when capable AND glass is the active mode', () => {
+  assert.equal(windowsGlassTransparency(true, glassOn), true)
+})
+
+test('capable OS with glass off/clear stays opaque (the #90237 default)', () => {
+  assert.equal(windowsGlassTransparency(true, off), false)
+  assert.equal(windowsGlassTransparency(true, clear), false)
+})
+
+test('incapable platform never goes transparent, even with glass requested', () => {
+  const normalizedWithoutGlass = normalizeState({ mode: 'glass', intensity: 50 }, false)
+
+  assert.equal(windowsGlassTransparency(false, glassOn), false)
+  // normalizeState itself demotes glass on incapable platforms — both gates agree.
+  assert.equal(windowsGlassTransparency(true, normalizedWithoutGlass), false)
+})


### PR DESCRIPTION
## Summary

Windows Snap layouts and FancyZones work again on Win11 22H2+ (#90237): chat windows are no longer born `transparent: true` unless the user actually runs glass.

Root cause: `chatWindowSurfaceOptions()` gated `transparent`/`backgroundMaterial` on `GLASS_SUPPORTED` — a pure OS-capability check (`glassSupportedOn(platform, release)`) that never consulted the user's setting. Every chat window on a glass-capable Windows build was transparent even with glass OFF (the default), and transparent windows change DWM hit-testing, which breaks Snap/FancyZones.

## Changes

- `apps/desktop/electron/translucency.ts`: new `windowsGlassTransparency(capable, state)` — one resolver for the decision (capability AND `glassActive(state)`), per the one-resolver-per-policy rule.
- `apps/desktop/electron/main.ts`: `chatWindowSurfaceOptions()` (`transparent` + `backgroundMaterial`) and the runtime `setBackgroundMaterial` re-apply both gate through it.
- `electron/windows-glass-transparency.test.ts`: 3 tests (glass-on transparent; off/clear opaque on capable OS — the #90237 default; incapable platform never transparent, including normalizeState's own demotion agreeing).

Trade-off, reversed consciously (flagged per the audit): the old always-transparent design existed so a live Clear→Glass toggle needed no window recreation. With the gate, a window born opaque shows the glass material only after the next window recreation/app relaunch. Correct default: snapping works for everyone; the relaunch cost is paid only by users opting INTO glass.

## Validation

| | Result |
|---|---|
| translucency + new tests | 60/60 pass |
| Sabotage (both files reverted, test kept) | 3/3 fail |
| tsc electron + eslint + app build | clean |
| Live Windows verification | not possible on this Linux box — gate logic is platform-pure and fully unit-covered; needs a Win11 smoke check post-merge |

## Infographic

![Windows snap works again](https://files.catbox.moe/qgjfif.png)
