### PR TITLE
fix(desktop): mermaid full-view overlay was blank (supersedes #88616, #83271)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.tsx
@@ -4,7 +4,7 @@ import mermaid from 'mermaid'
 import { useEffect, useState } from 'react'
 
 import { Zoomable } from '@/components/ui/zoomable'
-import { copySvgAsPng } from '@/lib/svg-image'
+import { copySvgAsPng, normalizeSvgSize } from '@/lib/svg-image'
 import { cn } from '@/lib/utils'
 
 import type { RichFenceProps } from './types'
@@ -63,7 +63,7 @@ export default function MermaidRenderer({ code, streaming }: RichFenceProps) {
         const result = await mermaid.render(id, code)
 
         if (!cancelled) {
-          setSvg(result.svg)
+          setSvg(normalizeSvgSize(result.svg))
         }
       } catch {
         if (!cancelled) {

--- a/apps/desktop/src/components/ui/zoomable.test.tsx
+++ b/apps/desktop/src/components/ui/zoomable.test.tsx
@@ -1,0 +1,44 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { Zoomable } from './zoomable'
+
+afterEach(cleanup)
+
+describe('Zoomable', () => {
+  it('opens the full-view overlay when the trigger is clicked', () => {
+    render(
+      <Zoomable label="Open diagram" overlay={<div data-testid="overlay">Expanded diagram</div>}>
+        <div>Inline diagram</div>
+      </Zoomable>
+    )
+
+    expect(screen.queryByTestId('overlay')).toBeNull()
+    fireEvent.click(screen.getByTitle('Open diagram'))
+    expect(screen.getByTestId('overlay')).toBeTruthy()
+  })
+
+  it('gives the full-view stage flex space inside the fixed-height dialog', () => {
+    render(
+      <Zoomable label="Open diagram" overlay={<div data-testid="overlay">Expanded diagram</div>}>
+        <div>Inline diagram</div>
+      </Zoomable>
+    )
+
+    fireEvent.click(screen.getByTitle('Open diagram'))
+
+    const dialog = screen.getByRole('dialog')
+    const body = dialog.firstElementChild
+
+    // jsdom does not compute flex layout, so height stays 0 either way. The
+    // contract that actually failed in Electron is: the body must grow
+    // (`flex-1`) inside the h-[85vh] shell, and the pan/zoom stage must too.
+    expect(body?.classList.contains('flex-1')).toBe(true)
+    expect(body?.classList.contains('min-h-0')).toBe(true)
+
+    const stage = body?.querySelector('.flex-1.overflow-hidden')
+
+    expect(stage).toBeTruthy()
+    expect(stage?.contains(screen.getByTestId('overlay'))).toBe(true)
+  })
+})

--- a/apps/desktop/src/components/ui/zoomable.tsx
+++ b/apps/desktop/src/components/ui/zoomable.tsx
@@ -80,7 +80,7 @@ function ZoomPanViewer({
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent
-        bodyClassName="flex min-h-0 flex-col gap-0 overflow-hidden p-0"
+        bodyClassName="flex min-h-0 flex-1 flex-col gap-0 overflow-hidden p-0"
         className="h-[85vh] w-[90vw] max-w-[90vw]"
         showCloseButton={false}
       >

--- a/apps/desktop/src/lib/svg-image.test.ts
+++ b/apps/desktop/src/lib/svg-image.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeSvgSize, svgSize } from './svg-image'
+
+// Real mermaid 11.16 render output shape (verified against the installed
+// package): width="100%" + inline style="max-width: Npx" + viewBox.
+const MERMAID_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="100%" class="flowchart" style="max-width: 260.34375px;" viewBox="0 0 260.34375 70" role="graphics-document document"><g><rect x="0" y="0" width="260.34375" height="70" fill="#eee"/></g></svg>`
+
+describe('svgSize', () => {
+  it('reads explicit pixel width/height', () => {
+    expect(svgSize('<svg width="312" height="90"><rect/></svg>')).toEqual({ width: 312, height: 90 })
+  })
+
+  it('falls back to the viewBox when width is a percentage (mermaid)', () => {
+    expect(svgSize(MERMAID_SVG)).toEqual({ width: 260.34375, height: 70 })
+  })
+
+  it('falls back to the viewBox when width/height are absent', () => {
+    expect(svgSize('<svg viewBox="0 0 400 100"><rect/></svg>')).toEqual({ width: 400, height: 100 })
+  })
+
+  it('falls back to a default size when nothing usable exists', () => {
+    expect(svgSize('<svg><rect/></svg>')).toEqual({ width: 800, height: 600 })
+  })
+
+  it('treats mixed-unit widths as absent (not parseFloat(100) == 100)', () => {
+    expect(svgSize('<svg width="100%" height="70" viewBox="0 0 500 200"><rect/></svg>')).toEqual({
+      width: 500,
+      height: 200
+    })
+  })
+})
+
+describe('normalizeSvgSize', () => {
+  it('replaces a 100% width with the viewBox pixel size', () => {
+    const out = normalizeSvgSize(MERMAID_SVG)
+
+    expect(out).toContain('width="260.34375"')
+    expect(out).toContain('height="70"')
+    expect(out).not.toContain('width="100%"')
+    expect(out).toContain('viewBox="0 0 260.34375 70"')
+    expect(out).toContain('role="graphics-document document"')
+  })
+
+  it('leaves an explicit pixel height when only width is a percentage', () => {
+    const svg =
+      '<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="70" viewBox="0 0 500 200"><rect/></svg>'
+    const out = normalizeSvgSize(svg)
+
+    expect(out).toContain('width="500"')
+    expect(out).toContain('height="70"')
+    expect(out).not.toContain('height="200"')
+  })
+
+  it('leaves svgs without a percentage width untouched', () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="312" viewBox="0 0 312 90"><rect/></svg>'
+
+    expect(normalizeSvgSize(svg)).toBe(svg)
+  })
+
+  it('leaves svgs with a percentage width but no viewBox untouched', () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="100%"><rect/></svg>'
+
+    expect(normalizeSvgSize(svg)).toBe(svg)
+  })
+})

--- a/apps/desktop/src/lib/svg-image.ts
+++ b/apps/desktop/src/lib/svg-image.ts
@@ -2,18 +2,75 @@
 // SVGs only (inline styles) — mermaid output qualifies. Falls back to copying
 // the SVG markup as text where image clipboard writes aren't permitted.
 
-function svgSize(svg: string): { height: number; width: number } {
+// Mermaid emits width="100%" plus a viewBox. That percentage is not an
+// intrinsic size: the zoom overlay's shrink-to-fit grid can collapse it, and
+// parseFloat("100%") makes a 100px PNG. Replace percentage attrs with the
+// viewBox pixels; leave explicit pixel attrs alone. No-op when nothing to do.
+function isPercentLength(raw: string | null): boolean {
+  return Boolean(raw?.trim().endsWith('%'))
+}
+
+function viewBoxSize(el: Element): { height: number; width: number } | null {
+  const [, , vbW, vbH] = (el.getAttribute('viewBox') || '').split(/[\s,]+/).map(Number)
+
+  return vbW > 0 && vbH > 0 ? { height: vbH, width: vbW } : null
+}
+
+export function normalizeSvgSize(svg: string): string {
   const el = new DOMParser().parseFromString(svg, 'image/svg+xml').documentElement
-  const width = parseFloat(el.getAttribute('width') || '')
-  const height = parseFloat(el.getAttribute('height') || '')
+
+  if (el.tagName !== 'svg') {
+    return svg
+  }
+
+  const width = el.getAttribute('width')
+  const height = el.getAttribute('height')
+  const widthPct = isPercentLength(width)
+  const heightPct = isPercentLength(height)
+
+  if (!widthPct && !heightPct) {
+    return svg
+  }
+
+  const box = viewBoxSize(el)
+
+  if (!box) {
+    return svg
+  }
+
+  if (widthPct) {
+    el.setAttribute('width', String(box.width))
+  }
+
+  // Mermaid usually omits height. Fill it from the viewBox so the overlay has
+  // both intrinsic dimensions; don't overwrite an explicit pixel height.
+  if (heightPct || (widthPct && !height)) {
+    el.setAttribute('height', String(box.height))
+  }
+
+  return new XMLSerializer().serializeToString(el)
+}
+
+function parseSvgLength(raw: string | null): number | null {
+  if (!raw || isPercentLength(raw)) {
+    return null
+  }
+
+  const value = Number.parseFloat(raw)
+
+  return Number.isFinite(value) ? value : null
+}
+
+export function svgSize(svg: string): { height: number; width: number } {
+  const el = new DOMParser().parseFromString(svg, 'image/svg+xml').documentElement
+  const width = parseSvgLength(el.getAttribute('width'))
+  const height = parseSvgLength(el.getAttribute('height'))
 
   if (width && height) {
     return { height, width }
   }
 
-  const [, , vbW, vbH] = (el.getAttribute('viewBox') || '').split(/[\s,]+/).map(Number)
-
-  return vbW && vbH ? { height: vbH, width: vbW } : { height: 600, width: 800 }
+  return viewBoxSize(el) ?? { height: 600, width: 800 }
 }
 
 export function svgToPngBlob(svg: string, scale = 2): Promise<Blob> {


### PR DESCRIPTION
## Summary

Supersedes #88616 and #83271.

Clicking a mermaid diagram in desktop opens a blank full-view. Two stacked failures: the Zoomable dialog body had no `flex-1`, so the pan/zoom stage collapsed to 0px (toolbar still painted); and mermaid's `width="100%"` has no intrinsic size, so copy-as-PNG parsed it as 100px and fell back to raw SVG text.

### What this PR does
- Give the Zoomable dialog body `flex-1` so the stage fills the 85vh shell
- Normalize mermaid percentage width/height to viewBox pixels before display and copy
- Tests for both layers

### What was dropped
- #83271's Zoomable test that asserted a pre-normalized fixture
- Overwriting an explicit pixel height when only width is a percentage

## Test plan
- [x] From `apps/desktop`: `npx vitest run src/lib/svg-image.test.ts src/components/ui/zoomable.test.tsx --project ui` → 11 passed
- [ ] Desktop: render a mermaid fence, open full view — diagram visible, pan/zoom works, copy is a PNG

Fixes #82836

Credit: @anuvratrastogi (layout), @Rmohid (SVG size + copy).