### PR TITLE
fix(skills): make hub updates rollback-safe

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1655,6 +1655,103 @@ class TestInstallPathSafety:
         assert installed.is_dir()
         record_installed.assert_called_once_with("good-skill")
 
+    def test_install_supports_symlinked_skills_root(self, tmp_path):
+        """A profile may point its whole skills root at a versioned catalog.
+
+        The updater must resolve the destination safely while recording the
+        portable path relative to the configured root, not reject the root
+        symlink or persist the external absolute target.
+        """
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        catalog_skills = tmp_path / "catalog" / "skills"
+        quarantine_root = catalog_skills / ".hub" / "quarantine"
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir(parents=True)
+        skill_md = "---\nname: linked-skill\n---\n\n# Linked\n"
+        (q_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
+
+        hermes_home = tmp_path / "home" / ".hermes"
+        hermes_home.mkdir(parents=True)
+        linked_root = hermes_home / "skills"
+        try:
+            linked_root.symlink_to(catalog_skills, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("directory symlinks unsupported on this platform")
+
+        bundle = hub.SkillBundle(
+            name="linked-skill",
+            files={"SKILL.md": skill_md},
+            source="community",
+            identifier="linked/source",
+            trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="linked-skill",
+            source="community",
+            trust_level="community",
+            verdict="safe",
+        )
+        lock_path = catalog_skills / ".hub" / "lock.json"
+
+        with patch.object(hub, "SKILLS_DIR", linked_root), \
+             patch.object(hub, "HUB_DIR", catalog_skills / ".hub"), \
+             patch.object(hub, "LOCK_FILE", lock_path), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root):
+            installed = hub.install_from_quarantine(
+                q_dir, "linked-skill", "personal", bundle, scan_result,
+            )
+            entry = hub.HubLockFile().get_installed("linked-skill")
+
+        assert installed == catalog_skills / "personal" / "linked-skill"
+        assert (installed / "SKILL.md").read_text(encoding="utf-8") == skill_md
+        assert entry["install_path"] == "personal/linked-skill"
+
+    def test_lock_failure_restores_previous_skill(self, tmp_path):
+        """The active directory and scanned bundle survive lock persistence failure."""
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        skills_dir = tmp_path / "skills"
+        existing = skills_dir / "safe-skill"
+        existing.mkdir(parents=True)
+        (existing / "SKILL.md").write_text("old active content", encoding="utf-8")
+
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir(parents=True)
+        skill_md = "---\nname: safe-skill\n---\n\nnew content\n"
+        (q_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
+        bundle = hub.SkillBundle(
+            name="safe-skill",
+            files={"SKILL.md": skill_md},
+            source="community",
+            identifier="safe/source",
+            trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="safe-skill",
+            source="community",
+            trust_level="community",
+            verdict="safe",
+        )
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "HUB_DIR", skills_dir / ".hub"), \
+             patch.object(hub, "LOCK_FILE", skills_dir / ".hub" / "lock.json"), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root), \
+             patch.object(hub.HubLockFile, "save", side_effect=OSError("disk full")):
+            with pytest.raises(OSError, match="disk full"):
+                hub.install_from_quarantine(
+                    q_dir, "safe-skill", "", bundle, scan_result,
+                )
+
+        assert (existing / "SKILL.md").read_text(encoding="utf-8") == "old active content"
+        assert (q_dir / "SKILL.md").read_text(encoding="utf-8") == skill_md
+        assert not (skills_dir / ".safe-skill.install-staging").exists()
+        assert not (skills_dir / ".safe-skill.install-backup").exists()
+
 
 # ---------------------------------------------------------------------------
 # parallel_search_sources — overall_timeout must be honoured even when a

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3745,7 +3745,18 @@ class HubLockFile:
 
     def save(self, data: dict) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        payload = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+        temporary = self.path.with_name(
+            f".{self.path.name}.{os.getpid()}.{time.time_ns()}.tmp"
+        )
+        try:
+            with temporary.open("x", encoding="utf-8") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self.path)
+        finally:
+            temporary.unlink(missing_ok=True)
 
     def record_install(
         self,
@@ -4007,8 +4018,6 @@ def install_from_quarantine(
                     f"{', '.join(sorted(skill_dirs_in))}. "
                     f"Use a different --name or install into a subcategory."
                 )
-        shutil.rmtree(install_dir)
-
     # Warn (but don't block) if SKILL.md is very large
     skill_md = quarantine_path / "SKILL.md"
     if skill_md.exists():
@@ -4041,22 +4050,72 @@ def install_from_quarantine(
         )
 
     install_dir.parent.mkdir(parents=True, exist_ok=True)
-    shutil.move(str(quarantine_path), str(install_dir))
-
-    # Record in lock file
+    staging_dir = install_dir.with_name(f".{safe_skill_name}.install-staging")
+    backup_dir = install_dir.with_name(f".{safe_skill_name}.install-backup")
     lock = HubLockFile()
-    lock.record_install(
-        name=safe_skill_name,
-        source=bundle.source,
-        identifier=bundle.identifier,
-        trust_level=bundle.trust_level,
-        scan_verdict=scan_result.verdict,
-        skill_hash=content_hash(install_dir),
-        install_path=install_dir.resolve().relative_to(_skills_dir().resolve()).as_posix(),
-        files=list(bundle.files.keys()),
-        metadata=bundle.metadata,
-        scan_provenance=scan_provenance or getattr(scan_result, "scan_provenance", None),
-    )
+
+    # Recover a previous interrupted swap before beginning a new one. The
+    # lock hash is the commit marker: matching target means the install
+    # committed and only backup cleanup was interrupted; otherwise restore
+    # the previous active directory.
+    if backup_dir.exists():
+        if not install_dir.exists():
+            os.replace(backup_dir, install_dir)
+        else:
+            locked = lock.get_installed(safe_skill_name)
+            if locked and locked.get("content_hash") == content_hash(install_dir):
+                shutil.rmtree(backup_dir)
+            else:
+                shutil.rmtree(install_dir)
+                os.replace(backup_dir, install_dir)
+    if staging_dir.exists():
+        shutil.rmtree(staging_dir)
+
+    # Stage on the destination filesystem before touching the active skill.
+    # The two os.replace calls make the visible directory swap atomic; a lock
+    # persistence failure rolls both the skill and its provenance back.
+    shutil.move(str(quarantine_path), str(staging_dir))
+    staged_hash = content_hash(staging_dir)
+    had_previous = install_dir.exists()
+    try:
+        if had_previous:
+            os.replace(install_dir, backup_dir)
+        os.replace(staging_dir, install_dir)
+        try:
+            lock.record_install(
+                name=safe_skill_name,
+                source=bundle.source,
+                identifier=bundle.identifier,
+                trust_level=bundle.trust_level,
+                scan_verdict=scan_result.verdict,
+                skill_hash=staged_hash,
+                install_path=install_rel_path,
+                files=list(bundle.files.keys()),
+                metadata=bundle.metadata,
+                scan_provenance=scan_provenance or getattr(scan_result, "scan_provenance", None),
+            )
+        except Exception:
+            # Keep the scanned bundle available for retry, then restore the
+            # exact directory that was active before this install.
+            if install_dir.exists():
+                try:
+                    shutil.move(str(install_dir), str(quarantine_path))
+                except Exception:
+                    # Restoring the previously active skill is the primary
+                    # safety invariant. If the retry copy cannot be preserved,
+                    # remove it so it cannot block the rollback.
+                    if install_dir.exists():
+                        shutil.rmtree(install_dir)
+            if had_previous and backup_dir.exists():
+                os.replace(backup_dir, install_dir)
+            raise
+    except Exception:
+        if staging_dir.exists() and not quarantine_path.exists():
+            shutil.move(str(staging_dir), str(quarantine_path))
+        raise
+    else:
+        if backup_dir.exists():
+            shutil.rmtree(backup_dir)
 
     append_audit_log(
         "INSTALL", safe_skill_name, bundle.source,


### PR DESCRIPTION
## Summary
- atomically persist the skills Hub lock file
- stage skill updates on the destination filesystem and restore the previous active skill when provenance persistence fails
- support a symlinked skills root while keeping lock paths portable
- recover interrupted staging/backup swaps

## Reproduction
A profile can point `$HERMES_HOME/skills` at a versioned catalog. Updating through that root previously deleted the active directory before the new directory and lock entry were safely committed. A failure while recording provenance could leave a partially updated active skill.

## Verification
- `scripts/run_tests.sh tests/tools/test_skills_hub.py -q` (72 passed)
- `.venv/bin/ruff check tools/skills_hub.py tests/tools/test_skills_hub.py`
- `git diff --check`