### PR TITLE
fix(desktop): unique tool-call ids at the runtime boundary

### DIFF
--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -1,11 +1,15 @@
+import type { ThreadMessage } from '@assistant-ui/react'
 import { describe, expect, it } from 'vitest'
 
+import type { ChatMessagePart } from '@/lib/chat-messages'
 import type { ComposerAttachment } from '@/store/composer'
 
 import {
   attachmentDisplayText,
   attachmentId,
+  coalesceToolOnlyAssistants,
   coerceThinkingText,
+  createToolMergeCache,
   messageCreatedAt,
   optimisticAttachmentRef,
   parseCommandDispatch,
@@ -249,5 +253,66 @@ describe('toRuntimeMessage timeline metadata', () => {
     })
 
     expect((runtime.metadata?.custom as { timelineTimestamp?: number }).timelineTimestamp).toBeUndefined()
+  })
+})
+
+describe('toRuntimeMessage tool-call id uniqueness', () => {
+  // Regression contract for "Duplicate key toolCallId-terminal_0 in
+  // useResources": Kimi's anthropic_messages mode numbers tool_use blocks per
+  // API response, so `terminal_0` recurs across the whole session, and any
+  // merge/graft/backfill path can land two of them in ONE rendered message.
+  // assistant-ui keys parts by toolCallId and throws on a duplicate, taking
+  // the workspace pane down. toRuntimeMessage is the last boundary before the
+  // runtime, so uniqueness is enforced there, per message.
+  const toolCall = (toolCallId: string): ChatMessagePart => ({
+    type: 'tool-call',
+    toolCallId,
+    toolName: 'terminal',
+    args: {} as never,
+    argsText: ''
+  })
+
+  const renderedToolCallIds = (runtime: ThreadMessage): string[] =>
+    (runtime.content as ChatMessagePart[])
+      .filter(part => part.type === 'tool-call')
+      .map(part => (part as { toolCallId: string }).toolCallId)
+
+  it('never hands the runtime two parts with the same toolCallId', () => {
+    const runtime = toRuntimeMessage({
+      id: 'a1',
+      role: 'assistant',
+      parts: [toolCall('terminal_0'), { text: 'done', type: 'text' }, toolCall('terminal_0'), toolCall('terminal_0')]
+    })
+
+    const ids = renderedToolCallIds(runtime)
+
+    expect(new Set(ids).size).toBe(ids.length)
+    // The first occurrence keeps the provider id, so keys stay stable across
+    // re-renders for the overwhelmingly common unique case.
+    expect(ids[0]).toBe('terminal_0')
+  })
+
+  it('covers the tool-only coalesce path: two merged bubbles that share an id still render unique', () => {
+    const merged = coalesceToolOnlyAssistants(
+      [
+        { id: 'a1', role: 'assistant', parts: [toolCall('terminal_0')] },
+        { id: 'a2', role: 'assistant', parts: [toolCall('terminal_0'), toolCall('read_file_0')] }
+      ],
+      createToolMergeCache()
+    )
+
+    expect(merged).toHaveLength(1)
+
+    const ids = renderedToolCallIds(toRuntimeMessage(merged[0]))
+
+    expect(ids).toHaveLength(3)
+    expect(new Set(ids).size).toBe(3)
+  })
+
+  it('preserves parts-array reference identity when every id is already unique', () => {
+    const parts: ChatMessagePart[] = [toolCall('terminal_0'), toolCall('terminal_1')]
+    const runtime = toRuntimeMessage({ id: 'a1', role: 'assistant', parts })
+
+    expect(runtime.content).toBe(parts)
   })
 })

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -422,6 +422,68 @@ export function messageCreatedAt(message: Pick<ChatMessage, 'timestamp'>, nowMs 
     : new Date(nowMs)
 }
 
+/**
+ * Per-rendered-message tool-call id uniqueness — the last boundary before the
+ * assistant-ui runtime, which keys each part as `toolCallId-${part.toolCallId}`
+ * and THROWS on a duplicate ("Duplicate key toolCallId-… in useResources"),
+ * taking the whole workspace pane down with it.
+ *
+ * Some providers (Kimi's anthropic_messages mode) number tool_use blocks per
+ * API response (`terminal_0`, `read_file_0`, …), restarting at 0 on every call
+ * of the tool loop, so the same id recurs across hundreds of stored rows. That
+ * is valid on the wire and must NOT be rewritten on the backend request path
+ * (prompt-cache prefix stability) — but the moment two same-id parts land in
+ * ONE rendered message, the runtime crashes. Hydration dedupes globally
+ * (`withUniqueToolCallIds`), yet paths that merge or append after hydration
+ * (background-sync graft, transcript backfill, live upsert, and the tool-only
+ * coalesce above) can still converge duplicates into a single bubble. Enforcing
+ * uniqueness here, per message, covers every path that reaches the runtime.
+ *
+ * Render-only and allocation-free on the happy path: a message whose part ids
+ * are already unique gets its original array back, preserving reference
+ * identity for the repository's WeakMap cache.
+ */
+function dedupeToolCallIdsForRender(parts: ChatMessagePart[]): ChatMessagePart[] {
+  const seen = new Set<string>()
+  let changed = false
+
+  const next = parts.map((part, index) => {
+    if (part.type !== 'tool-call') {
+      return part
+    }
+
+    const id = part.toolCallId || `render-tool-${index}`
+
+    if (!seen.has(id)) {
+      seen.add(id)
+
+      if (part.toolCallId) {
+        return part
+      }
+
+      changed = true
+
+      return { ...part, toolCallId: id } as ChatMessagePart
+    }
+
+    changed = true
+
+    // The index makes the rename unique against the original ids; the loop
+    // guards against colliding with a real id that happens to look renamed.
+    let uniqueId = `${id}~${index}`
+
+    while (seen.has(uniqueId)) {
+      uniqueId = `${uniqueId}~`
+    }
+
+    seen.add(uniqueId)
+
+    return { ...part, toolCallId: uniqueId } as ChatMessagePart
+  })
+
+  return changed ? next : parts
+}
+
 export function toRuntimeMessage(message: ChatMessage): ThreadMessage {
   const role =
     message.role === 'user' || message.role === 'assistant' || message.role === 'system' ? message.role : 'assistant'
@@ -466,7 +528,7 @@ export function toRuntimeMessage(message: ChatMessage): ThreadMessage {
   return {
     id: message.id,
     role,
-    content: message.parts as Extract<ThreadMessage, { role: 'assistant' }>['content'],
+    content: dedupeToolCallIdsForRender(message.parts) as Extract<ThreadMessage, { role: 'assistant' }>['content'],
     createdAt,
     status: message.error
       ? { type: 'incomplete', reason: 'error', error: message.error }


### PR DESCRIPTION
## Problem

Opening a long session crashes the whole workspace pane with:

```
Duplicate key toolCallId-terminal_0 in useResources
```

(thrown from `@assistant-ui/tap` via `@assistant-ui/core` `message-runtime-client.ts`, which keys each message part as `toolCallId-${part.toolCallId}`).

## Root cause

Providers in `anthropic_messages` mode (observed with Kimi's `api.kimi.com/coding` endpoint, `kimi-k3`) number `tool_use` blocks **per API response** — `terminal_0`, `read_file_0`, `patch_0`, ... restarting at 0 on every call of the tool loop. A long session accumulates hundreds of rows sharing the same ids (`terminal_0` appeared 147 times in one real `state.db`). That is valid on the wire — each `tool_use`/`tool_result` pair is self-contained per API call — and must NOT be rewritten on the backend request path (prompt-cache prefix stability).

It only breaks the desktop: hydration merges consecutive tool-only assistant rows into one bubble, so many same-id parts land in ONE rendered message. `withUniqueToolCallIds()` dedupes, but only at the end of `toChatMessages()` — paths that merge or append **after** hydration bypass it:

- `use-background-sync.ts`: graft + preserve append without re-dedupe
- `transcript-backfill.ts`: prepends an older page without cross-page dedupe
- `use-message-stream` `upsertToolPart()`: live events reuse the provider id
- `coalesceToolOnlyAssistants()` itself concatenates parts across message boundaries

## Fix

Enforce per-message tool-call id uniqueness inside `toRuntimeMessage()` (`apps/desktop/src/lib/chat-runtime.ts`) — the single boundary every one of those paths crosses before parts reach the assistant-ui runtime. Class-level fix: any current or future merge path is covered, not just today's callers.

- First occurrence keeps the provider id → keys stay stable across re-renders.
- Messages whose ids are already unique get their original parts array back → no allocation, reference identity preserved for the repository's WeakMap cache.
- Render-only: stored data and the backend request path are untouched.

## Tests

Behavior-contract tests in `chat-runtime.test.ts`:

- a message carrying three `terminal_0` parts never hands the runtime duplicate ids;
- the tool-only coalesce path (two merged bubbles sharing `terminal_0`) still renders unique;
- reference identity is preserved when ids are already unique.

`npx vitest run src/lib/chat-runtime.test.ts src/lib/tool-run-continuity.test.ts src/lib/chat-messages.test.ts src/app/chat/transcript-backfill.test.ts` → 110 passed. `npm run typecheck` and eslint clean.

Also verified live: rebuilt the packaged app (`hermes desktop --build-only`), reopened the exact session that produced 216 `Duplicate key` renderer crashes in `desktop.log` — renders and scrolls through the tool rows, zero new errors after the fix.