### PR TITLE
fix(desktop): authenticate gated file downloads like REST (supersedes #89013)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -188,6 +188,7 @@ import { createMediaProtocolHandler, MEDIA_PROTOCOL } from './media-protocol'
 import {
   oauthGuardMayHardFail,
   oauthSessionIsLive,
+  resolveGatedDownloadAuth,
   resolveJsonBody,
   resolveOauthRestAuth,
   resolveReadinessProbeAuth
@@ -4858,7 +4859,8 @@ function fetchJson(url, token, options: any = {}) {
 // Token-auth download that streams the response body straight to a
 // user-selected destination (via finalizeGatewayDownload) instead of buffering
 // the whole file in memory. The connect timeout is cleared once headers arrive
-// so a slow save dialog or a large stream doesn't trip it.
+// so a slow save dialog or a large stream doesn't trip it. `options.bearer`
+// switches the header to Authorization (RFC 8252 native flow), matching fetchJson.
 function downloadViaTokenToFile(url, token, ctx, options: any = {}) {
   return new Promise((resolve, reject) => {
     let parsed
@@ -4884,9 +4886,9 @@ function downloadViaTokenToFile(url, token, ctx, options: any = {}) {
       parsed,
       {
         method: 'GET',
-        headers: {
-          'X-Hermes-Session-Token': token
-        }
+        headers: options.bearer
+          ? { Authorization: `Bearer ${options.bearer}` }
+          : { 'X-Hermes-Session-Token': token }
       },
       res => {
         // Headers arrived — the connection phase is done. Drop the idle timeout
@@ -7250,6 +7252,13 @@ function readGatewayErrorText(res): Promise<string> {
   })
 }
 
+async function gatedFileAuth(connection) {
+  const nativeAt =
+    connection.authMode === 'oauth' ? await ensureNativeAccessToken(connection.baseUrl).catch(() => null) : null
+
+  return resolveGatedDownloadAuth(connection.authMode, nativeAt, connection.token)
+}
+
 async function saveGatewayFile(payload: any = {}) {
   const filePath = gatewayFilePath(payload.path)
 
@@ -7272,9 +7281,17 @@ async function saveGatewayFile(payload: any = {}) {
   const url = `${connection.baseUrl}${requestPath}`
 
   try {
-    return await (connection.authMode === 'oauth'
-      ? downloadViaOauthSessionToFile(url, ctx)
-      : downloadViaTokenToFile(url, connection.token, ctx))
+    const auth = await gatedFileAuth(connection)
+
+    if (auth.kind === 'bearer') {
+      return await downloadViaTokenToFile(url, auth.token, ctx, { bearer: auth.token })
+    }
+
+    if (auth.kind === 'cookie') {
+      return await downloadViaOauthSessionToFile(url, ctx)
+    }
+
+    return await downloadViaTokenToFile(url, auth.token, ctx)
   } catch (error) {
     // Desktop and the remote gateway update independently. A gateway predating
     // /api/fs/download 404s here; fall back (ONLY on 404) to the older capped
@@ -7299,10 +7316,16 @@ async function saveGatewayFileViaDataUrl(connection, profile, filePath, ctx: any
   )
 
   const url = `${connection.baseUrl}${requestPath}`
+  const auth = await gatedFileAuth(connection)
+  let json: any
 
-  const json = (
-    connection.authMode === 'oauth' ? await fetchJsonViaOauthSession(url) : await fetchJson(url, connection.token)
-  ) as any
+  if (auth.kind === 'bearer') {
+    json = await fetchJson(url, null, { bearer: auth.token })
+  } else if (auth.kind === 'cookie') {
+    json = await fetchJsonViaOauthSession(url)
+  } else {
+    json = await fetchJson(url, auth.token)
+  }
 
   const dataUrl = json?.dataUrl
 

--- a/apps/desktop/electron/native-auth-decisions.test.ts
+++ b/apps/desktop/electron/native-auth-decisions.test.ts
@@ -13,6 +13,7 @@ import { test } from 'vitest'
 import {
   oauthGuardMayHardFail,
   oauthSessionIsLive,
+  resolveGatedDownloadAuth,
   resolveJsonBody,
   resolveOauthRestAuth,
   resolveReadinessProbeAuth
@@ -129,4 +130,21 @@ test('oauthGuardMayHardFail keeps the strict guard when the list is unusable', (
   assert.equal(oauthGuardMayHardFail(undefined), true)
   assert.equal(oauthGuardMayHardFail('nonsense' as any), true)
   assert.equal(oauthGuardMayHardFail([{ supportsPassword: true }]), true)
+})
+
+// --- 6. gated download auth (guards the Files-panel 401 on cookieless native) ---
+
+test('resolveGatedDownloadAuth matches oauth REST: bearer first, then cookie', () => {
+  assert.deepEqual(resolveGatedDownloadAuth('oauth', 'native-at'), { kind: 'bearer', token: 'native-at' })
+  assert.deepEqual(resolveGatedDownloadAuth('oauth', null), { kind: 'cookie' })
+  assert.deepEqual(resolveGatedDownloadAuth('oauth', ''), { kind: 'cookie' })
+})
+
+test('resolveGatedDownloadAuth uses the session token for token and local modes', () => {
+  assert.deepEqual(resolveGatedDownloadAuth('token', 'native-at', 'session-token'), {
+    kind: 'token',
+    token: 'session-token'
+  })
+  assert.deepEqual(resolveGatedDownloadAuth('local', null, 'sess'), { kind: 'token', token: 'sess' })
+  assert.deepEqual(resolveGatedDownloadAuth(undefined, null, null), { kind: 'token', token: null })
 })

--- a/apps/desktop/electron/native-auth-decisions.ts
+++ b/apps/desktop/electron/native-auth-decisions.ts
@@ -2,7 +2,7 @@
  * native-auth-decisions.ts
  *
  * Pure decision helpers extracted from main.ts for the RFC 8252 native-app
- * auth flow. These encode three choices that were each the site of a real
+ * auth flow. These encode six choices that were each the site of a real
  * runtime bug — invisible to the mocked flow tests because the tests never
  * exercised the real main.ts internals. Keeping them pure + unit-tested here
  * prevents silent regressions:
@@ -31,7 +31,12 @@
  *      can satisfy neither the native-bearer nor the OAuth-partition-cookie
  *      check by design, so the pre-flight guard must not hard-fail it.
  *
- * All five are trivial once named; the value is the test that pins the
+ *   6. resolveGatedDownloadAuth — file save/read must present the SAME
+ *      credentials as oauth REST. `saveGatewayFile` used to always ride the
+ *      OAuth cookie partition, so a cookieless native (or native-password)
+ *      session could list files via `hermes:api` and still 401 on Download.
+ *
+ * All six are trivial once named; the value is the test that pins the
  * contract so the god-file call sites can't drift back to the buggy shape.
  */
 
@@ -104,6 +109,28 @@ export function resolveReadinessProbeAuth(
   }
 
   return { kind: 'public' }
+}
+
+export type GatedDownloadAuth = OauthRestAuth | { kind: 'token'; token: string | null }
+
+/**
+ * Decide how a gated file download authenticates.
+ *
+ * Must match oauth REST (`resolveOauthRestAuth`): native bearer when present,
+ * else the OAuth cookie partition. Token/local connections keep the static
+ * session-token header. A cookie-only download against a cookieless native
+ * session is the #88987 401 — Files panel listing works, Download does not.
+ */
+export function resolveGatedDownloadAuth(
+  authMode: string | null | undefined,
+  nativeAccessToken?: string | null,
+  connectionToken?: string | null
+): GatedDownloadAuth {
+  if (authMode === 'oauth') {
+    return resolveOauthRestAuth(nativeAccessToken)
+  }
+
+  return { kind: 'token', token: connectionToken ?? null }
 }
 
 export interface AdvertisedAuthProvider {


### PR DESCRIPTION
## What does this PR do?

Supersedes [#89013](https://github.com/NousResearch/hermes-agent/pull/89013). Files panel listing on a gated remote uses `hermes:api` (native bearer, then OAuth-partition cookies). Download used `saveGatewayFile`, which always rode the OAuth cookie partition. A cookieless native / native-password session can list files and still 401 on Download.

This makes save/read use the same bearer-then-cookie choice as REST. It drops the default-session cookie-jar walk from [#89013](https://github.com/NousResearch/hermes-agent/pull/89013): Desktop password login already posts into `persist:hermes-remote-oauth`.

## Related Issue

Fixes [#88987](https://github.com/NousResearch/hermes-agent/issues/88987)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `resolveGatedDownloadAuth` reuses `resolveOauthRestAuth` for oauth mode
- `saveGatewayFile` and the data-URL fallback present that auth (native bearer streams with `Authorization`)
- Tests pin bearer-first, then cookie; session-token for token/local

## How to Test

```text
cd apps/desktop
npx vitest run --project electron electron/native-auth-decisions.test.ts electron/gateway-file-download-transport.test.ts
```

- [ ] Connect Desktop to a password-gated remote (native or embedded login)
- [ ] Files panel Download writes the file locally (no 401)
- [ ] Local (non-remote) Files panel is unchanged

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (unit tests; not runtime-tested against a live password remote)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

Credit: @686f6c61 (primary). Related: [#89013](https://github.com/NousResearch/hermes-agent/pull/89013), [#89257](https://github.com/NousResearch/hermes-agent/pull/89257).