### PR TITLE
fix(desktop): show the remote host's projects for the focused profile

### DIFF
--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { NO_PROJECT_ID, type SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
 import { $sidebarAgentsGrouped, setSidebarAgentsGrouped } from '@/store/layout'
-import { $activeGatewayProfile } from '@/store/profile'
+import { $activeGatewayProfile, setShowAllProfiles } from '@/store/profile'
 import { $currentCwd, $selectedStoredSessionId, $sessions, applyConfiguredDefaultProjectDir } from '@/store/session'
 
 import {
@@ -21,6 +21,7 @@ import {
   endSessionMutation,
   enterProject,
   exitProjectScope,
+  fetchProjectSessions,
   openProjectCreate,
   pickProjectFolder,
   projectIdForCwd,
@@ -63,6 +64,7 @@ vi.mock('@/lib/desktop-git', async importOriginal => ({
 vi.mock('@/hermes', () => ({
   getHermesConfig: vi.fn(),
   getProfiles: vi.fn(),
+  hermesApi: vi.fn(),
   setApiRequestProfile: vi.fn(),
   STARTUP_REQUEST_TIMEOUT_MS: 1000
 }))
@@ -83,6 +85,16 @@ const hermes = await import('@/hermes')
 const getHermesConfig = vi.mocked(hermes.getHermesConfig)
 const notifications = await import('@/store/notifications')
 const notify = vi.mocked(notifications.notify)
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
 
 describe('project scope', () => {
   beforeEach(() => {
@@ -115,6 +127,50 @@ describe('project scope', () => {
   it('persists the scope to localStorage', () => {
     enterProject('p_abc')
     expect(window.localStorage.getItem('hermes.desktop.projectScope')).toBe('p_abc')
+  })
+})
+
+describe('projects RPC profile forwarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    $activeGatewayProfile.set('default')
+    $activeProjectId.set(null)
+    $projectTree.set([])
+    setShowAllProfiles(false)
+  })
+
+  it('forwards the normalized active profile to project read RPCs', async () => {
+    const request = vi.fn(async () => ({ active_id: null, projects: [], scoped_session_ids: [] }))
+    const gateway = { connectionState: 'open', request }
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
+    $activeGatewayProfile.set('  coder  ')
+
+    await refreshProjects()
+    await refreshProjectTree()
+    await fetchProjectSessions('p_123')
+
+    expect(request).toHaveBeenNthCalledWith(1, 'projects.list', { profile: 'coder' })
+    expect(request).toHaveBeenNthCalledWith(2, 'projects.tree', { preview_limit: 3, profile: 'coder' })
+    expect(request).toHaveBeenNthCalledWith(3, 'projects.project_sessions', {
+      profile: 'coder',
+      project_id: 'p_123'
+    })
+  })
+
+  it('skips project reads in the all-profiles view rather than forwarding its sentinel', async () => {
+    const request = vi.fn()
+    const gateway = { connectionState: 'open', request }
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
+    setShowAllProfiles(true)
+
+    await refreshProjects()
+    await refreshProjectTree()
+    await fetchProjectSessions('p_123')
+
+    expect(request).not.toHaveBeenCalled()
+    setShowAllProfiles(false)
   })
 })
 
@@ -478,6 +534,7 @@ describe('repository discovery policy', () => {
     expect(scanRepos).not.toHaveBeenCalled()
     expect(request).toHaveBeenCalledWith('projects.record_repos', {
       discovery_policy: { enabled: false, exclude_paths: [], roots: [] },
+      profile: 'default',
       repos: []
     })
   })
@@ -513,24 +570,154 @@ describe('repository discovery policy', () => {
         exclude_paths: ['/work/vendor'],
         roots: ['/work']
       },
+      profile: 'default',
       repos: [{ label: 'repo', root: '/work/repo' }]
     })
   })
 
-  it('does not scan the local filesystem for remote connections', async () => {
+  it('does not scan the local filesystem for remote connections but still refreshes the project tree', async () => {
     isDesktopFsRemoteMode.mockReturnValue(true)
     const scanRepos = vi.fn()
     desktopGit.mockReturnValue({ scanRepos } as never)
+    const request = vi.fn(async (method: string) =>
+      method === 'projects.tree'
+        ? { active_id: null, projects: [], scoped_session_ids: [] }
+        : { accepted: false, repos: [] }
+    )
+    gatewayWith(request)
+    $projectTree.set([{ id: 'seed', label: 'seed', path: null, repos: [], sessionCount: 0 } satisfies SidebarProjectTree])
 
     await scanAndRecordRepos(true)
 
     expect(scanRepos).not.toHaveBeenCalled()
     expect(getHermesConfig).not.toHaveBeenCalled()
+    // The desktop can't crawl the remote host's filesystem, so it asks the
+    // host to scan its own discovery roots (`projects.discover_repos` with
+    // `scan: true`) — repos with zero Hermes sessions must still surface —
+    // then refreshes the tree to pick up the merged list. Regression for
+    // #81723: the sidebar used to go silent in remote mode and never
+    // refresh again.
+    expect(request).toHaveBeenCalledWith('projects.discover_repos', { profile: 'default', scan: true })
+    expect(request).toHaveBeenCalledWith(
+      'projects.tree',
+      expect.objectContaining({ preview_limit: expect.any(Number), profile: 'default' })
+    )
+    // A successful scan refreshes the tree (here to the empty list the mock
+    // tree returns), so a later discover-repos call replaces it instead of
+    // keeping the stale seed.
+    expect($projectTree.get()).toEqual([])
+  })
+
+  it('surfaces a reject from remote discover_repos without clearing the sidebar', async () => {
+    // Backend error (RPC `error` frame) rejects the request — the sidebar must
+    // keep its last known list and flag the failure, not go silently blank.
+    isDesktopFsRemoteMode.mockReturnValue(true)
+    desktopGit.mockReturnValue({ scanRepos: vi.fn() } as never)
+    const request = vi.fn(async (method: string) => {
+      if (method === 'projects.discover_repos') {
+        throw new Error('discover_repos failed')
+      }
+      if (method === 'projects.tree') {
+        return { active_id: null, projects: [], scoped_session_ids: [] }
+      }
+      return { accepted: false, repos: [] }
+    })
+    gatewayWith(request)
+    $projectTree.set([{ id: 'seed', label: 'seed', path: null, repos: [], sessionCount: 0 } satisfies SidebarProjectTree])
+
+    await scanAndRecordRepos(true)
+
+    // The tree refresh must NOT run against a failed remote scan ...
+    expect(request).not.toHaveBeenCalledWith(
+      'projects.tree',
+      expect.objectContaining({ preview_limit: expect.any(Number) })
+    )
+    // ... the cached tree is preserved ...
+    expect($projectTree.get()).toEqual([
+      { id: 'seed', label: 'seed', path: null, repos: [], sessionCount: 0 }
+    ])
+  })
+
+  it('does not treat an error-shaped discover_repos response as a successful refresh', async () => {
+    // A resolved-but-error-shaped body (`{accepted:false}` / no `repos`) must
+    // be treated as a failure: keep the old list rather than refreshing into
+    // the silent, empty sidebar of #81723.
+    isDesktopFsRemoteMode.mockReturnValue(true)
+    desktopGit.mockReturnValue({ scanRepos: vi.fn() } as never)
+    const request = vi.fn(async (method: string) =>
+      method === 'projects.tree'
+        ? { active_id: null, projects: [], scoped_session_ids: [] }
+        : { accepted: false }
+    )
+    gatewayWith(request)
+    $projectTree.set([{ id: 'seed', label: 'seed', path: null, repos: [], sessionCount: 0 } satisfies SidebarProjectTree])
+
+    await scanAndRecordRepos(true)
+
+    expect(request).not.toHaveBeenCalledWith(
+      'projects.tree',
+      expect.objectContaining({ preview_limit: expect.any(Number) })
+    )
+    expect($projectTree.get()).toEqual([
+      { id: 'seed', label: 'seed', path: null, repos: [], sessionCount: 0 }
+    ])
+  })
+
+  it('records repos under the profile the scan started with, not one focused mid-scan', async () => {
+    const { promise: scanResult, resolve: resolveScan } = deferred<Array<{ label: string; root: string }>>()
+    const { promise: scanStarted, resolve: markScanStarted } = deferred<void>()
+
+    const request = vi.fn(async (method: string) =>
+      method === 'projects.tree'
+        ? {
+            active_id: null,
+            projects: [{ id: 'p_lured', label: 'Lured', path: null, repos: [], sessionCount: 0 }],
+            scoped_session_ids: []
+          }
+        : { accepted: true, repos: [] }
+    )
+
+    gatewayWith(request)
+    const scanRepos = vi.fn(() => {
+      markScanStarted()
+      return scanResult
+    })
+    desktopGit.mockReturnValue({ scanRepos } as never)
+    getHermesConfig.mockResolvedValue({
+      desktop: {
+        repo_scan_enabled: true,
+        repo_scan_exclude_paths: [],
+        repo_scan_roots: ['/work']
+      }
+    })
+    $activeGatewayProfile.set('launch')
+    $projectTree.set([])
+
+    const pending = scanAndRecordRepos()
+    await scanStarted
+    $activeGatewayProfile.set('coder')
+    resolveScan([{ label: 'repo', root: '/work/repo' }])
+    await pending
+
+    expect(request).toHaveBeenCalledWith('projects.record_repos', {
+      discovery_policy: { enabled: true, exclude_paths: [], roots: ['/work'] },
+      profile: 'launch',
+      repos: [{ label: 'repo', root: '/work/repo' }]
+    })
+    expect(request).not.toHaveBeenCalledWith('projects.record_repos', expect.objectContaining({ profile: 'coder' }))
+    expect($projectTree.get()).toEqual([])
   })
 })
 
 describe('project tree profile isolation', () => {
-  it('does not publish a late response from the previous profile', async () => {
+  beforeEach(() => {
+    setShowAllProfiles(false)
+    $activeGatewayProfile.set('default')
+    $projects.set([])
+    $projectTree.set([])
+  })
+
+  it('does not publish a late response from the previous gateway', async () => {
     let resolveA: ((value: unknown) => void) | undefined
 
     const responseA = new Promise(resolve => {
@@ -565,6 +752,84 @@ describe('project tree profile isolation', () => {
     await pendingA
 
     expect($projectTree.get().map(project => project.id)).toEqual(['profile-b'])
+  })
+
+  it('does not publish a late projects.list response from the previous profile', async () => {
+    const { promise: defaultResponse, resolve: resolveDefault } = deferred<unknown>()
+    const request = vi.fn((_method: string, params: Record<string, unknown>) =>
+      params.profile === 'default'
+        ? defaultResponse
+        : Promise.resolve({
+            active_id: null,
+            projects: [{ id: 'profile-b', label: 'Profile B' }]
+          })
+    )
+    const gateway = { connectionState: 'open', request }
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
+
+    const pendingDefault = refreshProjects()
+    $activeGatewayProfile.set('profile-b')
+    await refreshProjects()
+    resolveDefault({
+      active_id: null,
+      projects: [{ id: 'profile-a', label: 'Profile A' }]
+    })
+    await pendingDefault
+
+    expect($projects.get().map(project => project.id)).toEqual(['profile-b'])
+  })
+
+  it('does not publish a late projects.tree response from the previous profile', async () => {
+    const { promise: defaultResponse, resolve: resolveDefault } = deferred<unknown>()
+    const request = vi.fn((_method: string, params: Record<string, unknown>) =>
+      params.profile === 'default'
+        ? defaultResponse
+        : Promise.resolve({
+            active_id: null,
+            projects: [{ id: 'profile-b', label: 'Profile B', path: null, repos: [], sessionCount: 0 }],
+            scoped_session_ids: []
+          })
+    )
+    const gateway = { connectionState: 'open', request }
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
+
+    const pendingDefault = refreshProjectTree()
+    $activeGatewayProfile.set('profile-b')
+    await refreshProjectTree()
+    resolveDefault({
+      active_id: null,
+      projects: [{ id: 'profile-a', label: 'Profile A', path: null, repos: [], sessionCount: 0 }],
+      scoped_session_ids: []
+    })
+    await pendingDefault
+
+    expect($projectTree.get().map(project => project.id)).toEqual(['profile-b'])
+  })
+
+  it('drops a late hydrated-project response from the previous profile', async () => {
+    const { promise: defaultResponse, resolve: resolveDefault } = deferred<unknown>()
+    const request = vi.fn((_method: string, params: Record<string, unknown>) =>
+      params.profile === 'default'
+        ? defaultResponse
+        : Promise.resolve({
+            project: { id: 'profile-b', label: 'Profile B', path: null, repos: [], sessionCount: 0 }
+          })
+    )
+    const gateway = { connectionState: 'open', request }
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
+
+    const pendingDefault = fetchProjectSessions('p_123')
+    $activeGatewayProfile.set('profile-b')
+    const profileB = await fetchProjectSessions('p_123')
+    resolveDefault({
+      project: { id: 'profile-a', label: 'Profile A', path: null, repos: [], sessionCount: 0 }
+    })
+
+    expect(profileB?.id).toBe('profile-b')
+    await expect(pendingDefault).resolves.toBeNull()
   })
 })
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -16,7 +16,13 @@ import { persistentAtom } from '@/lib/persisted'
 import { $gateway, activeGateway, ensureActiveGatewayOpen } from '@/store/gateway'
 import { setSidebarAgentsGrouped } from '@/store/layout'
 import { notify } from '@/store/notifications'
-import { $activeGatewayProfile, $profileScope, ALL_PROFILES, requestFreshSession } from '@/store/profile'
+import {
+  $activeGatewayProfile,
+  $profileScope,
+  ALL_PROFILES,
+  normalizeProfileKey,
+  requestFreshSession
+} from '@/store/profile'
 import {
   $selectedStoredSessionId,
   $sessions,
@@ -341,6 +347,23 @@ async function gatewayRequest<T>(method: string, params: Record<string, unknown>
   return gateway.request<T>(method, params)
 }
 
+function projectProfile(): null | string {
+  const profile = normalizeProfileKey($activeGatewayProfile.get())
+
+  return $profileScope.get() === ALL_PROFILES || profile === ALL_PROFILES ? null : profile
+}
+
+function projectParams(
+  params: Record<string, unknown> = {},
+  profile: null | string = projectProfile()
+): Record<string, unknown> {
+  if (!profile) {
+    throw new Error('Projects are unavailable while viewing all profiles')
+  }
+
+  return { ...params, profile }
+}
+
 async function gatewayRequestOn<T>(
   gateway: HermesGateway,
   method: string,
@@ -354,15 +377,24 @@ interface ActiveProjectsContext {
   profile: string
 }
 
+function stillOnProjectsContext(context: ActiveProjectsContext): boolean {
+  return activeGateway() === context.gateway && projectProfile() === context.profile
+}
+
 async function activeProjectsContext(): Promise<ActiveProjectsContext> {
-  const profile = $activeGatewayProfile.get() || 'default'
+  const profile = projectProfile()
+
+  if (!profile) {
+    throw new Error('Projects are unavailable while viewing all profiles')
+  }
+
   let gateway = activeGateway()
 
   if (!gateway || gateway.connectionState !== 'open') {
     gateway = await ensureActiveGatewayOpen()
   }
 
-  if (!gateway || gateway !== activeGateway() || profile !== ($activeGatewayProfile.get() || 'default')) {
+  if (!gateway || gateway !== activeGateway() || profile !== projectProfile()) {
     throw new Error('Active Hermes profile changed while connecting')
   }
 
@@ -380,20 +412,24 @@ let projectsRefreshGeneration = 0
 // not up yet) leaves the cached atoms intact so the sidebar doesn't flicker.
 export async function refreshProjects(): Promise<void> {
   const generation = ++projectsRefreshGeneration
-  let gateway: HermesGateway | null = null
+  let context: ActiveProjectsContext | null = null
 
   try {
-    gateway = (await activeProjectsContext()).gateway
-    const payload = await gatewayRequestOn<ProjectsPayload>(gateway, 'projects.list')
+    context = await activeProjectsContext()
+    const payload = await gatewayRequestOn<ProjectsPayload>(
+      context.gateway,
+      'projects.list',
+      projectParams({}, context.profile)
+    )
 
-    if (generation !== projectsRefreshGeneration || activeGateway() !== gateway) {
+    if (generation !== projectsRefreshGeneration || !stillOnProjectsContext(context)) {
       return
     }
 
     applyPayload(payload)
     markProjectsRpcSuccess()
   } catch (err) {
-    if (generation === projectsRefreshGeneration && (!gateway || activeGateway() === gateway)) {
+    if (context && generation === projectsRefreshGeneration && stillOnProjectsContext(context)) {
       markProjectsRpcFailure(err)
     }
     // Backend may not be ready; keep the last known list.
@@ -433,26 +469,29 @@ function applyProjectTreePayload(res: ProjectTreePayload): void {
   }
 }
 
-async function refreshProjectTreeOn(gateway: HermesGateway): Promise<void> {
+async function refreshProjectTreeOn(context: ActiveProjectsContext): Promise<void> {
   const generation = ++projectTreeRefreshGeneration
+  const { gateway, profile } = context
 
   if (activeGateway() === gateway) {
     $projectTreeLoading.set(true)
   }
 
   try {
-    const res = await gatewayRequestOn<ProjectTreePayload>(gateway, 'projects.tree', {
-      preview_limit: PROJECT_TREE_PREVIEW_LIMIT
-    })
+    const res = await gatewayRequestOn<ProjectTreePayload>(
+      gateway,
+      'projects.tree',
+      projectParams({ preview_limit: PROJECT_TREE_PREVIEW_LIMIT }, profile)
+    )
 
-    if (generation !== projectTreeRefreshGeneration || activeGateway() !== gateway) {
+    if (generation !== projectTreeRefreshGeneration || !stillOnProjectsContext(context)) {
       return
     }
 
     applyProjectTreePayload(res)
     markProjectsRpcSuccess()
   } catch (err) {
-    if (activeGateway() === gateway) {
+    if (generation === projectTreeRefreshGeneration && stillOnProjectsContext(context)) {
       markProjectsRpcFailure(err)
     }
   } finally {
@@ -473,8 +512,7 @@ export async function refreshProjectTree(): Promise<void> {
   }
 
   try {
-    const { gateway } = await activeProjectsContext()
-    await refreshProjectTreeOn(gateway)
+    await refreshProjectTreeOn(await activeProjectsContext())
   } catch {
     // Backend may not be ready; keep the last known tree.
   }
@@ -514,11 +552,22 @@ async function refreshProjectTreeAcrossProfiles(): Promise<void> {
 // Fully hydrated lanes (repo -> lane -> session rows) for one project, fetched
 // when the user enters it. Same backend grouping as `projects.tree`, so ids and
 // membership match exactly.
+let projectSessionsRefreshGeneration = 0
+
 export async function fetchProjectSessions(projectId: string): Promise<SidebarProjectTree | null> {
+  const generation = ++projectSessionsRefreshGeneration
+
   try {
-    const res = await gatewayRequest<{ project: SidebarProjectTree | null }>('projects.project_sessions', {
-      project_id: projectId
-    })
+    const context = await activeProjectsContext()
+    const res = await gatewayRequestOn<{ project: SidebarProjectTree | null }>(
+      context.gateway,
+      'projects.project_sessions',
+      projectParams({ project_id: projectId }, context.profile)
+    )
+
+    if (generation !== projectSessionsRefreshGeneration || !stillOnProjectsContext(context)) {
+      return null
+    }
 
     return res.project ?? null
   } catch {
@@ -616,6 +665,41 @@ $gateway.subscribe(syncReposScanning)
 
 export async function scanAndRecordRepos(force = false): Promise<void> {
   if (isDesktopFsRemoteMode()) {
+    // On a remote backend the desktop can't crawl the host filesystem.
+    // Ask the host to scan its own discovery roots (`projects.discover_repos`
+    // with `scan: true` — added in #81723) so repos with zero Hermes
+    // sessions still surface, then refresh the tree so the sidebar picks up
+    // the merged session-derived + scanned list.
+    try {
+      const context = await activeProjectsContext()
+      const discovered = await gatewayRequestOn<{
+        repos?: unknown
+        discovery_policy?: unknown
+      }>(context.gateway, 'projects.discover_repos', projectParams({ scan: true }, context.profile))
+
+      // A resolved response must be the discovery shape. Anything else (an
+      // error/`accepted:false` body, or a backend that ignored `scan` and
+      // returned no repo list) means the scan didn't happen — bail out without
+      // touching the tree so the sidebar keeps its last known list instead of
+      // being blanked back to the silent, unpopulated state of #81723.
+      if (discovered?.repos === undefined) {
+        markProjectsRpcFailure(new Error('projects.discover_repos returned no repo list'))
+        return
+      }
+
+      // Remote scan succeeded: refresh the tree so the merged session-derived +
+      // scanned list surfaces. Skip if the user moved on — a stale scan must
+      // not publish into the newly focused profile.
+      if (stillOnProjectsContext(context)) {
+        await refreshProjectTreeOn(context)
+      }
+    } catch (err) {
+      // Surface the failure (stale backend, RPC error, gateway drop) instead
+      // of swallowing it: a silent return is exactly the "sidebar goes quiet"
+      // symptom `scan:true` was meant to fix (#81723). Keep the old list and
+      // let the sidebar show the error/absent state.
+      markProjectsRpcFailure(err)
+    }
     return
   }
 
@@ -649,10 +733,11 @@ export async function scanAndRecordRepos(force = false): Promise<void> {
     state.runningSignature = signature
 
     if (!policy.enabled) {
-      await gatewayRequestOn(context.gateway, 'projects.record_repos', {
-        discovery_policy: policy,
-        repos: []
-      })
+      await gatewayRequestOn(
+        context.gateway,
+        'projects.record_repos',
+        projectParams({ discovery_policy: policy, repos: [] }, context.profile)
+      )
     } else {
       scanningGatewayGenerations.set(context.gateway, generation)
       syncReposScanning()
@@ -666,10 +751,11 @@ export async function scanAndRecordRepos(force = false): Promise<void> {
         return
       }
 
-      await gatewayRequestOn(context.gateway, 'projects.record_repos', {
-        discovery_policy: policy,
-        repos
-      })
+      await gatewayRequestOn(
+        context.gateway,
+        'projects.record_repos',
+        projectParams({ discovery_policy: policy, repos }, context.profile)
+      )
     }
 
     if (state.generation !== generation) {
@@ -677,10 +763,13 @@ export async function scanAndRecordRepos(force = false): Promise<void> {
     }
 
     state.completedSignature = signature
-    // Scope-aware on purpose: the scan records into one profile, but folding
-    // its result back in through the active scope keeps an all-profiles tree
-    // from being overwritten by the scanned profile's own.
-    await refreshProjectTree()
+    // Completion refresh only when the focused profile still matches the one
+    // the scan was captured under. refreshProjectTree() re-derives the current
+    // context, so skipping on mismatch keeps a stale scan from publishing into
+    // the newly focused profile.
+    if (stillOnProjectsContext(context)) {
+      await refreshProjectTree()
+    }
   } catch {
     state.completedSignature = undefined
   } finally {
@@ -808,17 +897,20 @@ export async function createProject(input: CreateProjectInput): Promise<ProjectI
   let res: { project: ProjectInfo | null }
 
   try {
-    res = await gatewayRequest<{ project: ProjectInfo | null }>('projects.create', {
-      name: input.name,
-      folders: input.folders ?? [],
-      primary_path: input.primaryPath,
-      slug: input.slug,
-      description: input.description,
-      icon: input.icon,
-      color: input.color,
-      board_slug: input.boardSlug,
-      use: input.use ?? false
-    })
+    res = await gatewayRequest<{ project: ProjectInfo | null }>(
+      'projects.create',
+      projectParams({
+        name: input.name,
+        folders: input.folders ?? [],
+        primary_path: input.primaryPath,
+        slug: input.slug,
+        description: input.description,
+        icon: input.icon,
+        color: input.color,
+        board_slug: input.boardSlug,
+        use: input.use ?? false
+      })
+    )
   } catch (err) {
     if (isMissingRpcMethod(err)) {
       $projectsRpcAvailable.set(false)
@@ -891,12 +983,15 @@ export async function updateProject(
   // Backend treats null/undefined as "leave unchanged"; "" clears (stores NULL).
   // Map explicit null → "" so "no color"/"no icon" actually clear.
   await persistOrRollback(snap, () =>
-    gatewayRequest('projects.update', {
-      id,
-      ...patch,
-      ...(patch.color === null && { color: '' }),
-      ...(patch.icon === null && { icon: '' })
-    })
+    gatewayRequest(
+      'projects.update',
+      projectParams({
+        id,
+        ...patch,
+        ...(patch.color === null && { color: '' }),
+        ...(patch.icon === null && { icon: '' })
+      })
+    )
   )
 }
 
@@ -967,7 +1062,10 @@ export async function addProjectFolder(
   }
 
   await persistOrRollback(snap, () =>
-    gatewayRequest('projects.add_folder', { id, path, label: opts.label, is_primary: opts.isPrimary ?? false })
+    gatewayRequest(
+      'projects.add_folder',
+      projectParams({ id, path, label: opts.label, is_primary: opts.isPrimary ?? false })
+    )
   )
   reconcileProjects()
 }
@@ -1010,13 +1108,13 @@ export async function deleteProject(id: string): Promise<void> {
   }
 
   await persistOrRollback(snap, async () => {
-    applyPayload(await gatewayRequest<ProjectsPayload>('projects.delete', { id }))
+    applyPayload(await gatewayRequest<ProjectsPayload>('projects.delete', projectParams({ id })))
   })
   void refreshProjectTree()
 }
 
 export async function setActiveProject(id: null | string): Promise<void> {
-  const res = await gatewayRequest<{ active_id: null | string }>('projects.set_active', { id })
+  const res = await gatewayRequest<{ active_id: null | string }>('projects.set_active', projectParams({ id }))
   $activeProjectId.set(res.active_id ?? null)
 }
 

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import subprocess
+from pathlib import Path
 
 import pytest
 
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 import tui_gateway.server as server
 
 
@@ -336,6 +339,139 @@ def test_scan_time_is_not_treated_as_session_activity(tmp_path):
     assert active["last_active"] > idle["last_active"]
 
 
+def test_remote_scan_failure_merges_instead_of_replacing_cache(tmp_path, monkeypatch):
+    """A backend scan that can't fully walk its roots must NOT wipe the cache.
+
+    `projects.discover_repos` with `scan:true` asks the remote host to scan its
+    own discovery roots. When one root fails to walk, the scan result is not the
+    authoritative full universe — the previously cached repos must survive so a
+    failed remote refresh can't blank the sidebar back to the silent, empty
+    state of #81723 (regression for MEDIUM: `replace=True` was wiping on every
+    call regardless of success).
+    """
+    from hermes_cli import projects_db as pdb
+    import tui_gateway.server as server
+
+    def _git_repo(path):
+        repo = path
+        repo.mkdir(parents=True)
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        return str(repo)
+
+    # A cached repo the partial scan never visits, parked OUTSIDE the scan roots.
+    seed = _git_repo(tmp_path / "elsewhere" / "seed-repo")
+    with pdb.connect_closing() as conn:
+        pdb.record_discovered_repos(conn, [(seed, "seed-repo")])
+        seeded = [r["root"] for r in pdb.list_discovered_repos(conn)]
+    assert seed in seeded
+
+    good = _git_repo(tmp_path / "good-repo")
+
+    # Force one root to fail to walk: the scan becomes non-authoritative, so it
+    # must merge into the cache, never wipe it.
+    real_walk = os.walk
+    bad_root = str(tmp_path / "unwalkable")
+
+    def _flaky_walk(top, *a, **k):
+        if top == bad_root:
+            raise OSError("boom")
+        yield from real_walk(top, *a, **k)
+
+    monkeypatch.setattr(server.os, "walk", _flaky_walk)
+
+    policy = {"enabled": True, "roots": [good, bad_root], "exclude_paths": []}
+
+    with pdb.connect_closing() as conn:
+        authoritative = server._scan_discovered_repos_remote(conn, policy)
+        joined = [r["root"] for r in pdb.list_discovered_repos(conn)]
+
+    # The scan found the good repo and merged it, but the failed root means the
+    # result is not authoritative, so it must NOT have replaced the cache.
+    assert not authoritative
+    assert good in joined
+    # The seeded repo that the partial scan never saw is still cached.
+    assert seed in joined
+
+
+def test_remote_scan_missing_root_does_not_wipe_cache(tmp_path):
+    """A configured discovery root missing on disk must NOT wipe the cache.
+
+    ``os.walk`` on a non-existent root silently yields nothing instead of
+    raising, so a temporarily unavailable root (unmounted volume, moved path)
+    would otherwise make the scan look like a genuinely empty authoritative
+    set and DELETE-replace every cached repo that lived under it. The missing
+    root must contribute nothing, and the scan must merge — never wipe.
+    """
+    from hermes_cli import projects_db as pdb
+    import tui_gateway.server as server
+
+    def _git_repo(path):
+        repo = path
+        repo.mkdir(parents=True)
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        return str(repo)
+
+    # A cached repo the scan never visits, parked OUTSIDE the scan roots.
+    seed = _git_repo(tmp_path / "elsewhere" / "seed-repo")
+    with pdb.connect_closing() as conn:
+        pdb.record_discovered_repos(conn, [(seed, "seed-repo")])
+        seeded = [r["root"] for r in pdb.list_discovered_repos(conn)]
+    assert seed in seeded
+
+    good = _git_repo(tmp_path / "good-repo")
+
+    # This root is configured but does NOT exist on disk. os.walk on it yields
+    # nothing silently — without the guard the scan would stay authoritative
+    # and wipe the cache.
+    missing_root = str(tmp_path / "missing-root")
+
+    policy = {"enabled": True, "roots": [good, missing_root], "exclude_paths": []}
+
+    with pdb.connect_closing() as conn:
+        authoritative = server._scan_discovered_repos_remote(conn, policy)
+        joined = [r["root"] for r in pdb.list_discovered_repos(conn)]
+
+    # The missing root is not authoritative, so the scan must merge, not wipe.
+    assert not authoritative
+    assert good in joined
+    # The seeded repo the missing root would have wiped is still cached.
+    assert seed in joined
+
+
+def test_remote_scan_full_authoritative_replaces_cache(tmp_path):
+    """Only a fully-walked scan may replace the stale cache."""
+    from hermes_cli import projects_db as pdb
+    import tui_gateway.server as server
+
+    def _git_repo(path):
+        repo = path
+        repo.mkdir(parents=True)
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        return str(repo)
+
+    # Park the stale repo OUTSIDE the scan root so the authoritative scan no
+    # longer sees it, and the fresh repo inside the root it walks.
+    stale = _git_repo(tmp_path / "outside" / "stale-repo")
+    scandir = tmp_path / "scandir"
+    scandir.mkdir()
+    fresh = _git_repo(scandir / "fresh-repo")
+
+    with pdb.connect_closing() as conn:
+        pdb.record_discovered_repos(conn, [(stale, "stale-repo")])
+
+    policy = {"enabled": True, "roots": [str(scandir)], "exclude_paths": []}
+
+    with pdb.connect_closing() as conn:
+        authoritative = server._scan_discovered_repos_remote(conn, policy)
+        joined = [r["root"] for r in pdb.list_discovered_repos(conn)]
+
+    assert authoritative
+    assert fresh in joined
+    # A full, authoritative scan replaced the stale cache: the old repo the
+    # scan no longer saw is gone from the authoritative set.
+    assert stale not in joined
+
+
 def test_terminal_session_persists_its_launch_cwd():
     """A terminal session's cwd IS its workspace, so the row must record it.
 
@@ -458,5 +594,231 @@ def test_nondefault_policy_rejects_stale_or_legacy_results(monkeypatch, tmp_path
     assert stale["accepted"] is False
     assert accepted["accepted"] is True
     assert any(item["root"] == str(root) for item in accepted["repos"])
+
+
+def _profile_dir(tmp_path: Path, name: str) -> Path:
+    home = tmp_path / "homes" / name
+    home.mkdir(parents=True, exist_ok=True)
+    return home
+
+
+def _bind_profiles(monkeypatch, tmp_path: Path, homes: dict[str, Path]) -> None:
+    """Resolve profile names to this test's throwaway homes.
+
+    Unmapped names resolve to a path that does not exist, which is how the
+    gateway detects "not a real profile on this host" and stays on launch.
+    """
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir",
+        lambda name: homes.get(name, tmp_path / "homes" / "missing" / name),
+    )
+
+
+def _create_project(home: Path, name: str, folder: Path, *, use: bool = False) -> dict:
+    """Create a project in ``home``'s projects.db via the real RPC."""
+    token = set_hermes_home_override(home)
+    try:
+        return _call(
+            "projects.create", {"name": name, "folders": [str(folder)], "use": use}
+        )["project"]
+    finally:
+        reset_hermes_home_override(token)
+
+
+def _create_session(home: Path, session_id: str, cwd: Path) -> None:
+    """Seed one message-bearing session in ``home``'s state.db."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=home / "state.db")
+    try:
+        db.create_session(session_id, "cli", cwd=str(cwd))
+        db.append_message(session_id, "user", f"hello from {session_id}")
+    finally:
+        db.close()
+
+
+@contextlib.contextmanager
+def _serving_launch_profile(launch_home: Path):
+    """Run the handlers as a backend launched under ``launch_home``."""
+    from hermes_state import SessionDB
+
+    token = set_hermes_home_override(launch_home)
+    prev_db, prev_error = server._db, server._db_error
+    server._db = SessionDB(db_path=launch_home / "state.db")
+    server._db_error = None
+    try:
+        yield
+    finally:
+        server._db.close()
+        server._db, server._db_error = prev_db, prev_error
+        reset_hermes_home_override(token)
+
+
+def _cached_repo_labels(home: Path) -> list[str]:
+    """Labels in ``home``'s discovered-repo cache, read straight off disk."""
+    from hermes_cli import projects_db as pdb
+
+    with pdb.connect_closing(home / "projects.db") as conn:
+        return sorted(str(entry.get("label") or "") for entry in pdb.list_discovered_repos(conn))
+
+
+def test_projects_reads_are_scoped_to_the_requested_profile(monkeypatch, tmp_path):
+    """A ``profile`` param reads that profile's projects.db AND its state.db."""
+    launch_home = _profile_dir(tmp_path, "launch")
+    coder_home = _profile_dir(tmp_path, "coder")
+    launch_repo = tmp_path / "repos" / "launch-repo"
+    coder_repo = tmp_path / "repos" / "coder-repo"
+    launch_repo.mkdir(parents=True)
+    coder_repo.mkdir(parents=True)
+    _bind_profiles(monkeypatch, tmp_path, {"default": launch_home, "coder": coder_home})
+
+    launch_project = _create_project(launch_home, "Launch", launch_repo, use=True)
+    coder_project = _create_project(coder_home, "Coder", coder_repo, use=True)
+    _create_session(launch_home, "launch-session", launch_repo)
+    _create_session(coder_home, "coder-session", coder_repo)
+
+    with _serving_launch_profile(launch_home):
+        launch_listing = _call("projects.list")
+        coder_listing = _call("projects.list", {"profile": "coder"})
+        launch_tree = _call("projects.tree")
+        coder_tree = _call("projects.tree", {"profile": "coder"})
+        coder_sessions = _call(
+            "projects.project_sessions",
+            {"profile": "coder", "project_id": coder_project["id"]},
+        )
+        # The override must not leak: the very next unscoped read is launch again.
+        launch_again = _call("projects.list")
+
+    assert [p["name"] for p in launch_listing["projects"]] == ["Launch"]
+    assert [p["name"] for p in coder_listing["projects"]] == ["Coder"]
+    assert launch_listing["active_id"] == launch_project["id"]
+    assert coder_listing["active_id"] == coder_project["id"]
+    assert launch_again == launch_listing
+
+    assert [p["label"] for p in launch_tree["projects"]] == ["Launch"]
+    assert [p["label"] for p in coder_tree["projects"]] == ["Coder"]
+    # Session counts prove the SESSION db was swapped too, not just projects.db.
+    assert launch_tree["projects"][0]["sessionCount"] == 1
+    assert coder_tree["projects"][0]["sessionCount"] == 1
+    assert launch_tree["scoped_session_ids"] == ["launch-session"]
+    assert coder_tree["scoped_session_ids"] == ["coder-session"]
+
+    assert coder_sessions["project"]["id"] == coder_project["id"]
+    assert coder_sessions["project"]["sessionCount"] == 1
+    lane = coder_sessions["project"]["repos"][0]["groups"][0]
+    assert [s["id"] for s in lane["sessions"]] == ["coder-session"]
+
+
+def test_projects_tree_is_scoped_to_the_requested_profile(monkeypatch, tmp_path):
+    """``projects.tree`` on its own reads the requested profile's stores."""
+    launch_home = _profile_dir(tmp_path, "launch")
+    coder_home = _profile_dir(tmp_path, "coder")
+    launch_repo = tmp_path / "repos" / "tree-launch"
+    coder_repo = tmp_path / "repos" / "tree-coder"
+    launch_repo.mkdir(parents=True)
+    coder_repo.mkdir(parents=True)
+    _bind_profiles(monkeypatch, tmp_path, {"default": launch_home, "coder": coder_home})
+
+    _create_project(launch_home, "Launch", launch_repo, use=True)
+    _create_project(coder_home, "Coder", coder_repo, use=True)
+    _create_session(launch_home, "tree-launch-session", launch_repo)
+    _create_session(coder_home, "tree-coder-session", coder_repo)
+
+    with _serving_launch_profile(launch_home):
+        coder_tree = _call("projects.tree", {"profile": "coder"})
+        launch_tree = _call("projects.tree")
+
+    assert [p["label"] for p in coder_tree["projects"]] == ["Coder"]
+    assert coder_tree["scoped_session_ids"] == ["tree-coder-session"]
+    assert [p["label"] for p in launch_tree["projects"]] == ["Launch"]
+    assert launch_tree["scoped_session_ids"] == ["tree-launch-session"]
+
+
+def test_project_sessions_is_scoped_to_the_requested_profile(monkeypatch, tmp_path):
+    """``projects.project_sessions`` on its own hydrates from the requested profile."""
+    launch_home = _profile_dir(tmp_path, "launch")
+    coder_home = _profile_dir(tmp_path, "coder")
+    launch_repo = tmp_path / "repos" / "drill-launch"
+    coder_repo = tmp_path / "repos" / "drill-coder"
+    launch_repo.mkdir(parents=True)
+    coder_repo.mkdir(parents=True)
+    _bind_profiles(monkeypatch, tmp_path, {"default": launch_home, "coder": coder_home})
+
+    launch_project = _create_project(launch_home, "Launch", launch_repo, use=True)
+    coder_project = _create_project(coder_home, "Coder", coder_repo, use=True)
+    _create_session(launch_home, "drill-launch-session", launch_repo)
+    _create_session(coder_home, "drill-coder-session", coder_repo)
+
+    with _serving_launch_profile(launch_home):
+        coder_drill = _call(
+            "projects.project_sessions",
+            {"profile": "coder", "project_id": coder_project["id"]},
+        )
+        launch_drill = _call(
+            "projects.project_sessions", {"project_id": launch_project["id"]}
+        )
+
+    assert coder_drill["project"] is not None
+    assert coder_drill["project"]["id"] == coder_project["id"]
+    coder_lane = coder_drill["project"]["repos"][0]["groups"][0]
+    assert [s["id"] for s in coder_lane["sessions"]] == ["drill-coder-session"]
+
+    assert launch_drill["project"]["id"] == launch_project["id"]
+    launch_lane = launch_drill["project"]["repos"][0]["groups"][0]
+    assert [s["id"] for s in launch_lane["sessions"]] == ["drill-launch-session"]
+
+
+def test_record_repos_writes_to_the_requested_profiles_projects_db(monkeypatch, tmp_path):
+    """The scan cache is per-profile: a scoped write must not land on launch."""
+    launch_home = _profile_dir(tmp_path, "launch")
+    coder_home = _profile_dir(tmp_path, "coder")
+    launch_repo = tmp_path / "repos" / "launch-scan"
+    coder_repo = tmp_path / "repos" / "coder-scan"
+    launch_repo.mkdir(parents=True)
+    coder_repo.mkdir(parents=True)
+    _bind_profiles(monkeypatch, tmp_path, {"default": launch_home, "coder": coder_home})
+
+    with _serving_launch_profile(launch_home):
+        _call("projects.record_repos", {"repos": [{"root": str(launch_repo), "label": "launch"}]})
+        _call(
+            "projects.record_repos",
+            {"profile": "coder", "repos": [{"root": str(coder_repo), "label": "coder"}]},
+        )
+
+        launch_repos = _call("projects.discover_repos")["repos"]
+        coder_repos = _call("projects.discover_repos", {"profile": "coder"})["repos"]
+
+    assert [repo["label"] for repo in launch_repos] == ["launch"]
+    assert [repo["label"] for repo in coder_repos] == ["coder"]
+    assert _cached_repo_labels(launch_home) == ["launch"]
+    assert _cached_repo_labels(coder_home) == ["coder"]
+
+
+def test_projects_without_a_profile_stay_on_the_launch_home(monkeypatch, tmp_path):
+    """Omitted/blank/unknown profile is a no-op — the pre-scoping behavior."""
+    launch_home = _profile_dir(tmp_path, "launch")
+    coder_home = _profile_dir(tmp_path, "coder")
+    repo = tmp_path / "repos" / "launch-only"
+    repo.mkdir(parents=True)
+    _bind_profiles(monkeypatch, tmp_path, {"default": launch_home, "coder": coder_home})
+
+    with _serving_launch_profile(launch_home):
+        created = _call(
+            "projects.create", {"name": "Launch only", "folders": [str(repo)], "use": True}
+        )["project"]
+        _call("projects.record_repos", {"repos": [{"root": str(repo), "label": "only"}]})
+
+        omitted = _call("projects.list")
+        blank = _call("projects.list", {"profile": ""})
+        unknown = _call("projects.list", {"profile": "not-a-profile"})
+
+    assert [p["name"] for p in omitted["projects"]] == ["Launch only"]
+    assert blank == omitted
+    assert unknown == omitted
+    assert omitted["active_id"] == created["id"]
+
+    assert _cached_repo_labels(launch_home) == ["only"]
+    assert not (coder_home / "projects.db").exists()
+    assert not (Path(os.environ["HERMES_HOME"]) / "projects.db").exists()
 
 

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -17,31 +17,40 @@ _profile_scoped = _registry.profile_scoped
 
 
 @method("projects.discover_repos")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Repos for the desktop overview: scanned-from-disk (cached) ∪ session-derived."""
     try:
-        db = _get_db()
-        if db is None:
-            return _ok(rid, {"repos": []})
-        from hermes_cli import projects_db as pdb
+        with _profile_db(params) as db:
+            if db is None:
+                return _ok(rid, {"repos": []})
+            from hermes_cli import projects_db as pdb
 
-        policy = _repo_discovery_policy()
-        policy_key = _repo_discovery_policy_key(policy)
-        with pdb.connect_closing() as conn:
-            pdb.reconcile_discovered_repos_policy(
-                conn,
-                policy_key,
-                preserve_unversioned=_repo_discovery_policy_is_default(policy),
-            )
-            repos = _discover_repos_payload(
-                db, conn=conn, include_cached=policy["enabled"]
-            )
-        return _ok(rid, {"repos": repos, "discovery_policy": policy})
+            policy = _repo_discovery_policy()
+            policy_key = _repo_discovery_policy_key(policy)
+            with pdb.connect_closing() as conn:
+                pdb.reconcile_discovered_repos_policy(
+                    conn,
+                    policy_key,
+                    preserve_unversioned=_repo_discovery_policy_is_default(policy),
+                )
+                # `scan=true` (set by the desktop in remote-gateway mode): run a
+                # backend-side filesystem scan of the policy roots so repos with
+                # zero Hermes sessions still surface. The desktop's native scan
+                # only runs on the local filesystem; on a remote connection it
+                # must ask the host to scan itself (#81723).
+                if params.get("scan") and policy["enabled"]:
+                    _scan_discovered_repos_remote(conn, policy)
+                repos = _discover_repos_payload(
+                    db, conn=conn, include_cached=policy["enabled"]
+                )
+            return _ok(rid, {"repos": repos, "discovery_policy": policy})
     except Exception as e:
         return _err(rid, 5061, str(e))
 
 
 @method("projects.record_repos")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Persist git repo roots found by the client's filesystem scan, then return
     the merged repo list. The native crawl runs on the desktop (local fs); this
@@ -88,24 +97,25 @@ def _(rid, params: dict) -> dict:
             elif not policy["enabled"]:
                 pdb.clear_discovered_repos(conn, policy_key=policy_key)
 
-        db = _get_db()
-        return _ok(
-            rid,
-            {
-                "repos": _discover_repos_payload(
-                    db, include_cached=policy["enabled"]
-                )
-                if db is not None
-                else [],
-                "accepted": accepted,
-                "discovery_policy": policy,
-            },
-        )
+        with _profile_db(params) as db:
+            return _ok(
+                rid,
+                {
+                    "repos": _discover_repos_payload(
+                        db, include_cached=policy["enabled"]
+                    )
+                    if db is not None
+                    else [],
+                    "accepted": accepted,
+                    "discovery_policy": policy,
+                },
+            )
     except Exception as e:
         return _err(rid, 5061, str(e))
 
 
 @method("projects.tree")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Authoritative project overview: project -> repo -> lane structure with
     counts + a few preview sessions per project, plus the flat set of session
@@ -113,26 +123,27 @@ def _(rid, params: dict) -> dict:
     Lanes carry no session rows here; drill-in uses ``projects.project_sessions``.
     """
     try:
-        db = _get_db()
-        if db is None:
-            return _ok(rid, {"projects": [], "active_id": None, "scoped_session_ids": []})
+        with _profile_db(params) as db:
+            if db is None:
+                return _ok(rid, {"projects": [], "active_id": None, "scoped_session_ids": []})
 
-        tree, active_id = _build_project_tree(
-            db,
-            preview_limit=int(params.get("preview_limit") or 3),
-            hydrate=False,
-            session_limit=int(params.get("session_limit") or 2000),
-            include_discovered=True,
-        )
-        return _ok(
-            rid,
-            {"projects": tree["projects"], "active_id": active_id, "scoped_session_ids": tree["scoped_session_ids"]},
-        )
+            tree, active_id = _build_project_tree(
+                db,
+                preview_limit=int(params.get("preview_limit") or 3),
+                hydrate=False,
+                session_limit=int(params.get("session_limit") or 2000),
+                include_discovered=True,
+            )
+            return _ok(
+                rid,
+                {"projects": tree["projects"], "active_id": active_id, "scoped_session_ids": tree["scoped_session_ids"]},
+            )
     except Exception as e:
         return _err(rid, 5061, str(e))
 
 
 @method("projects.project_sessions")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Fully hydrated lanes (repo -> lane -> session rows) for one project,
     built from the same authoritative grouping as ``projects.tree`` so ids and
@@ -142,18 +153,18 @@ def _(rid, params: dict) -> dict:
         if not project_id:
             return _err(rid, 5063, "project_id required")
 
-        db = _get_db()
-        if db is None:
-            return _ok(rid, {"project": None})
+        with _profile_db(params) as db:
+            if db is None:
+                return _ok(rid, {"project": None})
 
-        # Drill-in only needs the entered project (which has sessions), so skip
-        # the zero-session discovery tier entirely.
-        tree, _active = _build_project_tree(
-            db, preview_limit=0, hydrate=True, session_limit=int(params.get("session_limit") or 5000),
-            include_discovered=False,
-        )
-        proj = next((p for p in tree["projects"] if p["id"] == project_id), None)
-        return _ok(rid, {"project": proj})
+            # Drill-in only needs the entered project (which has sessions), so skip
+            # the zero-session discovery tier entirely.
+            tree, _active = _build_project_tree(
+                db, preview_limit=0, hydrate=True, session_limit=int(params.get("session_limit") or 5000),
+                include_discovered=False,
+            )
+            proj = next((p for p in tree["projects"] if p["id"] == project_id), None)
+            return _ok(rid, {"project": proj})
     except Exception as e:
         return _err(rid, 5061, str(e))
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1534,13 +1534,12 @@ def _profile_home(profile: str | None) -> Path | None:
 
 
 def _profile_scoped(handler):
-    """Bind ``params['profile']``'s HERMES_HOME around a pet RPC handler.
+    """Bind ``params['profile']``'s HERMES_HOME around a handler.
 
-    Pets are per-profile: ``display.pet.*`` lives in the profile's config.yaml and
-    sprites install under its ``pets/`` dir (both resolve via ``get_hermes_home``).
-    The desktop sends ``profile`` on pet calls so config + pets dir resolve to the
-    focused profile even in app-global remote mode, where one backend serves every
-    profile. No-op for the launch profile (own-profile backends already resolve it).
+    Pets (config + sprites) and projects (projects.db, discovery policy) both
+    resolve via ``get_hermes_home``. The desktop sends ``profile`` so a single
+    backend serving every profile in app-global remote mode still hits the
+    focused profile's home. No-op for the launch profile.
     """
 
     def wrapper(rid, params):
@@ -12634,13 +12633,14 @@ def _projects_payload(conn) -> dict:
 def _projects_method(name: str):
     """Register a projects RPC, injecting (pdb, conn) and unifying error mapping.
 
-    Every project CRUD handler opened the per-profile DB, mapped a missing id to
-    5062, bad args to 5063, and everything else to 5061. This collapses that
-    boilerplate so each handler is just its one meaningful operation.
+    Binds ``params['profile']`` (via ``@_profile_scoped``) so app-global remote
+    mode reads that profile's ``projects.db``. Missing id maps to 5062, bad args
+    to 5063, everything else to 5061.
     """
 
     def decorator(fn):
         @method(name)
+        @_profile_scoped
         def handler(rid, params: dict) -> dict:
             try:
                 from hermes_cli import projects_db as pdb
@@ -12877,6 +12877,89 @@ def _repo_discovery_policy_is_default(policy: dict) -> bool:
     return _repo_discovery_policy_key(policy) == _repo_discovery_policy_key(
         _repo_discovery_policy(DEFAULT_CONFIG["desktop"])
     )
+
+
+def _scan_discovered_repos_remote(conn, policy: dict) -> bool:
+    """Backend-side disk scan of the discovery policy roots.
+
+    The desktop's native repo scan only runs on the local filesystem. On a
+    remote gateway connection the host must scan its own disk so repos with
+    zero Hermes sessions still appear in the sidebar (#81723). Mirrors the
+    desktop's behavior: walk each root (bounded depth), find `.git`
+    directories, record (root, label) pairs into the discovery cache.
+
+    Best-effort: any failure logs and leaves the cache untouched — the
+    session-derived repos from `_discover_repos_payload` still surface.
+
+    Returns True when the scan is authoritative (every root was walked to
+    completion without error and the per-scan cap was not hit). Only then may
+    the caller treat the result as a full replacement and pass ``replace=True``
+    to the cache write — a partial or errored scan must merge, never wipe, so
+    a failed remote refresh can't blank the previously cached repos into the
+    silent, unpopulated sidebar of #81723.
+    """
+    from hermes_cli import projects_db as pdb
+
+    roots = policy.get("roots") or []
+    excludes = policy.get("exclude_paths") or []
+    pairs: list[tuple[str, str | None]] = []
+    seen: set[str] = set()
+    authoritative = True
+
+    def _is_excluded(path: str) -> bool:
+        return any(path == ex or path.startswith(ex.rstrip("/\\") + os.sep) for ex in excludes if ex)
+
+    for root in roots:
+        if not os.path.isdir(root):
+            # `os.walk` on a missing root silently yields nothing instead of
+            # raising, so a temporarily unavailable root (unmounted volume,
+            # moved path) would otherwise look like a genuinely empty scan and
+            # let `authoritative` stay True — letting the replace wipe every
+            # cached repo that lived under the missing root. A missing root
+            # contributes nothing and must not be treated as authoritative.
+            authoritative = False
+            logger.debug("discover_repos scan root missing, skipping: %s", root)
+            continue
+        try:
+            for dirpath, dirnames, _filenames in os.walk(root):
+                if _is_excluded(dirpath):
+                    dirnames[:] = []
+                    continue
+                # A `.git` directory marks this directory as a repo root. Check
+                # BEFORE pruning hidden dirs — `.git` is itself hidden, so a
+                # prune-first order would drop it and never detect any repo.
+                if ".git" in dirnames:
+                    repo_root = dirpath
+                    if repo_root not in seen:
+                        seen.add(repo_root)
+                        pairs.append((repo_root, os.path.basename(repo_root)))
+                    # Don't descend into the repo's own .git to hunt nested repos.
+                    dirnames[:] = []
+                else:
+                    # Not a repo: skip hidden dirs (e.g. .hermes) and node_modules.
+                    dirnames[:] = [d for d in dirnames if not d.startswith(".") and d not in ("node_modules",)]
+                if len(pairs) >= 500:
+                    break
+        except Exception:
+            # A root that can't be walked yields no authoritative set — fall back
+            # to merging, never replacing, so the prior cache survives.
+            authoritative = False
+            logger.debug("discover_repos scan failed for root %s", root, exc_info=True)
+        if len(pairs) >= 500:
+            # Cap hit means the walk didn't cover the full roots; the collected
+            # set must not be treated as the complete authoritative universe.
+            authoritative = False
+            break
+
+    if pairs:
+        try:
+            pdb.record_discovered_repos(
+                conn, pairs, replace=authoritative, policy_key=_repo_discovery_policy_key(policy)
+            )
+        except Exception:
+            logger.debug("discover_repos cache write failed", exc_info=True)
+            authoritative = False
+    return authoritative
 
 
 def _discover_repos_payload(


### PR DESCRIPTION
## What does this PR do?

Supersedes #81783, #75114, #80147, #54310.

On a remote gateway the desktop cannot crawl the host filesystem, so the Projects list never asked the backend to scan. Separately, every `projects.*` handler read the launch profile's `projects.db` / `state.db`, so switching profiles left the launch list stuck on screen. Those are the same five files; landing the scan without the scope would write discovered repos into the wrong profile.

This PR does both: the host walks its own discovery roots (`scan: true`), and `projects.*` bind the focused profile the same way `session.*` already do (`@_profile_scoped` + `_profile_db`). The desktop stamps `profile` on every call, never sends `__all__`, and drops late responses from a profile the user already left.

### What this PR does
- Backend: `discover_repos scan:true` walks policy roots (`.git` before prune; merge, not replace, on a partial or missing root).
- Backend: the whole `projects.*` family, including `_projects_method` CRUD, honors `params.profile`.
- Desktop: remote `scanAndRecordRepos` calls that scan, then refreshes the tree; local scans record under the profile captured at start.
- Tests: remote-scan failure/merge/replace; cross-profile list/tree/sessions/record_repos; forwarding, late-response drop, switch-during-scan.

### What was dropped from the cluster
- #75114's `_projects_profile_home` (duplicates `_profile_scoped`).
- #80147's four-handler-only cut (CRUD and the desktop stamp were missing).
- #54310's pre-dispatcher patch.
- Unscoped `scan:true` from #81783.

## Related Issue

Fixes #81723. Fixes #54278.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How to Test

1. `scripts/run_tests.sh tests/tui_gateway/test_projects_rpc.py -q` (31 passed).
2. `cd apps/desktop && npx vitest run --project ui src/store/projects.test.ts` (39 passed).
3. Remote: `hermes serve` with two profiles that have different projects. Connect Desktop, switch profiles. The list should follow the focused profile, including git roots that have no Hermes sessions yet.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] Targeted tests pass (`scripts/run_tests.sh` / vitest as above)
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] Docs — N/A (restores intended per-profile remote behavior)
- [x] `cli-config.yaml.example` — N/A
- [x] CONTRIBUTING/AGENTS — N/A
- [x] Cross-platform: profile homes resolve through `get_profile_dir` / `get_hermes_home`; the scan uses `os.walk` + `.git` detection
- [x] Tool descriptions/schemas — N/A

Credit: @Enough1122 (remote scan), @weddle (desktop stamp + late-response guards), @webtoolbox (`@_profile_scoped` on the handlers), @izumi0uu (original profile-scope shape).