### PR TITLE
fix: Kimi K3 plan variants (k3-256k) no longer get the K2 effort vocabulary (salvage #76427 detection)

### DIFF
--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -36,7 +36,13 @@ Rules for call sites:
 
 from __future__ import annotations
 
+import re
 from typing import Optional, Sequence
+
+#: K3 slug detector — matches ``k3`` as a delimited token (``k3``,
+#: ``k3-256k``, ``kimi-k3``, ``kimi-k3-cot``) without matching K2-era names
+#: (``kimi-k2.6``). From #76427 by @ruizanthony.
+_KIMI_K3_SLUG_RE = re.compile(r"(?:^|[^a-z0-9])k3(?:[^a-z0-9]|$)")
 
 # Canonical low→high ordering used for nearest-level clamping. Superset of
 # hermes_constants.VALID_REASONING_EFFORTS ("none" included so an explicit
@@ -124,11 +130,14 @@ SOLAR_EFFORTS: tuple[str, ...] = ("low", "medium", "high")
 def kimi_supported_efforts(model: Optional[str]) -> tuple[str, ...]:
     """Supported effort set for a Moonshot/Kimi model slug.
 
-    K3 is served as the bare slug ``k3`` and the ``kimi-k3*`` aliases; its
-    documented set is low/high/max. Everything earlier speaks low/medium/high.
+    K3 is served as the bare slug ``k3``, plan variants like ``k3-256k``,
+    and the ``kimi-k3*`` aliases; its documented set is low/high/max.
+    Everything earlier speaks low/medium/high. Boundary-matched so K2-era
+    names (``kimi-k2.6``) never match (detection regex from #76427 by
+    @ruizanthony).
     """
     m = (model or "").strip().lower().split("/")[-1]
-    if m == "k3" or m.startswith("kimi-k3"):
+    if _KIMI_K3_SLUG_RE.search(m):
         return KIMI_K3_EFFORTS
     return KIMI_K2_EFFORTS
 

--- a/tests/agent/test_reasoning_effort_module.py
+++ b/tests/agent/test_reasoning_effort_module.py
@@ -112,13 +112,15 @@ class TestClampEffort:
 
 class TestKimiVocabulary:
     @pytest.mark.parametrize(
-        "model", ["k3", "kimi-k3", "kimi-k3-cot", "moonshotai/kimi-k3"]
+        "model",
+        ["k3", "kimi-k3", "kimi-k3-cot", "moonshotai/kimi-k3", "k3-256k"],
     )
     def test_k3_slugs(self, model):
         assert kimi_supported_efforts(model) is KIMI_K3_EFFORTS
 
     @pytest.mark.parametrize(
-        "model", ["kimi-k2.6", "moonshotai/kimi-k2-0905", "kimi-latest", None]
+        "model",
+        ["kimi-k2.6", "moonshotai/kimi-k2-0905", "kimi-latest", "mk3000", None],
     )
     def test_k2_era_slugs(self, model):
         assert kimi_supported_efforts(model) is KIMI_K2_EFFORTS


### PR DESCRIPTION
## Summary
Kimi K3 plan-variant slugs (`k3-256k`) now resolve to K3's effort vocabulary — the exact/prefix match in `kimi_supported_efforts()` missed them, so they fell back to the K2-era `low/medium/high` set and mistranslated efforts on a K3 wire.

## Changes
- `agent/reasoning_effort.py`: K3 detection uses the boundary-token regex from #76427 (credit @ruizanthony) — matches `k3`, `k3-256k`, `kimi-k3*`; never matches `kimi-k2.6` or embedded tokens like `mk3000`
- Tests: `k3-256k` pinned as K3, `mk3000` pinned as non-K3

## Validation
58 targeted tests green (reasoning-effort module, sibling-site transport tests, kimi profile).

Absorbs the detection half of #76427; the K2-era `medium` passthrough question raised there is already settled by the declared K2 vocabulary (`low/medium/high` — medium passes through).

## Infographic

![every slug finds its ladder](https://files.catbox.moe/7nj35k.png)
