### PR TITLE
fix(cli): /worktree output no longer shows garbled ANSI escapes

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1803,7 +1803,7 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True,
 
     repo_root = repo_root or _git_repo_root()
     if not repo_root:
-        print("\033[31m✗ --worktree requires being inside a git repository.\033[0m")
+        _cprint("\033[31m✗ --worktree requires being inside a git repository.\033[0m")
         print("  cd into your project repo first, then run hermes -w")
         return None
 
@@ -1822,7 +1822,7 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True,
 
     wt_path = worktrees_dir / wt_name
     if name and wt_path.exists():
-        print(f"\033[31m✗ Worktree already exists: {wt_path}\033[0m")
+        _cprint(f"\033[31m✗ Worktree already exists: {wt_path}\033[0m")
         print("  Pick a different name, or remove it with: "
               f"git worktree remove {wt_path}")
         return None
@@ -1887,7 +1887,7 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True,
                 )
             if result.returncode != 0:
                 _cleanup_failed_worktree_add(repo_root, wt_path, branch_name)
-                print(f"\033[31m✗ Failed to create worktree: {result.stderr.strip()}\033[0m")
+                _cprint(f"\033[31m✗ Failed to create worktree: {result.stderr.strip()}\033[0m")
                 return None
     except Exception as e:
         # A timed-out/failed `worktree add` is NOT atomic: git leaves the
@@ -1898,7 +1898,7 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True,
         # the error (Aug 2026 incident: 30s timeout during pack-sprawl left
         # exactly this poison).
         _cleanup_failed_worktree_add(repo_root, wt_path, branch_name)
-        print(f"\033[31m✗ Failed to create worktree: {e}\033[0m")
+        _cprint(f"\033[31m✗ Failed to create worktree: {e}\033[0m")
         return None
 
     # Copy files listed in .worktreeinclude (gitignored files the agent needs)
@@ -1993,7 +1993,7 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True,
         "base": base_ref,
     }
 
-    print(f"\033[32m✓ Worktree created:\033[0m {wt_path}")
+    _cprint(f"\033[32m✓ Worktree created:\033[0m {wt_path}")
     print(f"  Branch: {branch_name}")
     print(f"  Base:   {base_label}")
 
@@ -2385,10 +2385,10 @@ def _cleanup_worktree(info: Dict[str, str] = None) -> None:
             # origin/*, so already-public commits look "unpushed". Be honest
             # about why we're keeping it — the startup pruner deepens the
             # clone in the background and will reap it on a later startup.
-            print(f"\n\033[33m⚠ Shallow clone — cannot verify push state, keeping: {wt_path}\033[0m")
+            _cprint(f"\n\033[33m⚠ Shallow clone — cannot verify push state, keeping: {wt_path}\033[0m")
             print("  The next `hermes -w` session deepens the clone and prunes merged worktrees automatically.")
         else:
-            print(f"\n\033[33m⚠ Worktree has unpushed commits, keeping: {wt_path}\033[0m")
+            _cprint(f"\n\033[33m⚠ Worktree has unpushed commits, keeping: {wt_path}\033[0m")
             print(f"  To clean up manually: git worktree remove --force {wt_path}")
         _active_worktree = None
         return
@@ -2423,7 +2423,7 @@ def _cleanup_worktree(info: Dict[str, str] = None) -> None:
         logger.debug("Failed to delete branch %s: %s", branch, e)
 
     _active_worktree = None
-    print(f"\033[32m✓ Worktree cleaned up: {wt_path}\033[0m")
+    _cprint(f"\033[32m✓ Worktree cleaned up: {wt_path}\033[0m")
 
 
 def _run_state_db_auto_maintenance(session_db) -> None:

--- a/tests/hermes_cli/test_worktree_command.py
+++ b/tests/hermes_cli/test_worktree_command.py
@@ -28,8 +28,24 @@ class _Stub(CLICommandsMixin):
 
 
 def _run(stub, command):
+    """Capture handler output.
+
+    Worktree messages route through ``cli._cprint`` (the ANSI-aware
+    prompt_toolkit renderer) since the garbled-escape fix; its output binds
+    to the prompt_toolkit session output object, not ``sys.stdout``, so
+    ``redirect_stdout`` alone cannot capture it. Mirror ``_cprint`` into the
+    same buffer to keep asserting the user-visible text.
+    """
+    import re
+    from unittest.mock import patch as _patch
+
     buf = io.StringIO()
-    with contextlib.redirect_stdout(buf):
+    ansi = re.compile(r"\x1b\[[0-9;]*m")
+
+    def _fake_cprint(text):
+        buf.write(ansi.sub("", str(text)) + "\n")
+
+    with contextlib.redirect_stdout(buf), _patch.object(cli_mod, "_cprint", _fake_cprint):
         stub._handle_worktree_command(command)
     return buf.getvalue()
 


### PR DESCRIPTION
## Summary
Worktree lifecycle messages render their colors instead of printing raw ANSI escapes (`?[32m✓ Worktree created:?[0m`).

Found in the round-2 live QA sweep via `/worktree new`: eight raw `print("\033[...")` calls across the worktree create/cleanup paths write through prompt_toolkit's `patch_stdout` proxy, which swallows the ESC byte and renders the remainder literally — the same garbled-ANSI class as #83969/#87919/#87444 (deferred update notice, config warnings), at sites those fixes/PRs don't cover.

## Changes
- `cli.py`: all 8 raw-ANSI worktree prints (`--worktree` requires-repo error, already-exists, two create-failure paths, created, shallow-clone keep, unpushed-commits keep, cleaned-up) routed through `_cprint`, the existing ANSI-aware prompt_toolkit renderer

## Validation
| | Before | After |
|---|---|---|
| `/worktree new <name>` in live session | `?[32m✓ Worktree created:?[0m /tmp/...` | `✓ Worktree created: /tmp/...` in green (live-verified in tmux) |

Mechanical routing change only — message text and call sites unchanged. Sibling PRs #83972 / #87613 / #87924 cover the update-notice and startup-warning members of this class; this PR covers the worktree member none of them touch.

## Infographic

![worktree ansi fix infographic](https://files.catbox.moe/xbn0eq.png)
