### PR TITLE
fix(acp): send the terminal command as raw_input

### DIFF
--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -1121,6 +1121,7 @@ def _build_tool_start(
         content = [_text(f"$ {command}")]
         return acp.start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
+            raw_input={"command": command},
         )
 
     if tool_name == "read_file":

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -161,6 +161,16 @@ class TestBuildToolStart:
 
 
 
+    def test_terminal_start_sends_untruncated_command_as_raw_input(self):
+        """The title is truncated for display; raw_input must carry the whole command."""
+        long_cmd = "echo " + "x" * 500
+        result = build_tool_start("tc-terminal-start", "terminal", {"command": long_cmd})
+
+        assert isinstance(result, ToolCallStart)
+        assert result.kind == "execute"
+        assert "..." in result.title
+        assert result.raw_input == {"command": long_cmd}
+
     def test_build_tool_start_for_browser_navigate(self):
         """browser_navigate should emit a polished start event."""
         args = {"url": "https://x.com"}


### PR DESCRIPTION
## Human comments

I am using Hermes as an ACP agent in another app, and I noticed that terminal tool call create updates do not include the command in the [rawInput field](https://agentclientprotocol.com/protocol/v1/tool-calls#param-raw-input), unlike other ACP providers like Pi. This means many apps cannot display terminal tool calls properly from Hermes.

-----

## What does this PR do?

The terminal tool call's title is truncated to 80 characters for display, and the start event carried no raw_input, so an ACP client that records the command as structured data had only the title to read. It stored a shortened command with no way to recover the rest: the full text reaches the client once, in the `$ {command}` content block of the start event, and a completion update replaces that content with the result.

Send the untruncated command as raw_input, the way the permission request already does. Polished tools otherwise omit raw_input so clients do not render a second, raw copy of curated content; a lone command string is the tool's input, not a duplicate of the content block.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes https://github.com/NousResearch/hermes-agent/issues/90553

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `acp_adapter/tools.py` now includes `raw_input.command` field.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

Run Hermes as an ACP agent in https://github.com/get-bb/bb and see that terminal tool calls with commands >=500 chars are no longer truncated. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: macOS 14.3

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

