### PR TITLE
fix(api-server): 'max' and 'ultra' reasoning efforts no longer silently ignored (salvage #78216 api_server hunk)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -245,7 +245,15 @@ def _coerce_request_bool(value: Any, default: bool = False) -> bool:
 
 
 _REQUEST_OPTION_MISSING = object()
-_REASONING_EFFORTS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh"})
+# Full internal ladder + "none": the API server accepts what /reasoning and
+# config.yaml accept (hermes_constants.VALID_REASONING_EFFORTS); wire-level
+# clamping to each provider's vocabulary happens downstream in the
+# transports/profiles via agent.reasoning_effort. Rejecting "max"/"ultra"
+# here made API/browser clients second-class citizens of the ladder
+# (#78216's api_server observation).
+_REASONING_EFFORTS = frozenset(
+    {"none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"}
+)
 _RUNTIME_AGENT_OVERRIDE_KEYS = (
     "api_key",
     "base_url",

--- a/tests/gateway/test_api_server_reasoning_ladder.py
+++ b/tests/gateway/test_api_server_reasoning_ladder.py
@@ -1,0 +1,33 @@
+"""API-server reasoning-effort request parsing accepts the full ladder.
+
+_request_reasoning_config() previously whitelisted only none..xhigh, so an
+API/browser client sending ``max`` or ``ultra`` (both valid /reasoning and
+config.yaml levels) was silently ignored and the session ran at the default
+effort. The server now accepts the full internal ladder; per-provider wire
+clamping happens downstream in the transports/profiles via
+agent.reasoning_effort (#78216's api_server observation).
+"""
+
+from gateway.platforms.api_server import _request_reasoning_config
+from hermes_constants import VALID_REASONING_EFFORTS
+
+
+class TestRequestReasoningFullLadder:
+    def test_every_configurable_level_is_accepted(self):
+        for level in VALID_REASONING_EFFORTS:
+            out = _request_reasoning_config({"reasoning_effort": level})
+            assert out == {"enabled": True, "effort": level}, level
+
+    def test_none_disables(self):
+        assert _request_reasoning_config({"reasoning_effort": "none"}) == {
+            "enabled": False
+        }
+
+    def test_structured_object_shape(self):
+        out = _request_reasoning_config(
+            {"reasoning": {"enabled": True, "effort": "ultra"}}
+        )
+        assert out == {"enabled": True, "effort": "ultra"}
+
+    def test_unknown_level_still_ignored(self):
+        assert _request_reasoning_config({"reasoning_effort": "turbo"}) is None


### PR DESCRIPTION
## Summary
API/browser requests with `reasoning_effort: max` or `ultra` are no longer silently ignored — the API server now accepts the full internal ladder, matching every other entry surface (/reasoning, config.yaml, dashboard).

`_request_reasoning_config()` whitelisted `none..xhigh`, so a client sending `max`/`ultra` fell through to the default effort with no error. Wire clamping to each provider's vocabulary happens downstream via `agent.reasoning_effort` (#90350/#90441), so the entry gate has no reason to be narrower than the ladder.

## Changes
- `gateway/platforms/api_server.py`: `_REASONING_EFFORTS` widened to the full ladder + `none`
- New test pins every `VALID_REASONING_EFFORTS` level as accepted; bespoke levels still ignored

Salvages the api_server hunk of #78216 (credit @snowzlmbot). That PR's other hunks — removing the transport-level `ultra` clamp and the terminal_tool lifecycle bypass — were declined separately.

## Validation
113 API-server tests green (new ladder test + full test_api_server.py).

## Infographic

![the api door fits the whole ladder](https://files.catbox.moe/7m7kvy.png)
