### PR TITLE
fix(cli): key combos survive NumLock/CapsLock under kitty CSI-u (salvage #89676 + #90291)

### DIFF
--- a/contributors/emails/contact@grahfmusic.com
+++ b/contributors/emails/contact@grahfmusic.com
@@ -1,0 +1,1 @@
+grahfmusic

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -25,6 +25,11 @@ def _lock_variants(modifier: int) -> tuple[int, ...]:
     return tuple(modifier + off for off in _LOCK_BIT_OFFSETS)
 
 
+def _lock_twins(modifier: int) -> tuple[int, ...]:
+    """Return only the lock twins of ``modifier`` (never the base value)."""
+    return tuple(modifier + off for off in _LOCK_BIT_OFFSETS[1:])
+
+
 def _clear_vt100_prefix_cache() -> None:
     """Drop prompt_toolkit's memoized "is this a prefix of a longer match?"
     answers after mutating ``ANSI_SEQUENCES``.
@@ -50,6 +55,7 @@ def install_shift_enter_alias() -> int:
 
     Sequences mapped:
       - "\\x1b[13;2u"     — Kitty keyboard protocol / CSI-u, modifier=2 (Shift)
+        (plus its CapsLock/NumLock lock twins via ``_lock_variants``)
       - "\\x1b[27;2;13~"  — xterm modifyOtherKeys=2, modifier=2 (Shift)
       - "\\x1b[27;2;13u"  — alternate ordering some emitters use
 
@@ -93,10 +99,13 @@ def install_ctrl_enter_alias() -> int:
 
     Sequences mapped:
       - "\\x1b[13;5u"     — Kitty keyboard protocol / CSI-u, modifier=5 (Ctrl)
+        (plus its CapsLock/NumLock lock twins via ``_lock_variants``)
       - "\\x1b[27;5;13~"  — xterm modifyOtherKeys=2, modifier=5 (Ctrl)
       - "\\x1b[27;5;13u"  — alternate ordering some emitters use
 
-    Stock prompt_toolkit doesn't map any of these. Without this alias,
+    Stock prompt_toolkit maps only the tilde form ``\\x1b[27;5;13~`` (to
+    plain ``Keys.ControlM``, which this deliberately overwrites — same
+    bug-fix rationale as install_shift_enter_alias). Without this alias,
     Kitty/mintty/xterm-with-modifyOtherKeys users over SSH never get a
     Ctrl+Enter newline — the keystroke arrives as a raw CSI sequence that
     falls through to the default character-insert handler. See #22379.
@@ -133,7 +142,8 @@ def install_cmd_backspace_alias() -> int:
     literal insertion.
 
     Cmd+Backspace → ``Keys.ControlU`` (kill backward to start of line).
-    Codepoint 127 with modifier 9 (super) / 10 (super+shift):
+    Codepoint 127 with modifier 9 (super) / 10 (super+shift), each with
+    its CapsLock/NumLock lock twins via ``_lock_variants``:
       - ``\\x1b[127;9u`` / ``\\x1b[127;10u``  — Kitty CSI-u
       - ``\\x1b[27;9;127~``                   — xterm modifyOtherKeys
 
@@ -274,10 +284,14 @@ def install_modify_other_keys_aliases() -> int:
     # the CSI-u form needs them.
     def _install_paired(modifier: int, mapping: dict) -> None:
         """Install both modifyOtherKeys (ESC[27;N;CP~) and CSI-u (ESC[CP;Nu)
-        mappings for the given modifier and codepoint→key mapping."""
+        mappings for the given modifier and codepoint→key mapping.
+
+        The tilde form is skipped for modifier 1 ("no modifier") — xterm
+        never emits modifier-1 tilde sequences.
+        """
         nonlocal changed
         for codepoint, key_val in mapping.items():
-            seqs = [f"\x1b[27;{modifier};{codepoint}~"]
+            seqs = [] if modifier == 1 else [f"\x1b[27;{modifier};{codepoint}~"]
             for mod in _lock_variants(modifier):
                 seqs.append(f"\x1b[{codepoint};{mod}u")
             for seq in seqs:
@@ -353,9 +367,9 @@ def install_modify_other_keys_aliases() -> int:
     # how a lone Esc keypress arrives with a lock on. Lock bits (caps/num)
     # get the same variant treatment as _install_paired.
     for seq in ["\x1b[27u"] + [
-        f"\x1b[27;{m + lock_bits}u"
+        f"\x1b[27;{mod}u"
         for m in range(1, 17)
-        for lock_bits in _LOCK_BIT_OFFSETS
+        for mod in _lock_variants(m)
     ]:
         if seq not in ANSI_SEQUENCES:
             ANSI_SEQUENCES[seq] = Keys.Escape
@@ -405,27 +419,28 @@ def install_modify_other_keys_aliases() -> int:
     # the base modifier (stock prompt_toolkit entries included), so every
     # modifier the terminal can report keeps working under a lock.
     for m in range(1, 17):
-        for lock in _LOCK_BIT_OFFSETS[1:]:
-            # CSI-letter navigation: Up/Down/Right/Left/End/Home + F1-F4
-            for trailer in "ABCDFHPQRS":
-                base_seq = f"\x1b[1;{m}{trailer}" if m > 1 else f"\x1b[{trailer}"
-                key = ANSI_SEQUENCES.get(base_seq)
-                if key is None and m == 1:
-                    # Plain F1-F4 live in the table as SS3 (ESC O P) forms.
-                    key = ANSI_SEQUENCES.get(f"\x1bO{trailer}")
-                if key is None:
-                    continue
-                seq = f"\x1b[1;{m + lock}{trailer}"
+        # CSI-letter navigation: Up/Down/Right/Left/End/Home + F1-F4
+        for trailer in "ABCDFHPQRS":
+            base_seq = f"\x1b[1;{m}{trailer}" if m > 1 else f"\x1b[{trailer}"
+            key = ANSI_SEQUENCES.get(base_seq)
+            if key is None and m == 1:
+                # Plain F1-F4 live in the table as SS3 (ESC O P) forms.
+                key = ANSI_SEQUENCES.get(f"\x1bO{trailer}")
+            if key is None:
+                continue
+            for mod in _lock_twins(m):
+                seq = f"\x1b[1;{mod}{trailer}"
                 if seq not in ANSI_SEQUENCES:
                     ANSI_SEQUENCES[seq] = key
                     changed += 1
-            # CSI-tilde navigation: Insert/Delete/PageUp/PageDown/Home/End
-            for num in (1, 2, 3, 4, 5, 6, 7, 8):
-                base_seq = f"\x1b[{num};{m}~" if m > 1 else f"\x1b[{num}~"
-                key = ANSI_SEQUENCES.get(base_seq)
-                if key is None:
-                    continue
-                seq = f"\x1b[{num};{m + lock}~"
+        # CSI-tilde navigation: Insert/Delete/PageUp/PageDown/Home/End
+        for num in (1, 2, 3, 4, 5, 6, 7, 8):
+            base_seq = f"\x1b[{num};{m}~" if m > 1 else f"\x1b[{num}~"
+            key = ANSI_SEQUENCES.get(base_seq)
+            if key is None:
+                continue
+            for mod in _lock_twins(m):
+                seq = f"\x1b[{num};{mod}~"
                 if seq not in ANSI_SEQUENCES:
                     ANSI_SEQUENCES[seq] = key
                     changed += 1
@@ -465,7 +480,7 @@ def install_modify_other_keys_aliases() -> int:
             ANSI_SEQUENCES[seq] = key_val
             changed += 1
         # Lock twins: with a lock on these arrive as ESC[<code>;129u etc.
-        for mod in _lock_variants(1)[1:]:
+        for mod in _lock_twins(1):
             seq = f"\x1b[{code};{mod}u"
             if seq not in ANSI_SEQUENCES:
                 ANSI_SEQUENCES[seq] = key_val

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -366,6 +366,56 @@ def install_modify_other_keys_aliases() -> int:
                                             # matching Ink TUI + Desktop (#78285)
     })
 
+    # -- Lock-key modifier bits (NumLock=128, CapsLock=64) under the kitty
+    # disambiguate push: kitty encodes lock state into the CSI sequence, so
+    # a plain Down with NumLock on arrives as ESC[1;129B (NumLock), ESC[1;65B
+    # (CapsLock) or ESC[1;193B (both) instead of the legacy ESC[B that stock
+    # prompt_toolkit maps. Those fall through the parser and leak as literal
+    # text ("[1;129B") in the input line. Map them to the plain key; the
+    # +shift variants (130/66/194) to the Shift* keys.
+    lock_plain = (129, 65, 193)
+    lock_shift = (130, 66, 194)
+    for mod in lock_plain:
+        for trailer, key in (
+            ("A", Keys.Up), ("B", Keys.Down), ("C", Keys.Right), ("D", Keys.Left),
+            ("H", Keys.Home), ("F", Keys.End),
+        ):
+            seq = f"\x1b[1;{mod}{trailer}"
+            if seq not in ANSI_SEQUENCES:
+                ANSI_SEQUENCES[seq] = key
+                changed += 1
+        for num, key in (
+            (2, Keys.Insert), (3, Keys.Delete), (5, Keys.PageUp), (6, Keys.PageDown),
+        ):
+            seq = f"\x1b[{num};{mod}~"
+            if seq not in ANSI_SEQUENCES:
+                ANSI_SEQUENCES[seq] = key
+                changed += 1
+        for cp, key in (
+            (13, Keys.ControlM),   # Enter
+            (9, Keys.Tab),         # Tab
+            (127, Keys.Backspace),  # Backspace
+            (32, " "),             # Space
+        ):
+            seq = f"\x1b[{cp};{mod}u"
+            if seq not in ANSI_SEQUENCES:
+                ANSI_SEQUENCES[seq] = key
+                changed += 1
+    for mod in lock_shift:
+        for trailer, key in (
+            ("A", Keys.ShiftUp), ("B", Keys.ShiftDown), ("C", Keys.ShiftRight),
+            ("D", Keys.ShiftLeft), ("H", Keys.ShiftHome), ("F", Keys.ShiftEnd),
+        ):
+            seq = f"\x1b[1;{mod}{trailer}"
+            if seq not in ANSI_SEQUENCES:
+                ANSI_SEQUENCES[seq] = key
+                changed += 1
+        for num, key in ((2, Keys.ShiftInsert), (3, Keys.ShiftDelete)):
+            seq = f"\x1b[{num};{mod}~"
+            if seq not in ANSI_SEQUENCES:
+                ANSI_SEQUENCES[seq] = key
+                changed += 1
+
     # -- Kitty functional keys (Private Use Area codepoints) ----
     # kitty emits these CSI-u encodings even in LEGACY mode for keys that
     # have no legacy encoding, so unmapped they leak as literal text in any

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -11,6 +11,19 @@ can be unit-tested without importing the whole CLI runtime.
 
 from __future__ import annotations
 
+# kitty CSI-u ORs lock-key state into the modifier parameter of every key
+# event while a lock is on: CapsLock=64, NumLock=128, both=192 (#88221,
+# #89651).  Every fixed-modifier CSI-u (and legacy CSI-tilde / CSI-letter)
+# registration therefore needs lock-offset twins, or those events leak into
+# the prompt as literal text.  The xterm modifyOtherKeys ``ESC[27;N;CP~``
+# encoding never carries lock bits, so it never gets the twins.
+_LOCK_BIT_OFFSETS = (0, 64, 128, 192)
+
+
+def _lock_variants(modifier: int) -> tuple[int, ...]:
+    """Return ``modifier`` plus its CapsLock/NumLock/both twins."""
+    return tuple(modifier + off for off in _LOCK_BIT_OFFSETS)
+
 
 def _clear_vt100_prefix_cache() -> None:
     """Drop prompt_toolkit's memoized "is this a prefix of a longer match?"
@@ -62,7 +75,9 @@ def install_shift_enter_alias() -> int:
 
     alt_enter = (Keys.Escape, Keys.ControlM)
     changed = 0
-    for seq in ("\x1b[13;2u", "\x1b[27;2;13~", "\x1b[27;2;13u"):
+    seqs = [f"\x1b[13;{m}u" for m in _lock_variants(2)]
+    seqs += ["\x1b[27;2;13~", "\x1b[27;2;13u"]
+    for seq in seqs:
         if ANSI_SEQUENCES.get(seq) != alt_enter:
             ANSI_SEQUENCES[seq] = alt_enter
             changed += 1
@@ -96,7 +111,9 @@ def install_ctrl_enter_alias() -> int:
 
     alt_enter = (Keys.Escape, Keys.ControlM)
     changed = 0
-    for seq in ("\x1b[13;5u", "\x1b[27;5;13~", "\x1b[27;5;13u"):
+    seqs = [f"\x1b[13;{m}u" for m in _lock_variants(5)]
+    seqs += ["\x1b[27;5;13~", "\x1b[27;5;13u"]
+    for seq in seqs:
         if ANSI_SEQUENCES.get(seq) != alt_enter:
             ANSI_SEQUENCES[seq] = alt_enter
             changed += 1
@@ -133,13 +150,12 @@ def install_cmd_backspace_alias() -> int:
     except Exception:
         return 0
 
-    aliases = {
-        "\x1b[127;9u": Keys.ControlU,
-        "\x1b[127;10u": Keys.ControlU,
-        "\x1b[27;9;127~": Keys.ControlU,
-        "\x1b[3;9~": Keys.ControlK,
-        "\x1b[3;10~": Keys.ControlK,
-    }
+    aliases: dict[str, object] = {}
+    for base in (9, 10):  # super / super+shift
+        for mod in _lock_variants(base):
+            aliases[f"\x1b[127;{mod}u"] = Keys.ControlU
+            aliases[f"\x1b[3;{mod}~"] = Keys.ControlK
+    aliases["\x1b[27;9;127~"] = Keys.ControlU
     changed = 0
     for seq, key in aliases.items():
         if ANSI_SEQUENCES.get(seq) != key:
@@ -256,16 +272,14 @@ def install_modify_other_keys_aliases() -> int:
     # a lock is on (#89651) unless the lock variants are mapped too. The
     # xterm modifyOtherKeys encoding never carries the lock bits, so only
     # the CSI-u form needs them.
-    _CSI_U_LOCK_BIT_VARIANTS = (0, 64, 128, 192)
-
     def _install_paired(modifier: int, mapping: dict) -> None:
         """Install both modifyOtherKeys (ESC[27;N;CP~) and CSI-u (ESC[CP;Nu)
         mappings for the given modifier and codepoint→key mapping."""
         nonlocal changed
         for codepoint, key_val in mapping.items():
             seqs = [f"\x1b[27;{modifier};{codepoint}~"]
-            for lock_bits in _CSI_U_LOCK_BIT_VARIANTS:
-                seqs.append(f"\x1b[{codepoint};{modifier + lock_bits}u")
+            for mod in _lock_variants(modifier):
+                seqs.append(f"\x1b[{codepoint};{mod}u")
             for seq in seqs:
                 if seq not in ANSI_SEQUENCES:
                     ANSI_SEQUENCES[seq] = key_val
@@ -341,7 +355,7 @@ def install_modify_other_keys_aliases() -> int:
     for seq in ["\x1b[27u"] + [
         f"\x1b[27;{m + lock_bits}u"
         for m in range(1, 17)
-        for lock_bits in _CSI_U_LOCK_BIT_VARIANTS
+        for lock_bits in _LOCK_BIT_OFFSETS
     ]:
         if seq not in ANSI_SEQUENCES:
             ANSI_SEQUENCES[seq] = Keys.Escape
@@ -366,55 +380,55 @@ def install_modify_other_keys_aliases() -> int:
                                             # matching Ink TUI + Desktop (#78285)
     })
 
-    # -- Lock-key modifier bits (NumLock=128, CapsLock=64) under the kitty
-    # disambiguate push: kitty encodes lock state into the CSI sequence, so
-    # a plain Down with NumLock on arrives as ESC[1;129B (NumLock), ESC[1;65B
-    # (CapsLock) or ESC[1;193B (both) instead of the legacy ESC[B that stock
-    # prompt_toolkit maps. Those fall through the parser and leak as literal
-    # text ("[1;129B") in the input line. Map them to the plain key; the
-    # +shift variants (130/66/194) to the Shift* keys.
-    lock_plain = (129, 65, 193)
-    lock_shift = (130, 66, 194)
-    for mod in lock_plain:
-        for trailer, key in (
-            ("A", Keys.Up), ("B", Keys.Down), ("C", Keys.Right), ("D", Keys.Left),
-            ("H", Keys.Home), ("F", Keys.End),
-        ):
-            seq = f"\x1b[1;{mod}{trailer}"
-            if seq not in ANSI_SEQUENCES:
-                ANSI_SEQUENCES[seq] = key
-                changed += 1
-        for num, key in (
-            (2, Keys.Insert), (3, Keys.Delete), (5, Keys.PageUp), (6, Keys.PageDown),
-        ):
-            seq = f"\x1b[{num};{mod}~"
-            if seq not in ANSI_SEQUENCES:
-                ANSI_SEQUENCES[seq] = key
-                changed += 1
-        for cp, key in (
-            (13, Keys.ControlM),   # Enter
-            (9, Keys.Tab),         # Tab
-            (127, Keys.Backspace),  # Backspace
-            (32, " "),             # Space
-        ):
-            seq = f"\x1b[{cp};{mod}u"
-            if seq not in ANSI_SEQUENCES:
-                ANSI_SEQUENCES[seq] = key
-                changed += 1
-    for mod in lock_shift:
-        for trailer, key in (
-            ("A", Keys.ShiftUp), ("B", Keys.ShiftDown), ("C", Keys.ShiftRight),
-            ("D", Keys.ShiftLeft), ("H", Keys.ShiftHome), ("F", Keys.ShiftEnd),
-        ):
-            seq = f"\x1b[1;{mod}{trailer}"
-            if seq not in ANSI_SEQUENCES:
-                ANSI_SEQUENCES[seq] = key
-                changed += 1
-        for num, key in ((2, Keys.ShiftInsert), (3, Keys.ShiftDelete)):
-            seq = f"\x1b[{num};{mod}~"
-            if seq not in ANSI_SEQUENCES:
-                ANSI_SEQUENCES[seq] = key
-                changed += 1
+    # -- Unmodified keys with a lock bit set (kitty modifier 1 = "none") --
+    # With a lock on, kitty stamps the lock bit onto keys pressed with NO
+    # real modifier too, so plain Backspace arrives as ESC[127;129u
+    # (1 + 128) rather than \x7f. _install_paired(1, ...) registers the
+    # bare mod-1 spelling and its lock twins. Only keys kitty CSI-u-encodes
+    # on their own are listed; plain text characters are still delivered
+    # as UTF-8, lock bits or not.
+    _install_paired(1, {
+        9: Keys.ControlI,     # Tab
+        13: Keys.ControlM,    # Enter
+        32: " ",              # Space
+        127: Keys.ControlH,   # Backspace
+    })
+
+    # -- Lock-key modifier bits (NumLock=128, CapsLock=64) on the legacy
+    # CSI-letter / CSI-tilde forms kitty keeps using under the disambiguate
+    # push: kitty encodes lock state into the modifier parameter, so a
+    # plain Down with NumLock on arrives as ESC[1;129B (NumLock), ESC[1;65B
+    # (CapsLock) or ESC[1;193B (both) instead of the legacy ESC[B — and a
+    # modified one shifts the same way (Alt+Left → ESC[1;131D). Those fall
+    # through the parser and leak as literal text ("[1;129B") in the input
+    # line. Derive the lock twins from whatever the table already maps for
+    # the base modifier (stock prompt_toolkit entries included), so every
+    # modifier the terminal can report keeps working under a lock.
+    for m in range(1, 17):
+        for lock in _LOCK_BIT_OFFSETS[1:]:
+            # CSI-letter navigation: Up/Down/Right/Left/End/Home + F1-F4
+            for trailer in "ABCDFHPQRS":
+                base_seq = f"\x1b[1;{m}{trailer}" if m > 1 else f"\x1b[{trailer}"
+                key = ANSI_SEQUENCES.get(base_seq)
+                if key is None and m == 1:
+                    # Plain F1-F4 live in the table as SS3 (ESC O P) forms.
+                    key = ANSI_SEQUENCES.get(f"\x1bO{trailer}")
+                if key is None:
+                    continue
+                seq = f"\x1b[1;{m + lock}{trailer}"
+                if seq not in ANSI_SEQUENCES:
+                    ANSI_SEQUENCES[seq] = key
+                    changed += 1
+            # CSI-tilde navigation: Insert/Delete/PageUp/PageDown/Home/End
+            for num in (1, 2, 3, 4, 5, 6, 7, 8):
+                base_seq = f"\x1b[{num};{m}~" if m > 1 else f"\x1b[{num}~"
+                key = ANSI_SEQUENCES.get(base_seq)
+                if key is None:
+                    continue
+                seq = f"\x1b[{num};{m + lock}~"
+                if seq not in ANSI_SEQUENCES:
+                    ANSI_SEQUENCES[seq] = key
+                    changed += 1
 
     # -- Kitty functional keys (Private Use Area codepoints) ----
     # kitty emits these CSI-u encodings even in LEGACY mode for keys that
@@ -450,6 +464,12 @@ def install_modify_other_keys_aliases() -> int:
         if seq not in ANSI_SEQUENCES:
             ANSI_SEQUENCES[seq] = key_val
             changed += 1
+        # Lock twins: with a lock on these arrive as ESC[<code>;129u etc.
+        for mod in _lock_variants(1)[1:]:
+            seq = f"\x1b[{code};{mod}u"
+            if seq not in ANSI_SEQUENCES:
+                ANSI_SEQUENCES[seq] = key_val
+                changed += 1
 
     # New longer sequences can flip "is this a prefix of a longer match?"
     # answers the VT100 parser already cached — drop the cache so parsers

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -181,6 +181,11 @@ def install_modify_other_keys_aliases() -> int:
       Ctrl+Alt+Shift=8): normalized onto the same targets — Ctrl-bearing
       combos behave as the Ctrl key (Alt adds an ``Escape`` prefix),
       matching how dte/kakoune normalize these protocols.
+    * **Lock-bit variants**: every CSI-u mapping above is also installed
+      with the CapsLock (64) and NumLock (128) bits ORed into the modifier
+      parameter — kitty/ghostty include them while a lock is on, and
+      without the variants every key combo dies with the lock enabled
+      (``ESC[99;133u`` instead of ``ESC[99;5u``, #89651).
     * **Esc key**: ``ESC[27u`` / ``ESC[27;<mod>u`` (Kitty disambiguate mode
       reports Esc this way, #56684) → ``Keys.Escape``.
     * **Modified Enter/Tab/Backspace/Space**: Alt+Enter → the Alt+Enter
@@ -244,15 +249,24 @@ def install_modify_other_keys_aliases() -> int:
 
     changed = 0
 
+    # Kitty CSI-u encodes CapsLock/NumLock state as extra modifier bits
+    # (caps=64, num=128) ORed into the parameter: with NumLock on, Ctrl+C
+    # arrives as ESC[99;133u (5 + 128) instead of ESC[99;5u. Terminals
+    # that report these bits (kitty, ghostty) break every key combo while
+    # a lock is on (#89651) unless the lock variants are mapped too. The
+    # xterm modifyOtherKeys encoding never carries the lock bits, so only
+    # the CSI-u form needs them.
+    _CSI_U_LOCK_BIT_VARIANTS = (0, 64, 128, 192)
+
     def _install_paired(modifier: int, mapping: dict) -> None:
         """Install both modifyOtherKeys (ESC[27;N;CP~) and CSI-u (ESC[CP;Nu)
         mappings for the given modifier and codepoint→key mapping."""
         nonlocal changed
         for codepoint, key_val in mapping.items():
-            for seq in (
-                f"\x1b[27;{modifier};{codepoint}~",
-                f"\x1b[{codepoint};{modifier}u",
-            ):
+            seqs = [f"\x1b[27;{modifier};{codepoint}~"]
+            for lock_bits in _CSI_U_LOCK_BIT_VARIANTS:
+                seqs.append(f"\x1b[{codepoint};{modifier + lock_bits}u")
+            for seq in seqs:
                 if seq not in ANSI_SEQUENCES:
                     ANSI_SEQUENCES[seq] = key_val
                     changed += 1
@@ -319,9 +333,16 @@ def install_modify_other_keys_aliases() -> int:
     # Disambiguate mode reports the Esc key as CSI-u so it is
     # distinguishable from the ESC byte that starts escape sequences
     # (#56684 — previously leaked "[27u" as literal text into the prompt).
-    # Modifiers run to 16 because kitty reports Cmd as the super bit
-    # (mod 9+) — same reason install_cmd_backspace_alias maps 9/10.
-    for seq in ["\x1b[27u"] + [f"\x1b[27;{m}u" for m in range(2, 17)]:
+    # Modifiers run from 1 to 16: kitty reports Cmd as the super bit
+    # (mod 9+) — same reason install_cmd_backspace_alias maps 9/10 — and
+    # the lock-bit variants of the modifier-less form (1+64/128/192) are
+    # how a lone Esc keypress arrives with a lock on. Lock bits (caps/num)
+    # get the same variant treatment as _install_paired.
+    for seq in ["\x1b[27u"] + [
+        f"\x1b[27;{m + lock_bits}u"
+        for m in range(1, 17)
+        for lock_bits in _CSI_U_LOCK_BIT_VARIANTS
+    ]:
         if seq not in ANSI_SEQUENCES:
             ANSI_SEQUENCES[seq] = Keys.Escape
             changed += 1

--- a/tests/cli/test_modify_other_keys_aliases.py
+++ b/tests/cli/test_modify_other_keys_aliases.py
@@ -492,3 +492,71 @@ def test_modify_other_keys_tilde_form_has_no_lock_variants():
     +64/+128 variants of the ESC[27;N;CP~ form may be installed."""
     for seq in ("\x1b[27;69;99~", "\x1b[27;133;99~", "\x1b[27;197;99~"):
         assert seq not in ANSI_SEQUENCES
+
+
+# ---------------------------------------------------------------------------
+# Follow-up widening: lock twins on the alias installers, legacy CSI-letter /
+# CSI-tilde navigation, unmodified CSI-u keys, and PUA functional keys.
+# ---------------------------------------------------------------------------
+
+
+def test_lock_bits_on_legacy_cursor_keys_map_to_plain_keys():
+    """kitty stamps lock bits onto legacy CSI-letter arrows too:
+    plain Down + NumLock = ESC[1;129B, CapsLock = ESC[1;65B, both = 193."""
+    for mod, key in ((129, Keys.Down), (65, Keys.Down), (193, Keys.Down)):
+        assert _parse(f"\x1b[1;{mod}B") == [key]
+    assert _parse("\x1b[1;130B") == [Keys.ShiftDown]   # Shift + NumLock
+    assert _parse("\x1b[1;131D") == [Keys.Escape, Keys.Left]  # Alt + NumLock
+    assert _parse("\x1b[1;133D") == [Keys.ControlLeft]        # Ctrl + NumLock
+
+
+def test_lock_bits_on_tilde_navigation_keys():
+    """Delete/PageUp/etc. carry the modifier in CSI-tilde form."""
+    assert _parse("\x1b[3;129~") == [Keys.Delete]
+    assert _parse("\x1b[3;69~") == [Keys.ControlDelete]   # Ctrl+Delete + Caps
+    assert _parse("\x1b[5;193~") == [Keys.PageUp]         # both locks
+
+
+def test_lock_bits_on_plain_f1_through_f4():
+    """Plain F1-F4 base mappings are SS3 (ESC O P); their CSI lock twins
+    must still resolve (ESC[1;129P etc.)."""
+    base = _parse("\x1bOP")
+    assert _parse("\x1b[1;129P") == base
+    assert _parse("\x1b[1;65P") == base
+
+
+def test_lock_bits_on_unmodified_csi_u_keys():
+    """Tab/Enter/Space/Backspace with only a lock held (modifier 1+lock)."""
+    assert _parse("\x1b[9;65u") == _parse("\t")
+    assert _parse("\x1b[13;193u") == _parse("\r")
+    assert _parse("\x1b[32;129u") == _parse(" ")
+    assert _parse("\x1b[127;129u") == _parse("\x7f")
+
+
+def test_lock_bits_on_pua_functional_keys():
+    """Kitty PUA functional keys (keypad, F13+) keep working under locks —
+    NumLock especially matters because it gates the keypad itself."""
+    assert _parse("\x1b[57399;129u") == ["0"]        # KP_0 + NumLock
+    assert _parse("\x1b[57376;129u") == [Keys.F13]   # F13 + NumLock
+    assert _parse("\x1b[57427;129u") == [Keys.Ignore]  # KP_BEGIN + NumLock
+
+
+def test_lock_bits_on_shift_enter_and_ctrl_enter_aliases():
+    from hermes_cli.pt_input_extras import (
+        install_ctrl_enter_alias,
+        install_shift_enter_alias,
+    )
+    install_shift_enter_alias()
+    install_ctrl_enter_alias()
+    newline = _parse("\x1b\r")
+    assert _parse("\x1b[13;130u") == newline   # Shift+Enter + NumLock
+    assert _parse("\x1b[13;66u") == newline    # Shift+Enter + CapsLock
+    assert _parse("\x1b[13;133u") == newline   # Ctrl+Enter + NumLock
+
+
+def test_lock_bits_on_cmd_backspace_alias():
+    from hermes_cli.pt_input_extras import install_cmd_backspace_alias
+    install_cmd_backspace_alias()
+    assert _parse("\x1b[127;137u") == [Keys.ControlU]  # Cmd+Backspace + NumLock
+    assert _parse("\x1b[127;73u") == [Keys.ControlU]   # Cmd+Backspace + Caps
+    assert _parse("\x1b[3;137~") == [Keys.ControlK]    # Cmd+FwdDel + NumLock

--- a/tests/cli/test_modify_other_keys_aliases.py
+++ b/tests/cli/test_modify_other_keys_aliases.py
@@ -433,3 +433,62 @@ def test_cmd_backspace_alias_not_clobbered():
     install_cmd_backspace_alias()
     install_modify_other_keys_aliases()
     assert _parse("\x1b[127;9u") == [Keys.ControlU]
+
+
+# ---------------------------------------------------------------------------
+# Lock-bit variants (#89651): kitty/ghostty OR the CapsLock (64) / NumLock
+# (128) state into the CSI-u modifier parameter, so with a lock enabled
+# every combo arrives shifted (ESC[99;133u instead of ESC[99;5u) and died
+# as literal text without these aliases.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("letter", CTRL_LETTERS)
+def test_ctrl_letter_with_numlock_parses_as_raw_byte(letter):
+    """Ctrl+<letter> with NumLock on (modifier + 128) must parse identically
+    to the raw control byte — the exact garbage from #89651 ([127;133u)."""
+    raw_byte = chr(ord(letter) - ord('a') + 1)
+    raw_result = _parse(raw_byte)
+
+    numlock_seq = f"\x1b[{ord(letter)};133u"  # 5 + 128
+    assert _parse(numlock_seq) == raw_result, (
+        f"NumLock Ctrl+{letter} ({numlock_seq!r}) should parse identically "
+        f"to raw {raw_byte!r}"
+    )
+
+
+@pytest.mark.parametrize("letter", ["a", "c", "z"])
+def test_ctrl_letter_with_capslock_parses_as_raw_byte(letter):
+    raw_byte = chr(ord(letter) - ord('a') + 1)
+    capslock_seq = f"\x1b[{ord(letter)};69u"  # 5 + 64
+    assert _parse(capslock_seq) == _parse(raw_byte)
+
+
+def test_ctrl_c_with_both_locks_parses_as_raw_byte():
+    """Ctrl+C with CapsLock and NumLock both on (5 + 64 + 128 = 197)."""
+    assert _parse("\x1b[99;197u") == _parse("\x03")
+
+
+def test_alt_letter_with_numlock_keeps_escape_prefix():
+    assert _parse("\x1b[97;131u") == [Keys.Escape, "a"]  # 3 + 128
+
+
+def test_shift_letter_with_capslock_types_uppercase():
+    assert _parse("\x1b[97;66u") == ["A"]  # 2 + 64
+
+
+def test_esc_key_with_numlock_is_escape():
+    assert _parse("\x1b[27;129u") == [Keys.Escape]  # 1 + 128
+    assert _parse("\x1b[27;133u") == [Keys.Escape]  # 5 + 128
+
+
+def test_ctrl_backspace_with_numlock_is_backward_kill_word():
+    """The exact sequence from the #89651 report ([127;133u)."""
+    assert _parse("\x1b[127;133u") == [Keys.Escape, Keys.ControlH]
+
+
+def test_modify_other_keys_tilde_form_has_no_lock_variants():
+    """The xterm modifyOtherKeys encoding never carries lock bits, so no
+    +64/+128 variants of the ESC[27;N;CP~ form may be installed."""
+    for seq in ("\x1b[27;69;99~", "\x1b[27;133;99~", "\x1b[27;197;99~"):
+        assert seq not in ANSI_SEQUENCES


### PR DESCRIPTION
## Summary

Key combos no longer die (leak as literal text like `[99;133u`) when NumLock or CapsLock is on under the kitty keyboard protocol. Closes #88221, closes #89651.

kitty/ghostty OR lock-key state into the modifier parameter of every key event while a lock is on (CapsLock=+64, NumLock=+128, both=+192), so `Ctrl+C` arrives as `ESC[99;133u` instead of `ESC[99;5u` and plain `Down` as `ESC[1;129B` instead of `ESC[B`. None of those variants were in `ANSI_SEQUENCES`, so with a lock enabled every combo — and on keypads every plain nav key — broke.

Composite salvage of the two strongest PRs in the 4-PR cluster, with authorship preserved via cherry-pick:

- **#89676 (@liuhao1024)** — CSI-u lock twins in `_install_paired` + the Esc-key family, with the correct producer-contract insight that the xterm modifyOtherKeys `ESC[27;N;CP~` form never carries lock bits (so it gets no twins), plus a strong test suite.
- **#90291 (@grahfmusic)** — the legacy CSI-letter/CSI-tilde navigation slice (`ESC[1;129B` arrows, `ESC[3;129~` Delete, …) that every CSI-u-focused PR missed.

## Changes

- `hermes_cli/pt_input_extras.py`:
  - shared `_lock_variants()` helper; both cherry-picks and all follow-up sites use it
  - `install_shift_enter_alias` / `install_ctrl_enter_alias` / `install_cmd_backspace_alias`: CSI-u spellings get lock twins (Shift+Enter with NumLock = `ESC[13;130u` previously fell through)
  - legacy nav lock twins now **derived from the existing table** for all modifiers 1–16 (not just plain/shift as in #90291), covering Ctrl/Alt/Cmd-modified arrows + F1–F4 (SS3 base fallback) under locks
  - unmodified CSI-u keys (Tab/Enter/Space/Backspace at modifier 1) + lock twins
  - kitty PUA functional keys (keypad, F13–F24, Ignore range) + lock twins — NumLock especially matters here since it gates the keypad itself
- `tests/cli/test_modify_other_keys_aliases.py`: contributors' tests + 8 follow-up tests for the widened surface
- `contributors/emails/`: mapping for @grahfmusic

## Validation

| | Before | After |
|---|---|---|
| `Ctrl+C` + NumLock (`ESC[99;133u`) | literal text leak | `Keys.ControlC` |
| plain `Down` + NumLock (`ESC[1;129B`) | literal text leak | `Keys.Down` |
| `Shift+Enter` + NumLock (`ESC[13;130u`) | literal text leak | newline |
| `Cmd+Backspace` + NumLock (`ESC[127;137u`) | literal text leak | kill-line |
| KP_0 + NumLock (`ESC[57399;129u`) | literal text leak | `"0"` |
| modifyOtherKeys tilde form | no lock twins | still no lock twins (negative-tested) |

- 213 passed in `tests/cli/test_modify_other_keys_aliases.py`, 216+2s across `tests/cli/`
- Byte-stream E2E through a real `Vt100Parser`: 8-sequence locked stream parses with zero CSI leaks
- Idempotency: second install pass registers 0 sequences
- Behavior parity vs `origin/main` on 14 non-lock sequences: identical

## Credit

- @liuhao1024 — #89676 (cherry-picked, authorship preserved)
- @grahfmusic — #90291 (cherry-picked, authorship preserved)
- @Schrotti77 (#88265) and @iamlukethedev (#88673) independently diagnosed the same root cause; their PRs overlap the salvaged coverage and will be closed with credit.
