### PR TITLE
fix(compression): would-grow refusals strike the breaker; grown candidates get one salvage pass

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2373,6 +2373,31 @@ class ContextCompressor(ContextEngine):
         self._ineffective_compression_count = count
         self._persist_ineffective_compression_count()
 
+    def record_rejected_compaction(self) -> None:
+        """Record one compaction whose result was REJECTED before committing.
+
+        The anti-growth guard in the commit layer (conversation_compression)
+        discards a candidate that would grow the transcript and keeps the
+        original. Without recording the attempt, the anti-thrash breaker
+        never sees a strike, so automatic compression retries the SAME
+        unchanged transcript on every turn — same summary request, same
+        refusal, same user-facing warning (#88568). This counts one
+        ineffective strike (persisted, so the normal >= 2 latch and its
+        recovery window apply) WITHOUT arming post-compaction real-usage
+        verification — nothing was committed, so there is no new compaction
+        to verify — and without touching the fallback-summary streak (no
+        summary was accepted).
+        """
+        self._record_ineffective_compression_verdict(
+            self._ineffective_compression_count + 1
+        )
+        if not self.quiet_mode:
+            logger.warning(
+                "Compaction rejected before commit (would grow the "
+                "transcript); ineffective_compression_count=%d",
+                self._ineffective_compression_count,
+            )
+
     def record_completed_compaction(
         self, *, used_fallback: bool = False, feasibility_skip: bool = False,
     ) -> None:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -350,10 +350,8 @@ _SUMMARY_END_MARKER = (
 _MERGED_PRIOR_CONTEXT_HEADER = "[PRIOR CONTEXT — for reference only; not a new message]"
 _MERGED_SUMMARY_DELIMITER = "[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]"
 
-_SALVAGE_TOOL_PLACEHOLDER = "[Old tool output cleared to save context space]"
 _SALVAGE_SUMMARY_MAX_CHARS = 8_000
 _SALVAGE_KEEP_RECENT_TOOLS = 2
-_SALVAGE_REASONING_KEYS = ("reasoning", "reasoning_content", "reasoning_details")
 
 
 def _looks_like_compaction_summary(msg: Dict[str, Any], content: str) -> bool:
@@ -363,11 +361,15 @@ def _looks_like_compaction_summary(msg: Dict[str, Any], content: str) -> bool:
         return False
     if content.startswith(_MERGED_PRIOR_CONTEXT_HEADER):
         return False
-    # Content heuristics alone must never authorize mutating a live user turn.
-    # Compressor-generated user-role summaries carry this private marker;
-    # ordinary user input does not.
+    # Content heuristics alone must never authorize mutating a live turn.
+    # Compressor-generated summaries carry this private marker; ordinary
+    # user input — and live assistant replies or kept tool bodies that
+    # merely quote a summary header/marker — do not. Tool messages are
+    # handled exclusively by the stub/keep-recent pass, never the cap.
+    if msg.get("role") == "tool":
+        return False
     if (
-        msg.get("role") == "user"
+        msg.get("role") in ("user", "assistant")
         and not msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
     ):
         return False
@@ -380,9 +382,40 @@ def _looks_like_compaction_summary(msg: Dict[str, Any], content: str) -> bool:
     )
 
 
+def _salvage_reduce_todo_snapshot(out: List[Dict[str, Any]]) -> None:
+    """Last-resort shrink: reduce or drop the synthetic todo snapshot.
+
+    The snapshot is the only in-transcript todo re-injection at a compaction
+    boundary, and since 7a16840add the pruned-skill reload notice is coupled
+    into the same string — so it is only touched when the cheaper shrink ops
+    could not get under budget. When the snapshot carries a reload notice,
+    keep just the notice (the coupling must survive salvage); otherwise drop
+    the row entirely.
+    """
+    from agent.conversation_compression import _PRUNED_SKILL_RELOAD_NOTICE_HEADER
+
+    for i in range(len(out) - 1, -1, -1):
+        msg = out[i]
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("_todo_snapshot_synthetic") and msg.get("role") == "user":
+            content = msg.get("content")
+            notice_idx = (
+                content.find(_PRUNED_SKILL_RELOAD_NOTICE_HEADER)
+                if isinstance(content, str)
+                else -1
+            )
+            if isinstance(content, str) and notice_idx >= 0:
+                msg["content"] = content[notice_idx:]
+            else:
+                del out[i]
+            return
+
+
 def salvage_grown_transcript(
     original: List[Dict[str, Any]],
     candidate: List[Dict[str, Any]],
+    budget: Optional[int] = None,
 ) -> Optional[List[Dict[str, Any]]]:
     """Mechanically shrink a compression candidate, or return ``None``.
 
@@ -390,10 +423,17 @@ def salvage_grown_transcript(
     tool bodies, stale reasoning, or a synthetic todo snapshot tip the final
     candidate over the input size. Work on copies and admit the salvage only
     when the same rough estimator proves it is strictly smaller than the input.
+
+    Shrink order is cheapest-information-loss first: stale reasoning keys and
+    codex replay sidecars, then old tool bodies, then an oversized summary cap.
+    The synthetic todo snapshot (which carries the pruned-skill reload notice,
+    see ``_salvage_reduce_todo_snapshot``) is only reduced as a LAST resort
+    when everything else still leaves the candidate at or over budget.
     """
     if not candidate or not original:
         return None
-    budget = estimate_messages_tokens_rough(original)
+    if budget is None:
+        budget = estimate_messages_tokens_rough(original)
     if budget <= 0:
         return None
 
@@ -404,8 +444,6 @@ def salvage_grown_transcript(
         if not isinstance(msg, dict):
             out.append(msg)
             continue
-        if msg.get("_todo_snapshot_synthetic") and msg.get("role") == "user":
-            continue
         copied = dict(msg)
         out.append(copied)
         role = copied.get("role")
@@ -414,17 +452,18 @@ def salvage_grown_transcript(
         elif role == "assistant":
             last_assistant_idx = len(out) - 1
 
+    salvage_reasoning_keys = _NEWEST_TURN_ONLY_BUDGET_KEYS + ("reasoning_details",)
     keep_tools = set(tool_indices[-_SALVAGE_KEEP_RECENT_TOOLS:])
     for index, msg in enumerate(out):
         if not isinstance(msg, dict):
             continue
         if msg.get("role") == "assistant" and index != last_assistant_idx:
-            for key in _SALVAGE_REASONING_KEYS:
+            for key in salvage_reasoning_keys:
                 msg.pop(key, None)
         if msg.get("role") == "tool" and index not in keep_tools:
             content = msg.get("content")
-            if isinstance(content, str) and len(content) > 200:
-                msg["content"] = _SALVAGE_TOOL_PLACEHOLDER
+            if isinstance(content, str) and len(content) > _PRUNE_MIN_CHARS:
+                msg["content"] = _PRUNED_TOOL_PLACEHOLDER
         content = msg.get("content")
         if (
             isinstance(content, str)
@@ -436,6 +475,12 @@ def salvage_grown_transcript(
                 + "\n…[summary truncated so compaction can shrink]\n\n"
                 + _SUMMARY_END_MARKER
             )
+    # Heavier codex replay sidecars (encrypted reasoning blobs) — reuse the
+    # proven prune with its last-user-turn safety boundary (#71058).
+    _prune_stale_reasoning_replay(out)
+
+    if estimate_messages_tokens_rough(out) >= budget:
+        _salvage_reduce_todo_snapshot(out)
 
     if not any(
         isinstance(message, dict) and message.get("role") == "user"

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -350,6 +350,102 @@ _SUMMARY_END_MARKER = (
 _MERGED_PRIOR_CONTEXT_HEADER = "[PRIOR CONTEXT — for reference only; not a new message]"
 _MERGED_SUMMARY_DELIMITER = "[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]"
 
+_SALVAGE_TOOL_PLACEHOLDER = "[Old tool output cleared to save context space]"
+_SALVAGE_SUMMARY_MAX_CHARS = 8_000
+_SALVAGE_KEEP_RECENT_TOOLS = 2
+_SALVAGE_REASONING_KEYS = ("reasoning", "reasoning_content", "reasoning_details")
+
+
+def _looks_like_compaction_summary(msg: Dict[str, Any], content: str) -> bool:
+    # Only cap a standalone handoff. Merged carriers preserve a real tail ask
+    # in the same content string; truncating those could delete live user text.
+    if not content.rstrip().endswith(_SUMMARY_END_MARKER):
+        return False
+    if content.startswith(_MERGED_PRIOR_CONTEXT_HEADER):
+        return False
+    # Content heuristics alone must never authorize mutating a live user turn.
+    # Compressor-generated user-role summaries carry this private marker;
+    # ordinary user input does not.
+    if (
+        msg.get("role") == "user"
+        and not msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
+    ):
+        return False
+    head = content[:280]
+    return (
+        bool(msg.get(COMPRESSED_SUMMARY_METADATA_KEY))
+        or "CONTEXT COMPACTION" in head
+        or "[CONTEXT COMPACTION]" in head
+        or "Conversation Summary" in head
+    )
+
+
+def salvage_grown_transcript(
+    original: List[Dict[str, Any]],
+    candidate: List[Dict[str, Any]],
+) -> Optional[List[Dict[str, Any]]]:
+    """Mechanically shrink a compression candidate, or return ``None``.
+
+    Already-compacted middles can be summarized slightly larger while retained
+    tool bodies, stale reasoning, or a synthetic todo snapshot tip the final
+    candidate over the input size. Work on copies and admit the salvage only
+    when the same rough estimator proves it is strictly smaller than the input.
+    """
+    if not candidate or not original:
+        return None
+    budget = estimate_messages_tokens_rough(original)
+    if budget <= 0:
+        return None
+
+    out: List[Dict[str, Any]] = []
+    tool_indices: List[int] = []
+    last_assistant_idx = -1
+    for msg in candidate:
+        if not isinstance(msg, dict):
+            out.append(msg)
+            continue
+        if msg.get("_todo_snapshot_synthetic") and msg.get("role") == "user":
+            continue
+        copied = dict(msg)
+        out.append(copied)
+        role = copied.get("role")
+        if role == "tool":
+            tool_indices.append(len(out) - 1)
+        elif role == "assistant":
+            last_assistant_idx = len(out) - 1
+
+    keep_tools = set(tool_indices[-_SALVAGE_KEEP_RECENT_TOOLS:])
+    for index, msg in enumerate(out):
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") == "assistant" and index != last_assistant_idx:
+            for key in _SALVAGE_REASONING_KEYS:
+                msg.pop(key, None)
+        if msg.get("role") == "tool" and index not in keep_tools:
+            content = msg.get("content")
+            if isinstance(content, str) and len(content) > 200:
+                msg["content"] = _SALVAGE_TOOL_PLACEHOLDER
+        content = msg.get("content")
+        if (
+            isinstance(content, str)
+            and len(content) > _SALVAGE_SUMMARY_MAX_CHARS
+            and _looks_like_compaction_summary(msg, content)
+        ):
+            msg["content"] = (
+                content[:_SALVAGE_SUMMARY_MAX_CHARS].rstrip()
+                + "\n…[summary truncated so compaction can shrink]\n\n"
+                + _SUMMARY_END_MARKER
+            )
+
+    if not any(
+        isinstance(message, dict) and message.get("role") == "user"
+        for message in out
+    ):
+        return None
+    if estimate_messages_tokens_rough(out) < budget:
+        return out
+    return None
+
 # Handoff prefixes that shipped in earlier releases. A summary persisted under
 # one of these can be inherited into a resumed lineage (#35344); when it is
 # re-normalized on re-compaction we must strip the OLD prefix too, otherwise the

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3392,7 +3392,9 @@ def compress_context(
                     # candidate over. Give it one mechanical salvage pass.
                     from agent.context_compressor import salvage_grown_transcript
 
-                    _salvaged = salvage_grown_transcript(messages, compressed)
+                    _salvaged = salvage_grown_transcript(
+                        messages, compressed, budget=_rough_in
+                    )
                     if _salvaged is not None:
                         _salv_est = estimate_messages_tokens_rough(_salvaged)
                         if _salv_est < _rough_in:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3425,6 +3425,20 @@ def compress_context(
                         split_status="aborted",
                         failure_class="would_grow",
                     )
+                    # Record the rejected attempt as an ineffective
+                    # compaction strike so the anti-thrash breaker latches
+                    # after the normal threshold. Without this, the unchanged
+                    # transcript stays over the compression threshold and
+                    # automatic compression retries the identical summary
+                    # request on every turn (#88568). Manual /compress keeps
+                    # bypassing the latch (force=True skips the guards).
+                    try:
+                        agent.context_compressor.record_rejected_compaction()
+                    except Exception:
+                        logger.debug(
+                            "could not record rejected-compaction strike",
+                            exc_info=True,
+                        )
                     _release_lock()
                     return messages, _existing_sp
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3387,6 +3387,25 @@ def compress_context(
                 _rough_in = estimate_messages_tokens_rough(messages)
                 _rough_out = estimate_messages_tokens_rough(compressed)
                 if _rough_out > _rough_in:
+                    # Todo refresh and user-turn anchoring happen after the
+                    # compressor's own size check, so they can tip a break-even
+                    # candidate over. Give it one mechanical salvage pass.
+                    from agent.context_compressor import salvage_grown_transcript
+
+                    _salvaged = salvage_grown_transcript(messages, compressed)
+                    if _salvaged is not None:
+                        _salv_est = estimate_messages_tokens_rough(_salvaged)
+                        if _salv_est < _rough_in:
+                            logger.info(
+                                "Compression salvage recovered a shrinking "
+                                "transcript (session=%s, ~%s -> ~%s tokens)",
+                                agent.session_id or "none",
+                                f"{_rough_in:,}",
+                                f"{_salv_est:,}",
+                            )
+                            compressed = _salvaged
+                            _rough_out = _salv_est
+                if _rough_out > _rough_in:
                     logger.warning(
                         "Compression refused: compressed transcript would be "
                         "larger than the original (session=%s, ~%s -> ~%s "

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -833,11 +833,6 @@ memory:
   # every N user turns. Set to 0 to disable. Only active when memory is enabled.
   nudge_interval: 10        # Nudge every 10 user turns (0 = disabled)
 
-  # Memory flush: give the agent one turn to save memories before context is
-  # lost (compression, /new, /reset, exit). Set to 0 to disable.
-  # For exit/reset, only fires if the session had at least this many user turns.
-  flush_min_turns: 6        # Min user turns to trigger flush on exit/reset (0 = disabled)
-
 # =============================================================================
 # Session Reset Policy (Messaging Platforms)
 # =============================================================================

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1865,6 +1865,10 @@ DEFAULT_CONFIG = {
         "write_approval": False,
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        # Periodic built-in memory review. External providers with automatic
+        # turn/session extraction can set this to 0 and keep the small local
+        # store reserved for explicit high-frequency operational facts.
+        "nudge_interval": 10,
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".

--- a/tests/agent/test_compaction_anti_thrash.py
+++ b/tests/agent/test_compaction_anti_thrash.py
@@ -203,3 +203,47 @@ class TestMinimumMessagesBranch:
         assert len(out) == len(msgs), "nothing should have been compressed"
         assert cc._last_compression_made_progress is False
         assert cc._ineffective_compression_count == before + 1
+
+
+class TestRejectedCompactionStrike:
+    """#88568 — a would-grow refusal must count as an ineffective strike.
+
+    The anti-growth guard correctly keeps the original transcript, but the
+    rejection used to leave ``_ineffective_compression_count`` untouched, so
+    the breaker never latched and automatic compression retried the SAME
+    unchanged transcript on every turn.
+    """
+
+    def test_rejected_compaction_increments_strike(self):
+        cc = _compressor(threshold_tokens=1)
+        assert cc._ineffective_compression_count == 0
+
+        cc.record_rejected_compaction()
+
+        assert cc._ineffective_compression_count == 1
+
+    def test_two_rejections_stop_further_automatic_compression(self):
+        cc = _compressor(threshold_tokens=1)
+        cc.record_rejected_compaction()
+        cc.record_rejected_compaction()
+
+        # The latch consumers key on the counter itself (>= 2 blocks);
+        # pin the counter and the recovery-clock arming side effect.
+        assert cc._ineffective_compression_count >= 2
+
+    def test_rejection_does_not_arm_real_usage_verification(self):
+        """Nothing was committed, so the next response must not be scored
+        against the pre-rejection transcript (that verdict belongs to
+        committed compactions only)."""
+        cc = _compressor(threshold_tokens=1)
+        cc.record_rejected_compaction()
+
+        assert cc._verify_compaction_cleared_threshold is False
+
+    def test_rejection_leaves_fallback_streak_untouched(self):
+        cc = _compressor(threshold_tokens=1)
+        cc._fallback_compression_streak = 1
+
+        cc.record_rejected_compaction()
+
+        assert cc._fallback_compression_streak == 1

--- a/tests/agent/test_salvage_grown_transcript.py
+++ b/tests/agent/test_salvage_grown_transcript.py
@@ -1,0 +1,119 @@
+"""Mechanical salvage for compression candidates that would grow."""
+
+from agent.context_compressor import (
+    COMPRESSED_SUMMARY_METADATA_KEY,
+    _SUMMARY_END_MARKER,
+    salvage_grown_transcript,
+)
+from agent.model_metadata import estimate_messages_tokens_rough
+
+
+def test_salvage_stubs_old_tools_and_drops_todo():
+    original = [
+        {"role": "user", "content": "go"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "tool", "tool_call_id": "a", "content": "A" * 4000},
+        {"role": "tool", "tool_call_id": "b", "content": "B" * 4000},
+        {"role": "tool", "tool_call_id": "c", "content": "keep-latest"},
+    ]
+    grown = original + [
+        {
+            "role": "user",
+            "content": "Current todos:\n- [ ] x",
+            "_todo_snapshot_synthetic": True,
+        }
+    ]
+    assert estimate_messages_tokens_rough(grown) > estimate_messages_tokens_rough(original)
+
+    out = salvage_grown_transcript(original, grown)
+
+    assert out is not None
+    assert estimate_messages_tokens_rough(out) < estimate_messages_tokens_rough(original)
+    assert not any(m.get("_todo_snapshot_synthetic") for m in out)
+    tools = [m["content"] for m in out if m.get("role") == "tool"]
+    assert tools[-1] == "keep-latest"
+    assert any("cleared to save context space" in t for t in tools)
+
+
+def test_salvage_returns_none_when_nothing_can_shrink():
+    original = [{"role": "user", "content": "tiny"}]
+    huge = [{"role": "user", "content": "X" * 200_000}]
+
+    assert salvage_grown_transcript(original, huge) is None
+
+
+def test_salvage_caps_oversized_summary():
+    original = [
+        {"role": "user", "content": "ask " + ("o" * 12_000)},
+        {"role": "assistant", "content": "short reply"},
+    ]
+    grown = [
+        {
+            "role": "user",
+            "content": (
+                "[CONTEXT COMPACTION] "
+                + ("S" * 20_000)
+                + "\n\n"
+                + _SUMMARY_END_MARKER
+            ),
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        },
+        {"role": "assistant", "content": "short reply"},
+    ]
+    assert estimate_messages_tokens_rough(grown) > estimate_messages_tokens_rough(original)
+
+    out = salvage_grown_transcript(original, grown)
+
+    assert out is not None
+    assert len(out[0]["content"]) < 12_000
+    assert "truncated so compaction can shrink" in out[0]["content"]
+    assert out[0]["content"].endswith(_SUMMARY_END_MARKER)
+
+
+def test_salvage_never_truncates_merged_summary_with_live_user_tail():
+    original = [{"role": "user", "content": "O" * 12_000}]
+    merged = [
+        {
+            "role": "user",
+            "content": (
+                "[CONTEXT COMPACTION] "
+                + ("S" * 20_000)
+                + "\n\n"
+                + _SUMMARY_END_MARKER
+                + "\n\nLIVE USER REQUEST"
+            ),
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        }
+    ]
+
+    assert salvage_grown_transcript(original, merged) is None
+    assert merged[0]["content"].endswith("LIVE USER REQUEST")
+
+
+def test_salvage_does_not_cap_plain_user_text_quoting_summary_marker():
+    original = [{"role": "user", "content": "O" * 20_000}]
+    quoted = "ordinary user text " + ("Q" * 12_000) + "\n\n" + _SUMMARY_END_MARKER
+    candidate = [{"role": "user", "content": quoted}]
+
+    out = salvage_grown_transcript(original, candidate)
+
+    assert out is not None
+    assert out[0]["content"] == quoted
+    assert "truncated so compaction can shrink" not in out[0]["content"]
+
+
+def test_salvage_never_caps_unmarked_summary_shaped_live_user_text():
+    original = [{"role": "user", "content": "O" * 20_000}]
+    live_user_text = (
+        "[CONTEXT COMPACTION] "
+        + ("U" * 12_000)
+        + "\n\n"
+        + _SUMMARY_END_MARKER
+    )
+    candidate = [{"role": "user", "content": live_user_text}]
+
+    out = salvage_grown_transcript(original, candidate)
+
+    assert out is not None
+    assert out[0]["content"] == live_user_text
+    assert "truncated so compaction can shrink" not in out[0]["content"]

--- a/tests/agent/test_salvage_grown_transcript.py
+++ b/tests/agent/test_salvage_grown_transcript.py
@@ -8,7 +8,12 @@ from agent.context_compressor import (
 from agent.model_metadata import estimate_messages_tokens_rough
 
 
-def test_salvage_stubs_old_tools_and_drops_todo():
+def test_salvage_stubs_old_tools_and_keeps_todo_when_stubbing_suffices():
+    """Tool stubbing alone gets under budget → the todo snapshot survives.
+
+    The snapshot is the only in-transcript todo re-injection at the boundary
+    (and may carry the pruned-skill reload notice), so it is last-resort only.
+    """
     original = [
         {"role": "user", "content": "go"},
         {"role": "assistant", "content": "ok"},
@@ -29,10 +34,67 @@ def test_salvage_stubs_old_tools_and_drops_todo():
 
     assert out is not None
     assert estimate_messages_tokens_rough(out) < estimate_messages_tokens_rough(original)
-    assert not any(m.get("_todo_snapshot_synthetic") for m in out)
+    assert any(m.get("_todo_snapshot_synthetic") for m in out)
     tools = [m["content"] for m in out if m.get("role") == "tool"]
     assert tools[-1] == "keep-latest"
     assert any("cleared to save context space" in t for t in tools)
+
+
+def test_salvage_drops_todo_only_as_last_resort():
+    """When cheaper ops cannot get under budget, the snapshot is dropped."""
+    original = [
+        {"role": "user", "content": "please do the thing " + ("o" * 600)},
+        {"role": "assistant", "content": "ok"},
+    ]
+    grown = [
+        {"role": "user", "content": "summary of the ask"},
+        {"role": "assistant", "content": "ok"},
+        {
+            "role": "user",
+            "content": "Current todos:\n- [ ] " + ("t" * 800),
+            "_todo_snapshot_synthetic": True,
+        },
+    ]
+    assert estimate_messages_tokens_rough(grown) > estimate_messages_tokens_rough(original)
+
+    out = salvage_grown_transcript(original, grown)
+
+    assert out is not None
+    assert estimate_messages_tokens_rough(out) < estimate_messages_tokens_rough(original)
+    assert not any(m.get("_todo_snapshot_synthetic") for m in out)
+
+
+def test_salvage_last_resort_preserves_pruned_skill_reload_notice():
+    """7a16840add couples the reload notice into the snapshot — it survives."""
+    from agent.conversation_compression import _PRUNED_SKILL_RELOAD_NOTICE_HEADER
+
+    notice = (
+        f"{_PRUNED_SKILL_RELOAD_NOTICE_HEADER}\n"
+        "Reload with skill_view(name='example-skill') before acting."
+    )
+    original = [
+        {"role": "user", "content": "please do the thing " + ("o" * 3000)},
+        {"role": "assistant", "content": "ok"},
+    ]
+    grown = [
+        {"role": "user", "content": "summary of the ask"},
+        {"role": "assistant", "content": "ok"},
+        {
+            "role": "user",
+            "content": "Current todos:\n- [ ] " + ("t" * 4000) + f"\n\n{notice}",
+            "_todo_snapshot_synthetic": True,
+        },
+    ]
+    assert estimate_messages_tokens_rough(grown) > estimate_messages_tokens_rough(original)
+
+    out = salvage_grown_transcript(original, grown)
+
+    assert out is not None
+    assert estimate_messages_tokens_rough(out) < estimate_messages_tokens_rough(original)
+    snapshot_rows = [m for m in out if m.get("_todo_snapshot_synthetic")]
+    assert len(snapshot_rows) == 1
+    assert snapshot_rows[0]["content"].startswith(_PRUNED_SKILL_RELOAD_NOTICE_HEADER)
+    assert "Current todos" not in snapshot_rows[0]["content"]
 
 
 def test_salvage_returns_none_when_nothing_can_shrink():

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -111,6 +111,13 @@ class TestConfigYamlRouting:
         assert "not a recognized config key" not in capsys.readouterr().out
         assert "script_timeout_seconds: 600" in _read_config(_isolated_hermes_home)
 
+    def test_memory_nudge_interval_is_recognized(self, _isolated_hermes_home, capsys):
+        """The documented background-memory review interval is runtime config."""
+        set_config_value("memory.nudge_interval", "0")
+
+        assert "not a recognized config key" not in capsys.readouterr().out
+        assert "nudge_interval: 0" in _read_config(_isolated_hermes_home)
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)

--- a/tests/run_agent/test_in_place_compaction.py
+++ b/tests/run_agent/test_in_place_compaction.py
@@ -293,6 +293,60 @@ class TestInPlaceAntiGrowthGuard:
             assert agent.session_id == sid
             assert db.get_session(sid)["end_reason"] is None
 
+    def test_in_place_salvages_near_break_even_growth(self):
+        """Fat retained tool output + todo state should be salvaged and committed."""
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+        from agent.model_metadata import estimate_messages_tokens_rough
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260819_salvage"
+            _seed(db, sid, "salvage")
+            agent = _make_agent(db, sid, in_place=True)
+            agent._last_flushed_db_idx = 5
+
+            tool_calls = [
+                {"id": call_id, "function": {"name": "terminal", "arguments": "{}"}}
+                for call_id in ("c1", "c2", "c3")
+            ]
+            original = [
+                {"role": "user", "content": "do the work"},
+                {"role": "assistant", "content": "calling tools", "tool_calls": tool_calls},
+                {"role": "tool", "tool_call_id": "c1", "content": "OLD1 " + ("x" * 8000)},
+                {"role": "tool", "tool_call_id": "c2", "content": "OLD2 " + ("y" * 8000)},
+                {"role": "tool", "tool_call_id": "c3", "content": "keep-me " + ("z" * 100)},
+                {"role": "user", "content": "thanks"},
+            ]
+            grown = [
+                {"role": "user", "content": "[CONTEXT COMPACTION] " + ("S" * 200)},
+                {"role": "assistant", "content": "calling tools", "tool_calls": tool_calls},
+                {"role": "tool", "tool_call_id": "c1", "content": "OLD1 " + ("x" * 8000)},
+                {"role": "tool", "tool_call_id": "c2", "content": "OLD2 " + ("y" * 8000)},
+                {"role": "tool", "tool_call_id": "c3", "content": "keep-me " + ("z" * 100)},
+                {
+                    "role": "user",
+                    "content": "Current todos:\n- [ ] leftover",
+                    "_todo_snapshot_synthetic": True,
+                },
+            ]
+            assert estimate_messages_tokens_rough(grown) > estimate_messages_tokens_rough(original)
+            compressor = getattr(agent, "context_compressor")
+            compressor.compress = (
+                lambda messages, current_tokens=None, focus_topic=None, force=False: grown
+            )
+
+            compressed, _sp = compress_context(
+                agent, original, approx_tokens=100_000, system_message="sys"
+            )
+
+            assert getattr(agent, "_last_compaction_in_place") is True
+            assert estimate_messages_tokens_rough(compressed) < estimate_messages_tokens_rough(original)
+            tool_bodies = [m.get("content") for m in compressed if m.get("role") == "tool"]
+            assert any(isinstance(body, str) and body.startswith("keep-me") for body in tool_bodies)
+            assert any("cleared to save context space" in (body or "") for body in tool_bodies)
+            assert not any(m.get("_todo_snapshot_synthetic") for m in compressed)
+
     def test_in_place_still_commits_shrinking_compression(self):
         """The guard must not block legitimate compressions — a result SMALLER
         than the input still commits in place (regression net for #83339)."""

--- a/tests/run_agent/test_in_place_compaction.py
+++ b/tests/run_agent/test_in_place_compaction.py
@@ -345,7 +345,9 @@ class TestInPlaceAntiGrowthGuard:
             tool_bodies = [m.get("content") for m in compressed if m.get("role") == "tool"]
             assert any(isinstance(body, str) and body.startswith("keep-me") for body in tool_bodies)
             assert any("cleared to save context space" in (body or "") for body in tool_bodies)
-            assert not any(m.get("_todo_snapshot_synthetic") for m in compressed)
+            # Tool stubbing alone got under budget, so the todo snapshot (the
+            # only in-transcript todo re-injection) survives the salvage.
+            assert any(m.get("_todo_snapshot_synthetic") for m in compressed)
 
     def test_in_place_still_commits_shrinking_compression(self):
         """The guard must not block legitimate compressions — a result SMALLER


### PR DESCRIPTION
## Summary

Would-grow compaction refusals now latch the anti-thrash breaker and get one mechanical salvage attempt before refusing — ending the retry-same-transcript-every-turn loop (#88568). Also makes `memory.nudge_interval` a recognized config key.

Salvages three contributor PRs onto current main with authorship preserved:

- #88593 (@liuhao1024) — a would-grow refusal counts as an ineffective strike (persisted; normal >= 2 latch + recovery window apply; no real-usage verification armed; fallback streak untouched).
- #90353 (@MindDragonLabs) — before refusing, a grown candidate gets a mechanical shrink pass (stale reasoning, old tool bodies, oversized summary cap) and commits if strictly smaller than the input.
- #90354 (@MindDragonLabs) — `memory.nudge_interval` added to DEFAULT_CONFIG (consumer already existed in `agent_init.py`); removes the dead `flush_min_turns` example block (zero code references).

## Changes

- `agent/context_compressor.py`: `record_rejected_compaction()`; `salvage_grown_transcript()` + summary-cap heuristic with live-text guards
- `agent/conversation_compression.py`: salvage pass before the would-grow refusal; strike recording on refusal
- `hermes_cli/config_defaults.py`, `cli-config.yaml.example`: `nudge_interval` recognized, `flush_min_turns` removed
- Follow-up commit (review findings): todo snapshot (+ coupled pruned-skill reload notice, 7a16840add) reduced only as a LAST resort and the notice survives even then; reuse of `_PRUNED_TOOL_PLACEHOLDER` / `_PRUNE_MIN_CHARS` / `_NEWEST_TURN_ONLY_BUDGET_KEYS` / `_prune_stale_reasoning_replay` instead of re-hardcoded copies; assistant/tool messages without the summary metadata key are never truncatable by the cap; estimator runs 3x not 5x per would-grow pass

## Validation

| | Before | After |
|---|---|---|
| would-grow refusal | retries identical summary request every turn | 1 strike/refusal, breaker latches at 2 |
| near-break-even candidate | refused outright | salvaged + committed when strictly smaller |
| todo snapshot on salvage | n/a (dropped unconditionally in #90353 as filed) | survives unless last resort; reload notice always survives |
| `hermes config set memory.nudge_interval 0` | "not a recognized config key" | recognized |

115 targeted tests green (salvage, anti-thrash, in-place compaction, config); E2E smoke of real `compress_context` on both paths (salvaged commit: shrinks + no strike; unsalvageable: refusal + one strike + #90457's `_last_compress_refused_would_grow` co-fires + no verification armed). Coexists with just-landed #90457 — salvage runs first, refusal bookkeeping (flag + strike) only fires when salvage also failed.

Closes #88593. Closes #90353. Closes #90354. Fixes #88568.

## Credit

@liuhao1024 (#88593) and @MindDragonLabs (#90353, #90354) — commits cherry-picked with authorship preserved.

## Infographic

![salvage infographic](https://v3b.fal.media/files/b/0aa70f6b/7nbAW4-nvpt0f53URTg1l_O7NDNKp8.png)
