### PR TITLE
fix(update): bound the Windows update hand-off's step pipe drain

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -47,12 +47,13 @@ param(
     [string]$RelaunchExe = "",
     [switch]$NoUi,
     [switch]$NoMarkerCleanup,
-    [switch]$SelfTestUi
+    [switch]$SelfTestUi,
+    [switch]$SelfTestPipeDrain
 )
 
-if (-not $SelfTestUi -and -not $InstallRoot) {
-    # Mandatory in spirit; relaxed in the signature only so -SelfTestUi can
-    # drive the UI without a checkout.
+if (-not $SelfTestUi -and -not $SelfTestPipeDrain -and -not $InstallRoot) {
+    # Mandatory in spirit; relaxed in the signature only so the self-test
+    # switches can drive the UI / the pipe drain without a checkout.
     throw "-InstallRoot is required"
 }
 
@@ -746,6 +747,77 @@ if ($SelfTestUi) {
     } else {
         Close-ProgressWindow
     }
+    exit 0
+}
+
+# -SelfTestPipeDrain: prove Invoke-HermesStep survives a leaked pipe ------
+# The #90455 deadlock needs no update, no checkout and no Hermes install to
+# reproduce -- only a step whose grandchild outlives it holding the inherited
+# write end of the redirected pipe. That is exactly what this builds, so the
+# fix has an executable proof on Windows instead of a source-grep. Exits
+# before any marker/desktop machinery, same as -SelfTestUi; touches nothing
+# but its own temp files.
+if ($SelfTestPipeDrain) {
+    New-Item -ItemType Directory -Path $LogDir -Force -ErrorAction SilentlyContinue | Out-Null
+    $hold = 60
+    if ($env:HERMES_SELFTEST_HOLD_SECONDS) { $hold = [int]$env:HERMES_SELFTEST_HOLD_SECONDS }
+    # $PSHOME is this interpreter's own directory -- no hardcoded system path.
+    $powershell = Join-Path $PSHOME "powershell.exe"
+    $stamp = [Guid]::NewGuid().ToString("N")
+    $childPs1 = Join-Path $TempDir "hermes-pipe-drain-$stamp.ps1"
+    $pidFile = Join-Path $TempDir "hermes-pipe-drain-$stamp.pid"
+    # UseShellExecute=$false with no redirection is what makes the grandchild
+    # inherit our stdout/stderr -- the whole point of the fixture. Anything
+    # that redirects (Start-Process, subprocess with stdout=DEVNULL) would
+    # close the handle and the deadlock would not reproduce.
+    $childSource = @'
+param([int]$Hold, [string]$PidFile)
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = Join-Path $PSHOME "powershell.exe"
+$psi.Arguments = "-NoProfile -Command Start-Sleep -Seconds $Hold"
+$psi.UseShellExecute = $false
+$psi.CreateNoWindow = $true
+$grandchild = [System.Diagnostics.Process]::Start($psi)
+[System.IO.File]::WriteAllText($PidFile, [string]$grandchild.Id)
+Write-Output "pipe-drain step output"
+[Console]::Out.Flush()
+exit 7
+'@
+    [System.IO.File]::WriteAllText($childPs1, $childSource)
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $res = Invoke-HermesStep $powershell @(
+        "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $childPs1,
+        "-Hold", [string]$hold, "-PidFile", $pidFile
+    ) "pipedrain"
+    $sw.Stop()
+    $elapsed = [Math]::Round($sw.Elapsed.TotalSeconds, 2)
+
+    $leakPid = 0
+    if (Test-Path -LiteralPath $pidFile) {
+        [void][int]::TryParse((Get-Content -LiteralPath $pidFile -Raw).Trim(), [ref]$leakPid)
+    }
+    $leakAlive = $false
+    if ($leakPid -gt 0) {
+        $leakAlive = [bool](Get-Process -Id $leakPid -ErrorAction SilentlyContinue)
+        Stop-Process -Id $leakPid -Force -ErrorAction SilentlyContinue
+    }
+    Remove-Item -LiteralPath $childPs1, $pidFile -Force -ErrorAction SilentlyContinue
+
+    # The grandchild still being alive at return is what makes this a proof
+    # rather than a timing coincidence: the pipe was demonstrably still open.
+    $budget = $script:StepDrainGraceSeconds + 30
+    $problems = @()
+    if (-not $leakAlive) { $problems += "handle-holding grandchild was not alive on return (fixture did not reproduce the leak)" }
+    if ($elapsed -ge $budget) { $problems += "returned in ${elapsed}s, over the ${budget}s budget" }
+    if ($res.Code -ne 7) { $problems += "exit code $($res.Code), expected 7" }
+    if ($res.Output -notmatch "pipe-drain step output") { $problems += "step output was lost" }
+
+    $detail = "elapsed=${elapsed}s budget=${budget}s code=$($res.Code) grandchildAlive=$leakAlive"
+    if ($problems.Count -gt 0) {
+        Write-Host "PIPE-DRAIN SELF-TEST: FAIL $detail -- $($problems -join '; ')"
+        exit 1
+    }
+    Write-Host "PIPE-DRAIN SELF-TEST: PASS $detail"
     exit 0
 }
 

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -583,6 +583,56 @@ function Start-DesktopRelaunch {
     return $spawned
 }
 
+# How long a step's pipes get to reach EOF AFTER the step process itself has
+# exited (#90455). This is not a step timeout -- the step is already gone by
+# the time the clock starts, and everything it wrote is sitting in the pipe
+# buffer ready to read, so the grace only has to cover the final drain.
+#
+# It exists because pipe EOF is not the child's to give. Windows hands the
+# write end of a redirected pipe to the child as an INHERITABLE handle, so
+# every descendant that is spawned without its own redirection gets a
+# duplicate -- and the read side does not see EOF until the last of them
+# closes it. `hermes update` deliberately runs its build steps with stdout
+# inherited (hermes_cli/main.py, the tee-stderr runner), so the tree under a
+# step is arbitrarily deep and not something this script can enumerate. When
+# one of those descendants is a resident gateway, the pipe stays open for the
+# life of the gateway, i.e. forever.
+#
+# Overridable so the pipe-drain self-test does not have to sit out the real
+# grace; not documented as a user knob.
+$script:StepDrainGraceSeconds = 20
+if ($env:HERMES_UPDATE_PIPE_DRAIN_SECONDS) {
+    $parsedGrace = 0
+    if ([int]::TryParse($env:HERMES_UPDATE_PIPE_DRAIN_SECONDS, [ref]$parsedGrace) -and $parsedGrace -ge 0) {
+        $script:StepDrainGraceSeconds = $parsedGrace
+    }
+}
+
+function Step-PipeDrain($Reader, [ref]$Task, $Buffer, $Sink) {
+    # Advance one redirected pipe by whatever has already arrived, without
+    # ever blocking. Returns $true once the pipe has reached EOF (or its read
+    # faulted), $false while more may still come.
+    #
+    # The chunked ReadAsync loop is the point: ReadToEndAsync().Result cannot
+    # hand back a partial read, so abandoning it loses the whole step's output.
+    # Draining into a StringBuilder means an abandoned pipe still yields every
+    # byte that arrived before we gave up.
+    if ($null -eq $Task.Value) { return $true }
+    if (-not $Task.Value.IsCompleted) { return $false }
+    $count = 0
+    try {
+        $count = $Task.Value.Result
+    } catch {
+        # Faulted/cancelled read: treat as EOF rather than retrying forever.
+        $Task.Value = $null
+        return $true
+    }
+    if ($count -le 0) { $Task.Value = $null; return $true }
+    [void]$Sink.Append($Buffer, 0, $count)
+    $Task.Value = $Reader.ReadAsync($Buffer, 0, $Buffer.Length)
+    return $false
+}
+
 function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     # The window does not stream child output, so no line-pump: both pipes
     # drain asynchronously (no deadlock however chatty the child) while a small
@@ -590,6 +640,15 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     # stretches (pip installs) -- the old EndOfStream pump blocked on quiet
     # children and froze it. Full output still lands in the hand-off log
     # afterwards, where `hermes debug share` picks it up.
+    #
+    # The drain is bounded once the step exits (#90455). Waiting for pipe EOF
+    # is waiting on the step's whole surviving descendant tree, and this
+    # function sits upstream of every terminal obligation the hand-off has --
+    # .hermes-update-result.json, clearing .hermes-update-in-progress,
+    # relaunching the Desktop. One resident grandchild holding an inherited
+    # handle used to strand all three and leave the Desktop on "Updating
+    # Hermes" until the user killed something by hand. Losing the tail of a
+    # log is the strictly better failure.
     # System.Diagnostics.Process directly: Start-Process's .ExitCode is
     # unreliably $null under PS 5.1 even with the Handle-touch workaround.
     $psi = New-Object System.Diagnostics.ProcessStartInfo
@@ -611,15 +670,40 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     $psi.EnvironmentVariables["PYTHONUTF8"] = "1"
     $psi.CreateNoWindow = $true
     $proc = [System.Diagnostics.Process]::Start($psi)
-    $outTask = $proc.StandardOutput.ReadToEndAsync()
-    $errTask = $proc.StandardError.ReadToEndAsync()
-    while (-not $proc.HasExited) {
+    $outSink = New-Object System.Text.StringBuilder
+    $errSink = New-Object System.Text.StringBuilder
+    $outBuffer = New-Object char[] 16384
+    $errBuffer = New-Object char[] 16384
+    $outTask = $proc.StandardOutput.ReadAsync($outBuffer, 0, $outBuffer.Length)
+    $errTask = $proc.StandardError.ReadAsync($errBuffer, 0, $errBuffer.Length)
+    $abandonAt = $null
+    $abandoned = $false
+    while ($true) {
+        $outDone = Step-PipeDrain $proc.StandardOutput ([ref]$outTask) $outBuffer $outSink
+        $errDone = Step-PipeDrain $proc.StandardError ([ref]$errTask) $errBuffer $errSink
+        if ($proc.HasExited) {
+            if ($outDone -and $errDone) { break }
+            # Clock starts at the step's exit, not at its start: a slow step is
+            # not a stuck one, and only a pipe outliving its process is.
+            if ($null -eq $abandonAt) {
+                $abandonAt = (Get-Date).AddSeconds($script:StepDrainGraceSeconds)
+            } elseif ((Get-Date) -ge $abandonAt) {
+                $abandoned = $true
+                break
+            }
+        }
         Start-Sleep -Milliseconds 150
         if ($script:Ui) { [System.Windows.Forms.Application]::DoEvents() }
     }
-    $proc.WaitForExit()
-    $outText = $outTask.Result
-    $errText = $errTask.Result
+    # Bounded overload deliberately: the argument-less overload also waits on
+    # redirected streams, which is the very wait we just bounded. HasExited is
+    # already true here, so this call only settles ExitCode.
+    [void]$proc.WaitForExit(5000)
+    if ($abandoned) {
+        Write-HandoffLog ("{0}!| pipe drain abandoned after {1}s: '{0}' exited but a surviving descendant still holds its stdout/stderr handles. Continuing the hand-off with the output captured so far (#90455)." -f $Tag, $script:StepDrainGraceSeconds)
+    }
+    $outText = $outSink.ToString()
+    $errText = $errSink.ToString()
     foreach ($ln in ($outText -split "`r?`n")) {
         if ($ln.Trim()) { Write-HandoffLog ("{0}| {1}" -f $Tag, $ln) }
     }

--- a/tests/test_desktop_update_windows_pipe_drain.py
+++ b/tests/test_desktop_update_windows_pipe_drain.py
@@ -1,0 +1,193 @@
+"""Regression: the Windows Desktop update hand-off must not wait on pipe EOF.
+
+``scripts/desktop-update/windows.ps1`` runs each update step through
+``Invoke-HermesStep``, which starts the step with ``RedirectStandardOutput`` /
+``RedirectStandardError`` and used to collect its output with
+``ReadToEndAsync().Result``.
+
+``.Result`` on that task does not return when the *step* exits -- it returns
+when the *pipe* reaches EOF. On Windows the write end of a redirected pipe is
+handed to the child as an inheritable handle, so every descendant spawned
+without its own redirection holds a duplicate, and EOF waits for the last of
+them to close it. ``hermes update`` deliberately runs build steps with stdout
+inherited (the tee-stderr runner in ``hermes_cli/main.py``), so the process
+tree under a step is arbitrarily deep and not something the hand-off can
+enumerate. When one of those descendants is a resident gateway, the pipe never
+closes and ``Invoke-HermesStep`` blocks for the life of the gateway.
+
+Everything the hand-off owes the Desktop is downstream of that call:
+``.hermes-update-result.json`` is never written, ``.hermes-update-in-progress``
+is never cleared, and the Desktop is never relaunched -- so the app sits on
+"Updating Hermes" until the user kills the gateway by hand, and the stale
+marker then refuses the next update too (#90455).
+
+The fix drains both pipes in chunks into a ``StringBuilder`` and bounds the
+drain *after* the step has exited. The bound cannot truncate a slow step: the
+clock only starts once the process is gone, at which point everything it wrote
+is already sitting in the pipe buffer waiting to be read.
+
+The source-level guards below run on every host, because Linux CI cannot
+execute the PowerShell hand-off -- the same reason
+``test_desktop_update_windows_python_handoff.py`` is written that way. The
+``windows_only`` test at the bottom is the executable proof: it drives the
+script's own ``-SelfTestPipeDrain`` fixture, which builds a step whose
+grandchild outlives it holding the inherited handle.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WINDOWS_PS1 = REPO_ROOT / "scripts" / "desktop-update" / "windows.ps1"
+
+
+def _read() -> str:
+    return WINDOWS_PS1.read_text(encoding="utf-8")
+
+
+def _invoke_hermes_step_body() -> str:
+    """Return just the body of ``Invoke-HermesStep``.
+
+    Scoped deliberately: ``WaitForExit`` and ``.Result`` are legitimate
+    elsewhere in the script, so a whole-file grep would fire on unrelated
+    code.
+    """
+    source = _read()
+    start = source.find("function Invoke-HermesStep(")
+    assert start != -1, (
+        "Invoke-HermesStep no longer exists in "
+        "scripts/desktop-update/windows.ps1. The update hand-off structure "
+        "changed -- update this guard rather than deleting it."
+    )
+    end = source.find("\n}", start)
+    assert end != -1, "Could not find the end of Invoke-HermesStep."
+    return source[start:end]
+
+
+def test_step_drain_does_not_wait_for_pipe_eof() -> None:
+    body = _invoke_hermes_step_body()
+
+    assert "ReadToEndAsync" not in body, (
+        "Invoke-HermesStep must not collect step output with "
+        "ReadToEndAsync(): that task completes on pipe EOF, not on process "
+        "exit, so any surviving descendant holding the inherited write handle "
+        "(a resident gateway is the reported case) blocks the hand-off "
+        "forever. .Result also cannot hand back a partial read, so there is "
+        "no way to abandon it without losing the whole step's output. Read in "
+        "chunks into a StringBuilder instead (#90455)."
+    )
+
+
+def test_step_drain_is_bounded_once_the_step_has_exited() -> None:
+    body = _invoke_hermes_step_body()
+
+    assert "$script:StepDrainGraceSeconds" in body, (
+        "Invoke-HermesStep must bound how long it waits for the step's pipes "
+        "to reach EOF after the step process itself has exited (#90455)."
+    )
+    assert "HasExited" in body, (
+        "The drain bound must be keyed on the step having exited, so a slow "
+        "step is never mistaken for a stuck pipe."
+    )
+    assert re.search(r"\$abandonAt\s*=\s*\(Get-Date\)\.AddSeconds", body), (
+        "The abandon deadline must be armed from the moment the step exits, "
+        "not from when it started -- a long `uv pip install` is not a leaked "
+        "pipe (#90455)."
+    )
+
+
+def test_step_drain_does_not_use_the_stream_waiting_waitforexit() -> None:
+    body = _invoke_hermes_step_body()
+
+    assert not re.search(r"WaitForExit\(\s*\)", body), (
+        "The parameterless Process.WaitForExit() also waits on redirected "
+        "streams, which reintroduces exactly the unbounded pipe-EOF wait this "
+        "guard exists to prevent. Use the bounded WaitForExit(ms) overload "
+        "(#90455)."
+    )
+
+
+def test_abandoned_drain_is_reported_in_the_hand_off_log() -> None:
+    body = _invoke_hermes_step_body()
+
+    assert "pipe drain abandoned" in body, (
+        "Abandoning a step's pipes must leave a line in "
+        "logs/desktop-update-handoff.log. A silently truncated step log is "
+        "indistinguishable from a step that printed nothing, and that log is "
+        "what `hermes debug share` collects for update reports (#90455)."
+    )
+
+
+@pytest.mark.windows_only
+def test_pipe_drain_self_test_returns_while_a_descendant_holds_the_pipe(
+    tmp_path: Path,
+) -> None:
+    """Execute the real drain against a step that leaks its pipe handle.
+
+    ``-SelfTestPipeDrain`` starts a step which spawns a grandchild with
+    ``UseShellExecute = $false`` and no redirection -- the shape that makes the
+    grandchild inherit the step's stdout/stderr -- then exits 7 while the
+    grandchild sleeps on. The fixture asserts the grandchild was still alive
+    when ``Invoke-HermesStep`` returned, so a pass cannot be a timing
+    coincidence, and that both the exit code and the step's output survived the
+    abandonment.
+
+    Measured on Windows 11 / PowerShell 5.1: 4.3s with the fix, 47.4s (the
+    grandchild's full lifetime) with the previous drain restored.
+    """
+    system_root = Path(os.environ.get("SystemRoot", r"C:\Windows"))
+    powershell = (
+        system_root / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe"
+    )
+    if not powershell.is_file():
+        pytest.skip(f"Windows PowerShell not found at {powershell}")
+
+    env = {
+        **os.environ,
+        # The fixture writes its child script, pid file and hand-off log under
+        # TEMP; point that at tmp_path so the test leaves nothing behind.
+        "TEMP": str(tmp_path),
+        "TMP": str(tmp_path),
+        # Keep the test quick. The grace is what the fix bounds; the hold is
+        # how long the leaking grandchild lives. hold >> grace is what makes a
+        # regression measurable rather than lucky.
+        "HERMES_UPDATE_PIPE_DRAIN_SECONDS": "3",
+        "HERMES_SELFTEST_HOLD_SECONDS": "45",
+    }
+
+    result = subprocess.run(
+        [
+            str(powershell),
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(WINDOWS_PS1),
+            "-SelfTestPipeDrain",
+        ],
+        capture_output=True,
+        text=True,
+        # Comfortably past the 45s hold so a regression fails with the
+        # fixture's own diagnosis instead of an opaque timeout.
+        timeout=180,
+        env=env,
+        cwd=str(REPO_ROOT),
+    )
+
+    assert "PIPE-DRAIN SELF-TEST: PASS" in result.stdout, (
+        "Invoke-HermesStep did not return while a descendant still held its "
+        "stdout/stderr pipe. The Desktop update hand-off is deadlocked again "
+        f"(#90455).\n--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+    assert result.returncode == 0, (
+        f"-SelfTestPipeDrain exited {result.returncode}.\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )

--- a/tests/test_desktop_update_windows_python_handoff.py
+++ b/tests/test_desktop_update_windows_python_handoff.py
@@ -40,8 +40,24 @@ def _read() -> str:
     return WINDOWS_PS1.read_text(encoding="utf-8")
 
 
+def _handoff_source() -> str:
+    """The script with its ``-SelfTest*`` fixture blocks removed.
+
+    Those blocks exercise the hand-off machinery deliberately -- the pipe-drain
+    fixture runs a synthetic PowerShell step through ``Invoke-HermesStep`` to
+    prove the drain cannot deadlock (#90455) -- so they are not update steps
+    and the "must drive python.exe" rule does not apply to them. Each exits
+    before any marker/venv/desktop machinery runs.
+
+    Scoped here rather than allow-listing a target, so the rule stays absolute
+    for every real step. The non-greedy match ends at the first closing brace
+    in column 0; the blocks' own braces are all indented.
+    """
+    return re.sub(r"\nif \(\$SelfTest\w+\) \{.*?\n\}\n", "\n", _read(), flags=re.S)
+
+
 def test_invoke_hermes_step_calls_drive_python_not_the_shim() -> None:
-    source = _read()
+    source = _handoff_source()
 
     invocations = re.findall(r"Invoke-HermesStep\s+(\$\w+)", source)
     assert invocations, (


### PR DESCRIPTION
## What does this PR do?

`Invoke-HermesStep` in `scripts/desktop-update/windows.ps1` collected each update step's output with `ReadToEndAsync().Result`. That task does not complete when the **step** exits; it completes when the **pipe** reaches EOF. On Windows the write end of a redirected pipe is handed to the child as an *inheritable* handle, so every descendant spawned without its own redirection holds a duplicate, and EOF waits for the last of them to close it.

`hermes update` deliberately runs its build steps with stdout inherited (the tee-stderr runner in `hermes_cli/main.py`), so the process tree under a step is arbitrarily deep and not something this script can enumerate. When one of those descendants is a resident gateway, the pipe stays open for the life of the gateway.

Everything the hand-off owes the Desktop sits downstream of that one call: `.hermes-update-result.json` is never written, `.hermes-update-in-progress` is never cleared, and the Desktop is never relaunched. The app sits on "Updating Hermes" until the user kills the gateway by hand, and the stale marker then refuses the next update too.

**The fix:** drain both pipes in chunks into a `StringBuilder`, and bound the drain *after* the step process has exited.

The bound cannot truncate a slow step. The clock only starts once the process is gone, at which point everything it wrote is already sitting in the pipe buffer ready to read, so the grace only has to cover the final drain — a 40-minute `uv pip install` is untouched. Chunked reads are what make abandoning safe at all: `ReadToEndAsync().Result` cannot hand back a partial read, so there is no way to give up on it without losing the whole step's log.

### Why this layer, and one honest correction to the issue

The issue's suggested fix 1 is to stop the gateway inheriting the pipes. I went looking for that spawn site first and **could not find it** — worth saying plainly rather than leaving it implied. Every Windows gateway spawn on the update path already redirects:

| site | redirection |
|---|---|
| `gateway_windows._spawn_detached` | `stdin=DEVNULL`, `stdout`/`stderr` → `logs/gateway-stdio.log`, `close_fds=True` |
| `gateway._spawn_gateway_restart_watcher` (the watcher) | `stdout`/`stderr` `=DEVNULL` |
| the same watcher's inner respawn | `stdout`/`stderr` `=DEVNULL` |

So I cannot name the descendant that holds the handle in the reporter's tree, and I have not claimed to. What I can show is that the hand-off's *assumption* — "the step exited, therefore its pipes are closed" — is unsound by construction on Windows, and that the shim is the layer where that matters, because it is the layer holding the marker and the result file. A fix at this layer is correct for whichever descendant it turns out to be, including ones that do not exist yet.

Issue suggestion 3 (a stale-marker watchdog) is a real second layer of defence but a different change; not bundled here.

### The abandonment is visible

An abandoned drain writes one line to `logs/desktop-update-handoff.log` naming the cause. A silently truncated step log is indistinguishable from a step that printed nothing, and that log is what `hermes debug share` collects for update reports.

Also switched to the bounded `WaitForExit(ms)` overload: the argument-less one waits on redirected streams too, which is the same unbounded wait by another name.

## Related Issue

Fixes #90455

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**`scripts/desktop-update/windows.ps1`**

- `Invoke-HermesStep`: chunked `ReadAsync` into a `StringBuilder` for both pipes, with an abandon deadline armed at the step's exit (`$script:StepDrainGraceSeconds`, default 20s, overridable via `HERMES_UPDATE_PIPE_DRAIN_SECONDS` — used by the self-test, not documented as a user knob).
- New `Step-PipeDrain` helper: advances one pipe by whatever has already arrived, never blocks, reports EOF. A faulted read is treated as EOF rather than retried forever.
- Bounded `WaitForExit(5000)` in place of the argument-less overload.
- New `-SelfTestPipeDrain` switch beside the existing `-SelfTestUi`, exiting before any marker/venv/desktop machinery.

**`tests/test_desktop_update_windows_pipe_drain.py`** (new) — four source-level guards scoped to the `Invoke-HermesStep` body, plus the `windows_only` test that drives `-SelfTestPipeDrain`.

**`tests/test_desktop_update_windows_python_handoff.py`** — its "every step drives `python.exe`, never the `hermes.exe` shim" guard now reads the script with `-SelfTest*` blocks stripped. The pipe-drain fixture runs a synthetic *PowerShell* step through `Invoke-HermesStep`, and it is not an update step. Scoping the source that way rather than allow-listing a target keeps the rule absolute for every real step.

## How to Test

The deadlock needs no update, no checkout and no Hermes install — only a step whose grandchild outlives it holding the inherited write end. That is what `-SelfTestPipeDrain` builds:

```powershell
$env:HERMES_UPDATE_PIPE_DRAIN_SECONDS = "3"   # grace
$env:HERMES_SELFTEST_HOLD_SECONDS     = "45"  # how long the leaking grandchild lives
powershell -NoProfile -ExecutionPolicy Bypass -File scripts\desktop-update\windows.ps1 -SelfTestPipeDrain
```

The fixture asserts the grandchild was **still alive** when `Invoke-HermesStep` returned — so a pass cannot be a timing coincidence — and that the exit code (7) and the step's output both survived.

On Windows 11 / PowerShell 5.1:

```
# with this PR
pipedrain!| pipe drain abandoned after 3s: 'pipedrain' exited but a surviving
           descendant still holds its stdout/stderr handles. Continuing the
           hand-off with the output captured so far (#90455).
pipedrain| pipe-drain step output
PIPE-DRAIN SELF-TEST: PASS elapsed=4.31s budget=33s code=7 grandchildAlive=True

# same fixture, previous drain restored
pipedrain| pipe-drain step output
PIPE-DRAIN SELF-TEST: FAIL elapsed=47.44s budget=33s code=7 grandchildAlive=False
  -- handle-holding grandchild was not alive on return; returned in 47.44s
```

47.4s is the grandchild's full 45s lifetime plus startup: the pre-fix drain waited out the leak exactly, which is the bug at 45-second scale. Note both runs preserve the exit code and the step's output — the fix costs nothing on the happy path.

Then:

```
pytest tests/test_desktop_update_windows_pipe_drain.py -q      # 5 passed on Windows
pytest tests/test_desktop_update_*.py -q                       # 14 passed, 2 skipped
```

All four source guards fail against the previous drain, and the `windows_only` test fails with the FAIL line above, so none of them are decoration.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **partially**: I ran the affected suite (`tests/test_desktop_update_*.py`, 14 passed / 2 skipped) rather than the whole tree, which has a pre-existing Windows-local failure baseline unrelated to this change. Linux CI is the authority for the full run; the `windows_only` lane is the authority for the new executable test.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro 26200, Windows PowerShell 5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the reasoning lives in comments in the touched function and in the new test's module docstring; no user-facing docs change (the env var is a test seam, not a knob)
- [x] N/A — `cli-config.yaml.example`
- [x] N/A — `CONTRIBUTING.md` / `AGENTS.md`
- [x] I've considered cross-platform impact: the file is Windows-only and unreferenced elsewhere; `scripts/desktop-update/posix.sh` is untouched. The new test's behavioural half is `windows_only`; its source-level half runs everywhere and only reads the script.
- [x] N/A — tool descriptions/schemas

## Screenshots / Logs

Included inline under **How to Test** above.
