### PR TITLE
fix(mcp): persist spillover text without envelope

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -1,5 +1,7 @@
 """Tests for tools/tool_result_storage.py -- 3-layer tool result persistence."""
 
+import json
+
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -183,7 +185,6 @@ class TestMaybePersistToolResult:
 
     def test_persists_full_content_as_is(self):
         """Content is persisted verbatim — no JSON extraction."""
-        import json
         env = MagicMock()
         # Readability probe fails -> falls back to the in-sandbox write.
         env.execute.side_effect = [
@@ -277,6 +278,23 @@ class TestEnforceTurnBudget:
         )
         assert persisted_count >= 2  # Need to shed at least ~52K
 
+    def test_budget_spill_extracts_mcp_text(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        markdown = "# Archive\n\n" + "one page\n" * 4_000
+        envelope = json.dumps({"result": markdown})
+        msgs = [{
+            "role": "tool",
+            "name": "mcp__archive__read",
+            "tool_call_id": "tc_budget_mcp",
+            "content": envelope,
+        }]
+
+        enforce_turn_budget(msgs, env=None, config=BudgetConfig(turn_budget=10_000))
+
+        assert PERSISTED_OUTPUT_TAG in msgs[0]["content"]
+        spill_file = get_spillover_dir() / "tc_budget_mcp.txt"
+        assert spill_file.read_text(encoding="utf-8") == markdown
+
 
     def test_empty_messages(self):
         result = enforce_turn_budget([], env=None, config=BudgetConfig(turn_budget=200_000))
@@ -344,6 +362,63 @@ class TestSpillover:
         assert spill_file.exists()
         assert spill_file.read_text(encoding="utf-8") == content
         assert str(spill_file) in result
+
+    def test_mcp_envelope_persists_plain_text(self):
+        markdown = "# Research guide\n\n" + "pageable content\n" * 4_000
+        content = json.dumps({
+            "result": markdown,
+            "structuredContent": {"result": markdown},
+        })
+
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="mcp__archive__read_guide",
+            tool_use_id="tc_mcp_text",
+            env=None,
+            threshold=30_000,
+        )
+
+        spill_file = get_spillover_dir() / "tc_mcp_text.txt"
+        assert PERSISTED_OUTPUT_TAG in result
+        assert "# Research guide" in result
+        assert spill_file.read_text(encoding="utf-8") == markdown
+
+    def test_mcp_content_blocks_are_joined_as_plain_text(self):
+        first = "first section\n" * 2_000
+        second = "second section\n" * 2_000
+        content = json.dumps({
+            "content": [
+                {"type": "text", "text": first},
+                {"type": "image", "data": "ignored"},
+                {"type": "text", "text": second},
+            ],
+        })
+
+        maybe_persist_tool_result(
+            content=content,
+            tool_name="mcp__archive__read_sections",
+            tool_use_id="tc_mcp_blocks",
+            env=None,
+            threshold=30_000,
+        )
+
+        spill_file = get_spillover_dir() / "tc_mcp_blocks.txt"
+        assert spill_file.read_text(encoding="utf-8") == f"{first}\n{second}"
+
+    def test_non_mcp_json_envelope_remains_verbatim(self):
+        text = "ordinary tool output\n" * 3_000
+        content = json.dumps({"result": text})
+
+        maybe_persist_tool_result(
+            content=content,
+            tool_name="custom_json_tool",
+            tool_use_id="tc_json_envelope",
+            env=None,
+            threshold=30_000,
+        )
+
+        spill_file = get_spillover_dir() / "tc_json_envelope.txt"
+        assert spill_file.read_text(encoding="utf-8") == content
 
     def test_local_env_persists_to_spillover_not_sandbox(self):
         """LocalEnvironment routes host-side: no env.execute() shell-out."""

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -420,6 +420,20 @@ class TestSpillover:
         spill_file = get_spillover_dir() / "tc_json_envelope.txt"
         assert spill_file.read_text(encoding="utf-8") == content
 
+    def test_unrecognized_mcp_json_remains_verbatim(self):
+        content = json.dumps({"other": "opaque value\n" * 3_000})
+
+        maybe_persist_tool_result(
+            content=content,
+            tool_name="mcp__archive__opaque",
+            tool_use_id="tc_mcp_opaque",
+            env=None,
+            threshold=30_000,
+        )
+
+        spill_file = get_spillover_dir() / "tc_mcp_opaque.txt"
+        assert spill_file.read_text(encoding="utf-8") == content
+
     def test_local_env_persists_to_spillover_not_sandbox(self):
         """LocalEnvironment routes host-side: no env.execute() shell-out."""
         from tools.environments.local import LocalEnvironment

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -6,6 +6,7 @@ ran a terminal), remote backends get the translated in-sandbox path (probed for 
 else a copy in the sandbox temp dir; (3) ``enforce_turn_budget``."""
 
 import hashlib
+import json
 import logging
 import os
 import re
@@ -22,6 +23,7 @@ STORAGE_DIR = "/tmp/hermes-results"
 SPILLOVER_SUBDIR = "cache/spillover"
 SPILLOVER_MAX_AGE_HOURS = 24
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
+_MCP_TOOL_NAME_PREFIX = "mcp__"
 _UNSAFE_RESULT_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9_.-]+")
 _MAX_RESULT_FILENAME_STEM = 120
 
@@ -154,6 +156,46 @@ def generate_preview(content: str, max_chars: int = DEFAULT_PREVIEW_SIZE_CHARS) 
     return content[:last_nl + 1 if last_nl > max_chars // 2 else max_chars], True
 
 
+def _content_for_persistence(content: str, tool_name: str) -> str:
+    """Extract model-facing text from an MCP result envelope.
+
+    MCP handlers return a JSON string so structured metadata remains available
+    inline.  Persisting that string verbatim turns newlines in a large text
+    result into escapes on one giant line.  Only unwrap registered MCP tools;
+    JSON returned by every other tool remains opaque.
+    """
+    if not tool_name.startswith(_MCP_TOOL_NAME_PREFIX):
+        return content
+
+    try:
+        payload = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        return content
+    if not isinstance(payload, dict):
+        return content
+
+    result = payload.get("result")
+    if isinstance(result, str) and result:
+        return result
+
+    content_blocks = payload.get("content")
+    if content_blocks is None and isinstance(result, dict):
+        content_blocks = result.get("content")
+    if isinstance(content_blocks, list):
+        text_parts = [
+            block["text"]
+            for block in content_blocks
+            if isinstance(block, dict)
+            and block.get("type") == "text"
+            and isinstance(block.get("text"), str)
+            and block["text"]
+        ]
+        if text_parts:
+            return "\n".join(text_parts)
+
+    return content
+
+
 def _write_to_sandbox(content: str, remote_path: str, env) -> bool:
     """Write content into the sandbox via env.execute(); True on success. Content goes through
     stdin, not the command string: Linux ``MAX_ARG_STRLEN`` caps one argv element at 128 KB,
@@ -202,16 +244,18 @@ def maybe_persist_tool_result(content: str, tool_name: str, tool_use_id: str, en
         threshold = config.resolve_threshold(tool_name)
     if threshold == float("inf") or len(content) <= threshold:
         return content
+
+    persisted_content = _content_for_persistence(content, tool_name)
     filename = _safe_result_filename(tool_use_id)
-    preview, has_more = generate_preview(content, max_chars=config.preview_size)
+    preview, has_more = generate_preview(persisted_content, max_chars=config.preview_size)
 
     def _persisted(path: str, host_suffix: str = "") -> str:
         logger.info("Persisted large tool result: %s (%s, %d chars -> %s%s)",
-                    tool_name, tool_use_id, len(content), path, host_suffix)
-        return _build_persisted_message(preview, has_more, len(content), path)
+                    tool_name, tool_use_id, len(persisted_content), path, host_suffix)
+        return _build_persisted_message(preview, has_more, len(persisted_content), path)
 
     # Always persist host-side first: cache/spillover is the single canonical home.
-    host_path = _write_to_spillover(content, filename)
+    host_path = _write_to_spillover(persisted_content, filename)
     host_side = _is_host_side_env(env)
     if host_side and host_path is not None:
         return _persisted(host_path)
@@ -223,7 +267,7 @@ def maybe_persist_tool_result(content: str, tool_name: str, tool_use_id: str, en
             return _persisted(visible, f" [host: {host_path}]")
         remote_path = f"{_resolve_storage_dir(env)}/{filename}"
         try:
-            if _write_to_sandbox(content, remote_path, env):
+            if _write_to_sandbox(persisted_content, remote_path, env):
                 return _persisted(remote_path)
         except Exception as exc:
             logger.warning("Sandbox write failed for %s: %s", tool_use_id, exc)
@@ -249,8 +293,13 @@ def enforce_turn_budget(tool_messages: list[dict], env=None,
         content = tool_messages[idx]["content"]
         tool_use_id = tool_messages[idx].get("tool_call_id", f"budget_{idx}")
         replacement = maybe_persist_tool_result(
-            content=content, tool_name=_BUDGET_TOOL_NAME, tool_use_id=tool_use_id,
-            env=env, config=config, threshold=0)
+            content=content,
+            tool_name=tool_messages[idx].get("name") or _BUDGET_TOOL_NAME,
+            tool_use_id=tool_use_id,
+            env=env,
+            config=config,
+            threshold=0,
+        )
         if replacement != content:
             total_size += len(replacement) - size
             tool_messages[idx]["content"] = replacement

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -162,7 +162,10 @@ def _content_for_persistence(content: str, tool_name: str) -> str:
     MCP handlers return a JSON string so structured metadata remains available
     inline.  Persisting that string verbatim turns newlines in a large text
     result into escapes on one giant line.  Only unwrap registered MCP tools;
-    JSON returned by every other tool remains opaque.
+    JSON returned by every other tool remains opaque.  Spill files and their
+    previews intentionally contain the extracted model-facing text rather than
+    the original MCP envelope, even when that text is itself serialized JSON.
+    MCP payloads without a recognized text shape remain verbatim.
     """
     if not tool_name.startswith(_MCP_TOOL_NAME_PREFIX):
         return content


### PR DESCRIPTION
## What does this PR do?

Large MCP results are returned as JSON envelopes so inline callers retain structured metadata. When spillover persistence wrote that envelope verbatim, the actual text became a single JSON line with escaped newlines, making `read_file` pagination unusable.

This change keeps the existing size decision and inline behavior, but after an MCP result crosses the persistence threshold it extracts the model-facing string `result` (or joins text `content` blocks) for the preview and spill file. Non-MCP JSON remains opaque and unchanged. Aggregate per-turn spilling now preserves the message's tool name so the same normalization applies there.

## Related Issue

Fixes #90426

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Extract pageable text from oversized MCP result envelopes before host or sandbox persistence.
- Preserve structured/non-text envelopes when no usable text exists, and leave all non-MCP results verbatim.
- Apply the same behavior when aggregate turn-budget enforcement triggers persistence.
- Add regressions for string results, text content blocks, non-MCP JSON, and aggregate-budget spills.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_tool_result_storage.py tests/tools/test_mcp_structured_content.py -q`.
2. Call an MCP tool returning more than its inline threshold with multiline text.
3. Confirm the referenced spillover file contains plain text with real newlines rather than a one-line JSON envelope.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (50 targeted tests passed through `scripts/run_tests.sh`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `tests/tools/test_tool_result_storage.py`: 39 passed
- `tests/tools/test_mcp_structured_content.py`: 11 passed
- Ruff: passed on both changed files
- `git diff --check`: passed