### PR TITLE
docs(computer-use): screenshot delivery on chat surfaces is now documented (#90183 follow-up)

### DIFF
--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -284,6 +284,23 @@ the model substitutes the platform's idiomatic shortcut and app name):
 During all of this, your cursor stays wherever you left it and the email
 app never comes to front.
 
+## Receiving the actual screenshot
+
+Screenshots taken during computer control are normally internal — they exist
+so the model can see the screen, and the agent replies in text. But every
+image capture also saves a bounded, shareable copy under Hermes' image cache
+and reports its path, so on attachment-capable surfaces (Telegram, Discord,
+Desktop, and other gateway platforms) you can simply ask:
+
+> *"Send me a screenshot of my screen."*
+
+and the agent delivers the real image as a native attachment, not just a
+description. On the CLI there is no attachment channel, so the agent gives
+you the saved file's path instead.
+
+Only the 20 most recent capture files are kept, and screenshots are never
+sent automatically — only when you ask for one.
+
 ## Provider compatibility
 
 | Provider | Vision? | Works? | Notes |


### PR DESCRIPTION
## Summary
Documents the new computer_use screenshot-delivery behavior shipped in #90183: users on attachment-capable surfaces (Telegram, Discord, Desktop) can now ask Hermes to send the actual screenshot image, not just a text description.

## Changes
- `website/docs/user-guide/features/computer-use.md`: new "Receiving the actual screenshot" section — how to ask for the image, the bounded 20-file cache under `cache/images`, CLI path-only behavior, and the no-automatic-send rule.

## Validation
| | Before | After |
|---|---|---|
| Docs coverage of #90183 | none | dedicated section on the feature page |

## Infographic

![PR infographic](https://files.catbox.moe/szu7y8.png)
