### PR TITLE
fix(desktop): collapsed/floating sidebars get their solid background back under glass

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.tsx
@@ -150,6 +150,10 @@ export function NarrowOverlays() {
               ? 'left-0 border-r border-(--ui-stroke-secondary)'
               : 'right-0 border-l border-(--ui-stroke-secondary)'
           )}
+          // Floats OVER the layout, so under glass its surface must mask the
+          // panes beneath it — a see-through overlay reads as text bleeding
+          // through text. Contract: `[data-glass-opaque]` in styles.css.
+          data-glass-opaque=""
           onMouseLeave={() => setReveal(current => (current?.pinned ? current : null))}
           // Match the pane's docked width (sessions ~237px, files its rail
           // width) instead of a fat fixed 20rem — capped for tiny screens.


### PR DESCRIPTION
## Summary
- With glass translucency on, the narrow-viewport floating sidebar overlays (sessions, bots, files, review — anything collapsible revealed via hover or ⌘B/⌘G) rendered see-through: the glass block turns `--ui-sidebar-surface-background` transparent at `:root`, so a surface floating *over* other panes bled their content through.
- The overlay now declares `data-glass-opaque` at its call site — the existing contract for surfaces that mask siblings (same as the diff gutter and dragged sidebar rows) — which restores the opaque sidebar fill while glass is active.
- Inert with glass off: the token already resolves opaque there, so non-glass users see zero change.

## Test plan
- [ ] Glass on → collapse a sidebar on a narrow viewport → hover the edge / ⌘B: overlay paints solid, no pane text bleeding through
- [ ] Repeat for a right-side pane (files/review) and a zone with tabs (SESSIONS | BOTS)
- [ ] Glass off: overlay looks identical to before