### PR TITLE
fix(process_registry): make _worker_memory_max_bytes cross-platform and handle missing os.sysconf on Windows

### DIFF
--- a/tests/tools/test_process_registry_memory_crossplatform.py
+++ b/tests/tools/test_process_registry_memory_crossplatform.py
@@ -1,0 +1,56 @@
+"""Tests for cross-platform memory bound detection in tools/process_registry.py."""
+
+import os
+import sys
+import pytest
+from unittest.mock import patch, MagicMock
+
+import tools.process_registry as pr
+
+
+def test_worker_memory_max_bytes_runs_without_raising():
+    """_worker_memory_max_bytes should execute cleanly across all platforms."""
+    bound = pr._worker_memory_max_bytes()
+    assert isinstance(bound, int)
+    assert bound >= pr._MIN_WORKER_MEMORY_MAX_BYTES
+    assert bound <= pr._WORKER_MEMORY_MAX_CAP_BYTES
+
+
+def test_worker_memory_max_bytes_windows_attribute_error_handling(monkeypatch):
+    """When os.sysconf does not exist (AttributeError) and psutil fails, fallback gracefully."""
+    # Ensure cgroup is ignored
+    monkeypatch.setattr(
+        pr.Path,
+        "read_text",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("no cgroup")),
+    )
+    
+    # Simulate missing sysconf attribute on os
+    if hasattr(os, "sysconf"):
+        monkeypatch.delattr(os, "sysconf")
+
+    # Simulate psutil raising ImportError
+    with patch.dict("sys.modules", {"psutil": None}):
+        bound = pr._worker_memory_max_bytes()
+        assert bound == pr._DEFAULT_WORKER_MEMORY_MAX_BYTES
+
+
+def test_worker_memory_max_bytes_psutil_fallback(monkeypatch):
+    """When sysconf is absent, psutil should be used to compute physical memory."""
+    # Ensure cgroup is ignored
+    monkeypatch.setattr(
+        pr.Path,
+        "read_text",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("no cgroup")),
+    )
+    
+    if hasattr(os, "sysconf"):
+        monkeypatch.delattr(os, "sysconf")
+
+    fake_memory = MagicMock()
+    fake_memory.total = 4 * 1024 * 1024 * 1024  # 4 GiB
+    
+    with patch("psutil.virtual_memory", return_value=fake_memory):
+        bound = pr._worker_memory_max_bytes()
+        # 4 GiB // 2 = 2 GiB
+        assert bound == 2 * 1024 * 1024 * 1024

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -152,15 +152,19 @@ def _worker_memory_max_bytes() -> int:
         pass
 
     try:
-        physical_bytes = int(os.sysconf("SC_PHYS_PAGES")) * int(
-            os.sysconf("SC_PAGE_SIZE")
-        )
+        if hasattr(os, "sysconf"):
+            physical_bytes = int(os.sysconf("SC_PHYS_PAGES")) * int(
+                os.sysconf("SC_PAGE_SIZE")
+            )
+        else:
+            import psutil
+            physical_bytes = int(psutil.virtual_memory().total)
         physical_bound = min(
             _WORKER_MEMORY_MAX_CAP_BYTES,
             max(_MIN_WORKER_MEMORY_MAX_BYTES, physical_bytes // 2),
         )
         candidates.append(physical_bound)
-    except (OSError, ValueError, TypeError):
+    except (OSError, ValueError, TypeError, AttributeError, ImportError):
         pass
 
     safe_bound = min(candidates) if candidates else _DEFAULT_WORKER_MEMORY_MAX_BYTES

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -151,21 +151,34 @@ def _worker_memory_max_bytes() -> int:
     except (OSError, ValueError):
         pass
 
-    try:
-        if hasattr(os, "sysconf"):
-            physical_bytes = int(os.sysconf("SC_PHYS_PAGES")) * int(
-                os.sysconf("SC_PAGE_SIZE")
-            )
-        else:
+    physical_bytes = None
+    if hasattr(os, "sysconf"):
+        try:
+            pages = int(os.sysconf("SC_PHYS_PAGES"))
+            page_size = int(os.sysconf("SC_PAGE_SIZE"))
+            if pages > 0 and page_size > 0:
+                physical_bytes = pages * page_size
+        except (OSError, ValueError, TypeError, AttributeError):
+            pass
+
+    if physical_bytes is None:
+        try:
             import psutil
-            physical_bytes = int(psutil.virtual_memory().total)
-        physical_bound = min(
-            _WORKER_MEMORY_MAX_CAP_BYTES,
-            max(_MIN_WORKER_MEMORY_MAX_BYTES, physical_bytes // 2),
-        )
-        candidates.append(physical_bound)
-    except (OSError, ValueError, TypeError, AttributeError, ImportError):
-        pass
+            total = int(psutil.virtual_memory().total)
+            if total > 0:
+                physical_bytes = total
+        except (OSError, ValueError, TypeError, AttributeError, ImportError):
+            pass
+
+    if physical_bytes is not None:
+        try:
+            physical_bound = min(
+                _WORKER_MEMORY_MAX_CAP_BYTES,
+                max(_MIN_WORKER_MEMORY_MAX_BYTES, physical_bytes // 2),
+            )
+            candidates.append(physical_bound)
+        except (ValueError, TypeError):
+            pass
 
     safe_bound = min(candidates) if candidates else _DEFAULT_WORKER_MEMORY_MAX_BYTES
     return min(override_bound, safe_bound) if override_bound else safe_bound


### PR DESCRIPTION
## What does this PR do?

Makes `_worker_memory_max_bytes()` in `tools/process_registry.py` cross-platform and prevents unhandled `AttributeError: module 'os' has no attribute 'sysconf'` on Windows. On platforms lacking `sysconf`, it queries host physical memory using `psutil.virtual_memory().total` with a resilient fallback to `_DEFAULT_WORKER_MEMORY_MAX_BYTES`.

## Related Issue

Fixes #90570

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/process_registry.py`:
  - Added `hasattr(os, "sysconf")` check before calling `os.sysconf`.
  - Added fallback to `psutil.virtual_memory().total` on Windows and platforms without `os.sysconf`.
  - Extended caught exceptions to `(OSError, ValueError, TypeError, AttributeError, ImportError)` to safely handle any OS-level missing attribute or import failures.
- `tests/tools/test_process_registry_memory_crossplatform.py`:
  - Added unit test suite validating execution on all platforms, `AttributeError` handling, and `psutil` memory calculation.

## How to Test

1. Run `pytest tests/tools/test_process_registry_memory_crossplatform.py -v` (all 3 tests pass).
2. Run on Windows: `python -c "from tools.process_registry import _worker_memory_max_bytes; print(_worker_memory_max_bytes())"` (executes cleanly without crash).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
