### PR TITLE
fix(desktop): preserve remote POSIX preview paths

### DIFF
--- a/apps/desktop/src/lib/local-preview.test.ts
+++ b/apps/desktop/src/lib/local-preview.test.ts
@@ -37,11 +37,73 @@ describe('remote HTML previews', () => {
     const dataUrl = `data:text/html;base64,${btoa('<h1>remote</h1>')}`
     readDesktopFileDataUrl.mockResolvedValue(dataUrl)
 
-    await expect(normalizeOrLocalPreviewTarget('/srv/report.html')).resolves.toEqual({
+    await expect(normalizeOrLocalPreviewTarget('/srv/report.html')).resolves.toMatchObject({
       ...remoteTarget,
       dataUrl
     })
     expect(readDesktopFileDataUrl).toHaveBeenCalledWith('/srv/report.html')
+  })
+
+  it('keeps remote POSIX paths out of the Windows preview normalizer', async () => {
+    const normalizePreviewTarget = vi.fn(async () => ({
+      ...remoteTarget,
+      path: '\\\\wsl.localhost\\Ubuntu-20.04\\srv\\report.html',
+      url: 'file://wsl.localhost/Ubuntu-20.04/srv/report.html'
+    }))
+
+    window.hermesDesktop = { normalizePreviewTarget } as never
+    readDesktopFileDataUrl.mockResolvedValue(`data:text/html;base64,${btoa('<h1>remote</h1>')}`)
+
+    await expect(normalizeOrLocalPreviewTarget('/srv/report.html')).resolves.toMatchObject({
+      path: '/srv/report.html',
+      url: 'file:///srv/report.html'
+    })
+    expect(normalizePreviewTarget).not.toHaveBeenCalled()
+    expect(readDesktopFileDataUrl).toHaveBeenCalledWith('/srv/report.html')
+  })
+
+  it('resolves relative remote paths against a POSIX gateway cwd', async () => {
+    const normalizePreviewTarget = vi.fn(async () => remoteTarget)
+
+    window.hermesDesktop = { normalizePreviewTarget } as never
+    readDesktopFileDataUrl.mockResolvedValue(`data:text/html;base64,${btoa('<h1>remote</h1>')}`)
+
+    await expect(normalizeOrLocalPreviewTarget('report.html', '/srv')).resolves.toMatchObject({
+      path: '/srv/report.html',
+      url: 'file:///srv/report.html'
+    })
+    expect(normalizePreviewTarget).not.toHaveBeenCalled()
+    expect(readDesktopFileDataUrl).toHaveBeenCalledWith('/srv/report.html')
+  })
+
+  it('keeps remote POSIX file URLs out of the local normalizer', async () => {
+    const normalizePreviewTarget = vi.fn(async () => remoteTarget)
+
+    window.hermesDesktop = { normalizePreviewTarget } as never
+    readDesktopFileDataUrl.mockResolvedValue(`data:text/html;base64,${btoa('<h1>remote</h1>')}`)
+
+    await expect(normalizeOrLocalPreviewTarget('file:///srv/report.html')).resolves.toMatchObject({
+      path: '/srv/report.html',
+      url: 'file:///srv/report.html'
+    })
+    expect(normalizePreviewTarget).not.toHaveBeenCalled()
+    expect(readDesktopFileDataUrl).toHaveBeenCalledWith('/srv/report.html')
+  })
+
+  it.each([
+    ['https://example.test/report.html', '/srv'],
+    ['\\\\server\\share\\report.html', '/srv'],
+    ['file://server/share/report.html', '/srv'],
+    ['C:\\reports\\report.html', '/srv']
+  ])('leaves non-POSIX target %s to the Electron normalizer', async (target, cwd) => {
+    const normalizePreviewTarget = vi.fn(async () => remoteTarget)
+
+    window.hermesDesktop = { normalizePreviewTarget } as never
+    readDesktopFileDataUrl.mockResolvedValue(`data:text/html;base64,${btoa('<h1>remote</h1>')}`)
+
+    await normalizeOrLocalPreviewTarget(target, cwd)
+
+    expect(normalizePreviewTarget).toHaveBeenCalledWith(target, cwd)
   })
 
   it('falls back to source mode when the transport is not canonical HTML', async () => {

--- a/apps/desktop/src/lib/local-preview.ts
+++ b/apps/desktop/src/lib/local-preview.ts
@@ -64,6 +64,27 @@ function joinPath(base: string, rel: string) {
   return `${base.replace(/\/+$/, '')}/${rel.replace(/^\.?\//, '')}`
 }
 
+function isRemotePosixPreviewTarget(rawTarget: string, cwd?: string | null) {
+  const raw = rawTarget.trim().replace(/^`|`$/g, '')
+
+  if (raw.startsWith('/')) {
+    return true
+  }
+
+  if (/^file:\/\//i.test(raw)) {
+    try {
+      const url = new URL(raw)
+      const path = decodeURIComponent(url.pathname)
+
+      return !url.host && path.startsWith('/') && !/^\/[a-z]:\//i.test(path)
+    } catch {
+      return false
+    }
+  }
+
+  return Boolean(cwd?.trim().startsWith('/')) && !/^[a-z][a-z\d+.-]*:/i.test(raw) && !raw.startsWith('\\')
+}
+
 function pathToFileUrl(path: string) {
   const isWindowsUnc = path.startsWith('\\\\')
   const normalized = isWindowsUnc || /^[a-z]:[\\/]/i.test(path) ? path.replace(/\\/g, '/') : path
@@ -261,6 +282,12 @@ export async function normalizeOrLocalPreviewTarget(
   rawTarget: string,
   cwd?: string | null
 ): Promise<PreviewTarget | null> {
+  // POSIX paths in remote mode belong to the gateway host. Resolve them in the
+  // renderer so the local Electron process cannot rewrite them as local paths.
+  if (isDesktopFsRemoteMode() && isRemotePosixPreviewTarget(rawTarget, cwd)) {
+    return enrichPreviewTarget(localPreviewTarget(rawTarget, cwd))
+  }
+
   try {
     const normalized = await window.hermesDesktop?.normalizePreviewTarget?.(rawTarget, cwd || undefined)
 


### PR DESCRIPTION
## What does this PR do?

Remote gateways own their filesystem paths, but Hermes Desktop still sent remote POSIX preview paths through the local Electron normalizer. On Windows, that could rewrite a gateway path such as `/srv/report.html` into a local WSL UNC path before the renderer asked the remote filesystem API to read it.

This change keeps remote POSIX paths under gateway authority. Absolute paths, `file:///` URLs, and relative targets with a POSIX gateway cwd are classified in the renderer, while HTTP(S), UNC, and Windows drive paths retain the existing Electron normalization path.

## Related Issue

No matching issue found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `apps/desktop/src/lib/local-preview.ts` to identify remote POSIX preview targets before invoking the local Electron bridge.
- Cover absolute POSIX paths, POSIX file URLs, and relative paths resolved against a POSIX gateway cwd.
- Preserve the existing normalizer path for HTTP(S), UNC, and Windows drive targets.
- Add behavior tests proving that remote filesystem reads receive the canonical gateway path.

## How to Test

1. Run `cd apps/desktop && npx vitest run src/lib/local-preview.test.ts`.
2. Run `cd apps/desktop && npm run typecheck`.
3. Run `cd apps/desktop && npx eslint src/lib/local-preview.ts src/lib/local-preview.test.ts`.
4. Run `cd apps/desktop && npm run check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] Python test suite is N/A for this Desktop TypeScript-only change; the Desktop checks above pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] Windows Desktop with a remote POSIX gateway was not available for a manual E2E run

### Documentation & Housekeeping

- [x] Documentation update is N/A; behavior and architecture are unchanged
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` updates are N/A; no workflow or architecture changed
- [x] I've considered cross-platform impact; URL, UNC, Windows drive, and POSIX paths have explicit behavior tests
- [x] Tool description/schema updates are N/A; no tools changed

## Screenshots / Logs

Not applicable; this is a path-routing fix covered by automated tests.
