### PR TITLE
fix(tools): catch absent-sysconf AttributeError in the worker memory bound

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2142,6 +2142,26 @@ class TestSystemdCgroupIsolation:
 
         assert pr._worker_memory_max_bytes() == pr._DEFAULT_WORKER_MEMORY_MAX_BYTES
 
+    def test_worker_memory_limit_falls_back_when_sysconf_missing(
+        self, monkeypatch
+    ):
+        """#90570: on Windows os.sysconf doesn't exist at all, so the
+        attribute lookup itself raises AttributeError — the "sysconf
+        unavailable" shape. The fail-soft contract must hold for that form
+        too: fall back to the default bound, never raise."""
+        import tools.process_registry as pr
+
+        monkeypatch.setattr(
+            pr.Path,
+            "read_text",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("no cgroup")),
+        )
+        # Simulate the absent attribute (Windows) rather than a raising
+        # callable — monkeypatch.delattr on the module restores after.
+        monkeypatch.delattr(pr.os, "sysconf", raising=False)
+
+        assert pr._worker_memory_max_bytes() == pr._DEFAULT_WORKER_MEMORY_MAX_BYTES
+
     def test_kill_recovered_detached_already_exited_stops_persisted_scope(
         self, registry, monkeypatch
     ):

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -160,7 +160,10 @@ def _worker_memory_max_bytes() -> int:
             max(_MIN_WORKER_MEMORY_MAX_BYTES, physical_bytes // 2),
         )
         candidates.append(physical_bound)
-    except (OSError, ValueError, TypeError):
+    except (OSError, ValueError, TypeError, AttributeError):
+        # AttributeError is the Windows/absent-sysconf shape: os.sysconf
+        # itself doesn't exist there, and "sysconf unavailable" is exactly
+        # the fail-soft case this handler exists for (#90570).
         pass
 
     safe_bound = min(candidates) if candidates else _DEFAULT_WORKER_MEMORY_MAX_BYTES


### PR DESCRIPTION
## What does this PR do?

`_worker_memory_max_bytes()` in `tools/process_registry.py` opportunistically collects per-worker memory bounds and is designed to fail soft: when a source is unavailable it silently falls back to the default bound. But the physical-RAM branch's handler `except (OSError, ValueError, TypeError)` misses the Windows shape of "sysconf unavailable" — on Windows `os.sysconf` does not exist at all, so the attribute lookup itself raises `AttributeError`, which escapes the handler and crashes the caller (#90570). This PR adds `AttributeError` to the tuple so the function honors its own fail-soft contract.

Impact scope, stated honestly: both in-repo call sites are already Windows-guarded (the systemd scope probe short-circuits on `_IS_WINDOWS`, and the argv builder bails when `shutil.which("systemd-run")` returns None), so the crash today only affects direct calls, tests, and any future unguarded caller — the fix is contract repair plus future-proofing, not a live user-facing crash. The reporter's psutil suggestion is deliberately not taken: nothing on Windows consumes the physical-memory bound (systemd scopes are not used there), so a platform-specific query path would be dead code.

## Related Issue

Fixes #90570

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/process_registry.py` — physical-RAM branch handler extended with `AttributeError` (the absent-sysconf shape), with a comment naming the Windows case
- `tests/tools/test_process_registry.py` — regression test `test_worker_memory_limit_falls_back_when_sysconf_missing`: simulates the absent attribute via `monkeypatch.delattr(os, "sysconf")` and asserts the default bound is returned without raising, mirroring the existing OSError-shape test

## How to Test

1. `python -m pytest tests/tools/test_process_registry.py -q -k worker_memory` — should pass (3 passed: oversized-override, sysconf-raising-OSError, sysconf-absent-AttributeError)
2. Observed result: with the fix stashed, the new test fails with `AttributeError: module 'os' has no attribute 'sysconf'`; with the fix, all three pass
3. Full file comparison on this host: the 13 failures in the suite reproduce identically on clean upstream/main (systemd/cgroup-probe tests that cannot pass on macOS); the diff between branch and main failure lists is empty

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (handler comment names the Windows shape)
- [x] Tests added that prove the fix is effective or prevent regression
- [x] All new and existing tests pass locally (worker-memory tests 3/3; suite delta vs main is zero)
- [x] Platform: macOS (the fixed branch is Windows-specific behavior, verified via attribute-absence simulation per the issue's verification note)
