### PR TITLE
fix(auth): a suppressed source must stay suppressed inside a profile

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1017,10 +1017,50 @@ def suppress_credential_source(provider_id: str, source: str) -> None:
         _save_auth_store(auth_store)
 
 
+def _suppressed_sources_for(store: Dict[str, Any], provider_id: str) -> List[str]:
+    """The source names suppressed for ``provider_id`` in one auth store.
+
+    Both shapes of the per-provider entry are accepted: the writers above store a
+    list, but an older store may hold a mapping whose keys are the source names
+    (both migrate it in place the next time they touch it).
+    """
+    suppressed = store.get("suppressed_sources")
+    if not isinstance(suppressed, dict):
+        return []
+    entries = suppressed.get(provider_id)
+    if isinstance(entries, dict):
+        return [str(name) for name in entries]
+    if isinstance(entries, (list, tuple, set)):
+        return [str(name) for name in entries]
+    return []
+
+
 def is_source_suppressed(provider_id: str, source: str) -> bool:
-    """Check if a credential source has been suppressed by the user."""
+    """Check if a credential source has been suppressed by the user.
+
+    Consults the profile store AND the global root, and answers their UNION.
+
+    ``read_credential_pool`` and ``_load_provider_state_with_source`` already fall
+    back to the global root so a provider authed there is visible to a profile
+    process that has not configured it locally. This one did not, which left the
+    deny-list as the one piece of auth state a profile escaped by simply not
+    repeating it: ``hermes auth remove`` at the root writes a suppression marker
+    meaning "stop seeding this source", and every profile then re-seeded it anyway.
+
+    Union rather than shadow, deliberately. For a credential pool, a profile's own
+    answer should win when it has one — that is what shadowing is for. A deny-list
+    is the opposite: it must not be escapable by omission, or it is not a list. The
+    cost is that a global suppression can no longer be overridden in one profile;
+    expressing that now means unsuppressing globally and suppressing in the others,
+    which states the intent explicitly instead of relying on an absent key.
+
+    """
     try:
-        return source in _load_auth_store().get("suppressed_sources", {}).get(provider_id, [])
+        if source in _suppressed_sources_for(_load_auth_store(), provider_id):
+            return True
+        # Returns {} in classic mode and never raises, so this is a no-op when
+        # there is no global root distinct from the profile.
+        return source in _suppressed_sources_for(_load_global_auth_store(), provider_id)
     except Exception:
         return False
 
@@ -1042,6 +1082,42 @@ def unsuppress_credential_source(provider_id: str, source: str) -> bool:
             auth_store.pop("suppressed_sources", None)
         _save_auth_store(auth_store)
         return True
+
+
+def lift_provider_suppressions(provider_id: str) -> List[str]:
+    """Lift every suppression marker this scope can write for ``provider_id``.
+
+    Re-adding a credential is an explicit re-engagement signal, so ``hermes auth
+    add`` and the dashboard's pool-add both clear the provider's whole deny-list
+    rather than only the source being re-added.
+
+    Writes stay scoped to this process's store — a profile must not rewrite the
+    global root on the other profiles' behalf — so in profile mode a marker set at
+    the root survives, and because ``is_source_suppressed`` answers the union of
+    both scopes it stays in force. Those names are RETURNED rather than dropped so
+    the caller can say so, instead of reporting a clean re-engagement and leaving
+    the user to wonder why a provider they just re-added still will not seed from
+    that source. Always empty in classic mode, where there is no global scope
+    distinct from this one.
+    """
+    try:
+        local = _suppressed_sources_for(_load_auth_store(), provider_id)
+    except Exception:
+        logger.debug(
+            "auth: could not read suppression markers for %s", provider_id, exc_info=True
+        )
+        return []
+    for source in local:
+        try:
+            unsuppress_credential_source(provider_id, source)
+        except Exception:
+            logger.debug(
+                "auth: could not lift suppression %s/%s", provider_id, source, exc_info=True
+            )
+    try:
+        return _suppressed_sources_for(_load_global_auth_store(), provider_id)
+    except Exception:
+        return []
 
 
 def get_provider_auth_state(provider_id: str) -> Optional[Dict[str, Any]]:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -300,18 +300,6 @@ def _add_nous_oauth_credential(args, provider: str) -> PooledCredential:
     return _persist(creds, "Saved")
 
 
-def _unsuppress_provider_sources(provider: str) -> None:
-    """Clear ALL suppressions for this provider — re-adding a credential is a strong signal the
-    user wants auth re-enabled. Covers env:* (shell-exported vars), gh_cli (copilot), claude_code,
-    qwen-cli, device_code (codex), etc. — one consistent re-engagement pattern."""
-    try:
-        suppressed = auth_mod._load_auth_store().get("suppressed_sources", {})
-        for src in list(suppressed.get(provider, []) or []):
-            auth_mod.unsuppress_credential_source(provider, src)
-    except Exception:
-        pass
-
-
 def _add_api_key_credential(args, provider: str, pool) -> PooledCredential:
     token = ((getattr(args, "api_key", None) or "").strip()
              or masked_secret_prompt("Paste your API key: ").strip())
@@ -347,8 +335,26 @@ def auth_add_command(args) -> None:
         requested_type = AUTH_TYPE_OAUTH if oauth_default else AUTH_TYPE_API_KEY
 
     pool = load_pool(provider)
-    if not is_custom:
-        _unsuppress_provider_sources(provider)
+
+    # Clear every suppression this scope can write for the provider — re-adding a
+    # credential is a strong signal the user wants auth re-enabled.  This covers
+    # env:* (shell-exported vars), gh_cli (copilot), claude_code, qwen-cli,
+    # device_code (codex), etc.  One consistent re-engagement pattern.
+    # Matches the Codex device_code re-link pattern that predates this.
+    if not provider.startswith(CUSTOM_POOL_PREFIX):
+        try:
+            from hermes_cli.auth import lift_provider_suppressions
+
+            still_suppressed = lift_provider_suppressions(provider)
+            if still_suppressed:
+                print(
+                    f"Note: {provider} stays suppressed at the global root for "
+                    f"{', '.join(sorted(still_suppressed))} — a profile cannot lift a "
+                    f"marker it does not own.  Re-run outside the profile to seed "
+                    f"from those sources."
+                )
+        except Exception:
+            pass
 
     wanted_priority = getattr(args, "priority", None)
     entry = _add_credential(args, provider, pool, requested_type)

--- a/hermes_cli/web_routers/ops.py
+++ b/hermes_cli/web_routers/ops.py
@@ -355,11 +355,19 @@ async def add_credential_pool_entry(body: CredentialPoolAdd):
             # (mirrors `hermes auth add`).
             if not provider.startswith(CUSTOM_POOL_PREFIX):
                 try:
-                    from hermes_cli.auth import _load_auth_store, unsuppress_credential_source
+                    from hermes_cli.auth import lift_provider_suppressions
 
-                    suppressed = _load_auth_store().get("suppressed_sources", {})
-                    for src in list(suppressed.get(provider, []) or []):
-                        unsuppress_credential_source(provider, src)
+                    still_suppressed = lift_provider_suppressions(provider)
+                    if still_suppressed:
+                        # A profile cannot rewrite the global root and
+                        # is_source_suppressed answers the union of both scopes, so
+                        # name the sources that stay denied instead of logging a
+                        # re-engagement that only partly happened.
+                        _log.warning(
+                            "pool add: %s stays suppressed at the global root for %s",
+                            provider,
+                            ", ".join(sorted(still_suppressed)),
+                        )
                 except Exception:
                     _log.exception("unsuppress after pool add failed (non-fatal)")
             return {"ok": True, "provider": provider, "count": len(pool.entries())}

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -288,3 +288,166 @@ def test_write_pool_never_merges_cooldown_onto_reauthed_entry(classic_env):
     assert persisted["access_token"] == "sk-new"
     assert persisted.get("last_status") != "exhausted"
     assert persisted.get("last_error_code") is None
+# ---------------------------------------------------------------------------
+# is_source_suppressed — a deny-list must not be escapable by omission
+# ---------------------------------------------------------------------------
+
+
+def _suppressed_store(mapping: dict) -> dict:
+    # ``providers`` is not decoration: _load_auth_store() discards the whole
+    # store and returns an empty default unless it finds a dict-valued
+    # "providers" or "credential_pool" key, so a fixture carrying only
+    # suppressed_sources would read back as {} and pass for the wrong reason.
+    return {"version": 1, "providers": {}, "suppressed_sources": mapping}
+
+
+def test_a_global_suppression_is_honoured_inside_a_profile(profile_env):
+    """`hermes auth remove` at the root must not silently reverse per profile.
+
+    read_credential_pool and get_provider_auth_state already fall back to the
+    global root so a provider authed there is visible in profile mode.
+    is_source_suppressed did not, which left the deny-list as the one piece of
+    auth state a profile escaped by simply not repeating it: the root said "stop
+    seeding this source" and every profile re-seeded it on the next load.
+    """
+    from hermes_cli.auth import is_source_suppressed
+
+    _write(profile_env["global"] / "auth.json",
+           _suppressed_store({"copilot": ["env:GITHUB_TOKEN", "gh_cli"]}))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={}))
+
+    assert is_source_suppressed("copilot", "gh_cli") is True
+    assert is_source_suppressed("copilot", "env:GITHUB_TOKEN") is True
+    assert is_source_suppressed("copilot", "manual") is False
+    assert is_source_suppressed("openrouter", "gh_cli") is False
+
+
+def test_a_profile_suppression_still_works_on_its_own(profile_env):
+    """The pre-existing behaviour: a marker written in the profile is honoured
+    there even when the global root knows nothing about it."""
+    from hermes_cli.auth import is_source_suppressed
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={}))
+    _write(profile_env["profile"] / "auth.json",
+           _suppressed_store({"zai": ["env:GLM_API_KEY"]}))
+
+    assert is_source_suppressed("zai", "env:GLM_API_KEY") is True
+
+
+def test_the_two_scopes_are_unioned_not_shadowed(profile_env):
+    """A profile that suppresses ONE source does not un-suppress the others.
+
+    This is the difference between union and shadow, and it is the whole point:
+    with shadowing, a profile listing any marker at all would hide every global
+    marker for that provider.
+    """
+    from hermes_cli.auth import is_source_suppressed
+
+    _write(profile_env["global"] / "auth.json",
+           _suppressed_store({"copilot": ["gh_cli"]}))
+    _write(profile_env["profile"] / "auth.json",
+           _suppressed_store({"copilot": ["env:GH_TOKEN"]}))
+
+    assert is_source_suppressed("copilot", "gh_cli") is True
+    assert is_source_suppressed("copilot", "env:GH_TOKEN") is True
+
+
+def test_a_dict_shaped_entry_is_accepted(profile_env):
+    """unsuppress_credential_source already handles a dict as well as a list, so
+    the reader has to accept both or the two disagree about the same file."""
+    from hermes_cli.auth import is_source_suppressed
+
+    _write(profile_env["global"] / "auth.json",
+           _suppressed_store({"copilot": {"gh_cli": "2026-08-19T00:00:00Z"}}))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={}))
+
+    assert is_source_suppressed("copilot", "gh_cli") is True
+
+
+def test_a_malformed_global_store_does_not_break_the_check(profile_env):
+    """Same robustness the neighbouring fallback paths already have: an unreadable
+    global file must not make a profile process raise on an auth question."""
+    from hermes_cli.auth import is_source_suppressed
+
+    (profile_env["global"] / "auth.json").write_text("{not valid json")
+    _write(profile_env["profile"] / "auth.json",
+           _suppressed_store({"copilot": ["gh_cli"]}))
+
+    assert is_source_suppressed("copilot", "gh_cli") is True
+    assert is_source_suppressed("copilot", "manual") is False
+# ---------------------------------------------------------------------------
+# lift_provider_suppressions — re-engagement across the two scopes
+# ---------------------------------------------------------------------------
+
+
+def test_lifting_suppressions_reports_what_the_root_still_denies(profile_env):
+    """`hermes auth add` lifts what it owns and names what it cannot.
+
+    The re-engagement gesture clears the provider's whole deny-list, but a profile
+    must not rewrite the global root on the other profiles' behalf. Since
+    is_source_suppressed now answers the union, a root marker stays in force — so
+    it is returned, not dropped, and the caller says so rather than reporting a
+    clean re-engagement that only partly happened.
+    """
+    from hermes_cli.auth import is_source_suppressed, lift_provider_suppressions
+
+    _write(profile_env["global"] / "auth.json",
+           _suppressed_store({"copilot": ["gh_cli"]}))
+    _write(profile_env["profile"] / "auth.json",
+           _suppressed_store({"copilot": ["env:GH_TOKEN", "claude_code"]}))
+
+    assert lift_provider_suppressions("copilot") == ["gh_cli"]
+
+    # What the profile owned is gone for good...
+    assert is_source_suppressed("copilot", "env:GH_TOKEN") is False
+    assert is_source_suppressed("copilot", "claude_code") is False
+    # ...and the name that came back is not advisory: it is still denied.
+    assert is_source_suppressed("copilot", "gh_cli") is True
+
+
+def test_lifting_suppressions_leaves_other_providers_alone(profile_env):
+    """The gesture is per-provider: re-adding copilot must not re-enable zai."""
+    from hermes_cli.auth import is_source_suppressed, lift_provider_suppressions
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={}))
+    _write(profile_env["profile"] / "auth.json",
+           _suppressed_store({"copilot": ["gh_cli"], "zai": ["env:GLM_API_KEY"]}))
+
+    assert lift_provider_suppressions("copilot") == []
+
+    assert is_source_suppressed("copilot", "gh_cli") is False
+    assert is_source_suppressed("zai", "env:GLM_API_KEY") is True
+
+
+def test_lifting_suppressions_reports_nothing_without_a_distinct_global(profile_env,
+                                                                       monkeypatch):
+    """Classic mode: one scope, so there is never a residual to report.
+
+    Pointing the default root at the active home is what "no global scope distinct
+    from mine" means to _global_auth_file_path(), and is how the vast majority of
+    installs run.  Behaviour there must be exactly what it was before the union.
+    """
+    import hermes_constants
+    from hermes_cli.auth import is_source_suppressed, lift_provider_suppressions
+
+    monkeypatch.setattr(hermes_constants, "get_default_hermes_root",
+                        lambda: profile_env["profile"])
+    _write(profile_env["profile"] / "auth.json",
+           _suppressed_store({"copilot": ["gh_cli", "env:GH_TOKEN"]}))
+
+    assert lift_provider_suppressions("copilot") == []
+    assert is_source_suppressed("copilot", "gh_cli") is False
+    assert is_source_suppressed("copilot", "env:GH_TOKEN") is False
+
+
+def test_lifting_suppressions_accepts_a_dict_shaped_entry(profile_env):
+    """An older store holds a mapping keyed by source name; the write side already
+    migrated it in place, so the read side must not be the one to trip over it."""
+    from hermes_cli.auth import is_source_suppressed, lift_provider_suppressions
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={}))
+    _write(profile_env["profile"] / "auth.json",
+           _suppressed_store({"copilot": {"gh_cli": "2026-08-19T00:00:00Z"}}))
+
+    assert lift_provider_suppressions("copilot") == []
+    assert is_source_suppressed("copilot", "gh_cli") is False


### PR DESCRIPTION
## Problem

`is_source_suppressed()` reads the profile store only:

```python
def is_source_suppressed(provider_id: str, source: str) -> bool:
    """Check if a credential source has been suppressed by the user."""
    try:
        auth_store = _load_auth_store()
        suppressed = auth_store.get("suppressed_sources", {})
        return source in suppressed.get(provider_id, [])
    except Exception:
        return False
```

Every neighbouring read in the same module falls back to the global root when the
profile has no answer — `read_credential_pool()`, `_load_provider_state_with_source()`,
`get_provider_auth_state()` (the #18594 follow-up, so a provider authenticated at the
root is usable by a profile that never configured it). This one did not, which left
the suppression deny-list as the one piece of auth state a profile escaped by simply
not repeating it.

Reproduced in a real process, with `HOME` pointed at a scratch root so the marker is
written somewhere other than a live auth store:

```
=== what is on disk ===
  root   : {"version": 1, "providers": {}, "suppressed_sources": {"copilot": ["gh_cli"]}}
  profile: {"version": 1, "providers": {}}

=== root scope (classic install): the suppression holds ===
  HERMES_HOME     : /tmp/repro-root/.hermes
  global auth.json: None
  gh_cli suppressed: True

=== same marker, inside profile 'coder' ===
  HERMES_HOME     : /tmp/repro-root/.hermes/profiles/coder
  global auth.json: /tmp/repro-root/.hermes/auth.json
  gh_cli suppressed: False        <-- with this branch: True
```

So `hermes auth remove copilot gh_cli` at the root writes a marker meaning "stop
seeding this source", and all three seeding paths that gate on it re-seed anyway
inside a profile:

| `agent/credential_pool.py` | gate |
|---|---|
| `_seed_from_singletons` | `is_source_suppressed` (2509) |
| `_seed_from_env` → `_env_payload` | `if _is_source_suppressed(provider, source)` (2964, 3002) |
| `_seed_custom_pool` | `is_source_suppressed` (3066) |

The removal looks like it worked, because the scope you ran it in honours it. It is
silently reversed for every profile worker — which, on a profile-based install, is
where the work actually runs.

The same read appears on the write side: `hermes auth add` and
`POST /api/credentials/pool` both clear a provider's *whole* deny-list ("re-adding a
credential is a strong signal the user wants auth re-enabled"), and both enumerate
markers from the profile store only.

## Fix

**1. `_suppressed_sources_for(store, provider_id)`** — lifted out so the read and
write sides share one shape-tolerant reader. Both entry shapes are accepted: the
writers store a list, but an older store holds a mapping keyed by source name, which
`suppress_credential_source` / `unsuppress_credential_source` already migrate in place
when they touch it.

**2. `is_source_suppressed` answers the UNION** of the profile store and the global
root.

Union rather than the per-provider shadowing its neighbours use, deliberately. A
credential *pool* wants shadowing — a profile's own answer should win when it has one.
A deny-list is the opposite: it must not be escapable by omission, or it is not a
list. Shadowing is also not expressible here even if it were wanted, because
`unsuppress_credential_source` pops the provider key when its last entry goes, so
"this profile has spoken" and "this profile is silent" are the same bytes on disk.

The cost is that a global suppression can no longer be overridden in one profile.
Expressing that now means unsuppressing at the root and suppressing in the other
profiles — which states the intent explicitly instead of relying on an absent key.

**3. `lift_provider_suppressions(provider_id)`** — one helper replacing the duplicated
re-engagement loop in `auth_commands.py` and `web_server.py`. It lifts every marker the
current scope can write and *returns* the ones the root still denies, rather than
dropping them: writes stay scoped to this process's store (a profile must not rewrite
the root on the other profiles' behalf), and since the read is now a union those
markers stay in force. `hermes auth add` prints them; the dashboard logs them. Without
this, the gesture would report a clean re-engagement that only partly happened.

**Classic mode is unchanged.** `_global_auth_file_path()` returns `None` when the
active home and the default root coincide, so `_load_global_auth_store()` returns `{}`,
the added lookup is a no-op, and the residual list is always empty.

## Verification

`tests/hermes_cli/test_auth_profile_fallback.py`: **16 passed** (9 pre-existing, 7 new).
Wider selection — every `tests/hermes_cli/test_auth*.py` and
`tests/agent/test_credential*.py`, 29 files: **261 passed, 2 skipped**.

Each new test was mutation-checked, and each mutation is caught by exactly the test
that should catch it:

| mutation | fails |
|---|---|
| all three sources reverted to `upstream/main` | the 3 union tests behaviourally, the 4 lift tests on import |
| `lift_provider_suppressions` returns `[]` (the naive version) | `…reports_what_the_root_still_denies` |
| union replaced by shadow (`if local: return source in local`) | `…the_two_scopes_are_unioned_not_shadowed` |

One test-only trap worth recording, since it makes a fixture pass for the wrong
reason: `_load_auth_store()` discards the whole store and returns
`{"version": …, "providers": {}}` unless it finds a dict-valued `providers` or
`credential_pool` key. A fixture carrying only `suppressed_sources` reads back empty,
so the helper in these tests writes `providers: {}` alongside it and says why.
