### PR TITLE
feat(webhook): add opt-in persistent session keys

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -42,7 +42,7 @@ import subprocess
 import sys
 import time
 from collections import deque
-from contextvars import ContextVar
+from contextvars import ContextVar, Token
 from typing import Any, Deque, Dict, List, Optional
 
 try:
@@ -218,6 +218,12 @@ class WebhookAdapter(BasePlatformAdapter):
         self._delivery_info_order: Deque[tuple[float, str]] = deque()
         self._active_delivery_id: ContextVar[Optional[str]] = ContextVar(
             f"webhook_delivery_id_{id(self)}", default=None
+        )
+        # The processing hooks run in the task that owns one agent turn. Keep
+        # that task's reset token alongside its delivery id so a task reused by
+        # an embedding host cannot retain a completed turn's routing context.
+        self._active_delivery_token: ContextVar[Optional[Token]] = ContextVar(
+            f"webhook_delivery_token_{id(self)}", default=None
         )
 
         # Reference to gateway runner for cross-platform delivery (set externally)
@@ -1002,7 +1008,8 @@ class WebhookAdapter(BasePlatformAdapter):
     async def on_processing_start(self, event: "MessageEvent") -> None:
         """Bind response routing to this delivery for the current async turn."""
         if event.message_id:
-            self._active_delivery_id.set(str(event.message_id))
+            token = self._active_delivery_id.set(str(event.message_id))
+            self._active_delivery_token.set(token)
 
     async def on_processing_complete(
         self, event: "MessageEvent", outcome: Any
@@ -1026,9 +1033,15 @@ class WebhookAdapter(BasePlatformAdapter):
         ``end_session()`` is first-reason-wins and no-ops on an already-ended
         row, so this never clobbers a ``compression``/``agent_close`` reason.
         """
-        if bool((event.metadata or {}).get("webhook_persistent_session")):
-            return
-        await self._end_webhook_session(event, event.source.chat_id)
+        try:
+            if bool((event.metadata or {}).get("webhook_persistent_session")):
+                return
+            await self._end_webhook_session(event, event.source.chat_id)
+        finally:
+            token = self._active_delivery_token.get()
+            if token is not None:
+                self._active_delivery_id.reset(token)
+                self._active_delivery_token.set(None)
 
     async def _end_webhook_session(
         self, event: "MessageEvent", session_chat_id: str

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -42,6 +42,7 @@ import subprocess
 import sys
 import time
 from collections import deque
+from contextvars import ContextVar
 from typing import Any, Deque, Dict, List, Optional
 
 try:
@@ -201,7 +202,9 @@ class WebhookAdapter(BasePlatformAdapter):
         # (once-per-route so a busy sender doesn't spam the log).
         self._v1_signature_warned: set[str] = set()
 
-        # Delivery info keyed by session chat_id.
+        # One-shot routes key delivery info by session chat_id. Persistent
+        # routes key it by delivery_id so overlapping turns in one conversation
+        # cannot overwrite each other's rendered response target.
         #
         # Read by every send() invocation for the chat_id (status messages
         # AND the final response).  Cleaned up via TTL on each POST so the
@@ -213,6 +216,9 @@ class WebhookAdapter(BasePlatformAdapter):
         self._delivery_info: Dict[str, dict] = {}
         self._delivery_info_created: Dict[str, float] = {}
         self._delivery_info_order: Deque[tuple[float, str]] = deque()
+        self._active_delivery_id: ContextVar[Optional[str]] = ContextVar(
+            f"webhook_delivery_id_{id(self)}", default=None
+        )
 
         # Reference to gateway runner for cross-platform delivery (set externally)
         self.gateway_runner = None
@@ -359,8 +365,10 @@ class WebhookAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Deliver the agent's response to the configured destination.
 
-        chat_id is ``webhook:{route}:{delivery_id}``.  The delivery info
-        stored during webhook receipt is read with ``.get()`` (not popped)
+        ``chat_id`` identifies the conversation. Delivery identity stays
+        separate for persistent sessions so each turn keeps its own rendered
+        target. The delivery info stored during webhook receipt is read with
+        ``.get()`` (not popped)
         so that interim status messages emitted before the final response
         — fallback-model notifications, context-pressure warnings, etc. —
         do not consume the entry and silently downgrade the final response
@@ -372,7 +380,12 @@ class WebhookAdapter(BasePlatformAdapter):
             )
             return SendResult(success=True)
 
-        delivery = self._delivery_info.get(chat_id, {})
+        delivery_id = self._active_delivery_id.get()
+        delivery = self._delivery_info.get(delivery_id or "", {})
+        if not delivery and reply_to:
+            delivery = self._delivery_info.get(str(reply_to), {})
+        if not delivery:
+            delivery = self._delivery_info.get(chat_id, {})
         deliver_type = delivery.get("deliver", "log")
 
         if deliver_type == "log":
@@ -907,8 +920,9 @@ class WebhookAdapter(BasePlatformAdapter):
                 status=502,
             )
 
-        # Use delivery_id in session key so concurrent webhooks on the
-        # same route get independent agent runs (not queued/interrupted).
+        # Per-delivery remains the default. A successfully rendered session_key
+        # opts into a persistent conversation; unresolved templates fall back
+        # to the one-shot delivery identity.
         session_key = ""
         session_key_tpl = route_config.get("session_key", "")
         if session_key_tpl:
@@ -917,18 +931,21 @@ class WebhookAdapter(BasePlatformAdapter):
                 session_key = ""
         session_chat_id = f"webhook:{route_name}:{session_key or delivery_id}"
 
-        # Store delivery info for send().  Read by every send() invocation
-        # for this chat_id (interim status messages and the final response),
-        # so we do NOT pop on send.  TTL-based cleanup keeps the dict bounded.
+        is_persistent_session = bool(session_key)
+        delivery_info_key = delivery_id if is_persistent_session else session_chat_id
+
+        # Store delivery info for send(). Persistent conversations keep this
+        # per delivery rather than per chat_id so later requests cannot replace
+        # an in-flight turn's rendered deliver_extra.
         deliver_config = {
             "deliver": route_config.get("deliver", "log"),
             "deliver_extra": self._render_delivery_extra(
                 route_config.get("deliver_extra", {}), payload
             ),
         }
-        self._delivery_info[session_chat_id] = deliver_config
-        self._delivery_info_created[session_chat_id] = now
-        self._delivery_info_order.append((now, session_chat_id))
+        self._delivery_info[delivery_info_key] = deliver_config
+        self._delivery_info_created[delivery_info_key] = now
+        self._delivery_info_order.append((now, delivery_info_key))
         self._prune_delivery_info(now)
 
         # Build source and event
@@ -947,6 +964,7 @@ class WebhookAdapter(BasePlatformAdapter):
             source=source,
             raw_message=payload,
             message_id=delivery_id,
+            metadata={"webhook_persistent_session": is_persistent_session},
         )
 
         logger.info(
@@ -977,6 +995,11 @@ class WebhookAdapter(BasePlatformAdapter):
             status=202,
         )
 
+    async def on_processing_start(self, event: "MessageEvent") -> None:
+        """Bind response routing to this delivery for the current async turn."""
+        if event.message_id:
+            self._active_delivery_id.set(str(event.message_id))
+
     async def on_processing_complete(
         self, event: "MessageEvent", outcome: Any
     ) -> None:
@@ -999,8 +1022,7 @@ class WebhookAdapter(BasePlatformAdapter):
         ``end_session()`` is first-reason-wins and no-ops on an already-ended
         row, so this never clobbers a ``compression``/``agent_close`` reason.
         """
-        route_name = (event.source.user_id or "").removeprefix("webhook:")
-        if self._routes.get(route_name, {}).get("session_key"):
+        if bool((event.metadata or {}).get("webhook_persistent_session")):
             return
         await self._end_webhook_session(event, event.source.chat_id)
 

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -929,9 +929,13 @@ class WebhookAdapter(BasePlatformAdapter):
             session_key = self._render_prompt(session_key_tpl, payload, event_type, route_name).strip()
             if "{" in session_key:
                 session_key = ""
-        session_chat_id = f"webhook:{route_name}:{session_key or delivery_id}"
-
         is_persistent_session = bool(session_key)
+        session_identity = (
+            f"session:{session_key}"
+            if is_persistent_session
+            else f"delivery:{delivery_id}"
+        )
+        session_chat_id = f"webhook:{route_name}:{session_identity}"
         delivery_info_key = delivery_id if is_persistent_session else session_chat_id
 
         # Store delivery info for send(). Persistent conversations keep this

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -909,7 +909,13 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Use delivery_id in session key so concurrent webhooks on the
         # same route get independent agent runs (not queued/interrupted).
-        session_chat_id = f"webhook:{route_name}:{delivery_id}"
+        session_key = "";
+        session_key_tpl = route_config.get("session_key", "");
+        if session_key_tpl:
+            session_key = self._render_prompt(session_key_tpl, payload, event_type, route_name).strip();
+            if "{" in session_key:
+                session_key = "";
+        session_chat_id = f"webhook:{route_name}:{session_key or delivery_id}";
 
         # Store delivery info for send().  Read by every send() invocation
         # for this chat_id (interim status messages and the final response),
@@ -993,6 +999,9 @@ class WebhookAdapter(BasePlatformAdapter):
         ``end_session()`` is first-reason-wins and no-ops on an already-ended
         row, so this never clobbers a ``compression``/``agent_close`` reason.
         """
+        route_name = (event.source.user_id or "").removeprefix("webhook:");
+        if self._routes.get(route_name, {}).get("session_key"):
+            return;
         await self._end_webhook_session(event, event.source.chat_id)
 
     async def _end_webhook_session(

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -909,13 +909,13 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Use delivery_id in session key so concurrent webhooks on the
         # same route get independent agent runs (not queued/interrupted).
-        session_key = "";
-        session_key_tpl = route_config.get("session_key", "");
+        session_key = ""
+        session_key_tpl = route_config.get("session_key", "")
         if session_key_tpl:
-            session_key = self._render_prompt(session_key_tpl, payload, event_type, route_name).strip();
+            session_key = self._render_prompt(session_key_tpl, payload, event_type, route_name).strip()
             if "{" in session_key:
-                session_key = "";
-        session_chat_id = f"webhook:{route_name}:{session_key or delivery_id}";
+                session_key = ""
+        session_chat_id = f"webhook:{route_name}:{session_key or delivery_id}"
 
         # Store delivery info for send().  Read by every send() invocation
         # for this chat_id (interim status messages and the final response),
@@ -999,9 +999,9 @@ class WebhookAdapter(BasePlatformAdapter):
         ``end_session()`` is first-reason-wins and no-ops on an already-ended
         row, so this never clobbers a ``compression``/``agent_close`` reason.
         """
-        route_name = (event.source.user_id or "").removeprefix("webhook:");
+        route_name = (event.source.user_id or "").removeprefix("webhook:")
         if self._routes.get(route_name, {}).get("session_key"):
-            return;
+            return
         await self._end_webhook_session(event, event.source.chat_id)
 
     async def _end_webhook_session(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10156,14 +10156,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
 
         # Persistent webhook deliveries are ordered conversation turns, not
-        # live keystrokes steering an in-flight run. Let the adapter's normal
-        # busy path queue them instead of applying the profile's interrupt or
-        # steer policy.
+        # live keystrokes steering an in-flight run. Put each delivery into the
+        # gateway FIFO rather than the adapter's single pending slot: merging
+        # would collapse message IDs and lose the later delivery's response
+        # target (`deliver_extra`).
         if (
             event.source.platform == Platform.WEBHOOK
             and bool((event.metadata or {}).get("webhook_persistent_session"))
         ):
-            return False
+            self._queue_or_replace_pending_event(session_key, event)
+            return True
 
         _busy_state = self._peek_session_state(session_key)
         running_agent = _busy_state.turn.agent if _busy_state else None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10155,6 +10155,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if getattr(event, "internal", False):
             return False
 
+        # Persistent webhook deliveries are ordered conversation turns, not
+        # live keystrokes steering an in-flight run. Let the adapter's normal
+        # busy path queue them instead of applying the profile's interrupt or
+        # steer policy.
+        if (
+            event.source.platform == Platform.WEBHOOK
+            and bool((event.metadata or {}).get("webhook_persistent_session"))
+        ):
+            return False
+
         _busy_state = self._peek_session_state(session_key)
         running_agent = _busy_state.turn.agent if _busy_state else None
 

--- a/tests/gateway/test_multiplex_busy_input_mode.py
+++ b/tests/gateway/test_multiplex_busy_input_mode.py
@@ -311,6 +311,37 @@ async def test_default_busy_mode_is_unchanged_by_secondary_profile(tmp_path, mon
 
 
 @pytest.mark.asyncio
+async def test_persistent_webhook_turn_queues_under_interrupt_default():
+    """Conversation webhooks preserve arrival order instead of steering."""
+    runner = _runner(default_mode="interrupt")
+    adapter = _ProfileAdapter(
+        PlatformConfig(enabled=True),
+        Platform.WEBHOOK,
+    )
+    runner.adapters[Platform.WEBHOOK] = adapter
+    event = MessageEvent(
+        text="second turn",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.WEBHOOK,
+            chat_id="webhook:support:tenant-7:account-3:conversation-9",
+            chat_type="webhook",
+            user_id="webhook:support",
+        ),
+        message_id="delivery-2",
+        metadata={"webhook_persistent_session": True},
+    )
+    session_key = runner._session_key_for_source(event.source)
+    agent = MagicMock()
+    agent._active_children = []
+    runner._running_agents[session_key] = agent
+
+    assert await runner._handle_active_session_busy_message(event, session_key) is False
+    agent.interrupt.assert_not_called()
+    agent.steer.assert_not_called()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("secondary_mode", [None, "not-a-mode"])
 async def test_missing_or_invalid_secondary_mode_falls_back_to_gateway_default(
     tmp_path,

--- a/tests/gateway/test_multiplex_busy_input_mode.py
+++ b/tests/gateway/test_multiplex_busy_input_mode.py
@@ -311,34 +311,43 @@ async def test_default_busy_mode_is_unchanged_by_secondary_profile(tmp_path, mon
 
 
 @pytest.mark.asyncio
-async def test_persistent_webhook_turn_queues_under_interrupt_default():
-    """Conversation webhooks preserve arrival order instead of steering."""
+async def test_persistent_webhook_turns_queue_in_arrival_order_under_interrupt_default():
+    """Conversation webhooks use the FIFO, never interrupt or merge turns."""
     runner = _runner(default_mode="interrupt")
     adapter = _ProfileAdapter(
         PlatformConfig(enabled=True),
         Platform.WEBHOOK,
     )
     runner.adapters[Platform.WEBHOOK] = adapter
-    event = MessageEvent(
-        text="second turn",
-        message_type=MessageType.TEXT,
-        source=SessionSource(
-            platform=Platform.WEBHOOK,
-            chat_id="webhook:support:tenant-7:account-3:conversation-9",
-            chat_type="webhook",
-            user_id="webhook:support",
-        ),
-        message_id="delivery-2",
-        metadata={"webhook_persistent_session": True},
-    )
-    session_key = runner._session_key_for_source(event.source)
+    events = [
+        MessageEvent(
+            text=f"turn {number}",
+            message_type=MessageType.TEXT,
+            source=SessionSource(
+                platform=Platform.WEBHOOK,
+                chat_id="webhook:support:tenant-7:account-3:conversation-9",
+                chat_type="webhook",
+                user_id="webhook:support",
+            ),
+            message_id=f"delivery-{number}",
+            metadata={"webhook_persistent_session": True},
+        )
+        for number in (2, 3)
+    ]
+    session_key = runner._session_key_for_source(events[0].source)
     agent = MagicMock()
     agent._active_children = []
     runner._running_agents[session_key] = agent
 
-    assert await runner._handle_active_session_busy_message(event, session_key) is False
+    for event in events:
+        assert await runner._handle_active_session_busy_message(event, session_key) is True
+
     agent.interrupt.assert_not_called()
     agent.steer.assert_not_called()
+    assert adapter._pending_messages[session_key].message_id == "delivery-2"
+    assert [event.message_id for event in runner._session_state(
+        session_key
+    ).conversation.queued_events] == ["delivery-3"]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -22,7 +22,7 @@ from gateway.config import (
     Platform,
     PlatformConfig,
 )
-from gateway.platforms.base import MessageEvent, SendResult
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.platforms.webhook import WebhookAdapter, _INSECURE_NO_AUTH
 
 
@@ -309,6 +309,13 @@ class TestCrossPlatformDelivery:
             if event.message_id == "delivery-1":
                 first_started.set()
                 await release_first.wait()
+            # Background work spawned while a turn is active inherits that
+            # turn's ContextVar. It must therefore retain this delivery's
+            # rendered destination rather than falling back to the persistent
+            # session chat id (which deliberately is not a delivery-info key).
+            await asyncio.create_task(
+                adapter.send(event.source.chat_id, f"status-{event.message_id}")
+            )
             return f"reply-{event.message_id}"
 
         adapter._message_handler = _message_handler
@@ -344,9 +351,36 @@ class TestCrossPlatformDelivery:
         assert "delivery-1" in adapter._delivery_info
         assert "delivery-2" in adapter._delivery_info
         assert mock_tg_adapter.send.await_args_list == [
+            call("chat-a", "status-delivery-1", metadata=None),
             call("chat-a", "reply-delivery-1", metadata=None),
+            call("chat-b", "status-delivery-2", metadata=None),
             call("chat-b", "reply-delivery-2", metadata=None),
         ]
+
+    @pytest.mark.asyncio
+    async def test_processing_completion_restores_prior_delivery_context(self):
+        """A completed webhook turn cannot leak its delivery target in-task."""
+        adapter = _make_adapter({})
+        prior = adapter._active_delivery_id.set("prior-delivery")
+        event = MessageEvent(
+            text="test",
+            message_type=MessageType.TEXT,
+            source=adapter.build_source(
+                chat_id="webhook:alerts:delivery:new-delivery",
+                chat_name="webhook/alerts",
+                chat_type="webhook",
+                user_id="webhook:alerts",
+                user_name="alerts",
+            ),
+            message_id="new-delivery",
+            metadata={"webhook_persistent_session": True},
+        )
+
+        await adapter.on_processing_start(event)
+        assert adapter._active_delivery_id.get() == "new-delivery"
+        await adapter.on_processing_complete(event, outcome=None)
+        assert adapter._active_delivery_id.get() == "prior-delivery"
+        adapter._active_delivery_id.reset(prior)
 
     @pytest.mark.asyncio
     async def test_persistent_key_and_fallback_delivery_use_disjoint_session_ids(self):

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -257,7 +257,7 @@ class TestCrossPlatformDelivery:
             assert resp.status == 202
 
         # The adapter should have stored delivery info
-        chat_id = "webhook:alerts:alert-001"
+        chat_id = "webhook:alerts:delivery:alert-001"
         assert chat_id in adapter._delivery_info
 
         # Now call send() as if the agent has finished
@@ -338,14 +338,51 @@ class TestCrossPlatformDelivery:
             await _drain_background_tasks(adapter)
 
         assert seen_chat_ids == [
-            "webhook:support:tenant-7:account-3:conversation-9",
-            "webhook:support:tenant-7:account-3:conversation-9",
+            "webhook:support:session:tenant-7:account-3:conversation-9",
+            "webhook:support:session:tenant-7:account-3:conversation-9",
         ]
         assert "delivery-1" in adapter._delivery_info
         assert "delivery-2" in adapter._delivery_info
         assert mock_tg_adapter.send.await_args_list == [
             call("chat-a", "reply-delivery-1", metadata=None),
             call("chat-b", "reply-delivery-2", metadata=None),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_persistent_key_and_fallback_delivery_use_disjoint_session_ids(self):
+        """A fallback delivery ID cannot close or reuse a persistent conversation."""
+        routes = {
+            "support": {
+                "secret": _INSECURE_NO_AUTH,
+                "session_key": "{conversation_id}",
+                "prompt": "{message}",
+                "deliver": "log",
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            persistent = await cli.post(
+                "/webhooks/support",
+                json={"conversation_id": "abc", "message": "persistent turn"},
+                headers={"X-GitHub-Delivery": "persistent-delivery"},
+            )
+            fallback = await cli.post(
+                "/webhooks/support",
+                json={"message": "fallback turn"},
+                headers={"X-GitHub-Delivery": "abc"},
+            )
+            assert persistent.status == fallback.status == 202
+            await _drain_background_tasks(adapter)
+
+        seen_chat_ids = [
+            call.args[0].source.chat_id for call in adapter.handle_message.await_args_list
+        ]
+        assert seen_chat_ids == [
+            "webhook:support:session:abc",
+            "webhook:support:delivery:abc",
         ]
 
 
@@ -386,7 +423,7 @@ class TestGitHubCommentDelivery:
             )
             assert resp.status == 202
 
-        chat_id = "webhook:pr-bot:gh-comment-001"
+        chat_id = "webhook:pr-bot:delivery:gh-comment-001"
         assert chat_id in adapter._delivery_info
 
         # Verify deliver_extra was rendered with payload data

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -11,7 +11,7 @@ import asyncio
 import hashlib
 import hmac
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from aiohttp import web
@@ -51,6 +51,15 @@ def _github_signature(body: bytes, secret: str) -> str:
     return "sha256=" + hmac.new(
         secret.encode(), body, hashlib.sha256
     ).hexdigest()
+
+
+async def _drain_background_tasks(
+    adapter: WebhookAdapter, timeout: float = 5.0
+) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while adapter._background_tasks and asyncio.get_event_loop().time() < deadline:
+        await asyncio.sleep(0.02)
+    await asyncio.sleep(0.05)
 
 
 # A realistic GitHub pull_request event payload (trimmed)
@@ -261,6 +270,83 @@ class TestCrossPlatformDelivery:
         # Delivery info is retained after send() so interim status messages
         # don't strand the final response (TTL-based cleanup happens on POST).
         assert chat_id in adapter._delivery_info
+
+    @pytest.mark.asyncio
+    async def test_overlapping_persistent_turns_keep_per_delivery_targets(self):
+        """A later turn cannot replace an in-flight turn's rendered target."""
+        routes = {
+            "support": {
+                "secret": _INSECURE_NO_AUTH,
+                "session_key": "{tenant_id}:{account_id}:{conversation_id}",
+                "prompt": "{message}",
+                "deliver": "telegram",
+                "deliver_extra": {"chat_id": "{target}"},
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_tg_adapter = AsyncMock()
+        mock_tg_adapter.send = AsyncMock(return_value=SendResult(success=True))
+
+        class _Runner:
+            adapters = {Platform.TELEGRAM: mock_tg_adapter}
+            config = GatewayConfig(
+                platforms={
+                    Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")
+                }
+            )
+
+            @staticmethod
+            def _profile_name_for_source(source):
+                return None
+
+        adapter.gateway_runner = _Runner()
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        seen_chat_ids = []
+
+        async def _message_handler(event: MessageEvent):
+            seen_chat_ids.append(event.source.chat_id)
+            if event.message_id == "delivery-1":
+                first_started.set()
+                await release_first.wait()
+            return f"reply-{event.message_id}"
+
+        adapter._message_handler = _message_handler
+        app = _create_app(adapter)
+        common = {
+            "tenant_id": "tenant-7",
+            "account_id": "account-3",
+            "conversation_id": "conversation-9",
+        }
+
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post(
+                "/webhooks/support",
+                json={**common, "message": "first", "target": "chat-a"},
+                headers={"X-GitHub-Delivery": "delivery-1"},
+            )
+            assert first.status == 202
+            await asyncio.wait_for(first_started.wait(), timeout=2)
+
+            second = await cli.post(
+                "/webhooks/support",
+                json={**common, "message": "second", "target": "chat-b"},
+                headers={"X-GitHub-Delivery": "delivery-2"},
+            )
+            assert second.status == 202
+            release_first.set()
+            await _drain_background_tasks(adapter)
+
+        assert seen_chat_ids == [
+            "webhook:support:tenant-7:account-3:conversation-9",
+            "webhook:support:tenant-7:account-3:conversation-9",
+        ]
+        assert "delivery-1" in adapter._delivery_info
+        assert "delivery-2" in adapter._delivery_info
+        assert mock_tg_adapter.send.await_args_list == [
+            call("chat-a", "reply-delivery-1", metadata=None),
+            call("chat-b", "reply-delivery-2", metadata=None),
+        ]
 
 
 # ===================================================================

--- a/tests/gateway/test_webhook_session_close.py
+++ b/tests/gateway/test_webhook_session_close.py
@@ -67,8 +67,15 @@ def _make_store(tmp_path) -> SessionStore:
     return store
 
 
-def _make_event(adapter: WebhookAdapter, delivery_id: str, text: str) -> MessageEvent:
-    session_chat_id = f"webhook:alerts:{delivery_id}"
+def _make_event(
+    adapter: WebhookAdapter,
+    delivery_id: str,
+    text: str,
+    *,
+    conversation_id: str | None = None,
+    persistent: bool = False,
+) -> MessageEvent:
+    session_chat_id = f"webhook:alerts:{conversation_id or delivery_id}"
     source = adapter.build_source(
         chat_id=session_chat_id,
         chat_name="webhook/alerts",
@@ -82,6 +89,7 @@ def _make_event(adapter: WebhookAdapter, delivery_id: str, text: str) -> Message
         source=source,
         raw_message={"message": text},
         message_id=delivery_id,
+        metadata={"webhook_persistent_session": persistent},
     )
 
 
@@ -150,4 +158,79 @@ async def test_completed_webhook_delivery_closes_its_session(tmp_path):
     assert pruned >= 1
     store._db.close()
 
+
+@pytest.mark.asyncio
+async def test_unresolved_persistent_key_fallback_still_closes_session(tmp_path):
+    """Route capability alone must not exempt a fallback delivery from close."""
+    store = _make_store(tmp_path)
+    runner = _FakeRunner(store)
+    adapter = _make_adapter(
+        {
+            "alerts": {
+                "secret": _INSECURE_NO_AUTH,
+                "session_key": "{conversation_id}",
+                "prompt": "Alert: {message}",
+                "deliver": "log",
+            }
+        }
+    )
+    adapter.gateway_runner = runner
+    created = {}
+
+    async def _message_handler(event: MessageEvent):
+        entry = store.get_or_create_session(event.source)
+        created["session_id"] = entry.session_id
+        return ""
+
+    adapter._message_handler = _message_handler
+    await adapter.handle_message(
+        _make_event(adapter, "fallback-001", "missing conversation id")
+    )
+    await _drain_background_tasks(adapter)
+
+    row = store._db.get_session(created["session_id"])
+    assert row["end_reason"] == "webhook_complete"
+    store._db.close()
+
+
+@pytest.mark.asyncio
+async def test_persistent_webhook_turns_reuse_open_session(tmp_path):
+    """Same conversation identity reuses one session and keeps it resumable."""
+    store = _make_store(tmp_path)
+    runner = _FakeRunner(store)
+    adapter = _make_adapter(
+        {
+            "alerts": {
+                "secret": _INSECURE_NO_AUTH,
+                "session_key": "{conversation_id}",
+                "prompt": "{message}",
+                "deliver": "log",
+            }
+        }
+    )
+    adapter.gateway_runner = runner
+    session_ids = []
+
+    async def _message_handler(event: MessageEvent):
+        session_ids.append(store.get_or_create_session(event.source).session_id)
+        return ""
+
+    adapter._message_handler = _message_handler
+    for delivery_id in ("turn-001", "turn-002"):
+        await adapter.handle_message(
+            _make_event(
+                adapter,
+                delivery_id,
+                delivery_id,
+                conversation_id="tenant-7:account-3:conversation-9",
+                persistent=True,
+            )
+        )
+        await _drain_background_tasks(adapter)
+
+    assert session_ids[0] == session_ids[1]
+    row = store._db.get_session(session_ids[0])
+    assert row["ended_at"] is None
+    assert row["end_reason"] is None
+    store._db.close()
 

--- a/tests/gateway/test_webhook_session_close.py
+++ b/tests/gateway/test_webhook_session_close.py
@@ -56,11 +56,12 @@ class _FakeRunner:
         return self.session_store._generate_session_key(source)
 
 
-def _make_store(tmp_path) -> SessionStore:
+def _make_store(tmp_path, *, multiplex_profiles: bool = False) -> SessionStore:
     sessions_dir = tmp_path / "sessions"
     sessions_dir.mkdir()
     config = GatewayConfig(
-        platforms={Platform.WEBHOOK: PlatformConfig(enabled=True)}
+        platforms={Platform.WEBHOOK: PlatformConfig(enabled=True)},
+        multiplex_profiles=multiplex_profiles,
     )
     store = SessionStore(sessions_dir=sessions_dir, config=config)
     assert store._db is not None, "test requires a real SessionDB"
@@ -74,6 +75,7 @@ def _make_event(
     *,
     conversation_id: str | None = None,
     persistent: bool = False,
+    profile: str | None = None,
 ) -> MessageEvent:
     session_chat_id = f"webhook:alerts:{conversation_id or delivery_id}"
     source = adapter.build_source(
@@ -83,6 +85,7 @@ def _make_event(
         user_id="webhook:alerts",
         user_name="alerts",
     )
+    source.profile = profile
     return MessageEvent(
         text=text,
         message_type=MessageType.TEXT,
@@ -232,5 +235,50 @@ async def test_persistent_webhook_turns_reuse_open_session(tmp_path):
     row = store._db.get_session(session_ids[0])
     assert row["ended_at"] is None
     assert row["end_reason"] is None
+    store._db.close()
+
+
+@pytest.mark.asyncio
+async def test_persistent_webhook_sessions_are_profile_namespaced(tmp_path):
+    """Equal route and rendered key cannot cross a multiplexed profile boundary."""
+    store = _make_store(tmp_path, multiplex_profiles=True)
+    runner = _FakeRunner(store)
+    adapter = _make_adapter(
+        {
+            "alerts": {
+                "secret": _INSECURE_NO_AUTH,
+                "session_key": "{conversation_id}",
+                "prompt": "{message}",
+                "deliver": "log",
+            }
+        }
+    )
+    adapter.gateway_runner = runner
+    session_ids = []
+
+    async def _message_handler(event: MessageEvent):
+        session_ids.append(store.get_or_create_session(event.source).session_id)
+        return ""
+
+    adapter._message_handler = _message_handler
+    for delivery_id, profile in (
+        ("research-turn-001", "research"),
+        ("research-turn-002", "research"),
+        ("support-turn-001", "support"),
+    ):
+        await adapter.handle_message(
+            _make_event(
+                adapter,
+                delivery_id,
+                delivery_id,
+                conversation_id="conversation-9",
+                persistent=True,
+                profile=profile,
+            )
+        )
+        await _drain_background_tasks(adapter)
+
+    assert session_ids[0] == session_ids[1]
+    assert session_ids[2] != session_ids[0]
     store._db.close()
 

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -250,7 +250,7 @@ Two POSTs with the same tenant, account, and conversation IDs land in the same s
 Behavior notes:
 
 - **Idempotency is unchanged** — duplicate deliveries are still deduplicated by delivery ID, regardless of `session_key`.
-- **Fallback** — if the template doesn't resolve against a payload (e.g. the field is missing), that delivery gets a per-delivery session, same as an unconfigured route.
+- **Fallback** — if the template doesn't resolve against a payload (e.g. the field is missing), that delivery gets a per-delivery session, same as an unconfigured route. A rendered key containing `{` is also treated as unresolved, so use stable opaque IDs that do not contain braces.
 - **Lifecycle** — persistent sessions are not auto-closed after each event (they expect follow-up turns). Manage them with `hermes sessions prune` or your idle-timeout policy.
 - **Ordering vs. concurrency** — deliveries sharing a `session_key` are processed sequentially on that session. For conversational sources this is what you want (turns stay ordered); routes that need concurrent processing should leave `session_key` unset.
 - **Delivery routing stays per request** — `session_key` identifies the conversation only. Each delivery keeps its own rendered `deliver_extra`, so overlapping turns cannot redirect an earlier response.

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -84,6 +84,7 @@ Routes define how different webhook sources are handled. Each route is a named e
 | `prompt` | No | Template string with dot-notation payload access (e.g. `{pull_request.title}`). If omitted, the full JSON payload is dumped into the prompt. Payload fields are untrusted — see [Authenticated does not mean trusted](#authenticated-does-not-mean-trusted). |
 | `filters` | No | Declarative payload filters evaluated after auth/body/event filtering and before agent or direct delivery work. Non-matches return `{"status":"ignored","reason":"filter"}` with HTTP 200. |
 | `script` | No | Filter/transform script under `~/.hermes/scripts/`. The webhook payload is passed as JSON on stdin. JSON object stdout replaces the payload before templating; text stdout is exposed as `script_output`; empty stdout, `[SILENT]`, or a nonzero exit code ignores the webhook. |
+| `session_key` | No | Template string (same `{dot.notation}` syntax as `prompt`) that pins all deliveries with the same rendered value to one **persistent session**, instead of the default new-session-per-delivery. E.g. `"{satellite}"` gives each satellite its own ongoing conversation. If unset, or if the template doesn't resolve for a given payload, that delivery falls back to per-delivery behavior. See [Persistent Sessions](#persistent-sessions). |
 | `skills` | No | List of skill names to load for the agent run. |
 | `toolsets` | No | List of toolset keys (e.g. `["terminal", "file", "web"]`) that **replaces** the platform-level webhook toolset for runs triggered by this route only. Manual config edit only — not settable via `hermes webhook subscribe`, so agent-created subscriptions cannot self-grant elevated tools. Names are validated the same way as `platform_toolsets` entries (unknown or platform-restricted names are dropped). See [Per-route toolsets](#per-route-toolsets). |
 | `deliver` | No | Where to send the response: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, or `log` (default). |
@@ -226,6 +227,33 @@ webhooks:
 ```
 
 If `chat_id` is not provided in `deliver_extra`, the delivery falls back to the home channel configured for the target platform.
+
+---
+
+## Persistent Sessions {#persistent-sessions}
+
+By default, every webhook delivery runs in a fresh session — delivery identity *is* conversation identity. That's correct for event streams (each PR event is independent), but wrong for conversational sources like voice satellites or chat bridges, where each POST is one turn in an ongoing dialogue and the agent needs memory of previous turns.
+
+Setting `session_key` on a route separates the two: the rendered template becomes the conversation identity, so repeat events from the same source share one session — like a Telegram or WhatsApp thread.
+
+```yaml
+routes:
+  voice-assistant:
+    secret: "voice-webhook-secret"
+    session_key: "{satellite}"
+    prompt: "[voice from {satellite}] {message}"
+    deliver: homeassistant
+```
+
+Two POSTs with `"satellite": "assist_satellite.pod1"` land in the same session; a POST from `pod2` gets its own. Session count is bounded by distinct rendered values, not by delivery count.
+
+Behavior notes:
+
+- **Idempotency is unchanged** — duplicate deliveries are still deduplicated by delivery ID, regardless of `session_key`.
+- **Fallback** — if the template doesn't resolve against a payload (e.g. the field is missing), that delivery gets a per-delivery session, same as an unconfigured route.
+- **Lifecycle** — persistent sessions are not auto-closed after each event (they expect follow-up turns). Manage them with `hermes sessions prune` or your idle-timeout policy.
+- **Ordering vs. concurrency** — deliveries sharing a `session_key` are processed sequentially on that session. For conversational sources this is what you want (turns stay ordered); routes that need concurrent processing should leave `session_key` unset.
+- **Sender-controlled** — the key is rendered from the payload, so a sender chooses which of the route's sessions their event joins. This is scoped to the route (the route name is part of the session identity) and gated by the route's HMAC secret; the [untrusted-content warning](#authenticated-does-not-mean-trusted) applies to session_key values as it does to every payload field.
 
 ---
 

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -238,14 +238,14 @@ Setting `session_key` on a route separates the two: the rendered template become
 
 ```yaml
 routes:
-  voice-assistant:
-    secret: "voice-webhook-secret"
-    session_key: "{satellite}"
-    prompt: "[voice from {satellite}] {message}"
-    deliver: homeassistant
+  customer-chat:
+    secret: "chat-bridge-secret"
+    session_key: "{tenant_id}:{account_id}:{conversation_id}"
+    prompt: "Customer message: {message}"
+    deliver: telegram
 ```
 
-Two POSTs with `"satellite": "assist_satellite.pod1"` land in the same session; a POST from `pod2` gets its own. Session count is bounded by distinct rendered values, not by delivery count.
+Two POSTs with the same tenant, account, and conversation IDs land in the same session. Changing any one of those IDs creates an isolated session. Session count is bounded by distinct rendered keys, not by delivery count.
 
 Behavior notes:
 
@@ -253,6 +253,9 @@ Behavior notes:
 - **Fallback** — if the template doesn't resolve against a payload (e.g. the field is missing), that delivery gets a per-delivery session, same as an unconfigured route.
 - **Lifecycle** — persistent sessions are not auto-closed after each event (they expect follow-up turns). Manage them with `hermes sessions prune` or your idle-timeout policy.
 - **Ordering vs. concurrency** — deliveries sharing a `session_key` are processed sequentially on that session. For conversational sources this is what you want (turns stay ordered); routes that need concurrent processing should leave `session_key` unset.
+- **Delivery routing stays per request** — `session_key` identifies the conversation only. Each delivery keeps its own rendered `deliver_extra`, so overlapping turns cannot redirect an earlier response.
+- **Profile isolation is additional** — a route bound to a multiplexed `profile` is automatically namespaced to that profile. Use `session_key` for application boundaries such as tenant, account, and conversation; use profiles for isolated persona, memory, skills, tools, and credentials.
+- **Use stable opaque IDs** — include every application isolation boundary, and avoid names, secrets, email addresses, or other raw personal data. If any template field is unresolved, Hermes safely falls back to a one-shot session for that delivery.
 - **Sender-controlled** — the key is rendered from the payload, so a sender chooses which of the route's sessions their event joins. This is scoped to the route (the route name is part of the session identity) and gated by the route's HMAC secret; the [untrusted-content warning](#authenticated-does-not-mean-trusted) applies to session_key values as it does to every payload field.
 
 ---


### PR DESCRIPTION
## Summary

Adds an opt-in per-route `session_key` template so conversational webhook sources can reuse a Hermes session instead of creating a fresh delivery-ID session for every POST. Default behavior remains per-delivery.

This supersedes the stale/conflicting implementation path in #57972 and covers the narrower constant-route proposal in #71570. It intentionally does **not** address cross-session approval routing (#71571).

## Safety and behavior

- A successfully rendered `session_key` creates a persistent conversation identity; unresolved templates safely fall back to the existing one-shot delivery session and still auto-close.
- Persistent (`session:<key>`) and fallback (`delivery:<delivery-id>`) identities use disjoint namespaces, so a delivery ID cannot collide with, reuse, or auto-close a persistent conversation.
- Conversation identity is separate from delivery routing: each delivery retains its own rendered `deliver_extra`, preventing concurrent turns from redirecting another turn’s response.
- Persistent deliveries use the gateway FIFO rather than the adapter’s single pending slot, so multiple arrivals keep their own turns, delivery IDs, and response targets without text merging, interrupting, or steering.
- Multiplexed profiles remain separate even if the route and rendered key match.
- Documentation covers configuration, fallback, lifecycle, ordering, isolation, and sender-controlled key boundaries.

## Validation

```text
python -m pytest -o addopts= -q \
  tests/gateway/test_webhook_integration.py \
  tests/gateway/test_webhook_session_close.py \
  tests/gateway/test_multiplex_busy_input_mode.py \
  tests/gateway/test_webhook*.py
# 85 passed

git diff --check
python -m compileall -q gateway/platforms/webhook.py gateway/run.py
```

The full `tests/gateway` suite was also exercised locally. The targeted webhook coverage is green; remaining failures are existing macOS/environmental Discord/AF_UNIX/DNS isolation failures outside this diff.

## Credit

This branch preserves the authored commits from **Gilles Gameiro** and **Atroci**; the additional commits add profile-isolation, multi-delivery FIFO, and persistent-vs-fallback namespace-collision regression coverage.