### PR TITLE
The composer survives any pane width

### DIFF
--- a/apps/desktop/src/app/chat/composer/composer-utils.ts
+++ b/apps/desktop/src/app/chat/composer/composer-utils.ts
@@ -22,6 +22,24 @@ export const COMPOSER_STACK_BREAKPOINT_PX = 320
 // chevron frees is spent keeping the row single for another stretch.
 export const COMPOSER_COMPACT_PILL_PX = 560
 
+// The ladder keeps going below the stack breakpoint — a pane can be far
+// narrower than even the stacked controls row. Both rungs are budgeted
+// against that row's real cost: menu ~24 + surface padding 16 + the cluster
+// (~190; ~218 mid-turn with the queue button).
+//
+// At 260 the three voice toggles fold into the one menu HUD mode already
+// uses, clearing the mid-turn worst case with margin. Each stage sits clear
+// of the floor below it rather than arriving the instant the previous one
+// gives out — the mistake COMPOSER_COMPACT_PILL_PX documents.
+export const COMPOSER_FOLD_VOICE_PX = 260
+
+// Type and send, nothing else. A pane can be dragged to MIN_PANE_PX (80), and
+// even with voice folded the row still costs ~150, so the last rung drops the
+// pill AND the voice menu. Both stay reachable — the model by hotkey and the
+// full picker, dictation from any wider pane — and Send fits with room to
+// spare at any width the layout tree allows (~74 all-in).
+export const COMPOSER_MINIMAL_PX = 180
+
 // A single editor line is ~28px (--composer-input-min-height 1.625rem + 0.5rem
 // vertical padding). Anything taller means the text wrapped to a second line,
 // which is when the composer should expand to the stacked layout.

--- a/apps/desktop/src/app/chat/composer/controls.test.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.test.tsx
@@ -98,6 +98,37 @@ describe('HUD mode', () => {
   })
 })
 
+// A tile can be narrower than the controls cost, and the row is inside an
+// overflow-hidden surface — so anything that doesn't fold gets clipped off the
+// right edge, send button first. The ladder keeps going past `stacked`: voice
+// folds into the same menu the HUD uses, then the model pill drops. Send is
+// the last thing standing.
+describe('narrow tiles', () => {
+  it('folds the voice controls into one menu without entering HUD mode', () => {
+    renderControls({ foldVoice: true })
+
+    expect(screen.getByLabelText('Voice')).toBeTruthy()
+    expect(screen.queryByLabelText('Voice dictation')).toBeNull()
+    expect(screen.queryByLabelText('Read replies aloud')).toBeNull()
+
+    // Folding is a width decision, not the HUD: no exit affordance appears.
+    expect(screen.queryByLabelText('Exit HUD mode')).toBeNull()
+  })
+
+  it('keeps Send at the tightest width, with everything else dropped', () => {
+    renderControls({ foldVoice: true, minimal: true })
+
+    expect(screen.getByLabelText('Send')).toBeTruthy()
+    expect(screen.queryByLabelText('Voice')).toBeNull()
+  })
+
+  it('keeps Stop reachable mid-turn at the tightest width', () => {
+    renderControls({ busy: true, busyAction: 'stop', foldVoice: true, hasComposerPayload: false, minimal: true })
+
+    expect(screen.getByLabelText('Stop')).toBeTruthy()
+  })
+})
+
 describe('ComposerControls shortcut tooltips', () => {
   it('shows Enter for Send', async () => {
     renderControls()

--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -39,7 +39,9 @@ export function ComposerControls({
   compactModelPill = false,
   conversation,
   disabled,
+  foldVoice = false,
   hasComposerPayload,
+  minimal = false,
   state,
   voiceStatus,
   onDictate,
@@ -53,7 +55,9 @@ export function ComposerControls({
   compactModelPill?: boolean
   conversation: ConversationProps
   disabled: boolean
+  foldVoice?: boolean
   hasComposerPayload: boolean
+  minimal?: boolean
   state: ChatBarState
   voiceStatus: VoiceStatus
   onDictate: () => void
@@ -73,29 +77,38 @@ export function ComposerControls({
   // only when the composer is empty and a turn is running.
   const showStop = busy && !hasComposerPayload
   const showQueueButton = busyAction !== 'stop' && hasComposerPayload
+  // The HUD is a Spotlight bar a few hundred pixels wide, so the four separate
+  // voice toggles fold into one menu there and leave the row to the input. A
+  // narrow tile hits the same wall from the other direction and folds for the
+  // same reason — same controls, same state, different budget. Below that
+  // even the menu goes: at `minimal` the row is the send button and nothing
+  // else, which is the one thing that must survive every width.
+  const foldedVoice = hudMode || foldVoice
+
+  const voiceControls = foldedVoice ? (
+    <VoiceMenu
+      autoSpeak={autoSpeak}
+      disabled={disabled}
+      onDictate={onDictate}
+      onStartConversation={conversation.onStart}
+      onToggleAutoSpeak={onToggleAutoSpeak}
+      state={state}
+      voiceStatus={voiceStatus}
+    />
+  ) : (
+    <>
+      <DictationButton disabled={disabled} onToggle={onDictate} state={state.voice} status={voiceStatus} />
+      <AutoSpeakButton active={autoSpeak} disabled={disabled} onToggle={onToggleAutoSpeak} />
+      <WakeWordButton disabled={disabled} />
+    </>
+  )
 
   return (
-    <div className="ml-auto flex shrink-0 items-center gap-(--composer-control-gap)">
-      <ModelPill compact={compactModelPill} disabled={disabled} model={state.model} />
-      {/* The HUD is a Spotlight bar a few hundred pixels wide, so the four
-          separate voice toggles fold into one menu there and leave the row to
-          the input. The docked composer has the width and keeps them inline —
-          same controls, same state, different budget. */}
-      {hudMode ? (
-        <VoiceMenu
-          autoSpeak={autoSpeak}
-          disabled={disabled}
-          onDictate={onDictate}
-          onStartConversation={conversation.onStart}
-          onToggleAutoSpeak={onToggleAutoSpeak}
-          state={state}
-          voiceStatus={voiceStatus}
-        />
-      ) : (
+    <div className="ml-auto flex min-w-0 shrink items-center gap-(--composer-control-gap)">
+      {minimal ? null : (
         <>
-          <DictationButton disabled={disabled} onToggle={onDictate} state={state.voice} status={voiceStatus} />
-          <AutoSpeakButton active={autoSpeak} disabled={disabled} onToggle={onToggleAutoSpeak} />
-          <WakeWordButton disabled={disabled} />
+          <ModelPill compact={compactModelPill} disabled={disabled} model={state.model} />
+          {voiceControls}
         </>
       )}
       {showQueueButton ? (

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-metrics.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-metrics.ts
@@ -10,7 +10,13 @@ import {
 } from '@/app/chat/surface-vars'
 import { useResizeObserver } from '@/hooks/use-resize-observer'
 
-import { COMPOSER_COMPACT_PILL_PX, COMPOSER_SINGLE_LINE_MAX_PX, COMPOSER_STACK_BREAKPOINT_PX } from '../composer-utils'
+import {
+  COMPOSER_COMPACT_PILL_PX,
+  COMPOSER_FOLD_VOICE_PX,
+  COMPOSER_MINIMAL_PX,
+  COMPOSER_SINGLE_LINE_MAX_PX,
+  COMPOSER_STACK_BREAKPOINT_PX
+} from '../composer-utils'
 
 interface UseComposerMetricsArgs {
   composerDockRef: RefObject<HTMLDivElement | null>
@@ -20,13 +26,36 @@ interface UseComposerMetricsArgs {
   poppedOut: boolean
 }
 
+/** Every width-driven collapse stage, resolved from the composer's own width. */
+export interface ComposerFit {
+  compactPill: boolean
+  foldVoice: boolean
+  minimal: boolean
+  tight: boolean
+}
+
+const ROOMY: ComposerFit = { compactPill: false, foldVoice: false, minimal: false, tight: false }
+
+const fitForWidth = (width: number): ComposerFit => ({
+  compactPill: width < COMPOSER_COMPACT_PILL_PX,
+  foldVoice: width < COMPOSER_FOLD_VOICE_PX,
+  minimal: width < COMPOSER_MINIMAL_PX,
+  tight: width < COMPOSER_STACK_BREAKPOINT_PX
+})
+
+const sameFit = (a: ComposerFit, b: ComposerFit) =>
+  a.compactPill === b.compactPill && a.foldVoice === b.foldVoice && a.minimal === b.minimal && a.tight === b.tight
+
+interface UseComposerMetricsResult extends ComposerFit {
+  stacked: boolean
+}
+
 /**
  * Owns the composer's *sizing* engine: the stacked-vs-inline layout decision
  * and the measured-height CSS vars the thread reads for bottom clearance. All
  * work is edge-gated — the ResizeObserver only fires on real size changes, the
  * height vars are 8px-bucketed so per-keystroke growth never invalidates the
- * tree's computed style, and `tight` only flips when it crosses the breakpoint.
- * Returns `stacked` (the only value the render needs).
+ * tree's computed style, and the fit only re-renders when it crosses a stage.
  */
 export function useComposerMetrics({
   composerDockRef,
@@ -34,14 +63,9 @@ export function useComposerMetrics({
   composerSurfaceRef,
   editorRef,
   poppedOut
-}: UseComposerMetricsArgs): {
-  compactPill: boolean
-  stacked: boolean
-} {
+}: UseComposerMetricsArgs): UseComposerMetricsResult {
   const [expanded, setExpanded] = useState(false)
-  const [tight, setTight] = useState(false)
-  // Wider than `tight`: the pill goes icon-only before the row has to stack.
-  const [compactPill, setCompactPill] = useState(false)
+  const [fit, setFit] = useState<ComposerFit>(ROOMY)
 
   // Edge signals, not the live text: these only re-render when emptiness / the
   // presence of a non-trailing newline actually flips, so typing within a line
@@ -84,8 +108,7 @@ export function useComposerMetrics({
   // until a wrap or row change actually happens.
   const lastBucketedHeightRef = useRef(0)
   const lastBucketedSurfaceHeightRef = useRef(0)
-  const lastTightRef = useRef<boolean | null>(null)
-  const lastCompactPillRef = useRef<boolean | null>(null)
+  const lastFitRef = useRef(ROOMY)
   // Mirrored into a ref so `syncComposerMetrics` stays referentially stable —
   // it's the shared ResizeObserver's handler, and a new identity every render
   // would re-register the observation.
@@ -121,18 +144,11 @@ export function useComposerMetrics({
     const surfaceHeight = composerSurfaceRef.current?.getBoundingClientRect().height
 
     if (width > 0) {
-      const nextTight = width < COMPOSER_STACK_BREAKPOINT_PX
+      const nextFit = fitForWidth(width)
 
-      if (nextTight !== lastTightRef.current) {
-        lastTightRef.current = nextTight
-        setTight(nextTight)
-      }
-
-      const nextCompactPill = width < COMPOSER_COMPACT_PILL_PX
-
-      if (nextCompactPill !== lastCompactPillRef.current) {
-        lastCompactPillRef.current = nextCompactPill
-        setCompactPill(nextCompactPill)
+      if (!sameFit(nextFit, lastFitRef.current)) {
+        lastFitRef.current = nextFit
+        setFit(nextFit)
       }
     }
 
@@ -189,7 +205,7 @@ export function useComposerMetrics({
     }
   }, [composerRef])
 
-  // Both decisions come from the composer's OWN measured width, never the
+  // Every decision comes from the composer's OWN measured width, never the
   // viewport's. There used to be a `(max-width: 30rem)` media query in here as
   // well, and it quietly outranked everything: any window under 480px stacked
   // the row AND compacted the pill in the same instant, regardless of how much
@@ -199,7 +215,14 @@ export function useComposerMetrics({
   // stack) by 160px. The ResizeObserver knows the real width; the viewport is
   // not a proxy for it.
   //
-  // The pill still compacts whenever the row stacks, so the controls row can't
-  // over-run once it has the width to itself.
-  return { compactPill: compactPill || tight, stacked: expanded || tight }
+  // The ladder is monotonic: each stage implies the ones above it, so the pill
+  // is always compact by the time the row stacks, and the voice controls are
+  // always folded before minimal drops them.
+  return {
+    compactPill: fit.compactPill || fit.tight,
+    foldVoice: fit.foldVoice || fit.minimal,
+    minimal: fit.minimal,
+    stacked: expanded || fit.tight,
+    tight: fit.tight
+  }
 }

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -321,7 +321,7 @@ export function ChatBar({
     return onCancel()
   }, [activeQueueSessionKeyRef, onCancel])
 
-  const { compactPill, stacked } = useComposerMetrics({
+  const { compactPill, foldVoice, minimal, stacked } = useComposerMetrics({
     composerDockRef,
     composerRef,
     composerSurfaceRef,
@@ -984,7 +984,9 @@ export function ChatBar({
         status: conversation.status
       }}
       disabled={disabled}
+      foldVoice={foldVoice}
       hasComposerPayload={hasComposerPayload}
+      minimal={minimal}
       onDictate={dictate}
       onQueue={queueDraft}
       onToggleAutoSpeak={handleToggleAutoSpeak}
@@ -1242,7 +1244,13 @@ export function ChatBar({
               {hudMode && busy && <span aria-hidden className="arc-border arc-composer" />}
               <div
                 className={cn(
-                  'group/composer-surface relative z-4 isolate grid grid-rows-[auto_1fr] overflow-hidden rounded-[inherit] border border-[color-mix(in_srgb,var(--dt-composer-ring)_calc(18%*var(--composer-ring-strength)),var(--dt-input))]',
+                  // grid-cols-[minmax(0,1fr)]: the implicit `auto` column sized
+                  // itself to its items' min-content, so a status row whose
+                  // content out-measured a narrow pane silently widened the
+                  // track past the surface — and every `w-full` child (the fade,
+                  // the input/controls row) laid out against that phantom width
+                  // and got clipped by overflow-hidden, send button first.
+                  'group/composer-surface relative z-4 isolate grid grid-cols-[minmax(0,1fr)] grid-rows-[auto_1fr] overflow-hidden rounded-[inherit] border border-[color-mix(in_srgb,var(--dt-composer-ring)_calc(18%*var(--composer-ring-strength)),var(--dt-input))]',
                   COMPOSER_DROP_FADE_CLASS,
                   dragActive && COMPOSER_DROP_ACTIVE_CLASS
                 )}
@@ -1322,7 +1330,7 @@ export function ChatBar({
                       <ContribSlot area={COMPOSER_AREAS.leading} />
                     </div>
                     <div className="min-w-0 [grid-area:input]">{input}</div>
-                    <div className="flex items-center justify-end gap-(--composer-control-gap) [grid-area:controls]">
+                    <div className="flex min-w-0 items-center justify-end gap-(--composer-control-gap) [grid-area:controls]">
                       <ContribSlot area={COMPOSER_AREAS.actions} />
                       {controls}
                     </div>

--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -18,8 +18,11 @@ import { onComposerModelMenuRequest } from './focus'
 import { useComposerScope } from './scope'
 import type { ChatBarState } from './types'
 
+// `shrink` (not `shrink-0`) with a truncating label: the pill is the one
+// control in the row that can give width back continuously, so it absorbs the
+// squeeze between collapse stages instead of pushing Send past the edge.
 const PILL = cn(
-  'h-(--composer-control-size) max-w-40 shrink-0 gap-1 rounded-md px-2 text-xs font-normal',
+  'h-(--composer-control-size) min-w-0 max-w-40 shrink gap-1 rounded-md px-2 text-xs font-normal',
   'text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground'
 )
 


### PR DESCRIPTION
## Summary

A narrow tile clipped the composer's send button off the right edge — the surface is a grid that never declared a column, so the implicit `auto` column sized itself to its children's min-content. The coding status row (branch + PR chip + worktree path + counts, none of it wrapping) out-measured narrow panes and silently widened the track past the surface; every `w-full` child laid out against that phantom width and `overflow-hidden` ate the right edge, send button first. `grid-cols-[minmax(0,1fr)]` pins the track to the surface, verified against the live renderer (587px track in a 412px surface → 411px).

With the cause fixed, the collapse ladder also keeps going below stacking, since a pane can be dragged far narrower than the stacked controls row costs:

| composer width | controls row |
|---|---|
| ≥ 560 | everything inline, full model pill |
| < 560 | model pill → chevron only *(existing)* |
| < 320 | input takes its own row *(existing)* |
| < 260 | voice toggles fold into the one menu HUD mode already uses |
| < 180 | pill and menu drop — input + Send only, down to the 80px pane floor |

Every stage resolves from the composer's own measured width in the existing metrics engine (now one `ComposerFit` object, so a resize re-renders only when a stage flips), the pill shrinks/truncates between stages instead of holding its width, and Send stays reachable at any width the layout tree allows.

## Test plan

- [x] `vitest run src/app/chat/composer` — 370 passing, incl. new narrow-tile cases (fold without HUD mode, Send/Stop survive minimal)
- [x] `tsc --noEmit` clean on touched files
- [x] Live-verified in the running app over CDP: status-row content no longer widens the surface track; controls sit inside the surface edge