### PR TITLE
fix(gateway): tag remaining permanent loops out of the scale-to-zero busy check

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13004,6 +13004,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         start_time=getattr(self, "_gateway_started_at", 0.0),
                     )
                 )
+                # Permanent process-lifetime loop, not transient work: must not
+                # hold the scale-to-zero busy check open (same tag as
+                # _spawn_supervised; see _scale_to_zero_has_live_background_work).
+                self._loop_heartbeat_task._hermes_supervised_watcher = True  # type: ignore[attr-defined]
                 _bg = getattr(self, "_background_tasks", None)
                 if _bg is not None:
                     _bg.add(self._loop_heartbeat_task)
@@ -21248,6 +21252,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         try:
             task = asyncio.create_task(_poll_loop())
+            # Gateway-wide permanent poll loop (lives until process exit once
+            # any /heartbeat is registered) — tag it out of the scale-to-zero
+            # busy check like every other permanent loop. The heartbeat DUE
+            # check itself still wakes work through the adapter FIFO, which
+            # stamps real inbound and blocks suspend the normal way.
+            task._hermes_supervised_watcher = True  # type: ignore[attr-defined]
             self._heartbeat_poll_task = task
             _bg = getattr(self, "_background_tasks", None)
             if _bg is not None:

--- a/tests/gateway/test_scale_to_zero_watcher.py
+++ b/tests/gateway/test_scale_to_zero_watcher.py
@@ -370,3 +370,54 @@ async def test_done_supervised_watcher_is_ignored_either_way():
     await t
     r._background_tasks = {t}
     assert r._scale_to_zero_has_live_background_work() is False
+
+
+# ── OTHER permanent loops must carry the supervised tag too (staging E2E bug) ──
+#
+# The first staging E2E after the watcher-exclusion fix STILL never went
+# dormant: the loop-liveness heartbeat task (started in run(), not via
+# _spawn_supervised) sits untagged in _background_tasks for the whole process
+# life, holding the busy check True forever. Same class: any PERMANENT loop
+# parked in _background_tasks must carry _hermes_supervised_watcher. The
+# heartbeat POLLER (started on /heartbeat use) is the same shape.
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_poller_does_not_block_idle():
+    """_start_heartbeat_poller is a real call site that parks a permanent loop
+    in _background_tasks — it must tag it out of the busy check."""
+    r = GatewayRunner.__new__(GatewayRunner)
+    r._running = True
+    r._background_tasks = set()
+    r._heartbeat_watch = {}
+    r._running_agents = {}
+
+    r._start_heartbeat_poller()
+    await asyncio.sleep(0)
+    try:
+        assert r._heartbeat_poll_task is not None
+        assert r._heartbeat_poll_task in r._background_tasks
+        assert r._scale_to_zero_has_live_background_work() is False
+    finally:
+        r._heartbeat_poll_task.cancel()
+        await asyncio.gather(r._heartbeat_poll_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_loop_heartbeat_shape_is_excluded_when_tagged():
+    """The run()-started loop-liveness heartbeat is tagged at its call site;
+    a tagged forever-running task must be excluded from the busy check."""
+    r = GatewayRunner.__new__(GatewayRunner)
+    r._running = True
+
+    async def _forever():
+        await asyncio.sleep(3600)
+
+    tagged = asyncio.create_task(_forever())
+    tagged._hermes_supervised_watcher = True
+    r._background_tasks = {tagged}
+    try:
+        assert r._scale_to_zero_has_live_background_work() is False
+    finally:
+        tagged.cancel()
+        await asyncio.gather(tagged, return_exceptions=True)


### PR DESCRIPTION
## Summary

Follow-up to #84327 from the first live E2E run on staging (`hermes-agent-stg-test-6698`, 2026-08-20, post-#84339 image): the instance armed at 05:56:56, went fully idle (only cron fires + housekeeping), and **still** never logged `going dormant` after 25+ minutes.

## Root cause

#84327 excluded `_spawn_supervised` watchers from `_scale_to_zero_has_live_background_work()` — but two permanent loops are started **directly with `asyncio.create_task`**, parked in `_background_tasks`, and never tagged:

- the **loop-liveness heartbeat** (`_loop_heartbeat_task`, started in `run()` on every boot — confirmed alive on the staging box: `state/gateway.heartbeat` refreshing every tick), and
- the **gateway-wide heartbeat poller** (`_start_heartbeat_poller`, started once any `/heartbeat` is registered).

The loop-liveness task alone is enough to hold the busy check True for the whole process life on every gateway, hosted or not.

## Fix

Tag both call sites with `_hermes_supervised_watcher = True` (the same tag `_spawn_supervised` applies). No behavioral change to either loop; transient tasks in `_background_tasks` still block suspend. Audited the remaining `_background_tasks.add` sites: startup-resume events, plugin injection futures, completion-batch flushes, and supervised respawn helpers are all transient + self-discarding — correctly counted.

## Tests

- `test_heartbeat_poller_does_not_block_idle` — exercises the **real** `_start_heartbeat_poller` call site; **fails on main** (verified: 1 failed / 16 passed with the fix stashed), passes with the fix.
- `test_loop_heartbeat_shape_is_excluded_when_tagged` — the tagged-forever-task contract.
- `./scripts/run_tests.sh tests/gateway/test_scale_to_zero_watcher.py` — **17 passed, 0 failed**; ruff clean.

## Verification plan

Same staging E2E, after image roll: `going dormant ... then self-suspending` + `suspend accepted by flaps` in agent.log within ~5–6 min of idle, `suspension/suspended (flyd)` in Fly events, Chronos cold-fire resume. (The instance's recurring 15-min cron leaves a ~9-min idle window — enough for the 5-min timeout.)

Refs: #84295, #84327, #84339, NousResearch/nous-account-service#898.

## Infographic

![still-awake](https://v3b.fal.media/files/b/0aa7100a/vhrmRWZbglpTj-Rqc8w88_8uRRGg2g.png)
