### PR TITLE
fix(cli): /undo typo no longer quits the CLI (+3 slash-command papercuts)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11638,8 +11638,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                             from hermes_state import SessionDB
                             new_title = SessionDB.sanitize_title(raw_title)
                         except ValueError as e:
+                            # sanitize_title rejected the input (e.g. too long).
+                            # Print that one reason and stop — don't fall
+                            # through to the "empty after cleanup" branch and
+                            # print a second, contradictory error (SC-05).
                             _cprint(f"  {e}")
-                            new_title = None
+                            return True
                         if not new_title:
                             _cprint("  Title is empty after cleanup. Please use printable characters.")
                         elif self._session_db.get_session(self.session_id):
@@ -11729,9 +11733,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     _undo_n = int(_undo_parts[1])
                 except ValueError:
                     print(f"(._.) Invalid count {_undo_parts[1]!r} — use /undo or /undo N.")
-                    return
+                    return True  # bad arg — command handled, keep the REPL alive
                 if _undo_n < 1:
                     _undo_n = 1
+            # Nothing to undo → say so immediately; don't pop a destructive
+            # confirmation dialog for a guaranteed no-op (SC-06).
+            if not self.conversation_history:
+                print("(._.) No messages to undo.")
+                return True
             _undo_desc = (
                 "This removes the last user/assistant exchange from history."
                 if _undo_n == 1

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1048,7 +1048,7 @@ class CLICommandsMixin:
         session_meta = self._session_db.get_session(target_id)
         if not session_meta:
             _cprint(f"  Session not found: {target}")
-            _cprint("  Use /history or `hermes sessions list` to see available sessions.")
+            _cprint("  Use /sessions or `hermes sessions list` to see available sessions.")
             return
 
         # If the target is the empty head of a compression chain, redirect to

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -263,7 +263,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("diff", "Show git changes in the working directory", "Info",
                args_hint="[staged|all|session] [--stat] [path...]",
                subcommands=("staged", "all", "session")),
-    CommandDef("verbose", "Cycle tool progress display: off -> new -> all -> verbose -> log",
+    CommandDef("verbose", "Cycle tool progress display: off -> new -> all -> verbose",
                "Configuration", cli_only=True,
                gateway_config_gate="display.tool_progress_command",
                busy_policy="dispatch"),

--- a/tests/cli/test_slash_undo_title_robustness.py
+++ b/tests/cli/test_slash_undo_title_robustness.py
@@ -1,0 +1,55 @@
+"""Regression tests for slash-command dispatch robustness (round-3 QA).
+
+Covers:
+- SC-01: `/undo <non-numeric>` must NOT quit the CLI (process_command returns
+  True to keep the REPL alive), and must not raise.
+- SC-06: `/undo` on an empty session reports "nothing to undo" without popping
+  a destructive-confirmation dialog.
+- SC-05: `/title <too-long>` prints exactly one error, not the contradictory
+  "too long" + "empty after cleanup" pair.
+"""
+
+from unittest.mock import patch
+
+from tests.cli.test_cli_init import _make_cli
+
+
+def test_undo_non_numeric_count_keeps_repl_alive():
+    """`/undo abc` returned a bare None → REPL treated it as exit (SC-01)."""
+    cli = _make_cli()
+    cli.conversation_history = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    # Must not raise, and must return True (truthy → REPL continues).
+    result = cli.process_command("/undo abc")
+    assert result is True
+
+
+def test_undo_empty_session_no_confirmation_dialog():
+    """`/undo` with no history must short-circuit before the destructive prompt (SC-06)."""
+    cli = _make_cli()
+    cli.conversation_history = []
+
+    called = {"confirm": False}
+
+    def _spy_confirm(*a, **k):
+        called["confirm"] = True
+        return "approved"
+
+    with patch.object(cli, "_confirm_destructive_slash", _spy_confirm):
+        result = cli.process_command("/undo")
+
+    assert result is True
+    assert called["confirm"] is False  # no confirmation for a guaranteed no-op
+
+
+def test_title_too_long_prints_single_error(capsys):
+    """`/title <500 chars>` must print one error, not two contradictory ones (SC-05)."""
+    cli = _make_cli()
+    result = cli.process_command("/title " + "A" * 500)
+    out = capsys.readouterr().out
+    assert result is True
+    # The length error should fire; the contradictory "empty after cleanup"
+    # message must NOT also appear.
+    assert "empty after cleanup" not in out.lower()


### PR DESCRIPTION
## Summary
A typo like `/undo abc` no longer quits the whole CLI, plus three sibling slash-command papercuts found in the round-3 deep QA sweep.

## Changes
- **`/undo <non-numeric>` crash (SC-01, the important one):** the `except ValueError` branch did a bare `return` → `process_command` returned `None` → the REPL loop treated it as an exit signal (same protocol as `/quit`) and shut the session down. A fat-fingered `/undo l` killed your live conversation. Now `return True` like every sibling branch.
- **`/undo` on an empty session (SC-06):** popped a destructive-confirmation dialog *before* checking there was anything to undo. Now short-circuits to "No messages to undo" with no prompt (and no risk of "Always approve" being trained on a no-op).
- **`/title <too-long>` double error (SC-05):** the length-rejection path set `new_title=None` and fell through into the "empty after cleanup — use printable characters" branch, printing two contradictory errors for 500 printable chars. Now prints the one real reason and returns.
- **`/verbose` help lie (SC-02):** registry description advertised `off -> new -> all -> verbose -> log`, but the cycle is 4 states — `log` is unreachable. Dropped `-> log`.
- **`/resume <bad id>` wrong hint (UX-05):** pointed users to `/history` (current conversation's messages) instead of `/sessions` (the resumable-session browser). Fixed the hint.

## Validation
| | Before | After |
|---|---|---|
| `/undo abc` in live session | prints error, then "Fair winds!" — CLI exits | error prints, session stays alive (live-verified in tmux + unit test) |
| `/undo` empty session | destructive-confirm dialog for a no-op | "No messages to undo", no prompt |
| `/title <500 chars>` | "too long" + "empty after cleanup" | one "too long" error |
| targeted tests | — | 3 new tests pass (`test_slash_undo_title_robustness.py`) |

All four are independent one-to-three-line fixes in the same slash-dispatch area; batched as one review.

## Infographic

![undo crash fix infographic](https://files.catbox.moe/fa7565.png)
