### PR TITLE
fix(weixin): preserve wrapped list indentation / 修复微信列表换行缩进

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -180,6 +180,9 @@ TYPING_STOP = 2
 _HEADER_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
 _TABLE_RULE_RE = re.compile(r"^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*$")
 _FENCE_RE = re.compile(r"^```([^\n`]*)\s*$")
+_LIST_PREFIX_RE = re.compile(
+    r"^(?P<prefix>\s*(?:[-+*•]|\d+[.)]|[（(]\d+[）)])\s+(?:\[[ xX]\]\s+)?)"
+)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 
 
@@ -751,9 +754,14 @@ def _wrap_copy_friendly_lines_for_weixin(content: str) -> str:
             wrapped.append(line)
             continue
 
+        list_prefix = _LIST_PREFIX_RE.match(line)
+        continuation_indent = (
+            " " * len(list_prefix.group("prefix")) if list_prefix else ""
+        )
         wrapped_lines = textwrap.wrap(
             line,
             width=WEIXIN_COPY_LINE_WIDTH,
+            subsequent_indent=continuation_indent,
             break_long_words=False,
             break_on_hyphens=False,
             replace_whitespace=False,

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -72,6 +72,30 @@ class TestWeixinFormatting:
         assert " ".join(formatted.split()) == " ".join(content.split())
 
 
+    @pytest.mark.parametrize(
+        ("marker", "continuation_indent"),
+        [
+            ("- ", "  "),
+            ("10. ", "    "),
+        ],
+    )
+    def test_format_message_hanging_indents_wrapped_list_items(
+        self, marker, continuation_indent
+    ):
+        adapter = _make_adapter()
+        content = marker + " ".join(
+            f"knowledge-base-detail-{index}" for index in range(18)
+        )
+
+        formatted = adapter.format_message(content)
+        lines = formatted.splitlines()
+
+        assert len(lines) > 1
+        assert lines[0].startswith(marker)
+        assert all(line.startswith(continuation_indent) for line in lines[1:])
+        assert all(len(line) <= weixin.WEIXIN_COPY_LINE_WIDTH for line in lines)
+
+
 class TestWeixinChunking:
 
 


### PR DESCRIPTION
## What does this PR do? / 这个 PR 做了什么？

The Weixin copy-friendly formatter wraps long display lines, but wrapped list-item continuation lines previously started at column zero. This made one long list item look like multiple top-level paragraphs and caused visible misalignment in messages such as daily reviews.

微信的便于复制格式化器会对长行换行，但此前列表项的续行会从行首开始，导致一个长列表项看起来像多个顶层段落，并在每日复盘等消息中出现明显错位。

This change detects common unordered, ordered, and task-list prefixes and gives `textwrap.wrap()` a matching hanging indent. Plain text, tables, and code blocks keep their existing behavior.

本次修改识别常见的无序列表、有序列表和任务列表前缀，并为 `textwrap.wrap()` 设置与前缀等宽的悬挂缩进；普通文本、表格和代码块的既有行为保持不变。

## Related Issue / 关联 Issue

N/A — no exact matching issue was found. / 不适用——未找到完全相同的现有 Issue。

## Type of Change / 变更类型

- [x] 🐛 Bug fix (non-breaking change that fixes an issue) / Bug 修复（非破坏性）
- [ ] ✨ New feature (non-breaking change that adds functionality) / 新功能
- [ ] 🔒 Security fix / 安全修复
- [ ] 📝 Documentation update / 文档更新
- [ ] ✅ Tests (adding or improving test coverage) / 测试改进
- [ ] ♻️ Refactor (no behavior change) / 重构
- [ ] 🎯 New skill (bundled or hub) / 新技能

## Changes Made / 具体修改

- `gateway/platforms/weixin.py`: detect list prefixes and preserve their visual alignment on wrapped continuation lines. / 检测列表前缀，并让换行后的续行保持视觉对齐。
- `tests/gateway/test_weixin.py`: add regression coverage for unordered (`- `) and multi-digit ordered (`10. `) list items. / 为无序列表（`- `）和多位数字有序列表（`10. `）新增回归测试。

## How to Test / 如何测试

1. Pass a list item longer than `WEIXIN_COPY_LINE_WIDTH` to `WeixinAdapter.format_message()`. Before this fix, continuation lines start at column zero; after the fix, they align with the item text. / 向 `WeixinAdapter.format_message()` 传入超过 `WEIXIN_COPY_LINE_WIDTH` 的列表项。修复前续行从行首开始；修复后续行与列表正文对齐。
2. Run the focused regression test / 运行定向回归测试：

   ```bash
   scripts/run_tests.sh tests/gateway/test_weixin.py -q -k hanging_indents_wrapped_list_items
   ```

   Result / 结果：`2 passed, 0 failed`.

3. Run the full Weixin adapter test file / 运行完整微信适配器测试：

   ```bash
   scripts/run_tests.sh tests/gateway/test_weixin.py -q
   ```

   Result / 结果：`32 passed, 0 failed`.

4. Run lint on the changed files / 对变更文件运行格式检查：

   ```bash
   ruff check gateway/platforms/weixin.py tests/gateway/test_weixin.py
   ```

   Result / 结果：`All checks passed!`.

Full-suite note: `scripts/run_tests.sh` was attempted, but the local development environment could not collect unrelated ACP tests because the optional `acp` package was not installed (`ModuleNotFoundError: No module named 'acp'`). The scoped Weixin tests and lint above pass. / 完整测试说明：已尝试运行 `scripts/run_tests.sh`，但本地开发环境因未安装可选的 `acp` 包而无法收集与本修改无关的 ACP 测试（`ModuleNotFoundError: No module named 'acp'`）。上述微信专项测试与格式检查均已通过。

## Checklist / 检查清单

### Code / 代码

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md). / 已阅读贡献指南。
- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/). / 提交信息遵循 Conventional Commits。
- [x] I searched existing issues and PRs and found no exact duplicate. / 已搜索现有 Issue 和 PR，未发现完全重复项。
- [x] This PR contains only changes related to this fix. / 本 PR 只包含与该修复有关的修改。
- [ ] I've run the entire test suite and all tests pass. / 已运行全部测试且全部通过。（See the full-suite note above. / 见上方完整测试说明。）
- [x] I've added regression tests for the bug. / 已为该问题新增回归测试。
- [x] Tested on Ubuntu 22.04.5 LTS, x86_64, Python 3.11.15. / 已在 Ubuntu 22.04.5 LTS、x86_64、Python 3.11.15 上测试。

### Documentation & Housekeeping / 文档与维护

- [x] Documentation update: N/A; no user-facing API or configuration changed. / 文档更新：不适用；未改变用户接口或配置。
- [x] `cli-config.yaml.example` update: N/A; no configuration key changed. / 配置示例更新：不适用；未改变配置项。
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A; no architecture or workflow changed. / 贡献或代理规则更新：不适用；未改变架构或工作流。
- [x] Cross-platform impact considered: the change uses existing Python standard-library `re` and `textwrap` behavior. / 已考虑跨平台影响：修改仅使用现有 Python 标准库 `re` 与 `textwrap` 行为。
- [x] Tool descriptions/schemas update: N/A; no tool contract changed. / 工具描述或 schema 更新：不适用；未改变工具契约。

## Screenshots / Logs / 截图与日志

Not applicable; this is a text-formatting fix. The automated results are listed in **How to Test** above. / 不适用；这是文本格式修复，自动化验证结果已列在上方 **How to Test** 中。
