### PR TITLE
fix(cron): mark live deliveries as terminal notifications

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2850,6 +2850,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 route_metadata = {
                     "direct_messages_topic_id": str(thread_id),
                     "job_id": job["id"],
+                    # Cron output is a terminal delivery, not an intermediate
+                    # assistant message.  Telegram uses this marker to avoid
+                    # re-arming its one-shot typing timer after send().
+                    "notify": True,
                 }
                 # Media metadata mirrors the text routing so attachments land in
                 # the same DM topic instead of the General lane (#22773).
@@ -2864,7 +2868,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # anchor, so the metadata key bypasses that check and lets the
                 # adapter route via a plain message_thread_id.
                 route_thread_id = str(thread_id) if thread_id is not None else None
-                route_metadata = {"job_id": job["id"]}
+                route_metadata = {
+                    "job_id": job["id"],
+                    # Cron output is a terminal delivery, not an intermediate
+                    # assistant message.  Telegram uses this marker to avoid
+                    # re-arming its one-shot typing timer after send().
+                    "notify": True,
+                }
                 if route_thread_id:
                     route_metadata["thread_id"] = route_thread_id
                 media_metadata = {"thread_id": thread_id} if thread_id else None

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -486,6 +486,9 @@ class TestDeliverResultWrapping:
         text_sent = adapter.send.call_args[0][1]
         assert "MEDIA:" not in text_sent
         assert "Here is TTS" in text_sent
+        # Cron output is terminal.  Telegram's adapter consumes notify=True to
+        # avoid re-arming the ~5s typing timer after the final send (#48678).
+        assert adapter.send.call_args.kwargs["metadata"]["notify"] is True
 
         # Audio file should be sent as a voice attachment
         adapter.send_voice.assert_called_once()


### PR DESCRIPTION
## Summary
- mark live cron text deliveries with `notify=True`
- preserve the marker for Telegram forum and direct-message topic routing
- add a regression assertion at the scheduler-to-adapter boundary

## Why
Telegram intentionally re-arms its one-shot typing timer after intermediate sends. The adapter already skips that behavior for final sends carrying `metadata["notify"]`, but live cron deliveries only passed `job_id`, so every completed cron message re-triggered the typing bubble after delivery. Since cron has no active response lifecycle to refresh or cancel it, users saw a phantom `...typing` indicator after the job finished.

## Tests
`uv run --with pytest --with pytest-asyncio python -m pytest tests/cron/test_scheduler.py tests/gateway/test_telegram_format.py -o addopts= -q`

Result: `136 passed`.