### PR TITLE
fix(gateway): read launchd plists in binary or XML format

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -9,6 +9,7 @@ from hermes_cli.cli_output import line_input
 import json
 import logging
 import os
+import plistlib
 import shlex
 import shutil
 import signal
@@ -5081,7 +5082,24 @@ def launchd_plist_is_current() -> bool:
     if not plist_path.exists():
         return False
 
-    installed = plist_path.read_text(encoding="utf-8")
+    # macOS launchd commonly rewrites installed plists to binary format on
+    # bootstrap (and ``launchctl`` may also normalize XML plists back to binary).
+    # The previous ``read_text(encoding="utf-8")`` crashed on the binary header
+    # byte (``bplist00`` starts with ``0xd8``), throwing ``UnicodeDecodeError``
+    # out of every ``gateway status`` / ``gateway install`` / auto-refresh path
+    # once the plist was binary (issue #90606).
+    #
+    # ``plistlib`` transparently handles both binary and XML; re-emit as XML so
+    # the existing text normalizer can compare against the generated plist.  A
+    # corrupt or unparseable plist reports "not current" so the auto-refresh
+    # path self-heals by rewriting the plist instead of crashing with a
+    # different error (the original bug class).
+    try:
+        with plist_path.open("rb") as _f:
+            _installed_data = plistlib.load(_f)
+    except Exception:
+        return False
+    installed = plistlib.dumps(_installed_data, fmt=plistlib.FMT_XML).decode("utf-8")
     expected = generate_launchd_plist()
     return _normalize_launchd_plist_for_comparison(
         installed


### PR DESCRIPTION
fix(gateway): read launchd plists in binary or XML format

`launchd_plist_is_current()` called `plist_path.read_text(encoding="utf-8")`,
which crashed with UnicodeDecodeError when the installed plist was in Apple's
binary plist format (header `bplist00\xd8` — the `\xd8` byte is not valid
UTF-8). macOS launchd commonly rewrites installed plists to binary on
bootstrap, so any Hermes install whose `launchctl` had decided to write
binary would hit this on every `hermes gateway status`, `hermes gateway
install`, and every auto-refresh path that gates on the staleness check.

Parse with `plistlib` (handles both binary and XML transparently) and
re-emit as XML before passing to the existing text normalizer so the PATH
strip-and-compare contract is preserved verbatim.

Symptom (seen on macOS, Python 3.11):

  $ hermes gateway status
  Traceback (most recent call last):
    ...
    File ".../hermes_cli/gateway.py", line 4704, in launchd_plist_is_current
      installed = plist_path.read_text(encoding="utf-8")
  UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd8 in position 8:
  invalid continuation byte

Gateway runtime was unaffected — only status/install/refresh paths crashed.
Service definition on disk was valid; `plutil -convert xml1 -o - <plist>`
confirmed the keys/values were correct.

Fix is stdlib-only (`plistlib` ships with Python). No new dependencies,
no behavior change for XML plists (the round-trip preserves all keys and
values used by the comparison), no change to the comparison normalizer.
