### PR TITLE
fix(desktop): keep cron jobs visible in project view

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1848,7 +1848,7 @@ export function ChatSidebar({
                 )
               })}
 
-            {!trimmedQuery && !worktreeGroupingActive && cronJobs.length > 0 && (
+            {!trimmedQuery && cronJobs.length > 0 && (
               <SidebarCronJobsSection
                 jobs={cronJobs}
                 label={s.cronJobs}


### PR DESCRIPTION
## Summary
- In Project grouping view, Cron jobs section is now rendered even when `worktreeGroupingActive` is true.
- This is a narrow render-layer behavior fix for #90579.

## Test Plan
- [x] `git diff --check` (clean: no whitespace/syntax diff issues).
- [x] Independent reviewer (`requesting-code-review` path) found no blocking security or logic issues.
- [x] Manual verification of the changed condition in `apps/desktop/src/app/chat/sidebar/index.tsx`.
- [ ] Frontend typecheck/lint/tests for `apps/desktop` could not be fully run due environment constraints:
  - `npm run install:desktop` fails due Node/npm engine constraints in this runner.
  - `bunx tsc --project tsconfig.json` fails due missing `@types/node` (workspace dependencies not installed).

Closes #90579
