### PR TITLE
fix(model-metadata): treat the OpenAI-style completion split as an output-cap error

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1614,6 +1614,57 @@ def get_context_length_from_provider_error(
     return None
 
 
+# OpenAI-compatible servers word an output-cap rejection as a two-part split
+# inside parentheses.  vLLM and llama-cpp-python both inherit OpenAI's original
+# text:
+#   "This model's maximum context length is 102400 tokens. However, you
+#    requested 102401 tokens (36865 in the messages, 65536 in the completion).
+#    Please reduce the length of the messages or completion."
+# The legacy completions endpoint words the same split as
+#   "(771 in your prompt; 4000 for the completion)".
+# Either way the first number is the MEASURED prompt size and the second is the
+# max_tokens that was requested, so window - prompt is a real output budget.
+_COMPLETION_SPLIT_RE = re.compile(
+    r'\((\d+)\s+(?:tokens\s+)?in (?:the messages|your prompt|the prompt)\s*[;,]\s*'
+    r'(\d+)\s+(?:tokens\s+)?(?:in|for) the completion\)'
+)
+
+
+def _parse_completion_split(error_lower: str) -> Optional[Tuple[int, int]]:
+    """Return (prompt_tokens, requested_output_tokens) from an OpenAI-style split.
+
+    ``error_lower`` must already be lowercased.  Returns None when the error
+    does not carry the parenthetical breakdown.
+    """
+    match = _COMPLETION_SPLIT_RE.search(error_lower)
+    if match is None:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+def _split_output_budget(error_lower: str) -> Optional[int]:
+    """Return the output budget an OpenAI-style split implies, or None.
+
+    ``error_lower`` must already be lowercased.  None means "not an output-cap
+    error of this shape", for any of three reasons: the error carries no split,
+    the context window is unreadable, or the measured prompt alone fills the
+    window.  That last case is a genuine input overflow, which only compression
+    can fix, so it must stay off the max_tokens retry path.
+
+    Both callers go through this one function so the predicate ("is this an
+    output-cap error?") and the number ("how much output fits?") cannot drift
+    apart.
+    """
+    split = _parse_completion_split(error_lower)
+    if split is None:
+        return None
+    m_ctx = re.search(r'maximum context length is (\d+)', error_lower)
+    if m_ctx is None:
+        return None
+    available = int(m_ctx.group(1)) - split[0]
+    return available if available >= 1 else None
+
+
 def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     """Detect an "output cap too large" error and return how many output tokens are available.
 
@@ -1666,6 +1717,14 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         # This is independent of the input context window.
         "exceeds model" in error_lower
         and "maximum output tokens" in error_lower
+    ) or (
+        # OpenAI-compatible split form, e.g. vLLM / llama-cpp-python:
+        #   "... (36865 in the messages, 65536 in the completion)".
+        # This wording never mentions max_tokens by name, so none of the
+        # clauses above fire and the error used to fall through to the
+        # compression path -- which re-sends the same oversized max_tokens and
+        # collects the identical 400 until "cannot compress further" (#55546).
+        _parse_completion_split(error_lower) is not None
     )
     if not is_output_cap_error:
         return None
@@ -1718,6 +1777,15 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         _available = int(_m_ctx.group(1)) - int(_m_parts.group(1)) - int(_m_parts.group(2))
         if _available >= 1:
             return _available
+
+    # OpenAI-compatible split form: "(A in the messages, B in the completion)".
+    # A is the prompt size the server actually measured, so the rest of the
+    # window is a trustworthy output budget.  When the prompt alone fills the
+    # window this stays None and the caller falls through to compression, which
+    # is the correct remedy for a genuine input overflow.
+    _split_available = _split_output_budget(error_lower)
+    if _split_available is not None:
+        return _split_available
 
     # LM Studio / llama.cpp style: context window is reported in tokens but the
     # prompt size is reported in CHARACTERS, e.g.
@@ -1796,6 +1864,16 @@ def is_output_cap_error(error_msg: str) -> bool:
     path (a real input overflow can also mention max_tokens).
     """
     error_lower = error_msg.lower()
+
+    # OpenAI-style split form: "(36865 in the messages, 65536 in the
+    # completion)".  It names neither max_tokens nor any of its aliases, so the
+    # mentions_output_param gate below rejects it outright even though it is
+    # exactly the deterministic output-cap 400 this function exists to catch.
+    # Only claim it when the measured prompt still leaves room in the window:
+    # if the prompt alone fills the window the request is a genuine input
+    # overflow and belongs on the compression path.
+    if _split_output_budget(error_lower) is not None:
+        return True
 
     mentions_output_param = (
         "max_tokens" in error_lower

--- a/tests/test_output_cap_parsing.py
+++ b/tests/test_output_cap_parsing.py
@@ -191,3 +191,89 @@ class TestParseVllmTokenBasedOutputCap:
             cap = available
         assert real_input + cap <= window, f"did not converge: cap={cap}"
 
+
+
+class TestParseCompletionSplitOutputCap:
+    """OpenAI-compatible servers report the split as "(A in the messages,
+    B in the completion)".  vLLM and llama-cpp-python both inherit this
+    wording, and it names neither max_tokens nor "output tokens", so it used to
+    miss every branch and land on the compression path.  Compression cannot fix
+    an output-cap error: the retry re-sends the same max_tokens and collects the
+    identical 400 until "cannot compress further" (#55546)."""
+
+    def test_vllm_completion_split_format(self):
+        msg = ("Error code: 400 - This model's maximum context length is 102400 "
+               "tokens. However, you requested 102401 tokens (36865 in the "
+               "messages, 65536 in the completion). Please reduce the length of "
+               "the messages or completion.")
+        # available output = 102400 - 36865 = 65535
+        assert parse_available_output_tokens_from_error(msg) == 65535
+
+    def test_openai_legacy_prompt_split_format(self):
+        msg = ("This model's maximum context length is 4097 tokens, however you "
+               "requested 4771 tokens (771 in your prompt; 4000 for the "
+               "completion). Please reduce your prompt; or completion length.")
+        # available output = 4097 - 771 = 3326
+        assert parse_available_output_tokens_from_error(msg) == 3326
+
+    def test_completion_split_is_output_cap_error(self):
+        msg = ("This model's maximum context length is 102400 tokens. However, "
+               "you requested 102401 tokens (36865 in the messages, 65536 in "
+               "the completion). Please reduce the length of the messages or "
+               "completion.")
+        assert is_output_cap_error(msg) is True
+
+    def test_completion_split_retry_cap_fits_the_window(self):
+        # The whole point: the retried cap plus the measured prompt must fit.
+        window, prompt = 102400, 36865
+        available = parse_available_output_tokens_from_error(
+            f"This model's maximum context length is {window} tokens. However, "
+            f"you requested {window + 1} tokens ({prompt} in the messages, "
+            f"{window + 1 - prompt} in the completion)."
+        )
+        assert available is not None
+        assert available + prompt <= window
+
+    def test_split_with_oversized_prompt_stays_on_compression_path(self):
+        # The prompt alone fills the window, so this is a genuine input
+        # overflow.  Trimming max_tokens cannot help; compression can.
+        msg = ("This model's maximum context length is 8192 tokens. However, you "
+               "requested 20000 tokens (20000 in the messages, 0 in the "
+               "completion). Please reduce the length of the messages or "
+               "completion.")
+        assert parse_available_output_tokens_from_error(msg) is None
+        assert is_output_cap_error(msg) is False
+
+    def test_plain_overflow_without_split_is_untouched(self):
+        # No parenthetical breakdown -> still an input overflow, still routed
+        # to compression.
+        msg = ("This endpoint's maximum context length is 128000 tokens. "
+               "However, you requested about 200000 tokens. Please reduce the "
+               "length of the messages.")
+        assert parse_available_output_tokens_from_error(msg) is None
+        assert is_output_cap_error(msg) is False
+
+    def test_split_without_a_readable_window_is_declined(self):
+        # The split is there but the context window is not, so there is no
+        # budget to compute. Both predicates must decline rather than guess.
+        msg = "you requested 4771 tokens (771 in the messages, 4000 in the completion)."
+        assert parse_available_output_tokens_from_error(msg) is None
+        assert is_output_cap_error(msg) is False
+
+    def test_split_predicates_stay_in_lockstep(self):
+        # Both functions read the split through one helper, so claiming the
+        # error and producing a budget must always agree. If they ever drift,
+        # a request gets claimed as output-cap-shaped with no budget to retry
+        # on, or vice versa.
+        msgs = [
+            "This model's maximum context length is 102400 tokens. However, you "
+            "requested 102401 tokens (36865 in the messages, 65536 in the completion).",
+            "This model's maximum context length is 4097 tokens, however you "
+            "requested 4771 tokens (771 in your prompt; 4000 for the completion).",
+            "This model's maximum context length is 8192 tokens. However, you "
+            "requested 20000 tokens (20000 in the messages, 0 in the completion).",
+            "you requested 4771 tokens (771 in the messages, 4000 in the completion).",
+        ]
+        for msg in msgs:
+            has_budget = parse_available_output_tokens_from_error(msg) is not None
+            assert has_budget is is_output_cap_error(msg), msg


### PR DESCRIPTION
## What does this PR do?

An output-cap overflow written in OpenAI's original parenthetical wording is not recognized as an output-cap error by either detector, so it gets routed into context compression, which cannot fix it.

OpenAI's API and the OpenAI-compatible servers that copied its error text (vLLM, llama-cpp-python) reject an over-cap request like this:

```text
This model's maximum context length is 102400 tokens. However, you requested 102401 tokens (36865 in the messages, 65536 in the completion). Please reduce the length of the messages or completion.
```

The legacy completions endpoint words the same split slightly differently:

```text
This model's maximum context length is 4097 tokens, however you requested 4771 tokens (771 in your prompt; 4000 for the completion). Please reduce your prompt; or completion length.
```

Neither sentence contains `max_tokens`, and neither contains `output tokens`. That is enough to defeat both functions:

- in `parse_available_output_tokens_from_error()`, every clause of the `is_output_cap_error` gate is False, so the function returns `None` before any numeric branch runs;
- `is_output_cap_error()` fails on its first check, `mentions_output_param`, which only accepts `max_tokens`, `max_output_tokens` and `max_completion_tokens`. This wording puts the output side in the phrase "in the completion".

The classifier still routes the 400 to `FailoverReason.context_overflow`, so it reaches the recovery path in `agent/conversation_loop.py`, takes the compression branch, re-issues the call with the same oversized `max_tokens`, and collects the identical 400. The turn burns every compression attempt and ends in `cannot compress further`.

The fix reads the numbers the server already gave us. The first number in the parenthetical is the prompt size the server actually measured, so `context_window - prompt_tokens` is a real output budget, and the existing ephemeral `max_tokens` retry takes it from there. `context_length` is never touched, because the window did not shrink.

Why this approach: the two functions were already gated on provider specific phrases, and this adds one more phrase rather than loosening the existing gates. Nothing that used to reach the compression path stops reaching it, because the new branch is the only thing that fires on this wording, and it declines to fire whenever the prompt on its own fills the window.

## Related Issue

Fixes #90607

Same failure family as three other open issues, but a distinct wording:

- #55546, DashScope range wording, parsed on current main
- #63161, vLLM `prompt contains N input tokens` wording, parsed on current main
- #83521, SGLang `N tokens from the input messages` wording, covered by open PR #83558

This parenthetical form is the oldest and most widely copied of the group and was handled by none of them.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py`: new `_COMPLETION_SPLIT_RE` and `_parse_completion_split()`, returning `(prompt_tokens, requested_output_tokens)` from either spelling of the parenthetical.
- `agent/model_metadata.py`: new `_split_output_budget()`, the single place the split is turned into a decision. It returns `context_window - prompt_tokens` when that is at least 1, and None in all three declining cases: no split present, no readable window, or a measured prompt that already fills the window.
- `agent/model_metadata.py`: `parse_available_output_tokens_from_error()` accepts the split form in its gate and returns the budget from `_split_output_budget()`.
- `agent/model_metadata.py`: `is_output_cap_error()` claims the split form early, before the `mentions_output_param` precondition that would otherwise reject it, gated on the same `_split_output_budget()` call.
- `tests/test_output_cap_parsing.py`: new `TestParseCompletionSplitOutputCap` with eight cases.

Routing both call sites through one function is deliberate: the predicate ("is this an output-cap error?") and the number ("how much output fits?") are now the same computation, so they cannot drift into a state where the error is claimed as output-cap-shaped with no budget to retry on. `test_split_predicates_stay_in_lockstep` pins that.

No deletions and no changes to existing behavior. The diff is 164 added lines across the two files.

## How to Test

Reproduce the bug on `main`:

```bash
python - <<'PY'
from agent.model_metadata import (
    is_output_cap_error,
    parse_available_output_tokens_from_error,
)

msg = (
    "This model's maximum context length is 102400 tokens. However, you "
    "requested 102401 tokens (36865 in the messages, 65536 in the completion). "
    "Please reduce the length of the messages or completion."
)
print(parse_available_output_tokens_from_error(msg))  # None on main, 65535 with this PR
print(is_output_cap_error(msg))                       # False on main, True with this PR
PY
```

Confirm the 400 really does reach the recovery path, so the parser is actually consulted:

```bash
python - <<'PY'
from agent.error_classifier import classify_api_error

class E(Exception):
    status_code = 400

msg = (
    "Error code: 400 - This model's maximum context length is 102400 tokens. "
    "However, you requested 102401 tokens (36865 in the messages, 65536 in the "
    "completion). Please reduce the length of the messages or completion."
)
print(classify_api_error(E(msg), provider="lmstudio", model="m").reason)
# FailoverReason.context_overflow, which lands on the output-cap branch in conversation_loop.py
PY
```

Run the tests:

```bash
scripts/run_tests.sh tests/test_output_cap_parsing.py
```

Four of the eight new tests fail on `main` and pass with this change. The other four pass either way by design: three are negative controls pinning behavior that must not change, and the lockstep test guards against future drift rather than reproducing the bug.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the full suite via `scripts/run_tests.sh` (see the note below on pre-existing failures in my sandbox)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04.3 LTS, Python 3.11.16

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A. Both changed functions carry the reasoning in comments next to the code.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A. No config keys touched.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A. No architecture change.
- [x] I've considered cross-platform impact. Pure string parsing, no platform surface.
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A. No tool behavior change.

## Note on the rebase

This sits on current `main`, which since I started has picked up `99c980f46` (the "exceeds model maximum output tokens" clause) in the same gate tuple. Merged cleanly, both clauses coexist.

## Note on overlap with PR #83558

#83558 fixes the SGLang wording and edits the same two functions. The two changes are complementary, not competing: different wordings, different regexes, different branches. They will conflict textually, because both add a clause to the same gate tuple in `parse_available_output_tokens_from_error()` and both touch the top of `is_output_cap_error()`. Whichever lands second is a small rebase. Happy to do that rebase if this one goes second.

## Full suite results

`scripts/run_tests.sh -q` on this branch: **35404 passed, 94 failed**. That run was on base `bbb7b607b`. The branch has since been rebased onto current `main`, where the targeted suites (`test_output_cap_parsing.py`, `test_ctx_halving_fix.py`, `test_error_classifier.py`, the three `model_metadata` suites, `test_413_compression.py`, `test_overflow_overhead_aware_tokens.py`) are 283 passed, 0 failed.

All 94 failures are pre-existing and environmental, not regressions. They sit in 29 files, none of which touch the changed code: sandboxed DNS (`Blocked request, DNS resolution failed for: example.com` in the Tavily and web-provider tests), external service integrations (Daytona, Modal, fal, video generation), and build/environment guards.

To prove they are not mine, I reverted only the two changed files to their pre-fix state on the same tree and re-ran those 29 files: **93 failed**, with an identical per-file breakdown except for one file.

That one file is `tests/gateway/test_turn_lease.py`, which failed once under full-suite parallel load and passes 3 out of 3 in isolation with the fix applied. It is timing-flaky and unrelated to token parsing.
