### PR TITLE
Add timeanchor plugin to community index

### DIFF
--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -70,7 +70,7 @@
       "author": "uhyuuuuu",
       "tags": ["time", "date", "clock", "hook", "chinese", "pre-llm-call"],
       "repo": "uhyuuuuu/hermes-timeanchor",
-      "ref": "be95ba10ce3fe49d6fa34b57d9204e550125d3bd",
+      "ref": "d4efd6a21356a5f7d14b10a2b4457c3b6e6f3d8c",
       "homepage": "https://github.com/uhyuuuuu/hermes-timeanchor",
       "api_version": 1,
       "added_at": "2026-08-20"

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -70,7 +70,7 @@
       "author": "uhyuuuuu",
       "tags": ["time", "date", "clock", "hook", "chinese", "pre-llm-call"],
       "repo": "uhyuuuuu/hermes-timeanchor",
-      "ref": "d4efd6a21356a5f7d14b10a2b4457c3b6e6f3d8c",
+      "ref": "d4efd6af3edbfd80286f0abe63352c859df901b3",
       "homepage": "https://github.com/uhyuuuuu/hermes-timeanchor",
       "api_version": 1,
       "added_at": "2026-08-20"

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -63,6 +63,17 @@
       "capabilities": ["tools"],
       "api_version": 1,
       "added_at": "2026-08-12"
+    },
+    {
+      "name": "timeanchor",
+      "description": "每轮自动注入当前时间（年/月/日/星期/时分），跨天自动强调。pre_llm_call 钩子，零依赖、零配置，几乎零 token 成本。",
+      "author": "uhyuuuuu",
+      "tags": ["time", "date", "clock", "hook", "chinese", "pre-llm-call"],
+      "repo": "uhyuuuuu/hermes-timeanchor",
+      "ref": "be95ba10ce3fe49d6fa34b57d9204e550125d3bd",
+      "homepage": "https://github.com/uhyuuuuu/hermes-timeanchor",
+      "api_version": 1,
+      "added_at": "2026-08-20"
     }
   ]
 }


### PR DESCRIPTION
将 timeanchor 插件加入社区插件索引（hermes_cli/data/plugin_index.json）。

timeanchor 是 Hermes 时间锚点插件：每次 LLM 请求前通过 pre_llm_call 钩子自动注入当前时间（年/月/日/星期/时分，Asia/Shanghai），跨天自动强调。解决 LLM 无时间感知的问题。

- 纯 Python 标准库，零依赖、零配置
- 不写聊天历史、不碰系统提示缓存，几乎零 token 成本
- 仓库：https://github.com/uhyuuuuu/hermes-timeanchor（已打 tag v1.0.0）
- ref 固定为 commit SHA：be95ba10ce3fe49d6fa34b57d9204e550125d3bd

安装方式：hermes plugins install timeanchor