### PR TITLE
fix(agent): recognize OpenAI's parenthetical output-cap wording

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1666,6 +1666,25 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         # This is independent of the input context window.
         "exceeds model" in error_lower
         and "maximum output tokens" in error_lower
+    ) or (
+        # OpenAI's parenthetical split of an over-cap request (chat wording;
+        # vLLM and llama-cpp-python copied it verbatim):
+        #   "This model's maximum context length is 102400 tokens. However, you
+        #    requested 102401 tokens (36865 in the messages, 65536 in the
+        #    completion). Please reduce the length of the messages or completion."
+        # The parenthetical names the completion share, so the output cap can be
+        # the binding constraint — the number check below confirms the input
+        # itself fits (issue #90607).
+        "in the messages" in error_lower
+        and "in the completion" in error_lower
+        and "maximum context length" in error_lower
+    ) or (
+        # Same split, legacy completions wording:
+        #   "... maximum context length is 4097 tokens, however you requested
+        #    4771 tokens (771 in your prompt; 4000 for the completion). ..."
+        "in your prompt" in error_lower
+        and "for the completion" in error_lower
+        and "maximum context length" in error_lower
     )
     if not is_output_cap_error:
         return None
@@ -1769,6 +1788,22 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         if _available >= 1:
             return _available
 
+    # OpenAI parenthetical split (chat + legacy completions wording, #90607):
+    #   "... maximum context length is N tokens ... (A in the messages, B in
+    #    the completion)"  /  "(A in your prompt; B for the completion)"
+    # When A alone fits inside the window (A < N) the output cap is the
+    # binding constraint; available output = N - A.  When A >= N the input
+    # itself overflows and this stays None so the caller compresses instead.
+    _m_openai_paren = re.search(
+        r'\((\d+)\s+in (?:the messages|your prompt)[;,]\s*(\d+)\s+'
+        r'(?:in|for) the completion\)',
+        error_lower,
+    )
+    if _m_ctx_tok and _m_openai_paren:
+        _available = int(_m_ctx_tok.group(1)) - int(_m_openai_paren.group(1))
+        if _available >= 1:
+            return _available
+
     return None
 
 
@@ -1797,10 +1832,22 @@ def is_output_cap_error(error_msg: str) -> bool:
     """
     error_lower = error_msg.lower()
 
+    # OpenAI's parenthetical split never names max_tokens at all — the
+    # completion share only appears as "(A in the messages, B in the
+    # completion)" / "(A in your prompt; B for the completion)" — so the
+    # parenthetical itself must count as mentioning the output parameter
+    # (#90607).
+    _openai_paren = re.search(
+        r'\(\d+\s+in (?:the messages|your prompt)[;,]\s*\d+\s+'
+        r'(?:in|for) the completion\)',
+        error_lower,
+    )
+
     mentions_output_param = (
         "max_tokens" in error_lower
         or "max_output_tokens" in error_lower
         or "max_completion_tokens" in error_lower
+        or _openai_paren is not None
     )
     if not mentions_output_param:
         return False
@@ -1819,6 +1866,7 @@ def is_output_cap_error(error_msg: str) -> bool:
         or "must be" in error_lower
         or ("exceeds model" in error_lower
             and "maximum output tokens" in error_lower)
+        or _openai_paren is not None                        # OpenAI parenthetical (#90607)
     )
     if not output_cap_signal:
         return False
@@ -1835,7 +1883,24 @@ def is_output_cap_error(error_msg: str) -> bool:
         or "prompt contains" in error_lower
         or "reduce the length" in error_lower
     )
-    return not input_overflow_signal
+    if not input_overflow_signal:
+        return True
+
+    # OpenAI's boilerplate ("Please reduce the length of the messages or
+    # completion") trips "reduce the length" even when the input fits.  When
+    # the parenthetical's input share is strictly below the reported window,
+    # the completion is the binding overage — the output-cap path applies.
+    if _openai_paren:
+        _m_ctx = re.search(r'maximum context length is (\d+)', error_lower)
+        _m_parts = re.search(
+            r'\((\d+)\s+in (?:the messages|your prompt)[;,]\s*(\d+)\s+'
+            r'(?:in|for) the completion\)',
+            error_lower,
+        )
+        if _m_ctx and _m_parts:
+            if int(_m_parts.group(1)) < int(_m_ctx.group(1)):
+                return True
+    return False
 
 
 def _model_id_matches(candidate_id: str, lookup_model: str) -> bool:

--- a/tests/test_output_cap_parsing.py
+++ b/tests/test_output_cap_parsing.py
@@ -191,3 +191,50 @@ class TestParseVllmTokenBasedOutputCap:
             cap = available
         assert real_input + cap <= window, f"did not converge: cap={cap}"
 
+
+class TestParseOpenAIParentheticalOutputCap:
+    """OpenAI (and vLLM / llama-cpp-python, which copied the wording) split an
+    over-cap request parenthetically without ever naming max_tokens (#90607).
+
+    Both detectors missed it, the 400 was routed into context compression,
+    and compression re-issued the identical request until "cannot compress
+    further".
+    """
+
+    def test_chat_endpoint_parenthetical_format(self):
+        msg = ("This model's maximum context length is 102400 tokens. "
+               "However, you requested 102401 tokens (36865 in the messages, "
+               "65536 in the completion). Please reduce the length of the "
+               "messages or completion.")
+        # available output = 102400 - 36865 = 65535
+        assert parse_available_output_tokens_from_error(msg) == 65535
+
+    def test_chat_endpoint_parenthetical_is_output_cap(self):
+        msg = ("This model's maximum context length is 102400 tokens. "
+               "However, you requested 102401 tokens (36865 in the messages, "
+               "65536 in the completion). Please reduce the length of the "
+               "messages or completion.")
+        # "reduce the length" must not push this into the compression path:
+        # the messages share (36865) fits, so the completion is the binding
+        # overage.
+        assert is_output_cap_error(msg) is True
+
+    def test_legacy_completions_parenthetical_format(self):
+        msg = ("This model's maximum context length is 4097 tokens, however "
+               "you requested 4771 tokens (771 in your prompt; 4000 for the "
+               "completion). Please reduce your prompt; or completion length.")
+        # available output = 4097 - 771 = 3326
+        assert parse_available_output_tokens_from_error(msg) == 3326
+        assert is_output_cap_error(msg) is True
+
+    def test_parenthetical_with_oversized_input_is_not_output_cap(self):
+        """When the messages share alone exceeds the window, the input is the
+        real overflow — the compression path applies even in the OpenAI
+        parenthetical wording."""
+        msg = ("This model's maximum context length is 102400 tokens. "
+               "However, you requested 102601 tokens (102401 in the messages, "
+               "200 in the completion). Please reduce the length of the "
+               "messages or completion.")
+        assert parse_available_output_tokens_from_error(msg) is None
+        assert is_output_cap_error(msg) is False
+


### PR DESCRIPTION
## What does this PR do?

OpenAI (and vLLM / llama-cpp-python, which copied the error text) reject an over-cap request **without ever naming `max_tokens`**:

> This model's maximum context length is 102400 tokens. However, you requested 102401 tokens (36865 in the messages, 65536 in the completion). Please reduce the length of the messages or completion.

The legacy completions endpoint words the same split as `(771 in your prompt; 4000 for the completion)`. Neither wording contains `max_tokens` or `output tokens`, so every clause in both output-cap detectors missed it: `parse_available_output_tokens_from_error` returned `None` and `is_output_cap_error()` failed its very first check. The 400 was then classified as a context overflow and routed into compression, which re-issued the call with the same oversized `max_tokens`, got the identical 400 back, and burned every compression attempt before ending in "cannot compress further" (#90607) — the same death-loop family as #55546, #63161, #83521.

This PR teaches both detectors the parenthetical split: the gate clauses match both wordings, and the numeric path returns `window - input_share` when the input share alone fits (`input < window`). When the input share is at or over the window the function stays `None`/`False`, so a genuine input overflow in the same wording still goes to compression. The "reduce the length" boilerplate no longer misroutes the output-cap form — the parenthetical's numbers, not the boilerplate, decide.

## Related Issue

Fixes #90607

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py` — `parse_available_output_tokens_from_error`: two new gate clauses for the chat (`in the messages` / `in the completion`) and legacy (`in your prompt` / `for the completion`) parenthetical wordings, plus a numeric path computing `window - input_share` (guarded to `>= 1` so an oversized input still falls through)
- `agent/model_metadata.py` — `is_output_cap_error`: the parenthetical counts as mentioning the output parameter and as an output-cap signal; when the generic "reduce the length" input-overflow signal trips, the parenthetical's input share is compared against the reported window — strictly below means the completion is the binding overage
- `tests/test_output_cap_parsing.py` — regression class covering both wordings (parse + classify), and the negative case where the messages share alone exceeds the window (stays a compression-path error)

## How to Test

1. `python -m pytest tests/test_output_cap_parsing.py tests/test_ctx_halving_fix.py -q` — should pass (35 passed), including the four new tests
2. `python -m pytest tests/run_agent/test_run_agent.py -k "output_cap or compress or context_overflow" -q` — should pass (11 passed), confirming the conversation-loop consumer's expectations are unchanged
3. Observed result: with the fix stashed, the three positive new tests fail (detectors return `None`/`False` for both wordings); the oversized-input negative test passes on main as well, since main already (correctly) sends it to compression

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (each new clause documents its provider wording; the boilerplate-vs-numbers decision is commented)
- [x] Tests added that prove the fix is effective or prevent regression (both wordings + the input-overflow negative)
- [x] All new and existing tests pass locally (35 + 7 + 11 passed across the output-cap, num-ctx, and run-agent consumer suites)
- [x] Platform: macOS (pure string-classification logic, platform-independent)
