### PR TITLE
fix(sessions): prune/archive no longer destroy pinned sessions (data loss)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13497,6 +13497,11 @@ def main():
         help="Also delete archived sessions (excluded by default)",
     )
     sessions_prune.add_argument(
+        "--include-pinned",
+        action="store_true",
+        help="Also delete pinned sessions (excluded by default — pin is a keep flag)",
+    )
+    sessions_prune.add_argument(
         "--never-active",
         action="store_true",
         help=(

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -866,12 +866,21 @@ def cmd_sessions(args, sessions_parser=None):
         if not resolved_session_id:
             print(f"Session '{args.session_id}' not found.")
             return
+        # Note when the explicit target is pinned — the user named this id
+        # directly so we honor the delete, but a pin is a "keep" flag and
+        # silently destroying it (round-3 QA SES-01) is surprising.
+        _get_session = getattr(db, "get_session", None)
+        _meta = (_get_session(resolved_session_id) or {}) if callable(_get_session) else {}
+        _pinned_note = " (this session is PINNED)" if _meta.get("pinned") else ""
         if not args.yes:
             if not _confirm_prompt(
-                f"Delete session '{resolved_session_id}' and all its messages? [y/N] "
+                f"Delete session '{resolved_session_id}'{_pinned_note} "
+                "and all its messages? [y/N] "
             ):
                 print("Cancelled.")
                 return
+        elif _pinned_note:
+            print(f"Warning: deleting a pinned session '{resolved_session_id}'.")
         sessions_dir = get_hermes_home() / "sessions"
         if db.delete_session(resolved_session_id, sessions_dir=sessions_dir):
             print(f"Deleted session '{resolved_session_id}'.")
@@ -940,6 +949,37 @@ def cmd_sessions(args, sessions_parser=None):
             )
         else:
             filters["archived"] = False
+
+        # Pinned sessions are excluded by default from bulk prune/archive
+        # (pin = durable keep). `prune --include-pinned` opts in; archive has
+        # no such flag, so archive always spares pinned rows. Surface a count
+        # of pinned matches being skipped so the user knows they were spared.
+        _include_pinned = getattr(args, "include_pinned", False)
+        filters["include_pinned"] = _include_pinned
+        _count_matches = getattr(db, "count_prune_matches", None)
+        if not _include_pinned and callable(_count_matches):
+            _base = {k: v for k, v in filters.items() if k != "include_pinned"}
+            try:
+                _with_pinned = int(_count_matches(**_base, include_pinned=True))
+                _without_pinned = int(_count_matches(**_base, include_pinned=False))
+                _pinned_skipped = max(_with_pinned - _without_pinned, 0)
+            except TypeError:
+                # A db double without include_pinned support — skip the note.
+                _pinned_skipped = 0
+            if _pinned_skipped:
+                _suffix = "" if _pinned_skipped == 1 else "s"
+                _verb_word = "deleted" if action == "prune" else "archived"
+                _optin = (
+                    "Pass --include-pinned to delete them anyway, or unpin "
+                    "first with `hermes sessions unpin <id>`."
+                    if action == "prune"
+                    else "Unpin first with `hermes sessions unpin <id>` to include them."
+                )
+                print(
+                    f"Note: {_pinned_skipped} pinned session{_suffix} also match "
+                    f"these filters but will NOT be {_verb_word} (pin is a keep "
+                    f"flag). {_optin}"
+                )
 
         candidates = db.list_prune_candidates(**filters)
         # Archive expands each selected row to its compression lineage, which

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11692,6 +11692,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         max_cost: Optional[float] = None,
         min_tool_calls: Optional[int] = None,
         max_tool_calls: Optional[int] = None,
+        include_pinned: bool = False,
     ) -> Tuple[str, list]:
         """Build the shared WHERE clause for bulk prune/archive selection.
 
@@ -11804,6 +11805,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             clauses.append("s.archived = 1")
         elif archived is False:
             clauses.append("s.archived = 0")
+        # Pinned sessions are a durable "keep" flag (exempt from the stale
+        # auto-archive sweep). Bulk prune/delete/archive must honor that too:
+        # exclude pinned rows unless the caller explicitly opts in. Without
+        # this, `sessions prune`/`delete`/`archive` with a filter silently
+        # destroyed pinned conversations (round-3 QA SES-01, data loss).
+        if not include_pinned:
+            clauses.append("COALESCE(s.pinned, 0) = 0")
         return " AND ".join(clauses), params
 
     @staticmethod
@@ -11853,6 +11861,26 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 params,
             )
             return [dict(row) for row in cursor.fetchall()]
+
+    def count_prune_matches(
+        self,
+        older_than_days: Optional[float] = None,
+        source: str = None,
+        **filters,
+    ) -> int:
+        """Count sessions a matching prune/archive would touch.
+
+        Same filter surface as :meth:`list_prune_candidates` (including the
+        ``include_pinned`` tri-state), but returns only a count. Used by the
+        CLI to report how many pinned sessions are being spared.
+        """
+        self._apply_prune_age_filter(older_than_days, filters)
+        where, params = self._prune_filter_where(source=source, **filters)
+        with self._lock:
+            cursor = self._conn.execute(
+                f"SELECT COUNT(*) FROM sessions s WHERE {where}", params
+            )
+            return int(cursor.fetchone()[0])
 
     def count_open_prune_matches(
         self,

--- a/tests/hermes_cli/test_prune_spares_pinned.py
+++ b/tests/hermes_cli/test_prune_spares_pinned.py
@@ -1,0 +1,80 @@
+"""Regression tests: pinned sessions survive bulk prune/archive (round-3 SES-01).
+
+Pinning is a durable "keep" flag. Before this fix `_prune_filter_where` had no
+pinned exclusion, so `hermes sessions prune`/`archive` with a filter silently
+destroyed pinned conversations. These drive the real SessionDB (temp file DB).
+"""
+
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    d = SessionDB(tmp_path / "state.db")
+    yield d
+    try:
+        d.close()
+    except Exception:
+        pass
+
+
+def _mk(db, sid, title, pinned=False):
+    db.create_session(sid, source="cli")
+    db.set_session_title(sid, title)
+    # mark ended + old so it is prune-eligible
+    with db._lock:
+        db._conn.execute(
+            "UPDATE sessions SET ended_at=?, started_at=?, message_count=1 WHERE id=?",
+            (time.time() - 100 * 86400, time.time() - 100 * 86400, sid),
+        )
+        db._conn.commit()
+    if pinned:
+        db.set_session_pinned(sid, True)
+
+
+def test_prune_spares_pinned_by_default(db):
+    _mk(db, "20260101_000000_aaaaaa", "keep me", pinned=True)
+    _mk(db, "20260101_000001_bbbbbb", "delete me", pinned=False)
+
+    # Filter matches both by title substring "me"; default must spare pinned.
+    cands = db.list_prune_candidates(title_like="me")
+    ids = {c["id"] for c in cands}
+    assert "20260101_000001_bbbbbb" in ids
+    assert "20260101_000000_aaaaaa" not in ids  # pinned excluded
+
+    deleted = db.prune_sessions(older_than_days=None, title_like="me")
+    assert deleted == 1
+    assert db.get_session("20260101_000000_aaaaaa") is not None  # pinned survived
+    assert db.get_session("20260101_000001_bbbbbb") is None
+
+
+def test_prune_include_pinned_opts_in(db):
+    _mk(db, "20260101_000000_aaaaaa", "keep me", pinned=True)
+
+    # With the opt-in, the pinned row IS eligible.
+    cands = db.list_prune_candidates(title_like="me", include_pinned=True)
+    assert {c["id"] for c in cands} == {"20260101_000000_aaaaaa"}
+
+    deleted = db.prune_sessions(older_than_days=None, title_like="me", include_pinned=True)
+    assert deleted == 1
+    assert db.get_session("20260101_000000_aaaaaa") is None
+
+
+def test_count_prune_matches_reflects_pinned_flag(db):
+    _mk(db, "20260101_000000_aaaaaa", "keep me", pinned=True)
+    _mk(db, "20260101_000001_bbbbbb", "delete me", pinned=False)
+
+    assert db.count_prune_matches(title_like="me", include_pinned=False) == 1
+    assert db.count_prune_matches(title_like="me", include_pinned=True) == 2
+
+
+def test_archive_spares_pinned(db):
+    _mk(db, "20260101_000000_aaaaaa", "keep me", pinned=True)
+    _mk(db, "20260101_000001_bbbbbb", "arch me", pinned=False)
+
+    archived = db.archive_sessions(older_than_days=None, title_like="me")
+    assert archived == 1  # only the unpinned one


### PR DESCRIPTION
## Summary
`hermes sessions prune` / `archive` no longer silently destroy pinned sessions. Pin is a durable "keep" flag; bulk destructive ops now spare pinned rows by default, with a `--include-pinned` opt-in for prune.

Found in round-3 deep QA (SES-01) — reproduced **actual data loss**: pinning a session then running `sessions prune` with a filter that matched it deleted the pinned session with no warning.

Root cause: the shared `_prune_filter_where` builder (used by `list_prune_candidates`, `count_open_prune_matches`, `prune_sessions`, `archive_sessions`) had no pinned exclusion — only the separate never-active pruner and the stale auto-archive sweep did. This is the "fix the class" shape: one shared filter, one shared fix.

## Changes
- `hermes_state.py`: `_prune_filter_where` gains an `include_pinned=False` tri-state that appends `COALESCE(s.pinned,0)=0` unless opted in — so every bulk selector (prune/archive/candidates/count) inherits the protection; new `count_prune_matches()` helper for the skipped-count notice.
- `hermes_cli/main.py`: `sessions prune --include-pinned` flag (archive intentionally has no opt-in — always spares pinned).
- `hermes_cli/sessions_cmd.py`: prune/archive print "Note: N pinned session(s) also match … will NOT be deleted" when sparing pins; single `sessions delete <id>` (explicit target) now flags a pinned id in its confirmation prompt. Both new db calls are `getattr`-guarded so existing test doubles keep working.
- `tests/hermes_cli/test_prune_spares_pinned.py`: real-SessionDB tests — prune spares pinned, `--include-pinned` opts in, count reflects the flag, archive spares pinned.

## Validation
| | Before | After |
|---|---|---|
| `prune --source cli` with a pinned match | pinned session deleted (data loss) | "Note: 1 pinned … will NOT be deleted"; only unpinned removed (live-verified) |
| `prune --source cli --include-pinned` | n/a | pinned session removed as requested (live-verified) |
| targeted tests | 4 delete-path tests | 8 passing (4 delete + 4 new pinned) |

## Infographic

![prune spares pinned infographic](https://files.catbox.moe/4yze4q.png)
