### PR TITLE
fix(cli): flag a configured TTS provider whose SDK is missing in status

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -8,10 +8,13 @@ import os
 import sys
 import time
 import importlib.util
+import logging
 import subprocess  # noqa: F401 — re-exported for tests that monkeypatch status.subprocess to guard against regressions
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
+
+logger = logging.getLogger(__name__)
 
 from hermes_cli.auth import AuthError, resolve_provider
 from hermes_cli.colors import Colors, color
@@ -229,14 +232,19 @@ def show_status(args):
 
         _tts_provider = (_load_tts_config().get("provider") or "").strip()
         if _tts_provider and not check_tts_requirements():
+            # check_tts_requirements() can fail for any prerequisite (SDK,
+            # ffmpeg for some providers, ...), not just a missing SDK —
+            # name the general cause so the line cannot misdiagnose the
+            # remediation (review on #90610).
             print(
                 f"  {'TTS':<12}  {check_mark(False)} "
-                f"{_tts_provider} provider not runnable — SDK missing; voice "
-                "replies silently degrade to text"
+                f"{_tts_provider} not runnable — check that its "
+                "SDK/prerequisites are installed; voice replies silently "
+                "degrade to text"
             )
     except Exception:
         # The status probe must never fail the whole report.
-        pass
+        logger.debug("TTS status probe failed", exc_info=True)
 
     # =========================================================================
     # Auth Providers (OAuth)

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -218,6 +218,26 @@ def show_status(args):
     anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
+    # TTS readiness (#90610): the provider row above only proves an API key
+    # resolved — the selected provider's SDK must also be importable, or
+    # every voice reply silently degrades to text (the failure is swallowed
+    # by the gateway auto-TTS path). Surface that mismatch here. Only check
+    # when a provider was explicitly configured: the free Edge default is
+    # not part of anyone's setup contract.
+    try:
+        from tools.tts_tool import _load_tts_config, check_tts_requirements
+
+        _tts_provider = (_load_tts_config().get("provider") or "").strip()
+        if _tts_provider and not check_tts_requirements():
+            print(
+                f"  {'TTS':<12}  {check_mark(False)} "
+                f"{_tts_provider} provider not runnable — SDK missing; voice "
+                "replies silently degrade to text"
+            )
+    except Exception:
+        # The status probe must never fail the whole report.
+        pass
+
     # =========================================================================
     # Auth Providers (OAuth)
     # =========================================================================

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -255,8 +255,8 @@ def test_show_status_flags_missing_tts_provider_sdk(monkeypatch, capsys, tmp_pat
 
     output = capsys.readouterr().out
     assert "TTS" in output
-    assert "elevenlabs provider not runnable" in output
-    assert "SDK missing" in output
+    assert "elevenlabs not runnable" in output
+    assert "SDK/prerequisites are installed" in output
 
 
 def test_show_status_no_tts_warning_without_explicit_provider(
@@ -274,4 +274,4 @@ def test_show_status_no_tts_warning_without_explicit_provider(
     show_status(SimpleNamespace(all=True, deep=False))
 
     output = capsys.readouterr().out
-    assert "SDK missing" not in output
+    assert "not runnable" not in output

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -237,3 +237,41 @@ def test_show_status_reports_gateway_session_last_activity(monkeypatch, capsys, 
     assert "Active:       2 session(s)" in output
     assert "Last activity:" in output
     assert "1m ago" in output
+
+
+def test_show_status_flags_missing_tts_provider_sdk(monkeypatch, capsys, tmp_path):
+    """#90610: a configured TTS provider whose SDK is missing must be flagged
+    in status — the ElevenLabs API-key row alone shows ✓ while every voice
+    reply silently degrades to text."""
+    import tools.tts_tool as tts_mod
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        tts_mod, "_load_tts_config", lambda: {"provider": "elevenlabs"}
+    )
+    monkeypatch.setattr(tts_mod, "check_tts_requirements", lambda: False)
+
+    show_status(SimpleNamespace(all=True, deep=False))
+
+    output = capsys.readouterr().out
+    assert "TTS" in output
+    assert "elevenlabs provider not runnable" in output
+    assert "SDK missing" in output
+
+
+def test_show_status_no_tts_warning_without_explicit_provider(
+    monkeypatch, capsys, tmp_path
+):
+    """The free Edge default is nobody's setup contract: with no explicit
+    tts.provider configured, status must not print a TTS readiness line even
+    when the edge runtime happens to be unavailable."""
+    import tools.tts_tool as tts_mod
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(tts_mod, "_load_tts_config", lambda: {})
+    monkeypatch.setattr(tts_mod, "check_tts_requirements", lambda: False)
+
+    show_status(SimpleNamespace(all=True, deep=False))
+
+    output = capsys.readouterr().out
+    assert "SDK missing" not in output

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3290,7 +3290,7 @@ def _text_to_speech_single(
             except ImportError:
                 return json.dumps({
                     "success": False,
-                    "error": "ElevenLabs provider selected but 'elevenlabs' package not installed. Run: pip install elevenlabs"
+                    "error": "ElevenLabs provider selected but 'elevenlabs' package not installed. Run: uv pip install --python <hermes-venv>/bin/python3 elevenlabs (the uv-managed venv has no bare pip)"
                 }, ensure_ascii=False)
             logger.info("Generating speech with ElevenLabs...")
             _generate_elevenlabs(text, file_str, tts_config)


### PR DESCRIPTION
## What does this PR do?

`hermes status` proved only that a TTS provider's **API key** resolved (`ElevenLabs ✓ sk_...48bf`) — never that the provider can actually run. With `tts.provider: elevenlabs` configured and the `elevenlabs` package absent from the venv, every visible check passed while every voice reply silently degraded to text: the tool's accurate error string never reached the user (the gateway auto-TTS path reduces it to a `logger.warning` before delivering the text reply), and the remediation it suggested (`pip install elevenlabs`) doesn't even work — the uv-managed venv has no bare `pip` (#90610).

This PR fixes the diagnosis side:

- **status now consults the existing `check_tts_requirements()`** — the function already mirrors real dispatch readiness (importability + key) — and prints a TTS line naming the unrunnable provider (`TTS ✗ elevenlabs provider not runnable — SDK missing; voice replies silently degrade to text`). The line only appears when a provider was **explicitly configured**: the free Edge default is not part of anyone's setup contract, so an unconfigured install never sees a spurious warning. The probe is fully exception-guarded so it can never fail the status report.
- **The elevenlabs missing-package error string now names the invocation that works in a uv-managed venv** (`uv pip install --python <hermes-venv>/bin/python3 elevenlabs`) instead of the nonexistent bare `pip`.

Deliberately out of scope (separate surfaces, noted for maintainers): surfacing a one-time user-visible notice on the chat platform at first synthesis failure (changes the gateway message-delivery path), and declaring provider SDKs as package extras (packaging).

## Related Issue

Fixes #90610

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/status.py` — after the API-keys table, consult `check_tts_requirements()` when `tts.provider` is explicitly set and print a readiness line on failure; exception-guarded
- `tools/tts_tool.py` — the elevenlabs ImportError string now carries the uv-form install command with a note that the uv-managed venv has no bare pip
- `tests/hermes_cli/test_status.py` — two regression tests: a configured provider with a failing readiness check produces the warning line; an unconfigured install (no explicit provider) produces none

## How to Test

1. `python -m pytest tests/hermes_cli/test_status.py -q` — should pass (12 passed), including the two new tests
2. Observed result: with the status change stashed, the positive test fails (no TTS line is printed); the negative test passes on main as well, since main also prints no TTS line
3. `python -m pytest tests/tools/ -q -k tts` — the 7 failures in the tts suites reproduce identically on clean upstream/main (environment-dependent); the branch-vs-main failure diff is empty

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (why the check is explicit-config-only; why the probe is guarded)
- [x] Tests added that prove the fix is effective or prevent regression (positive + no-false-positive negative)
- [x] All new and existing tests pass locally (status suite 12/12; tts suite delta vs main is zero)
- [x] Platform: macOS (pure CLI rendering logic, platform-independent)
