### PR TITLE
fix(sessions): error paths exit non-zero (delete/rename/prune/import)

### DIFF
--- a/hermes_cli/foreign_sessions.py
+++ b/hermes_cli/foreign_sessions.py
@@ -456,6 +456,11 @@ def run_sessions_import(args, db=None) -> Optional[str]:
     path = getattr(args, "path", None)
 
     if path:
+        # Report a missing file distinctly instead of the misleading
+        # "cannot infer source" (SES-10).
+        if not Path(path).exists():
+            print(f"Error: file not found: {path}")
+            return None
         if not source:
             # Guess from the path shape.
             p = str(path)

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -305,7 +305,13 @@ def cmd_sessions(args, sessions_parser=None):
     if action == "import":
         from hermes_cli.foreign_sessions import run_sessions_import
 
-        run_sessions_import(args)
+        result = run_sessions_import(args)
+        # A path was explicitly given but nothing imported → real error (bad
+        # path, unknown source, no turns). Propagate a non-zero exit so
+        # scripts can detect the failure (SES-04/SES-10). An interactive
+        # picker cancel (no path) returning None is a normal no-op → exit 0.
+        if result is None and getattr(args, "path", None):
+            return 1
         return
 
     try:
@@ -314,7 +320,7 @@ def cmd_sessions(args, sessions_parser=None):
         db = SessionDB()
     except Exception as e:
         print(f"Error: Could not open session database: {e}")
-        return
+        return 1
 
     # Hide third-party tool sessions by default, but honour explicit --source
     _source = getattr(args, "source", None)
@@ -865,7 +871,7 @@ def cmd_sessions(args, sessions_parser=None):
         resolved_session_id = db.resolve_session_id(args.session_id)
         if not resolved_session_id:
             print(f"Session '{args.session_id}' not found.")
-            return
+            return 1
         # Note when the explicit target is pinned — the user named this id
         # directly so we honor the delete, but a pin is a "keep" flag and
         # silently destroying it (round-3 QA SES-01) is surprising.
@@ -886,6 +892,7 @@ def cmd_sessions(args, sessions_parser=None):
             print(f"Deleted session '{resolved_session_id}'.")
         else:
             print(f"Session '{args.session_id}' not found.")
+            return 1
 
     elif action == "prune" and getattr(args, "never_active", False):
         # Separate branch on purpose: the shared prune/archive selector is
@@ -930,7 +937,7 @@ def cmd_sessions(args, sessions_parser=None):
             filters = build_prune_filters(args)
         except ValueError as e:
             print(f"Error: {e}")
-            return
+            return 1
 
         if action == "archive" and not any(
             v for k, v in filters.items() if k != "older_than_days"
@@ -1053,15 +1060,27 @@ def cmd_sessions(args, sessions_parser=None):
         resolved_session_id = db.resolve_session_id(args.session_id)
         if not resolved_session_id:
             print(f"Session '{args.session_id}' not found.")
-            return
+            return 1
         title = " ".join(args.title)
+        # Reject blank / whitespace-only / newline-bearing titles (SES-05):
+        # an empty title renders as "—" and embedded newlines corrupt the
+        # `list` table. length is validated in set_session_title; guard
+        # emptiness + control chars here.
+        if not title.strip():
+            print("Error: title cannot be empty or whitespace-only.")
+            return 1
+        if "\n" in title or "\r" in title:
+            print("Error: title cannot contain newlines.")
+            return 1
         try:
             if db.set_session_title(resolved_session_id, title):
                 print(f"Session '{resolved_session_id}' renamed to: {title}")
             else:
                 print(f"Session '{args.session_id}' not found.")
+                return 1
         except ValueError as e:
             print(f"Error: {e}")
+            return 1
 
     elif action in ("pin", "unpin"):
         # CLI surface for the durable "keep" flag (issue #52955). Pinned

--- a/tests/hermes_cli/test_sessions_error_exit_codes.py
+++ b/tests/hermes_cli/test_sessions_error_exit_codes.py
@@ -1,0 +1,49 @@
+"""Regression tests: `hermes sessions` error paths return non-zero (SES-04).
+
+Before this, delete/rename not-found, prune bad-arg, blank rename, and import
+of a missing file all printed an error and returned exit 0 — a scripting/CI
+hazard (a script pinning a bad id failed loudly via `pin` but deleting a bad
+id "succeeded" silently). The subcommand dispatcher already maps an int
+handler return to the process exit code; these tests pin the returns.
+"""
+
+from argparse import Namespace
+
+import pytest
+
+import hermes_cli.sessions_cmd as sc
+
+
+def _args(action, **kw):
+    base = dict(
+        sessions_action=action,
+        session_id=None, title=None, yes=True, source=None, path=None,
+        from_source=None, dry_run=False, older_than=None, newer_than=None,
+        before=None, after=None, limit=50,
+    )
+    base.update(kw)
+    return Namespace(**base)
+
+
+def test_delete_missing_returns_1(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_state import SessionDB
+    SessionDB(tmp_path / "state.db")  # initialize an empty store
+    rc = sc.cmd_sessions(_args("delete", session_id="nope_xyz"))
+    assert rc == 1
+    assert "not found" in capsys.readouterr().out.lower()
+
+
+def test_rename_missing_returns_1(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_state import SessionDB
+    SessionDB(tmp_path / "state.db")
+    rc = sc.cmd_sessions(_args("rename", session_id="nope_xyz", title=["New"]))
+    assert rc == 1
+
+
+def test_import_missing_file_returns_1(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    rc = sc.cmd_sessions(_args("import", path=str(tmp_path / "nope.jsonl")))
+    assert rc == 1
+    assert "file not found" in capsys.readouterr().out.lower()


### PR DESCRIPTION
## Summary
`hermes sessions` error paths now return a non-zero exit code so scripts and CI can detect failure. Before, most error branches printed a message and returned exit 0.

Found in round-3 deep QA (SES-04, SES-05, SES-10): `sessions delete <bad-id>`, `rename <bad-id>`, `prune --older-than abc`, and `import <missing-file>` all printed an error yet exited 0, while `pin`/`recover` correctly exited 1 — a sharp, surprising inconsistency (a script pinning a bad id failed loudly but deleting a bad id "succeeded" silently). The subcommand dispatcher already maps an int handler return to the process exit code; the error branches just weren't returning one.

## Changes
- `hermes_cli/sessions_cmd.py`: `delete`/`rename` not-found, DB-open failure, `prune` bad-arg, and `import` (with an explicit path) failures now `return 1`.
- Blank/whitespace-only/newline titles rejected on `rename` (SES-05) — previously stored an empty title that rendered as "—" and newlines corrupted the `list` table.
- `hermes_cli/foreign_sessions.py`: `import <path>` reports `Error: file not found: <path>` before trying to infer the source (SES-10), instead of the misleading "Cannot infer source from path."
- `tests/hermes_cli/test_sessions_error_exit_codes.py`: pins the non-zero returns for delete/rename/import.

## Validation
| command | before | after |
|---|---|---|
| `sessions delete <bad-id> --yes` | "not found", exit 0 | "not found", exit 1 |
| `sessions rename <bad-id> X` | "not found", exit 0 | "not found", exit 1 |
| `sessions rename <id> "   "` | stored blank title, exit 0 | "title cannot be empty", exit 1 |
| `sessions prune --older-than abc` | "Invalid value", exit 0 | same message, exit 1 |
| `sessions import <missing>` | "Cannot infer source", exit 0 | "file not found", exit 1 |
| `sessions list` (happy) | exit 0 | exit 0 (unchanged) |
| `rename <id> <valid>` (happy) | exit 0 | exit 0 (unchanged) |

All live-verified in a sandbox; 7 targeted tests pass (3 new + 4 existing delete tests). Scoped deliberately to the `sessions` surface — the same exit-0-on-error class exists in tools/cron/skills/mcp (round-3 T1) and will be a follow-up per-surface PR.

## Infographic

![sessions exit codes infographic](https://files.catbox.moe/skv3vp.png)
