### PR TITLE
fix(cron): don't count suppressed delivery (silence filter) as delivered

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2705,6 +2705,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             and getattr(loop, "is_running", lambda: False)()
         )
         delivered = False
+        suppressed = False
         target_errors = []
 
         # Continuable cron surface (D1/D2/D6): resolve the delivery surface for
@@ -2973,15 +2974,34 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                             # {"success": True, "delivered": False, ...}.
                             # Normalize both shapes so a getattr default doesn't
                             # misread a dict, and so a None / success-less object
-                            # is NOT counted as delivered (#47056).
+                            # is NOT counted as delivered (#47056).  A dict with
+                            # explicit delivered=False means the message was
+                            # deliberately NOT sent — success=True there only
+                            # means the filter ran, so it must not be logged as
+                            # a delivery either.
                             if isinstance(send_result, dict):
                                 send_success = bool(send_result.get("success", False))
+                                suppressed = send_result.get("delivered") is False
+                                suppressed_kind = send_result.get("filtered", "filtered")
                                 send_raw_response = send_result.get("raw_response")
                             else:
                                 send_success = _confirm_adapter_delivery(send_result)
+                                suppressed_kind = "filtered"
                                 send_raw_response = getattr(send_result, "raw_response", None)
 
-                            if not send_success:
+                            if suppressed:
+                                # Deliberately suppressed (e.g. silence-narration
+                                # filter): the message must NOT be sent.  Resolve
+                                # the obligation without claiming delivery and
+                                # without falling through to a standalone resend.
+                                logger.info(
+                                    "Job '%s': delivery suppressed to %s:%s (%s, not sent)",
+                                    job["id"], platform_name, chat_id,
+                                    suppressed_kind,
+                                )
+                                adapter_ok = False
+                                delivered = True
+                            elif not send_success:
                                 if isinstance(send_result, dict):
                                     err = send_result.get("error", "unknown")
                                     shape = "dict"

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -492,6 +492,58 @@ class TestDeliverResultWrapping:
         voice_call = adapter.send_voice.call_args
         assert voice_call[1]["audio_path"] == str(media_path)
 
+    def test_suppressed_delivery_not_counted_as_delivered(self, tmp_path, monkeypatch, caplog):
+        """A live-adapter send that returns {success: True, delivered: False}
+        (silence-narration filter) must NOT be logged as \"delivered via live
+        adapter\", and must not fall through to a standalone resend."""
+        from gateway.config import Platform
+        from concurrent.futures import Future
+
+        adapter = AsyncMock()
+        adapter.send.return_value = {
+            "success": True,
+            "delivered": False,
+            "filtered": "silence_narration",
+        }
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            import asyncio as _asyncio
+            future = Future()
+            try:
+                future.set_result(_asyncio.run(coro))
+            except BaseException as _e:  # noqa: BLE001
+                future.set_exception(_e)
+            return future
+
+        job = {
+            "id": "silent-job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "12345"},
+        }
+
+        with (
+            patch("gateway.config.load_gateway_config", return_value=mock_cfg),
+            patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),
+            patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro),
+            patch("tools.send_message_tool._send_to_platform", new=AsyncMock()) as standalone_send,
+            caplog.at_level(logging.INFO, logger="cron.scheduler"),
+        ):
+            result = _deliver_result(job, "*(silent)*", adapters={Platform.TELEGRAM: adapter}, loop=loop)
+
+        assert result is None  # suppression is not an error
+        standalone_send.assert_not_awaited()  # no standalone resend
+        logs = caplog.text
+        assert "delivered to telegram:12345 via live adapter" not in logs
+        assert "delivery suppressed to telegram:12345" in logs
+
 
 class TestDeliverResultErrorReturns:
     """Verify _deliver_result returns error strings on failure, None on success."""


### PR DESCRIPTION
## Symptom
A cron job whose output is dropped by the silence-narration filter (`*(silent)*` etc.) is logged as `delivered to <chat> via live adapter` and recorded delivered — but nothing was ever sent. This is the same false-delivery-evidence class as #47056: the scheduler claims delivery while the gateway deliberately withheld the message.

## Root cause
`_deliver_to_platform` returns `{"success": True, "delivered": False, "filtered": "silence_narration"}` when the filter drops the message (success=True only means the filter ran). `_deliver_result` read only `success`, so the dict was treated as a confirmed live-adapter delivery.

## Fix
- Detect `delivered is False` on the dict result as a suppression.
- Log `delivery suppressed to <chat> (silence_narration, not sent)` instead of claiming delivery.
- Resolve the obligation without falling through to the standalone resend — the message must NOT be sent (anti-loop guard).

## Test
`test_suppressed_delivery_not_counted_as_delivered` — asserts no `delivered via live adapter` log, a `delivery suppressed` log, no standalone resend, and no error. Full file: 95 passed.