### PR TITLE
fix(bot-mode): group chat picker rows overflow and scroll names out of view

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/create-dialog.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/create-dialog.tsx
@@ -1271,7 +1271,7 @@ export function CreateGroupChatDialog({ open, roster, onClose, onCreated }: Crea
                 return (
                   <label
                     className={cn(
-                      'flex cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 transition-colors hover:bg-(--chrome-action-hover)',
+                      'flex min-w-0 cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 transition-colors hover:bg-(--chrome-action-hover)',
                       disabled && 'cursor-not-allowed opacity-50'
                     )}
                     key={botRosterKey(bot)}


### PR DESCRIPTION
## What does this PR do?

Fixes the New Group Chat bot picker scrolling bot names out of view the moment you click one.

Each picker row is a `label` flex container wrapping a `min-w-0 flex-1` text column whose two lines are `truncate`. The label itself has no `min-w-0`, so as a flex item it keeps its `auto` minimum width and can't shrink below its content. `truncate` never fires — the row grows to fit its longest secondary line instead:

```
@handle · in "Group A", "Group B", …
```

which scales with how many groups a bot already belongs to. The row is a grid item inside a Radix `ScrollArea`, whose viewport wraps children in a `display: table` div that sizes to content, so the list widens rather than clipping.

Nothing looks wrong until the first click. The checkbox now sits past the right edge, so focusing it scrolls it into view — and every row shifts left, clipping the names. The user clicks a name and the names vanish. The offset persists after unchecking, until the dialog is remounted.

The fix adds `min-w-0` to the label so it can shrink and `truncate` engages as the markup already intended. `display: table` on the ScrollArea wrapper is left alone — the fix works with it, not around it.

## Related Issue

No existing issue — I couldn't find one open or closed for this, and no open PR touching this line. Happy to file one first if you'd prefer that order.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js` — added `min-w-0` to the picker row `label` in `CreateGroupChatDialog`. One class, one line.

## How to Test

1. Have a bot that belongs to two or three groups (the longer its `in "…"` list, the wider the row).
2. Open the roster's **+** → **New Group Chat**.
3. Click any row. On `main`, the list jumps sideways and the bot names are clipped from the left; unchecking doesn't restore it — only closing and reopening does.
4. With this change, the row truncates with an ellipsis and clicking does nothing to the scroll position.

Measured against a packaged build over CDP, before and after, same roster and same 414px viewport:

| | `main` | with fix |
|---|---|---|
| ScrollArea wrapper width | 593 | 414 |
| widest row | 585 | 406 |
| viewport overflows | yes | no |
| `scrollLeft` after clicking a row | 0 → 178.38 | 0 → 0 |
| wrapper `display` | `table` | `table` (unchanged) |

178.38 is exactly 593 − 414, i.e. the browser scrolling the off-screen checkbox into view.

## A note on the missing test

I've deliberately left the "added tests" box unticked rather than tick it with something that doesn't test anything.

AGENTS.md's prescribed alternative to a source-regex test is "extract the logic into a small pure/DI-testable function and call it for real." There's no logic here to extract — `min-w-0` is a class name, and the behaviour under test belongs to the layout engine. jsdom doesn't lay out, so a unit test can't observe the overflow. A `readFileSync` + regex assertion would pass without ever laying anything out, which is the false confidence AGENTS.md specifically warns about, so I didn't write one even though the neighbouring plugin tests are all in that style.

The Playwright suite *could* observe it, but there's no bots-roster fixture there yet — a sizeable scaffold to hang off a one-class change. The before/after measurements above are offered as the evidence instead. If you'd rather have the fixture, say so and I'll build it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] `node --test src/plugins/hermes-bots/tests/*.test.mjs` passes (45/45 on the group-chat suites)
- [ ] I've added tests for my changes — see the note above; happy to add a Playwright case on request
- [x] I've tested on my platform: macOS 27.0 (arm64), packaged build

### Documentation & Housekeeping

- [x] Documentation — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — CSS-only, no platform-specific behaviour
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

**Before** — Hermes ticked. Its checkbox sits past the right edge, so focusing it scrolls the list sideways and drags every name and avatar out of view; all that's left is `tion"` and `ering", "Ralphs QA and Telemetary", ...`. You can't tell which row is which bot.

<img width="2160" height="1872" alt="image" src="https://github.com/user-attachments/assets/e31a47db-b8f9-489d-8365-1fae40984d50" />

**After** — same click, same selection. Nothing scrolls, and the Hermes row truncates at `"Ra...` as the markup already intended.

<img width="2160" height="1872" alt="image" src="https://github.com/user-attachments/assets/707a6228-d2c6-4605-8f20-654c0f95458b" />
