### PR TITLE
fix(terminal): fall back when sysconf is unavailable

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2142,6 +2142,38 @@ class TestSystemdCgroupIsolation:
 
         assert pr._worker_memory_max_bytes() == pr._DEFAULT_WORKER_MEMORY_MAX_BYTES
 
+    def test_worker_memory_limit_falls_back_without_sysconf(self, monkeypatch):
+        import tools.process_registry as pr
+
+        monkeypatch.delenv("TERMINAL_LOCAL_MEMORY_MAX_MB", raising=False)
+        monkeypatch.setattr(
+            pr.Path,
+            "read_text",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("no cgroup")),
+        )
+        monkeypatch.delattr(pr.os, "sysconf")
+
+        assert pr._worker_memory_max_bytes() == pr._DEFAULT_WORKER_MEMORY_MAX_BYTES
+
+    def test_worker_memory_limit_falls_back_when_sysconf_raises_attribute_error(
+        self, monkeypatch
+    ):
+        import tools.process_registry as pr
+
+        monkeypatch.delenv("TERMINAL_LOCAL_MEMORY_MAX_MB", raising=False)
+        monkeypatch.setattr(
+            pr.Path,
+            "read_text",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("no cgroup")),
+        )
+        monkeypatch.setattr(
+            pr.os,
+            "sysconf",
+            lambda *_args: (_ for _ in ()).throw(AttributeError("no sysconf")),
+        )
+
+        assert pr._worker_memory_max_bytes() == pr._DEFAULT_WORKER_MEMORY_MAX_BYTES
+
     def test_kill_recovered_detached_already_exited_stops_persisted_scope(
         self, registry, monkeypatch
     ):

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -160,7 +160,7 @@ def _worker_memory_max_bytes() -> int:
             max(_MIN_WORKER_MEMORY_MAX_BYTES, physical_bytes // 2),
         )
         candidates.append(physical_bound)
-    except (OSError, ValueError, TypeError):
+    except (AttributeError, OSError, ValueError, TypeError):
         pass
 
     safe_bound = min(candidates) if candidates else _DEFAULT_WORKER_MEMORY_MAX_BYTES


### PR DESCRIPTION
## Summary

- treat a missing `os.sysconf` as an unavailable physical-memory probe
- retain the existing 1 GiB safe fallback when neither cgroup nor sysconf data is available
- cover both Windows-style attribute absence and an implementation that raises `AttributeError`

Fixes #90570.

## Reproduction

Base `c2f5d2da211fddf6841aa911a2d79406116203d8`: deleting `os.sysconf` makes `_worker_memory_max_bytes()` raise `AttributeError` before it can return the established safe default.

Head `5f700e2e5adda01e95ef7c82142f6b5096fdf970`: both missing and raising `sysconf` paths return `_DEFAULT_WORKER_MEMORY_MAX_BYTES`; existing `OSError` behavior remains covered.

## Validation

- `HERMES_PYTHON=/Users/xin/Documents/openclaw开源贡献/hermes-89516/.venv/bin/python scripts/run_tests.sh tests/tools/test_process_registry.py -q` (87 passed, 5 skipped platform-specific tests)
- `ruff check tools/process_registry.py tests/tools/test_process_registry.py`
- `diff` against exact base confirms 1 production-line change and 32 test lines
- TruffleHog 3.97.0 on both changed files: 0 verified, 0 unverified findings

`ruff format --check` is not a usable file-wide gate here: it reports extensive pre-existing formatting drift in both unchanged files; this PR leaves that baseline untouched.
