### PR TITLE
fix(config): config set value coercion + malformed-key rejection

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5277,6 +5277,32 @@ def _looks_structured_value(value: str) -> bool:
     return False
 
 
+def _coerce_int(value: str):
+    """Return int(value) for a clean integer literal, else None.
+
+    Uses ``int()`` so signs, surrounding whitespace, and underscores parse —
+    unlike ``str.isdigit()`` which rejects "-5"/" 5 ". Rejects float-looking
+    strings (that's ``_coerce_float``'s job) and bools masquerading as ints.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_float(value: str):
+    """Return float(value) for a clean float literal, else None."""
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    # Reject NaN/inf spellings — they are almost never intended config values
+    # and round-trip confusingly through YAML.
+    if f != f or f in (float("inf"), float("-inf")):
+        return None
+    return f
+
+
 def set_config_value(key: str, value: str, force: bool = False):
     """Set a configuration value.
 
@@ -5294,6 +5320,21 @@ def set_config_value(key: str, value: str, force: bool = False):
     if is_managed():
         managed_error("set configuration values")
         return
+    # Reject malformed dotted keys with empty segments (leading/trailing/
+    # double dots). ``"agent."`` split to ["agent", ""] and _set_nested wrote
+    # config["agent"][""] = ..., polluting a live schema section with a
+    # garbage empty-string key that round-tripped through get (CFG-04).
+    if key != key.strip() or not key.strip():
+        print(f"✗ Invalid config key: {key!r} (empty or surrounding whitespace).",
+              file=sys.stderr)
+        sys.exit(1)
+    if any(seg == "" for seg in key.split(".")):
+        print(
+            f"✗ Invalid config key: {key!r} — contains an empty path segment "
+            "(leading, trailing, or doubled '.').",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     # Managed scope guard (D2): a key pinned by the managed layer cannot be set by
     # the user — the next load would override it anyway. Hard-reject and name the
     # source. Distinct from is_managed() above (the package-manager write-lock).
@@ -5359,14 +5400,25 @@ def set_config_value(key: str, value: str, force: bool = False):
     # retain the historical best-effort coercion behavior.
     coerced_value: Any = value
     if not isinstance(_default_value_for_key(key), str):
-        if value.lower() in {'true', 'yes', 'on'}:
+        _stripped = value.strip()
+        _lower = _stripped.lower()
+        if _lower in {'true', 'yes', 'on'}:
             coerced_value = True
-        elif value.lower() in {'false', 'no', 'off'}:
+        elif _lower in {'false', 'no', 'off'}:
             coerced_value = False
-        elif value.isdigit():
-            coerced_value = int(value)
-        elif value.replace('.', '', 1).isdigit():
-            coerced_value = float(value)
+        elif _lower in {'null', 'none', '~'}:
+            # YAML null / "off" state. Many DEFAULT_CONFIG leaves default to
+            # None and are documented as "null/absent = off"; without this,
+            # ``config set X null`` stored the truthy string "null" and the
+            # feature could never be cleared via set (CFG-05).
+            coerced_value = None
+        elif _coerce_int(_stripped) is not None:
+            # int() handles signs, surrounding whitespace, and underscores —
+            # unlike the old ``value.isdigit()`` which rejected "-5" and " 5 "
+            # and silently stored them as strings on int-typed keys (CFG-02).
+            coerced_value = _coerce_int(_stripped)
+        elif _coerce_float(_stripped) is not None:
+            coerced_value = _coerce_float(_stripped)
         elif _looks_structured_value(value):
             # List/mapping literals -- e.g.
             #   hermes config set platform_toolsets.line '["file","web"]'

--- a/tests/hermes_cli/test_config_set_coercion.py
+++ b/tests/hermes_cli/test_config_set_coercion.py
@@ -1,0 +1,68 @@
+"""Regression tests for `config set` value coercion + key validation (round-3 CFG).
+
+Covers:
+- CFG-02: negative / whitespace-padded numerics coerce to int/float on
+  numeric-typed keys (old code used str.isdigit() and stored strings).
+- CFG-05: null/none/~ coerce to None so a nullable field can be cleared.
+- CFG-04: malformed dotted keys with empty segments are rejected.
+- Guard: string-typed enum keys (approvals.mode) are NOT coerced.
+"""
+
+import pytest
+
+from hermes_cli import config as cfg
+
+
+def _read(tmp_path, *path):
+    """Read a nested value straight from the on-disk config.yaml."""
+    import yaml
+    data = yaml.safe_load((tmp_path / "config.yaml").read_text()) or {}
+    node = data
+    for seg in path:
+        node = node[seg]
+    return node
+
+
+class TestNumericCoercion:
+    def test_negative_int(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg.set_config_value("agent.max_turns", "-5")
+        v = _read(tmp_path, "agent", "max_turns")
+        assert v == -5 and isinstance(v, int)
+
+    def test_whitespace_padded_int(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg.set_config_value("agent.max_turns", " 42 ")
+        v = _read(tmp_path, "agent", "max_turns")
+        assert v == 42 and isinstance(v, int)
+
+    def test_negative_float(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg.set_config_value("agent.max_turns", "-2.5")
+        v = _read(tmp_path, "agent", "max_turns")
+        assert v == -2.5 and isinstance(v, float)
+
+
+class TestNullCoercion:
+    @pytest.mark.parametrize("token", ["null", "none", "None", "~"])
+    def test_null_tokens_coerce_to_none(self, tmp_path, monkeypatch, token):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg.set_config_value("agent.run_budget_seconds", token)
+        assert _read(tmp_path, "agent", "run_budget_seconds") is None
+
+
+class TestMalformedKey:
+    @pytest.mark.parametrize("bad", ["agent.", ".agent", "agent..max_turns", "  "])
+    def test_empty_segment_rejected(self, tmp_path, monkeypatch, bad):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with pytest.raises(SystemExit) as exc:
+            cfg.set_config_value(bad, "5")
+        assert exc.value.code == 1
+
+
+class TestStringTypedGuardPreserved:
+    def test_enum_off_stays_string(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg.set_config_value("approvals.mode", "off")
+        v = _read(tmp_path, "approvals", "mode")
+        assert v == "off" and isinstance(v, str)  # not bool False


### PR DESCRIPTION
## Summary
`hermes config set` now coerces values correctly and rejects malformed keys, instead of silently storing wrong-typed strings on typed keys.

Found in round-3 deep QA (CFG-02/04/05). Four bugs in one coercion path:
- **CFG-02:** `config set agent.max_turns -5` stored the **string** `"-5"` on an int-typed key (coercion used `str.isdigit()`, which rejects signs and surrounding whitespace). Every downstream reader that did arithmetic then hit a TypeError far from the cause. `" 42 "` had the same problem.
- **CFG-05:** `config set X null` stored the **truthy string** `"null"`, so a nullable "off" field (many DEFAULT_CONFIG leaves default to `None`) could never be cleared via `set` — and the feature the user tried to disable stayed on.
- **CFG-04:** `config set "agent." 5` split to `["agent", ""]` and wrote `config["agent"][""] = 5`, polluting a live schema section with a garbage empty-string key that round-tripped through `get`.

## Changes
- `hermes_cli/config.py`:
  - New `_coerce_int` / `_coerce_float` helpers using `int()`/`float()` (handle signs, whitespace, underscores; reject NaN/inf) replace the `isdigit()` checks.
  - `null`/`none`/`~` → `None` added to the coercion ladder (guarded inside the existing string-typed check, so string-typed keys keep the literal).
  - Malformed dotted keys with empty segments (leading/trailing/doubled dots) are rejected with exit 1 before any write.
- `tests/hermes_cli/test_config_set_coercion.py`: negatives/whitespace→int/float, null tokens→None, malformed-key rejection, and the string-typed-enum guard (`approvals.mode off` stays `"off"`, not `False`).

## Validation
| `config set` | before | after |
|---|---|---|
| `agent.max_turns -5` | `"-5"` (str) | `-5` (int) |
| `agent.max_turns " 42 "` | `" 42 "` (str) | `42` (int) |
| `agent.run_budget_seconds null` | `"null"` (str) | `None` |
| `"agent." 5` | corrupts `agent` section, exit 0 | rejected, exit 1 |
| `approvals.mode off` | `"off"` (unchanged) | `"off"` (guard preserved) |

Live-verified in a sandbox (types confirmed on disk via yaml.safe_load); 12 new tests pass, 92 existing config tests still green.

## Infographic

![config coercion infographic](https://files.catbox.moe/zx6kjr.png)
