### PR TITLE
fix(desktop): route remote file APIs to registered gateway

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -455,6 +455,20 @@ test('apiRequestRegistryConnectionId extracts a genuinely non-local connection i
   assert.equal(apiRequestRegistryConnectionId({ connectionId: '  gw-1  ', path: '/x' }), 'gw-1')
 })
 
+test('registry filesystem requests stay on their gateway and shared-remote profile', () => {
+  const request = {
+    connectionId: 'gateway-proxmox',
+    path: '/api/fs/list?path=%2Fsrv%2Fproject',
+    profile: 'remote-docker'
+  }
+
+  assert.equal(apiRequestRegistryConnectionId(request), 'gateway-proxmox')
+  assert.equal(
+    pathWithProfileScope(request.path, request.profile),
+    '/api/fs/list?path=%2Fsrv%2Fproject&profile=remote-docker'
+  )
+})
+
 test('apiRequestRegistryConnectionId preserves an explicit local registry route', () => {
   assert.equal(apiRequestRegistryConnectionId({ connectionId: 'local', path: '/x' }), 'local')
 })

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { setApiRequestConnection } from '@/api/client'
 import { $connection } from '@/store/session'
 
 import {
@@ -12,7 +13,8 @@ import {
   readDesktopFileDataUrlLocalFirst,
   readDesktopFileText,
   selectDesktopPaths,
-  setDesktopFsRemotePicker
+  setDesktopFsRemotePicker,
+  writeDesktopFileText
 } from './desktop-fs'
 
 const readDir = vi.fn(async () => ({ entries: [{ name: 'local', path: '/local', isDirectory: true }] }))
@@ -32,6 +34,10 @@ const api = vi.fn(async ({ path }: { path: string }) => {
 
   if (path.startsWith('/api/fs/read-data-url?')) {
     return { dataUrl: 'data:text/plain;base64,cmVtb3Rl' }
+  }
+
+  if (path === '/api/fs/write-text') {
+    return { ok: true, path: '/remote/file.txt' }
   }
 
   if (path.startsWith('/api/fs/git-root?')) {
@@ -65,12 +71,14 @@ function stubBridge() {
 describe('desktop filesystem facade', () => {
   beforeEach(() => {
     stubBridge()
+    setApiRequestConnection(null)
     $connection.set(null)
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
     vi.clearAllMocks()
+    setApiRequestConnection(null)
     $connection.set(null)
     setDesktopFsRemotePicker(null)
   })
@@ -142,6 +150,33 @@ describe('desktop filesystem facade', () => {
 
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/list?path=%2Fsrv%2Fproject', profile: 'remote-docker' })
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/default-cwd', profile: 'remote-docker' })
+  })
+
+  it('targets the active registry connection for remote filesystem requests', async () => {
+    setApiRequestConnection('gateway-proxmox')
+    $connection.set({ mode: 'remote', profile: 'remote-docker' } as never)
+
+    await readDesktopDir('/srv/project')
+    await desktopDefaultCwd()
+    await writeDesktopFileText('/srv/project/a.txt', 'hello')
+
+    expect(api).toHaveBeenCalledWith({
+      connectionId: 'gateway-proxmox',
+      path: '/api/fs/list?path=%2Fsrv%2Fproject',
+      profile: 'remote-docker'
+    })
+    expect(api).toHaveBeenCalledWith({
+      connectionId: 'gateway-proxmox',
+      path: '/api/fs/default-cwd',
+      profile: 'remote-docker'
+    })
+    expect(api).toHaveBeenCalledWith({
+      body: { content: 'hello', path: '/srv/project/a.txt' },
+      connectionId: 'gateway-proxmox',
+      method: 'POST',
+      path: '/api/fs/write-text',
+      profile: 'remote-docker'
+    })
   })
 
   it('keys SSH filesystem caches by stable host identity instead of the forwarded port', () => {

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -1,3 +1,4 @@
+import { hermesApi } from '@/api/client'
 import type {
   HermesConnection,
   HermesReadDirResult,
@@ -58,7 +59,9 @@ function bridge() {
 }
 
 function remoteFsApi<T>(path: string, body?: Record<string, unknown>): Promise<T> {
-  return bridge().api<T>(
+  bridge()
+
+  return hermesApi<T>(
     body ? { body, method: 'POST', path, profile: desktopFsProfile() } : { path, profile: desktopFsProfile() }
   )
 }

--- a/apps/desktop/src/lib/desktop-git.test.ts
+++ b/apps/desktop/src/lib/desktop-git.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { setApiRequestConnection } from '@/api/client'
 import { $connection } from '@/store/session'
 
 import { desktopGit } from './desktop-git'
@@ -33,12 +34,14 @@ const api = vi.fn(async ({ path }: { path: string }) => {
 describe('desktop git facade', () => {
   beforeEach(() => {
     vi.stubGlobal('window', { hermesDesktop: { api, git: localGit } })
+    setApiRequestConnection(null)
     $connection.set(null)
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
     vi.clearAllMocks()
+    setApiRequestConnection(null)
     $connection.set(null)
   })
 
@@ -75,15 +78,21 @@ describe('desktop git facade', () => {
     expect(repoStatus).not.toHaveBeenCalled()
   })
 
-  it('targets the active profile backend so a remote profile never touches the local repo', async () => {
+  it('targets the active registry connection and profile for remote git requests', async () => {
+    setApiRequestConnection('gateway-proxmox')
     $connection.set({ mode: 'remote', profile: 'remote-docker' } as never)
 
     await desktopGit()?.repoStatus('/srv/work')
     await desktopGit()?.review.stage('/srv/work', 'a.txt')
 
-    expect(api).toHaveBeenCalledWith({ path: '/api/git/status?path=%2Fsrv%2Fwork', profile: 'remote-docker' })
+    expect(api).toHaveBeenCalledWith({
+      connectionId: 'gateway-proxmox',
+      path: '/api/git/status?path=%2Fsrv%2Fwork',
+      profile: 'remote-docker'
+    })
     expect(api).toHaveBeenCalledWith({
       body: { file: 'a.txt', path: '/srv/work' },
+      connectionId: 'gateway-proxmox',
       method: 'POST',
       path: '/api/git/review/stage',
       profile: 'remote-docker'

--- a/apps/desktop/src/lib/desktop-git.ts
+++ b/apps/desktop/src/lib/desktop-git.ts
@@ -1,3 +1,4 @@
+import { hermesApi } from '@/api/client'
 import type {
   HermesGitBaseBranch,
   HermesGitBranch,
@@ -25,7 +26,7 @@ function desktopApi<T>(path: string, body?: Record<string, unknown>): Promise<T>
     throw new Error('Hermes Desktop bridge is unavailable')
   }
 
-  return desktop.api<T>(
+  return hermesApi<T>(
     body ? { body, method: 'POST', path, profile: desktopFsProfile() } : { path, profile: desktopFsProfile() }
   )
 }


### PR DESCRIPTION
<!-- codex-oss-sweep -->

## What does this PR do?

Registered remote gateway file requests carried the selected profile but not the registry connection ID. Electron therefore skipped the registered-backend route and fell through to the legacy/local backend, where a remote workspace path does not exist and `/api/fs/list` returns `ENOENT`.

This routes the remote filesystem facade through the existing `hermesApi()` helper, which attaches the active registry `connectionId` while preserving the selected profile. The sibling remote Git REST facade used the same direct bridge path, so it receives the same narrowly scoped routing hardening. Issue #90424 reports the filesystem symptom; the Git change covers the same underlying routing bug class.

## Related Issue

Fixes #90424

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Route remote `/api/fs/*` requests through the active registered gateway while retaining profile scope.
- Route sibling remote `/api/git/*` requests through the same connection-scoped helper.
- Add renderer GET/POST regression coverage for both facades and Electron registry/profile routing coverage.

## How to Test

From `apps/desktop`:

1. Run `../../node_modules/.bin/vitest run --project ui src/lib/desktop-fs.test.ts src/lib/desktop-git.test.ts` (18 tests passed).
2. Run `../../node_modules/.bin/vitest run --project electron electron/connection-config.test.ts` (108 tests passed).
3. Run `npm run typecheck` (all desktop TypeScript configs passed).
4. Run Prettier and ESLint on the five changed files (passed), then `git diff --check` (passed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not run; this is a desktop TypeScript-only change, and the relevant Vitest/typecheck suites are listed above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: automated tests on macOS 26.6.1; no manual Windows multi-gateway environment was available

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); the bridge routing change uses existing platform-neutral request metadata
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable; this is request-routing behavior covered by automated renderer and Electron tests.
