### PR TITLE
fix(kanban): stop repeated review corrections from looping forever

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2600,6 +2600,10 @@ DEFAULT_CONFIG = {
         # same task/profile (spawn_failed, timed_out, or crashed). Reassignment
         # resets the streak for the new profile.
         "failure_limit": 2,
+        # Auto-block after the same review correction is requested this many
+        # times in a row. Distinct feedback resets the streak so normal iterative
+        # review remains unbounded. Set to 0 to disable this loop breaker.
+        "repeated_review_changes_limit": 3,
         # Worker stdout/stderr logs rotate at spawn time. Defaults preserve
         # the historical 2 MiB + one-backup behavior; long-running workers can
         # raise these to keep more early failure evidence.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -26,6 +26,7 @@ from typing import Any, Optional
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_swarm as ks
+from hermes_cli.config import cfg_get, load_config
 
 
 # ---------------------------------------------------------------------------
@@ -2478,6 +2479,12 @@ def _cmd_request_changes(args: argparse.Namespace) -> int:
             tid,
             reason=reason,
             expected_run_id=_worker_run_id_for(tid),
+            changes_limit=int(cfg_get(
+                load_config(),
+                "kanban",
+                "repeated_review_changes_limit",
+                default=kb.DEFAULT_REPEATED_REVIEW_CHANGES_LIMIT,
+            )),
         )
         if not ok:
             print(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -11126,19 +11126,26 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     # current instruction. Keep this block ahead of the original task body and
     # outside the bounded attempt history so it cannot be buried or omitted.
     all_prior = [r for r in list_runs(conn, task_id) if r.ended_at is not None]
-    latest_prior = all_prior[-1] if all_prior else None
+    latest_review_transition = next(
+        (
+            run
+            for run in reversed(all_prior)
+            if run.outcome in {"review_requested", "changes_requested"}
+        ),
+        None,
+    )
     if (
-        latest_prior is not None
-        and latest_prior.outcome == "changes_requested"
-        and latest_prior.summary
-        and latest_prior.summary.strip()
+        latest_review_transition is not None
+        and latest_review_transition.outcome == "changes_requested"
+        and latest_review_transition.summary
+        and latest_review_transition.summary.strip()
     ):
         lines.append("## Current review instruction")
         lines.append(
             "Address this correction before requesting review again. The Body "
             "below is the original task, not a replacement for this instruction."
         )
-        lines.append(_cap(latest_prior.summary))
+        lines.append(_cap(latest_review_transition.summary))
         lines.append("")
 
     if task.body and task.body.strip():

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -132,6 +132,10 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # spirit (default 2) but counts a different signal: manual unblock recurrences,
 # not dispatcher spawn/crash/timeout failures.
 BLOCK_RECURRENCE_LIMIT = 2
+# Review rework is a successful lifecycle transition, so it is intentionally
+# independent from crash/spawn failure accounting. Bound repeated autonomous
+# review cycles separately; callers may override or disable this with 0.
+DEFAULT_REPEATED_REVIEW_CHANGES_LIMIT = 3
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 
 
@@ -6655,6 +6659,7 @@ def request_changes(
     *,
     reason: str,
     expected_run_id: Optional[int] = None,
+    changes_limit: int = DEFAULT_REPEATED_REVIEW_CHANGES_LIMIT,
 ) -> tuple[bool, Optional[str]]:
     """Finish an active review run and route the task back for rework.
 
@@ -6667,6 +6672,8 @@ def request_changes(
     reason = str(redact_review_value(reason or "")).strip()
     if not reason:
         return False, "reason is required"
+    if changes_limit < 0:
+        raise ValueError("changes_limit must be non-negative")
 
     with write_txn(conn):
         task_row = conn.execute(
@@ -6727,7 +6734,23 @@ def request_changes(
         else:
             reviewer = None
 
-        new_status = _landing_status_after_parents(conn, task_id)
+        prior_changes = conn.execute(
+            "SELECT summary FROM task_runs "
+            "WHERE task_id = ? AND outcome = 'changes_requested' "
+            "ORDER BY id DESC",
+            (task_id,),
+        ).fetchall()
+        repeat_count = 1
+        for prior in prior_changes:
+            if str(prior["summary"] or "").strip() != reason:
+                break
+            repeat_count += 1
+        review_loop_detected = changes_limit > 0 and repeat_count >= changes_limit
+        new_status = (
+            "blocked"
+            if review_loop_detected
+            else _landing_status_after_parents(conn, task_id)
+        )
         # NOTE: consecutive_failures is deliberately PRESERVED (neither
         # reset nor incremented). Review transitions are not evidence the
         # pathology cleared — only complete_task's success path resets the
@@ -6739,10 +6762,17 @@ def request_changes(
                    assignee = COALESCE(?, assignee),
                    claim_lock = NULL,
                    claim_expires = NULL,
-                   worker_pid = NULL
+                   worker_pid = NULL,
+                   block_kind = CASE WHEN ? THEN 'needs_input' ELSE block_kind END
              WHERE id = ? AND status = 'running' AND current_run_id = ?
             """,
-            (new_status, implementer, task_id, int(current_run_id)),
+            (
+                new_status,
+                implementer,
+                int(review_loop_detected),
+                task_id,
+                int(current_run_id),
+            ),
         )
         if cur.rowcount != 1:
             return False, "task changed during review handoff"
@@ -6765,6 +6795,34 @@ def request_changes(
             },
             run_id=run_id,
         )
+        if review_loop_detected:
+            loop_payload = {
+                "repeat_count": repeat_count,
+                "limit": changes_limit,
+                "implementer": implementer,
+                "reviewer": reviewer,
+            }
+            _append_event(
+                conn,
+                task_id,
+                "review_loop_detected",
+                loop_payload,
+                run_id=run_id,
+            )
+            _append_event(
+                conn,
+                task_id,
+                "blocked",
+                {
+                    "reason": (
+                        "review changes limit reached "
+                        f"({repeat_count}/{changes_limit} repeated instructions)"
+                    ),
+                    "kind": "needs_input",
+                    "source_status": "review",
+                },
+                run_id=run_id,
+            )
     return True, implementer
 
 
@@ -11006,18 +11064,19 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
 
     Order:
       1. Task title (mandatory).
-      2. Task body (optional opening post, capped at 8 KB).
-      3. Prior attempts on THIS task (most recent ``_CTX_MAX_PRIOR_ATTEMPTS``
+      2. The latest review correction when this is a rework run.
+      3. Task body (optional opening post, capped at 8 KB).
+      4. Prior attempts on THIS task (most recent ``_CTX_MAX_PRIOR_ATTEMPTS``
          shown; older attempts collapsed into a one-line summary).
          Each attempt's ``summary`` / ``error`` / ``metadata`` capped at
          ``_CTX_MAX_FIELD_BYTES`` each.
-      4. Structured handoff results of every done parent task. Prefers
+      5. Structured handoff results of every done parent task. Prefers
          ``run.summary`` / ``run.metadata`` when the parent was executed
          via a run; falls back to ``task.result`` for older data. Same
          per-field cap.
-      5. Cross-task role history for the assignee (most recent 5
+      6. Cross-task role history for the assignee (most recent 5
          completed runs on other tasks).
-      6. Comment thread (most recent ``_CTX_MAX_COMMENTS`` shown, older
+      7. Comment thread (most recent ``_CTX_MAX_COMMENTS`` shown, older
          collapsed).
 
     All caps exist so worker prompts stay bounded even on pathological
@@ -11063,6 +11122,25 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
         lines.append(f"Branch:   {task.branch_name}")
     lines.append("")
 
+    # A retry spawned immediately after review must treat the correction as its
+    # current instruction. Keep this block ahead of the original task body and
+    # outside the bounded attempt history so it cannot be buried or omitted.
+    all_prior = [r for r in list_runs(conn, task_id) if r.ended_at is not None]
+    latest_prior = all_prior[-1] if all_prior else None
+    if (
+        latest_prior is not None
+        and latest_prior.outcome == "changes_requested"
+        and latest_prior.summary
+        and latest_prior.summary.strip()
+    ):
+        lines.append("## Current review instruction")
+        lines.append(
+            "Address this correction before requesting review again. The Body "
+            "below is the original task, not a replacement for this instruction."
+        )
+        lines.append(_cap(latest_prior.summary))
+        lines.append("")
+
     if task.body and task.body.strip():
         lines.append("## Body")
         lines.append(_cap(task.body, _CTX_MAX_BODY_BYTES))
@@ -11092,7 +11170,6 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     # Cap at _CTX_MAX_PRIOR_ATTEMPTS most-recent closed runs; older
     # attempts get collapsed into a one-line marker so the worker knows
     # more exist without bloating the prompt.
-    all_prior = [r for r in list_runs(conn, task_id) if r.ended_at is not None]
     # list_runs returns ascending by started_at; "most recent" = last N
     if len(all_prior) > _CTX_MAX_PRIOR_ATTEMPTS:
         omitted = len(all_prior) - _CTX_MAX_PRIOR_ATTEMPTS

--- a/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
@@ -644,6 +644,122 @@ def _failures(conn, task_id: str) -> int:
     ).fetchone()[0])
 
 
+def test_repeated_changes_requests_trip_independent_review_breaker(conn) -> None:
+    task_id = kb.create_task(conn, title="stuck review", assignee="builder")
+    implementation = kb.claim_task(conn, task_id, claimer="builder:1")
+    assert implementation is not None
+
+    for attempt in range(1, 4):
+        assert kb.request_review(
+            conn,
+            task_id,
+            summary=f"attempt {attempt}",
+            reviewer="reviewer" if attempt == 1 else None,
+            expected_run_id=implementation.current_run_id,
+        )
+        review = kb.claim_review_task(conn, task_id, claimer=f"reviewer:{attempt}")
+        assert review is not None
+        assert kb.request_changes(
+            conn,
+            task_id,
+            reason="Fix the unchanged boundary.",
+            expected_run_id=review.current_run_id,
+            changes_limit=3,
+        ) == (True, "builder")
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        if attempt < 3:
+            assert task.status == "ready"
+            implementation = kb.claim_task(
+                conn, task_id, claimer=f"builder:{attempt + 1}"
+            )
+            assert implementation is not None
+        else:
+            assert task.status == "blocked"
+
+    detected = _event(kb.list_events(conn, task_id), "review_loop_detected")
+    assert detected.payload == {
+        "repeat_count": 3,
+        "limit": 3,
+        "implementer": "builder",
+        "reviewer": "reviewer",
+    }
+    assert _failures(conn, task_id) == 0
+
+
+def test_distinct_review_feedback_does_not_trip_repeat_breaker(conn) -> None:
+    task_id = kb.create_task(conn, title="iterative review", assignee="builder")
+    implementation = kb.claim_task(conn, task_id, claimer="builder:1")
+    assert implementation is not None
+
+    for attempt in range(1, 5):
+        assert kb.request_review(
+            conn,
+            task_id,
+            summary=f"attempt {attempt}",
+            reviewer="reviewer" if attempt == 1 else None,
+            expected_run_id=implementation.current_run_id,
+        )
+        review = kb.claim_review_task(conn, task_id, claimer=f"reviewer:{attempt}")
+        assert review is not None
+        assert kb.request_changes(
+            conn,
+            task_id,
+            reason=f"Address review concern {attempt}.",
+            expected_run_id=review.current_run_id,
+            changes_limit=3,
+        ) == (True, "builder")
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "ready"
+        implementation = kb.claim_task(
+            conn, task_id, claimer=f"builder:{attempt + 1}"
+        )
+        assert implementation is not None
+
+    assert not any(
+        event.kind == "review_loop_detected"
+        for event in kb.list_events(conn, task_id)
+    )
+
+
+def test_rework_context_foregrounds_latest_review_instruction(conn) -> None:
+    task_id = kb.create_task(
+        conn,
+        title="correct the export",
+        body="Original task description that is now background context.",
+        assignee="builder",
+    )
+    implementation = kb.claim_task(conn, task_id, claimer="builder:1")
+    assert implementation is not None
+    assert kb.request_review(
+        conn,
+        task_id,
+        summary="first review handoff",
+        reviewer="reviewer",
+        expected_run_id=implementation.current_run_id,
+    )
+    review = kb.claim_review_task(conn, task_id, claimer="reviewer:1")
+    assert review is not None
+    assert kb.request_changes(
+        conn,
+        task_id,
+        reason="Change the exact boundary check, not the heading.",
+        expected_run_id=review.current_run_id,
+    ) == (True, "builder")
+    retry = kb.claim_task(conn, task_id, claimer="builder:2")
+    assert retry is not None
+
+    context = kb.build_worker_context(conn, task_id)
+    current = context.index("## Current review instruction")
+    original = context.index("## Body")
+    history = context.index("## Prior attempts on this task")
+    assert current < original < history
+    assert "Change the exact boundary check, not the heading." in context
+    assert "The Body below is the original task, not a replacement" in context
+
+
 def test_review_transitions_preserve_consecutive_failures(conn) -> None:
     """M2 regression: review transitions neither reset nor increment the
     circuit-breaker counter.

--- a/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
@@ -760,6 +760,46 @@ def test_rework_context_foregrounds_latest_review_instruction(conn) -> None:
     assert "The Body below is the original task, not a replacement" in context
 
 
+def test_rework_context_keeps_instruction_foregrounded_after_crash(
+    conn, monkeypatch
+) -> None:
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    task_id = kb.create_task(
+        conn,
+        title="retry the correction",
+        body="Original task description.",
+        assignee="builder",
+    )
+    implementation = kb.claim_task(conn, task_id)
+    assert implementation is not None
+    assert kb.request_review(
+        conn,
+        task_id,
+        summary="ready for review",
+        reviewer="reviewer",
+        expected_run_id=implementation.current_run_id,
+    )
+    review = kb.claim_review_task(conn, task_id, claimer="reviewer:1")
+    assert review is not None
+    assert kb.request_changes(
+        conn,
+        task_id,
+        reason="Fix the exact boundary.",
+        expected_run_id=review.current_run_id,
+    ) == (True, "builder")
+
+    retry = kb.claim_task(conn, task_id)
+    assert retry is not None
+    kb._set_worker_pid(conn, task_id, 98765)
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    assert kb.detect_crashed_workers(conn) == [task_id]
+    assert kb.claim_task(conn, task_id) is not None
+
+    context = kb.build_worker_context(conn, task_id)
+    assert context.index("## Current review instruction") < context.index("## Body")
+    assert "Fix the exact boundary." in context
+
+
 def test_review_transitions_preserve_consecutive_failures(conn) -> None:
     """M2 regression: review transitions neither reset nor increment the
     circuit-breaker counter.

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -999,6 +999,12 @@ def _handle_request_changes(args: dict, **kw) -> str:
                 tid,
                 reason=reason,
                 expected_run_id=_worker_run_id(tid),
+                changes_limit=int(cfg_get(
+                    load_config(),
+                    "kanban",
+                    "repeated_review_changes_limit",
+                    default=kb.DEFAULT_REPEATED_REVIEW_CHANGES_LIMIT,
+                )),
             )
             if not ok:
                 return tool_error(

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -793,12 +793,14 @@ All commands are also available as a slash command in the interactive CLI and in
 |------------|---------|--------------|
 | `kanban.max_in_progress` | unset (unlimited) | Caps the number of simultaneously running tasks. When the board already has N running, the dispatcher skips spawning more — useful for slow workers (local LLMs, resource-constrained hosts) so they finish what they have before more pile up and time out. Invalid or below-1 values log a warning and behave as unlimited. |
 | `kanban.max_in_progress_per_profile` | unset (unlimited) | Per-profile variant of `max_in_progress` — caps how many tasks any single assignee profile may run concurrently. Useful when one profile is slow or rate-limited but others should keep flowing. Applies alongside the board-wide `max_in_progress`; both must allow a spawn for it to proceed. |
+| `kanban.repeated_review_changes_limit` | `3` | Blocks a task when a reviewer returns the same correction this many times in a row. A different correction resets the streak, so normal iterative review is not capped. Set to `0` to disable this breaker. |
 | `kanban.auto_promote_children` | `true` | After `decompose_triage_task()` produces children with no parent-blocker dependencies, they're automatically promoted to `ready` so the dispatcher can pick them up. Set to `false` to require manual review — children stay in `todo` until you promote them. |
 | `kanban.default_workdir` | unset | Board-level default working directory applied to new tasks when neither `--workspace` nor the task itself overrides it. Per-task `workspace:` still wins. |
 
 ```yaml
 kanban:
   max_in_progress: 2
+  repeated_review_changes_limit: 3
   auto_promote_children: false
   default_workdir: ~/work/active-project
 ```
@@ -1130,6 +1132,7 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 | `blocked` | `{reason, kind, recurrences}` | Worker or human flipped the task to `blocked`. `kind` is the typed block reason (`needs_input`, `capability`, `transient`, or `null` for a generic block); `recurrences` is the unblock-loop counter. Synthesizes a zero-duration run when called on a never-claimed task with `--reason`. |
 | `dependency_wait` | `{reason, kind}` | Worker blocked with `kind=dependency` — the task is only waiting on another task, so it routes to `todo` (parent-gated, auto-promoted) instead of `blocked`. No human needed. |
 | `block_loop_detected` | `{reason, kind, recurrences, limit}` | A task was unblocked and re-blocked for the same reason `BLOCK_RECURRENCE_LIMIT` times (default 2). Instead of landing in `blocked` again — where a cron would keep unblocking it — it routes to `triage` for a human decision, breaking the unblock↔re-block loop. |
+| `review_loop_detected` | `{repeat_count, limit, implementer, reviewer}` | The reviewer returned the same correction `kanban.repeated_review_changes_limit` times in a row. The task stays assigned to the implementer but moves to `blocked` for human intervention. |
 | `unblocked` | — | `blocked → ready` (or `todo` if parents are still open), either manually or via `/unblock`. Resets the dispatcher's `consecutive_failures` but deliberately preserves `block_recurrences` so the loop breaker keeps its memory. `run_id` is `NULL`. |
 | `archived` | — | Hidden from the default board. If the task was still running, carries the `run_id` of the run that was reclaimed as a side effect. |
 


### PR DESCRIPTION
## What does this PR do?

Kanban tasks can currently cycle forever when a reviewer repeatedly returns the same correction: each review transition is considered successful, so existing crash and protocol-failure budgets never advance. This change adds an independent configurable breaker for byte-identical consecutive review corrections and foregrounds the current correction in worker context so rework attempts cannot mistake the original task body for the latest instruction.

### Symptom

A task can repeatedly move from review to rework and back to review with the reviewer returning the same unresolved correction each time. The implementer sees the original task body before the correction, and the correction can be buried or omitted by capped attempt history.

### Impact

Autonomous Kanban workflows can consume unbounded worker and reviewer runs until a human notices and manually blocks the task. The reported run reached 11 attempts with four identical review cycles while `consecutive_failures` remained zero.

### Bug Cause

**Trigger:** `hermes_cli/kanban_db.py` / `request_changes()` and `build_worker_context()`

**Causal chain:**
1. A reviewer requests the same unresolved correction on successive review attempts.
2. `request_changes()` records each transition as a successful lifecycle outcome, so neither crash failure accounting nor protocol-violation accounting advances.
3. The task returns to the implementer indefinitely, while `build_worker_context()` presents the original body before the latest correction and may truncate that correction with attempt history.

**Why it is wrong:** Successful review transitions need a separate pathology signal when feedback is unchanged, and retry context must identify the latest correction as the current instruction.

**Working sibling / contrast:** Distinct review feedback represents legitimate iterative progress and must remain routable; the new streak only counts consecutive byte-identical corrections and resets when feedback changes.

**Ruled out:** Dispatcher crash and clean-exit protocol budgets cannot bound this loop because every `changes_requested` transition ends normally and preserves crash accounting by design.

### Fix

- Add `kanban.repeated_review_changes_limit`, defaulting to 3 and allowing 0 to disable the breaker.
- Count consecutive identical `changes_requested` outcomes independently from dispatcher failure accounting; move the task to `blocked` and emit `review_loop_detected` when the limit is reached.
- Put the latest active review correction in a `Current review instruction` block before the original body and outside capped prior-attempt history, while suppressing stale corrections after a new review handoff.
- Apply the configured limit consistently through both the CLI and structured Kanban tool paths.

## Related Issue

Closes #90574

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` - add repeated-correction accounting, loop termination, audit events, and current-instruction context framing.
- `hermes_cli/config_defaults.py` - define the configurable breaker default.
- `hermes_cli/kanban.py` and `tools/kanban_tools.py` - pass the configured limit through both public request-changes surfaces.
- `tests/hermes_cli/test_kanban_review_lifecycle_complete.py` - cover identical-feedback blocking, distinct-feedback routing, context ordering, history truncation, and retry preservation.
- `website/docs/user-guide/features/kanban.md` - document configuration and the new lifecycle event.

## How to Test

1. Request the same review correction three times and verify the third request moves the task to `blocked` with a `review_loop_detected` event.
2. Request distinct corrections across four review cycles and verify the task continues routing to the implementer.
3. Run the related lifecycle and surface suite:

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py tests/hermes_cli/test_kanban_review_surfaces.py -q
```

Result: 54 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all 54 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because defaults are generated from `DEFAULT_CONFIG`
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because this does not change contributor workflow
- [x] I've considered cross-platform impact; the change is platform-independent SQLite and Python lifecycle logic
- [x] I've updated the Kanban tool behavior path and user documentation

## Screenshots / Logs

N/A - the behavior is covered by deterministic lifecycle tests.