### PR TITLE
feat(desktop): updating now updates every target — remote backends, other gateways, and the app itself

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12737,42 +12737,59 @@ ipcMain.handle('hermes:gateway:ws-url-for', async (_event, payload) => {
 // app's own update pipeline; remote/ssh POST the backend's own
 // /api/hermes/update endpoint (the dashboard updater), which runs
 // `hermes update` on THAT machine.
-ipcMain.handle('hermes:connections:update-all', async () => {
+ipcMain.handle('hermes:connections:update-all', async (_event, payload) => {
   const registry = readDesktopConnectionsRegistry()
 
+  // Optional renderer-side exclusions: the everything-update flow dispatches
+  // the ACTIVE backend through its own detailed-progress path and chains the
+  // local client apply LAST (it relaunches the app), so it excludes those ids
+  // here to avoid double-dispatch. No payload keeps the Settings button's
+  // original all-rows behavior byte-identical.
+  const excludeIds = new Set<string>(
+    Array.isArray((payload as any)?.excludeIds) ? (payload as any).excludeIds.map((id: unknown) => String(id)) : []
+  )
+
   const results = await Promise.all(
-    registry.connections.map(async connection => {
-      const base = { connectionId: connection.id, label: connection.label, kind: connection.kind }
-      const eligibility = updateEligibility(connection)
+    registry.connections
+      .filter(connection => !excludeIds.has(connection.id))
+      .map(async connection => {
+        const base = { connectionId: connection.id, label: connection.label, kind: connection.kind }
+        const eligibility = updateEligibility(connection)
 
-      if (!eligibility.eligible) {
-        return { ...base, ok: false, skipped: true, reason: eligibility.reason }
-      }
-
-      try {
-        if (connection.kind === 'local') {
-          // The app-managed runtime updates through the same pipeline as the
-          // Settings → Updates button (marker + venv gate + relaunch flow).
-          const result: any = await applyUpdates({})
-
-          return { ...base, ok: result?.ok !== false, detail: result?.message || 'update started' }
+        if (!eligibility.eligible) {
+          return { ...base, ok: false, skipped: true, reason: eligibility.reason }
         }
 
-        const descriptor: any = await ensureRegistryBackend(connection.id, null)
+        try {
+          if (connection.kind === 'local') {
+            // The app-managed runtime updates through the same pipeline as the
+            // Settings → Updates button (marker + venv gate + relaunch flow).
+            const result: any = await applyUpdates({})
 
-        const body: any = await postJsonForBackend(descriptor, '/api/hermes/update', {}, { timeoutMs: 15_000 })
+            return { ...base, ok: result?.ok !== false, detail: result?.message || 'update started' }
+          }
 
-        if (body?.ok === false) {
-          // The backend refused (docker/nix/externally-managed installs) —
-          // surface ITS message, per-row, instead of failing the batch.
-          return { ...base, ok: false, skipped: true, reason: body?.error || 'backend-refused', detail: body?.message }
+          const descriptor: any = await ensureRegistryBackend(connection.id, null)
+
+          const body: any = await postJsonForBackend(descriptor, '/api/hermes/update', {}, { timeoutMs: 15_000 })
+
+          if (body?.ok === false) {
+            // The backend refused (docker/nix/externally-managed installs) —
+            // surface ITS message, per-row, instead of failing the batch.
+            return {
+              ...base,
+              ok: false,
+              skipped: true,
+              reason: body?.error || 'backend-refused',
+              detail: body?.message
+            }
+          }
+
+          return { ...base, ok: true, detail: body?.message || 'update started' }
+        } catch (error: any) {
+          return { ...base, ok: false, error: String(error?.message || error) }
         }
-
-        return { ...base, ok: true, detail: body?.message || 'update started' }
-      } catch (error: any) {
-        return { ...base, ok: false, error: String(error?.message || error) }
-      }
-    })
+      })
   )
 
   return { ok: true, results }

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -155,7 +155,8 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     setLastUsed: id => ipcRenderer.invoke('hermes:connections:set-last-used', id),
     test: id => ipcRenderer.invoke('hermes:connections:test', id),
     // Fan out `hermes update` to every eligible registered connection.
-    updateAll: () => ipcRenderer.invoke('hermes:connections:update-all'),
+    // Optional excludeIds skips rows the caller updates through another path.
+    updateAll: options => ipcRenderer.invoke('hermes:connections:update-all', options),
     // Registry lifecycle push (main → renderer): a connection was removed or
     // materially edited, so secondaries scoped to it must be disposed (and,
     // for edits, re-dialed at the new target).

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -151,7 +151,11 @@ declare global {
         test: (id: string) => Promise<DesktopConnectionTestResult>
         // Fan out `hermes update` to every eligible registered connection;
         // cloud entries are skipped (platform-managed), each row independent.
-        updateAll?: () => Promise<{ ok: boolean; results: DesktopConnectionUpdateResult[] }>
+        // excludeIds skips connections the caller updates through another
+        // path (the everything-update flow's active backend + local client).
+        updateAll?: (options?: {
+          excludeIds?: string[]
+        }) => Promise<{ ok: boolean; results: DesktopConnectionUpdateResult[] }>
         // Registry lifecycle push: fired when a connection is removed or
         // materially edited so the renderer can dispose (and re-dial) the
         // secondary gateways scoped to it. Optional: older Electron mains

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1971,6 +1971,14 @@ export const ar = defineLocale({
     pidLabel: pid => `معرّف العملية ${pid}`,
     technicalDetails: 'التفاصيل التقنية',
     notNow: 'ليس الآن',
+    clientAlsoBehindTitle: 'تطبيق سطح المكتب متأخر',
+    clientAlsoBehindMessage:
+      'الخادم الخلفي محدث، لكن تطبيق سطح المكتب هذا لا يزال على إصدار أقدم. حدّثه للحصول على أحدث الإصلاحات.',
+    clientAlsoBehindAction: 'تحديث تطبيق سطح المكتب',
+    everythingDispatched: 'تم إرسال التحديث',
+    everythingSkipped: 'تم التخطي',
+    everythingRowFailed: 'فشل التحديث',
+    everythingFanoutFailedTitle: 'تعذر تحديث المثيلات الأخرى',
     applyStatus: {
       preparing: 'جار تحديث الواجهة الخلفية...',
       pulling: 'جار تحديث الواجهة الخلفية...',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2512,6 +2512,14 @@ export const en: Translations = {
     pidLabel: pid => `PID ${pid}`,
     technicalDetails: 'Technical details',
     notNow: 'Not now',
+    clientAlsoBehindTitle: 'Desktop app is behind',
+    clientAlsoBehindMessage:
+      'The backend is up to date, but this desktop app is still on an older version. Update it to pick up the latest fixes.',
+    clientAlsoBehindAction: 'Update desktop app',
+    everythingDispatched: 'Update dispatched',
+    everythingSkipped: 'Skipped',
+    everythingRowFailed: 'Update failed',
+    everythingFanoutFailedTitle: 'Couldn’t update other instances',
     applyStatus: {
       preparing: 'Updating backend…',
       pulling: 'Backend updating…',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2178,6 +2178,14 @@ export const ja = defineLocale({
     pidLabel: pid => `PID ${pid}`,
     technicalDetails: '技術的な詳細',
     notNow: '今は後で',
+    clientAlsoBehindTitle: 'デスクトップアプリが古くなっています',
+    clientAlsoBehindMessage:
+      'バックエンドは最新ですが、このデスクトップアプリはまだ古いバージョンです。最新の修正を反映するには更新してください。',
+    clientAlsoBehindAction: 'デスクトップアプリを更新',
+    everythingDispatched: '更新を開始しました',
+    everythingSkipped: 'スキップ',
+    everythingRowFailed: '更新に失敗しました',
+    everythingFanoutFailedTitle: '他のインスタンスを更新できませんでした',
     applyStatus: {
       preparing: 'バックエンドを更新しています…',
       pulling: 'バックエンドを更新中…',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2122,6 +2122,15 @@ export interface Translations {
     pidLabel: (pid: number) => string
     technicalDetails: string
     notNow: string
+    /** Multi-target update flow: client nudge after a backend update, and
+     *  per-row fan-out outcomes when updating every registered instance. */
+    clientAlsoBehindTitle: string
+    clientAlsoBehindMessage: string
+    clientAlsoBehindAction: string
+    everythingDispatched: string
+    everythingSkipped: string
+    everythingRowFailed: string
+    everythingFanoutFailedTitle: string
     applyStatus: {
       preparing: string
       pulling: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2110,6 +2110,13 @@ export const zhHant = defineLocale({
     pidLabel: pid => `PID ${pid}`,
     technicalDetails: '技術詳細資料',
     notNow: '暫不',
+    clientAlsoBehindTitle: '桌面應用版本落後',
+    clientAlsoBehindMessage: '後端已是最新，但此桌面應用仍是舊版本。請更新以取得最新修復。',
+    clientAlsoBehindAction: '更新桌面應用',
+    everythingDispatched: '更新已派送',
+    everythingSkipped: '已略過',
+    everythingRowFailed: '更新失敗',
+    everythingFanoutFailedTitle: '無法更新其他執行個體',
     applyStatus: {
       preparing: '正在更新後端…',
       pulling: '後端更新中…',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2693,6 +2693,13 @@ export const zh: Translations = {
     pidLabel: pid => `PID ${pid}`,
     technicalDetails: '技术详情',
     notNow: '暂不',
+    clientAlsoBehindTitle: '桌面应用版本落后',
+    clientAlsoBehindMessage: '后端已是最新，但此桌面应用仍是旧版本。请更新以获得最新修复。',
+    clientAlsoBehindAction: '更新桌面应用',
+    everythingDispatched: '更新已分发',
+    everythingSkipped: '已跳过',
+    everythingRowFailed: '更新失败',
+    everythingFanoutFailedTitle: '无法更新其他实例',
     applyStatus: {
       preparing: '正在更新后端…',
       pulling: '后端更新中…',

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -31,6 +31,17 @@ vi.mock('@/store/notifications', () => ({
   dismissNotification: (...args: unknown[]) => dismissSpy(...args)
 }))
 
+// updates.ts reads the connections registry (multi-target gating + the
+// everything-flow fan-out). Mock the store shallowly: the real module drags in
+// the profile/gateway-switch graph, which is far heavier than these tests need.
+const { atom: registryAtom } = await import('nanostores')
+const $mockConnectionsRegistry = registryAtom<unknown>(null)
+
+vi.mock('@/store/connections', () => ({
+  $connectionsRegistry: $mockConnectionsRegistry,
+  refreshConnectionsRegistry: () => Promise.resolve($mockConnectionsRegistry.get())
+}))
+
 const checkHermesUpdateSpy = vi.fn()
 const updateHermesSpy = vi.fn()
 const getActionStatusSpy = vi.fn()
@@ -49,7 +60,10 @@ const {
   $backendUpdateApply,
   reportBackendContract,
   applyUpdates,
+  applyEverythingUpdate,
+  hasMultipleUpdateTargets,
   $updateApply,
+  $updateEverything,
   $updateOverlayOpen,
   $updateOverlayTarget,
   requestActiveUpdate,
@@ -60,6 +74,13 @@ const {
 } = await import('./updates')
 
 const { setConnection } = await import('./session')
+
+const registryOf = (ids: string[]) => ({
+  version: 2,
+  primary: ids[0] ?? 'local',
+  secureTokenStorage: true,
+  connections: ids.map(id => ({ id, kind: id === 'local' ? 'local' : 'remote', label: id }))
+})
 
 const status = (over: Partial<DesktopUpdateStatus> = {}): DesktopUpdateStatus => ({
   supported: true,
@@ -304,6 +325,9 @@ describe('requestActiveUpdate', () => {
     // memoizes the in-flight run, so a dangling promise here would be handed
     // to the next suite's tests instead of a fresh run.
     await vi.waitFor(() => expect($backendUpdateApply.get().applying).toBe(false), { timeout: 5000 })
+    // Remote-mode rows now route through the everything-flow; drain its tail
+    // (fan-out + client check) so it can't bleed into the next test.
+    await vi.waitFor(() => expect($updateEverything.get().running).toBe(false), { timeout: 5000 })
     setRemote(false)
     delete (globalThis as unknown as { window?: unknown }).window
   })
@@ -356,6 +380,239 @@ describe('requestActiveUpdate', () => {
 
     requestActiveUpdate()
     await vi.waitFor(() => expect(updateHermesSpy).toHaveBeenCalled())
+  })
+})
+
+// The everything-flow: on multi-target installs (remote mode / multi-connection
+// registry) "update" must mean every machine — active backend, other registered
+// sources via the Electron fan-out, and the client LAST. Before this flow,
+// every remote-mode affordance updated only the backend, so users "updated"
+// forever while the desktop app itself stayed weeks stale (the Aug 2026
+// mac-app-on-v0.20.0 report).
+describe('applyEverythingUpdate', () => {
+  const applyClientMock = vi.fn()
+  const checkClientMock = vi.fn()
+  const updateAllMock = vi.fn()
+
+  beforeEach(() => {
+    storage.clear()
+    notifySpy.mockClear()
+    dismissSpy.mockClear()
+    applyClientMock.mockReset().mockResolvedValue({ ok: true, handedOff: true })
+    checkClientMock.mockReset().mockResolvedValue(status({ behind: 0, updateAvailable: false }))
+    updateAllMock.mockReset().mockResolvedValue({ ok: true, results: [] })
+    updateHermesSpy.mockReset().mockResolvedValue({ ok: true, name: 'update' })
+    checkHermesUpdateSpy.mockReset().mockResolvedValue({
+      install_method: 'git',
+      current_version: '0.4.2',
+      behind: 0,
+      update_available: false,
+      can_apply: true,
+      update_command: null,
+      message: null
+    })
+    getActionStatusSpy.mockReset().mockResolvedValue({ lines: [], running: false, exit_code: 0 })
+    resetUpdateApplyState()
+    $updateStatus.set(null)
+    $backendUpdateStatus.set(null)
+    $updateOverlayOpen.set(false)
+    $mockConnectionsRegistry.set(null)
+    ;(globalThis as unknown as { window: unknown }).window = {
+      hermesDesktop: {
+        updates: { apply: applyClientMock, check: checkClientMock },
+        connections: { updateAll: updateAllMock }
+      }
+    }
+    vi.useRealTimers()
+  })
+
+  afterEach(async () => {
+    await vi.waitFor(() => expect($updateEverything.get().running).toBe(false), { timeout: 5000 })
+    await vi.waitFor(() => expect($backendUpdateApply.get().applying).toBe(false), { timeout: 5000 })
+    setRemote(false)
+    $mockConnectionsRegistry.set(null)
+    delete (globalThis as unknown as { window?: unknown }).window
+  })
+
+  it('gates on multiple targets: remote mode OR a multi-connection registry', () => {
+    setRemote(false)
+    $mockConnectionsRegistry.set(null)
+    expect(hasMultipleUpdateTargets()).toBe(false)
+
+    setRemote(true)
+    expect(hasMultipleUpdateTargets()).toBe(true)
+
+    setRemote(false)
+    $mockConnectionsRegistry.set(registryOf(['local', 'vps']))
+    expect(hasMultipleUpdateTargets()).toBe(true)
+  })
+
+  it('remote mode: updates the backend, then the still-behind client — the stale-GUI gap', async () => {
+    setRemote(true)
+    $backendUpdateStatus.set(status({ behind: 3 }))
+    // The client is ALSO behind; the old flow never touched it.
+    checkClientMock.mockResolvedValue(status({ behind: 7, updateAvailable: true }))
+
+    await applyEverythingUpdate()
+
+    expect(updateHermesSpy).toHaveBeenCalledTimes(1)
+    expect(applyClientMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('remote mode: skips the client apply when the client is already current', async () => {
+    setRemote(true)
+    $backendUpdateStatus.set(status({ behind: 3 }))
+    checkClientMock.mockResolvedValue(status({ behind: 0, updateAvailable: false }))
+
+    await applyEverythingUpdate()
+
+    expect(updateHermesSpy).toHaveBeenCalledTimes(1)
+    expect(applyClientMock).not.toHaveBeenCalled()
+  })
+
+  it('fans out to other registered connections, excluding local and the active backend', async () => {
+    setRemote(true)
+    $mockConnectionsRegistry.set(registryOf(['local', 'vps', 'homelab']))
+    $backendUpdateStatus.set(status({ behind: 1 }))
+
+    await applyEverythingUpdate()
+
+    expect(updateAllMock).toHaveBeenCalledTimes(1)
+    const options = updateAllMock.mock.calls[0]?.[0] as { excludeIds: string[] }
+    expect(options.excludeIds).toContain('local')
+  })
+
+  it('local mode with a multi-connection registry: fans out and updates the client, no active-backend leg', async () => {
+    setRemote(false)
+    $mockConnectionsRegistry.set(registryOf(['local', 'vps']))
+    checkClientMock.mockResolvedValue(status({ behind: 2, updateAvailable: true }))
+    $updateStatus.set(status({ behind: 2, updateAvailable: true }))
+
+    await applyEverythingUpdate()
+
+    expect(updateHermesSpy).not.toHaveBeenCalled()
+    expect(updateAllMock).toHaveBeenCalledTimes(1)
+    expect(applyClientMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('a failed backend leg does not strand the fan-out or the client', async () => {
+    setRemote(true)
+    $mockConnectionsRegistry.set(registryOf(['local', 'vps']))
+    updateHermesSpy.mockRejectedValue(new Error('backend gone'))
+    checkClientMock.mockResolvedValue(status({ behind: 4, updateAvailable: true }))
+
+    await applyEverythingUpdate()
+
+    expect(updateAllMock).toHaveBeenCalledTimes(1)
+    expect(applyClientMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces per-row fan-out outcomes as notifications', async () => {
+    setRemote(false)
+    $mockConnectionsRegistry.set(registryOf(['local', 'vps', 'dead-box']))
+    updateAllMock.mockResolvedValue({
+      ok: true,
+      results: [
+        { connectionId: 'vps', label: 'vps', kind: 'remote', ok: true, detail: 'update started' },
+        { connectionId: 'dead-box', label: 'dead-box', kind: 'remote', ok: false, error: 'ECONNREFUSED' }
+      ]
+    })
+
+    await applyEverythingUpdate()
+
+    const titles = notifySpy.mock.calls.map(call => (call[0] as { title?: string }).title)
+    expect(titles).toContain('vps')
+    expect(titles).toContain('dead-box')
+  })
+
+  it('memoizes the in-flight run so a double click cannot double-dispatch', async () => {
+    setRemote(false)
+    $mockConnectionsRegistry.set(registryOf(['local', 'vps']))
+
+    const first = applyEverythingUpdate()
+    const second = applyEverythingUpdate()
+
+    expect(second).toBe(first)
+    await Promise.all([first, second])
+    expect(updateAllMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('requestActiveUpdate routes through the everything-flow when EITHER target is behind', async () => {
+    setRemote(true)
+    // Backend current, client behind — the exact case the old remote-only
+    // ternary missed entirely.
+    $backendUpdateStatus.set(status({ behind: 0, updateAvailable: false }))
+    $updateStatus.set(status({ behind: 5, updateAvailable: true }))
+    checkClientMock.mockResolvedValue(status({ behind: 5, updateAvailable: true }))
+
+    requestActiveUpdate()
+
+    // The everything-flow runs the backend leg first (a 1.5s status poll on
+    // real timers) before reaching the client apply — give it room.
+    await vi.waitFor(() => expect(applyClientMock).toHaveBeenCalled(), { timeout: 5000 })
+  })
+})
+
+// Post-backend-update client nudge: a successful backend apply re-checks the
+// CLIENT and warns when it is still behind, with a one-click client update.
+describe('client nudge after a backend update', () => {
+  const applyClientMock = vi.fn()
+  const checkClientMock = vi.fn()
+
+  beforeEach(() => {
+    storage.clear()
+    notifySpy.mockClear()
+    dismissSpy.mockClear()
+    applyClientMock.mockReset().mockResolvedValue({ ok: true, handedOff: true })
+    checkClientMock.mockReset()
+    updateHermesSpy.mockReset().mockResolvedValue({ ok: true, name: 'update' })
+    checkHermesUpdateSpy.mockReset().mockResolvedValue({
+      install_method: 'git',
+      current_version: '0.4.2',
+      behind: 0,
+      update_available: false,
+      can_apply: true,
+      update_command: null,
+      message: null
+    })
+    getActionStatusSpy.mockReset().mockResolvedValue({ lines: [], running: false, exit_code: 0 })
+    resetUpdateApplyState()
+    $updateStatus.set(null)
+    $backendUpdateStatus.set(null)
+    $mockConnectionsRegistry.set(null)
+    setRemote(true)
+    ;(globalThis as unknown as { window: unknown }).window = {
+      hermesDesktop: { updates: { apply: applyClientMock, check: checkClientMock } }
+    }
+    vi.useRealTimers()
+  })
+
+  afterEach(async () => {
+    await vi.waitFor(() => expect($backendUpdateApply.get().applying).toBe(false), { timeout: 5000 })
+    setRemote(false)
+    delete (globalThis as unknown as { window?: unknown }).window
+  })
+
+  it('warns when the client is still behind after the backend caught up', async () => {
+    checkClientMock.mockResolvedValue(status({ behind: 6, updateAvailable: true }))
+
+    await applyBackendUpdate()
+
+    await vi.waitFor(() => {
+      const ids = notifySpy.mock.calls.map(call => (call[0] as { id?: string }).id)
+      expect(ids).toContain('client-update-after-backend')
+    })
+  })
+
+  it('stays silent when the client is already current', async () => {
+    checkClientMock.mockResolvedValue(status({ behind: 0, updateAvailable: false }))
+
+    await applyBackendUpdate()
+
+    // Give the fire-and-forget nudge a beat to (not) fire.
+    await new Promise(resolve => setTimeout(resolve, 50))
+    const ids = notifySpy.mock.calls.map(call => (call[0] as { id?: string }).id)
+    expect(ids).not.toContain('client-update-after-backend')
   })
 })
 

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -17,8 +17,8 @@ import type {
 import { checkHermesUpdate, getActionStatus, updateHermes } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { persistString, storedString } from '@/lib/storage'
-import { dismissNotification, notify } from '@/store/notifications'
 import { $connectionsRegistry, refreshConnectionsRegistry } from '@/store/connections'
+import { dismissNotification, notify } from '@/store/notifications'
 import { $connection } from '@/store/session'
 import type { BackendUpdateCheckResponse } from '@/types/hermes'
 

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -18,6 +18,7 @@ import { checkHermesUpdate, getActionStatus, updateHermes } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { persistString, storedString } from '@/lib/storage'
 import { dismissNotification, notify } from '@/store/notifications'
+import { $connectionsRegistry, refreshConnectionsRegistry } from '@/store/connections'
 import { $connection } from '@/store/session'
 import type { BackendUpdateCheckResponse } from '@/types/hermes'
 
@@ -256,8 +257,20 @@ export function openUpdatesWindow(): void {
  * renders ApplyingView once `applying` flips true), then kicks off the install.
  * Used by the "Update now" affordance on the About panel, which would otherwise
  * only be able to open the changelog overlay.
+ *
+ * Multi-target installs (remote mode / multi-connection registry) route
+ * through the everything-flow so "update" means every machine, not just the
+ * active target — the single-target ternary is what left remote-mode users
+ * updating the backend forever while the GUI itself went stale.
  */
 export function startActiveUpdate(): void {
+  if (hasMultipleUpdateTargets()) {
+    $updateOverlayOpen.set(true)
+    void applyEverythingUpdate()
+
+    return
+  }
+
   const target: UpdateTarget = isRemoteMode() ? 'backend' : 'client'
   $updateOverlayTarget.set(target)
   $updateOverlayOpen.set(true)
@@ -268,9 +281,28 @@ export function startActiveUpdate(): void {
  * Command-palette entry point. The About panel's "Update now" only renders once
  * we know an update is waiting; this row is always listed, so it also has to
  * handle "already current" — open the overlay for the active target and let its
- * check answer, and only apply when there's something to install.
+ * check answer, and only apply when there's something to install. On
+ * multi-target installs an update waiting on EITHER the client or the backend
+ * triggers the everything-flow.
  */
 export function requestActiveUpdate(): void {
+  if (hasMultipleUpdateTargets()) {
+    const clientStatus = $updateStatus.get()
+    const backendStatus = $backendUpdateStatus.get()
+
+    const anyBehind =
+      (clientStatus?.behind ?? 0) > 0 ||
+      clientStatus?.updateAvailable ||
+      (backendStatus?.behind ?? 0) > 0 ||
+      backendStatus?.updateAvailable
+
+    if (anyBehind) {
+      startActiveUpdate()
+
+      return
+    }
+  }
+
   const target: UpdateTarget = isRemoteMode() ? 'backend' : 'client'
   const status = target === 'backend' ? $backendUpdateStatus.get() : $updateStatus.get()
 
@@ -507,6 +539,11 @@ function finishBackendApply(returned: boolean): DesktopUpdateApplyResult {
     $backendUpdateApply.set(IDLE)
     setUpdateOverlayOpen(false)
     void checkBackendUpdates()
+    // The backend caught up, but the CLIENT may still be behind — the exact
+    // gap that strands remote-mode users on an old GUI forever (every update
+    // affordance in remote mode targets the backend, so nothing ever told
+    // them the app itself was stale). Nudge with a one-click client update.
+    void maybeNudgeClientAfterBackendUpdate()
 
     return { ok: true, message: 'Backend update applied.' }
   }
@@ -699,6 +736,152 @@ export function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
   })
 
   return backendUpdateInFlight
+}
+
+// ── Update everything: the client + every registered backend in one action ──
+//
+// Remote-mode installs update on two (or more) clocks: the GUI app on this
+// machine, the connected backend, and any other registered sources. Each has
+// its own updater, and before this flow existed every remote-mode affordance
+// targeted only the backend — so users "updated" and stayed on a stale GUI.
+// This orchestration drives all of them:
+//   1. The ACTIVE backend (remote mode) through the detailed-progress path.
+//   2. Every OTHER eligible registered connection via the Electron fan-out
+//      (cloud rows are platform-managed and report as skipped).
+//   3. The local client LAST — its apply relaunches or hands off the app, so
+//      it must not preempt the dispatches above.
+
+const CLIENT_BEHIND_TOAST_ID = 'client-update-after-backend'
+
+/** After a successful backend update, tell the user when the desktop app
+ *  itself is still behind, with a one-click client update. Silent when the
+ *  client is current, so aligned installs never see it. */
+async function maybeNudgeClientAfterBackendUpdate(): Promise<void> {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const status = (await checkUpdates().catch(() => null)) ?? $updateStatus.get()
+
+  if (!status || status.error || (!status.updateAvailable && (status.behind ?? 0) <= 0)) {
+    return
+  }
+
+  notify({
+    action: {
+      label: translateNow('updates.clientAlsoBehindAction'),
+      onClick: () => {
+        dismissNotification(CLIENT_BEHIND_TOAST_ID)
+        $updateOverlayTarget.set('client')
+        $updateOverlayOpen.set(true)
+        void applyUpdates()
+      }
+    },
+    durationMs: 0,
+    id: CLIENT_BEHIND_TOAST_ID,
+    kind: 'warning',
+    message: translateNow('updates.clientAlsoBehindMessage'),
+    title: translateNow('updates.clientAlsoBehindTitle')
+  })
+}
+
+export interface UpdateEverythingState {
+  running: boolean
+}
+
+export const $updateEverything = atom<UpdateEverythingState>({ running: false })
+
+/** True when this install has more than one update target — a remote-mode
+ *  window (backend + client) or a multi-connection registry. Gates the
+ *  "Update everything" affordance so single-machine installs keep the
+ *  one-button experience. */
+export function hasMultipleUpdateTargets(): boolean {
+  return isRemoteMode() || ($connectionsRegistry.get()?.connections.length ?? 0) > 1
+}
+
+let updateEverythingInFlight: Promise<void> | null = null
+
+export function applyEverythingUpdate(): Promise<void> {
+  if (updateEverythingInFlight) {
+    return updateEverythingInFlight
+  }
+
+  updateEverythingInFlight = runEverythingUpdate().finally(() => {
+    updateEverythingInFlight = null
+  })
+
+  return updateEverythingInFlight
+}
+
+async function runEverythingUpdate(): Promise<void> {
+  $updateEverything.set({ running: true })
+
+  try {
+    // 1. Active backend first (remote mode), with the detailed overlay flow.
+    //    Its own finish path re-checks and nudges, but the everything-flow
+    //    continues regardless of the outcome: one unreachable backend must
+    //    not strand the other machines or the client.
+    if (isRemoteMode()) {
+      $updateOverlayTarget.set('backend')
+
+      await applyBackendUpdate().catch(() => null)
+    }
+
+    // 2. Fan out to every OTHER eligible registered connection. The active
+    //    backend was just updated (excluded), and the local runtime updates
+    //    with the client in step 3 (excluded). No registry/bridge → skip.
+    const bridge = window.hermesDesktop?.connections
+    const registry = $connectionsRegistry.get() ?? (await refreshConnectionsRegistry().catch(() => null))
+    const excludeIds = ['local']
+    const activeConnectionId = $connection.get()?.connectionId
+
+    if (isRemoteMode() && activeConnectionId && !excludeIds.includes(activeConnectionId)) {
+      excludeIds.push(activeConnectionId)
+    }
+
+    const remaining = (registry?.connections ?? []).filter(connection => !excludeIds.includes(connection.id))
+
+    if (bridge?.updateAll && remaining.length > 0) {
+      try {
+        const { results } = await bridge.updateAll({ excludeIds })
+
+        for (const row of results) {
+          if (row.ok) {
+            notify({ title: row.label, message: row.detail || translateNow('updates.everythingDispatched') })
+          } else if (row.skipped) {
+            notify({
+              title: row.label,
+              message: row.detail || row.reason || translateNow('updates.everythingSkipped')
+            })
+          } else {
+            notify({
+              kind: 'warning',
+              title: row.label,
+              message: row.error || row.detail || translateNow('updates.everythingRowFailed')
+            })
+          }
+        }
+      } catch (error) {
+        notify({
+          kind: 'warning',
+          title: translateNow('updates.everythingFanoutFailedTitle'),
+          message: error instanceof Error ? error.message : String(error)
+        })
+      }
+    }
+
+    // 3. The client last — its apply relaunches or hands off the app, so it
+    //    must come after every dispatch above. Skipped when already current.
+    const clientStatus = $updateStatus.get() ?? (await checkUpdates())
+
+    if ((clientStatus?.behind ?? 0) > 0 || clientStatus?.updateAvailable) {
+      $updateOverlayTarget.set('client')
+      $updateOverlayOpen.set(true)
+      await applyUpdates()
+    }
+  } finally {
+    $updateEverything.set({ running: false })
+  }
 }
 
 function ingestProgress(payload: DesktopUpdateProgress): void {

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -247,6 +247,10 @@ chats decide who replies: [Bot Mode: A Roster of Agents](./bot-mode.md).
 
 The app checks for updates in the background and offers a one-click update when one is ready.
 
+The desktop app and the Hermes backend it talks to update on separate clocks — the app package on your machine, the backend wherever it runs. When more than one update target exists (a remote gateway, or several registered gateways), the update affordances (**Update now** on the About panel, the ⌘K **Update Hermes** row, and the update-ready toast) update **everything**: the connected backend first, then every other eligible registered gateway (Hermes Cloud entries are platform-managed and skipped), and the desktop app itself last, since applying the client update relaunches the app. Single-machine installs keep the one-button experience.
+
+After any backend update, the app also re-checks its own version and warns with a one-click **Update desktop app** action if the GUI is still behind — so updating a remote backend can never silently leave you on a stale desktop build.
+
 The [manual update process](https://hermes-agent.nousresearch.com/docs/getting-started/updating) also works with the GUI.
 
 ## Uninstalling

--- a/website/docs/user-guide/multi-connection-desktop.md
+++ b/website/docs/user-guide/multi-connection-desktop.md
@@ -238,6 +238,13 @@ Each instance reports independently, so one unreachable box never wedges the
 batch. Backends that manage updates externally (Docker, Nix) refuse politely
 with their own message, per row.
 
+You rarely need the Settings button, though: once more than one update target
+exists, the app's regular update affordances (**Update now** on the About
+panel, ⌘K **Update Hermes**, the update-ready toast) run the same fan-out
+automatically — active backend first, then every other eligible gateway, then
+the desktop app itself last. See
+[Updating](./desktop.md#updating) in the desktop guide.
+
 ## Security notes
 
 - **Where tokens live.** Remote-gateway session tokens are encrypted at rest


### PR DESCRIPTION
## Summary
On multi-target installs, updating from the desktop now updates **everything** — the connected backend, every other registered gateway, and the desktop app itself — instead of only the backend.

Root cause of the reported symptom (Santiago Sarceda, mac app stuck on the Aug 3 build): every remote-mode update affordance (`About → Update now`, `⌘K → Update Hermes`, the update-ready toast) resolved `isRemoteMode() ? 'backend' : 'client'`, so remote users updated their VPS forever while the GUI went weeks stale — and the skew warning only fired in the other direction (backend older than GUI), so nothing ever told them.

## Changes
- `src/store/updates.ts`: new `applyEverythingUpdate()` orchestration — active backend first (existing detailed-progress path), every other eligible registered gateway via the existing `hermes:connections:update-all` fan-out (cloud rows skipped as platform-managed), the client **last** since its apply relaunches the app. `startActiveUpdate()` / `requestActiveUpdate()` route through it whenever `hasMultipleUpdateTargets()` (remote mode OR >1 registered connections); single-machine installs keep the exact one-button flow.
- Reverse-skew safety net: after **any** successful backend update, the client version is re-checked and a persistent one-click "Update desktop app" warning fires if the GUI is still behind.
- `electron/main.ts` + `preload.ts` + `global.d.ts`: `updateAll` accepts optional `excludeIds` so the everything-flow doesn't double-dispatch the active backend / local runtime. No payload → byte-identical Settings-button behavior.
- i18n: 7 new `updates.*` keys across en / zh / zh-hant / ja / ar.
- Docs: `user-guide/desktop.md` Updating section + `user-guide/multi-connection-desktop.md` cross-reference.

## Validation
| | Before | After |
|---|---|---|
| Remote-mode "Update now" | backend only; GUI stays stale silently | backend → other gateways → client, in order |
| Backend current, client behind (remote) | no-op besides overlay | everything-flow applies the client update |
| Backend updated, client behind | silent | warning toast with one-click client update |
| Failed backend leg | n/a | fan-out + client still proceed |
| `src/store/updates.test.ts` | 46 tests | 56 tests, all passing (10 new) |
| `electron/connection-registry.test.ts` | 62 passing | 62 passing |

## Infographic

![Update everything infographic](https://files.catbox.moe/neqwab.png)
