### PR TITLE
fix(desktop): preserve npm-scoped package refs

### DIFF
--- a/apps/desktop/src/app/chat/composer/path-refs.test.ts
+++ b/apps/desktop/src/app/chat/composer/path-refs.test.ts
@@ -53,6 +53,18 @@ describe('pathifyRefs', () => {
     expect(pathifyRefs('cc @teknium1 on this')).toBe('cc @teknium1 on this')
   })
 
+  it('leaves extensionless npm-scoped package tokens alone', () => {
+    expect(pathifyRefs('install @openai/codex')).toBe('install @openai/codex')
+    expect(pathifyRefs('install @openai/codex@0.148.0')).toBe('install @openai/codex@0.148.0')
+    expect(pathifyRefs('min-release-age-exclude=@openai/codex')).toBe('min-release-age-exclude=@openai/codex')
+  })
+
+  it('leaves npm-scoped package tokens before prose punctuation alone', () => {
+    expect(pathifyRefs('install @openai/codex, then retry')).toBe('install @openai/codex, then retry')
+    expect(pathifyRefs('install (@openai/codex)')).toBe('install (@openai/codex)')
+    expect(pathifyRefs('install `@openai/codex`')).toBe('install `@openai/codex`')
+  })
+
   it('leaves simple refs alone', () => {
     expect(pathifyRefs('check @diff and @staged')).toBe('check @diff and @staged')
   })
@@ -93,6 +105,25 @@ describe('chipTypedPathOnSpace', () => {
 
     expect(chipTypedPathOnSpace(event)).toBe(false)
     expect(editor.querySelector('[data-ref-text]')).toBeNull()
+  })
+
+  it('leaves npm-scoped package forms as text', () => {
+    const examples = [
+      'install @openai/codex',
+      'install @openai/codex@0.148.0',
+      'min-release-age-exclude=@openai/codex',
+      'install @openai/codex,',
+      'install (@openai/codex)',
+      'install `@openai/codex`',
+    ]
+
+    for (const text of examples) {
+      const { editor, event } = spaceOn(text)
+
+      expect(chipTypedPathOnSpace(event), text).toBe(false)
+      expect(editor.querySelector('[data-ref-text]'), text).toBeNull()
+      editor.remove()
+    }
   })
 
   it('leaves an already-typed ref alone', () => {

--- a/apps/desktop/src/app/chat/composer/path-refs.test.ts
+++ b/apps/desktop/src/app/chat/composer/path-refs.test.ts
@@ -114,7 +114,7 @@ describe('chipTypedPathOnSpace', () => {
       'min-release-age-exclude=@openai/codex',
       'install @openai/codex,',
       'install (@openai/codex)',
-      'install `@openai/codex`',
+      'install `@openai/codex`'
     ]
 
     for (const text of examples) {

--- a/apps/desktop/src/app/chat/composer/path-refs.ts
+++ b/apps/desktop/src/app/chat/composer/path-refs.ts
@@ -22,12 +22,25 @@ import { textBeforeCaret } from './text-utils'
 const BARE_PATH_RE = /(?<![\w@/])@((?!(?:file|folder|url|image|tool|line|terminal|session|git):)[^\s@:]*\/[^\s@:]*)/g
 const TYPED_BARE_PATH_RE = new RegExp(`${BARE_PATH_RE.source}$`)
 
+// An extensionless `@scope/package` token is indistinguishable from a
+// two-segment relative path. Preserve the package-shaped token instead of
+// silently attaching it; file-like paths such as `@src/main.ts` still promote.
+// Explicit `@file:` remains available for an ambiguous extensionless path.
+const EXTENSIONLESS_SCOPED_PACKAGE_RE = /^[a-z0-9][a-z0-9._~-]*\/[a-z0-9][a-z0-9_~-]*$/
+const TRAILING_PROSE_RE = /[`'",.;!?)}\]]+$/
+
+function isExtensionlessScopedPackageToken(path: string) {
+  return EXTENSIONLESS_SCOPED_PACKAGE_RE.test(path.replace(TRAILING_PROSE_RE, ''))
+}
+
 /** Trailing `/` means a directory — that's how the gateway's completion emits
  *  folders, and what Tab-descending leaves behind. */
 export function barePathRef(path: string) {
   const trimmed = path.replace(/\/+$/, '')
 
-  return trimmed ? `@${path.endsWith('/') ? 'folder' : 'file'}:${quoteRefValue(trimmed)}` : null
+  return trimmed && (path.endsWith('/') || !isExtensionlessScopedPackageToken(trimmed))
+    ? `@${path.endsWith('/') ? 'folder' : 'file'}:${quoteRefValue(trimmed)}`
+    : null
 }
 
 /** Rewrite bare `@path` tokens as typed `@file:`/`@folder:` directives, leaving


### PR DESCRIPTION
## Summary

- stop the desktop composer’s bare-path promotion from rewriting extensionless npm-scoped package tokens as local `@file:` references
- preserve existing folder tokens with a trailing slash and file-like paths such as `@src/main.ts`
- cover unversioned/versioned packages, `.npmrc` assignments, prose punctuation, inline code, submit-time rewriting, and space-to-chip behavior

## Root cause

`BARE_PATH_RE` intentionally treats an `@` token containing `/` as a path. That also matches npm’s `@scope/package` syntax, so text such as `@openai/codex` was silently rewritten to a file reference and produced a false “file not found” context warning.

`barePathRef()` now preserves extensionless two-segment package-shaped tokens after ignoring trailing prose punctuation. The syntax is lexically ambiguous, so an actual extensionless two-segment path can still be attached explicitly with `@file:`. Folder tokens ending in `/` and file-like paths continue to promote as before.

## Verification

- `npm test --workspace apps/desktop -- --project ui src/app/chat/composer/path-refs.test.ts` — **15/15 passed**
- `npm run typecheck --workspace apps/desktop` — **passed**
- ESLint on both changed files — **passed**
- Prettier check on both changed files — **passed**
- independent pre-commit review — **no blocking security or logic findings**
- full `npm run test:ui --workspace apps/desktop` — the changed `path-refs` tests passed inside the full run; the suite finished **5,117 passed / 18 failed**, with the failures confined to six unrelated existing UI test files (timeouts/DOM-state failures). No changed-file failure remained.

## Safety

No runtime configuration, credentials, gateway state, scheduler state, or user data is changed.
