### PR TITLE
fix(desktop): bundled variant uses hermes:// scheme, not hermes-bundled://

### DIFF
--- a/apps/desktop/electron/product-identity.test.ts
+++ b/apps/desktop/electron/product-identity.test.ts
@@ -56,6 +56,12 @@ test('a nightly payload tag moves BOTH variants onto their nightly feed channel'
   assert.equal(light.channel, 'light-nightly')
 })
 
+test('bundled variant uses hermes:// scheme, not hermes-bundled://', async () => {
+  const bundled = await identityForVariant('bundled')
+  assert.equal(bundled.protocolScheme, 'hermes')
+  assert.equal(bundled.light, false)
+})
+
 test('stable tags and tagless dev builds publish to the stable channels', async () => {
   process.env.HERMES_PAYLOAD_TAG = 'v0.28.0'
   assert.equal((await identityForVariant(undefined)).channel, 'latest')

--- a/apps/desktop/product-identity.cjs
+++ b/apps/desktop/product-identity.cjs
@@ -52,7 +52,14 @@ const identity = {
   displayName: name.display,
   appId: `com.nousresearch.${name.kebab}`,
   channel: light ? (nightly ? 'light-nightly' : 'light') : (nightly ? 'nightly' : 'latest'),
-  protocolScheme: name.kebab,
+  // The deep-link protocol scheme. Only the light variant gets its own
+  // scheme (hermes-light://) so it can install side-by-side with the full
+  // app without fighting over the OS handler. Full and bundled both use
+  // hermes:// — the bundled variant must NOT use hermes-bundled:// because
+  // deep-link-route.ts derives 'hermes' for any non-light payload, so a
+  // hermes-bundled:// scheme in the OS manifest would mismatch the runtime
+  // registration (app.setAsDefaultProtocolClient).
+  protocolScheme: light ? 'hermes-light' : 'hermes',
   appNamePascal: name.pascal,
   msixAppIdWithOrg: `NousResearch.${name.pascal}`
 }


### PR DESCRIPTION
## What

The bundled variant's protocol scheme was `hermes-bundled://` in the OS manifest (from `product-identity.cjs` deriving `protocolScheme` from `name.kebab`), but `hermes://` at runtime (`deep-link-route.ts` `deepLinkScheme()` returns `'hermes'` for any non-light payload). The OS manifest and runtime registration disagreed.

## Fix

Hardcode `'hermes'` for non-light variants in `product-identity.cjs`. Only the light variant keeps its own scheme (`hermes-light://`) for side-by-side installs.

## Test

Added a test asserting the bundled variant uses `hermes://` as its protocol scheme.