### PR TITLE
fix(installation): export CAMOFOX_INSTALL_DIR when camoufox is provisioned

### DIFF
--- a/installation/env.py
+++ b/installation/env.py
@@ -180,6 +180,18 @@ def managed_tool_env(
         if fact is not None and (store / fact.path).is_file():
             env["PLAYWRIGHT_BROWSERS_PATH"] = str(store)
             break
+
+    # Camoufox: the pin table stages the browser binary in the tool store
+    # and writes version.json so camoufox-js sees it as installed, but
+    # camoufox-js also reads CAMOFOX_INSTALL_DIR to locate the binary
+    # directory. Without this env var, camoufox-js ignores the provisioned
+    # copy and downloads ~650MB itself at first run — duplicating the
+    # provisioner's work and hitting the GitHub releases API that the pin
+    # was specifically designed to avoid (rate limits, non-reproducible
+    # versions). Only exported when the fact exists and the path is valid.
+    camoufox = facts.get("camoufox")
+    if camoufox is not None and (store / camoufox.path).is_file():
+        env["CAMOFOX_INSTALL_DIR"] = str((store / camoufox.path).parent)
     return env
 
 


### PR DESCRIPTION
## Problem

The provisioner stages the Camoufox browser binary in the tool store and writes `version.json` so camofox-js sees it as installed. But `CAMOFOX_INSTALL_DIR` — the env var camofox-js reads to locate the binary directory — was never set anywhere in the codebase.

Without it, camoufox-js ignores the provisioned copy and downloads ~650MB itself at first run, duplicating the provisioner's work and hitting the GitHub releases API that the pin was specifically designed to avoid (60 req/hour rate limits, non-reproducible versions).

## Fix

Add `CAMOFOX_INSTALL_DIR` to `managed_tool_env()` in `installation/env.py`, following the same pattern as `PLAYWRIGHT_BROWSERS_PATH`: only export when the camoufox fact exists and the binary path is valid. Points at the staged binary's parent directory (the camoufox install root).

## Context

Found during the desktop bundles audit of `ethie/desktop-bundles-restack`. The pin table comment in `runtime-pins.json` says "Hermes points camoufox-js at this staged copy with CAMOFOX_INSTALL_DIR" but the env var was never actually wired up.