### PR TITLE
fix(weixin): preserve native wrapping for lists and CJK prose / 保留列表与中文段落自然换行

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -180,6 +180,9 @@ TYPING_STOP = 2
 _HEADER_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
 _TABLE_RULE_RE = re.compile(r"^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*$")
 _FENCE_RE = re.compile(r"^```([^\n`]*)\s*$")
+_LIST_PREFIX_RE = re.compile(
+    r"^\s*(?:[-+*•]|\d+[.)]|[（(]\d+[）)])\s+(?:\[[ xX]\]\s+)?"
+)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 
 
@@ -725,7 +728,7 @@ def _normalize_markdown_blocks(content: str) -> str:
 
 
 def _wrap_copy_friendly_lines_for_weixin(content: str) -> str:
-    """Wrap long display lines that are hard to copy in WeChat clients."""
+    """Wrap long non-list lines that are hard to copy in WeChat clients."""
     if not content:
         return content
 
@@ -747,6 +750,10 @@ def _wrap_copy_friendly_lines_for_weixin(content: str) -> str:
             or not stripped
             or stripped.startswith("|")
             or _TABLE_RULE_RE.match(stripped)
+            # WeChat clients handle native wrapping after list markers, but
+            # treat server-inserted newlines as new paragraphs and discard
+            # their leading spaces. Keep each list item on one physical line.
+            or _LIST_PREFIX_RE.match(line)
         ):
             wrapped.append(line)
             continue

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -183,6 +183,7 @@ _FENCE_RE = re.compile(r"^```([^\n`]*)\s*$")
 _LIST_PREFIX_RE = re.compile(
     r"^\s*(?:[-+*•]|\d+[.)]|[（(]\d+[）)])\s+(?:\[[ xX]\]\s+)?"
 )
+_CJK_RE = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]")
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 
 
@@ -754,6 +755,12 @@ def _wrap_copy_friendly_lines_for_weixin(content: str) -> str:
             # treat server-inserted newlines as new paragraphs and discard
             # their leading spaces. Keep each list item on one physical line.
             or _LIST_PREFIX_RE.match(line)
+            # CJK prose is primarily read on narrow mobile screens. A hard
+            # server newline combines with the client's own wrapping and
+            # creates short, ragged fragments around embedded Latin terms.
+            # Keep the original English copy-field wrapping behaviour below,
+            # but let WeChat wrap CJK prose at the actual viewport width.
+            or _CJK_RE.search(line)
         ):
             wrapped.append(line)
             continue

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -72,6 +72,18 @@ class TestWeixinFormatting:
         assert " ".join(formatted.split()) == " ".join(content.split())
 
 
+    @pytest.mark.parametrize("marker", ["- ", "10. "])
+    def test_format_message_leaves_long_list_items_for_native_client_wrapping(
+        self, marker
+    ):
+        adapter = _make_adapter()
+        content = marker + " ".join(
+            f"knowledge-base-detail-{index}" for index in range(18)
+        )
+
+        assert adapter.format_message(content) == content
+
+
 class TestWeixinChunking:
 
 

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -83,6 +83,18 @@ class TestWeixinFormatting:
 
         assert adapter.format_message(content) == content
 
+    def test_format_message_leaves_long_cjk_prose_for_native_client_wrapping(self):
+        adapter = _make_adapter()
+        content = (
+            "Meta 设计并开源了 MetaRoCE，一个专为 AI 工作负载在通用以太网上打造的 "
+            "RDMA 传输协议，已通过 Open Compute Project（OCP）发布规范、参考软件实现和"
+            "合规测试套件。现有 RDMA Verbs API 和软件栈无需修改即可运行，并可用于规划"
+            "大规模 GPU 集群。"
+        )
+
+        assert len(content) > weixin.WEIXIN_COPY_LINE_WIDTH
+        assert adapter.format_message(content) == content
+
 
 class TestWeixinChunking:
 


### PR DESCRIPTION
## Summary / 概要

- Preserve long Markdown list items and CJK prose as single physical lines so Weixin clients can wrap them at the real viewport width.
- Keep the existing copy-friendly hard wrapping for long non-CJK technical text such as ASCII `key=value` fields.
- Add behavior-level regressions for ordered/unordered lists and mixed Chinese/Latin prose.

- 长 Markdown 列表项和中文普通段落保持为单一物理行，由微信客户端按实际屏幕宽度自然折行。
- 长非中文技术文本（例如 ASCII `key=value` 字段）继续保留原有的便于复制的硬换行行为。
- 为有序/无序列表以及中英文混排段落新增行为级回归测试。

## Problem / 问题

`_wrap_copy_friendly_lines_for_weixin()` hard-wraps long lines before delivery. Weixin mobile then wraps the inserted fragments again at its narrower viewport. Server newlines are treated as paragraph boundaries, which causes list continuations to lose their hanging indentation and CJK prose to break into short, ragged fragments around embedded Latin terms such as `Open Compute Project` and `RDMA Verbs API`. The wider desktop client makes the same physical newlines much less noticeable.

`_wrap_copy_friendly_lines_for_weixin()` 会在发送前对长行插入硬换行。微信手机端还会根据更窄的屏幕再次折行；服务端插入的换行又会被当成段落边界，导致列表续行失去悬挂缩进，也会让中英文混排段落在 `Open Compute Project`、`RDMA Verbs API` 等英文术语附近形成短而参差的碎片。电脑端更宽，因此同一物理换行不容易被注意到。

## Fix / 修复

The formatter now bypasses server hard wrapping when a line is either:

1. a Markdown list item; or
2. CJK prose.

Explicit author line breaks, Markdown tables, and fenced code blocks keep their existing behavior. Long non-CJK copy-field lines still use the 120-character wrapping path, so this does not remove the original copy-friendly feature.

格式化器现在会在以下两类文本上跳过服务端硬换行：

1. Markdown 列表项；
2. 包含中日韩文字的普通段落。

作者主动写出的换行、Markdown 表格和代码块保持原有行为；长非中文复制字段仍走 120 字符换行逻辑，因此没有撤掉原有的便于复制功能。

## Tests / 测试

- Red reproduction on current upstream `main`:
  - `scripts/run_tests.sh tests/gateway/test_weixin.py -k leaves_long_cjk_prose_for_native_client_wrapping`
  - **1 failed**: the real mixed CJK/Latin paragraph was split after `RDMA Verbs API`.
- Fix branch, rebased onto current upstream `main`:
  - `scripts/run_tests.sh tests/gateway/test_weixin.py`
  - **33 passed, 0 failed**.
- `ruff check gateway/platforms/weixin.py tests/gateway/test_weixin.py`
  - **All checks passed**.

- 在当前上游 `main` 上的失败复现：
  - `scripts/run_tests.sh tests/gateway/test_weixin.py -k leaves_long_cjk_prose_for_native_client_wrapping`
  - **1 项失败**：真实的中英文混排段落在 `RDMA Verbs API` 后被硬拆行。
- 修复分支已同步当前上游 `main`：
  - `scripts/run_tests.sh tests/gateway/test_weixin.py`
  - **33 项通过，0 项失败**。
- `ruff check gateway/platforms/weixin.py tests/gateway/test_weixin.py`
  - **全部通过**。

## Screenshots / Logs / 截图与日志

The screenshots below document the original list-continuation symptom on both clients. The new CJK prose case is locked by the mixed Chinese/Latin formatter regression above; a refreshed real-client screenshot can be added after client confirmation.

以下截图记录了原列表续行问题在手机端和电脑端的表现。新增的中文普通段落问题已由上面的中英文混排格式化回归用例锁定；真实客户端确认后可继续补充新截图。

### Mobile / 手机端

| Before / 修复前 | After list fix / 列表修复后 |
| --- | --- |
| ![Mobile before the fix](https://raw.githubusercontent.com/vv-get-ti/hermes-agent/ed39db68f37998bab2b370cfacbfb3f59e95accb/docs/pr-evidence/weixin-list-native-wrap-20260820/before-mobile.png) | ![Mobile after the list fix](https://raw.githubusercontent.com/vv-get-ti/hermes-agent/ed39db68f37998bab2b370cfacbfb3f59e95accb/docs/pr-evidence/weixin-list-native-wrap-20260820/after-mobile.jpg) |

### Desktop / 电脑端

| Before / 修复前 | After list fix / 列表修复后 |
| --- | --- |
| ![Desktop before the fix](https://raw.githubusercontent.com/vv-get-ti/hermes-agent/ed39db68f37998bab2b370cfacbfb3f59e95accb/docs/pr-evidence/weixin-list-native-wrap-20260820/before-desktop.png) | ![Desktop after the list fix](https://raw.githubusercontent.com/vv-get-ti/hermes-agent/ed39db68f37998bab2b370cfacbfb3f59e95accb/docs/pr-evidence/weixin-list-native-wrap-20260820/after-desktop.png) |

## Scope / 修改范围

- `gateway/platforms/weixin.py`
- `tests/gateway/test_weixin.py`

No configuration, dependency, protocol, or unrelated file changes.

不修改配置、依赖、协议或任何无关文件。
