### PR TITLE
fix(agent): recover custom endpoints when APIs live under v1

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -66,6 +66,58 @@ _PROVIDER_STREAM_ERROR_TEXT_LIMIT = 4096
 _FALLBACK_EXHAUSTED_COOLDOWN_S = 5.0
 
 
+def _try_recover_custom_endpoint_missing_v1(agent, diag: dict[str, Any]) -> bool:
+    """Route later chat requests through ``/v1`` after a proven SPA response.
+
+    Some OpenAI-compatible deployments expose their web app at the configured
+    root while serving the API below ``/v1``.  The OpenAI SDK accepts the root
+    URL, POSTs to ``/chat/completions``, then presents the HTTP 200 HTML body as
+    an empty stream.  Only adapt after that exact POST response; probing a
+    guessed API path would reject endpoints that intentionally support POST
+    without a corresponding GET route.
+
+    The override is request-local runtime state.  ``agent.base_url``, stored
+    client kwargs, credential-pool identity, and config.yaml remain unchanged.
+    """
+    providers = {
+        str(getattr(agent, name, "") or "").strip().lower()
+        for name in ("provider", "requested_provider")
+    }
+    if not any(value == "custom" or value.startswith("custom:") for value in providers):
+        return False
+    if getattr(agent, "api_mode", None) != "chat_completions":
+        return False
+    if not isinstance(diag, dict) or diag.get("http_status") != 200:
+        return False
+    if int(diag.get("chunks") or 0) != 0:
+        return False
+    if "text/html" not in str(diag.get("content_type") or "").lower():
+        return False
+
+    base_url = str(
+        (getattr(agent, "_client_kwargs", {}) or {}).get("base_url")
+        or getattr(agent, "base_url", "")
+        or ""
+    ).strip().rstrip("/")
+    if not base_url or base_url.lower().endswith("/v1"):
+        return False
+    existing = getattr(agent, "_chat_completions_base_url_override", None)
+    if isinstance(existing, dict) and existing.get("source") == base_url:
+        return False
+
+    target = f"{base_url}/v1"
+    agent._chat_completions_base_url_override = {
+        "source": base_url,
+        "target": target,
+    }
+    logger.warning(
+        "Custom endpoint returned HTTP 200 HTML at /chat/completions; "
+        "retrying this session through %s without changing config.yaml.",
+        target,
+    )
+    return True
+
+
 def _context_thread_target(callback):
     """Bind a no-argument thread target to the caller's ContextVars."""
     context = contextvars.copy_context()
@@ -4751,6 +4803,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     )
                     _is_stream_parse_err = agent._is_provider_stream_parse_error(e)
                     _is_empty_stream = isinstance(e, EmptyStreamError)
+                    _adapted_missing_v1 = (
+                        _is_empty_stream
+                        and _stream_attempt < _max_stream_retries
+                        and _try_recover_custom_endpoint_missing_v1(
+                            agent, request_client_holder.get("diag") or {}
+                        )
+                    )
 
                     # If the stream died AFTER some tokens were delivered:
                     # normally we don't retry (the user already saw text,
@@ -4898,6 +4957,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         # Transient network / timeout error. Retry the
                         # streaming request with a fresh connection first.
                         if _stream_attempt < _max_stream_retries:
+                            if _adapted_missing_v1:
+                                logger.info(
+                                    "Retrying empty custom-endpoint stream with "
+                                    "runtime /v1 route adaptation."
+                                )
                             agent._emit_stream_drop(
                                 error=e,
                                 attempt=_stream_attempt + 2,

--- a/agent/stream_diag.py
+++ b/agent/stream_diag.py
@@ -52,6 +52,7 @@ def stream_diag_init() -> Dict[str, Any]:
         "bytes": 0,
         "headers": {},
         "http_status": None,
+        "content_type": None,
     }
 
 
@@ -70,6 +71,9 @@ def stream_diag_capture_response(agent: Any, diag: Dict[str, Any], http_response
         pass
     try:
         headers = getattr(http_response, "headers", None) or {}
+        content_type = headers.get("content-type")
+        if content_type:
+            diag["content_type"] = str(content_type)[:120]
         captured: Dict[str, str] = {}
         # Allow per-agent override of the headers list (back-compat).
         target_headers = getattr(agent, "_STREAM_DIAG_HEADERS", STREAM_DIAG_HEADERS)

--- a/run_agent.py
+++ b/run_agent.py
@@ -5370,6 +5370,13 @@ class AIAgent:
             return primary_client
         with self._openai_client_lock():
             request_kwargs = dict(self._client_kwargs)
+        endpoint_override = getattr(
+            self, "_chat_completions_base_url_override", None
+        )
+        if isinstance(endpoint_override, dict):
+            configured_base = str(request_kwargs.get("base_url") or "").rstrip("/")
+            if configured_base == endpoint_override.get("source"):
+                request_kwargs["base_url"] = endpoint_override.get("target")
         # Per-request OpenAI-wire clients (used by both the non-streaming
         # chat-completions path and the streaming chat-completions path
         # in `_interruptible_api_call`) should not run the SDK's built-in

--- a/tests/run_agent/test_create_openai_client_reuse.py
+++ b/tests/run_agent/test_create_openai_client_reuse.py
@@ -189,6 +189,31 @@ def test_replace_primary_openai_client_survives_repeated_rebuilds():
     )
 
 
+def test_request_client_applies_runtime_endpoint_override_without_mutating_configured_base():
+    agent = _make_agent()
+    source = "https://custom.example"
+    target = f"{source}/v1"
+    agent._client_kwargs = {"api_key": "test-key", "base_url": source}
+    agent._chat_completions_base_url_override = {
+        "source": source,
+        "target": target,
+    }
+    captured = {}
+    request_client = SimpleNamespace(close=lambda: None)
+
+    def _create(kwargs, **_):
+        captured.update(kwargs)
+        return request_client
+
+    with patch.object(agent, "_ensure_primary_openai_client", return_value=object()), \
+         patch.object(agent, "_create_openai_client", side_effect=_create):
+        created = agent._create_request_openai_client(reason="test")
+
+    assert created is request_client
+    assert captured["base_url"] == target
+    assert agent._client_kwargs["base_url"] == source
+
+
 def test_force_close_tcp_sockets_descends_httpcore_1_connection_wrapper():
     """httpcore 1.x stores the real stream below conn._connection.
 

--- a/tests/run_agent/test_stream_drop_logging.py
+++ b/tests/run_agent/test_stream_drop_logging.py
@@ -42,6 +42,7 @@ def test_stream_diag_init_returns_well_formed_dict():
     assert diag["bytes"] == 0
     assert diag["first_chunk_at"] is None
     assert diag["http_status"] is None
+    assert diag["content_type"] is None
     assert diag["headers"] == {}
 
 
@@ -73,8 +74,20 @@ def test_stream_diag_capture_response_collects_known_headers():
     assert diag["headers"]["x-openrouter-provider"] == "Anthropic"
     assert diag["headers"]["x-openrouter-id"] == "gen-abc123"
     assert diag["headers"]["server"] == "cloudflare"
+    assert diag["content_type"] is None
     # Headers not in _STREAM_DIAG_HEADERS must not be captured (PII surface).
     assert "irrelevant-header" not in diag["headers"]
+
+
+def test_stream_diag_capture_response_records_content_type_separately():
+    agent = _make_agent()
+    diag = AIAgent._stream_diag_init()
+    resp = _FakeResponse({"content-type": "text/html; charset=utf-8"})
+
+    agent._stream_diag_capture_response(diag, resp)
+
+    assert diag["content_type"] == "text/html; charset=utf-8"
+    assert "content-type" not in diag["headers"]
 
 
 

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -960,6 +960,116 @@ class TestAnthropicStreamCallbacks:
         assert mock_rebuild.call_count == 0
 
 
+class TestCustomEndpointVersionRecovery:
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_html_empty_stream_retries_custom_endpoint_with_v1(
+        self, mock_close, mock_create, monkeypatch,
+    ):
+        """A custom endpoint's SPA route must not consume every stream retry."""
+        from run_agent import AIAgent
+
+        class _Headers(dict):
+            def get(self, key, default=None):
+                return super().get(key.lower(), default)
+
+        class _ProviderStream:
+            def __init__(self, chunks, content_type):
+                self._chunks = chunks
+                self.response = SimpleNamespace(
+                    status_code=200,
+                    headers=_Headers({"content-type": content_type}),
+                )
+
+            def __iter__(self):
+                return iter(self._chunks)
+
+            def close(self):
+                pass
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://custom.example",
+            provider="custom",
+            model="test-model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+        attempted_bases = []
+
+        def _request_client(*args, **kwargs):
+            override = getattr(agent, "_chat_completions_base_url_override", {})
+            request_base = override.get("target", agent.base_url)
+            attempted_bases.append(request_base)
+            client = MagicMock()
+            if request_base == "https://custom.example":
+                stream = _ProviderStream([], "text/html; charset=utf-8")
+            else:
+                stream = _ProviderStream(
+                    [
+                        _make_stream_chunk(
+                            content="recovered",
+                            finish_reason="stop",
+                            model="test-model",
+                        )
+                    ],
+                    "text/event-stream",
+                )
+            client.chat.completions.create.return_value = stream
+            return client
+
+        mock_create.side_effect = _request_client
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "1")
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.choices[0].message.content == "recovered"
+        assert attempted_bases == [
+            "https://custom.example",
+            "https://custom.example/v1",
+        ]
+        assert agent.base_url == "https://custom.example"
+        assert agent._client_kwargs["base_url"] == "https://custom.example"
+        assert agent._primary_runtime["base_url"] == "https://custom.example"
+        assert agent._chat_completions_base_url_override == {
+            "source": "https://custom.example",
+            "target": "https://custom.example/v1",
+        }
+
+    def test_json_empty_stream_does_not_guess_v1(self):
+        """Only an observed HTML POST response permits route adaptation."""
+        from agent.chat_completion_helpers import (
+            _try_recover_custom_endpoint_missing_v1,
+        )
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://post-only.example",
+            provider="custom",
+            model="test-model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+        recovered = _try_recover_custom_endpoint_missing_v1(
+            agent,
+            {
+                "http_status": 200,
+                "chunks": 0,
+                "content_type": "application/json",
+            },
+        )
+
+        assert recovered is False
+        assert not hasattr(agent, "_chat_completions_base_url_override")
+        assert agent.base_url == "https://post-only.example"
+
+
 class TestPartialToolCallWarning:
     """Regression: when a stream dies mid tool-call argument generation after
     text was already delivered, the partial-stream stub at run_agent.py


### PR DESCRIPTION
## What does this PR do?

Custom OpenAI-compatible endpoints configured without a trailing `/v1` can return their SPA HTML from `/chat/completions`, leaving every chat attempt with `EmptyStreamError` even though the API is available at `/v1/chat/completions`. This change detects that exact zero-chunk HTTP 200 HTML response and retries later requests through a session-local `/v1` route without changing the configured endpoint or credential identity.

### Symptom

A custom endpoint's model probe can succeed, but chat requests repeatedly return `EmptyStreamError` because the SDK receives HTTP 200 HTML with no SSE chunks from `/chat/completions`.

### Impact

Affected custom endpoints cannot complete chat requests until users manually add `/v1` to their configured base URL. The failure persists across the agent's normal streaming retries.

### Bug Cause

**Trigger:** `agent/chat_completion_helpers.py` / `interruptible_streaming_api_call()` handles a zero-chunk stream from a custom chat-completions endpoint.

**Causal chain:**
1. A user configures the root URL of an OpenAI-compatible deployment whose API is served below `/v1`.
2. The OpenAI SDK posts to `/chat/completions`; the deployment returns HTTP 200 `text/html` for its SPA, which the SDK exposes as an empty stream.
3. Hermes classifies the result as transient and retries the same root URL until `EmptyStreamError` is exhausted, so the chat never reaches `/v1/chat/completions`.

**Why it is wrong:** The retry path rebuilt the request client but preserved the same ineffective route even after response diagnostics proved that the custom endpoint returned HTML instead of an SSE stream.

**Working sibling / contrast:** The same deployment returns a valid OpenAI SSE completion when the request is sent to `/v1/chat/completions`.

**Ruled out:** Broad setup-time or GET probing is not required and could misclassify POST-only APIs. Recovery is gated on an observed custom-provider chat POST that returns HTTP 200 `text/html` with zero chunks.

### Fix

Capture the response content type in stream diagnostics. When the exact custom-endpoint failure is observed and a retry remains, install a session-local source-to-`/v1` request override. Request clients then use the adapted route while `agent.base_url`, `_client_kwargs`, credential-pool identity, and `config.yaml` remain unchanged.

## Related Issue

Closes #90595

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` - detect the proven HTML empty-stream failure and install a bounded session-local `/v1` recovery route.
- `agent/stream_diag.py` - capture response content type for safe recovery gating and diagnostics.
- `run_agent.py` - apply the route override only when constructing chat-completions request clients.
- `tests/run_agent/` - cover recovery gates, client identity preservation, diagnostics, and streaming retry behavior.

## How to Test

1. Configure a controlled OpenAI-compatible endpoint where `/chat/completions` returns HTTP 200 `text/html` with no SSE events and `/v1/chat/completions` returns a valid OpenAI SSE completion.
2. Submit a streaming chat request and verify that the first empty response triggers a retry through `/v1` and returns the completion.
3. Verify that the configured base URL and `config.yaml` remain unchanged.
4. Run the related automated tests:

```bash
scripts/run_tests.sh tests/run_agent/test_streaming.py -k CustomEndpointVersionRecovery -q
scripts/run_tests.sh tests/run_agent/test_create_openai_client_reuse.py tests/run_agent/test_stream_drop_logging.py -q
```

The related test runs completed with 18 passing tests. The real-environment check also reproduced the baseline failure over a real HTTP socket and OpenAI SDK, then verified recovery on this branch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the related tests and all related tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - the behavior is automatic and does not add user-facing configuration.
- [x] `cli-config.yaml.example` update: N/A - no configuration keys changed.
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow contract changed.
- [x] Cross-platform impact considered - the adaptation uses URL and HTTP response metadata without platform-specific behavior.
- [x] Tool descriptions/schemas update: N/A - no model tool behavior changed.

## Screenshots / Logs

N/A - the regression is covered by automated streaming tests and a controlled real HTTP/OpenAI SDK verification.
