### PR TITLE
fix(desktop): stage browser runtimes (camoufox, chromium) in bundled payload

### DIFF
--- a/apps/desktop/scripts/stage-agent-payloads.mjs
+++ b/apps/desktop/scripts/stage-agent-payloads.mjs
@@ -367,6 +367,36 @@ function stageManagedRuntimes(target, outDir, pythonExe) {
     ], { cwd: REPO_ROOT })
   }
 
+  // Stage browser runtimes (camoufox, chromium, chromium-headless-shell)
+  // so a bundled install can browse without a ~650MB+170MB lazy download
+  // on first use. These are optional in the pin table — the sweep above
+  // skips them — so we ask for them by name, same as git on Windows.
+  //
+  // Non-fatal: win32-arm64 has no upstream chromium/camoufox build (the
+  // pin table marks it missing), and the provisioner exits 1 when any
+  // tool fails. A missing browser on one arch must not fail the whole
+  // payload build — the runtime falls back to lazy-install or system
+  // browser on that target.
+  const browserTools = ["camoufox", "chromium", "chromium-headless-shell"]
+  const browserArgs = [
+    "-m",
+    "installation.provisioner",
+    "--runtime-dir",
+    outDir,
+    "--target",
+    targetKey,
+    "--archive-cache",
+    path.join(REPO_ROOT, "apps", "desktop", "build", "pin-archives"),
+  ]
+  for (const tool of browserTools) {
+    browserArgs.push("--only", tool)
+  }
+  try {
+    run(pythonExe, browserArgs, { cwd: REPO_ROOT })
+  } catch (e) {
+    console.warn(`[stage-agent-payloads] browser runtime staging had failures (non-fatal): ${e.message}`)
+  }
+
   assertPayloadArch(target, outDir)
 }
 


### PR DESCRIPTION
## Problem

`stageManagedRuntimes` in `stage-agent-payloads.mjs` only staged required tools (node, npm, uv, gh, ripgrep) plus git on Windows. Optional browser tools (camoufox, chromium, chromium-headless-shell) were explicitly skipped — the comment said "The sweep skips optional tools (provisioned on demand)." So a bundled desktop install shipped with zero browser binaries. Browser automation was completely broken until a ~650MB (camoufox) + 170MB (chromium) lazy download at first use.

## Fix

Stage `camoufox`, `chromium`, and `chromium-headless-shell` via `--only` flags to the provisioner, following the exact same pattern as the existing git-on-Windows staging. The provisioner already knows how to stage these (`_stage_camoufox()` writes `version.json`, `_stage_playwright_browser()` writes the `INSTALLATION_COMPLETE` marker).

Non-fatal: the provisioner exits 1 when any tool fails, and win32-arm64 has no upstream chromium/camoufox build (declared `missing` in the pin table). Wrapped in try/catch so a missing browser on one arch doesn't fail the whole payload build — the runtime falls back to lazy-install or system browser on that target.

## Related

- #90643 — exports `CAMOFOX_INSTALL_DIR` so camofox-js finds the staged binary
- #90642 — fixes the `hermes://` protocol scheme mismatch for bundled variant

Together these three PRs fix the full browser toolchain in bundled installs: the binary is staged, the env var points at it, and the protocol handler works.