### PR TITLE
feat(desktop): add per-auxiliary reasoning effort control

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -301,6 +301,40 @@ describe('ModelSettings', () => {
     expect(screen.getAllByText('auto · use main model').length).toBeGreaterThan(0)
   })
 
+  it('edits auxiliary reasoning effort below the selected model and applies it with the assignment', async () => {
+    getAuxiliaryModels.mockResolvedValueOnce({
+      main: { provider: 'nous', model: 'hermes-4' },
+      tasks: [{ task: 'vision', provider: 'nous', model: 'hermes-4', base_url: '', reasoning_effort: null }]
+    })
+
+    await renderModelSettings()
+
+    expect(screen.queryByRole('combobox', { name: 'Vision reasoning effort' })).toBeNull()
+
+    fireEvent.click((await screen.findAllByRole('button', { name: 'Change' }))[0])
+
+    const reasoningSelect = await screen.findByRole('combobox', { name: 'Vision reasoning effort' })
+    expect(reasoningSelect.compareDocumentPosition(await screen.findByRole('combobox', { name: 'Vision model' }))).toBe(
+      Node.DOCUMENT_POSITION_PRECEDING
+    )
+
+    fireEvent.click(reasoningSelect)
+    fireEvent.click(await screen.findByRole('option', { name: 'High' }))
+
+    const applyButtons = await screen.findAllByRole('button', { name: 'Apply' })
+    fireEvent.click(applyButtons.at(-1)!)
+
+    await waitFor(() =>
+      expect(setModelAssignment).toHaveBeenCalledWith({
+        model: 'hermes-4',
+        provider: 'nous',
+        scope: 'auxiliary',
+        task: 'vision',
+        reasoning_effort: 'high'
+      })
+    )
+  })
+
   it('assigns an auxiliary task to the main model via setModelAssignment', async () => {
     await renderModelSettings()
 

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -205,7 +205,13 @@ export function ModelSettings({ onMainModelChanged, scopeProfile = null }: Model
   const setConfig = useMemo(() => hermesConfigCacheWriter(scopeProfile), [scopeProfile])
   const [applying, setApplying] = useState(false)
   const [editingAuxTask, setEditingAuxTask] = useState<null | string>(null)
-  const [auxDraft, setAuxDraft] = useState<{ model: string; provider: string }>({ model: '', provider: '' })
+
+  const [auxDraft, setAuxDraft] = useState<{ model: string; provider: string; reasoningEffort: string }>({
+    model: '',
+    provider: '',
+    reasoningEffort: '__inherit__'
+  })
+
   // Aux slots reported stale by the backend immediately after a main-model
   // switch (provider differs from the new main). Cleared on next switch/reset.
   const [switchStaleAux, setSwitchStaleAux] = useState<StaleAuxAssignment[]>([])
@@ -722,6 +728,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile = null }: Model
           {
             model: auxDraft.model,
             provider: auxDraft.provider,
+            reasoning_effort: auxDraft.reasoningEffort === '__inherit__' ? null : auxDraft.reasoningEffort,
             scope: 'auxiliary',
             task,
             ...endpointForProvider(auxDraft.provider)
@@ -747,7 +754,8 @@ export function ModelSettings({ onMainModelChanged, scopeProfile = null }: Model
         current?.provider && current.provider !== 'auto' ? current.provider : (mainModel?.provider ?? '')
 
       const initialModel = current?.model || mainModel?.model || ''
-      setAuxDraft({ provider: initialProvider, model: initialModel })
+      const initialReasoningEffort = current?.reasoning_effort ?? '__inherit__'
+      setAuxDraft({ provider: initialProvider, model: initialModel, reasoningEffort: initialReasoningEffort })
       setEditingAuxTask(task)
     },
     [auxiliary, mainModel]
@@ -968,47 +976,76 @@ export function ModelSettings({ onMainModelChanged, scopeProfile = null }: Model
                   }
                   below={
                     isEditing && (
-                      <div className="mt-2 flex flex-wrap items-center gap-2 pt-1">
-                        <Select
-                          onValueChange={value => setAuxDraft(prev => ({ ...prev, provider: value, model: '' }))}
-                          value={auxDraft.provider}
-                        >
-                          <SelectTrigger className={cn('min-w-32', CONTROL_TEXT)}>
-                            <SelectValue placeholder={m.provider} />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {providerOptions.map(provider => (
-                              <SelectItem key={provider.slug || 'none'} value={provider.slug || 'none'}>
-                                {provider.name}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <Select
-                          onValueChange={value => setAuxDraft(prev => ({ ...prev, model: value }))}
-                          value={auxDraft.model}
-                        >
-                          <SelectTrigger className={cn('min-w-48', CONTROL_TEXT)}>
-                            <SelectValue placeholder={m.model} />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {withActive(auxDraftProviderModels, auxDraft.model).map(model => (
-                              <SelectItem key={model} value={model}>
-                                {model}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <Button
-                          disabled={!auxDraft.provider || !auxDraft.model || applying}
-                          onClick={() => void applyAuxiliaryDraft(meta.key)}
-                          size="sm"
-                        >
-                          {applying ? m.applying : t.common.apply}
-                        </Button>
-                        <Button onClick={() => setEditingAuxTask(null)} size="sm" variant="ghost">
-                          {t.common.cancel}
-                        </Button>
+                      <div className="mt-2 grid gap-2 pt-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Select
+                            onValueChange={value => setAuxDraft(prev => ({ ...prev, provider: value, model: '' }))}
+                            value={auxDraft.provider}
+                          >
+                            <SelectTrigger
+                              aria-label={`${copy.label} provider`}
+                              className={cn('min-w-32', CONTROL_TEXT)}
+                            >
+                              <SelectValue placeholder={m.provider} />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {providerOptions.map(provider => (
+                                <SelectItem key={provider.slug || 'none'} value={provider.slug || 'none'}>
+                                  {provider.name}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <Select
+                            onValueChange={value => setAuxDraft(prev => ({ ...prev, model: value }))}
+                            value={auxDraft.model}
+                          >
+                            <SelectTrigger aria-label={`${copy.label} model`} className={cn('min-w-48', CONTROL_TEXT)}>
+                              <SelectValue placeholder={m.model} />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {withActive(auxDraftProviderModels, auxDraft.model).map(model => (
+                                <SelectItem key={model} value={model}>
+                                  {model}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                        <div className="flex flex-wrap items-center gap-2 text-xs">
+                          <span className="text-muted-foreground">{m.reasoning}</span>
+                          <Select
+                            onValueChange={value => setAuxDraft(prev => ({ ...prev, reasoningEffort: value }))}
+                            value={auxDraft.reasoningEffort}
+                          >
+                            <SelectTrigger
+                              aria-label={`${copy.label} reasoning effort`}
+                              className={cn('min-w-32', CONTROL_TEXT)}
+                            >
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="__inherit__">{m.autoUseMain}</SelectItem>
+                              {REASONING_EFFORT_VALUES.map(value => (
+                                <SelectItem key={value} value={value}>
+                                  {value === 'none' ? m.reasoningOff : t.shell.modelOptions[value]}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Button
+                            disabled={!auxDraft.provider || !auxDraft.model || applying}
+                            onClick={() => void applyAuxiliaryDraft(meta.key)}
+                            size="sm"
+                          >
+                            {applying ? m.applying : t.common.apply}
+                          </Button>
+                          <Button onClick={() => setEditingAuxTask(null)} size="sm" variant="ghost">
+                            {t.common.cancel}
+                          </Button>
+                        </div>
                       </div>
                     )
                   }

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1254,6 +1254,8 @@ export interface AuxiliaryTaskAssignment {
   base_url: string
   model: string
   provider: string
+  /** Null/absent means inherit the profile's agent.reasoning_effort. */
+  reasoning_effort?: string | null
   task: string
 }
 
@@ -1308,8 +1310,10 @@ export interface ModelAssignmentRequest {
   /** OpenAI-compatible endpoint URL. Only honored for custom/local providers
    *  on the main slot — wires a self-hosted endpoint into runtime resolution. */
   base_url?: string
-  model: string
-  provider: string
+  model?: string
+  provider?: string
+  /** Per-auxiliary-task override; null removes only that task override. */
+  reasoning_effort?: string | null
   scope: 'main' | 'auxiliary'
   task?: string
 }

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -128,9 +128,12 @@ class ModelAssignment(BaseModel):
     scope="auxiliary" with task="__reset__"  → resets every slot to provider="auto"
     """
     scope: str
-    provider: str
-    model: str
+    provider: Optional[str] = None
+    model: Optional[str] = None
     task: str = ""
+    # Optional per-auxiliary-task reasoning override. An explicit null clears
+    # only that task's override; an omitted field leaves it unchanged.
+    reasoning_effort: Optional[str] = None
     # Optional OpenAI-compatible endpoint URL. Honored for custom/local
     # providers on the main slot AND on auxiliary slots — lets the GUI wire a
     # self-hosted endpoint (vLLM, llama.cpp, Ollama, …) that needs no API key.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7149,6 +7149,7 @@ def get_auxiliary_models(profile: Optional[str] = None):
                 "provider": str(slot_cfg.get("provider", "auto") or "auto"),
                 "model": str(slot_cfg.get("model", "") or ""),
                 "base_url": str(slot_cfg.get("base_url", "") or ""),
+                "reasoning_effort": slot_cfg.get("reasoning_effort") or None,
             })
 
         model_cfg = cfg.get("model", {})
@@ -7272,6 +7273,7 @@ async def set_model_assignment(body: ModelAssignment, profile: Optional[str] = N
     task = (body.task or "").strip().lower()
     base_url = (body.base_url or "").strip()
     api_key = (body.api_key or "").strip()
+    reasoning_effort_set = "reasoning_effort" in getattr(body, "model_fields_set", set())
 
     if scope not in {"main", "auxiliary"}:
         raise HTTPException(status_code=400, detail="scope must be 'main' or 'auxiliary'")
@@ -7308,7 +7310,14 @@ async def set_model_assignment(body: ModelAssignment, profile: Optional[str] = N
         def _apply_assignment():
             with _profile_scope(body.profile or profile):
                 return _apply_model_assignment_sync(
-                    scope, provider, model, task, base_url, api_key
+                    scope,
+                    provider,
+                    model,
+                    task,
+                    base_url,
+                    api_key,
+                    body.reasoning_effort,
+                    reasoning_effort_set,
                 )
 
         return await asyncio.to_thread(_apply_assignment)
@@ -7320,7 +7329,14 @@ async def set_model_assignment(body: ModelAssignment, profile: Optional[str] = N
 
 
 def _apply_model_assignment_sync(
-    scope: str, provider: str, model: str, task: str, base_url: str, api_key: str = ""
+    scope: str,
+    provider: str,
+    model: str,
+    task: str,
+    base_url: str,
+    api_key: str = "",
+    reasoning_effort: Optional[str] = None,
+    reasoning_effort_set: bool = False,
 ):
     """Synchronous body of POST /api/model/set.
 
@@ -7456,6 +7472,23 @@ def _apply_model_assignment_sync(
     if not isinstance(aux, dict):
         aux = {}
 
+    normalized_reasoning_effort = None
+    if reasoning_effort_set and reasoning_effort is not None:
+        from hermes_constants import parse_reasoning_effort
+
+        parsed_reasoning = parse_reasoning_effort(reasoning_effort)
+        if parsed_reasoning is None:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "reasoning_effort must be one of: none, minimal, low, medium, "
+                    "high, xhigh, max, ultra"
+                ),
+            )
+        normalized_reasoning_effort = (
+            "none" if not parsed_reasoning.get("enabled", True) else parsed_reasoning["effort"]
+        )
+
     if task == "__reset__":
         # Reset every slot to provider="auto", model="" — keeps other fields intact.
         for slot in _AUX_TASK_SLOTS:
@@ -7471,8 +7504,13 @@ def _apply_model_assignment_sync(
         save_config(cfg)
         return {"ok": True, "scope": "auxiliary", "reset": True}
 
-    if not provider:
+    if not provider and not reasoning_effort_set:
         raise HTTPException(status_code=400, detail="provider required for auxiliary")
+    if reasoning_effort_set and not task:
+        raise HTTPException(
+            status_code=400,
+            detail="task required when setting auxiliary reasoning_effort",
+        )
 
     targets = [task] if task else list(_AUX_TASK_SLOTS)
     for slot in targets:
@@ -7481,25 +7519,31 @@ def _apply_model_assignment_sync(
         slot_cfg = aux.get(slot)
         if not isinstance(slot_cfg, dict):
             slot_cfg = {}
-        prev_provider = str(slot_cfg.get("provider") or "").strip().lower()
-        new_provider = provider.strip().lower()
-        slot_cfg["provider"] = provider
-        slot_cfg["model"] = model
-        if base_url:
-            # Sibling of the main-slot endpoint handling (#65254): an aux
-            # assignment for a custom/local endpoint must carry its own
-            # base_url, or the slot silently rebinds to whatever
-            # model.base_url happens to hold — and breaks entirely once the
-            # main slot switches away and clears it. The auxiliary resolver
-            # already reads auxiliary.<task>.base_url/api_key
-            # (_resolve_task_provider_model), so persisting them here is
-            # what actually wires the endpoint in.
-            slot_cfg["base_url"] = base_url
-            if api_key:
-                slot_cfg["api_key"] = api_key
-        elif new_provider != prev_provider and new_provider != "custom":
-            slot_cfg.pop("base_url", None)
-            clear_model_endpoint_credentials(slot_cfg)
+        if provider:
+            prev_provider = str(slot_cfg.get("provider") or "").strip().lower()
+            new_provider = provider.strip().lower()
+            slot_cfg["provider"] = provider
+            slot_cfg["model"] = model
+            if base_url:
+                # Sibling of the main-slot endpoint (#65254): an aux
+                # assignment for a custom/local endpoint must carry its own
+                # base_url, or the slot silently rebinds to whatever
+                # model.base_url happens to hold — and breaks entirely once the
+                # main slot switches away and clears it. The auxiliary resolver
+                # already reads auxiliary.<task>.base_url/api_key
+                # (_resolve_task_provider_model), so persisting them here is
+                # what actually wires the endpoint in.
+                slot_cfg["base_url"] = base_url
+                if api_key:
+                    slot_cfg["api_key"] = api_key
+            elif new_provider != prev_provider and new_provider != "custom":
+                slot_cfg.pop("base_url", None)
+                clear_model_endpoint_credentials(slot_cfg)
+        if reasoning_effort_set:
+            if reasoning_effort is None:
+                slot_cfg.pop("reasoning_effort", None)
+            else:
+                slot_cfg["reasoning_effort"] = normalized_reasoning_effort
         aux[slot] = slot_cfg
 
     cfg["auxiliary"] = aux
@@ -7510,6 +7554,7 @@ def _apply_model_assignment_sync(
         "tasks": targets,
         "provider": provider,
         "model": model,
+        **({"reasoning_effort": normalized_reasoning_effort} if reasoning_effort_set else {}),
     }
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7490,6 +7490,11 @@ def _apply_model_assignment_sync(
         )
 
     if task == "__reset__":
+        if reasoning_effort_set:
+            raise HTTPException(
+                status_code=400,
+                detail="reasoning_effort cannot be combined with task=__reset__",
+            )
         # Reset every slot to provider="auto", model="" — keeps other fields intact.
         for slot in _AUX_TASK_SLOTS:
             slot_cfg = aux.get(slot)

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -349,6 +349,134 @@ class TestProfileScopedModel:
         assert confirmation.json()["confirm_required"] is True
         assert "cron_model_impact" not in confirmation.json()
 
+    def test_auxiliary_reasoning_update_preserves_provider_and_model(
+        self, client, isolated_profiles
+    ):
+        from hermes_cli.config import load_config, save_config
+        from hermes_cli.web_server import _profile_scope
+
+        with _profile_scope("worker_beta"):
+            cfg = load_config()
+            cfg["auxiliary"]["vision"].update(
+                {"provider": "openrouter", "model": "old/model", "reasoning_effort": "low"}
+            )
+            save_config(cfg)
+
+        response = client.post(
+            "/api/model/set",
+            json={
+                "scope": "auxiliary",
+                "task": "vision",
+                "reasoning_effort": "high",
+                "profile": "worker_beta",
+            },
+        )
+
+        assert response.status_code == 200
+        vision = _cfg(isolated_profiles["worker_beta"])["auxiliary"]["vision"]
+        assert vision["provider"] == "openrouter"
+        assert vision["model"] == "old/model"
+        assert vision["reasoning_effort"] == "high"
+
+        current = client.get("/api/model/auxiliary", params={"profile": "worker_beta"})
+        assert current.status_code == 200
+        vision_payload = next(item for item in current.json()["tasks"] if item["task"] == "vision")
+        assert vision_payload["reasoning_effort"] == "high"
+
+    def test_auxiliary_reasoning_none_is_an_explicit_override(
+        self, client, isolated_profiles
+    ):
+        from hermes_cli.config import load_config, save_config
+        from hermes_cli.web_server import _profile_scope
+
+        with _profile_scope("worker_beta"):
+            cfg = load_config()
+            cfg["auxiliary"]["vision"].update(
+                {"provider": "openrouter", "model": "old/model", "reasoning_effort": "high"}
+            )
+            save_config(cfg)
+
+        response = client.post(
+            "/api/model/set",
+            json={
+                "scope": "auxiliary",
+                "task": "vision",
+                "reasoning_effort": "none",
+                "profile": "worker_beta",
+            },
+        )
+
+        assert response.status_code == 200
+        vision = _cfg(isolated_profiles["worker_beta"])["auxiliary"]["vision"]
+        assert vision["provider"] == "openrouter"
+        assert vision["model"] == "old/model"
+        assert vision["reasoning_effort"] == "none"
+
+    def test_auxiliary_reasoning_null_removes_only_task_override(
+        self, client, isolated_profiles
+    ):
+        from hermes_cli.config import load_config, save_config
+        from hermes_cli.web_server import _profile_scope
+
+        with _profile_scope("worker_beta"):
+            cfg = load_config()
+            cfg["auxiliary"]["vision"].update(
+                {
+                    "provider": "openrouter",
+                    "model": "old/model",
+                    "base_url": "https://example.test/v1",
+                    "reasoning_effort": "high",
+                }
+            )
+            save_config(cfg)
+
+        response = client.post(
+            "/api/model/set",
+            json={
+                "scope": "auxiliary",
+                "task": "vision",
+                "reasoning_effort": None,
+                "profile": "worker_beta",
+            },
+        )
+
+        assert response.status_code == 200
+        vision = _cfg(isolated_profiles["worker_beta"])["auxiliary"]["vision"]
+        assert vision["provider"] == "openrouter"
+        assert vision["model"] == "old/model"
+        assert vision["base_url"] == "https://example.test/v1"
+        assert "reasoning_effort" not in vision
+
+    def test_auxiliary_model_assignment_without_reasoning_preserves_override(
+        self, client, isolated_profiles
+    ):
+        from hermes_cli.config import load_config, save_config
+        from hermes_cli.web_server import _profile_scope
+
+        with _profile_scope("worker_beta"):
+            cfg = load_config()
+            cfg["auxiliary"]["vision"].update(
+                {"provider": "openrouter", "model": "old/model", "reasoning_effort": "high"}
+            )
+            save_config(cfg)
+
+        response = client.post(
+            "/api/model/set",
+            json={
+                "scope": "auxiliary",
+                "task": "vision",
+                "provider": "nous",
+                "model": "new/model",
+                "profile": "worker_beta",
+            },
+        )
+
+        assert response.status_code == 200
+        vision = _cfg(isolated_profiles["worker_beta"])["auxiliary"]["vision"]
+        assert vision["provider"] == "nous"
+        assert vision["model"] == "new/model"
+        assert vision["reasoning_effort"] == "high"
+
 
 
 

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -222,6 +222,19 @@ class TestProfileScopedMcp:
 
 
 class TestProfileScopedModel:
+    def test_main_assignment_requires_provider(self, client, isolated_profiles):
+        response = client.post(
+            "/api/model/set",
+            json={
+                "scope": "main",
+                "model": "test/model-1",
+                "profile": "worker_beta",
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "provider and model required for main"
+
     def test_model_set_main_scoped(self, client, isolated_profiles):
         resp = client.post(
             "/api/model/set",
@@ -348,6 +361,24 @@ class TestProfileScopedModel:
         assert confirmation.status_code == 200
         assert confirmation.json()["confirm_required"] is True
         assert "cron_model_impact" not in confirmation.json()
+
+    def test_auxiliary_reset_rejects_reasoning_effort(self, client, isolated_profiles):
+        before = _cfg(isolated_profiles["worker_beta"])
+        response = client.post(
+            "/api/model/set",
+            json={
+                "scope": "auxiliary",
+                "task": "__reset__",
+                "reasoning_effort": "high",
+                "profile": "worker_beta",
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == (
+            "reasoning_effort cannot be combined with task=__reset__"
+        )
+        assert _cfg(isolated_profiles["worker_beta"]) == before
 
     def test_auxiliary_reasoning_update_preserves_provider_and_model(
         self, client, isolated_profiles


### PR DESCRIPTION
## What does this PR do?

Adds a per-auxiliary-task reasoning-effort control to Desktop Settings → Model → Auxiliary.

This exposes the task-level configuration path already consumed by the auxiliary runtime, without changing the main model's reasoning setting or other auxiliary tasks.

## Related Issue

Fixes #89259

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/settings/model-settings.tsx`
  - Add an Auxiliary reasoning-effort selector.
  - Support inherit/reset (`auto · use main model`), `none`, and the existing Hermes reasoning levels.
  - Persist the selected value with the auxiliary task assignment.
- `apps/desktop/src/types/hermes.ts`
  - Add the optional auxiliary `reasoning_effort` field to the Desktop API types.
- `hermes_cli/web_models.py` and `hermes_cli/web_server.py`
  - Accept, validate, persist, and reload task-level reasoning overrides.
  - Allow reasoning-only updates to preserve provider, model, and endpoint settings.
  - Preserve an existing reasoning override when provider/model is changed without specifying reasoning.
- `apps/desktop/src/app/settings/model-settings.test.tsx`
  - Add UI coverage for editing and applying auxiliary reasoning effort.
- `tests/hermes_cli/test_web_server_profile_unification.py`
  - Add profile-scoped coverage for save, reload, explicit `none`, inherit/reset, and provider/model preservation.

## How to Test

1. Run the profile-scoped API tests:

   ```bash
   pytest tests/hermes_cli/test_web_server_profile_unification.py -q
   ```

2. Run the existing auxiliary runtime reasoning tests:

   ```bash
   pytest tests/agent/test_auxiliary_client.py -q -k "reasoning_effort or task_extra_body"
   pytest tests/agent/test_reasoning_effort_module.py -q
   ```

3. Run the focused Desktop UI test:

   ```bash
   npm -w apps/desktop test -- --run src/app/settings/model-settings.test.tsx
   ```

4. Run Desktop typecheck:

   ```bash
   npm -w apps/desktop run typecheck
   ```

5. In Desktop, open **Settings → Model → Auxiliary**, select **Change** for an auxiliary task, choose a reasoning effort, and apply it. Refresh the settings and confirm that the selected value remains saved. Select inherit/reset and confirm that the task-specific override is removed.

Results on Windows 11:

- Profile-scoped API tests: 27 passed.
- Auxiliary runtime reasoning tests: 5 passed, 177 deselected.
- Reasoning-effort module tests: 29 passed.
- Desktop UI tests: 21 passed.
- Desktop TypeScript typecheck: passed.
- Python Ruff, Python syntax compilation, Prettier, and `git diff --check`: passed.
- Regression sabotage run: the new API tests failed 3 cases and the new Desktop test failed 1 case when the production changes were temporarily reverted.

The full repository test suite was not run; validation is focused on the changed Desktop/API paths and the existing auxiliary reasoning runtime paths.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature and its tests (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the full suite was not run; focused tests are listed above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A; no documentation change is required for this settings/API feature
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A; no new config key was introduced
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A; no architecture or workflow change was made
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific code was introduced; Windows 11 validation passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A; no tool schema changed

## Screenshots / Logs

No screenshot is applicable. Focused test output and validation results are recorded in the **How to Test** section above.
