### PR TITLE
fix(web/tavily): prefer .env over stale shell value for TAVILY_API_KEY

### DIFF
--- a/plugins/web/tavily/provider.py
+++ b/plugins/web/tavily/provider.py
@@ -43,7 +43,17 @@ def _tavily_request(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
 
     from agent.web_search_provider import get_provider_env
 
-    api_key = get_provider_env("TAVILY_API_KEY")
+    # Prefer a deliberate ~/.hermes/.env edit over a stale value inherited
+    # from the parent shell: rotating TAVILY_API_KEY mid-session otherwise
+    # leaves long-lived processes serving the old key until restart
+    # (persistent 432/401s). Mirrors the credential-pool seeding path in
+    # hermes_cli.auth, which uses get_env_value_prefer_dotenv for the same
+    # reason.
+    try:
+        from hermes_cli.config import get_env_value_prefer_dotenv
+        api_key = get_env_value_prefer_dotenv("TAVILY_API_KEY") or ""
+    except ImportError:
+        api_key = get_provider_env("TAVILY_API_KEY")
     if not api_key:
         raise ValueError(
             "TAVILY_API_KEY environment variable not set. "

--- a/tests/tools/test_web_tools_tavily.py
+++ b/tests/tools/test_web_tools_tavily.py
@@ -61,6 +61,46 @@ class TestTavilyRequest:
                 with pytest.raises(_httpx.HTTPStatusError):
                     _tavily_request("search", {"query": "test"})
 
+    def test_dotenv_edit_wins_over_stale_environ(self, monkeypatch, tmp_path):
+        """Rotating TAVILY_API_KEY in .env mid-session takes effect without a
+        restart: the .env value must win over a stale inherited shell value
+        (long-lived gateway process seeded from the old .env at startup)."""
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True)
+        (home / ".env").write_text("TAVILY_API_KEY=tvly-fresh-dotenv-key\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        # Simulate the stale in-process value the fix targets.
+        monkeypatch.setenv("TAVILY_API_KEY", "tvly-stale-shell-key")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("tools.web_tools.httpx.post", return_value=mock_response) as mock_post:
+            from tools.web_tools import _tavily_request
+            _tavily_request("search", {"query": "hello"})
+            payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+            assert payload["api_key"] == "tvly-fresh-dotenv-key"
+
+    def test_environ_still_used_when_dotenv_has_no_key(self, monkeypatch, tmp_path):
+        """Fallback ordering is unchanged: no .env entry → os.environ wins,
+        so plain ``export TAVILY_API_KEY=...`` workflows keep working."""
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True)
+        (home / ".env").write_text("OTHER_KEY=irrelevant\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("TAVILY_API_KEY", "tvly-from-shell")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("tools.web_tools.httpx.post", return_value=mock_response) as mock_post:
+            from tools.web_tools import _tavily_request
+            _tavily_request("search", {"query": "hello"})
+            payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+            assert payload["api_key"] == "tvly-from-shell"
+
 
 # ─── _normalize_tavily_search_results ─────────────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

Rotating `TAVILY_API_KEY` in `~/.hermes/.env` mid-session (e.g. after hitting the monthly quota — persistent 432s) had no effect on running processes until restart: a long-lived process (gateway, delegate child, agent subprocess) inherits the key into `os.environ` at startup via `load_env()`, and `_tavily_request()` resolved it with `get_provider_env()`, which checks `os.environ` **first** and only falls back to `.env`. The stale inherited value therefore shadowed every deliberate `.env` edit.

`~/.hermes/.env` is the documented rotation path, so the .env edit must win. This PR resolves the key via `hermes_cli.config.get_env_value_prefer_dotenv()` — the reader the credential-pool seeding path in `hermes_cli.auth` already uses for exactly this reason (its docstring: *"Without this, rotating a key in .env mid-session leaves callers serving the stale shell value and produces persistent 401s"*).

Fallback ordering is otherwise unchanged: no `.env` entry → `os.environ` wins, so plain `export TAVILY_API_KEY=...` workflows keep working. `load_env()` memoises on the .env file mtime, so the fresh key is picked up on the next request after the edit — no restart needed. The `ImportError` fallback keeps stripped installs (config module unavailable) on the old `get_provider_env()` path.

## Related Issue

Searched open+closed PRs and issues for tavily key rotation/quota topics. The open pool-rotation PRs (#84983, #29772, #31045) cover retry/ring-failover/pool architectures and none change this resolution order, so this fix is complementary, not a duplicate. No standalone issue exists for this symptom.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/web/tavily/provider.py` — `_tavily_request()` resolves `TAVILY_API_KEY` via `get_env_value_prefer_dotenv()` (with `ImportError` fallback to `get_provider_env()`); covers search, extract, and crawl since all go through this choke point
- `tests/tools/test_web_tools_tavily.py` — two new tests in `TestTavilyRequest`: .env edit wins over a stale environ value; environ still used when .env has no entry

## How to Test

1. Start a long-lived process with a working key in `.env`
2. Exhaust or invalidate that key, then write a fresh `TAVILY_API_KEY` to `~/.hermes/.env`
3. Before this PR: every subsequent web_search/web_extract keeps using the stale key (432/401) until restart. After: the next call picks up the new key
4. `pytest tests/tools/test_web_tools_tavily.py -q` → 11 passed (9 pre-existing + 2 new); related domain (`test_web_providers*.py`, `test_get_env_value_scope.py`) → 67 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — *(targeted + related-domain suites: 78 passed; full-suite run impractical on this machine but no cross-module coupling — the change is a single lookup swap behind an existing import)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 27 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — inline comment explains the why; no user-facing behavior change beyond the fix itself
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A