### PR TITLE
feat(cli): import Kimi Code sessions (sessions import / --resume @kimi)

### DIFF
--- a/hermes_cli/foreign_sessions.py
+++ b/hermes_cli/foreign_sessions.py
@@ -1,8 +1,8 @@
-"""Import sessions from foreign coding agents (Claude Code, Codex CLI).
+"""Import sessions from foreign coding agents (Claude Code, Codex CLI, Kimi Code).
 
-``hermes sessions import`` (and ``--resume @claude`` / ``--resume @codex``)
-let a user pull a conversation they started in another agent CLI into
-Hermes and continue it here.
+``hermes sessions import`` (and ``--resume @claude`` / ``--resume @codex`` /
+``--resume @kimi``) let a user pull a conversation they started in another
+agent CLI into Hermes and continue it here.
 
 Sources (read-only — foreign files are never modified):
 
@@ -21,6 +21,16 @@ Sources (read-only — foreign files are never modified):
   "output_text", "text": ...}]}`` plus ``custom_tool_call`` /
   ``function_call`` payloads for tool activity.  (Schema verified against
   real rollout files, Codex CLI 0.147.)
+
+* **Kimi Code** stores one directory per session under
+  ``~/.kimi-code/sessions/<wd>/<session>/`` with a ``state.json`` (cwd,
+  title, updatedAt) and ``agents/main/wire.jsonl``.  Wire records:
+  ``context.append_message`` carries typed user messages (``origin.kind``
+  ``user``; ``injection``/``task`` rows are not typed input), and assistant
+  output streams as ``context.append_loop_event`` records — ``content.part``
+  (``part.type`` ``text`` or ``think``) and ``tool.call`` / ``tool.result``.
+  ``turn.prompt`` duplicates every typed user message and is ignored.
+  (Schema verified against real wire files, protocol 1.5.)
 
 Conversion contract — imported history must satisfy the provider
 role-alternation invariant Hermes enforces everywhere else:
@@ -58,7 +68,7 @@ _TITLE_MAX = 60
 class ForeignSession:
     """A discoverable session in another tool's on-disk store."""
 
-    source: str  # "claude" | "codex"
+    source: str  # "claude" | "codex" | "kimi"
     path: Path
     mtime: float
     cwd: Optional[str] = None
@@ -68,7 +78,7 @@ class ForeignSession:
 
     @property
     def label(self) -> str:
-        name = {"claude": "Claude Code", "codex": "Codex CLI"}.get(
+        name = {"claude": "Claude Code", "codex": "Codex CLI", "kimi": "Kimi Code"}.get(
             self.source, self.source
         )
         title = (self.title_guess or "").strip() or self.path.stem
@@ -311,10 +321,117 @@ def _first_user_line(turns: List[Tuple[str, str]]) -> Optional[str]:
     return None
 
 
+# ── Kimi Code ────────────────────────────────────────────────────────────
+
+
+def _kimi_session_dir(wire_path: Path) -> Path:
+    # wire.jsonl lives at <session>/agents/main/wire.jsonl
+    return wire_path.parent.parent.parent
+
+
+def _kimi_state(session_dir: Path) -> Dict[str, Any]:
+    try:
+        state = json.loads((session_dir / "state.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return {}
+    return state if isinstance(state, dict) else {}
+
+
+def parse_kimi_session(path: Path) -> Dict[str, Any]:
+    """Parse one Kimi Code wire.jsonl into normalized turns + meta."""
+    path = Path(path)
+    turns: List[Tuple[str, str]] = []
+    for obj in _read_json_lines(path):
+        otype = obj.get("type")
+        if otype == "context.append_message":
+            message = obj.get("message")
+            if not isinstance(message, dict) or message.get("role") != "user":
+                continue
+            origin = message.get("origin")
+            kind = origin.get("kind") if isinstance(origin, dict) else None
+            # "injection" rows are context wrappers and "task" rows are async
+            # delegation notices — neither is typed input. turn.prompt records
+            # duplicate every typed user message and are ignored entirely.
+            if kind in ("injection", "task"):
+                continue
+            text = _flatten_blocks(message.get("content"), source="kimi")
+            if not text or _is_wrapper_text(text):
+                continue
+            turns.append(("user", text))
+        elif otype == "context.append_loop_event":
+            event = obj.get("event")
+            if not isinstance(event, dict):
+                continue
+            etype = event.get("type")
+            if etype == "content.part":
+                part = event.get("part")
+                if isinstance(part, dict) and part.get("type") == "text":
+                    text = part.get("text")
+                    if isinstance(text, str) and text.strip():
+                        turns.append(("assistant", text))
+                # "think" parts are chain-of-thought — never imported.
+            elif etype == "tool.call":
+                name = event.get("name") or "tool"
+                # Attach as assistant activity; merged into neighbors later.
+                turns.append(("assistant", f"[ran tool: {name}]"))
+            # tool.result / step.* records carry no conversational text.
+
+    state = _kimi_state(_kimi_session_dir(path))
+    cwd = state.get("cwd")
+    title = state.get("title")
+    sid = state.get("id")
+    title_text = title.strip() if isinstance(title, str) else ""
+    return {
+        "turns": _merge_turns(turns),
+        "cwd": cwd if isinstance(cwd, str) else None,
+        "title_guess": title_text or _first_user_line(turns),
+        "session_id": sid if isinstance(sid, str) else _kimi_session_dir(path).name,
+    }
+
+
+def list_kimi_sessions(root: Optional[Path] = None) -> List[ForeignSession]:
+    """Discover Kimi Code sessions under ``~/.kimi-code/sessions``."""
+    root = Path(root) if root else Path.home() / ".kimi-code" / "sessions"
+    results: List[ForeignSession] = []
+    if not root.is_dir():
+        return results
+    for wire in sorted(root.glob("*/*/agents/main/wire.jsonl")):
+        parsed = parse_kimi_session(wire)
+        if not parsed["turns"]:
+            continue
+        updated = _kimi_state(_kimi_session_dir(wire)).get("updatedAt")
+        try:
+            mtime = (
+                float(updated) / 1000.0
+                if isinstance(updated, (int, float))
+                else wire.stat().st_mtime
+            )
+        except OSError:
+            continue
+        results.append(
+            ForeignSession(
+                source="kimi",
+                path=wire,
+                mtime=mtime,
+                cwd=parsed["cwd"],
+                title_guess=parsed["title_guess"],
+                turn_count=len(parsed["turns"]),
+                session_id=parsed["session_id"],
+            )
+        )
+    results.sort(key=lambda s: s.mtime, reverse=True)
+    return results
+
+
 # ── Import ───────────────────────────────────────────────────────────────
 
-_SOURCE_LABELS = {"claude": "Claude Code", "codex": "Codex CLI"}
-_SOURCE_DB_NAMES = {"claude": "claude-code", "codex": "codex-cli"}
+_SOURCE_LABELS = {"claude": "Claude Code", "codex": "Codex CLI", "kimi": "Kimi Code"}
+_SOURCE_DB_NAMES = {"claude": "claude-code", "codex": "codex-cli", "kimi": "kimi-code"}
+_SOURCE_PARSERS = {
+    "claude": parse_claude_session,
+    "codex": parse_codex_session,
+    "kimi": parse_kimi_session,
+}
 
 
 def import_foreign_session(source: str, path, db=None) -> str:
@@ -331,11 +448,7 @@ def import_foreign_session(source: str, path, db=None) -> str:
     if not path.is_file():
         raise ValueError(f"Session file not found: {path}")
 
-    parsed = (
-        parse_claude_session(path)
-        if source == "claude"
-        else parse_codex_session(path)
-    )
+    parsed = _SOURCE_PARSERS[source](path)
     turns = parsed["turns"]
     if not turns:
         raise ValueError(
@@ -395,6 +508,7 @@ def gather_foreign_sessions(
     *,
     claude_root: Optional[Path] = None,
     codex_root: Optional[Path] = None,
+    kimi_root: Optional[Path] = None,
     limit: int = 25,
 ) -> List[ForeignSession]:
     """List foreign sessions across sources, newest first."""
@@ -403,6 +517,8 @@ def gather_foreign_sessions(
         sessions.extend(list_claude_sessions(claude_root))
     if source in (None, "codex"):
         sessions.extend(list_codex_sessions(codex_root))
+    if source in (None, "kimi"):
+        sessions.extend(list_kimi_sessions(kimi_root))
     sessions.sort(key=lambda s: s.mtime, reverse=True)
     return sessions[:limit] if limit else sessions
 
@@ -416,7 +532,7 @@ def pick_foreign_session(
 
     sessions = gather_foreign_sessions(source, limit=limit)
     if not sessions:
-        where = _SOURCE_LABELS.get(source or "", "Claude Code or Codex CLI")
+        where = _SOURCE_LABELS.get(source or "", "Claude Code, Codex CLI, or Kimi Code")
         print(f"No {where} sessions found on this machine.")
         return None
     print("Foreign sessions (newest first):")
@@ -429,7 +545,7 @@ def pick_foreign_session(
     if not sys.stdin.isatty():
         print(
             "Non-interactive terminal — pass the file path directly:\n"
-            "  hermes sessions import --from claude|codex <path>"
+            "  hermes sessions import --from claude|codex|kimi <path>"
         )
         return None
     try:
@@ -463,8 +579,10 @@ def run_sessions_import(args, db=None) -> Optional[str]:
                 source = "claude"
             if "/.codex/" in p or Path(p).name.startswith("rollout-"):
                 source = "codex"
+            if "/.kimi-code/" in p or Path(p).name == "wire.jsonl":
+                source = "kimi"
         if not source:
-            print("Cannot infer source from path; pass --from claude|codex.")
+            print("Cannot infer source from path; pass --from claude|codex|kimi.")
             return None
         chosen_path = Path(path)
     else:

--- a/hermes_cli/foreign_sessions.py
+++ b/hermes_cli/foreign_sessions.py
@@ -348,11 +348,23 @@ def parse_kimi_session(path: Path) -> Dict[str, Any]:
             if not isinstance(message, dict) or message.get("role") != "user":
                 continue
             origin = message.get("origin")
-            kind = origin.get("kind") if isinstance(origin, dict) else None
-            # "injection" rows are context wrappers and "task" rows are async
-            # delegation notices — neither is typed input. turn.prompt records
+            # Only rows Kimi tags as typed input are imported. This is an
+            # ALLOWLIST on purpose: role=="user" is a transport role, not a
+            # statement about authorship, and Kimi keeps adding
+            # machine-generated kinds under it. A survey of real wire logs
+            # found "injection" (context wrappers), "task" (async delegation
+            # notices), "system_trigger" (goal-loop nudges),
+            # "background_task" (job-completion notifications) and
+            # "skill_activation" (skill instruction preambles) alongside the
+            # genuine "user" rows — so a denylist both misses kinds shipping
+            # today and fails open on every future one. turn.prompt records
             # duplicate every typed user message and are ignored entirely.
-            if kind in ("injection", "task"):
+            #
+            # A missing ``origin`` is treated as typed input for
+            # backward-compatibility with wires written before Kimi tagged
+            # message provenance; a *present* origin must say "user", which
+            # is what makes this fail closed against protocol drift.
+            if isinstance(origin, dict) and origin.get("kind") != "user":
                 continue
             text = _flatten_blocks(message.get("content"), source="kimi")
             if not text or _is_wrapper_text(text):
@@ -395,6 +407,11 @@ def list_kimi_sessions(root: Optional[Path] = None) -> List[ForeignSession]:
     results: List[ForeignSession] = []
     if not root.is_dir():
         return results
+    # Only the "main" agent's wire is a conversation the user had. Subagent
+    # wires (``agents/agent-0/``, ``agent-1/``, ... — they do exist in real
+    # session dirs) are delegated work, not typed dialogue, and importing
+    # them would surface fragments of one session as separate ones. Layout
+    # observed on Kimi wire protocol 1.5; revisit if that changes.
     for wire in sorted(root.glob("*/*/agents/main/wire.jsonl")):
         parsed = parse_kimi_session(wire)
         if not parsed["turns"]:

--- a/hermes_cli/foreign_sessions.py
+++ b/hermes_cli/foreign_sessions.py
@@ -24,7 +24,9 @@ Sources (read-only — foreign files are never modified):
 
 * **Kimi Code** stores one directory per session under
   ``~/.kimi-code/sessions/<wd>/<session>/`` with a ``state.json`` (cwd,
-  title, updatedAt) and ``agents/main/wire.jsonl``.  Wire records:
+  title, updatedAt — the legacy shape spells these ``workDir``, an
+  ISO-8601 ``updatedAt``, and carries no ``id``) and
+  ``agents/main/wire.jsonl``.  Wire records:
   ``context.append_message`` carries typed user messages (``origin.kind``
   ``user``; ``injection``/``task`` rows are not typed input), and assistant
   output streams as ``context.append_loop_event`` records — ``content.part``
@@ -337,6 +339,43 @@ def _kimi_state(session_dir: Path) -> Dict[str, Any]:
     return state if isinstance(state, dict) else {}
 
 
+# Kimi writes this when a session has no user-supplied or generated title.
+# It is a placeholder, not a name: taking it literally makes every untitled
+# session render identically in the picker, so it falls back like a missing
+# title does.
+_KIMI_PLACEHOLDER_TITLES = {"new session", "untitled session"}
+
+
+def _kimi_title(state: Dict[str, Any]) -> Optional[str]:
+    title = state.get("title")
+    if not isinstance(title, str):
+        return None
+    title = title.strip()
+    if not title or title.lower() in _KIMI_PLACEHOLDER_TITLES:
+        return None
+    return title
+
+
+def _kimi_mtime(state: Dict[str, Any]) -> Optional[float]:
+    """``updatedAt`` as a POSIX timestamp, or ``None`` if unusable.
+
+    Current wires store epoch milliseconds; legacy ones store an ISO-8601
+    string.  A bare-seconds value is accepted too so a future writer that
+    drops the millisecond scale doesn't land every session in 1970.
+    """
+    updated = state.get("updatedAt")
+    if isinstance(updated, bool):
+        return None
+    if isinstance(updated, (int, float)):
+        return float(updated) / 1000.0 if updated > 1e11 else float(updated)
+    if isinstance(updated, str):
+        try:
+            return datetime.fromisoformat(updated.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
 def parse_kimi_session(path: Path) -> Dict[str, Any]:
     """Parse one Kimi Code wire.jsonl into normalized turns + meta."""
     path = Path(path)
@@ -388,16 +427,21 @@ def parse_kimi_session(path: Path) -> Dict[str, Any]:
                 turns.append(("assistant", f"[ran tool: {name}]"))
             # tool.result / step.* records carry no conversational text.
 
-    state = _kimi_state(_kimi_session_dir(path))
-    cwd = state.get("cwd")
-    title = state.get("title")
+    session_dir = _kimi_session_dir(path)
+    state = _kimi_state(session_dir)
+    # Two state.json shapes exist side by side in a real store (a survey of
+    # one found 402 current dirs and 25 legacy). The current shape has
+    # ``cwd`` / ``id`` / epoch-ms ``updatedAt``; the legacy one has
+    # ``workDir``, no ``id``, and an ISO-8601 ``updatedAt``. Reading only
+    # the current keys silently drops cwd and the session id on the legacy
+    # dirs, so both spellings are accepted.
+    cwd = state.get("cwd") or state.get("workDir")
     sid = state.get("id")
-    title_text = title.strip() if isinstance(title, str) else ""
     return {
         "turns": _merge_turns(turns),
         "cwd": cwd if isinstance(cwd, str) else None,
-        "title_guess": title_text or _first_user_line(turns),
-        "session_id": sid if isinstance(sid, str) else _kimi_session_dir(path).name,
+        "title_guess": _kimi_title(state) or _first_user_line(turns),
+        "session_id": sid if isinstance(sid, str) else session_dir.name,
     }
 
 
@@ -416,13 +460,10 @@ def list_kimi_sessions(root: Optional[Path] = None) -> List[ForeignSession]:
         parsed = parse_kimi_session(wire)
         if not parsed["turns"]:
             continue
-        updated = _kimi_state(_kimi_session_dir(wire)).get("updatedAt")
         try:
-            mtime = (
-                float(updated) / 1000.0
-                if isinstance(updated, (int, float))
-                else wire.stat().st_mtime
-            )
+            mtime = _kimi_mtime(_kimi_state(_kimi_session_dir(wire)))
+            if mtime is None:
+                mtime = wire.stat().st_mtime
         except OSError:
             continue
         results.append(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2982,12 +2982,14 @@ def cmd_chat(args):
     # Resolve --continue into --resume with the latest session or by name
     _resolve_continue_arg(args, use_tui=use_tui)
 
-    # --resume @claude / --resume @codex: import a foreign session (Claude
-    # Code / Codex CLI) and resume the newly created Hermes session.
+    # --resume @claude / --resume @codex / --resume @kimi: import a foreign
+    # session (Claude Code / Codex CLI / Kimi Code) and resume the newly
+    # created Hermes session.
     _resume_foreign = getattr(args, "resume", None)
     if isinstance(_resume_foreign, str) and _resume_foreign.strip().lower() in (
         "@claude",
         "@codex",
+        "@kimi",
     ):
         from hermes_cli.foreign_sessions import (
             import_foreign_session,
@@ -13753,19 +13755,20 @@ def main():
 
     sessions_import = sessions_subparsers.add_parser(
         "import",
-        help="Import a Claude Code or Codex CLI session into Hermes",
+        help="Import a Claude Code, Codex CLI, or Kimi Code session into Hermes",
         description=(
-            "Pull a conversation started in Claude Code (~/.claude/projects) "
-            "or Codex CLI (~/.codex/sessions) into the Hermes session store "
-            "so it can be resumed with 'hermes --resume <id>'. The foreign "
-            "files are only read, never modified."
+            "Pull a conversation started in Claude Code (~/.claude/projects), "
+            "Codex CLI (~/.codex/sessions), or Kimi Code (~/.kimi-code/sessions) "
+            "into the Hermes session store so it can be resumed with "
+            "'hermes --resume <id>'. The foreign files are only read, never "
+            "modified."
         ),
     )
     sessions_import.add_argument(
         "--from",
         dest="from_source",
-        choices=["claude", "codex"],
-        help="Which tool to import from (default: pick across both)",
+        choices=["claude", "codex", "kimi"],
+        help="Which tool to import from (default: pick across all three)",
     )
     sessions_import.add_argument(
         "path",

--- a/tests/hermes_cli/test_foreign_sessions.py
+++ b/tests/hermes_cli/test_foreign_sessions.py
@@ -13,8 +13,10 @@ from hermes_cli.foreign_sessions import (
     import_foreign_session,
     list_claude_sessions,
     list_codex_sessions,
+    list_kimi_sessions,
     parse_claude_session,
     parse_codex_session,
+    parse_kimi_session,
 )
 
 
@@ -93,6 +95,91 @@ def _write_codex_fixture(tmp_path, extra_lines=None):
         lines = extra_lines + lines
     f.write_text("\n".join(lines) + "\n", encoding="utf-8")
     return f
+
+
+def _write_kimi_fixture(tmp_path, extra_lines=None):
+    """A Kimi Code session dir: state.json + agents/main/wire.jsonl.
+
+    Mirrors the real on-disk layout (~/.kimi-code/sessions/<wd>/<session>/)
+    and the real wire record types observed in protocol 1.5: turn.prompt
+    duplicates every typed user message into context.append_message, and
+    assistant output streams as loop events (content.part / tool.call).
+    """
+    session_dir = (
+        tmp_path / ".kimi-code" / "sessions" / "wd_user_abc123" / "session_kimi-0001"
+    )
+    wire_dir = session_dir / "agents" / "main"
+    wire_dir.mkdir(parents=True)
+    (session_dir / "state.json").write_text(
+        json.dumps(
+            {
+                "id": "session_kimi-0001",
+                "cwd": "/home/user/kproj",
+                "title": "Fix the importer",
+                "updatedAt": 1786707200000,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def append_user(text, kind="user"):
+        return {
+            "type": "context.append_message",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": text}],
+                "origin": {"kind": kind},
+                "id": "msg_" + kind,
+            },
+        }
+
+    def loop_event(event):
+        return {"type": "context.append_loop_event", "event": event}
+
+    entries = [
+        {"type": "metadata", "protocol_version": "1.5", "created_at": 1786707196309},
+        # turn.prompt duplicates the typed message — must NOT double-import
+        {
+            "type": "turn.prompt",
+            "input": [{"type": "text", "text": "Summarize the repo please."}],
+            "origin": {"kind": "user"},
+        },
+        append_user("Summarize the repo please."),
+        # injected context / async-task notices are not typed input
+        append_user("<system-reminder>injected wrapper", kind="injection"),
+        append_user("async delegation finished", kind="task"),
+        loop_event({"type": "step.begin", "turnId": "0", "step": 1}),
+        loop_event(
+            {"type": "content.part", "part": {"type": "think", "think": "secret reasoning"}}
+        ),
+        loop_event(
+            {"type": "content.part", "part": {"type": "text", "text": "Reading the files."}}
+        ),
+        loop_event(
+            {
+                "type": "tool.call",
+                "name": "Bash",
+                "args": {"command": "ls"},
+                "toolCallId": "tool_1",
+            }
+        ),
+        loop_event(
+            {"type": "tool.result", "toolCallId": "tool_1", "result": {"output": "ok"}}
+        ),
+        loop_event(
+            {
+                "type": "content.part",
+                "part": {"type": "text", "text": "Done — the summary is above."},
+            }
+        ),
+        append_user("Thanks!"),
+    ]
+    lines = [json.dumps(entry) for entry in entries]
+    if extra_lines:
+        lines = extra_lines + lines
+    wire = wire_dir / "wire.jsonl"
+    wire.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return wire
 
 
 @pytest.fixture
@@ -180,6 +267,10 @@ def test_list_sessions(tmp_path):
     both = gather_foreign_sessions(
         claude_root=tmp_path / ".claude" / "projects",
         codex_root=tmp_path / ".codex" / "sessions",
+        # Pin the kimi root to a nonexistent dir too — otherwise the gather
+        # scans the real ~/.kimi-code/sessions and the count depends on the
+        # machine running the test.
+        kimi_root=tmp_path / ".kimi-code" / "sessions",
     )
     assert len(both) == 2
     assert both[0].mtime >= both[1].mtime  # newest first
@@ -259,3 +350,81 @@ def test_leading_assistant_gets_single_stub(tmp_path):
     _assert_alternating(parsed["turns"])
     assert len(parsed["turns"]) == 2
     assert parsed["turns"][0]["role"] == "user"
+
+
+# ── Kimi Code ────────────────────────────────────────────────────────────
+
+
+def test_parse_kimi_session(tmp_path):
+    f = _write_kimi_fixture(tmp_path)
+    parsed = parse_kimi_session(f)
+    turns = parsed["turns"]
+    _assert_alternating(turns)
+    # user: "Summarize..." / assistant: text+tool+text merged / user: "Thanks!"
+    assert len(turns) == 3
+    assert parsed["cwd"] == "/home/user/kproj"
+    assert parsed["title_guess"] == "Fix the importer"
+    assert parsed["session_id"] == "session_kimi-0001"
+
+    all_text = "\n".join(t["content"] for t in turns)
+    # the typed message appears exactly once (turn.prompt duplicate ignored)
+    assert all_text.count("Summarize the repo please.") == 1
+    # injection/task-origin user rows are not typed input
+    assert "system-reminder" not in all_text
+    assert "async delegation" not in all_text
+    # thinking stays out; the tool call is a bracketed assistant summary
+    assert "secret reasoning" not in all_text
+    assert "[ran tool: Bash]" in all_text
+    assert all(set(t) == {"role", "content"} for t in turns)
+
+
+def test_parse_kimi_session_skips_malformed_lines(tmp_path):
+    f = _write_kimi_fixture(
+        tmp_path, extra_lines=["not json {{{", json.dumps({"type": "context.append_message"})]
+    )
+    parsed = parse_kimi_session(f)
+    assert len(parsed["turns"]) == 3
+
+
+def test_parse_kimi_session_without_state_json(tmp_path):
+    f = _write_kimi_fixture(tmp_path)
+    (tmp_path / ".kimi-code" / "sessions" / "wd_user_abc123" / "session_kimi-0001" / "state.json").unlink()
+    parsed = parse_kimi_session(f)
+    # falls back to the session dir name and the first typed line
+    assert parsed["session_id"] == "session_kimi-0001"
+    assert parsed["cwd"] is None
+    assert parsed["title_guess"].startswith("Summarize the repo")
+
+
+def test_list_kimi_sessions(tmp_path):
+    _write_kimi_fixture(tmp_path)
+    kimi = list_kimi_sessions(tmp_path / ".kimi-code" / "sessions")
+    assert len(kimi) == 1
+    assert kimi[0].source == "kimi"
+    assert kimi[0].turn_count == 3
+    assert kimi[0].mtime == 1786707200000 / 1000.0
+    assert list_kimi_sessions(tmp_path / "nope") == []
+
+    both = gather_foreign_sessions(
+        source="kimi", kimi_root=tmp_path / ".kimi-code" / "sessions"
+    )
+    assert len(both) == 1 and both[0].source == "kimi"
+
+
+def test_import_kimi_session(tmp_path, session_db):
+    f = _write_kimi_fixture(tmp_path)
+    session_id = import_foreign_session("@kimi", f, db=session_db)
+    row = session_db.get_session(session_id)
+    assert row is not None
+    assert row["source"] == "kimi-code"
+    assert row["cwd"] == "/home/user/kproj"
+    assert row["message_count"] == 3
+    title = session_db.get_session_title(session_id)
+    assert title.startswith("Imported from Kimi Code: ")
+    assert "Summarize the repo" in title
+    messages = session_db.get_messages(session_id)
+    _assert_alternating(messages)
+    origin = json.loads(row["origin_json"])
+    assert origin["imported_from"]["tool"] == "kimi-code"
+    assert origin["imported_from"]["foreign_session_id"] == "session_kimi-0001"
+    assert session_db.resolve_session_id(session_id) == session_id

--- a/tests/hermes_cli/test_foreign_sessions.py
+++ b/tests/hermes_cli/test_foreign_sessions.py
@@ -1,10 +1,11 @@
-"""Tests for hermes_cli.foreign_sessions — Claude Code / Codex CLI import.
+"""Tests for hermes_cli.foreign_sessions — Claude Code / Codex CLI / Kimi Code import.
 
 Fixture JSONL is synthesized inline (tmp_path); the SessionDB is opened
 against a temp path so nothing touches the real HERMES_HOME store.
 """
 
 import json
+from datetime import datetime, timezone
 
 import pytest
 
@@ -489,3 +490,53 @@ def test_import_kimi_session(tmp_path, session_db):
     assert origin["imported_from"]["tool"] == "kimi-code"
     assert origin["imported_from"]["foreign_session_id"] == "session_kimi-0001"
     assert session_db.resolve_session_id(session_id) == session_id
+
+
+def _rewrite_kimi_state(wire, state):
+    """Replace a fixture's state.json with ``state`` (None deletes it)."""
+    path = wire.parent.parent.parent / "state.json"
+    if state is None:
+        path.unlink()
+    else:
+        path.write_text(json.dumps(state), encoding="utf-8")
+    return wire
+
+
+def test_parse_kimi_session_legacy_state_shape(tmp_path):
+    """The older state.json spells cwd ``workDir`` and dates ISO-8601.
+
+    Both shapes exist side by side in a real store, so reading only the
+    current keys drops the cwd and the session id on every legacy dir.
+    """
+    f = _rewrite_kimi_state(
+        _write_kimi_fixture(tmp_path),
+        {
+            "workDir": "/home/user/legacy",
+            "title": "New Session",  # Kimi's placeholder, not a name
+            "updatedAt": "2026-08-24T00:37:56.953Z",
+            "isCustomTitle": False,
+        },
+    )
+    parsed = parse_kimi_session(f)
+
+    assert parsed["cwd"] == "/home/user/legacy"
+    # no "id" key in this shape — fall back to the session dir name
+    assert parsed["session_id"] == "session_kimi-0001"
+    # the placeholder title must not win over the first typed line
+    assert parsed["title_guess"].startswith("Summarize the repo")
+
+    listed = list_kimi_sessions(tmp_path / ".kimi-code" / "sessions")
+    assert len(listed) == 1
+    assert listed[0].mtime == datetime(
+        2026, 8, 24, 0, 37, 56, 953000, tzinfo=timezone.utc
+    ).timestamp()
+
+
+def test_list_kimi_sessions_falls_back_to_file_mtime(tmp_path):
+    """An unusable ``updatedAt`` must not sort the session into 1970."""
+    f = _rewrite_kimi_state(
+        _write_kimi_fixture(tmp_path), {"id": "s1", "updatedAt": "not a date"}
+    )
+    listed = list_kimi_sessions(tmp_path / ".kimi-code" / "sessions")
+    assert len(listed) == 1
+    assert listed[0].mtime == f.stat().st_mtime

--- a/tests/hermes_cli/test_foreign_sessions.py
+++ b/tests/hermes_cli/test_foreign_sessions.py
@@ -145,9 +145,25 @@ def _write_kimi_fixture(tmp_path, extra_lines=None):
             "origin": {"kind": "user"},
         },
         append_user("Summarize the repo please."),
-        # injected context / async-task notices are not typed input
+        # A wire written before Kimi tagged provenance: no origin at all.
+        # Backward-compatibility says treat it as typed input.
+        {
+            "type": "context.append_message",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "And check the tests."}],
+                "id": "msg_untagged",
+            },
+        },
+        # Every machine-generated kind observed on real wires rides the same
+        # role=="user" transport and must stay out of the imported turns.
         append_user("<system-reminder>injected wrapper", kind="injection"),
         append_user("async delegation finished", kind="task"),
+        append_user("Continue working toward the active goal.", kind="system_trigger"),
+        append_user("<notification>bun run check completed", kind="background_task"),
+        append_user("Skill tool loaded instructions.", kind="skill_activation"),
+        # A kind this parser has never seen — an allowlist must drop it too.
+        append_user("some future machine row", kind="totally_new_kind"),
         loop_event({"type": "step.begin", "turnId": "0", "step": 1}),
         loop_event(
             {"type": "content.part", "part": {"type": "think", "think": "secret reasoning"}}
@@ -165,6 +181,16 @@ def _write_kimi_fixture(tmp_path, extra_lines=None):
         ),
         loop_event(
             {"type": "tool.result", "toolCallId": "tool_1", "result": {"output": "ok"}}
+        ),
+        # A second call back-to-back: the two bracketed summaries must stay
+        # readable once _merge_turns folds them into one assistant turn.
+        loop_event(
+            {
+                "type": "tool.call",
+                "name": "Read",
+                "args": {"path": "README.md"},
+                "toolCallId": "tool_2",
+            }
         ),
         loop_event(
             {
@@ -369,13 +395,48 @@ def test_parse_kimi_session(tmp_path):
     all_text = "\n".join(t["content"] for t in turns)
     # the typed message appears exactly once (turn.prompt duplicate ignored)
     assert all_text.count("Summarize the repo please.") == 1
-    # injection/task-origin user rows are not typed input
+    # non-"user" origin rows are not typed input
     assert "system-reminder" not in all_text
     assert "async delegation" not in all_text
+    # an untagged row (pre-provenance wire) still counts as typed input
+    assert "And check the tests." in all_text
     # thinking stays out; the tool call is a bracketed assistant summary
     assert "secret reasoning" not in all_text
     assert "[ran tool: Bash]" in all_text
     assert all(set(t) == {"role", "content"} for t in turns)
+
+
+def test_kimi_origin_filter_is_an_allowlist_not_a_denylist(tmp_path):
+    """Every machine-generated ``role=="user"`` kind must stay out.
+
+    role=="user" is a transport role, not a claim about authorship: Kimi
+    ships several machine-generated kinds on it, and a denylist of the two
+    known ones both missed kinds already in the wild and would fail open on
+    every kind added later.
+    """
+    f = _write_kimi_fixture(tmp_path)
+    all_text = "\n".join(t["content"] for t in parse_kimi_session(f)["turns"])
+
+    assert "Continue working toward the active goal." not in all_text
+    assert "bun run check completed" not in all_text
+    assert "Skill tool loaded instructions." not in all_text
+    # the point of the allowlist: an unknown future kind is dropped by default
+    assert "some future machine row" not in all_text
+
+
+def test_kimi_adjacent_tool_calls_stay_readable_when_merged(tmp_path):
+    """Two back-to-back tool calls must not run together into one blob.
+
+    Each call becomes a synthetic assistant row that ``_merge_turns`` folds
+    into its neighbors; the join has to keep the bracketed names separate.
+    """
+    f = _write_kimi_fixture(tmp_path)
+    all_text = "\n".join(t["content"] for t in parse_kimi_session(f)["turns"])
+
+    assert "[ran tool: Bash]" in all_text
+    assert "[ran tool: Read]" in all_text
+    assert "[ran tool: Bash][ran tool: Read]" not in all_text
+    assert "[ran tool: Bash]\n\n[ran tool: Read]" in all_text
 
 
 def test_parse_kimi_session_skips_malformed_lines(tmp_path):


### PR DESCRIPTION
## What

Adds **Kimi Code** as a third foreign session source for `hermes sessions import` and `hermes --resume @kimi`, alongside the existing Claude Code and Codex CLI sources.

Kimi Code stores one directory per session under `~/.kimi-code/sessions/<wd>/<session>/`:

- `state.json` — `cwd`, `title`, `updatedAt`, session `id`
- `agents/main/wire.jsonl` — the conversation wire log (protocol 1.5)

## Wire format → conversion contract

Schema verified against real wire files on a live install:

| Wire record | Handling |
|---|---|
| `context.append_message` (`origin.kind: "user"`) | typed user input → user turn |
| `context.append_message` (`origin.kind: "injection"` / `"task"`) | context wrappers / async delegation notices — **skipped** |
| `turn.prompt` | duplicates every typed user message — **ignored** (prevents double user turns) |
| `content.part` (`part.type: "text"`) | assistant text → assistant turn |
| `content.part` (`part.type: "think"`) | chain-of-thought — **never imported** |
| `tool.call` | `[ran tool: <name>]` bracketed assistant summary (same contract as claude/codex) |
| `tool.result` | skipped (same as codex) |

### `state.json` — two shapes

A real store carries two shapes side by side (a survey of one found 402 dirs on the current shape, 25 on the legacy one), and both are read:

| | current | legacy |
|---|---|---|
| working dir | `cwd` | `workDir` |
| session id | `id` | absent → session dir name |
| `updatedAt` | epoch ms | ISO-8601 string |

Title comes from `state.json` too, falling back to the first typed line when it is missing — or when it is Kimi's literal `"New Session"` placeholder, which otherwise renders every untitled session identically in the picker. An unusable `updatedAt` falls back to the wire file's mtime. Everything goes through the existing seams: `_SOURCE_PARSERS` dispatch, `gather_foreign_sessions`, the picker, `import_foreign_session`, `--from` choices, path guessing (`/.kimi-code/` or `wire.jsonl`), and the `--resume @kimi` shortcut.

## Tests

Seven new tests in `tests/hermes_cli/test_foreign_sessions.py` synthesizing the real on-disk layout in `tmp_path`:

- parsing: `turn.prompt` dedup (typed text appears exactly once), origin-kind filtering, think/result exclusion, strict role alternation, malformed-line tolerance, `state.json` fallback to dir name + first user line
- discovery: source/mtime/turn-count, missing root — plus the existing gather test now pins `kimi_root` so it stays hermetic on machines that actually have `~/.kimi-code/sessions`
- import into a temp `SessionDB`: `source=kimi-code`, alternating messages, `origin_json`, resumable id
- the legacy `state.json` shape: `workDir` → cwd, missing `id` → dir name, ISO-8601 `updatedAt` → mtime, `"New Session"` placeholder → first typed line; and an unparseable `updatedAt` falling back to the file mtime

Also verified live on a real install: `hermes sessions import --from kimi <real wire.jsonl>` produced an 8-message alternating session in `state.db` with the right source/origin/title, and `list_kimi_sessions()` discovers the machine's real sessions with their `state.json` titles.

`scripts/run_tests.sh tests/hermes_cli/` — 53 passed, 1 pre-existing failure (`test_doctor.py::test_doctor_reports_vercel_backend_diagnostics`, confirmed failing without this change too). `ruff check` clean.



## Follow-up verification (2026-08-26)

Re-checked on Linux (Fedora, Python 3.13) against a real Kimi store of 427 session dirs, with the branch replayed onto current `main`:

- **origin kinds actually present:** 126 `user` vs 203 machine-generated across five kinds — `injection` (173), `system_trigger` (18), `background_task` (6), `task` (5), `skill_activation` (1); 0 rows untagged. The allowlist is what keeps the last three out — a denylist of `injection`/`task` alone was already missing kinds in the wild.
- **live import:** `import_foreign_session("@kimi", …)` on the largest real session → 115 strictly alternating messages, correct `cwd` / `source=kimi-code` / `origin_json` / resumable id, 316 bracketed tool summaries, none run together.
- **leak check on that session:** 0 of 174 `think` parts and 0 of 163 machine-origin rows appear anywhere in the imported text.
- `scripts/run_tests.sh` over all 25 `tests/hermes_cli/*session*.py` files — 127 passed, 0 failed. `ruff check` clean; `ty check` reports the same 3 pre-existing diagnostics as the base file, none new.

Platforms tested: Linux (Fedora 44, Python 3.13). Nothing in the change is platform-specific — pure `pathlib` + `json`, read-only.