### PR TITLE
fix(install): pin the uv bootstrap installer to the CI-verified version

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -311,6 +311,14 @@ UV_SELF_UPDATE_INTERVAL_SECONDS = 7 * 24 * 3600
 # blackholed connection (no default timeout in uv's downloader path).
 UV_SELF_UPDATE_TIMEOUT_SECONDS = 60
 
+# Version pinned for the bootstrap installer URLs. CI generates and verifies
+# uv.lock with this exact version; newer uv changed how pyproject's global
+# exclude-newer is handled ("removal of global exclude newer"), which makes
+# --locked report a pristine checkout's lockfile as stale — silently knocking
+# installs off the hash-verified tier onto an unverified PyPI resolve
+# (#90650). Keep in sync with scripts/install.sh and .github/workflows/*.
+PINNED_UV_INSTALL_VERSION = "0.9.28"
+
 
 def update_managed_uv(
     *,
@@ -1337,12 +1345,13 @@ def _install_uv(target: Path) -> None:
 
 def _install_uv_posix(env: dict[str, str]) -> None:
     """Download + sh the POSIX installer (two-stage to avoid curl|sh pitfalls)."""
+    url = f"https://astral.sh/uv/{PINNED_UV_INSTALL_VERSION}/install.sh"
     with tempfile.NamedTemporaryFile(suffix=".sh", delete=False) as f:
         installer_path = f.name
 
     try:
         subprocess.run(
-            ["curl", "-LsSf", "https://astral.sh/uv/install.sh", "-o", installer_path],
+            ["curl", "-LsSf", url, "-o", installer_path],
             check=True,
             capture_output=True,
         )
@@ -1361,7 +1370,9 @@ def _install_uv_posix(env: dict[str, str]) -> None:
 
 def _install_uv_windows(env: dict[str, str]) -> None:
     """Invoke the PowerShell installer."""
-    cmd = "irm https://astral.sh/uv/install.ps1 | iex"
+    cmd = (
+        f"irm https://astral.sh/uv/{PINNED_UV_INSTALL_VERSION}/install.ps1 | iex"
+    )
     subprocess.run(
         ["powershell", "-ExecutionPolicy", "Bypass", "-c", cmd],
         env=env,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -58,6 +58,13 @@ else
 fi
 PYTHON_VERSION="3.11"
 NODE_VERSION="26"
+# Pinned uv: CI generates and verifies uv.lock with this exact version, and
+# newer uv releases changed how pyproject's global exclude-newer is handled
+# ("removal of global exclude newer"), which makes --locked report the
+# pristine checkout's lockfile as stale. An unpinned installer therefore
+# silently knocks every fresh install off the hash-verified Tier 0 and onto
+# an unverified PyPI resolve (#90650). Keep in sync with .github/workflows/*.
+UV_VERSION="0.9.28"
 
 # FHS-style root install layout (set by resolve_install_layout when applicable):
 #   code at /usr/local/lib/hermes-agent, command at /usr/local/bin/hermes,
@@ -581,8 +588,8 @@ install_uv() {
     local _uv_install_log _uv_installer
     _uv_install_log="$(mktemp 2>/dev/null || echo "/tmp/hermes-uv-install.$$.log")"
     _uv_installer="$(mktemp 2>/dev/null || echo "/tmp/hermes-uv-installer.$$.sh")"
-    if ! curl -LsSf https://astral.sh/uv/install.sh -o "$_uv_installer" 2>"$_uv_install_log"; then
-        log_error "Failed to download uv installer from https://astral.sh/uv/install.sh"
+    if ! curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" -o "$_uv_installer" 2>"$_uv_install_log"; then
+        log_error "Failed to download uv installer from https://astral.sh/uv/${UV_VERSION}/install.sh"
         log_info "curl output:"
         sed 's/^/    /' "$_uv_install_log" >&2
         log_info "Install manually: https://docs.astral.sh/uv/getting-started/installation/"

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -29,6 +29,11 @@ NC='\033[0m'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Pinned to match CI's uv (see scripts/install.sh for the full rationale —
+# newer uv marks the pristine lockfile stale and knocks installs off the
+# hash-verified tier, #90650).
+UV_PINNED_VERSION="0.9.28"
+
 # Prevent uv from discovering config files (uv.toml, pyproject.toml) from the
 # wrong user's home directory when running under sudo -u <user>.  See #21269.
 export UV_NO_CONFIG=1
@@ -89,7 +94,7 @@ else
         # failures (sh exits 0 on empty stdin under no pipefail).
         _uv_log="$(mktemp 2>/dev/null || echo "/tmp/hermes-uv-install.$$.log")"
         _uv_installer="$(mktemp 2>/dev/null || echo "/tmp/hermes-uv-installer.$$.sh")"
-        if ! curl -LsSf https://astral.sh/uv/install.sh -o "$_uv_installer" 2>"$_uv_log"; then
+        if ! curl -LsSf "https://astral.sh/uv/${UV_PINNED_VERSION}/install.sh" -o "$_uv_installer" 2>"$_uv_log"; then
             echo -e "${RED}✗${NC} Failed to download uv installer."
             sed 's/^/    /' "$_uv_log" >&2
             echo -e "${CYAN}→${NC} Install manually: https://docs.astral.sh/uv/"

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -615,6 +615,44 @@ class TestInstallUvInternals:
             call_env = mock_posix.call_args[0][0]
             assert call_env["UV_UNMANAGED_INSTALL"] == str(tmp_path / "bin")
 
+    def test_posix_installer_url_is_version_pinned(self, tmp_path):
+        """#90650: an unpinned astral.sh URL installs the latest uv, whose
+        changed exclude-newer handling marks the pristine lockfile stale and
+        knocks installs off the hash-verified tier. The installer URL must
+        carry the pinned version."""
+        import hermes_cli.managed_uv as muv
+
+        calls = []
+        with patch(
+            "hermes_cli.managed_uv.subprocess.run",
+            side_effect=lambda *a, **k: calls.append(a),
+        ):
+            muv._install_uv_posix({})
+        curl_args = next(a for a in calls if a and a[0] and a[0][0] == "curl")
+        url = curl_args[0][2]
+        assert url == (
+            f"https://astral.sh/uv/{muv.PINNED_UV_INSTALL_VERSION}/install.sh"
+        )
+        # The unversioned form is the exact regression this pins away from.
+        assert url != "https://astral.sh/uv/install.sh"
+
+    def test_windows_installer_cmd_is_version_pinned(self):
+        import hermes_cli.managed_uv as muv
+
+        commands = []
+        with patch(
+            "hermes_cli.managed_uv.subprocess.run",
+            side_effect=lambda *a, **k: commands.append(a),
+        ):
+            muv._install_uv_windows({})
+        # argv: ["powershell", "-ExecutionPolicy", "Bypass", "-c", cmd]
+        cmd = commands[0][0][4]
+        assert (
+            f"https://astral.sh/uv/{muv.PINNED_UV_INSTALL_VERSION}/install.ps1"
+            in cmd
+        )
+        assert "irm https://astral.sh/uv/install.ps1 | iex" not in cmd
+
 
 class TestRuntimeRequestMinorLine:
     """The repair must request the CPython minor line, not the exact patch.

--- a/tests/test_install_uv_version_pin.py
+++ b/tests/test_install_uv_version_pin.py
@@ -1,0 +1,72 @@
+"""The uv bootstrap installers must download a version-pinned astral.sh URL.
+
+An unpinned URL installs the latest uv, whose changed handling of pyproject's
+global ``exclude-newer`` makes ``--locked`` report a pristine checkout's
+uv.lock as stale — silently knocking every fresh install off the hash-verified
+Tier 0 and onto an unverified PyPI resolve (#90650). CI pins the same version
+when generating/verifying the lockfile, so the user-facing installers must
+agree with it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+SETUP_SH = REPO_ROOT / "setup-hermes.sh"
+MANAGED_UV = REPO_ROOT / "hermes_cli" / "managed_uv.py"
+
+CI_UV_VERSION_RE = re.compile(r'version:\s*"?(\d+\.\d+\.\d+)"?')
+INSTALLER_VERSION_RE = re.compile(
+    r'^(UV_VERSION|UV_PINNED_VERSION|PINNED_UV_INSTALL_VERSION)\s*=\s*["\'](\d+\.\d+\.\d+)["\']',
+    re.MULTILINE,
+)
+
+
+def _ci_uv_version() -> str:
+    workflow = REPO_ROOT / ".github" / "workflows" / "tests.yml"
+    match = CI_UV_VERSION_RE.search(workflow.read_text(encoding="utf-8"))
+    assert match, "could not find the pinned uv version in tests.yml"
+    return match.group(1)
+
+
+def test_install_sh_pins_uv_to_the_ci_version():
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    match = INSTALLER_VERSION_RE.search(text)
+    assert match, "scripts/install.sh must define UV_VERSION=<x.y.z>"
+    assert match.group(2) == _ci_uv_version(), (
+        "scripts/install.sh installs a different uv than CI verifies the "
+        "lockfile with; the hash-verified install tier goes stale for every "
+        "fresh install again (#90650)"
+    )
+    assert "https://astral.sh/uv/${UV_VERSION}/install.sh" in text
+    # The unversioned form is the exact regression this pins away from.
+    assert 'https://astral.sh/uv/install.sh -o' not in text.replace(
+        "https://astral.sh/uv/${UV_VERSION}/install.sh", ""
+    )
+
+
+def test_setup_hermes_sh_pins_uv_to_the_ci_version():
+    text = SETUP_SH.read_text(encoding="utf-8")
+    match = INSTALLER_VERSION_RE.search(text)
+    assert match, "setup-hermes.sh must define UV_PINNED_VERSION=<x.y.z>"
+    assert match.group(2) == _ci_uv_version()
+
+
+def test_managed_uv_pins_uv_to_the_ci_version():
+    text = MANAGED_UV.read_text(encoding="utf-8")
+    match = INSTALLER_VERSION_RE.search(text)
+    assert match, (
+        "hermes_cli/managed_uv.py must define PINNED_UV_INSTALL_VERSION"
+    )
+    assert match.group(2) == _ci_uv_version()
+    assert "https://astral.sh/uv/install.sh" not in text.replace(
+        f"https://astral.sh/uv/{match.group(2)}/install.sh", ""
+    )
+    # POSIX URL is a plain literal; the Windows cmd is an f-string on the
+    # same constant, so assert its template references the pin.
+    assert (
+        "https://astral.sh/uv/{PINNED_UV_INSTALL_VERSION}/install.ps1" in text
+    )


### PR DESCRIPTION
## What does this PR do?

The hash-verified install tier — `uv sync --locked` against `uv.lock`, the tier whose own comment calls it "the *only* path that protects against the 'direct dep is fine, but the dep's dep got worm-poisoned overnight' failure mode" — **never applies on a clean checkout** (#90650). The bootstrap installers (`scripts/install.sh`, `setup-hermes.sh`, `hermes_cli/managed_uv.py`) all download uv from the unversioned `https://astral.sh/uv/install.sh` URL, i.e. the latest release, while CI generates and verifies `uv.lock` with a pinned uv (0.9.28). Newer uv changed how pyproject's global `exclude-newer` is handled ("Resolving despite existing lockfile due to removal of global exclude newer"), so `--locked` reports the pristine lockfile as stale and every fresh install silently falls back to the unverified PyPI resolve.

This PR pins all three bootstrap paths to the same version CI uses (0.9.28): the POSIX installer URL becomes `https://astral.sh/uv/0.9.28/install.sh`, the Windows PowerShell command becomes `irm https://astral.sh/uv/0.9.28/install.ps1`, and each file carries a named constant with the rationale so the next bump is one deliberate edit (CI workflows already pin this version; the pin comment in `tests.yml` documents why).

Scope note: migrating `pyproject.toml` off the global `exclude-newer` syntax for future uv versions is a separate toolchain decision — this PR restores the security posture of the current lockfile generation without presupposing that migration.

## Related Issue

Fixes #90650

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh` — `UV_VERSION="0.9.28"` constant (alongside the existing `PYTHON_VERSION`/`NODE_VERSION` pins) + versioned installer URL in `install_uv()`
- `setup-hermes.sh` — `UV_PINNED_VERSION="0.9.28"` + versioned URL
- `hermes_cli/managed_uv.py` — `PINNED_UV_INSTALL_VERSION = "0.9.28"` + versioned URLs in `_install_uv_posix()` and `_install_uv_windows()`
- `tests/test_install_uv_version_pin.py` — regression tests: each installer defines a pin matching the CI workflow's version, the URL/command carries it, and the unversioned form is gone
- `tests/hermes_cli/test_managed_uv.py` — two tests asserting the POSIX curl argv and the Windows PowerShell command embed `PINNED_UV_INSTALL_VERSION`

## How to Test

1. `python -m pytest tests/test_install_uv_version_pin.py tests/hermes_cli/test_managed_uv.py -q` — should pass (45 passed, 1 skipped)
2. Observed result: against upstream/main, all three pin-definition assertions fail (`must define UV_VERSION...`) and the bare `astral.sh/uv/install.sh` URL is present in every installer — verified via `git show upstream/main:<file>`; with the fix, the pins match CI's `version: "0.9.28"` exactly
3. Manual confirmation of the reported failure mode (from the issue): a fresh clone at a pinned commit with latest uv (0.12.5) shows `uv sync --locked` rejecting the pristine lockfile; installing uv 0.9.28 instead makes the same checkout's Tier 0 succeed

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (each constant documents the tier-0/stale-lockfile rationale and the CI sync requirement)
- [x] Tests added that prove the fix is effective or prevent regression (CI-version consistency assertions across all three installers + URL embedding checks)
- [x] All new and existing tests pass locally (45 passed, 1 skipped)
- [x] Platform: macOS (POSIX paths verified; Windows command pinned in lockstep and asserted via the same constant)
