### PR TITLE
fix(desktop): add rejection handler to preview.read.request tool bridge

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { readActivePreview } from '@/app/chat/right-rail/preview-reader'
+import { $gateway } from '@/store/gateway'
+import { handleDesktopBridgeEvent } from './desktop-bridge'
+
+vi.mock('@/app/chat/right-rail/preview-reader')
+vi.mock('@/store/gateway')
+
+const mockRequest = vi.fn()
+
+describe('handleDesktopBridgeEvent - preview.read.request', () => {
+  beforeEach(() => {
+    mockRequest.mockReset()
+    vi.mocked($gateway.get).mockReturnValue({ request: mockRequest } as any)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('sends preview.read.respond with text when readActivePreview resolves', async () => {
+    vi.mocked(readActivePreview).mockResolvedValue({ text: 'hello', title: 'Page', url: 'https://x.com' })
+    handleDesktopBridgeEvent({
+      event: { type: 'preview.read.request' },
+      payload: { request_id: 'req-1' },
+      isActiveEvent: true,
+    } as any)
+    await Promise.resolve()
+    expect(mockRequest).toHaveBeenCalledWith('preview.read.respond', {
+      request_id: 'req-1',
+      text: expect.any(String),
+    })
+  })
+
+  it('sends empty preview.read.respond when readActivePreview rejects', async () => {
+    vi.mocked(readActivePreview).mockRejectedValue(new Error('pane unavailable'))
+    handleDesktopBridgeEvent({
+      event: { type: 'preview.read.request' },
+      payload: { request_id: 'req-2' },
+      isActiveEvent: true,
+    } as any)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(mockRequest).toHaveBeenCalledWith('preview.read.respond', {
+      request_id: 'req-2',
+      text: '',
+    })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
@@ -73,11 +73,17 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
       const start = typeof payload?.start === 'number' ? payload.start : undefined
       const count = typeof payload?.count === 'number' ? payload.count : undefined
 
-      void readActivePreview({ count, start }).then(result => {
-        void $gateway.get()?.request('preview.read.respond', {
+      const answer = (result: unknown) =>
+        $gateway.get()?.request('preview.read.respond', {
           request_id: requestId,
           text: result ? JSON.stringify(result) : ''
         })
+      // .catch: readActivePreview rejects if the preview pane is unavailable
+      // or the webview read fails — without an empty answer the tool would
+      // stall its full 30s timeout.
+      void readActivePreview({ count, start }).then(answer, (err: unknown) => {
+        console.debug('[preview.read] readActivePreview rejected:', err)
+        answer(null)
       })
     }
 


### PR DESCRIPTION
## What does this PR do?

The `preview.read.request` handler in `desktop-bridge.ts` calls `readActivePreview().then(result => ...)` with no rejection branch. If `readActivePreview()` rejects (preview pane unavailable, webview read failure, or IPC error), `preview.read.respond` is never sent and the agent's `read_preview` tool call blocks for the full 30s timeout.

The sibling `window.read.request` handler in the same file documents this failure mode with a comment and uses the two-argument `.then(answer, () => answer(null))` pattern. This fix applies the same pattern to `preview.read.request`.

## Related Issue

Fixes #

## Type of Change

* 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

* `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts`: extracted the respond call into an `answer` helper and added `() => answer(null)` as the rejection branch, matching the `window.read.request` pattern.
* `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts`: 2 regression tests covering the resolve and reject paths of the `preview.read.request` handler.

## How to Test

```
cd apps/desktop && npx vitest run src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
```

2 tests pass.

## Checklist

### Code

* Contributing Guide read
* Conventional Commits followed
* No duplicate PRs found
* Only this fix in the PR
* 2 tests pass
* Tested on: WSL2 Ubuntu

### Documentation & Housekeeping

* No docs changes needed — N/A
* No config key changes — N/A
* Security impact: none