### PR TITLE
fix(desktop): drop client ordinal when a durable row id is bound

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
@@ -475,7 +475,7 @@ describe('runRewindSubmit durable-address discipline (#87059)', () => {
     expect(submit?.params?.confirm_truncate).toBeUndefined()
   })
 
-  it('leaves a bound durable rowId untouched (no extra history call)', async () => {
+  it('leaves a bound durable rowId untouched (no extra history call) but drops the client ordinal', async () => {
     const calls: Call[] = []
 
     await runRewindSubmit(makeGateway(calls), 'sid', 'fixed prompt', 1, undefined, false, undefined, 13, 'typo prompt')
@@ -485,7 +485,7 @@ describe('runRewindSubmit durable-address discipline (#87059)', () => {
     const submit = calls.find(call => call.method === 'prompt.submit')
 
     expect(submit?.params?.truncate_before_row_id).toBe(13)
-    expect(submit?.params?.truncate_before_user_ordinal).toBe(1)
+    expect(submit?.params?.truncate_before_user_ordinal).toBeUndefined()
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
@@ -260,6 +260,15 @@ export async function runRewindSubmit(
     // gateway's 4030 cross-check. Unresolved: plain resubmit, no truncation.
     resolvedOrdinal = undefined
     resolvedMessageId = undefined
+  } else if (wantsTruncation && typeof truncateRowId === 'number') {
+    // The caller already bound a durable ROW id. Keep it as the SOLE address
+    // and drop the ordinal the same way: the two ordinal spaces can diverge
+    // (failed turns are skipped client-side while durable repair merges
+    // adjacent user rows), and the gateway refuses the ordinal+row_id
+    // combination with 4030 whenever they disagree (#82756). messageId-only
+    // restores keep their ordinal — there the ordinal is still part of the
+    // address (stale rendered ids fall back to it, #82462).
+    resolvedOrdinal = undefined
   }
 
   const interrupt = async () => {


### PR DESCRIPTION
## Summary
- When a rewind/restore already carries a durable `truncate_before_row_id`, drop the client-computed `truncate_before_user_ordinal` instead of sending both.
- messageId-only restores keep their ordinal (stale rendered ids fall back to it, #82462); only the rowId path changes.

## Motivation
Restore-to-checkpoint fails with `Restore failed` / `truncate_before_user_ordinal (N) does not match truncate_before_row_id target turn (M)` on sessions whose client ordinal space diverged from the gateway's durable ordinal space — e.g. after queued/re-sent turns following a 429: failed turns are skipped client-side (`isFailedUserTurn`) while durable repair merges adjacent user rows, so the same target resolves to different ordinals on each side. The gateway's fail-closed 4030 cross-check (#82756) then refuses the pair, and the client had no path to send the row id alone.

## Implementation
In `runRewindSubmit`, the ordinal-only branch already resolved a durable row id by content and dropped the client ordinal (#87059). This extends the same discipline to the already-bound-rowId branch: keep the durable row id as the sole address, set `resolvedOrdinal = undefined`. The cut is always aimed by the resolved durable target, so dropping the ordinal cannot re-aim a truncation.

## Validation
- `npx vitest run src/app/session/hooks/use-prompt-actions/` — 214 passed (updated the bound-rowId case to assert ordinal is dropped)
- `npx tsc -p . --noEmit` — exit 0
- Manual repro on the affected session: 4030 REFUSED before (ordinal=11 vs row_id=13), submits with row_id only after

## Impact
None identified beyond the behavior above. Backend (tui_gateway) unchanged; gateway 4030 protection remains in force for genuinely stale ordinals.

Refs: #82756, #87059, #82462