### PR TITLE
fix(backup): reject corrupt quick snapshots

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1422,11 +1422,11 @@ def _create_quick_snapshot_locked(
                 dst = staging_dir / sub_rel
                 dst.parent.mkdir(parents=True, exist_ok=True)
                 try:
-                    # Route SQLite DBs through the WAL-safe backup() path so a
-                    # board DB with an open WAL (the gateway may hold it at
-                    # snapshot time) is captured consistently.
+                    # Route SQLite DBs through the WAL-safe backup() path and
+                    # verify the offline destination so a corrupt source
+                    # cannot become a seemingly valid recovery artifact.
                     if sub.suffix == ".db":
-                        if not _safe_copy_db(sub, dst):
+                        if not copy_db_and_verify(sub, dst):
                             failed_dbs.append(sub_rel)
                             print(
                                 f"  ⚠ Snapshot: SQLite safe copy FAILED for {sub_rel} "
@@ -1458,7 +1458,7 @@ def _create_quick_snapshot_locked(
 
         try:
             if src.suffix == ".db":
-                if not _safe_copy_db(src, dst):
+                if not copy_db_and_verify(src, dst):
                     failed_dbs.append(rel)
                     print(
                         f"  ⚠ Snapshot: SQLite safe copy FAILED for {rel} "

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1128,7 +1128,62 @@ class TestQuickSnapshot:
         conn.close()
         return home
 
+    def test_corrupt_state_db_is_not_published_as_snapshot(
+        self, hermes_home, capsys
+    ):
+        """A corrupt source must not become a seemingly valid recovery artifact."""
+        db_path = hermes_home / "state.db"
+        index_name = "idx_sessions_data"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(f"CREATE INDEX {index_name} ON sessions(data)")
+        conn.commit()
+        original_sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='index' AND name=?",
+            (index_name,),
+        ).fetchone()[0]
 
+        # Build a stale B-tree: rebuild the index under WHERE 0, then restore
+        # the original schema definition so integrity_check detects the mismatch.
+        conn.execute("PRAGMA writable_schema=ON")
+        conn.execute(
+            "UPDATE sqlite_master SET sql=? WHERE type='index' AND name=?",
+            (original_sql + " WHERE 0", index_name),
+        )
+        schema_version = conn.execute("PRAGMA schema_version").fetchone()[0]
+        conn.execute(f"PRAGMA schema_version={schema_version + 1}")
+        conn.execute("PRAGMA writable_schema=OFF")
+        conn.commit()
+        conn.close()
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(f"REINDEX {index_name}")
+        conn.commit()
+        conn.execute("PRAGMA writable_schema=ON")
+        conn.execute(
+            "UPDATE sqlite_master SET sql=? WHERE type='index' AND name=?",
+            (original_sql, index_name),
+        )
+        schema_version = conn.execute("PRAGMA schema_version").fetchone()[0]
+        conn.execute(f"PRAGMA schema_version={schema_version + 1}")
+        conn.execute("PRAGMA writable_schema=OFF")
+        conn.commit()
+        conn.close()
+
+        from hermes_cli.backup import create_quick_snapshot
+
+        snapshot_id = create_quick_snapshot(hermes_home=hermes_home)
+        output = capsys.readouterr().out
+
+        assert snapshot_id is not None
+        manifest = json.loads(
+            (hermes_home / "state-snapshots" / snapshot_id / "manifest.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert "state.db" in manifest["failed_dbs"]
+        assert "state.db" not in manifest["files"]
+        assert "SQLite safe copy FAILED" in output or "CRITICAL" in output
+        assert not (hermes_home / "state-snapshots" / snapshot_id / "state.db").exists()
 
     def test_state_db_safely_copied(self, hermes_home):
         from hermes_cli.backup import create_quick_snapshot


### PR DESCRIPTION
## Summary

- Route quick-snapshot SQLite copies through the existing `copy_db_and_verify()` helper.
- Reject and remove a snapshot destination when the copied database fails SQLite integrity verification.
- Add a real stale B-tree regression test proving a corrupt `state.db` is recorded in `failed_dbs` instead of being published as a recovery artifact.

Fixes #90613

## Test plan

- `scripts/run_tests.sh tests/hermes_cli/test_backup.py tests/hermes_cli/test_backup_stability.py tests/hermes_cli/test_state_db_guard.py tests/hermes_cli/test_update_*.py -q`
- Result: **393 passed, 0 failed, 4 skipped** (Windows-only tests skipped on macOS).
- `git diff --check`
- `python -m py_compile hermes_cli/backup.py tests/hermes_cli/test_backup.py`

The change is limited to `hermes_cli/backup.py` and its regression coverage in `tests/hermes_cli/test_backup.py`.