### PR TITLE
fix(desktop): stop re-appending stale orphan errors below newer turns

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -607,6 +607,60 @@ describe('preserveLocalAssistantErrors', () => {
     ])
   })
 
+  it('does not re-append a stale orphan error when a later turn has committed', () => {
+    // 429-style failure: the failed turn's assistant error row exists only
+    // locally (the gateway never persisted it), and the user has since sent a
+    // NEW turn whose reply committed. Re-appending the orphan error to the
+    // tail would stick the red error below the fresh answer.
+    const nextMessages: ChatMessage[] = [
+      {
+        id: 'stored-user',
+        parts: [{ text: 'earlier', type: 'text' }],
+        role: 'user'
+      },
+      {
+        id: 'stored-assistant',
+        parts: [{ text: 'earlier reply', type: 'text' }],
+        role: 'assistant'
+      },
+      {
+        id: 'user-456',
+        parts: [{ text: 'follow-up', type: 'text' }],
+        role: 'user'
+      },
+      {
+        id: 'assistant-456',
+        parts: [{ text: 'the follow-up answer', type: 'text' }],
+        role: 'assistant'
+      }
+    ]
+
+    const currentMessages: ChatMessage[] = [
+      ...nextMessages.slice(0, 2),
+      {
+        id: 'user-123',
+        parts: [{ text: 'prompt that hit 429', type: 'text' }],
+        role: 'user'
+      },
+      {
+        error: 'HTTP 429: rate limit exceeded',
+        id: 'assistant-error-1',
+        parts: [],
+        role: 'assistant'
+      },
+      ...nextMessages.slice(2)
+    ]
+
+    const merged = preserveLocalAssistantErrors(nextMessages, currentMessages)
+
+    expect(merged.map(message => message.id)).toEqual([
+      'stored-user',
+      'stored-assistant',
+      'user-456',
+      'assistant-456'
+    ])
+  })
+
   it('keeps local assistant error when hydrated message reuses same id', () => {
     const nextMessages: ChatMessage[] = [
       {

--- a/apps/desktop/src/lib/chat-messages/reconciliation.ts
+++ b/apps/desktop/src/lib/chat-messages/reconciliation.ts
@@ -162,6 +162,18 @@ export function preserveLocalAssistantErrors(
       continue
     }
 
+    // A failed turn that is NOT the tail of the live thread has been
+    // superseded: the user already sent a later turn. Re-appending this
+    // orphan error below the newer replies is the "stale 429 error sticks
+    // to the tail" bug — only the LAST turn's failure survives the merge.
+    const hasLaterVisibleUserTurn = currentMessages
+      .slice(index + 1)
+      .some(candidate => candidate.role === 'user' && !candidate.hidden)
+
+    if (hasLaterVisibleUserTurn) {
+      continue
+    }
+
     preserveIds.add(message.id)
 
     for (let probe = index - 1; probe >= 0; probe -= 1) {


### PR DESCRIPTION
## Summary
- `preserveLocalAssistantErrors` no longer re-appends an orphan assistant error row when the failed turn has been superseded by a newer user turn.
- The orphan error (and its tool parts) is still preserved when it is the LAST turn's failure — the original hydration-omits-failed-turn case keeps working.

## Motivation
A failed turn (e.g. HTTP 429 from a rate-limited endpoint) keeps its red assistant error row only in local state — the gateway never persists it. On the next hydrate/resume/background-sync, `preserveLocalAssistantErrors` appends such orphan error rows to the reconciled tail so the failure stays visible. But when the user has since sent a NEWER turn whose reply committed, re-appending the old error below it sticks the red error (plus its tool-call parts) to the bottom of the thread, trailing every later answer until a manual restore-to-checkpoint.

## Implementation
In the orphan-preservation loop, skip an orphan error assistant when any visible user row follows it in the live thread — the turn was superseded, so the failure is historical noise. The existing `matchesTailUserInNext` logic already handled the "user re-sent the same text" shape; this closes the "user sent a different follow-up" shape.

## Validation
- Added regression test `does not re-append a stale orphan error when a later turn has committed` (429-style failure + follow-up turn → merged list has no orphan error).
- `npx vitest run src/lib/chat-messages.test.ts src/app/session/hooks/use-session-actions/` — 195 passed
- `npx tsc -p . --noEmit` — exit 0

## Impact
None identified. Live-thread failures (no later user turn) still surface exactly as before; only superseded errors stop being re-appended.