### PR TITLE
fix(honcho): stop concurrent 401 refresh handlers invalidating winners

### DIFF
--- a/plugins/memory/honcho/oauth.py
+++ b/plugins/memory/honcho/oauth.py
@@ -539,7 +539,12 @@ def ensure_fresh_token(
         return rotated.access_token, True
 
 
-def force_refresh_token(path: Path, host: str) -> str | None:
+def force_refresh_token(
+    path: Path,
+    host: str,
+    *,
+    rejected_access_token: str | None = None,
+) -> str | None:
     """Rotate ``host``'s access token now, ignoring local expiry.
 
     Recovers a 401 on a token the local clock still thinks is valid.
@@ -559,6 +564,19 @@ def force_refresh_token(path: Path, host: str) -> str | None:
             # cycle — callers fail open and retry after the cooldown.
             return None
         cached = _expiry_cache.get(key)
+        # A sibling thread/process may already have rotated the single-use
+        # refresh grant after this request left with ``rejected_access_token``.
+        # Adopt that newer valid disk token.  Comparing only against this
+        # process's expiry cache is insufficient: the winning thread updates
+        # both disk and cache, so every waiter would otherwise rotate again and
+        # invalidate the winner in sequence (a persistent 401 storm).
+        if (
+            rejected_access_token
+            and cred.access_token != rejected_access_token
+            and not cred.is_expired(now=now)
+        ):
+            _expiry_cache[key] = (cred.expires_at, cred.access_token)
+            return cred.access_token
         # Another thread or process already rotated: adopt the newer on-disk token.
         if cached is not None and cred.access_token != cached[1] and not cred.is_expired(now=now):
             _expiry_cache[key] = (cred.expires_at, cred.access_token)

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -290,16 +290,28 @@ class HonchoSessionManager:
             host = getattr(self._config, "host", "") or ""
             if not host:
                 return False
-            token = oauth.force_refresh_token(self._bound_config_path(), host)
+            live_http = getattr(self.honcho, "_http", None)
+            rejected_token = getattr(live_http, "api_key", None)
+            token = oauth.force_refresh_token(
+                self._bound_config_path(),
+                host,
+                rejected_access_token=(
+                    rejected_token if isinstance(rejected_token, str) else None
+                ),
+            )
             if not token:
                 return False
-            if not oauth.apply_token_to_client(self.honcho, token):
+            applied_in_place = oauth.apply_token_to_client(self.honcho, token)
+            if not applied_in_place:
                 # SDK shape changed: rebuild the client and drop objects holding the old transport.
                 reset_honcho_client()
-                with self._cache_lock:
-                    self._client_generation += 1
-                    self._peers_cache.clear()
-                    self._sessions_cache.clear()
+            # Peer and Session SDK objects may retain their own transport/auth
+            # state even when the root client's Bearer rotated in place.  Always
+            # evict them so the retry resolves objects against the fresh token.
+            with self._cache_lock:
+                self._client_generation += 1
+                self._peers_cache.clear()
+                self._sessions_cache.clear()
             return True
         except Exception:
             logger.warning("Honcho post-401 token refresh failed", exc_info=True)

--- a/tests/honcho_plugin/test_auth_recovery.py
+++ b/tests/honcho_plugin/test_auth_recovery.py
@@ -193,6 +193,30 @@ class TestForceRefreshToken:
         )
         assert oauth.force_refresh_token(path, "hermes") == "hch-at-2"
 
+    def test_waiting_401_adopts_winner_even_when_cache_already_advanced(
+        self, tmp_path, monkeypatch
+    ):
+        """A waiter must not rotate again after the winner updated disk+cache."""
+        path = tmp_path / "honcho.json"
+        far = int(time.time() + 7200)
+        old = _host_block(expires_at=far)
+        _write(path, {"hosts": {"hermes": old}})
+        oauth.ensure_fresh_token(path, "hermes")
+
+        winner = _host_block(refresh="hch-rt-2", expires_at=far)
+        winner["apiKey"] = "hch-at-2"
+        _write(path, {"hosts": {"hermes": winner}})
+        oauth._expiry_cache[(str(path), "hermes")] = (far, "hch-at-2")
+        monkeypatch.setattr(
+            oauth,
+            "_http_post_form_status",
+            lambda *a, **k: pytest.fail("waiter must adopt the winner"),
+        )
+
+        assert oauth.force_refresh_token(
+            path, "hermes", rejected_access_token="hch-at-old"
+        ) == "hch-at-2"
+
     def test_transient_failure_returns_none(self, tmp_path, monkeypatch):
         path = tmp_path / "honcho.json"
         _write(path, {"hosts": {"hermes": _host_block(expires_at=time.time() + 3600)}})
@@ -344,7 +368,13 @@ class TestForceReauth:
         applied = {}
         monkeypatch.setattr(session_mod, "get_honcho_client", lambda *a, **k: fake_client)
         monkeypatch.setattr(client_mod, "resolve_config_path", lambda: tmp_path / "honcho.json")
-        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h: "hch-at-new")
+        rejected = {}
+
+        def force(p, h, **kw):
+            rejected.update(kw)
+            return "hch-at-new"
+
+        monkeypatch.setattr(oauth, "force_refresh_token", force)
 
         def apply(client, token):
             applied["client"] = client
@@ -354,14 +384,20 @@ class TestForceReauth:
         monkeypatch.setattr(oauth, "apply_token_to_client", apply)
 
         mgr = HonchoSessionManager(config=HonchoClientConfig(host="hermes"))
+        mgr._peers_cache["u"] = object()
+        mgr._sessions_cache["s"] = object()
         assert mgr._force_reauth() is True
         assert applied == {"client": fake_client, "token": "hch-at-new"}
+        assert rejected == {"rejected_access_token": None}
+        assert mgr._peers_cache == {}
+        assert mgr._sessions_cache == {}
+        assert mgr._client_generation == 1
 
     def test_returns_false_when_refresh_yields_nothing(self, tmp_path, monkeypatch):
         from plugins.memory.honcho import client as client_mod
 
         monkeypatch.setattr(client_mod, "resolve_config_path", lambda: tmp_path / "honcho.json")
-        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h: None)
+        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h, **kw: None)
         mgr = HonchoSessionManager(config=HonchoClientConfig(host="hermes"))
         assert mgr._force_reauth() is False
 
@@ -731,7 +767,7 @@ def _wire_rebuild(tmp_path, monkeypatch, fresh_client):
     clients = {"current": MagicMock()}
     monkeypatch.setattr(session_mod, "get_honcho_client", lambda *a, **k: clients["current"])
     monkeypatch.setattr(client_mod, "resolve_config_path", lambda: tmp_path / "honcho.json")
-    monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h: "hch-at-rotated")
+    monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h, **kw: "hch-at-rotated")
     monkeypatch.setattr(oauth, "apply_token_to_client", lambda c, t: False)
     monkeypatch.setattr(
         client_mod, "reset_honcho_client",
@@ -871,7 +907,7 @@ def _wire_init(tmp_path, monkeypatch, client, *, recall_mode="hybrid", dead_refr
     monkeypatch.setattr(client_mod, "get_honcho_client", lambda *a, **k: client)
     monkeypatch.setattr(session_mod, "get_honcho_client", lambda *a, **k: client)
     if dead_refresh:
-        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h: None)
+        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h, **kw: None)
     cfg = HonchoClientConfig(
         host="hermes", api_key="hch-at-old", enabled=True, recall_mode=recall_mode,
         timeout=0.5, session_strategy="per-session",
@@ -980,7 +1016,7 @@ class TestInitAuthFailureNotice:
         client.peer.side_effect = TimeoutError("request timed out")
         _wire_init(tmp_path, monkeypatch, client, dead_refresh=False)
         reauths = []
-        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h: reauths.append(1))
+        monkeypatch.setattr(oauth, "force_refresh_token", lambda p, h, **kw: reauths.append(1))
         provider = _initialized_provider()
 
         assert provider._manager is None


### PR DESCRIPTION
## Summary

Follow-up hardening for the Honcho OAuth 401 recovery merged in #81616.

A long-lived Desktop/backend can still enter a refresh storm when several Honcho operations receive `401 Invalid or expired access token` concurrently:

1. the first handler rotates the single-use refresh grant and updates both disk and the process expiry cache;
2. a waiting handler acquires the refresh lock;
3. because the on-disk token now equals the advanced cache entry, the existing concurrent-rotation check does not recognize it as newer;
4. the waiter rotates again, invalidating the first winner before its retry completes.

This was reproduced in a live Desktop process where CLI `hermes honcho status` refreshed successfully while the process repeatedly paused memory with `Invalid or expired access token`.

## Fix

- Pass the exact Bearer rejected by the failed request into `force_refresh_token()`.
- Under the refresh lock, adopt a different, still-valid on-disk access token even when this process's expiry cache already contains that winner.
- Always increment the client generation and evict cached SDK `Peer`/`Session` objects after token recovery, including when the root client's Bearer was updated in place. Cached objects may retain transport/auth state independently.

The existing one-retry bound, dead-grant handling, cooldown, token redaction, and fail-open behavior remain unchanged.

## Tests

- Added a regression where disk **and** `_expiry_cache` already contain the winning token while a waiting 401 handler still identifies the rejected old Bearer. The token endpoint must not be called again.
- Extended the live-client recovery test to verify rejected-token propagation, cache eviction, and client-generation advancement.

Validation:

```text
python -m pytest tests/honcho_plugin/test_auth_recovery.py -q -o 'addopts='
66 passed

python -m pytest tests/honcho_plugin -q -o 'addopts='
331 passed
```

Live no-LLM Honcho Cloud proof also passed: temporary session create, message write, exact readback, and delete acceptance.

## Risk

Low and scoped to post-401 OAuth recovery. Static API-key paths are unchanged. The new argument is keyword-only and optional for compatibility.
