### PR TITLE
fix(desktop): make MEDIA file links reachable and reveal in Finder

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.media-md.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.media-md.test.tsx
@@ -39,7 +39,10 @@ describe('markdown documents delivered via MEDIA', () => {
 
     render(<MarkdownTextContent isRunning={false} text={`[archive.zip](${href})`} />)
 
-    expect(await screen.findByText(/archive\.zip/)).toBeTruthy()
-    expect(screen.queryByRole('button')).toBeNull()
+    // Media fallback's file branch: an "Open ..." anchor + reveal-in-finder
+    // action — NOT the preview attachment's "Open preview" toggle.
+    expect(await screen.findByRole('link', { name: /Open archive\.zip/ })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Open preview' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Reveal in Finder' })).toBeTruthy()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/markdown-text.reveal.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.reveal.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { renderMediaTags } from '@/lib/chat-messages'
+import { $connection } from '@/store/session'
+
+import { MarkdownTextContent } from './markdown-text'
+
+// Regression for the dead "Open Link" on MEDIA file outputs: the file branch
+// of MediaAttachment rendered with a literal `#` href, so the native
+// right-click "Open Link"/"Copy Link" resolved to the app's own page URL
+// instead of the file. The file branch now carries a real file:// href (so the
+// native menu and "Copy Link" work again) and a "Reveal in Finder" action for
+// local connections (the file lives on this disk, so the shell can reveal it).
+describe('MediaAttachment file outputs', () => {
+  const revealPath = vi.fn().mockResolvedValue(true)
+  const openExternal = vi.fn()
+  let originalDesktop: typeof window.hermesDesktop
+
+  beforeEach(() => {
+    originalDesktop = window.hermesDesktop
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { api: vi.fn(), openExternal, revealPath }
+    })
+    $connection.set(null)
+    revealPath.mockClear()
+    openExternal.mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    $connection.set(null)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: originalDesktop
+    })
+  })
+
+  it('renders a real file href plus a reveal-in-finder action for MEDIA files', async () => {
+    render(<MarkdownTextContent isRunning={false} text={renderMediaTags('MEDIA:/tmp/report.pdf')} />)
+
+    const openLink = await screen.findByRole('link', { name: /Open report\.pdf/ })
+    expect(openLink.getAttribute('href')).toBe('file:///tmp/report.pdf')
+
+    const reveal = screen.getByRole('button', { name: 'Reveal in Finder' })
+    fireEvent.click(reveal)
+    await waitFor(() => expect(revealPath).toHaveBeenCalledWith('/tmp/report.pdf'))
+  })
+
+  it('keeps left-click opening the file (not navigating the anchor)', async () => {
+    render(<MarkdownTextContent isRunning={false} text={renderMediaTags('MEDIA:/tmp/report.pdf')} />)
+
+    const openLink = await screen.findByRole('link', { name: /Open report\.pdf/ })
+    fireEvent.click(openLink)
+
+    // useOpenMediaFile routes to openExternalLink(file://…) on a local
+    // connection; the bridge receives the file URL.
+    await waitFor(() =>
+      expect(window.hermesDesktop?.openExternal).toHaveBeenCalledWith('file:///tmp/report.pdf')
+    )
+  })
+
+  it('hides reveal-in-finder on a remote gateway', async () => {
+    $connection.set({ mode: 'remote', profile: 'remote-work' } as never)
+    render(<MarkdownTextContent isRunning={false} text={renderMediaTags('MEDIA:/tmp/report.pdf')} />)
+
+    await screen.findByRole('link', { name: /Open report\.pdf/ })
+    expect(screen.queryByRole('button', { name: 'Reveal in Finder' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -15,13 +15,16 @@ import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
 import { ZoomableImage } from '@/components/chat/zoomable-image'
 import { ErrorBoundary } from '@/components/error-boundary'
+import { useI18n } from '@/i18n'
 import { detectArtifact } from '@/lib/artifact-detect'
+import { revealDesktopPath } from '@/lib/desktop-fs'
 import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
 import {
   downloadGatewayMediaFile,
+  filePathFromMediaPath,
   isFileMediaPath,
   isInlineMediaSrc,
   isMarkdownDocumentPath,
@@ -143,8 +146,10 @@ function OpenMediaButton({ kind, path }: { kind: 'audio' | 'video'; path: string
 }
 
 function MediaAttachment({ path }: { path: string }) {
+  const { t } = useI18n()
   const [src, setSrc] = useState('')
   const [failed, setFailed] = useState(false)
+  const [revealFailed, setRevealFailed] = useState(false)
   const { open, openFailed } = useOpenMediaFile(path)
   const kind = mediaKind(path)
   const name = mediaName(path)
@@ -225,10 +230,10 @@ function MediaAttachment({ path }: { path: string }) {
   }
 
   return (
-    <span className="wrap-anywhere">
+    <span className="wrap-anywhere inline-flex flex-wrap items-center gap-x-2">
       <a
         className="ref wrap-anywhere"
-        href="#"
+        href={mediaExternalUrl(path)}
         onClick={event => {
           event.preventDefault()
           open()
@@ -236,7 +241,19 @@ function MediaAttachment({ path }: { path: string }) {
       >
         {failed ? `Open ${name}` : `Loading ${name}...`}
       </a>
+      {!isRemoteGateway() && (
+        <button
+          type="button"
+          className="ref text-xs font-medium text-muted-foreground hover:text-foreground"
+          onClick={() => {
+            void revealDesktopPath(filePathFromMediaPath(path)).catch(() => setRevealFailed(true))
+          }}
+        >
+          {t.fileMenu.revealFinder}
+        </button>
+      )}
       {openFailed && <OpenMediaFailedNote name={name} />}
+      {revealFailed && <OpenMediaFailedNote name={name} />}
     </span>
   )
 }


### PR DESCRIPTION
## Summary

Clicking a `MEDIA:` file output in the desktop chat is a dead end. The file
branch of `MediaAttachment` renders its "Open <name>" link with a literal
`href="#"`, so:

- right-click **Open Link** resolves to the app's own page URL (a silent no-op),
- right-click **Copy Link** copies `#`,
- and there is no way to reach the file on disk from the chat at all.

Every delivered file (reports, exports, artifacts) is effectively unreachable
without manually hunting the path in Finder.

## What changed

`apps/desktop/src/components/assistant-ui/markdown-text.tsx` — `MediaAttachment`
file branch:

1. **Real href.** The "Open" link now uses `mediaExternalUrl(path)`:
   - local connection → `file://<path>` (native "Open Link"/"Copy Link" work
     again; `shell.openPath` already falls back to reveal-in-Finder when no
     default handler exists — see #68953),
   - remote gateway → authenticated `/api/files/download?...` URL (remote
     behavior unchanged).
2. **Reveal in Finder action.** A compact "Reveal in Finder" action next to the
   link, rendered only on local connections (`!isRemoteGateway()`), reusing the
   existing `revealDesktopPath` bridge + `fileMenu.revealFinder` i18n key.
   Remote gateways keep it hidden (the path is not on this disk) — the same
   gating pattern as #74861.

No new IPC channel, no new i18n strings, no new dependencies — every building
block already existed (`mediaExternalUrl`, `filePathFromMediaPath`,
`revealDesktopPath`, `isRemoteGateway`, `t.fileMenu.revealFinder`).

## How to test

1. Ask the agent to output a non-media file in a **local** desktop session,
   e.g. `MEDIA:/tmp/report.pdf` (or any txt/pdf).
2. Right-click the "Open report.pdf" link → **Open Link** opens the file (or
   reveals it in Finder when no default handler exists).
3. Click **Reveal in Finder** → Finder opens and selects the file.
4. On a **remote gateway** connection: "Reveal in Finder" is hidden; "Open
   Link" still resolves to the authenticated download URL.

## Related

- Fixes the dead-href half of #84361 (a real `file://` href instead of `#`).
  The other half of #84361 (MEDIA tag regex absorbing trailing markdown) is
  addressed separately by #85790.
- Chat-attachment reveal parallels #58997 / #84986 (those cover Preview links;
  this covers MEDIA chat attachments).

## Platforms tested

- macOS (arm64, packaged desktop build), local connection.
- Desktop vitest suite green — 420 tests incl. new
  `markdown-text.reveal.test.tsx` (real href + reveal click + remote-hide).
