### PR TITLE
fix(desktop): add rejection handlers to preview open/close routing

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-preview-routing.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-preview-routing.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/local-preview')
+vi.mock('@/lib/preview-reach')
+vi.mock('@/store/preview')
+vi.mock('@/lib/gateway-events')
+
+import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
+import { reachablePreviewUrl } from '@/lib/preview-reach'
+import { closePreviewMatching, openPreview } from '@/store/preview'
+
+import { resolveAndClosePreview, resolveAndOpenPreview } from './use-preview-routing'
+
+describe('use-preview-routing rejection handlers', () => {
+  afterEach(() => { vi.clearAllMocks() })
+
+  describe('resolveAndOpenPreview', () => {
+    it('opens preview when normalizeOrLocalPreviewTarget resolves', async () => {
+      vi.mocked(normalizeOrLocalPreviewTarget).mockResolvedValue({ kind: 'url', url: 'https://x.com', source: 'https://x.com', label: '' } as any)
+      vi.mocked(reachablePreviewUrl).mockResolvedValue('https://x.com')
+      await resolveAndOpenPreview('https://x.com', 'Page', undefined)
+      expect(openPreview).toHaveBeenCalled()
+    })
+
+    it('does not throw and does not open preview when normalizeOrLocalPreviewTarget rejects', async () => {
+      vi.mocked(normalizeOrLocalPreviewTarget).mockRejectedValue(new Error('network'))
+      await expect(resolveAndOpenPreview('bad://url', '', undefined)).resolves.toBeUndefined()
+      expect(openPreview).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('resolveAndClosePreview', () => {
+    it('closes preview with resolved candidates when normalizeOrLocalPreviewTarget resolves', async () => {
+      vi.mocked(normalizeOrLocalPreviewTarget).mockResolvedValue({ kind: 'url', url: 'https://x.com', source: 'https://x.com' } as any)
+      vi.mocked(reachablePreviewUrl).mockResolvedValue('https://x.com')
+      await resolveAndClosePreview('https://x.com', undefined)
+      expect(closePreviewMatching).toHaveBeenCalledWith('https://x.com', 'https://x.com', 'https://x.com', 'https://x.com')
+    })
+
+    it('falls back to raw target when normalizeOrLocalPreviewTarget rejects', async () => {
+      vi.mocked(normalizeOrLocalPreviewTarget).mockRejectedValue(new Error('network'))
+      await resolveAndClosePreview('https://x.com', undefined)
+      expect(closePreviewMatching).toHaveBeenCalledWith('https://x.com')
+    })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-preview-routing.ts
+++ b/apps/desktop/src/app/session/hooks/use-preview-routing.ts
@@ -37,6 +37,48 @@ function sessionIsOnScreen(sessionId: string): boolean {
   )
 }
 
+export async function resolveAndOpenPreview(target: string, label: string, cwd: string | undefined): Promise<void> {
+  await normalizeOrLocalPreviewTarget(target, cwd).then(
+    async resolved => {
+      if (!resolved) {
+        return
+      }
+
+      const trimmedLabel = label.trim()
+      // The agent's loopback is the GATEWAY's loopback. Give the pane a
+      // URL this machine can load, keeping the original as the label so
+      // the user still sees the address the agent named.
+      const url = resolved.kind === 'url' ? await reachablePreviewUrl(resolved.url) : resolved.url
+      const reached = url === resolved.url ? resolved : { ...resolved, label: resolved.label || target, url }
+
+      openPreview(trimmedLabel ? { ...reached, label: trimmedLabel } : reached, 'tool-result')
+    }
+  ).catch(err => {
+    console.debug('[preview.open] normalizeOrLocalPreviewTarget rejected:', err)
+  })
+}
+
+export async function resolveAndClosePreview(target: string, cwd: string | undefined): Promise<void> {
+  await normalizeOrLocalPreviewTarget(target, cwd).then(
+    async resolved => {
+      const candidates = [target]
+
+      if (resolved) {
+        candidates.push(resolved.source, resolved.url)
+
+        if (resolved.kind === 'url') {
+          candidates.push(await reachablePreviewUrl(resolved.url))
+        }
+      }
+
+      closePreviewMatching(...candidates)
+    }
+  ).catch(() => {
+    // normalizeOrLocalPreviewTarget rejected — fall back to closing by the raw target string
+    closePreviewMatching(target)
+  })
+}
+
 export function usePreviewRouting({ baseHandleGatewayEvent, currentCwd, requestGateway }: PreviewRoutingOptions) {
   const restartPreviewServer = useCallback(
     async (url: string, context?: string) => {
@@ -87,22 +129,7 @@ export function usePreviewRouting({ baseHandleGatewayEvent, currentCwd, requestG
         const target = typeof url === 'string' ? url.trim() : ''
 
         if (target && (!event.session_id || sessionIsOnScreen(event.session_id))) {
-          void normalizeOrLocalPreviewTarget(target, $currentCwd.get() || currentCwd || undefined).then(
-            async resolved => {
-              if (!resolved) {
-                return
-              }
-
-              const trimmedLabel = typeof label === 'string' ? label.trim() : ''
-              // The agent's loopback is the GATEWAY's loopback. Give the pane a
-              // URL this machine can load, keeping the original as the label so
-              // the user still sees the address the agent named.
-              const url = resolved.kind === 'url' ? await reachablePreviewUrl(resolved.url) : resolved.url
-              const reached = url === resolved.url ? resolved : { ...resolved, label: resolved.label || target, url }
-
-              openPreview(trimmedLabel ? { ...reached, label: trimmedLabel } : reached, 'tool-result')
-            }
-          )
+          void resolveAndOpenPreview(target, typeof label === 'string' ? label : '', $currentCwd.get() || currentCwd || undefined)
         }
 
         return
@@ -129,21 +156,7 @@ export function usePreviewRouting({ baseHandleGatewayEvent, currentCwd, requestG
           return
         }
 
-        void normalizeOrLocalPreviewTarget(target, $currentCwd.get() || currentCwd || undefined).then(
-          async resolved => {
-            const candidates = [target]
-
-            if (resolved) {
-              candidates.push(resolved.source, resolved.url)
-
-              if (resolved.kind === 'url') {
-                candidates.push(await reachablePreviewUrl(resolved.url))
-              }
-            }
-
-            closePreviewMatching(...candidates)
-          }
-        )
+        void resolveAndClosePreview(target, $currentCwd.get() || currentCwd || undefined)
 
         return
       }


### PR DESCRIPTION
## What does this PR do?

Two calls to `normalizeOrLocalPreviewTarget(...).then(...)` in `use-preview-routing.ts` have no rejection branch. If `normalizeOrLocalPreviewTarget` rejects (network error, unsupported URL scheme, or IPC failure), the preview pane silently fails to open or close with no error feedback.

* `preview.open` path (line 90): rejection causes the preview pane to silently not open — the agent emitted `open_preview` but nothing happened.
* `preview.close` path (line 132): rejection causes the preview pane to silently not close — the agent emitted `close_preview` but the pane stayed open.

**Fix:** added `.catch()` to both call sites. The open path ignores the rejection (leaves the pane as-is). The close path falls back to `closePreviewMatching(target)` using the raw target string, which may still match an open tab.

## Related Issue

Fixes #

## Type of Change

* 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

* `apps/desktop/src/app/session/hooks/use-preview-routing.ts`: added `.catch()` to both `normalizeOrLocalPreviewTarget` call sites.
* `apps/desktop/src/app/session/hooks/use-preview-routing.test.ts`: 4 tests covering resolve and reject paths for both open and close routing.

## How to Test

```
cd apps/desktop && npx vitest run src/app/session/hooks/use-preview-routing.test.ts
```

4 tests pass.

## Checklist

### Code

* Contributing Guide read
* Conventional Commits followed
* No duplicate PRs found
* Only this fix in the PR
* 4 tests pass
* Tested on: WSL2 Ubuntu

### Documentation & Housekeeping

* No docs changes needed — N/A
* No config key changes — N/A
* Security impact: none