### PR TITLE
fix(gateway): send CORS headers on session chat/stream and run-events SSE

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4075,6 +4075,15 @@ class APIServerAdapter(BasePlatformAdapter):
             "X-Accel-Buffering": "no",
             "X-Hermes-Session-Id": session_id,
         }
+        # CORS middleware can't inject headers into StreamResponse after
+        # prepare() flushes them, so resolve CORS headers up front — same as
+        # _write_sse_chat_completion. Without this a cross-origin browser
+        # client gets a 200 it is forbidden to read: the request succeeds and
+        # the agent runs, but the caller sees only a generic fetch error.
+        origin = request.headers.get("Origin", "")
+        cors = self._cors_headers_for_origin(origin) if origin else None
+        if cors:
+            headers.update(cors)
         if gateway_session_key:
             headers["X-Hermes-Session-Key"] = gateway_session_key
         response = web.StreamResponse(status=200, headers=headers)
@@ -7128,14 +7137,19 @@ class APIServerAdapter(BasePlatformAdapter):
         q = self._run_streams[run_id]
         self._run_stream_subscribers.add(run_id)
 
-        response = web.StreamResponse(
-            status=200,
-            headers={
-                "Content-Type": "text/event-stream",
-                "Cache-Control": "no-cache",
-                "X-Accel-Buffering": "no",
-            },
-        )
+        sse_headers = {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        }
+        # Same up-front CORS resolution as _write_sse_chat_completion: the
+        # middleware cannot amend a StreamResponse after prepare(), and
+        # /v1/capabilities advertises run_events_sse to browser clients.
+        origin = request.headers.get("Origin", "")
+        cors = self._cors_headers_for_origin(origin) if origin else None
+        if cors:
+            sse_headers.update(cors)
+        response = web.StreamResponse(status=200, headers=sse_headers)
         await response.prepare(request)
 
         try:

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -891,3 +891,85 @@ async def test_patch_session_still_rejects_unknown_fields(adapter, session_db):
         resp = await cli.patch(f"/api/sessions/{session_id}", json={"nonsense": 1})
         assert resp.status == 400, await resp.text()
         assert (await resp.json())["error"]["code"] == "unsupported_session_field"
+
+
+# ── CORS on streaming responses ──────────────────────────────────────────────
+# The CORS middleware cannot amend a StreamResponse after prepare() flushes
+# its headers, so SSE handlers must resolve CORS up front (the pattern
+# _write_sse_chat_completion and _write_sse_responses already follow). Two SSE
+# exits shipped without it — POST /api/sessions/{id}/chat/stream and
+# GET /v1/runs/{id}/events — so a cross-origin browser client received a 200
+# it was forbidden to read: the request succeeded, the agent ran and billed
+# tokens, but the caller saw only a generic fetch error. /v1/capabilities
+# advertises both surfaces (session_chat_streaming, run_events_sse) to
+# browser clients, so they must actually be browser-readable.
+
+
+@pytest.fixture
+def cors_adapter(session_db):
+    adapter = APIServerAdapter(
+        PlatformConfig(enabled=True, extra={"cors_origins": "https://app.example"})
+    )
+    adapter._session_db = session_db
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_carries_cors_headers(cors_adapter, session_db):
+    session_id = session_db.create_session("cors-stream", "api_server")
+
+    async def fake_run(**kwargs):
+        return {"final_response": "ok", "session_id": session_id}, {"total_tokens": 1}
+
+    app = _create_session_app(cors_adapter)
+    with patch.object(cors_adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                json={"message": "hi"},
+                headers={"Origin": "https://app.example"},
+            )
+            assert resp.status == 200
+            assert resp.headers.get("Access-Control-Allow-Origin") == "https://app.example"
+            assert resp.headers.get("Content-Type", "").startswith("text/event-stream")
+            await resp.text()
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_without_origin_adds_no_cors(cors_adapter, session_db):
+    """Non-browser callers keep exactly the old header surface."""
+    session_id = session_db.create_session("no-origin", "api_server")
+
+    async def fake_run(**kwargs):
+        return {"final_response": "ok", "session_id": session_id}, {"total_tokens": 1}
+
+    app = _create_session_app(cors_adapter)
+    with patch.object(cors_adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream", json={"message": "hi"}
+            )
+            assert resp.status == 200
+            assert "Access-Control-Allow-Origin" not in resp.headers
+            await resp.text()
+
+
+@pytest.mark.asyncio
+async def test_run_events_sse_carries_cors_headers(cors_adapter):
+    import asyncio as _asyncio
+
+    run_id = "run_cors_events"
+    q: "_asyncio.Queue" = _asyncio.Queue()
+    cors_adapter._run_streams[run_id] = q
+    q.put_nowait(None)  # terminate the stream right after the headers
+
+    app = web.Application()
+    app.router.add_get("/v1/runs/{run_id}/events", cors_adapter._handle_run_events)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get(
+            f"/v1/runs/{run_id}/events",
+            headers={"Origin": "https://app.example"},
+        )
+        assert resp.status == 200
+        assert resp.headers.get("Access-Control-Allow-Origin") == "https://app.example"
+        await resp.text()


### PR DESCRIPTION
## Problem

Two SSE endpoints return `200 text/event-stream` without any `Access-Control-*` headers, so a cross-origin browser client is forbidden from reading the response body:

- `POST /api/sessions/{session_id}/chat/stream`
- `GET /v1/runs/{run_id}/events`

The failure mode is nasty: the request **succeeds** server-side — the agent runs and consumes model tokens — but the browser surfaces only a generic `Failed to fetch`. Both surfaces are advertised to browser clients via `/v1/capabilities` (`session_chat_streaming`, `run_events_sse`), so as shipped the capability announcement is not honoured for cross-origin callers.

## Root cause

The CORS middleware cannot inject headers into a `web.StreamResponse` after `prepare()` flushes them. `_write_sse_chat_completion` and `_write_sse_responses` already resolve CORS up front for exactly this reason (the comment is in the file), but these two exits were missed.

## Fix

Apply the same idiom at both sites: resolve `self._cors_headers_for_origin(origin)` before constructing the `StreamResponse`. Same configured-allowlist policy as every other endpoint — nothing is opened up that the non-streaming endpoints don't already allow, and callers without an `Origin` header keep exactly the old header surface.

## Tests

Three tests added to `tests/gateway/test_session_api.py`:

- chat/stream carries `Access-Control-Allow-Origin` for an allowed origin
- chat/stream without `Origin` adds no CORS headers (negative — non-browser callers unchanged)
- run-events SSE carries `Access-Control-Allow-Origin`

All three fail without the fix; full `tests/gateway/test_session_api.py` suite passes with it.

Found while integrating a cross-origin SPA that talks directly to the gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)