### PR TITLE
fix(tui): restore Shift+letter case in the composer for extended-key terminals

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/events/cmd-shortcuts.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/events/cmd-shortcuts.test.ts
@@ -62,4 +62,32 @@ describe('enhanced keyboard modifier parsing', () => {
     expect(right.key.rightArrow).toBe(true)
     expect(right.key.super).toBe(true)
   })
+
+  it('restores uppercase for Shift+letter via kitty CSI u (Ghostty) so the composer gets "R"', () => {
+    // Ghostty with TERM=xterm-ghostty reports Shift+R as CSI 82;2u. The
+    // parser lowercases the keycode to name 'r' and sets shift=true; the
+    // input layer must re-capitalize so the composer receives 'R', not 'r'.
+    const shiftR = new InputEvent(parseOne('\u001b[82;2u'))
+    expect(shiftR.key.shift).toBe(true)
+    expect(shiftR.input).toBe('R')
+
+    const shiftA = new InputEvent(parseOne('\u001b[65;2u'))
+    expect(shiftA.input).toBe('A')
+
+    // Plain lowercase must stay lowercase.
+    const plainR = new InputEvent(parseOne('\u001b[114;1u'))
+    expect(plainR.key.shift).toBe(false)
+    expect(plainR.input).toBe('r')
+  })
+
+  it('restores uppercase for Shift+letter via xterm modifyOtherKeys so the composer gets "R"', () => {
+    // modifyOtherKeys form of the same bug: Shift+R is [27;2;82~.
+    const shiftR = new InputEvent(parseOne('\u001b[27;2;82~'))
+    expect(shiftR.key.shift).toBe(true)
+    expect(shiftR.input).toBe('R')
+
+    const plainR = new InputEvent(parseOne('\u001b[27;1;114~'))
+    expect(plainR.key.shift).toBe(false)
+    expect(plainR.input).toBe('r')
+  })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/events/input-event.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/events/input-event.ts
@@ -2,8 +2,20 @@ import { nonAlphanumericKeys, type ParsedKey } from '../parse-keypress.js'
 
 import { Event } from './event.js'
 
-const inputForSpecialSequence = (name: string): string =>
-  name === 'space' ? ' ' : name === 'return' || name === 'escape' ? '' : name
+const inputForSpecialSequence = (name: string, shift: boolean): string => {
+  const input = name === 'space' ? ' ' : name === 'return' || name === 'escape' ? '' : name
+
+  // Extended-key protocols (CSI u / xterm modifyOtherKeys) report printable
+  // letters as their lowercase keycode, so Shift+R arrives as name 'r' with
+  // shift=true. Re-apply shift to a single lowercase letter so the composer
+  // receives 'R', not 'r'. Keybinding consumers still see the lowercase
+  // canonical name via key.name — only the inserted text is case-restored.
+  if (shift && input.length === 1 && input >= 'a' && input <= 'z') {
+    return input.toUpperCase()
+  }
+
+  return input
+}
 
 export type Key = {
   upArrow: boolean
@@ -112,7 +124,7 @@ function parseKey(keypress: ParsedKey): [Key, string] {
       // so the raw "[57358u" doesn't leak into the prompt. See #38781.
       input = ''
     } else {
-      input = inputForSpecialSequence(keypress.name)
+      input = inputForSpecialSequence(keypress.name, keypress.shift)
     }
 
     processedAsSpecialSequence = true
@@ -130,7 +142,7 @@ function parseKey(keypress: ParsedKey): [Key, string] {
       // guards against future terminal behavior.
       input = ''
     } else {
-      input = inputForSpecialSequence(keypress.name)
+      input = inputForSpecialSequence(keypress.name, keypress.shift)
     }
 
     processedAsSpecialSequence = true


### PR DESCRIPTION
## What does this PR do?

Restores uppercase input in the Ink TUI composer for terminals that report
modified letters via the extended-key protocols (kitty CSI-u and xterm
modifyOtherKeys). On Ghostty with `TERM=xterm-ghostty`, typing `Shift+R`
inserted a lowercase `r` — uppercase input was silently destroyed.

Root cause: `keycodeToName()` lowercases the printable ASCII range
(`parse-keypress.ts`), so `Shift+R` arrives as name `'r'` with
`shift: true`. The input layer then built the composer text from that
lowercased name and discarded the `shift` flag. The flag was parsed
correctly the whole time — it just never got re-applied to the inserted
character.

The fix re-applies `shift` to a single lowercase letter in
`inputForSpecialSequence`, which is the shared helper for both the CSI-u and
modifyOtherKeys paths. Keybinding consumers still see the lowercase
canonical name via `key.name` (so `shift+r`-style bindings are unaffected);
only the inserted text is case-restored.

## Related Issue

Fixes #90663

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/packages/hermes-ink/src/ink/events/input-event.ts`
  - `inputForSpecialSequence(name, shift)` now takes the shift flag and
    re-capitalizes a single lowercase letter (`a`–`z`) when `shift` is set.
  - Both call sites (CSI-u branch and modifyOtherKeys branch) now pass
    `keypress.shift`.
- `ui-tui/packages/hermes-ink/src/ink/events/cmd-shortcuts.test.ts`
  - Added regression tests covering both protocols: `Shift+R` (CSI `82;2u`
    and modifyOtherKeys `[27;2;82~`) yields input `"R"` with `shift: true`,
    and plain `r` stays lowercase.

## How to Test

1. On macOS with Ghostty, `TERM=xterm-ghostty` (the default), run the TUI.
2. Type `Shift+R` into the prompt composer — it now inserts `R`, not `r`.
3. Verify plain `r` still inserts `r`, and `Shift+Enter` still inserts a
   newline (the extended-key path this machinery exists for is untouched).
4. Unit tests:
   ```
   cd ui-tui && npm install && node_modules/.bin/vitest run \
     packages/hermes-ink/src/ink/events/cmd-shortcuts.test.ts
   ```
   All 6 tests in the file pass (2 new). Full hermes-ink suite: 228 passed;
   the single failure in `ink-backpressure.test.ts` is pre-existing and
   unrelated (reproduces on a clean tree with this change stashed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tui): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (see #87631 — that is the classic CLI/Python/prompt_toolkit variant; this is the TypeScript/Ink TUI path)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test suite and the affected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5, Ghostty, `TERM=xterm-ghostty`

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or architecture changes