### PR TITLE
fix(api-server): require API_SERVER_KEY on GET /health when configured

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2996,7 +2996,15 @@ class APIServerAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def _handle_health(self, request: "web.Request") -> "web.Response":
-        """GET /health — simple health check."""
+        """GET /health — liveness JSON.
+
+        Uses the same bearer check as other API routes when ``API_SERVER_KEY``
+        is configured. A missing key still allows the historical no-auth
+        test/manual-wiring path used by ``_check_auth``.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
         return web.json_response(
             {"status": "ok", "platform": "hermes-agent", "version": _hermes_version()}
         )

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -691,6 +691,26 @@ class TestHealthEndpoint:
             assert isinstance(data["version"], str)
             assert data["version"] != ""
 
+    @pytest.mark.asyncio
+    async def test_health_requires_bearer_when_key_configured(self, auth_adapter):
+        """When API_SERVER_KEY is set, GET /health matches other API routes."""
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            unauth = await cli.get("/health")
+            assert unauth.status == 401
+            body = await unauth.json()
+            assert body["error"]["code"] == "gateway_auth_failed"
+
+            auth = await cli.get("/health", headers={"Authorization": "Bearer sk-secret"})
+            assert auth.status == 200
+            data = await auth.json()
+            assert data["status"] == "ok"
+            assert isinstance(data.get("version"), str) and data["version"] != ""
+
+            v1 = await cli.get("/v1/health", headers={"Authorization": "Bearer sk-secret"})
+            assert v1.status == 200
+
+
 
 # ---------------------------------------------------------------------------
 # /health/detailed endpoint


### PR DESCRIPTION
## Summary

`GET /health` (and `/v1/health`) ignored `API_SERVER_KEY` while `/v1/models` and `/v1/chat/completions` returned 401 without a bearer. Docs say the key is required for every API server deployment, including loopback.

`_handle_health` now uses the same `_check_auth` path as `/health/detailed`. When no key is configured, the existing test/manual-wiring behavior is unchanged (200).

Fixes https://github.com/NousResearch/hermes-agent/issues/90315

## Tests

Added `test_health_requires_bearer_when_key_configured` on `auth_adapter`. Existing no-key `/health` tests still expect 200.

## Notes

No hostnames, tokens, or debug dumps attached.