### PR TITLE
fix(desktop): expanding an overview project shows its full session history

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -156,7 +156,7 @@ import {
   orderProjectsByIds,
   overlayLiveLanes,
   overlayLivePreviews,
-  PROJECT_PREVIEW_COUNT,
+  PROJECT_EXPANDED_SESSION_LIMIT,
   ProjectBackRow,
   ProjectMenu,
   projectTreeCwd,
@@ -1112,10 +1112,10 @@ export function ChatSidebar({
   // matching the flat Recents list. Keyed by project id for the rows.
   const overviewPreviews = useMemo<Record<string, SessionInfo[]>>(
     () =>
-      overlayLivePreviews(projectOverview ?? [], agentSessions, projects, PROJECT_PREVIEW_COUNT, {
+      overlayLivePreviews(projectOverview ?? [], agentSessions, projects, PROJECT_EXPANDED_SESSION_LIMIT, {
         removed: removedSessionIds,
-        // Rank before the trim, so "3 priciest in this project" isn't "3 most
-        // recent, priciest first".
+        // Rank before the trim, so "the priciest in this project" isn't "the
+        // most recent, priciest first".
         rankIds: sortOrderIds
       }),
     [projectOverview, agentSessions, projects, removedSessionIds, sortOrderIds]

--- a/apps/desktop/src/app/chat/sidebar/projects/index.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/index.ts
@@ -2,6 +2,7 @@
 export { EnteredProjectContent } from './entered-content'
 export {
   orderProjectsByIds,
+  PROJECT_EXPANDED_SESSION_LIMIT,
   PROJECT_PREVIEW_COUNT,
   projectTreeCwd,
   sortProjectsForOverview,

--- a/apps/desktop/src/app/chat/sidebar/projects/model.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/model.ts
@@ -16,6 +16,13 @@ export const SIDEBAR_GROUP_PAGE = 5
 // Recent sessions previewed under each project in the overview.
 export const PROJECT_PREVIEW_COUNT = 3
 
+// Sessions rendered when an overview project row is EXPANDED. The tree request
+// ships up to this many sessions per project (aligned with the backend's
+// session window, projects.tree session_limit=2000), so expanding a project
+// shows its full loaded history instead of a 3-row stub with older
+// conversations unreachable from the overview.
+export const PROJECT_EXPANDED_SESSION_LIMIT = 2000
+
 // Max concurrent `git worktree list` probes when a project spans many repos.
 const WORKTREE_PROBE_CONCURRENCY = 4
 

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
@@ -24,10 +24,13 @@ vi.mock('@/i18n', () => ({
   })
 }))
 
+const openState = vi.hoisted(() => ({ value: false }))
+
 vi.mock('./model', () => ({
+  PROJECT_EXPANDED_SESSION_LIMIT: 2000,
   PROJECT_PREVIEW_COUNT: 3,
   latestProjectSessions: () => [],
-  useWorkspaceNodeOpen: () => [false, vi.fn()]
+  useWorkspaceNodeOpen: () => [openState.value, vi.fn()]
 }))
 
 // ProjectMenu (the kebab) has its own dedicated test file — stub it here so
@@ -91,5 +94,23 @@ describe('ProjectOverviewRow', () => {
     const { container } = render(<ProjectOverviewRow project={project} />)
 
     expect(container.querySelector('[data-sessions-project="p1"]')).toBeTruthy()
+  })
+
+  it('expanding renders ALL loaded preview sessions, not a 3-row stub (regression for the four stacked preview caps)', () => {
+    const rows = vi.fn<(sessions: SessionInfo[]) => null>(() => null)
+    const five = Array.from({ length: 5 }, (_, i) => ({ id: `s${i + 1}` }) as unknown as SessionInfo)
+
+    const { rerender } = render(<ProjectOverviewRow previewSessions={five} project={project} renderRows={rows} />)
+
+    // Collapsed by default — nothing rendered yet.
+    expect(rows).not.toHaveBeenCalled()
+
+    // Expand the row.
+    openState.value = true
+    rerender(<ProjectOverviewRow previewSessions={five} project={project} renderRows={rows} />)
+
+    expect(rows).toHaveBeenCalledTimes(1)
+    const received = rows.mock.calls[0]![0] as unknown as SessionInfo[]
+    expect(received.map(session => session.id)).toEqual(['s1', 's2', 's3', 's4', 's5'])
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -19,7 +19,11 @@ import {
   SidebarRowShell
 } from '../chrome'
 
-import { latestProjectSessions, PROJECT_PREVIEW_COUNT, useWorkspaceNodeOpen } from './model'
+import {
+  PROJECT_EXPANDED_SESSION_LIMIT,
+  latestProjectSessions,
+  useWorkspaceNodeOpen
+} from './model'
 import { ProjectContextMenu, ProjectMenu } from './project-menu'
 import type { SidebarProjectTree } from './workspace-groups'
 import { WorkspaceAddButton } from './workspace-header'
@@ -94,8 +98,18 @@ export function ProjectOverviewRow({
   // The appearance popover anchors here (the full row) so it opens flush with
   // the sidebar's content edge regardless of which side the sidebar is on.
   const rowRef = useRef<HTMLDivElement>(null)
-  const fetched = (previewSessions ?? []).slice(0, PROJECT_PREVIEW_COUNT)
-  const preview = renderRows ? (fetched.length ? fetched : latestProjectSessions(project, PROJECT_PREVIEW_COUNT)) : []
+  // Expanding a project shows its FULL loaded history, not a 3-row stub: the
+  // tree now ships up to PROJECT_EXPANDED_SESSION_LIMIT sessions per project,
+  // so an expanded row renders them all. Slicing to a small preview here made
+  // older conversations unreachable from the overview (they only appeared
+  // after drilling into the project). The slice is kept as a ceiling guard
+  // against a backend that ever ships more than the window.
+  const fetched = (previewSessions ?? []).slice(0, PROJECT_EXPANDED_SESSION_LIMIT)
+  const preview = renderRows
+    ? fetched.length
+      ? fetched
+      : latestProjectSessions(project, PROJECT_EXPANDED_SESSION_LIMIT)
+    : []
 
   const lead = reorderable ? (
     <SidebarRowGrab

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -443,7 +443,11 @@ interface ProjectTreePayload {
   scoped_session_ids: string[]
 }
 
-const PROJECT_TREE_PREVIEW_LIMIT = 3
+// Sessions per project the overview tree ships. 3 previews meant expanding a
+// project row showed a stub with no way to reach older conversations; the
+// backend's own session window is 2000 (projects.tree session_limit), so
+// request the full window and let the sidebar render it on expand.
+const PROJECT_TREE_SESSION_LIMIT = 2000
 // The all-profiles fan-out reads one database per profile, so it is allowed the
 // same headroom as the cross-profile session list rather than the interactive
 // default.
@@ -482,7 +486,7 @@ async function refreshProjectTreeOn(context: ActiveProjectsContext): Promise<voi
     const res = await gatewayRequestOn<ProjectTreePayload>(
       gateway,
       'projects.tree',
-      projectParams({ preview_limit: PROJECT_TREE_PREVIEW_LIMIT }, profile)
+      projectParams({ preview_limit: PROJECT_TREE_SESSION_LIMIT }, profile)
     )
 
     if (generation !== projectTreeRefreshGeneration || !stillOnProjectsContext(context)) {
@@ -529,7 +533,7 @@ async function refreshProjectTreeAcrossProfiles(): Promise<void> {
 
   try {
     const res = await hermesApi<ProjectTreePayload>({
-      path: `/api/profiles/projects/tree?preview_limit=${PROJECT_TREE_PREVIEW_LIMIT}`,
+      path: `/api/profiles/projects/tree?preview_limit=${PROJECT_TREE_SESSION_LIMIT}`,
       timeoutMs: PROJECT_TREE_REQUEST_TIMEOUT_MS
     })
 


### PR DESCRIPTION
## Summary

Fixes the Desktop Projects-overview session cap reported in #70421 (and duplicate #90527): expanding any project row showed only the **3 most recent sessions** with no load-more path, making older conversations unreachable from the overview. Since the app returns to the overview on every launch, the cap was hit on every restart.

## Root cause: four stacked "3" truncations

| # | Location | Mechanism |
|---|---|---|
| 1 | `apps/desktop/src/store/projects.ts` — `PROJECT_TREE_PREVIEW_LIMIT = 3` | Tree request sends `preview_limit=3` |
| 2 | `tui_gateway/project_tree.py` — `build_tree(..., hydrate=False)` | Overview mode empties lane `sessions` arrays; each project carries only `previewSessions` (≤ preview_limit). Drill-in (hydrate=True) returns full rows |
| 3 | `apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx` | `fetched.slice(0, PROJECT_PREVIEW_COUNT)` trims again at render |
| 4 | `apps/desktop/src/app/chat/sidebar/index.tsx` — `overlayLivePreviews(..., PROJECT_PREVIEW_COUNT, ...)` | Merged live+tree previews trimmed to 3 again |

## Change

- `store/projects.ts`: `PROJECT_TREE_PREVIEW_LIMIT = 3 → 2000`, aligned with the backend's existing session window (`projects.tree` `session_limit=2000`). Tree rows are compact (~18 fields), so the payload stays slim.
- `projects/model.ts`: add `PROJECT_EXPANDED_SESSION_LIMIT = 2000`. **`PROJECT_PREVIEW_COUNT` stays 3** — it is also used by profile-group previews (`workspace-group.tsx`), where a small summary is intentional.
- `overview-row.tsx`: expanded rows render the full loaded `previewSessions` (slice kept only as a ceiling guard).
- `sidebar/index.tsx`: `overlayLivePreviews` trims at the expanded limit instead of the preview count.
- `projects/index.ts` re-exports the new constant; `overview-row.test.tsx` mock updated.

**Backend unchanged**: both `projects.tree` RPC and `/api/profiles/projects/tree` already accept `preview_limit`.

## Verification

- `npx vitest run src/app/chat/sidebar` — 171/171 pass
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npm run pack` builds; unpacked bundle confirmed to ship `preview_limit=2000`
- Live: expanded project rows render the full session list (verified in the running app on macOS arm64)

Refs #70421, #90527
