### PR TITLE
fix(cron): nudge review of escaped-run failures too

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6608,7 +6608,14 @@ def _run_one_job_body(
                 delivery_attempted = True
                 delivery_error = _deliver_result(
                     job,
-                    _summarize_cron_failure_for_delivery(job, _err_text),
+                    # Composed exactly like the normal failure delivery above.
+                    # mark_job_run below records THIS run in failure_streak
+                    # whichever layer failed, so a job that fails before the
+                    # run body every tick builds a streak nobody is ever told
+                    # about: its alerts only ever leave through here, and the
+                    # nudge only ever left through there (#88655).
+                    _summarize_cron_failure_for_delivery(job, _err_text)
+                    + _failure_streak_nudge(job),
                     adapters=adapters,
                     loop=loop,
                 )

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -161,6 +161,82 @@ def test_run_one_job_exception_records_failure_alert_delivery_error(monkeypatch)
     ]
 
 
+def _patch_escaped_failure(monkeypatch, delivered, *, exec_id, err):
+    """Make run_job raise, and capture what the escape handler delivers."""
+    monkeypatch.setattr(s, "create_execution", lambda *_a, **_kw: {"id": exec_id})
+    monkeypatch.setattr(s, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(s, "mark_execution_running", lambda _execution_id: None)
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError(err)),
+    )
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda job, content, **_kw: delivered.append(content) or None,
+    )
+    monkeypatch.setattr(s, "mark_job_run", lambda *_a, **_kw: None)
+    monkeypatch.setattr(s, "finish_execution", lambda *_a, **_kw: None)
+    # Deterministic threshold: default 3, independent of the host config.
+    monkeypatch.setattr(s, "load_config", lambda: {})
+
+
+def test_escaped_failure_delivery_carries_the_streak_nudge(monkeypatch):
+    """A repeatedly-failing job must be nudged even when it fails at the
+    scheduler layer (#88655).
+
+    ``mark_job_run`` increments ``failure_streak`` for an escaped failure just
+    as it does for an agent failure, so the counter climbs either way. But the
+    nudge that spends it was only composed on the normal delivery path, so a
+    job that raises before the run body on every tick - a bad import from a
+    half-applied update, a provider client that cannot construct - alerts
+    forever and is never told it should be reviewed or paused. Nothing else
+    surfaces the streak in chat.
+    """
+    delivered = []
+    _patch_escaped_failure(
+        monkeypatch, delivered, exec_id="exec-j5", err="cannot import name X"
+    )
+
+    ok = s.run_one_job(
+        {
+            "id": "j5",
+            "name": "scout",
+            "deliver": "telegram",
+            "schedule": {"kind": "interval"},
+            "failure_streak": 2,  # + this run = 3 = default threshold
+        }
+    )
+
+    assert ok is False
+    assert len(delivered) == 1
+    assert "cannot import name X" in delivered[0]
+    assert "failed 3 runs in a row" in delivered[0]
+    assert "hermes cron pause scout" in delivered[0]
+
+
+def test_escaped_failure_delivery_stays_quiet_below_the_threshold(monkeypatch):
+    """The nudge is appended, not always-on: a first failure reads as before."""
+    delivered = []
+    _patch_escaped_failure(
+        monkeypatch, delivered, exec_id="exec-j6", err="provider failed"
+    )
+
+    ok = s.run_one_job(
+        {
+            "id": "j6",
+            "name": "scout",
+            "deliver": "telegram",
+            "schedule": {"kind": "interval"},
+            "failure_streak": 0,
+        }
+    )
+
+    assert ok is False
+    assert delivered == ["⚠️ Cron 'scout' failed: provider failed"]
+
+
 def test_run_one_job_exception_after_delivery_does_not_redeliver(monkeypatch):
     """Once delivery has been attempted, the outer handler must not send again."""
     delivered = []

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -330,13 +330,15 @@ ledger is included in quick backups.
 
 ### Repeated-failure review nudge
 
-Each job tracks a `failure_streak` — consecutive runs where the agent failed
-(delivery failures don't count). When a *recurring* job's streak reaches the
-threshold, the failure message delivered to chat gains a review nudge telling
-you the job has failed N runs in a row and suggesting you fix, pause
-(`hermes cron pause <job>`), or remove it. Any successful run resets the
-streak, and `hermes cron list` shows the streak alongside a failing job's last
-run. One-shot jobs never nudge.
+Each job tracks a `failure_streak` — consecutive failed runs (delivery
+failures don't count). A run that fails before the agent is reached at all —
+a bad import after a half-applied update, a provider client that cannot be
+constructed — counts and alerts the same as one the agent itself failed. When
+a *recurring* job's streak reaches the threshold, the failure message
+delivered to chat gains a review nudge telling you the job has failed N runs
+in a row and suggesting you fix, pause (`hermes cron pause <job>`), or remove
+it. Any successful run resets the streak, and `hermes cron list` shows the
+streak alongside a failing job's last run. One-shot jobs never nudge.
 
 ```yaml
 cron:


### PR DESCRIPTION
## What does this PR do?

Makes the repeated-failure review nudge reach the failures that need it most.

`_failure_streak_nudge` (#80752) appends "this job has failed N runs in a row, worth a review" to a recurring job's failure alert once its streak hits `cron.failure_nudge_threshold`. It is composed at exactly one place: the normal delivery in `_run_one_job_body`'s `try` body.

Eight days later, `4668750fa` gave the outer `except BaseException` handler a delivery of its own, so an exception that escapes the run body finally alerts instead of being bookkeeping-only. That new site calls `_summarize_cron_failure_for_delivery` **without** the nudge, so the nudge is unreachable for a job whose failures all escape.

That is not a hypothetical set of failures. It is the set that repeats:

- **The streak is layer-agnostic.** `mark_job_run(job_id, False, ...)` increments `failure_streak` regardless of which layer failed, and the escape handler calls it (right after the delivery, same ordering as the normal path, so the helper's `stored + 1` arithmetic is already correct there).
- **So the counter climbs and is spendable nowhere.** `hermes cron list` shows `(N failures in a row)`; the chat alert never says it. Chat is where an unattended operator actually is.
- **Escaped failures are deterministic by nature**: a bad import from a half-applied update, a provider client that cannot construct, a missing script interpreter. They fail identically on every tick. A job on `every 10m` sends 30 identical one-liners over five hours and is never told the automation is worth pausing, which is exactly what #88655 reports.

The fix is to compose the alert at the escape handler the same way the normal path composes it. Same helper, same config gate, same threshold gate: a first-time escaped failure is byte-for-byte what it was before.

**Why here and not inside the summarizer.** Folding the nudge into `_summarize_cron_failure_for_delivery` would make it unforgettable, which is tempting given this is the second delivery site to be written without it. I did not, for two reasons, and I will take a maintainer's call to the contrary: the summarizer is a pure formatting helper (folding it in makes it read config), and every existing caller composes the two explicitly, so folding in would double-append for anyone who keeps that composition, including the open #88493, which composes it at two call sites. Worth noting that PR rewrites both delivery sites and preserves this asymmetry; I have left a note there so it survives whichever of us rebases onto the other.

**What this does not cover.** `deliver: local` jobs still receive no alert at all, nudge or otherwise, because `_deliver_result` has nowhere to send it. That is a separate gap, already tracked as #86998 and addressed by #87024.

## Related Issue

Fixes #88655

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`cron/scheduler.py`** (~line 6611): the `except BaseException` handler's `_deliver_result` call now sends `_summarize_cron_failure_for_delivery(job, _err_text) + _failure_streak_nudge(job)`, matching the normal failure delivery. A comment records why the two sites must stay in step.
- **`tests/cron/test_run_one_job.py`**: two cases on the escaped-failure delivery path, plus a small `_patch_escaped_failure` helper in the style of the existing escaped-failure tests from `4668750fa`.
- **`website/docs/user-guide/features/cron.md`**: the nudge section said the streak counts "consecutive runs where the agent failed". `mark_job_run` has never distinguished layers, and that sentence is what the reporter read before concluding their failures were out of scope by design. Corrected to match the code.

## How to Test

1. `pytest tests/cron/test_run_one_job.py -q` gives **10 passed**.
2. Revert the `cron/scheduler.py` hunk and re-run `-k escaped_failure`:

   ```
   >       assert "failed 3 runs in a row" in delivered[0]
   E       assert 'failed 3 runs in a row' in "⚠️ Cron 'scout' failed: cannot import name X"
   FAILED tests/cron/test_run_one_job.py::test_escaped_failure_delivery_carries_the_streak_nudge
   1 failed, 1 passed
   ```

   The threshold case fails with the exact pre-fix message; the below-threshold case passes either way, so it is a real guard against an unconditional nudge rather than a copy of the change.
3. End to end, without waiting for a real streak: create a recurring job whose prompt cannot run (e.g. a script job pointing at a missing interpreter), set `cron.failure_nudge_threshold: 1`, and let it fire. The delivered alert carries the review nudge; before this change it never did, at any threshold or streak length.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites and all tests pass, see the note below
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.12

> On the full-suite box: `pytest tests/cron -q` gives **766 passed, 10 failed** here, and I checked every one of those 10 against the same commit with this diff stashed. Eight are POSIX-only and fail identically unpatched (`test_file_permissions.py` asserting `0700`/`0600` modes, `test_cron_workdir.py::test_tilde_expands`, `test_media_delivery_parity.py`). The other two (`test_cleanup_timeout.py::test_run_job_bounds_sessiondb_finalization`, `test_script_claim_heartbeat.py::test_repeated_heartbeat_errors_cancel_after_bounded_grace`) are wall-clock-bounded and pass in isolation with this diff applied, so they are load-sensitive under the full run rather than caused by this change. Linux CI is the authority on all ten.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings): the cron nudge section, see above
- [x] N/A, no config keys added or changed (`cron.failure_nudge_threshold` already exists and is unchanged)
- [x] N/A, no architecture or workflow change
- [x] N/A, pure Python string composition, no platform-specific behaviour
- [x] N/A, no tool descriptions or schemas touched

## Screenshots / Logs

The reporter's incident, as it reads before and after. A job on `every 10m` whose every run dies at the scheduler layer:

**Before**, the same line, every ten minutes, for five hours:

```
⚠️ Cron 'morning-scout' failed: cannot import name '_MAX_TOOL_ERROR_CHARS' from 'tools.registry'
```

**After**, identical for the first two, then from the third onward:

```
⚠️ Cron 'morning-scout' failed: cannot import name '_MAX_TOOL_ERROR_CHARS' from 'tools.registry'
This job has failed 3 runs in a row - worth a review. Fix its prompt/config, or pause it with `hermes cron pause morning-scout` (resume/remove also available) to stop the noise.
```
