### PR TITLE
fix(desktop): preserve registry scope for remote fs and git

### DIFF
--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -144,6 +144,18 @@ describe('desktop filesystem facade', () => {
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/default-cwd', profile: 'remote-docker' })
   })
 
+  it('keeps remote filesystem requests on the active registry connection', async () => {
+    $connection.set({ connectionId: 'rankast-linux', mode: 'remote', profile: 'coder' } as never)
+
+    await readDesktopDir('/srv/project')
+
+    expect(api).toHaveBeenCalledWith({
+      connectionId: 'rankast-linux',
+      path: '/api/fs/list?path=%2Fsrv%2Fproject',
+      profile: 'coder'
+    })
+  })
+
   it('keys SSH filesystem caches by stable host identity instead of the forwarded port', () => {
     $connection.set({
       mode: 'remote',

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -37,10 +37,16 @@ export function isDesktopFsRemoteMode() {
   return $connection.get()?.mode === 'remote'
 }
 
-// Active profile for FS/git REST calls. Without it the Electron api bridge
-// hits the primary (local) backend even when the user switched to a remote profile.
-export function desktopFsProfile(): string | undefined {
-  return $connection.get()?.profile || undefined
+// Active scope for FS/git REST calls. Without the registry connection id the
+// Electron API bridge falls back to the local profile pool, even when the
+// selected profile belongs to a registered remote gateway.
+export function desktopFsApiScope(): { connectionId?: string; profile?: string } {
+  const connection = $connection.get()
+
+  return {
+    ...(connection?.connectionId ? { connectionId: connection.connectionId } : {}),
+    ...(connection?.profile ? { profile: connection.profile } : {})
+  }
 }
 
 function fsPath(endpoint: string, filePath: string) {
@@ -59,7 +65,7 @@ function bridge() {
 
 function remoteFsApi<T>(path: string, body?: Record<string, unknown>): Promise<T> {
   return bridge().api<T>(
-    body ? { body, method: 'POST', path, profile: desktopFsProfile() } : { path, profile: desktopFsProfile() }
+    body ? { body, method: 'POST', path, ...desktopFsApiScope() } : { path, ...desktopFsApiScope() }
   )
 }
 

--- a/apps/desktop/src/lib/desktop-git.test.ts
+++ b/apps/desktop/src/lib/desktop-git.test.ts
@@ -90,6 +90,20 @@ describe('desktop git facade', () => {
     })
   })
 
+  it('keeps remote git mutations on the active registry connection', async () => {
+    $connection.set({ connectionId: 'rankast-linux', mode: 'remote', profile: 'coder' } as never)
+
+    await desktopGit()?.branchSwitch('/srv/work', 'main')
+
+    expect(api).toHaveBeenCalledWith({
+      body: { branch: 'main', path: '/srv/work' },
+      connectionId: 'rankast-linux',
+      method: 'POST',
+      path: '/api/git/branch/switch',
+      profile: 'coder'
+    })
+  })
+
   it('sends mutations as POST bodies on a remote gateway', async () => {
     $connection.set({ mode: 'remote' } as never)
 

--- a/apps/desktop/src/lib/desktop-git.ts
+++ b/apps/desktop/src/lib/desktop-git.ts
@@ -8,7 +8,7 @@ import type {
   HermesReviewShipInfo
 } from '@/global'
 
-import { desktopFsProfile, isDesktopFsRemoteMode } from './desktop-fs'
+import { desktopFsApiScope, isDesktopFsRemoteMode } from './desktop-fs'
 
 // Remote-aware git facade. Locally the desktop runs git through Electron
 // (window.hermesDesktop.git); on a remote gateway that's the wrong filesystem,
@@ -26,7 +26,7 @@ function desktopApi<T>(path: string, body?: Record<string, unknown>): Promise<T>
   }
 
   return desktop.api<T>(
-    body ? { body, method: 'POST', path, profile: desktopFsProfile() } : { path, profile: desktopFsProfile() }
+    body ? { body, method: 'POST', path, ...desktopFsApiScope() } : { path, ...desktopFsApiScope() }
   )
 }
 


### PR DESCRIPTION
## What does this PR do?

Remote Desktop filesystem and git REST requests carried the active `profile`, but not the registered gateway `connectionId`. After Desktop introduced registry-routed sources, a request such as `/api/git/branch/switch` could therefore fall through to Electron's local profile pool. For a profile that exists only on the remote gateway, that produced `Profile "coder" no longer exists` and prevented starting work on the selected branch.

This change derives one `{ connectionId, profile }` scope from the active renderer connection and applies it consistently to remote FS and git GET/POST requests. Local operations still use the native Electron bridge, while legacy remote requests without a registry connection retain their previous profile-only or unscoped shapes.

## Related Issue

No issue filed; reproduced against current `main` with a registered remote gateway profile.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `desktopFsApiScope()` as the single owner of remote `{ connectionId, profile }` routing metadata.
- Route remote filesystem reads/writes and remote git reads/mutations through that complete scope.
- Add regression coverage for a registered `rankast-linux` connection using remote profile `coder`.
- Preserve existing local, unscoped remote, and profile-only legacy behavior.

## How to Test

1. Register a remote gateway connection with a profile that does not exist locally.
2. Select that profile in Desktop and start work on the repository's `main` branch.
3. Confirm the `/api/git/branch/switch` request is routed with both the owning `connectionId` and profile, and no local `Profile "..." no longer exists` error appears.

Automated verification:

- `npm run test:ui -- src/lib/desktop-fs.test.ts src/lib/desktop-git.test.ts` — 19/19 passed
- `npm run typecheck` — passed
- `npm exec eslint -- src/lib/desktop-fs.ts src/lib/desktop-fs.test.ts src/lib/desktop-git.ts src/lib/desktop-git.test.ts` — passed
- `git diff --check origin/main...HEAD` — passed
- Windows x64 NSIS package built successfully with Electron Builder/Wine; packaged bundle and native binding verified

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing open and merged PRs/issues for duplicates
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` — N/A, this is a renderer-only TypeScript change
- [x] I've added tests for my changes
- [x] I've built the Windows x64 NSIS target; final manual install/reproduction remains for a Windows host

### Documentation & Housekeeping

- [x] Documentation update — N/A; no public API or configuration changes
- [x] `cli-config.yaml.example` update — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no workflow or architecture change
- [x] Cross-platform impact considered: local Electron behavior is unchanged; remote routing metadata is platform-independent
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

The regression is request-routing metadata rather than a visual change. The added tests assert the exact Electron API request shape for remote FS and git operations.
