### PR TITLE
feat(gateway): bind authenticated Discord guild provenance

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24277,6 +24277,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _adapters = getattr(self, "adapters", None) or {}
         _adapter = _adapters.get(context.source.platform)
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
+        source_guild_id = str(getattr(context.source, "guild_id", "") or "")
+        source_scope_id = str(getattr(context.source, "scope_id", "") or "")
+        guild_id = ""
+        if context.source.platform is Platform.DISCORD:
+            if source_guild_id and source_scope_id and source_guild_id != source_scope_id:
+                guild_id = ""
+            else:
+                guild_id = source_guild_id or source_scope_id
         return set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
@@ -24288,6 +24296,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_id_alt=str(context.source.user_id_alt) if context.source.user_id_alt else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
+            guild_id=guild_id,
             scope_id=str(getattr(context.source, "scope_id", "") or ""),
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -80,6 +80,10 @@ _SESSION_THREAD_ID: ContextVar = ContextVar("HERMES_SESSION_THREAD_ID", default=
 _SESSION_USER_ID: ContextVar = ContextVar("HERMES_SESSION_USER_ID", default=_UNSET)
 _SESSION_USER_ID_ALT: ContextVar = ContextVar("HERMES_SESSION_USER_ID_ALT", default=_UNSET)
 _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
+# Discord-specific authenticated guild provenance. Unlike scope_id, this is
+# deliberately not platform-neutral and must only be bound by the gateway from
+# a Discord SessionSource.
+_SESSION_GUILD_ID: ContextVar = ContextVar("HERMES_SESSION_GUILD_ID", default=_UNSET)
 # Platform-neutral scope discriminator (Discord guild / Slack workspace /
 # Matrix server) of the originating chat. Captured at session-bind time so
 # async producers (delegate_task background=True, terminal watchers) can
@@ -145,6 +149,7 @@ _VAR_MAP = {
     "HERMES_SESSION_USER_ID": _SESSION_USER_ID,
     "HERMES_SESSION_USER_ID_ALT": _SESSION_USER_ID_ALT,
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
+    "HERMES_SESSION_GUILD_ID": _SESSION_GUILD_ID,
     "HERMES_SESSION_SCOPE_ID": _SESSION_SCOPE_ID,
     "HERMES_SESSION_KEY": _SESSION_KEY,
     "HERMES_SESSION_ID": _SESSION_ID,
@@ -223,6 +228,7 @@ def set_session_vars(
     user_id: str = "",
     user_id_alt: str = "",
     user_name: str = "",
+    guild_id: str = "",
     scope_id: str = "",
     session_key: str = "",
     session_id: str = "",
@@ -267,6 +273,7 @@ def set_session_vars(
         _SESSION_USER_ID.set(user_id),
         _SESSION_USER_ID_ALT.set(user_id_alt),
         _SESSION_USER_NAME.set(user_name),
+        _SESSION_GUILD_ID.set(guild_id),
         _SESSION_SCOPE_ID.set(scope_id),
         _SESSION_KEY.set(session_key),
         _SESSION_ID.set(session_id),
@@ -306,6 +313,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_USER_ID,
         _SESSION_USER_ID_ALT,
         _SESSION_USER_NAME,
+        _SESSION_GUILD_ID,
         _SESSION_SCOPE_ID,
         _SESSION_KEY,
         _SESSION_ID,

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -374,6 +374,8 @@ async def test_dispatch_thread_session_builds_thread_event(adapter):
     assert event.source.chat_id == "555"
     assert event.source.chat_type == "thread"
     assert event.source.thread_id == "555"
+    assert event.source.guild_id is None
+    assert event.source.scope_id is None
     assert "TestGuild" in event.source.chat_name
 
 
@@ -395,6 +397,8 @@ def test_build_slash_event_preserves_thread_context(adapter):
     assert event.source.chat_id == "555"
     assert event.source.chat_type == "thread"
     assert event.source.thread_id == "555"
+    assert event.source.guild_id is None
+    assert event.source.scope_id is None
     assert "TestGuild" in event.source.chat_name
 
 
@@ -602,3 +606,16 @@ def test_register_skill_command_payload_fits_discord_8kb_limit(adapter):
     )
 
 
+
+
+def test_normal_discord_source_retains_authenticated_guild_and_user(adapter):
+    source = adapter.build_source(
+        chat_id="200",
+        chat_type="group",
+        guild_id="300",
+        user_id="100",
+    )
+
+    assert source.guild_id == "300"
+    assert source.scope_id == "300"
+    assert source.user_id == "100"

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -12,7 +12,8 @@ import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent
-from gateway.session import SessionSource
+from gateway.session import SessionContext, SessionSource
+from gateway.session_context import get_session_env
 
 
 def _clear_auth_env(monkeypatch) -> None:
@@ -118,3 +119,52 @@ async def test_hook_fires_without_session_store_attribute(monkeypatch):
     # Hook actually fired (skip short-circuited before auth) with a None store.
     assert seen == {"session_store": None}
     adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_hook_and_handler_share_authenticated_source(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "*")
+    seen = {}
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_dispatch":
+            source = kwargs["event"].source
+            seen["hook"] = (source.guild_id, source.user_id, source.chat_id)
+            return [{"action": "allow"}]
+        return []
+
+    async def _capture(event, source, _quick_key, _run_generation):
+        context = SessionContext(source=source, connected_platforms=[], home_channels={})
+        tokens = runner._set_session_env(context)
+        try:
+            seen["handler"] = (
+                get_session_env("HERMES_SESSION_GUILD_ID"),
+                get_session_env("HERMES_SESSION_USER_ID"),
+                get_session_env("HERMES_SESSION_CHAT_ID"),
+            )
+        finally:
+            runner._clear_session_env(tokens)
+        return "ok"
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    runner, _adapter = _make_runner(Platform.DISCORD)
+    runner._handle_message_with_agent = _capture
+    event = MessageEvent(
+        text="approve",
+        message_id="500",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            user_id="100",
+            chat_id="200",
+            chat_type="group",
+            guild_id="300",
+        ),
+    )
+
+    await runner._handle_message(event)
+
+    assert seen == {
+        "hook": ("300", "100", "200"),
+        "handler": ("300", "100", "200"),
+    }

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -273,3 +273,115 @@ def test_cron_session_set_clear_and_reset_tristate(monkeypatch):
     reset_session_vars()
     assert get_session_env("HERMES_CRON_SESSION") == "1"
 
+
+
+def test_discord_guild_provenance_is_bound_and_cleared(monkeypatch):
+    runner = object.__new__(GatewayRunner)
+    monkeypatch.setenv("HERMES_SESSION_GUILD_ID", "stale")
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="200",
+        user_id="100",
+        guild_id="300",
+    )
+    context = SessionContext(source=source, connected_platforms=[], home_channels={})
+
+    tokens = runner._set_session_env(context)
+    assert get_session_env("HERMES_SESSION_GUILD_ID") == "300"
+    runner._clear_session_env(tokens)
+    assert get_session_env("HERMES_SESSION_GUILD_ID") == ""
+
+
+def test_non_discord_scope_never_becomes_guild_provenance():
+    runner = object.__new__(GatewayRunner)
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="200",
+        user_id="100",
+        scope_id="workspace",
+    )
+    context = SessionContext(source=source, connected_platforms=[], home_channels={})
+
+    tokens = runner._set_session_env(context)
+    try:
+        assert get_session_env("HERMES_SESSION_GUILD_ID") == ""
+    finally:
+        runner._clear_session_env(tokens)
+
+
+def test_discord_guild_scope_disagreement_fails_closed():
+    runner = object.__new__(GatewayRunner)
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="200",
+        user_id="100",
+        guild_id="300",
+    )
+    source.scope_id = "other"
+    context = SessionContext(source=source, connected_platforms=[], home_channels={})
+
+    tokens = runner._set_session_env(context)
+    try:
+        assert get_session_env("HERMES_SESSION_GUILD_ID") == ""
+    finally:
+        runner._clear_session_env(tokens)
+
+
+@pytest.mark.asyncio
+async def test_executor_preserves_discord_guild_and_user_provenance():
+    runner = object.__new__(GatewayRunner)
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="200",
+        user_id="100",
+        guild_id="300",
+    )
+    context = SessionContext(source=source, connected_platforms=[], home_channels={})
+
+    tokens = runner._set_session_env(context)
+    try:
+        result = await runner._run_in_executor_with_context(
+            lambda: (
+                get_session_env("HERMES_SESSION_GUILD_ID"),
+                get_session_env("HERMES_SESSION_USER_ID"),
+            )
+        )
+    finally:
+        runner._clear_session_env(tokens)
+        runner._shutdown_executor()
+
+    assert result == ("300", "100")
+
+
+@pytest.mark.asyncio
+async def test_concurrent_discord_contexts_keep_guild_and_user_pairs_isolated():
+    results = {}
+
+    async def bind(name, guild_id, user_id, delay):
+        runner = object.__new__(GatewayRunner)
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id=name,
+            user_id=user_id,
+            guild_id=guild_id,
+        )
+        context = SessionContext(source=source, connected_platforms=[], home_channels={})
+        tokens = runner._set_session_env(context)
+        try:
+            await asyncio.sleep(delay)
+            results[name] = (
+                get_session_env("HERMES_SESSION_GUILD_ID"),
+                get_session_env("HERMES_SESSION_USER_ID"),
+            )
+        finally:
+            runner._clear_session_env(tokens)
+
+    await asyncio.gather(
+        bind("a", "guild-a", "user-a", 0.02),
+        bind("b", "guild-b", "user-b", 0),
+    )
+
+    assert results == {
+        "a": ("guild-a", "user-a"),
+        "b": ("guild-b", "user-b"),
+    }


### PR DESCRIPTION
Adds a Discord-specific task-local HERMES_SESSION_GUILD_ID derived only from the authenticated Discord SessionSource. The value participates in clear/reset handling, fails closed on guild/scope disagreement, remains blank for non-Discord sources, and propagates through the existing copy_context executor path.\n\nVerification: uv run --extra dev python -m pytest tests/gateway/test_session_env.py (13 passed).