### PR TITLE
fix(desktop): only set transparent:true when glass is active to restore Win11 rounded corners

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -997,7 +997,7 @@ function chatWindowSurfaceOptions() {
     // (electron#49443). Chat windows on glass-capable Windows are born
     // transparent so a live Clear→Glass toggle doesn't need a recreate; the
     // opaque themed backgroundColor covers it while glass is off.
-    ...(IS_WINDOWS && GLASS_SUPPORTED ? { transparent: true } : {}),
+    ...(IS_WINDOWS && GLASS_SUPPORTED && glassActive(translucencyState) ? { transparent: true } : {}),
     backgroundMaterial: IS_WINDOWS && GLASS_SUPPORTED ? backgroundMaterialFor(translucencyState) : undefined,
     opacity: windowOpacity(),
     ...windowBackingOptions(translucencyState, getWindowBackgroundColor())


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where Hermes Desktop chat windows on Windows 11 lost their native rounded corners and drop shadows, rendering with sharp 90-degree edges instead.

`chatWindowSurfaceOptions()` unconditionally injected `{ transparent: true }` whenever `IS_WINDOWS && GLASS_SUPPORTED` was true. Electron's `transparent: true` disables DWM's non-client area composition, which strips native rounded corners and drop shadows across the entire window frame — even when glass is off and an opaque theme background covers the window.

This change injects `transparent: true` only when glass is actually active (`glassActive(translucencyState)`). When glass is toggled on later, `applyWindowTranslucency`'s `setBackgroundColor('#00000000')` already switches the backing to transparent, so the material still reaches the client area without any window recreation.

## Related Issue

Fixes #90505

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.ts` — gate `transparent: true` on `glassActive(translucencyState)` in `chatWindowSurfaceOptions()` (1 line)

## How to Test

1. On Windows 11, build and launch the latest source with `hermes desktop --force-build`
2. Confirm the chat window has rounded corners and a drop shadow (before the fix: square corners)
3. In Settings → Window Translucency, toggle Glass ↔ Clear several times and confirm the native corners/shadow are preserved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<img width="489" height="687" alt="image" src="https://github.com/user-attachments/assets/8c112e1b-79d1-4430-8ce3-082a8307c099" />

