### PR TITLE
feat(feishu): add stale message filter to prevent processing delayed events

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -439,6 +439,7 @@ class FeishuAdapterSettings:
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
+    max_message_age_seconds: int = _DEFAULT_MAX_MESSAGE_AGE_SECONDS
 
 
 @dataclass
@@ -2623,13 +2624,17 @@ class FeishuAdapter(BasePlatformAdapter):
         if create_time_ms:
             max_age = self._max_message_age_seconds
             if max_age > 0:
-                msg_age = time.time() - (int(create_time_ms) / 1000)
-                if msg_age > max_age:
-                    logger.warning(
-                        "[Feishu] Dropping stale message: id=%s age=%.1fs max=%ds",
-                        message_id, msg_age, max_age,
-                    )
-                    return
+                try:
+                    msg_age = time.time() - (int(create_time_ms) / 1000)
+                except (TypeError, ValueError):
+                    logger.debug("[Feishu] Non-numeric create_time=%r, skipping staleness check", create_time_ms)
+                else:
+                    if msg_age > max_age:
+                        logger.warning(
+                            "[Feishu] Dropping stale message: id=%s age=%.1fs max=%ds",
+                            message_id, msg_age, max_age,
+                        )
+                        return
 
         if not message_id or self._is_duplicate(message_id):
             logger.debug("[Feishu] Dropping duplicate/missing message_id: %s", message_id)

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1701,6 +1701,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_ping_timeout = settings.ws_ping_timeout
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
+        self._max_message_age_seconds = settings.max_message_age_seconds
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -225,6 +225,9 @@ _DEFAULT_TEXT_BATCH_MAX_MESSAGES = 8
 _DEFAULT_TEXT_BATCH_MAX_CHARS = 4000
 _DEFAULT_MEDIA_BATCH_DELAY_SECONDS = 0.8
 _DEFAULT_DEDUP_CACHE_SIZE = 2048
+# Default max message age in seconds. Messages with create_time older than
+# this are dropped to avoid processing stale/replayed events after restart.
+_DEFAULT_MAX_MESSAGE_AGE_SECONDS = 300  # 5 minutes
 _DEFAULT_WEBHOOK_HOST = "127.0.0.1"
 _DEFAULT_WEBHOOK_PORT = 8765
 _DEFAULT_WEBHOOK_PATH = "/feishu/webhook"
@@ -1650,6 +1653,10 @@ class FeishuAdapter(BasePlatformAdapter):
                 str(extra.get("webhook_path") or os.getenv("FEISHU_WEBHOOK_PATH", _DEFAULT_WEBHOOK_PATH)).strip()
                 or _DEFAULT_WEBHOOK_PATH
             ),
+            max_message_age_seconds=max(
+                0,
+                env_int("FEISHU_MAX_MESSAGE_AGE_SECONDS", _DEFAULT_MAX_MESSAGE_AGE_SECONDS),
+            ),
             ws_reconnect_nonce=_coerce_required_int(extra.get("ws_reconnect_nonce"), default=30, min_value=0),
             ws_reconnect_interval=_coerce_required_int(extra.get("ws_reconnect_interval"), default=120, min_value=1),
             ws_ping_interval=_coerce_int(extra.get("ws_ping_interval"), default=None, min_value=1),
@@ -2610,6 +2617,20 @@ class FeishuAdapter(BasePlatformAdapter):
             return
 
         message_id = getattr(message, "message_id", None)
+
+        # --- Timestamp staleness check ---
+        create_time_ms = getattr(message, "create_time", None)
+        if create_time_ms:
+            max_age = self._max_message_age_seconds
+            if max_age > 0:
+                msg_age = time.time() - (int(create_time_ms) / 1000)
+                if msg_age > max_age:
+                    logger.warning(
+                        "[Feishu] Dropping stale message: id=%s age=%.1fs max=%ds",
+                        message_id, msg_age, max_age,
+                    )
+                    return
+
         if not message_id or self._is_duplicate(message_id):
             logger.debug("[Feishu] Dropping duplicate/missing message_id: %s", message_id)
             return


### PR DESCRIPTION
## Summary

Add timestamp-based stale message filter to the Feishu adapter. Messages with `create_time` older than a configurable threshold are silently dropped **before** the dedup check, preventing stale or replayed events from being processed after restarts or webhook delivery delays.

## Motivation

When Hermes restarts or when webhook events are redelivered with delay, the adapter may process a backlog of old messages. This is wasteful and can cause unexpected behavior. A time-window filter at the entry point provides a clean cutoff.

## Changes

| # | Location | Description |
|---|----------|-------------|
| 1 | Constants (L228) | Add `_DEFAULT_MAX_MESSAGE_AGE_SECONDS = 300` |
| 2 | `__init__` | Read `FEISHU_MAX_MESSAGE_AGE_SECONDS` via `env_int()` |
| 3 | `_handle_message_event_data` | Check `message.create_time` age before `_is_duplicate` |

## Configuration

| Env Var | Default | Description |
|---------|---------|-------------|
| `FEISHU_MAX_MESSAGE_AGE_SECONDS` | `300` (5 min) | Max age in seconds. Set `0` to disable. |

## Design Notes

- **Position**: Checked before `_is_duplicate` — stale messages don't need dedup processing
- **Log level**: `warning` (not debug) to aid backlog troubleshooting
- **Time unit**: `create_time` is millisecond-precision (per Feishu SDK), converted to seconds
- **Backward compatible**: Default 300s is generous; existing behavior unchanged for recent messages

## Testing

```bash
# Disable check
export FEISHU_MAX_MESSAGE_AGE_SECONDS=0

# Strict 30s window
export FEISHU_MAX_MESSAGE_AGE_SECONDS=30

# Default (5 min) — no env var needed
```