### PR TITLE
fix(agent): a terminal memory degradation is not a tool failure

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1361,6 +1361,14 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
     # Memory: distinguish "store full" from real errors.
     if tool_name == "memory":
         if isinstance(data, dict):
+            # done=True is the memory tool's terminal graceful-degradation
+            # result (#42405): it already tells the model to stop retrying.
+            # Rendering it as a failure also feeds the same-tool halt counter,
+            # which aborts the turn and eats the user's reply - the exact
+            # outcome #42405 exists to prevent. Keep in lockstep with
+            # agent/tool_guardrails.py:classify_tool_failure.
+            if data.get("done") is True:
+                return False, ""
             if data.get("success") is False and "exceed the limit" in data.get("error", ""):
                 return True, " [full]"
 

--- a/agent/display.py
+++ b/agent/display.py
@@ -18,7 +18,10 @@ from urllib.parse import urlsplit
 
 from utils import safe_json_loads
 from agent.redact import redact_sensitive_text
-from agent.tool_result_classification import file_mutation_result_landed
+from agent.tool_result_classification import (
+    classify_memory_result,
+    file_mutation_result_landed,
+)
 
 # ANSI escape codes for coloring tool failure indicators
 _RED = "\033[31m"
@@ -1358,19 +1361,13 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
                 return True, f" [exit {exit_code}]"
         return False, ""
 
-    # Memory: distinguish "store full" from real errors.
+    # Memory: settled payloads and "store full" are decided by the shared
+    # classifier; anything it does not decide falls through to the generic
+    # rules below, as before.
     if tool_name == "memory":
-        if isinstance(data, dict):
-            # done=True is the memory tool's terminal graceful-degradation
-            # result (#42405): it already tells the model to stop retrying.
-            # Rendering it as a failure also feeds the same-tool halt counter,
-            # which aborts the turn and eats the user's reply - the exact
-            # outcome #42405 exists to prevent. Keep in lockstep with
-            # agent/tool_guardrails.py:classify_tool_failure.
-            if data.get("done") is True:
-                return False, ""
-            if data.get("success") is False and "exceed the limit" in data.get("error", ""):
-                return True, " [full]"
+        verdict = classify_memory_result(data)
+        if verdict is not None:
+            return verdict
 
     # Structured error in JSON result (any tool that surfaces {"error": ...}).
     if isinstance(data, dict):

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -14,7 +14,10 @@ from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 from utils import safe_json_loads
-from agent.tool_result_classification import file_mutation_result_landed
+from agent.tool_result_classification import (
+    classify_memory_result,
+    file_mutation_result_landed,
+)
 
 
 IDEMPOTENT_TOOL_NAMES = frozenset(
@@ -299,8 +302,13 @@ def canonical_tool_args(args: Mapping[str, Any]) -> str:
 def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]:
     """Safety-fallback classifier used only when callers don't pass ``failed``.
 
-    Mirrors ``agent.display._detect_tool_failure`` exactly so the guardrail
-    never disagrees with the CLI's user-visible ``[error]`` tag. Production
+    Tracks ``agent.display._detect_tool_failure`` so the guardrail never
+    disagrees with the CLI's user-visible ``[error]`` tag. The memory verdict
+    is literally shared (``classify_memory_result``); the rest only tracks it
+    — today the display side additionally trims a terminal ``error`` message
+    into the suffix, tags any structured ``{"error": ...}`` payload, and
+    short-circuits non-string (multimodal) results, none of which happen here.
+    Production
     callers in ``run_agent.py`` always pass an explicit ``failed=`` derived
     from ``_detect_tool_failure``; this function exists so standalone callers
     (tests, tooling) still get consistent behavior.
@@ -319,18 +327,9 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
         return False, ""
 
     if tool_name == "memory":
-        data = safe_json_loads(result)
-        if isinstance(data, dict):
-            # done=True is the memory tool's terminal graceful-degradation
-            # result (#42405): it already tells the model to stop retrying.
-            # Counting it as a failure feeds the same-tool halt counter, which
-            # aborts the turn and suppresses the user-facing reply - the exact
-            # outcome #42405 exists to prevent. Keep in lockstep with
-            # agent/display.py:_detect_tool_failure.
-            if data.get("done") is True:
-                return False, ""
-            if data.get("success") is False and "exceed the limit" in data.get("error", ""):
-                return True, " [full]"
+        verdict = classify_memory_result(safe_json_loads(result))
+        if verdict is not None:
+            return verdict
 
     lower = result[:500].lower()
     if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -321,6 +321,14 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
     if tool_name == "memory":
         data = safe_json_loads(result)
         if isinstance(data, dict):
+            # done=True is the memory tool's terminal graceful-degradation
+            # result (#42405): it already tells the model to stop retrying.
+            # Counting it as a failure feeds the same-tool halt counter, which
+            # aborts the turn and suppresses the user-facing reply - the exact
+            # outcome #42405 exists to prevent. Keep in lockstep with
+            # agent/display.py:_detect_tool_failure.
+            if data.get("done") is True:
+                return False, ""
             if data.get("success") is False and "exceed the limit" in data.get("error", ""):
                 return True, " [full]"
 

--- a/agent/tool_result_classification.py
+++ b/agent/tool_result_classification.py
@@ -23,6 +23,40 @@ def tool_may_have_side_effect(tool_name: str) -> bool:
     return tool_name not in NO_EFFECT_TOOL_NAMES
 
 
+def classify_memory_result(data: Any) -> tuple[bool, str] | None:
+    """Classify a ``memory`` tool payload as ``(is_failure, suffix)``.
+
+    Shared by ``agent.display._detect_tool_failure`` and
+    ``agent.tool_guardrails.classify_tool_failure`` so the CLI tag and the
+    guardrail counter can never disagree about a memory result.
+
+    ``done=True`` marks a payload the tool considers SETTLED — both the
+    ordinary success and the terminal graceful degradation returned once
+    consolidation has failed too often in one turn (#42405). Neither is a
+    failure the model should react to, and counting one feeds the same-tool
+    halt counter, which aborts the turn and suppresses the user-facing reply:
+    the exact outcome #42405 exists to prevent.
+
+    The ``done`` check comes FIRST and that order is load-bearing. An
+    at-capacity refusal is routed through the same consolidation-failure
+    budget, so the Nth consecutive one comes back as the terminal payload —
+    at which point the model has been told to stop retrying and a ``[full]``
+    tag is no longer actionable. (The two cannot both match in any case: the
+    terminal payload carries a fixed error text that never mentions a limit.)
+
+    ``None`` means "no memory verdict" — the caller keeps applying its own
+    generic rules, exactly as each did before this was factored out. That is
+    why the return is optional rather than ``(False, "")``.
+    """
+    if not isinstance(data, dict):
+        return None
+    if data.get("done") is True:
+        return False, ""
+    if data.get("success") is False and "exceed the limit" in data.get("error", ""):
+        return True, " [full]"
+    return None
+
+
 def file_mutation_result_landed(tool_name: str, result: Any) -> bool:
     """Return True when a file mutation result proves the write landed."""
     if tool_name not in FILE_MUTATING_TOOL_NAMES or not isinstance(result, str):

--- a/contributors/emails/adrien.didot@gmail.com
+++ b/contributors/emails/adrien.didot@gmail.com
@@ -1,0 +1,2 @@
+Adridot
+# PR: memory done=True is not a tool failure

--- a/tests/agent/test_display_tool_failure.py
+++ b/tests/agent/test_display_tool_failure.py
@@ -76,6 +76,24 @@ class TestDetectToolFailureMemory:
         assert "invalid action" in suffix
 
 
+    def test_memory_terminal_degradation_is_not_a_failure(self):
+        # done=True is the memory tool's terminal graceful-degradation result
+        # (#42405): it already instructs the model to stop retrying. Rendering
+        # it as a failure also feeds the same-tool halt counter, which aborts
+        # the turn and suppresses the user's reply. Keep in lockstep with
+        # agent/tool_guardrails.py:classify_tool_failure.
+        result = json.dumps({
+            "success": False,
+            "done": True,
+            "error": (
+                "Memory consolidation failed 4 times this turn. Stop retrying "
+                "memory calls - leave memory unchanged for now and continue "
+                "with your reply to the user."
+            ),
+        })
+        assert _detect_tool_failure("memory", result) == (False, "")
+
+
 class TestDetectToolFailureStructured:
     """Generic path: any tool that returns {"error": ...} JSON."""
 

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -119,6 +119,31 @@ def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution()
 
 
 
+def test_memory_terminal_degradation_is_not_a_tool_failure():
+    # The memory tool's terminal graceful-degradation result (#42405) carries
+    # done=True and already tells the model to stop retrying. Counting it as a
+    # failure feeds the same-tool halt counter, which aborts the turn and eats
+    # the user-facing reply - the exact outcome #42405 exists to prevent.
+    # Keep in lockstep with agent/display.py:_detect_tool_failure.
+    terminal = json.dumps({
+        "success": False,
+        "done": True,
+        "error": (
+            "Memory consolidation failed 4 times this turn. Stop retrying "
+            "memory calls - leave memory unchanged for now and continue with "
+            "your reply to the user."
+        ),
+    })
+    full = json.dumps({
+        "success": False,
+        "error": "Memory at 3,990/4,000 chars. Adding this entry would exceed the limit.",
+    })
+
+    assert classify_tool_failure("memory", terminal) == (False, "")
+    # A genuine at-capacity error is still a failure.
+    assert classify_tool_failure("memory", full) == (True, " [full]")
+
+
 def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_success_output_by_default():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -124,7 +124,8 @@ def test_memory_terminal_degradation_is_not_a_tool_failure():
     # done=True and already tells the model to stop retrying. Counting it as a
     # failure feeds the same-tool halt counter, which aborts the turn and eats
     # the user-facing reply - the exact outcome #42405 exists to prevent.
-    # Keep in lockstep with agent/display.py:_detect_tool_failure.
+    # The verdict is shared with agent/display.py:_detect_tool_failure through
+    # agent.tool_result_classification.classify_memory_result.
     terminal = json.dumps({
         "success": False,
         "done": True,
@@ -142,6 +143,49 @@ def test_memory_terminal_degradation_is_not_a_tool_failure():
     assert classify_tool_failure("memory", terminal) == (False, "")
     # A genuine at-capacity error is still a failure.
     assert classify_tool_failure("memory", full) == (True, " [full]")
+    # And a memory error that is neither settled nor at-capacity still falls
+    # through to the generic rules — the shared classifier returns "no verdict"
+    # for it rather than swallowing it as a success.
+    other = json.dumps({"success": False, "error": "target 'USER' not found"})
+    assert classify_tool_failure("memory", other) == (True, " [error]")
+
+
+def test_repeated_terminal_degradation_never_halts_the_turn():
+    """The consequence, not just the classification.
+
+    The #42405 symptom is the halt controller aborting the turn after enough
+    same-tool failures. Feeding the terminal payload straight through the
+    controller — past the halt threshold — is what proves the reply survives;
+    a classifier assertion alone would not notice a consumer that stopped
+    honouring it.
+    """
+    terminal = json.dumps({
+        "success": False,
+        "done": True,
+        "error": "Memory consolidation failed 4 times this turn. Stop retrying memory calls.",
+    })
+    args = {"action": "add", "content": "Adrien prefers HT amounts"}
+
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True, same_tool_failure_halt_after=3)
+    )
+    for _ in range(6):  # twice the halt threshold
+        decision = controller.after_call("memory", args, terminal)
+        assert decision.code != "same_tool_failure_halt"
+        assert decision.should_halt is False
+
+
+def test_repeated_real_memory_failure_still_halts_the_turn():
+    """Control for the test above: the halt itself is not what got broken."""
+    failing = json.dumps({"success": False, "error": "target 'USER' not found"})
+    args = {"action": "add", "content": "Adrien prefers HT amounts"}
+
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True, same_tool_failure_halt_after=3)
+    )
+    decisions = [controller.after_call("memory", args, failing) for _ in range(3)]
+    assert decisions[-1].code == "same_tool_failure_halt"
+    assert decisions[-1].should_halt is True
 
 
 def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_success_output_by_default():


### PR DESCRIPTION
## What does this PR do?

The memory tool has a deliberate terminal graceful-degradation result. When consolidation keeps failing inside one turn, `memory_tool.py` stops the model from retrying by returning:

```json
{"success": false, "done": true,
 "error": "Memory consolidation failed 4 times this turn. Stop retrying memory calls — leave memory unchanged for now and continue with your reply to the user. The fact can be saved in a later turn."}
```

That payload is the fix for #42405 — *"a failed memory side effect must never block the turn's reply"* (`tools/memory_tool.py:187`). It is not an error the model should react to; it is the runtime telling the model the matter is settled.

Both failure classifiers read it as a failure anyway, because they only test `success is False`:

- **`agent/tool_guardrails.py: classify_tool_failure`** feeds the per-turn same-tool counter. A few of these degradations therefore reach `same_tool_failure_halt`, which aborts the turn and suppresses the user-facing reply — the exact outcome #42405 exists to prevent, triggered by the one result designed to let the turn continue.
- **`agent/display.py: _detect_tool_failure`** independently renders the same payload as a failure on the CLI completion line, so the user sees an error suffix for a tool that degraded exactly as intended.

Both now treat `done=True` as terminal-and-handled. The at-capacity error (`success=False` with no `done`) is untouched and still classifies as a failure with the ` [full]` suffix; non-memory paths are untouched.

**Why the two sites travel together.** They read the same payload to make the same decision, so the verdict is now *shared code* rather than a comment asking a future reader to keep two copies aligned: `classify_memory_result` lives in `agent/tool_result_classification.py`, the module both files already import for `file_mutation_result_landed`. Splitting the two across separate PRs would leave an interval where one classifier halts the turn while the other reports success, which is worse than either bug alone.

Only the *memory* block is extracted, because only it was duplicated. `_detect_tool_failure` and `classify_tool_failure` are not twins despite the latter's docstring: the display side also trims a terminal `error` into the suffix, tags any structured `{"error": ...}` payload, and short-circuits non-string (multimodal) results — none of which the guardrail side does. That docstring is corrected here to say what is actually shared.

The helper returns `tuple[bool, str] | None`, not `tuple[bool, str]`. The memory block never returned on a no-match: it *fell through* to each caller's generic rules, which is why `{"success": false, "error": "target not found"}` classifies as a failure at all. A helper answering `(False, "")` there would have quietly converted those into successes — `None` means "no memory verdict, keep going", and a test pins it.

## Related Issue

Relates to #42405 (closed). This does not reopen it: the memory tool's own retry loop is fixed. It extends the same reasoning one layer out, to the two classifiers that read the result that fix produces.

**Prior art I found while searching, none of which covers this:**

- #64816 (open) — touches both `classify_tool_failure` and `_detect_tool_failure`, and the same test file, but for a different purpose: broadening the ` [full]` match to any error containing "full". Independent of this change; the two compose semantically, though they will need a trivial textual merge since they land within a few lines of each other. I have no objection to it going first.
- #45162 (open) — guards `classify_tool_failure` against non-string results. Adjacent, unrelated.
- #88357 (open, mine) — also modifies `agent/tool_guardrails.py`, but in `ToolCallGuardrailController` (how a parallel batch is counted), not in `classify_tool_failure`. Different defect, different function, no overlap; neither PR should be read as covering the other.

I found no PR proposing the `done=True` check.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/tool_result_classification.py` — new `classify_memory_result(data) -> tuple[bool, str] | None`: `done=True` → not a failure, at-capacity → `(True, " [full]")`, anything else → `None` (caller keeps its own rules). Carries the precedence rationale.
- `agent/tool_guardrails.py` — `classify_tool_failure` delegates the memory verdict; docstring corrected to state what is shared and what merely tracks.
- `agent/display.py` — `_detect_tool_failure` delegates the same verdict.
- `tests/agent/test_tool_guardrails.py` — terminal payload is not a failure; at-capacity still is; a non-settled memory error still falls through to `[error]`; **`test_repeated_terminal_degradation_never_halts_the_turn`** drives the payload through `ToolCallGuardrailController` past the halt threshold; `test_repeated_real_memory_failure_still_halts_the_turn` as its control.
- `tests/agent/test_display_tool_failure.py` — `TestDetectToolFailureMemory::test_memory_terminal_degradation_is_not_a_failure`.

**On `done=True`.** It marks the memory tool's ordinary **success** response as well as the terminal degradation — both are payloads it considers settled, and neither is a failure. And the `done`-before-`[full]` order is load-bearing rather than incidental: an at-capacity refusal is routed through the same consolidation-failure budget (`_consolidation_failure`), so the Nth consecutive one comes back *as* the terminal payload, at which point the model has already been told to stop and `[full]` is no longer actionable. The two can never both match — the terminal payload's error text is fixed and never mentions a limit.

## How to Test

1. On `main`, add the tests and run them — three fail:
   ```
   FAILED tests/agent/test_tool_guardrails.py::test_memory_terminal_degradation_is_not_a_tool_failure
     - AssertionError: assert (True, ' [error]') == (False, '')
   FAILED tests/agent/test_display_tool_failure.py::TestDetectToolFailureMemory::test_memory_terminal_degradation_is_not_a_failure
     - AssertionError: assert (True, ' [Mem...his turn...]') == (False, '')
   FAILED tests/agent/test_tool_guardrails.py::test_repeated_terminal_degradation_never_halts_the_turn
     - assert 'same_tool_failure_halt' == ToolGuardrailDecision(action='halt', ...).code
   ```

   The third is the #42405 symptom itself: on `main` the controller halts the turn on the 3rd terminal degradation.
2. Apply the two production hunks and re-run: `pytest tests/agent/test_tool_guardrails.py tests/agent/test_display_tool_failure.py -q` → 22 passed.
3. Regression scope actually run (see checklist): 276 passed, 0 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — what I found is listed under *Related Issue* rather than glossed over
- [x] My PR contains **only** changes related to this fix (two commits — the second is the review response — 5 files)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run in full.** I ran a scoped selection on this branch and on its parent commit `fa2601c2f5`, and compared the failure sets: `tests/agent/test_tool_guardrails.py`, `test_display.py`, `test_display_tool_failure.py`, `tests/tools/test_mcp_circuit_breaker.py`, `test_skill_manager_tool.py`, `tests/cron/test_scheduler.py`, `tests/gateway/test_telegram_format.py`, `test_webhook_adapter.py`, `test_webhook_deliver_only.py`. Parent: 272 passed / 0 failed. This branch: 276 passed / 0 failed. Same failure set (empty); the four added tests account for the difference.
- [x] I've added tests for my changes (4 new, 3 RED on `main`)
- [x] I've tested on my platform: Ubuntu 24.04 (aarch64), Python 3.11.15, pytest 9.1.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the added comments explain the invariant and name the twin site; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A in substance: a dict lookup on an already-parsed payload, no paths, processes, signals or encodings
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool schema or description touched