### PR TITLE
fix(cli): stop one-shot sessions from launching doomed reviews

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -910,6 +910,7 @@ def run_codex_app_server_turn(
     if (
         turn.final_text
         and not turn.interrupted
+        and not getattr(agent, "skip_background_review", False)
         and (should_review_memory or should_review_skills)
     ):
         try:

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -533,6 +533,7 @@ class CLIAgentSetupMixin:
                 pass_session_id=self.pass_session_id,
                 skip_context_files=self.ignore_rules,
                 skip_memory=self.ignore_rules,
+                skip_background_review=getattr(self, "_single_query_mode", False),
                 tool_progress_callback=self._on_tool_progress,
                 tool_start_callback=self._on_tool_start if self._inline_diffs_enabled else None,
                 tool_complete_callback=self._on_tool_complete if self._inline_diffs_enabled else None,

--- a/tests/hermes_cli/test_cli_background_review_lifecycle.py
+++ b/tests/hermes_cli/test_cli_background_review_lifecycle.py
@@ -1,0 +1,47 @@
+"""CLI lifecycle coverage for automatic background reviews."""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from hermes_cli import mcp_startup
+
+
+@pytest.mark.parametrize(
+    ("single_query", "expected_skip"),
+    [(True, True), (False, False)],
+)
+def test_agent_background_review_matches_cli_lifetime(
+    monkeypatch: pytest.MonkeyPatch,
+    single_query: bool,
+    expected_skip: bool,
+) -> None:
+    """One-shot agents skip daemon review work; interactive agents retain it."""
+    import cli as cli_mod
+
+    cli = cli_mod.HermesCLI(compact=True)
+    cli._session_db = object()
+    cli._resumed = False
+    cli.conversation_history = []
+    cli._install_tool_callbacks = lambda: None
+    cli._ensure_tirith_security = lambda: None
+    cli._ensure_runtime_credentials = lambda: True
+    cli._single_query_mode = single_query
+
+    captured: dict[str, object] = {}
+
+    def _fake_agent(*_args, **kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace()
+
+    monkeypatch.setattr(
+        mcp_startup,
+        "ensure_mcp_discovery_before_agent_build",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(cli_mod, "AIAgent", _fake_agent)
+
+    assert cli._init_agent() is True
+    assert captured["skip_background_review"] is expected_skip

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -305,6 +305,21 @@ class TestRunConversationCodexPath:
         # Counter should be reset after the review fires
         assert agent._iters_since_skill == 0
 
+    def test_background_review_skip_flag_suppresses_trigger(self, fake_session):
+        """Short-lived agents must not spawn review work on the early-return path."""
+        agent = _make_codex_agent(skip_background_review=True)
+        agent._skill_nudge_interval = 1
+        agent._iters_since_skill = 0
+        agent.valid_tool_names = set(getattr(agent, "valid_tool_names", set()))
+        agent.valid_tool_names.add("skill_manage")
+
+        with patch.object(
+            agent, "_spawn_background_review", return_value=None
+        ) as spawn:
+            agent.run_conversation("do tool work")
+
+        spawn.assert_not_called()
+
     def test_background_review_signature_never_breaks(self, fake_session):
         """Even when no trigger fires, the helper must never call
         _spawn_background_review with the wrong signature. Run a turn,


### PR DESCRIPTION
## What does this PR do?

Short-lived CLI sessions no longer launch automatic background reviews that cannot outlive the process. This prevents kanban and other one-shot workers from issuing a full-conversation review request that is silently terminated during normal CLI exit, while preserving automatic review for interactive sessions and explicit `/refine` requests.

### Symptom

A `hermes chat -q` or `-Q` worker can finish its only turn, start a daemon background review, and then exit before the review completes. Operators see a review start with no completion or failure record.

### Impact

Every affected one-shot run can waste a full-context provider request without producing review results. The reported deployment observed 14 review starts with zero completions; long-lived sessions were unaffected.

### Bug Cause

**Trigger:** `hermes_cli/cli_agent_setup_mixin.py:CLIAgentSetupMixin._init_agent` constructs an `AIAgent` for a one-shot CLI session without forwarding the session lifetime to the existing review skip gate.

**Causal chain:**
1. `-q` or `-Q` sets `_single_query_mode` before agent initialization.
2. The agent retains `skip_background_review=False`, and a turn threshold starts daemon review work after the final response. The Codex app-server early-return path also had an independent review trigger that did not consult this flag.
3. Normal CLI cleanup exits the process and silently terminates the daemon request before completion.

**Why it is wrong:** Automatic review assumes a long-lived owner process, but one-shot CLI workers have no remaining lifetime in which that daemon work can finish.

**Working sibling / contrast:** Interactive CLI sessions keep automatic review enabled, cron already opts out explicitly, and explicit `/refine` calls the review spawn path directly.

**Ruled out:** Joining every review thread during shutdown was unnecessary and would delay all short-lived workers. Preventing automatic review at construction closes the request before it starts while retaining long-lived behavior.

### Fix

Forward `_single_query_mode` into the existing `skip_background_review` constructor option, and apply the same gate to the Codex app-server finalizer. Behavior tests cover one-shot and interactive construction, the Codex early-return path, and explicit `/refine` preservation.

## Related Issue

Closes #90683

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/cli_agent_setup_mixin.py` - map one-shot CLI lifetime to the automatic review skip option.
- `agent/codex_runtime.py` - honor the same skip option in the Codex app-server early-return path.
- `tests/hermes_cli/test_cli_background_review_lifecycle.py` - verify one-shot sessions skip review while interactive sessions retain it.
- `tests/run_agent/test_codex_app_server_integration.py` - verify the Codex runtime suppresses triggered review work when requested.

## How to Test

1. Run a real one-shot CLI turn with background review thresholds enabled and confirm the process exits normally without starting automatic review work.
2. Run the focused lifecycle, finalizer, Codex runtime, and explicit `/refine` tests.
3. Confirm an interactive CLI agent still enables automatic review and explicit `/refine` still reaches the review spawn path.

```bash
scripts/run_tests.sh tests/hermes_cli/test_cli_background_review_lifecycle.py tests/agent/test_skip_background_review.py tests/run_agent/test_codex_app_server_integration.py tests/agent/test_refine_focus.py -q
```

Result: 40 passed. A real OpenAI Codex one-shot session returned normally with no `bg-review` or background-review completion entries because no automatic review was started.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test entry and all focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A because this changes internal lifecycle behavior without user configuration.
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow contract changed.
- [x] I've considered cross-platform impact per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); the fix uses existing platform-independent lifecycle state.
- [x] Tool description and schema updates are N/A because no model tool behavior changed.

## Screenshots / Logs

A real one-shot run completed with its normal response and cleanup. Log inspection found zero automatic background review entries for that run.
