### PR TITLE
fix(auth): resolve named custom providers in resolve_provider

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2091,6 +2091,16 @@ def resolve_provider(
         return "openrouter"
     if normalized == "custom":
         return "custom"
+    # Named custom providers (``custom:<name>`` from ``custom_providers``) are a
+    # valid runtime identity that never appears in PROVIDER_REGISTRY. Mirror the
+    # check in ``is_runtime_provider_routable`` (see the ``startswith`` branch
+    # above) so MoA reference/aggregator entries and fallback_providers pointing
+    # at a named custom provider don't raise "Unknown provider".
+    # The name is returned verbatim rather than collapsed to bare "custom" so
+    # callers that key off the specific entry (runtime_provider.py) keep routing
+    # to that provider's own base_url/api_key instead of the generic path.
+    if normalized.startswith("custom:") and normalized[len("custom:"):].strip():
+        return normalized
     if normalized in PROVIDER_REGISTRY:
         return normalized
     if normalized != "auto":

--- a/tests/hermes_cli/test_resolve_provider_named_custom.py
+++ b/tests/hermes_cli/test_resolve_provider_named_custom.py
@@ -1,0 +1,55 @@
+"""``resolve_provider`` must accept named custom providers (``custom:<name>``).
+
+Named entries from ``custom_providers`` never appear in ``PROVIDER_REGISTRY``,
+so every config path routing through ``resolve_provider`` — MoA reference and
+aggregator models, ``fallback_providers`` — used to die at agent init with
+"Unknown provider 'custom:<name>'".
+"""
+
+import pytest
+
+from hermes_cli.auth import AuthError, resolve_provider
+
+
+@pytest.mark.parametrize(
+    "provider",
+    ["custom:grok-gate", "custom:qwen-gate", "custom:dario", "custom:deepseek-gate"],
+)
+def test_named_custom_provider_resolves_to_itself(provider):
+    """The name survives verbatim: callers key off the specific entry."""
+    assert resolve_provider(provider) == provider
+
+
+def test_named_custom_is_not_collapsed_to_bare_custom():
+    """Collapsing would reroute a named provider onto the generic custom path.
+
+    ``runtime_provider`` looks the name up to pick that provider's own
+    ``base_url``/``api_key``; bare "custom" loses the endpoint identity.
+    """
+    assert resolve_provider("custom:grok-gate") != "custom"
+
+
+def test_named_custom_matches_is_runtime_provider_routable():
+    """The two resolution paths in this module must agree on the same shape."""
+    from hermes_cli.auth import is_runtime_provider_routable
+
+    assert is_runtime_provider_routable("custom:grok-gate") is True
+    assert resolve_provider("custom:grok-gate") == "custom:grok-gate"
+
+
+def test_bare_custom_still_resolves():
+    """The pre-existing bare-``custom`` contract is untouched."""
+    assert resolve_provider("custom") == "custom"
+
+
+@pytest.mark.parametrize("provider", ["custom:", "custom:   "])
+def test_empty_custom_suffix_still_raises(provider):
+    """An empty name is not a provider identity — fail closed."""
+    with pytest.raises(AuthError):
+        resolve_provider(provider)
+
+
+def test_unknown_provider_still_raises():
+    """Unrelated garbage must not slip through the new branch."""
+    with pytest.raises(AuthError):
+        resolve_provider("totally-bogus-provider")


### PR DESCRIPTION
## Summary

`resolve_provider()` raises `Unknown provider` for **named** custom providers — the `custom:<name>` entries that come from `custom_providers` in `config.yaml`. They never appear in `PROVIDER_REGISTRY`, so the function falls through to `raise AuthError`.

Every config path that routes through it dies at agent init:

```
agent init failed: Unknown provider 'custom:grok-gate'. Check 'hermes model'
for available providers, or run 'hermes doctor' to diagnose config issues.
```

`is_runtime_provider_routable()` — in the same module, ~500 lines above — already accepts exactly this shape:

```py
if normalized in {"auto", "openrouter", "custom", "moa"}:
    return True
if normalized.startswith("custom:"):
    return True
```

`resolve_provider()` did not. This PR mirrors that check.

## Reproduction

Any `custom_providers` entry referenced from a MoA preset or from `fallback_providers`:

```yaml
custom_providers:
  - name: grok-gate
    base_url: http://10.0.0.25:8000/v1
    api_key_env: GROK_GATE_API_KEY

moa:
  enabled: true
  active_preset: my-preset
  presets:
    my-preset:
      reference_models:
        - provider: custom:grok-gate
          model: grok-4.6
      aggregator:
        provider: custom:dario
        model: claude-opus-4-8
```

Start the agent → `Unknown provider 'custom:grok-gate'`.

The provider name in the error varies between runs (`custom:dario`, `custom:grok-gate`, …) because the preset traversal order isn't fixed — which makes this look like several unrelated failures rather than one resolver gap.

## Fix

```py
 if normalized == "custom":
     return "custom"
+if normalized.startswith("custom:") and normalized[len("custom:"):].strip():
+    return normalized
 if normalized in PROVIDER_REGISTRY:
     return normalized
```

**The name is returned verbatim, not collapsed to bare `"custom"`.** That is deliberate: `runtime_provider.py` keys off the specific entry to pick that provider's own `base_url`/`api_key`. Collapsing would silently reroute a named provider onto the generic custom path — the same class of bug this fixes.

Note the guard already downstream at `runtime_provider.py`:

```py
if requested_norm != "custom":
    if _resolve_provider(requested_norm) == "custom":
        requested_norm = "custom"     # would erase the name
```

An empty suffix (`custom:`, `custom:   `) still raises `AuthError` — no new way to smuggle a nameless provider through.

## Test plan

New: `tests/hermes_cli/test_resolve_provider_named_custom.py` (10 cases)

- named providers resolve to themselves, verbatim
- result is **not** collapsed to bare `custom`
- agrees with `is_runtime_provider_routable` on the same input
- bare `custom` contract unchanged
- `custom:` / `custom:   ` still raise
- unrelated garbage still raises

**Verified RED against the unpatched resolver** — 6 of 10 cases fail without the fix, all 10 pass with it.

Regression across the provider area — **228 passed**:

```
test_resolve_provider_named_custom      test_runtime_provider_resolution
test_canonical_custom_identity          test_custom_provider_identity
test_custom_provider_model_switch       test_custom_provider_normalize_no_mutate
test_main_model_custom_provider_normalization
test_env_custom_keys                    test_api_key_providers
test_custom_provider_extra_headers      test_custom_provider_context_length
test_custom_provider_tls                test_cli_custom_provider_vision
```

Also verified live: with the fix in place, a MoA preset whose reference and aggregator models both point at named custom providers resolves all three entries and the agent initialises cleanly.

## Related

Same class of bug, different call sites — the built-in-only `resolve_provider()` used where the user-aware path belongs:

- #14849 — `hermes model` / `doctor` misclassify `providers:` entries as unknown (closed as not planned)
- #6945 — `Unknown provider 'custom'` from the model picker and `--provider`
- #5392 — custom/Google unresolved in `fallback_providers`; notes #4172 *"only addressed the primary model path"*

This PR covers the MoA / `fallback_providers` path through `resolve_provider`. The validation/display entrypoints in #14849 are a separate fix and are left alone here.
