### PR TITLE
fix(gateway): a webhook route must not deliver an error placeholder as the answer

### DIFF
--- a/contributors/emails/adrien.didot@gmail.com
+++ b/contributors/emails/adrien.didot@gmail.com
@@ -1,0 +1,2 @@
+Adridot
+# PR: webhook delivery guard

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -96,15 +96,21 @@ def _is_webhook_silence_response(content: Any) -> bool:
     """
     return is_autonomous_silence_response(content)
 
-# Terminal error placeholders that `agent/conversation_loop.py` puts in a run's
+# Terminal diagnostics that `agent/conversation_loop.py` puts in a run's
 # `final_response` when the turn ends without producing an answer (truncated
-# output, a stream that kept dropping mid tool-call, an oversized payload...).
-# They explain why the turn stopped; they are not the answer the caller asked
-# for. Every other surface shows them as an error, but a webhook route hands
-# whatever it receives to its delivery target, so the recipient gets the
-# placeholder as if it were the requested output.
-# `test_webhook_delivery_guard.py` fails if any of these drifts out of
-# conversation_loop.py, so this set cannot silently go stale.
+# output, a stream that kept dropping mid tool-call, an oversized payload,
+# compression exhausted, an invalid tool call...). They explain why the turn
+# stopped; they are not the answer the caller asked for. Every other surface
+# shows them as an error, but a webhook route hands whatever it receives to
+# its delivery target, so the recipient gets the diagnostic as if it were the
+# requested output.
+#
+# Two shapes, because that is how the loop writes them: fixed sentences, and
+# templates that interpolate a retry count, a token count or a provider
+# message. `test_webhook_delivery_guard.py` parses conversation_loop.py and
+# fails when this inventory falls behind it IN EITHER DIRECTION — a rewording
+# upstream and a newly added diagnostic both break the test rather than
+# silently narrowing the guard.
 _TERMINAL_ERROR_PLACEHOLDERS = frozenset({
     "Response truncated due to output length limit",
     "First response truncated due to output length limit",
@@ -112,12 +118,60 @@ _TERMINAL_ERROR_PLACEHOLDERS = frozenset({
     "Incomplete REASONING_SCRATCHPAD after 2 retries",
     "Codex response remained incomplete after 3 continuation attempts",
     "Request payload too large (413). Cannot compress further.",
+    "Context overflow and auto-compaction is disabled "
+    "(compression.enabled: false). Run /compress to compact manually, "
+    "/new to start fresh, or switch to a larger-context model.",
+    "max_tokens exceeds the provider's output cap for this model. "
+    "Lower model.max_tokens in config.yaml.",
+    "(empty)",
 })
+
+# Cap on the diagnostic echoed back inside the notice (the WARNING keeps
+# the full text). One templated diagnostic embeds a provider error message.
+_GUARD_REASON_MAX_CHARS = 200
+
+_TERMINAL_ERROR_PLACEHOLDER_PATTERNS = (
+    re.compile(r"\AInvalid API response after \d+ retries: "),
+    re.compile(r"\AAPI call failed after \d+ retries: "),
+    re.compile(r"\AModel generated invalid tool call: "),
+    re.compile(
+        r"\ARequest payload too large: max compression attempts \(\d+\) reached\.\Z"
+    ),
+    re.compile(
+        r"\AContext length exceeded"
+        r"(?: \([\d,]+ tokens\)\. Cannot compress further\."
+        r"|: max compression attempts \(\d+\) reached\.)\Z"
+    ),
+    # Rate limit with no fallback configured: the variable part comes first,
+    # so this one is matched on its fixed tail rather than anchored.
+    re.compile(r"No fallback provider available\. Try again after the reset,"),
+    re.compile(
+        r"\AI apologize, but I encountered "
+        r"(?:an error while processing the model response|repeated errors): "
+    ),
+)
 
 
 def _is_terminal_error_placeholder(content: Any) -> bool:
-    """True when ``content`` is a turn-ended-early placeholder, not an answer."""
-    return isinstance(content, str) and content.strip() in _TERMINAL_ERROR_PLACEHOLDERS
+    """True when ``content`` is a turn-ended-early diagnostic, not an answer."""
+    if not isinstance(content, str):
+        return False
+    text = content.strip()
+    if text in _TERMINAL_ERROR_PLACEHOLDERS:
+        return True
+    return any(p.search(text) for p in _TERMINAL_ERROR_PLACEHOLDER_PATTERNS)
+
+
+def _route_from_chat_id(chat_id: str) -> str:
+    """Route name out of a ``webhook:{route}:{delivery_id}`` session id.
+
+    Delivery entries created before the ``route`` key existed (a gateway
+    restarted into a newer build with sessions still in flight) have no key
+    to read, and the session id already carries the route.
+    """
+    head, _, rest = str(chat_id or "").partition(":")
+    route, sep, _ = rest.rpartition(":")
+    return route if head == "webhook" and sep else ""
 
 
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
@@ -416,8 +470,8 @@ class WebhookAdapter(BasePlatformAdapter):
         # `deliver: log`, both left untouched above. It does not hold for a
         # route configured to deliver to a human, which is what this covers.
         if _is_terminal_error_placeholder(content):
-            route = delivery.get("route") or "?"
-            reason = content.strip()
+            route = delivery.get("route") or _route_from_chat_id(chat_id) or "?"
+            reason = " ".join(content.split())
             logger.warning(
                 "[webhook] delivery-guard: session=%s route=%s produced no answer "
                 "(agent reported: %s) - delivering a notice instead",
@@ -425,6 +479,15 @@ class WebhookAdapter(BasePlatformAdapter):
                 route,
                 reason,
             )
+            # The templated diagnostics carry a provider message whose length
+            # and markup are not ours; the notice only has to say that no
+            # answer was produced, so cap it. The WARNING above keeps the
+            # untruncated text. No escaping here on purpose: the delivery
+            # target owns its own markup (the chat adapters escape on send,
+            # a GitHub comment is markdown), and pre-escaping would corrupt
+            # whichever of the two this route is not.
+            if len(reason) > _GUARD_REASON_MAX_CHARS:
+                reason = reason[:_GUARD_REASON_MAX_CHARS].rstrip() + "\u2026"
             content = (
                 f"\u26a0\ufe0f No answer was produced for this request "
                 f"(webhook route: {route}).\n"

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -96,6 +96,30 @@ def _is_webhook_silence_response(content: Any) -> bool:
     """
     return is_autonomous_silence_response(content)
 
+# Terminal error placeholders that `agent/conversation_loop.py` puts in a run's
+# `final_response` when the turn ends without producing an answer (truncated
+# output, a stream that kept dropping mid tool-call, an oversized payload...).
+# They explain why the turn stopped; they are not the answer the caller asked
+# for. Every other surface shows them as an error, but a webhook route hands
+# whatever it receives to its delivery target, so the recipient gets the
+# placeholder as if it were the requested output.
+# `test_webhook_delivery_guard.py` fails if any of these drifts out of
+# conversation_loop.py, so this set cannot silently go stale.
+_TERMINAL_ERROR_PLACEHOLDERS = frozenset({
+    "Response truncated due to output length limit",
+    "First response truncated due to output length limit",
+    "Stream repeatedly dropped mid tool-call (network); the tool was not executed",
+    "Incomplete REASONING_SCRATCHPAD after 2 retries",
+    "Codex response remained incomplete after 3 continuation attempts",
+    "Request payload too large (413). Cannot compress further.",
+})
+
+
+def _is_terminal_error_placeholder(content: Any) -> bool:
+    """True when ``content`` is a turn-ended-early placeholder, not an answer."""
+    return isinstance(content, str) and content.strip() in _TERMINAL_ERROR_PLACEHOLDERS
+
+
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None
 # (no prefix / multiplexing off → handle as the default profile).
@@ -378,6 +402,35 @@ class WebhookAdapter(BasePlatformAdapter):
         if deliver_type == "log":
             logger.info("[webhook] Response for %s: %s", chat_id, content[:200])
             return SendResult(success=True)
+
+        # Past this point the response reaches a person: a GitHub comment, or
+        # a chat adapter. A run that ended early leaves an error placeholder in
+        # `final_response`, and delivering it unchanged tells that person the
+        # placeholder *is* the answer, with nothing anywhere recording that the
+        # request produced no output. Replace it with a notice that says so and
+        # leave a WARNING behind.
+        #
+        # `gateway/run.py:_sanitize_gateway_final_response` does this for the
+        # chat gateways, and deliberately exempts `webhook` as a programmatic
+        # surface — correct for the route's own HTTP response and for
+        # `deliver: log`, both left untouched above. It does not hold for a
+        # route configured to deliver to a human, which is what this covers.
+        if _is_terminal_error_placeholder(content):
+            route = delivery.get("route") or "?"
+            reason = content.strip()
+            logger.warning(
+                "[webhook] delivery-guard: session=%s route=%s produced no answer "
+                "(agent reported: %s) - delivering a notice instead",
+                chat_id,
+                route,
+                reason,
+            )
+            content = (
+                f"\u26a0\ufe0f No answer was produced for this request "
+                f"(webhook route: {route}).\n"
+                f"The run ended early - the agent reported: {reason}\n"
+                f"Nothing else was generated; re-send the request to retry."
+            )
 
         if deliver_type == "github_comment":
             return await self._deliver_github_comment(content, delivery)
@@ -919,6 +972,9 @@ class WebhookAdapter(BasePlatformAdapter):
             "deliver_extra": self._render_delivery_extra(
                 route_config.get("deliver_extra", {}), payload
             ),
+            # Read only by the delivery guard in send(), to name the route in
+            # its warning and its notice.
+            "route": route_name,
         }
         self._delivery_info[session_chat_id] = deliver_config
         self._delivery_info_created[session_chat_id] = now

--- a/tests/gateway/test_webhook_delivery_guard.py
+++ b/tests/gateway/test_webhook_delivery_guard.py
@@ -1,10 +1,11 @@
-"""The webhook delivery guard: an error placeholder is not an answer.
+"""The webhook delivery guard: an error diagnostic is not an answer.
 
 When a turn ends without producing an answer, ``agent/conversation_loop.py``
-puts a short placeholder in ``final_response`` ("Response truncated due to
-output length limit", ...). Interactive surfaces render that as an error. A
+puts a short diagnostic in ``final_response`` ("Response truncated due to
+output length limit", "Context length exceeded (174,833 tokens). Cannot
+compress further.", ...). Interactive surfaces render that as an error. A
 webhook route hands whatever it receives to its delivery target, so before
-this guard the recipient got the placeholder itself — a one-line string that
+this guard the recipient got the diagnostic itself — a one-line string that
 reads like a terse reply — with nothing in the logs saying the request had
 produced no output.
 
@@ -15,14 +16,18 @@ not hold for a route configured to deliver to a person, which is what the
 guard here covers.
 
 Covers:
-- every placeholder is caught, and the delivered text says no answer was produced
-- the original placeholder text is preserved inside the notice, not swallowed
+- every guarded diagnostic is caught, fixed sentences and templates alike
+- the delivered text says no answer was produced, and keeps the reason
+- a long provider message is capped in the notice but not in the log
 - a WARNING naming the session and route is logged
+- the route is named even when the delivery entry predates the `route` key
 - `deliver: log` keeps the raw diagnostic (programmatic surface, unguarded)
 - ordinary responses pass through untouched
-- the placeholder set has not drifted away from conversation_loop.py
+- the inventory has not drifted from conversation_loop.py, in EITHER
+  direction: a rewording and a newly added diagnostic both fail the test
 """
 
+import ast
 import asyncio
 import logging
 import pathlib
@@ -32,8 +37,10 @@ from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import SendResult
 from gateway.platforms.webhook import (
     WebhookAdapter,
+    _GUARD_REASON_MAX_CHARS,
     _TERMINAL_ERROR_PLACEHOLDERS,
     _is_terminal_error_placeholder,
+    _route_from_chat_id,
 )
 
 CHAT_ID = "webhook:daily-report:1785970121225"
@@ -45,6 +52,114 @@ ORDINARY_RESPONSE = (
     "- Retry queue empty\n"
     "No action needed."
 )
+
+# Every string literal / f-string template `conversation_loop.py` can put in
+# `final_response`, mapped to a rendering of it — or to None when it is
+# deliberately not guarded, with the reason. `test_inventory_matches_source`
+# below extracts the same set from the source and compares, so this dict is
+# the classification of the loop's diagnostics, not a copy that can rot.
+KNOWN_FINAL_RESPONSES = {
+    # -- guarded: the turn ended with no answer -----------------------------
+    "Response truncated due to output length limit":
+        "Response truncated due to output length limit",
+    "First response truncated due to output length limit":
+        "First response truncated due to output length limit",
+    "Stream repeatedly dropped mid tool-call (network); the tool was not executed":
+        "Stream repeatedly dropped mid tool-call (network); the tool was not executed",
+    "Incomplete REASONING_SCRATCHPAD after 2 retries":
+        "Incomplete REASONING_SCRATCHPAD after 2 retries",
+    "Codex response remained incomplete after 3 continuation attempts":
+        "Codex response remained incomplete after 3 continuation attempts",
+    "Request payload too large (413). Cannot compress further.":
+        "Request payload too large (413). Cannot compress further.",
+    "Context overflow and auto-compaction is disabled (compression.enabled: "
+    "false). Run /compress to compact manually, /new to start fresh, or "
+    "switch to a larger-context model.":
+        "Context overflow and auto-compaction is disabled (compression.enabled: "
+        "false). Run /compress to compact manually, /new to start fresh, or "
+        "switch to a larger-context model.",
+    "max_tokens exceeds the provider's output cap for this model. Lower "
+    "model.max_tokens in config.yaml.":
+        "max_tokens exceeds the provider's output cap for this model. Lower "
+        "model.max_tokens in config.yaml.",
+    "(empty)": "(empty)",
+    "Invalid API response after {} retries: {}":
+        "Invalid API response after 3 retries: no choices in response",
+    "API call failed after {} retries: {}":
+        "API call failed after 3 retries: Connection reset by peer",
+    "Model generated invalid tool call: {}":
+        'Model generated invalid tool call: {"name": "read_file", "argum',
+    "Request payload too large: max compression attempts ({}) reached.":
+        "Request payload too large: max compression attempts (5) reached.",
+    "Context length exceeded: max compression attempts ({}) reached.":
+        "Context length exceeded: max compression attempts (5) reached.",
+    "Context length exceeded ({} tokens). Cannot compress further.":
+        "Context length exceeded (174,833 tokens). Cannot compress further.",
+    "⏳ {}\n\nNo fallback provider available. Try again after the reset, or "
+    "add a fallback provider in config.yaml.":
+        "⏳ Rate limit reached, resets at 04:00 UTC\n\nNo fallback provider "
+        "available. Try again after the reset, or add a fallback provider in "
+        "config.yaml.",
+    "I apologize, but I encountered an error while processing the model "
+    "response: {}":
+        "I apologize, but I encountered an error while processing the model "
+        "response: Expecting value: line 1 column 1",
+    "I apologize, but I encountered repeated errors: {}":
+        "I apologize, but I encountered repeated errors: 502 Bad Gateway",
+    # -- not guarded --------------------------------------------------------
+    # Nothing is delivered for an empty response, so there is nothing to
+    # mistake for an answer.
+    "": None,
+    # The interrupt sentinel. Its fixed part lives in
+    # `conversation_loop.INTERRUPT_WAITING_FOR_MODEL_PREFIX`, so only the tail
+    # appears here; `_sanitize_gateway_final_response` already suppresses this
+    # sentinel on chat surfaces (#7921) and the interruption is operator-
+    # initiated, so it is not a silent failure.
+    "{}{}s elapsed).": None,
+}
+
+
+def _final_response_templates_in_source() -> set:
+    """Every literal `final_response` value in conversation_loop.py.
+
+    Parsed rather than grepped so a diagnostic wrapped across source lines is
+    seen as the one string it is. f-strings come back as templates with `{}`
+    for each interpolation; values that are not literals (a variable, a call)
+    are not classifiable from the source and are skipped.
+    """
+    source = (
+        pathlib.Path(__file__).resolve().parents[2] / "agent" / "conversation_loop.py"
+    ).read_text(encoding="utf-8")
+
+    def literal(node):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return [node.value]
+        if isinstance(node, ast.JoinedStr):
+            out = ""
+            for part in node.values:
+                out += (
+                    part.value
+                    if isinstance(part, ast.Constant) and isinstance(part.value, str)
+                    else "{}"
+                )
+            return [out]
+        if isinstance(node, ast.IfExp):  # a ternary picks between two of them
+            return literal(node.body) + literal(node.orelse)
+        return []
+
+    found = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Assign):
+            if any(
+                isinstance(t, ast.Name) and t.id in ("final_response", "_final_response")
+                for t in node.targets
+            ):
+                found.update(literal(node.value))
+        elif isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values):
+                if isinstance(key, ast.Constant) and key.value == "final_response":
+                    found.update(literal(value))
+    return found
 
 
 def _make_adapter() -> WebhookAdapter:
@@ -72,43 +187,60 @@ def _send(adapter: WebhookAdapter, content: str) -> SendResult:
 # The classifier
 # ---------------------------------------------------------------------------
 
-def test_every_placeholder_is_classified_as_terminal():
-    for placeholder in _TERMINAL_ERROR_PLACEHOLDERS:
-        assert _is_terminal_error_placeholder(placeholder), placeholder
+def test_every_guarded_diagnostic_is_classified_as_terminal():
+    guarded = [v for v in KNOWN_FINAL_RESPONSES.values() if v is not None]
+    assert len(guarded) > len(_TERMINAL_ERROR_PLACEHOLDERS), (
+        "the templated diagnostics are guarded by pattern, not by exact string"
+    )
+    for rendered in guarded:
+        assert _is_terminal_error_placeholder(rendered), rendered
         # Surrounding whitespace must not smuggle one past the guard.
-        assert _is_terminal_error_placeholder(f"\n  {placeholder}  \n")
+        assert _is_terminal_error_placeholder(f"\n  {rendered}  \n")
 
 
 def test_ordinary_response_is_not_classified_as_terminal():
     assert not _is_terminal_error_placeholder(ORDINARY_RESPONSE)
     assert not _is_terminal_error_placeholder("")
     assert not _is_terminal_error_placeholder(None)
-    # A response that merely *quotes* a placeholder is a real answer.
+    # A response that merely *quotes* a diagnostic is a real answer.
     assert not _is_terminal_error_placeholder(
         "The run failed: Response truncated due to output length limit. Retrying."
     )
+    # ... including one that quotes a templated diagnostic mid-sentence.
+    assert not _is_terminal_error_placeholder(
+        "Two runs died with 'Context length exceeded (174,833 tokens). Cannot "
+        "compress further.' — raising the compression tier fixed it."
+    )
 
 
-def test_placeholder_set_has_not_drifted_from_conversation_loop():
-    """Every guarded string must still be produced by conversation_loop.py.
+def test_inventory_matches_source_in_both_directions():
+    """The guard's inventory is exactly what conversation_loop.py can emit.
 
-    Without this, a rewording upstream would silently reopen the hole: the
-    guard would keep passing its own tests while no longer matching anything
-    the loop emits.
+    Set membership alone only proves the guarded strings still exist upstream;
+    it cannot see a *new* diagnostic, which would silently fall outside the
+    guard while every test stayed green. Comparing both ways turns that into
+    a failure that names the string to classify.
     """
-    source = (
-        pathlib.Path(__file__).resolve().parents[2]
-        / "agent"
-        / "conversation_loop.py"
-    ).read_text(encoding="utf-8")
-    # Some are written as adjacent string literals wrapped across source
-    # lines, so drop the quote characters and collapse whitespace on both
-    # sides before comparing.
-    flat = " ".join(source.replace('"', " ").replace("'", " ").split())
-    missing = [
-        p for p in _TERMINAL_ERROR_PLACEHOLDERS if " ".join(p.split()) not in flat
-    ]
-    assert not missing, f"no longer emitted by conversation_loop.py: {missing}"
+    in_source = _final_response_templates_in_source()
+    classified = set(KNOWN_FINAL_RESPONSES)
+    assert not in_source - classified, (
+        "conversation_loop.py emits final_response values this guard has never "
+        f"been told about: {sorted(in_source - classified)!r} — add each one to "
+        "KNOWN_FINAL_RESPONSES with a rendering (guarded) or None (with the "
+        "reason it is not)"
+    )
+    assert not classified - in_source, (
+        "no longer emitted by conversation_loop.py, so the guard is matching "
+        f"strings that cannot occur: {sorted(classified - in_source)!r}"
+    )
+
+
+def test_route_is_recovered_from_the_session_id():
+    assert _route_from_chat_id(CHAT_ID) == "daily-report"
+    # Route names come from a URL path segment, so a colon is possible.
+    assert _route_from_chat_id("webhook:team:daily:1785970121225") == "team:daily"
+    assert _route_from_chat_id("telegram:-1001234567890") == ""
+    assert _route_from_chat_id("") == ""
 
 
 # ---------------------------------------------------------------------------
@@ -134,6 +266,45 @@ def test_placeholder_is_not_delivered_as_the_answer():
     # The reason still travels — the guard explains, it does not hide.
     assert placeholder in delivered
     assert "daily-report" in delivered
+
+
+def test_templated_diagnostic_is_guarded_too():
+    """The set of fixed sentences is not the whole surface (six of eighteen)."""
+    adapter = _make_adapter()
+    target = _wire_target(adapter)
+    adapter._delivery_info[CHAT_ID] = {
+        "deliver": "telegram",
+        "deliver_extra": {"chat_id": "-1001234567890"},
+        "route": "daily-report",
+    }
+
+    assert _send(
+        adapter, "Context length exceeded (174,833 tokens). Cannot compress further."
+    ).success
+    delivered = target.send.await_args.args[1]
+    assert "No answer was produced" in delivered
+    assert "174,833 tokens" in delivered
+
+
+def test_long_provider_message_is_capped_in_the_notice_but_not_in_the_log(caplog):
+    adapter = _make_adapter()
+    target = _wire_target(adapter)
+    adapter._delivery_info[CHAT_ID] = {
+        "deliver": "telegram",
+        "deliver_extra": {"chat_id": "-1001234567890"},
+        "route": "daily-report",
+    }
+
+    tail = "x" * 900
+    with caplog.at_level(logging.WARNING, logger="gateway.platforms.webhook"):
+        assert _send(adapter, f"API call failed after 3 retries: {tail}").success
+
+    delivered = target.send.await_args.args[1]
+    assert "…" in delivered
+    assert tail not in delivered
+    assert len(delivered) < _GUARD_REASON_MAX_CHARS + 300
+    # The operator still gets the whole thing where it belongs.
+    assert tail in " ".join(r.getMessage() for r in caplog.records)
 
 
 def test_ordinary_response_is_delivered_untouched():
@@ -169,8 +340,8 @@ def test_guard_logs_a_warning_naming_the_session_and_route(caplog):
     assert "daily-report" in line
 
 
-def test_guard_still_fires_when_the_route_is_unknown():
-    """A delivery entry that predates the `route` key must not crash the guard."""
+def test_route_is_named_even_without_the_delivery_key():
+    """A delivery entry that predates the `route` key still names its route."""
     adapter = _make_adapter()
     target = _wire_target(adapter)
     adapter._delivery_info[CHAT_ID] = {
@@ -181,6 +352,8 @@ def test_guard_still_fires_when_the_route_is_unknown():
     assert _send(adapter, "Incomplete REASONING_SCRATCHPAD after 2 retries").success
     delivered = target.send.await_args.args[1]
     assert "No answer was produced" in delivered
+    assert "daily-report" in delivered
+    assert "?" not in delivered
 
 
 def test_log_delivery_keeps_the_raw_diagnostic(caplog):

--- a/tests/gateway/test_webhook_delivery_guard.py
+++ b/tests/gateway/test_webhook_delivery_guard.py
@@ -1,0 +1,197 @@
+"""The webhook delivery guard: an error placeholder is not an answer.
+
+When a turn ends without producing an answer, ``agent/conversation_loop.py``
+puts a short placeholder in ``final_response`` ("Response truncated due to
+output length limit", ...). Interactive surfaces render that as an error. A
+webhook route hands whatever it receives to its delivery target, so before
+this guard the recipient got the placeholder itself — a one-line string that
+reads like a terse reply — with nothing in the logs saying the request had
+produced no output.
+
+`gateway/run.py:_sanitize_gateway_final_response` already does this for the
+chat gateways and deliberately exempts `webhook` as a programmatic surface.
+That holds for the route's own HTTP response and for `deliver: log`; it does
+not hold for a route configured to deliver to a person, which is what the
+guard here covers.
+
+Covers:
+- every placeholder is caught, and the delivered text says no answer was produced
+- the original placeholder text is preserved inside the notice, not swallowed
+- a WARNING naming the session and route is logged
+- `deliver: log` keeps the raw diagnostic (programmatic surface, unguarded)
+- ordinary responses pass through untouched
+- the placeholder set has not drifted away from conversation_loop.py
+"""
+
+import asyncio
+import logging
+import pathlib
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.platforms.webhook import (
+    WebhookAdapter,
+    _TERMINAL_ERROR_PLACEHOLDERS,
+    _is_terminal_error_placeholder,
+)
+
+CHAT_ID = "webhook:daily-report:1785970121225"
+
+# A plausible webhook report: an actual answer, which must pass untouched.
+ORDINARY_RESPONSE = (
+    "Overnight batch finished at 04:12 UTC.\n"
+    "- 1,204 rows ingested, 3 rejected (schema mismatch on `order_ref`)\n"
+    "- Retry queue empty\n"
+    "No action needed."
+)
+
+
+def _make_adapter() -> WebhookAdapter:
+    config = PlatformConfig(
+        enabled=True, extra={"host": "127.0.0.1", "port": 0, "routes": {}}
+    )
+    return WebhookAdapter(config)
+
+
+def _wire_target(adapter: WebhookAdapter):
+    target = AsyncMock()
+    target.send = AsyncMock(return_value=SendResult(success=True))
+    runner = MagicMock()
+    runner.adapters = {Platform("telegram"): target}
+    runner.config.get_home_channel.return_value = None
+    adapter.gateway_runner = runner
+    return target
+
+
+def _send(adapter: WebhookAdapter, content: str) -> SendResult:
+    return asyncio.run(adapter.send(CHAT_ID, content))
+
+
+# ---------------------------------------------------------------------------
+# The classifier
+# ---------------------------------------------------------------------------
+
+def test_every_placeholder_is_classified_as_terminal():
+    for placeholder in _TERMINAL_ERROR_PLACEHOLDERS:
+        assert _is_terminal_error_placeholder(placeholder), placeholder
+        # Surrounding whitespace must not smuggle one past the guard.
+        assert _is_terminal_error_placeholder(f"\n  {placeholder}  \n")
+
+
+def test_ordinary_response_is_not_classified_as_terminal():
+    assert not _is_terminal_error_placeholder(ORDINARY_RESPONSE)
+    assert not _is_terminal_error_placeholder("")
+    assert not _is_terminal_error_placeholder(None)
+    # A response that merely *quotes* a placeholder is a real answer.
+    assert not _is_terminal_error_placeholder(
+        "The run failed: Response truncated due to output length limit. Retrying."
+    )
+
+
+def test_placeholder_set_has_not_drifted_from_conversation_loop():
+    """Every guarded string must still be produced by conversation_loop.py.
+
+    Without this, a rewording upstream would silently reopen the hole: the
+    guard would keep passing its own tests while no longer matching anything
+    the loop emits.
+    """
+    source = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "agent"
+        / "conversation_loop.py"
+    ).read_text(encoding="utf-8")
+    # Some are written as adjacent string literals wrapped across source
+    # lines, so drop the quote characters and collapse whitespace on both
+    # sides before comparing.
+    flat = " ".join(source.replace('"', " ").replace("'", " ").split())
+    missing = [
+        p for p in _TERMINAL_ERROR_PLACEHOLDERS if " ".join(p.split()) not in flat
+    ]
+    assert not missing, f"no longer emitted by conversation_loop.py: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# The delivered message
+# ---------------------------------------------------------------------------
+
+def test_placeholder_is_not_delivered_as_the_answer():
+    adapter = _make_adapter()
+    target = _wire_target(adapter)
+    adapter._delivery_info[CHAT_ID] = {
+        "deliver": "telegram",
+        "deliver_extra": {"chat_id": "-1001234567890"},
+        "route": "daily-report",
+    }
+
+    placeholder = "Response truncated due to output length limit"
+    result = _send(adapter, placeholder)
+
+    assert result.success
+    delivered = target.send.await_args.args[1]
+    assert delivered != placeholder
+    assert "No answer was produced" in delivered
+    # The reason still travels — the guard explains, it does not hide.
+    assert placeholder in delivered
+    assert "daily-report" in delivered
+
+
+def test_ordinary_response_is_delivered_untouched():
+    adapter = _make_adapter()
+    target = _wire_target(adapter)
+    adapter._delivery_info[CHAT_ID] = {
+        "deliver": "telegram",
+        "deliver_extra": {"chat_id": "-1001234567890"},
+        "route": "daily-report",
+    }
+
+    assert _send(adapter, ORDINARY_RESPONSE).success
+    assert target.send.await_args.args[1] == ORDINARY_RESPONSE
+
+
+def test_guard_logs_a_warning_naming_the_session_and_route(caplog):
+    adapter = _make_adapter()
+    _wire_target(adapter)
+    adapter._delivery_info[CHAT_ID] = {
+        "deliver": "telegram",
+        "deliver_extra": {"chat_id": "-1001234567890"},
+        "route": "daily-report",
+    }
+
+    with caplog.at_level(logging.WARNING, logger="gateway.platforms.webhook"):
+        _send(adapter, "Request payload too large (413). Cannot compress further.")
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "the guard must leave a WARNING behind"
+    line = warnings[-1].getMessage()
+    assert "delivery-guard" in line
+    assert CHAT_ID in line
+    assert "daily-report" in line
+
+
+def test_guard_still_fires_when_the_route_is_unknown():
+    """A delivery entry that predates the `route` key must not crash the guard."""
+    adapter = _make_adapter()
+    target = _wire_target(adapter)
+    adapter._delivery_info[CHAT_ID] = {
+        "deliver": "telegram",
+        "deliver_extra": {"chat_id": "-1001234567890"},
+    }
+
+    assert _send(adapter, "Incomplete REASONING_SCRATCHPAD after 2 retries").success
+    delivered = target.send.await_args.args[1]
+    assert "No answer was produced" in delivered
+
+
+def test_log_delivery_keeps_the_raw_diagnostic(caplog):
+    """`deliver: log` is a programmatic surface: no notice, no rewrite."""
+    adapter = _make_adapter()
+    adapter._delivery_info[CHAT_ID] = {"deliver": "log", "route": "daily-report"}
+
+    placeholder = "Response truncated due to output length limit"
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.webhook"):
+        assert _send(adapter, placeholder).success
+
+    logged = " ".join(r.getMessage() for r in caplog.records)
+    assert placeholder in logged
+    assert "delivery-guard" not in logged


### PR DESCRIPTION
## What does this PR do?

When a turn ends without producing an answer, `agent/conversation_loop.py` puts a short diagnostic in `final_response` — `Response truncated due to output length limit`, `Context length exceeded (174,833 tokens). Cannot compress further.`, `API call failed after 3 retries: …`, and fifteen others. They explain why the turn stopped. They are not the answer the caller asked for.

`gateway/run.py:_sanitize_gateway_final_response` already replaces them on the chat gateways, and deliberately exempts `webhook` as a programmatic surface (`_GATEWAY_RAW_TEXT_PLATFORMS`). **That exemption is right for the route's own HTTP response and for `deliver: log`. It does not hold for a route configured to deliver to a person.**

A webhook route with `deliver: telegram` (or any other chat adapter, or `github_comment`) hands whatever `send()` receives to that adapter. So the recipient gets:

> Response truncated due to output length limit

as the report they were waiting for — a bare one-line sentence that reads like a terse reply — and nothing in the gateway log distinguishes that delivery from a successful one.

This adds the guard on the human-facing paths only, **after** the `deliver: log` branch has already returned. The programmatic surfaces stay raw, matching the convention the sanitizing layer already sets.

### Reproduction on `main`

```python
adapter._delivery_info[CHAT_ID] = {"deliver": "telegram",
                                   "deliver_extra": {"chat_id": "-100..."}}
asyncio.run(adapter.send(CHAT_ID, "Response truncated due to output length limit"))
```

```
main   → delivered text : 'Response truncated due to output length limit'   ← shipped as the answer
branch → delivered text : '⚠️ No answer was produced for this request (webhook route: daily-report).\n
                            The run ended early - the agent reported: Response truncated due to output length limit\n
                            Nothing else was generated; re-send the request to retry.'
```

Observed in production on a self-hosted gateway: a report route delivering to Telegram shipped the truncation placeholder as the report four times over two days, with nothing in the logs to distinguish it from a successful run. To be clear about what I have and have not verified — that is the *bug* as observed in production; the patch in this PR has been verified by the tests and the snippet above, not yet by a live deployment of this exact code.

### On the inventory, and why it is not a set of constants

The guard has to recognise strings owned by `conversation_loop.py`, which is exactly how this kind of guard rots. Two things keep it honest.

First, the inventory is *complete*, not a sample. `tests/gateway/test_webhook_delivery_guard.py` parses `conversation_loop.py` with `ast` and collects every literal and f-string template it can put in `final_response` — 20 values, 18 of them terminal. Twelve of those are written as f-strings (`Context length exceeded ({n:,} tokens). Cannot compress further.`, `API call failed after {n} retries: {summary}`, `(empty)`, …), which is why the guard classifies by exact string **or** by pattern: a set of constants, wherever it lived, could not have held half of them.

Second, the drift test compares **both ways**. Set-membership alone only proves that what the guard holds is still emitted upstream; it cannot see a diagnostic that was *added*, which would silently fall outside the guard with every test still green. `KNOWN_FINAL_RESPONSES` classifies each of the 20 — a rendering when guarded, `None` plus the reason when not — and the test fails, naming the string, if the source grows one, loses one, or rewords one. Verified by doing all three.

Two are deliberately unguarded: `""` (nothing is delivered, so nothing can be mistaken for an answer) and the interrupt sentinel (its fixed part lives in `INTERRUPT_WAITING_FOR_MODEL_PREFIX`, `_sanitize_gateway_final_response` already suppresses it on chat surfaces per #7921, and the interruption is operator-initiated).

For the record on where this belongs: `_sanitize_gateway_final_response` on `main` does not keep its own copy of these strings — it routes through `_looks_like_gateway_provider_error` — so this is two sites, the loop and this guard, not three. That is why I kept the inventory in `webhook.py` rather than adding an `agent/` module for a single consumer. If a maintainer prefers the exact half exported from `conversation_loop.py` and imported here, that is a one-line move; the pattern half has to stay a predicate either way.

The structurally clean fix is not string matching at all: every one of these returns sets `completed: False` with `error` carrying the same text. But `BasePlatformAdapter._message_handler` returns a bare string, so no failure flag survives to `send()` — and `send()` is the only place that knows whether this route delivers to a machine or to a person. Threading that flag through the delivery boundary is a contract change I did not want to smuggle into a bug fix; happy to open it separately if that is the direction maintainers want.

## Related Issue

No open issue that I could find. Prior art I did find, none of which closes this:

- **#61128** (open, @ZK-Snarky, 2026-07-08) — the same six sentinels, fixed at the shared `gateway/run.py` layer for the chat gateways. It explicitly keeps `webhook` in `_GATEWAY_RAW_TEXT_PLATFORMS`, so a `deliver:`-configured route is exactly the case it leaves open. **That PR predates this one and should land first if both are wanted**; the two do not conflict (different files, different layers), and this one stays useful after it because the exemption it preserves is the hole here. If maintainers would rather fix this by dropping `webhook` from `_GATEWAY_RAW_TEXT_PLATFORMS`, that would break routes whose HTTP response is consumed by a machine, which is presumably why the exemption exists.
- **#83229** (open) — argues one of these placeholders is *misleading* for malformed tool args. Orthogonal: it changes what the loop emits, not who receives it. This guard keeps working either way as long as the drift test is kept green.
- **#31670**, **#33396** — webhook delivery, unrelated concerns.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/webhook.py`
  - `_TERMINAL_ERROR_PLACEHOLDERS` (exact sentences) + `_TERMINAL_ERROR_PLACEHOLDER_PATTERNS` (the templated ones) + `_is_terminal_error_placeholder()`, next to the existing response classifiers.
  - In `send()`, after the `deliver: log` branch returns: replace a diagnostic with a notice and log a `delivery-guard` WARNING carrying session, route and the untruncated reason.
  - The reason echoed in the *notice* is whitespace-collapsed and capped at 200 chars — one template embeds a provider error message. No escaping here on purpose: `send()` cannot know its target's markup (chat adapters escape on their own send, a GitHub comment body is markdown), so escaping would corrupt whichever of the two the route is not.
  - `_route_from_chat_id()`: name the route from the `webhook:{route}:{delivery_id}` session id when the delivery entry predates the `route` key, instead of `?`.
  - Store `route` in the per-delivery info dict.
- `tests/gateway/test_webhook_delivery_guard.py` (new, 11 tests).

## How to Test

1. `pytest tests/gateway/test_webhook_delivery_guard.py -q` → 11 passed.
2. Revert `gateway/platforms/webhook.py` and run the snippet under *Reproduction* — the diagnostic is delivered verbatim.
3. Drift check, both directions: add `_final_response = "Brand new terminal diagnostic"` anywhere in `agent/conversation_loop.py`, or reword `Incomplete REASONING_SCRATCHPAD after 2 retries` to `... after 4 retries`, and `test_inventory_matches_source_in_both_directions` fails naming the string.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — the nearest is #61128, discussed under *Related Issue* rather than glossed over
- [x] My PR contains **only** changes related to this fix (two commits — the second is the review response — 3 files)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run in full.** I ran a scoped selection on this branch and on its parent commit `fa2601c2f5` and compared the failure sets: `tests/gateway/test_webhook_adapter.py`, `test_webhook_deliver_only.py`, `test_webhook_integration.py`, `test_webhook_session_close.py`, `test_webhook_dynamic_routes.py`, `test_webhook_route_toolsets.py`, `test_telegram_format.py`, plus `tests/agent/test_tool_guardrails.py`, `test_display.py`, `test_display_tool_failure.py`, `tests/tools/test_mcp_circuit_breaker.py`, `test_skill_manager_tool.py`, `tests/cron/test_scheduler.py`. Parent: 294 passed / 0 failed. This branch: 305 passed / 0 failed. Same failure set (empty); the 11 added tests account for the difference.
- [x] I've added tests for my changes (11 new)
- [x] I've tested on my platform: Ubuntu 24.04 (aarch64), Python 3.11.15, pytest 9.1.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the comments state the invariant and name the layer this complements; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys added; `route` is an internal dict key, not route configuration
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A in substance: string comparison and logging, no paths, processes, signals or encodings. The drift test reads `agent/conversation_loop.py` through `pathlib` with an explicit `utf-8` encoding, so it does not depend on the platform's default codec
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool touched