### PR TITLE
feat(config): agent.max_turns unlimited by default (salvage #67696, fixes #82813)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -520,7 +520,7 @@ def init_agent(
     command: str = None,
     args: list[str] | None = None,
     model: str = "",
-    max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
+    max_iterations: int = sys.maxsize,  # Default: unlimited tool-calling iterations (shared with subagents)
     enabled_toolsets: List[str] = None,
     disabled_toolsets: List[str] = None,
     save_trajectories: bool = False,

--- a/cli.py
+++ b/cli.py
@@ -5233,25 +5233,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         else:
             self.api_key = api_key or os.getenv("OPENAI_API_KEY") or os.getenv("OPENROUTER_API_KEY")
         # Max turns priority: CLI arg > config file > env var > default
+        # All paths go through resolve_turn_limit() so that agent.max_turns
+        # accepts "none"/"unlimited" (→ sys.maxsize) in addition to ints.
+        # See hermes_cli.config.resolve_turn_limit for the full spelling table.
+        from hermes_cli.config import resolve_turn_limit as _resolve_turn_limit
         if max_turns is not None:  # CLI arg was explicitly set
-            self.max_turns = max_turns
-        elif CLI_CONFIG["agent"].get("max_turns"):
-            self.max_turns = CLI_CONFIG["agent"]["max_turns"]
-        elif CLI_CONFIG.get("max_turns"):  # Backwards compat: root-level max_turns
+            self.max_turns = _resolve_turn_limit(max_turns)
+        elif CLI_CONFIG["agent"].get("max_turns") is not None:
+            self.max_turns = _resolve_turn_limit(CLI_CONFIG["agent"]["max_turns"])
+        elif CLI_CONFIG.get("max_turns") is not None:  # Backwards compat: root-level max_turns
             # KEEP (evaluated for the v12 support-floor cleanup, July 2026):
             # no versioned config migration ever rewrote root-level max_turns
             # to agent.max_turns on disk — only load-time normalization
             # (_normalize_max_turns_config) folds it, and configs read through
             # other paths may bypass it. This fallback is therefore the only
             # safety net for configs that still carry the root key.
-            self.max_turns = CLI_CONFIG["max_turns"]
-        elif os.getenv("HERMES_MAX_ITERATIONS"):
-            try:
-                self.max_turns = int(os.getenv("HERMES_MAX_ITERATIONS", ""))
-            except (TypeError, ValueError):
-                self.max_turns = 500
+            self.max_turns = _resolve_turn_limit(CLI_CONFIG["max_turns"])
         else:
-            self.max_turns = 500
+            # Env var bridge (set by gateway/run.py from config.yaml, or by the
+            # user directly). Empty/unset → default (unlimited).
+            self.max_turns = _resolve_turn_limit(os.getenv("HERMES_MAX_ITERATIONS"))
 
         # Wall-clock run budget: CLI flag wins over config; both optional.
         # None keeps the feature fully off (AIAgent stays dormant).
@@ -5259,7 +5260,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self.run_budget_seconds = run_budget
         else:
             self.run_budget_seconds = CLI_CONFIG["agent"].get("run_budget_seconds")
-        
+
         # Parse and validate toolsets
         self.enabled_toolsets = toolsets
         from agent.skill_utils import parse_config_string_list

--- a/contributors/emails/fattchris@users.noreply.github.com
+++ b/contributors/emails/fattchris@users.noreply.github.com
@@ -1,0 +1,1 @@
+fattchris

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5411,8 +5411,14 @@ def run_job(
                     logger.warning("Job '%s': failed to parse prefill messages file '%s': %s", job_id, pfpath, e)
                     prefill_messages = None
 
-        # Max iterations
-        max_iterations = _cfg.get("agent", {}).get("max_turns") or _cfg.get("max_turns") or 500
+        # Max iterations — resolved through resolve_turn_limit() so that
+        # agent.max_turns: none / unlimited → sys.maxsize sentinel, and
+        # explicit 0 / null / "none" are honored instead of skipped by `or`.
+        from hermes_cli.config import resolve_turn_limit as _resolve_turn_limit
+        _mt = _cfg.get("agent", {}).get("max_turns")
+        if _mt is None:
+            _mt = _cfg.get("max_turns")
+        max_iterations = _resolve_turn_limit(_mt)
 
         # Provider routing
         pr = _cfg.get("provider_routing") or {}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2049,10 +2049,18 @@ def _bridge_max_turns_from_config(home: "Path") -> None:
 
     agent_cfg = cfg.get("agent", {})
     if isinstance(agent_cfg, dict) and "max_turns" in agent_cfg:
+        raw = agent_cfg["max_turns"]
         # Preserve the raw value's spelling (e.g. "none", "unlimited", "120")
         # so resolve_turn_limit() in _current_max_iterations can interpret it.
-        # str() round-trips both Python None (→ "None") and YAML strings.
-        os.environ["HERMES_MAX_ITERATIONS"] = str(agent_cfg["max_turns"])
+        # Skip bridging when the YAML value is Python None (from `null` or bare
+        # `key:`) — this preserves "absent = default" semantics downstream.
+        # Without this guard, str(None) → "None" → resolve_turn_limit maps it
+        # to the unlimited sentinel instead of the default (90/500).
+        if raw is not None:
+            os.environ["HERMES_MAX_ITERATIONS"] = str(raw)
+        elif "HERMES_MAX_ITERATIONS" in os.environ:
+            # Clear stale bridge so downstream resolver applies its default.
+            del os.environ["HERMES_MAX_ITERATIONS"]
     # config-authoritative knobs for the session-search index (config.yaml
     # sessions.* wins over stale env; env stays the cross-process carrier).
     sessions_cfg = cfg.get("sessions", {})
@@ -2362,7 +2370,13 @@ if _config_path.exists():
         _agent_cfg = _cfg.get("agent", {})
         if _agent_cfg and isinstance(_agent_cfg, dict):
             if "max_turns" in _agent_cfg:
-                os.environ["HERMES_MAX_ITERATIONS"] = str(_agent_cfg["max_turns"])
+                _raw_mt = _agent_cfg["max_turns"]
+                # Same None-guard as _bridge_max_turns_from_config: str(None)
+                # → "None" → resolve_turn_limit maps to unlimited, not default.
+                if _raw_mt is not None:
+                    os.environ["HERMES_MAX_ITERATIONS"] = str(_raw_mt)
+                elif "HERMES_MAX_ITERATIONS" in os.environ:
+                    del os.environ["HERMES_MAX_ITERATIONS"]
             if "gateway_timeout" in _agent_cfg:
                 os.environ["HERMES_AGENT_TIMEOUT"] = str(_agent_cfg["gateway_timeout"])
             if "gateway_turn_lease_timeout" in _agent_cfg:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2049,6 +2049,9 @@ def _bridge_max_turns_from_config(home: "Path") -> None:
 
     agent_cfg = cfg.get("agent", {})
     if isinstance(agent_cfg, dict) and "max_turns" in agent_cfg:
+        # Preserve the raw value's spelling (e.g. "none", "unlimited", "120")
+        # so resolve_turn_limit() in _current_max_iterations can interpret it.
+        # str() round-trips both Python None (→ "None") and YAML strings.
         os.environ["HERMES_MAX_ITERATIONS"] = str(agent_cfg["max_turns"])
     # config-authoritative knobs for the session-search index (config.yaml
     # sessions.* wins over stale env; env stays the cross-process carrier).
@@ -2061,12 +2064,16 @@ def _bridge_max_turns_from_config(home: "Path") -> None:
 
 
 def _current_max_iterations() -> int:
-    """Return the current per-turn iteration budget after runtime env refresh."""
+    """Return the current per-turn iteration budget after runtime env refresh.
+
+    Goes through :func:`hermes_cli.config.resolve_turn_limit` so that
+    ``agent.max_turns: none`` / ``unlimited`` (bridged into
+    ``HERMES_MAX_ITERATIONS`` as a string) resolves to the unlimited sentinel
+    instead of crashing ``int()``.
+    """
     _reload_runtime_env_preserving_config_authority()
-    try:
-        return int(os.getenv("HERMES_MAX_ITERATIONS", "500"))
-    except (TypeError, ValueError):
-        return 500
+    from hermes_cli.config import resolve_turn_limit as _resolve_turn_limit
+    return _resolve_turn_limit(os.getenv("HERMES_MAX_ITERATIONS"))
 
 
 from contextlib import contextmanager as _contextmanager

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3078,6 +3078,77 @@ def is_provider_enabled(provider_cfg: Optional[Dict[str, Any]]) -> bool:
     return bool(flag)
 
 
+# Sentinel used when the user requests an unlimited turn budget.
+# ``sys.maxsize`` (9,223,372,036,854,775,807) is chosen so it:
+#   - survives the ``str() → int()`` round-trip through the HERMES_MAX_ITERATIONS
+#     env-var bridge in gateway/run.py,
+#   - works correctly in every ``<``, ``>=``, and ``remaining = max - used``
+#     comparison in agent/iteration_budget.py and agent/conversation_loop.py
+#     without requiring those call sites to learn about a special "unlimited"
+#     value, and
+#   - is large enough that no real conversation will ever reach it (a turn
+#     takes seconds; 9.2e18 turns would take ~10^11 years).
+TURN_LIMIT_UNLIMITED = sys.maxsize
+
+# String spellings that mean "no limit".  Lowercased, whitespace-stripped
+# before comparison so ``"None"``, ``" unlimited "`` etc. all match.
+_UNLIMITED_SPELLINGS = frozenset({"none", "unlimited", "infinite", "∞", "-1", "0"})
+
+
+def resolve_turn_limit(raw: Any, default: int = 90) -> int:
+    """Normalize a raw ``agent.max_turns`` value into an int iteration cap.
+
+    Accepts:
+      - ``int`` / ``float`` → ``int(raw)`` (floats truncated; negatives rejected
+        → fall through to ``default``).
+      - numeric string (``"120"``) → ``int(raw)``.
+      - ``"none"`` / ``"unlimited"`` / ``"infinite"`` / ``"-1"`` / ``"0"``
+        (case-insensitive, whitespace-tolerant) → :data:`TURN_LIMIT_UNLIMITED`.
+      - YAML ``None`` / ``null`` (the value is explicitly absent) → ``default``.
+      - Anything unparseable → ``default`` (with a debug log).
+
+    The returned int is always ≥ 1, so loop conditions like
+    ``while api_call_count < agent.max_iterations`` behave correctly even when
+    the default path is taken.
+
+    This is the single normalization point for the turn-limit value type.
+    Config-reading sites (cli.py, gateway/run.py, cron/scheduler.py) call this
+    instead of bare ``int(...)``, so ``agent.max_turns: none`` in config.yaml
+    becomes a first-class supported spelling of "unlimited".
+    """
+    if raw is None:
+        return default
+    if isinstance(raw, bool):
+        # bool is a subclass of int; reject it explicitly so True/False don't
+        # silently become 1/0.
+        return default
+    if isinstance(raw, (int, float)):
+        n = int(raw)
+        if n <= 0:
+            return TURN_LIMIT_UNLIMITED
+        return n
+    if isinstance(raw, str):
+        s = raw.strip().lower()
+        if not s:
+            return default
+        if s in _UNLIMITED_SPELLINGS:
+            return TURN_LIMIT_UNLIMITED
+        try:
+            n = int(s)
+        except ValueError:
+            try:
+                n = int(float(s))
+            except ValueError:
+                logger.debug("resolve_turn_limit: unparseable value %r → default %d", raw, default)
+                return default
+        if n <= 0:
+            return TURN_LIMIT_UNLIMITED
+        return n
+    # Unknown type (list, dict, …) — don't crash the agent over a bad config.
+    logger.debug("resolve_turn_limit: unsupported type %s (%r) → default %d", type(raw).__name__, raw, default)
+    return default
+
+
 def cfg_get(cfg: Optional[Dict[str, Any]], *keys: str, default: Any = None) -> Any:
     """Traverse nested dict keys safely, returning ``default`` on any miss.
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3092,29 +3092,35 @@ TURN_LIMIT_UNLIMITED = sys.maxsize
 
 # String spellings that mean "no limit".  Lowercased, whitespace-stripped
 # before comparison so ``"None"``, ``" unlimited "`` etc. all match.
-_UNLIMITED_SPELLINGS = frozenset({"none", "unlimited", "infinite", "∞", "-1", "0"})
+_UNLIMITED_SPELLINGS = frozenset({
+    "none", "null", "unlimited", "infinite", "infinity", "inf",
+    "∞", "-1", "0",
+})
 
 
-def resolve_turn_limit(raw: Any, default: int = 90) -> int:
+def resolve_turn_limit(raw: Any, default: int = TURN_LIMIT_UNLIMITED) -> int:
     """Normalize a raw ``agent.max_turns`` value into an int iteration cap.
 
     Accepts:
-      - ``int`` / ``float`` → ``int(raw)`` (floats truncated; negatives rejected
-        → fall through to ``default``).
+      - ``int`` / ``float`` → ``int(raw)`` (floats truncated; values ≤ 0 mean
+        "no limit" → :data:`TURN_LIMIT_UNLIMITED`).
       - numeric string (``"120"``) → ``int(raw)``.
-      - ``"none"`` / ``"unlimited"`` / ``"infinite"`` / ``"-1"`` / ``"0"``
+      - ``"none"`` / ``"null"`` / ``"unlimited"`` / ``"infinite"`` /
+        ``"infinity"`` / ``"inf"`` / ``"∞"`` / ``"-1"`` / ``"0"``
         (case-insensitive, whitespace-tolerant) → :data:`TURN_LIMIT_UNLIMITED`.
-      - YAML ``None`` / ``null`` (the value is explicitly absent) → ``default``.
+      - YAML ``None`` / ``null`` / absent value → ``default`` (which is itself
+        :data:`TURN_LIMIT_UNLIMITED` — max_turns is unlimited by default).
       - Anything unparseable → ``default`` (with a debug log).
 
     The returned int is always ≥ 1, so loop conditions like
     ``while api_call_count < agent.max_iterations`` behave correctly even when
-    the default path is taken.
+    the default (unlimited) path is taken.
 
     This is the single normalization point for the turn-limit value type.
     Config-reading sites (cli.py, gateway/run.py, cron/scheduler.py) call this
     instead of bare ``int(...)``, so ``agent.max_turns: none`` in config.yaml
-    becomes a first-class supported spelling of "unlimited".
+    becomes a first-class supported spelling of "unlimited". max_turns is
+    unlimited unless the user sets an explicit positive integer cap.
     """
     if raw is None:
         return default

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -43,7 +43,11 @@ DEFAULT_CONFIG = {
         "terminal_continue": True,
     },
     "agent": {
-        "max_turns": 500,
+        # Unlimited by default. The agent turn cap caused more problems than
+        # it solved (silent mid-task truncation). null = unlimited; set a
+        # positive integer to cap, or use "none"/"unlimited"/"inf"/0/-1 —
+        # all normalized by hermes_cli.config.resolve_turn_limit.
+        "max_turns": None,
         # Optional wall-clock budget in seconds per conversation run.
         # null/absent = feature fully off (zero behavior change). When set,
         # the agent gets a one-time wrap-up notice at 80% elapsed and

--- a/run_agent.py
+++ b/run_agent.py
@@ -443,7 +443,7 @@ class AIAgent:
         command: str = None,
         args: list[str] | None = None,
         model: str = "",
-        max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
+        max_iterations: int = sys.maxsize,  # Default: unlimited tool-calling iterations (shared with subagents)
         tool_delay: float = None,  # Deprecated: accepted for compatibility, ignored
         enabled_toolsets: List[str] = None,
         disabled_toolsets: List[str] = None,

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -73,10 +73,14 @@ def _make_cli(env_overrides=None, config_overrides=None, **kwargs):
 class TestMaxTurnsResolution:
     """max_turns must always resolve to a positive integer, never None."""
 
-    def test_default_max_turns_is_integer(self):
+    def test_default_max_turns_is_unlimited(self):
+        # Default is now unlimited (max_turns caused more problems than it
+        # solved). Still a positive int (the sys.maxsize sentinel), so loop
+        # conditions like `count < max_iterations` keep working.
+        import sys
         cli = _make_cli()
         assert isinstance(cli.max_turns, int)
-        assert cli.max_turns == 500
+        assert cli.max_turns == sys.maxsize
 
     def test_explicit_max_turns_honored(self):
         cli = _make_cli(max_turns=25)

--- a/tests/hermes_cli/test_resolve_turn_limit.py
+++ b/tests/hermes_cli/test_resolve_turn_limit.py
@@ -1,0 +1,132 @@
+"""Tests for :func:`hermes_cli.config.resolve_turn_limit` and the
+``TURN_LIMIT_UNLIMITED`` sentinel.
+
+Covers the full spelling table (int, float, numeric string, ``"none"``,
+``"unlimited"``, ``"infinite"``, ``"-1"``, ``"0"``, YAML ``None``, bool,
+garbage) and the str→int env-var round-trip that the gateway bridge relies on.
+"""
+import sys
+import pytest
+
+from hermes_cli.config import resolve_turn_limit, TURN_LIMIT_UNLIMITED
+
+
+class TestNumericValues:
+    def test_int_passthrough(self):
+        assert resolve_turn_limit(90) == 90
+        assert resolve_turn_limit(120) == 120
+        assert resolve_turn_limit(1) == 1
+
+    def test_float_truncated(self):
+        assert resolve_turn_limit(3.7) == 3
+        assert resolve_turn_limit(3.0) == 3
+        assert resolve_turn_limit(100.9) == 100
+
+    def test_numeric_string(self):
+        assert resolve_turn_limit("120") == 120
+        assert resolve_turn_limit("3") == 3
+        assert resolve_turn_limit("3.7") == 3  # float string → int
+
+    def test_negative_int_is_unlimited(self):
+        assert resolve_turn_limit(-5) == TURN_LIMIT_UNLIMITED
+
+    def test_negative_string_is_unlimited(self):
+        assert resolve_turn_limit("-1") == TURN_LIMIT_UNLIMITED
+        assert resolve_turn_limit("-42") == TURN_LIMIT_UNLIMITED
+
+
+class TestUnlimitedSpellings:
+    @pytest.mark.parametrize("spelling", [
+        "none", "None", "NONE", "nOnE",
+        "unlimited", "UNLIMITED", "Unlimited",
+        "infinite", "INFINITE",
+        "∞",
+        "-1", "0",
+    ])
+    def test_string_spellings_resolve_to_sentinel(self, spelling):
+        assert resolve_turn_limit(spelling) == TURN_LIMIT_UNLIMITED
+
+    @pytest.mark.parametrize("spelling", [" none ", "  unlimited  ", "\tinfinite\t"])
+    def test_whitespace_tolerant(self, spelling):
+        assert resolve_turn_limit(spelling) == TURN_LIMIT_UNLIMITED
+
+    def test_zero_int_is_unlimited(self):
+        assert resolve_turn_limit(0) == TURN_LIMIT_UNLIMITED
+
+    def test_zero_float_is_unlimited(self):
+        assert resolve_turn_limit(0.0) == TURN_LIMIT_UNLIMITED
+
+
+class TestAbsentAndDefault:
+    def test_none_returns_default(self):
+        assert resolve_turn_limit(None) == 90
+
+    def test_none_custom_default(self):
+        assert resolve_turn_limit(None, default=500) == 500
+
+    def test_empty_string_returns_default(self):
+        assert resolve_turn_limit("") == 90
+
+    def test_whitespace_only_returns_default(self):
+        assert resolve_turn_limit("   ") == 90
+
+    def test_absent_env_var_returns_default(self):
+        """Simulates os.getenv() returning None when HERMES_MAX_ITERATIONS unset."""
+        assert resolve_turn_limit(None) == 90
+
+
+class TestInvalidInputs:
+    def test_bool_rejected(self):
+        # bool is an int subclass — must not silently become 1/0
+        assert resolve_turn_limit(True) == 90
+        assert resolve_turn_limit(False) == 90
+
+    def test_garbage_string_returns_default(self):
+        assert resolve_turn_limit("garbage") == 90
+        assert resolve_turn_limit("not_a_number") == 90
+
+    def test_list_returns_default(self):
+        assert resolve_turn_limit([]) == 90
+        assert resolve_turn_limit([90]) == 90
+
+    def test_dict_returns_default(self):
+        assert resolve_turn_limit({}) == 90
+        assert resolve_turn_limit({"max_turns": 90}) == 90
+
+
+class TestSentinelProperties:
+    def test_sentinel_is_sys_maxsize(self):
+        assert TURN_LIMIT_UNLIMITED == sys.maxsize
+
+    def test_sentinel_str_int_round_trip(self):
+        """The gateway bridge writes str(value) to HERMES_MAX_ITERATIONS,
+        then _current_max_iterations reads it back.  The sentinel must survive."""
+        s = str(TURN_LIMIT_UNLIMITED)
+        assert int(s) == TURN_LIMIT_UNLIMITED
+
+    def test_sentinel_greater_than_any_realistic_count(self):
+        assert TURN_LIMIT_UNLIMITED > 10_000_000
+        assert TURN_LIMIT_UNLIMITED > 1_000_000_000
+
+
+class TestEnvVarBridgeSimulation:
+    """Simulates the full gateway chain: config value → str() → env var →
+    resolve_turn_limit()."""
+
+    def test_none_string_round_trip(self):
+        # config has: agent.max_turns: "none"
+        env_val = str("none")
+        assert resolve_turn_limit(env_val) == TURN_LIMIT_UNLIMITED
+
+    def test_yaml_null_round_trip(self):
+        # YAML bare 'none' parses to Python None, str(None) = "None"
+        env_val = str(None)  # "None"
+        assert resolve_turn_limit(env_val) == TURN_LIMIT_UNLIMITED
+
+    def test_int_round_trip(self):
+        env_val = str(120)
+        assert resolve_turn_limit(env_val) == 120
+
+    def test_unlimited_string_round_trip(self):
+        env_val = str("unlimited")
+        assert resolve_turn_limit(env_val) == TURN_LIMIT_UNLIMITED

--- a/tests/hermes_cli/test_resolve_turn_limit.py
+++ b/tests/hermes_cli/test_resolve_turn_limit.py
@@ -5,6 +5,7 @@ Covers the full spelling table (int, float, numeric string, ``"none"``,
 ``"unlimited"``, ``"infinite"``, ``"-1"``, ``"0"``, YAML ``None``, bool,
 garbage) and the str→int env-var round-trip that the gateway bridge relies on.
 """
+import os
 import sys
 import pytest
 
@@ -130,3 +131,100 @@ class TestEnvVarBridgeSimulation:
     def test_unlimited_string_round_trip(self):
         env_val = str("unlimited")
         assert resolve_turn_limit(env_val) == TURN_LIMIT_UNLIMITED
+
+
+class TestGatewayBridgeNullHandling:
+    """Verify that _bridge_max_turns_from_config does NOT serialize Python None
+    (from YAML ``null`` or bare ``key:``) into the env var as the string
+    "None", which would resolve to unlimited instead of the default."""
+
+    def test_none_value_not_bridged(self, monkeypatch, tmp_path):
+        """YAML ``max_turns: null`` should not set HERMES_MAX_ITERATIONS."""
+        import yaml
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text("agent:\n  max_turns: null\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_MAX_ITERATIONS", "stale-120")
+        # Import here to avoid module-level gateway dependency
+        from gateway.run import _bridge_max_turns_from_config
+        _bridge_max_turns_from_config(tmp_path)
+        # The stale env var should be cleared so downstream resolver
+        # applies the default rather than using the stale value.
+        assert "HERMES_MAX_ITERATIONS" not in os.environ
+
+    def test_string_none_bridged_correctly(self, monkeypatch, tmp_path):
+        """YAML ``max_turns: "none"`` should bridge as the string "none"."""
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text('agent:\n  max_turns: "none"\n', encoding="utf-8")
+        monkeypatch.delenv("HERMES_MAX_ITERATIONS", raising=False)
+        from gateway.run import _bridge_max_turns_from_config
+        _bridge_max_turns_from_config(tmp_path)
+        assert os.environ.get("HERMES_MAX_ITERATIONS") == "none"
+
+    def test_int_bridged_correctly(self, monkeypatch, tmp_path):
+        """YAML ``max_turns: 120`` should bridge as "120"."""
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text("agent:\n  max_turns: 120\n", encoding="utf-8")
+        monkeypatch.delenv("HERMES_MAX_ITERATIONS", raising=False)
+        from gateway.run import _bridge_max_turns_from_config
+        _bridge_max_turns_from_config(tmp_path)
+        assert os.environ.get("HERMES_MAX_ITERATIONS") == "120"
+
+    def test_bare_key_treated_as_null(self, monkeypatch, tmp_path):
+        """YAML ``max_turns:`` (bare key, no value) parses as Python None."""
+        import yaml
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text("agent:\n  max_turns:\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_MAX_ITERATIONS", "stale-90")
+        from gateway.run import _bridge_max_turns_from_config
+        _bridge_max_turns_from_config(tmp_path)
+        assert "HERMES_MAX_ITERATIONS" not in os.environ
+
+
+class TestTUIResolver:
+    """Verify that _cfg_max_turns in tui_gateway/server.py routes through
+    resolve_turn_limit instead of bare int()."""
+
+    def test_string_none_resolves_to_unlimited(self):
+        from tui_gateway.server import _cfg_max_turns
+        cfg = {"agent": {"max_turns": "none"}}
+        assert _cfg_max_turns(cfg, default=25) == TURN_LIMIT_UNLIMITED
+
+    def test_int_zero_resolves_to_unlimited(self):
+        from tui_gateway.server import _cfg_max_turns
+        cfg = {"agent": {"max_turns": 0}}
+        assert _cfg_max_turns(cfg, default=25) == TURN_LIMIT_UNLIMITED
+
+    def test_string_unlimited_resolves_to_unlimited(self):
+        from tui_gateway.server import _cfg_max_turns
+        cfg = {"agent": {"max_turns": "unlimited"}}
+        assert _cfg_max_turns(cfg, default=25) == TURN_LIMIT_UNLIMITED
+
+    def test_int_passthrough(self):
+        from tui_gateway.server import _cfg_max_turns
+        cfg = {"agent": {"max_turns": 50}}
+        assert _cfg_max_turns(cfg, default=25) == 50
+
+    def test_none_falls_through_to_default(self):
+        from tui_gateway.server import _cfg_max_turns
+        cfg = {"agent": {}}
+        assert _cfg_max_turns(cfg, default=25) == 25
+
+    def test_env_var_override(self, monkeypatch):
+        from tui_gateway.server import _cfg_max_turns
+        monkeypatch.setenv("HERMES_TUI_MAX_TURNS", "none")
+        cfg = {"agent": {"max_turns": 50}}
+        assert _cfg_max_turns(cfg, default=25) == TURN_LIMIT_UNLIMITED
+
+    def test_env_var_zero_is_unlimited(self, monkeypatch):
+        """Old code swallowed 0 via `int(0) > 0` → False. Now it routes
+        through resolve_turn_limit which treats 0 as unlimited."""
+        from tui_gateway.server import _cfg_max_turns
+        monkeypatch.setenv("HERMES_TUI_MAX_TURNS", "0")
+        cfg = {"agent": {"max_turns": 50}}
+        assert _cfg_max_turns(cfg, default=25) == TURN_LIMIT_UNLIMITED
+
+    def test_root_level_max_turns(self):
+        """Legacy root-level max_turns still works."""
+        from tui_gateway.server import _cfg_max_turns
+        cfg = {"max_turns": "none"}
+        assert _cfg_max_turns(cfg, default=25) == TURN_LIMIT_UNLIMITED

--- a/tests/hermes_cli/test_resolve_turn_limit.py
+++ b/tests/hermes_cli/test_resolve_turn_limit.py
@@ -60,39 +60,40 @@ class TestUnlimitedSpellings:
 
 class TestAbsentAndDefault:
     def test_none_returns_default(self):
-        assert resolve_turn_limit(None) == 90
+        # Default is now unlimited (max_turns caused more problems than it solved).
+        assert resolve_turn_limit(None) == TURN_LIMIT_UNLIMITED
 
     def test_none_custom_default(self):
         assert resolve_turn_limit(None, default=500) == 500
 
     def test_empty_string_returns_default(self):
-        assert resolve_turn_limit("") == 90
+        assert resolve_turn_limit("") == TURN_LIMIT_UNLIMITED
 
     def test_whitespace_only_returns_default(self):
-        assert resolve_turn_limit("   ") == 90
+        assert resolve_turn_limit("   ") == TURN_LIMIT_UNLIMITED
 
     def test_absent_env_var_returns_default(self):
         """Simulates os.getenv() returning None when HERMES_MAX_ITERATIONS unset."""
-        assert resolve_turn_limit(None) == 90
+        assert resolve_turn_limit(None) == TURN_LIMIT_UNLIMITED
 
 
 class TestInvalidInputs:
     def test_bool_rejected(self):
         # bool is an int subclass — must not silently become 1/0
-        assert resolve_turn_limit(True) == 90
-        assert resolve_turn_limit(False) == 90
+        assert resolve_turn_limit(True) == TURN_LIMIT_UNLIMITED
+        assert resolve_turn_limit(False) == TURN_LIMIT_UNLIMITED
 
     def test_garbage_string_returns_default(self):
-        assert resolve_turn_limit("garbage") == 90
-        assert resolve_turn_limit("not_a_number") == 90
+        assert resolve_turn_limit("garbage") == TURN_LIMIT_UNLIMITED
+        assert resolve_turn_limit("not_a_number") == TURN_LIMIT_UNLIMITED
 
     def test_list_returns_default(self):
-        assert resolve_turn_limit([]) == 90
-        assert resolve_turn_limit([90]) == 90
+        assert resolve_turn_limit([]) == TURN_LIMIT_UNLIMITED
+        assert resolve_turn_limit([90]) == TURN_LIMIT_UNLIMITED
 
     def test_dict_returns_default(self):
-        assert resolve_turn_limit({}) == 90
-        assert resolve_turn_limit({"max_turns": 90}) == 90
+        assert resolve_turn_limit({}) == TURN_LIMIT_UNLIMITED
+        assert resolve_turn_limit({"max_turns": 90}) == TURN_LIMIT_UNLIMITED
 
 
 class TestSentinelProperties:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6618,14 +6618,20 @@ def _apply_personality_to_session(
 
 
 def _cfg_max_turns(cfg: dict, default: int) -> int:
-    try:
-        env_max = int(os.environ.get("HERMES_TUI_MAX_TURNS", "") or 0)
-        if env_max > 0:
-            return env_max
-    except (TypeError, ValueError):
-        pass
+    from hermes_cli.config import resolve_turn_limit as _resolve_turn_limit
+    # Env var override (highest priority)
+    env_val = os.environ.get("HERMES_TUI_MAX_TURNS")
+    if env_val:
+        return _resolve_turn_limit(env_val, default=default)
+    # Config file value — route through resolve_turn_limit so that
+    # "none"/"unlimited"/0 are first-class spellings, not int() crashes.
     agent_cfg = cfg.get("agent") or {}
-    return int(agent_cfg.get("max_turns") or cfg.get("max_turns") or default)
+    raw = agent_cfg.get("max_turns")
+    if raw is None:
+        raw = cfg.get("max_turns")
+    if raw is not None:
+        return _resolve_turn_limit(raw, default=default)
+    return default
 
 
 def _parse_tui_skills_env() -> list[str]:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1023,14 +1023,13 @@ Instead, when the budget is actually exhausted (500/500), Hermes injects one mes
 
 ```yaml
 agent:
-  max_turns: 90                # Max iterations per conversation turn (default: 90)
-                               # Set to "none", "unlimited", or 0 for no limit
+  max_turns: none              # Iterations per conversation turn (default: none = unlimited)
+                               # Set a positive integer to cap; "none"/"null"/
+                               # "unlimited"/"inf"/"infinity"/"infinite"/0/-1 = no limit
   api_max_retries: 3           # Retries per provider before fallback engages (default: 3)
 ```
 
-When the iteration budget is fully exhausted, the CLI shows a notification to the user: `⚠ Iteration budget reached (500/500) — response may be incomplete`.
-
-`agent.max_turns` accepts the following "unlimited" spellings (case-insensitive): `"none"`, `"unlimited"`, `"infinite"`, `0`, `-1`. These resolve to a sentinel value (`sys.maxsize`) so the loop never exits on a turn count. Use this for long-running autonomous sessions where the turn budget would otherwise interrupt work.
+`agent.max_turns` is **unlimited by default** — the turn cap caused more problems than it solved (silent mid-task truncation), so out of the box Hermes runs a conversation turn to completion. To impose a cap, set a positive integer. To be explicit about "no limit", any of these case-insensitive spellings work: `"none"`, `"null"`, `"unlimited"`, `"infinite"`, `"infinity"`, `"inf"`, `0`, `-1` (they resolve to a `sys.maxsize` sentinel so the loop never exits on a turn count).
 
 `agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1023,11 +1023,14 @@ Instead, when the budget is actually exhausted (500/500), Hermes injects one mes
 
 ```yaml
 agent:
-  max_turns: 500               # Max iterations per conversation turn (default: 500)
+  max_turns: 90                # Max iterations per conversation turn (default: 90)
+                               # Set to "none", "unlimited", or 0 for no limit
   api_max_retries: 3           # Retries per provider before fallback engages (default: 3)
 ```
 
 When the iteration budget is fully exhausted, the CLI shows a notification to the user: `⚠ Iteration budget reached (500/500) — response may be incomplete`.
+
+`agent.max_turns` accepts the following "unlimited" spellings (case-insensitive): `"none"`, `"unlimited"`, `"infinite"`, `0`, `-1`. These resolve to a sentinel value (`sys.maxsize`) so the loop never exits on a turn count. Use this for long-running autonomous sessions where the turn budget would otherwise interrupt work.
 
 `agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
 


### PR DESCRIPTION
## Summary
`agent.max_turns` is now **unlimited by default**. The per-turn iteration cap caused more problems than it solved — silent mid-task truncation — so out of the box Hermes runs a conversation turn to completion. A user who wants a cap still sets a positive integer.

Salvage of #67696 by @fattchris (the author of #82813), adapted to default-unlimited per maintainer direction.

Fixes #82813 (P2: `agent.max_turns: none`/`unlimited` in config.yaml crashed cron/gateway with `TypeError` or was silently ignored). Supersedes the partial cluster #82729 / #82845 / #82848.

## Changes
- **`hermes_cli/config.py`**: `resolve_turn_limit()` — the single normalization point for the turn-limit value type (from @fattchris). Default flipped to `TURN_LIMIT_UNLIMITED` (`sys.maxsize`); unlimited spellings extended to `none`, `null`, `unlimited`, `infinite`, `infinity`, `inf`, `∞`, `0`, `-1` (case-insensitive, whitespace-tolerant). Positive ints honored; bool/garbage/None → default (unlimited).
- **Read sites converted** to `resolve_turn_limit()` (no more bare `int()`/`or`-chains that crash on strings): `cli.py`, `gateway/run.py` (+ null-safe env bridge), `cron/scheduler.py`, `tui_gateway/server.py`.
- **Default flipped everywhere**: `DEFAULT_CONFIG agent.max_turns` → `None` (unlimited); `AIAgent`/`init_agent` `max_iterations` signature defaults → `sys.maxsize`, so subagents and direct construction default unlimited too.
- Docs updated; `goals.max_turns` (the separate goal-mode judge cap) intentionally left alone.

## Validation
| input | before | after |
|---|---|---|
| default (unset) | cap 500 | unlimited |
| `agent.max_turns: none` | `TypeError` in cron/gateway | unlimited |
| `null` / `unlimited` / `inf` / `infinity` / `0` / `-1` | crash or ignored | unlimited |
| `50` | honored | honored |
| bare int in loop condition | works | works (sentinel is a real int) |

Live-verified end to end: fresh install defaults to unlimited, all spellings resolve via a real subprocess, `config set` accepts them, and a real agent turn completes. 178 targeted tests pass (resolver + cli-init + gateway max-iterations + cron + config), incl. @fattchris's 231-line resolver suite updated for the new default.

## Infographic

![max_turns unlimited default infographic](https://files.catbox.moe/mbnvch.png)
