### PR TITLE
fix(skills): validate skill file_path before the approval gate stages the write

### DIFF
--- a/contributors/emails/adrien.didot@gmail.com
+++ b/contributors/emails/adrien.didot@gmail.com
@@ -1,0 +1,2 @@
+Adridot
+# PR: validate skill file_path before the approval gate

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -947,3 +947,95 @@ class TestCuratorConsolidationDeleteGuard:
             assert allowed["success"] is True, allowed
 
         _reset_background_review_read_marks()
+
+
+# =============================================================================
+# file_path validation must run before the approval gate
+# =============================================================================
+
+
+class TestValidateFilePathAbsolute:
+    """An absolute path can never name a location inside a skill directory."""
+
+    def test_absolute_path_is_rejected(self):
+        error = _validate_file_path("/etc/passwd")
+        assert error is not None
+        assert "Absolute paths are not allowed" in error
+        # The message must point at the tool that can write there, instead of
+        # reading as "use references/ instead" and inviting a doomed retry.
+        assert "terminal tool" in error
+
+    def test_absolute_path_under_an_allowed_name_is_still_rejected(self):
+        # 'references' as the first component would satisfy the subdirectory
+        # rule if the leading slash were ignored.
+        error = _validate_file_path("/references/guide.md")
+        assert error is not None
+        assert "Absolute paths are not allowed" in error
+
+    def test_relative_path_under_an_allowed_subdir_still_passes(self):
+        assert _validate_file_path("references/guide.md") is None
+
+    def test_skill_md_at_the_root_still_passes(self):
+        assert _validate_file_path("SKILL.md") is None
+
+
+class TestWriteFileValidatedBeforeGate:
+    """The gate stages a write and answers success:true.
+
+    A file_path the write could never honour must be refused on the call that
+    made it, not staged into pending/skills under a "staged for review"
+    success and rejected later, out of band.
+    """
+
+    def _staging_gate(self):
+        from tools import write_approval as wa
+        return patch.object(
+            wa, "evaluate_gate",
+            return_value=wa.GateDecision(stage=True, message="staged for review"),
+        )
+
+    def test_absolute_path_is_rejected_and_never_staged(self):
+        from tools import write_approval as wa
+        with self._staging_gate(), patch.object(
+            wa, "stage_write", return_value={"id": "test-pending-1"}
+        ) as mock_stage:
+            result = json.loads(skill_manage(
+                action="write_file",
+                name="some-skill",
+                file_path="/tmp/notes.txt",
+                file_content="hello",
+            ))
+        assert result["success"] is False
+        assert "Absolute paths are not allowed" in result["error"]
+        assert not result.get("staged")
+        mock_stage.assert_not_called()
+
+    def test_traversal_path_is_rejected_and_never_staged(self):
+        from tools import write_approval as wa
+        with self._staging_gate(), patch.object(
+            wa, "stage_write", return_value={"id": "test-pending-1"}
+        ) as mock_stage:
+            result = json.loads(skill_manage(
+                action="write_file",
+                name="some-skill",
+                file_path="references/../../../etc/passwd",
+                file_content="hello",
+            ))
+        assert result["success"] is False
+        assert not result.get("staged")
+        mock_stage.assert_not_called()
+
+    def test_valid_relative_path_still_reaches_the_gate(self):
+        from tools import write_approval as wa
+        with self._staging_gate(), patch.object(
+            wa, "stage_write", return_value={"id": "test-pending-1"}
+        ) as mock_stage:
+            result = json.loads(skill_manage(
+                action="write_file",
+                name="some-skill",
+                file_path="references/guide.md",
+                file_content="ok",
+            ))
+        assert result["success"] is True
+        assert result["staged"] is True
+        mock_stage.assert_called_once()

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1039,3 +1039,65 @@ class TestWriteFileValidatedBeforeGate:
         assert result["success"] is True
         assert result["staged"] is True
         mock_stage.assert_called_once()
+
+    def test_remove_file_is_rejected_and_never_staged(self):
+        """`remove_file` stages too, so it needs the same pre-gate refusal.
+
+        Without it the caller is told the removal is staged for review and
+        only learns at apply time that the path was never removable.
+        """
+        from tools import write_approval as wa
+        with self._staging_gate(), patch.object(
+            wa, "stage_write", return_value={"id": "test-pending-1"}
+        ) as mock_stage:
+            result = json.loads(skill_manage(
+                action="remove_file",
+                name="some-skill",
+                file_path="/etc/passwd",
+            ))
+        assert result["success"] is False
+        assert "Absolute paths are not allowed" in result["error"]
+        assert not result.get("staged")
+        mock_stage.assert_not_called()
+
+    def test_an_approved_staged_write_is_revalidated_on_apply(self):
+        """Apply never trusts the staged payload.
+
+        `apply_skill_pending` replays it through `skill_manage` with the gate
+        bypassed, so it meets the pre-gate check first and `_write_file`'s own
+        `_validate_file_path` after. Two independent layers: a payload that
+        reached `pending/skills` before this fix, or through some future path
+        that stages without the pre-gate check, is still refused at apply
+        time. This pins that property, not the layer that enforces it.
+        """
+        from tools.skill_manager_tool import apply_skill_pending
+        from tools import write_approval as wa
+        with patch.object(wa, "stage_write") as mock_stage:
+            result = json.loads(apply_skill_pending({
+                "action": "write_file",
+                "name": "some-skill",
+                "file_path": "/tmp/notes.txt",
+                "file_content": "hello",
+            }))
+        assert result["success"] is False
+        assert "Absolute paths are not allowed" in result["error"]
+        mock_stage.assert_not_called()
+
+
+class TestValidateFilePathSeparators:
+    """Backslash paths are refused on both platforms, by different rules.
+
+    `has_traversal_component` splits with `pathlib.Path`, which is
+    platform-dependent: on Windows a backslash separates components and the
+    traversal check sees the `..`; on POSIX the whole string is one filename,
+    which cannot escape anything and is refused by the allowed-subdirectory
+    rule instead. Either way the answer is a refusal, which is what this pins.
+    """
+
+    def test_backslash_traversal_is_refused(self):
+        error = _validate_file_path("references\\..\\..\\etc\\passwd")
+        assert error is not None
+
+    def test_backslash_only_path_is_refused(self):
+        error = _validate_file_path("references\\guide.md")
+        assert error is not None

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -853,6 +853,20 @@ def _validate_file_path(file_path: str) -> Optional[str]:
 
     normalized = Path(file_path)
 
+    # An absolute path can never name a location inside the skill directory,
+    # so say that plainly and point at the tool that does write elsewhere.
+    # Without this it falls through to the allowed-subdirectory message below,
+    # which reads as "use references/ instead" and invites the caller to retry
+    # a path shape that cannot work.
+    if normalized.is_absolute():
+        allowed = ", ".join(sorted(ALLOWED_SUBDIRS))
+        return (
+            f"Absolute paths are not allowed: skill files live inside the "
+            f"skill's own directory ({allowed}), and file_path is relative to "
+            f"it. To write a file anywhere else, use the terminal tool rather "
+            f"than skill_manage. Got: '{file_path}'"
+        )
+
     # Prevent path traversal (checked before any allow-listing so the SKILL.md
     # exception below can never be reached by a traversal-laden path).
     if has_traversal_component(file_path):
@@ -1562,6 +1576,16 @@ def skill_manage(
     preflight = _background_review_preflight(action, name)
     if preflight is not None:
         return json.dumps(preflight, ensure_ascii=False)
+
+    # Validate file_path BEFORE the approval gate. The gate stages a write into
+    # pending/skills and answers success:true ("staged for review"), so a path
+    # the write could never have honoured is reported to the caller as accepted
+    # and only fails later, at apply time, out of band. Rejecting here makes an
+    # impossible path fail on the call that made it.
+    if action in {"write_file", "remove_file"} and file_path:
+        path_error = _validate_file_path(file_path)
+        if path_error:
+            return tool_error(path_error, success=False)
 
     # Approval gate: when on, stages the write for review (skills are too large
     # to review inline, so they always stage regardless of origin); when off


### PR DESCRIPTION
## What does this PR do?

Two defects on the same path in `skill_manage`, both of which make it report success for a write that can never happen.

### 1. An absolute `file_path` gets the wrong diagnosis

`_validate_file_path` checks the first path component against `ALLOWED_SUBDIRS`, so `/root/notes.txt` falls through to:

> File must be under one of: assets, references, scripts, templates. Got: '/root/notes.txt'

That reads as *"use `references/` instead"*. But `file_path` is relative to the skill's own directory, so **no absolute path can ever name a location inside it** — the suggestion invites the caller to retry a shape that cannot work. `/references/guide.md` fails for the same reason while looking like it should pass.

The new message says the path shape is wrong, and names the tool that does write elsewhere.

### 2. Validation runs *after* the approval gate

`skill_manage` calls `_apply_skill_write_gate` before any `file_path` check. With the gate on, the gate stages the write into `pending/skills` and returns:

```json
{"success": true, "staged": true, "message": "staged for review"}
```

So the caller is told an impossible write was accepted. It only fails later, at apply time, out of band — by which point whoever asked for the file has moved on and the content is sitting in a staging area nobody is watching.

Moving the check before the gate makes an impossible path fail on the call that made it. Valid paths reach the gate exactly as before.

Neither is theoretical: this is how content handed to `skill_manage` with an out-of-skill path was silently lost on a self-hosted instance, with the tool reporting success each time.

## Related Issue

No open issue or PR that I could find covering either half — I searched for `skill_manage absolute path`, `skill_manager file_path validation gate`, and `pending skills staged write_file path`. The only nearby hit is #33625 (closed, V4A patches), which is unrelated.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skill_manager_tool.py`
  - `_validate_file_path`: reject an absolute path explicitly, before the allowed-subdirectory check, with a message that names the terminal tool.
  - `skill_manage`: run `_validate_file_path` for `write_file` / `remove_file` before `_apply_skill_write_gate`, returning `tool_error(..., success=False)`.
- `tests/tools/test_skill_manager_tool.py` — 11 new tests in three classes: the message for absolute paths (including `/references/guide.md`), that valid relative paths and root `SKILL.md` still pass, that an absolute or traversal path never reaches `stage_write` for `write_file` *or* `remove_file` while a valid one still does, that `apply_skill_pending` revalidates a staged payload, and that backslash paths are refused on both platforms.

### Behaviour change

For `write_file` and `remove_file`, an absolute `file_path` was already refused on `main` — by the allowed-subdirectory rule, inside `_write_file` / `_remove_file`, i.e. *after* the gate. Two things change: the message is now the absolute-path one instead of `File must be under one of: ...`, and with the gate on the refusal happens on the call that made it instead of at apply time. Nothing shipped tells an agent to pass an absolute path — the tool schema already documents `file_path` as relative to the skill directory (`references/`, `templates/`, `scripts/`, `assets/`) — so there is no prompt or skill text to update.

## How to Test

```bash
pytest tests/tools/test_skill_manager_tool.py -q     # 58 passed
```

Revert `tools/skill_manager_tool.py` and re-run — 6 of the 11 fail on `main`:

```
FAILED ...TestValidateFilePathAbsolute::test_absolute_path_is_rejected
  - assert 'Absolute paths are not allowed' in "File must be under one of: asse..."
FAILED ...TestValidateFilePathAbsolute::test_absolute_path_under_an_allowed_name_is_still_rejected
FAILED ...TestWriteFileValidatedBeforeGate::test_absolute_path_is_rejected_and_never_staged
  - assert True is False        # main answers success:true, staged:true
FAILED ...TestWriteFileValidatedBeforeGate::test_traversal_path_is_rejected_and_never_staged
  - assert True is False
FAILED ...TestWriteFileValidatedBeforeGate::test_remove_file_is_rejected_and_never_staged
  - assert True is False        # remove_file stages the same way
FAILED ...TestWriteFileValidatedBeforeGate::test_an_approved_staged_write_is_revalidated_on_apply
  - assert 'Absolute paths are not allowed' in "File must be under one of: asse..."
```

The last one is RED on the *message* only: `main` already refuses at apply, via `_write_file`'s own `_validate_file_path`. It pins that property — apply never trusts a staged payload — rather than a bug.

The remaining five pass on `main` too: they pin behaviour this change must not break.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(skills):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — search terms and the one nearby hit are listed under *Related Issue*
- [x] My PR contains **only** changes related to this fix (one commit, 3 files, production diff +24/−0)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run in full.** I ran a scoped selection on this branch and on its parent commit `fa2601c2f5` and compared the failure sets: `tests/tools/test_skill_manager_tool.py`, `test_setup_mcp_tool.py`, `test_mcp_circuit_breaker.py`, the whole of `tests/skills`, plus `tests/agent/test_tool_guardrails.py`, `test_display.py`, `test_display_tool_failure.py`, `tests/cron/test_scheduler.py`, `tests/gateway/test_telegram_format.py`, `test_webhook_adapter.py`, `test_webhook_deliver_only.py`. Parent: 1871 passed / 0 failed. This branch: 1882 passed / 0 failed. Same failure set (empty); the 11 added tests account for the difference.
- [x] I've added tests for my changes (11 new, 6 RED on `main`)
- [x] I've tested on my platform: Ubuntu 24.04 (aarch64), Python 3.11.15, pytest 9.1.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the added comments state why an absolute path cannot be valid and why the check has to precede the gate; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — this one is not N/A: the check is `pathlib.Path(file_path).is_absolute()`, which is platform-aware by design, so I checked what it changes on each. **Nothing that was accepted becomes rejected, or vice versa** — only which message you get. On POSIX it is the leading-slash test. On Windows, `C:\Users\x\notes.txt` and UNC `\\srv\share\f.txt` become `is_absolute() == True`, so they now get the accurate message; they were already rejected before, by the first-component check, just with the misleading "use one of: assets, references, ..." wording. Conversely a POSIX-style `/etc/passwd` is *not* `is_absolute()` on Windows (it is drive-relative), so there it keeps falling through to the first-component check exactly as it does today. No new path construction, so nothing else is OS-dependent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — the `skill_manage` schema already documents `file_path` as relative to the skill directory; this change makes the runtime match that description rather than changing it