### PR TITLE
fix(update): reload cli_output so the gateway restart phase survives the pull

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -107,11 +107,24 @@ def _reload_config_modules() -> None:
     ``_subprocess_compat`` (e.g. ``bounded_probe_run``) is invisible to the
     cached module object, causing ``ImportError`` during the cleanup step
     that runs later in the same process.
+
+    ``hermes_cli.cli_output`` is reloaded for the same reason, one phase
+    later: the gateway auto-restart imports ``hermes_cli.gateway``, whose
+    import graph reaches modules that do a module-level
+    ``from hermes_cli.cli_output import line_input``
+    (``hermes_cli.plugins_cmd``, ``hermes_cli.bundles``). ``cli_output`` is
+    already in ``sys.modules`` from CLI startup, so an update that adds a
+    symbol to it makes the whole restart phase abort with
+    ``cannot import name 'line_input' from 'hermes_cli.cli_output'`` — and
+    every gateway keeps serving pre-update modules against the replaced
+    checkout, exactly the state #78574 made visible. It is reloaded first
+    because it sits below the config modules in the import graph.
     """
     import importlib
 
     importlib.invalidate_caches()
     for mod_name in (
+        "hermes_cli.cli_output",
         "hermes_cli.config_defaults",
         "hermes_cli.config",
         "hermes_cli.config_migrations",

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -438,6 +438,48 @@ class TestConfigVersionCheckUsesFreshModules:
 
         mock_reload.assert_called_once()
 
+    def test_reload_config_modules_includes_cli_output(self):
+        """cli_output must be reloaded before the gateway restart phase.
+
+        Regression: the gateway auto-restart imports hermes_cli.gateway,
+        whose import graph reaches modules that do a module-level
+        ``from hermes_cli.cli_output import line_input``
+        (hermes_cli.plugins_cmd, hermes_cli.bundles). cli_output is already
+        in sys.modules from CLI startup, so an update that ADDS a symbol to
+        it aborted the whole restart phase with
+
+            cannot import name 'line_input' from 'hermes_cli.cli_output'
+
+        leaving every gateway serving pre-update modules against the
+        replaced checkout (the #78574 failure state).
+        """
+        import sys
+        from unittest.mock import patch
+
+        import hermes_cli.update_cmd as update_cmd
+
+        # Ensure the module is cached, otherwise the loop skips it.
+        import hermes_cli.cli_output  # noqa: F401
+
+        reloaded = []
+
+        def fake_reload(mod):
+            reloaded.append(mod.__name__)
+            return mod
+
+        with patch("importlib.reload", side_effect=fake_reload), patch(
+            "importlib.invalidate_caches"
+        ):
+            update_cmd._reload_config_modules()
+
+        assert "hermes_cli.cli_output" in reloaded
+        # cli_output sits below the config modules in the import graph, so it
+        # must be reloaded before them.
+        for later in ("hermes_cli.config", "hermes_cli.dashboard_procs"):
+            if later in reloaded:
+                assert reloaded.index("hermes_cli.cli_output") < reloaded.index(later)
+        assert sys.modules["hermes_cli.cli_output"] is not None
+
 
 class TestCmdUpdateProfileSkillSync:
     """cmd_update syncs bundled skills to all profiles, including the active one.


### PR DESCRIPTION
`hermes update` pulls new source and then restarts every gateway from inside the same long-running Python process. `_reload_config_modules` already force-reloads the modules that later phases import, because the pre-update process holds the OLD module objects in `sys.modules` while the files on disk are new. `hermes_cli.cli_output` was missing from that set.

### The failure

The gateway auto-restart imports `hermes_cli.gateway`, whose import graph reaches modules that do a module-level `from hermes_cli.cli_output import line_input` (`hermes_cli.plugins_cmd`, `hermes_cli.bundles`). `cli_output` is already cached from CLI startup, so an update that **adds** a symbol to it aborts the entire restart phase:

```
⚠ Update incomplete — gateway auto-restart failed: cannot import name 'line_input' from 'hermes_cli.cli_output'
  Any gateway still running is serving pre-update code
  (mixed sys.modules) against the updated checkout.
```

That is exactly the state #78574 made visible: `hermes update` exits 1 and every gateway keeps serving pre-update modules against the replaced checkout.

### Observed in the wild

fa62b22ee7 added `line_input` to `cli_output`. The next nightly `hermes update --yes` pulled it, aborted the restart phase, and left an eleven-gateway fleet running pre-pull code. Five hours later a scheduled job died with the same class of error one module down:

```
ImportError: cannot import name 'NOUS_MANAGED_PROVIDER' from 'tools.tool_backend_helpers'
  File "cron/scheduler.py", line 415, in _merge_mcp_into_per_job_toolsets
```

The source on disk defined `NOUS_MANAGED_PROVIDER` the whole time — the gateway just held the pre-pull `tools.tool_backend_helpers` in `sys.modules`, and `tools.registry` re-imported the freshly-pulled `image_generation_tool` and `tts_tool` against it. Restarting the gateways cleared it.

### The change

Add `hermes_cli.cli_output` to the reload set, first in the tuple: it imports only `hermes_cli.colors` and `hermes_cli.secret_prompt`, so it sits below the config modules in the import graph. `_reload_config_modules()` runs before the restart phase in the same process, so the reloaded module is what `plugins_cmd`/`bundles` bind against.

### Test

`test_reload_config_modules_includes_cli_output` asserts `cli_output` is reloaded, and reloaded before the config modules. It fails on `main` and passes with this change. Full `tests/hermes_cli/test_cmd_update.py`: 36 passed.