### PR TITLE
fix(tui): validate the RPC profile param before any path resolution

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -19854,6 +19854,23 @@ def test_profile_home_rejects_traversal_and_absolute_names(monkeypatch):
     assert calls == []
 
 
+def test_profile_home_reserved_name_rejected_by_its_own_branch(monkeypatch):
+    """Reserved names (root/hermes) are rejected by validate_profile_name's
+    reserved-word branch, a different path than the regex — pin that both
+    rejection routes fall back to the launch profile (review on #90699)."""
+    from pathlib import Path as _Path
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir",
+        lambda n: calls.append(n) or _Path("/definitely/should-not-matter"),
+    )
+
+    assert server._profile_home("root") is None
+    assert server._profile_home("hermes") is None
+    assert calls == []
+
+
 def test_profile_home_valid_name_reaches_path_resolution(monkeypatch, tmp_path):
     """A valid profile name still goes through get_profile_dir; the
     containment check happens before, not instead of, normal resolution."""

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -19830,3 +19830,38 @@ def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):
     assert captured["row_update"] == (target, str(new_cwd))
     assert live["cwd"] == str(new_cwd)
     assert live.get("explicit_cwd") is True
+
+
+def test_profile_home_rejects_traversal_and_absolute_names(monkeypatch):
+    """#90699: the raw RPC ``profile`` param must never reach path math —
+    a "../x" traversal or an absolute path would escape the profiles root
+    and point session.* RPCs / the HERMES_HOME override at an arbitrary
+    directory. Invalid names fall back to the launch profile (None),
+    same as unknown ones."""
+    from pathlib import Path as _Path
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir",
+        lambda n: calls.append(n) or _Path("/definitely/should-not-matter"),
+    )
+
+    assert server._profile_home("../../outside") is None
+    assert server._profile_home("/etc") is None
+    assert server._profile_home("..") is None
+    assert server._profile_home("a/b") is None
+    # Path resolution was never reached for any of the malicious names.
+    assert calls == []
+
+
+def test_profile_home_valid_name_reaches_path_resolution(monkeypatch, tmp_path):
+    """A valid profile name still goes through get_profile_dir; the
+    containment check happens before, not instead of, normal resolution."""
+    real_dir = tmp_path / "profiles" / "work"
+    real_dir.mkdir(parents=True)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir", lambda n: real_dir
+    )
+    monkeypatch.setattr(server, "_hermes_home", str(tmp_path / "launch"))
+
+    assert server._profile_home("work") == real_dir

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1530,10 +1530,19 @@ def _profile_home(profile: str | None) -> Path | None:
         # entirely (pathlib join semantics) — pointing session.* RPCs and the
         # HERMES_HOME override at an attacker-chosen directory. An invalid
         # name falls through to the launch profile, same as an unknown one.
-        profiles_mod.validate_profile_name(
-            profiles_mod.normalize_profile_name(name)
-        )
-        home = Path(profiles_mod.get_profile_dir(name))
+        # Bind once: validate and resolve the SAME canonical value, so a
+        # future change to either helper's normalization cannot let the
+        # resolved name diverge from the validated one.
+        canonical = profiles_mod.normalize_profile_name(name)
+        try:
+            profiles_mod.validate_profile_name(canonical)
+        except ValueError:
+            # Distinguish a probing client from a mere typo in the logs —
+            # both fall back to the launch profile, but only one deserves
+            # attention (review finding on #90699).
+            logger.warning("Rejected invalid RPC profile param: %r", name)
+            return None
+        home = Path(profiles_mod.get_profile_dir(canonical))
     except Exception:
         return None
     # Already the launch profile? No override needed.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1524,6 +1524,15 @@ def _profile_home(profile: str | None) -> Path | None:
     try:
         from hermes_cli import profiles as profiles_mod
 
+        # Reject traversal/absolute/reserved names BEFORE any path math
+        # (#90699): get_profile_dir only strip()+lower()s, so an unvalidated
+        # "../x" escapes the profiles root and an absolute path replaces it
+        # entirely (pathlib join semantics) — pointing session.* RPCs and the
+        # HERMES_HOME override at an attacker-chosen directory. An invalid
+        # name falls through to the launch profile, same as an unknown one.
+        profiles_mod.validate_profile_name(
+            profiles_mod.normalize_profile_name(name)
+        )
         home = Path(profiles_mod.get_profile_dir(name))
     except Exception:
         return None


### PR DESCRIPTION
## What does this PR do?

The TUI gateway's per-profile RPC scoping resolved the raw `params['profile']` to a filesystem path **without validating the name** (#90699): `get_profile_dir()` only `strip()`+`lower()`s its input, so `"../../outside"` traversed out of the profiles root and an absolute path like `"/etc"` replaced the root entirely (pathlib join semantics). That pointed `session.list`/`session.resume` at an arbitrary directory's `state.db` and bound `set_hermes_home_override()` over config/skills/projects for the attacker-chosen location.

`hermes_cli.profiles.validate_profile_name()` — a strict `[a-z0-9][a-z0-9_-]{0,63}` regex plus reserved-name checks — already existed for exactly this purpose but was not on this path. `_profile_home()` now runs it (after the same `normalize_profile_name` step `get_profile_dir` applies) **before any path math**. An invalid name falls back to the launch profile through the existing `except`, identical to how an unknown profile name is already treated: a traversal attempt gets no redirect at all.

## Related Issue

Fixes #90699

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — `_profile_home()` validates the normalized profile name via the existing `validate_profile_name()` before resolving the directory; invalid names return None (launch-profile fallback), so `_db_for_profile()` and `_profile_scoped()` consumers are contained without any change on their side
- `tests/test_tui_gateway_server.py` — two regression tests: traversal/absolute/segmented names (`../../outside`, `/etc`, `..`, `a/b`) never reach `get_profile_dir` (asserted via a spy — path math is never invoked), and a valid name still resolves through it normally

## How to Test

1. `python -m pytest tests/test_tui_gateway_server.py -q -k profile` — should pass (27 passed), including the two new tests
2. Observed result: with the server change stashed, `test_profile_home_rejects_traversal_and_absolute_names` fails (the spy records `get_profile_dir` being called with the traversal payload); with the fix, none of the malicious names reach path resolution
3. Full-file comparison on this host: the 15 failures in the suite reproduce identically on clean upstream/main (environment-dependent); the branch-vs-main failure diff is empty

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (why validation must precede path math; why the fallback matches unknown-name semantics)
- [x] Tests added that prove the fix is effective or prevent regression (spy-asserted containment both directions)
- [x] All new and existing tests pass locally (profile-scoped suite 27/27; full-suite delta vs main is zero)
- [x] Platform: macOS (pure path/validation logic, platform-independent)
