### PR TITLE
fix(bot-mode): group chat no longer doubles into the Bots pane beside its main tab

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -9534,12 +9534,32 @@ function GroupChatWorkspace({ group, members, onBack }) {
  *  disband (or the room view's own Back) can retire the tab it opened. */
 const groupChatMainTabs = new Map()
 
+/** Reactive shadow of `groupChatMainTabs` membership. The Map itself can't
+ *  notify React, and #89788's first fix read it non-reactively: a BotsPane
+ *  render that landed between selecting the group and recording its main
+ *  tab kept the in-pane room on screen forever (the map write repaints
+ *  nothing). Every map mutation goes through the two helpers below so the
+ *  rev bump re-evaluates the gate. */
+const $groupMainTabsRev = atom(0)
+
+function recordGroupMainTab(group, close) {
+  groupChatMainTabs.set(group, close)
+  $groupMainTabsRev.set($groupMainTabsRev.get() + 1)
+}
+
+function dropGroupMainTab(group) {
+  if (groupChatMainTabs.delete(group)) {
+    $groupMainTabsRev.set($groupMainTabsRev.get() + 1)
+  }
+}
+
 /** The in-panel room is the FALLBACK surface, not a second copy: it renders
  *  only while no main-window tab owns the group. On desktops with the door
  *  the room already lives in a main tab, and painting it here too produced
  *  two live panes with independent drafts driving one shared engine (#89788).
  *  The selection atom stays set either way so the roster row still
- *  highlights. */
+ *  highlights. Callers must subscribe to `$groupMainTabsRev` (BotsPane does)
+ *  so ownership changes re-run this gate. */
 function shouldRenderGroupChatInPane(group) {
   return Boolean(group && !groupChatMainTabs.has(group))
 }
@@ -9547,7 +9567,7 @@ function shouldRenderGroupChatInPane(group) {
 function closeGroupChatMainTab(group) {
   const close = groupChatMainTabs.get(group)
 
-  groupChatMainTabs.delete(group)
+  dropGroupMainTab(group)
 
   if ($groupChatWorkspace.get() === group) {
     $groupChatWorkspace.set(null)
@@ -9577,10 +9597,16 @@ function GroupChatMainView({ group }) {
 
 /** Open a group chat the Discord way: a tab taking over the MAIN chat window
  *  (host.openWorkspace, newer desktops), falling back to the in-panel room
- *  view on desktops whose SDK predates the main-area door. */
+ *  view on desktops whose SDK predates the main-area door.
+ *
+ *  Ordering matters (#89788 follow-up): the main tab must be RECORDED before
+ *  the selection atom is set. Setting the atom first opened a window where
+ *  BotsPane rendered with a selected group and an empty tab map — the
+ *  in-pane fallback painted alongside the main tab, and because the map
+ *  write itself repaints nothing, the duplicate stuck until an unrelated
+ *  re-render. */
 function openGroupChat(group) {
   $groupNeedsYou.set({ ...$groupNeedsYou.get(), [group]: false })
-  $groupChatWorkspace.set(group)
 
   if (typeof host.openWorkspace === 'function') {
     try {
@@ -9589,7 +9615,7 @@ function openGroupChat(group) {
         minWidth: '24rem',
         render: () => jsx(GroupChatMainView, { group }),
         onClose: () => {
-          groupChatMainTabs.delete(group)
+          dropGroupMainTab(group)
 
           if ($groupChatWorkspace.get() === group) {
             $groupChatWorkspace.set(null)
@@ -9597,7 +9623,10 @@ function openGroupChat(group) {
         }
       })
 
-      groupChatMainTabs.set(group, close)
+      recordGroupMainTab(group, close)
+      // Tab ownership is on record — the atom now only drives the roster
+      // highlight; shouldRenderGroupChatInPane stays false throughout.
+      $groupChatWorkspace.set(group)
 
       return
     } catch {
@@ -9605,8 +9634,9 @@ function openGroupChat(group) {
     }
   }
 
-  // The selected-group atom was set before trying the main-window door, so
-  // older desktops naturally render the in-panel room as the fallback.
+  // No main-window door (older desktop) or it threw: select the group so
+  // the in-panel room renders as the fallback surface.
+  $groupChatWorkspace.set(group)
 }
 
 /** One group chat as ONE roster row — the Discord shape: stacked member
@@ -9735,6 +9765,11 @@ function BotsPane() {
   const activityToasts = useValue($activityToasts)
   const sessionsWorkspaceName = useValue($botSessionsWorkspace)
   const groupChatName = useValue($groupChatWorkspace)
+  // Main-tab ownership is a module Map; this rev subscription makes the
+  // shouldRenderGroupChatInPane gate below reactive to tab open/close
+  // (#89788 follow-up — without it a stale render could paint the in-pane
+  // room beside a live main tab and stick).
+  useValue($groupMainTabsRev)
   const groupNeedsYou = useValue($groupNeedsYou)
   const groupRooms = useValue($groupChats)
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -104,7 +104,7 @@ function load(turnScript, { busyUntilResumeCall } = {}) {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, disbandGroupChat, updateGroupChat, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, $groupChats, $groupNeedsYou, $groupChatWorkspace, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, disbandGroupChat, updateGroupChat, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -390,6 +390,48 @@ test('older and failed workspace hosts keep the in-pane group fallback', () => {
   failed.openGroupChat('Ops')
   assert.equal(failed.$groupChatWorkspace.get(), 'Ops')
   assert.equal(failed.shouldRenderGroupChatInPane('Ops'), true)
+})
+
+test('main-tab ownership is recorded before the selection atom paints (#89788 follow-up)', () => {
+  const gc = load(() => '(pass)')
+  // Simulate a BotsPane render racing the open: sample the gate at the
+  // moment the selection atom flips. If the tab were recorded after the
+  // atom set, this probe would observe selected-but-unowned and the
+  // in-pane duplicate would paint beside the main tab.
+  let gateAtSelection = null
+  const realSet = gc.$groupChatWorkspace.set
+
+  gc.$groupChatWorkspace.set = value => {
+    if (value === 'Core' && gateAtSelection === null) {
+      gateAtSelection = gc.shouldRenderGroupChatInPane('Core')
+    }
+
+    realSet(value)
+  }
+  gc.host.openWorkspace = () => () => undefined
+
+  gc.openGroupChat('Core')
+  assert.equal(gateAtSelection, false)
+})
+
+test('tab open/close bumps the reactive rev so the pane gate re-evaluates', () => {
+  const gc = load(() => '(pass)')
+  let onClose
+
+  gc.host.openWorkspace = (_id, options) => {
+    onClose = options.onClose
+    return () => onClose()
+  }
+
+  const before = gc.$groupMainTabsRev.get()
+
+  gc.openGroupChat('Core')
+  assert.ok(gc.$groupMainTabsRev.get() > before, 'recording the main tab must bump the rev')
+
+  const afterOpen = gc.$groupMainTabsRev.get()
+
+  onClose()
+  assert.ok(gc.$groupMainTabsRev.get() > afterOpen, 'closing the main tab must bump the rev')
 })
 
 test('closing an older selected group does not clear the newer selection', () => {


### PR DESCRIPTION
## Summary

Opening a Bot Mode group chat no longer paints the room twice — the in-pane duplicate that replaced the roster beside the main-window tab is gone.

Root cause (why #89788's first fix didn't hold): `shouldRenderGroupChatInPane()` read main-tab ownership from a plain module `Map`, which React can't observe — and `openGroupChat` set the selection atom **before** recording the tab. Every open therefore rendered `BotsPane` in a selected-but-unowned window: the in-pane fallback painted alongside the main tab, and since the later `Map` write repaints nothing, the duplicate stuck (and the roster stayed hidden behind it).

## Changes

- `plugin.js`: `$groupMainTabsRev` atom shadows tab-map membership; all mutations route through `recordGroupMainTab`/`dropGroupMainTab`; `BotsPane` subscribes so the in-pane gate re-evaluates on tab open/close.
- `plugin.js`: `openGroupChat` records the main tab **before** setting the selection atom. Older desktops without `host.openWorkspace` (and a throwing door) still set the atom and get the in-pane fallback.
- `tests/group-chat.test.mjs`: pins the ordering (gate must be false at the instant the selection atom flips — fails on the old ordering, sabotage-verified) and the rev bump on tab open/close.

## Validation

| | Before | After |
|---|---|---|
| Open group chat (main-window door) | Room in main tab **and** in Bots pane; roster hidden | Room in main tab only; roster stays |
| Older desktop / door throws | In-pane room | In-pane room (unchanged) |
| `node --test tests/*.test.mjs` | 330 pass | 332 pass (2 new regression tests) |
| Sabotage run (old ordering restored) | — | new ordering test fails as intended |

Reported by @salihsungur via Discord (screenshots of v0.20.4 build).

## Infographic

![One room, one pane — Bot Mode group chat fix](https://files.catbox.moe/fmg4ko.png)
