### PR TITLE
fix(desktop): preserve wallpaper metadata for built-in skins

### DIFF
--- a/apps/desktop/e2e/backend-skin-wallpaper.spec.ts
+++ b/apps/desktop/e2e/backend-skin-wallpaper.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * End-to-end coverage for a user skin that deliberately reuses a built-in
+ * Desktop theme name. The real Python gateway loads the YAML, resolves the
+ * relative image path, publishes gateway.ready, and Electron reads the image
+ * before the renderer paints it.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+
+import type { ElectronApplication, Page } from '@playwright/test'
+
+import {
+  buildAppEnv,
+  createSandbox,
+  launchDesktop,
+  type Sandbox,
+  writeEnvFile,
+  writeMockProviderConfig
+} from './fixtures'
+import { type MockServer, startMockServer } from './mock-server'
+import { allowErrorBanners, collectErrorBanners, expect, test } from './test'
+
+const ONE_PIXEL_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+  'base64'
+)
+
+let app: ElectronApplication | null = null
+let page: Page | null = null
+let mock: MockServer | null = null
+let sandbox: Sandbox | null = null
+
+async function setUpFixture(): Promise<void> {
+  mock = await startMockServer()
+  sandbox = createSandbox('backend-skin-wallpaper')
+  writeMockProviderConfig(sandbox.hermesHome, mock.url, '  skin: mono')
+  writeEnvFile(sandbox.hermesHome)
+
+  const skinsDir = path.join(sandbox.hermesHome, 'skins')
+  fs.mkdirSync(skinsDir, { recursive: true })
+  fs.writeFileSync(path.join(skinsDir, 'wallpaper.png'), ONE_PIXEL_PNG)
+  fs.writeFileSync(
+    path.join(skinsDir, 'mono.yaml'),
+    [
+      'name: mono',
+      'colors:',
+      "  background: '#ff00ff'",
+      "  ui_text: '#00ff00'",
+      'background_image: wallpaper.png',
+      'background_image_fit: contain',
+      'background_image_position: top right',
+      "background_overlay: '#10203099'",
+      ''
+    ].join('\n'),
+    'utf8'
+  )
+
+  const launched = await launchDesktop(buildAppEnv(sandbox))
+  app = launched.app
+  page = launched.page
+
+  // Select the built-in theme before reconnecting. gateway.ready then decorates
+  // that palette with the backend skin's wallpaper without adopting its colours.
+  await page.evaluate(() => {
+    window.localStorage.setItem('hermes-desktop-theme-v2', 'mono')
+    window.localStorage.setItem('hermes-desktop-mode-v1', 'dark')
+  })
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await page.waitForSelector('[data-hermes-skin-wallpaper]', {
+    state: 'attached',
+    timeout: 120_000
+  })
+}
+
+test.afterAll(async () => {
+  if (app) {
+    const runningApp = app
+
+    const closed = await Promise.race([
+      runningApp.close().then(
+        () => true,
+        () => true
+      ),
+      new Promise<boolean>(resolve => setTimeout(() => resolve(false), 15_000))
+    ])
+
+    if (!closed && runningApp.process().exitCode === null) {
+      runningApp.process().kill()
+    }
+  }
+
+  await mock?.close()
+  sandbox?.cleanup()
+})
+
+test('keeps the built-in palette and renders the backend wallpaper metadata', async () => {
+  // This spec owns the Electron page lifecycle, so inspect the guard before
+  // cleanup rather than asking the shared post-test hook to inspect a closing page.
+  allowErrorBanners()
+  await setUpFixture()
+
+  const wallpaper = page!.locator('[data-hermes-skin-wallpaper]')
+  const image = wallpaper.locator('img')
+  const overlay = wallpaper.locator('[data-hermes-skin-wallpaper-overlay]')
+
+  await expect(wallpaper).toBeVisible()
+  await expect(image).toHaveAttribute('src', /^data:image\/png;base64,/)
+  await expect(image).toHaveCSS('object-fit', 'contain')
+  await expect(image).toHaveCSS('object-position', '100% 0%')
+  await expect(overlay).toHaveCSS('background-color', 'rgba(16, 32, 48, 0.6)')
+
+  const colours = await page!.evaluate(() => ({
+    background: document.documentElement.style.getPropertyValue('--theme-background-seed'),
+    foreground: document.documentElement.style.getPropertyValue('--theme-foreground')
+  }))
+
+  expect(colours).toEqual({ background: '#0e0e0e', foreground: '#eaeaea' })
+  expect(await collectErrorBanners(page)).toEqual([])
+})

--- a/apps/desktop/src/components/Backdrop.tsx
+++ b/apps/desktop/src/components/Backdrop.tsx
@@ -1,24 +1,95 @@
 import { useStore } from '@nanostores/react'
+import { type CSSProperties, useEffect, useState } from 'react'
 
+import { isFileMediaPath, resolveMediaDisplaySrc } from '@/lib/media'
 import { $backdrop } from '@/store/backdrop'
+import { useTheme } from '@/themes/context'
 
 const assetPath = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^\/+/, '')}`
 
 export function Backdrop() {
   const on = useStore($backdrop)
+  const { theme } = useTheme()
+  const wallpaper = (theme.backgroundImage ?? '').trim()
+  const [wallpaperSrc, setWallpaperSrc] = useState('')
 
-  if (!on) {
+  useEffect(() => {
+    let cancelled = false
+
+    if (!wallpaper) {
+      setWallpaperSrc('')
+
+      return
+    }
+
+    // A backend skin may be remote. Keep the renderer from making arbitrary
+    // outbound requests: files use the existing authenticated media path and
+    // inline data must identify itself as an image.
+    if (!isFileMediaPath(wallpaper) && !/^data:image\//i.test(wallpaper)) {
+      setWallpaperSrc('')
+
+      return
+    }
+
+    void resolveMediaDisplaySrc(wallpaper)
+      .then(src => {
+        if (!cancelled) {
+          setWallpaperSrc(src)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setWallpaperSrc('')
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [wallpaper])
+
+  if (!on && !wallpaperSrc) {
     return null
   }
 
   return (
-    <div aria-hidden className="pointer-events-none absolute inset-0 z-2 opacity-[0.025] mix-blend-difference">
-      <img
-        alt=""
-        className="h-[160dvh] w-auto min-w-dvw object-cover object-left-top [filter:invert(var(--backdrop-invert-mul,1))]"
-        fetchPriority="low"
-        src={assetPath('ds-assets/filler-bg0.jpg')}
-      />
-    </div>
+    <>
+      {wallpaperSrc ? (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 z-1 overflow-hidden"
+          data-hermes-skin-wallpaper
+        >
+          <img
+            alt=""
+            className="h-full w-full"
+            fetchPriority="low"
+            src={wallpaperSrc}
+            style={{
+              objectFit: (theme.backgroundImageFit || 'cover') as CSSProperties['objectFit'],
+              objectPosition: theme.backgroundImagePosition || 'center'
+            }}
+          />
+          {theme.backgroundOverlay ? (
+            <div
+              className="absolute inset-0"
+              data-hermes-skin-wallpaper-overlay
+              style={{ background: theme.backgroundOverlay }}
+            />
+          ) : null}
+        </div>
+      ) : null}
+
+      {on && !wallpaperSrc ? (
+        <div aria-hidden className="pointer-events-none absolute inset-0 z-2 opacity-[0.025] mix-blend-difference">
+          <img
+            alt=""
+            className="h-[160dvh] w-auto min-w-dvw object-cover object-left-top [filter:invert(var(--backdrop-invert-mul,1))]"
+            fetchPriority="low"
+            src={assetPath('ds-assets/filler-bg0.jpg')}
+          />
+        </div>
+      ) : null}
+    </>
   )
 }

--- a/apps/desktop/src/themes/backend-sync.test.ts
+++ b/apps/desktop/src/themes/backend-sync.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { $backendThemes, $pendingSkinApply, __resetBackendSkinSync, ingestBackendSkin } from './backend-sync'
+import { BUILTIN_THEMES } from './presets'
 
 const skin = (name: string) => ({
   name,
@@ -98,6 +99,38 @@ describe('ingestBackendSkin', () => {
 
     expect($backendThemes.get().mono).toBeUndefined()
     expect($pendingSkinApply.get()).toBe('mono')
+  })
+
+  it('decorates a built-in palette with backend wallpaper metadata', () => {
+    ingestBackendSkin(
+      {
+        ...skin('mono'),
+        background_image: 'C:/Hermes/skins/mono.png',
+        background_image_fit: 'contain',
+        background_image_position: 'top right',
+        background_overlay: '#120a22ba'
+      },
+      { apply: true }
+    )
+
+    const decorated = $backendThemes.get().mono
+
+    expect(decorated.colors).toEqual(BUILTIN_THEMES.mono.colors)
+    expect(decorated.colors).not.toEqual(skin('mono').colors)
+    expect(decorated.backgroundImage).toBe('C:/Hermes/skins/mono.png')
+    expect(decorated.backgroundImageFit).toBe('contain')
+    expect(decorated.backgroundImagePosition).toBe('top right')
+    expect(decorated.backgroundOverlay).toBe('#120a22ba')
+    expect($pendingSkinApply.get()).toBe('mono')
+  })
+
+  it('removes stale built-in wallpaper metadata when the backend clears it', () => {
+    ingestBackendSkin({ ...skin('mono'), background_image: 'data:image/png;base64,AA==' }, { apply: false })
+    expect($backendThemes.get().mono?.backgroundImage).toBe('data:image/png;base64,AA==')
+
+    ingestBackendSkin(skin('mono'), { apply: false })
+
+    expect($backendThemes.get().mono).toBeUndefined()
   })
 
   it('ignores empty payloads', () => {

--- a/apps/desktop/src/themes/backend-sync.ts
+++ b/apps/desktop/src/themes/backend-sync.ts
@@ -7,7 +7,8 @@
  *
  *   1. Registers the converted theme in `$backendThemes` so it appears wherever a
  *      built-in does — Appearance, Cmd-K, `/skin` — with no per-surface wiring
- *      (`listAllThemes` merges this store).
+ *      (`listAllThemes` merges this store). A skin sharing a built-in name keeps
+ *      the hand-tuned built-in palette while contributing wallpaper metadata.
  *   2. When asked to apply (an explicit change), requests the switch via
  *      `$pendingSkinApply`, which the ThemeProvider drains through `setTheme`.
  *
@@ -47,7 +48,8 @@ export function __resetBackendSkinSync(): void {
 /**
  * Fold a resolved skin into the desktop. `apply: false` (connect-time seed) only
  * records the baseline; `apply: true` (runtime change / poll) repaints on a name
- * change. Built-in names keep the desktop's own palette but can still be applied.
+ * change. Built-in names keep the desktop's own palette while still accepting
+ * wallpaper, fit, position, and overlay from the canonical backend skin.
  */
 export function ingestBackendSkin(skin: HermesSkin | undefined | null, { apply }: { apply: boolean }): void {
   const name = (skin && typeof skin === 'object' ? (skin.name ?? '') : '').trim()
@@ -61,18 +63,35 @@ export function ingestBackendSkin(skin: HermesSkin | undefined | null, { apply }
   // valid apply TARGET though: a runtime switch back to `default` must repaint the
   // desktop to its own default (setTheme normalizes `default` → nous). So we only
   // skip the registry step here and let it flow through the apply logic below.
-  // Built-in names (mono/slate/…) already have a hand-tuned desktop palette — we
-  // never shadow it, but the name is still a valid apply target.
-  if (name !== 'default' && !BUILTIN_THEMES[name]) {
-    const theme = skinToDesktopTheme(skin as HermesSkin)
+  // Built-in names (mono/slate/…) already have a hand-tuned desktop palette.
+  // Preserve it, but do not discard wallpaper metadata carried by the skin —
+  // Backdrop owns that presentation layer independently from the colour tokens.
+  if (name !== 'default') {
+    const converted = skinToDesktopTheme(skin as HermesSkin)
 
-    if (!theme) {
+    if (!converted) {
       return
     }
 
     const current = $backendThemes.get()
+    const builtin = BUILTIN_THEMES[name]
 
-    if (JSON.stringify(current[name]) !== JSON.stringify(theme)) {
+    const theme = builtin
+      ? converted.backgroundImage
+        ? {
+            ...builtin,
+            backgroundImage: converted.backgroundImage,
+            backgroundImageFit: converted.backgroundImageFit,
+            backgroundImagePosition: converted.backgroundImagePosition,
+            backgroundOverlay: converted.backgroundOverlay
+          }
+        : null
+      : converted
+
+    if (!theme && current[name]) {
+      const { [name]: _removed, ...rest } = current
+      $backendThemes.set(rest)
+    } else if (theme && JSON.stringify(current[name]) !== JSON.stringify(theme)) {
       $backendThemes.set({ ...current, [name]: theme })
     }
   }

--- a/apps/desktop/src/themes/skin.test.ts
+++ b/apps/desktop/src/themes/skin.test.ts
@@ -47,4 +47,21 @@ describe('skinToDesktopTheme', () => {
 
     expect(theme.colors.destructive).toBe(normalizeHex('#ff5566'))
   })
+
+  it('maps wallpaper presentation without changing the palette conversion', () => {
+    const theme = skinToDesktopTheme({
+      name: 'wallpaper',
+      colors: { background: '#101010', ui_text: '#f0f0f0' },
+      background_image: '  C:/Hermes/skins/wallpaper.png  ',
+      background_image_fit: ' contain ',
+      background_image_position: ' top right ',
+      background_overlay: ' #00000066 '
+    })!
+
+    expect(theme.backgroundImage).toBe('C:/Hermes/skins/wallpaper.png')
+    expect(theme.backgroundImageFit).toBe('contain')
+    expect(theme.backgroundImagePosition).toBe('top right')
+    expect(theme.backgroundOverlay).toBe('#00000066')
+    expect(theme.colors.background).toBe('#101010')
+  })
 })

--- a/apps/desktop/src/themes/skin.ts
+++ b/apps/desktop/src/themes/skin.ts
@@ -23,6 +23,8 @@ import type { DesktopTheme, DesktopThemeColors } from './types'
 // The accent labels the sidebar in small uppercase text, so it must clear WCAG AA
 // for normal text or section headers go invisible — mirrors the VS Code importer.
 const ACCENT_MIN_CONTRAST = 4.5
+const WALLPAPER_FITS = new Set(['contain', 'cover', 'fill', 'none', 'scale-down'])
+const WALLPAPER_OVERLAY = /^#(?:[\da-f]{3}|[\da-f]{4}|[\da-f]{6}|[\da-f]{8})$/i
 
 /** First normalizable hex among `keys`, alpha flattened over `backdrop`. */
 const pick = (colors: SkinColors, keys: string[], backdrop: string): string | null => {
@@ -75,6 +77,8 @@ export function skinToDesktopTheme(skin: HermesSkin): DesktopTheme | null {
     pick(colors, ['banner_dim', 'session_border'], background) ?? mix(foreground, background, 0.45)
 
   const destructive = pick(colors, ['ui_error'], background) ?? '#e25563'
+  const backgroundImageFit = (skin.background_image_fit ?? 'cover').trim()
+  const backgroundOverlay = (skin.background_overlay ?? '').trim()
 
   const palette: DesktopThemeColors = {
     background,
@@ -112,6 +116,10 @@ export function skinToDesktopTheme(skin: HermesSkin): DesktopTheme | null {
     // Single palette in both slots: a skin is one-mode, so the light/dark toggle
     // shouldn't invert it. renderedModeFor still paints `.dark` from luminance.
     colors: palette,
-    darkColors: palette
+    darkColors: palette,
+    backgroundImage: (skin.background_image ?? '').trim() || undefined,
+    backgroundImageFit: WALLPAPER_FITS.has(backgroundImageFit) ? backgroundImageFit : 'cover',
+    backgroundImagePosition: (skin.background_image_position ?? 'center').trim() || 'center',
+    backgroundOverlay: WALLPAPER_OVERLAY.test(backgroundOverlay) ? backgroundOverlay : undefined
   }
 }

--- a/apps/desktop/src/themes/types.ts
+++ b/apps/desktop/src/themes/types.ts
@@ -98,4 +98,9 @@ export interface DesktopTheme {
   terminal?: DesktopTerminalPalette
   /** Dark-variant terminal ANSI palette. Falls back to `terminal`. */
   darkTerminal?: DesktopTerminalPalette
+  /** Optional wallpaper presentation supplied by a backend skin. */
+  backgroundImage?: string
+  backgroundImageFit?: string
+  backgroundImagePosition?: string
+  backgroundOverlay?: string
 }

--- a/apps/desktop/src/themes/user-themes.test.ts
+++ b/apps/desktop/src/themes/user-themes.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
+import { $backendThemes } from './backend-sync'
 import { BUILTIN_THEMES, DEFAULT_SKIN_NAME } from './presets'
 import {
   $marketplaceInstalls,
@@ -26,6 +27,7 @@ const makeTheme = (label: string, source?: string) =>
 describe('user theme registry', () => {
   beforeEach(() => {
     window.localStorage.clear()
+    $backendThemes.set({})
     $userThemes.set({})
   })
 
@@ -58,6 +60,18 @@ describe('user theme registry', () => {
     expect(resolveTheme(DEFAULT_SKIN_NAME)).toBe(BUILTIN_THEMES[DEFAULT_SKIN_NAME])
   })
 
+  it('resolves one wallpaper-decorated built-in without duplicating the theme list', () => {
+    const decorated = {
+      ...BUILTIN_THEMES.mono,
+      backgroundImage: 'data:image/png;base64,AA=='
+    }
+
+    $backendThemes.set({ mono: decorated })
+
+    expect(resolveTheme('mono')).toBe(decorated)
+    expect(listAllThemes().filter(theme => theme.name === 'mono')).toEqual([decorated])
+  })
+
   it('refuses to shadow a built-in name', () => {
     const builtinName = makeTheme('x')
     builtinName.name = DEFAULT_SKIN_NAME
@@ -77,6 +91,7 @@ describe('user theme registry', () => {
 describe('marketplace install tracking', () => {
   beforeEach(() => {
     window.localStorage.clear()
+    $backendThemes.set({})
     $userThemes.set({})
   })
 

--- a/apps/desktop/src/themes/user-themes.ts
+++ b/apps/desktop/src/themes/user-themes.ts
@@ -171,9 +171,9 @@ export function contributedThemes(): DesktopTheme[] {
 /** Resolve a theme by name across the merged set (built-in + user + backend + contributed). */
 export function resolveTheme(name: string): DesktopTheme | undefined {
   return (
-    BUILTIN_THEMES[name] ??
     $userThemes.get()[name] ??
     $backendThemes.get()[name] ??
+    BUILTIN_THEMES[name] ??
     contributedThemes().find(theme => theme.name === name)
   )
 }
@@ -185,9 +185,9 @@ export function listAllThemes(): DesktopTheme[] {
   const shadows = (theme: DesktopTheme) => user[theme.name] || backend[theme.name]
 
   return [
-    ...Object.values(BUILTIN_THEMES),
+    ...Object.values(BUILTIN_THEMES).map(theme => backend[theme.name] ?? theme),
     ...contributedThemes().filter(theme => !shadows(theme)),
-    ...Object.values(backend).filter(theme => !user[theme.name]),
+    ...Object.values(backend).filter(theme => !BUILTIN_THEMES[theme.name] && !user[theme.name]),
     ...Object.values(user)
   ]
 }

--- a/apps/shared/src/skin.ts
+++ b/apps/shared/src/skin.ts
@@ -107,4 +107,10 @@ export interface HermesSkin {
   banner_hero?: string
   tool_prefix?: string
   help_header?: string
+  /** Desktop wallpaper path or inline image URL. */
+  background_image?: string
+  background_image_fit?: 'cover' | 'contain' | 'fill' | 'scale-down' | string
+  background_image_position?: string
+  /** CSS colour placed over the wallpaper to retain text contrast. */
+  background_overlay?: string
 }

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -175,6 +175,12 @@ class SkinConfig:
     tool_emojis: Dict[str, str] = field(default_factory=dict)  # per-tool emoji overrides
     banner_logo: str = ""    # Rich-markup ASCII art logo (replaces HERMES_AGENT_LOGO)
     banner_hero: str = ""    # Rich-markup hero art (replaces HERMES_CADUCEUS)
+    # Optional desktop wallpaper presentation. Relative paths are resolved
+    # beside the user skin file before the payload leaves the backend.
+    background_image: str = ""
+    background_image_fit: str = "cover"
+    background_image_position: str = "center"
+    background_overlay: str = ""
 
     def get_color(self, key: str, fallback: str = "") -> str:
         """Get a color value with fallback."""
@@ -818,7 +824,7 @@ def _mapping_or_empty(value: Any, *, section: str, skin_name: str) -> Dict[str, 
     return {}
 
 
-def _build_skin_config(data: Dict[str, Any]) -> SkinConfig:
+def _build_skin_config(data: Dict[str, Any], *, source_dir: Optional[Path] = None) -> SkinConfig:
     """Build a SkinConfig from a raw dict (built-in or loaded from YAML)."""
     # Start with default values as base for missing keys
     default = _BUILTIN_SKINS["default"]
@@ -843,6 +849,13 @@ def _build_skin_config(data: Dict[str, Any]) -> SkinConfig:
     light_colors = _mapping_or_empty(data.get("light_colors"), section="light_colors", skin_name=skin_name)
     dark_colors = _mapping_or_empty(data.get("dark_colors"), section="dark_colors", skin_name=skin_name)
 
+    background_image = str(data.get("background_image", "") or "").strip()
+    if background_image and source_dir is not None:
+        candidate = Path(background_image).expanduser()
+        has_url_scheme = background_image.lower().startswith(("data:", "file:", "http://", "https://"))
+        if not candidate.is_absolute() and not has_url_scheme:
+            background_image = str((source_dir / candidate).resolve())
+
     return SkinConfig(
         name=skin_name,
         description=data.get("description", ""),
@@ -855,6 +868,12 @@ def _build_skin_config(data: Dict[str, Any]) -> SkinConfig:
         tool_emojis=emoji_overrides,
         banner_logo=data.get("banner_logo", ""),
         banner_hero=data.get("banner_hero", ""),
+        background_image=background_image,
+        background_image_fit=str(data.get("background_image_fit", "cover") or "cover").strip() or "cover",
+        background_image_position=(
+            str(data.get("background_image_position", "center") or "center").strip() or "center"
+        ),
+        background_overlay=str(data.get("background_overlay", "") or "").strip(),
     )
 
 
@@ -897,7 +916,7 @@ def load_skin(name: str) -> SkinConfig:
     if user_file.is_file():
         data = _load_skin_from_yaml(user_file)
         if data:
-            return _build_skin_config(data)
+            return _build_skin_config(data, source_dir=user_file.parent)
 
     # Check built-in skins
     if name in _BUILTIN_SKINS:

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -117,6 +117,35 @@ class TestUserSkins:
         # Should inherit defaults for unspecified colors
         assert skin.get_color("banner_border") == "#CD7F32"  # from default
 
+    def test_load_user_skin_resolves_wallpaper_metadata(self, tmp_path, monkeypatch):
+        from hermes_cli.skin_engine import load_skin
+
+        skins_dir = tmp_path / "skins"
+        skins_dir.mkdir()
+        import yaml
+
+        (skins_dir / "mono.yaml").write_text(
+            yaml.dump(
+                {
+                    "name": "mono",
+                    "colors": {"background": "#ff00ff"},
+                    "background_image": "wallpaper.png",
+                    "background_image_fit": "contain",
+                    "background_image_position": "top right",
+                    "background_overlay": "#10101099",
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("hermes_cli.skin_engine._skins_dir", lambda: skins_dir)
+
+        skin = load_skin("mono")
+
+        assert skin.background_image == str((skins_dir / "wallpaper.png").resolve())
+        assert skin.background_image_fit == "contain"
+        assert skin.background_image_position == "top right"
+        assert skin.background_overlay == "#10101099"
+
     def test_load_user_skin_invalid_section_types_fall_back_to_defaults(self, tmp_path, monkeypatch):
         from hermes_cli.skin_engine import load_skin
 

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1141,7 +1141,15 @@ def test_skin_live_switch_end_to_end(server, tmp_path, monkeypatch):
 
     (tmp_path / "skins").mkdir()
     (tmp_path / "skins" / "midnight.yaml").write_text(
-        "name: midnight\ndescription: t\ncolors:\n  banner_title: '#00ffcc'\n  background: '#001010'\n"
+        "name: midnight\n"
+        "description: t\n"
+        "colors:\n"
+        "  banner_title: '#00ffcc'\n"
+        "  background: '#001010'\n"
+        "background_image: wallpaper.png\n"
+        "background_image_fit: contain\n"
+        "background_image_position: top right\n"
+        "background_overlay: '#00000066'\n"
     )
     monkeypatch.setattr(skin_engine, "get_hermes_home", lambda: tmp_path)
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
@@ -1164,6 +1172,10 @@ def test_skin_live_switch_end_to_end(server, tmp_path, monkeypatch):
     assert [ev for ev, _ in emitted] == ["skin.changed"]
     assert emitted[0][1]["name"] == "midnight"
     assert emitted[0][1]["colors"]["banner_title"] == "#00ffcc"
+    assert emitted[0][1]["background_image"] == str((tmp_path / "skins" / "wallpaper.png").resolve())
+    assert emitted[0][1]["background_image_fit"] == "contain"
+    assert emitted[0][1]["background_image_position"] == "top right"
+    assert emitted[0][1]["background_overlay"] == "#00000066"
 
 
 def test_broadcast_skin_if_changed_on_any_signature_move(server, monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3722,6 +3722,10 @@ def resolve_skin() -> dict:
             "banner_hero": skin.banner_hero,
             "tool_prefix": skin.tool_prefix,
             "help_header": (skin.branding or {}).get("help_header", ""),
+            "background_image": skin.background_image,
+            "background_image_fit": skin.background_image_fit,
+            "background_image_position": skin.background_image_position,
+            "background_overlay": skin.background_overlay,
         }
     except Exception:
         return {}


### PR DESCRIPTION
## What does this PR do?

Desktop deliberately protects its hand-tuned built-in palettes when a backend skin reuses a built-in theme name. The current collision path, however, drops the entire backend skin, including wallpaper metadata that is independent of the colour palette.

This change keeps the built-in Desktop colours, typography and terminal settings, whilst decorating that theme with the backend skin's wallpaper image, fit, position and overlay. It also carries those fields through the existing skin engine and JSON-RPC contract, resolves relative image paths beside the user skin file, and removes stale decoration when the backend clears the wallpaper.

The renderer accepts authenticated file paths and `data:image/` values only. It does not turn a remotely supplied skin into an arbitrary HTTP(S) request.

## Related Issue

No issue. I searched open and merged PRs and issues for wallpaper skins, `background_image`, backend theme collisions and built-in theme wallpaper metadata; no matching implementation was found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Extend `SkinConfig`, the TUI gateway payload and `HermesSkin` with optional wallpaper presentation fields.
- Resolve relative wallpaper paths against the user skin directory before publishing them to clients.
- Preserve the official built-in Desktop palette when names collide, whilst retaining wallpaper metadata and avoiding duplicate Appearance entries.
- Render file-backed or inline image wallpapers through the existing media resolver, with validated fit and overlay values.
- Add Python protocol coverage, Desktop registry/conversion regressions and a real Python-gateway-to-Electron Playwright scenario.

## How to Test

1. Create `$HERMES_HOME/skins/mono.yaml` with `name: mono`, a deliberately different `colors` block, `background_image: wallpaper.png`, and optional fit, position and overlay fields.
2. Start Desktop with `display.skin: mono`, then select the built-in Mono theme.
3. Confirm that Mono's built-in colours remain unchanged whilst the backend wallpaper and presentation metadata are rendered.

Focused verification completed on Windows 11 Pro, Python 3.12.13 and Node.js 26.7.0:

- `python -m pytest -p no:cacheprovider tests/hermes_cli/test_skin_engine.py::TestUserSkins::test_load_user_skin_resolves_wallpaper_metadata tests/tui_gateway/test_protocol.py::test_skin_live_switch_end_to_end -q` — 2 passed.
- `npm exec -- vitest run --project ui src/themes/backend-sync.test.ts src/themes/skin.test.ts src/themes/user-themes.test.ts` — 30 passed.
- `npm run typecheck` — passed.
- `npm run build` — passed.
- Targeted ESLint, Prettier, Ruff and `git diff --check` — passed.

The Windows Playwright run reached and passed every wallpaper and palette assertion on repeated attempts. On this heavily loaded shared host, the complete process did not produce a stable green exit because Electron/gateway start-up or shutdown exceeded the suite timeout. The committed E2E scenario uses the repository's real Python gateway and a bounded Electron clean-up path so that a clean CI runner can exercise the same route.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the optional fields are documented at their typed API and implementation boundary
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; these are user skin YAML fields, not `config.yaml` keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behaviour — N/A; no model tool changed

## Screenshots / Logs

The Playwright test asserts the rendered wallpaper data URL, `object-fit`, `object-position`, overlay colour and the unchanged built-in Mono palette through the real Desktop renderer.