### PR TITLE
fix(memory): handle empty-string new_text alias in single-op path (#90468)

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1083,7 +1083,7 @@ def memory_tool(
         return tool_error("Memory is not available. It may be disabled in config or this environment.", success=False)
 
     # Accept new_text as an alias for content (single-op path). See docstring.
-    if content is None and new_text is not None:
+    if not content and new_text is not None:
         content = new_text
 
     # Some strict providers fill optional schema fields with JSON null rather


### PR DESCRIPTION
## Summary
Fixes #90468.

The single-op `new_text` alias fallback in `memory_tool()` only triggers when `content is None`, but some runtimes materialize omitted optional fields as empty string `""` rather than `None`/absent. This causes the alias to be skipped and returns a validation error.

The multi-op path already handles this correctly using the `or` operator (`content = (op.get("content") or op.get("new_text") or "").strip()`).

## Changes
- `tools/memory_tool.py`: Change `if content is None and new_text is not None:` to `if not content and new_text is not None:` to match multi-op behavior.

## Testing
Verified the single-op path now correctly falls back to `new_text` when `content` is empty string.
