### PR TITLE
fix(api): require API_SERVER_KEY auth on GET /health (#90315)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2997,6 +2997,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_health(self, request: "web.Request") -> "web.Response":
         """GET /health — simple health check."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
         return web.json_response(
             {"status": "ok", "platform": "hermes-agent", "version": _hermes_version()}
         )


### PR DESCRIPTION
## Summary
Fixes #90315.

The `GET /health` endpoint on the API server returned HTTP 200 without checking `API_SERVER_KEY`, contradicting the documented requirement that all API server routes require authentication. This made it easy to mistake an authenticated server as open.

The `GET /health/detailed` endpoint already has `_check_auth()` — this PR applies the same check to the simple `/health` endpoint.

## Changes
- `gateway/platforms/api_server.py`: Add `_check_auth(request)` call to `_handle_health()` handler.

## Testing
With `API_SERVER_KEY` set, `GET /health` without auth now returns 401 (matching `/health/detailed` behavior).
