### PR TITLE
fix(cron): fail-open preflight for router-internal provider names (#90220)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4301,6 +4301,16 @@ def _preflight_check_provider_key(job: dict, cfg: dict) -> Optional[str]:
             kwargs["explicit_base_url"] = job.get("base_url")
         resolve_runtime_provider(**kwargs)
     except AuthError as exc:
+        # Router-internal provider names (e.g. lmstudio-qwen-studio-qwen38
+        # from router.yaml) are valid at runtime but invisible to
+        # resolve_runtime_provider.  Only surface the missing-credential
+        # warning when the provider is a well-known built-in; for anything
+        # else let the real resolution path handle it (fail-open).
+        from hermes_cli.auth import resolve_provider as _rp
+        try:
+            _rp(requested)  # if this succeeds, it IS a known provider
+        except Exception:
+            return None  # non-standard name → fail-open
         return (
             f"provider credential missing: {exc}. "
             "Set the provider API key in .env (or `hermes setup`), or pin a "


### PR DESCRIPTION
## Summary
Fixes #90220.

The cron preflight check (`_preflight_check_provider_key`) calls `resolve_runtime_provider()` which doesn't recognize router-internal provider names (e.g. `lmstudio-qwen-studio-qwen38` from `router.yaml`). It raises `AuthError` for these valid names, incorrectly blocking the cron job.

## Changes
- `cron/scheduler.py`: When `AuthError` is raised, check if the provider name resolves through `resolve_provider()` (the built-in resolver). If it doesn't, the name is a non-standard/router-internal provider and the preflight should fail-open, letting the real runtime resolution path handle it.

## Testing
Router-internal provider names no longer trigger false "provider credential missing" errors in cron preflight.
