### PR TITLE
feat(gateway): add required inbound plugin gates

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -660,6 +660,8 @@ class GatewayConfig:
     """
     # Platform configurations
     platforms: Dict[Platform, PlatformConfig] = field(default_factory=dict)
+    required_plugins: List[str] = field(default_factory=list)
+    required_plugin_hooks: Dict[str, List[str]] = field(default_factory=dict)
     
     # Session reset policies by type
     default_reset_policy: SessionResetPolicy = field(default_factory=SessionResetPolicy)
@@ -805,6 +807,11 @@ class GatewayConfig:
             "platforms": {
                 p.value: c.to_dict() for p, c in self.platforms.items()
             },
+            "required_plugins": list(self.required_plugins),
+            "required_plugin_hooks": {
+                plugin: list(hooks)
+                for plugin, hooks in self.required_plugin_hooks.items()
+            },
             "default_reset_policy": self.default_reset_policy.to_dict(),
             "reset_by_type": {
                 k: v.to_dict() for k, v in self.reset_by_type.items()
@@ -919,8 +926,38 @@ class GatewayConfig:
         except (TypeError, ValueError):
             session_store_max_age_days = 90
 
+        required_plugins_raw = data.get("required_plugins", [])
+        if not isinstance(required_plugins_raw, list) or any(
+            not isinstance(item, str) or not item.strip()
+            for item in required_plugins_raw
+        ):
+            raise ValueError("required_plugins_invalid")
+        required_plugins = [item.strip() for item in required_plugins_raw]
+
+        required_plugin_hooks_raw = data.get("required_plugin_hooks", {})
+        if not isinstance(required_plugin_hooks_raw, dict):
+            raise ValueError("required_plugin_hooks_invalid")
+        required_plugin_hooks: Dict[str, List[str]] = {}
+        for plugin, hooks in required_plugin_hooks_raw.items():
+            if (
+                not isinstance(plugin, str)
+                or not plugin.strip()
+                or not isinstance(hooks, list)
+                or not hooks
+                or any(not isinstance(hook, str) or not hook.strip() for hook in hooks)
+            ):
+                raise ValueError("required_plugin_hooks_invalid")
+            plugin_name = plugin.strip()
+            if plugin_name not in required_plugins:
+                raise ValueError("required_plugin_hooks_plugin_not_required")
+            required_plugin_hooks[plugin_name] = [hook.strip() for hook in hooks]
+        if set(required_plugin_hooks) != set(required_plugins):
+            raise ValueError("required_plugin_hooks_missing")
+
         return cls(
             platforms=platforms,
+            required_plugins=required_plugins,
+            required_plugin_hooks=required_plugin_hooks,
             default_reset_policy=default_policy,
             reset_by_type=reset_by_type,
             reset_by_platform=reset_by_platform,
@@ -1055,6 +1092,12 @@ def load_gateway_config() -> GatewayConfig:
 
             gateway_section = yaml_cfg.get("gateway")
             if isinstance(gateway_section, dict):
+                if "required_plugins" in gateway_section:
+                    gw_data["required_plugins"] = gateway_section["required_plugins"]
+                if "required_plugin_hooks" in gateway_section:
+                    gw_data["required_plugin_hooks"] = gateway_section[
+                        "required_plugin_hooks"
+                    ]
                 if "multiplex_profiles" in gateway_section and "multiplex_profiles" not in gw_data:
                     # gateway.multiplex_profiles written by `hermes config set gateway.multiplex_profiles true`
                     gw_data["multiplex_profiles"] = gateway_section["multiplex_profiles"]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7014,13 +7014,71 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # gateway lazily imports run_agent inside per-request handlers,
         # so the discover_plugins() side-effect in model_tools.py is NOT
         # guaranteed to have run by the time we reach this point.
+        _plugin_discovery_error = None
         try:
             from hermes_cli.plugins import discover_plugins
             discover_plugins()
-        except Exception:
+        except Exception as _plugin_exc:
+            _plugin_discovery_error = _plugin_exc
             logger.warning(
                 "plugin discovery failed at gateway startup", exc_info=True,
             )
+
+        _required_plugins = list(getattr(self.config, "required_plugins", []) or [])
+        if _required_plugins:
+            _required_failure = None
+            if os.getenv("HERMES_SAFE_MODE", "").lower() in {"1", "true", "yes", "on"}:
+                _required_failure = "required plugins unavailable in safe mode"
+            elif _plugin_discovery_error is not None:
+                _required_failure = "required plugin discovery failed"
+            else:
+                try:
+                    from hermes_cli.plugins import get_plugin_manager
+                    _loaded_by_id = {}
+                    for _state in get_plugin_manager().list_plugins():
+                        for _plugin_id in (_state.get("key"), _state.get("name")):
+                            if isinstance(_plugin_id, str) and _plugin_id:
+                                _loaded_by_id[_plugin_id] = _state
+                    for _required in _required_plugins:
+                        _state = _loaded_by_id.get(_required)
+                        if _state is None or not _state.get("enabled") or _state.get("error"):
+                            _required_failure = f"required plugin unavailable: {_required}"
+                            break
+                        _required_hooks = set(
+                            getattr(self.config, "required_plugin_hooks", {}).get(
+                                _required, []
+                            )
+                        )
+                        if not _required_hooks:
+                            _required_failure = (
+                                f"required plugin hooks not configured: {_required}"
+                            )
+                            break
+                        _registered_hooks = set(_state.get("hook_names") or [])
+                        _missing_hooks = sorted(_required_hooks - _registered_hooks)
+                        if _missing_hooks:
+                            _required_failure = (
+                                f"required plugin hooks unavailable: {_required}: "
+                                f"{','.join(_missing_hooks)}"
+                            )
+                            break
+                except Exception:
+                    logger.warning("required plugin preflight failed", exc_info=True)
+                    _required_failure = "required plugin preflight failed"
+
+            if _required_failure:
+                logger.error("Refusing to start gateway: %s", _required_failure)
+                try:
+                    from gateway.status import write_runtime_status
+                    write_runtime_status(
+                        gateway_state="startup_failed",
+                        exit_reason=_required_failure,
+                    )
+                except Exception:
+                    pass
+                self._exit_code = GATEWAY_FATAL_CONFIG_EXIT_CODE
+                self._request_clean_exit(_required_failure)
+                return True
 
         # Register the generic relay adapter when a connector relay URL is
         # configured (GATEWAY_RELAY_URL / gateway.relay_url). No URL -> no-op, so
@@ -9025,6 +9083,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             except Exception as _hook_exc:
                 logger.warning("pre_gateway_dispatch invocation failed: %s", _hook_exc)
+                if getattr(self.config, "required_plugins", None):
+                    logger.error(
+                        "Blocking inbound dispatch because required plugin gate failed"
+                    )
+                    return None
                 _hook_results = []
 
             for _result in _hook_results:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2828,6 +2828,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
     _startup_restore_in_progress: bool = False
+    # Upper bound on the per-runner STT dedupe cache (see
+    # _transcribe_audio_deduped). One entry per recently transcribed audio
+    # file; small on purpose — it only has to span the few moments in which
+    # the interrupt path and the normal inbound path both handle one event.
+    _STT_RESULT_CACHE_MAX: int = 32
 
     def __init__(self, config: Optional[GatewayConfig] = None):
         global _gateway_runner_ref
@@ -15293,6 +15298,87 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return prefix
         return user_text
 
+    @staticmethod
+    def _stt_cache_key(path: str) -> tuple:
+        """Stable identity for a cached audio file.
+
+        Path alone is not enough: the media cache can reuse a name. Include the
+        inode identity plus size/mtime so a *different* file that happens to
+        land on the same path is transcribed on its own merits. When stat()
+        fails we fall back to the absolute path — the transcription attempt
+        then surfaces the real I/O error instead of us guessing here.
+        """
+        abs_path = os.path.abspath(path)
+        try:
+            st = os.stat(abs_path)
+        except OSError:
+            return (abs_path, None, None, None, None)
+        return (abs_path, st.st_dev, st.st_ino, st.st_size, st.st_mtime_ns)
+
+    async def _transcribe_audio_deduped(self, path: str) -> tuple[dict, bool]:
+        """Transcribe ``path`` once, even when two paths race on the same file.
+
+        A voice message that arrives during an active run is transcribed by the
+        interrupt/drain path AND again by the normal inbound preprocessing
+        pipeline, because both receive the same MessageEvent pointing at the
+        same cached audio file. That billed Whisper twice and echoed the 🎙️
+        transcript twice for one voice note.
+
+        Returns ``(result, is_first_delivery)``. ``is_first_delivery`` is True
+        only for the caller that first consumes this file's transcript; later
+        (or concurrently waiting) callers still get the transcript for the
+        agent prompt but must not echo it again.
+
+        Only successful results are retained: a failed or raising provider is
+        evicted so the next attempt genuinely retries, and the failure is
+        handed to every waiter rather than swallowed.
+        """
+        from tools.transcription_tools import transcribe_audio
+
+        cache = getattr(self, "_stt_result_cache", None)
+        if cache is None:
+            cache = OrderedDict()
+            self._stt_result_cache = cache
+
+        key = self._stt_cache_key(path)
+        entry = cache.get(key)
+        if entry is not None:
+            cache.move_to_end(key)
+            # shield(): a cancelled waiter must not cancel the shared future
+            # out from under the other callers.
+            result = await asyncio.shield(entry["future"])
+            first = not entry["delivered"]
+            entry["delivered"] = True
+            return result, first
+
+        loop = asyncio.get_running_loop()
+        entry = {"future": loop.create_future(), "delivered": False}
+        # No await between the get() above and this insert, so the event loop
+        # cannot interleave a second owner for the same key.
+        cache[key] = entry
+        while len(cache) > self._STT_RESULT_CACHE_MAX:
+            cache.popitem(last=False)
+
+        future = entry["future"]
+        try:
+            result = await asyncio.to_thread(transcribe_audio, path)
+        except BaseException as exc:
+            cache.pop(key, None)
+            if not future.done():
+                future.set_exception(exc)
+                # Mark retrieved: when nobody else is waiting, asyncio would
+                # otherwise log a spurious "exception was never retrieved".
+                future.exception()
+            raise
+
+        if not result.get("success"):
+            # Don't cache failures — the next call should hit the provider again.
+            cache.pop(key, None)
+        if not future.done():
+            future.set_result(result)
+        entry["delivered"] = True
+        return result, True
+
     async def _enrich_message_with_transcription(
         self,
         user_text: str,
@@ -15311,9 +15397,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
               - ``enriched_text``: the message string with transcription wrappers
                 prepended (same as before).
               - ``successful_transcripts``: the raw transcript strings for audio
-                clips that were successfully transcribed, in input order. Empty
-                list if every clip failed or STT is disabled. Callers can use
-                this to echo transcripts back to the user before the agent loop.
+                clips that were successfully transcribed *by this call*, in
+                input order. Empty list if every clip failed, STT is disabled,
+                or another path already transcribed the same file (see
+                ``_transcribe_audio_deduped``). Callers use this to echo
+                transcripts back to the user before the agent loop, so a clip
+                appears here exactly once no matter how many paths process it.
         """
         if not getattr(self.config, "stt_enabled", True):
             notes = []
@@ -15336,17 +15425,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return f"{prefix}\n\n{user_text}", []
             return prefix, []
 
-        from tools.transcription_tools import transcribe_audio
-
         enriched_parts = []
         successful_transcripts: List[str] = []
         for path in audio_paths:
             try:
                 logger.debug("Transcribing user voice: %s", path)
-                result = await asyncio.to_thread(transcribe_audio, path)
+                result, _is_first_delivery = await self._transcribe_audio_deduped(path)
                 if result["success"]:
                     transcript = result["transcript"]
-                    successful_transcripts.append(transcript)
+                    # Only the first consumer of a given file reports the
+                    # transcript as "new". Callers echo 🎙️ from this list, so
+                    # gating it here keeps one echo per voice note when the
+                    # interrupt path and the normal path both run.
+                    if _is_first_delivery:
+                        successful_transcripts.append(transcript)
                     # Pass the transcript through as a plain quoted line. The
                     # earlier wording ("The user sent a voice message~ Here's
                     # what they said: ...") read as a meta-instruction and made

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -171,6 +171,11 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Platform adapter gate fired before downloading or caching inbound media.
+    # Plugins may return {"action": "skip", "reason": "..."} to consume the
+    # message before bytes are fetched or an agent turn is created.
+    # Kwargs: platform: str, metadata: dict[str, object].
+    "pre_gateway_media_download",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs an approval decision -- fires for CLI-interactive prompts,
     # gateway/ACP approvals, and smart-mode auxiliary-LLM decisions.
@@ -1924,6 +1929,11 @@ class PluginManager:
                     getattr(cb, "__name__", repr(cb)),
                     exc,
                 )
+                if hook_name in {
+                    "pre_gateway_dispatch",
+                    "pre_gateway_media_download",
+                }:
+                    results.append({"action": "skip", "reason": "hook_error"})
         return results
 
     def has_hook(self, hook_name: str) -> bool:
@@ -1992,6 +2002,7 @@ class PluginManager:
                     "enabled": loaded.enabled,
                     "tools": len(loaded.tools_registered),
                     "hooks": len(loaded.hooks_registered),
+                    "hook_names": sorted(loaded.hooks_registered),
                     "middleware": len(loaded.middleware_registered),
                     "commands": len(loaded.commands_registered),
                     "error": loaded.error,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8037,6 +8037,41 @@ class TelegramAdapter(BasePlatformAdapter):
 
         self._pending_photo_batch_tasks[batch_key] = asyncio.create_task(self._flush_photo_batch(batch_key))
 
+    def _pre_media_download_blocked(self, update: Update, msg: Message) -> bool:
+        from hermes_cli.plugins import invoke_hook
+
+        reply = getattr(msg, "reply_to_message", None)
+        sender = getattr(msg, "from_user", None)
+        chat = getattr(msg, "chat", None)
+        received_at = getattr(msg, "date", None)
+        metadata = {
+            "update_id": getattr(update, "update_id", None),
+            "chat_id": getattr(chat, "id", None),
+            "thread_id": getattr(msg, "message_thread_id", None),
+            "message_id": getattr(msg, "message_id", None),
+            "reply_to_message_id": getattr(reply, "message_id", None) if reply else None,
+            "sender_user_id": getattr(sender, "id", None),
+            "media_kind": self._media_message_type(msg).value,
+            "received_at": received_at.isoformat() if received_at else None,
+        }
+        try:
+            results = invoke_hook(
+                "pre_gateway_media_download",
+                platform="telegram",
+                metadata=metadata,
+            )
+        except Exception:
+            logger.exception("[Telegram] Pre-download media hook failed closed")
+            return True
+        for result in results:
+            if isinstance(result, dict) and result.get("action") == "skip":
+                logger.info(
+                    "[Telegram] Media consumed by pre-download hook: %s",
+                    result.get("reason", "no reason provided"),
+                )
+                return True
+        return False
+
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
         if not update.message:
@@ -8059,6 +8094,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._observe_unmentioned_group_message(
                     _m, _event.message_type, update_id=update.update_id, event=_event
                 )
+            return
+        if self._pre_media_download_blocked(update, update.message):
             return
 
         msg = update.message

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -4,6 +4,8 @@ import logging
 import os
 from unittest.mock import patch
 
+import pytest
+
 from agent.secret_scope import reset_secret_scope, set_secret_scope
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from gateway.config import (
@@ -291,6 +293,60 @@ class TestStreamingConfig:
 
 
 class TestGatewayConfigRoundtrip:
+    def test_required_plugins_roundtrip(self):
+        config = GatewayConfig(
+            required_plugins=["pontomais-inbound"],
+            required_plugin_hooks={
+                "pontomais-inbound": [
+                    "pre_gateway_dispatch",
+                    "pre_gateway_media_download",
+                ]
+            },
+        )
+
+        restored = GatewayConfig.from_dict(config.to_dict())
+
+        assert restored.required_plugins == ["pontomais-inbound"]
+        assert restored.required_plugin_hooks == {
+            "pontomais-inbound": [
+                "pre_gateway_dispatch",
+                "pre_gateway_media_download",
+            ]
+        }
+
+    @pytest.mark.parametrize(
+        "raw_value",
+        ["pontomais-inbound", [""], [1], ["pontomais-inbound", None]],
+    )
+    def test_required_plugins_rejects_malformed_values(self, raw_value):
+        with pytest.raises(ValueError, match="required_plugins_invalid"):
+            GatewayConfig.from_dict({"required_plugins": raw_value})
+
+    @pytest.mark.parametrize(
+        "raw_value",
+        ["pre_gateway_dispatch", [], {"pontomais-inbound": []}, {"": ["hook"]}],
+    )
+    def test_required_plugin_hooks_rejects_malformed_values(self, raw_value):
+        with pytest.raises(ValueError, match="required_plugin_hooks_invalid"):
+            GatewayConfig.from_dict(
+                {
+                    "required_plugins": ["pontomais-inbound"],
+                    "required_plugin_hooks": raw_value,
+                }
+            )
+
+    def test_required_plugin_hooks_must_reference_required_plugin(self):
+        with pytest.raises(
+            ValueError, match="required_plugin_hooks_plugin_not_required"
+        ):
+            GatewayConfig.from_dict(
+                {"required_plugin_hooks": {"pontomais-inbound": ["hook"]}}
+            )
+
+    def test_each_required_plugin_must_declare_required_hooks(self):
+        with pytest.raises(ValueError, match="required_plugin_hooks_missing"):
+            GatewayConfig.from_dict({"required_plugins": ["pontomais-inbound"]})
+
     def test_full_roundtrip(self):
         config = GatewayConfig(
             platforms={

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -511,6 +511,128 @@ async def test_runner_exits_with_ex_config_on_nonretryable_startup_error(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_runner_fails_before_adapter_connect_when_required_plugin_is_missing(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")
+        },
+        sessions_dir=tmp_path / "sessions",
+        required_plugins=["pontomais-inbound"],
+    )
+    runner = GatewayRunner(config)
+
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_manager",
+        lambda: type("Manager", (), {"list_plugins": lambda self: []})(),
+    )
+    monkeypatch.setattr(
+        runner,
+        "_create_adapter",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("adapter creation must not run")
+        ),
+    )
+
+    ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is True
+    assert runner.exit_code == GATEWAY_FATAL_CONFIG_EXIT_CODE
+    assert runner.adapters == {}
+    state = read_runtime_status()
+    assert state["gateway_state"] == "startup_failed"
+    assert state["exit_reason"] == "required plugin unavailable: pontomais-inbound"
+
+
+@pytest.mark.asyncio
+async def test_runner_fails_when_required_plugin_did_not_register_required_hooks(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        sessions_dir=tmp_path / "sessions",
+        required_plugins=["pontomais-inbound"],
+        required_plugin_hooks={
+            "pontomais-inbound": [
+                "pre_gateway_dispatch",
+                "pre_gateway_media_download",
+            ]
+        },
+    )
+    runner = GatewayRunner(config)
+
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_manager",
+        lambda: type(
+            "Manager",
+            (),
+            {
+                "list_plugins": lambda self: [
+                    {
+                        "name": "pontomais-inbound",
+                        "key": "pontomais-inbound",
+                        "enabled": True,
+                        "error": None,
+                        "hook_names": ["pre_gateway_dispatch"],
+                    }
+                ]
+            },
+        )(),
+    )
+
+    ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is True
+    assert runner.exit_code == GATEWAY_FATAL_CONFIG_EXIT_CODE
+    assert runner.exit_reason == (
+        "required plugin hooks unavailable: pontomais-inbound: "
+        "pre_gateway_media_download"
+    )
+
+
+@pytest.mark.asyncio
+async def test_runner_rejects_direct_config_with_required_plugin_but_no_hooks(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    runner = GatewayRunner(
+        GatewayConfig(
+            sessions_dir=tmp_path / "sessions",
+            required_plugins=["pontomais-inbound"],
+        )
+    )
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_manager",
+        lambda: type(
+            "Manager",
+            (),
+            {
+                "list_plugins": lambda self: [
+                    {
+                        "name": "pontomais-inbound",
+                        "key": "pontomais-inbound",
+                        "enabled": True,
+                        "error": None,
+                        "hook_names": [],
+                    }
+                ]
+            },
+        )(),
+    )
+
+    assert await runner.start() is True
+    assert runner.exit_code == GATEWAY_FATAL_CONFIG_EXIT_CODE
+    assert runner.exit_reason == "required plugin hooks not configured: pontomais-inbound"
+
+
+@pytest.mark.asyncio
 async def test_start_gateway_propagates_fatal_config_exit_code(monkeypatch, tmp_path):
     """A clean exit carrying GATEWAY_FATAL_CONFIG_EXIT_CODE must surface as a
     process-level SystemExit(78) — NOT a truthy return — so main() exits 78

--- a/tests/gateway/test_stt_transcription_dedupe.py
+++ b/tests/gateway/test_stt_transcription_dedupe.py
@@ -1,0 +1,335 @@
+"""Regression tests: a voice message must reach Whisper exactly once.
+
+Production bug: when a voice message arrives during an active agent run, the
+adapter queues the event and signals an interrupt. The interrupt path
+(``_dequeue_pending_with_transcription``) transcribes the cached audio file,
+and then the very same event/file is preprocessed again through the normal
+inbound path (``_prepare_inbound_message_text``), which transcribes it a second
+time. Logs showed a single cached audio file and two consecutive Whisper calls
+— and, with ``stt.echo_transcripts: true``, two 🎙️ echoes for one voice note.
+
+These tests pin: one STT call per audio file across both paths, exactly one
+echo when echoing is enabled, none when it is disabled, distinct files still
+transcribed independently, and failures never silently reused.
+"""
+
+import asyncio
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+class _FakeAdapter:
+    """Minimal adapter double: pending-message queue + recorded sends."""
+
+    def __init__(self, pending=None):
+        self._pending = dict(pending or {})
+        self.sent = []
+
+    def get_pending_message(self, session_key):
+        return self._pending.pop(session_key, None)
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append((chat_id, text, metadata))
+        return True
+
+
+def _make_runner(adapter, *, echo=True):
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True, stt_echo_transcripts=echo)
+    runner.adapters = {}
+    runner._model = "test-model"
+    runner._base_url = ""
+    runner._has_setup_skill = lambda: False
+    runner._adapter_for_source = lambda source: adapter
+    runner._thread_metadata_for_source = lambda source, anchor=None: None
+    runner._reply_anchor_for_event = lambda event: None
+    return runner
+
+
+def _make_source():
+    return SessionSource(platform=Platform.TELEGRAM, chat_id="123", chat_type="dm")
+
+
+def _make_voice_event(source, path):
+    return MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=[str(path)],
+        media_types=["audio/ogg"],
+    )
+
+
+def _write_audio(tmp_path, name="voice.ogg", content=b"OggS-fake-audio"):
+    path = tmp_path / name
+    path.write_bytes(content)
+    return path
+
+
+class _CountingTranscriber:
+    """Stand-in for ``transcribe_audio`` that counts calls per path."""
+
+    def __init__(self, transcript="hello from the voice note", delay=0.0):
+        self.transcript = transcript
+        self.delay = delay
+        self.calls = []
+        self._lock = threading.Lock()
+
+    def __call__(self, path):
+        with self._lock:
+            self.calls.append(path)
+        if self.delay:
+            time.sleep(self.delay)
+        return {
+            "success": True,
+            "transcript": self.transcript,
+            "provider": "local_command",
+        }
+
+
+@pytest.mark.asyncio
+async def test_interrupt_then_normal_path_transcribes_and_echoes_once(tmp_path):
+    """The interrupt path and the normal path must share one transcription."""
+    audio = _write_audio(tmp_path)
+    adapter = _FakeAdapter()
+    source = _make_source()
+    event = _make_voice_event(source, audio)
+    session_key = "telegram:123"
+    adapter._pending[session_key] = event
+
+    runner = _make_runner(adapter, echo=True)
+    transcriber = _CountingTranscriber()
+
+    with patch("tools.transcription_tools.transcribe_audio", transcriber):
+        # 1. Voice message arrives mid-run: the adapter queues it and the
+        #    interrupt path drains + transcribes it.
+        interrupt_text = await runner._dequeue_pending_with_transcription(
+            adapter, session_key, source,
+        )
+        # 2. The same event is then preprocessed by the normal inbound path.
+        normal_text = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    # Both paths still hand the agent the real transcript...
+    assert interrupt_text is not None and transcriber.transcript in interrupt_text
+    assert normal_text is not None and transcriber.transcript in normal_text
+    # ...but Whisper is called exactly once for the one cached audio file.
+    assert transcriber.calls == [str(audio)], (
+        f"expected a single STT call, got {len(transcriber.calls)}: {transcriber.calls}"
+    )
+    # And the user sees exactly one 🎙️ echo, not two.
+    echoes = [text for _chat, text, _meta in adapter.sent if text.startswith("🎙️")]
+    assert echoes == [f'🎙️ "{transcriber.transcript}"'], f"duplicate echoes: {echoes}"
+
+
+@pytest.mark.asyncio
+async def test_normal_path_then_interrupt_path_transcribes_and_echoes_once(tmp_path):
+    """Order must not matter: the reverse sequence dedupes identically."""
+    audio = _write_audio(tmp_path)
+    adapter = _FakeAdapter()
+    source = _make_source()
+    event = _make_voice_event(source, audio)
+    session_key = "telegram:123"
+    adapter._pending[session_key] = event
+
+    runner = _make_runner(adapter, echo=True)
+    transcriber = _CountingTranscriber()
+
+    with patch("tools.transcription_tools.transcribe_audio", transcriber):
+        normal_text = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+        interrupt_text = await runner._dequeue_pending_with_transcription(
+            adapter, session_key, source,
+        )
+
+    assert normal_text is not None and transcriber.transcript in normal_text
+    assert interrupt_text is not None and transcriber.transcript in interrupt_text
+    assert len(transcriber.calls) == 1
+    echoes = [text for _chat, text, _meta in adapter.sent if text.startswith("🎙️")]
+    assert len(echoes) == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_for_same_file_share_one_transcription(tmp_path):
+    """Two paths racing on the same file must not both hit Whisper."""
+    audio = _write_audio(tmp_path)
+    adapter = _FakeAdapter()
+    runner = _make_runner(adapter, echo=True)
+    transcriber = _CountingTranscriber(delay=0.15)
+
+    with patch("tools.transcription_tools.transcribe_audio", transcriber):
+        first, second = await asyncio.gather(
+            runner._enrich_message_with_transcription("", [str(audio)]),
+            runner._enrich_message_with_transcription("", [str(audio)]),
+        )
+
+    assert len(transcriber.calls) == 1
+    # Both callers get usable enriched text for the agent...
+    assert transcriber.transcript in first[0]
+    assert transcriber.transcript in second[0]
+    # ...but only one of them owns the echo, so the user sees one 🎙️ line.
+    assert sorted([len(first[1]), len(second[1])]) == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_sequential_calls_for_same_file_share_one_transcription(tmp_path):
+    audio = _write_audio(tmp_path)
+    adapter = _FakeAdapter()
+    runner = _make_runner(adapter, echo=True)
+    transcriber = _CountingTranscriber()
+
+    with patch("tools.transcription_tools.transcribe_audio", transcriber):
+        first = await runner._enrich_message_with_transcription("", [str(audio)])
+        second = await runner._enrich_message_with_transcription("", [str(audio)])
+
+    assert len(transcriber.calls) == 1
+    assert transcriber.transcript in first[0]
+    assert transcriber.transcript in second[0]
+    assert first[1] == [transcriber.transcript]
+    assert second[1] == []
+
+
+@pytest.mark.asyncio
+async def test_distinct_files_are_each_transcribed_and_echoed(tmp_path):
+    """Dedupe is per-file: two different voice notes stay independent."""
+    audio_a = _write_audio(tmp_path, "a.ogg", b"OggS-a")
+    audio_b = _write_audio(tmp_path, "b.ogg", b"OggS-b")
+    adapter = _FakeAdapter()
+    source = _make_source()
+    runner = _make_runner(adapter, echo=True)
+    transcriber = _CountingTranscriber()
+
+    with patch("tools.transcription_tools.transcribe_audio", transcriber):
+        text_a = await runner._prepare_inbound_message_text(
+            event=_make_voice_event(source, audio_a),
+            source=source,
+            history=[],
+        )
+        text_b = await runner._prepare_inbound_message_text(
+            event=_make_voice_event(source, audio_b),
+            source=source,
+            history=[],
+        )
+
+    assert sorted(transcriber.calls) == sorted([str(audio_a), str(audio_b)])
+    assert text_a is not None and text_b is not None
+    echoes = [text for _chat, text, _meta in adapter.sent if text.startswith("🎙️")]
+    assert len(echoes) == 2
+
+
+@pytest.mark.asyncio
+async def test_no_echo_when_stt_echo_transcripts_disabled(tmp_path):
+    """echo_transcripts=false: still one STT call, and zero 🎙️ messages."""
+    audio = _write_audio(tmp_path)
+    adapter = _FakeAdapter()
+    source = _make_source()
+    event = _make_voice_event(source, audio)
+    session_key = "telegram:123"
+    adapter._pending[session_key] = event
+
+    runner = _make_runner(adapter, echo=False)
+    transcriber = _CountingTranscriber()
+
+    with patch("tools.transcription_tools.transcribe_audio", transcriber):
+        interrupt_text = await runner._dequeue_pending_with_transcription(
+            adapter, session_key, source,
+        )
+        normal_text = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert len(transcriber.calls) == 1
+    assert transcriber.transcript in interrupt_text
+    assert transcriber.transcript in normal_text
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_failed_transcription_is_not_cached(tmp_path):
+    """Failures must not be reused: a later attempt retries the provider."""
+    audio = _write_audio(tmp_path)
+    adapter = _FakeAdapter()
+    runner = _make_runner(adapter, echo=True)
+
+    calls = []
+
+    def _flaky(path):
+        calls.append(path)
+        if len(calls) == 1:
+            return {"success": False, "error": "backend timeout"}
+        return {"success": True, "transcript": "second time lucky", "provider": "x"}
+
+    with patch("tools.transcription_tools.transcribe_audio", _flaky):
+        first_text, first_transcripts = await runner._enrich_message_with_transcription(
+            "", [str(audio)],
+        )
+        second_text, second_transcripts = await runner._enrich_message_with_transcription(
+            "", [str(audio)],
+        )
+
+    assert len(calls) == 2, "a failed transcription must be retried, not cached"
+    assert "[voice message could not be transcribed]" in first_text
+    assert first_transcripts == []
+    assert "second time lucky" in second_text
+    assert second_transcripts == ["second time lucky"]
+
+
+@pytest.mark.asyncio
+async def test_raising_transcriber_is_not_cached_and_stays_visible(tmp_path, caplog):
+    """A raising provider must be logged and retried, never silently reused."""
+    audio = _write_audio(tmp_path)
+    adapter = _FakeAdapter()
+    runner = _make_runner(adapter, echo=True)
+
+    calls = []
+
+    def _boom(path):
+        calls.append(path)
+        raise RuntimeError("whisper exploded")
+
+    with caplog.at_level("ERROR"), patch(
+        "tools.transcription_tools.transcribe_audio", _boom
+    ):
+        text_one, _ = await runner._enrich_message_with_transcription("", [str(audio)])
+        text_two, _ = await runner._enrich_message_with_transcription("", [str(audio)])
+
+    assert len(calls) == 2
+    assert "[voice message could not be transcribed]" in text_one
+    assert "[voice message could not be transcribed]" in text_two
+    assert "whisper exploded" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_transcription_cache_is_bounded(tmp_path):
+    """The per-runner cache must not grow without bound."""
+    from gateway.run import GatewayRunner
+
+    adapter = _FakeAdapter()
+    runner = _make_runner(adapter, echo=True)
+    transcriber = _CountingTranscriber()
+
+    limit = GatewayRunner._STT_RESULT_CACHE_MAX
+    with patch("tools.transcription_tools.transcribe_audio", transcriber):
+        for i in range(limit + 5):
+            audio = _write_audio(tmp_path, f"voice-{i}.ogg", f"OggS-{i}".encode())
+            await runner._enrich_message_with_transcription("", [str(audio)])
+
+    assert len(transcriber.calls) == limit + 5
+    assert len(runner._stt_result_cache) <= limit

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -474,6 +474,43 @@ class TestDocumentDownloadBlock:
         event = adapter.handle_message.call_args[0][0]
         assert "could not be downloaded" in (event.text or "")
 
+    @pytest.mark.asyncio
+    async def test_pre_media_hook_skips_voice_before_download_and_dispatch(self, adapter):
+        msg = _make_message()
+        msg.voice = MagicMock()
+        msg.voice.file_size = 100
+        msg.voice.get_file = AsyncMock()
+        msg.date = MagicMock()
+        msg.date.isoformat.return_value = "2026-08-19T20:00:00+00:00"
+        update = _make_update(msg)
+
+        hook = MagicMock(
+            return_value=[{"action": "skip", "reason": "not authorized"}]
+        )
+        with patch("hermes_cli.plugins.invoke_hook", hook):
+            await adapter._handle_media_message(update, MagicMock())
+
+        assert hook.call_args.kwargs["metadata"]["received_at"]
+        msg.voice.get_file.assert_not_awaited()
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pre_media_hook_invocation_failure_blocks_voice(self, adapter):
+        msg = _make_message()
+        msg.voice = MagicMock()
+        msg.voice.file_size = 100
+        msg.voice.get_file = AsyncMock()
+        update = _make_update(msg)
+
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            side_effect=RuntimeError("plugin manager unavailable"),
+        ):
+            await adapter._handle_media_message(update, MagicMock())
+
+        msg.voice.get_file.assert_not_awaited()
+        adapter.handle_message.assert_not_awaited()
+
 
 class TestVideoDownloadBlock:
     @pytest.mark.asyncio

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -400,6 +400,7 @@ class TestPluginDiscovery:
         }
         assert len(non_bundled) == 1
 
+
     def test_discover_skips_dir_without_manifest(self, tmp_path, monkeypatch):
         """Directories without plugin.yaml are silently skipped."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"
@@ -658,6 +659,10 @@ class TestPluginHooks:
         )
         assert len(results) == 1
         assert results[0] == {"action": "skip", "reason": "test"}
+        state = next(
+            item for item in mgr.list_plugins() if item["name"] == "predispatch_plugin"
+        )
+        assert state["hook_names"] == ["pre_gateway_dispatch"]
 
     def test_register_and_invoke_hook(self, tmp_path, monkeypatch):
         """Registered hooks are called on invoke_hook()."""
@@ -708,6 +713,30 @@ class TestPluginHooks:
 
         # Should not raise despite 1/0
         mgr.invoke_hook("post_tool_call", tool_name="x", args={}, result="r", task_id="")
+
+    @pytest.mark.parametrize(
+        "hook_name",
+        ["pre_gateway_dispatch", "pre_gateway_media_download"],
+    )
+    def test_gateway_gate_hook_exception_returns_fail_closed_skip(
+        self, tmp_path, monkeypatch, hook_name
+    ):
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "bad_media_hook",
+            register_body=(
+                f'ctx.register_hook("{hook_name}", lambda **kw: 1/0)'
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert mgr.invoke_hook(
+            hook_name, platform="telegram", metadata={}
+        ) == [{"action": "skip", "reason": "hook_error"}]
 
     def test_hook_return_values_collected(self, tmp_path, monkeypatch):
         """invoke_hook() collects non-None return values from callbacks."""


### PR DESCRIPTION
## Summary

- adds required-plugin validation during gateway startup
- adds `pre_gateway_dispatch` for fail-closed text handling before agent dispatch
- adds `pre_media_download` after native Telegram gates and before media download
- exposes canonical gateway user authorization to required plugins
- keeps all new behavior disabled by default

## Validation

- 289 affected tests passed
- Ruff 0.15.10 passed
- compileall and diff checks passed
- independently audited together with the consuming PontoMais plugin

## Safety properties

- missing or invalid required plugins abort gateway startup
- hook failures block the scoped event instead of dispatching it to the agent
- unauthorized text events cannot be persisted by the plugin
- media hooks run only after native chat, topic, trigger and authorization gates
- no gateway restart or production activation was performed

## Residual test note

The full Hermes suite was not counted as passing because it remained inconclusive under the available execution window due to a historical timeout in unrelated areas. The complete affected matrix passed.