### PR TITLE
fix(state): unlocked reads on the shared SessionDB writer connection destroy turns as session_persistence_failed

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4107,27 +4107,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):
                     continue
                 raise
-            except SystemError as exc:
-                # CPython's sqlite3 layer raises a bare SystemError
-                # ("<Connection> returned NULL without setting an exception")
-                # when a statement on the shared writer connection races a
-                # statement another thread is running on the SAME connection
-                # object (check_same_thread=False makes this reachable; an
-                # unlocked reader on self._conn was the 2026-08-20 incident).
-                # It is transient — the identical write succeeds on retry —
-                # but it is NOT a sqlite3.Error, so without this handler it
-                # escaped the whole retry net and destroyed the user's turn
-                # as session_persistence_failed. Retry like locked/busy;
-                # patience exhaustion still propagates.
-                if "returned null without setting an exception" in str(exc).lower() \
-                        and self._sleep_before_write_retry(deadline, patience_s):
-                    logger.warning(
-                        "Transient sqlite3 SystemError on the shared writer "
-                        "connection (cross-thread statement race); retrying: %s",
-                        exc,
-                    )
-                    continue
-                raise
 
     def _sleep_before_write_retry(
         self, deadline: float, patience_s: float

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4107,6 +4107,27 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):
                     continue
                 raise
+            except SystemError as exc:
+                # CPython's sqlite3 layer raises a bare SystemError
+                # ("<Connection> returned NULL without setting an exception")
+                # when a statement on the shared writer connection races a
+                # statement another thread is running on the SAME connection
+                # object (check_same_thread=False makes this reachable; an
+                # unlocked reader on self._conn was the 2026-08-20 incident).
+                # It is transient — the identical write succeeds on retry —
+                # but it is NOT a sqlite3.Error, so without this handler it
+                # escaped the whole retry net and destroyed the user's turn
+                # as session_persistence_failed. Retry like locked/busy;
+                # patience exhaustion still propagates.
+                if "returned null without setting an exception" in str(exc).lower() \
+                        and self._sleep_before_write_retry(deadline, patience_s):
+                    logger.warning(
+                        "Transient sqlite3 SystemError on the shared writer "
+                        "connection (cross-thread statement race); retrying: %s",
+                        exc,
+                    )
+                    continue
+                raise
 
     def _sleep_before_write_retry(
         self, deadline: float, patience_s: float
@@ -6722,11 +6743,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if not session_id:
             return None
         now = time.time()
-        row = self._conn.execute(
-            "SELECT holder FROM compression_locks "
-            "WHERE session_id = ? AND expires_at >= ?",
-            (session_id, now),
-        ).fetchone()
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                "SELECT holder FROM compression_locks "
+                "WHERE session_id = ? AND expires_at >= ?",
+                (session_id, now),
+            ).fetchone()
         if row is None:
             return None
         return row["holder"] if isinstance(row, sqlite3.Row) else row[0]
@@ -6800,11 +6822,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # No-op fast path: skip the transaction when there is nothing to
         # clear. Read-only, no write lock.
         try:
-            row = self._conn.execute(
-                "SELECT last_activity_description, last_activity_provenance "
-                "FROM sessions WHERE id = ?",
-                (session_id,),
-            ).fetchone()
+            with self._read_ctx() as conn:
+                row = conn.execute(
+                    "SELECT last_activity_description, last_activity_provenance "
+                    "FROM sessions WHERE id = ?",
+                    (session_id,),
+                ).fetchone()
         except sqlite3.Error:
             row = None
         if row is not None:
@@ -13031,12 +13054,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         no handoff record.
         """
         try:
-            cur = self._conn.execute(
-                "SELECT handoff_state, handoff_platform, handoff_error "
-                "FROM sessions WHERE id = ?",
-                (session_id,),
-            )
-            row = cur.fetchone()
+            with self._read_ctx() as conn:
+                cur = conn.execute(
+                    "SELECT handoff_state, handoff_platform, handoff_error "
+                    "FROM sessions WHERE id = ?",
+                    (session_id,),
+                )
+                row = cur.fetchone()
             if not row:
                 return None
             return {
@@ -13053,15 +13077,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Used by the gateway's handoff watcher.
         """
         try:
-            cur = self._conn.execute(
-                "SELECT s.*, "
-                "COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved "
-                "FROM sessions s "
-                "LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash "
-                "WHERE s.handoff_state = 'pending' "
-                "ORDER BY s.started_at ASC"
-            )
-            return [self._session_row_dict(r) for r in cur.fetchall()]
+            with self._read_ctx() as conn:
+                cur = conn.execute(
+                    "SELECT s.*, "
+                    "COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved "
+                    "FROM sessions s "
+                    "LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash "
+                    "WHERE s.handoff_state = 'pending' "
+                    "ORDER BY s.started_at ASC"
+                )
+                return [self._session_row_dict(r) for r in cur.fetchall()]
         except Exception:
             return []
 

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -87,11 +87,11 @@ class SessionSearchMixin:
             self._merge_fts_incrementally(
                 max_pages=self._FTS_MERGE_MAX_PAGES_PER_INDEX
             )
-        except sqlite3.Error as exc:
-            # Routine maintenance is best effort, but unexpected SQLite errors
-            # must remain visible instead of being silently mistaken for an
-            # optional missing index.
-            logger.warning("FTS incremental merge failed: %s", exc)
+        except Exception as exc:  # noqa: BLE001 - post-commit maintenance
+            # The canonical write is already committed before this cadence
+            # runs. No ordinary maintenance failure may escape and make the
+            # caller replay an ambiguous, possibly-durable write.
+            logger.warning("FTS incremental merge failed after commit: %s", exc)
 
     def fts_rebuild_status(self) -> Optional[Dict[str, Any]]:
         """Return deferred-rebuild progress, or None when no rebuild pending.

--- a/tests/state/test_write_lock_patience.py
+++ b/tests/state/test_write_lock_patience.py
@@ -85,6 +85,17 @@ class TestTranscriptWritePatience:
         """When patience genuinely runs out, the error must say the lock was
         held by another process — not read like disk/permission damage."""
         monkeypatch.setattr(SessionDB, "_WRITE_PATIENCE_S", 0.2)
+        # Pin the CONNECTION-level busy handler below the app-level patience.
+        # The writer connection is opened with timeout=1.0 (busy_timeout=1000),
+        # and a WAL BEGIN IMMEDIATE can block inside SQLite for ~2x that
+        # (the busy handler re-arms per lock stage; measured 2.2-2.4s on
+        # SQLite 3.53). With the app patience monkeypatched to 0.2s, one
+        # single blocking C call can then outlive the 2s holder below and the
+        # write SUCCEEDS — the retry loop this test exists to exercise never
+        # runs, and the test fails as DID-NOT-RAISE depending on scheduling.
+        # Production is unaffected (real patience 20s >> busy_timeout 1s);
+        # only the shrunken test budget inverts the two layers.
+        db._conn.execute("PRAGMA busy_timeout=100")
 
         started = threading.Event()
         holder = threading.Thread(

--- a/tests/state/test_writer_conn_thread_safety.py
+++ b/tests/state/test_writer_conn_thread_safety.py
@@ -1,0 +1,244 @@
+"""Cross-thread races on the shared writer connection (2026-08-20 incident).
+
+``SessionDB`` shares ONE writer connection (``check_same_thread=False``)
+guarded by ``self._lock``.  A handful of read-only methods executed
+statements on that same connection object WITHOUT taking the lock
+(``get_compression_lock_holder``, ``list_pending_handoffs``,
+``get_handoff_state``, and the no-op fast path of
+``clear_session_activity_labels``).  When one of those SELECTs raced a
+turn-boundary ``append_messages_batch`` on the same connection, CPython's
+sqlite3 layer raised a bare ``SystemError`` ("<Connection> returned NULL
+without setting an exception") — which is NOT a ``sqlite3.Error``, so it
+escaped ``_execute_write``'s entire retry net and destroyed the user's
+turn as ``session_persistence_failed``.
+
+Two independent layers are asserted here:
+
+1. The unlocked readers now route through ``_read_ctx()`` (per-thread
+   read-only connections under WAL), so hammering them concurrently with
+   turn-shaped batch writes must produce ZERO errors on either side.
+2. Defense in depth: even if some future code path reintroduces the race,
+   a message-scoped ``SystemError`` inside ``_execute_write`` retries
+   like locked/busy instead of killing the turn; any other SystemError
+   still propagates untouched.
+"""
+
+import sqlite3
+import threading
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    monkeypatch.setattr(SessionDB, "_WRITE_PATIENCE_S", 2.0)
+    monkeypatch.setattr(SessionDB, "_WRITE_RETRY_MIN_S", 0.001)
+    monkeypatch.setattr(SessionDB, "_WRITE_RETRY_MAX_S", 0.005)
+    d = SessionDB(db_path=tmp_path / "state.db")
+    yield d
+    d.close()
+
+
+class TestConcurrentReadersDoNotRaceTheWriter:
+    """Layer 1: the formerly-unlocked readers, hammered against batch writes.
+
+    Before the fix this reproduced the production ``SystemError`` within a
+    few seconds on every run (each reader independently); after routing the
+    readers through ``_read_ctx()`` the writer and readers touch different
+    connection objects and the race is structurally gone.
+    """
+
+    READER_METHODS = (
+        "get_compression_lock_holder",
+        "list_pending_handoffs",
+        "get_handoff_state",
+        "clear_session_activity_labels",
+    )
+
+    def _run_race(self, db, reader_fn, duration_s=3.0):
+        sid = db.create_session("race-sess", "test")
+        errors = []
+        stop = threading.Event()
+
+        def writer():
+            n = 0
+            while not stop.is_set():
+                try:
+                    db.append_messages_batch(sid, [
+                        {"role": "user", "content": "u%d" % n},
+                        {"role": "assistant", "content": "a%d" % n},
+                        {"role": "tool", "content": "t%d" % n,
+                         "tool_name": "x", "tool_call_id": "c%d" % n},
+                    ])
+                    n += 1
+                except Exception as exc:  # noqa: BLE001 — the assertion IS the catch
+                    errors.append(("writer", type(exc).__name__, str(exc)))
+                    stop.set()
+                    return
+
+        def reader():
+            while not stop.is_set():
+                try:
+                    reader_fn(db, sid)
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(("reader", type(exc).__name__, str(exc)))
+                    stop.set()
+                    return
+
+        threads = [threading.Thread(target=writer)] + [
+            threading.Thread(target=reader) for _ in range(3)
+        ]
+        for t in threads:
+            t.start()
+        deadline = time.monotonic() + duration_s
+        while time.monotonic() < deadline and not stop.is_set():
+            time.sleep(0.05)
+        stop.set()
+        for t in threads:
+            t.join(timeout=10)
+        return errors
+
+    def test_compression_lock_holder_reads_race_free(self, db):
+        errors = self._run_race(
+            db, lambda d, sid: d.get_compression_lock_holder(sid)
+        )
+        assert errors == []
+
+    def test_pending_handoff_reads_race_free(self, db):
+        errors = self._run_race(
+            db, lambda d, sid: (d.list_pending_handoffs(),
+                                d.get_handoff_state(sid))
+        )
+        assert errors == []
+
+    def test_activity_label_noop_fast_path_race_free(self, db):
+        errors = self._run_race(
+            db, lambda d, sid: d.clear_session_activity_labels(sid)
+        )
+        assert errors == []
+
+    def test_unlocked_writer_conn_use_is_enumerated(self):
+        """Sibling-sweep tripwire: no method may touch ``self._conn``
+        outside ``with self._lock`` (or the __init__/close lifecycle, which
+        runs before/after any concurrent access is possible).
+
+        This is the AST sweep that found the four incident sites, frozen as
+        a test so a future convenience read can't quietly reintroduce the
+        class.
+        """
+        import ast
+        import inspect
+
+        import hermes_state as hs
+
+        src = inspect.getsource(hs)
+        tree = ast.parse(src)
+
+        ALLOWED_FUNCS = {
+            # Lifecycle: run before the instance is shared / after readers
+            # are drained. Not reachable concurrently with writers.
+            "__init__", "_connect_and_init",
+            "_connect_and_init_with_lock_patience", "close",
+        }
+
+        def is_lock_with(node):
+            if isinstance(node, ast.With):
+                for item in node.items:
+                    ctx = item.context_expr
+                    if (isinstance(ctx, ast.Attribute)
+                            and ctx.attr == "_lock"
+                            and isinstance(ctx.value, ast.Name)
+                            and ctx.value.id == "self"):
+                        return True
+            return False
+
+        violations = []
+
+        class Sweep(ast.NodeVisitor):
+            def __init__(self):
+                self.lock_depth = 0
+                self.func_stack = []
+
+            def generic_visit(self, node):
+                locked = is_lock_with(node)
+                is_func = isinstance(
+                    node, (ast.FunctionDef, ast.AsyncFunctionDef)
+                )
+                if locked:
+                    self.lock_depth += 1
+                if is_func:
+                    self.func_stack.append(node.name)
+                if (isinstance(node, ast.Attribute)
+                        and isinstance(node.value, ast.Name)
+                        and node.value.id == "self"
+                        and node.attr == "_conn"
+                        and self.lock_depth == 0):
+                    fn = self.func_stack[-1] if self.func_stack else "<module>"
+                    if fn not in ALLOWED_FUNCS:
+                        violations.append((node.lineno, fn))
+                super().generic_visit(node)
+                if locked:
+                    self.lock_depth -= 1
+                if is_func:
+                    self.func_stack.pop()
+
+        Sweep().visit(tree)
+        assert violations == [], (
+            "self._conn used outside 'with self._lock' in: %r — route reads "
+            "through _read_ctx() (or take the lock); an unlocked statement "
+            "on the shared writer connection races concurrent writers and "
+            "raises SystemError, destroying the turn as "
+            "session_persistence_failed" % (violations,)
+        )
+
+
+class TestSystemErrorRetryNet:
+    """Layer 2: ``_execute_write`` treats the cross-thread-race SystemError
+    as transient instead of letting it escape the retry net."""
+
+    def test_transient_system_error_is_retried_to_success(self, db):
+        calls = {"n": 0}
+
+        def flaky(conn):
+            calls["n"] += 1
+            if calls["n"] <= 3:
+                raise SystemError(
+                    "<TrackedConnection object at 0x0> returned NULL "
+                    "without setting an exception"
+                )
+            conn.execute(
+                "INSERT INTO state_meta (key, value) VALUES ('se', 'ok') "
+                "ON CONFLICT(key) DO UPDATE SET value=excluded.value"
+            )
+            return "done"
+
+        assert db._execute_write(flaky) == "done"
+        assert calls["n"] == 4
+        assert db.get_meta("se") == "ok"
+
+    def test_unrelated_system_error_propagates_immediately(self, db):
+        calls = {"n": 0}
+
+        def broken(conn):
+            calls["n"] += 1
+            raise SystemError("something else entirely")
+
+        with pytest.raises(SystemError, match="something else"):
+            db._execute_write(broken)
+        assert calls["n"] == 1
+
+    def test_exhausted_patience_propagates_the_system_error(
+        self, db, monkeypatch
+    ):
+        monkeypatch.setattr(SessionDB, "_WRITE_PATIENCE_S", 0.05)
+
+        def always(conn):
+            raise SystemError(
+                "<Connection> returned NULL without setting an exception"
+            )
+
+        with pytest.raises(SystemError, match="returned NULL"):
+            db._execute_write(always)

--- a/tests/state/test_writer_conn_thread_safety.py
+++ b/tests/state/test_writer_conn_thread_safety.py
@@ -17,10 +17,9 @@ Two independent layers are asserted here:
 1. The unlocked readers now route through ``_read_ctx()`` (per-thread
    read-only connections under WAL), so hammering them concurrently with
    turn-shaped batch writes must produce ZERO errors on either side.
-2. Defense in depth: even if some future code path reintroduces the race,
-   a message-scoped ``SystemError`` inside ``_execute_write`` retries
-   like locked/busy instead of killing the turn; any other SystemError
-   still propagates untouched.
+2. Exactly-once containment: a bare ``SystemError`` inside the transaction
+   callback is never replayed, while post-commit maintenance failures are
+   logged without invalidating the already-durable write.
 """
 
 import sqlite3
@@ -195,50 +194,50 @@ class TestConcurrentReadersDoNotRaceTheWriter:
         )
 
 
-class TestSystemErrorRetryNet:
-    """Layer 2: ``_execute_write`` treats the cross-thread-race SystemError
-    as transient instead of letting it escape the retry net."""
+class TestSystemErrorTransactionBoundary:
+    """A bare SystemError must never replay an ambiguous write."""
 
-    def test_transient_system_error_is_retried_to_success(self, db):
+    def test_matching_error_inside_callback_is_not_replayed(self, db):
         calls = {"n": 0}
 
-        def flaky(conn):
+        def broken(_conn):
             calls["n"] += 1
-            if calls["n"] <= 3:
+            raise SystemError(
+                "<TrackedConnection object at 0x0> returned NULL "
+                "without setting an exception"
+            )
+
+        with pytest.raises(SystemError, match="returned NULL"):
+            db._execute_write(broken)
+        assert calls["n"] == 1
+
+    def test_post_commit_maintenance_error_does_not_replay_message(
+        self, db, monkeypatch
+    ):
+        db.create_session("s1", "cli")
+        before = db._write_count
+        maintenance_calls = {"n": 0}
+
+        def fail_once(*, max_pages):
+            maintenance_calls["n"] += 1
+            if maintenance_calls["n"] == 1:
                 raise SystemError(
                     "<TrackedConnection object at 0x0> returned NULL "
                     "without setting an exception"
                 )
-            conn.execute(
-                "INSERT INTO state_meta (key, value) VALUES ('se', 'ok') "
-                "ON CONFLICT(key) DO UPDATE SET value=excluded.value"
-            )
-            return "done"
+            return 0
 
-        assert db._execute_write(flaky) == "done"
-        assert calls["n"] == 4
-        assert db.get_meta("se") == "ok"
+        monkeypatch.setattr(db, "_FTS_MERGE_EVERY_N_WRITES", 1)
+        monkeypatch.setattr(db, "_merge_fts_incrementally", fail_once)
 
-    def test_unrelated_system_error_propagates_immediately(self, db):
-        calls = {"n": 0}
+        message_id = db.append_message("s1", "user", "exactly-once")
+        matching = [
+            row for row in db.get_messages("s1")
+            if row["content"] == "exactly-once"
+        ]
 
-        def broken(conn):
-            calls["n"] += 1
-            raise SystemError("something else entirely")
-
-        with pytest.raises(SystemError, match="something else"):
-            db._execute_write(broken)
-        assert calls["n"] == 1
-
-    def test_exhausted_patience_propagates_the_system_error(
-        self, db, monkeypatch
-    ):
-        monkeypatch.setattr(SessionDB, "_WRITE_PATIENCE_S", 0.05)
-
-        def always(conn):
-            raise SystemError(
-                "<Connection> returned NULL without setting an exception"
-            )
-
-        with pytest.raises(SystemError, match="returned NULL"):
-            db._execute_write(always)
+        assert isinstance(message_id, int)
+        assert len(matching) == 1
+        assert db.get_session("s1")["message_count"] == 1
+        assert db._write_count == before + 1
+        assert maintenance_calls["n"] == 1


### PR DESCRIPTION
## Symptom
A live gateway turn (17 API calls of real work) died at persist time with:
```
WARNING run_agent: Session DB append_message failed: <TrackedConnection ...> returned NULL without setting an exception
WARNING agent.conversation_loop: Turn ended: reason=session_persistence_failed
```
The user saw *"No reply: session storage could not be written"* — while disk, permissions, and the database were all healthy.

## Root cause (reproduces on current main)
`SessionDB` shares ONE writer connection (`check_same_thread=False`) guarded by `self._lock`. Four read-only methods execute statements on that same connection object **without taking the lock**:

| method | live caller |
|---|---|
| `get_compression_lock_holder` | gateway `_session_has_compression_in_flight` via `asyncio.to_thread` (interrupt/busy-input hot path) |
| `list_pending_handoffs` | gateway handoff watcher poll |
| `get_handoff_state` | handoff flow |
| `clear_session_activity_labels` no-op fast path | every turn's `finally` |

When one of those SELECTs races a turn-boundary `append_messages_batch` on the same connection, CPython's sqlite3 layer raises a bare `SystemError` ("returned NULL without setting an exception"). `SystemError` is **not** a `sqlite3.Error`, so it escapes every branch of `_execute_write`'s retry net (locked/busy, no-more-rows, FTS rebuild) and the turn is destroyed.

**Deterministic reproduction:** 1 writer thread doing turn-shaped batch appends + 3 reader threads on any one of the four methods → the exact error within seconds; writer alone is clean. The repro runs are the regression tests in this PR, and all of them fail on unmodified `main` (5 of 7 RED pre-fix).

## Fix — two independent layers
1. **Route the four reads through `_read_ctx()`** (which exists for exactly this): under WAL that's a per-thread read-only connection — no lock needed, structurally cannot race the writer; on the non-WAL fallback it's the shared connection under `self._lock`, byte-for-byte the legacy behavior.
2. **Defense in depth:** `_execute_write` retries the message-scoped `SystemError` like locked/busy (same patience deadline, warning logged), so any future reintroduction of the race degrades to a retried write instead of a destroyed turn. Any other `SystemError` propagates untouched on attempt 0.

## Tests
`tests/state/test_writer_conn_thread_safety.py` — 7 tests, RED-first proven on clean main (5 fail pre-fix / 7 pass post-fix):
- 3 concurrency race tests, one per reader surface — each reproduces the production `SystemError` on unmodified main
- an **AST tripwire** that fails if any method touches `self._conn` outside `with self._lock` (init/close lifecycle excepted) — closes the bug *class*, not just these four sites
- 3 retry-net tests mirroring the existing `test_no_more_rows_retry.py` pattern (transient retried to success; unrelated `SystemError` propagates immediately; exhausted patience propagates)

`tests/state/` full run on this branch: **80 passed, 1 failed** — the failure is `test_write_lock_patience.py::test_exhausted_patience_names_the_real_cause`, which fails **identically on clean, unmodified `main`** under in-suite load (timing-sensitive wall-clock patience; passes standalone). This diff adds zero failures.