### PR TITLE
fix(qqbot): make API_BASE overridable via QQ_API_BASE env var

### DIFF
--- a/gateway/platforms/qqbot/constants.py
+++ b/gateway/platforms/qqbot/constants.py
@@ -18,7 +18,7 @@ QQBOT_VERSION = "1.1.0"
 # or test environments.  Default: q.qq.com (production).
 PORTAL_HOST = os.getenv("QQ_PORTAL_HOST", "q.qq.com")
 
-API_BASE = "https://api.sgroup.qq.com"
+API_BASE = os.getenv("QQ_API_BASE", "https://api.sgroup.qq.com")
 TOKEN_URL = "https://bots.qq.com/app/getAppAccessToken"
 GATEWAY_URL_PATH = "/gateway"
 


### PR DESCRIPTION
# Allow selecting the sandbox API endpoint (sandbox.api.sgroup.qq.com) without editing source. Falls back to the production URL as before.

## What does this PR do?

The QQBot adapter hardcodes the production API_BASE. Sandbox bots can't connect without patching source (lost on every hermes update). This PR makes it configurable via QQ_API_BASE env var, defaulting to production.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/qqbot/constants.py`: `API_BASE = os.getenv("QQ_API_BASE", "https://api.sgroup.qq.com")` (mirrors existing `QQ_PORTAL_HOST` pattern)

## How to Test

1. Without env var: connects to production (unchanged behavior).
2. With `QQ_API_BASE=https://sandbox.api.sgroup.qq.com`: connects to sandbox, bot comes online.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run pytest tests/ -q and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Debian 13 cloud)

### Documentation & Housekeeping

- [x] Docs: N/A
- [x] Config keys: N/A
- [x] Architecture/workflow: N/A
- [x] Cross-platform: N/A (pure Python)
- [x] Tool schemas: N/A