### PR TITLE
fix(dashboard-auth): stop trusting client-controlled X-Forwarded-For for rate-limiting/attribution

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -87,10 +87,12 @@ def _path_is_public(path: str) -> bool:
 
 
 def _client_ip(request: Request) -> str:
-    fwd = request.headers.get("x-forwarded-for", "")
-    if fwd:
-        return fwd.split(",")[0].strip()
-    return request.client.host if request.client else ""
+    """See hermes_cli.dashboard_auth.prefix.client_ip() -- the single,
+    XFF-spoofing-resistant implementation all _client_ip() call sites in
+    this package now share (issue #90702)."""
+    from hermes_cli.dashboard_auth.prefix import client_ip
+
+    return client_ip(request)
 
 
 def _ordered_session_providers(

--- a/hermes_cli/dashboard_auth/prefix.py
+++ b/hermes_cli/dashboard_auth/prefix.py
@@ -230,3 +230,43 @@ def resolve_public_url() -> str:
     if not cfg_clean:
         _warn_if_malformed("dashboard.public_url in config.yaml", cfg_raw)
     return cfg_clean
+
+
+# ---------------------------------------------------------------------------
+# Client IP resolution
+# ---------------------------------------------------------------------------
+
+
+def client_ip(request) -> str:
+    """Resolve the request's client IP for security-relevant purposes
+    (rate-limiting keys, pending-authorization attribution, audit log
+    entries).
+
+    ``request.client.host`` -- the true peer TCP connection address --
+    is the default: it is never attacker-controlled. X-Forwarded-For is
+    trusted ONLY when the operator has explicitly configured a reverse
+    proxy in front of the dashboard (:func:`resolve_public_url`
+    returning non-empty, via ``HERMES_DASHBOARD_PUBLIC_URL`` /
+    ``dashboard.public_url`` -- the same signal this module already
+    treats as "a trusted proxy sits in front of us" for redirect_uri
+    reconstruction). When trusted, uses the LAST XFF element (the
+    proxy-appended one; the first element(s) are whatever the client
+    itself sent and are not trustworthy even behind a real proxy that
+    APPENDS rather than overwrites).
+
+    Without this gate, any unauthenticated client can spoof XFF to
+    sidestep per-IP rate limits and pending-authorization caps (issue
+    #90702; same weakness family as #55101). Three call sites
+    (routes.py, middleware.py, token_auth.py) previously each defined
+    an identical, vulnerable copy of this function trusting the FIRST
+    XFF element unconditionally -- deduplicated here into one, correct
+    implementation all three now import.
+    """
+    trusted_proxy = bool(resolve_public_url())
+    if trusted_proxy:
+        fwd = request.headers.get("x-forwarded-for", "")
+        if fwd:
+            parts = [p.strip() for p in fwd.split(",") if p.strip()]
+            if parts:
+                return parts[-1]
+    return request.client.host if request.client else ""

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -106,10 +106,12 @@ def _redirect_uri(request: Request) -> str:
 
 
 def _client_ip(request: Request) -> str:
-    fwd = request.headers.get("x-forwarded-for", "")
-    if fwd:
-        return fwd.split(",")[0].strip()
-    return request.client.host if request.client else ""
+    """See hermes_cli.dashboard_auth.prefix.client_ip() -- the single,
+    XFF-spoofing-resistant implementation all _client_ip() call sites in
+    this package now share (issue #90702)."""
+    from hermes_cli.dashboard_auth.prefix import client_ip
+
+    return client_ip(request)
 
 
 def _prefix(request: Request) -> str:

--- a/hermes_cli/dashboard_auth/token_auth.py
+++ b/hermes_cli/dashboard_auth/token_auth.py
@@ -81,10 +81,12 @@ def clear_token_routes() -> None:
 
 
 def _client_ip(request: Request) -> str:
-    fwd = request.headers.get("x-forwarded-for", "")
-    if fwd:
-        return fwd.split(",")[0].strip()
-    return request.client.host if request.client else ""
+    """See hermes_cli.dashboard_auth.prefix.client_ip() -- the single,
+    XFF-spoofing-resistant implementation all _client_ip() call sites in
+    this package now share (issue #90702)."""
+    from hermes_cli.dashboard_auth.prefix import client_ip
+
+    return client_ip(request)
 
 
 def extract_bearer_token(request: Request) -> str:

--- a/tests/hermes_cli/test_dashboard_auth_prefix.py
+++ b/tests/hermes_cli/test_dashboard_auth_prefix.py
@@ -525,3 +525,108 @@ class TestCookiePathRespectsPrefix:
         assert "Path=/hermes" in at_cookies[0]
         assert "Secure" in at_cookies[0]
         assert "HttpOnly" in at_cookies[0]
+
+
+# ---------------------------------------------------------------------------
+# client_ip() -- XFF spoofing resistance (issue #90702)
+# ---------------------------------------------------------------------------
+
+
+class _FakeRequestForIp:
+    def __init__(self, xff=None, peer_ip="203.0.113.9"):
+        self.headers = {"x-forwarded-for": xff} if xff else {}
+        self.client = type("Client", (), {"host": peer_ip})() if peer_ip else None
+
+
+class TestClientIpXffSpoofingResistance:
+    """Regression for issue #90702: an unauthenticated client could
+    spoof X-Forwarded-For to sidestep per-IP rate limits and pending-
+    authorization caps in the native-login flow (and, since _client_ip
+    was duplicated three times identically, in password-login rate
+    limiting and audit-log attribution too)."""
+
+    def test_no_proxy_configured_ignores_client_supplied_xff(self, monkeypatch):
+        """The default, no-reverse-proxy case: XFF must be completely
+        ignored -- request.client.host (the true peer address, never
+        attacker-controlled) is used unconditionally."""
+        monkeypatch.delenv("HERMES_DASHBOARD_PUBLIC_URL", raising=False)
+        monkeypatch.setattr(prefix_mod, "_load_dashboard_section", lambda: {})
+
+        req = _FakeRequestForIp(
+            xff="10.0.0.1", peer_ip="203.0.113.9"
+        )
+        assert prefix_mod.client_ip(req) == "203.0.113.9"
+
+    def test_proxy_configured_trusts_the_last_xff_element(self, monkeypatch):
+        """When the operator has explicitly configured a reverse proxy
+        (dashboard.public_url / HERMES_DASHBOARD_PUBLIC_URL set), XFF is
+        trusted -- but using the LAST element (the proxy-appended one),
+        never the first (client-controlled, even behind a real
+        append-only proxy)."""
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_PUBLIC_URL", "https://mission-control.example"
+        )
+
+        req = _FakeRequestForIp(
+            xff="203.0.113.9, 10.0.0.1", peer_ip="10.0.0.1"
+        )
+        assert prefix_mod.client_ip(req) == "10.0.0.1"
+
+    def test_spoofed_xff_cannot_bypass_per_ip_caps_without_a_configured_proxy(
+        self, monkeypatch
+    ):
+        """The exact reported attack: an attacker sending a fresh,
+        fabricated X-Forwarded-For on every request must not be able to
+        mint distinct per-IP-bucket identities -- every request from the
+        same real peer connection resolves to the SAME client_ip when no
+        proxy is configured, regardless of what XFF claims."""
+        monkeypatch.delenv("HERMES_DASHBOARD_PUBLIC_URL", raising=False)
+        monkeypatch.setattr(prefix_mod, "_load_dashboard_section", lambda: {})
+
+        seen_ips = {
+            prefix_mod.client_ip(_FakeRequestForIp(xff=f"10.0.0.{i}", peer_ip="203.0.113.9"))
+            for i in range(50)
+        }
+        assert seen_ips == {"203.0.113.9"}, (
+            "50 requests spoofing 50 different XFF values from the same "
+            "real connection must all resolve to the same client_ip"
+        )
+
+    def test_no_client_and_no_trusted_proxy_returns_empty_string(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DASHBOARD_PUBLIC_URL", raising=False)
+        monkeypatch.setattr(prefix_mod, "_load_dashboard_section", lambda: {})
+
+        req = _FakeRequestForIp(xff="10.0.0.1", peer_ip=None)
+        assert prefix_mod.client_ip(req) == ""
+
+    def test_proxy_configured_but_no_xff_header_falls_back_to_peer(
+        self, monkeypatch
+    ):
+        """A configured proxy doesn't guarantee every request carries
+        XFF (e.g. a health check hitting the backend directly) -- must
+        fall back to the peer address, not error or return empty."""
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_PUBLIC_URL", "https://mission-control.example"
+        )
+        req = _FakeRequestForIp(xff=None, peer_ip="203.0.113.9")
+        assert prefix_mod.client_ip(req) == "203.0.113.9"
+
+    def test_routes_middleware_and_token_auth_all_delegate_to_the_shared_implementation(
+        self, monkeypatch
+    ):
+        """Regression against re-introducing the triplicated, vulnerable
+        copy: all three package modules' _client_ip() must call through
+        to prefix.client_ip(), not re-implement XFF parsing locally."""
+        monkeypatch.delenv("HERMES_DASHBOARD_PUBLIC_URL", raising=False)
+        monkeypatch.setattr(prefix_mod, "_load_dashboard_section", lambda: {})
+
+        from hermes_cli.dashboard_auth import middleware as middleware_mod
+        from hermes_cli.dashboard_auth import routes as routes_mod
+        from hermes_cli.dashboard_auth import token_auth as token_auth_mod
+
+        req = _FakeRequestForIp(xff="10.0.0.1", peer_ip="203.0.113.9")
+        for mod in (routes_mod, middleware_mod, token_auth_mod):
+            assert mod._client_ip(req) == "203.0.113.9", (
+                f"{mod.__name__}._client_ip must delegate to the shared, "
+                f"XFF-spoofing-resistant implementation"
+            )


### PR DESCRIPTION
Fixes #90702.

## Root cause

`_client_ip()` trusted the FIRST X-Forwarded-For element unconditionally. An unauthenticated attacker could spoof a fresh XFF value on every `POST /auth/native/authorize` request, sidestepping `native_flow.py`'s per-IP cap entirely -- 256 such requests fill the global pending-authorization store for the full 10-minute TTL, locking out every legitimate native desktop sign-in. Same weakness family as #55101, a different store/mechanism.

While investigating, found `_client_ip()` was defined **identically three times** (routes.py, middleware.py, token_auth.py) -- all three carried the same vulnerability, affecting password-login rate limiting and audit-log attribution too, not just the native flow the issue cites.

## Fix

Deduplicated into one implementation, `client_ip()`, in `prefix.py` -- already this package's "single source of truth" for forwarded-header concerns. `request.client.host` is the default. XFF is trusted ONLY when `resolve_public_url()` is non-empty -- the existing, operator-explicit "we run behind a reverse proxy" signal this same module already uses for OAuth redirect_uri reconstruction, so no new config surface was needed. When trusted, uses the LAST XFF element (proxy-appended) per RFC 7239 convention, not the first.

All three original `_client_ip()` functions are now thin wrappers delegating to the shared implementation.

## Verification

Added 6 regression tests, including the exact reported attack (50 spoofed XFF values from the same connection all resolve to the same client_ip). Verified as genuine regressions by reverting to the original logic and confirming 5/6 tests fail with the exact reported symptoms.

19/19 pass in the modified test file; 37/37 across three related dashboard-auth test files (no regression).