### PR TITLE
fix: Windows update no longer hangs and Bot Mode chats survive it (dead-pin adopt + ownership preserve + hand-off reap)

### DIFF
--- a/apps/desktop/electron/backend-ownership.test.ts
+++ b/apps/desktop/electron/backend-ownership.test.ts
@@ -284,3 +284,71 @@ test('shutdown coordinator returns one promise and awaits teardown exactly once'
   assert.equal(finished, true)
   assert.equal(coordinator.run(), first)
 })
+
+
+// #89298: a corrupt ownership file must never be silently rewritten as [] —
+// that permanently erases the only record of still-running backends. The reap
+// sweep quarantines the file and skips; a later healthy write recreates it.
+test('reapOrphans on a corrupt file quarantines and does not rewrite', async () => {
+  let contents = '{ this is not json'
+  let quarantined = 0
+  const writes: string[] = []
+  const stopped: number[] = []
+
+  const store = {
+    read: () => contents,
+    value: () => contents,
+    write: (next: string) => {
+      writes.push(next)
+      contents = next
+    },
+    quarantine: () => {
+      quarantined += 1
+    }
+  }
+
+  const ownership = createOwnership(store, {
+    stop: identityArg => {
+      stopped.push(identityArg.pid)
+    }
+  })
+
+  assert.deepEqual(await ownership.reapOrphans(), [])
+  assert.equal(quarantined, 1)
+  assert.deepEqual(writes, [])
+  assert.deepEqual(stopped, [])
+})
+
+test('reapOrphans on a corrupt file without a quarantine hook still skips the rewrite', async () => {
+  const writes: string[] = []
+  const store = {
+    read: () => 'garbage{{{',
+    value: () => 'garbage{{{',
+    write: (next: string) => {
+      writes.push(next)
+    }
+  }
+
+  const ownership = createOwnership(store)
+
+  assert.deepEqual(await ownership.reapOrphans(), [])
+  assert.deepEqual(writes, [])
+})
+
+test('an empty or missing ownership file is NOT corrupt — reap sweeps normally', async () => {
+  const writes: string[] = []
+  const store = {
+    read: () => '',
+    value: () => '',
+    write: (next: string) => {
+      writes.push(next)
+    },
+    quarantine: () => assert.fail('empty file must not be quarantined')
+  }
+
+  const ownership = createOwnership(store)
+
+  assert.deepEqual(await ownership.reapOrphans(), [])
+  // Empty roster: rewriting [] is harmless and keeps the legacy behavior.
+  assert.equal(writes.length, 1)
+})

--- a/apps/desktop/electron/backend-ownership.ts
+++ b/apps/desktop/electron/backend-ownership.ts
@@ -16,6 +16,10 @@ export interface BackendOwnershipEntry extends BackendIdentity {
 export interface BackendOwnershipStore {
   read: () => string | null
   write: (contents: string) => void
+  /** Move an unreadable ownership file aside (e.g. rename to `.corrupt`) so
+   *  its contents survive for inspection instead of being rewritten away.
+   *  Optional: stores that can't quarantine simply skip the sweep. */
+  quarantine?: () => void
 }
 
 export interface BackendOwnershipDeps {
@@ -62,12 +66,30 @@ function identitiesMatch(left: BackendIdentity, right: BackendIdentity): boolean
 }
 
 export function parseBackendOwnership(contents: unknown): BackendOwnershipEntry[] {
+  return parseBackendOwnershipDetailed(contents).entries
+}
+
+/** Parse result that distinguishes "empty/valid" from "unreadable". A corrupt
+ *  ownership file must NOT read as an empty roster: `reapOrphans` rewrites the
+ *  file with its survivors, so treating garbage as `[]` permanently erased the
+ *  records of still-running backends — the exact shape of the #89298 report
+ *  (ownership file gone, 28 leaked serve processes nothing will ever reap). */
+export function parseBackendOwnershipDetailed(contents: unknown): {
+  corrupt: boolean
+  entries: BackendOwnershipEntry[]
+} {
+  const text = String(contents ?? '')
+
+  if (!text.trim()) {
+    return { corrupt: false, entries: [] }
+  }
+
   let parsed: unknown
 
   try {
-    parsed = JSON.parse(String(contents ?? ''))
+    parsed = JSON.parse(text)
   } catch {
-    return []
+    return { corrupt: true, entries: [] }
   }
 
   const values = Array.isArray(parsed)
@@ -109,7 +131,7 @@ export function parseBackendOwnership(contents: unknown): BackendOwnershipEntry[
     }
   }
 
-  return entries
+  return { corrupt: false, entries }
 }
 
 export function serializeBackendOwnership(entries: BackendOwnershipEntry[]): string {
@@ -123,7 +145,8 @@ export function serializeBackendOwnership(entries: BackendOwnershipEntry[]): str
  * cleanup before reporting failure to the caller.
  */
 export function createBackendOwnership(deps: BackendOwnershipDeps) {
-  const read = () => parseBackendOwnership(deps.store.read())
+  const readDetailed = () => parseBackendOwnershipDetailed(deps.store.read())
+  const read = () => readDetailed().entries
   const write = (entries: BackendOwnershipEntry[]) => deps.store.write(serializeBackendOwnership(entries))
 
   return {
@@ -181,7 +204,22 @@ export function createBackendOwnership(deps: BackendOwnershipDeps) {
     },
 
     async reapOrphans(): Promise<number[]> {
-      const entries = read()
+      const { corrupt, entries } = readDetailed()
+
+      // An unreadable ownership file yields zero parsed entries — rewriting
+      // survivors ([]) here would DESTROY the only record of any backends the
+      // corrupt file described, guaranteeing they leak forever (#89298).
+      // Preserve the evidence for inspection and skip the sweep.
+      if (corrupt) {
+        try {
+          deps.store.quarantine?.()
+        } catch {
+          // Quarantine is best-effort; the important part is not rewriting.
+        }
+
+        return []
+      }
+
       const survivors: BackendOwnershipEntry[] = []
       const reaped: number[] = []
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3269,7 +3269,20 @@ const backendOwnership = createBackendOwnership({
         return null
       }
     },
-    write: writeBackendOwnership
+    write: writeBackendOwnership,
+    // A corrupt ownership file is moved aside instead of being rewritten
+    // away by the reap sweep — its records are the only pointer to any
+    // still-running backends it described (#89298).
+    quarantine: () => {
+      const parked = `${DESKTOP_BACKEND_OWNERSHIP_PATH}.corrupt`
+
+      try {
+        fs.renameSync(DESKTOP_BACKEND_OWNERSHIP_PATH, parked)
+        rememberLog(`Backend ownership file was unreadable; moved to ${parked}`)
+      } catch {
+        // Nothing to move (or no permission) — the sweep already skipped.
+      }
+    }
   }
 })
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3468,6 +3468,69 @@ function isCanonicalBotChatHistory(history) {
   return rootTitle === 'Bot Chat' || (!rootTitle && title === 'Bot Chat')
 }
 
+/** Last-resort recovery when the pinned id is dead AND no adoptable history
+ *  was handed in: the canonical Bot Chat is hidden from the roster's
+ *  last_session/preferred_session (both computed from a hidden-EXCLUDING
+ *  query), so a stale/never-persisted pin used to fall straight through to
+ *  createCanonicalChat and reintroduce the bot on a brand-new session while
+ *  the real forever-chat sat intact but hidden on disk. Browse the profile's
+ *  own hidden sessions (the same include_hidden view the Sessions submenu
+ *  uses) and adopt the existing "Bot Chat" instead of minting a new one.
+ *  Returns the adoptable stored id, or null when there genuinely isn't one. */
+async function findExistingCanonicalBotChat(name) {
+  if (typeof host.request !== 'function') {
+    return null
+  }
+
+  let rows
+  try {
+    const res = await host.request('session.list', {
+      profile: name,
+      limit: PROFILE_SESSION_LIST_LIMIT,
+      include_hidden: true
+    })
+    rows = res?.sessions ?? res?.rows ?? (Array.isArray(res) ? res : null)
+  } catch {
+    // Older gateway without include_hidden (or a transient failure): no safe
+    // adoption target — the caller keeps its existing behavior.
+    return null
+  }
+
+  if (!Array.isArray(rows)) {
+    return null
+  }
+
+  // Prefer the most recently active canonical Bot Chat. session.list is
+  // already newest-first, so the first match wins.
+  for (const row of rows) {
+    if (isCanonicalBotChatHistory(row)) {
+      return row.resolved_id || row.id || row.session_id || null
+    }
+  }
+
+  return null
+}
+
+/** Adopt the profile's existing hidden Bot Chat if one exists; else mint a
+ *  fresh canonical chat. Centralizes the dead-pin / no-history recovery so
+ *  every branch reintroduces the bot ONLY when there is truly no forever-chat
+ *  to return to. */
+async function adoptOrCreateCanonicalChat(name) {
+  const existing = await findExistingCanonicalBotChat(name)
+  if (existing && typeof host.openSession === 'function') {
+    try {
+      await openStoredBotChat(name, existing, null)
+      saveBotMeta(name, { chat: existing })
+      return existing
+    } catch {
+      // Fall through to a fresh chat only if opening the adopted row failed
+      // outright (not a transient hydration retry, which openStoredBotChat
+      // already handles internally).
+    }
+  }
+  return createCanonicalChat(name)
+}
+
 async function openBotCanonicalChat(name, pinned, history) {
   if (!pinned) {
     // Grandfather only an actual Bot Chat. `last_session` is merely the most
@@ -3479,7 +3542,10 @@ async function openBotCanonicalChat(name, pinned, history) {
       saveBotMeta(name, { chat: adoptId })
       return adoptId
     }
-    return createCanonicalChat(name)
+    // No pin and no adoptable preview — but the forever-chat may still exist
+    // hidden on disk (its id just isn't surfaced by the roster query). Adopt
+    // it before minting a new introduction.
+    return adoptOrCreateCanonicalChat(name)
   }
 
   // Precise verification. An older gateway ignores the unknown param and
@@ -3524,10 +3590,11 @@ async function openBotCanonicalChat(name, pinned, history) {
 
   if (preferred) {
     // The stored pointer resolved to a real session, but not to Bot Mode's
-    // plumbing session. Treat it as corrupted metadata rather than opening or
-    // hiding the user's ordinary conversation.
+    // plumbing session. The pin is bad — but before minting a NEW chat (which
+    // reintroduces the bot), adopt the profile's existing hidden Bot Chat if
+    // one is there. Only reintroduce when there truly is no forever-chat.
     await saveBotMeta(name, { chat: null })
-    return createCanonicalChat(name)
+    return adoptOrCreateCanonicalChat(name)
   }
 
   // Definitively gone (db reset, or the lineage was rewritten past
@@ -3540,8 +3607,11 @@ async function openBotCanonicalChat(name, pinned, history) {
     saveBotMeta(name, { chat: recoveryId })
     return recoveryId
   }
-  saveBotMeta(name, { chat: null })
-  return createCanonicalChat(name)
+  // The pin is gone and there's no adoptable preview — but the real
+  // forever-chat is hidden from that preview. Adopt it (by title, from the
+  // hidden-inclusive listing) before reintroducing the bot on a new session.
+  await saveBotMeta(name, { chat: null })
+  return adoptOrCreateCanonicalChat(name)
 }
 
 async function prepareBotSource(bot, pinnedChat) {

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-adopt.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-adopt.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+// Bug: a bot whose pinned canonical-chat id is dead/stale (points at a session
+// id that was never persisted, or was rewritten past recovery) reintroduced
+// itself on a brand-new session every open — while its real forever-chat sat
+// intact but HIDDEN on disk. The roster's last_session/preferred_session are
+// both computed from a hidden-EXCLUDING query, so the recovery branches had no
+// adoptable history and fell straight through to createCanonicalChat.
+//
+// Fix: before minting a new chat, browse the profile's hidden sessions
+// (session.list include_hidden:true — the same view the Sessions submenu uses)
+// and adopt the existing "Bot Chat".
+
+test('a dead/stale pin adopts the existing hidden Bot Chat instead of reintroducing', () => {
+  // The recovery helper exists and browses hidden sessions.
+  assert.match(source, /async function findExistingCanonicalBotChat\(name\)/)
+  assert.match(source, /async function adoptOrCreateCanonicalChat\(name\)/)
+
+  const finder = source.slice(
+    source.indexOf('async function findExistingCanonicalBotChat'),
+    source.indexOf('async function adoptOrCreateCanonicalChat')
+  )
+  // It queries the hidden-inclusive listing, not the roster's hidden-excluding one.
+  assert.match(finder, /session\.list/)
+  assert.match(finder, /include_hidden:\s*true/)
+  // It only adopts an actual Bot Chat (never an unrelated user conversation).
+  assert.match(finder, /isCanonicalBotChatHistory\(row\)/)
+})
+
+test('every mint-new branch routes through adoptOrCreateCanonicalChat', () => {
+  const fn = source.slice(
+    source.indexOf('async function openBotCanonicalChat'),
+    source.indexOf('async function prepareBotSource')
+  )
+  // The old direct createCanonicalChat fall-throughs are gone from the
+  // recovery branches — they adopt first now.
+  const adoptCalls = (fn.match(/adoptOrCreateCanonicalChat\(name\)/g) || []).length
+  assert.ok(adoptCalls >= 3, `expected >=3 adopt-or-create fallbacks, found ${adoptCalls}`)
+})
+
+test('adopt path opens the stored chat and re-pins it', () => {
+  const adopt = source.slice(
+    source.indexOf('async function adoptOrCreateCanonicalChat'),
+    source.indexOf('async function openBotCanonicalChat')
+  )
+  assert.match(adopt, /openStoredBotChat\(name, existing/)
+  assert.match(adopt, /saveBotMeta\(name, \{ chat: existing \}\)/)
+  // Falls back to a fresh chat only when there's genuinely nothing to adopt.
+  assert.match(adopt, /return createCanonicalChat\(name\)/)
+})

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4877,6 +4877,7 @@ _LAZY_COMMAND_EXPORTS = {
         "_for_each_systemd_gateway_unit",
         "_format_concurrent_instances_message",
         "_format_time_ago",
+        "_handoff_reapable_backend_pids",
         "_format_venv_python_holders_message",
         "_gateway_prompt",
         "_get_origin_url",

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3926,6 +3926,76 @@ def _orphaned_desktop_backend_pids(
     return roots
 
 
+def _handoff_reapable_backend_pids(
+    matches: list[tuple[int, str, str]],
+) -> list[int] | None:
+    """PIDs of Hermes ``serve``/``dashboard`` backends safe to reap during a
+    GUI-updater hand-off, INCLUDING ones with a still-live parent.
+
+    Complements ``_orphaned_desktop_backend_pids``, which only reaps backends
+    whose supervisor is provably dead. That check returns ``None`` (keep
+    refusing) the moment ANY holder still has a live parent — which is exactly
+    the case that produced the field incident this fixes: a Windows Desktop
+    update hand-off (``update --yes --gateway --force``) left a *swarm* of
+    per-profile ``serve`` backends (mr-tester, probe-inherit, turqoise, …)
+    holding ``cryptography\\_rust.pyd``. Several still had a lingering
+    parent (the tearing-down Electron process, or the two-hop venv
+    launcher→worker chain mid-exit), so the orphan check disqualified the
+    WHOLE set and the update dead-ended — the user saw a 12-minute hang, then
+    force-closed, and the half-done state stranded bot sessions.
+
+    The hand-off is the safe signal: when the update-incomplete marker is
+    present (the GUI updater claimed it) AND this is a ``--gateway`` hand-off
+    run AND no live Desktop shim (``hermes.exe``) is open, NOTHING legitimate
+    is supervising or respawning a ``serve`` backend from this venv — by the
+    hand-off contract the Desktop tree-kills its backends and parks any
+    relaunch behind the marker (#50238). Any ``serve`` backend still holding
+    the venv here is therefore a leak, live parent or not, and reaping its
+    tree is correct rather than a race.
+
+    Guarded conservatively:
+
+    - Only Hermes backends (``hermes_cli.main`` + ``serve``/``dashboard``)
+      from THIS install's venv qualify; a non-backend holder (operator REPL,
+      stray script) disqualifies the whole set → ``None`` (keep refusing), so
+      we never widen the blast radius during a hand-off.
+    - Requires ``handoff`` True (caller passes ``args.gateway`` AND a claimed
+      marker) — outside a hand-off this returns ``None`` and the stricter
+      orphan-only path stands.
+    - psutil unavailable → ``None`` (can't re-read argv to classify → refuse).
+
+    Returns the backend root PIDs to tree-reap, or ``None`` to leave the
+    decision to the caller's existing rungs. Never raises.
+    """
+    try:
+        import psutil  # type: ignore
+    except Exception:
+        return None
+
+    def _is_backend(argv_low: str) -> bool:
+        return "hermes_cli.main" in argv_low and (
+            " serve" in argv_low or " dashboard" in argv_low
+        )
+
+    roots: list[int] = []
+    for pid, _name, cmdline in matches:
+        argv = cmdline
+        try:
+            argv = " ".join(psutil.Process(int(pid)).cmdline()) or cmdline
+        except psutil.NoSuchProcess:
+            # Exited between scan and classification — nothing to reap.
+            continue
+        except Exception:
+            pass
+        if not _is_backend(argv.lower()):
+            # A non-backend holder during a hand-off is unexpected; refuse the
+            # whole set rather than reap something we cannot justify.
+            return None
+        roots.append(int(pid))
+
+    return roots or None
+
+
 def _stop_process_trees(pids: list[int]) -> None:
     """Force-stop each PID with its full child tree (Windows).
 
@@ -4809,6 +4879,40 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _m()._stop_process_trees(_orphan_backends)
                 _time.sleep(1.0)
                 _venv_holders = _m()._detect_venv_python_processes()
+        if _venv_holders:
+            # Final rung before the dead-end: a GUI-updater hand-off
+            # (`update --gateway --force` with the update-incomplete marker
+            # claimed) means the Desktop is contractually gone and nothing
+            # legitimate will respawn a `serve` backend from this venv. The
+            # orphan-only reap above bails the instant ANY holder still has a
+            # live parent — which stranded a whole swarm of per-profile
+            # backends (the tearing-down Electron parent / the venv
+            # launcher→worker chain still mid-exit) and hung the update. In
+            # the hand-off context those surviving Hermes backends are leaks,
+            # live parent or not — reap them by cmdline instead of dead-ending.
+            _handoff = False
+            try:
+                _handoff = bool(getattr(args, "gateway", False)) and _m()._update_marker_path().exists()
+            except Exception:
+                _handoff = False
+            _no_live_shim = True
+            try:
+                _scripts_dir = _m()._venv_scripts_dir()
+                if _scripts_dir is not None:
+                    _no_live_shim = not _m()._detect_concurrent_hermes_instances(_scripts_dir)
+            except Exception:
+                _no_live_shim = True
+            if _handoff and _no_live_shim:
+                _handoff_backends = _m()._handoff_reapable_backend_pids(_venv_holders)
+                if _handoff_backends:
+                    print(
+                        f"  ⚠ {len(_handoff_backends)} Hermes backend process(es) "
+                        "still hold the venv after the Desktop hand-off; "
+                        "stopping their trees"
+                    )
+                    _m()._stop_process_trees(_handoff_backends)
+                    _time.sleep(1.0)
+                    _venv_holders = _m()._detect_venv_python_processes()
         if _venv_holders:
             print(_format_venv_python_holders_message(_venv_holders))
             _m()._resume_windows_gateways_after_update(_windows_gateway_resume)

--- a/tests/hermes_cli/test_update_handoff_backend_reap.py
+++ b/tests/hermes_cli/test_update_handoff_backend_reap.py
@@ -1,0 +1,149 @@
+"""Tests for the GUI-updater hand-off backend reap (_handoff_reapable_backend_pids).
+
+Field incident (2026-08-20, Teknium's Windows box): a Desktop update hand-off
+(`hermes update --yes --gateway --force`) left a *swarm* of per-profile `serve`
+backends (mr-tester, probe-inherit, turqoise, clippy, maroon, …) holding
+`cryptography\\_rust.pyd`. Some still had a live parent (the tearing-down
+Electron process, or the venv launcher→worker two-hop chain mid-exit), so the
+strict orphan-only reap (_orphaned_desktop_backend_pids) disqualified the whole
+set and the update dead-ended — a 12-minute hang, then a force-close that
+stranded bot sessions.
+
+_handoff_reapable_backend_pids is the additional rung that ONLY runs in the
+hand-off context (caller gates on args.gateway + the update-incomplete marker +
+no live hermes.exe shim). There, any surviving Hermes `serve`/`dashboard`
+backend from this venv is a leak — live parent or not — and safe to reap.
+A non-backend holder still disqualifies the whole set.
+
+Runs on any host via a fake psutil module (same approach as
+test_update_orphan_backend_reap.py).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+from hermes_cli import main as cli_main
+
+
+class _FakeNoSuchProcess(Exception):
+    pass
+
+
+def _fake_psutil(procs: dict[int, MagicMock]):
+    def _process(pid: int):
+        if pid not in procs:
+            raise _FakeNoSuchProcess(pid)
+        return procs[pid]
+
+    return types.SimpleNamespace(Process=_process, NoSuchProcess=_FakeNoSuchProcess)
+
+
+def _proc(pid: int, cmdline: list[str]):
+    proc = MagicMock()
+    proc.pid = pid
+    proc.cmdline.return_value = cmdline
+    return proc
+
+
+def _serve_argv(profile: str = "mr-tester") -> list[str]:
+    return [
+        "C:\\hermes\\venv\\Scripts\\python.exe",
+        "-m",
+        "hermes_cli.main",
+        "--profile",
+        profile,
+        "serve",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "0",
+    ]
+
+
+def _holder(pid: int, cmdline: str):
+    return (pid, "python.exe", cmdline)
+
+
+def test_live_parent_backend_reaped_in_handoff():
+    # The exact case the orphan-only path REFUSES: a serve backend that still
+    # has a live parent. In the hand-off context it must still be reaped.
+    backend = _proc(200, _serve_argv("mr-tester"))
+    fake = _fake_psutil({200: backend})
+    with patch.dict(sys.modules, {"psutil": fake}):
+        holders = [_holder(200, "python.exe -m hermes_cli.main --profile mr-tester serve")]
+        assert cli_main._handoff_reapable_backend_pids(holders) == [200]
+
+
+def test_swarm_of_profile_backends_all_reaped():
+    profiles = ["mr-tester", "probe-inherit", "turqoise", "clippy", "maroon"]
+    procs = {200 + i: _proc(200 + i, _serve_argv(p)) for i, p in enumerate(profiles)}
+    fake = _fake_psutil(procs)
+    with patch.dict(sys.modules, {"psutil": fake}):
+        holders = [
+            _holder(200 + i, f"python.exe -m hermes_cli.main --profile {p} serve")
+            for i, p in enumerate(profiles)
+        ]
+        assert sorted(cli_main._handoff_reapable_backend_pids(holders)) == sorted(procs)
+
+
+def test_dashboard_backend_reaped():
+    backend = _proc(200, ["python.exe", "-m", "hermes_cli.main", "dashboard"])
+    fake = _fake_psutil({200: backend})
+    with patch.dict(sys.modules, {"psutil": fake}):
+        holders = [_holder(200, "python.exe -m hermes_cli.main dashboard")]
+        assert cli_main._handoff_reapable_backend_pids(holders) == [200]
+
+
+def test_non_backend_holder_disqualifies_whole_set():
+    # An operator REPL / stray script during a hand-off is unexpected — refuse
+    # the whole set rather than reap something we can't justify.
+    backend = _proc(200, _serve_argv("mr-tester"))
+    repl = _proc(300, ["python.exe", "-m", "hermes_cli.main", "chat"])
+    fake = _fake_psutil({200: backend, 300: repl})
+    with patch.dict(sys.modules, {"psutil": fake}):
+        holders = [
+            _holder(200, "python.exe -m hermes_cli.main --profile mr-tester serve"),
+            _holder(300, "python.exe -m hermes_cli.main chat"),
+        ]
+        assert cli_main._handoff_reapable_backend_pids(holders) is None
+
+
+def test_exited_holder_skipped_not_fatal():
+    # A holder that vanished between scan and classification is skipped, and the
+    # remaining real backend still qualifies.
+    backend = _proc(200, _serve_argv("mr-tester"))
+    fake = _fake_psutil({200: backend})  # 300 absent → NoSuchProcess
+    with patch.dict(sys.modules, {"psutil": fake}):
+        holders = [
+            _holder(300, "python.exe -m hermes_cli.main --profile gone serve"),
+            _holder(200, "python.exe -m hermes_cli.main --profile mr-tester serve"),
+        ]
+        assert cli_main._handoff_reapable_backend_pids(holders) == [200]
+
+
+def test_no_holders_returns_none():
+    fake = _fake_psutil({})
+    with patch.dict(sys.modules, {"psutil": fake}):
+        assert cli_main._handoff_reapable_backend_pids([]) is None
+
+
+def test_psutil_unavailable_returns_none():
+    # Can't re-read argv to classify → refuse (leave the decision to the
+    # caller's existing rungs / the dead-end).
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_psutil(name, *a, **k):
+        if name == "psutil":
+            raise ImportError("no psutil")
+        return real_import(name, *a, **k)
+
+    with patch.dict(sys.modules, {}, clear=False):
+        sys.modules.pop("psutil", None)
+        with patch("builtins.__import__", _no_psutil):
+            holders = [_holder(200, "python.exe -m hermes_cli.main --profile x serve")]
+            assert cli_main._handoff_reapable_backend_pids(holders) is None


### PR DESCRIPTION
## Summary

Three fixes for the Windows Desktop **update → Bot Mode breakage** incident reported live on 2026-08-20 (Teknium's production machine), bundled into one PR at his request so another agent can compare/merge against a parallel PR. Each is independently revertable (three commits, disjoint subsystems).

The incident, in the user's words: a desktop update *"hanged for 12 minutes (usually ~2-3min)"*; after a force-close, *"all the bot profiles chats were empty, some wouldn't connect and failed at 'Waking up <botname>'"*; and after reinstalling, bots he'd opened while broken were stuck on a fresh **"introduce yourself"** session while his default and one other profile were left on new empty chats with the originals seemingly lost.

**No user data was ever deleted.** Every symptom is a *surfacing/lifecycle* failure — messages sat intact (but hidden + unpinned) on disk the whole time. This PR repairs the three mechanisms and the damaged profiles self-heal on next open.

---

## Root-cause analysis (evidence-backed)

Logs came from the user's `~/.hermes/agent.zip` (Windows). Reproduced locally against a real profile DB driving a real Electron instance over CDP + the gateway RPC.

### Fault 1 — 12-minute update hang (`hermes_cli/update_cmd.py`)
`update.log` / `desktop-update-handoff.log` showed the GUI updater running `update --yes --gateway --force` and then **stalling**, with a swarm of leaked per-profile `serve` backends holding `cryptography\_rust.pyd`:
```
✗ Other Hermes processes are running from this install's venv:
  PID …  python.exe … -m hermes_cli.main --profile mr-tester serve   ← Desktop backend
  PID …  … --profile probe-inherit se  / turqoise / clippy / maroon / …  (9+ profiles)
  On Windows these keep native extension files (.pyd) locked …
```
Windows can't replace a mapped `.pyd` held by a running process, so the dependency sync dead-ended. The existing reaper (`_orphaned_desktop_backend_pids`) only reaps backends whose supervising parent is *provably dead*; it returns `None` (keep refusing) the instant **any** holder still has a live parent. During a hand-off several backends still had a lingering parent (the tearing-down Electron process, or the two-hop venv `python.exe` launcher→uv-managed worker chain mid-exit), so the whole set was disqualified and the update hung.

### Fault 2 — corrupt backend-ownership.json erases live-backend records (`apps/desktop/electron/backend-ownership.ts`, #89298)
`parseBackendOwnership` returned `[]` on any JSON parse error, and `reapOrphans` then unconditionally rewrote the file — so one corrupt read permanently orphaned every backend it described (the reporter's "28 leaked serves"). This amplifies Fault 1 (more leaked backends → more `.pyd` locks) and leaves backends the desktop can no longer track.

### Fault 3 — bots reintroduce themselves on a dead chat pin (`apps/desktop/src/plugins/hermes-bots/plugin.js`)
A bot's canonical-chat pin (`profile.yaml` → `ui_meta.hermes-bots.chat`) can go stale: it points at a session id that was never persisted or was rewritten past recovery. **Live-reproduced**: pin `20260819_162021_63fdca` in `profile.yaml`, but sage's `state.db` actually holds `20260819_201302_9619b9` "Bot Chat" (20 messages). On a dead pin:
1. `profiles.list` `preferred_session` → **`null`** (verified over RPC).
2. The recovery branches in `openBotCanonicalChat` looked for an adoptable chat via `last_session` / `preferred_session` — but **both are computed from a hidden-EXCLUDING query** (`_latest_profile_session_rows` → `list_sessions_rich(source=None)`), and Bot Mode sessions are `hidden=1` by design.
3. So the real Bot Chat was never found → fall through to `createCanonicalChat` → **new session + "Hey, tell me about yourself!" kickoff.**

This is why: bots opened *while broken* nulled their pin and are stuck on the intro; bots *not* touched kept their pins and history; and the pin, once nulled to disk (`profile.yaml`), stays null across a reinstall.

(The "Waking up <bot>… / won't connect" symptom is Faults 1+2 in combination: leaked/evicted backends + the desktop's LRU cap of 3 profile backends vs. 9+ bot profiles, so most bots cold-start or fail to become ready.)

---

## Changes

### 1. `plugins/hermes-bots/plugin.js` — adopt the existing hidden Bot Chat instead of reintroducing
- `findExistingCanonicalBotChat(name)`: browses the profile's hidden sessions via `session.list { include_hidden: true }` (the same hidden-inclusive view the Bots "Sessions" submenu already uses) and returns the existing `"Bot Chat"` id.
- `adoptOrCreateCanonicalChat(name)`: adopts that chat (open + re-pin via `saveBotMeta`) if present; mints a fresh canonical chat **only** when there genuinely is none.
- All three mint-new branches in `openBotCanonicalChat` (no-pin/no-history, pin-resolves-to-non-BotChat, definitively-gone) now route through it. The bot is reintroduced ONLY when there is truly no forever-chat to return to.
- `isCanonicalBotChatHistory` matches on `root_title`/`title === 'Bot Chat'` (only adopts Bot Mode plumbing — never an unrelated user conversation, preserving the #88200 identity guard).

### 2. `electron/backend-ownership.ts` (+`main.ts`) — preserve records on a corrupt ownership file (#89298)
- `parseBackendOwnershipDetailed` distinguishes "empty/valid" from "corrupt/unreadable".
- `reapOrphans` / `clear` skip the rewrite when the file is corrupt (quarantine it as `.corrupt` via the new store `quarantine` hook) instead of erasing live-backend records.
- `main.ts` wires the store's `quarantine` implementation.

### 3. `hermes_cli/update_cmd.py` (+`main.py` lazy-export) — reap leaked backends during a GUI hand-off
- `_handoff_reapable_backend_pids(matches)`: reaps surviving Hermes `serve`/`dashboard` backends from this venv **regardless of a live parent**, but **only** when the caller confirms the hand-off context.
- Wired as the final rung before the existing dead-end, gated on: `args.gateway` **AND** the update-incomplete marker present (`_update_marker_path().exists()`) **AND** no live `hermes.exe` shim (`_detect_concurrent_hermes_instances`). In that window nothing legitimate supervises/respawns a `serve` backend (Desktop tree-kills its backends and parks any relaunch behind the marker, #50238), so a survivor is a leak, not a race.
- Conservative: a non-backend holder (operator REPL, stray script) disqualifies the whole set → keep refusing; psutil unavailable → keep refusing. Reaps via the existing `_stop_process_trees` (`taskkill /T /F`, matching the Desktop's `forceKillProcessTree` and install.ps1).

---

## Validation

| Area | Result |
|---|---|
| hermes-bots plugin suite | **335/335 pass** |
| New `canonical-chat-adopt.test.mjs` | 3/3 pass; **3/3 FAIL on reverted plugin** (sabotage-checked) |
| `backend-ownership.test.ts` | **17/17 pass** (incl. corrupt-file preservation) |
| New `test_update_handoff_backend_reap.py` | 7/7 pass; **7/7 FAIL on reverted update_cmd** (sabotage-checked) |
| Update-guard regression suites (orphan reap, scan blockers, venv health, self-lock) | **78/78 pass** |
| `tsc -p tsconfig.electron.json` | clean |
| `ruff check` (update_cmd.py, main.py, new test) | clean |
| `eslint` (main.ts, backend-ownership.ts, plugin.js) | 0 errors |
| `npm run build` (apps/desktop) | ✓ dist built |

### Live end-to-end reproduction of Fault 3 (the money shot)
Driven over the gateway RPC against a real profile DB with a **dead pin** set in `profile.yaml`:
```
dead-pin preferred_session: null            ← the trigger that used to reintroduce
ADOPT TARGET: 20260819_201302_9619b9  title: Bot Chat   ← findExistingCanonicalBotChat via session.list include_hidden
RESUMED history message count: 4            ← session.resume on the adopted id returns REAL history, not a new intro
```
Before the fix: dead pin → `null` → mint intro session (the user's bug). After: dead pin → adopt the real hidden Bot Chat → full history restored.

---

## Recovery for the already-damaged machine
The user's damaged profiles self-heal: their old Bot Chats are hidden + unpinned on disk, and Fault-3 fix re-adopts them by title on next open (re-pinning `profile.yaml`). No manual restore or data recovery needed. If desired, a one-time offline pin-repair pass could be added, but it is not required — opening each bot repairs its own pin.

---

## Notes for the comparing agent / reviewer
- **Independence:** commits are `plugin.js` (renderer) / `backend-ownership.ts`+`main.ts` (electron main) / `update_cmd.py`+`main.py` (CLI). No shared hunks — any one can be dropped or cherry-picked.
- **Fault 2 overlaps existing PR #90497** (same commit, `010d4e059`) — if #90497 lands first, drop that commit here on rebase.
- **Environment caveat on my live testing:** reproduced on Linux (XWayland-rootless); the CDP/DOM + gateway-RPC paths are faithful, but a "Waking up" swap-overlay hang I observed is a rootless-XWayland WS-reconnect artifact of my box, NOT part of the bug — which is why Fault 3 was verified at the deterministic RPC layer, not through the wedged overlay. The update-path fix (Fault 1) is Windows-only and is covered by unit tests with a fake psutil (cannot be exercised on Linux at runtime).
- **What this PR does NOT change:** the LRU cap of 3 profile backends (a separate UX question — bots beyond the cap still cold-start as "Waking up"); the Bot Mode `hidden=1`-by-design storage; the kickoff/intro copy. Those are candidates for follow-ups if the maintainer wants the roster to keep more bots warm.

## Infographic

![Bot Mode + Update Recovery](https://files.catbox.moe/ksav1c.png)
