### PR TITLE
feat(dashboard): add subscription API-equivalent cost

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1504,6 +1504,56 @@ def estimate_usage_cost(
     )
 
 
+_API_EQUIVALENT_PROVIDERS = {
+    # ChatGPT/Codex OAuth uses the subscription backend, but the equivalent
+    # pay-per-token product is OpenAI's direct API for the same model id.
+    "openai-codex": "openai",
+}
+
+
+def estimate_api_equivalent_cost(
+    model_name: str,
+    usage: CanonicalUsage,
+    *,
+    provider: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> Optional[CostResult]:
+    """Value subscription-included usage at the matching public API rate.
+
+    This is an observability-only shadow estimate.  It deliberately leaves the
+    canonical billing result untouched: callers still persist ``included`` and
+    a zero provider invoice for subscription routes.  ``None`` means the route
+    is not subscription-included or has no trustworthy API equivalent mapping.
+    """
+    route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
+    if route.billing_mode != "subscription_included":
+        return None
+
+    equivalent_provider = _API_EQUIVALENT_PROVIDERS.get(route.provider)
+    if not equivalent_provider:
+        return None
+
+    result = estimate_usage_cost(
+        route.model,
+        usage,
+        provider=equivalent_provider,
+    )
+    if result.amount_usd is None:
+        return result
+
+    return CostResult(
+        amount_usd=result.amount_usd,
+        status=result.status,
+        source=result.source,
+        label=result.label,
+        fetched_at=result.fetched_at,
+        pricing_version=result.pricing_version,
+        notes=result.notes + (
+            "API-equivalent estimate only; not a provider invoice.",
+        ),
+    )
+
+
 def has_known_pricing(
     model_name: str,
     provider: Optional[str] = None,

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1794,6 +1794,12 @@ updates:
 # Local dev / on-prem deploys should typically set these via config.yaml
 # (the ~/.hermes/.env file is reserved for API keys and secrets).
 #
+# Token analytics and subscription API-equivalent shadow cost are both opt-in:
+#
+# dashboard:
+#   show_token_analytics: false
+#   show_api_equivalent_cost: false  # public API-rate estimate, not an invoice
+#
 # dashboard:
 #   oauth:
 #     client_id: ""    # agent:{instance_id}; Portal provisions this at deploy

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1532,6 +1532,11 @@ DEFAULT_CONFIG = {
         # Set this to True to re-enable the surfaces with the understanding
         # that the numbers are a local lower-bound estimate, not billing.
         "show_token_analytics": False,
+        # Optional shadow value for subscription-included model usage.  When
+        # enabled, the dashboard prices recorded subscription tokens at the
+        # matching public API rate while keeping actual/estimated billing
+        # fields unchanged and clearly labelling the value as API-equivalent.
+        "show_api_equivalent_cost": False,
         # OAuth gate configuration (engaged when ``--host`` is set and
         # ``--insecure`` is not). The bundled Nous Portal plugin reads
         # both keys at startup; they are the canonical surface for these

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15403,6 +15403,94 @@ def _aux_task_summary(aux_rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return result
 
 
+def _subscription_api_equivalent_totals(db, cutoff: float) -> Tuple[float, int]:
+    """Return a shadow API-rate value for subscription-included usage.
+
+    Route-level rows preserve model switches and auxiliary calls.  Aggregate
+    session counters are used only for a non-negative legacy residual, matching
+    the reconciliation contract in ``InsightsEngine._compute_model_breakdown``.
+    Canonical ``included`` / zero-invoice accounting fields remain untouched.
+    """
+    from agent.usage_pricing import (
+        CanonicalUsage,
+        estimate_api_equivalent_cost,
+    )
+
+    route_rows = [dict(row) for row in db._conn.execute("""
+        SELECT u.session_id, u.task, u.model, u.billing_provider, u.billing_base_url,
+               u.input_tokens, u.output_tokens, u.cache_read_tokens,
+               u.cache_write_tokens, u.reasoning_tokens,
+               COALESCE(u.api_call_count, 0) as api_calls
+        FROM session_model_usage u
+        JOIN sessions s ON s.id = u.session_id
+        WHERE s.started_at > ?
+    """, (cutoff,)).fetchall()]
+
+    token_keys = (
+        "input_tokens", "output_tokens", "cache_read_tokens",
+        "cache_write_tokens", "reasoning_tokens", "api_calls",
+    )
+    attributed: Dict[str, Dict[str, int]] = {}
+    total = 0.0
+    unpriced_tokens = 0
+
+    def _price(row: Dict[str, Any]) -> None:
+        nonlocal total, unpriced_tokens
+        usage = CanonicalUsage(
+            input_tokens=row.get("input_tokens") or 0,
+            output_tokens=row.get("output_tokens") or 0,
+            cache_read_tokens=row.get("cache_read_tokens") or 0,
+            cache_write_tokens=row.get("cache_write_tokens") or 0,
+            reasoning_tokens=row.get("reasoning_tokens") or 0,
+            request_count=row.get("api_calls") or 0,
+        )
+        result = estimate_api_equivalent_cost(
+            row.get("model") or "",
+            usage,
+            provider=row.get("billing_provider") or None,
+            base_url=row.get("billing_base_url") or None,
+        )
+        if result is None:
+            return
+        if result.amount_usd is None:
+            unpriced_tokens += usage.total_tokens
+        else:
+            total += float(result.amount_usd)
+
+    for row in route_rows:
+        _price(row)
+        if row.get("task"):
+            # Auxiliary counters do not roll up into sessions, so they are
+            # priced above but cannot reduce the main-loop legacy residual.
+            continue
+        session_totals = attributed.setdefault(
+            row["session_id"], {key: 0 for key in token_keys}
+        )
+        for key in token_keys:
+            session_totals[key] += row.get(key) or 0
+
+    session_rows = db._conn.execute("""
+        SELECT id, model, billing_provider, billing_base_url,
+               input_tokens, output_tokens, cache_read_tokens,
+               cache_write_tokens, reasoning_tokens,
+               COALESCE(api_call_count, 0) as api_calls
+        FROM sessions
+        WHERE started_at > ? AND model IS NOT NULL
+    """, (cutoff,)).fetchall()
+    for session_row in session_rows:
+        row = dict(session_row)
+        session_totals = attributed.get(row["id"], {})
+        residual = {
+            key: max(0, (row.get(key) or 0) - (session_totals.get(key) or 0))
+            for key in token_keys
+        }
+        if not any(residual.values()):
+            continue
+        _price({**row, **residual})
+
+    return total, unpriced_tokens
+
+
 def _get_usage_analytics(days: int = 30, profile: Optional[str] = None):
     from agent.insights import InsightsEngine
 
@@ -15444,6 +15532,13 @@ def _get_usage_analytics(days: int = 30, profile: Optional[str] = None):
         aux_rows = _aux_usage_rows(db, cutoff)
         by_model = _merge_aux_into_by_model(by_model, aux_rows)
 
+        with _config_profile_scope(profile):
+            dashboard_cfg = load_config().get("dashboard") or {}
+        show_api_equivalent_cost = bool(
+            isinstance(dashboard_cfg, dict)
+            and dashboard_cfg.get("show_api_equivalent_cost") is True
+        )
+
         cur3 = db._conn.execute("""
             SELECT SUM(input_tokens) as total_input,
                    SUM(output_tokens) as total_output,
@@ -15456,6 +15551,15 @@ def _get_usage_analytics(days: int = 30, profile: Optional[str] = None):
             FROM sessions WHERE started_at > ?
         """, (cutoff,))
         totals = dict(cur3.fetchone())
+        if show_api_equivalent_cost:
+            api_equivalent_cost, unpriced_tokens = (
+                _subscription_api_equivalent_totals(db, cutoff)
+            )
+            totals["total_api_equivalent_cost"] = api_equivalent_cost
+            totals["api_equivalent_unpriced_tokens"] = unpriced_tokens
+        else:
+            totals["total_api_equivalent_cost"] = None
+            totals["api_equivalent_unpriced_tokens"] = None
         usage = InsightsEngine(db).get_usage_breakdown(days=days)
 
         return {

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from agent.usage_pricing import (
     CanonicalUsage,
     format_cost_label,
+    estimate_api_equivalent_cost,
     estimate_usage_cost,
     get_pricing_entry,
     normalize_usage,
@@ -458,6 +459,41 @@ class TestSubscriptionIncludedNotes:
         assert result.amount_usd == Decimal("0")
         assert len(result.notes) > 0
         assert any("subscription" in note.lower() for note in result.notes)
+
+
+def test_api_equivalent_cost_values_subscription_usage_without_changing_billing():
+    usage = CanonicalUsage(
+        input_tokens=1_000_000,
+        output_tokens=100_000,
+        cache_read_tokens=2_000_000,
+        cache_write_tokens=0,
+    )
+
+    included = estimate_usage_cost(
+        "gpt-5.6-sol", usage, provider="openai-codex"
+    )
+    equivalent = estimate_api_equivalent_cost(
+        "gpt-5.6-sol", usage, provider="openai-codex"
+    )
+    direct_api = estimate_usage_cost(
+        "gpt-5.6-sol", usage, provider="openai"
+    )
+
+    assert included.status == "included"
+    assert included.amount_usd == Decimal("0")
+    assert equivalent is not None
+    assert equivalent.status == "estimated"
+    assert equivalent.amount_usd == direct_api.amount_usd
+    assert equivalent.source == direct_api.source
+    assert any("not a provider invoice" in note.lower() for note in equivalent.notes)
+
+
+def test_api_equivalent_cost_ignores_pay_per_token_routes():
+    usage = CanonicalUsage(input_tokens=1_000, output_tokens=100)
+
+    assert estimate_api_equivalent_cost(
+        "gpt-5.6-sol", usage, provider="openai"
+    ) is None
 
 
 def test_normalize_usage_reads_kimi_top_level_cached_tokens():

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2844,6 +2844,190 @@ class TestNewEndpoints:
         mock_generate.assert_not_called()
         assert any(tool["tool"] == "read_file" for tool in resp.json()["tools"])
 
+    def test_analytics_usage_can_show_subscription_api_equivalent_cost(self):
+        from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
+        from hermes_cli.config import load_config, save_config
+        from hermes_state import SessionDB
+
+        config = load_config()
+        config.setdefault("dashboard", {})["show_api_equivalent_cost"] = True
+        save_config(config)
+
+        usage = CanonicalUsage(
+            input_tokens=1_000_000,
+            output_tokens=100_000,
+            cache_read_tokens=2_000_000,
+        )
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="api-equivalent-analytics-test",
+                source="cli",
+                model="gpt-5.6-sol",
+            )
+            db.update_token_counts(
+                "api-equivalent-analytics-test",
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                cache_read_tokens=usage.cache_read_tokens,
+                model="gpt-5.6-sol",
+                billing_provider="openai-codex",
+                billing_mode="subscription_included",
+                cost_status="included",
+                estimated_cost_usd=0,
+                actual_cost_usd=0,
+            )
+        finally:
+            db.close()
+
+        response = self.client.get("/api/analytics/usage?days=7")
+        assert response.status_code == 200
+        totals = response.json()["totals"]
+        direct_api = estimate_usage_cost(
+            "gpt-5.6-sol", usage, provider="openai"
+        )
+
+        assert direct_api.amount_usd is not None
+        assert totals["total_api_equivalent_cost"] == float(direct_api.amount_usd)
+        assert totals["total_actual_cost"] == 0
+        assert totals["total_estimated_cost"] == 0
+
+    def test_analytics_api_equivalent_cost_attributes_model_switches_by_route(self):
+        from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
+        from hermes_cli.config import load_config, save_config
+        from hermes_state import SessionDB
+
+        config = load_config()
+        config.setdefault("dashboard", {})["show_api_equivalent_cost"] = True
+        save_config(config)
+
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="api-equivalent-route-switch-test",
+                source="cli",
+                model="gpt-5.6-sol",
+            )
+            db.update_token_counts(
+                "api-equivalent-route-switch-test",
+                input_tokens=1_000_000,
+                model="gpt-5.6-sol",
+                billing_provider="openai-codex",
+                billing_mode="subscription_included",
+                cost_status="included",
+            )
+            db.update_token_counts(
+                "api-equivalent-route-switch-test",
+                input_tokens=1_000_000,
+                model="gpt-5.6-sol",
+                billing_provider="openai",
+                billing_mode="api",
+                cost_status="estimated",
+            )
+        finally:
+            db.close()
+
+        response = self.client.get("/api/analytics/usage?days=7")
+        assert response.status_code == 200
+        direct_api = estimate_usage_cost(
+            "gpt-5.6-sol",
+            CanonicalUsage(input_tokens=1_000_000),
+            provider="openai",
+        )
+
+        assert direct_api.amount_usd is not None
+        assert response.json()["totals"]["total_api_equivalent_cost"] == float(
+            direct_api.amount_usd
+        )
+
+    def test_analytics_api_equivalent_cost_does_not_subtract_aux_from_legacy_main(self):
+        from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
+        from hermes_cli.config import load_config, save_config
+        from hermes_state import SessionDB
+
+        config = load_config()
+        config.setdefault("dashboard", {})["show_api_equivalent_cost"] = True
+        save_config(config)
+
+        db = SessionDB()
+        try:
+            session_id = "api-equivalent-legacy-aux-test"
+            db.create_session(session_id=session_id, source="cli", model="gpt-5.6-sol")
+            db.update_token_counts(
+                session_id,
+                input_tokens=1_000_000,
+                model="gpt-5.6-sol",
+                billing_provider="openai-codex",
+                billing_mode="subscription_included",
+                cost_status="included",
+            )
+            db._conn.execute(
+                "DELETE FROM session_model_usage WHERE session_id = ? AND task = ''",
+                (session_id,),
+            )
+            db._conn.commit()
+            db.record_auxiliary_usage(
+                session_id,
+                "title_generation",
+                model="claude-sonnet-4",
+                billing_provider="anthropic",
+                input_tokens=400_000,
+            )
+        finally:
+            db.close()
+
+        response = self.client.get("/api/analytics/usage?days=7")
+        direct_api = estimate_usage_cost(
+            "gpt-5.6-sol",
+            CanonicalUsage(input_tokens=1_000_000),
+            provider="openai",
+        )
+
+        assert response.status_code == 200
+        assert direct_api.amount_usd is not None
+        assert response.json()["totals"]["total_api_equivalent_cost"] == float(
+            direct_api.amount_usd
+        )
+
+    def test_analytics_api_equivalent_cost_reports_unpriced_subscription_tokens(self):
+        from hermes_cli.config import load_config, save_config
+        from hermes_state import SessionDB
+
+        config = load_config()
+        config.setdefault("dashboard", {})["show_api_equivalent_cost"] = True
+        save_config(config)
+
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="api-equivalent-unpriced-test",
+                source="cli",
+                model="gpt-5.4",
+            )
+            db.update_token_counts(
+                "api-equivalent-unpriced-test",
+                input_tokens=1_000_000,
+                model="gpt-5.4",
+                billing_provider="openai-codex",
+                billing_mode="subscription_included",
+                cost_status="included",
+            )
+        finally:
+            db.close()
+
+        response = self.client.get("/api/analytics/usage?days=7")
+
+        assert response.status_code == 200
+        totals = response.json()["totals"]
+        assert totals["total_api_equivalent_cost"] == 0
+        assert totals["api_equivalent_unpriced_tokens"] == 1_000_000
+
+    def test_analytics_usage_hides_api_equivalent_cost_by_default(self):
+        response = self.client.get("/api/analytics/usage?days=7")
+
+        assert response.status_code == 200
+        assert response.json()["totals"]["total_api_equivalent_cost"] is None
+
 # ---------------------------------------------------------------------------
 # Model context length: normalize/denormalize + /api/model/info
 # ---------------------------------------------------------------------------

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -203,6 +203,9 @@ export const en: Translations = {
   analytics: {
     period: "Period:",
     totalTokens: "Total Tokens",
+    apiEquivalentCost: "API-equivalent cost",
+    apiEquivalentCostHint:
+      "Shadow estimate at public API rates — not your provider invoice. A + or N/A means some subscription tokens have no matching public price.",
     totalSessions: "Total Sessions",
     apiCalls: "API Calls",
     dailyTokenUsage: "Daily Token Usage",

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -217,6 +217,8 @@ export interface Translations {
   analytics: {
     period: string;
     totalTokens: string;
+    apiEquivalentCost?: string;
+    apiEquivalentCostHint?: string;
     totalSessions: string;
     apiCalls: string;
     dailyTokenUsage: string;

--- a/web/src/i18n/zh-hant.ts
+++ b/web/src/i18n/zh-hant.ts
@@ -178,6 +178,8 @@ export const zhHant: Translations = {
   analytics: {
     period: "時間範圍：",
     totalTokens: "Token 總數",
+    apiEquivalentCost: "API 等價費用",
+    apiEquivalentCostHint: "按公開 API 價格計算的影子估值，不是服務商帳單。+ 或 N/A 表示部分訂閱 Token 沒有匹配的公開價格。",
     totalSessions: "工作階段總數",
     apiCalls: "API 呼叫",
     dailyTokenUsage: "每日 Token 用量",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -176,6 +176,8 @@ export const zh: Translations = {
   analytics: {
     period: "时间范围：",
     totalTokens: "总 Token 数",
+    apiEquivalentCost: "API 等价费用",
+    apiEquivalentCostHint: "按公开 API 价格计算的影子估值，不是服务商账单。+ 或 N/A 表示部分订阅 Token 没有匹配的公开价格。",
     totalSessions: "总会话数",
     apiCalls: "API 调用",
     dailyTokenUsage: "每日 Token 用量",

--- a/web/src/lib/api-equivalent-cost.test.ts
+++ b/web/src/lib/api-equivalent-cost.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { apiEquivalentCostStat } from "./api-equivalent-cost";
+
+describe("apiEquivalentCostStat", () => {
+  it("omits the shadow-cost stat when the backend keeps the feature disabled", () => {
+    expect(apiEquivalentCostStat(null, "API-equivalent cost")).toBeNull();
+  });
+
+  it("labels and formats an enabled API-equivalent shadow cost", () => {
+    expect(apiEquivalentCostStat(52.547839, "API-equivalent cost", 0)).toEqual({
+      label: "API-equivalent cost",
+      value: "$52.55",
+    });
+  });
+
+  it("marks partial coverage instead of presenting a precise total", () => {
+    expect(apiEquivalentCostStat(52.547839, "API-equivalent cost", 1_000)).toEqual({
+      label: "API-equivalent cost",
+      value: "$52.55+",
+    });
+  });
+
+  it("does not present zero dollars when all subscription usage is unpriced", () => {
+    expect(apiEquivalentCostStat(0, "API-equivalent cost", 1_000)).toEqual({
+      label: "API-equivalent cost",
+      value: "N/A",
+    });
+  });
+});

--- a/web/src/lib/api-equivalent-cost.ts
+++ b/web/src/lib/api-equivalent-cost.ts
@@ -1,0 +1,19 @@
+export interface AnalyticsStat {
+  label: string;
+  value: string;
+}
+
+export function apiEquivalentCostStat(
+  amount: number | null | undefined,
+  label: string,
+  unpricedTokens = 0,
+): AnalyticsStat | null {
+  if (amount === null || amount === undefined) return null;
+  if (amount === 0 && unpricedTokens > 0) {
+    return { label, value: "N/A" };
+  }
+  return {
+    label,
+    value: `$${amount.toFixed(2)}${unpricedTokens > 0 ? "+" : ""}`,
+  };
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2148,6 +2148,8 @@ export interface AnalyticsResponse {
     total_reasoning: number;
     total_estimated_cost: number;
     total_actual_cost: number;
+    total_api_equivalent_cost: number | null;
+    api_equivalent_unpriced_tokens: number | null;
     total_sessions: number;
     total_api_calls: number;
   };

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -17,6 +17,7 @@ import type {
   AnalyticsSkillEntry,
 } from "@/lib/api";
 import { timeAgo } from "@/lib/utils";
+import { apiEquivalentCostStat } from "@/lib/api-equivalent-cost";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { Stats } from "@nous-research/ui/ui/components/stats";
@@ -481,6 +482,14 @@ export default function AnalyticsPage() {
     load();
   }, [load]);
 
+  const apiEquivalentStat = data
+    ? apiEquivalentCostStat(
+        data.totals.total_api_equivalent_cost,
+        t.analytics.apiEquivalentCost ?? "API-equivalent cost",
+        data.totals.api_equivalent_unpriced_tokens ?? 0,
+      )
+    : null;
+
   return (
     <div className="flex flex-col gap-6">
       <PluginSlot name="analytics:top" />
@@ -557,6 +566,7 @@ export default function AnalyticsPage() {
                       label: t.analytics.output,
                       value: formatTokens(data.totals.total_output),
                     },
+                    ...(apiEquivalentStat ? [apiEquivalentStat] : []),
                     {
                       label: t.analytics.totalSessions,
                       value: `${data.totals.total_sessions} (~${(data.totals.total_sessions / days).toFixed(1)}${t.analytics.perDayAvg})`,
@@ -570,6 +580,12 @@ export default function AnalyticsPage() {
                     },
                   ]}
                 />
+                {apiEquivalentStat && (
+                  <p className="mt-3 font-mondwest normal-case text-xs text-muted-foreground">
+                    {t.analytics.apiEquivalentCostHint ??
+                      "Shadow estimate at public API rates — not your provider invoice."}
+                  </p>
+                )}
               </CardContent>
             </Card>
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2593,6 +2593,7 @@ Configuration for the [web dashboard](/user-guide/features/web-dashboard) — vi
 dashboard:
   theme: "default"            # "default" | "midnight" | "ember" | "mono" | "cyberpunk" | "rose"
   show_token_analytics: false # Re-enable the (local-estimate-only) token/cost analytics surfaces
+  show_api_equivalent_cost: false # Value subscription usage at matching public API rates
   public_url: ""              # Full public authority for OAuth redirect_uri (env: HERMES_DASHBOARD_PUBLIC_URL)
   oauth:                      # Portal OAuth gate (engaged with --host and not --insecure)
     client_id: ""             # agent:{instance_id} — Portal provisions this
@@ -2610,5 +2611,6 @@ dashboard:
 
 - `theme` — dashboard visual theme.
 - `show_token_analytics` — off by default. The Analytics page and token/cost figures are a **local lower-bound estimate** (they exclude auxiliary calls, retries, fallbacks, and cache writes), so they can read far below the provider bill. Set `true` only if you understand they're not billing.
+- `show_api_equivalent_cost` — off by default. When enabled alongside token analytics, subscription-included usage is also shown as a separate **API-equivalent cost** using Hermes' public API pricing snapshot. This is a shadow estimate for comparison, not a provider invoice; Hermes keeps the canonical subscription cost at `$0 / included` and never rewrites session billing data. A `+` suffix indicates a lower bound when only some matching public prices are available; `N/A` means none of the recorded subscription usage could be priced.
 - `public_url` — when set, this is the complete authority (scheme + host + optional path prefix) the OAuth `redirect_uri` is built from. Set it for deploys behind reverse proxies that don't reliably forward `X-Forwarded-*` headers. Leave empty to use proxy-header reconstruction.
 - `oauth` / `basic_auth` / `drain_auth` — auth provider config read by the bundled dashboard-auth plugins. The drain secret itself is **not** set here; it's provisioned via the `HERMES_DASHBOARD_DRAIN_SECRET` env var. See [Web Dashboard](/user-guide/features/web-dashboard) for full auth setup.

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -279,7 +279,7 @@ View agent, gateway, and error log files with filtering and live tailing.
 
 Usage and cost analytics computed from session history. Select a time period (7, 30, or 90 days) to see:
 
-- **Summary cards** — total tokens (input/output), cache hit percentage, total estimated or actual cost, and total session count with daily average
+- **Summary cards** — total tokens (input/output), cache hit percentage, total estimated or actual cost, and total session count with daily average. Set `dashboard.show_api_equivalent_cost: true` to add a separately labelled API-equivalent shadow cost for subscription-included usage; it uses public API rates and is not a provider invoice.
 - **Daily token chart** — stacked bar chart showing input and output token usage per day, with hover tooltips showing breakdowns and cost
 - **Daily breakdown table** — date, session count, input tokens, output tokens, cache hit rate, and cost for each day
 - **Per-model breakdown** — table showing each model used, its session count, token usage, and estimated cost


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in Dashboard shadow-cost view for subscription-included model usage.

When `dashboard.show_api_equivalent_cost` is enabled, Hermes prices recorded subscription tokens with the matching public API pricing snapshot and shows a separate **API-equivalent cost** card in Analytics. It does **not** change persisted `estimated_cost_usd`, `actual_cost_usd`, `cost_status`, or the canonical `$0 / included` subscription semantics.

This is intentionally narrower than #57387: that PR adds user-defined global pricing overrides consumed by every cost surface, while this PR adds an automatic, Dashboard-only comparison value using Hermes' existing official pricing table.

## Related Issue

Related to #9403 and #57387; does not close either because it does not add global/custom pricing overrides.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `estimate_api_equivalent_cost()` for mapping subscription routes (currently `openai-codex`) to the matching direct API pricing entry.
- Added `dashboard.show_api_equivalent_cost: false` as an explicit opt-in.
- Aggregated route-level usage from `session_model_usage`, including model switches and auxiliary calls, with a legacy session residual that does not double-count auxiliary usage.
- Added honest pricing coverage: `+` marks a partial lower bound and `N/A` means no matching public price was available.
- Added the Analytics summary card, English/Simplified Chinese/Traditional Chinese copy, config examples, and docs.
- Added backend, route-switch, auxiliary-reconciliation, unpriced-coverage, and UI formatting tests.

## How to Test

1. Enable analytics and the shadow-cost view:
   ```bash
   hermes config set dashboard.show_token_analytics true
   hermes config set dashboard.show_api_equivalent_cost true
   ```
2. Run `hermes dashboard`, open Analytics, and confirm the separate API-equivalent card appears for subscription usage.
3. Confirm the explanatory text says it is not a provider invoice and that canonical subscription cost fields remain `$0 / included`.

Automated checks run locally:

```text
scripts/run_tests.sh tests/agent/test_usage_pricing.py tests/hermes_cli/test_web_server.py
# 212 passed

cd web && npm run check
# 37 files / 279 tests passed; typecheck and lint passed

cd web && npm run build
# production build passed

.venv/bin/ruff check <changed Python files>
# All checks passed
```

The full `scripts/run_tests.sh` suite was also run locally. It did not pass in this minimal environment: 160 tests failed across 56 files and 40 files did not collect or timed out, with representative failures caused by disabled lazy installs and missing optional dependencies (for example Daytona and Anthropic). The affected suites above pass; the live PR/maintainer CI result remains authoritative.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (full canonical suite still running locally; affected tests pass)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example`
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No screenshot attached. The card renders only when the new opt-in setting is enabled; tests cover disabled, fully priced, partially priced, unpriced, model-switch, and legacy/auxiliary reconciliation paths.
