### PR TITLE
fix(sessions): keep tool arguments and output when importing foreign sessions (#90433)

### DIFF
--- a/contributors/emails/boni.alessandro997@gmail.com
+++ b/contributors/emails/boni.alessandro997@gmail.com
@@ -1,0 +1,2 @@
+sandrohub013
+# sessions import: preserve tool content (#90433)

--- a/hermes_cli/foreign_sessions.py
+++ b/hermes_cli/foreign_sessions.py
@@ -53,6 +53,19 @@ _WRAPPER_TAG_RE = re.compile(
 
 _TITLE_MAX = 60
 
+# Tool activity is the substance of most coding-agent sessions, so it is
+# imported rather than reduced to a bare marker.  It is also the bulk of the
+# bytes, so it is bounded: arguments collapse to a one-line digest, results
+# are truncated with an explicit marker, and non-text payloads (a PDF read
+# back through a view tool, an image dump) are replaced by a placeholder
+# instead of pouring megabytes of noise into the conversation.
+_TOOL_ARG_MAX = 200
+_TOOL_RESULT_MAX = 2000
+_PRINTABLE_MIN_RATIO = 0.85
+# Argument keys that carry the "what did it actually do" signal, in priority
+# order; anything else falls back to compact JSON.
+_TOOL_ARG_KEYS = ("file_path", "path", "command", "pattern", "url", "query")
+
 
 @dataclass
 class ForeignSession:
@@ -93,6 +106,100 @@ def _read_json_lines(path: Path):
         return
 
 
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}… [truncated, {len(text) - limit} more chars]"
+
+
+def _is_mostly_printable(text: str) -> bool:
+    """Cheap text/binary test over a bounded sample."""
+    sample = text[:4096]
+    if not sample:
+        return True
+    printable = sum(1 for ch in sample if ch.isprintable() or ch in "\n\r\t")
+    return printable / len(sample) >= _PRINTABLE_MIN_RATIO
+
+
+def _summarize_tool_args(raw: Any) -> str:
+    """One-line digest of a tool call's arguments.
+
+    Codex passes them as a JSON string, Claude Code as a dict; both end up
+    as the single most informative value when there is one, compact JSON
+    otherwise.
+    """
+    if isinstance(raw, str):
+        stripped = raw.strip()
+        if not stripped:
+            return ""
+        try:
+            raw = json.loads(stripped)
+        except (json.JSONDecodeError, ValueError):
+            return _truncate(" ".join(stripped.split()), _TOOL_ARG_MAX)
+    if isinstance(raw, dict):
+        for key in _TOOL_ARG_KEYS:
+            value = raw.get(key)
+            if isinstance(value, str) and value.strip():
+                return _truncate(" ".join(value.split()), _TOOL_ARG_MAX)
+        if not raw:
+            return ""
+        try:
+            compact = json.dumps(
+                raw, ensure_ascii=False, separators=(",", ":"), default=str
+            )
+        except (TypeError, ValueError):
+            compact = str(raw)
+        return _truncate(compact, _TOOL_ARG_MAX)
+    if raw is None:
+        return ""
+    return _truncate(" ".join(str(raw).split()), _TOOL_ARG_MAX)
+
+
+def _render_tool_call(name: Any, raw_args: Any) -> str:
+    name = name if isinstance(name, str) and name else "tool"
+    return f"[tool: {name}] {_summarize_tool_args(raw_args)}".rstrip()
+
+
+def _tool_result_text(content: Any) -> str:
+    """Pull the human-readable payload out of a tool result of any shape."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        chunks: List[str] = []
+        for block in content:
+            if isinstance(block, str):
+                chunks.append(block)
+            elif isinstance(block, dict):
+                if block.get("type") == "image":
+                    chunks.append("[image]")
+                    continue
+                text = block.get("text")
+                if isinstance(text, str):
+                    chunks.append(text)
+        return "\n".join(c for c in chunks if c)
+    if isinstance(content, dict):
+        for key in ("text", "output", "content", "stdout"):
+            value = content.get(key)
+            if isinstance(value, str):
+                return value
+        try:
+            return json.dumps(content, ensure_ascii=False, default=str)
+        except (TypeError, ValueError):
+            return str(content)
+    if content is None:
+        return ""
+    return str(content)
+
+
+def _render_tool_result(content: Any) -> str:
+    text = _tool_result_text(content)
+    if not text.strip():
+        return ""
+    if not _is_mostly_printable(text):
+        return f"[tool result: {len(text)} chars of non-text output omitted]"
+    return "[tool result]\n" + _truncate(text.strip(), _TOOL_RESULT_MAX)
+
+
 def _flatten_blocks(content: Any, *, source: str) -> str:
     """Flatten a message ``content`` (string or block list) to plain text.
 
@@ -115,11 +222,13 @@ def _flatten_blocks(content: Any, *, source: str) -> str:
             if isinstance(text, str) and text:
                 parts.append(text)
         elif btype == "tool_use":  # Claude Code assistant block
-            name = block.get("name") or "tool"
-            parts.append(f"[ran tool: {name}]")
+            parts.append(_render_tool_call(block.get("name"), block.get("input")))
         elif btype == "tool_result":
-            # Tool output echoed into a user message — not typed input.
-            continue
+            # Echoed into a user message by the foreign tool; keeping it there
+            # preserves the transcript's own user/assistant alternation.
+            rendered = _render_tool_result(block.get("content"))
+            if rendered:
+                parts.append(rendered)
         elif btype in ("thinking", "redacted_thinking", "reasoning"):
             continue
         elif btype == "image":
@@ -261,10 +370,23 @@ def parse_codex_session(path: Path) -> Dict[str, Any]:
                 continue
             turns.append((role, text))
         elif ptype in ("custom_tool_call", "function_call", "local_shell_call"):
-            name = payload.get("name") or payload.get("tool") or "tool"
+            name = payload.get("name") or payload.get("tool")
+            raw_args = payload.get("arguments")
+            if raw_args is None:
+                raw_args = payload.get("input", payload.get("action"))
             # Attach as assistant activity; merged into neighbors later.
-            turns.append(("assistant", f"[ran tool: {name}]"))
-        # tool outputs / reasoning / web_search etc. are skipped
+            turns.append(("assistant", _render_tool_call(name, raw_args)))
+        elif ptype in (
+            "custom_tool_call_output",
+            "function_call_output",
+            "local_shell_call_output",
+        ):
+            # Codex has no echoed user message for tool output, so it lands on
+            # the user side to match where Claude Code puts the same content.
+            rendered = _render_tool_result(payload.get("output"))
+            if rendered:
+                turns.append(("user", rendered))
+        # reasoning / web_search etc. are skipped
     return {
         "turns": _merge_turns(turns),
         "cwd": cwd,

--- a/tests/hermes_cli/test_foreign_sessions.py
+++ b/tests/hermes_cli/test_foreign_sessions.py
@@ -120,13 +120,13 @@ def test_parse_claude_session(tmp_path):
     parsed = parse_claude_session(f)
     turns = parsed["turns"]
     _assert_alternating(turns)
-    assert len(turns) == 4  # tool_result-only user line skipped; assistants merge
+    assert len(turns) == 6  # tool_use args + tool_result content are kept
     assert parsed["cwd"] == "/home/user/proj"
     assert parsed["title_guess"] == "Fix the flaky test"
     assert parsed["session_id"] == "abc-123"
     # tool_use flattened to a bracketed summary, merged with adjacent text
     joined_assistant = "\n".join(t["content"] for t in turns if t["role"] == "assistant")
-    assert "[ran tool: Bash]" in joined_assistant
+    assert "[tool: Bash]" in joined_assistant
     # no fabricated tool_call structures
     assert all(set(t) == {"role", "content"} for t in turns)
 
@@ -136,7 +136,7 @@ def test_parse_codex_session(tmp_path):
     parsed = parse_codex_session(f)
     turns = parsed["turns"]
     _assert_alternating(turns)
-    assert len(turns) == 4
+    assert len(turns) == 6
     assert parsed["cwd"] == "/home/user/repo"
     assert parsed["session_id"] == "0000-1111"
     assert parsed["title_guess"].startswith("Summarize the transcripts")
@@ -145,7 +145,9 @@ def test_parse_codex_session(tmp_path):
     assert "skills_instructions" not in all_text
     assert "recommended_plugins" not in all_text
     # tool call summarized in assistant text
-    assert "[ran tool: shell]" in all_text
+    assert "[tool: shell]" in all_text
+    # tool output is imported, not discarded
+    assert "big output" in all_text
 
 
 def test_malformed_lines_are_skipped(tmp_path):
@@ -158,11 +160,11 @@ def test_malformed_lines_are_skipped(tmp_path):
     ]
     f = _write_claude_fixture(tmp_path, extra_lines=garbage)
     parsed = parse_claude_session(f)
-    assert len(parsed["turns"]) == 4  # good lines still parse
+    assert len(parsed["turns"]) == 6  # good lines still parse
 
     g = _write_codex_fixture(tmp_path, extra_lines=["not json", json.dumps({"type": "response_item"})])
     parsed_codex = parse_codex_session(g)
-    assert len(parsed_codex["turns"]) == 4
+    assert len(parsed_codex["turns"]) == 6
 
 
 # ── discovery ────────────────────────────────────────────────────────────
@@ -174,9 +176,9 @@ def test_list_sessions(tmp_path):
     claude = list_claude_sessions(tmp_path / ".claude" / "projects")
     codex = list_codex_sessions(tmp_path / ".codex" / "sessions")
     assert len(claude) == 1 and claude[0].source == "claude"
-    assert claude[0].turn_count == 4
+    assert claude[0].turn_count == 6
     assert len(codex) == 1 and codex[0].source == "codex"
-    assert codex[0].turn_count == 4
+    assert codex[0].turn_count == 6
     both = gather_foreign_sessions(
         claude_root=tmp_path / ".claude" / "projects",
         codex_root=tmp_path / ".codex" / "sessions",
@@ -200,12 +202,12 @@ def test_import_claude_session(tmp_path, session_db):
     assert row is not None
     assert row["source"] == "claude-code"
     assert row["cwd"] == "/home/user/proj"
-    assert row["message_count"] == 4
+    assert row["message_count"] == 6
     title = session_db.get_session_title(session_id)
     assert title.startswith("Imported from Claude Code: ")
     assert "Please fix the flaky test" in title
     messages = session_db.get_messages(session_id)
-    assert len(messages) == 4
+    assert len(messages) == 6
     _assert_alternating(messages)
     origin = json.loads(row["origin_json"])
     assert origin["imported_from"]["tool"] == "claude-code"
@@ -218,7 +220,7 @@ def test_import_codex_session(tmp_path, session_db):
     row = session_db.get_session(session_id)
     assert row is not None
     assert row["source"] == "codex-cli"
-    assert row["message_count"] == 4
+    assert row["message_count"] == 6
     title = session_db.get_session_title(session_id)
     assert title.startswith("Imported from Codex CLI: ")
     messages = session_db.get_messages(session_id)
@@ -259,3 +261,190 @@ def test_leading_assistant_gets_single_stub(tmp_path):
     _assert_alternating(parsed["turns"])
     assert len(parsed["turns"]) == 2
     assert parsed["turns"][0]["role"] == "user"
+
+
+# ── tool activity survives the import (#90433) ───────────────────────────
+
+
+def _write_claude_tool_session(tmp_path, blocks, name="tools.jsonl"):
+    """A session whose whole substance is one tool call plus its result."""
+    proj = tmp_path / ".claude" / "projects" / "-home-user-proj"
+    proj.mkdir(parents=True, exist_ok=True)
+    f = proj / name
+    lines = [
+        {
+            "type": "user",
+            "cwd": "/home/user/proj",
+            "message": {"role": "user", "content": "Have a look."},
+        },
+        {"type": "assistant", "message": {"role": "assistant", "content": [blocks[0]]}},
+        {"type": "user", "message": {"role": "user", "content": [blocks[1]]}},
+    ]
+    f.write_text(
+        "\n".join(json.dumps(entry) for entry in lines) + "\n", encoding="utf-8"
+    )
+    return f
+
+
+def _turn_text(parsed):
+    return "\n".join(t["content"] for t in parsed["turns"])
+
+
+def test_claude_tool_arguments_and_output_are_kept(tmp_path):
+    f = _write_claude_tool_session(
+        tmp_path,
+        [
+            {
+                "type": "tool_use",
+                "name": "Bash",
+                "id": "t1",
+                "input": {"command": "pytest -q", "description": "run tests"},
+            },
+            {"type": "tool_result", "tool_use_id": "t1", "content": "3 passed in 0.4s"},
+        ],
+    )
+    text = _turn_text(parse_claude_session(f))
+    assert "[tool: Bash] pytest -q" in text
+    assert "3 passed in 0.4s" in text
+
+
+def test_tool_argument_summary_prefers_the_identifying_key(tmp_path):
+    f = _write_claude_tool_session(
+        tmp_path,
+        [
+            {
+                "type": "tool_use",
+                "name": "Read",
+                "id": "t1",
+                "input": {"file_path": "/repo/app.py", "offset": 10},
+            },
+            {"type": "tool_result", "tool_use_id": "t1", "content": "line one"},
+        ],
+    )
+    text = _turn_text(parse_claude_session(f))
+    assert "[tool: Read] /repo/app.py" in text
+    # a tool with no recognizable key still shows something usable
+    g = _write_claude_tool_session(
+        tmp_path,
+        [
+            {"type": "tool_use", "name": "Odd", "id": "t2", "input": {"flag": True}},
+            {"type": "tool_result", "tool_use_id": "t2", "content": "done"},
+        ],
+        name="odd.jsonl",
+    )
+    assert '[tool: Odd] {"flag":true}' in _turn_text(parse_claude_session(g))
+
+
+def test_long_tool_output_is_truncated_with_a_marker(tmp_path):
+    payload = "x" * 9000
+    f = _write_claude_tool_session(
+        tmp_path,
+        [
+            {"type": "tool_use", "name": "Bash", "id": "t1", "input": {}},
+            {"type": "tool_result", "tool_use_id": "t1", "content": payload},
+        ],
+    )
+    text = _turn_text(parse_claude_session(f))
+    assert "truncated" in text
+    assert len(text) < len(payload)
+
+
+def test_binary_tool_output_is_replaced_not_inlined(tmp_path):
+    blob = "".join(chr(i % 32) for i in range(6000))
+    f = _write_claude_tool_session(
+        tmp_path,
+        [
+            {"type": "tool_use", "name": "Read", "id": "t1", "input": {"file_path": "a.pdf"}},
+            {"type": "tool_result", "tool_use_id": "t1", "content": blob},
+        ],
+    )
+    text = _turn_text(parse_claude_session(f))
+    assert "non-text output omitted" in text
+    assert blob[:200] not in text
+
+
+def test_codex_tool_output_payloads_are_imported(tmp_path):
+    day = tmp_path / ".codex" / "sessions" / "2026" / "02" / "02"
+    day.mkdir(parents=True)
+    f = day / "rollout-tools.jsonl"
+    entries = [
+        {"type": "session_meta", "payload": {"session_id": "s1", "cwd": "/repo"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Check the config."}],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "read_file",
+                "call_id": "c1",
+                "arguments": '{"path": "/repo/config.yaml"}',
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "c1",
+                "output": "display:\n  language: zh",
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "local_shell_call_output",
+                "call_id": "c2",
+                "output": "exit code 0",
+            },
+        },
+    ]
+    f.write_text(
+        "\n".join(json.dumps(entry) for entry in entries) + "\n", encoding="utf-8"
+    )
+    parsed = parse_codex_session(f)
+    _assert_alternating(parsed["turns"])
+    text = _turn_text(parsed)
+    assert "[tool: read_file] /repo/config.yaml" in text
+    assert "language: zh" in text
+    assert "exit code 0" in text
+
+
+def test_tool_only_session_still_imports(tmp_path, session_db):
+    """Previously raised "No user/assistant conversation turns found"."""
+    day = tmp_path / ".codex" / "sessions" / "2026" / "03" / "03"
+    day.mkdir(parents=True)
+    f = day / "rollout-toolonly.jsonl"
+    entries = [
+        {"type": "session_meta", "payload": {"session_id": "s2", "cwd": "/repo"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "name": "shell",
+                "call_id": "c1",
+                "input": "ls -la",
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call_output",
+                "call_id": "c1",
+                "output": "total 4",
+            },
+        },
+    ]
+    f.write_text(
+        "\n".join(json.dumps(entry) for entry in entries) + "\n", encoding="utf-8"
+    )
+    session_id = import_foreign_session("codex", f, db=session_db)
+    messages = session_db.get_messages(session_id)
+    _assert_alternating(messages)
+    joined = "\n".join(m["content"] for m in messages)
+    assert "[tool: shell] ls -la" in joined
+    assert "total 4" in joined


### PR DESCRIPTION
## What does this PR do?

`hermes sessions import` reduced every tool call to `[ran tool: <name>]` and dropped tool results entirely. A Claude Code or Codex session whose substance was tool work imported as a run of bare markers — no file contents, no command output, no web fetches — so the imported conversation was not continuable, because nothing in it said what had actually happened.

Two sites in `hermes_cli/foreign_sessions.py`:

- `_flatten_blocks` printed the tool name and discarded `input`, then `continue`d past every `tool_result` block.
- `parse_codex_session` did the same for `custom_tool_call` / `function_call` / `local_shell_call`, and never handled the matching `*_output` payloads at all.

Tool calls now render as `[tool: <name>] <arg-digest>` and results as `[tool result]` followed by their content. The digest prefers the key that says what the call did (`file_path`, `command`, `pattern`, `url`, …) and falls back to compact JSON.

**Why this approach.** No `tool_calls` structures are fabricated — the import still produces only plain alternating user/assistant text, which is the invariant the module's own docstring promises and which the role-alternation checks depend on. Codex tool output lands on the user side because that is where Claude Code's transcript already puts the same content, so both sources import to the same shape and neither needs a special case downstream.

Tool output is also the bulk of the bytes, so it is bounded rather than inlined whole: arguments truncate at 200 chars, results at 2000, and a payload that fails a printable-character ratio test is replaced by a placeholder instead of dumping a PDF read back through a view tool into the conversation.

A session whose only content was tool activity previously failed the `No user/assistant conversation turns found` check and was not imported at all. It now imports — the case the reporter measured as 2 of 26 sessions lost outright.

**Measured on a real 38-session Claude Code corpus** (11,091 `tool_use` and 11,090 `tool_result` blocks, 171M chars of raw tool payload on disk):

| | before | after |
|---|---|---|
| sessions importable | 38 | 38 |
| imported content | 1,797,727 chars | 9,007,546 chars |

5.0x more content recovered, while the bounding keeps the result at ~5% of the raw payload rather than inlining it.

## Related Issue

Fixes #90433

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/foreign_sessions.py`
  - new helpers `_truncate`, `_is_mostly_printable`, `_summarize_tool_args`, `_render_tool_call`, `_tool_result_text`, `_render_tool_result`
  - `_flatten_blocks`: `tool_use` keeps its arguments; `tool_result` is rendered instead of skipped
  - `parse_codex_session`: tool calls keep `arguments` / `input` / `action`; `custom_tool_call_output`, `function_call_output` and `local_shell_call_output` are imported
  - bounds as module constants: `_TOOL_ARG_MAX`, `_TOOL_RESULT_MAX`, `_PRINTABLE_MIN_RATIO`, `_TOOL_ARG_KEYS`
- `tests/hermes_cli/test_foreign_sessions.py`
  - the assertions that pinned `[ran tool: …]` and the old turn counts move to the new behavior
  - six new cases: argument extraction, identifying-key preference, JSON fallback, truncation marker, binary-payload placeholder, Codex `*_output` payloads, tool-only session import
- `contributors/emails/boni.alessandro997@gmail.com` — attribution mapping required by the `Contributor Attribution Check` job

## How to Test

1. `python -m pytest tests/hermes_cli/test_foreign_sessions.py -q` → 15 passed.
2. Against a real corpus, with a Claude Code store at `~/.claude/projects`:
   ```python
   from hermes_cli.foreign_sessions import parse_claude_session
   from pathlib import Path
   for f in sorted((Path.home() / ".claude" / "projects").glob("*/*.jsonl"))[:5]:
       parsed = parse_claude_session(f)
       print(f.name, sum(len(t["content"]) for t in parsed["turns"]))
   ```
   Compare against the same loop run on `main`. On my 38-session corpus the totals are 1,797,727 (before) and 9,007,546 (after).
3. Tool-only session: import a Codex rollout containing only `custom_tool_call` + `custom_tool_call_output`. On `main` it raises `No user/assistant conversation turns found`; here it imports with the call and its output intact.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run in full, deliberately**: per #90196 the `tests/hermes_cli/` directory mutates the checkout it runs from (real `git stash` / `checkout` / `merge`). I ran the affected file and searched the tree for other dependents on the old `[ran tool: …]` marker; there are none.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (the module docstring's conversion contract still holds and is unchanged) — the rendering shapes are described in code comments at each bound
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — pure text handling, no paths or process work; `scripts/check-windows-footguns.py` clean on both files
- [x] Tool descriptions/schemas — N/A

## Not addressed here

Claude Code writes oversized results to `<session-dir>/tool-results/<id>.{json,txt}` and leaves a pointer in the JSONL; the importer still stores the pointer rather than following it (the reporter counted 13 such sidecars, 764KB, in their corpus). Following them means the importer starts reading sibling files, which is a wider change than this one and worth its own PR.
