### PR TITLE
fix(backup): wait for the backup slot on the update path, and stop blaming the backup

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -159,14 +159,46 @@ class _SQLiteBackupTimeout(RuntimeError):
     """Raised when a SQLite snapshot remains busy past its deadline."""
 
 
+# Default wait for the shared backup slot.  Short on purpose: an interactive
+# `hermes backup` should fail fast rather than hang behind a scheduled one.
+_BACKUP_LOCK_DEFAULT_TIMEOUT = 0.25
+
+# Wait for the slot on the `hermes update` path.  A pre-update backup is the
+# only rollback an update has, so it is worth blocking for: losing a 0.25s race
+# with a concurrent snapshot used to silently skip the backup and continue the
+# update unprotected.  Bounded so a wedged backup process cannot stall an update
+# indefinitely.
+_PRE_UPDATE_LOCK_TIMEOUT = 180.0
+
+# Emit one "still waiting" line after this long so a multi-minute wait does not
+# look like a hang.
+_BACKUP_LOCK_WAIT_NOTICE_AFTER = 2.0
+
+
 @contextmanager
-def _backup_operation_lock(hermes_home: Path, timeout_seconds: float = 0.25):
+def _backup_operation_lock(
+    hermes_home: Path,
+    timeout_seconds: float = _BACKUP_LOCK_DEFAULT_TIMEOUT,
+):
     """Acquire one cross-process backup slot for full and quick snapshots."""
     lock_path = hermes_home / ".backup.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     handle = lock_path.open("a+b")
     acquired = False
-    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    started = time.monotonic()
+    deadline = started + max(0.0, timeout_seconds)
+    notified = False
+
+    def _notice() -> None:
+        nonlocal notified
+        if notified or time.monotonic() - started < _BACKUP_LOCK_WAIT_NOTICE_AFTER:
+            return
+        notified = True
+        logger.warning(
+            "Waiting for the Hermes backup slot (another backup is running); "
+            "up to %.0fs.",
+            max(0.0, timeout_seconds),
+        )
     try:
         if os.name == "nt":
             import msvcrt
@@ -183,6 +215,7 @@ def _backup_operation_lock(hermes_home: Path, timeout_seconds: float = 0.25):
                 except (OSError, PermissionError):
                     if time.monotonic() >= deadline:
                         raise BackupInProgressError("another Hermes backup is already running")
+                    _notice()
                     time.sleep(0.05)
         else:
             import fcntl
@@ -195,6 +228,7 @@ def _backup_operation_lock(hermes_home: Path, timeout_seconds: float = 0.25):
                 except (BlockingIOError, OSError):
                     if time.monotonic() >= deadline:
                         raise BackupInProgressError("another Hermes backup is already running")
+                    _notice()
                     time.sleep(0.05)
 
         yield
@@ -1315,10 +1349,11 @@ def create_quick_snapshot(
     hermes_home: Optional[Path] = None,
     keep: Optional[int] = None,
     max_file_size: Optional[int] = None,
+    lock_timeout: float = _BACKUP_LOCK_DEFAULT_TIMEOUT,
 ) -> Optional[str]:
     """Create one atomic quick snapshot while holding the shared backup slot."""
     home = hermes_home or get_hermes_home()
-    with _backup_operation_lock(home):
+    with _backup_operation_lock(home, timeout_seconds=lock_timeout):
         return _create_quick_snapshot_locked(
             label=label,
             hermes_home=home,
@@ -1819,13 +1854,26 @@ def run_quick_backup(args) -> None:
 # Shared full-zip backup helper
 # ---------------------------------------------------------------------------
 
-def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
-    """Single-flight wrapper for automatic full zip backups."""
+def _write_full_zip_backup(
+    out_path: Path,
+    hermes_root: Path,
+    lock_timeout: float = _BACKUP_LOCK_DEFAULT_TIMEOUT,
+    raise_if_busy: bool = False,
+) -> Optional[Path]:
+    """Single-flight wrapper for automatic full zip backups.
+
+    ``raise_if_busy`` lets a caller tell "another backup holds the slot" apart
+    from "there was nothing to back up / the write failed".  Both used to
+    collapse into ``None``, so ``hermes update`` reported a lock conflict as
+    "no files found or write failed".
+    """
     try:
-        with _backup_operation_lock(hermes_root):
+        with _backup_operation_lock(hermes_root, timeout_seconds=lock_timeout):
             return _write_full_zip_backup_locked(out_path, hermes_root)
     except BackupInProgressError as exc:
         logger.warning("Full-zip backup skipped: %s", exc)
+        if raise_if_busy:
+            raise
         return None
 
 
@@ -1977,6 +2025,8 @@ def _prune_pre_update_backups(backup_dir: Path, keep: int) -> int:
 def create_pre_update_backup(
     hermes_home: Optional[Path] = None,
     keep: int = _PRE_UPDATE_DEFAULT_KEEP,
+    lock_timeout: float = _PRE_UPDATE_LOCK_TIMEOUT,
+    raise_if_busy: bool = False,
 ) -> Optional[Path]:
     """Create a full zip backup of HERMES_HOME under ``backups/``.
 
@@ -1986,7 +2036,14 @@ def create_pre_update_backup(
 
     Returns the path to the created zip, or ``None`` if no files were
     found or the backup could not be created.  Never raises — the caller
-    (``hermes update``) should continue even if the backup fails.
+    (``hermes update``) should continue even if the backup fails — except
+    when ``raise_if_busy`` is set, which re-raises
+    :class:`BackupInProgressError` so the caller can say so accurately.
+
+    Waits up to ``lock_timeout`` seconds for the shared backup slot
+    (``_PRE_UPDATE_LOCK_TIMEOUT``, far longer than the interactive default):
+    an update that silently skips its own rollback point is worse than an
+    update that waits.
     """
     hermes_root = hermes_home or get_default_hermes_root()
     if not hermes_root.is_dir():
@@ -2002,7 +2059,12 @@ def create_pre_update_backup(
     stamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
     out_path = backup_dir / f"{_PRE_UPDATE_PREFIX}{stamp}.zip"
 
-    result = _write_full_zip_backup(out_path, hermes_root)
+    result = _write_full_zip_backup(
+        out_path,
+        hermes_root,
+        lock_timeout=lock_timeout,
+        raise_if_busy=raise_if_busy,
+    )
     if result is None:
         return None
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2831,6 +2831,7 @@ def _run_pre_update_backup(args) -> Optional[str]:
     snapshot_id = None
     try:
         from hermes_cli.backup import (
+            _PRE_UPDATE_LOCK_TIMEOUT,
             _quick_snapshot_root,
             create_quick_snapshot,
             verify_sqlite_integrity,
@@ -2845,6 +2846,7 @@ def _run_pre_update_backup(args) -> Optional[str]:
             label="pre-update",
             keep=_PRE_UPDATE_SNAPSHOT_KEEP,
             max_file_size=_PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE,
+            lock_timeout=_PRE_UPDATE_LOCK_TIMEOUT,
         )
 
         # After the snapshot, verify the source state.db is still intact.
@@ -2903,7 +2905,11 @@ def _run_pre_update_backup(args) -> Optional[str]:
         return snapshot_id
 
     try:
-        from hermes_cli.backup import create_pre_update_backup
+        from hermes_cli.backup import (
+            _PRE_UPDATE_LOCK_TIMEOUT,
+            BackupInProgressError,
+            create_pre_update_backup,
+        )
     except Exception as exc:
         print(
             f"⚠ Pre-update backup: could not load backup module ({exc}); continuing update."
@@ -2921,7 +2927,31 @@ def _run_pre_update_backup(args) -> Optional[str]:
     print("◆ Creating pre-update backup...")
     t0 = _time.monotonic()
     try:
-        out_path = create_pre_update_backup(keep=int(_keep))
+        # Pass the timeout explicitly rather than leaning on the default: a
+        # default argument binds at def time, which makes the wait impossible to
+        # override and impossible to test without actually waiting it out.
+        out_path = create_pre_update_backup(
+            keep=int(_keep),
+            lock_timeout=_PRE_UPDATE_LOCK_TIMEOUT,
+            raise_if_busy=True,
+        )
+    except BackupInProgressError:
+        # Distinct from a failed write: another process held the backup slot for
+        # the whole wait.  Saying "no files found" here sent a past investigation
+        # looking for a broken backup that was working fine.
+        print(
+            "  ⚠ Backup skipped: another Hermes backup held the backup slot "
+            "for the full wait."
+        )
+        print(
+            "    Nothing is wrong with the backup itself. Re-run 'hermes update "
+            "--backup' once it finishes,"
+        )
+        print(
+            "    or run 'hermes backup' by hand before updating. Continuing with update."
+        )
+        print()
+        return snapshot_id
     except Exception as exc:  # defensive — helper already swallows, but just in case
         print(f"  ⚠ Backup failed: {exc}")
         print("  Continuing with update.")
@@ -2931,7 +2961,10 @@ def _run_pre_update_backup(args) -> Optional[str]:
     elapsed = _time.monotonic() - t0
 
     if out_path is None:
-        print("  ⚠ Backup skipped (no files found or write failed); continuing update.")
+        print(
+            "  ⚠ Backup skipped: nothing to archive, or the archive could not "
+            "be written; continuing update."
+        )
         print()
         return snapshot_id
 

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1518,6 +1518,39 @@ class TestRunPreUpdateBackup:
         assert "Creating pre-update backup" in out
         assert len(self._zips(hermes_home)) == 1
 
+    def test_full_mode_names_lock_contention_instead_of_blaming_the_backup(
+        self, hermes_home, capsys, monkeypatch
+    ):
+        """When another process owns the backup slot for the whole wait, say so.
+
+        This used to print "no files found or write failed", which sent an
+        investigation looking for a broken backup that was working fine.
+        """
+        import hermes_cli.backup as backup_mod
+
+        self._set_mode(hermes_home, "full")
+        # Don't actually wait out the update-path timeout in a test.
+        monkeypatch.setattr(backup_mod, "_PRE_UPDATE_LOCK_TIMEOUT", 0)
+
+        from hermes_cli.main import _run_pre_update_backup
+
+        import time as _t
+
+        started = _t.monotonic()
+        with backup_mod._backup_operation_lock(hermes_home):
+            _run_pre_update_backup(Namespace(no_backup=False, backup=True))
+        elapsed = _t.monotonic() - started
+
+        # The patched timeout must actually reach the call. A default argument
+        # binds at def time, so a timeout passed that way is unoverridable and
+        # this test would sit through the real 180s wait instead of failing.
+        assert elapsed < 30, f"pre-update backup ignored the patched timeout ({elapsed:.0f}s)"
+
+        out = capsys.readouterr().out
+        assert "another Hermes backup held the backup slot" in out
+        assert "no files found" not in out
+        assert not self._zips(hermes_home)
+
 
 
 

--- a/tests/hermes_cli/test_backup_stability.py
+++ b/tests/hermes_cli/test_backup_stability.py
@@ -10,6 +10,7 @@ from hermes_cli.backup import (
     _atomic_output_path,
     _backup_operation_lock,
     _write_full_zip_backup,
+    create_pre_update_backup,
     create_quick_snapshot,
     list_quick_snapshots,
 )
@@ -103,3 +104,63 @@ def test_failed_automatic_backup_preserves_previous_archive(tmp_path, monkeypatc
     assert _write_full_zip_backup(archive, home) is None
     assert archive.read_bytes() == b"previous-valid-backup"
     assert list(tmp_path.glob(".*.partial")) == []
+
+
+def test_busy_slot_is_distinguishable_from_a_failed_write(tmp_path) -> None:
+    """A held lock and an unwritable archive both returned None, so callers
+    could not tell "another backup is running" from "the backup is broken".
+    ``raise_if_busy`` separates them."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+    archive = tmp_path / "automatic.zip"
+
+    with _backup_operation_lock(home):
+        # Default: still swallowed, so existing callers are unaffected.
+        assert _write_full_zip_backup(archive, home, lock_timeout=0) is None
+        assert not archive.exists()
+
+        with pytest.raises(BackupInProgressError):
+            _write_full_zip_backup(archive, home, lock_timeout=0, raise_if_busy=True)
+
+
+def test_pre_update_backup_reports_a_busy_slot_when_asked(tmp_path) -> None:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+
+    with _backup_operation_lock(home):
+        assert create_pre_update_backup(hermes_home=home, lock_timeout=0) is None
+
+        with pytest.raises(BackupInProgressError):
+            create_pre_update_backup(
+                hermes_home=home, lock_timeout=0, raise_if_busy=True
+            )
+
+    # Slot free again: the same call now produces a real archive, which is the
+    # point — the skip was never about the backup being broken.
+    out = create_pre_update_backup(hermes_home=home, lock_timeout=0)
+    assert out is not None and out.exists()
+
+
+def test_pre_update_backup_waits_for_the_slot(tmp_path, monkeypatch) -> None:
+    """The update path must wait for a busy slot rather than lose a 0.25s race
+    and skip the only rollback point the update has."""
+    import hermes_cli.backup as backup_mod
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+
+    waited: list[float] = []
+    real_lock = backup_mod._backup_operation_lock
+
+    def recording_lock(hermes_home, timeout_seconds=backup_mod._BACKUP_LOCK_DEFAULT_TIMEOUT):
+        waited.append(timeout_seconds)
+        return real_lock(hermes_home, timeout_seconds=timeout_seconds)
+
+    monkeypatch.setattr(backup_mod, "_backup_operation_lock", recording_lock)
+
+    assert create_pre_update_backup(hermes_home=home) is not None
+    assert waited == [backup_mod._PRE_UPDATE_LOCK_TIMEOUT]
+    assert backup_mod._PRE_UPDATE_LOCK_TIMEOUT > backup_mod._BACKUP_LOCK_DEFAULT_TIMEOUT


### PR DESCRIPTION
## What does this PR do?

`hermes update --backup` can print

```
◆ Creating pre-update backup...
  ⚠ Backup skipped (no files found or write failed); continuing update.
```

and then run the whole update with **no rollback point** — on an install where the backup works
perfectly. Neither half of that message is true.

`_backup_operation_lock` (added in #77913 to serialize snapshots) waits **0.25s** for the shared
backup slot. On timeout it raises `BackupInProgressError`, which `_write_full_zip_backup` swallows
into a `logger.warning` and a `None` return — the same `None` the caller gets from an empty scan or
a failed write. `_run_pre_update_backup` therefore cannot tell contention from failure, and reports
a lost quarter-second race as a broken backup.

Two things are wrong with that, and this PR fixes both:

1. **0.25s is the wrong wait for the update path.** A fail-fast makes sense for an interactive
   `hermes backup` — the user is sitting there and can retry. The pre-update backup is the only
   thing standing between a bad update and an unrecoverable `~/.hermes` (cf. #48200), so it should
   wait rather than skip. Any concurrent snapshot — a scheduled backup, the desktop/gateway
   process, a second terminal — is enough to lose the race.
2. **The message sends you after the wrong bug.** It cost me an investigation: I went looking for a
   broken backup, and found a backup that works.

## Related Issue

No existing issue — found while debugging a live install. Adjacent, different causes:
#75724 (a non-SQLite `.db` aborts the full backup) and #48200 (the update that wiped `~/.hermes`,
which is why the pre-update backup exists at all).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

**`hermes_cli/backup.py`**

- `_BACKUP_LOCK_DEFAULT_TIMEOUT = 0.25` — names the existing interactive default; unchanged.
- `_PRE_UPDATE_LOCK_TIMEOUT = 180.0` — the update path's wait. Bounded so a wedged backup process
  cannot stall an update forever.
- `_backup_operation_lock` logs one "waiting for the Hermes backup slot" warning after 2s, so a
  multi-minute wait does not look like a hang.
- `_write_full_zip_backup(..., lock_timeout=..., raise_if_busy=False)` — `raise_if_busy` re-raises
  `BackupInProgressError` instead of collapsing it into `None`, so a caller can say which happened.
- `create_pre_update_backup(..., lock_timeout=_PRE_UPDATE_LOCK_TIMEOUT, raise_if_busy=False)` and
  `create_quick_snapshot(..., lock_timeout=_BACKUP_LOCK_DEFAULT_TIMEOUT)` plumb it through.

**`hermes_cli/update_cmd.py`**

- The quick snapshot and the full zip both wait `_PRE_UPDATE_LOCK_TIMEOUT` on the update path,
  passed explicitly at both call sites. Not left to the default argument: a default binds at def
  time, so a timeout taken that way cannot be overridden and cannot be tested without sitting
  through the real wait (which is how my own test first passed for the wrong reason — see below).
- Contention now prints what actually happened, and says the backup itself is fine.
- The remaining `None` case says "nothing to archive, or the archive could not be written" instead
  of asserting both at once.

**Backwards compatibility:** `raise_if_busy` defaults to `False` and the lock's default timeout is
unchanged, so `hermes backup` and `create_pre_migration_backup` behave exactly as before.

## How to Test

Reproduction (no patch): hold the slot in one process, ask for a backup in another.

```python
import time
from hermes_cli import backup as B
from hermes_cli.config import get_hermes_home

with B._backup_operation_lock(get_hermes_home()):
    print(B.create_pre_update_backup(keep=5))   # -> None, in ~0.25s
```

Before: `None` after 0.25s, and `hermes update --backup` prints "no files found or write failed".
After: the call waits for the slot; if it never frees within the bound, `hermes update` says the
slot was held and that the backup is not the problem.

That the backup is healthy the whole time — same install, slot free:

```
create_pre_update_backup() -> ~/.hermes/backups/pre-update-....zip
14,003 files, 345 MB, 80s, every .db through _safe_copy_db
```

Tests added in `tests/hermes_cli/test_backup_stability.py`:

- `test_busy_slot_is_distinguishable_from_a_failed_write`
- `test_pre_update_backup_reports_a_busy_slot_when_asked`
- `test_pre_update_backup_waits_for_the_slot`

and in `tests/hermes_cli/test_backup.py`:

- `TestRunPreUpdateBackup::test_full_mode_names_lock_contention_instead_of_blaming_the_backup`
  (asserts the old "no files found" wording is gone, and that the patched timeout actually reaches
  the call — it caught a real defect: the first version of this patch took the timeout as a default
  argument, so the test waited out the full 180s and passed for the wrong reason. The full-suite
  run surfaced it as a 120s pytest-timeout; the assertion now fails fast instead.)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (#84475 and #82042 also touch
      `backup.py`, but both are about `_safe_copy_db` hanging on locked SQLite sources — a different
      lock, a different failure)
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **`tests/hermes_cli` in full**: see below
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 13 (VM), against a live install; the repro was found there

On the suite: I ran **all of `tests/hermes_cli` (634 files)** under the install's own venv:
**5,922 passed, 63 skipped, 9 errors in 29m40s**. All 9 errors are teardown errors in
`tests/hermes_cli/test_web_server_approvals_broadcast.py`
(`AttributeError: 'types.SimpleNamespace' object has no attribute '_methods'` in the
`_reset_tui_gateway_server_state` fixture) — nothing to do with this change; that install carries a
local modification to `hermes_cli/web_server.py`, so I would not read those as upstream-clean
either. The one failure that *was* mine — the pre-update backup test hitting a 120s timeout — is
the defect described above and is fixed in this PR; the affected suites now run
**97 passed in 1m40s** (`test_backup.py`, `test_backup_stability.py`, `test_cmd_update.py`).

I did not run the other ~2,400 test files outside `tests/hermes_cli`, so I have not checked that
box.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the changed functions) — the new constants
      are internal, so no `cli-config.yaml.example` key was added
- [x] N/A — no config keys added
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: the change is in the shared timeout/plumbing path, above the
      `msvcrt`/`fcntl` split; both branches get the same `_notice()` and the same deadline
      arithmetic. Not executed on Windows or macOS.
- [x] N/A — no tool behaviour change
