### PR TITLE
feat(api): return caller-managed history from runs

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1500,6 +1500,24 @@ class APIServerAdapter(BasePlatformAdapter):
     # should complete the interrupted work rather than acknowledge (#57056).
     interactive_resume: bool = False
 
+    # Public message fields that can safely cross the caller-managed
+    # ``conversation_history`` boundary.  Private persistence/cache markers
+    # deliberately stay server-side, while tool-call linkage and provider
+    # reasoning carriers must survive a return -> resubmit round trip.
+    _RUN_HISTORY_MESSAGE_FIELDS = (
+        "role",
+        "content",
+        "name",
+        "tool_name",
+        "tool_call_id",
+        "tool_calls",
+        "reasoning",
+        "reasoning_content",
+        "reasoning_details",
+        "codex_reasoning_items",
+        "codex_message_items",
+    )
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.API_SERVER)
         extra = config.extra or {}
@@ -3347,6 +3365,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_submission": True,
                 "run_status": True,
                 "run_events_sse": True,
+                "run_conversation_history": True,
                 "run_stop": True,
                 "run_steer": True,
                 "run_approval_response": True,
@@ -7000,6 +7019,22 @@ class APIServerAdapter(BasePlatformAdapter):
         full_history.append({"role": "assistant", "content": final_response})
         return full_history
 
+    @classmethod
+    def _run_conversation_history_response(
+        cls,
+        conversation_history: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Return caller-managed history without internal state markers."""
+        return [
+            {
+                key: message[key]
+                for key in cls._RUN_HISTORY_MESSAGE_FIELDS
+                if key in message
+            }
+            for message in conversation_history
+            if isinstance(message, dict)
+        ]
+
     @staticmethod
     def _response_messages_turn_start_index(
         conversation_history: List[Dict[str, Any]],
@@ -7587,6 +7622,18 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
 
+        raw_include = body.get("include", [])
+        if raw_include is None:
+            raw_include = []
+        if not isinstance(raw_include, list) or not all(
+            isinstance(item, str) for item in raw_include
+        ):
+            return web.json_response(
+                _openai_error("'include' must be an array of strings"),
+                status=400,
+            )
+        include_conversation_history = "conversation_history" in raw_include
+
         raw_input = body.get("input")
         if not raw_input:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
@@ -7614,7 +7661,19 @@ class APIServerAdapter(BasePlatformAdapter):
                         _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
                         status=400,
                     )
-                conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
+                message = {
+                    key: entry[key]
+                    for key in self._RUN_HISTORY_MESSAGE_FIELDS
+                    if key in entry
+                }
+                message["role"] = str(entry["role"])
+                content = entry["content"]
+                message["content"] = (
+                    content
+                    if content is None or isinstance(content, str)
+                    else str(content)
+                )
+                conversation_history.append(message)
             if previous_response_id:
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
@@ -7819,6 +7878,25 @@ class APIServerAdapter(BasePlatformAdapter):
                                 conversation_history=conversation_history,
                                 task_id=effective_task_id,
                             )
+                            # /v1/runs owns a direct AIAgent lifecycle instead
+                            # of using _run_agent(), so mirror its authoritative
+                            # compression signals before building a caller-
+                            # managed continuation history below.
+                            effective_session_id = getattr(agent, "session_id", session_id)
+                            compacted_in_place = (
+                                getattr(agent, "_last_compaction_in_place", False)
+                                is True
+                            )
+                            session_rotated = (
+                                isinstance(effective_session_id, str)
+                                and bool(effective_session_id)
+                                and effective_session_id != session_id
+                            )
+                            if (
+                                isinstance(r, dict)
+                                and (compacted_in_place or session_rotated)
+                            ):
+                                r["_compressed"] = True
                         finally:
                             # Worker finished (interrupted or complete) —
                             # clear turn ownership immediately so a later
@@ -7877,6 +7955,16 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                 else:
                     final_response = result.get("final_response", "") if isinstance(result, dict) else ""
+                    effective_history = None
+                    if include_conversation_history:
+                        effective_history = self._run_conversation_history_response(
+                            self._build_response_conversation_history(
+                                conversation_history,
+                                user_message,
+                                result if isinstance(result, dict) else {},
+                                final_response,
+                            )
+                        )
                     # Undelivered steer text (accepted after the final response;
                     # see turn_finalizer) rides on the terminal event/status so
                     # the client can replay it as the next user turn.
@@ -7890,6 +7978,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     }
                     if pending_steer:
                         completed_event["pending_steer"] = pending_steer
+                    if effective_history is not None:
+                        completed_event["conversation_history"] = effective_history
                     _put_event_if_active(completed_event)
                     self._set_run_status(
                         run_id,
@@ -7897,6 +7987,11 @@ class APIServerAdapter(BasePlatformAdapter):
                         output=final_response,
                         usage=usage,
                         last_event="run.completed",
+                        **(
+                            {"conversation_history": effective_history}
+                            if effective_history is not None
+                            else {}
+                        ),
                         **({"pending_steer": pending_steer} if pending_steer else {}),
                     )
             except asyncio.CancelledError:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -266,6 +266,10 @@ MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 RESPONSES_AUTO_TRUNCATION_HISTORY_LIMIT = 100
 _COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
+# Internal result-bus marker consumed by transcript reconstruction. It must
+# never be serialized as a public API field; /v1/runs exposes the corresponding
+# caller-facing state as ``compressed``.
+_RESULT_COMPRESSED_KEY = "_compressed"
 
 
 class ThreadSafeAsyncQueue(asyncio.Queue):
@@ -1504,6 +1508,10 @@ class APIServerAdapter(BasePlatformAdapter):
     # ``conversation_history`` boundary.  Private persistence/cache markers
     # deliberately stay server-side, while tool-call linkage and provider
     # reasoning carriers must survive a return -> resubmit round trip.
+    # Provider integrations that add a structured reasoning/tool carrier must
+    # register it here and extend the round-trip contract test in
+    # tests/gateway/test_api_server_runs.py; otherwise the field is
+    # intentionally stripped at this API boundary.
     _RUN_HISTORY_MESSAGE_FIELDS = (
         "role",
         "content",
@@ -6136,7 +6144,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     final_response_text,
                 )
                 # Compression-aware transcript substitution happens inside
-                # _build_response_conversation_history (result["_compressed"]);
+                # _build_response_conversation_history (via the internal
+                # _RESULT_COMPRESSED_KEY marker);
                 # here we only propagate a compression-rotated session_id so
                 # previous_response_id chaining resumes the child session.
                 _result_sid = result.get("session_id") if isinstance(result, dict) else None
@@ -6980,7 +6989,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         When context compression occurs during a turn the agent returns a
         compressed full transcript in ``result["messages"]`` (starting with a
-        summary) and sets ``result["_compressed"] = True``.  Because the
+        summary) and sets an internal result marker. Because the
         compressed transcript does not share the input ``conversation_history``
         prefix, the normal turn-start detection fails and old code would
         concatenate the uncompressed history on front, bloating the stored
@@ -7003,10 +7012,10 @@ class APIServerAdapter(BasePlatformAdapter):
             # This can happen because compression rewrote the transcript
             # (summary prefix replaces original history), OR because
             # agent_messages only carries the current turn without prior.
-            # The ``_compressed`` flag (set by _run_agent after compaction)
+            # The internal flag (set by _run_agent after compaction)
             # distinguishes — skip the concatenation and use the compressed
             # transcript directly.
-            if result.get("_compressed"):
+            if result.get(_RESULT_COMPRESSED_KEY):
                 return list(agent_messages)
 
             full_history = prior
@@ -7235,7 +7244,7 @@ class APIServerAdapter(BasePlatformAdapter):
     async def _run_agent(
         self,
         user_message: str,
-        conversation_history: List[Dict[str, str]],
+        conversation_history: List[Dict[str, Any]],
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
@@ -7370,7 +7379,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         and _eff_sid != session_id
                     )
                     if _compacted_in_place or _session_rotated:
-                        result["_compressed"] = True
+                        result[_RESULT_COMPRESSED_KEY] = True
                     include_runtime = bool(
                         requested_runtime
                         or route
@@ -7633,6 +7642,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
         include_conversation_history = "conversation_history" in raw_include
+        unknown_includes = sorted(
+            set(raw_include).difference({"conversation_history"})
+        )
+        if unknown_includes:
+            logger.debug(
+                "Ignoring unsupported /v1/runs include value(s): %s",
+                unknown_includes,
+            )
 
         raw_input = body.get("input")
         if not raw_input:
@@ -7647,7 +7664,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, str]] = []
+        conversation_history: List[Dict[str, Any]] = []
         raw_history = body.get("conversation_history")
         if raw_history:
             if not isinstance(raw_history, list):
@@ -7661,16 +7678,35 @@ class APIServerAdapter(BasePlatformAdapter):
                         _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
                         status=400,
                     )
+                role = str(entry["role"])
+                content = entry["content"]
+                has_structured_assistant_payload = any(
+                    entry.get(key)
+                    for key in (
+                        "tool_calls",
+                        "reasoning",
+                        "reasoning_content",
+                        "reasoning_details",
+                        "codex_reasoning_items",
+                        "codex_message_items",
+                    )
+                )
+                preserve_null_content = (
+                    content is None
+                    and role == "assistant"
+                    and has_structured_assistant_payload
+                )
                 message = {
                     key: entry[key]
                     for key in self._RUN_HISTORY_MESSAGE_FIELDS
                     if key in entry
                 }
-                message["role"] = str(entry["role"])
-                content = entry["content"]
+                message["role"] = role
                 message["content"] = (
-                    content
-                    if content is None or isinstance(content, str)
+                    None
+                    if preserve_null_content
+                    else content
+                    if isinstance(content, str)
                     else str(content)
                 )
                 conversation_history.append(message)
@@ -7896,7 +7932,10 @@ class APIServerAdapter(BasePlatformAdapter):
                                 isinstance(r, dict)
                                 and (compacted_in_place or session_rotated)
                             ):
-                                r["_compressed"] = True
+                                # Internal reconstruction marker only. The
+                                # terminal event/status uses public
+                                # ``compressed`` below.
+                                r[_RESULT_COMPRESSED_KEY] = True
                         finally:
                             # Worker finished (interrupted or complete) —
                             # clear turn ownership immediately so a later
@@ -7955,6 +7994,10 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                 else:
                     final_response = result.get("final_response", "") if isinstance(result, dict) else ""
+                    history_was_compressed = bool(
+                        isinstance(result, dict)
+                        and result.get(_RESULT_COMPRESSED_KEY)
+                    )
                     effective_history = None
                     if include_conversation_history:
                         effective_history = self._run_conversation_history_response(
@@ -7980,6 +8023,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         completed_event["pending_steer"] = pending_steer
                     if effective_history is not None:
                         completed_event["conversation_history"] = effective_history
+                        completed_event["compressed"] = history_was_compressed
                     _put_event_if_active(completed_event)
                     self._set_run_status(
                         run_id,
@@ -7988,7 +8032,10 @@ class APIServerAdapter(BasePlatformAdapter):
                         usage=usage,
                         last_event="run.completed",
                         **(
-                            {"conversation_history": effective_history}
+                            {
+                                "conversation_history": effective_history,
+                                "compressed": history_was_compressed,
+                            }
                             if effective_history is not None
                             else {}
                         ),

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -870,6 +870,7 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["chat_completions"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
+            assert data["features"]["run_conversation_history"] is True
             assert data["features"]["model_options"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -174,6 +174,18 @@ class TestStartRun:
                     }
                 ],
                 "reasoning": "I should inspect the schema first.",
+                "reasoning_content": "provider reasoning carrier",
+                "reasoning_details": [{"type": "summary", "text": "inspect schema"}],
+                "codex_reasoning_items": [
+                    {"type": "reasoning", "encrypted_content": "opaque"}
+                ],
+                "codex_message_items": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "checking"}],
+                    }
+                ],
             },
             {
                 "role": "tool",
@@ -208,6 +220,44 @@ class TestStartRun:
         assert passed_history == history
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("role", ["user", "system", "tool"])
+    async def test_start_does_not_forward_null_content_outside_structured_assistant(
+        self,
+        adapter,
+        role,
+    ):
+        app = _create_runs_app(adapter)
+        entry = {"role": role, "content": None}
+        if role == "tool":
+            entry["tool_call_id"] = "call_123"
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "conversation_history": [entry]},
+                )
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+                for _ in range(40):
+                    if adapter._run_statuses.get(run_id, {}).get("status") == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        passed_history = mock_agent.run_conversation.call_args.kwargs[
+            "conversation_history"
+        ]
+        assert passed_history[0]["role"] == role
+        assert passed_history[0]["content"] == "None"
+
+    @pytest.mark.asyncio
     async def test_start_rejects_non_array_include(self, adapter):
         app = _create_runs_app(adapter)
         async with TestClient(TestServer(app)) as cli:
@@ -220,6 +270,35 @@ class TestStartRun:
         assert resp.status == 400
         assert "array of strings" in data["error"]["message"]
         assert adapter._run_statuses == {}
+
+    @pytest.mark.asyncio
+    async def test_start_logs_unknown_include_values(self, adapter, caplog):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                with caplog.at_level(
+                    "DEBUG", logger="gateway.platforms.api_server"
+                ):
+                    resp = await cli.post(
+                        "/v1/runs",
+                        json={"input": "hello", "include": ["conversation_histroy"]},
+                    )
+                    run_id = (await resp.json())["run_id"]
+                    for _ in range(40):
+                        if adapter._run_statuses.get(run_id, {}).get("status") == "completed":
+                            break
+                        await asyncio.sleep(0.05)
+
+        assert resp.status == 202
+        assert "conversation_histroy" in caplog.text
+        assert "Ignoring unsupported /v1/runs include" in caplog.text
 
     @pytest.mark.asyncio
     async def test_start_binds_chat_id_for_delegation_wake_target(self, adapter):
@@ -429,6 +508,8 @@ class TestRunStatus:
                     await asyncio.sleep(0.05)
 
         assert status["conversation_history"] == compacted_history
+        assert status["compressed"] is True
+        assert "_compressed" not in status
         assert not any(message in status["conversation_history"] for message in prior_history)
 
     @pytest.mark.asyncio
@@ -460,6 +541,8 @@ class TestRunStatus:
                     await asyncio.sleep(0.05)
 
         assert "conversation_history" not in status
+        assert "compressed" not in status
+        assert "_compressed" not in status
 
 
 # ---------------------------------------------------------------------------
@@ -524,6 +607,8 @@ class TestRunEvents:
                 "content": "done",
                 "_db_persisted": True,
                 "_api_content": "private cache payload",
+                "_compressed_summary": True,
+                "unregistered_provider_field": "private by default",
             },
         ]
         public_history = [
@@ -561,7 +646,21 @@ class TestRunEvents:
                     break
         assert completed is not None
         assert completed["conversation_history"] == public_history
+        assert completed["compressed"] is False
+        assert "_compressed" not in completed
+        assert not any(
+            key in message
+            for message in completed["conversation_history"]
+            for key in (
+                "_db_persisted",
+                "_api_content",
+                "_compressed_summary",
+                "unregistered_provider_field",
+            )
+        )
         assert adapter._run_statuses[run_id]["conversation_history"] == public_history
+        assert adapter._run_statuses[run_id]["compressed"] is False
+        assert "_compressed" not in adapter._run_statuses[run_id]
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -10,6 +10,7 @@ Covers:
 """
 
 import asyncio
+import json
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -152,6 +153,73 @@ class TestStartRun:
                 assert status["run_id"] == data["run_id"]
                 assert status["status"] in {"queued", "running", "completed"}
                 assert status["object"] == "hermes.run"
+
+    @pytest.mark.asyncio
+    async def test_start_preserves_structured_conversation_history(self, adapter):
+        """Caller-managed history must retain tool-call linkage on the way in."""
+        app = _create_runs_app(adapter)
+        history = [
+            {"role": "user", "content": "Inspect the orders table"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path":"schema.sql"}',
+                        },
+                    }
+                ],
+                "reasoning": "I should inspect the schema first.",
+            },
+            {
+                "role": "tool",
+                "name": "read_file",
+                "tool_name": "read_file",
+                "tool_call_id": "call_123",
+                "content": "CREATE TABLE orders (...)",
+            },
+        ]
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "What indexes should I add?", "conversation_history": history},
+                )
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+                for _ in range(40):
+                    if adapter._run_statuses.get(run_id, {}).get("status") == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        passed_history = mock_agent.run_conversation.call_args.kwargs["conversation_history"]
+        assert passed_history == history
+
+    @pytest.mark.asyncio
+    async def test_start_rejects_non_array_include(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/runs",
+                json={"input": "hello", "include": "conversation_history"},
+            )
+            data = await resp.json()
+
+        assert resp.status == 400
+        assert "array of strings" in data["error"]["message"]
+        assert adapter._run_statuses == {}
 
     @pytest.mark.asyncio
     async def test_start_binds_chat_id_for_delegation_wake_target(self, adapter):
@@ -304,6 +372,95 @@ class TestRunStatus:
                 assert mock_agent.run_conversation.call_args.kwargs["task_id"] == "space-session"
                 assert status["session_id"] == "space-session"
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("compacted_in_place", "effective_session_id"),
+        [(True, "managed-session"), (False, "rotated-session")],
+    )
+    async def test_status_returns_opt_in_effective_compressed_history(
+        self,
+        adapter,
+        compacted_in_place,
+        effective_session_id,
+    ):
+        """The terminal status must expose the compacted continuation baseline."""
+        prior_history = [
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+        ] * 10
+        compacted_history = [
+            {"role": "user", "content": "[Compressed summary of earlier conversation]"},
+            {"role": "user", "content": "latest question"},
+            {"role": "assistant", "content": "latest answer"},
+        ]
+
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {
+                    "final_response": "latest answer",
+                    "messages": compacted_history,
+                }
+                mock_agent._last_compaction_in_place = compacted_in_place
+                mock_agent.session_id = effective_session_id
+                mock_agent.session_prompt_tokens = 10
+                mock_agent.session_completion_tokens = 5
+                mock_agent.session_total_tokens = 15
+                mock_create.return_value = mock_agent
+
+                start_resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": "latest question",
+                        "session_id": "managed-session",
+                        "conversation_history": prior_history,
+                        "include": ["conversation_history"],
+                    },
+                )
+                assert start_resp.status == 202
+                run_id = (await start_resp.json())["run_id"]
+
+                for _ in range(40):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert status["conversation_history"] == compacted_history
+        assert not any(message in status["conversation_history"] for message in prior_history)
+
+    @pytest.mark.asyncio
+    async def test_status_omits_history_without_include(self, adapter):
+        """Existing clients must not receive the potentially sensitive transcript."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {
+                    "final_response": "done",
+                    "messages": [
+                        {"role": "user", "content": "hello"},
+                        {"role": "assistant", "content": "done"},
+                    ],
+                }
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                start_resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await start_resp.json())["run_id"]
+                for _ in range(40):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert "conversation_history" not in status
+
 
 # ---------------------------------------------------------------------------
 # GET /v1/runs/{run_id}/events — SSE event stream
@@ -338,6 +495,73 @@ class TestRunEvents:
                 # Should contain run.completed
                 assert "run.completed" in body
                 assert "Hello!" in body
+
+    @pytest.mark.asyncio
+    async def test_completed_event_returns_opt_in_conversation_history(self, adapter):
+        """SSE and pollable terminal state must carry the same continuation baseline."""
+        internal_history = [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_456",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "name": "read_file",
+                "tool_name": "read_file",
+                "tool_call_id": "call_456",
+                "content": "result",
+            },
+            {
+                "role": "assistant",
+                "content": "done",
+                "_db_persisted": True,
+                "_api_content": "private cache payload",
+            },
+        ]
+        public_history = [
+            *internal_history[:-1],
+            {"role": "assistant", "content": "done"},
+        ]
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {
+                    "final_response": "done",
+                    "messages": internal_history,
+                }
+                mock_agent._last_compaction_in_place = False
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                start_resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "include": ["conversation_history"]},
+                )
+                run_id = (await start_resp.json())["run_id"]
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                body = await events_resp.text()
+
+        completed = None
+        for line in body.splitlines():
+            if line.startswith("data: "):
+                payload = json.loads(line[len("data: "):])
+                if payload.get("event") == "run.completed":
+                    completed = payload
+                    break
+        assert completed is not None
+        assert completed["conversation_history"] == public_history
+        assert adapter._run_statuses[run_id]["conversation_history"] == public_history
 
 
     @pytest.mark.asyncio

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -156,6 +156,12 @@ Use `/v1/models` for OpenAI-client compatibility. Use `/api/model/options` or
 
 A `200` (and the `run.steered` event) means the text was **queued**, not that the agent consumed it. If a steer lands after the agent's final response — with no later tool boundary to deliver it at — the undelivered text is returned as `pending_steer` on the terminal `run.completed` event and run status, so the client can replay it as the next user turn instead of losing it.
 
+For caller-managed conversation state, send `include: ["conversation_history"]`
+when creating a run. The terminal event and pollable status return Hermes'
+effective post-run history, including a compressed transcript when context
+compression fired. Persist that value as the next request's baseline instead
+of rebuilding the entire conversation from an external message archive.
+
 ---
 
 ## Which one should I use?

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -160,7 +160,9 @@ For caller-managed conversation state, send `include: ["conversation_history"]`
 when creating a run. The terminal event and pollable status return Hermes'
 effective post-run history, including a compressed transcript when context
 compression fired. Persist that value as the next request's baseline instead
-of rebuilding the entire conversation from an external message archive.
+of rebuilding the entire conversation from an external message archive. The
+same payload exposes this state as the public `compressed` boolean; the
+underscore-prefixed marker Hermes uses internally is never serialized.
 
 ---
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -444,6 +444,29 @@ Create a new agent run. Returns a `run_id` that can be used to subscribe to prog
 
 Runs accept a simple `input` string and optional `session_id`, `instructions`, `conversation_history`, or `previous_response_id`. When `session_id` is provided, Hermes surfaces it in the run status so external UIs can correlate runs with their own conversation IDs.
 
+Callers that persist conversation state outside Hermes can request the
+effective post-run continuation history with `include`. Hermes returns the
+field only when explicitly requested because it may contain prompts and tool
+results that should be stored as sensitive data.
+
+```json
+{
+  "input": "What should I investigate next?",
+  "conversation_history": [
+    {"role": "user", "content": "Inspect the slow query"},
+    {"role": "assistant", "content": "The query is missing an index."}
+  ],
+  "include": ["conversation_history"]
+}
+```
+
+The terminal `run.completed` event and pollable run status then contain the
+same `conversation_history`. When context compression occurs during the turn,
+this is the compressed effective transcript rather than the uncompressed
+input plus a summary. Submit it unchanged with the next user message;
+structured tool-call fields are preserved so recent tool calls and results
+remain paired.
+
 ### GET /v1/runs/\{run_id\}
 
 Poll the current run state. This is useful for dashboards that need status without holding an SSE connection open, or for UIs that reconnect after navigation.
@@ -456,6 +479,11 @@ Poll the current run state. This is useful for dashboards that need status witho
   "session_id": "space-session",
   "model": "hermes-agent",
   "output": "Done.",
+  "conversation_history": [
+    {"role": "user", "content": "[Compressed summary of earlier turns]"},
+    {"role": "user", "content": "What should I investigate next?"},
+    {"role": "assistant", "content": "Done."}
+  ],
   "usage": {"input_tokens": 50, "output_tokens": 200, "total_tokens": 250}
 }
 ```

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -465,7 +465,10 @@ same `conversation_history`. When context compression occurs during the turn,
 this is the compressed effective transcript rather than the uncompressed
 input plus a summary. Submit it unchanged with the next user message;
 structured tool-call fields are preserved so recent tool calls and results
-remain paired.
+remain paired. The adjacent `compressed` boolean tells the caller whether
+Hermes replaced the baseline during this turn. Unknown `include` values are
+ignored for forward compatibility and recorded at debug level to diagnose
+misspelled field names.
 
 ### GET /v1/runs/\{run_id\}
 
@@ -479,6 +482,7 @@ Poll the current run state. This is useful for dashboards that need status witho
   "session_id": "space-session",
   "model": "hermes-agent",
   "output": "Done.",
+  "compressed": true,
   "conversation_history": [
     {"role": "user", "content": "[Compressed summary of earlier turns]"},
     {"role": "user", "content": "What should I investigate next?"},


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in caller-managed conversation-state contract to `POST /v1/runs`.

External orchestrators can send `include: ["conversation_history"]`. Hermes then returns the effective post-run history on both the terminal `run.completed` SSE event and the pollable run status. If Hermes compressed context during the turn, the returned value is the compacted transcript rather than the original history concatenated with the summary.

The field is opt-in because it can contain prompts and tool results. Private persistence/cache markers remain server-side, while structured tool-call linkage and reasoning carriers survive a return-and-resubmit round trip.

This closes the current API asymmetry: `/v1/runs` accepts caller-provided history, but previously did not return the history Hermes actually continued with after its agent loop and compression.

## Related Issue

No existing issue or PR covers returning effective caller-managed history from `/v1/runs`. I searched open and closed issues/PRs before implementation. The open multimodal-history PR #26695 is separate and this change does not adopt its multimodal normalization scope.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `include: ["conversation_history"]` handling to `/v1/runs`.
- Return the same effective history in `run.completed` and `GET /v1/runs/{run_id}`.
- Detect both in-place compaction and legacy session rotation on the direct Runs agent path, then reuse the existing compressed-history builder.
- Preserve public structured message fields such as `tool_calls`, `tool_call_id`, and reasoning carriers when caller-managed history is resubmitted.
- Strip private Hermes persistence/cache markers from the public history payload.
- Advertise the capability as `features.run_conversation_history` and document the workflow.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_api_server_runs.py -q` — 29 passed.
2. `scripts/run_tests.sh tests/gateway/test_api_server.py -k capabilities_advertises_plugin_safe_contract -q` — 1 passed.
3. `.venv/bin/python -m py_compile gateway/platforms/api_server.py tests/gateway/test_api_server_runs.py tests/gateway/test_api_server.py`
4. `.venv/bin/python -m ruff check gateway/platforms/api_server.py tests/gateway/test_api_server_runs.py tests/gateway/test_api_server.py`
5. `.venv/bin/python scripts/check-windows-footguns.py gateway/platforms/api_server.py tests/gateway/test_api_server_runs.py tests/gateway/test_api_server.py`

The full `tests/gateway/test_api_server.py` file produced 108 passes plus the pre-existing `TestHealthDetailedEndpoint::test_health_detailed_returns_ok` readiness-environment failure (`degraded` vs `ok`). The same failure was reproduced from a clean detached `origin/main` worktree.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this feature.
- [ ] I've run the complete `tests/` suite.
- [x] I've added tests for my changes.
- [x] I've tested on macOS.

### Documentation & Housekeeping

- [x] I've updated relevant documentation.
- [x] `cli-config.yaml.example` update is N/A; no config was added.
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A; no architecture workflow changed.
- [x] I've considered cross-platform impact; the change adds no OS-specific behavior.
- [x] Tool descriptions/schemas update is N/A.
