### PR TITLE
fix(stt): send Voxtral context_bias, stop sending the non-existent prompt

### DIFF
--- a/contributors/emails/adrien.didot@gmail.com
+++ b/contributors/emails/adrien.didot@gmail.com
@@ -1,0 +1,2 @@
+Adridot
+# PR STT context_bias

--- a/tests/test_stt_mistral_context_bias.py
+++ b/tests/test_stt_mistral_context_bias.py
@@ -1,0 +1,109 @@
+"""Voxtral requests carry the declared language and the vocabulary bias.
+
+Pins three things the Mistral STT path got wrong before:
+
+* ``context_bias`` (the real Voxtral parameter) is resolved from config and
+  sent; ``prompt`` (which the SDK signature does not accept) never is;
+* a server refusing the vocabulary costs a retry, not the transcription;
+* a genuine outage is reported as such, without a pointless second call.
+"""
+import sys
+import types
+
+import pytest
+
+import tools.transcription_tools as tt
+
+
+class _FakeComplete:
+    def __init__(self, failures=()):
+        self.calls = []
+        self._failures = list(failures)
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._failures:
+            err = self._failures.pop(0)
+            if err:
+                raise err
+        return types.SimpleNamespace(text="bonjour")
+
+
+@pytest.fixture
+def fake_sdk(monkeypatch):
+    """Install a stub ``mistralai.client`` and return the recorded calls."""
+    complete = _FakeComplete()
+
+    class _Client:
+        def __init__(self, api_key=None):
+            self.audio = types.SimpleNamespace(
+                transcriptions=types.SimpleNamespace(complete=complete)
+            )
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    module = types.ModuleType("mistralai.client")
+    module.Mistral = _Client
+    monkeypatch.setitem(sys.modules, "mistralai", types.ModuleType("mistralai"))
+    monkeypatch.setitem(sys.modules, "mistralai.client", module)
+    monkeypatch.setattr(tt, "_resolve_provider_key", lambda *a, **k: "key")
+    return complete
+
+
+@pytest.fixture
+def audio(tmp_path):
+    path = tmp_path / "voice.ogg"
+    path.write_bytes(b"\x00")
+    return str(path)
+
+
+def _config(monkeypatch, **stt):
+    monkeypatch.setattr(tt, "_load_stt_config", lambda: stt)
+
+
+def test_language_and_vocabulary_reach_the_request(fake_sdk, audio, monkeypatch):
+    _config(monkeypatch, language="fr", mistral={"context_bias": ["Soundboks", "Connemara"]})
+    result = tt._transcribe_mistral(audio, "voxtral-mini-latest")
+    assert result["success"] is True
+    (call,) = fake_sdk.calls
+    assert call["language"] == "fr"
+    assert call["context_bias"] == ["Soundboks", "Connemara"]
+
+
+def test_dead_prompt_parameter_is_never_sent(fake_sdk, audio, monkeypatch):
+    _config(monkeypatch, language="fr")
+    tt._transcribe_mistral(audio, "m", prompt="du contexte")
+    (call,) = fake_sdk.calls
+    assert "prompt" not in call        # the SDK signature would raise TypeError
+    assert "context_bias" not in call  # nothing configured → nothing sent
+
+
+def test_global_context_bias_is_the_fallback_source(fake_sdk, audio, monkeypatch):
+    _config(monkeypatch, context_bias=["LJT"], mistral={})
+    tt._transcribe_mistral(audio, "m")
+    assert fake_sdk.calls[0]["context_bias"] == ["LJT"]
+
+
+def test_refused_vocabulary_is_retried_without_it(fake_sdk, audio, monkeypatch, caplog):
+    _config(monkeypatch, language="fr", mistral={"context_bias": ["Le Jockey Tricolore"]})
+    fake_sdk._failures = [Exception(
+        "API error occurred: Status 400. Body: {\"message\":\"Context bias item "
+        "'Le Jockey Tricolore' must not contain commas or whitespace\"}"
+    )]
+    result = tt._transcribe_mistral(audio, "m")
+    assert result["success"] is True and result["transcript"] == "bonjour"
+    assert len(fake_sdk.calls) == 2
+    assert "context_bias" not in fake_sdk.calls[1]
+    assert fake_sdk.calls[1]["language"] == "fr"  # the language survives the retry
+
+
+def test_real_outage_is_not_blamed_on_the_vocabulary(fake_sdk, audio, monkeypatch):
+    _config(monkeypatch, mistral={"context_bias": ["LJT"]})
+    fake_sdk._failures = [Exception("API error occurred: Status 503. Body: upstream down")]
+    result = tt._transcribe_mistral(audio, "m")
+    assert result["success"] is False
+    assert len(fake_sdk.calls) == 1  # no second call on a genuine failure

--- a/tests/test_stt_mistral_context_bias.py
+++ b/tests/test_stt_mistral_context_bias.py
@@ -89,10 +89,10 @@ def test_global_context_bias_is_the_fallback_source(fake_sdk, audio, monkeypatch
 
 
 def test_refused_vocabulary_is_retried_without_it(fake_sdk, audio, monkeypatch, caplog):
-    _config(monkeypatch, language="fr", mistral={"context_bias": ["Le Jockey Tricolore"]})
+    _config(monkeypatch, language="fr", mistral={"context_bias": ["Soundboks"]})
     fake_sdk._failures = [Exception(
-        "API error occurred: Status 400. Body: {\"message\":\"Context bias item "
-        "'Le Jockey Tricolore' must not contain commas or whitespace\"}"
+        "API error occurred: Status 400. Body: {\"message\":\"Context bias "
+        "rejected\"}"
     )]
     result = tt._transcribe_mistral(audio, "m")
     assert result["success"] is True and result["transcript"] == "bonjour"
@@ -107,3 +107,28 @@ def test_real_outage_is_not_blamed_on_the_vocabulary(fake_sdk, audio, monkeypatc
     result = tt._transcribe_mistral(audio, "m")
     assert result["success"] is False
     assert len(fake_sdk.calls) == 1  # no second call on a genuine failure
+
+
+def test_a_multi_word_entry_is_split_instead_of_being_refused(fake_sdk, audio, monkeypatch):
+    """A space in an entry is a guaranteed 400. Splitting it up front spares
+    every transcription the refused request and its retry."""
+    _config(monkeypatch, mistral={"context_bias": ["Le Jockey Tricolore", "Soundboks"]})
+    result = tt._transcribe_mistral(audio, "m")
+    assert result["success"] is True
+    (call,) = fake_sdk.calls  # one request, no retry
+    assert call["context_bias"] == ["Le", "Jockey", "Tricolore", "Soundboks"]
+
+
+def test_an_unrelated_400_is_not_blamed_on_the_vocabulary(fake_sdk, audio, monkeypatch, caplog):
+    """A 400 alone proves nothing. When dropping the vocabulary does not help,
+    the original error is what surfaces — the operator's config is not accused,
+    and the second error does not stand in for the first."""
+    _config(monkeypatch, mistral={"context_bias": ["Soundboks"]})
+    unrelated = "API error occurred: Status 400. Body: {\"message\":\"unknown model 'm'\"}"
+    fake_sdk._failures = [Exception(unrelated), Exception(unrelated)]
+    with caplog.at_level("WARNING"):
+        result = tt._transcribe_mistral(audio, "m")
+    assert result["success"] is False
+    assert len(fake_sdk.calls) == 2                   # the retry is still attempted
+    assert "unknown model" in caplog.text             # the real cause is reported
+    assert "refused the transcription vocabulary" not in caplog.text

--- a/tests/tools/test_pre_transcription_hook.py
+++ b/tests/tools/test_pre_transcription_hook.py
@@ -158,8 +158,11 @@ class TestPromptThreading:
         _, kwargs = mock_client.audio.transcriptions.create.call_args
         assert kwargs["prompt"] == PROMPT
 
-    def test_prompt_reaches_mistral(self, monkeypatch, tmp_path):
-        """Unit-level: _transcribe_mistral forwards prompt to the SDK call."""
+    def test_prompt_is_never_forwarded_to_mistral(self, monkeypatch, tmp_path):
+        """Mistral is the exception in this class: Voxtral has no ``prompt``
+        parameter at all, and the SDK signature is strict — forwarding one
+        raises TypeError. The hook's prompt is accepted and dropped here;
+        ``context_bias`` is the live equivalent."""
         audio = _make_audio(tmp_path)
         monkeypatch.setenv("MISTRAL_API_KEY", "mk-test")
         # Never attempt a lazy install in tests.
@@ -180,7 +183,7 @@ class TestPromptThreading:
 
         assert result["success"] is True
         _, kwargs = mock_client.audio.transcriptions.complete.call_args
-        assert kwargs["prompt"] == PROMPT
+        assert "prompt" not in kwargs
 
 
 # ---------------------------------------------------------------------------

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2363,6 +2363,30 @@ def _transcribe_openai(
 # ---------------------------------------------------------------------------
 
 
+def _resolve_mistral_context_bias() -> list:
+    """Resolve the Voxtral vocabulary bias: ``stt.mistral.context_bias`` then
+    ``stt.context_bias``. Each entry is one token — the API rejects any item
+    holding a space or a comma."""
+    stt_config = _load_stt_config()
+    for source in (_get_stt_section(stt_config, "mistral"), stt_config):
+        raw = source.get("context_bias")
+        if isinstance(raw, (list, tuple)):
+            terms = [str(term).strip() for term in raw if str(term).strip()]
+            if terms:
+                return terms
+    return []
+
+
+def _is_context_bias_rejection(err: Exception) -> bool:
+    """Whether *err* is the server refusing the vocabulary rather than failing.
+
+    A 400 on a request that only differs from a working one by its vocabulary
+    is the vocabulary's fault; 5xx, timeouts and auth errors are not.
+    """
+    message = str(err).lower()
+    return "context_bias" in message or "context bias" in message or "status 400" in message
+
+
 def _transcribe_mistral(
     file_path: str,
     model_name: str,
@@ -2379,6 +2403,14 @@ def _transcribe_mistral(
     if not api_key:
         return {"success": False, "transcript": "", "error": "MISTRAL_API_KEY not set"}
 
+    if prompt:
+        # Voxtral has no ``prompt`` parameter — the SDK signature is strict and
+        # would raise TypeError. ``context_bias`` below is the live equivalent.
+        logger.debug(
+            "STT provider 'mistral' does not support transcription prompts — "
+            "proceeding without the prompt."
+        )
+
     try:
         try:
             from tools.lazy_deps import ensure as _lazy_ensure
@@ -2387,29 +2419,47 @@ def _transcribe_mistral(
             pass
         from mistralai.client import Mistral
 
-        with Mistral(api_key=api_key) as client:
-            with open(file_path, "rb") as audio_file:
-                complete_kwargs: Dict[str, Any] = {
-                    "model": model_name,
-                    "file": {"content": audio_file, "file_name": Path(file_path).name},
-                }
-                # Language: hook override > stt.mistral.language >
-                # stt.language > env > auto.
-                language = language or _resolve_stt_language("mistral")
-                if language:
-                    complete_kwargs["language"] = language
-                if prompt:
-                    # Only send the prompt when set so the no-hook, no-config
-                    # request stays byte-identical to today's.
-                    complete_kwargs["prompt"] = prompt
-                result = client.audio.transcriptions.complete(**complete_kwargs)
+        # Language: hook override > stt.mistral.language > stt.language > env > auto.
+        language = language or _resolve_stt_language("mistral")
+        context_bias = _resolve_mistral_context_bias()
 
-            transcript_text = _extract_transcript_text(result)
-            logger.info(
-                "Transcribed %s via Mistral API (%s, %d chars)",
-                Path(file_path).name, model_name, len(transcript_text),
+        def _complete(bias):
+            """One request. Reopens the file — a retry can't reuse a read handle."""
+            with Mistral(api_key=api_key) as client:
+                with open(file_path, "rb") as audio_file:
+                    complete_kwargs: Dict[str, Any] = {
+                        "model": model_name,
+                        "file": {"content": audio_file, "file_name": Path(file_path).name},
+                    }
+                    if language:
+                        complete_kwargs["language"] = language
+                    if bias:
+                        complete_kwargs["context_bias"] = bias
+                    return client.audio.transcriptions.complete(**complete_kwargs)
+
+        try:
+            result = _complete(context_bias)
+        except Exception as bias_err:
+            # A vocabulary the server refuses (bad shape, too many terms) must
+            # never cost the transcription: retry once without it. Anything
+            # that isn't the vocabulary's fault falls through untouched.
+            if not (context_bias and _is_context_bias_rejection(bias_err)):
+                raise
+            logger.warning(
+                "Mistral rejected the transcription vocabulary (%d terms) — "
+                "retrying without it: %s", len(context_bias), bias_err,
             )
-            return {"success": True, "transcript": transcript_text, "provider": "mistral"}
+            context_bias = []
+            result = _complete([])
+
+        transcript_text = _extract_transcript_text(result)
+        logger.info(
+            "Transcribed %s via Mistral API (%s, %d chars, language=%s, vocabulary=%s)",
+            Path(file_path).name, model_name, len(transcript_text),
+            language or "auto",
+            ("%d terms" % len(context_bias)) if context_bias else "none",
+        )
+        return {"success": True, "transcript": transcript_text, "provider": "mistral"}
 
     except PermissionError:
         return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2363,25 +2363,50 @@ def _transcribe_openai(
 # ---------------------------------------------------------------------------
 
 
+_BIAS_TOKEN_SPLIT = re.compile(r"[,\s]+")
+_BIAS_SPLIT_WARNED: set = set()
+
+
 def _resolve_mistral_context_bias() -> list:
     """Resolve the Voxtral vocabulary bias: ``stt.mistral.context_bias`` then
-    ``stt.context_bias``. Each entry is one token — the API rejects any item
-    holding a space or a comma."""
+    ``stt.context_bias``.
+
+    Each entry must be a single token: the API answers 400 to any item holding
+    a space or a comma. A multi-word entry is therefore split into its tokens
+    here rather than sent as-is — left alone, one misconfigured line would cost
+    a refused request plus a retry on *every* transcription.
+    """
     stt_config = _load_stt_config()
     for source in (_get_stt_section(stt_config, "mistral"), stt_config):
         raw = source.get("context_bias")
-        if isinstance(raw, (list, tuple)):
-            terms = [str(term).strip() for term in raw if str(term).strip()]
-            if terms:
-                return terms
+        if not isinstance(raw, (list, tuple)):
+            continue
+        terms: list = []
+        for entry in raw:
+            tokens = [tok for tok in _BIAS_TOKEN_SPLIT.split(str(entry).strip()) if tok]
+            if len(tokens) > 1 and str(entry) not in _BIAS_SPLIT_WARNED:
+                # Once per distinct entry: a misconfiguration deserves to be
+                # seen, not to be repeated on every voice message.
+                _BIAS_SPLIT_WARNED.add(str(entry))
+                logger.warning(
+                    "STT context_bias entry %r is not a single token — sending "
+                    "it as %s instead. Split it in the config to silence this.",
+                    entry, tokens,
+                )
+            terms.extend(tokens)
+        if terms:
+            return terms
     return []
 
 
-def _is_context_bias_rejection(err: Exception) -> bool:
-    """Whether *err* is the server refusing the vocabulary rather than failing.
+def _may_be_context_bias_rejection(err: Exception) -> bool:
+    """Whether *err* is worth one retry without the vocabulary.
 
-    A 400 on a request that only differs from a working one by its vocabulary
-    is the vocabulary's fault; 5xx, timeouts and auth errors are not.
+    A candidate test, not a verdict. The server names the vocabulary only
+    sometimes, so a bare 400 has to qualify too — which means this alone cannot
+    tell a refused vocabulary from an unrelated bad request. What settles it is
+    the retry itself, in :func:`_transcribe_mistral`. 5xx, timeouts and auth
+    errors never qualify.
     """
     message = str(err).lower()
     return "context_bias" in message or "context bias" in message or "status 400" in message
@@ -2443,14 +2468,22 @@ def _transcribe_mistral(
             # A vocabulary the server refuses (bad shape, too many terms) must
             # never cost the transcription: retry once without it. Anything
             # that isn't the vocabulary's fault falls through untouched.
-            if not (context_bias and _is_context_bias_rejection(bias_err)):
+            if not (context_bias and _may_be_context_bias_rejection(bias_err)):
                 raise
+            try:
+                result = _complete([])
+            except Exception:
+                # It fails without the vocabulary too, so the vocabulary was
+                # not the problem: report the original error, and never claim
+                # the operator's configuration was at fault.
+                raise bias_err from None
+            # Only now is the diagnosis earned — the same request succeeded
+            # once the vocabulary was dropped.
             logger.warning(
-                "Mistral rejected the transcription vocabulary (%d terms) — "
-                "retrying without it: %s", len(context_bias), bias_err,
+                "Mistral refused the transcription vocabulary (%d terms) — "
+                "transcribed without it: %s", len(context_bias), bias_err,
             )
             context_bias = []
-            result = _complete([])
 
         transcript_text = _extract_transcript_text(result)
         logger.info(


### PR DESCRIPTION
## Problem

The Mistral STT provider does not expose `context_bias` — the only vocabulary parameter the Voxtral transcription API accepts — and it forwards a `prompt=` keyword that exists in **no** SDK signature (`mistralai` 2.4.8, `AudioTranscriptionRequest`):

https://github.com/NousResearch/hermes-agent/blob/e69b8e561d/tools/transcription_tools.py#L2401-L2405

```python
if prompt:
    complete_kwargs["prompt"] = prompt
result = client.audio.transcriptions.complete(**complete_kwargs)
```

`complete()` is generated and strict — no `**kwargs`. So the moment a `pre_transcription` hook sets a prompt (the mechanism added for #64168, and `prompt` is one of `_PRE_TRANSCRIPTION_MUTABLE_FIELDS`), the call raises `TypeError`, the surrounding `except Exception` swallows it, and the transcription fails entirely with a generic error. Harmless only while nobody configures such a hook — a dead parameter sitting exactly where the live one is missing.

## Fix

- resolve `stt.mistral.context_bias`, then `stt.context_bias`, and send it when non-empty;
- log-and-ignore `prompt`, the same shape the `xai` branch already uses for its unsupported prompt;
- **retry once without the vocabulary** when the server refuses it: an oversized or malformed list should cost fidelity, never the transcription. A genuine outage (5xx, timeout) is not retried and is not blamed on the vocabulary;
- log the declared language and the vocabulary size, so a bad transcript can be diagnosed without replaying the audio.

Nothing site-specific: the term list lives in configuration, not in code.

## Measured, not assumed

Against the live API on 2026-08-20 (`voxtral-mini-latest`):

| input | result |
|---|---|
| `context_bias` entry with a space or comma | **HTTP 400**, code 3051, `context_bias_input_method=comma_separated` |
| repeated multipart field / JSON string / SDK list | all normalised server-side to comma-separated — same 400 |
| accents, apostrophes, hyphens, digits, underscores | accepted |
| 500 entries | accepted (no count limit found) |

So an entry is **one token**. That is what makes the retry worth having: the constraint is undocumented client-side, and a list that grows past whatever the server accepts must not silently take every transcription down with it.

Effect on a real French voice message that named a place the model got wrong (`Konemara` → `Connemara`): the vocabulary fixes it, and the rest of the transcript is untouched.

## Tests

`tests/test_stt_mistral_context_bias.py` — 5 tests, no network: language and vocabulary reach the request, `prompt` never does, the global config key is the fallback source, a refused vocabulary is retried without it (language preserved), and a 503 is *not* retried.