### PR TITLE
fix(dashboard): stop leaking free-text platform error_message / gateway_exit_reason on public /api/status

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3493,18 +3493,33 @@ def _status_platform_key_allowed(
     return configured is None or key in configured
 
 
-# Per-entry writer-identity stamps (added by gateway.status.write_runtime_status
-# for the aggregation ownership check) are process recon — the same class of
-# detail as the auth-gated top-level ``gateway_pid`` — and must not project
-# onto the public endpoint.
-_PRIVATE_PLATFORM_ENTRY_KEYS = frozenset({"writer_pid", "writer_start_time"})
+# Allowlist of platform-entry fields safe for the UNAUTHENTICATED /api/status
+# path -- matches the canonical field set gateway.status.write_runtime_status()
+# actually writes: state (enum), error_code (already a coarse code -- see
+# that function's own split from the free-text error_message field),
+# needs_attention (bool), retrying_since (timestamp), updated_at (timestamp).
+# Deliberately excludes error_message: free-text, produced independently by
+# every platform adapter's own exception handling, and routinely embeds
+# endpoint URLs, response bodies, or exception detail an unauthenticated
+# caller should not see (issue #90700). Full detail remains available via
+# the authenticated /health/detailed endpoint. An allowlist (not the prior
+# denylist, which only stripped two writer-identity keys and let everything
+# else -- including any NEW field a future adapter writes -- through
+# unfiltered) keeps this endpoint safe-by-default as adapters evolve.
+_PUBLIC_PLATFORM_ENTRY_KEYS = frozenset({
+    "state",
+    "error_code",
+    "needs_attention",
+    "retrying_since",
+    "updated_at",
+})
 
 
 def _public_platform_entry(value: Any) -> Any:
-    """Strip writer-identity stamps from a platform entry before projection."""
+    """Project a platform entry down to the public-safe field allowlist."""
     if not isinstance(value, dict):
         return value
-    return {k: v for k, v in value.items() if k not in _PRIVATE_PLATFORM_ENTRY_KEYS}
+    return {k: v for k, v in value.items() if k in _PUBLIC_PLATFORM_ENTRY_KEYS}
 
 
 def _merge_profile_gateway_platforms(
@@ -3652,6 +3667,24 @@ async def get_status(profile: Optional[str] = None):
                 if _status_platform_key_allowed(key, configured_gateway_platforms)
             }
             gateway_exit_reason = runtime.get("exit_reason")
+            if gateway_exit_reason is not None:
+                # Public path: reduce free-text exit_reason (adapter/gateway
+                # failure detail, potentially embedding URLs or exception
+                # text -- some write_runtime_status() callers store the raw
+                # value directly, bypassing classification at write time)
+                # to the same bounded operational category the authenticated
+                # monitoring path already uses. Full detail stays available
+                # on /health/detailed (issue #90700).
+                try:
+                    from agent.monitoring.gateway_health import classify_exit_reason
+
+                    gateway_exit_reason = classify_exit_reason(
+                        gateway_exit_reason,
+                        state=gateway_state,
+                        restart_requested=bool(runtime.get("restart_requested")),
+                    )
+                except Exception:
+                    gateway_exit_reason = "unknown"
             # Contract: gateway_updated_at is RFC3339 string | null, never a
             # number. ``runtime`` here may be the local gateway_state.json
             # (legacy gateways wrote epoch floats; hand edits can inject

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3514,12 +3514,57 @@ _PUBLIC_PLATFORM_ENTRY_KEYS = frozenset({
     "updated_at",
 })
 
+# Known platform lifecycle states (gateway/run.py's platform_state=...
+# call sites). A value outside this set is either stale/from a future
+# adapter revision or a malformed/hijacked field -- normalized to
+# "unknown" rather than forwarded verbatim.
+_KNOWN_PLATFORM_STATES = frozenset({
+    "connected", "connecting", "disabled", "disconnected",
+    "fatal", "paused", "retrying", "running",
+})
+
+# error_code is short, adapter-defined, and expected to grow over time
+# (new adapters add new codes) -- an exact enum would be too brittle, so
+# this validates SHAPE (short, lowercase snake_case) rather than
+# membership. A value that doesn't match is free text (an embedded URL,
+# traceback, or other malformed content) and is dropped, not forwarded.
+_SAFE_ERROR_CODE_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+
+# Timestamp fields (retrying_since, updated_at) are written as
+# ``_utc_now_iso()`` output elsewhere in this codebase -- a plain
+# ISO-8601-shaped string. Reject anything else (an object, a URL, an
+# oversized string) rather than forward it unchecked.
+_ISO_TIMESTAMP_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?$"
+)
+
 
 def _public_platform_entry(value: Any) -> Any:
-    """Project a platform entry down to the public-safe field allowlist."""
+    """Project a platform entry down to the public-safe field allowlist,
+    validating the SHAPE of every retained value -- not just its key
+    name -- before it reaches the unauthenticated response (review of
+    #90750, P2). A malformed or unexpectedly-typed value in an
+    allowlisted field is dropped rather than forwarded: this endpoint
+    has no way to distinguish "legitimate new adapter data" from
+    "hijacked/corrupted retained field" at the value level, so the safe
+    default is to omit rather than guess.
+    """
     if not isinstance(value, dict):
-        return value
-    return {k: v for k, v in value.items() if k in _PUBLIC_PLATFORM_ENTRY_KEYS}
+        return {}
+    projected: dict = {}
+    state = value.get("state")
+    if "state" in value:
+        projected["state"] = state if state in _KNOWN_PLATFORM_STATES else "unknown"
+    error_code = value.get("error_code")
+    if isinstance(error_code, str) and _SAFE_ERROR_CODE_RE.match(error_code):
+        projected["error_code"] = error_code
+    if isinstance(value.get("needs_attention"), bool):
+        projected["needs_attention"] = value["needs_attention"]
+    for ts_key in ("retrying_since", "updated_at"):
+        ts = value.get(ts_key)
+        if isinstance(ts, str) and _ISO_TIMESTAMP_RE.match(ts):
+            projected[ts_key] = ts
+    return projected
 
 
 def _merge_profile_gateway_platforms(

--- a/tests/hermes_cli/test_web_server_gateway_topology.py
+++ b/tests/hermes_cli/test_web_server_gateway_topology.py
@@ -535,3 +535,168 @@ class TestStatusEndpointTopology:
             monkeypatch.setattr(
                 web_server.app.state, "auth_required", False, raising=False
             )
+
+
+# ---------------------------------------------------------------------------
+# Public projection allowlist (issue #90700)
+# ---------------------------------------------------------------------------
+
+class TestPublicStatusFieldProjection:
+    """Regression for issue #90700: /api/status is unauthenticated (NAS
+    liveness probing, SPA pre-login bootstrap). Free-text diagnostic
+    fields -- error_message on a platform entry, and the top-level
+    gateway_exit_reason -- must never reach that public payload; both
+    routinely embed endpoint URLs, response bodies, or exception detail
+    from adapter failures."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_client(self, monkeypatch, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_state
+        from hermes_constants import get_hermes_home
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        monkeypatch.setattr(
+            hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db"
+        )
+        self.client = TestClient(app)
+        self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+    def test_error_message_never_reaches_the_public_payload(self, monkeypatch):
+        """The exact reported leak: a platform entry's free-text
+        error_message (here containing an embedded URL, matching the
+        issue's own described failure shape) must not survive the
+        public projection, on either a running or startup_failed
+        gateway."""
+        monkeypatch.setattr(web_server, "get_running_pid_cached", lambda: 123)
+        monkeypatch.setattr(
+            web_server,
+            "read_runtime_status",
+            lambda path=None: {
+                "gateway_state": "startup_failed",
+                "exit_reason": "startup_failed",
+                "platforms": {
+                    "telegram": {
+                        "state": "fatal",
+                        "error_code": "duplicate_credential",
+                        "error_message": (
+                            "POST https://api.telegram.org/bot123456:ABCsecret/"
+                            "getMe failed: 409 Conflict — terminated by other "
+                            "getUpdates request"
+                        ),
+                        "writer_pid": 123,
+                        "writer_start_time": 456,
+                    }
+                },
+            },
+        )
+        monkeypatch.setattr(
+            web_server, "_load_configured_gateway_platforms", lambda: {"telegram"}
+        )
+
+        resp = self.client.get("/api/status")
+
+        assert resp.status_code == 200
+        entry = resp.json()["gateway_platforms"]["telegram"]
+        assert entry["state"] == "fatal"
+        assert entry["error_code"] == "duplicate_credential"
+        assert "error_message" not in entry
+        body_text = resp.text
+        assert "api.telegram.org" not in body_text
+        assert "123456:ABCsecret" not in body_text
+
+    def test_only_the_documented_field_allowlist_survives(self, monkeypatch):
+        """Direct allowlist check: every field write_runtime_status()
+        actually writes to a platform entry is accounted for -- the
+        safe ones pass, error_message and writer identity don't, and an
+        unknown future field (simulating an adapter-specific addition
+        no reviewer has vetted for the public path) is dropped too."""
+        monkeypatch.setattr(web_server, "get_running_pid_cached", lambda: 123)
+        monkeypatch.setattr(
+            web_server,
+            "read_runtime_status",
+            lambda path=None: {
+                "gateway_state": "running",
+                "platforms": {
+                    "telegram": {
+                        "state": "connected",
+                        "error_code": "some_code",
+                        "error_message": "sensitive detail",
+                        "needs_attention": True,
+                        "retrying_since": "2026-01-01T00:00:00Z",
+                        "updated_at": "2026-01-01T00:00:01Z",
+                        "writer_pid": 123,
+                        "writer_start_time": 456,
+                        "some_future_adapter_field": "unreviewed",
+                    }
+                },
+            },
+        )
+        monkeypatch.setattr(
+            web_server, "_load_configured_gateway_platforms", lambda: {"telegram"}
+        )
+
+        resp = self.client.get("/api/status")
+        entry = resp.json()["gateway_platforms"]["telegram"]
+
+        assert entry == {
+            "state": "connected",
+            "error_code": "some_code",
+            "needs_attention": True,
+            "retrying_since": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:01Z",
+        }
+
+    def test_gateway_exit_reason_is_reduced_to_a_coarse_category(self, monkeypatch):
+        """gateway_exit_reason must never reach the public payload
+        verbatim -- reduced to the same bounded category
+        classify_exit_reason() already produces for the authenticated
+        monitoring path."""
+        monkeypatch.setattr(web_server, "get_running_pid_cached", lambda: 123)
+        monkeypatch.setattr(
+            web_server,
+            "read_runtime_status",
+            lambda path=None: {
+                "gateway_state": "stopped",
+                "exit_reason": (
+                    "Traceback (most recent call last): ... "
+                    "ConnectionError: could not connect to internal-db-host:5432 "
+                    "user=admin password=hunter2"
+                ),
+                "platforms": {},
+            },
+        )
+        monkeypatch.setattr(web_server, "_load_configured_gateway_platforms", lambda: set())
+
+        resp = self.client.get("/api/status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data["gateway_exit_reason"], str)
+        assert len(data["gateway_exit_reason"]) < 40, (
+            "must be a short, bounded category, not free text"
+        )
+        raw_leak_markers = ("hunter2", "internal-db-host", "Traceback")
+        for marker in raw_leak_markers:
+            assert marker not in resp.text
+
+    def test_none_exit_reason_stays_none(self, monkeypatch):
+        """Sanity: a genuinely absent exit reason (the common, healthy
+        case) must not be coerced into some non-null placeholder."""
+        monkeypatch.setattr(web_server, "get_running_pid_cached", lambda: 123)
+        monkeypatch.setattr(
+            web_server,
+            "read_runtime_status",
+            lambda path=None: {
+                "gateway_state": "running",
+                "platforms": {},
+            },
+        )
+        monkeypatch.setattr(web_server, "_load_configured_gateway_platforms", lambda: set())
+
+        resp = self.client.get("/api/status")
+        assert resp.json()["gateway_exit_reason"] is None

--- a/tests/hermes_cli/test_web_server_gateway_topology.py
+++ b/tests/hermes_cli/test_web_server_gateway_topology.py
@@ -700,3 +700,101 @@ class TestPublicStatusFieldProjection:
 
         resp = self.client.get("/api/status")
         assert resp.json()["gateway_exit_reason"] is None
+
+
+# ---------------------------------------------------------------------------
+# Value-shape validation on retained fields (review of #90750, P2)
+# ---------------------------------------------------------------------------
+
+class TestPublicPlatformEntryValueValidation:
+    """Regression for review of #90750: an allowlisted field NAME alone
+    was not enough -- a malformed or hijacked VALUE in state, error_code,
+    needs_attention, retrying_since, or updated_at previously still
+    reached the public response unchanged. _public_platform_entry() must
+    validate shape, not just key membership."""
+
+    def test_non_dict_platform_entry_projects_to_empty(self):
+        from hermes_cli.web_server import _public_platform_entry
+
+        assert _public_platform_entry("not a dict") == {}
+        assert _public_platform_entry(None) == {}
+        assert _public_platform_entry(["also", "not", "a", "dict"]) == {}
+
+    def test_unknown_state_value_normalizes_to_unknown(self):
+        from hermes_cli.web_server import _public_platform_entry
+
+        entry = _public_platform_entry({
+            "state": "https://attacker.example/exfil?data=leaked",
+        })
+        assert entry["state"] == "unknown"
+
+    def test_known_state_values_pass_through(self):
+        from hermes_cli.web_server import _public_platform_entry
+
+        for state in (
+            "connected", "connecting", "disabled", "disconnected",
+            "fatal", "paused", "retrying", "running",
+        ):
+            assert _public_platform_entry({"state": state})["state"] == state
+
+    def test_free_text_error_code_is_dropped_not_forwarded(self):
+        """The exact residual bypass the review identified: error_code
+        is an allowlisted FIELD NAME, but a value that's actually free
+        text (a URL, an embedded traceback line, oversized content)
+        must not be forwarded just because the key name is safe."""
+        from hermes_cli.web_server import _public_platform_entry
+
+        entry = _public_platform_entry({
+            "error_code": "see https://internal.example/logs/abc123 for detail",
+        })
+        assert "error_code" not in entry
+
+    def test_short_snake_case_error_code_passes_through(self):
+        from hermes_cli.web_server import _public_platform_entry
+
+        entry = _public_platform_entry({"error_code": "duplicate_credential"})
+        assert entry["error_code"] == "duplicate_credential"
+
+    def test_non_bool_needs_attention_is_dropped(self):
+        from hermes_cli.web_server import _public_platform_entry
+
+        for bad_value in ("true", 1, "yes", None, ["x"]):
+            entry = _public_platform_entry({"needs_attention": bad_value})
+            assert "needs_attention" not in entry, f"failed for {bad_value!r}"
+
+    def test_real_bool_needs_attention_passes_through(self):
+        from hermes_cli.web_server import _public_platform_entry
+
+        assert _public_platform_entry({"needs_attention": True})["needs_attention"] is True
+        assert _public_platform_entry({"needs_attention": False})["needs_attention"] is False
+
+    def test_malformed_timestamp_is_dropped(self):
+        from hermes_cli.web_server import _public_platform_entry
+
+        for bad_ts in (
+            "not a timestamp",
+            "javascript:alert(1)",
+            "2026-01-01",  # date only, not the ISO-8601 datetime shape actually written
+            12345,
+            {"nested": "object"},
+        ):
+            for key in ("retrying_since", "updated_at"):
+                entry = _public_platform_entry({key: bad_ts})
+                assert key not in entry, f"failed for {key}={bad_ts!r}"
+
+    def test_valid_iso_timestamp_passes_through(self):
+        from hermes_cli.web_server import _public_platform_entry
+
+        entry = _public_platform_entry({
+            "retrying_since": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:01.123456+00:00",
+        })
+        assert entry["retrying_since"] == "2026-01-01T00:00:00Z"
+        assert entry["updated_at"] == "2026-01-01T00:00:01.123456+00:00"
+
+    def test_absent_fields_stay_absent_not_defaulted(self):
+        """A field the adapter never wrote must not appear with a
+        synthetic default -- absence should stay absence."""
+        from hermes_cli.web_server import _public_platform_entry
+
+        assert _public_platform_entry({"state": "connected"}) == {"state": "connected"}

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -544,7 +544,11 @@ class TestProfileScopedGateway:
         data = resp.json()
         assert data["gateway_running"] is False
         assert data["gateway_state"] == "startup_failed"
-        assert data["gateway_exit_reason"] == "telegram: token rejected"
+        # gateway_exit_reason is classified to a bounded category on the
+        # public path (issue #90700, review follow-up) -- the raw
+        # diagnostic text must not survive.
+        assert data["gateway_exit_reason"] == "auth_failed"
+        assert "telegram: token rejected" not in resp.text
         # Fatal entries (root and namespaced) survive; the stale non-fatal is dropped.
         assert set(data["gateway_platforms"]) == {"telegram", "alpha:telegram"}
         assert data["gateway_platforms"]["alpha:telegram"]["error_code"] == "credential_collision"


### PR DESCRIPTION
Fixes #90700.

## Root cause

`/api/status` is intentionally unauthenticated, but its platform-entry projection was a denylist stripping only two writer-identity keys. Every other field written by `write_runtime_status()` survived unfiltered -- including `error_message`, free text routinely embedding endpoint URLs, response bodies, or exception detail. `gateway_exit_reason` also passed through verbatim -- some write call sites store the raw failure string directly, bypassing the existing classifier. On a `startup_failed` gateway, the "fatal" entries are deliberately kept for diagnosis, making these exactly the entries most likely to carry credential-collision detail.

## Fix

1. `_public_platform_entry` switched from a denylist to an allowlist (`state`, `error_code`, `needs_attention`, `retrying_since`, `updated_at`) matching the canonical field set actually written. `error_message` is dropped entirely on the public path; full detail remains on the authenticated `/health/detailed`. Safe-by-default going forward -- a new field a future adapter writes is invisible until explicitly added.

2. `gateway_exit_reason` now runs through the already-existing `classify_exit_reason()` classifier before inclusion in the public payload, reducing it to a bounded operational category rather than raw text.

## Verification

Added 4 regression tests to the existing end-to-end test file, including the exact reported leak shape (embedded URL + API token, verified absent from the full response body) and a raw-traceback-plus-password exit_reason test. Verified as genuine regressions by reverting each fix independently and confirming the corresponding tests fail with the exact reported leak content present.

20/20 pass in the modified test file; 16/16 across two related dashboard-auth test files (no regression).