### PR TITLE
feat: desktop updates no longer re-apply local source edits (--keep-stash)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4870,6 +4870,7 @@ _LAZY_COMMAND_EXPORTS = {
         "_defer_update_for_self_lock",
         "_discard_lockfile_churn",
         "_discard_stashed_changes",
+        "_park_stashed_changes",
         "_ensure_acp_launcher",
         "_ensure_fhs_path_guard",
         "_ensure_uv_for_termux",

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -51,6 +51,18 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         help="Assume yes for interactive prompts (config migration, stash restore). API-key entry is skipped; run 'hermes config migrate' separately for those.",
     )
     update_parser.add_argument(
+        "--keep-stash",
+        action="store_true",
+        default=False,
+        help=(
+            "Do NOT re-apply local changes after the update. Uncommitted "
+            "changes are still stashed so the update can proceed, but they "
+            "stay parked in git stash instead of being restored onto the "
+            "updated code. Used by the desktop updater so local source edits "
+            "never silently ride along across updates."
+        ),
+    )
+    update_parser.add_argument(
         "--branch",
         default=None,
         metavar="NAME",

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1611,6 +1611,20 @@ def _stash_apply_failed_only_on_existing_untracked(stderr: str) -> bool:
             return False
     return saw_untracked_error
 
+def _park_stashed_changes(stash_ref: str) -> None:
+    """Leave a pre-update autostash parked instead of re-applying it.
+
+    Used by ``hermes update --keep-stash`` (the desktop updater's mode): the
+    stash made the update possible on a dirty tree, but local source edits
+    must never be silently re-applied onto the updated code. Nothing is
+    lost — the entry stays in ``git stash`` with printed recovery guidance.
+    """
+    print()
+    print("ℹ️  Local changes were stashed before updating and were NOT re-applied (--keep-stash).")
+    print(f"  Stash ref: {stash_ref}")
+    print(f"  Restore manually with: git stash apply {stash_ref}")
+
+
 def _restore_stashed_changes(
     git_cmd: list[str],
     cwd: Path,
@@ -4784,6 +4798,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
         else None
     )
     assume_yes = bool(getattr(args, "yes", False))
+    # --keep-stash (desktop updater): stash local changes so the update can
+    # proceed, but never re-apply them afterward — they stay parked in git
+    # stash. Only applies when an update actually landed; abort/no-op paths
+    # still restore, since the tree they restore onto is unchanged.
+    keep_stash = bool(getattr(args, "keep_stash", False))
 
     # Whether this update is running without a human at the keyboard.
     # Interactive terminal updates always stash-and-ask (unchanged behavior);
@@ -5449,6 +5468,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         _m().PROJECT_ROOT,
                         auto_stash_ref,
                     )
+                elif keep_stash:
+                    # --keep-stash (desktop updater): the update landed; leave
+                    # local edits parked in the stash instead of silently
+                    # re-applying them onto the updated code.
+                    _m()._park_stashed_changes(auto_stash_ref)
                 else:
                     _m()._restore_stashed_changes(
                         git_cmd,

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -498,9 +498,19 @@ cd "$INSTALL_ROOT" || {
   log "$FINAL_MSG"; exit 3
 }
 export PYTHONUNBUFFERED=1
-log "running: hermes update --yes --gateway --branch $BRANCH"
+# --keep-stash: never re-apply local source edits after the update (they stay
+# parked in git stash). Probe --help first: older installed backends don't
+# know the flag and argparse would abort with exit 2, which collides with the
+# "close all Hermes windows" sentinel.
+KEEP_STASH=""
+if "$HERMES_BIN" update --help 2>/dev/null | grep -q -- '--keep-stash'; then
+  KEEP_STASH="--keep-stash"
+else
+  log "installed hermes predates --keep-stash; running without it"
+fi
+log "running: hermes update --yes --gateway $KEEP_STASH --branch $BRANCH"
 publish_stage "Updating code and dependencies"
-OUT="$("$HERMES_BIN" update --yes --gateway --branch "$BRANCH" 2>&1)"; CODE=$?
+OUT="$("$HERMES_BIN" update --yes --gateway $KEEP_STASH --branch "$BRANCH" 2>&1)"; CODE=$?
 printf '%s\n' "$OUT" >> "$LOG" 2>/dev/null
 log "hermes update exit code: $CODE"
 
@@ -509,7 +519,7 @@ if [ "$CODE" -ne 0 ] && [ "$CODE" -ne 2 ]; then
   # Exit 2 ("close all Hermes windows") is not retryable.
   log "retrying once (freshly pulled fix loads on the second run)"
   publish_stage "Retrying update"
-  OUT="$("$HERMES_BIN" update --yes --gateway --branch "$BRANCH" 2>&1)"; CODE=$?
+  OUT="$("$HERMES_BIN" update --yes --gateway $KEEP_STASH --branch "$BRANCH" 2>&1)"; CODE=$?
   printf '%s\n' "$OUT" >> "$LOG" 2>/dev/null
   log "retry exit code: $CODE"
 fi

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -776,6 +776,20 @@ try {
         exit $finalCode
     }
     $updateArgs = @("-m", "hermes_cli.main", "update", "--yes", "--gateway", "--force", "--branch", $Branch)
+    # --keep-stash: never re-apply local source edits after the update (they
+    # stay parked in git stash). Probe --help first: the flag ships with newer
+    # backends and an unknown flag would abort argparse with exit 2, which
+    # collides with the "close all Hermes windows" sentinel.
+    try {
+        $updateHelp = & $pythonExe -m hermes_cli.main update --help 2>$null | Out-String
+        if ($updateHelp -match "--keep-stash") {
+            $updateArgs += "--keep-stash"
+        } else {
+            Write-HandoffLog "installed hermes predates --keep-stash; running without it"
+        }
+    } catch {
+        Write-HandoffLog "could not probe update --help; running without --keep-stash"
+    }
     Write-HandoffLog ("running: python " + ($updateArgs -join " "))
     Publish-UiProgress "Updating code and dependencies"
     $res = Invoke-HermesStep $pythonExe $updateArgs "update"

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -229,6 +229,104 @@ def _setup_setting_test(monkeypatch, tmp_path, mode):
     return restore_calls, discard_calls, recorded
 
 
+# ---------------------------------------------------------------------------
+# --keep-stash (desktop updater): stash for the update, never re-apply.
+# ---------------------------------------------------------------------------
+
+def _setup_keep_stash_test(monkeypatch, tmp_path):
+    """Wiring for --keep-stash tests: stash returns a ref; restore, discard,
+    and park are all recorded."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(
+        hermes_main, "_stash_local_changes_if_needed",
+        lambda *a, **kw: "abc123deadbeef",
+    )
+    restore_calls = []
+    discard_calls = []
+    park_calls = []
+    monkeypatch.setattr(
+        hermes_main, "_restore_stashed_changes",
+        lambda *a, **kw: restore_calls.append(1) or True,
+    )
+    monkeypatch.setattr(
+        hermes_main, "_discard_stashed_changes",
+        lambda *a, **kw: discard_calls.append(1) or True,
+    )
+    monkeypatch.setattr(
+        hermes_main, "_park_stashed_changes",
+        lambda *a, **kw: park_calls.append(a) or None,
+    )
+    # Keep the update flow away from the real gateway fleet on this machine —
+    # a live gateway PID would trip the test-suite kill guard and turn the
+    # run into exit 1 (gateway_fleet_restart_incomplete).
+    monkeypatch.setattr(
+        "hermes_cli.gateway.find_gateway_pids", lambda **kw: [], raising=False
+    )
+    return restore_calls, discard_calls, park_calls
+
+
+def test_update_keep_stash_parks_instead_of_restoring(monkeypatch, tmp_path):
+    """--keep-stash: after a successful update, the autostash is parked (left
+    in git stash) — never re-applied, never discarded."""
+    restore_calls, discard_calls, park_calls = _setup_keep_stash_test(monkeypatch, tmp_path)
+    side_effect, _ = _make_update_side_effect()
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace(yes=True, keep_stash=True))
+
+    assert len(park_calls) == 1
+    assert park_calls[0][0] == "abc123deadbeef"
+    assert restore_calls == []
+    assert discard_calls == []
+
+
+def test_update_without_keep_stash_still_restores(monkeypatch, tmp_path):
+    """Regression guard: default behavior (no --keep-stash) is unchanged —
+    the autostash is auto-restored under --yes."""
+    restore_calls, discard_calls, park_calls = _setup_keep_stash_test(monkeypatch, tmp_path)
+    side_effect, _ = _make_update_side_effect()
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace(yes=True, keep_stash=False))
+
+    assert restore_calls == [1]
+    assert park_calls == []
+    assert discard_calls == []
+
+
+def test_update_keep_stash_failure_path_still_preserves(monkeypatch, tmp_path, capsys):
+    """--keep-stash + failed update: neither restore nor park runs; the
+    existing preserved-in-stash message fires (working tree unknown)."""
+    restore_calls, discard_calls, park_calls = _setup_keep_stash_test(monkeypatch, tmp_path)
+    side_effect, _ = _make_update_side_effect(ff_only_fails=True, reset_fails=True)
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace(yes=True, keep_stash=True))
+
+    assert restore_calls == []
+    assert park_calls == []
+    assert discard_calls == []
+    assert "preserved in stash" in capsys.readouterr().out
+
+
+def test_update_parser_accepts_keep_stash():
+    """The flag parses and defaults off."""
+    import argparse
+
+    from hermes_cli.subcommands.update import build_update_parser
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    build_update_parser(subparsers, cmd_update=lambda args: None)
+
+    args = parser.parse_args(["update", "--keep-stash"])
+    assert args.keep_stash is True
+    args = parser.parse_args(["update"])
+    assert args.keep_stash is False
+
+
 
 
 

--- a/tests/test_desktop_update_shim_progress.py
+++ b/tests/test_desktop_update_shim_progress.py
@@ -116,6 +116,10 @@ def test_unreadable_status_still_serves_a_running_state(progress):
 # while it ran -- the update child is the only thing that can observe the
 # window's state at the exact moment of the longest wait in the hand-off.
 FAKE_HERMES = """#!/bin/bash
+# The hand-off probes `update --help` for --keep-stash support before the
+# real update call; answer it without consuming a counted call so the
+# exits.N mapping below still refers to actual update attempts.
+case "$*" in *--help*) echo "--keep-stash"; exit 0 ;; esac
 n="$(cat "$HERMES_TEST_CALLS" 2>/dev/null || echo 0)"; n=$((n + 1))
 printf '%s' "$n" > "$HERMES_TEST_CALLS"
 for f in "$TMPDIR"/hermes-update-status.[0-9]*; do

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -66,6 +66,16 @@ updates:
 
 In the desktop app this is **Settings → Advanced → In-App Update Local Changes**.
 
+**Desktop updates never auto-restore.** The desktop updater invokes `hermes update --keep-stash`: local source edits are still stashed so the update can proceed, but they are **not** re-applied afterward — they stay parked in `git stash` and the update log prints the exact `git stash apply <ref>` command to bring them back. This prevents local edits from silently riding along across desktop updates and breaking the freshly updated install. (`non_interactive_local_changes: discard` still wins if you've opted into discarding.) To restore parked changes manually:
+
+```bash
+cd ~/.hermes/hermes-agent   # or your install root
+git stash list --format='%gd %H %s'   # find the hermes-update-autostash entry
+git stash apply stash@{0}
+```
+
+You can pass `--keep-stash` to a terminal `hermes update` too if you want the same never-reapply behavior interactively.
+
 ### Preview-only: `hermes update --check`
 
 Want to know if an update is available before pulling? Run `hermes update --check` — it fetches and compares commits against `origin/main`. No files are modified, no gateway is restarted. Useful in scripts and cron jobs that gate on "is there an update".


### PR DESCRIPTION
## Summary
Desktop-driven updates no longer re-apply local source edits onto the freshly updated checkout — the handoff scripts now run `hermes update --keep-stash`, which stashes local changes so the update can proceed but leaves them parked in `git stash` instead of auto-restoring them.

Root cause of the field report (Windows update handoff leaving the app "crashed"): the desktop updater passed `--yes`, which forces `prompt_for_restore=False` and unconditionally re-applies dirty-tree edits after the pull, so local modifications silently rode along across every update and could break the rebuilt app.

## Changes
- `hermes_cli/subcommands/update.py`: new `--keep-stash` flag on `hermes update`.
- `hermes_cli/update_cmd.py`: new `_park_stashed_changes()` (prints stash ref + `git stash apply` recovery guidance); success-path finally block parks instead of restoring when the flag is set. Failure path unchanged (stash preserved, no restore); `updates.non_interactive_local_changes: discard` still wins.
- `hermes_cli/main.py`: `_park_stashed_changes` registered in the lazy re-export table (historical test/patch surface).
- `scripts/desktop-update/windows.ps1` + `posix.sh`: pass `--keep-stash`, probing `update --help` first so older installed backends without the flag keep working (an unknown flag would exit 2, colliding with the "close all Hermes windows" sentinel).
- `website/docs/getting-started/updating.md`: documents the desktop never-auto-restore behavior + manual recovery commands.

## Validation
| | Before | After |
|---|---|---|
| Desktop update on dirty tree | edits auto re-applied onto updated code | edits parked in git stash, recovery command printed |
| Terminal `hermes update` (no flag) | stash + ask / auto-restore | unchanged (regression test) |
| Update failure with stash | preserved, not restored | unchanged (test) |
| Old backend + new handoff script | n/a | `--help` probe skips the flag |

- `tests/hermes_cli/test_update_autostash.py`: 9/9 pass, including a sabotage-verified regression test (removing the keep_stash branch makes it fail) and a parser test.
- Real-import E2E: parser accepts `--yes --gateway --keep-stash --branch main`; `hermes_cli.main._park_stashed_changes` resolves through the lazy re-export and prints the guidance.
- `bash -n posix.sh` clean; ruff clean.

## Infographic

![Desktop updates keep your edits parked](https://files.catbox.moe/olyj1h.png)
