### PR TITLE
feat(tui): add required prompt dispatch hooks

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -226,6 +226,11 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # TUI/Desktop turn gate. Runs on the turn worker after attached-image
+    # snapshotting and before provider-specific image routing or agent dispatch.
+    # Plugins return allow/respond directives without receiving private gateway
+    # or session objects.
+    "pre_prompt_dispatch",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs an approval decision -- fires for CLI-interactive prompts,
     # gateway/ACP approvals, and smart-mode auxiliary-LLM decisions.

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -26,6 +26,7 @@ gateway:
   no_active_goal:   "Geen aktiewe doelwit nie."
   config_read_failed: "⚠️ Kon nie config.yaml lees nie: {error}"
   config_save_failed: "⚠️ Kon nie konfigurasie stoor nie: {error}"
+  required_prompt_handler_unavailable: "Die vereiste prompt-hanteerder is tans nie beskikbaar nie. Jou aanhegsels is nie na die agent gestuur nie. Probeer weer wanneer die hanteerder beskikbaar is."
 
   model:
     error_prefix:           "Fout: {error}"

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -49,6 +49,7 @@ gateway:
   no_active_goal:   "لا يوجد هدف نشط."
   config_read_failed: "⚠️ تعذّر قراءة config.yaml: {error}"
   config_save_failed: "⚠️ تعذّر حفظ الإعدادات: {error}"
+  required_prompt_handler_unavailable: "معالج الطلب المطلوب غير متاح حاليًا. لم تُرسل مرفقاتك إلى الوكيل. حاول مرة أخرى عندما يصبح المعالج متاحًا."
 
   model:
     error_prefix:           "خطأ: {error}"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -26,6 +26,7 @@ gateway:
   no_active_goal:   "Kein aktives Ziel."
   config_read_failed: "⚠️ config.yaml konnte nicht gelesen werden: {error}"
   config_save_failed: "⚠️ Konfiguration konnte nicht gespeichert werden: {error}"
+  required_prompt_handler_unavailable: "Der erforderliche Prompt-Handler ist derzeit nicht verfügbar. Ihre Anhänge wurden nicht an den Agenten weitergegeben. Versuchen Sie es erneut, sobald der Handler verfügbar ist."
 
   model:
     error_prefix:           "Fehler: {error}"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -37,6 +37,7 @@ gateway:
   no_active_goal:   "No active goal."
   config_read_failed: "⚠️ Could not read config.yaml: {error}"
   config_save_failed: "⚠️ Could not save config: {error}"
+  required_prompt_handler_unavailable: "The required prompt handler is currently unavailable. Your attachments were not sent to the agent. Please try again after the handler is available."
 
   # /model command output -- shown after a model switch or when listing models.
   # Provider names, model IDs, capability strings, and cost figures are NOT

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -26,6 +26,7 @@ gateway:
   no_active_goal:   "No hay objetivo activo."
   config_read_failed: "⚠️ No se pudo leer config.yaml: {error}"
   config_save_failed: "⚠️ No se pudo guardar la configuración: {error}"
+  required_prompt_handler_unavailable: "El controlador de solicitudes requerido no está disponible en este momento. Tus archivos adjuntos no se enviaron al agente. Inténtalo de nuevo cuando el controlador esté disponible."
 
   model:
     error_prefix:           "Error: {error}"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -26,6 +26,7 @@ gateway:
   no_active_goal:   "Aucun objectif actif."
   config_read_failed: "⚠️ Impossible de lire config.yaml : {error}"
   config_save_failed: "⚠️ Impossible de sauvegarder la configuration : {error}"
+  required_prompt_handler_unavailable: "Le gestionnaire de requête requis est actuellement indisponible. Vos pièces jointes n'ont pas été envoyées à l'agent. Réessayez lorsque le gestionnaire sera disponible."
 
   model:
     error_prefix:           "Erreur : {error}"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -30,6 +30,7 @@ gateway:
   no_active_goal:   "Níl aon sprioc ghníomhach ann."
   config_read_failed: "⚠️ Níorbh fhéidir config.yaml a léamh: {error}"
   config_save_failed: "⚠️ Níorbh fhéidir an chumraíocht a shábháil: {error}"
+  required_prompt_handler_unavailable: "Níl an láimhseálaí leide riachtanach ar fáil faoi láthair. Níor seoladh d'iatáin chuig an ngníomhaire. Bain triail eile as nuair a bheidh an láimhseálaí ar fáil."
 
   model:
     error_prefix:           "Earráid: {error}"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -26,6 +26,7 @@ gateway:
   no_active_goal:   "Nincs aktív cél."
   config_read_failed: "⚠️ Nem sikerült olvasni a config.yaml fájlt: {error}"
   config_save_failed: "⚠️ Nem sikerült menteni a konfigurációt: {error}"
+  required_prompt_handler_unavailable: "A szükséges promptkezelő jelenleg nem érhető el. A mellékleteket nem küldtük el az ügynöknek. Próbálja újra, amikor a kezelő elérhető lesz."
 
   model:
     error_prefix:           "Hiba: {error}"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -26,6 +26,7 @@ gateway:
   no_active_goal:   "Nessun obiettivo attivo."
   config_read_failed: "⚠️ Impossibile leggere config.yaml: {error}"
   config_save_failed: "⚠️ Impossibile salvare la configurazione: {error}"
+  required_prompt_handler_unavailable: "Il gestore di prompt richiesto non è attualmente disponibile. I tuoi allegati non sono stati inviati all'agente. Riprova quando il gestore sarà disponibile."
 
   model:
     error_prefix:           "Errore: {error}"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -26,6 +26,7 @@ gateway:
   no_active_goal:   "アクティブな目標はありません。"
   config_read_failed: "⚠️ config.yaml を読み込めませんでした: {error}"
   config_save_failed: "⚠️ 設定を保存できませんでした: {error}"
+  required_prompt_handler_unavailable: "必須なプロンプトハンドラーは現在利用できません。添付ファイルはエージェントに送信されませんでした。ハンドラーが利用可能になってからもう一度お試しください。"
 
   model:
     error_prefix:           "エラー: {error}"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -26,6 +26,7 @@ gateway:
   no_active_goal:   "활성 목표가 없습니다."
   config_read_failed: "⚠️ config.yaml을 읽을 수 없습니다: {error}"
   config_save_failed: "⚠️ 설정을 저장할 수 없습니다: {error}"
+  required_prompt_handler_unavailable: "필수 프롬프트 처리기를 현재 사용할 수 없습니다. 첨부 파일은 에이전트로 전송되지 않았습니다. 처리기를 사용할 수 있게 되면 다시 시도하세요."
 
   model:
     error_prefix:           "오류: {error}"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -26,6 +26,7 @@ gateway:
   no_active_goal:   "Não há objetivo ativo."
   config_read_failed: "⚠️ Não foi possível ler config.yaml: {error}"
   config_save_failed: "⚠️ Não foi possível guardar a configuração: {error}"
+  required_prompt_handler_unavailable: "O processador de pedidos obrigatório não está disponível neste momento. Os seus anexos não foram enviados ao agente. Tente novamente quando o processador estiver disponível."
 
   model:
     error_prefix:           "Erro: {error}"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -26,6 +26,7 @@ gateway:
   no_active_goal:   "Нет активной цели."
   config_read_failed: "⚠️ Не удалось прочитать config.yaml: {error}"
   config_save_failed: "⚠️ Не удалось сохранить конфигурацию: {error}"
+  required_prompt_handler_unavailable: "Требуемый обработчик запроса сейчас недоступен. Ваши вложения не были отправлены агенту. Повторите попытку, когда обработчик станет доступным."
 
   model:
     error_prefix:           "Ошибка: {error}"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -26,6 +26,7 @@ gateway:
   no_active_goal:   "Aktif hedef yok."
   config_read_failed: "⚠️ config.yaml okunamadı: {error}"
   config_save_failed: "⚠️ Yapılandırma kaydedilemedi: {error}"
+  required_prompt_handler_unavailable: "Gerekli istem işleyicisi şu anda kullanılamıyor. Ekleriniz ajana gönderilmedi. İşleyici kullanılabilir olduğunda tekrar deneyin."
 
   model:
     error_prefix:           "Hata: {error}"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -26,6 +26,7 @@ gateway:
   no_active_goal:   "Немає активної цілі."
   config_read_failed: "⚠️ Не вдалося прочитати config.yaml: {error}"
   config_save_failed: "⚠️ Не вдалося зберегти конфігурацію: {error}"
+  required_prompt_handler_unavailable: "Потрібний обробник запиту зараз недоступний. Ваші вкладення не було надіслано агенту. Спробуйте ще раз, коли обробник стане доступним."
 
   model:
     error_prefix:           "Помилка: {error}"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -26,6 +26,7 @@ gateway:
   no_active_goal:   "目前沒有作用中的目標。"
   config_read_failed: "⚠️ 無法讀取 config.yaml：{error}"
   config_save_failed: "⚠️ 無法儲存設定：{error}"
+  required_prompt_handler_unavailable: "所需的提示處理常式目前無法使用。您的附件未傳送給代理程式。請在處理常式可用後再試一次。"
 
   model:
     error_prefix:           "錯誤：{error}"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -26,6 +26,7 @@ gateway:
   no_active_goal:   "当前没有活跃的目标。"
   config_read_failed: "⚠️ 无法读取 config.yaml：{error}"
   config_save_failed: "⚠️ 无法保存配置：{error}"
+  required_prompt_handler_unavailable: "所需的提示处理程序当前不可用。您的附件未发送给智能体。请在该处理程序可用后重试。"
 
   model:
     error_prefix:           "错误：{error}"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -325,6 +325,17 @@ def test_prompt_submit_dispatches_to_compute_host_when_turn_isolation_enabled(mo
         server._sessions.pop("iso-sid", None)
 
 
+def test_compute_host_turn_frame_carries_normalized_required_handler():
+    session = _session(
+        required_prompt_handler="hoppe_ocr_approval",
+        attached_images=["/tmp/protected.png"],
+    )
+
+    frame = server._compute_host_turn_frame("rid", "sid", session, "inspect")
+
+    assert frame["required_prompt_handler"] == "hoppe_ocr_approval"
+
+
 def test_compute_host_explicit_images_do_not_clear_later_attachment(monkeypatch):
     class _Supervisor:
         def submit_turn(self, _frame, *, on_complete=None):

--- a/tests/tui_gateway/test_compute_host_phase1.py
+++ b/tests/tui_gateway/test_compute_host_phase1.py
@@ -1,10 +1,12 @@
 import io
 import json
+import multiprocessing
 import os
 import sys
 import threading
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -15,6 +17,133 @@ from tui_gateway.host_supervisor import (
     HostSupervisor,
     append_log_record,
 )
+
+
+def _isolated_ocr_probe(frame: dict, result_queue) -> None:
+    """Run the real prompt worker in a clean spawned child process."""
+    from tui_gateway import server as child_server
+    from tui_gateway.compute_host import ComputeHost as ChildComputeHost
+
+    agent_runs = []
+    persisted = []
+    events = []
+
+    class _DB:
+        def append_messages_batch(self, session_id, messages, **_kwargs):
+            persisted.append((session_id, list(messages)))
+            return len(messages)
+
+    class _Agent:
+        session_id = "stored-ios"
+        _session_db = _DB()
+
+        def clear_interrupt(self):
+            return None
+
+        def run_conversation(self, *_args, **_kwargs):
+            agent_runs.append(True)
+            return {"final_response": "agent-ran", "messages": []}
+
+    fake_server = SimpleNamespace(
+        _sessions={},
+        _make_agent=lambda *_args, **_kwargs: _Agent(),
+        _transfer_db_to_agent=lambda *_args: False,
+        _load_show_reasoning=lambda: False,
+        _load_tool_progress_mode=lambda: "all",
+        _sanitize_client_source=lambda value: value,
+    )
+
+    def _init_session(sid, key, agent, history, **kwargs):
+        fake_server._sessions[sid] = {
+            "agent": agent,
+            "session_key": key,
+            "history": list(history),
+            "history_lock": threading.Lock(),
+            "history_version": 0,
+            "inflight_turn": None,
+            "running": True,
+            "attached_images": [],
+            "image_counter": 0,
+            "cwd": frame.get("cwd") or os.getcwd(),
+            "cols": 80,
+            "slash_worker": None,
+            "show_reasoning": False,
+            "tool_progress_mode": "all",
+            "source": frame.get("source") or "ios",
+            "transport": None,
+            "required_prompt_handler": kwargs.get("required_prompt_handler"),
+        }
+
+    fake_server._init_session = _init_session
+    host = ChildComputeHost(stdout=io.StringIO(), heartbeat_secs=0)
+    try:
+        child_session = host._ensure_server_session(fake_server, frame)
+        child_server._sessions = {frame["sid"]: child_session}
+        child_server._emit = (
+            lambda name, sid, payload=None: events.append((name, sid, payload))
+        )
+        child_server._wire_callbacks = lambda _sid: None
+        child_server._apply_pending_model_switch = lambda *_args: None
+        child_server._sync_agent_model_with_config = lambda *_args: None
+        child_server._sync_bot_capabilities = lambda *_args: None
+        child_server._session_cwd = lambda _session: frame.get("cwd") or os.getcwd()
+        child_server._register_session_cwd = lambda _session: None
+        child_server._emit_settled_session_info = lambda *_args: None
+        child_server.record_turn_start = lambda *_args, **_kwargs: None
+        child_server._retire_turn_marker = lambda *_args: None
+        child_server.render_message = lambda *_args: None
+
+        child_server._run_prompt_submit(
+            frame["request_id"],
+            frame["sid"],
+            child_session,
+            frame["text"],
+            image_paths=list(frame.get("attached_images") or []),
+        )
+        child_session["_run_thread"].join(timeout=5)
+
+        cleared = host._ensure_server_session(
+            fake_server, {**frame, "required_prompt_handler": None}
+        )
+        clear_decision = child_server.invoke_pre_prompt_dispatch(
+            session_id=frame["sid"],
+            session_key=frame["session_key"],
+            source=frame["source"],
+            text="cleared",
+            attached_images=frame["attached_images"],
+            required_prompt_handler=cleared.get("required_prompt_handler"),
+        )
+        if clear_decision.action == "allow":
+            cleared["agent"].run_conversation("cleared")
+        cleared_handler = cleared.get("required_prompt_handler")
+
+        reasserted = host._ensure_server_session(fake_server, frame)
+        reassert_decision = child_server.invoke_pre_prompt_dispatch(
+            session_id=frame["sid"],
+            session_key=frame["session_key"],
+            source=frame["source"],
+            text="reasserted",
+            attached_images=frame["attached_images"],
+            required_prompt_handler=reasserted.get("required_prompt_handler"),
+        )
+        if reassert_decision.action == "allow":
+            reasserted["agent"].run_conversation("reasserted")
+
+        result_queue.put(
+            {
+                "initial_handler": frame.get("required_prompt_handler"),
+                "cleared_handler": cleared_handler,
+                "reasserted_handler": reasserted.get("required_prompt_handler"),
+                "clear_action": clear_decision.action,
+                "reassert_action": reassert_decision.action,
+                "agent_runs": len(agent_runs),
+                "history": child_session.get("history"),
+                "persisted": persisted,
+                "event_types": [event[0] for event in events],
+            }
+        )
+    finally:
+        host.close()
 
 
 def _json_lines(out: io.StringIO) -> list[dict]:
@@ -155,6 +284,123 @@ def _record_finalize(monkeypatch, events: list[str], *sids: str) -> None:
 def _register_turn(host: ComputeHost, fn, sid: str = "s1") -> None:
     """Submit a turn exactly the way ``_handle_turn_start`` does."""
     host._track_turn_future(host._executor.submit(fn), sid)
+
+
+def test_compute_host_refreshes_and_clears_handler_on_existing_child_session():
+    child_session = {
+        "required_prompt_handler": None,
+        "history_lock": threading.Lock(),
+    }
+    fake_server = SimpleNamespace(_sessions={"ios-ui": child_session})
+    host = ComputeHost(stdout=io.StringIO(), heartbeat_secs=0)
+    try:
+        first = host._ensure_server_session(
+            fake_server,
+            {
+                "sid": "ios-ui",
+                "required_prompt_handler": "hoppe_ocr_approval",
+            },
+        )
+        assert first["required_prompt_handler"] == "hoppe_ocr_approval"
+
+        second = host._ensure_server_session(
+            fake_server,
+            {"sid": "ios-ui", "required_prompt_handler": None},
+        )
+        assert second["required_prompt_handler"] is None
+    finally:
+        host.close()
+
+
+def test_isolated_required_image_is_blocked_before_agent_execution(tmp_path):
+    """The serialized turn must retain fail-closed OCR policy in the child."""
+    image_path = tmp_path / "protected.png"
+    image_path.write_bytes(b"image")
+    parent_session = {
+        "session_key": "stored-ios",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "attached_images": [str(image_path)],
+        "cols": 80,
+        "cwd": str(tmp_path),
+        "source": "ios",
+        "required_prompt_handler": "hoppe_ocr_approval",
+    }
+    frame = server._compute_host_turn_frame(
+        "isolated-image", "ios-ui", parent_session, "Bitte prüfen"
+    )
+    ctx = multiprocessing.get_context("spawn")
+    result_queue = ctx.Queue()
+    process = ctx.Process(target=_isolated_ocr_probe, args=(frame, result_queue))
+    process.start()
+    process.join(timeout=15)
+    if process.is_alive():
+        process.terminate()
+        process.join(timeout=5)
+        pytest.fail("isolated OCR probe timed out")
+
+    assert process.exitcode == 0
+    result = result_queue.get(timeout=2)
+    assert result["initial_handler"] == "hoppe_ocr_approval"
+    assert result["cleared_handler"] is None
+    assert result["reasserted_handler"] == "hoppe_ocr_approval"
+    assert result["clear_action"] == "allow"
+    assert result["reassert_action"] == "block"
+    assert result["agent_runs"] == 1
+    assert result["history"][0]["role"] == "user"
+    assert result["history"][1]["role"] == "assistant"
+    assert result["persisted"]
+    assert result["event_types"] == [
+        "message.start",
+        "message.delta",
+        "message.complete",
+    ]
+
+
+@pytest.mark.parametrize("init_fails", [False, True], ids=["normal-init", "fallback"])
+def test_compute_host_new_child_session_retains_required_handler(init_fails):
+    init_calls = []
+    fake_server = SimpleNamespace(
+        _sessions={},
+        _make_agent=lambda *_args, **_kwargs: SimpleNamespace(),
+        _transfer_db_to_agent=lambda *_args: False,
+        _load_show_reasoning=lambda: False,
+        _load_tool_progress_mode=lambda: "all",
+        _sanitize_client_source=lambda value: value,
+    )
+
+    def init_session(sid, key, agent, history, **kwargs):
+        init_calls.append(kwargs)
+        if init_fails:
+            raise RuntimeError("force fallback")
+        fake_server._sessions[sid] = {
+            "agent": agent,
+            "session_key": key,
+            "history": history,
+            "history_lock": threading.Lock(),
+            "required_prompt_handler": kwargs.get("required_prompt_handler"),
+        }
+
+    fake_server._init_session = init_session
+    host = ComputeHost(stdout=io.StringIO(), heartbeat_secs=0)
+    try:
+        session = host._ensure_server_session(
+            fake_server,
+            {
+                "sid": "ios-ui",
+                "session_key": "stored-ios",
+                "required_prompt_handler": "hoppe_ocr_approval",
+                "attached_images": ["/tmp/protected.png"],
+                "source": "ios",
+            },
+        )
+    finally:
+        host.close()
+
+    assert session["required_prompt_handler"] == "hoppe_ocr_approval"
+    if not init_fails:
+        assert init_calls[0]["required_prompt_handler"] == "hoppe_ocr_approval"
 
 
 def test_shutdown_drains_in_flight_turn_before_finalizing_sessions(monkeypatch):

--- a/tests/tui_gateway/test_prompt_dispatch_hooks.py
+++ b/tests/tui_gateway/test_prompt_dispatch_hooks.py
@@ -1,0 +1,196 @@
+"""Behavior contract for the TUI pre-prompt plugin dispatch gate."""
+
+from typing import Any
+
+
+def test_pre_prompt_dispatch_is_a_public_plugin_hook():
+    """Removing the public registration point must break its real consumer."""
+    from hermes_cli.plugins import VALID_HOOKS
+
+    assert "pre_prompt_dispatch" in VALID_HOOKS
+
+
+def test_required_image_turn_blocks_without_matching_directive():
+    """A removed or unloaded required plugin must not expose the image to the agent."""
+    from tui_gateway.prompt_dispatch_hooks import (
+        REQUIRED_HANDLER_UNAVAILABLE_TEXT,
+        resolve_prompt_dispatch_results,
+    )
+
+    decision = resolve_prompt_dispatch_results(
+        [],
+        required_prompt_handler="hoppe_ocr_approval",
+        has_images=True,
+    )
+
+    assert decision.action == "block"
+    assert decision.handler == "hoppe_ocr_approval"
+    assert decision.text == REQUIRED_HANDLER_UNAVAILABLE_TEXT
+    assert decision.reason == "required_prompt_handler_unavailable"
+
+
+def test_required_image_turn_ignores_foreign_and_handlerless_directives():
+    """Only the client-required handler may decide its protected image turn."""
+    from tui_gateway.prompt_dispatch_hooks import (
+        PromptDispatchDecision,
+        resolve_prompt_dispatch_results,
+    )
+
+    decision = resolve_prompt_dispatch_results(
+        [
+            {"action": "allow"},
+            {"action": "respond", "handler": "other", "text": "wrong"},
+            {
+                "action": "respond",
+                "handler": "hoppe_ocr_approval",
+                "text": "Freigabe angelegt",
+                "reason": "ocr_approval_created",
+            },
+        ],
+        required_prompt_handler="hoppe_ocr_approval",
+        has_images=True,
+    )
+
+    assert decision == PromptDispatchDecision(
+        action="respond",
+        handler="hoppe_ocr_approval",
+        text="Freigabe angelegt",
+        reason="ocr_approval_created",
+    )
+
+
+def test_required_image_turn_accepts_matching_explicit_allow():
+    """A matching handler can deliberately release a protected image turn."""
+    from tui_gateway.prompt_dispatch_hooks import resolve_prompt_dispatch_results
+
+    decision = resolve_prompt_dispatch_results(
+        [
+            {"action": "allow", "handler": "hoppe_ocr_approval"},
+            {
+                "action": "respond",
+                "handler": "hoppe_ocr_approval",
+                "text": "too late",
+            },
+        ],
+        required_prompt_handler="hoppe_ocr_approval",
+        has_images=True,
+    )
+
+    assert decision.action == "allow"
+    assert decision.handler == "hoppe_ocr_approval"
+
+
+def test_optional_desktop_image_uses_first_valid_response():
+    """Desktop images retain OCR interception without claiming manual acceptance."""
+    from tui_gateway.prompt_dispatch_hooks import resolve_prompt_dispatch_results
+
+    decision = resolve_prompt_dispatch_results(
+        [
+            None,
+            {"action": "allow"},
+            {"action": "respond", "handler": "", "text": ""},
+            {
+                "action": "respond",
+                "handler": "hoppe_ocr_approval",
+                "text": "Desktop-Inbox",
+            },
+            {
+                "action": "respond",
+                "handler": "later",
+                "text": "must not win",
+            },
+        ],
+        required_prompt_handler=None,
+        has_images=True,
+    )
+
+    assert decision.action == "respond"
+    assert decision.handler == "hoppe_ocr_approval"
+    assert decision.text == "Desktop-Inbox"
+
+
+def test_plain_text_without_directive_allows_agent():
+    """The image-only client policy must not block ordinary iOS text chat."""
+    from tui_gateway.prompt_dispatch_hooks import resolve_prompt_dispatch_results
+
+    decision = resolve_prompt_dispatch_results(
+        [],
+        required_prompt_handler="hoppe_ocr_approval",
+        has_images=False,
+    )
+
+    assert decision.action == "allow"
+
+
+def test_hook_invocation_exposes_only_immutable_public_payload(monkeypatch):
+    """Plugins receive the stable public values, never mutable session internals."""
+    from hermes_cli import lifecycle
+    from tui_gateway.prompt_dispatch_hooks import invoke_pre_prompt_dispatch
+
+    captured: dict[str, Any] = {}
+
+    def capture(name: str, **kwargs: Any) -> list[dict[str, str]]:
+        captured["name"] = name
+        captured.update(kwargs)
+        return [
+            {
+                "action": "respond",
+                "handler": "hoppe_ocr_approval",
+                "text": "Inbox",
+            }
+        ]
+
+    monkeypatch.setattr(lifecycle, "invoke_hook", capture)
+
+    decision = invoke_pre_prompt_dispatch(
+        session_id="ios-ui",
+        session_key="stored-ios",
+        source="ios",
+        text="Kontakt prüfen",
+        attached_images=["/tmp/card.png"],
+        required_prompt_handler="hoppe_ocr_approval",
+    )
+
+    assert decision.action == "respond"
+    assert captured == {
+        "name": "pre_prompt_dispatch",
+        "session_id": "ios-ui",
+        "session_key": "stored-ios",
+        "surface": "tui",
+        "source": "ios",
+        "text": "Kontakt prüfen",
+        "attached_images": ("/tmp/card.png",),
+        "required_prompt_handler": "hoppe_ocr_approval",
+    }
+
+
+def test_hook_dispatch_failure_blocks_only_required_image_turn(monkeypatch):
+    """A host/plugin dispatch failure closes the protected path without breaking text."""
+    from hermes_cli import lifecycle
+    from tui_gateway.prompt_dispatch_hooks import invoke_pre_prompt_dispatch
+
+    monkeypatch.setattr(
+        lifecycle,
+        "invoke_hook",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("broken")),
+    )
+
+    blocked = invoke_pre_prompt_dispatch(
+        session_id="ios-ui",
+        session_key="stored-ios",
+        source="ios",
+        text="Bild",
+        attached_images=["/tmp/card.png"],
+        required_prompt_handler="hoppe_ocr_approval",
+    )
+    allowed = invoke_pre_prompt_dispatch(
+        session_id="ios-ui",
+        session_key="stored-ios",
+        source="ios",
+        text="Hallo",
+        attached_images=[],
+        required_prompt_handler="hoppe_ocr_approval",
+    )
+
+    assert blocked.action == "block"
+    assert allowed.action == "allow"

--- a/tests/tui_gateway/test_prompt_dispatch_hooks.py
+++ b/tests/tui_gateway/test_prompt_dispatch_hooks.py
@@ -1,6 +1,81 @@
 """Behavior contract for the TUI pre-prompt plugin dispatch gate."""
 
+import threading
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
+
+import pytest
+
+from tui_gateway import server
+
+
+class _InlineThread:
+    def __init__(self, target=None, daemon=None, args=(), kwargs=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        if self._target is not None:
+            self._target(*self._args, **self._kwargs)
+
+    def is_alive(self):
+        return False
+
+    def join(self, timeout=None):
+        return None
+
+
+class _RecordingDB:
+    def __init__(self):
+        self.batches = []
+
+    def append_messages_batch(self, session_id, messages, **_kwargs):
+        self.batches.append((session_id, messages))
+        return len(messages)
+
+
+class _FailingDB:
+    def append_messages_batch(self, *_args, **_kwargs):
+        raise RuntimeError("database unavailable")
+
+
+def _worker_session(agent, image_path: Path | None = None):
+    return {
+        "agent": agent,
+        "session_key": "stored-ios",
+        "source": "ios",
+        "required_prompt_handler": "hoppe_ocr_approval",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": True,
+        "attached_images": [str(image_path)] if image_path else [],
+        "image_counter": 1 if image_path else 0,
+        "cols": 80,
+        "slash_worker": None,
+        "show_reasoning": False,
+        "tool_progress_mode": "all",
+        "inflight_turn": None,
+    }
+
+
+@pytest.fixture()
+def worker_env(monkeypatch, tmp_path):
+    events = []
+    monkeypatch.setattr(server.threading, "Thread", _InlineThread)
+    monkeypatch.setattr(server, "_emit", lambda name, sid, payload=None: events.append((name, sid, payload)))
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_apply_pending_model_switch", lambda *_args: None)
+    monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda *_args: None)
+    monkeypatch.setattr(server, "_sync_bot_capabilities", lambda *_args: None)
+    monkeypatch.setattr(server, "_session_cwd", lambda _session: str(tmp_path))
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    monkeypatch.setattr(server, "_emit_settled_session_info", lambda *_args: None)
+    monkeypatch.setattr(server, "record_turn_start", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_retire_turn_marker", lambda *_args: None)
+    return events
 
 
 def test_pre_prompt_dispatch_is_a_public_plugin_hook():
@@ -194,3 +269,155 @@ def test_hook_dispatch_failure_blocks_only_required_image_turn(monkeypatch):
 
     assert blocked.action == "block"
     assert allowed.action == "allow"
+
+
+def test_worker_blocks_required_image_before_agent_and_persists_response(
+    monkeypatch,
+    tmp_path,
+    worker_env,
+):
+    """A missing required handler must become one durable assistant turn."""
+    from tui_gateway.prompt_dispatch_hooks import PromptDispatchDecision
+
+    image_path = tmp_path / "required.png"
+    image_path.write_bytes(b"image")
+    db = _RecordingDB()
+    agent = SimpleNamespace(
+        session_id="stored-ios",
+        _session_db=db,
+        clear_interrupt=lambda: None,
+        run_conversation=lambda *_args, **_kwargs: pytest.fail("agent must not run"),
+    )
+    session = _worker_session(agent, image_path)
+    monkeypatch.setattr(
+        server,
+        "invoke_pre_prompt_dispatch",
+        lambda **_kwargs: PromptDispatchDecision(
+            action="block",
+            handler="hoppe_ocr_approval",
+            text="Freigabe-Handler nicht verfügbar",
+            reason="required_prompt_handler_unavailable",
+        ),
+        raising=False,
+    )
+
+    assert server._run_prompt_submit("rid", "ios-ui", session, "Bitte prüfen")
+
+    assert session["attached_images"] == []
+    assert session["history"] == [
+        {
+            "role": "user",
+            "content": f"Bitte prüfen\n@image:{image_path}",
+        },
+        {"role": "assistant", "content": "Freigabe-Handler nicht verfügbar"},
+    ]
+    assert db.batches == [("stored-ios", session["history"])]
+    assert [event[0] for event in worker_env] == [
+        "message.start",
+        "message.delta",
+        "message.complete",
+    ]
+    assert worker_env[-1][2]["status"] == "complete"
+
+
+def test_worker_uses_matching_hook_response_without_agent(
+    monkeypatch,
+    tmp_path,
+    worker_env,
+):
+    """A plugin response closes the turn before image routing or model work."""
+    from tui_gateway.prompt_dispatch_hooks import PromptDispatchDecision
+
+    image_path = tmp_path / "contact.png"
+    image_path.write_bytes(b"image")
+    db = _RecordingDB()
+    calls = []
+    agent = SimpleNamespace(
+        session_id="stored-ios",
+        _session_db=db,
+        clear_interrupt=lambda: None,
+        run_conversation=lambda *_args, **_kwargs: calls.append("agent"),
+    )
+    session = _worker_session(agent, image_path)
+    monkeypatch.setattr(
+        server,
+        "invoke_pre_prompt_dispatch",
+        lambda **kwargs: (
+            calls.append(("hook", kwargs)),
+            PromptDispatchDecision(
+                action="respond",
+                handler="hoppe_ocr_approval",
+                text="Freigabe angelegt",
+                reason="ocr_approval_created",
+            ),
+        )[1],
+        raising=False,
+    )
+
+    server._run_prompt_submit("rid", "ios-ui", session, "Kontakt prüfen")
+
+    assert [kind for kind, *_rest in calls] == ["hook"]
+    assert calls[0][1]["attached_images"] == [str(image_path)]
+    assert session["history"][-1] == {
+        "role": "assistant",
+        "content": "Freigabe angelegt",
+    }
+    assert len(db.batches) == 1
+    assert worker_env[-1][2]["text"] == "Freigabe angelegt"
+
+
+def test_worker_persistence_failure_never_falls_through_to_agent(
+    monkeypatch,
+    tmp_path,
+    worker_env,
+):
+    """A durable-write failure must close as an error, not leak the protected image."""
+    from tui_gateway.prompt_dispatch_hooks import PromptDispatchDecision
+
+    image_path = tmp_path / "protected.png"
+    image_path.write_bytes(b"image")
+    calls = []
+    agent = SimpleNamespace(
+        session_id="stored-ios",
+        _session_db=_FailingDB(),
+        clear_interrupt=lambda: None,
+        run_conversation=lambda *_args, **_kwargs: calls.append("agent"),
+    )
+    session = _worker_session(agent, image_path)
+    monkeypatch.setattr(
+        server,
+        "invoke_pre_prompt_dispatch",
+        lambda **_kwargs: PromptDispatchDecision(
+            action="respond",
+            handler="hoppe_ocr_approval",
+            text="Freigabe angelegt",
+        ),
+    )
+
+    server._run_prompt_submit("rid", "ios-ui", session, "Kontakt prüfen")
+
+    assert calls == []
+    assert session["history"] == []
+    assert worker_env[-1][0] == "message.complete"
+    assert worker_env[-1][2]["status"] == "error"
+    assert worker_env[-1][2]["recoverable"] is True
+
+
+def test_worker_allows_plain_text_to_reach_agent(monkeypatch, worker_env):
+    """The new dispatch point must preserve ordinary text turns."""
+    calls = []
+    agent = SimpleNamespace(
+        session_id="stored-ios",
+        clear_interrupt=lambda: None,
+        run_conversation=lambda message, **_kwargs: (
+            calls.append(message),
+            {"final_response": "normal", "messages": []},
+        )[1],
+    )
+    session = _worker_session(agent)
+    monkeypatch.setattr(server, "_start_usage_ticker", lambda *_args: (threading.Event(), _InlineThread()))
+
+    server._run_prompt_submit("rid", "ios-ui", session, "Hallo")
+
+    assert calls == ["Hallo"]
+    assert worker_env[-1][2]["text"] == "normal"

--- a/tests/tui_gateway/test_prompt_dispatch_hooks.py
+++ b/tests/tui_gateway/test_prompt_dispatch_hooks.py
@@ -85,12 +85,13 @@ def test_pre_prompt_dispatch_is_a_public_plugin_hook():
     assert "pre_prompt_dispatch" in VALID_HOOKS
 
 
-def test_required_image_turn_blocks_without_matching_directive():
+def test_required_image_turn_blocks_with_generic_english_default(monkeypatch):
     """A removed or unloaded required plugin must not expose the image to the agent."""
-    from tui_gateway.prompt_dispatch_hooks import (
-        REQUIRED_HANDLER_UNAVAILABLE_TEXT,
-        resolve_prompt_dispatch_results,
-    )
+    from agent import i18n
+    from tui_gateway.prompt_dispatch_hooks import resolve_prompt_dispatch_results
+
+    monkeypatch.setenv("HERMES_LANGUAGE", "en")
+    i18n.reset_language_cache()
 
     decision = resolve_prompt_dispatch_results(
         [],
@@ -100,8 +101,33 @@ def test_required_image_turn_blocks_without_matching_directive():
 
     assert decision.action == "block"
     assert decision.handler == "hoppe_ocr_approval"
-    assert decision.text == REQUIRED_HANDLER_UNAVAILABLE_TEXT
+    assert decision.text == (
+        "The required prompt handler is currently unavailable. "
+        "Your attachments were not sent to the agent. Please try again after "
+        "the handler is available."
+    )
     assert decision.reason == "required_prompt_handler_unavailable"
+
+
+def test_required_image_turn_uses_configured_translation(monkeypatch):
+    """Changing the UI language must localize the host-owned refusal."""
+    from agent import i18n
+    from tui_gateway.prompt_dispatch_hooks import resolve_prompt_dispatch_results
+
+    monkeypatch.setenv("HERMES_LANGUAGE", "de")
+    i18n.reset_language_cache()
+
+    decision = resolve_prompt_dispatch_results(
+        [],
+        required_prompt_handler="any_required_handler",
+        has_images=True,
+    )
+
+    assert decision.text == (
+        "Der erforderliche Prompt-Handler ist derzeit nicht verfügbar. "
+        "Ihre Anhänge wurden nicht an den Agenten weitergegeben. Versuchen Sie "
+        "es erneut, sobald der Handler verfügbar ist."
+    )
 
 
 def test_required_image_turn_ignores_foreign_and_handlerless_directives():
@@ -317,6 +343,58 @@ def test_worker_blocks_required_image_before_agent_and_persists_response(
         "message.delta",
         "message.complete",
     ]
+    assert worker_env[-1][2]["status"] == "complete"
+    assert "usage" not in worker_env[-1][2]
+
+
+def test_worker_retries_history_commit_before_persisting(
+    monkeypatch,
+    tmp_path,
+    worker_env,
+):
+    """A concurrent history update must not drop the turn or outrun memory."""
+    from tui_gateway.prompt_dispatch_hooks import PromptDispatchDecision
+
+    image_path = tmp_path / "required.png"
+    image_path.write_bytes(b"image")
+    db = _RecordingDB()
+    agent = SimpleNamespace(
+        session_id="stored-ios",
+        _session_db=db,
+        clear_interrupt=lambda: None,
+        run_conversation=lambda *_args, **_kwargs: pytest.fail("agent must not run"),
+    )
+    session = _worker_session(agent, image_path)
+    concurrent_history = [
+        {"role": "user", "content": "Earlier turn"},
+        {"role": "assistant", "content": "Already handled"},
+    ]
+
+    def update_history_before_response(**_kwargs):
+        with session["history_lock"]:
+            session["history"] = list(concurrent_history)
+            session["history_version"] = 1
+        return PromptDispatchDecision(
+            action="respond",
+            handler="hoppe_ocr_approval",
+            text="Protected intake completed",
+        )
+
+    monkeypatch.setattr(server, "invoke_pre_prompt_dispatch", update_history_before_response)
+
+    server._run_prompt_submit("rid", "ios-ui", session, "Please review")
+
+    new_messages = [
+        {
+            "role": "user",
+            "content": f"Please review\n@image:{image_path}",
+        },
+        {"role": "assistant", "content": "Protected intake completed"},
+    ]
+    assert session["history"] == concurrent_history + new_messages
+    assert session["history_version"] == 2
+    assert db.batches == [("stored-ios", new_messages)]
+    assert worker_env[-1][0] == "message.complete"
     assert worker_env[-1][2]["status"] == "complete"
 
 

--- a/tests/tui_gateway/test_required_prompt_handler_session.py
+++ b/tests/tui_gateway/test_required_prompt_handler_session.py
@@ -1,0 +1,206 @@
+"""Session propagation tests for the client-required pre-prompt handler."""
+
+import pytest
+from types import SimpleNamespace
+
+from tui_gateway import server
+
+
+class _StoredSessionDB:
+    def __init__(self, session_id: str, cwd: str):
+        self.session_id = session_id
+        self.cwd = cwd
+
+    def get_session(self, session_id: str):
+        if session_id != self.session_id:
+            return None
+        return {"id": session_id, "cwd": self.cwd, "message_count": 0}
+
+    def get_session_by_title(self, _title: str):
+        return None
+
+    def resolve_resume_session_id(self, session_id: str) -> str:
+        return session_id
+
+    def assert_resume_safe(self, _session_id: str) -> None:
+        return None
+
+    def reopen_session(self, _session_id: str) -> None:
+        return None
+
+    def get_resume_conversations(self, _session_id: str):
+        return [], []
+
+    def get_messages_as_conversation(self, _session_id: str, **_kwargs):
+        return []
+
+    def get_ancestor_display_prefix(self, _session_id: str):
+        return []
+
+
+def _prepare_resume(monkeypatch, tmp_path, target: str) -> None:
+    monkeypatch.setattr(server, "_sessions", {})
+    monkeypatch.setattr(server, "_get_db", lambda: _StoredSessionDB(target, str(tmp_path)))
+    monkeypatch.setattr(server, "_profile_home", lambda _profile: None)
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_maybe_schedule_auto_continue", lambda *_args: False)
+    monkeypatch.setattr(server, "_schedule_resume_hydration", lambda *_args, **_kwargs: None)
+
+
+def test_session_create_retains_required_prompt_handler(monkeypatch, tmp_path):
+    """Dropping the create parameter would silently remove iOS fail-closed policy."""
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    monkeypatch.setattr(server, "_completion_cwd", lambda _params=None: str(tmp_path))
+
+    response = server._methods["session.create"](
+        "create-required-handler",
+        {
+            "source": "ios",
+            "profile": "router",
+            "required_prompt_handler": "hoppe_ocr_approval",
+        },
+    )
+    sid = response["result"]["session_id"]
+    try:
+        assert server._sessions[sid]["required_prompt_handler"] == "hoppe_ocr_approval"
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_cold_session_resume_retains_required_prompt_handler(monkeypatch, tmp_path):
+    """A backend restart must not discard the iOS-required gate on resume."""
+    target = "stored-ios"
+    _prepare_resume(monkeypatch, tmp_path, target)
+
+    response = server._methods["session.resume"](
+        "resume-required-handler",
+        {
+            "session_id": target,
+            "source": "ios",
+            "profile": "router",
+            "required_prompt_handler": "hoppe_ocr_approval",
+        },
+    )
+
+    sid = response["result"]["session_id"]
+    assert server._sessions[sid]["required_prompt_handler"] == "hoppe_ocr_approval"
+
+
+@pytest.mark.parametrize(
+    "resume_mode",
+    [
+        {"lazy": True},
+        {"defer_history": True},
+    ],
+    ids=["lazy-watch", "deferred-history"],
+)
+def test_alternate_session_resume_modes_retain_required_prompt_handler(
+    monkeypatch,
+    tmp_path,
+    resume_mode,
+):
+    """Alternate cold-resume branches must preserve the same iOS policy."""
+    target = "stored-ios-alternate"
+    _prepare_resume(monkeypatch, tmp_path, target)
+    params = {
+        "session_id": target,
+        "source": "ios",
+        "profile": "router",
+        "required_prompt_handler": "hoppe_ocr_approval",
+        **resume_mode,
+    }
+
+    response = server._methods["session.resume"]("resume-alternate", params)
+
+    sid = response["result"]["session_id"]
+    assert server._sessions[sid]["required_prompt_handler"] == "hoppe_ocr_approval"
+
+
+def test_live_session_resume_refreshes_required_prompt_handler(monkeypatch, tmp_path):
+    """Reconnect must reassert policy even when Hermes reuses a live session."""
+    target = "stored-ios-live"
+    _prepare_resume(monkeypatch, tmp_path, target)
+    record = server._deferred_session_record(
+        target,
+        cols=80,
+        cwd=str(tmp_path),
+        history=[],
+        lease=None,
+        source="ios",
+    )
+    server._sessions["live-ios-ui"] = record
+
+    response = server._methods["session.resume"](
+        "resume-live-required-handler",
+        {
+            "session_id": target,
+            "source": "ios",
+            "profile": "router",
+            "required_prompt_handler": "hoppe_ocr_approval",
+        },
+    )
+
+    assert response["result"]["session_id"] == "live-ios-ui"
+    assert record["required_prompt_handler"] == "hoppe_ocr_approval"
+
+
+def test_eager_session_constructor_retains_required_prompt_handler(monkeypatch, tmp_path):
+    """The eager resume constructor must carry the same gate as deferred records."""
+    monkeypatch.setattr(server, "_sessions", {})
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_start_notification_poller", lambda *_args: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args: None)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_schedule_mcp_late_refresh", lambda *_args: None)
+
+    server._init_session(
+        "eager-ios-ui",
+        "stored-ios-eager",
+        SimpleNamespace(model="test"),
+        [],
+        cwd=str(tmp_path),
+        source="ios",
+        required_prompt_handler="hoppe_ocr_approval",
+    )
+
+    assert (
+        server._sessions["eager-ios-ui"]["required_prompt_handler"]
+        == "hoppe_ocr_approval"
+    )
+
+
+def test_eager_session_resume_passes_required_prompt_handler(monkeypatch, tmp_path):
+    """The real eager-resume branch must pass the client policy to its constructor."""
+    target = "stored-ios-eager-resume"
+    _prepare_resume(monkeypatch, tmp_path, target)
+    monkeypatch.setattr(server, "_make_agent", lambda *_args, **_kwargs: SimpleNamespace(model="test"))
+    monkeypatch.setattr(server, "_set_session_context", lambda _target: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_start_notification_poller", lambda *_args: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args: None)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_schedule_mcp_late_refresh", lambda *_args: None)
+    monkeypatch.setattr(server, "_transfer_db_to_agent", lambda *_args: None)
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+
+    response = server._methods["session.resume"](
+        "resume-eager-required-handler",
+        {
+            "session_id": target,
+            "source": "ios",
+            "profile": "router",
+            "required_prompt_handler": "hoppe_ocr_approval",
+            "eager_build": True,
+        },
+    )
+
+    sid = response["result"]["session_id"]
+    assert server._sessions[sid]["required_prompt_handler"] == "hoppe_ocr_approval"

--- a/tests/tui_gateway/test_required_prompt_handler_session.py
+++ b/tests/tui_gateway/test_required_prompt_handler_session.py
@@ -61,12 +61,31 @@ def test_session_create_retains_required_prompt_handler(monkeypatch, tmp_path):
         {
             "source": "ios",
             "profile": "router",
-            "required_prompt_handler": "hoppe_ocr_approval",
+            "required_prompt_handler": "  hoppe_ocr_approval  ",
         },
     )
     sid = response["result"]["session_id"]
     try:
         assert server._sessions[sid]["required_prompt_handler"] == "hoppe_ocr_approval"
+        assert response["result"]["required_prompt_handler"] == "hoppe_ocr_approval"
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_session_create_reports_no_required_prompt_handler(monkeypatch, tmp_path):
+    """An omitted create policy must be acknowledged explicitly as absent."""
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    monkeypatch.setattr(server, "_completion_cwd", lambda _params=None: str(tmp_path))
+
+    response = server._methods["session.create"](
+        "create-without-required-handler",
+        {"source": "ios", "profile": "router"},
+    )
+    sid = response["result"]["session_id"]
+    try:
+        assert response["result"]["required_prompt_handler"] is None
     finally:
         server._sessions.pop(sid, None)
 
@@ -82,12 +101,26 @@ def test_cold_session_resume_retains_required_prompt_handler(monkeypatch, tmp_pa
             "session_id": target,
             "source": "ios",
             "profile": "router",
-            "required_prompt_handler": "hoppe_ocr_approval",
+            "required_prompt_handler": "  hoppe_ocr_approval  ",
         },
     )
 
     sid = response["result"]["session_id"]
     assert server._sessions[sid]["required_prompt_handler"] == "hoppe_ocr_approval"
+    assert response["result"]["required_prompt_handler"] == "hoppe_ocr_approval"
+
+
+def test_cold_session_resume_reports_no_required_prompt_handler(monkeypatch, tmp_path):
+    """Cold resume must distinguish an omitted policy from an old backend."""
+    target = "stored-ios-without-handler"
+    _prepare_resume(monkeypatch, tmp_path, target)
+
+    response = server._methods["session.resume"](
+        "resume-without-required-handler",
+        {"session_id": target, "source": "ios", "profile": "router"},
+    )
+
+    assert response["result"]["required_prompt_handler"] is None
 
 
 @pytest.mark.parametrize(
@@ -140,12 +173,35 @@ def test_live_session_resume_refreshes_required_prompt_handler(monkeypatch, tmp_
             "session_id": target,
             "source": "ios",
             "profile": "router",
-            "required_prompt_handler": "hoppe_ocr_approval",
+            "required_prompt_handler": "  hoppe_ocr_approval  ",
         },
     )
 
     assert response["result"]["session_id"] == "live-ios-ui"
     assert record["required_prompt_handler"] == "hoppe_ocr_approval"
+    assert response["result"]["required_prompt_handler"] == "hoppe_ocr_approval"
+
+
+def test_live_session_resume_reports_no_required_prompt_handler(monkeypatch, tmp_path):
+    """Live resume must explicitly confirm that no policy was requested."""
+    target = "stored-ios-live-without-handler"
+    _prepare_resume(monkeypatch, tmp_path, target)
+    record = server._deferred_session_record(
+        target,
+        cols=80,
+        cwd=str(tmp_path),
+        history=[],
+        lease=None,
+        source="ios",
+    )
+    server._sessions["live-ios-ui"] = record
+
+    response = server._methods["session.resume"](
+        "resume-live-without-required-handler",
+        {"session_id": target, "source": "ios", "profile": "router"},
+    )
+
+    assert response["result"]["required_prompt_handler"] is None
 
 
 def test_eager_session_constructor_retains_required_prompt_handler(monkeypatch, tmp_path):

--- a/tests/tui_gateway/test_required_prompt_handler_session.py
+++ b/tests/tui_gateway/test_required_prompt_handler_session.py
@@ -124,17 +124,25 @@ def test_cold_session_resume_reports_no_required_prompt_handler(monkeypatch, tmp
 
 
 @pytest.mark.parametrize(
-    "resume_mode",
+    ("resume_mode", "required_handler"),
     [
-        {"lazy": True},
-        {"defer_history": True},
+        ({"lazy": True}, "  hoppe_ocr_approval  "),
+        ({"lazy": True}, None),
+        ({"defer_history": True}, "  hoppe_ocr_approval  "),
+        ({"defer_history": True}, None),
     ],
-    ids=["lazy-watch", "deferred-history"],
+    ids=[
+        "lazy-watch-handler",
+        "lazy-watch-null",
+        "deferred-history-handler",
+        "deferred-history-null",
+    ],
 )
 def test_alternate_session_resume_modes_retain_required_prompt_handler(
     monkeypatch,
     tmp_path,
     resume_mode,
+    required_handler,
 ):
     """Alternate cold-resume branches must preserve the same iOS policy."""
     target = "stored-ios-alternate"
@@ -143,14 +151,16 @@ def test_alternate_session_resume_modes_retain_required_prompt_handler(
         "session_id": target,
         "source": "ios",
         "profile": "router",
-        "required_prompt_handler": "hoppe_ocr_approval",
+        "required_prompt_handler": required_handler,
         **resume_mode,
     }
 
     response = server._methods["session.resume"]("resume-alternate", params)
 
     sid = response["result"]["session_id"]
-    assert server._sessions[sid]["required_prompt_handler"] == "hoppe_ocr_approval"
+    expected = "hoppe_ocr_approval" if required_handler else None
+    assert server._sessions[sid]["required_prompt_handler"] == expected
+    assert response["result"]["required_prompt_handler"] == expected
 
 
 def test_live_session_resume_refreshes_required_prompt_handler(monkeypatch, tmp_path):
@@ -231,7 +241,17 @@ def test_eager_session_constructor_retains_required_prompt_handler(monkeypatch, 
     )
 
 
-def test_eager_session_resume_passes_required_prompt_handler(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    ("required_handler", "expected"),
+    [
+        ("  hoppe_ocr_approval  ", "hoppe_ocr_approval"),
+        (None, None),
+    ],
+    ids=["handler", "null"],
+)
+def test_eager_session_resume_passes_required_prompt_handler(
+    monkeypatch, tmp_path, required_handler, expected
+):
     """The real eager-resume branch must pass the client policy to its constructor."""
     target = "stored-ios-eager-resume"
     _prepare_resume(monkeypatch, tmp_path, target)
@@ -253,10 +273,57 @@ def test_eager_session_resume_passes_required_prompt_handler(monkeypatch, tmp_pa
             "session_id": target,
             "source": "ios",
             "profile": "router",
-            "required_prompt_handler": "hoppe_ocr_approval",
+            "required_prompt_handler": required_handler,
             "eager_build": True,
         },
     )
 
     sid = response["result"]["session_id"]
-    assert server._sessions[sid]["required_prompt_handler"] == "hoppe_ocr_approval"
+    assert server._sessions[sid]["required_prompt_handler"] == expected
+    assert response["result"]["required_prompt_handler"] == expected
+
+
+def test_eager_resume_race_reasserts_handler_on_concurrent_live_winner(
+    monkeypatch, tmp_path
+):
+    """A concurrent eager winner must use the same reconnect contract."""
+    target = "stored-ios-eager-race"
+    _prepare_resume(monkeypatch, tmp_path, target)
+    winner = server._deferred_session_record(
+        target,
+        cols=80,
+        cwd=str(tmp_path),
+        history=[],
+        lease=None,
+        source="ios",
+        required_prompt_handler=None,
+    )
+    closed = []
+
+    class _RedundantAgent:
+        def close(self):
+            closed.append(True)
+
+    def build_then_lose_race(*_args, **_kwargs):
+        server._sessions["winner-ui"] = winner
+        return _RedundantAgent()
+
+    monkeypatch.setattr(server, "_make_agent", build_then_lose_race)
+    monkeypatch.setattr(server, "_set_session_context", lambda _target: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+
+    response = server._methods["session.resume"](
+        "resume-eager-race",
+        {
+            "session_id": target,
+            "source": "ios",
+            "profile": "router",
+            "required_prompt_handler": "  hoppe_ocr_approval  ",
+            "eager_build": True,
+        },
+    )
+
+    assert response["result"]["session_id"] == "winner-ui"
+    assert response["result"]["required_prompt_handler"] == "hoppe_ocr_approval"
+    assert winner["required_prompt_handler"] == "hoppe_ocr_approval"
+    assert closed == [True]

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any, Callable, Collection
 
 from agent.interrupt_compat import request_hard_interrupt
+from tui_gateway.prompt_dispatch_hooks import normalize_required_prompt_handler
 
 
 def now_ns() -> int:
@@ -525,9 +526,13 @@ class ComputeHost:
     def _ensure_server_session(self, server: Any, frame: dict[str, Any]) -> dict:
         sid = str(frame.get("sid") or "")
         key = str(frame.get("session_key") or sid)
+        required_prompt_handler = normalize_required_prompt_handler(
+            frame.get("required_prompt_handler")
+        )
         session = server._sessions.get(sid)
         if session is not None:
             session["transport"] = self._transport
+            session["required_prompt_handler"] = required_prompt_handler
             if frame.get("cols") is not None:
                 session["cols"] = int(frame.get("cols") or 80)
             if frame.get("cwd"):
@@ -598,6 +603,7 @@ class ComputeHost:
                     cwd=str(frame.get("cwd") or "") or None,
                     session_db=session_db,
                     source=frame.get("source"),
+                    required_prompt_handler=required_prompt_handler,
                 )
             finally:
                 reset_transport(token)
@@ -626,10 +632,12 @@ class ComputeHost:
                 "tool_started_at": {},
                 "model_override": frame.get("model_override"),
                 "source": server._sanitize_client_source(frame.get("source")),
+                "required_prompt_handler": required_prompt_handler,
                 "transport": self._transport,
             }
         session = server._sessions[sid]
         session["transport"] = self._transport
+        session["required_prompt_handler"] = required_prompt_handler
         session["profile_home"] = profile_home or session.get("profile_home")
         if isinstance(frame.get("attached_images"), list):
             session["attached_images"] = list(frame.get("attached_images") or [])

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -136,6 +136,7 @@ def _(rid, params: dict) -> dict:
         {
             "session_id": sid,
             "stored_session_id": key,
+            "required_prompt_handler": required_prompt_handler,
             "message_count": len(history),
             "messages": _history_to_messages(history),
             "info": {
@@ -676,6 +677,7 @@ def _(rid, params: dict) -> dict:
             payload = {
                 "session_id": sid,
                 "resumed": target,
+                "required_prompt_handler": required_prompt_handler,
                 "message_count": len(raw_history) if omit_messages else len(messages),
                 "messages": messages,
                 "messages_omitted": omit_messages,

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -524,6 +524,7 @@ def _(rid, params: dict) -> dict:
                 {
                     "session_id": sid,
                     "resumed": target,
+                    "required_prompt_handler": required_prompt_handler,
                     "message_count": len(display_history) if omit_messages else len(messages),
                     "messages": messages,
                     "messages_omitted": omit_messages,
@@ -586,6 +587,7 @@ def _(rid, params: dict) -> dict:
                 {
                     "session_id": sid,
                     "resumed": target,
+                    "required_prompt_handler": required_prompt_handler,
                     "message_count": record["resume_message_count"],
                     "messages": [],
                     "hydrating": True,
@@ -778,17 +780,7 @@ def _(rid, params: dict) -> dict:
                     pass
                 if lease is not None:
                     lease.release()
-                other_sid, other_session = live
-                payload = _live_session_payload(
-                    other_sid,
-                    other_session,
-                    cols=cols,
-                    touch=True,
-                    transport=current_transport() or _stdio_transport,
-                    omit_messages=omit_messages,
-                )
-                payload["resumed"] = target
-                return _ok(rid, payload)
+                return _ok(rid, _reuse_live_payload(*live))
             try:
                 init_home_token = (
                     set_hermes_home_override(str(profile_home))
@@ -889,6 +881,7 @@ def _(rid, params: dict) -> dict:
     payload = {
         "session_id": sid,
         "resumed": target,
+        "required_prompt_handler": required_prompt_handler,
         "message_count": len(raw_history) if omit_messages else len(messages),
         "messages": messages,
         "messages_omitted": omit_messages,

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -33,6 +33,11 @@ def _(rid, params: dict) -> dict:
         explicit_cwd = False
     resolved_cwd = _completion_cwd(params)
     source = _resolve_session_source(str(params.get("source") or "").strip() or None)
+    from tui_gateway.prompt_dispatch_hooks import normalize_required_prompt_handler
+
+    required_prompt_handler = normalize_required_prompt_handler(
+        params.get("required_prompt_handler")
+    )
     _enable_gateway_prompts()
 
     # ``profile`` (app-global remote mode): a new chat started under a non-launch
@@ -100,6 +105,7 @@ def _(rid, params: dict) -> dict:
             "pending_title": title or None,
             "pending_hidden": is_truthy_value(params.get("hidden", False)),
             "profile_home": str(profile_home) if profile_home is not None else None,
+            "required_prompt_handler": required_prompt_handler,
             "running": False,
             "session_key": key,
             "show_reasoning": _load_show_reasoning(),
@@ -318,6 +324,11 @@ def _(rid, params: dict) -> dict:
     profile = (params.get("profile") or "").strip() or None
     profile_home = _profile_home(profile)
     defer_history = is_truthy_value(params.get("defer_history", False))
+    from tui_gateway.prompt_dispatch_hooks import normalize_required_prompt_handler
+
+    required_prompt_handler = normalize_required_prompt_handler(
+        params.get("required_prompt_handler")
+    )
     # Desktop hydrates persisted transcripts through the authenticated REST
     # route in parallel. Suppress the duplicate WebSocket transcript only when
     # the caller explicitly requests it; other clients keep upstream behavior.
@@ -416,6 +427,10 @@ def _(rid, params: dict) -> dict:
         )
 
         def _reuse_live_payload(sid: str, session: dict) -> dict:
+            # The handler policy is transport/client-owned rather than durable
+            # conversation state. Reconnects reassert (or clear) it before the
+            # reused session can accept another turn.
+            session["required_prompt_handler"] = required_prompt_handler
             payload = _live_session_payload(
                 sid,
                 session,
@@ -482,6 +497,7 @@ def _(rid, params: dict) -> dict:
                 close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
                 profile_home=profile_home,
                 lazy=True,
+                required_prompt_handler=required_prompt_handler,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
                 return _ok(rid, _reuse_live_payload(*live))
@@ -550,6 +566,7 @@ def _(rid, params: dict) -> dict:
                 profile_home=profile_home,
                 model_override=overrides.get("model_override"),
                 resume_runtime_overrides=overrides or None,
+                required_prompt_handler=required_prompt_handler,
             )
             record["resume_history_ready"] = threading.Event()
             record["resume_hydrating"] = True
@@ -646,6 +663,7 @@ def _(rid, params: dict) -> dict:
                 profile_home=profile_home,
                 model_override=overrides.get("model_override"),
                 resume_runtime_overrides=overrides or None,
+                required_prompt_handler=required_prompt_handler,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
                 return _ok(rid, _reuse_live_payload(*live))
@@ -790,6 +808,7 @@ def _(rid, params: dict) -> dict:
                         cwd=profile_resume_cwd,
                         session_db=db,
                         source=source,
+                        required_prompt_handler=required_prompt_handler,
                     )
                     # Ownership TRANSFER — the registered session's agent now
                     # holds this handle for its whole life, and _init_session

--- a/tui_gateway/prompt_dispatch_hooks.py
+++ b/tui_gateway/prompt_dispatch_hooks.py
@@ -1,0 +1,135 @@
+"""Stable plugin contract for pre-agent TUI prompt dispatch decisions.
+
+The resolver is intentionally independent of TUI server internals. Plugins see
+only immutable public values, while the gateway keeps ownership of session
+state, history persistence, and event delivery.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Iterable, Literal, Sequence
+
+
+logger = logging.getLogger(__name__)
+
+REQUIRED_HANDLER_UNAVAILABLE_TEXT = (
+    "Das erforderliche OCR-Freigabe-Gate ist momentan nicht verfügbar. "
+    "Das Bild wurde nicht an einen Agenten weitergegeben. Bitte versuche es "
+    "nach der technischen Prüfung erneut."
+)
+
+
+@dataclass(frozen=True)
+class PromptDispatchDecision:
+    """Validated host-side outcome of all pre-prompt plugin callbacks."""
+
+    action: Literal["allow", "respond", "block"]
+    handler: str | None = None
+    text: str = ""
+    reason: str = ""
+
+
+def normalize_required_prompt_handler(value: Any) -> str | None:
+    """Normalize the optional opaque handler id carried by a live session."""
+
+    handler = str(value or "").strip()
+    return handler or None
+
+
+def resolve_prompt_dispatch_results(
+    results: Iterable[Any],
+    *,
+    required_prompt_handler: str | None,
+    has_images: bool,
+) -> PromptDispatchDecision:
+    """Validate plugin results and enforce a required image handler.
+
+    Required image turns accept only a directive from the exact handler named
+    by the client. Optional turns prefer the first valid response so a generic
+    handlerless ``allow`` cannot mask a later image consumer.
+    """
+
+    required_handler = normalize_required_prompt_handler(required_prompt_handler)
+    required_image_turn = bool(required_handler and has_images)
+    optional_allow: PromptDispatchDecision | None = None
+
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        action = str(result.get("action") or "").strip().lower()
+        if action not in {"allow", "respond"}:
+            continue
+        handler = normalize_required_prompt_handler(result.get("handler"))
+        if required_image_turn and handler != required_handler:
+            continue
+        reason = str(result.get("reason") or "").strip()
+
+        if action == "allow":
+            decision = PromptDispatchDecision(
+                action="allow",
+                handler=handler,
+                reason=reason,
+            )
+            if required_image_turn:
+                return decision
+            if optional_allow is None:
+                optional_allow = decision
+            continue
+
+        text = str(result.get("text") or "").strip()
+        if not text:
+            continue
+        return PromptDispatchDecision(
+            action="respond",
+            handler=handler,
+            text=text,
+            reason=reason,
+        )
+
+    if required_image_turn:
+        return PromptDispatchDecision(
+            action="block",
+            handler=required_handler,
+            text=REQUIRED_HANDLER_UNAVAILABLE_TEXT,
+            reason="required_prompt_handler_unavailable",
+        )
+    return optional_allow or PromptDispatchDecision(action="allow")
+
+
+def invoke_pre_prompt_dispatch(
+    *,
+    session_id: str,
+    session_key: str,
+    source: str,
+    text: Any,
+    attached_images: Sequence[str],
+    required_prompt_handler: str | None,
+) -> PromptDispatchDecision:
+    """Invoke plugins with public immutable data and resolve their directives."""
+
+    images = tuple(str(path) for path in attached_images)
+    required_handler = normalize_required_prompt_handler(required_prompt_handler)
+    try:
+        from hermes_cli.lifecycle import invoke_hook
+
+        results = invoke_hook(
+            "pre_prompt_dispatch",
+            session_id=str(session_id),
+            session_key=str(session_key),
+            surface="tui",
+            source=str(source or "tui"),
+            text=text if isinstance(text, str) else str(text),
+            attached_images=images,
+            required_prompt_handler=required_handler,
+        )
+    except Exception:
+        logger.warning("pre_prompt_dispatch hook invocation failed", exc_info=True)
+        results = []
+
+    return resolve_prompt_dispatch_results(
+        results,
+        required_prompt_handler=required_handler,
+        has_images=bool(images),
+    )

--- a/tui_gateway/prompt_dispatch_hooks.py
+++ b/tui_gateway/prompt_dispatch_hooks.py
@@ -11,13 +11,15 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Iterable, Literal, Sequence
 
+from agent.i18n import t
+
 
 logger = logging.getLogger(__name__)
 
-REQUIRED_HANDLER_UNAVAILABLE_TEXT = (
-    "Das erforderliche OCR-Freigabe-Gate ist momentan nicht verfügbar. "
-    "Das Bild wurde nicht an einen Agenten weitergegeben. Bitte versuche es "
-    "nach der technischen Prüfung erneut."
+_REQUIRED_HANDLER_UNAVAILABLE_KEY = "gateway.required_prompt_handler_unavailable"
+REQUIRED_HANDLER_UNAVAILABLE_TEXT = t(
+    _REQUIRED_HANDLER_UNAVAILABLE_KEY,
+    lang="en",
 )
 
 
@@ -92,7 +94,7 @@ def resolve_prompt_dispatch_results(
         return PromptDispatchDecision(
             action="block",
             handler=required_handler,
-            text=REQUIRED_HANDLER_UNAVAILABLE_TEXT,
+            text=t(_REQUIRED_HANDLER_UNAVAILABLE_KEY),
             reason="required_prompt_handler_unavailable",
         )
     return optional_allow or PromptDispatchDecision(action="allow")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8769,6 +8769,7 @@ def _live_session_payload(
         "message_count": len(history),
         "messages": [] if omit_messages else _history_to_messages(history),
         "messages_omitted": omit_messages,
+        "required_prompt_handler": session.get("required_prompt_handler"),
         "running": running,
         "turn_started_at": turn_started_at,
         "session_id": sid,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7027,6 +7027,7 @@ def _init_session(
     session_db=None,
     source: str | None = None,
     profile_home: str | None = None,
+    required_prompt_handler: str | None = None,
 ):
     now = time.time()
     with _sessions_lock:
@@ -7054,6 +7055,7 @@ def _init_session(
             # launch profile. SessionBranch copies the parent's value so the
             # child stays on the same state.db.
             "profile_home": profile_home,
+            "required_prompt_handler": required_prompt_handler,
             # Per-session model override set by an in-session /model switch.
             # Honored on rebuild (/new, resume) so a switch in THIS session
             # never leaks into siblings via process-global env vars.
@@ -8388,6 +8390,7 @@ def _deferred_session_record(
     lazy: bool = False,
     model_override=None,
     resume_runtime_overrides: dict | None = None,
+    required_prompt_handler: str | None = None,
 ) -> dict:
     """A live-session record whose AIAgent is built later (lazy watch / cold
     resume) — _init_session's shape minus the agent."""
@@ -8415,6 +8418,7 @@ def _deferred_session_record(
         "model_override": model_override,
         "pending_title": None,
         "profile_home": str(profile_home) if profile_home is not None else None,
+        "required_prompt_handler": required_prompt_handler,
         "resume_runtime_overrides": resume_runtime_overrides,
         "resume_session_id": session_key,
         "running": False,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -38,6 +38,7 @@ from agent.replay_cleanup import sanitize_replay_history
 from agent.skill_commands import describe_skill_invocation
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from tui_gateway import git_probe
+from tui_gateway.prompt_dispatch_hooks import invoke_pre_prompt_dispatch
 from tui_gateway.turn_marker import (
     clear_turn_marker,
     read_turn_marker,
@@ -10470,6 +10471,67 @@ def _start_usage_ticker(
     return stop, thread
 
 
+def _complete_prompt_dispatch_response(
+    sid: str,
+    session: dict,
+    agent,
+    *,
+    user_text: Any,
+    images: list[str],
+    response_text: str,
+    history: list[dict],
+    history_version: int,
+    marker_key: str,
+    display_kind: str | None = None,
+    display_metadata: dict | None = None,
+) -> dict:
+    """Persist and emit a plugin-owned response without invoking the agent."""
+
+    clean_user_text = user_text if isinstance(user_text, str) else str(user_text)
+    persisted_user = _build_persist_message_with_image_refs(clean_user_text, images)
+    user_entry: dict[str, Any] = {"role": "user", "content": persisted_user}
+    if display_kind:
+        user_entry["display_kind"] = display_kind
+        if display_metadata:
+            user_entry["display_metadata"] = display_metadata
+    assistant_entry = {"role": "assistant", "content": response_text}
+    messages = [user_entry, assistant_entry]
+
+    db = getattr(agent, "_session_db", None)
+    if db is not None:
+        db.append_messages_batch(session["session_key"], messages)
+    else:
+        with _session_db(session) as scoped_db:
+            if scoped_db is None:
+                raise RuntimeError("prompt dispatch response persistence unavailable")
+            scoped_db.append_messages_batch(session["session_key"], messages)
+
+    with session["history_lock"]:
+        if int(session.get("history_version", 0)) != history_version:
+            raise RuntimeError("history changed during prompt dispatch")
+        session["history"] = [*history, *messages]
+        session["history_version"] = history_version + 1
+        _clear_inflight_turn(session)
+
+    if response_text:
+        _emit("message.delta", sid, {"text": response_text})
+    payload = {
+        "text": response_text,
+        "usage": _get_usage(agent),
+        "status": "complete",
+    }
+    rendered = render_message(response_text, session.get("cols", 80))
+    if rendered:
+        payload["rendered"] = rendered
+    _retire_turn_marker(session, marker_key)
+    _emit("message.complete", sid, payload)
+    return {
+        "final_response": response_text,
+        "messages": session["history"],
+        "prompt_dispatch_response": True,
+    }
+
+
 def _run_prompt_submit(
     rid,
     sid: str,
@@ -10609,6 +10671,29 @@ def _run_prompt_submit(
             with session["history_lock"]:
                 history = list(session["history"])
                 history_version = int(session.get("history_version", 0))
+            dispatch_decision = invoke_pre_prompt_dispatch(
+                session_id=sid,
+                session_key=session.get("session_key") or sid,
+                source=_session_source(session),
+                text=text,
+                attached_images=images,
+                required_prompt_handler=session.get("required_prompt_handler"),
+            )
+            if dispatch_decision.action in {"respond", "block"}:
+                result = _complete_prompt_dispatch_response(
+                    sid,
+                    session,
+                    agent,
+                    user_text=text,
+                    images=images,
+                    response_text=dispatch_decision.text,
+                    history=history,
+                    history_version=history_version,
+                    marker_key=marker_key,
+                    display_kind=display_kind,
+                    display_metadata=display_metadata,
+                )
+                return
             cwd = _session_cwd(session)
             _register_session_cwd(session)
             cols = session.get("cols", 80)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -38,7 +38,10 @@ from agent.replay_cleanup import sanitize_replay_history
 from agent.skill_commands import describe_skill_invocation
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from tui_gateway import git_probe
-from tui_gateway.prompt_dispatch_hooks import invoke_pre_prompt_dispatch
+from tui_gateway.prompt_dispatch_hooks import (
+    invoke_pre_prompt_dispatch,
+    normalize_required_prompt_handler,
+)
 from tui_gateway.turn_marker import (
     clear_turn_marker,
     read_turn_marker,
@@ -1785,6 +1788,9 @@ def _compute_host_turn_frame(
         "reasoning_config_override": session.get("create_reasoning_override"),
         "service_tier_override": session.get("create_service_tier_override"),
         "source": _session_source(session),
+        "required_prompt_handler": normalize_required_prompt_handler(
+            session.get("required_prompt_handler")
+        ),
         "attached_images": attached_images,
         "queued_prompt_generation": queued_prompt_generation,
     }

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10505,26 +10505,31 @@ def _complete_prompt_dispatch_response(
     messages = [user_entry, assistant_entry]
 
     db = getattr(agent, "_session_db", None)
-    if db is not None:
-        db.append_messages_batch(session["session_key"], messages)
-    else:
-        with _session_db(session) as scoped_db:
-            if scoped_db is None:
-                raise RuntimeError("prompt dispatch response persistence unavailable")
-            scoped_db.append_messages_batch(session["session_key"], messages)
-
-    with session["history_lock"]:
-        if int(session.get("history_version", 0)) != history_version:
-            raise RuntimeError("history changed during prompt dispatch")
-        session["history"] = [*history, *messages]
-        session["history_version"] = history_version + 1
-        _clear_inflight_turn(session)
+    db_context = contextlib.nullcontext(db) if db is not None else _session_db(session)
+    with db_context as scoped_db:
+        if scoped_db is None:
+            raise RuntimeError("prompt dispatch response persistence unavailable")
+        while True:
+            with session["history_lock"]:
+                current_version = int(session.get("history_version", 0))
+                if current_version != history_version:
+                    # Match the compaction path's optimistic guard: discard the
+                    # stale snapshot and retry against the current history. Do
+                    # this before persistence so the DB can never get ahead of
+                    # the in-memory history on a version miss.
+                    history = list(session["history"])
+                    history_version = current_version
+                    continue
+                scoped_db.append_messages_batch(session["session_key"], messages)
+                session["history"] = [*history, *messages]
+                session["history_version"] = history_version + 1
+                _clear_inflight_turn(session)
+                break
 
     if response_text:
         _emit("message.delta", sid, {"text": response_text})
     payload = {
         "text": response_text,
-        "usage": _get_usage(agent),
         "status": "complete",
     }
     rendered = render_message(response_text, session.get("cols", 80))

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -462,6 +462,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `subagent_start` | Observer | Child constructed and about to run; return ignored. | `parent_session_id`, `parent_turn_id`, `parent_subagent_id`, `child_session_id`, `child_subagent_id`, `child_role`, `child_goal` | Child goal may contain user/project content. |
 | `subagent_stop` | Observer | Child exit; return ignored. | `parent_session_id`, `parent_turn_id`, `child_session_id`, `child_role`, `child_summary`, `child_status`, `tool_call_history`, `duration_ms` | Summary and redacted tool-history metadata may reveal project structure. |
 | `pre_gateway_dispatch` | Directive/control | Incoming non-internal message before auth/pairing/dispatch; first valid `skip`, `rewrite`, or `allow` controls flow. | `event`, `gateway`, `session_store` | Extremely privileged in-process objects expose inbound user/routing data and host handles. |
+| `pre_prompt_dispatch` | Directive/control | TUI/Desktop turn worker after attached-image snapshotting and before image routing or agent dispatch; first valid scoped `respond` wins, while a client-required image handler fails closed without a matching `allow` or `respond`. Python plugins only. | `session_id`, `session_key`, `surface`, `source`, `text`, `attached_images`, `required_prompt_handler` | Raw user text and local image paths; no server, session, gateway, or agent objects. |
 | `gateway_platform_event` | Observer | After the gateway's profile-scoped authorization succeeds, when a supported platform-native event is normalized at the gateway boundary (Telegram: reactions, message edits; Discord: message edits/deletes, thread created/renamed); return ignored. | `platform`, `event_type`, `payload` (event-type-specific dict — see the per-event contracts below) | Normalized plain-dict envelope only; raw SDK objects, adapter handles, and bot clients are never exposed. |
 | `pre_command` | Observer | Recognized slash command about to be dispatched, before the handler runs, on CLI and gateway cold-path dispatch; return ignored in v1 (directive-shaped dicts are logged at debug). Gateway running-agent intercept commands (`/stop`, `/approve` during an active run) are deliberately excluded — control-plane escape hatches must stay outside plugin reach. | `surface` (`"cli"` \| `"gateway"`), `command` (canonical name), `alias_used`, `args_raw`, `session_key`, `platform` | `args_raw` may contain user content or secrets typed after the command. |
 | `pre_approval_request` | Observer | Before prompted or smart approval; return ignored. | `command`, `description`, `pattern_key`, `pattern_keys`, `session_key`, `surface`, `turn_id`, `tool_call_id` | Command may contain secrets; smart observer preparation force-redacts, but surfaces do not all have identical redaction. |
@@ -1221,6 +1222,63 @@ def buffer_or_rewrite(event, **kwargs):
 def register(ctx):
     ctx.register_hook("pre_gateway_dispatch", buffer_or_rewrite)
 ```
+
+---
+
+### `pre_prompt_dispatch`
+
+Fires once on the TUI/Desktop turn worker after Hermes atomically snapshots
+and clears `attached_images`, but before provider-specific image routing or
+`agent.run_conversation`. The RPC reader is therefore not blocked by plugin
+work. This hook is intended for deterministic prompt gates that must complete
+before an agent sees the turn.
+
+**Callback signature:**
+
+```python
+def my_callback(
+    session_id,
+    session_key,
+    surface,
+    source,
+    text,
+    attached_images,
+    required_prompt_handler,
+    **kwargs,
+):
+```
+
+`attached_images` is an immutable tuple of local paths. `surface` is `"tui"`;
+`source` retains the session origin such as `"ios"`, `"desktop"`, or `"tui"`.
+No live server, session, gateway, transport, or agent object is exposed.
+
+Callbacks may return `None`, an explicit allow directive, or a response:
+
+```python
+return {
+    "action": "respond",
+    "handler": "example_gate",
+    "text": "The protected intake completed.",
+    "reason": "intake_complete",
+}
+```
+
+| Return | Effect |
+|--------|--------|
+| `None` | Decline this turn. |
+| `{"action": "allow", "handler": "example_gate"}` | Permit normal agent dispatch. A client-required image turn accepts this only from the exact required handler. |
+| `{"action": "respond", "handler": "example_gate", "text": "..."}` | Persist and deliver the text through normal TUI history/events without calling the agent. `text` must be non-empty. |
+
+All callbacks run with isolated failures. Results are resolved in registration
+order. Optional turns use the first valid response; a handlerless `allow`
+cannot hide a later response consumer. When an image turn declares
+`required_prompt_handler`, only an exact handler match is actionable. If no
+matching directive remains after callback failures and validation, Hermes
+returns a local safe error and never calls the agent.
+
+`required_prompt_handler` is session-scoped and must be reasserted by a client
+on `session.create` and `session.resume`; Hermes does not persist it to the
+conversation database.
 
 ---
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -1268,6 +1268,7 @@ return {
 | `None` | Decline this turn. |
 | `{"action": "allow", "handler": "example_gate"}` | Permit normal agent dispatch. A client-required image turn accepts this only from the exact required handler. |
 | `{"action": "respond", "handler": "example_gate", "text": "..."}` | Persist and deliver the text through normal TUI history/events without calling the agent. `text` must be non-empty. |
+| `{"action": "block"}` | Reserved for the host; plugin-supplied `block` directives are ignored. |
 
 All callbacks run with isolated failures. Results are resolved in registration
 order. Optional turns use the first valid response; a handlerless `allow`


### PR DESCRIPTION
## What does this PR do?

Adds a public, fail-closed prompt-dispatch hook for TUI gateway clients that need to handle a prompt before the agent turn begins. A client can require a named handler during session creation or resume, and the gateway persists that requirement for the session.

## Related Issue

No linked issue.

Related work, but not duplicates:

- #32116 adds a pre_system_prompt hook that can modify the system prompt before an LLM call. It does not handle a user prompt, enforce a named handler, or short-circuit the agent turn.
- #34112 registers existing declarative shell hooks in the separate TUI gateway process. It does not define a request-handler contract or persist a required handler across session create/resume.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)

## Changes Made

- Add the public pre_prompt_dispatch lifecycle hook and dispatcher.
- Preserve required_prompt_handler across session create and resume paths.
- Short-circuit before image routing and agent execution when a hook handles the prompt.
- Persist the handled user/assistant exchange and fail closed on missing or failing required handlers.
- Document the hook contract and add focused gateway regression coverage.

## How to Test

1. Run scripts/run_tests.sh tests/tui_gateway/test_prompt_dispatch_hooks.py tests/tui_gateway/test_required_prompt_handler_session.py tests/test_tui_gateway_server.py -q
2. Confirm 604 tests pass with zero failures.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run the entire repository test suite; the complete affected gateway scope passed (604/604)
- [x] I've added tests for my changes
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] cli-config.yaml.example is N/A
- [x] CONTRIBUTING.md and AGENTS.md are N/A
- [x] I've considered cross-platform impact
- [x] Tool descriptions and schemas are N/A

## Screenshots / Logs

Focused canonical runner result: 3 files, 604 tests passed, 0 failed.
