### PR TITLE
fix(bot-mode): disband dialog no longer points at the removed session browser

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -9419,7 +9419,7 @@ function GroupChatWorkspace({ group, members, onBack }) {
             String(members.length),
             ' bots and clears the shared room log. The bots themselves and their “Group: ',
             group,
-            '” sessions are kept — you can still open those from each bot’s session browser.'
+            '” sessions are kept.'
           ]
         }),
         destructive: true,

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-preview.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-preview.test.mjs
@@ -191,8 +191,8 @@ test('render: BotRow renders plain previews without a badge', () => {
   const text = textOf(tree)
   assert.match(text, /All hosts are healthy/)
   assert.doesNotMatch(text, /@manager/)
-  // The inline session-history chip is gone — stored history lives in the
-  // Sessions workspace (context menu), so the title no longer renders inline.
+  // The inline session-history chip is gone — the conversation lives in the
+  // bot's one canonical chat, so the title no longer renders inline.
   assert.doesNotMatch(text, /Weekly review/)
 })
 


### PR DESCRIPTION
## Summary

The Disband-group confirm dialog no longer directs users to the per-bot session browser that #90732 removed.

#90732 dropped the right-click → Sessions browser (Bot Mode's contract is one forever-chat per bot), but the disband dialog's copy still read "…their 'Group: X' sessions are kept — you can still open those from each bot's session browser." That affordance no longer exists, so the sentence now ends at "sessions are kept."

## Changes

- `apps/desktop/src/plugins/hermes-bots/plugin.js`: drop the stale "open those from each bot's session browser" clause from the Disband-group ConfirmDialog.
- `apps/desktop/src/plugins/hermes-bots/tests/roster-preview.test.mjs`: comment referenced the removed Sessions workspace; now points at the canonical chat. Assertion unchanged.

## Validation

| | Result |
|---|---|
| `node --check plugin.js` | clean |
| `node --test` roster-preview + adopt-before-mint + group-chat | 64/64 pass |

Review follow-up from #90732 (surfaced by the post-merge review pass). The remaining non-blocking observations from that review (bare `catch → null` in `findExistingCanonicalChat` minting on transient scan failure; no kickoff when adopting an empty titled fork) were partly addressed by 21e9d4532f's exact-title lookup; the rest ride with the durable-plumbing-marker follow-up already noted in #90732.
