### PR TITLE
fix(state): strip the caller-appended prefix wildcard from CJK queries (#90636)

### DIFF
--- a/contributors/emails/boni.alessandro997@gmail.com
+++ b/contributors/emails/boni.alessandro997@gmail.com
@@ -1,0 +1,2 @@
+sandrohub013
+# CJK search prefix wildcard (#90636)

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1853,6 +1853,19 @@ class SessionSearchMixin:
         is_cjk = self._contains_cjk(query)
         if is_cjk:
             raw_query = query.strip('"').strip()
+            # Drop the trailing prefix wildcard callers append so partial
+            # English words match ("nimb" -> "nimb*"). None of the three CJK
+            # routes below can honour it: the bigram and trigram routes quote
+            # every token before MATCH, so `*` is matched literally, and LIKE
+            # has no `*` wildcard at all (its wildcards are % and _). Left in
+            # place it turns every CJK search coming from the web/desktop
+            # search box into a search for a term ending in a literal
+            # asterisk, which never matches anything (#90636).
+            raw_query = " ".join(
+                token if token.upper() in {"AND", "OR", "NOT"}
+                else (token.rstrip("*") or token)
+                for token in raw_query.split()
+            ) or raw_query
             cjk_count = self._count_cjk(raw_query)
 
             # Per-token CJK length check (#20494): trigram needs >=3 CJK chars

--- a/tests/test_search_cjk_prefix_wildcard.py
+++ b/tests/test_search_cjk_prefix_wildcard.py
@@ -1,0 +1,70 @@
+"""CJK search must survive the prefix wildcard callers append (#90636).
+
+The web/desktop search endpoint turns every unquoted token into ``token*`` so
+partial English words match. The three CJK routes cannot honour that: the
+bigram and trigram routes quote each token before ``MATCH`` (so ``*`` is
+matched literally) and the LIKE route has no ``*`` wildcard at all. Without
+normalization every CJK search typed into the UI searches for a term ending in
+a literal asterisk and returns nothing, while the identical query without the
+star returns rows — which is what makes the bug look like "search is broken
+for Chinese".
+
+These tests run on the LIKE / trigram routes, so they do not need the loadable
+``cjk_unicode61`` tokenizer that ``test_fts_cjk_bigram.py`` builds.
+"""
+
+import pytest
+
+from hermes_state import SessionDB
+
+TWO_CHAR = "秃发"          # 2 CJK chars — below the trigram threshold
+FOUR_CHAR = "秃发应对"      # 4 CJK chars — trigram-eligible
+CONTENT = "秃发应对方案请总结"
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "20260820_000001_cjk001"
+    database.create_session(session_id, "cli")
+    database.append_message(session_id, "user", CONTENT)
+    database.append_message(session_id, "assistant", "hello nimby world")
+    yield database
+    database.close()
+
+
+def _hits(database, query):
+    return database.search_messages(
+        query=query, limit=10, fields=("session_id", "snippet")
+    )
+
+
+@pytest.mark.parametrize("term", [TWO_CHAR, FOUR_CHAR])
+def test_trailing_star_matches_the_bare_query(db, term):
+    """The star must not change the result set — only widen it, never empty it."""
+    bare = _hits(db, term)
+    starred = _hits(db, term + "*")
+    assert bare, f"{term!r} should match the seeded message"
+    assert len(starred) == len(bare), (
+        f"{term + '*'!r} returned {len(starred)} rows vs {len(bare)} for {term!r} — "
+        "the prefix wildcard is being matched literally"
+    )
+
+
+def test_star_is_stripped_per_token_in_boolean_queries(db):
+    """A multi-token CJK OR query keeps working with wildcards on each token."""
+    assert _hits(db, "秃发* OR 桂林*")
+
+
+def test_ascii_prefix_wildcard_still_works(db):
+    """The normalization is CJK-only; English prefix search is untouched."""
+    assert _hits(db, "nimb*")
+
+
+def test_a_lone_star_is_not_turned_into_a_match_all(db):
+    """Stripping must not leave an empty term that matches every row."""
+    assert _hits(db, "*") == []
+
+
+def test_mixed_cjk_and_ascii_query_survives_the_star(db):
+    assert _hits(db, "秃发* nimby*") or _hits(db, "秃发*")


### PR DESCRIPTION
## What does this PR do?

The web/desktop search endpoint appends `*` to every unquoted token so partial English words match (`nimb` → `nimb*`). No CJK route in `search_messages` can honour that wildcard, and all three fail on it differently:

- the **CJK-bigram** route quotes each token before `MATCH`, so `"秃发*"` looks for a term ending in a literal asterisk;
- the **trigram** route quotes tokens the same way, and sets `_trigram_succeeded` on an empty result, so the LIKE fallback never runs;
- the **LIKE** route inside the `is_cjk` branch builds its predicate straight from `raw_query` — unlike `_compile_like_boolean_query`, which does strip `*` — so the executed predicate is `LIKE '%秃发*%'`, and `*` is not a LIKE wildcard.

Net effect: every CJK search typed into the desktop or web search box returns zero results, while the identical query without the star returns rows.

Reproduced on a fresh `SessionDB` on current `main`:

| query | before | after |
|---|---|---|
| `秃发` | 1 row | 1 row |
| `秃发*` | **0 rows** | 1 row |
| `秃发应对` | 1 row | 1 row |
| `秃发应对*` | **0 rows** | 1 row |
| `nimb` / `nimb*` | 1 row | 1 row |

**Scope correction to the issue.** #90636 describes this as a 1–2 character problem routed through the LIKE fallback, and states that queries of 3+ CJK characters work. They don't: the trigram route quotes the token with the star too, so CJK queries of *every* length coming from the search box are affected. The 4-character row above is the evidence.

**Why the fix is in the state layer, not the endpoint.** The issue suggests patching `web_routers/sessions.py` to skip the star for CJK tokens. `search_messages` is a public API and the desktop search box is one caller of several; fixing the router leaves every other caller broken. One normalization at the top of the `is_cjk` branch covers all three routes at once.

Boolean operators (`AND` / `OR` / `NOT`) are left alone, and a token that is nothing but asterisks keeps its original text, so stripping can never produce an empty term that matches every row — `search_messages('*')` still returns nothing.

## Related Issue

Fixes #90636

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_search.py` — in `search_messages`, normalize `raw_query` inside the `is_cjk` branch: strip a trailing `*` per token, preserving boolean operators and guarding the all-asterisk token.
- `tests/test_search_cjk_prefix_wildcard.py` — new file, six cases: both CJK lengths (parametrized), multi-token boolean queries, the untouched ASCII prefix search, the lone-star guard, and a mixed CJK/ASCII query. They exercise the LIKE and trigram routes, so unlike `test_fts_cjk_bigram.py` they need no C toolchain.
- `contributors/emails/boni.alessandro997@gmail.com` — attribution mapping required by the `Contributor Attribution Check` job.

## How to Test

1. `python -m pytest tests/test_search_cjk_prefix_wildcard.py -q` → 6 passed. On `main`, four of the six fail.
2. Manual, against a fresh database:
   ```python
   from hermes_state import SessionDB
   db = SessionDB(db_path="/tmp/state.db")
   db.create_session("20260820_000001_cjk001", "cli")
   db.append_message("20260820_000001_cjk001", "user", "秃发应对方案请总结")
   for q in ("秃发", "秃发*", "秃发应对", "秃发应对*"):
       print(q, len(db.search_messages(query=q, limit=10, fields=("session_id",))))
   ```
   On `main` the starred queries print `0`; here they print `1`.
3. End to end: type a 2-character CJK term into the desktop session search box. Before, no results; after, the sessions containing it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the search and state suites rather than the whole tree: `tests/test_search_cjk_prefix_wildcard.py tests/test_fts_cjk_bigram.py tests/test_search_slow_query_log.py tests/test_fts_update_of_narrowing.py tests/test_hermes_state.py` → **257 passed, 11 skipped** (the skips are the CJK-bigram tokenizer tests, which need gcc).
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.12

### Documentation & Housekeeping

- [x] Documentation — N/A, no user-facing surface changed
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — pure string handling; `scripts/check-windows-footguns.py` clean
- [x] Tool descriptions/schemas — N/A
