### PR TITLE
fix(desktop): show persisted no-agent cron runs

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -20,7 +20,7 @@ import { notify, notifyError } from '@/store/notifications'
 import { $selectedStoredSessionId } from '@/store/session'
 import type { CronJob } from '@/types/hermes'
 
-import { jobState, jobTitle, STATE_DOT } from '../../cron/job-state'
+import { jobState, jobTitle, noAgentRunTime, STATE_DOT } from '../../cron/job-state'
 import { SidebarPanelLabel } from '../../shell/sidebar-label'
 
 import { SidebarRowBody, SidebarRowLabel, SidebarRowLead, SidebarRowShell } from './chrome'
@@ -377,12 +377,12 @@ function CronJobSidebarRow({
           </Tip>
         </SidebarRowShell>
       </ActionsContextMenu>
-      {expanded && <CronJobSidebarRuns jobId={job.id} onOpenRun={onOpenRun} />}
+      {expanded && <CronJobSidebarRuns job={job} onOpenRun={onOpenRun} />}
     </div>
   )
 }
 
-function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (sessionId: string) => void }) {
+function CronJobSidebarRuns({ job, onOpenRun }: { job: CronJob; onOpenRun: (sessionId: string) => void }) {
   const { t } = useI18n()
   const c = t.cron
   const selectedSessionId = useStore($selectedStoredSessionId)
@@ -390,12 +390,13 @@ function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (s
   const cronChangeTick = useStore($cronChangeTick)
   const [runs, setRuns] = useState<null | SessionInfo[]>(null)
   const visible = usePaneVisible()
+  const noAgentRunAt = noAgentRunTime(job)
 
   useEffect(() => {
     let cancelled = false
 
     const load = () =>
-      getCronJobRuns(jobId, PEEK_RUN_LIMIT)
+      getCronJobRuns(job.id, PEEK_RUN_LIMIT)
         .then(result => {
           if (!cancelled) {
             setRuns(result)
@@ -432,13 +433,17 @@ function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (s
       window.clearInterval(intervalId)
     }
     // cronChangeTick: a fired run reloads the peek immediately.
-  }, [changeEventsAvailable, cronChangeTick, jobId, visible])
+  }, [changeEventsAvailable, cronChangeTick, job.id, visible])
 
   return (
     <div className="mb-1 ml-[1.375rem] flex flex-col gap-px">
       {runs === null ? (
         <div className="flex items-center gap-1.5 py-1 pl-1 text-[0.6875rem] text-(--ui-text-tertiary)">
           <GlyphSpinner ariaLabel={c.loading} className="text-[0.75rem]" />
+        </div>
+      ) : runs.length === 0 && noAgentRunAt !== null ? (
+        <div className="py-1 pl-1 text-[0.6875rem] text-(--ui-text-tertiary)">
+          {c.last} {formatRunTime(noAgentRunAt / 1000)}
         </div>
       ) : runs.length === 0 ? (
         <div className="py-1 pl-1 text-[0.6875rem] text-(--ui-text-tertiary)">{c.noRuns}</div>

--- a/apps/desktop/src/app/cron/job-state.test.ts
+++ b/apps/desktop/src/app/cron/job-state.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { noAgentRunTime } from './job-state'
+
+describe('noAgentRunTime', () => {
+  it('returns the persisted execution time for a no-agent cron job', () => {
+    expect(
+      noAgentRunTime({
+        last_run_at: '2026-08-20T08:20:18.088489+09:00',
+        no_agent: true
+      })
+    ).toBe(Date.parse('2026-08-20T08:20:18.088489+09:00'))
+  })
+
+  it('does not treat an agent job or an invalid timestamp as a script execution', () => {
+    expect(noAgentRunTime({ last_run_at: '2026-08-20T08:20:18+09:00' })).toBeNull()
+    expect(noAgentRunTime({ last_run_at: 'not-a-date', no_agent: true })).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/cron/job-state.ts
+++ b/apps/desktop/src/app/cron/job-state.ts
@@ -19,6 +19,18 @@ export function jobState(job: CronJob): string {
   return state || (job.enabled === false ? 'disabled' : 'scheduled')
 }
 
+// Script-only (no-agent) jobs write no conversational run session. Their
+// persisted job timestamp is the authoritative execution record instead.
+export function noAgentRunTime(job: Pick<CronJob, 'last_run_at' | 'no_agent'>): null | number {
+  if (!job.no_agent || typeof job.last_run_at !== 'string') {
+    return null
+  }
+
+  const timestamp = Date.parse(job.last_run_at)
+
+  return Number.isNaN(timestamp) ? null : timestamp
+}
+
 // Human label for a job: name → first 60 of prompt → first 60 of script → id.
 // One source for the sidebar row and the Cron page so the two never drift.
 export function jobTitle(job: CronJob): string {


### PR DESCRIPTION
## Summary
- show the persisted `last_run_at` for no-agent/script-only cron jobs when they have no conversational run session
- preserve `No runs yet` for agent-backed jobs with no run sessions
- add a focused regression test for persisted no-agent timestamps

## Verification
- `npx vitest run src/app/cron/job-state.test.ts`
- `npm run typecheck`
- `npm run test:desktop:platforms` (1502 passed, 2 skipped)

No profile configuration, credentials, or user cron data is included.