### PR TITLE
fix(docker): grant the gateway group access to the Fly Machines API socket

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -476,14 +476,21 @@ fi
 # (gateway/scale_to_zero.py suspend_self) must POST to it, but the gateway runs
 # as the unprivileged `hermes` user — without this it gets EACCES on every
 # suspend attempt and the machine can never sleep (fail-awake; verified live on
-# staging 2026-08-20: "flaps suspend request failed: [Errno 13]"). stage2 runs
-# as root before the supervision tree starts, so grant group access here.
-# Group-write is the minimal widening: the socket stays root-owned and
-# non-hermes users gain nothing. No-op off Fly (socket absent).
+# staging 2026-08-20: "flaps suspend request failed: [Errno 13]"). This hook
+# runs as root before user services (the gateway) start, so grant group access
+# here. Scope note: group-write exposes the WHOLE local Machines API to the
+# hermes group (any group member could e.g. stop/suspend this machine), not
+# just the suspend endpoint — accepted because the agent already executes
+# arbitrary user code as that same principal and the socket only controls THIS
+# machine. No-op off Fly (socket absent).
 if [ -S /.fly/api ]; then
-    chgrp hermes /.fly/api 2>/dev/null || true
-    chmod g+w /.fly/api 2>/dev/null || true
-    echo "[stage2] Granted hermes group access to the Fly Machines API socket"
+    if refuse_symlinked_path "chgrp/chmod" /.fly/api; then
+        :
+    elif chgrp hermes /.fly/api 2>/dev/null && chmod g+w /.fly/api 2>/dev/null; then
+        echo "[stage2] Granted hermes group access to the Fly Machines API socket"
+    else
+        echo "[stage2] Warning: could not grant group access to /.fly/api — scale-to-zero self-suspend will fail EACCES (fail-awake)"
+    fi
 fi
 
 # --- Migrate persisted config schema ---

--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -470,6 +470,22 @@ if [ -f "$HERMES_HOME/.env" ]; then
     fi
 fi
 
+# --- Grant the gateway access to the Fly Machines API socket (scale-to-zero) ---
+# On Fly, flyd mounts the local Machines API ("flaps") unix socket at /.fly/api
+# owned root:root 0755. The gateway's scale-to-zero self-suspend
+# (gateway/scale_to_zero.py suspend_self) must POST to it, but the gateway runs
+# as the unprivileged `hermes` user — without this it gets EACCES on every
+# suspend attempt and the machine can never sleep (fail-awake; verified live on
+# staging 2026-08-20: "flaps suspend request failed: [Errno 13]"). stage2 runs
+# as root before the supervision tree starts, so grant group access here.
+# Group-write is the minimal widening: the socket stays root-owned and
+# non-hermes users gain nothing. No-op off Fly (socket absent).
+if [ -S /.fly/api ]; then
+    chgrp hermes /.fly/api 2>/dev/null || true
+    chmod g+w /.fly/api 2>/dev/null || true
+    echo "[stage2] Granted hermes group access to the Fly Machines API socket"
+fi
+
 # --- Migrate persisted config schema ---
 # Docker image upgrades replace the code under $INSTALL_DIR but preserve
 # $HERMES_HOME on the mounted volume. Run the same safe, non-interactive


### PR DESCRIPTION
## Summary

Live E2E on staging (`hermes-agent-stg-test-6698`, 2026-08-20, first run after #84558 merged) reached the suspend call for the first time — and every attempt failed:

```
10:37:06 scale-to-zero: gateway idle for >= 300s — going dormant ... then self-suspending
10:37:07 scale-to-zero: flaps suspend request failed: [Errno 13] Permission denied
10:37:07 scale-to-zero: self-suspend not accepted — machine stays awake (fail-awake); will retry
```

(repeating every 60s watcher tick). flyd mounts the local Machines API ("flaps") socket at `/.fly/api` as `root:root 0755`; the gateway runs as the unprivileged `hermes` user, so `suspend_self()` (#84295) gets EACCES on every connect. Fail-awake held — nothing broke — but the feature was inert on every Fly instance.

## Fix

`docker/stage2-hook.sh` (runs as root before the s6 supervision tree): when `/.fly/api` exists, `chgrp hermes` + `chmod g+w`. Scope: group-write exposes the whole local Machines API to the hermes group, not just suspend — accepted because the agent already executes arbitrary user code as that principal and the socket controls only this machine. The mutation goes through the script's refuse_symlinked_path guard and success is only logged when both chgrp and chmod succeed. No-op off Fly (socket absent), so plain Docker users are untouched.

## Verified live

Applied exactly this change by hand on the staging box mid-E2E; the very next watcher tick completed the full cycle:

```
10:43:07 going dormant (relay buffered, socket closed) then self-suspending
10:43:08 machine suspend accepted by flaps (HTTP/1.1 200 OK)
10:43:09 Fly event: suspension/suspended (flyd)          ← first ever clean gateway-owned suspend
10:45:01 start/starting (proxy)                          ← Chronos cold-fire wake, 0.4s resume
10:45:22 cron job completed
10:45:33 suspension/suspended (flyd)                     ← re-suspend after wake
```

`bash -n` / `sh -n` clean. The manual chmod dies on the next machine recreate; this makes it durable.

Refs: #84295, #84327, #84339, #84558, NousResearch/nous-account-service#898. Companion: the cron-aware idle predicate PR (https://github.com/NousResearch/hermes-agent/pull/90761).

## Infographic

![open-the-socket](https://v3b.fal.media/files/b/0aa71611/kyGVF00x2S8Z7snARMSIt_lDSdJ3Qo.png)


