### PR TITLE
fix(gateway): count cron and API-server work in the scale-to-zero idle predicate

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8672,8 +8672,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _scale_to_zero_is_idle(self) -> bool:
         from gateway.scale_to_zero import is_idle
 
+        # _active_work_count(), NOT _running_agent_count(): cron jobs run
+        # through a standalone AIAgent on the scheduler's own thread pool and
+        # API-server runs live on the adapter — both entirely outside
+        # _running_agents (the same blind spot as the #60432 shutdown drain).
+        # Counting agents alone let the idle predicate read True DURING a
+        # running cron job; a suspend then freezes the job mid-flight.
+        # Observed live on staging 2026-08-20: is_idle held True throughout a
+        # cron run at 10:45:04-22 — only watcher-tick timing (next tick 9s
+        # after the job finished) avoided a mid-job freeze.
         return is_idle(
-            running_agent_count=self._running_agent_count(),
+            running_agent_count=self._active_work_count(),
             seconds_since_last_inbound=time.time() - self._last_inbound_at,
             idle_timeout_seconds=self._scale_to_zero_idle_timeout_seconds(),
             has_live_background_work=self._scale_to_zero_has_live_background_work(),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8672,17 +8672,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _scale_to_zero_is_idle(self) -> bool:
         from gateway.scale_to_zero import is_idle
 
-        # _active_work_count(), NOT _running_agent_count(): cron jobs run
-        # through a standalone AIAgent on the scheduler's own thread pool and
-        # API-server runs live on the adapter — both entirely outside
-        # _running_agents (the same blind spot as the #60432 shutdown drain).
-        # Counting agents alone let the idle predicate read True DURING a
-        # running cron job; a suspend then freezes the job mid-flight.
-        # Observed live on staging 2026-08-20: is_idle held True throughout a
-        # cron run at 10:45:04-22 — only watcher-tick timing (next tick 9s
-        # after the job finished) avoided a mid-job freeze.
+        # The FULL work aggregate, not _running_agent_count(): cron jobs run
+        # on the scheduler's own thread pool and API-server runs live on the
+        # adapter — both outside _running_agents (the #60432 blind spot), so
+        # counting agents alone let a suspend land mid-cron-job.
+        #
+        # Fail-AWAKE accounting: the shared shutdown-drain counters
+        # (_active_cron_job_count/_active_api_run_count) swallow exceptions to
+        # 0, which is fine for a drain but unsafe for a suspend predicate — a
+        # transient read failure would make live work look idle and reopen the
+        # mid-job freeze. Here an unreadable source counts as work (sentinel 1)
+        # so the machine stays awake until the source is readable again.
+        try:
+            from cron.scheduler import get_running_job_ids
+
+            cron_count = len(get_running_job_ids())
+        except Exception:  # noqa: BLE001 - unreadable source => assume busy
+            logger.debug("scale-to-zero: cron work count unreadable — staying awake", exc_info=True)
+            cron_count = 1
+        try:
+            adapter = getattr(self, "adapters", {}).get(Platform.API_SERVER)
+            helper = getattr(adapter, "active_agent_work_count", None)
+            api_count = max(0, int(helper())) if callable(helper) else 0
+        except Exception:  # noqa: BLE001 - unreadable source => assume busy
+            logger.debug("scale-to-zero: api work count unreadable — staying awake", exc_info=True)
+            api_count = 1
         return is_idle(
-            running_agent_count=self._active_work_count(),
+            active_work_count=self._running_agent_count() + cron_count + api_count,
             seconds_since_last_inbound=time.time() - self._last_inbound_at,
             idle_timeout_seconds=self._scale_to_zero_idle_timeout_seconds(),
             has_live_background_work=self._scale_to_zero_has_live_background_work(),

--- a/gateway/scale_to_zero.py
+++ b/gateway/scale_to_zero.py
@@ -133,18 +133,25 @@ def should_arm(
 
 def is_idle(
     *,
-    running_agent_count: int,
+    active_work_count: int,
     seconds_since_last_inbound: float,
     idle_timeout_seconds: float,
     has_live_background_work: bool,
 ) -> bool:
     """The idle predicate (D2/D3/F7). Pure — composes the three conjuncts.
 
-    Idle iff: no in-flight agent turn, no inbound within the timeout window, and
-    no live background work (backgrounded delegate_task / kanban / bg terminal).
-    Any active work keeps the gateway awake — suspending mid-flight would lose it.
+    Idle iff: no counted active work (in-flight agent turns + cron jobs +
+    API-server runs — the caller aggregates every foreground work source),
+    no inbound within the timeout window, and no live background work
+    (backgrounded delegate_task / kanban / bg terminal). Any active work
+    keeps the gateway awake — suspending mid-flight would lose it.
+
+    ``active_work_count`` deliberately names the BROAD aggregate, not just
+    agents: a caller passing only ``len(_running_agents)`` reopens the
+    mid-cron-job suspend hole. Callers that cannot read a work source must
+    fail AWAKE (pass a positive sentinel), never fail to 0.
     """
-    if running_agent_count > 0:
+    if active_work_count > 0:
         return False
     if has_live_background_work:
         return False

--- a/tests/gateway/test_scale_to_zero.py
+++ b/tests/gateway/test_scale_to_zero.py
@@ -71,7 +71,7 @@ def test_arm_blocked_without_wake_url():
 
 def _idle_kwargs(**over):
     base = dict(
-        running_agent_count=0,
+        active_work_count=0,
         seconds_since_last_inbound=600.0,
         idle_timeout_seconds=300.0,
         has_live_background_work=False,
@@ -81,7 +81,7 @@ def _idle_kwargs(**over):
 
 
 def test_not_idle_with_running_agent():
-    assert is_idle(**_idle_kwargs(running_agent_count=1)) is False
+    assert is_idle(**_idle_kwargs(active_work_count=1)) is False
 
 
 def test_idle_exactly_at_threshold():

--- a/tests/gateway/test_scale_to_zero_watcher.py
+++ b/tests/gateway/test_scale_to_zero_watcher.py
@@ -460,3 +460,38 @@ def test_active_api_run_blocks_idle(monkeypatch):
 def test_idle_true_when_all_work_sources_quiet(monkeypatch):
     r = _work_count_runner(monkeypatch)
     assert r._scale_to_zero_is_idle() is True
+
+
+def test_unreadable_cron_source_fails_awake(monkeypatch):
+    """A transient failure reading the cron work source must count as WORK
+    (stay awake), not as idle — fail-open accounting would reopen the
+    mid-job-freeze hole exactly when bookkeeping is broken."""
+    r = _work_count_runner(monkeypatch)
+
+    def _boom():
+        raise RuntimeError("registry unavailable")
+
+    monkeypatch.setattr("cron.scheduler.get_running_job_ids", _boom)
+    assert r._scale_to_zero_is_idle() is False
+
+
+def test_unreadable_api_source_fails_awake(monkeypatch):
+    from types import SimpleNamespace
+
+    def _boom():
+        raise RuntimeError("adapter wedged")
+
+    r = _work_count_runner(monkeypatch)
+    from gateway.platforms.base import Platform
+
+    r.adapters = {Platform.API_SERVER: SimpleNamespace(active_agent_work_count=_boom)}
+    assert r._scale_to_zero_is_idle() is False
+
+
+def test_missing_api_adapter_is_not_work(monkeypatch):
+    """No api_server adapter at all (common: relay-only instance before the
+    key existed) is a NORMAL state, not an unreadable source — must not hold
+    the machine awake."""
+    r = _work_count_runner(monkeypatch)
+    r.adapters = {}
+    assert r._scale_to_zero_is_idle() is True

--- a/tests/gateway/test_scale_to_zero_watcher.py
+++ b/tests/gateway/test_scale_to_zero_watcher.py
@@ -415,3 +415,48 @@ async def test_heartbeat_poll_task_does_not_block_idle():
     finally:
         r._heartbeat_poll_task.cancel()
         await asyncio.gather(r._heartbeat_poll_task, return_exceptions=True)
+
+
+# ── in-flight cron / API-server work must block suspend (the 10:45 near-miss) ──
+#
+# Cron jobs run on the scheduler's thread pool and API-server runs live on the
+# adapter — both outside _running_agents (the #60432 blind spot). The idle
+# predicate must consume _active_work_count() (agents + cron + api runs), or a
+# suspend can freeze a cron job mid-run: observed on staging 2026-08-20, where
+# is_idle held True throughout a live cron run and only tick timing saved it.
+
+
+def _work_count_runner(monkeypatch, *, agents=0, cron_ids=(), api_runs=0):
+    from types import SimpleNamespace
+
+    r = GatewayRunner.__new__(GatewayRunner)
+    r._running = True
+    r._running_agents = {f"a{i}": object() for i in range(agents)}
+    r._background_tasks = set()
+    r._last_inbound_at = 0.0  # inbound-quiet for hours
+    monkeypatch.setattr(
+        r, "_scale_to_zero_idle_timeout_seconds", lambda: 300.0, raising=False
+    )
+    monkeypatch.setattr(
+        "cron.scheduler.get_running_job_ids", lambda: set(cron_ids)
+    )
+    api_adapter = SimpleNamespace(active_agent_work_count=lambda: api_runs)
+    from gateway.platforms.base import Platform
+
+    r.adapters = {Platform.API_SERVER: api_adapter}
+    return r
+
+
+def test_running_cron_job_blocks_idle(monkeypatch):
+    r = _work_count_runner(monkeypatch, cron_ids={"job1"})
+    assert r._scale_to_zero_is_idle() is False
+
+
+def test_active_api_run_blocks_idle(monkeypatch):
+    r = _work_count_runner(monkeypatch, api_runs=1)
+    assert r._scale_to_zero_is_idle() is False
+
+
+def test_idle_true_when_all_work_sources_quiet(monkeypatch):
+    r = _work_count_runner(monkeypatch)
+    assert r._scale_to_zero_is_idle() is True


### PR DESCRIPTION
## Summary

Found during the same staging E2E that validated #84558: `_scale_to_zero_is_idle()` fed `_running_agent_count()` into the idle predicate — but cron jobs run through a standalone `AIAgent` on the scheduler's own thread pool, and API-server runs live on the adapter. Both are **outside `_running_agents`** — the identical blind spot the #60432 shutdown-drain fix already solved with `_active_work_count()`.

Consequence: the idle predicate reads True **while a cron job is running**. A watcher tick landing mid-job would suspend the machine and freeze the job mid-flight — the exact "suspended while still processing" failure this whole workstream exists to prevent, reintroduced through the cron door.

**Observed live (2026-08-20):** the Chronos wake-fire ran a cron job 10:45:04→10:45:22; `is_idle` was True throughout (inbound clock stale ≫ 300s, agents 0, bg work none). The suspend at 10:45:31 missed the running job by 9 seconds of watcher-tick luck. Any cron job longer than the tick interval loses that race.

## Fix

`_scale_to_zero_is_idle()` now aggregates agents + running cron jobs + active API-server runs. Unlike the shutdown-drain helpers (which swallow read errors to 0 — fine for a drain, unsafe for a suspend), the suspend path reads both extra sources itself and treats an UNREADABLE source as work (fail-awake sentinel), so broken bookkeeping can never make live work look idle. A missing api_server adapter remains a normal not-work state. `is_idle()`'s parameter is renamed `running_agent_count` → `active_work_count` to match what it now receives.

## Tests

- `test_running_cron_job_blocks_idle` and `test_active_api_run_blocks_idle` — **both fail without the fix** (verified: 2 failed / 18 passed with `run.py` stashed).
- `test_idle_true_when_all_work_sources_quiet` — guards against over-blocking.
- `./scripts/run_tests.sh tests/gateway/test_scale_to_zero_watcher.py tests/gateway/test_scale_to_zero.py` — **37 passed, 0 failed**; ruff clean.

Note: the post-quiesce re-check in the watcher (#84295) also goes through `_scale_to_zero_is_idle()`, so a cron fire landing during the dormant drain now correctly aborts the suspend too.

Refs: #84295, #84327, #84339, #84558, #60432. Companion: the flaps socket-permission PR (https://github.com/NousResearch/hermes-agent/pull/90760).

## Infographic

![dont-freeze-the-job](https://v3b.fal.media/files/b/0aa71619/xR4mMRczg7rauEJtdztu5_kR5ye1lZ.png)


**Review-round addendum (sol-reviewer):** fail-awake accounting for unreadable work sources (+2 mutation-verified failure-path tests), `active_work_count` rename, missing-adapter-stays-idle test. 44/44 local.
