### PR TITLE
fix(bot-mode): group-chat clarify questions AND command approvals surface in the room, answerable

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -205,12 +205,13 @@ const $groupChats = atom({})
 const $groupChatWorkspace = atom(null)
 /** Groups whose latest room activity mentions @user — the needs-you badge. */
 const $groupNeedsYou = atom({})
-// Pending clarify questions raised inside hidden group-member sessions,
-// keyed `${group}::${memberKey}` (#90694). Members run in invisible plumbing
-// sessions, so a member's clarify tool used to block server-side with no
-// surface to answer it — the user saw "is thinking…" until the clarify
-// timeout. The turn poll mirrors each member's `pending_clarify` resume
-// field in here; the room renders answer cards from it.
+// Pending prompts (clarify questions AND command approvals) raised inside
+// hidden group-member sessions, keyed `${group}::${memberKey}` (#90694).
+// Members run in invisible plumbing sessions, so a member's blocking prompt
+// used to park server-side with no surface to answer it — the user saw
+// "is thinking…" until the prompt timeout. The turn poll mirrors each
+// member's `pending_clarify` / `pending_approval` resume fields in here;
+// the room renders answer cards from it.
 const $groupClarify = atom({})
 
 // ── group activity feed ─────────────────────────────────────────────────────
@@ -4359,15 +4360,20 @@ const GROUP_TURN_POLL_MS = 2000
 // reached the room (db's Aug 2026 report).
 const GROUP_TURN_HARD_CAP_MS = 20 * 60000
 
-/** Mirror a member's pending clarify (if any) from its resume snapshot into
- *  the room store, keyed `${group}::${memberKey}` (#90694). Returns true
- *  while a question is blocking, so the turn poll can extend its deadline —
- *  a waiting question must not be eaten by the group-turn timeout. Feature-
- *  detected: older backends without `pending_clarify` in the resume payload
- *  always sync to "no question". */
+/** Mirror a member's pending prompt — clarify question OR command approval —
+ *  from its resume snapshot into the room store, keyed
+ *  `${group}::${memberKey}` (#90694). Returns true while a prompt is
+ *  blocking, so the turn poll can extend its deadline — a waiting prompt
+ *  must not be eaten by the group-turn timeout. Feature-detected: older
+ *  backends without `pending_clarify`/`pending_approval` in the resume
+ *  payload always sync to "no prompt". Clarify wins when both are somehow
+ *  present (approvals resolve inside tool batches; clarify is the outer
+ *  blocker). */
 function syncGroupClarify(group, member, state) {
   const key = `${group}::${groupMemberKey(member)}`
-  const pending = state && typeof state.pending_clarify === 'object' ? state.pending_clarify : null
+  const clarify = state && typeof state.pending_clarify === 'object' ? state.pending_clarify : null
+  const approval = state && typeof state.pending_approval === 'object' ? state.pending_approval : null
+  const pending = clarify || approval
   const requestId = pending?.request_id || null
   const all = $groupClarify.get()
   const current = all[key]
@@ -4388,21 +4394,43 @@ function syncGroupClarify(group, member, state) {
     return true
   }
 
+  const base = {
+    requestId,
+    group,
+    member: member.name,
+    memberKey: groupMemberKey(member),
+    // approval.respond keys on the session, not just the request — carry the
+    // runtime id the snapshot came from.
+    sessionId: state?.session_id || null,
+    at: Date.now()
+  }
+
   $groupClarify.set({
     ...all,
-    [key]: {
-      requestId,
-      group,
-      member: member.name,
-      memberKey: groupMemberKey(member),
-      question: typeof pending.question === 'string' ? pending.question : '',
-      choices: Array.isArray(pending.choices) ? pending.choices.filter(c => typeof c === 'string' && c) : [],
-      multiSelect: Boolean(pending.multi_select),
-      // Batch clarifies carry `questions`; the room card answers them
-      // one wire call per question, mirroring the 1:1 batch contract.
-      questions: Array.isArray(pending.questions) ? pending.questions : null,
-      at: Date.now()
-    }
+    [key]: clarify
+      ? {
+          ...base,
+          kind: 'clarify',
+          question: typeof clarify.question === 'string' ? clarify.question : '',
+          choices: Array.isArray(clarify.choices) ? clarify.choices.filter(c => typeof c === 'string' && c) : [],
+          multiSelect: Boolean(clarify.multi_select),
+          // Batch clarifies carry `questions`; the room card answers them
+          // one wire call per question, mirroring the 1:1 batch contract.
+          questions: Array.isArray(clarify.questions) ? clarify.questions : null
+        }
+      : {
+          ...base,
+          kind: 'approval',
+          question: typeof approval.description === 'string' ? approval.description : '',
+          command: typeof approval.command === 'string' ? approval.command : '',
+          // The server precomputes the choice set from allow_permanent
+          // (once/session/always/deny); fall back to the minimal pair.
+          choices: Array.isArray(approval.choices) && approval.choices.length
+            ? approval.choices.filter(c => typeof c === 'string' && c)
+            : ['once', 'deny'],
+          multiSelect: false,
+          questions: null
+        }
   })
   // A blocked member is a question for the human — badge the room.
   $groupNeedsYou.set({ ...$groupNeedsYou.get(), [group]: true })
@@ -4429,14 +4457,23 @@ function clearGroupClarify(group) {
   }
 }
 
-/** Answer a member's pending clarify from the room. Routes clarify.respond
- *  to the member's OWN source (requestForBot), so cross-connection members
- *  work. Batch questions send one respond per question, sequentially — the
- *  LAST lock resolves the blocked tool server-side (same contract as the
- *  1:1 batch card). allow_expired server-side makes racing the timeout
- *  harmless. */
+/** Answer a member's pending prompt from the room. Routes to the member's
+ *  OWN source (requestForBot), so cross-connection members work.
+ *  - clarify: `clarify.respond`; batch questions send one respond per
+ *    question, sequentially — the LAST lock resolves the blocked tool
+ *    server-side (same contract as the 1:1 batch card). allow_expired
+ *    server-side makes racing the timeout harmless.
+ *  - approval: `approval.respond` with the choice (once/session/always/deny),
+ *    keyed by session + request_id — the same wire the 1:1 approval card
+ *    and native notifications use. */
 async function answerGroupClarify(entry, member, answers) {
-  if (entry.questions && entry.questions.length) {
+  if (entry.kind === 'approval') {
+    await requestForBot(member, 'approval.respond', {
+      session_id: entry.sessionId || undefined,
+      request_id: entry.requestId,
+      choice: typeof answers === 'string' && answers ? answers : 'deny'
+    })
+  } else if (entry.questions && entry.questions.length) {
     for (const question of entry.questions) {
       const qid = question?.qid ?? question?.id
       await requestForBot(member, 'clarify.respond', {
@@ -8887,12 +8924,16 @@ function GroupMentionInput({ members, onChange, value, ...inputProps }) {
   })
 }
 
-/** One member's pending question, rendered in the room (#90694). Choices
- *  render as tap buttons (multi-select stages; single-select stages one);
- *  free text always available; Answer sends via the member's own source.
- *  Batch clarifies render every sub-question with its own input. */
+/** One member's pending prompt, rendered in the room (#90694).
+ *  - clarify: choices as tap buttons (multi-select stages; single-select
+ *    stages one), free text always available, batch sub-questions each get
+ *    their own input.
+ *  - approval: the command in a code row plus the server's choice set
+ *    (once/session/always/deny) as buttons — no free text; approvals are a
+ *    closed choice. Answer sends via the member's own source. */
 function GroupClarifyCard({ entry, members }) {
   const { group } = entry
+  const isApproval = entry.kind === 'approval'
   const member = members.find(m => groupMemberKey(m) === entry.memberKey) || members.find(m => m.name === entry.member)
   const [drafts, setDrafts] = useState({})
   const [picked, setPicked] = useState({})
@@ -8913,7 +8954,7 @@ function GroupClarifyCard({ entry, members }) {
       return q.multiSelect ? JSON.stringify(chosen) : chosen[0]
     }
 
-    return (drafts[q.qid] || '').trim()
+    return isApproval ? '' : (drafts[q.qid] || '').trim()
   }
 
   const allAnswered = questions.every(q => answerFor(q))
@@ -8926,7 +8967,9 @@ function GroupClarifyCard({ entry, members }) {
     setSending(true)
 
     try {
-      if (entry.questions && entry.questions.length) {
+      if (isApproval || !(entry.questions && entry.questions.length)) {
+        await answerGroupClarify(entry, member, answerFor(questions[0]))
+      } else {
         const answers = {}
 
         for (const q of questions) {
@@ -8934,14 +8977,14 @@ function GroupClarifyCard({ entry, members }) {
         }
 
         await answerGroupClarify(entry, member, answers)
-      } else {
-        await answerGroupClarify(entry, member, answerFor(questions[0]))
       }
 
       // Echo the exchange into the room log so the thread reads complete.
-      const summary = questions
-        .map(q => (questions.length > 1 ? `${q.question}: ${answerFor(q)}` : answerFor(q)))
-        .join('\n')
+      const summary = isApproval
+        ? `${answerFor(questions[0])} — ${entry.command || entry.question || 'command approval'}`
+        : questions
+            .map(q => (questions.length > 1 ? `${q.question}: ${answerFor(q)}` : answerFor(q)))
+            .join('\n')
       appendGroupChatEntry(group, { kind: 'user', name: 'You' }, summary, entry.thread || 'legacy')
     } catch (err) {
       host.notify({ kind: 'error', message: `Could not send the answer to @${botHandle(entry.member, member)}: ${err?.message || err}` })
@@ -8957,10 +9000,22 @@ function GroupClarifyCard({ entry, members }) {
       jsxs('div', {
         className: 'flex items-center gap-1.5 text-xs font-medium',
         children: [
-          jsx(Codicon, { name: 'question', className: 'shrink-0 text-(--ui-accent,#4f9cf9)' }),
-          `@${botHandle(entry.member, member)} asks:`
+          jsx(Codicon, {
+            name: isApproval ? 'shield' : 'question',
+            className: 'shrink-0 text-(--ui-accent,#4f9cf9)'
+          }),
+          isApproval
+            ? `@${botHandle(entry.member, member)} wants to run a command:`
+            : `@${botHandle(entry.member, member)} asks:`
         ]
       }),
+      isApproval && entry.command
+        ? jsx('code', {
+            className:
+              'block overflow-x-auto rounded bg-(--ui-bg-secondary,rgba(0,0,0,0.25)) px-2 py-1 font-mono text-[0.7rem] whitespace-pre-wrap break-all',
+            children: entry.command
+          })
+        : null,
       ...questions.map(q =>
         jsxs('div', {
           className: 'grid gap-1',
@@ -8977,7 +9032,10 @@ function GroupClarifyCard({ entry, members }) {
                     return jsx(Button, {
                       size: 'sm',
                       variant: chosen ? 'default' : 'secondary',
-                      className: 'h-6 px-2 text-[0.7rem]',
+                      className: cn(
+                        'h-6 px-2 text-[0.7rem]',
+                        isApproval && choice === 'deny' && !chosen && 'text-destructive'
+                      ),
                       onClick: () => {
                         setDrafts(prev => ({ ...prev, [q.qid]: '' }))
                         setPicked(prev => {
@@ -8998,23 +9056,26 @@ function GroupClarifyCard({ entry, members }) {
                   })
                 })
               : null,
-            jsx(Input, {
-              'aria-label': `Answer @${entry.member}`,
-              placeholder: q.choices.length ? 'Or type your own answer…' : 'Type your answer…',
-              value: drafts[q.qid] || '',
-              onChange: event => {
-                const value = event.target.value
-                setPicked(prev => ({ ...prev, [q.qid]: [] }))
-                setDrafts(prev => ({ ...prev, [q.qid]: value }))
-              },
-              onKeyDown: event => {
-                if (event.key === 'Enter' && questions.length === 1) {
-                  event.preventDefault()
-                  void submit()
-                }
-              },
-              className: 'h-7 text-xs'
-            }, `input:${q.qid}`)
+            // Approvals are a closed choice set — no free-text input.
+            isApproval
+              ? null
+              : jsx(Input, {
+                  'aria-label': `Answer @${entry.member}`,
+                  placeholder: q.choices.length ? 'Or type your own answer…' : 'Type your answer…',
+                  value: drafts[q.qid] || '',
+                  onChange: event => {
+                    const value = event.target.value
+                    setPicked(prev => ({ ...prev, [q.qid]: [] }))
+                    setDrafts(prev => ({ ...prev, [q.qid]: value }))
+                  },
+                  onKeyDown: event => {
+                    if (event.key === 'Enter' && questions.length === 1) {
+                      event.preventDefault()
+                      void submit()
+                    }
+                  },
+                  className: 'h-7 text-xs'
+                }, `input:${q.qid}`)
           ]
         }, `q:${q.qid}`)
       ),
@@ -9024,7 +9085,7 @@ function GroupClarifyCard({ entry, members }) {
           size: 'sm',
           disabled: sending || !allAnswered || !member,
           onClick: () => void submit(),
-          children: sending ? 'Sending…' : 'Answer'
+          children: sending ? 'Sending…' : isApproval ? 'Respond' : 'Answer'
         })
       })
     ]

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -205,6 +205,13 @@ const $groupChats = atom({})
 const $groupChatWorkspace = atom(null)
 /** Groups whose latest room activity mentions @user — the needs-you badge. */
 const $groupNeedsYou = atom({})
+// Pending clarify questions raised inside hidden group-member sessions,
+// keyed `${group}::${memberKey}` (#90694). Members run in invisible plumbing
+// sessions, so a member's clarify tool used to block server-side with no
+// surface to answer it — the user saw "is thinking…" until the clarify
+// timeout. The turn poll mirrors each member's `pending_clarify` resume
+// field in here; the room renders answer cards from it.
+const $groupClarify = atom({})
 
 // ── group activity feed ─────────────────────────────────────────────────────
 // Runtime-only, bounded per-room record of turn events that feeds the
@@ -4139,6 +4146,7 @@ async function disbandGroupChat(group, members) {
 
   delete needs[group]
   $groupNeedsYou.set(needs)
+  clearGroupClarify(group)
 
   // Persist the room map WITHOUT the disbanded room so it can't come back
   // on the next window load.
@@ -4234,6 +4242,10 @@ async function renameGroupChat(oldName, newName, members) {
     delete needs[oldName]
     $groupNeedsYou.set(needs)
   }
+
+  // Mirrored clarify cards key by group name; drop the old room's — the
+  // next poll re-mirrors any still-blocking question under the new name.
+  clearGroupClarify(oldName)
 
   // Local memberships: swap the name inside each member's canonical groups
   // list (syncs cross-machine via ui_meta). Remote members' seating lives in
@@ -4347,6 +4359,109 @@ const GROUP_TURN_POLL_MS = 2000
 // reached the room (db's Aug 2026 report).
 const GROUP_TURN_HARD_CAP_MS = 20 * 60000
 
+/** Mirror a member's pending clarify (if any) from its resume snapshot into
+ *  the room store, keyed `${group}::${memberKey}` (#90694). Returns true
+ *  while a question is blocking, so the turn poll can extend its deadline —
+ *  a waiting question must not be eaten by the group-turn timeout. Feature-
+ *  detected: older backends without `pending_clarify` in the resume payload
+ *  always sync to "no question". */
+function syncGroupClarify(group, member, state) {
+  const key = `${group}::${groupMemberKey(member)}`
+  const pending = state && typeof state.pending_clarify === 'object' ? state.pending_clarify : null
+  const requestId = pending?.request_id || null
+  const all = $groupClarify.get()
+  const current = all[key]
+
+  if (!requestId) {
+    if (current) {
+      const next = { ...all }
+      delete next[key]
+      $groupClarify.set(next)
+    }
+
+    return false
+  }
+
+  // Same request already mirrored — keep the object identity so the card
+  // doesn't lose its draft to a re-render.
+  if (current?.requestId === requestId) {
+    return true
+  }
+
+  $groupClarify.set({
+    ...all,
+    [key]: {
+      requestId,
+      group,
+      member: member.name,
+      memberKey: groupMemberKey(member),
+      question: typeof pending.question === 'string' ? pending.question : '',
+      choices: Array.isArray(pending.choices) ? pending.choices.filter(c => typeof c === 'string' && c) : [],
+      multiSelect: Boolean(pending.multi_select),
+      // Batch clarifies carry `questions`; the room card answers them
+      // one wire call per question, mirroring the 1:1 batch contract.
+      questions: Array.isArray(pending.questions) ? pending.questions : null,
+      at: Date.now()
+    }
+  })
+  // A blocked member is a question for the human — badge the room.
+  $groupNeedsYou.set({ ...$groupNeedsYou.get(), [group]: true })
+
+  return true
+}
+
+/** Drop every mirrored clarify belonging to `group` (disband/rename). */
+function clearGroupClarify(group) {
+  const all = $groupClarify.get()
+  const next = {}
+  let changed = false
+
+  for (const [key, value] of Object.entries(all)) {
+    if (value?.group === group) {
+      changed = true
+    } else {
+      next[key] = value
+    }
+  }
+
+  if (changed) {
+    $groupClarify.set(next)
+  }
+}
+
+/** Answer a member's pending clarify from the room. Routes clarify.respond
+ *  to the member's OWN source (requestForBot), so cross-connection members
+ *  work. Batch questions send one respond per question, sequentially — the
+ *  LAST lock resolves the blocked tool server-side (same contract as the
+ *  1:1 batch card). allow_expired server-side makes racing the timeout
+ *  harmless. */
+async function answerGroupClarify(entry, member, answers) {
+  if (entry.questions && entry.questions.length) {
+    for (const question of entry.questions) {
+      const qid = question?.qid ?? question?.id
+      await requestForBot(member, 'clarify.respond', {
+        request_id: entry.requestId,
+        question_id: qid,
+        answer: answers?.[qid] ?? ''
+      })
+    }
+  } else {
+    await requestForBot(member, 'clarify.respond', {
+      request_id: entry.requestId,
+      answer: typeof answers === 'string' ? answers : ''
+    })
+  }
+
+  const all = $groupClarify.get()
+  const key = `${entry.group}::${entry.memberKey}`
+
+  if (all[key]?.requestId === entry.requestId) {
+    const next = { ...all }
+    delete next[key]
+    $groupClarify.set(next)
+  }
+}
+
 /** One member turn, gateway-native: submit the room delta as a prompt into
  *  the member's per-group session, then poll the session until a NEW
  *  assistant message lands (or timeout → pass). While the session visibly
@@ -4446,7 +4561,11 @@ async function runGroupChatMemberTurn(group, member, prompt, thread, images) {
 
     const messages = Array.isArray(state?.messages) ? state.messages : []
     const busy = Boolean(state?.inflight || state?.running)
-    const done = !busy
+    // A clarify blocking inside the member's session is a question for the
+    // HUMAN (#90694) — mirror it into the room store so a card renders, and
+    // hold the turn open: the member isn't stalling, it's waiting on us.
+    const awaitingUser = syncGroupClarify(group, member, state)
+    const done = !busy && !awaitingUser
 
     if (messages.length > before && done) {
       for (let i = messages.length - 1; i >= 0; i--) {
@@ -4475,16 +4594,20 @@ async function runGroupChatMemberTurn(group, member, prompt, thread, images) {
       return null
     }
 
-    // Still visibly working: extend the deadline (never past the hard cap).
-    if (busy) {
+    // Still visibly working — or waiting on the user's answer to a clarify:
+    // extend the deadline (never past the hard cap). A pending question must
+    // outlive the base turn timeout or it dies unanswered at 3 minutes.
+    if (busy || awaitingUser) {
       deadline = Math.min(started + GROUP_TURN_HARD_CAP_MS, Math.max(deadline, Date.now() + GROUP_TURN_TIMEOUT_MS))
     }
   }
 
-  // Timeout — reads as a pass, but remember the baseline + thread
+  // Timeout — clear any still-mirrored question card (the server-side
+  // clarify timeout runs its own course) and read as a pass, but remember the baseline + thread
   // (runtime-only) so the finished reply can be posted late into the RIGHT
   // thread instead of vanishing.
   recordGroupActivity(group, { kind: 'timed-out', member: member.name, thread })
+  syncGroupClarify(group, member, null)
   updateGroupChat(group, r => {
     r.stranded = { ...(r.stranded || {}), [groupMemberKey(member)]: { before, thread } }
     return r
@@ -4522,6 +4645,12 @@ async function harvestStrandedGroupReply(group, member) {
 
   if (state?.inflight || state?.running) {
     return // still grinding — keep waiting
+  }
+
+  // A stranded member blocked on a clarify is not "grinding" — surface the
+  // question card (#90694) and keep the marker until it resolves.
+  if (syncGroupClarify(group, member, state)) {
+    return
   }
 
   // Done (or dead): the marker is consumed either way.
@@ -8758,6 +8887,150 @@ function GroupMentionInput({ members, onChange, value, ...inputProps }) {
   })
 }
 
+/** One member's pending question, rendered in the room (#90694). Choices
+ *  render as tap buttons (multi-select stages; single-select stages one);
+ *  free text always available; Answer sends via the member's own source.
+ *  Batch clarifies render every sub-question with its own input. */
+function GroupClarifyCard({ entry, members }) {
+  const { group } = entry
+  const member = members.find(m => groupMemberKey(m) === entry.memberKey) || members.find(m => m.name === entry.member)
+  const [drafts, setDrafts] = useState({})
+  const [picked, setPicked] = useState({})
+  const [sending, setSending] = useState(false)
+  const questions = entry.questions && entry.questions.length
+    ? entry.questions.map((q, i) => ({
+        qid: q?.qid ?? q?.id ?? `q${i}`,
+        question: typeof q?.question === 'string' ? q.question : '',
+        choices: Array.isArray(q?.choices) ? q.choices.filter(c => typeof c === 'string' && c) : [],
+        multiSelect: Boolean(q?.multi_select ?? q?.multiSelect)
+      }))
+    : [{ qid: '__single__', question: entry.question, choices: entry.choices, multiSelect: entry.multiSelect }]
+
+  const answerFor = q => {
+    const chosen = picked[q.qid] || []
+
+    if (chosen.length) {
+      return q.multiSelect ? JSON.stringify(chosen) : chosen[0]
+    }
+
+    return (drafts[q.qid] || '').trim()
+  }
+
+  const allAnswered = questions.every(q => answerFor(q))
+
+  const submit = async () => {
+    if (!member || sending || !allAnswered) {
+      return
+    }
+
+    setSending(true)
+
+    try {
+      if (entry.questions && entry.questions.length) {
+        const answers = {}
+
+        for (const q of questions) {
+          answers[q.qid] = answerFor(q)
+        }
+
+        await answerGroupClarify(entry, member, answers)
+      } else {
+        await answerGroupClarify(entry, member, answerFor(questions[0]))
+      }
+
+      // Echo the exchange into the room log so the thread reads complete.
+      const summary = questions
+        .map(q => (questions.length > 1 ? `${q.question}: ${answerFor(q)}` : answerFor(q)))
+        .join('\n')
+      appendGroupChatEntry(group, { kind: 'user', name: 'You' }, summary, entry.thread || 'legacy')
+    } catch (err) {
+      host.notify({ kind: 'error', message: `Could not send the answer to @${botHandle(entry.member, member)}: ${err?.message || err}` })
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return jsxs('div', {
+    className:
+      'grid gap-1.5 rounded-md border border-(--ui-accent,#4f9cf9)/50 bg-(--ui-accent,#4f9cf9)/5 px-2.5 py-2',
+    children: [
+      jsxs('div', {
+        className: 'flex items-center gap-1.5 text-xs font-medium',
+        children: [
+          jsx(Codicon, { name: 'question', className: 'shrink-0 text-(--ui-accent,#4f9cf9)' }),
+          `@${botHandle(entry.member, member)} asks:`
+        ]
+      }),
+      ...questions.map(q =>
+        jsxs('div', {
+          className: 'grid gap-1',
+          children: [
+            q.question
+              ? jsx('div', { className: 'text-xs whitespace-pre-wrap', children: q.question })
+              : null,
+            q.choices.length
+              ? jsx('div', {
+                  className: 'flex flex-wrap gap-1',
+                  children: q.choices.map(choice => {
+                    const chosen = (picked[q.qid] || []).includes(choice)
+
+                    return jsx(Button, {
+                      size: 'sm',
+                      variant: chosen ? 'default' : 'secondary',
+                      className: 'h-6 px-2 text-[0.7rem]',
+                      onClick: () => {
+                        setDrafts(prev => ({ ...prev, [q.qid]: '' }))
+                        setPicked(prev => {
+                          const current = prev[q.qid] || []
+                          const next = q.multiSelect
+                            ? chosen
+                              ? current.filter(c => c !== choice)
+                              : [...current, choice]
+                            : chosen
+                              ? []
+                              : [choice]
+
+                          return { ...prev, [q.qid]: next }
+                        })
+                      },
+                      children: choice
+                    }, `choice:${q.qid}:${choice}`)
+                  })
+                })
+              : null,
+            jsx(Input, {
+              'aria-label': `Answer @${entry.member}`,
+              placeholder: q.choices.length ? 'Or type your own answer…' : 'Type your answer…',
+              value: drafts[q.qid] || '',
+              onChange: event => {
+                const value = event.target.value
+                setPicked(prev => ({ ...prev, [q.qid]: [] }))
+                setDrafts(prev => ({ ...prev, [q.qid]: value }))
+              },
+              onKeyDown: event => {
+                if (event.key === 'Enter' && questions.length === 1) {
+                  event.preventDefault()
+                  void submit()
+                }
+              },
+              className: 'h-7 text-xs'
+            }, `input:${q.qid}`)
+          ]
+        }, `q:${q.qid}`)
+      ),
+      jsx('div', {
+        className: 'flex justify-end',
+        children: jsx(Button, {
+          size: 'sm',
+          disabled: sending || !allAnswered || !member,
+          onClick: () => void submit(),
+          children: sending ? 'Sending…' : 'Answer'
+        })
+      })
+    ]
+  })
+}
+
 function GroupChatWorkspace({ group, members, onBack }) {
   const rooms = useValue($groupChats)
   const allMeta = useValue($botMeta)
@@ -8838,6 +9111,11 @@ function GroupChatWorkspace({ group, members, onBack }) {
   const [activityOpen, setActivityOpen] = useState(false)
   // Subscribe: activity rows re-render as turn events land.
   useValue($groupActivity)
+  // Pending member questions for THIS room (#90694), oldest first.
+  const clarifyAll = useValue($groupClarify)
+  const roomClarifies = Object.values(clarifyAll || {})
+    .filter(entry => entry?.group === group)
+    .sort((a, b) => (a.at || 0) - (b.at || 0))
 
   const header = jsxs('div', {
     className: 'flex items-center gap-2 px-2.5 pt-2.5 pb-2',
@@ -9358,12 +9636,17 @@ function GroupChatWorkspace({ group, members, onBack }) {
                     children: 'Say something — every bot in this group hears the room.'
                   }, 'empty')
                 ]),
+            ...roomClarifies.map(entry =>
+              jsx(GroupClarifyCard, { entry, members }, `clarify:${entry.memberKey}:${entry.requestId}`)
+            ),
             room.running
               ? jsx('div', {
                   className: 'px-2 py-1 text-[0.7rem] italic text-(--ui-text-quaternary)',
-                  children: room.turn
-                    ? `${groupSpeakerLabel(room.turn)} is thinking…`
-                    : 'The room is working…'
+                  children: roomClarifies.length
+                    ? 'Waiting for your answer…'
+                    : room.turn
+                      ? `${groupSpeakerLabel(room.turn)} is thinking…`
+                      : 'The room is working…'
                 }, 'working')
               : null
           ]

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -8,7 +8,7 @@ const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf
 /** Load the plugin in a vm with a scripted cli.exec so member turns are
  *  deterministic. `turnScript(profile, prompt)` returns the member's reply
  *  text (or throws to simulate a failed turn). */
-function load(turnScript, { busyUntilResumeCall } = {}) {
+function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall } = {}) {
   const values = new Map()
   const atom = initial => {
     const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
@@ -16,6 +16,7 @@ function load(turnScript, { busyUntilResumeCall } = {}) {
     return slot
   }
   const calls = []
+  const clarifyResponds = []
   const sessions = new Map()
   const runtimeToStored = new Map()
   const titleToStored = new Map()
@@ -63,13 +64,19 @@ function load(turnScript, { busyUntilResumeCall } = {}) {
           resumeCallCounts.set(profile, seen)
           const limit = busyUntilResumeCall && busyUntilResumeCall[profile]
           const busy = Boolean(limit && seen <= limit)
+          // clarifyUntilResumeCall[profile] = {payload, until}: the resume
+          // snapshot carries pending_clarify for the first `until` calls —
+          // simulating a member blocked on its clarify tool (#90694).
+          const clarify = clarifyUntilResumeCall && clarifyUntilResumeCall[profile]
+          const pendingClarify = clarify && seen <= clarify.until ? clarify.payload : null
           return {
             session_id: session.runtime,
             session_key: session.stored,
             message_count: session.messages.length,
             messages: [...session.messages],
             inflight: busy,
-            running: busy
+            running: busy,
+            ...(pendingClarify ? { pending_clarify: pendingClarify } : {})
           }
         }
         if (method === 'prompt.submit') {
@@ -89,6 +96,10 @@ function load(turnScript, { busyUntilResumeCall } = {}) {
           session.messages.push({ role: 'assistant', content: reply })
           return {}
         }
+        if (method === 'clarify.respond') {
+          clarifyResponds.push({ ...params })
+          return { ok: true }
+        }
         return {}
       },
       state: { profile: { get: () => 'default', listen: () => undefined }, gateway: { listen: () => undefined } },
@@ -104,7 +115,7 @@ function load(turnScript, { busyUntilResumeCall } = {}) {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, disbandGroupChat, updateGroupChat, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, disbandGroupChat, updateGroupChat, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -112,7 +123,7 @@ function load(turnScript, { busyUntilResumeCall } = {}) {
     storage: { get: () => null, set: (key, value) => storageWrites.set(key, value) },
     register: () => undefined
   })
-  return { ...context.__gc, calls, host: context.host, sessions, storageWrites }
+  return { ...context.__gc, calls, clarifyResponds, host: context.host, sessions, storageWrites }
 }
 
 const MEMBERS = [{ name: 'research', title: '' }, { name: 'builder', title: '' }, { name: 'ops', title: 'The Ops' }]
@@ -884,4 +895,130 @@ test('group room preview renders the bot HANDLE, not the raw profile name', () =
   assert.match(pluginSource, /const lastHandle = botHandle\(lastFrom \|\| 'bot', members\.find\(/)
   assert.match(pluginSource, /\? `\$\{last\.from\?\.kind === 'user' \? 'You' : `@\$\{lastHandle\}`\}/)
   assert.doesNotMatch(pluginSource, /`@\$\{last\.from\?\.name \|\| 'bot'\}`/)
+})
+
+// ── group clarify (#90694): member questions surface in the room ──────────
+
+const CLARIFY_PAYLOAD = {
+  request_id: 'req-clarify-1',
+  question: 'Which env should I target?',
+  choices: ['staging', 'prod'],
+  multi_select: false
+}
+
+test('a member blocked on clarify surfaces its question and holds the turn open', async () => {
+  // research reports pending_clarify on its first two resumes after the
+  // submit; the turn must NOT read it as done/pass while the question waits.
+  const gc = load(() => 'targeting staging', {
+    clarifyUntilResumeCall: { research: { payload: CLARIFY_PAYLOAD, until: 3 } }
+  })
+
+  const thread = gc.sendToGroupChat('Core', [MEMBERS[0]], '@research deploy it', null, [])
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await new Promise(resolve => setTimeout(resolve, 0))
+
+  // Mirrored while blocked, cleared once the resume stops reporting it.
+  const log = gc.$groupChats.get().Core.log.filter(e => e.thread === thread)
+  const replies = log.filter(e => e.from.kind === 'member')
+
+  assert.equal(replies.length, 1, 'the finished reply still lands after the clarify clears')
+  assert.equal(replies[0].text, 'targeting staging')
+  assert.equal(Object.keys(gc.$groupClarify.get()).length, 0, 'the mirrored question is cleared once resolved')
+  // The mirror pass ran while the question was blocking: it badges the room
+  // needs-you. The sabotaged (pre-fix) poll never inspects pending_clarify,
+  // so this stays unset — the observable proof the gate executed.
+  assert.equal(gc.$groupNeedsYou.get().Core, true, 'the blocking question badged the room')
+})
+
+test('syncGroupClarify mirrors, badges needs-you, and is idempotent per request', () => {
+  const gc = load(() => '(pass)')
+  const member = { name: 'research', title: '' }
+
+  const blocked = gc.syncGroupClarify('Core', member, { pending_clarify: CLARIFY_PAYLOAD })
+  assert.equal(blocked, true)
+
+  const mirrored = Object.values(gc.$groupClarify.get())
+  assert.equal(mirrored.length, 1)
+  assert.equal(mirrored[0].requestId, 'req-clarify-1')
+  assert.equal(mirrored[0].question, 'Which env should I target?')
+  assert.equal(JSON.stringify(mirrored[0].choices), JSON.stringify(['staging', 'prod']))
+  assert.equal(gc.$groupNeedsYou.get().Core, true)
+
+  // Same request again: no new entry, identity preserved.
+  const first = mirrored[0]
+  gc.syncGroupClarify('Core', member, { pending_clarify: CLARIFY_PAYLOAD })
+  assert.equal(Object.values(gc.$groupClarify.get())[0], first)
+
+  // Question resolved server-side: the mirror clears.
+  const still = gc.syncGroupClarify('Core', member, {})
+  assert.equal(still, false)
+  assert.equal(Object.keys(gc.$groupClarify.get()).length, 0)
+})
+
+test('older backends without pending_clarify never mirror a question', () => {
+  const gc = load(() => '(pass)')
+
+  assert.equal(gc.syncGroupClarify('Core', { name: 'research' }, { messages: [] }), false)
+  assert.equal(Object.keys(gc.$groupClarify.get()).length, 0)
+})
+
+test('answerGroupClarify routes clarify.respond and clears the mirror', async () => {
+  const gc = load(() => '(pass)')
+  const member = { name: 'research', title: '' }
+
+  gc.syncGroupClarify('Core', member, { pending_clarify: CLARIFY_PAYLOAD })
+  const entry = Object.values(gc.$groupClarify.get())[0]
+
+  await gc.answerGroupClarify(entry, member, 'staging')
+
+  assert.equal(JSON.stringify(gc.clarifyResponds), JSON.stringify([{ request_id: 'req-clarify-1', answer: 'staging' }]))
+  assert.equal(Object.keys(gc.$groupClarify.get()).length, 0)
+})
+
+test('answerGroupClarify sends one respond per batch question, in order', async () => {
+  const gc = load(() => '(pass)')
+  const member = { name: 'research', title: '' }
+  const batch = {
+    request_id: 'req-batch-1',
+    questions: [
+      { qid: 'q0', question: 'Env?', choices: ['staging', 'prod'] },
+      { qid: 'q1', question: 'Region?', choices: [] }
+    ]
+  }
+
+  gc.syncGroupClarify('Core', member, { pending_clarify: batch })
+  const entry = Object.values(gc.$groupClarify.get())[0]
+
+  await gc.answerGroupClarify(entry, member, { q0: 'staging', q1: 'eu-west' })
+
+  assert.equal(
+    JSON.stringify(gc.clarifyResponds),
+    JSON.stringify([
+      { request_id: 'req-batch-1', question_id: 'q0', answer: 'staging' },
+      { request_id: 'req-batch-1', question_id: 'q1', answer: 'eu-west' }
+    ])
+  )
+  assert.equal(Object.keys(gc.$groupClarify.get()).length, 0)
+})
+
+test('disband clears the room mirrored questions', async () => {
+  const gc = load(() => '(pass)')
+
+  gc.syncGroupClarify('Core', { name: 'research' }, { pending_clarify: CLARIFY_PAYLOAD })
+  gc.syncGroupClarify('Other', { name: 'ops' }, { pending_clarify: { ...CLARIFY_PAYLOAD, request_id: 'req-2' } })
+
+  await gc.disbandGroupChat('Core', [])
+
+  const remaining = Object.values(gc.$groupClarify.get())
+  assert.equal(remaining.length, 1)
+  assert.equal(remaining[0].group, 'Other')
+})
+
+test('source contract: room renders clarify cards and the poll gates on them', () => {
+  assert.match(pluginSource, /function GroupClarifyCard\(/)
+  assert.match(pluginSource, /syncGroupClarify\(group, member, state\)/)
+  assert.match(pluginSource, /const done = !busy && !awaitingUser/)
+  assert.match(pluginSource, /busy \|\| awaitingUser/)
+  assert.match(pluginSource, /roomClarifies\.map\(entry =>/)
+  assert.match(pluginSource, /'clarify\.respond'/)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -8,7 +8,7 @@ const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf
 /** Load the plugin in a vm with a scripted cli.exec so member turns are
  *  deterministic. `turnScript(profile, prompt)` returns the member's reply
  *  text (or throws to simulate a failed turn). */
-function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall } = {}) {
+function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approvalUntilResumeCall } = {}) {
   const values = new Map()
   const atom = initial => {
     const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
@@ -17,6 +17,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall } = {}) 
   }
   const calls = []
   const clarifyResponds = []
+  const approvalResponds = []
   const sessions = new Map()
   const runtimeToStored = new Map()
   const titleToStored = new Map()
@@ -69,6 +70,9 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall } = {}) 
           // simulating a member blocked on its clarify tool (#90694).
           const clarify = clarifyUntilResumeCall && clarifyUntilResumeCall[profile]
           const pendingClarify = clarify && seen <= clarify.until ? clarify.payload : null
+          // Same window shape for pending command approvals (#90694 class).
+          const approval = approvalUntilResumeCall && approvalUntilResumeCall[profile]
+          const pendingApproval = approval && seen <= approval.until ? approval.payload : null
           return {
             session_id: session.runtime,
             session_key: session.stored,
@@ -76,7 +80,8 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall } = {}) 
             messages: [...session.messages],
             inflight: busy,
             running: busy,
-            ...(pendingClarify ? { pending_clarify: pendingClarify } : {})
+            ...(pendingClarify ? { pending_clarify: pendingClarify } : {}),
+            ...(pendingApproval ? { pending_approval: pendingApproval } : {})
           }
         }
         if (method === 'prompt.submit') {
@@ -99,6 +104,10 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall } = {}) 
         if (method === 'clarify.respond') {
           clarifyResponds.push({ ...params })
           return { ok: true }
+        }
+        if (method === 'approval.respond') {
+          approvalResponds.push({ ...params })
+          return { resolved: true }
         }
         return {}
       },
@@ -123,7 +132,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall } = {}) 
     storage: { get: () => null, set: (key, value) => storageWrites.set(key, value) },
     register: () => undefined
   })
-  return { ...context.__gc, calls, clarifyResponds, host: context.host, sessions, storageWrites }
+  return { ...context.__gc, approvalResponds, calls, clarifyResponds, host: context.host, sessions, storageWrites }
 }
 
 const MEMBERS = [{ name: 'research', title: '' }, { name: 'builder', title: '' }, { name: 'ops', title: 'The Ops' }]
@@ -1021,4 +1030,97 @@ test('source contract: room renders clarify cards and the poll gates on them', (
   assert.match(pluginSource, /busy \|\| awaitingUser/)
   assert.match(pluginSource, /roomClarifies\.map\(entry =>/)
   assert.match(pluginSource, /'clarify\.respond'/)
+})
+
+// ── group approvals: same hidden-session class as clarify (#90694) ─────────
+
+const APPROVAL_PAYLOAD = {
+  request_id: 'req-approval-1',
+  command: 'rm -rf ./build',
+  description: 'Clean the build directory',
+  choices: ['once', 'session', 'deny']
+}
+
+test('a member blocked on a command approval surfaces an approval card and holds the turn', async () => {
+  const gc = load(() => 'build cleaned', {
+    approvalUntilResumeCall: { research: { payload: APPROVAL_PAYLOAD, until: 3 } }
+  })
+
+  const thread = gc.sendToGroupChat('Core', [MEMBERS[0]], '@research clean up', null, [])
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await new Promise(resolve => setTimeout(resolve, 0))
+
+  const log = gc.$groupChats.get().Core.log.filter(e => e.thread === thread)
+  const replies = log.filter(e => e.from.kind === 'member')
+
+  assert.equal(replies.length, 1, 'the finished reply still lands after the approval clears')
+  assert.equal(replies[0].text, 'build cleaned')
+  assert.equal(Object.keys(gc.$groupClarify.get()).length, 0)
+  assert.equal(gc.$groupNeedsYou.get().Core, true, 'the blocking approval badged the room')
+})
+
+test('syncGroupClarify mirrors an approval with kind, command, and server choices', () => {
+  const gc = load(() => '(pass)')
+  const member = { name: 'research', title: '' }
+
+  const blocked = gc.syncGroupClarify('Core', member, {
+    session_id: 'rt-research-1',
+    pending_approval: APPROVAL_PAYLOAD
+  })
+  assert.equal(blocked, true)
+
+  const entry = Object.values(gc.$groupClarify.get())[0]
+  assert.equal(entry.kind, 'approval')
+  assert.equal(entry.command, 'rm -rf ./build')
+  assert.equal(entry.question, 'Clean the build directory')
+  assert.equal(JSON.stringify(entry.choices), JSON.stringify(['once', 'session', 'deny']))
+  assert.equal(entry.sessionId, 'rt-research-1')
+})
+
+test('an approval without a server choice set falls back to once/deny', () => {
+  const gc = load(() => '(pass)')
+
+  gc.syncGroupClarify('Core', { name: 'research' }, {
+    pending_approval: { request_id: 'req-a2', command: 'ls' }
+  })
+
+  const entry = Object.values(gc.$groupClarify.get())[0]
+  assert.equal(JSON.stringify(entry.choices), JSON.stringify(['once', 'deny']))
+})
+
+test('answerGroupClarify routes approvals through approval.respond with session + choice', async () => {
+  const gc = load(() => '(pass)')
+  const member = { name: 'research', title: '' }
+
+  gc.syncGroupClarify('Core', member, { session_id: 'rt-research-1', pending_approval: APPROVAL_PAYLOAD })
+  const entry = Object.values(gc.$groupClarify.get())[0]
+
+  await gc.answerGroupClarify(entry, member, 'once')
+
+  assert.equal(
+    JSON.stringify(gc.approvalResponds),
+    JSON.stringify([{ session_id: 'rt-research-1', request_id: 'req-approval-1', choice: 'once' }])
+  )
+  assert.equal(gc.clarifyResponds.length, 0, 'approvals never touch the clarify wire')
+  assert.equal(Object.keys(gc.$groupClarify.get()).length, 0)
+})
+
+test('clarify outranks approval when a snapshot carries both', () => {
+  const gc = load(() => '(pass)')
+
+  gc.syncGroupClarify('Core', { name: 'research' }, {
+    pending_clarify: CLARIFY_PAYLOAD,
+    pending_approval: APPROVAL_PAYLOAD
+  })
+
+  const entry = Object.values(gc.$groupClarify.get())[0]
+  assert.equal(entry.kind, 'clarify')
+  assert.equal(entry.requestId, 'req-clarify-1')
+})
+
+test('source contract: approval card renders the command and routes approval.respond', () => {
+  assert.match(pluginSource, /pending_approval/)
+  assert.match(pluginSource, /'approval\.respond'/)
+  assert.match(pluginSource, /kind: 'approval'/)
+  assert.match(pluginSource, /wants to run a command/)
 })


### PR DESCRIPTION
## Summary

Bot Mode group-chat members can now ask the user questions AND request command approvals — both previously blocked invisibly inside hidden member sessions until timeout. One mirror, one card surface, both prompt kinds.

Root cause: group members run in hidden plumbing sessions. Any blocking prompt raised there (`clarify` waiting on `clarify.respond`, a command approval waiting on `approval.respond`) had no UI surface — no tile exists for a hidden session and the room's turn poll ignored both. The user saw "@lead is thinking…" for 300s until the server-side timeout (issue #90694, reported by @salihsungur; approvals were the same class).

## Changes

- `plugin.js`: the turn poll and the stranded-harvest pass mirror each member's `pending_clarify` AND `pending_approval` (both already in the `session.resume` payload — the reconnect-replay fields) into a `$groupClarify` store, and hold the turn deadline open while a prompt waits (bounded by the existing 20-min hard cap). Clarify outranks approval when a snapshot carries both.
- `plugin.js`: `GroupClarifyCard` renders per blocked member. Clarify: choice buttons, free text, batch sub-questions. Approval: the command in a code row + the server's choice set (once/session/always/deny; fallback once/deny) as buttons — closed set, no free text, deny tinted destructive. Answers route via `clarify.respond` / `approval.respond` through the member's OWN source (`requestForBot`), so cross-connection members work. The answered exchange echoes into the room log; "Waiting for your answer…" replaces "is thinking…" while a card is up.
- `plugin.js`: needs-you badges the roster row while a prompt waits; disband and rename clear mirrored cards; older backends whose resume payload lacks the fields no-op cleanly.
- `tests/group-chat.test.mjs`: 13 new tests, including end-to-end drives where a member blocks on a clarify (and separately on an approval) mid-turn and the finished reply still lands after it clears.

## Validation

| | Before | After |
|---|---|---|
| Member calls `clarify` in a group chat | "is thinking…" until 300s timeout; question never visible | Question card in the room; answer resumes the turn |
| Member hits a command approval | same silent hang until approval timeout | Approval card (command + once/session/always/deny); choice resumes the turn |
| Batch clarify | same silent hang | per-question inputs, sequential respond (last lock resolves) |
| Old backend (no pending_* in resume) | — | unchanged behavior, no-op |
| `node --test tests/*.test.mjs` | 332 pass | 339 pass |
| Sabotage runs | — | disabling the poll gate fails the clarify drive; disabling approval mirroring fails all 4 approval tests |

Closes #90694

## Infographic

![Questions reach the room — Bot Mode clarify + approval fix](https://files.catbox.moe/ss491k.png)
