### PR TITLE
fix(buzz): resume watched channels from a durable cursor across restarts (#90464)

### DIFF
--- a/contributors/emails/boni.alessandro997@gmail.com
+++ b/contributors/emails/boni.alessandro997@gmail.com
@@ -1,0 +1,2 @@
+sandrohub013
+# buzz durable channel cursors (#90464)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -92,6 +92,9 @@ _CHAT_KIND = 9
 _FETCH_LIMIT = 50
 # Bound on the per-channel de-dupe set (events, not bytes).
 _SEEN_CAP = 500
+# Where the per-channel cursors survive a restart, relative to HERMES_HOME.
+_CURSOR_STATE_SUBDIR = "buzz"
+_CURSOR_STATE_FILENAME = "channel-cursors.json"
 # Re-run DM discovery (``dms list`` plus the channels-list fallback) every
 # N poll sweeps to pick up conversations opened mid-run.
 _DM_DISCOVERY_EVERY = 5
@@ -430,6 +433,9 @@ class BuzzAdapter(BasePlatformAdapter):
         self._lock_key: Optional[str] = None
         # channel_id -> {"chat_type", "last_ts", "seen": OrderedDict[event_id, None]}
         self._channel_state: Dict[str, dict] = {}
+        # Cursors read back from disk at connect() and consumed by the first
+        # seed of each channel; empty on a first-ever run.
+        self._restored_cursors: Dict[str, dict] = {}
         self._channel_names: Dict[str, str] = {}
         # channel_id -> raw ``channels list`` entry; drives DM-vs-channel
         # classification (see _may_reclassify_as_dm).
@@ -533,10 +539,14 @@ class BuzzAdapter(BasePlatformAdapter):
             return False
 
         # Seed high-water marks from the newest events so a (re)start never
-        # replays channel history into the agent.
+        # replays channel history into the agent — except where a previous run
+        # left a cursor, which is restored instead so the events that landed
+        # while we were down still dispatch (#90464).
+        self._load_cursors()
         for channel_id in watch:
             await self._seed_channel(channel_id, chat_type="group")
         await self._discover_dms(seed=True)
+        self._save_cursors()
 
         # Inbound transport: prefer the NIP-42-authenticated WebSocket
         # subscription (push, near-zero latency); fall back to CLI polling
@@ -881,8 +891,11 @@ class BuzzAdapter(BasePlatformAdapter):
                                 channel_id = subscriptions.get(subscription_id)
                                 state = self._channel_state.get(channel_id or "")
                                 if channel_id and state is not None:
+                                    before = self._cursor_mark(state)
                                     await self._handle_event(channel_id, state, event)
                                     self._trim_seen(state)
+                                    if self._cursor_mark(state) != before:
+                                        self._save_cursors()
                             elif message[0] == "CLOSED":
                                 detail = message[-1] if len(message) > 2 else "subscription closed"
                                 raise ConnectionError(str(detail))
@@ -918,8 +931,114 @@ class BuzzAdapter(BasePlatformAdapter):
         except asyncio.CancelledError:
             raise
 
+    # ── Durable channel cursors ───────────────────────────────────────────
+
+    @staticmethod
+    def _cursor_path() -> Path:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home() / _CURSOR_STATE_SUBDIR / _CURSOR_STATE_FILENAME
+
+    def _load_cursors(self) -> None:
+        """Read back the cursors a previous run persisted.
+
+        A file written by a different identity or against a different relay is
+        ignored rather than trusted: channel ids would collide while the event
+        stream behind them is a different one.  Any read/parse failure leaves
+        the cursors empty, which degrades to the old seed-from-history
+        behaviour instead of failing the connect.
+        """
+        self._restored_cursors = {}
+        try:
+            path = self._cursor_path()
+            if not path.exists():
+                return
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            logger.debug("Buzz: could not read channel cursors", exc_info=True)
+            return
+        if not isinstance(data, dict):
+            return
+        if (
+            data.get("identity") != self._self_pubkey
+            or data.get("relay") != self.relay_url
+        ):
+            return
+        channels = data.get("channels")
+        if not isinstance(channels, dict):
+            return
+        for channel_id, entry in channels.items():
+            if not isinstance(entry, dict):
+                continue
+            try:
+                last_ts = int(entry.get("last_ts") or 0)
+            except (TypeError, ValueError):
+                continue
+            raw_seen = entry.get("seen")
+            seen = (
+                [str(event_id) for event_id in raw_seen][-_SEEN_CAP:]
+                if isinstance(raw_seen, list)
+                else []
+            )
+            self._restored_cursors[str(channel_id)] = {
+                "chat_type": str(entry.get("chat_type") or ""),
+                "last_ts": last_ts,
+                "seen": seen,
+            }
+
+    def _save_cursors(self) -> None:
+        """Persist every watched channel's cursor.  Never raises."""
+        payload = {
+            "identity": self._self_pubkey,
+            "relay": self.relay_url,
+            "channels": {
+                channel_id: {
+                    "chat_type": state.get("chat_type") or "group",
+                    "last_ts": int(state.get("last_ts") or 0),
+                    "seen": list(state.get("seen") or ()),
+                }
+                for channel_id, state in self._channel_state.items()
+            },
+        }
+        try:
+            from utils import atomic_json_write
+
+            atomic_json_write(self._cursor_path(), payload, indent=None)
+        except Exception:
+            logger.debug("Buzz: could not persist channel cursors", exc_info=True)
+
+    @staticmethod
+    def _cursor_mark(state: dict) -> tuple:
+        """Cheap change detector for one channel's cursor."""
+        seen = state.get("seen") or ()
+        return (
+            int(state.get("last_ts") or 0),
+            len(seen),
+            next(reversed(seen), None) if seen else None,
+        )
+
+    def _restore_channel_state(self, channel_id: str, chat_type: str) -> bool:
+        """Install a persisted cursor for *channel_id*; True when one existed.
+
+        Restoring is what closes the restart gap: seeding from current history
+        instead would mark everything that arrived while the gateway was down
+        as already seen, so the relay's durable copy is never dispatched
+        (#90464).
+        """
+        restored = self._restored_cursors.pop(channel_id, None)
+        if restored is None:
+            return False
+        self._channel_state[channel_id] = {
+            "chat_type": restored["chat_type"] or chat_type,
+            "last_ts": restored["last_ts"],
+            "seen": OrderedDict((event_id, None) for event_id in restored["seen"]),
+        }
+        return True
+
     async def _seed_channel(self, channel_id: str, chat_type: str) -> None:
         """Initialize a channel's high-water mark from its newest events."""
+        if self._restore_channel_state(channel_id, chat_type):
+            return
         state = {"chat_type": chat_type, "last_ts": 0, "seen": OrderedDict()}
         self._channel_state[channel_id] = state
         code, out, err = await self._run_cli(
@@ -966,7 +1085,7 @@ class BuzzAdapter(BasePlatformAdapter):
                     continue
                 if seed:
                     await self._seed_channel(dm_id, chat_type="dm")
-                else:
+                elif not self._restore_channel_state(dm_id, "dm"):
                     self._channel_state[dm_id] = {"chat_type": "dm", "last_ts": 0, "seen": OrderedDict()}
                 self._channel_names.setdefault(dm_id, "DM")
 
@@ -983,7 +1102,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 continue
             if seed:
                 await self._seed_channel(ch_id, chat_type="group")
-            else:
+            elif not self._restore_channel_state(ch_id, "group"):
                 self._channel_state[ch_id] = {"chat_type": "group", "last_ts": 0, "seen": OrderedDict()}
 
     async def _poll_channel(self, channel_id: str) -> None:
@@ -1001,9 +1120,14 @@ class BuzzAdapter(BasePlatformAdapter):
                 "Buzz: poll of channel %s failed — %s", channel_id, _cli_error_message(err, code)
             )
             return
+        before = self._cursor_mark(state)
         for event in _parse_json_list(out):
             await self._handle_event(channel_id, state, event)
         self._trim_seen(state)
+        # Persist only when the sweep actually moved the cursor, so an idle
+        # channel does not rewrite the file every poll interval.
+        if self._cursor_mark(state) != before:
+            self._save_cursors()
 
     async def _handle_event(self, channel_id: str, state: dict, event: dict) -> None:
         """De-dupe, filter, and dispatch a single ``messages get`` event."""

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -538,3 +538,155 @@ class TestStandaloneSend:
         assert all("nsec1x" not in str(a) for a in captured["args"])
 
 
+# ── Durable channel cursors across restart (#90464) ───────────────────────
+
+
+class TestChannelCursorPersistence:
+    """A restart must resume from the saved cursor, not reseed from history.
+
+    Seeding marks every event currently in the channel as seen. Anything that
+    arrived while the gateway was down is in that history, so an unconditional
+    reseed swallows it permanently even though the relay still has it.
+    """
+
+    @pytest.fixture
+    def adapter(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        a = _make_adapter()
+        a._dispatched = []
+
+        async def capture(**kwargs):
+            a._dispatched.append(kwargs)
+
+        a._dispatch_message = capture
+        a._message_handler = AsyncMock()
+        return a
+
+    @staticmethod
+    def _cursor_file(tmp_path):
+        return tmp_path / "buzz" / "channel-cursors.json"
+
+    async def _seed(self, adapter, *events):
+        cli = _ScriptedCli()
+        cli.script("messages", "get", list(events))
+        adapter._run_cli = cli
+        adapter._load_cursors()
+        await adapter._seed_channel(CHANNEL, chat_type="group")
+        adapter._save_cursors()
+        return cli
+
+    @pytest.mark.asyncio
+    async def test_seed_writes_a_cursor(self, adapter, tmp_path):
+        await self._seed(adapter, _event("e1", created_at=100), _event("e2", created_at=200))
+
+        saved = json.loads(self._cursor_file(tmp_path).read_text(encoding="utf-8"))
+        assert saved["identity"] == SELF_PUBKEY
+        assert saved["relay"] == "https://test.relay"
+        assert saved["channels"][CHANNEL]["last_ts"] == 200
+        assert saved["channels"][CHANNEL]["seen"] == ["e1", "e2"]
+
+    @pytest.mark.asyncio
+    async def test_restart_resumes_instead_of_reseeding(self, adapter, tmp_path, monkeypatch):
+        await self._seed(adapter, _event("e1", content="@Chip first", created_at=100))
+
+        # Restart. The relay now also holds a mention that landed while the
+        # gateway was down, and it sits in the same history a reseed reads.
+        restarted = _make_adapter()
+        restarted._dispatched = []
+
+        async def capture(**kwargs):
+            restarted._dispatched.append(kwargs)
+
+        restarted._dispatch_message = capture
+        restarted._message_handler = AsyncMock()
+        cli = _ScriptedCli()
+        cli.script("messages", "get", [
+            _event("e1", content="@Chip first", created_at=100),
+            _event("e2", content="@Chip sent while you were down", created_at=150),
+        ])
+        restarted._run_cli = cli
+        restarted._load_cursors()
+        await restarted._seed_channel(CHANNEL, chat_type="group")
+
+        # Restoring must not spend a CLI call on history it is not going to use.
+        assert cli.calls == []
+        state = restarted._channel_state[CHANNEL]
+        assert set(state["seen"]) == {"e1"}
+        assert state["last_ts"] == 100
+
+        # The first poll after the restart delivers the missed mention.
+        await restarted._poll_channel(CHANNEL)
+        assert [d["message_id"] for d in restarted._dispatched] == ["e2"]
+
+    @pytest.mark.asyncio
+    async def test_cursor_survives_only_for_the_same_identity_and_relay(self, adapter, tmp_path, monkeypatch):
+        await self._seed(adapter, _event("e1", created_at=100))
+
+        # Same machine, different bot: channel ids would collide but the event
+        # stream behind them is another one, so the cursor must be ignored.
+        other = _make_adapter()
+        other._self_pubkey = OTHER_PUBKEY
+        other._load_cursors()
+        assert other._restored_cursors == {}
+
+        elsewhere = _make_adapter({"relay_url": "https://other.relay"})
+        elsewhere._load_cursors()
+        assert elsewhere._restored_cursors == {}
+
+    @pytest.mark.asyncio
+    async def test_unreadable_cursor_file_falls_back_to_seeding(self, adapter, tmp_path):
+        path = self._cursor_file(tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{ not json", encoding="utf-8")
+
+        cli = _ScriptedCli()
+        cli.script("messages", "get", [_event("e1", created_at=100)])
+        adapter._run_cli = cli
+        adapter._load_cursors()
+        await adapter._seed_channel(CHANNEL, chat_type="group")
+
+        # Degrades to the old behaviour rather than failing the connect.
+        assert adapter._restored_cursors == {}
+        assert set(adapter._channel_state[CHANNEL]["seen"]) == {"e1"}
+
+    @pytest.mark.asyncio
+    async def test_restored_seen_set_stays_bounded(self, adapter, tmp_path):
+        cap = _buzz_mod._SEEN_CAP
+        path = self._cursor_file(tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({
+                "identity": SELF_PUBKEY,
+                "relay": "https://test.relay",
+                "channels": {
+                    CHANNEL: {
+                        "chat_type": "group",
+                        "last_ts": 100,
+                        "seen": [f"e{i}" for i in range(cap * 2)],
+                    }
+                },
+            }),
+            encoding="utf-8",
+        )
+        adapter._load_cursors()
+        await adapter._seed_channel(CHANNEL, chat_type="group")
+
+        seen = adapter._channel_state[CHANNEL]["seen"]
+        assert len(seen) == cap
+        # The newest ids are the ones worth keeping for de-dupe.
+        assert f"e{cap * 2 - 1}" in seen
+        assert "e0" not in seen
+
+    @pytest.mark.asyncio
+    async def test_idle_poll_does_not_rewrite_the_cursor(self, adapter, tmp_path):
+        cli = await self._seed(adapter, _event("e1", created_at=100))
+        path = self._cursor_file(tmp_path)
+        before = path.stat().st_mtime_ns
+
+        cli.responses.clear()
+        cli.script("messages", "get", [_event("e1", created_at=100)])
+        await adapter._poll_channel(CHANNEL)
+
+        assert path.stat().st_mtime_ns == before
+
+


### PR DESCRIPTION
## What does this PR do?

`connect()` calls `_seed_channel()` unconditionally, and seeding marks every event currently in the channel as seen so a start never replays history at the agent. A message that arrives after the process starts but before the seed completes — or at any point while the gateway is down — sits in exactly that history, so the seed swallows it permanently even though the Buzz relay still has it. The `seen` set and `last_ts` lived only in memory, so there was nothing to distinguish "already handled" from "never seen".

Each watched channel's cursor (`chat_type`, `last_ts`, and the bounded `seen` id list) is now persisted under `HERMES_HOME/buzz/channel-cursors.json` and restored at connect. Where a cursor exists the channel resumes from it and the history fetch is skipped entirely; where none exists the old seed-from-history behaviour is unchanged, so a first-ever run still never replays a backlog.

Details worth reviewing:

- **Scoped to the identity and relay it was written for.** A cursor from a different bot or relay is ignored rather than trusted — the channel ids would collide while the event stream behind them is a different one.
- **Fails open.** Any read or parse failure leaves the cursors empty, which degrades to seeding instead of failing the connect. Writes go through `utils.atomic_json_write` (temp + fsync + replace), so a crash mid-write cannot leave a truncated cursor behind.
- **Bounded on load.** The restored `seen` list is trimmed to `_SEEN_CAP`, keeping the newest ids, so a hand-edited or legacy file cannot grow the de-dupe set without bound.
- **Quiet when idle.** Saves are gated on the cursor actually moving, so an idle channel does not rewrite the file every poll interval. Both inbound transports are covered — the poll sweep and the WebSocket event path share the same check.

The issue also suggests retaining chat classification across restarts; `chat_type` is part of the persisted cursor, so a DM that latched via p-tag detection stays a DM after a restart instead of re-entering as a mention-gated group.

## Related Issue

Fixes #90464

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/buzz/adapter.py`
  - `_cursor_path`, `_load_cursors`, `_save_cursors`, `_restore_channel_state`, `_cursor_mark`
  - `_seed_channel` restores a persisted cursor and returns before fetching history when one exists
  - `_discover_dms(seed=False)` restores too, so a channel found mid-run resumes rather than starting from zero
  - `connect()` loads cursors before seeding and saves once the watch set is known
  - `_poll_channel` and the WebSocket event branch save when the cursor moved
  - constants `_CURSOR_STATE_SUBDIR`, `_CURSOR_STATE_FILENAME`
- `tests/gateway/test_buzz_adapter.py` — new `TestChannelCursorPersistence` (six cases)
- `contributors/emails/boni.alessandro997@gmail.com` — attribution mapping required by the `Contributor Attribution Check` job

## How to Test

1. `python -m pytest tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py -q` → 33 passed. On `main` the six new cases fail.
2. The regression case directly (`test_restart_resumes_instead_of_reseeding`): seed a channel, persist, then build a fresh adapter against the same `HERMES_HOME` whose history now also holds a mention that landed while the gateway was down. Before, the reseed marked it seen and it never dispatched; here the restore skips the history fetch entirely (`cli.calls == []`) and the first poll delivers it.
3. Against a live relay: run `hermes gateway run` with a Buzz channel, stop it, send a mentioned message, start it again. The message dispatches on the first poll instead of being dropped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the Buzz suites rather than the whole tree: `tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py` → **33 passed**. Note these need `pytest-asyncio` (pinned at 1.3.0 in `pyproject.toml`); without it every async case in the file errors as an unknown mark, which reads as 15 failures unrelated to any change.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.12

### Documentation & Housekeeping

- [x] Documentation — N/A, no user-facing surface changed; the state file is internal
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — the write goes through `utils.atomic_json_write`, which is already the repo's cross-platform atomic write; no new path or process handling. `scripts/check-windows-footguns.py` clean
- [x] Tool descriptions/schemas — N/A

## Not addressed here

The issue mentions same-second overlap retention. The existing poll already re-fetches same-second events (`--since` is inclusive on Nostr) and de-dupes them by id, and the persisted `seen` list is what makes that de-dupe survive the restart — so no separate mechanism was added.
