### PR TITLE
fix(cli): persist workspace for --create-if-missing sessions

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1781,7 +1781,9 @@ def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
     return None
 
 
-def _create_titled_session(title: str) -> Optional[str]:
+def _create_titled_session(
+    title: str, *, cwd: Optional[str] = None
+) -> Optional[str]:
     """Create a fresh session with the given title; return its session id.
 
     Used by ``chat -c <title> --create-if-missing`` (#86794): programmatic
@@ -1804,7 +1806,7 @@ def _create_titled_session(title: str) -> Optional[str]:
         new_session_id = f"{timestamp_str}_{short_uuid}"
 
         db = SessionDB()
-        db.create_session(new_session_id, source="cli")
+        db.create_session(new_session_id, source="cli", cwd=cwd)
         db.set_session_title(new_session_id, title)
         return new_session_id
     except Exception:
@@ -1847,7 +1849,7 @@ def _resolve_continue_arg(args, *, use_tui: bool) -> None:
                 # programmatic-caller primitive ("send to this named thread,
                 # making it if needed"); without it a background/quiet send to
                 # a not-yet-existing named session silently no-ops (#86794).
-                new_sid = _create_titled_session(continue_val)
+                new_sid = _create_titled_session(continue_val, cwd=os.getcwd())
                 if new_sid:
                     args.resume = new_sid
                 else:

--- a/tests/hermes_cli/test_chat_c_fail_loudly.py
+++ b/tests/hermes_cli/test_chat_c_fail_loudly.py
@@ -133,9 +133,11 @@ class TestChatCFailLoudlyOnStderr:
         assert any("No session found matching 'Bot Chat'" in l for l in stderr_lines)
         assert not stderr_lines[0].startswith("Use 'hermes sessions list'")
 
-    def test_create_if_missing_sets_resume(self, isolated_home, monkeypatch):
+    def test_create_if_missing_sets_resume(self, isolated_home, monkeypatch, tmp_path):
         """--create-if-missing resolves to a new session id on args.resume."""
         import hermes_cli.main as main_mod
+
+        monkeypatch.chdir(tmp_path)
 
         args = type(
             "Args",
@@ -155,5 +157,8 @@ class TestChatCFailLoudlyOnStderr:
         db = SessionDB()
         try:
             assert db.get_session_title(args.resume) == "Bot Chat"
+            from pathlib import Path
+
+            assert Path(db.get_session(args.resume)["cwd"]).resolve() == tmp_path.resolve()
         finally:
             db.close()


### PR DESCRIPTION
## What does this PR do?

Fixes a state-loss bug in `hermes chat -c "<title>" --create-if-missing`.

When the titled session did not exist, Hermes created it with `cwd=NULL`, so a later resume could not retain the explicit workspace selected by `--in`. The new session creation path persists the caller's current workspace at creation time.

## Related Issue

N/A — no existing issue found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: accept an optional `cwd` in `_create_titled_session()` and pass `os.getcwd()` from `_resolve_continue_arg()`.
- `tests/hermes_cli/test_chat_c_fail_loudly.py`: assert that the created session stores the caller workspace.

## How to Test

1. Start from a temporary workspace and call `_resolve_continue_arg()` with `--create-if-missing`.
2. Read the created row from `SessionDB`.
3. Confirm that its stored `cwd` resolves to the temporary workspace.

Targeted regression command:

```text
uv run --extra all --extra dev --extra messaging pytest tests/hermes_cli/test_chat_c_fail_loudly.py -q
```

Result: `6 passed in 0.37s`.

The repository-wide suite was also attempted with the required optional dependencies. It did not complete cleanly in this macOS environment: the broad all-extras setup cannot build `python-olm` without `cmake`/`gmake`, and the non-Matrix run emitted unrelated existing E2E/logging failures. The full-suite checklist item therefore remains unchecked.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted regression output: `6 passed in 0.37s`. No screenshots apply to this CLI/session-state fix.