### PR TITLE
fix(desktop): confirm before closing the main window

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -314,6 +314,7 @@ import {
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
 import { readWindowBelow } from './window-below'
+import { closeActionForResponse, windowCloseDecision } from './window-close-policy'
 import { installWindowRendererLifecycle } from './window-renderer-lifecycle'
 import { createWindowRevealController } from './window-reveal'
 import {
@@ -2965,6 +2966,8 @@ let updateInFlight = false
 // set, window-all-closed calls app.quit() on every platform so the process
 // actually dies and the hand-off script can proceed immediately.
 let isQuittingForHandoff = false
+let nativeQuitInProgress = false
+let closePromptOpen = false
 
 // Quit-guard latches: one while the confirmation is on screen (a second
 // Cmd-Q must not stack dialogs), one after the user has said "quit anyway"
@@ -11923,7 +11926,55 @@ function createWindow() {
   bindGeometryPersistence(mainWindow, schedulePersistWindowState)
   mainWindow.on('maximize', schedulePersistWindowState)
   mainWindow.on('unmaximize', schedulePersistWindowState)
-  mainWindow.on('close', () => schedulePersistWindowState.flush())
+  mainWindow.on('close', event => {
+    schedulePersistWindowState.flush()
+
+    const decision = windowCloseDecision({
+      handoffInProgress: isQuittingForHandoff,
+      platform: process.platform,
+      promptOpen: closePromptOpen || quitPromptOpen,
+      quitInProgress: nativeQuitInProgress
+    })
+
+    if (decision === 'proceed') {
+      return
+    }
+
+    event.preventDefault()
+
+    if (decision === 'hold') {
+      return
+    }
+
+    closePromptOpen = true
+    void dialog
+      .showMessageBox(createdMainWindow, {
+        type: 'question',
+        title: 'Keep Hermes running?',
+        message: 'Minimize Hermes to keep the gateway connection ready, or quit and reconnect next time.',
+        buttons: ['Minimize', 'Quit Hermes', 'Cancel'],
+        defaultId: 0,
+        cancelId: 2,
+        noLink: true
+      })
+      .then(({ response }) => {
+        const action = closeActionForResponse(response)
+
+        if (action === 'minimize') {
+          createdMainWindow.minimize()
+        } else if (action === 'quit') {
+          app.quit()
+        }
+      })
+      .catch(error => {
+        // A failed native dialog must leave the window open, not turn the close
+        // gesture into an unhandled rejection or an accidental quit.
+        rememberLog(`[window-close] confirmation failed: ${error?.message || error}`)
+      })
+      .finally(() => {
+        closePromptOpen = false
+      })
+  })
 
   // the closed wrapper remains truthy, so clear only the window this callback owns.
   mainWindow.on('closed', () => {
@@ -14959,6 +15010,8 @@ app.on('before-quit', event => {
   if (heldQuitForActiveWork(event)) {
     return
   }
+
+  nativeQuitInProgress = true
 
   if (!backendQuitTeardownDone) {
     event.preventDefault()

--- a/apps/desktop/electron/window-close-policy.test.ts
+++ b/apps/desktop/electron/window-close-policy.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { closeActionForResponse, windowCloseDecision } from './window-close-policy'
+
+test('Windows and Linux prompt on a user window close', () => {
+  assert.equal(windowCloseDecision({ platform: 'win32' }), 'prompt')
+  assert.equal(windowCloseDecision({ platform: 'linux' }), 'prompt')
+})
+
+test('macOS and real application quits bypass the close prompt', () => {
+  assert.equal(windowCloseDecision({ platform: 'darwin' }), 'proceed')
+  assert.equal(windowCloseDecision({ platform: 'win32', quitInProgress: true }), 'proceed')
+  assert.equal(windowCloseDecision({ handoffInProgress: true, platform: 'linux' }), 'proceed')
+})
+
+test('a pending close or active-work prompt holds repeated close gestures', () => {
+  assert.equal(windowCloseDecision({ platform: 'win32', promptOpen: true }), 'hold')
+  assert.equal(windowCloseDecision({ platform: 'linux', promptOpen: true }), 'hold')
+})
+
+test('close dialog responses map to minimize, quit, and cancel', () => {
+  assert.equal(closeActionForResponse(0), 'minimize')
+  assert.equal(closeActionForResponse(1), 'quit')
+  assert.equal(closeActionForResponse(2), 'cancel')
+  assert.equal(closeActionForResponse(-1), 'cancel')
+})

--- a/apps/desktop/electron/window-close-policy.ts
+++ b/apps/desktop/electron/window-close-policy.ts
@@ -1,0 +1,34 @@
+export type WindowCloseAction = 'cancel' | 'minimize' | 'quit'
+export type WindowCloseDecision = 'hold' | 'proceed' | 'prompt'
+
+interface WindowClosePromptInput {
+  handoffInProgress?: boolean
+  platform: NodeJS.Platform
+  promptOpen?: boolean
+  quitInProgress?: boolean
+}
+
+export function windowCloseDecision({
+  handoffInProgress = false,
+  platform,
+  promptOpen = false,
+  quitInProgress = false
+}: WindowClosePromptInput): WindowCloseDecision {
+  if (platform === 'darwin' || handoffInProgress || quitInProgress) {
+    return 'proceed'
+  }
+
+  return promptOpen ? 'hold' : 'prompt'
+}
+
+export function closeActionForResponse(response: number): WindowCloseAction {
+  if (response === 0) {
+    return 'minimize'
+  }
+
+  if (response === 1) {
+    return 'quit'
+  }
+
+  return 'cancel'
+}


### PR DESCRIPTION
## Summary

Add a native close confirmation for the main Hermes Desktop window on Windows and Linux:

- **Minimize** keeps the app and its gateway connection running.
- **Quit Hermes** follows the normal `app.quit()` lifecycle and existing active-work guard.
- **Cancel** leaves the window unchanged.

macOS keeps its existing Dock convention and is not intercepted.

## Why

On Windows and Linux, clicking the title-bar close button currently destroys the last window and quits Hermes. That also tears down remote SSH tunnels, so an accidental click can turn the next launch into a full reconnect.

A user hit this in a real remote-gateway workflow and asked for an explicit choice rather than an implicit close-to-tray behavior. The same implementation has been built and manually exercised on Linux: Minimize preserved the process and connection, Cancel kept the window open, and Quit used the normal teardown path.

## Implementation

- Add `window-close-policy.ts` with a pure, tested `proceed / hold / prompt` decision and dialog response mapping.
- Intercept the main window's `close` event on non-macOS platforms.
- Set a dedicated `nativeQuitInProgress` latch in `before-quit` so File -> Quit, updater handoffs, and programmatic quits never reopen the dialog or loop.
- Hold repeated close gestures while either the close dialog or the existing active-work quit dialog is open.
- Keep geometry persistence and the existing active-work confirmation path intact.

## Overlap disclosure

Related open work exists, but implements different behavior:

- #87748 and #81342 add configurable Windows system-tray behavior.
- #73046 makes the active-work quit guard reachable from the Windows/Linux last-window close path.

This PR does not add a tray icon or a setting. It provides a smaller cross-platform confirmation choice for Windows and Linux. If a tray implementation lands, the policy can either remain as the explicit close choice or be reconciled with that setting during review.

## Test plan

- [x] New test observed failing before implementation because the policy module did not exist.
- [x] `npx vitest run --project electron electron/window-close-policy.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint` - 0 errors; existing warnings only.
- [x] `npm run test:desktop:platforms` - 1,509 passed, 2 skipped.
- [x] `npm run build`
- [x] `npm run test:desktop:all` - packaged Linux app successfully.
- [x] Static scan of added lines found no secrets, shell injection, eval/exec, or unsafe deserialization.

## Behavior matrix

| Path | Windows/Linux | macOS |
|---|---|---|
| User clicks window close | Show Minimize / Quit / Cancel | Existing behavior |
| User chooses Minimize | Keep process and connection alive | N/A |
| User chooses Quit | Normal quit and teardown | N/A |
| File -> Quit or programmatic `app.quit()` | Bypass close prompt | Existing behavior |
| Update/install handoff | Bypass close prompt | Existing behavior |
| Close clicked repeatedly while prompt is open | Keep close held, no stacked dialogs | N/A |
