### PR TITLE
feat(process): Hermes processes are positively identified and guaranteed dead at update time

### DIFF
--- a/apps/desktop/electron/parent-process-identity.test.ts
+++ b/apps/desktop/electron/parent-process-identity.test.ts
@@ -5,7 +5,8 @@ import { test, vi } from 'vitest'
 import {
   createParentStartMarkerResolver,
   electronProcessStartMarker,
-  parentWatchdogEnv
+  parentWatchdogEnv,
+  spawnTag
 } from './parent-process-identity'
 
 test('electronProcessStartMarker uses Electron creation time only for its own PID', () => {
@@ -60,14 +61,26 @@ test('parentWatchdogEnv emits an exact identity when the marker is available', (
   assert.deepEqual(parentWatchdogEnv(42, 'winms:1723456789123', 'nonce-1'), {
     HERMES_PARENT_NONCE: 'nonce-1',
     HERMES_PARENT_PID: '42',
-    HERMES_PARENT_START_MARKER: 'winms:1723456789123'
+    HERMES_PARENT_START_MARKER: 'winms:1723456789123',
+    // Spawn tag mirrored by hermes_cli/process_identity.py — spawner create
+    // time in seconds derived from the same winms marker.
+    HERMES_SPAWN: 'v1:-:serve:42:1723456789.123'
   })
 })
 
 test('parentWatchdogEnv atomically falls back to PID-only identity', () => {
   assert.deepEqual(parentWatchdogEnv(42, null, 'unused-nonce'), {
-    HERMES_PARENT_PID: '42'
+    HERMES_PARENT_PID: '42',
+    // Marker probe failed → spawn tag still present, create time unknown.
+    HERMES_SPAWN: 'v1:-:serve:42:-'
   })
   assert.throws(() => parentWatchdogEnv(42, '', 'nonce-1'), /marker and nonce must be non-empty/)
   assert.throws(() => parentWatchdogEnv(42, 'winms:1723456789123', ''), /marker and nonce must be non-empty/)
+})
+
+test('spawnTag derives seconds from a winms marker and dashes without one', () => {
+  assert.equal(spawnTag(42, 'winms:1723456789123'), 'v1:-:serve:42:1723456789.123')
+  assert.equal(spawnTag(42, null), 'v1:-:serve:42:-')
+  assert.equal(spawnTag(42, 'win:638908765432100000'), 'v1:-:serve:42:-')
+  assert.equal(spawnTag(42, 'winms:garbage'), 'v1:-:serve:42:-')
 })

--- a/apps/desktop/electron/parent-process-identity.ts
+++ b/apps/desktop/electron/parent-process-identity.ts
@@ -2,6 +2,10 @@ export type ParentWatchdogEnv = {
   HERMES_PARENT_PID: string
   HERMES_PARENT_START_MARKER?: string
   HERMES_PARENT_NONCE?: string
+  /** Spawn tag consumed by hermes_cli.process_identity (`v1:<install>:<purpose>:<spawner_pid>:<spawner_create_s>`).
+   *  Install is `-` (unknown) from the Desktop — the Python side scopes by
+   *  venv membership, so the tag only needs lineage, not install identity. */
+  HERMES_SPAWN?: string
 }
 
 export interface ParentStartMarkerResolverOptions {
@@ -69,6 +73,7 @@ export function parentWatchdogEnv(pid: number, startMarker: string | null, nonce
   }
 
   const env: ParentWatchdogEnv = { HERMES_PARENT_PID: String(pid) }
+  env.HERMES_SPAWN = spawnTag(pid, startMarker)
 
   if (startMarker === null) {
     return env
@@ -82,4 +87,22 @@ export function parentWatchdogEnv(pid: number, startMarker: string | null, nonce
   env.HERMES_PARENT_NONCE = nonce
 
   return env
+}
+
+/** Build the `HERMES_SPAWN` tag mirrored by hermes_cli/process_identity.py.
+ *  The Desktop only ever spawns backend servers, so purpose is `serve`; the
+ *  spawner create-time is derived from the same `winms:` marker the parent
+ *  watchdog uses (seconds, 3 decimals), `-` when the marker probe failed. */
+export function spawnTag(pid: number, startMarker: string | null): string {
+  let createPart = '-'
+
+  if (startMarker?.startsWith('winms:')) {
+    const ms = Number(startMarker.slice('winms:'.length))
+
+    if (Number.isFinite(ms) && ms > 0) {
+      createPart = (ms / 1000).toFixed(3)
+    }
+  }
+
+  return `v1:-:serve:${pid}:${createPart}`
 }

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30813,6 +30813,20 @@ def main():
     os.environ.setdefault("AI_AGENT", "hermes-agent")
     os.environ.setdefault("HERMES_AGENT", "true")
 
+    # Positive process identity: ledger registration + Windows job-object
+    # self-attach, so update-time reapers can identify this gateway (and its
+    # child tree dies with it on Windows). Best-effort — never blocks startup.
+    try:
+        from hermes_cli.process_identity import (
+            attach_self_to_kill_on_close_job,
+            register_self,
+        )
+
+        register_self("gateway")
+        attach_self_to_kill_on_close_job()
+    except Exception:
+        pass
+
     # Force UTF-8 stdio on Windows — gateway logs and startup banner would
     # otherwise UnicodeEncodeError on cp1252 consoles.  No-op on POSIX.
     try:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4878,6 +4878,7 @@ _LAZY_COMMAND_EXPORTS = {
         "_format_concurrent_instances_message",
         "_format_time_ago",
         "_handoff_reapable_backend_pids",
+        "_ledger_reapable_backend_pids",
         "_format_venv_python_holders_message",
         "_gateway_prompt",
         "_get_origin_url",

--- a/hermes_cli/process_identity.py
+++ b/hermes_cli/process_identity.py
@@ -1,0 +1,421 @@
+"""Process identity: spawn tags, the machine-wide spawn ledger, and the
+Windows job-object self-attach.
+
+Three layers that make every long-lived Hermes process positively
+identifiable, so reapers (``hermes update``, Desktop startup sweeps) never
+have to guess lineage from PPID archaeology or cmdline pattern-matching:
+
+1. **Spawn tag** (``HERMES_SPAWN`` env var): every spawner stamps its children
+   with ``v1:<install_id>:<purpose>:<spawner_pid>:<spawner_create>``. A scanner
+   that can read the child's environment classifies it instantly: which
+   install, what it is, who spawned it, and when.
+
+2. **Spawn ledger** (``spawn-ledger.json`` at the machine Hermes root): every
+   long-lived process (serve/dashboard backend, gateway) self-registers
+   ``pid + create_time + purpose + spawner`` at startup. ``pid`` alone is
+   forgeable by reuse; the ``(pid, create_time)`` pair is not. Reapers
+   cross-check live processes against the ledger for positive identification
+   even when environment reads are denied (Windows frequently denies
+   ``Process.environ()`` cross-session).
+
+3. **Job object self-attach** (Windows): a backend places itself in a job with
+   ``KILL_ON_JOB_CLOSE`` so its whole child tree dies atomically with it —
+   no launcher→worker two-hop chains left holding ``.pyd`` locks after the
+   visible root is killed. ``BREAKAWAY_OK`` is set so the existing
+   ``CREATE_BREAKAWAY_FROM_JOB`` spawns (gateway relaunch during update,
+   watchers that must outlive their spawner) keep working unchanged.
+
+All of it is best-effort and fail-safe: identity failures degrade to the
+legacy heuristics, they never block startup or updates. The ledger tolerates
+corruption the same way ``backend-ownership.json`` does post-#89298:
+an unreadable ledger is quarantined aside (``.corrupt``), never rewritten
+blind.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import platform
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+SPAWN_ENV_VAR = "HERMES_SPAWN"
+_TAG_VERSION = "v1"
+LEDGER_FILENAME = "spawn-ledger.json"
+
+#: Purposes a reaper may treat as "safe to kill when the owner is gone".
+#: Interactive processes (chat, REPLs) are deliberately NOT in this set.
+REAPABLE_PURPOSES = frozenset({"serve", "dashboard", "gateway"})
+
+_IS_WINDOWS = platform.system() == "Windows"
+
+# Module-global job handle: must live exactly as long as this process so the
+# kernel closes it (and kills the job) when we die. Never close it manually.
+_JOB_HANDLE = None
+_LEDGER_LOCK = threading.Lock()
+
+
+# ---------------------------------------------------------------------------
+# Install identity
+# ---------------------------------------------------------------------------
+
+def install_id(project_root: Optional[Path] = None) -> str:
+    """Stable 12-hex identifier for THIS install (derived from its path).
+
+    Lets a reaper reject processes from a different Hermes install on the
+    same machine without path comparisons at scan time.
+    """
+    if project_root is None:
+        try:
+            from hermes_constants import PROJECT_ROOT as _root
+
+            project_root = Path(_root)
+        except Exception:
+            project_root = Path(__file__).resolve().parent.parent
+    try:
+        canonical = str(Path(project_root).resolve()).lower()
+    except OSError:
+        canonical = str(project_root).lower()
+    return hashlib.sha256(canonical.encode("utf-8", "replace")).hexdigest()[:12]
+
+
+def _own_create_time() -> Optional[float]:
+    try:
+        import psutil
+
+        return float(psutil.Process(os.getpid()).create_time())
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — spawn tags
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class SpawnTag:
+    install: str
+    purpose: str
+    spawner_pid: int
+    spawner_create: Optional[float]
+
+
+def build_spawn_tag(purpose: str, *, project_root: Optional[Path] = None) -> str:
+    """Value for the child's ``HERMES_SPAWN`` env var, stamped by the spawner."""
+    create = _own_create_time()
+    create_part = f"{create:.3f}" if create is not None else "-"
+    return ":".join(
+        (_TAG_VERSION, install_id(project_root), purpose, str(os.getpid()), create_part)
+    )
+
+
+def spawn_env(purpose: str, *, project_root: Optional[Path] = None) -> dict[str, str]:
+    """Env fragment a spawner merges into a child's environment."""
+    return {SPAWN_ENV_VAR: build_spawn_tag(purpose, project_root=project_root)}
+
+
+def parse_spawn_tag(raw: object) -> Optional[SpawnTag]:
+    """Parse a ``HERMES_SPAWN`` value; ``None`` for anything malformed."""
+    if not isinstance(raw, str):
+        return None
+    parts = raw.split(":")
+    if len(parts) != 5 or parts[0] != _TAG_VERSION:
+        return None
+    _, install, purpose, pid_s, create_s = parts
+    if not install or not purpose:
+        return None
+    try:
+        pid = int(pid_s)
+    except ValueError:
+        return None
+    if pid <= 0:
+        return None
+    create: Optional[float] = None
+    if create_s != "-":
+        try:
+            create = float(create_s)
+        except ValueError:
+            return None
+    return SpawnTag(install=install, purpose=purpose, spawner_pid=pid, spawner_create=create)
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — spawn ledger
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LedgerEntry:
+    pid: int
+    create_time: Optional[float]
+    purpose: str
+    install: str
+    spawner_pid: Optional[int]
+    spawner_create: Optional[float]
+    registered_at: float
+    argv: str
+
+
+def _ledger_path() -> Path:
+    """Machine-root ledger path (shared by every profile of this install)."""
+    try:
+        from hermes_constants import get_default_hermes_root
+
+        return Path(get_default_hermes_root()) / LEDGER_FILENAME
+    except Exception:
+        from hermes_cli.config import get_hermes_home
+
+        return Path(get_hermes_home()) / LEDGER_FILENAME
+
+
+def _read_ledger(path: Path) -> Optional[list[dict]]:
+    """Entries list, ``[]`` for empty/missing, ``None`` for CORRUPT.
+
+    Mirrors the #89298 contract: corrupt is a distinct state that must never
+    be silently treated as an empty roster.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return []
+    except OSError:
+        return None
+    if not text.strip():
+        return []
+    try:
+        parsed = json.loads(text)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(parsed, list):
+        return None
+    return [e for e in parsed if isinstance(e, dict)]
+
+
+def _quarantine_ledger(path: Path) -> None:
+    parked = path.with_suffix(path.suffix + ".corrupt")
+    try:
+        os.replace(path, parked)
+        logger.warning("spawn ledger was unreadable; moved to %s", parked)
+    except OSError:
+        pass
+
+
+def _pid_alive_matches(pid: int, create_time: Optional[float]) -> Optional[bool]:
+    """True/False when provable; ``None`` when psutil can't say."""
+    try:
+        import psutil
+    except Exception:
+        return None
+    try:
+        proc = psutil.Process(int(pid))
+        if create_time is None:
+            return True
+        return abs(float(proc.create_time()) - float(create_time)) < 2.0
+    except psutil.NoSuchProcess:
+        return False
+    except Exception:
+        return None
+
+
+def register_self(purpose: str, *, project_root: Optional[Path] = None) -> bool:
+    """Record this process in the machine spawn ledger. Best-effort.
+
+    Called at the top of every long-lived entry point (serve/dashboard
+    backend, gateway run loop). Dead entries — ``(pid, create_time)`` no
+    longer live — are pruned on every write so the ledger tracks reality
+    instead of growing forever.
+    """
+    tag = parse_spawn_tag(os.environ.get(SPAWN_ENV_VAR))
+    spawner_pid: Optional[int] = tag.spawner_pid if tag else None
+    spawner_create: Optional[float] = tag.spawner_create if tag else None
+    if spawner_pid is None:
+        # Desktop compatibility: the Electron app already stamps children with
+        # HERMES_PARENT_PID (+ optional `winms:<ms>` start marker) for its
+        # parent-death watchdog. Reuse it as spawner identity so ledger
+        # lineage works with every Desktop version, no TS change needed.
+        try:
+            raw = int(os.environ.get("HERMES_PARENT_PID", ""))
+            if raw > 0:
+                spawner_pid = raw
+        except (TypeError, ValueError):
+            pass
+        marker = os.environ.get("HERMES_PARENT_START_MARKER", "")
+        if spawner_pid is not None and marker.startswith("winms:"):
+            try:
+                spawner_create = float(marker.split(":", 1)[1]) / 1000.0
+            except (ValueError, IndexError):
+                spawner_create = None
+    entry = LedgerEntry(
+        pid=os.getpid(),
+        create_time=_own_create_time(),
+        purpose=purpose,
+        install=install_id(project_root),
+        spawner_pid=spawner_pid,
+        spawner_create=spawner_create,
+        registered_at=time.time(),
+        argv="",
+    )
+    try:
+        import sys as _sys
+
+        entry.argv = " ".join(_sys.argv[:6])
+    except Exception:
+        pass
+
+    path = _ledger_path()
+    with _LEDGER_LOCK:
+        entries = _read_ledger(path)
+        if entries is None:
+            _quarantine_ledger(path)
+            entries = []
+        pruned: list[dict] = []
+        for e in entries:
+            pid = e.get("pid")
+            if not isinstance(pid, int) or pid == entry.pid:
+                continue
+            alive = _pid_alive_matches(pid, e.get("create_time"))
+            if alive is False:
+                continue  # provably dead → prune
+            pruned.append(e)
+        pruned.append(asdict(entry))
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_suffix(path.suffix + f".tmp{os.getpid()}")
+            tmp.write_text(json.dumps(pruned, indent=2), encoding="utf-8")
+            os.replace(tmp, path)
+            return True
+        except OSError:
+            logger.debug("spawn ledger write failed", exc_info=True)
+            return False
+
+
+def ledger_entries(*, project_root: Optional[Path] = None) -> list[dict]:
+    """Live-verified ledger entries for THIS install.
+
+    Entries whose ``(pid, create_time)`` no longer matches a live process are
+    excluded (PID reuse reads as dead, thanks to the create-time pair). A
+    corrupt ledger is quarantined and read as empty — identical philosophy to
+    the backend-ownership fix (#89298): never let corruption erase or fake
+    a roster; never let it block the caller either.
+    """
+    want_install = install_id(project_root)
+    path = _ledger_path()
+    with _LEDGER_LOCK:
+        entries = _read_ledger(path)
+        if entries is None:
+            _quarantine_ledger(path)
+            return []
+    out: list[dict] = []
+    for e in entries:
+        if e.get("install") != want_install:
+            continue
+        pid = e.get("pid")
+        if not isinstance(pid, int):
+            continue
+        if _pid_alive_matches(pid, e.get("create_time")) is False:
+            continue
+        out.append(e)
+    return out
+
+
+def spawner_is_dead(entry: dict) -> Optional[bool]:
+    """Is the recorded spawner of this entry provably gone?
+
+    ``True`` → owner gone (orphaned by identity, not by PPID guessing).
+    ``False`` → owner still alive. ``None`` → no spawner recorded / unprovable.
+    """
+    spawner_pid = entry.get("spawner_pid")
+    if not isinstance(spawner_pid, int) or spawner_pid <= 0:
+        return None
+    alive = _pid_alive_matches(spawner_pid, entry.get("spawner_create"))
+    if alive is None:
+        return None
+    return not alive
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — Windows job-object self-attach
+# ---------------------------------------------------------------------------
+
+def attach_self_to_kill_on_close_job() -> bool:
+    """Place this process in a job that dies (whole tree) when we die.
+
+    Windows-only, best-effort, idempotent. ``BREAKAWAY_OK`` is included so
+    children spawned with ``CREATE_BREAKAWAY_FROM_JOB`` (gateway relaunch
+    during update, detached watchers) keep escaping exactly as they do today.
+    Nested jobs are supported since Windows 8, so being inside another job
+    (Terminal, CI runners) does not prevent the attach on any supported OS.
+    """
+    global _JOB_HANDLE
+    if not _IS_WINDOWS or _JOB_HANDLE is not None:
+        return _JOB_HANDLE is not None
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+        JOB_OBJECT_LIMIT_BREAKAWAY_OK = 0x0800
+        JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK = 0x1000
+        JobObjectExtendedLimitInformation = 9
+
+        class IO_COUNTERS(ctypes.Structure):
+            _fields_ = [(n, ctypes.c_ulonglong) for n in (
+                "ReadOperationCount", "WriteOperationCount", "OtherOperationCount",
+                "ReadTransferCount", "WriteTransferCount", "OtherTransferCount")]
+
+        class JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+            _fields_ = [
+                ("PerProcessUserTimeLimit", wintypes.LARGE_INTEGER),
+                ("PerJobUserTimeLimit", wintypes.LARGE_INTEGER),
+                ("LimitFlags", wintypes.DWORD),
+                ("MinimumWorkingSetSize", ctypes.c_size_t),
+                ("MaximumWorkingSetSize", ctypes.c_size_t),
+                ("ActiveProcessLimit", wintypes.DWORD),
+                ("Affinity", ctypes.POINTER(wintypes.ULONG)),
+                ("PriorityClass", wintypes.DWORD),
+                ("SchedulingClass", wintypes.DWORD),
+            ]
+
+        class JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+            _fields_ = [
+                ("BasicLimitInformation", JOBOBJECT_BASIC_LIMIT_INFORMATION),
+                ("IoInfo", IO_COUNTERS),
+                ("ProcessMemoryLimit", ctypes.c_size_t),
+                ("JobMemoryLimit", ctypes.c_size_t),
+                ("PeakProcessMemoryUsed", ctypes.c_size_t),
+                ("PeakJobMemoryUsed", ctypes.c_size_t),
+            ]
+
+        job = kernel32.CreateJobObjectW(None, None)
+        if not job:
+            return False
+        info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+        info.BasicLimitInformation.LimitFlags = (
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+            | JOB_OBJECT_LIMIT_BREAKAWAY_OK
+            | JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK
+        )
+        ok = kernel32.SetInformationJobObject(
+            job, JobObjectExtendedLimitInformation, ctypes.byref(info), ctypes.sizeof(info)
+        )
+        if not ok:
+            kernel32.CloseHandle(job)
+            return False
+        if not kernel32.AssignProcessToJobObject(job, kernel32.GetCurrentProcess()):
+            kernel32.CloseHandle(job)
+            return False
+        _JOB_HANDLE = job  # keep alive for the life of the process — never close
+        logger.debug("attached to kill-on-close job object")
+        return True
+    except Exception:
+        logger.debug("job object self-attach failed", exc_info=True)
+        return False

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3941,6 +3941,50 @@ def _orphaned_desktop_backend_pids(
     return roots
 
 
+def _ledger_reapable_backend_pids(
+    matches: list[tuple[int, str, str]],
+) -> list[int]:
+    """PIDs positively identified by the spawn ledger as orphaned backends.
+
+    The strongest rung: instead of inferring lineage from PPIDs or cmdline
+    shape, look each venv holder up in the machine spawn ledger
+    (``hermes_cli.process_identity``). A holder qualifies when ALL of:
+
+    - its ``(pid, create_time)`` matches a live ledger entry (PID reuse
+      cannot forge this pair);
+    - the entry's purpose is a reapable backend kind (serve/dashboard/
+      gateway — never interactive processes);
+    - the entry's recorded SPAWNER is provably dead (``spawner_is_dead``).
+
+    Unlike the heuristic rungs, this is safe in ANY update context — no
+    hand-off contract needed — because the ownership claim is explicit: the
+    process itself declared who supervises it, and that supervisor is gone.
+    Holders not in the ledger are simply not returned (they fall through to
+    the later rungs); they never disqualify the identified ones. Never raises.
+    """
+    try:
+        from hermes_cli.process_identity import (
+            REAPABLE_PURPOSES,
+            ledger_entries,
+            spawner_is_dead,
+        )
+
+        entries = ledger_entries()
+    except Exception:
+        return []
+    by_pid = {e.get("pid"): e for e in entries if isinstance(e.get("pid"), int)}
+    roots: list[int] = []
+    for pid, _name, _cmdline in matches:
+        entry = by_pid.get(int(pid))
+        if not entry:
+            continue
+        if entry.get("purpose") not in REAPABLE_PURPOSES:
+            continue
+        if spawner_is_dead(entry) is True:
+            roots.append(int(pid))
+    return roots
+
+
 def _handoff_reapable_backend_pids(
     matches: list[tuple[int, str, str]],
 ) -> list[int] | None:
@@ -4873,6 +4917,21 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         logger.debug(
                             "Could not stop leftover gateway %s: %s", _pid, exc
                         )
+                _time.sleep(1.0)
+                _venv_holders = _m()._detect_venv_python_processes()
+        if _venv_holders:
+            # Positive-identity rung (runs FIRST, any update context): holders
+            # the spawn ledger proves are orphaned Hermes backends — the
+            # process self-registered (pid, create_time, purpose, spawner) at
+            # startup and its recorded spawner is provably dead. No PPID
+            # archaeology, no hand-off contract required.
+            _ledger_backends = _m()._ledger_reapable_backend_pids(_venv_holders)
+            if _ledger_backends:
+                print(
+                    f"  ⚠ {len(_ledger_backends)} ledger-identified orphaned "
+                    "Hermes backend process(es) hold the venv; stopping their trees"
+                )
+                _m()._stop_process_trees(_ledger_backends)
                 _time.sleep(1.0)
                 _venv_holders = _m()._detect_venv_python_processes()
         if _venv_holders:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19081,6 +19081,21 @@ def start_server(
             # for standalone `hermes serve` (no HERMES_PARENT_PID env).
             _start_parent_death_watchdog()
 
+            # Positive process identity: record (pid, create_time, purpose,
+            # spawner) in the machine spawn ledger and — on Windows — attach
+            # to a kill-on-close job so this backend's whole child tree dies
+            # with it. Both best-effort; failures degrade to legacy behavior.
+            try:
+                from hermes_cli.process_identity import (
+                    attach_self_to_kill_on_close_job,
+                    register_self,
+                )
+
+                register_self("serve" if headless else "dashboard")
+                attach_self_to_kill_on_close_job()
+            except Exception as exc:
+                _log.debug("process-identity registration skipped: %s", exc)
+
             actual_port = _read_bound_port(server, fallback=port)
             app.state.bound_port = actual_port
 

--- a/tests/hermes_cli/test_process_identity.py
+++ b/tests/hermes_cli/test_process_identity.py
@@ -1,0 +1,244 @@
+"""Tests for hermes_cli.process_identity — spawn tags, the machine spawn
+ledger, and the updater's ledger-identified reap rung.
+
+Layer context (Aug 2026, after the 12-minute Windows update hang): reapers
+previously inferred process lineage from PPIDs and cmdline shape. These
+primitives make identity positive instead: spawners stamp children
+(HERMES_SPAWN), long-lived processes self-register (pid, create_time,
+purpose, spawner) in spawn-ledger.json, and `hermes update` reaps holders the
+ledger PROVES are orphaned backends — in any update context, no hand-off
+contract needed.
+
+Runs on any host: psutil interactions go through a fake module.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli import process_identity as pi
+
+
+class _FakeNoSuchProcess(Exception):
+    pass
+
+
+def _fake_psutil(procs: dict[int, float]):
+    """pid -> create_time; missing pid raises NoSuchProcess."""
+
+    def _process(pid: int):
+        if pid not in procs:
+            raise _FakeNoSuchProcess(pid)
+        proc = MagicMock()
+        proc.pid = pid
+        proc.create_time.return_value = procs[pid]
+        return proc
+
+    return types.SimpleNamespace(Process=_process, NoSuchProcess=_FakeNoSuchProcess)
+
+
+# ---------------------------------------------------------------------------
+# Spawn tags
+# ---------------------------------------------------------------------------
+
+def test_spawn_tag_roundtrip():
+    with patch.dict(sys.modules, {"psutil": _fake_psutil({999: 1234.5})}):
+        with patch.object(pi.os, "getpid", return_value=999):
+            raw = pi.build_spawn_tag("serve", project_root=Path("/x/install"))
+    tag = pi.parse_spawn_tag(raw)
+    assert tag is not None
+    assert tag.purpose == "serve"
+    assert tag.spawner_pid == 999
+    assert tag.spawner_create == pytest.approx(1234.5, abs=0.01)
+    assert tag.install == pi.install_id(Path("/x/install"))
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        None,
+        "",
+        "v0:abc:serve:1:2.0",          # wrong version
+        "v1:abc:serve:notanint:2.0",   # bad pid
+        "v1:abc:serve:-4:2.0",         # non-positive pid
+        "v1::serve:10:2.0",            # empty install
+        "v1:abc::10:2.0",              # empty purpose
+        "v1:abc:serve:10",             # wrong arity
+        "v1:abc:serve:10:zzz",         # bad create
+    ],
+)
+def test_parse_spawn_tag_rejects_malformed(raw):
+    assert pi.parse_spawn_tag(raw) is None
+
+
+def test_parse_spawn_tag_dash_create_is_none():
+    tag = pi.parse_spawn_tag("v1:abcdef:serve:42:-")
+    assert tag is not None
+    assert tag.spawner_create is None
+
+
+def test_desktop_style_tag_parses():
+    # The Electron side emits install `-` with a winms-derived create time.
+    tag = pi.parse_spawn_tag("v1:-:serve:5100:1755689000.123")
+    assert tag is not None
+    assert tag.spawner_pid == 5100
+
+
+def test_install_id_stable_and_path_scoped():
+    a = pi.install_id(Path("/opt/hermes"))
+    assert a == pi.install_id(Path("/opt/hermes"))
+    assert a != pi.install_id(Path("/opt/other"))
+    assert len(a) == 12
+
+
+# ---------------------------------------------------------------------------
+# Ledger
+# ---------------------------------------------------------------------------
+
+def _entry(pid, create, purpose="serve", install=None, spawner_pid=None, spawner_create=None):
+    return {
+        "pid": pid,
+        "create_time": create,
+        "purpose": purpose,
+        "install": install or pi.install_id(Path("/x/install")),
+        "spawner_pid": spawner_pid,
+        "spawner_create": spawner_create,
+        "registered_at": 0.0,
+        "argv": "",
+    }
+
+
+def test_register_self_writes_and_prunes_dead(tmp_path):
+    ledger = tmp_path / "spawn-ledger.json"
+    # Pre-existing: pid 300 dead, pid 400 alive.
+    ledger.write_text(json.dumps([_entry(300, 1.0), _entry(400, 2.0)]), encoding="utf-8")
+    fake = _fake_psutil({400: 2.0, 999: 50.0})
+    with patch.dict(sys.modules, {"psutil": fake}), \
+         patch.object(pi, "_ledger_path", return_value=ledger), \
+         patch.object(pi.os, "getpid", return_value=999):
+        assert pi.register_self("serve", project_root=Path("/x/install")) is True
+    entries = json.loads(ledger.read_text(encoding="utf-8"))
+    pids = {e["pid"] for e in entries}
+    assert pids == {400, 999}  # 300 pruned as provably dead
+    me = next(e for e in entries if e["pid"] == 999)
+    assert me["purpose"] == "serve"
+    assert me["create_time"] == pytest.approx(50.0, abs=0.01)
+
+
+def test_register_self_inherits_spawn_tag_lineage(tmp_path):
+    ledger = tmp_path / "spawn-ledger.json"
+    fake = _fake_psutil({999: 50.0})
+    env = {pi.SPAWN_ENV_VAR: "v1:-:serve:777:123.000"}
+    with patch.dict(sys.modules, {"psutil": fake}), \
+         patch.dict(pi.os.environ, env, clear=False), \
+         patch.object(pi, "_ledger_path", return_value=ledger), \
+         patch.object(pi.os, "getpid", return_value=999):
+        pi.register_self("serve", project_root=Path("/x/install"))
+    me = json.loads(ledger.read_text(encoding="utf-8"))[0]
+    assert me["spawner_pid"] == 777
+    assert me["spawner_create"] == pytest.approx(123.0, abs=0.01)
+
+
+def test_register_self_falls_back_to_desktop_parent_env(tmp_path):
+    # Legacy Desktop: no HERMES_SPAWN, but HERMES_PARENT_PID + winms marker.
+    ledger = tmp_path / "spawn-ledger.json"
+    fake = _fake_psutil({999: 50.0})
+    env = {
+        "HERMES_PARENT_PID": "888",
+        "HERMES_PARENT_START_MARKER": "winms:1755689000123",
+    }
+    with patch.dict(sys.modules, {"psutil": fake}), \
+         patch.dict(pi.os.environ, env, clear=False), \
+         patch.object(pi.os.environ, "get", pi.os.environ.get), \
+         patch.object(pi, "_ledger_path", return_value=ledger), \
+         patch.object(pi.os, "getpid", return_value=999):
+        pi.os.environ.pop(pi.SPAWN_ENV_VAR, None)
+        pi.register_self("serve", project_root=Path("/x/install"))
+    me = json.loads(ledger.read_text(encoding="utf-8"))[0]
+    assert me["spawner_pid"] == 888
+    assert me["spawner_create"] == pytest.approx(1755689000.123, abs=0.01)
+
+
+def test_corrupt_ledger_quarantined_not_rewritten_blind(tmp_path):
+    # #89298 contract: corruption is quarantined aside, never treated as [].
+    ledger = tmp_path / "spawn-ledger.json"
+    ledger.write_text("{ not json", encoding="utf-8")
+    fake = _fake_psutil({999: 50.0})
+    with patch.dict(sys.modules, {"psutil": fake}), \
+         patch.object(pi, "_ledger_path", return_value=ledger), \
+         patch.object(pi.os, "getpid", return_value=999):
+        assert pi.register_self("serve", project_root=Path("/x/install")) is True
+    parked = tmp_path / "spawn-ledger.json.corrupt"
+    assert parked.exists()
+    assert parked.read_text(encoding="utf-8") == "{ not json"
+    entries = json.loads(ledger.read_text(encoding="utf-8"))
+    assert [e["pid"] for e in entries] == [999]
+
+
+def test_ledger_entries_filters_dead_reused_and_foreign(tmp_path):
+    ledger = tmp_path / "spawn-ledger.json"
+    entries = [
+        _entry(100, 10.0),                                  # alive, matches
+        _entry(200, 20.0),                                  # pid reused (create mismatch)
+        _entry(300, 30.0),                                  # dead
+        _entry(400, 40.0, install="ffffffffffff"),          # other install
+    ]
+    ledger.write_text(json.dumps(entries), encoding="utf-8")
+    fake = _fake_psutil({100: 10.0, 200: 9999.0, 400: 40.0})
+    with patch.dict(sys.modules, {"psutil": fake}), \
+         patch.object(pi, "_ledger_path", return_value=ledger):
+        live = pi.ledger_entries(project_root=Path("/x/install"))
+    assert [e["pid"] for e in live] == [100]
+
+
+def test_spawner_is_dead_tristate():
+    fake = _fake_psutil({500: 5.0})
+    with patch.dict(sys.modules, {"psutil": fake}):
+        assert pi.spawner_is_dead(_entry(1, 1.0, spawner_pid=500, spawner_create=5.0)) is False
+        assert pi.spawner_is_dead(_entry(1, 1.0, spawner_pid=600, spawner_create=6.0)) is True
+        # PID reuse: recorded spawner create differs from live process → dead.
+        assert pi.spawner_is_dead(_entry(1, 1.0, spawner_pid=500, spawner_create=999.0)) is True
+        assert pi.spawner_is_dead(_entry(1, 1.0)) is None
+
+
+# ---------------------------------------------------------------------------
+# Updater rung: _ledger_reapable_backend_pids
+# ---------------------------------------------------------------------------
+
+def _holders(*pids):
+    return [(p, "python.exe", f"python.exe -m hermes_cli.main --profile p{p} serve") for p in pids]
+
+
+def test_updater_reaps_ledger_proven_orphans():
+    from hermes_cli import main as cli_main
+
+    entries = [
+        _entry(200, 2.0, spawner_pid=700, spawner_create=7.0),   # spawner dead → reap
+        _entry(201, 2.1, spawner_pid=500, spawner_create=5.0),   # spawner alive → keep
+        _entry(202, 2.2, purpose="chat", spawner_pid=700, spawner_create=7.0),  # not reapable purpose
+    ]
+    fake = _fake_psutil({500: 5.0})
+    with patch.dict(sys.modules, {"psutil": fake}), \
+         patch.object(pi, "ledger_entries", return_value=entries), \
+         patch.object(pi, "spawner_is_dead", wraps=pi.spawner_is_dead):
+        assert cli_main._ledger_reapable_backend_pids(_holders(200, 201, 202, 203)) == [200]
+
+
+def test_updater_ledger_rung_empty_without_ledger():
+    from hermes_cli import main as cli_main
+
+    with patch.object(pi, "ledger_entries", return_value=[]):
+        assert cli_main._ledger_reapable_backend_pids(_holders(200)) == []
+
+
+def test_updater_ledger_rung_never_raises():
+    from hermes_cli import main as cli_main
+
+    with patch.object(pi, "ledger_entries", side_effect=RuntimeError("boom")):
+        assert cli_main._ledger_reapable_backend_pids(_holders(200)) == []


### PR DESCRIPTION
## Summary

Every long-lived Hermes process is now positively identifiable — tagged at spawn, self-registered in a machine spawn ledger, and (on Windows) bound into a kill-on-close job — so `hermes update` reaps leaked backends by proof instead of PPID archaeology, and Hermes reliably dies when we update.

Follow-through on the 2026-08-20 Windows incident pair: #90497 stopped the leak factory (ownership-file corruption), #90746 cleaned up hand-off leaks with a contract-gated heuristic. This PR replaces guesswork with identity so the whole class stays dead.

## The three layers

1. **Spawn tags** — spawners stamp children with `HERMES_SPAWN=v1:<install>:<purpose>:<spawner_pid>:<spawner_create>`. The Desktop stamps its backend spawns (`parent-process-identity.ts`); the Python side also accepts legacy `HERMES_PARENT_PID` + `winms:` markers as lineage, so it works with every Desktop version.
2. **Spawn ledger** (`spawn-ledger.json` at the machine Hermes root) — serve/dashboard backends and the gateway self-register `(pid, create_time, purpose, spawner)` at startup. The `(pid, create_time)` pair defeats PID reuse. Dead entries are pruned on every write; a corrupt ledger is quarantined to `.corrupt`, never rewritten blind (same contract as #90497 / #89298).
3. **Windows job objects** — backends and the gateway self-attach to a job with `KILL_ON_JOB_CLOSE`, so their whole child tree (launcher→worker chains holding `.pyd` locks) dies atomically with them. `BREAKAWAY_OK` + `SILENT_BREAKAWAY_OK` preserve every existing `CREATE_BREAKAWAY_FROM_JOB` escape (gateway respawn watcher, detached relaunch).

## Updater wiring

`hermes update` gains a positive-identity rung that runs FIRST, in any update context (no hand-off contract needed): `_ledger_reapable_backend_pids()` reaps venv holders the ledger proves are orphaned backends — reapable purpose (`serve`/`dashboard`/`gateway`, never interactive) AND recorded spawner provably dead. Ledger-unknown holders fall through to the existing rungs (gateway pause → orphan reap → hand-off reap → refuse), which remain untouched as the compatibility path for processes started by pre-ledger versions.

## Changes

- `hermes_cli/process_identity.py` (new): tags, ledger, job-object attach — all best-effort/fail-safe, never blocks startup or update.
- `hermes_cli/web_server.py`, `gateway/run.py`: self-registration + job attach at the two long-lived entry points.
- `apps/desktop/electron/parent-process-identity.ts`: `spawnTag()` + `HERMES_SPAWN` in the watchdog env.
- `hermes_cli/update_cmd.py`: `_ledger_reapable_backend_pids()` + the new first rung; `hermes_cli/main.py`: lazy-export.

## Validation

| | Result |
|---|---|
| New `test_process_identity.py` | 22/22 pass (tags, ledger prune/quarantine/PID-reuse, tristate spawner probe, updater rung) |
| Sabotage (ledger rung neutered) | positive test FAILS as intended; 22/22 on restore |
| Regression: hand-off + orphan reap suites | 45/45 combined pass |
| ruff (all touched py files) | clean |

## Infographic

![Every process accounted for](https://v3b.fal.media/files/b/0aa716c2/3XEtUKWgFPE9keNuG0ZG6_dE7kNuej.png)
