### PR TITLE
test(windows): isolate baseline runner from live runtime

### DIFF
--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -433,6 +433,13 @@ def _run_one_file_once(
 
         output +=  "\n"
 
+    if rc not in (0, 5) and not output.strip():
+        output = (
+            "runner infrastructure failure: pytest subprocess exited with "
+            f"code {rc} and produced no output. It may have been terminated "
+            "before collection or failed to start; this file did not run.\n"
+        )
+
     if rc == 5:
         # No tests collected in THIS file — legitimate per-file: a
         # platform-gated or fully-marker-filtered file (e.g. a win32-only
@@ -1054,17 +1061,21 @@ def main() -> int:
         try:
             fpath, rc, output, summary, subproc_wall = fut.result()
         except Exception as exc:  # noqa: BLE001 — must always advance counter
+            crash_output = f"runner crashed before pytest completed: {exc!r}"
             with lock:
                 files_done += 1
                 tests_done += n_tests
                 fail_count += 1
-                failures.append((file, f"runner crashed: {exc!r}", {}))
+                failures.append((file, crash_output, {}))
                 _print_progress(
                     tests_done, approx_total_tests, file, 1,
                     time.monotonic() - started_at,
                     repo_root, tests_passed, tests_failed,
                     test_counts,
                     subproc_wall=0.0,
+                )
+                _print_inline_failure(
+                    file, crash_output, repo_root, pytest_passthrough
                 )
             return
         with lock:

--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -7,6 +7,7 @@ launching profile preselected. `--isolated` opts out.
 """
 import sys
 import types
+
 import pytest
 
 
@@ -31,21 +32,34 @@ class TestUnifiedDashboardRouting:
 
     def test_profile_launch_reexecs_machine_dashboard(self, main_mod, monkeypatch):
         monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.delenv("HERMES_DESKTOP", raising=False)
         monkeypatch.setattr(
             "hermes_cli.profiles.get_active_profile_name", lambda: "worker_x"
         )
         monkeypatch.setattr(main_mod, "_dashboard_listening", lambda host, port: False)
         execs = []
 
-        def fake_exec(exe, argv, env):
+        def record_exec(exe, argv, env):
             execs.append((exe, argv, env))
             raise SystemExit(0)  # execvpe never returns
 
-        monkeypatch.setattr(main_mod.os, "execvpe", fake_exec)
+        if sys.platform == "win32":
+            class _CompletedReexec:
+                def wait(self):
+                    return 0
 
-        with pytest.raises(SystemExit):
+            def record_popen(argv, env):
+                execs.append((argv[0], argv, env))
+                return _CompletedReexec()
+
+            monkeypatch.setattr(main_mod.subprocess, "Popen", record_popen)
+        else:
+            monkeypatch.setattr(main_mod.os, "execvpe", record_exec)
+
+        with pytest.raises(SystemExit) as exc:
             main_mod.cmd_dashboard(_args())
 
+        assert exc.value.code == 0
         assert len(execs) == 1
         exe, argv, env = execs[0]
         assert exe == sys.executable
@@ -61,7 +75,9 @@ class TestUnifiedDashboardRouting:
         assert env.get("HERMES_HOME") == str(get_default_hermes_root())
 
 
-    def test_desktop_profile_backend_skips_machine_dashboard_reroute(self, main_mod, monkeypatch):
+    def test_desktop_profile_backend_skips_machine_dashboard_reroute(
+        self, main_mod, monkeypatch, tmp_path
+    ):
         """A desktop-spawned named-profile backend (HERMES_DESKTOP=1) must NOT
         reroute into the machine dashboard. The reroute re-execs as the default
         profile and exits, so the desktop never sees a ready backend → boot
@@ -77,12 +93,71 @@ class TestUnifiedDashboardRouting:
         )
         execs = []
         monkeypatch.setattr(main_mod.os, "execvpe", lambda *a, **k: execs.append(a))
-        monkeypatch.setitem(sys.modules, "fastapi", None)
+        monkeypatch.setattr(
+            main_mod.subprocess,
+            "Popen",
+            lambda *a, **k: pytest.fail("desktop backend must not re-exec"),
+        )
 
-        with pytest.raises((SystemExit, AttributeError, ImportError, TypeError)):
+        # Keep the assertion on routing only. Every downstream startup seam is
+        # replaced so this test cannot build the UI, discover plugins, start
+        # MCP, or bind a real dashboard server on the developer's machine.
+        web_dist = tmp_path / "web-dist"
+        web_dist.mkdir()
+        (web_dist / "index.html").write_text("test", encoding="utf-8")
+        monkeypatch.setenv("HERMES_WEB_DIST", str(web_dist))
+        monkeypatch.setattr(main_mod, "_sync_bundled_skills_quietly", lambda: None)
+        monkeypatch.setattr(
+            main_mod, "_maybe_setup_dashboard_auth_interactively", lambda _args: None
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "hermes_logging",
+            types.SimpleNamespace(setup_logging=lambda **_kwargs: None),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "hermes_cli.resource_limits",
+            types.SimpleNamespace(apply_nofile_soft_limit=lambda: None),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "hermes_cli.config",
+            types.SimpleNamespace(apply_terminal_config_to_env=lambda: None),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "hermes_cli.plugins",
+            types.SimpleNamespace(discover_plugins=lambda: None),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "hermes_cli.mcp_startup",
+            types.SimpleNamespace(start_background_mcp_discovery=lambda **_kwargs: None),
+        )
+
+        starts = []
+
+        class _ServerReached(Exception):
+            pass
+
+        def fake_start_server(**kwargs):
+            starts.append(kwargs)
+            raise _ServerReached
+
+        monkeypatch.setitem(
+            sys.modules,
+            "hermes_cli.web_server",
+            types.SimpleNamespace(start_server=fake_start_server),
+        )
+
+        with pytest.raises(_ServerReached):
             main_mod.cmd_dashboard(_args())
         assert listening_calls == []
         assert execs == []
+        assert len(starts) == 1
+        assert starts[0]["host"] == "127.0.0.1"
+        assert starts[0]["port"] == 9119
 
 
 

--- a/tests/hermes_cli/test_doctor_journal_modes.py
+++ b/tests/hermes_cli/test_doctor_journal_modes.py
@@ -142,7 +142,10 @@ class TestReadJournalMode:
             holder.close()
 
     @pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
-    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+    @pytest.mark.skipif(
+        getattr(os, "geteuid", lambda: -1)() == 0,
+        reason="root ignores file permissions",
+    )
     def test_read_only_directory_is_still_readable(self, tmp_path):
         db = tmp_path / "state.db"
         _make_db(db, journal_mode="WAL")
@@ -363,7 +366,8 @@ class TestReportDatabaseJournalModes:
         assert "state.db is in WAL mode" in out
         assert "projects.db: rollback journal mode" in out
         assert "kanban.db: rollback journal mode" in out
-        assert "kanban/boards/myboard/kanban.db is in WAL mode" in out
+        board_name = os.path.join("kanban", "boards", "myboard", "kanban.db")
+        assert f"{board_name} is in WAL mode" in out
 
     def test_missing_databases_are_skipped(self, tmp_path, capsys):
         doctor._report_database_journal_modes(tmp_path, VULNERABLE)
@@ -387,7 +391,10 @@ class TestReportDatabaseJournalModes:
         assert "state.db: rollback journal mode" in out
 
     @pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
-    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+    @pytest.mark.skipif(
+        getattr(os, "geteuid", lambda: -1)() == 0,
+        reason="root ignores file permissions",
+    )
     def test_unreadable_database_does_not_crash(self, tmp_path, capsys):
         db = tmp_path / "state.db"
         _make_db(db)

--- a/tests/hermes_cli/test_doctor_journal_modes.py
+++ b/tests/hermes_cli/test_doctor_journal_modes.py
@@ -281,9 +281,13 @@ class TestLiveConnectionSafety:
 
 class TestUnreadableReason:
     def test_missing_file_keeps_the_os_error_text(self, tmp_path):
-        reason = doctor._unreadable_reason(tmp_path / "gone.db")
+        missing = tmp_path / "gone.db"
+        with pytest.raises(FileNotFoundError) as exc_info:
+            missing.stat()
 
-        assert "No such file or directory" in reason
+        reason = doctor._unreadable_reason(missing)
+
+        assert reason == str(exc_info.value)
 
     @pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
     @pytest.mark.skipif(

--- a/tests/hermes_cli/test_ensure_acp_launcher.py
+++ b/tests/hermes_cli/test_ensure_acp_launcher.py
@@ -50,9 +50,10 @@ def test_does_not_follow_symlink_into_venv(fake_home, tmp_path):
 
 
 
+@pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
 def test_unwritable_bin_dir_is_skipped(fake_home):
     (fake_home / "hermes").write_text("#!/bin/sh\n", encoding="utf-8")
-    if os.geteuid() == 0:
+    if getattr(os, "geteuid", lambda: -1)() == 0:
         pytest.skip("root ignores directory write permissions")
     fake_home.chmod(0o555)
     try:

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -67,6 +67,13 @@ def _setup_update_mocks(monkeypatch, tmp_path):
     monkeypatch.setattr(hermes_config, "migrate_config", lambda **kw: {"env_added": [], "config_added": []})
     monkeypatch.setattr(hermes_main, "_upgrade_pip_before_lazy_refresh", lambda *a, **kw: None)
     monkeypatch.setattr(hermes_main, "_refresh_active_lazy_features", lambda *a, **kw: True)
+    # cmd_update always pauses/resumes installed gateways in a finally path.
+    # On Windows, leaving these unmocked lets a failure-path unit test rewrite
+    # the real launcher scripts and cold-start an audit-venv gateway.
+    monkeypatch.setattr(hermes_main, "_pause_windows_gateways_for_update", lambda: None)
+    monkeypatch.setattr(
+        hermes_main, "_resume_windows_gateways_after_update", lambda token: None
+    )
 
 
 

--- a/tests/plugins/platforms/photon/test_sidecar_paths.py
+++ b/tests/plugins/platforms/photon/test_sidecar_paths.py
@@ -88,13 +88,14 @@ def test_mirror_refresh_updates_changed_files_and_keeps_node_modules(
     assert (mirror / "node_modules" / "installed.txt").exists()
 
 
+@pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
 def test_dir_writable_probe(tmp_path) -> None:
     assert sidecar_paths.dir_writable(tmp_path) is True
     ro = tmp_path / "ro"
     ro.mkdir()
     ro.chmod(0o555)
     try:
-        if os.geteuid() == 0:  # pragma: no cover - root ignores perms
+        if getattr(os, "geteuid", lambda: -1)() == 0:  # pragma: no cover - root ignores perms
             pytest.skip("root bypasses directory permissions")
         assert sidecar_paths.dir_writable(ro) is False
     finally:

--- a/tests/test_install_ps1_venv_process_tree.py
+++ b/tests/test_install_ps1_venv_process_tree.py
@@ -75,7 +75,6 @@ def _write_cmd(path: Path, text: str) -> None:
         handle.write(text)
 
 
-@pytest.mark.live_system_guard_bypass
 @pytest.mark.skipif(
     os.name != "nt" or POWERSHELL is None,
     reason="needs Windows and PowerShell",
@@ -107,18 +106,6 @@ def test_venv_sweep_stops_managed_runtime_children_but_not_unrelated_processes(
     unrelated_script = tmp_path / "unrelated.cmd"
     _write_cmd(unrelated_script, "@ping -t 127.0.0.1 >nul\n")
 
-    # Keep the test away from real gateway tasks and real Hermes launchers
-    # while still exercising the installer's actual process enumeration and
-    # per-PID taskkill behavior.
-    _write_cmd(fake_bin / "schtasks.cmd", "@exit /b 0\n")
-    _write_cmd(
-        fake_bin / "taskkill.cmd",
-        "@echo off\n"
-        'echo %* | "%SystemRoot%\\System32\\findstr.exe" /I '
-        '/C:"/IM hermes.exe" >nul\n'
-        "if not errorlevel 1 exit /b 0\n"
-        '"%SystemRoot%\\System32\\taskkill.exe" %*\n',
-    )
     _write_cmd(
         fake_bin / "uv.cmd",
         "@echo off\n"
@@ -152,20 +139,58 @@ def test_venv_sweep_stops_managed_runtime_children_but_not_unrelated_processes(
             "OS": "Windows_NT",
             "PATH": str(fake_bin) + os.pathsep + os.environ["PATH"],
         }
+        # Define command functions inside the child PowerShell scope instead
+        # of relying on PATH shims. In a prior native-Windows full run those
+        # shims did not isolate this test: installer output proved it observed
+        # and disabled the operator's real \Hermes_Gateway Scheduled Task.
+        # Functions have higher command precedence and fail closed here. The
+        # task function returns no rows; taskkill allows only the process root
+        # created above. The production installer still performs its real CIM
+        # enumeration and real /T kill.
+        def _ps_literal(value: Path | str) -> str:
+            return str(value).replace("'", "''")
+
+        powershell_probe = f"""
+            $ErrorActionPreference = 'Stop'
+            $allowedPid = '{parent.pid}'
+            $realTaskkill = '{_ps_literal(Path(os.environ['SystemRoot']) / 'System32' / 'taskkill.exe')}'
+
+            function schtasks {{
+                param([Parameter(ValueFromRemainingArguments=$true)][object[]] $Rest)
+                return
+            }}
+
+            function taskkill {{
+                param([Parameter(ValueFromRemainingArguments=$true)][object[]] $Rest)
+                $tokens = @($Rest | ForEach-Object {{ [string]$_ }})
+                $joined = $tokens -join ' '
+                if (($tokens -contains '/IM') -and $joined -match '(?i)hermes\\.exe') {{
+                    return
+                }}
+                $pidIndex = -1
+                for ($i = 0; $i -lt $tokens.Count; $i++) {{
+                    if ($tokens[$i] -eq '/PID') {{ $pidIndex = $i; break }}
+                }}
+                if ($pidIndex -ge 0 -and $pidIndex + 1 -lt $tokens.Count -and
+                    $tokens[$pidIndex + 1] -eq $allowedPid) {{
+                    & $realTaskkill @tokens
+                    if ($LASTEXITCODE -ne 0) {{
+                        throw "taskkill failed for allowed test PID $allowedPid"
+                    }}
+                    return
+                }}
+                throw "blocked taskkill outside test-owned PID: $joined"
+            }}
+
+            & '{_ps_literal(INSTALL_PS1)}' `
+                -Stage venv `
+                -NonInteractive `
+                -InstallDir '{_ps_literal(install_dir)}' `
+                -HermesHome '{_ps_literal(hermes_home)}'
+            exit $LASTEXITCODE
+        """
         result = subprocess.run(
-            [
-                POWERSHELL,
-                "-NoProfile",
-                "-File",
-                str(INSTALL_PS1),
-                "-Stage",
-                "venv",
-                "-NonInteractive",
-                "-InstallDir",
-                str(install_dir),
-                "-HermesHome",
-                str(hermes_home),
-            ],
+            [POWERSHELL, "-NoProfile", "-Command", powershell_probe],
             cwd=tmp_path,
             env=env,
             capture_output=True,

--- a/tests/test_run_tests_parallel_stdio.py
+++ b/tests/test_run_tests_parallel_stdio.py
@@ -67,3 +67,81 @@ def test_glyph_safe_stdio_noop_without_reconfigure(monkeypatch) -> None:
     print("✓ still fine")
 
     assert "✓ still fine" in plain.getvalue()
+
+
+def test_nonzero_child_without_output_gets_infrastructure_diagnostic(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A child killed before pytest starts must not render as a blank failure."""
+    mod = _load_runner()
+    test_file = tmp_path / "test_never_started.py"
+    test_file.write_text("def test_never_started():\n    assert True\n", encoding="utf-8")
+
+    class _SilentFailedProcess:
+        pid = 12345
+        returncode = 9
+
+        def communicate(self, timeout=None):
+            return "", None
+
+    monkeypatch.setattr(mod.subprocess, "Popen", lambda *args, **kwargs: _SilentFailedProcess())
+    monkeypatch.setattr(mod, "_kill_tree", lambda *args, **kwargs: None)
+
+    _file, rc, output, summary, _wall = mod._run_one_file_once(
+        test_file, [], tmp_path, 30
+    )
+
+    assert rc == 9
+    assert summary == {}
+    assert "produced no output" in output
+    assert "infrastructure" in output.lower()
+
+
+def test_exit_five_without_output_stays_per_file_no_collection(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Pytest's no-collection exit remains tolerated for one gated file."""
+    mod = _load_runner()
+    test_file = tmp_path / "test_platform_gated.py"
+    test_file.write_text("", encoding="utf-8")
+
+    class _NoCollectionProcess:
+        pid = 12345
+        returncode = 5
+
+        def communicate(self, timeout=None):
+            return "", None
+
+    monkeypatch.setattr(mod.subprocess, "Popen", lambda *args, **kwargs: _NoCollectionProcess())
+    monkeypatch.setattr(mod, "_kill_tree", lambda *args, **kwargs: None)
+
+    _file, rc, output, summary, _wall = mod._run_one_file_once(
+        test_file, [], tmp_path, 30
+    )
+
+    assert rc == 0
+    assert summary == {}
+    assert "infrastructure failure" not in output
+
+
+def test_worker_exception_is_printed_in_inline_failure_box(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    """A Popen-level runner crash must be visible at the failing progress line."""
+    mod = _load_runner()
+    test_file = tmp_path / "test_never_spawned.py"
+    test_file.write_text("def test_never_spawned():\n    assert True\n", encoding="utf-8")
+
+    def _raise_before_pytest(*args, **kwargs):
+        raise OSError("simulated process creation failure")
+
+    monkeypatch.setattr(mod, "_run_one_file", _raise_before_pytest)
+    monkeypatch.setattr(mod.sys, "argv", [str(_RUNNER_PATH), "--files", str(test_file), "-j", "1"])
+
+    assert mod.main() == 1
+    output = capsys.readouterr().out
+    box_start = output.index("Failed:")
+    box_end = output.index("Repro:", box_start)
+    inline_box = output[box_start:box_end]
+    assert "runner crashed before pytest completed" in inline_box
+    assert "simulated process creation failure" in inline_box


### PR DESCRIPTION
## Summary

- isolate Windows baseline tests from the live Hermes Gateway Scheduled Task and existing process tree
- keep the parallel test runner's no-output diagnostics deterministic without touching the production runtime
- isolate dashboard/launcher routing tests from the user's real Hermes home and active Python installation
- make the Windows doctor assertion tolerate localized `FileNotFoundError` text

## Motivation

The Windows default-unit baseline previously allowed several tests to observe or mutate machine-global state. That made failures dependent on whether a real Hermes Gateway/Desktop process was running and risked touching a user's live Scheduled Task. This bundle contains only the baseline-safety/test-isolation commits so it can be reviewed independently from the later Windows product fixes.

## Test plan

Executed on Windows 11 with Python 3.11.15 in an isolated AppData venv and isolated `HERMES_HOME`, after rebasing onto `c47f0b4590e6b5bb05fb73a42f447ca5444f5188`:

```text
56 passed, 6 skipped, 0 failed
Ruff: PASS
git diff --check: PASS
```

Covered files:

- `tests/hermes_cli/test_dashboard_unified_launch.py`
- `tests/hermes_cli/test_doctor_journal_modes.py`
- `tests/hermes_cli/test_ensure_acp_launcher.py`
- `tests/hermes_cli/test_update_autostash.py`
- `tests/plugins/platforms/photon/test_sidecar_paths.py`
- `tests/test_install_ps1_venv_process_tree.py`
- `tests/test_run_tests_parallel_stdio.py`

## Runtime safety evidence

Before and after the standalone gate:

```text
Hermes_Gateway Scheduled Task XML SHA-256:
4d172df046bf315973541782dafe0d8d39df1fccc584933183eddd6cc6d0a3e5

Protected Hermes Desktop backend identity:
PID 8892 / create_time 1787210203.846641
```

Both remained unchanged. No Gateway restart, deployment, merge, or production runtime modification was performed.

## Scope

This PR contains Bundle 01 only and is now ready for CI and maintainer review. The other reconciled Windows fixes remain on separate local candidate branches and are not part of this PR. No merge or deployment is authorized.
