### PR TITLE
fix(web): reconcile dashboard token at startup

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -485,6 +485,12 @@ def load_hermes_dotenv(
       dependencies into the process that replaces that same environment.
     """
     loaded: list[Path] = []
+    # This token is minted/injected by the process launcher (Desktop, a
+    # companion app, or a service wrapper).  A profile dotenv is persistent
+    # configuration and must not replace the launcher's current pairing.
+    process_dashboard_session_token = os.environ.get(
+        "HERMES_DASHBOARD_SESSION_TOKEN"
+    )
 
     home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
     user_env = home_path / ".env"
@@ -551,6 +557,11 @@ def load_hermes_dotenv(
     # so the merged config (which already carries the managed overlay) is
     # what lands in the env.
     _reapply_terminal_config_bridge(home_path)
+
+    if process_dashboard_session_token is not None:
+        os.environ["HERMES_DASHBOARD_SESSION_TOKEN"] = (
+            process_dashboard_session_token
+        )
 
     return loaded
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -19,6 +19,11 @@ from utils import atomic_replace, fast_safe_load
 # pure ASCII (they become HTTP header values).
 _CREDENTIAL_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET", "_KEY")
 
+# Values minted or injected by the process launcher must win over persistent
+# profile/project dotenv files, external secret sources, and managed config.
+# Add launcher-owned variables here instead of adding one-off restore blocks.
+LAUNCHER_PROTECTED_ENV_VARS = ("HERMES_DASHBOARD_SESSION_TOKEN",)
+
 # Names we've already warned about during this process, so repeated
 # load_hermes_dotenv() calls (user env + project env, gateway hot-reload,
 # tests) don't spam the same warning multiple times.
@@ -480,17 +485,18 @@ def load_hermes_dotenv(
     - project `.env` acts as a dev fallback and only fills missing values when
       the user env exists.
     - if no user env exists, the project `.env` also overrides stale shell vars.
+    - process-launcher values named in ``LAUNCHER_PROTECTED_ENV_VARS`` win over
+      profile/project dotenv, external secret sources, and managed config.
     - callers that only maintain the installation can set
       ``load_external_secrets=False`` to avoid loading optional secret-manager
       dependencies into the process that replaces that same environment.
     """
     loaded: list[Path] = []
-    # This token is minted/injected by the process launcher (Desktop, a
-    # companion app, or a service wrapper).  A profile dotenv is persistent
-    # configuration and must not replace the launcher's current pairing.
-    process_dashboard_session_token = os.environ.get(
-        "HERMES_DASHBOARD_SESSION_TOKEN"
-    )
+    launcher_values = {
+        name: os.environ[name]
+        for name in LAUNCHER_PROTECTED_ENV_VARS
+        if name in os.environ
+    }
 
     home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
     user_env = home_path / ".env"
@@ -558,10 +564,8 @@ def load_hermes_dotenv(
     # what lands in the env.
     _reapply_terminal_config_bridge(home_path)
 
-    if process_dashboard_session_token is not None:
-        os.environ["HERMES_DASHBOARD_SESSION_TOKEN"] = (
-            process_dashboard_session_token
-        )
+    for name, value in launcher_values.items():
+        os.environ[name] = value
 
     return loaded
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -511,6 +511,14 @@ def _apply_ssh_session_token(token: str) -> None:
         _SESSION_TOKEN = token
 
 
+def _apply_startup_session_token(ssh_session_token: Optional[str]) -> None:
+    """Reconcile the auth token at listen time after all bootstrap paths ran."""
+    token = ssh_session_token or os.environ.get(
+        "HERMES_DASHBOARD_SESSION_TOKEN", ""
+    )
+    _apply_ssh_session_token(token)
+
+
 def _apply_ssh_owner_nonce(nonce: Optional[str]) -> None:
     global _SSH_OWNER_NONCE
     _SSH_OWNER_NONCE = nonce
@@ -18869,7 +18877,7 @@ def start_server(
     ``ssh_session_token`` and ``ssh_owner_nonce`` are process-local Desktop SSH
     bootstrap state. Neither is persisted or exported to child processes.
     """
-    _apply_ssh_session_token(ssh_session_token or "")
+    _apply_startup_session_token(ssh_session_token)
     _apply_ssh_owner_nonce(ssh_owner_nonce)
 
     # Raise RLIMIT_NOFILE for dashboard-mode starts that don't route through

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -6,6 +6,20 @@ import sys
 from hermes_cli.env_loader import load_hermes_dotenv
 
 
+def test_process_dashboard_session_token_survives_profile_dotenv(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / ".env").write_text(
+        "HERMES_DASHBOARD_SESSION_TOKEN=stale-profile-token\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "process-token")
+
+    load_hermes_dotenv(hermes_home=home, load_external_secrets=False)
+
+    assert os.environ["HERMES_DASHBOARD_SESSION_TOKEN"] == "process-token"
+
+
 def test_recovered_update_retry_skips_external_secret_sources(tmp_path, monkeypatch):
     """The post-recovery updater must not remap native vault dependencies."""
     import hermes_cli.env_loader as env_loader

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -6,18 +6,36 @@ import sys
 from hermes_cli.env_loader import load_hermes_dotenv
 
 
-def test_process_dashboard_session_token_survives_profile_dotenv(tmp_path, monkeypatch):
+def test_launcher_protected_env_vars_survive_dotenv_layers(tmp_path, monkeypatch):
+    import hermes_cli.env_loader as env_loader
+
     home = tmp_path / "profile"
     home.mkdir()
     (home / ".env").write_text(
-        "HERMES_DASHBOARD_SESSION_TOKEN=stale-profile-token\n",
+        "PROTECTED_ONE=stale-profile-one\nPROTECTED_TWO=stale-profile-two\n",
         encoding="utf-8",
     )
-    monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "process-token")
+    project_env = tmp_path / "project.env"
+    project_env.write_text(
+        "PROTECTED_ONE=stale-project-one\nPROTECTED_TWO=stale-project-two\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        env_loader,
+        "LAUNCHER_PROTECTED_ENV_VARS",
+        ("PROTECTED_ONE", "PROTECTED_TWO"),
+    )
+    monkeypatch.setenv("PROTECTED_ONE", "process-one")
+    monkeypatch.setenv("PROTECTED_TWO", "process-two")
 
-    load_hermes_dotenv(hermes_home=home, load_external_secrets=False)
+    load_hermes_dotenv(
+        hermes_home=home,
+        project_env=project_env,
+        load_external_secrets=False,
+    )
 
-    assert os.environ["HERMES_DASHBOARD_SESSION_TOKEN"] == "process-token"
+    assert os.environ["PROTECTED_ONE"] == "process-one"
+    assert os.environ["PROTECTED_TWO"] == "process-two"
 
 
 def test_recovered_update_retry_skips_external_secret_sources(tmp_path, monkeypatch):

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -73,6 +73,7 @@ def _stub_uvicorn(monkeypatch):
 
 def test_start_server_applies_process_local_ssh_bootstrap_state(monkeypatch):
     captured = _stub_uvicorn(monkeypatch)
+    monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "stable-app-token")
 
     web_server.start_server(
         host="127.0.0.1",
@@ -85,6 +86,26 @@ def test_start_server_applies_process_local_ssh_bootstrap_state(monkeypatch):
     assert web_server._SESSION_TOKEN == "s" * 64
     assert web_server._SSH_OWNER_NONCE == "0123456789abcdef"
     assert captured["port"] == 0
+
+
+def test_start_server_reapplies_environment_session_token(monkeypatch):
+    _stub_uvicorn(monkeypatch)
+    monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "stable-app-token")
+    monkeypatch.setattr(web_server, "_SESSION_TOKEN", "stale-import-token")
+
+    web_server.start_server(host="127.0.0.1", port=0, open_browser=False)
+
+    assert web_server._SESSION_TOKEN == "stable-app-token"
+
+
+def test_start_server_without_configured_token_keeps_current_token(monkeypatch):
+    _stub_uvicorn(monkeypatch)
+    monkeypatch.delenv("HERMES_DASHBOARD_SESSION_TOKEN", raising=False)
+    monkeypatch.setattr(web_server, "_SESSION_TOKEN", "process-local-token")
+
+    web_server.start_server(host="127.0.0.1", port=0, open_browser=False)
+
+    assert web_server._SESSION_TOKEN == "process-local-token"
 
 
 def test_start_server_disables_ws_ping_on_loopback(monkeypatch):


### PR DESCRIPTION
## Summary
- preserve a launcher-injected dashboard session token across profile dotenv loading
- reconcile that stable token again at listen time
- preserve explicit SSH bootstrap precedence
- avoid rotating an existing process-local token when no launcher token exists

## Why
Profile dotenv loading uses `override=True`. A stale persisted dashboard token could therefore replace the keychain-backed token supplied by a companion-app launcher. The backend stayed reachable but rejected the app with HTTP 401. Process-scoped pairing must win over persistent profile configuration.

## Tests
- `tests/hermes_cli/test_env_loader.py`: 27 passed
- `tests/test_web_server.py`: 8 passed, 3 skipped
- `tests/hermes_cli/test_web_server.py`: 165 passed
- Ruff: passed

## Runtime verification
With the keychain-backed launch token, authenticated requests returned HTTP 200 both directly and through the Tailnet reverse-proxy path.