### PR TITLE
fix(mem0): fall back to gateway session key for user scope

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -21,8 +21,10 @@ setup`):
   user_id            — Canonical user identifier. When set, it is applied
                        uniformly across every gateway (CLI, Telegram, Slack,
                        Discord, …) so the same human gets one merged memory
-                       store. When unset, the gateway-native id (e.g. Telegram
-                       numeric id, Discord snowflake) is used instead.
+                       store. When unset, a gateway-native user id (e.g.
+                       Telegram numeric id, Discord snowflake) is used, with
+                       the stable gateway session key as a fallback for API
+                       clients that do not expose a separate user id.
   agent_id           — Agent identifier (default: hermes)
 
 The matching MEM0_MODE / MEM0_USER_ID / MEM0_AGENT_ID environment variables are
@@ -343,17 +345,23 @@ class Mem0MemoryProvider(MemoryProvider):
         #   1. Operator-configured MEM0_USER_ID (env or $HERMES_HOME/mem0.json) —
         #      the canonical principal, applied across every gateway so the same
         #      human gets one merged memory store.
-        #   2. Gateway-native id from kwargs (Telegram numeric id, Discord
-        #      snowflake, etc.) — preserves per-platform isolation when no
-        #      override is configured.
-        #   3. Hardcoded fallback _DEFAULT_USER_ID (CLI with no auth).
+        #   2. Gateway-native user id from kwargs (Telegram numeric id,
+        #      Discord snowflake, etc.).
+        #   3. Stable gateway session key for API and other clients that do
+        #      not expose a separate user id.
+        #   4. Hardcoded fallback _DEFAULT_USER_ID (CLI with no auth).
         # The literal _DEFAULT_USER_ID string is treated as unset so users who
         # ran the setup wizard with the suggested default still get gateway-
         # native ids instead of being silently bucketed together.
         configured = self._config.get("user_id")
         if configured == _DEFAULT_USER_ID:
             configured = None
-        self._user_id = configured or kwargs.get("user_id") or _DEFAULT_USER_ID
+        self._user_id = (
+            configured
+            or kwargs.get("user_id")
+            or kwargs.get("gateway_session_key")
+            or _DEFAULT_USER_ID
+        )
         self._agent_id = self._config.get("agent_id", "hermes")
         # Persisted rerank preference (setup wizard / mem0.json). Used as the
         # DEFAULT for mem0_search when the model doesn't pass ``rerank``

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -323,6 +323,40 @@ class TestMem0UserIdResolution:
         provider.initialize("test", user_id="123456789", platform="telegram")
         assert provider._user_id == "123456789"
 
+    def test_gateway_user_id_beats_gateway_session_key(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MEM0_USER_ID", raising=False)
+        provider = self._provider(monkeypatch, tmp_path)
+        provider.initialize(
+            "test",
+            user_id="123456789",
+            gateway_session_key="agent:main:telegram:dm:123456789",
+            platform="telegram",
+        )
+        assert provider._user_id == "123456789"
+
+    def test_api_clients_use_distinct_gateway_session_keys(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MEM0_USER_ID", raising=False)
+        first = self._provider(monkeypatch, tmp_path)
+        second = self._provider(monkeypatch, tmp_path)
+        first.initialize(
+            "test",
+            gateway_session_key="agent:main:webui:dm:user-7",
+            platform="api_server",
+        )
+        second.initialize(
+            "test",
+            gateway_session_key="agent:main:webui:dm:user-8",
+            platform="api_server",
+        )
+        assert first._user_id == "agent:main:webui:dm:user-7"
+        assert second._user_id == "agent:main:webui:dm:user-8"
+        assert first._user_id != second._user_id
+
+    def test_cli_without_runtime_identity_keeps_default(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MEM0_USER_ID", raising=False)
+        provider = self._provider(monkeypatch, tmp_path)
+        provider.initialize("test", platform="cli")
+        assert provider._user_id == "hermes-user"
 
     def test_legacy_placeholder_in_config_does_not_override_kwargs(self, monkeypatch, tmp_path):
         # Setup wizard historically wrote {"user_id": "hermes-user"} as the
@@ -407,5 +441,3 @@ class TestSelfHostedConfig:
     def test_load_config_reads_mem0_host_env(self, monkeypatch):
         monkeypatch.setenv("MEM0_HOST", "http://localhost:8888")
         assert mem0_plugin._load_config()["host"] == "http://localhost:8888"
-
-


### PR DESCRIPTION
## What does this PR do?

Fixes Mem0 user scoping for API and other clients that provide a stable
gateway session key but no separate gateway user id.

Hermes already threads `X-Hermes-Session-Key` into memory providers as
`gateway_session_key` and documents it as the stable long-term-memory scope.
Mem0 previously ignored that value and fell back to the shared
`hermes-user` placeholder whenever `user_id` was absent, so unrelated API
clients could land in the same Mem0 user bucket.

Mem0 now resolves its principal in this backward-compatible order:

1. operator-configured `user_id`
2. gateway-native `user_id`
3. stable `gateway_session_key`
4. legacy `hermes-user` fallback

Existing CLI and native-gateway behavior is unchanged.

## Related Issue

N/A. I searched open and merged PRs/issues for Mem0 session-key and user-scope
handling and found no duplicate implementation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/mem0/__init__.py`: use `gateway_session_key` only when no
  configured or gateway-native `user_id` is available, and document the
  complete precedence chain.
- `tests/plugins/memory/test_mem0_v3.py`: cover explicit-user precedence,
  distinct API session-key scopes, and the unchanged CLI fallback.

## How to Test

1. Run the Mem0 provider suite:
   ```bash
   scripts/run_tests.sh tests/plugins/memory/test_mem0_v3.py -q
   ```
   Result: 26 passed.
2. Run the existing gateway-to-agent identity-chain tests:
   ```bash
   scripts/run_tests.sh tests/agent/test_memory_user_id.py tests/run_agent/test_memory_provider_init.py tests/gateway/test_api_server.py -k 'session_key or memory_user_id or gateway_session' -q
   ```
   Result: 12 passed.
3. Run static checks:
   ```bash
   ruff check plugins/memory/mem0/__init__.py tests/plugins/memory/test_mem0_v3.py
   python -m compileall -q plugins/memory/mem0/__init__.py tests/plugins/memory/test_mem0_v3.py
   python scripts/check-windows-footguns.py plugins/memory/mem0/__init__.py
   ```

Broader memory-plugin run: 349 tests passed and 6 Hindsight tests failed
because `hindsight_client_api` is not installed in this environment.
Representative failures reproduce from a clean detached `origin/main`
worktree and do not touch either file in this PR.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on macOS with Python 3.11

### Documentation & Housekeeping

- [x] I've updated the relevant provider documentation
- [x] `cli-config.yaml.example` update is N/A; no config key changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A
- [x] I've considered cross-platform impact; no OS-specific behavior changed
- [x] Tool descriptions/schemas update is N/A
