### PR TITLE
feat(gateway): add fail-closed Telegram brief mode

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -612,6 +612,44 @@ def finalize_turn(
         except Exception as exc:
             logger.warning("transform_llm_output hook failed: %s", exc)
 
+    # Required final-output guards run after all legacy transforms. They are
+    # sequential and fail closed: an exception must never release the text
+    # they were supposed to validate.
+    if final_response and not interrupted:
+        try:
+            from hermes_cli.plugins import (
+                invoke_text_hook as _invoke_text_hook,
+                invoke_validation_hook as _invoke_validation_hook,
+            )
+
+            _final_hook_kwargs = {
+                "session_id": agent.session_id or "",
+                "model": agent.model,
+                "platform": getattr(agent, "platform", None) or "",
+            }
+            final_response, _finalized = _invoke_text_hook(
+                "finalize_llm_output",
+                response_text=final_response,
+                **_final_hook_kwargs,
+            )
+            _invoke_validation_hook(
+                "validate_llm_output",
+                response_text=final_response,
+                **_final_hook_kwargs,
+            )
+            _response_transformed = _response_transformed or _finalized
+        except Exception as exc:
+            logger.warning("finalize_llm_output hook failed closed: %s", exc)
+            if str(getattr(agent, "platform", "") or "").lower() == "telegram":
+                final_response = (
+                    "結果：無法安全顯示\n"
+                    "變更：最終輸出安全檢查失敗。\n"
+                    "下一步：請重新執行；若持續失敗，再檢查 Gateway 日誌。"
+                )
+            else:
+                final_response = "Unable to safely display the final response."
+            _response_transformed = True
+
     # Plugin hook: post_llm_call
     # Fired once per turn after the tool-calling loop completes.
     # Plugins can use this to persist conversation data (e.g. sync

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -837,6 +837,70 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     return redacted
 
 
+def _finalize_gateway_output(
+    source: Any,
+    text: str,
+    *,
+    user_message: str = "",
+    gateway: Any = None,
+    force_brief: bool = False,
+) -> str:
+    """Apply strict plugin transforms at the actual gateway egress boundary."""
+    if not text:
+        return text
+    platform = getattr(source, "platform", None)
+    try:
+        from hermes_cli.plugins import invoke_text_hook, invoke_validation_hook
+
+        final_text, _ = invoke_text_hook(
+            "finalize_gateway_output",
+            response_text=str(text),
+            platform=platform,
+            source=source,
+            user_message=user_message,
+            gateway=gateway,
+            force_brief=force_brief,
+        )
+        invoke_validation_hook(
+            "validate_gateway_output",
+            response_text=final_text,
+            platform=platform,
+            source=source,
+            user_message=user_message,
+            gateway=gateway,
+            force_brief=force_brief,
+        )
+        return final_text
+    except Exception as exc:
+        logger.warning("Gateway final-output hook failed closed: %s", exc)
+        if _gateway_platform_value(platform) == "telegram":
+            return (
+                "結果：無法安全顯示\n"
+                "變更：最終 Gateway 輸出安全檢查失敗。\n"
+                "下一步：請重新執行；若持續失敗，再檢查 Gateway 日誌。"
+            )
+        return "Unable to safely display the gateway response."
+
+
+def _build_auto_reset_notice(platform: Any, reason_text: str, session_info: str = "") -> str:
+    """Build a reset notice without exposing runtime metadata to Telegram."""
+    if _gateway_platform_value(platform) == "telegram":
+        return (
+            "結果：工作階段已自動重設\n"
+            f"變更：舊對話紀錄已清除（{reason_text}）。\n"
+            "下一步：可使用 /resume 瀏覽或還原先前的工作階段。"
+        )
+    notice = (
+        f"◐ Session automatically reset ({reason_text}). "
+        "Conversation history cleared.\n"
+        "Use /resume to browse and restore a previous session.\n"
+        "Adjust reset timing in config.yaml under session_reset."
+    )
+    if session_info:
+        notice = f"{notice}\n\n{session_info}"
+    return notice
+
+
 def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:
     """Filter/sanitize agent status callbacks before platform delivery.
 
@@ -16421,6 +16485,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not is_internal:
             self._scale_to_zero_note_real_inbound()
 
+        # Fire transport-safety hooks for every event, including internal
+        # background completions. These hooks may only fail closed by skipping;
+        # rewriting remains exclusive to the user-originated dispatch hook.
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _transport_results = _invoke_hook(
+                "pre_gateway_transport",
+                fail_closed=True,
+                event=event,
+                gateway=self,
+                session_store=getattr(self, "session_store", None),
+            )
+        except Exception as _transport_exc:
+            logger.warning("pre_gateway_transport invocation failed: %s", _transport_exc)
+            # Telegram presentation safety is fail-closed if hook dispatch itself
+            # cannot be evaluated; other platforms preserve legacy behavior.
+            if source.platform is Platform.TELEGRAM:
+                return None
+            _transport_results = []
+
+        for _transport_result in _transport_results:
+            if isinstance(_transport_result, dict) and _transport_result.get("action") == "skip":
+                logger.info(
+                    "pre_gateway_transport skip: reason=%s platform=%s chat=%s",
+                    _transport_result.get("reason"),
+                    source.platform.value if source.platform else "unknown",
+                    source.chat_id or "unknown",
+                )
+                return None
+
         # Fire pre_gateway_dispatch plugin hook for user-originated messages.
         # Plugins receive the MessageEvent and may return a dict influencing flow:
         #   {"action": "skip",    "reason": ...}    -> drop (no reply, plugin handled)
@@ -16907,6 +17001,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _denied = self._check_slash_access(source, _cmd_def_inner.name)
                 if _denied is not None:
                     return _denied
+
+            # Plugin commands are presentation/control operations and must not
+            # be queued, steered, or interpreted as agent input mid-turn.
+            if _evt_cmd and _cmd_def_inner is None:
+                try:
+                    from hermes_cli.plugins import (
+                        get_plugin_command_handler as _get_plugin_handler,
+                        invoke_plugin_command as _invoke_plugin_command,
+                    )
+                    _plugin_command = _evt_cmd.replace("_", "-")
+                    if _get_plugin_handler(_plugin_command):
+                        _denied = self._check_slash_access(source, _plugin_command)
+                        if _denied is not None:
+                            return _denied
+                        _plugin_result = _invoke_plugin_command(
+                            _plugin_command,
+                            event.get_command_args().strip(),
+                            event=event,
+                            gateway=self,
+                        )
+                        if asyncio.iscoroutine(_plugin_result):
+                            _plugin_result = await _plugin_result
+                        return str(_plugin_result) if _plugin_result else None
+                except Exception as _plugin_exc:
+                    logger.warning("Active-session plugin command dispatch failed: %s", _plugin_exc)
+                    return "Command failed safely; it was not sent to the active agent."
 
             # Any recognized slash command: dispatch according to its
             # declared busy_policy (dispatch / interrupt_then_dispatch /
@@ -17635,19 +17755,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Plugin-registered slash commands
         if command:
             try:
-                from hermes_cli.plugins import get_plugin_command_handler
+                from hermes_cli.plugins import (
+                    get_plugin_command_handler,
+                    invoke_plugin_command,
+                )
                 # Normalize underscores to hyphens so Telegram's underscored
                 # autocomplete form matches plugin commands registered with
                 # hyphens. See hermes_cli/commands.py:_build_telegram_menu.
-                plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
+                plugin_command = command.replace("_", "-")
+                plugin_handler = get_plugin_command_handler(plugin_command)
                 if plugin_handler:
+                    denied = self._check_slash_access(source, plugin_command)
+                    if denied is not None:
+                        return denied
                     user_args = event.get_command_args().strip()
-                    result = plugin_handler(user_args)
+                    result = invoke_plugin_command(
+                        plugin_command,
+                        user_args,
+                        event=event,
+                        gateway=self,
+                    )
                     if asyncio.iscoroutine(result):
                         result = await result
                     return str(result) if result else None
             except Exception as e:
                 logger.warning("Plugin command dispatch failed: %s", e)
+                return "Command failed safely; it was not sent to the agent."
 
         # Skill slash commands: /skill-name loads the skill and sends to agent.
         # resolve_skill_command_key() handles the Telegram underscore/hyphen
@@ -18941,20 +19074,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             mins = policy.idle_minutes % 60
                             duration = f"{hours}h" if not mins else f"{hours}h {mins}m" if hours else f"{mins}m"
                             reason_text = f"inactive for {duration}"
-                        notice = (
-                            f"◐ Session automatically reset ({reason_text}). "
-                            f"Conversation history cleared.\n"
-                            f"Use /resume to browse and restore a previous session.\n"
-                            f"Adjust reset timing in config.yaml under session_reset."
-                        )
+                        session_info = ""
                         try:
                             session_info = await asyncio.to_thread(
                                 self._reset_notice_session_info, source
                             )
-                            if session_info:
-                                notice = f"{notice}\n\n{session_info}"
                         except Exception:
                             pass
+                        notice = _build_auto_reset_notice(
+                            source.platform, reason_text, session_info
+                        )
+                        notice = _finalize_gateway_output(
+                            source,
+                            notice,
+                            user_message=str(getattr(event, "text", "") or ""),
+                            gateway=self,
+                            force_brief=True,
+                        )
                         await adapter.send(
                             source.chat_id, notice,
                             metadata=self._thread_metadata_for_source(source),
@@ -20186,6 +20322,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Prepend reasoning/thinking if display is enabled (per-platform).
             # Mattermost requires explicit per-platform opt-in because this is
             # scratch text, not ordinary final-answer content.
+            _gateway_metadata_added = False
             try:
                 _show_reasoning_effective = _resolve_gateway_display_bool(
                     _load_gateway_config(),
@@ -20240,6 +20377,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # break the outer code block used to render it.
                         display_reasoning = escape_code_fences_for_display(display_reasoning)
                         response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
+                    _gateway_metadata_added = True
 
             # Runtime-metadata footer — only on the FINAL message of the turn.
             # Off by default (display.runtime_footer.enabled=false).  When
@@ -20262,6 +20400,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _footer_line = ""
             if _footer_line and response and not agent_result.get("already_sent") and not _intentional_silence:
                 response = f"{response}\n\n{_footer_line}"
+                _gateway_metadata_added = True
 
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {
@@ -20602,7 +20741,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_entry.session_id,
                 )
                 response = ""
-
+            elif response:
+                # Last text mutation before voice/media delivery or returning to
+                # the adapter send path. Nothing user-visible may be appended
+                # after this strict transform + immutable validation boundary.
+                response = _finalize_gateway_output(
+                    source,
+                    response,
+                    user_message=str(getattr(event, "text", "") or ""),
+                    gateway=self,
+                    force_brief=_gateway_metadata_added,
+                )
             # Auto voice reply: send TTS audio before the text response
             _already_sent = bool(agent_result.get("already_sent"))
             # Skip when streaming TTS already delivered audio for this turn (#60671).
@@ -20643,9 +20792,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     try:
                         _foot_adapter = self._adapter_for_source(source)
                         if _foot_adapter:
+                            _safe_footer = _finalize_gateway_output(
+                                source,
+                                _footer_line,
+                                user_message=str(getattr(event, "text", "") or ""),
+                                gateway=self,
+                                force_brief=True,
+                            )
                             await _foot_adapter.send(
                                 source.chat_id,
-                                _footer_line,
+                                _safe_footer,
                                 metadata=self._thread_metadata_for_source(source, self._reply_anchor_for_event(event)),
                             )
                     except Exception as _e:
@@ -20766,17 +20922,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # 500 with a large session often means the payload is too large
                 # for the API to process — treat it the same way.
                 if _hist_len > 50:
-                    return (
+                    return _finalize_gateway_output(
+                        source,
                         "⚠️ Session too large for the model's context window.\n"
                         "Use /compact to compress the conversation, or "
-                        "/reset to start fresh."
+                        "/reset to start fresh.",
+                        user_message=str(getattr(event, "text", "") or ""),
+                        gateway=self,
                     )
                 elif status_code == 400:
                     status_hint = " The request was rejected by the API."
-            return (
-                f"Sorry, I encountered an unexpected error.{status_hint}\n"
-                "Try again or use /reset to start a fresh session."
+            return _finalize_gateway_output(
+                source,
+                (
+                    f"Sorry, I encountered an unexpected error.{status_hint}\n"
+                    "Try again or use /reset to start a fresh session."
+                ),
+                user_message=str(getattr(event, "text", "") or ""),
+                gateway=self,
             )
+
         finally:
             # Restore session context variables to their pre-handler state
             self._clear_session_env(_session_env_tokens)
@@ -22316,6 +22481,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
 
         _thread_metadata = self._thread_metadata_for_source(source, event_message_id)
+        _is_telegram = _platform_config_key(source.platform) == "telegram"
 
         try:
             user_config = _load_gateway_config()
@@ -22324,9 +22490,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 user_config=user_config,
             )
             if not runtime_kwargs.get("api_key"):
+                _no_credentials_text = (
+                    "結果：背景任務未執行\n"
+                    "變更：目前無法安全啟動背景任務。\n"
+                    "下一步：請檢查模型供應商設定後重試。"
+                    if _is_telegram
+                    else f"❌ Background task {task_id} failed: no provider credentials configured."
+                )
                 await adapter.send(
                     source.chat_id,
-                    f"❌ Background task {task_id} failed: no provider credentials configured.",
+                    _no_credentials_text,
                     metadata=_thread_metadata,
                 )
                 return
@@ -22411,7 +22584,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             response = result.get("final_response", "") if result else ""
             if not response and result and result.get("error"):
-                response = f"Error: {result['error']}"
+                response = (
+                    "結果：背景任務失敗\n"
+                    "變更：背景處理未能安全完成。\n"
+                    "下一步：請重試；若持續失敗，再檢查 Gateway 日誌。"
+                    if _is_telegram
+                    else f"Error: {result['error']}"
+                )
 
             # Extract media files from the response
             if response:
@@ -22421,7 +22600,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 images, text_content = adapter.extract_images(response)
 
                 preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
-                header = f'✅ Background task complete\nPrompt: "{preview}"\n\n'
+                header = "" if _is_telegram else f'✅ Background task complete\nPrompt: "{preview}"\n\n'
 
                 if text_content:
                     await adapter.send(
@@ -22430,9 +22609,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         metadata=_thread_metadata,
                     )
                 elif not images and not media_files:
+                    _empty_extracted_text = (
+                        "結果：背景任務已完成\n"
+                        "變更：任務沒有產生可顯示的文字或附件。\n"
+                        "下一步：如有需要，請調整要求後重試。"
+                        if _is_telegram
+                        else header + "(No response generated)"
+                    )
                     await adapter.send(
                         chat_id=source.chat_id,
-                        content=header + "(No response generated)",
+                        content=_empty_extracted_text,
                         metadata=_thread_metadata,
                     )
 
@@ -22487,18 +22673,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         pass
             else:
                 preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+                _empty_text = (
+                    "結果：背景任務已完成\n"
+                    "變更：任務沒有產生可顯示的文字或附件。\n"
+                    "下一步：如有需要，請調整要求後重試。"
+                    if _is_telegram
+                    else f'✅ Background task complete\nPrompt: "{preview}"\n\n(No response generated)'
+                )
                 await adapter.send(
                     chat_id=source.chat_id,
-                    content=f'✅ Background task complete\nPrompt: "{preview}"\n\n(No response generated)',
+                    content=_empty_text,
                     metadata=_thread_metadata,
                 )
 
         except Exception as e:
             logger.exception("Background task %s failed", task_id)
             try:
+                _failure_text = (
+                    "結果：背景任務失敗\n"
+                    "變更：背景處理未能安全完成。\n"
+                    "下一步：請重試；若持續失敗，再檢查 Gateway 日誌。"
+                    if _is_telegram
+                    else f"❌ Background task {task_id} failed: {e}"
+                )
                 await adapter.send(
                     chat_id=source.chat_id,
-                    content=f"❌ Background task {task_id} failed: {e}",
+                    content=_failure_text,
                     metadata=_thread_metadata,
                 )
             except Exception:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -123,6 +123,26 @@ def _home_thread_from_source(source) -> Optional[str]:
     return str(thread_id)
 
 
+def _apply_status_extensions(status: str, *, event: MessageEvent, gateway: Any) -> str:
+    """Apply presentation-only plugin extensions to canonical /status output.
+
+    This runs inside the built-in status handler, after normal authorization and
+    active-agent routing have selected it. Plugins cannot rewrite the command or
+    bypass command access control through this extension point.
+    """
+    try:
+        from hermes_cli.plugins import invoke_hook
+
+        for result in invoke_hook(
+            "extend_gateway_status", status=status, event=event, gateway=gateway
+        ):
+            if isinstance(result, str) and result:
+                status = result
+    except Exception as exc:
+        logger.warning("Status extension hook failed: %s", exc)
+    return status
+
+
 class GatewaySlashCommandsMixin:
     """In-session slash-command handlers for GatewayRunner."""
 
@@ -768,7 +788,7 @@ class GatewaySlashCommandsMixin:
             t("gateway.status.platforms", platforms=', '.join(connected_platforms)),
         ])
 
-        return "\n".join(lines)
+        return _apply_status_extensions("\n".join(lines), event=event, gateway=self)
 
     @staticmethod
     def _redact_matrix_session_key(session_key: str) -> str:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -543,7 +543,16 @@ def should_bypass_active_session(command_name: str | None) -> bool:
     ACTIVE_SESSION_BYPASS_COMMANDS remains the subset of commands with
     explicit Level-2 handlers; the rest fall through to the catch-all.
     """
-    return resolve_command(command_name) is not None if command_name else False
+    if not command_name:
+        return False
+    if resolve_command(command_name) is not None:
+        return True
+    try:
+        from hermes_cli.plugins import get_plugin_command_handler
+
+        return get_plugin_command_handler(command_name.replace("_", "-")) is not None
+    except Exception:
+        return False
 
 
 def _resolve_config_gates() -> set[str]:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -5380,7 +5380,9 @@ class PluginManager:
         transformed = False
         for cb in self._hooks.get(hook_name, []):
             try:
-                ret = cb(response_text=current, **kwargs)
+                ret = self._invoke_hook_callback(
+                    cb, {"response_text": current, **kwargs}
+                )
             except Exception as exc:
                 logger.warning(
                     "Required text hook '%s' callback %s raised: %s",
@@ -5410,7 +5412,9 @@ class PluginManager:
         """
         kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
         for callback in self._hooks.get(hook_name, ()):
-            result = callback(response_text=response_text, **kwargs)
+            result = self._invoke_hook_callback(
+                callback, {"response_text": response_text, **kwargs}
+            )
             if result is False:
                 raise RuntimeError(f"Terminal validation hook '{hook_name}' rejected output")
             if result is not None and result is not True:
@@ -5971,14 +5975,14 @@ def invoke_text_hook(
     hook_name: str, *, response_text: str, **kwargs: Any
 ) -> tuple[str, bool]:
     """Invoke a required sequential text hook without swallowing failures."""
-    return get_plugin_manager().invoke_text_hook(
+    return _delivery_manager().invoke_text_hook(
         hook_name, response_text=response_text, **kwargs
     )
 
 
 def invoke_validation_hook(hook_name: str, *, response_text: str, **kwargs: Any) -> None:
     """Invoke terminal validators; any rejection propagates to the caller."""
-    get_plugin_manager().invoke_validation_hook(
+    _delivery_manager().invoke_validation_hook(
         hook_name, response_text=response_text, **kwargs
     )
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -163,10 +163,22 @@ VALID_HOOKS: Set[str] = {
     "post_tool_call",
     "transform_terminal_output",
     "transform_tool_result",
+    "finalize_gateway_output",
+    "validate_gateway_output",
+    # Terminal, non-mutating output validators. Callbacks may only return
+    # None/True; any rejection or exception fails closed at the egress caller.
+    "validate_llm_output",
+    # Required final-output guard. Unlike transform_llm_output, callbacks are
+    # chained in registration order and exceptions propagate to the caller.
+    "finalize_llm_output",
     # Transform LLM output before it's returned to the user.
     # Plugins return a string to replace the response text, or None/empty to leave unchanged.
     # First non-None string wins. Useful for vocabulary/personality transformation.
     "transform_llm_output",
+    # Extend canonical gateway /status output after auth and active-run routing.
+    # Callback kwargs: status, event, gateway. Return a complete replacement
+    # status string, or None to leave it unchanged.
+    "extend_gateway_status",
     "pre_llm_call",
     "post_llm_call",
     # Streaming LLM output observer hooks. Fired asynchronously off the token
@@ -223,7 +235,12 @@ VALID_HOOKS: Set[str] = {
     "on_skill_lifecycle",
     "subagent_start",
     "subagent_stop",
-    # Gateway pre-dispatch hook. Fired once per incoming MessageEvent
+    # Gateway transport-safety hook. Fired for every inbound MessageEvent,
+    # including internal events, before any user hook or possible output.
+    # Safety plugins may return {"action": "skip", "reason": "..."}.
+    # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
+    "pre_gateway_transport",
+    # Gateway pre-dispatch hook. Fired once per user-originated MessageEvent
     # after the internal-event guard but BEFORE auth/pairing and agent
     # dispatch. Plugins may return a dict to influence flow:
     #   {"action": "skip",    "reason": "..."}  -> drop message (no reply)
@@ -5101,14 +5118,18 @@ class PluginManager:
         }
         return callback(**accepted_payload)
 
-    def invoke_hook(self, hook_name: str, **kwargs: Any) -> List[Any]:
+    def invoke_hook(
+        self, hook_name: str, *, fail_closed: bool = False, **kwargs: Any
+    ) -> List[Any]:
         """Call all registered callbacks for *hook_name*.
 
         Hook payloads evolve additively. Callbacks that accept ``**kwargs``
         receive the complete payload; older callbacks with a narrow signature
         receive only the keyword arguments they declare. Each callback is
         wrapped in its own try/except so a misbehaving plugin cannot break the
-        core agent loop.
+        core agent loop. When ``fail_closed`` is true, a callback exception is
+        surfaced as an ``action=skip`` result so a security-sensitive caller
+        can halt dispatch.
 
         Returns a list of non-``None`` return values from callbacks.
 
@@ -5144,6 +5165,8 @@ class PluginManager:
                     getattr(cb, "__name__", repr(cb)),
                     exc,
                 )
+                if fail_closed:
+                    results.append({"action": "skip", "reason": "hook-callback-error"})
         return results
 
     def _subscribe_event(
@@ -5342,6 +5365,59 @@ class PluginManager:
             self._event_pending_by_generation[generation] = pending + 1
             self._ensure_event_worker_locked()
             return len(subscriptions)
+
+    def invoke_text_hook(
+        self, hook_name: str, *, response_text: str, **kwargs: Any
+    ) -> tuple[str, bool]:
+        """Run required text callbacks sequentially and propagate failures.
+
+        Each non-empty string becomes the input to the next callback. ``None``
+        or an empty string is pass-through. Any other return type, or any
+        callback exception, is a hard failure for the caller to handle safely.
+        """
+        kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
+        current = response_text
+        transformed = False
+        for cb in self._hooks.get(hook_name, []):
+            try:
+                ret = cb(response_text=current, **kwargs)
+            except Exception as exc:
+                logger.warning(
+                    "Required text hook '%s' callback %s raised: %s",
+                    hook_name,
+                    getattr(cb, "__name__", repr(cb)),
+                    exc,
+                )
+                raise
+            if ret is None or ret == "":
+                continue
+            if not isinstance(ret, str):
+                raise TypeError(
+                    f"Required text hook '{hook_name}' callback returned "
+                    f"{type(ret).__name__}, expected str or None"
+                )
+            current = ret
+            transformed = True
+        return current, transformed
+
+    def invoke_validation_hook(
+        self, hook_name: str, *, response_text: str, **kwargs: Any
+    ) -> None:
+        """Run terminal validators without permitting output mutation.
+
+        Validators receive the immutable final text and may return ``None`` or
+        ``True``. ``False``, any other type, or an exception rejects delivery.
+        """
+        kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
+        for callback in self._hooks.get(hook_name, ()):
+            result = callback(response_text=response_text, **kwargs)
+            if result is False:
+                raise RuntimeError(f"Terminal validation hook '{hook_name}' rejected output")
+            if result is not None and result is not True:
+                raise TypeError(
+                    f"Terminal validation hook '{hook_name}' must return None or True, "
+                    f"got {type(result).__name__}"
+                )
 
     def has_hook(self, hook_name: str) -> bool:
         """Return True when at least one callback is registered for a hook."""
@@ -5889,6 +5965,22 @@ def render_system_prompt_sections(
 ) -> List[RenderedPluginSystemPromptSection]:
     """Render plugin prompt sections after idempotent plugin discovery."""
     return _ensure_plugins_discovered().render_system_prompt_sections(session_info)
+
+
+def invoke_text_hook(
+    hook_name: str, *, response_text: str, **kwargs: Any
+) -> tuple[str, bool]:
+    """Invoke a required sequential text hook without swallowing failures."""
+    return get_plugin_manager().invoke_text_hook(
+        hook_name, response_text=response_text, **kwargs
+    )
+
+
+def invoke_validation_hook(hook_name: str, *, response_text: str, **kwargs: Any) -> None:
+    """Invoke terminal validators; any rejection propagates to the caller."""
+    get_plugin_manager().invoke_validation_hook(
+        hook_name, response_text=response_text, **kwargs
+    )
 
 
 def invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:
@@ -6458,6 +6550,26 @@ def get_plugin_command_handler(name: str) -> Optional[Callable]:
     """Return the handler for a plugin-registered slash command, or ``None``."""
     entry = _ensure_plugins_discovered()._plugin_commands.get(name)
     return entry["handler"] if entry else None
+
+
+def invoke_plugin_command(name: str, args: str, **context: Any) -> Any:
+    """Invoke a plugin command, passing only context parameters it accepts.
+
+    Legacy one-argument handlers remain compatible. Event-aware handlers can
+    request ``event``/``gateway`` explicitly or accept ``**kwargs``.
+    """
+    handler = get_plugin_command_handler(name)
+    if handler is None:
+        return None
+    signature = inspect.signature(handler)
+    accepts_all = any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
+    accepted = context if accepts_all else {
+        key: value for key, value in context.items() if key in signature.parameters
+    }
+    return handler(args, **accepted)
 
 
 _PLUGIN_COMMAND_AWAIT_TIMEOUT_SECS = 30.0

--- a/plugins/telegram-brief/__init__.py
+++ b/plugins/telegram-brief/__init__.py
@@ -1,0 +1,422 @@
+"""Telegram final-answer-first reporting mode.
+
+Only Telegram presentation is changed. Tools, approvals, authorization, project
+selection, credentials, and execution behavior remain owned by Hermes core.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import math
+import re
+from typing import Any
+
+_DEFAULT_MODE = "brief"
+_MAX_BRIEF_LINES = 10
+_MAX_BRIEF_CHARS = 3500
+_MAX_FIELD_CHARS = 240
+_MAX_MEDIA = 10
+_MAX_MEDIA_PATH_CHARS = 300
+_MAX_MEDIA_PATH_TOTAL = 1200
+_MAX_SERIALIZED_CHARS = 3900
+
+_modes_by_identity: dict[str, str] = {}
+_turn_identity: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "telegram_brief_turn_identity", default=None
+)
+_turn_allows_detail: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "telegram_brief_turn_allows_detail", default=False
+)
+_final_output_allows_detail: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "telegram_brief_final_output_allows_detail", default=False
+)
+
+_BRIEF_CONTEXT = """[TELEGRAM REPORT MODE: BRIEF]
+This instruction controls only the final user-facing Telegram response; retain and use every normal agent capability, tool, approval, permission, secret rule, and project rule.
+Do not narrate progress. Do not expose reasoning, tool calls, tool output, assistant deltas, commands, diffs, logs, stack traces, or file-by-file edits. Do not include complete code or a code fence.
+Return only the final conclusion, normally within 10 lines and in Traditional Chinese when the user writes Chinese. Use this schema:
+結果：完成／部分完成／失敗
+變更：1～3 sentences
+驗證：tests, build, and real inspection results
+交付：commit, push, and deploy state (omit when none)
+阻礙：only when a real blocker exists
+下一步：only when the user must decide or act
+On failure, include only the key error, root cause, impact, and next step; keep full logs locally and provide only their path. Do not make another model call merely to summarize.
+"""
+
+_DETAIL_CONTEXT = """[TELEGRAM REPORT MODE: DETAIL]
+A detailed final technical explanation is allowed for this turn. Never expose private reasoning or hidden chain-of-thought. Do not stream tool calls, tool output, assistant deltas, or progress narration; send technical detail only in the final response.
+"""
+
+# Exact, whole-message requests only. Analytical or quoted text with a trigger
+# phrase must not silently disable brief sanitization.
+_DIRECT_DETAIL_RE = re.compile(
+    r"^\s*(?:"
+    r"(?:請|麻煩|這次請)\s*(?:貼(?:出)?程式碼|顯示\s*diff|提供(?:完整)?程式碼|"
+    r"提供完整(?:錯誤|log|日誌|技術說明)|詳細說明)|"
+    r"(?:please\s+)?(?:show|paste)\s+(?:the\s+)?(?:code|diff)|"
+    r"(?:please\s+)?provide\s+(?:the\s+)?(?:full\s+)?(?:code|error|log|stack\s*trace)|"
+    r"(?:please\s+)?(?:give|write)\s+(?:a\s+)?detailed\s+(?:technical\s+)?explanation"
+    r")\s*(?:please|給我|for\s+this\s+turn)?\s*[.!。！]?\s*$",
+    re.IGNORECASE,
+)
+_FIELD_RE = re.compile(r"^(結果|變更|驗證|交付|阻礙|下一步)[：:]\s*(.*)$")
+_FIELD_ORDER = ("結果", "變更", "驗證", "交付", "阻礙", "下一步")
+_REQUIRED_TELEGRAM_DISPLAY = {
+    "streaming": False,
+    "tool_progress": "off",
+    "show_reasoning": False,
+    "thinking_progress": False,
+    "interim_assistant_messages": False,
+    "busy_ack_detail": False,
+    "long_running_notifications": False,
+}
+_UNSAFE_VALUE_RE = re.compile(
+    r"MEDIA:|```|~~~|diff\s+--git|traceback|stack\s*trace|tool\s*(?:call|output|result)|"
+    r"assistant\s*delta|private\s*reasoning|思考過程|runtimeerror|keyerror|"
+    r"(?:^|\s)(?:def|class|function|import|from|const|let|var)\s+[A-Za-z_$]|"
+    r"\b[A-Za-z_$][\w$]*\([^\n)]*\)|"
+    r"(?:^|\s)(?:git|python|npm|pnpm|yarn|curl|powershell|cmd\.exe|bash|pytest)\s+[-/A-Za-z]|"
+    r"=>|@@\s|\b(?:secret|token|password|credential|api[_ -]?key|private[_ -]?key)\b|"
+    r"(?:密碼|權杖|憑證|私鑰|金鑰)",
+    re.IGNORECASE,
+)
+_CREDENTIAL_SHAPED_RE = re.compile(
+    r"(?:\bBearer\s+\S{16,}|"
+    r"\b(?:sk-(?:proj-)?|gh[pousr]_|xox[baprs]-|hf_)[A-Za-z0-9_-]{16,}|"
+    r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}|"
+    r"\b(?:api[_-]?key|access[_-]?token|password|secret)\s*[:=]\s*\S{8,})",
+    re.IGNORECASE,
+)
+_OPAQUE_TOKEN_RE = re.compile(r"\S{32,}")
+
+
+def _has_high_entropy_token(value: str) -> bool:
+    for match in _OPAQUE_TOKEN_RE.finditer(value):
+        # Evaluate the credential material across arbitrary non-whitespace
+        # delimiters so attackers cannot split a token into sub-threshold
+        # slash/colon/pipe/etc. segments. Punctuation itself contributes no
+        # entropy and therefore cannot manufacture a false positive.
+        candidate = re.sub(r"[^A-Za-z0-9]", "", match.group(0))
+        if len(candidate) < 32:
+            continue
+        counts = {char: candidate.count(char) for char in set(candidate)}
+        entropy = -sum(
+            (count / len(candidate)) * math.log2(count / len(candidate))
+            for count in counts.values()
+        )
+        if len(counts) >= 10 and entropy >= 3.5:
+            return True
+    return False
+
+
+def _contains_sensitive_material(value: str) -> bool:
+    value = str(value or "")
+    # Evaluate the exact character stream controls could collapse into at any
+    # later output-normalization boundary, including detail-mode callers.
+    screened = re.sub(r"[\x00-\x1f\x7f]", "", value)
+    if _CREDENTIAL_SHAPED_RE.search(screened) or _has_high_entropy_token(screened):
+        return True
+    try:
+        from agent.redact import redact_sensitive_text
+
+        return redact_sensitive_text(screened, force=True) != screened
+    except Exception:
+        # Secret screening is part of the security boundary.
+        return True
+
+
+# Natural-language summaries only: reject code delimiters/operators, shell
+# quoting, Windows paths, and serialized structures instead of guessing.
+_SAFE_VALUE_RE = re.compile(
+    r"^[\w\s\u3000-\u303f，。！？：；、（）「」『』《》〈〉…·％%＋+\-－／/：:,.!?()'\";–—’“”]+$",
+    re.UNICODE,
+)
+
+
+def _platform_name(value: Any) -> str:
+    return str(getattr(value, "value", value) or "").lower()
+
+
+def _identity_from_source(source: Any) -> str:
+    platform = _platform_name(getattr(source, "platform", None))
+    profile = str(getattr(source, "profile", None) or "default")
+    user = getattr(source, "user_id", None) or getattr(source, "user_id_alt", None)
+    if user not in (None, ""):
+        return f"{profile}:{platform}:user:{user}"
+    chat = str(getattr(source, "chat_id", None) or "unknown-chat")
+    thread = str(getattr(source, "thread_id", None) or "root")
+    return f"{profile}:{platform}:chat:{chat}:thread:{thread}"
+
+
+def _identity_for_turn(sender_id: Any = None) -> str:
+    identity = _turn_identity.get()
+    if identity:
+        return identity
+    if sender_id not in (None, ""):
+        return f"default:telegram:user:{sender_id}"
+    return "default:telegram:chat:unknown-chat:thread:root"
+
+
+def _mode_for_identity(identity: str) -> str:
+    return _modes_by_identity.get(str(identity), _DEFAULT_MODE)
+
+
+def _is_explicit_detail_request(text: str) -> bool:
+    return bool(_DIRECT_DETAIL_RE.fullmatch(str(text or "")))
+
+
+def _transport_is_safe(source: Any, gateway: Any) -> bool:
+    """Read-only, profile-scoped fail-closed transport verification."""
+    try:
+        from gateway.run import _profile_runtime_scope
+        from hermes_cli.config import load_config
+
+        profile_home = gateway._resolve_profile_home_for_source(source)
+        with _profile_runtime_scope(profile_home):
+            config = load_config()
+        from gateway.runtime_footer import resolve_footer_config
+
+        if resolve_footer_config(config, "telegram").get("enabled"):
+            return False
+        actual = (((config.get("display") or {}).get("platforms") or {}).get("telegram") or {})
+        for key, required in _REQUIRED_TELEGRAM_DISPLAY.items():
+            current = actual.get(key)
+            if key == "tool_progress":
+                if current not in (False, "off"):
+                    return False
+            elif current is not required and current != required:
+                return False
+        return True
+    except Exception:
+        return False
+
+
+def _on_pre_gateway_dispatch(**kwargs: Any) -> dict[str, str] | None:
+    event = kwargs.get("event")
+    source = getattr(event, "source", None)
+    if _platform_name(getattr(source, "platform", None)) != "telegram":
+        _turn_identity.set(None)
+        _turn_allows_detail.set(False)
+        return None
+    gateway = kwargs.get("gateway")
+    if not _transport_is_safe(source, gateway):
+        _turn_identity.set(None)
+        _turn_allows_detail.set(False)
+        return {"action": "skip", "reason": "Telegram brief transport settings are unsafe"}
+    _turn_identity.set(_identity_from_source(source))
+    return None
+
+
+def _command_identity(event: Any) -> str | None:
+    source = getattr(event, "source", None)
+    if _platform_name(getattr(source, "platform", None)) != "telegram":
+        return None
+    return _identity_from_source(source)
+
+
+def _handle_brief(_args: str, *, event: Any = None, **_kwargs: Any) -> str:
+    identity = _command_identity(event)
+    if identity is None:
+        return "此指令僅適用於 Telegram。"
+    _modes_by_identity[identity] = "brief"
+    return "回報模式：brief（Telegram 僅傳送精簡最終結論）"
+
+
+def _handle_detail(_args: str, *, event: Any = None, **_kwargs: Any) -> str:
+    identity = _command_identity(event)
+    if identity is None:
+        return "此指令僅適用於 Telegram。"
+    _modes_by_identity[identity] = "detail"
+    return "回報模式：detail（允許完整最終技術說明；仍不顯示私人 reasoning）"
+
+
+def _extend_gateway_status(**kwargs: Any) -> str | None:
+    event = kwargs.get("event")
+    source = getattr(event, "source", None)
+    if _platform_name(getattr(source, "platform", None)) != "telegram":
+        return None
+    status = str(kwargs.get("status") or "")
+    mode = _mode_for_identity(_identity_from_source(source))
+    return f"{status}\n回報模式：{mode}" if status else f"回報模式：{mode}"
+
+
+def _on_pre_llm_call(**kwargs: Any) -> dict[str, str] | None:
+    if _platform_name(kwargs.get("platform")) != "telegram":
+        _turn_allows_detail.set(False)
+        return None
+    identity = _identity_for_turn(kwargs.get("sender_id"))
+    explicit_detail = _is_explicit_detail_request(str(kwargs.get("user_message") or ""))
+    allow_detail = explicit_detail or _mode_for_identity(identity) == "detail"
+    _turn_allows_detail.set(allow_detail)
+    return {"context": _DETAIL_CONTEXT if allow_detail else _BRIEF_CONTEXT}
+
+
+def _safe_field_value(value: str) -> str:
+    value = str(value or "")
+    # Screen the exact normalized value that can be emitted. Otherwise removed
+    # control characters could join individually short fragments into a secret
+    # only after the security check had already accepted them.
+    value = re.sub(r"[\x00-\x1f\x7f]", "", value)
+    value = re.sub(r"\s+", " ", value).strip().replace("`", "")
+    if _contains_sensitive_material(value):
+        return "技術細節已省略；可明確要求詳細說明。"
+    if not value or _UNSAFE_VALUE_RE.search(value) or not _SAFE_VALUE_RE.fullmatch(value):
+        return "技術細節已省略；可明確要求詳細說明。" if value else ""
+    return value[: _MAX_FIELD_CHARS - 1] + "…" if len(value) > _MAX_FIELD_CHARS else value
+
+
+def _sanitize_brief_response(text: str) -> str:
+    original = str(text or "")
+    fields: dict[str, str] = {}
+    for raw_line in original.splitlines():
+        match = _FIELD_RE.match(raw_line.strip())
+        if match and match.group(1) not in fields:
+            value = _safe_field_value(match.group(2))
+            if value:
+                fields[match.group(1)] = value
+
+    if "結果" not in fields:
+        fields = {
+            "結果": "部分完成",
+            "變更": "任務已結束，但最終摘要未符合 brief 格式。",
+            "下一步": "如需查看技術內容，請明確要求詳細說明。",
+        }
+    lines = [f"{name}：{fields[name]}" for name in _FIELD_ORDER if name in fields][:_MAX_BRIEF_LINES]
+    while lines and len("\n".join(lines)) > _MAX_BRIEF_CHARS:
+        lines.pop()
+    summary = "\n".join(lines) or "結果：部分完成\n變更：最終摘要未符合 brief 格式。"
+
+    # Canonical parser is the sole media syntax allowlist. Bound paths, count,
+    # aggregate size, and final serialized size before reconstructing tags.
+    bounded: list[tuple[str, bool]] = []
+    path_total = 0
+    try:
+        from gateway.platforms.base import BasePlatformAdapter
+
+        media_files, _ = BasePlatformAdapter.extract_media(original[:20000])
+        for path, is_voice in media_files:
+            path = str(path)
+            if (
+                not path
+                or len(path) > _MAX_MEDIA_PATH_CHARS
+                or re.search(r"[\x00-\x1f\x7f]", path)
+                or _contains_sensitive_material(path)
+            ):
+                continue
+            if len(bounded) >= _MAX_MEDIA or path_total + len(path) > _MAX_MEDIA_PATH_TOTAL:
+                break
+            bounded.append((path, bool(is_voice)))
+            path_total += len(path)
+    except Exception:
+        bounded = []
+
+    if not bounded:
+        return summary
+    media_lines: list[str] = []
+    if any(is_voice for _, is_voice in bounded):
+        media_lines.append("[[audio_as_voice]]")
+    if "[[as_document]]" in original:
+        media_lines.append("[[as_document]]")
+    for path, _ in bounded:
+        candidate = media_lines + [f"MEDIA:{path}"]
+        if len(summary) + 1 + len("\n".join(candidate)) > _MAX_SERIALIZED_CHARS:
+            break
+        media_lines = candidate
+    return summary + (("\n" + "\n".join(media_lines)) if any(line.startswith("MEDIA:") for line in media_lines) else "")
+
+
+def _transform_llm_output(**kwargs: Any) -> str | None:
+    if _platform_name(kwargs.get("platform")) != "telegram":
+        _turn_allows_detail.set(False)
+        _final_output_allows_detail.set(False)
+        return None
+    allow_detail = _turn_allows_detail.get()
+    _turn_allows_detail.set(False)
+    _final_output_allows_detail.set(allow_detail)
+    if allow_detail:
+        return None
+    original = str(kwargs.get("response_text") or "")
+    transformed = _sanitize_brief_response(original)
+    return transformed if transformed != original else None
+
+
+def _validate_llm_output(**kwargs: Any) -> bool:
+    """Terminally validate the immutable result after every finalizer callback."""
+    if _platform_name(kwargs.get("platform")) != "telegram":
+        _final_output_allows_detail.set(False)
+        return True
+    allow_detail = _final_output_allows_detail.get()
+    _final_output_allows_detail.set(False)
+    output = str(kwargs.get("response_text") or "")
+    if allow_detail:
+        if _contains_sensitive_material(output):
+            raise RuntimeError("Telegram terminal validation rejected sensitive detail output")
+        return True
+    if _sanitize_brief_response(output) != output:
+        raise RuntimeError("Telegram terminal validation rejected post-sanitizer output")
+    return True
+
+
+def _gateway_allows_detail(**kwargs: Any) -> bool:
+    if kwargs.get("force_brief"):
+        return False
+    source = kwargs.get("source")
+    if _platform_name(getattr(source, "platform", kwargs.get("platform"))) != "telegram":
+        return False
+    identity = _identity_from_source(source)
+    return _mode_for_identity(identity) == "detail" or _is_explicit_detail_request(
+        str(kwargs.get("user_message") or "")
+    )
+
+
+def _revalidate_gateway_transport(**kwargs: Any) -> None:
+    source = kwargs.get("source")
+    gateway = kwargs.get("gateway")
+    if gateway is not None and not _transport_is_safe(source, gateway):
+        raise RuntimeError("Telegram gateway transport configuration became unsafe")
+
+
+def _transform_gateway_output(**kwargs: Any) -> str | None:
+    """Re-sanitize after every gateway mutation at the true send boundary."""
+    if _platform_name(kwargs.get("platform")) != "telegram":
+        return None
+    _revalidate_gateway_transport(**kwargs)
+    if _gateway_allows_detail(**kwargs):
+        return None
+    original = str(kwargs.get("response_text") or "")
+    transformed = _sanitize_brief_response(original)
+    return transformed if transformed != original else None
+
+
+def _validate_gateway_output(**kwargs: Any) -> bool:
+    if _platform_name(kwargs.get("platform")) != "telegram":
+        return True
+    _revalidate_gateway_transport(**kwargs)
+    output = str(kwargs.get("response_text") or "")
+    if _gateway_allows_detail(**kwargs):
+        if _contains_sensitive_material(output):
+            raise RuntimeError("Telegram gateway validation rejected sensitive detail output")
+        return True
+    if _sanitize_brief_response(output) != output:
+        raise RuntimeError("Telegram gateway validation rejected noncanonical output")
+    return True
+
+
+def _reset_state_for_tests() -> None:
+    _modes_by_identity.clear()
+    _turn_identity.set(None)
+    _turn_allows_detail.set(False)
+    _final_output_allows_detail.set(False)
+
+
+def register(ctx: Any) -> None:
+    ctx.register_hook("pre_gateway_transport", _on_pre_gateway_dispatch)
+    ctx.register_hook("pre_llm_call", _on_pre_llm_call)
+    ctx.register_hook("finalize_llm_output", _transform_llm_output)
+    ctx.register_hook("validate_llm_output", _validate_llm_output)
+    ctx.register_hook("finalize_gateway_output", _transform_gateway_output)
+    ctx.register_hook("validate_gateway_output", _validate_gateway_output)
+    ctx.register_hook("extend_gateway_status", _extend_gateway_status)
+    ctx.register_command("brief", _handle_brief, description="Use concise final-only Telegram reporting.")
+    ctx.register_command("detail", _handle_detail, description="Allow detailed final Telegram explanations.")

--- a/plugins/telegram-brief/__init__.py
+++ b/plugins/telegram-brief/__init__.py
@@ -12,13 +12,13 @@ import re
 from typing import Any
 
 _DEFAULT_MODE = "brief"
-_MAX_BRIEF_LINES = 10
-_MAX_BRIEF_CHARS = 3500
-_MAX_FIELD_CHARS = 240
+_MAX_BRIEF_LINES = 500
+_MAX_BRIEF_CHARS = 30000
+_MAX_FIELD_CHARS = 10000
 _MAX_MEDIA = 10
 _MAX_MEDIA_PATH_CHARS = 300
 _MAX_MEDIA_PATH_TOTAL = 1200
-_MAX_SERIALIZED_CHARS = 3900
+_MAX_SERIALIZED_CHARS = 32000
 
 _modes_by_identity: dict[str, str] = {}
 _turn_identity: contextvars.ContextVar[str | None] = contextvars.ContextVar(
@@ -34,7 +34,7 @@ _final_output_allows_detail: contextvars.ContextVar[bool] = contextvars.ContextV
 _BRIEF_CONTEXT = """[TELEGRAM REPORT MODE: BRIEF]
 This instruction controls only the final user-facing Telegram response; retain and use every normal agent capability, tool, approval, permission, secret rule, and project rule.
 Do not narrate progress. Do not expose reasoning, tool calls, tool output, assistant deltas, commands, diffs, logs, stack traces, or file-by-file edits. Do not include complete code or a code fence.
-Return only the final conclusion, normally within 10 lines and in Traditional Chinese when the user writes Chinese. Use this schema:
+Return only the final conclusion, normally within 10 lines and in Traditional Chinese when the user writes Chinese. Use this schema when it fits:
 結果：完成／部分完成／失敗
 變更：1～3 sentences
 驗證：tests, build, and real inspection results
@@ -42,6 +42,7 @@ Return only the final conclusion, normally within 10 lines and in Traditional Ch
 阻礙：only when a real blocker exists
 下一步：only when the user must decide or act
 On failure, include only the key error, root cause, impact, and next step; keep full logs locally and provide only their path. Do not make another model call merely to summarize.
+Never replace an explicitly requested answer, value, list, error reason, or verification result with a status word or an omission notice. If the user asks to list information, include the requested list in the final response. Concision may remove process narration and duplicate logs, never the answer itself.
 """
 
 _DETAIL_CONTEXT = """[TELEGRAM REPORT MODE: DETAIL]
@@ -73,7 +74,7 @@ _REQUIRED_TELEGRAM_DISPLAY = {
 }
 _UNSAFE_VALUE_RE = re.compile(
     r"MEDIA:|```|~~~|diff\s+--git|traceback|stack\s*trace|tool\s*(?:call|output|result)|"
-    r"assistant\s*delta|private\s*reasoning|思考過程|runtimeerror|keyerror|"
+    r"assistant\s*delta|private\s*reasoning|思考過程|"
     r"(?:^|\s)(?:def|class|function|import|from|const|let|var)\s+[A-Za-z_$]|"
     r"\b[A-Za-z_$][\w$]*\([^\n)]*\)|"
     r"(?:^|\s)(?:git|python|npm|pnpm|yarn|curl|powershell|cmd\.exe|bash|pytest)\s+[-/A-Za-z]|"
@@ -129,8 +130,15 @@ def _contains_sensitive_material(value: str) -> bool:
 # Natural-language summaries only: reject code delimiters/operators, shell
 # quoting, Windows paths, and serialized structures instead of guessing.
 _SAFE_VALUE_RE = re.compile(
-    r"^[\w\s\u3000-\u303f，。！？：；、（）「」『』《》〈〉…·％%＋+\-－／/：:,.!?()'\";–—’“”]+$",
+    r"^[\w\s\u3000-\u303f，。！？：；、（）「」『』《》〈〉…·％%＋+\-－／/：:,.!?()'\";–—’“”|*]+$",
     re.UNICODE,
+)
+_MARKDOWN_PREFIX_RE = re.compile(r"^(?:[-*•]\s+|\d+[.)、]\s*|>\s*|\|\s*)")
+_TOKEN_FRAGMENT_RE = re.compile(r"^[A-Za-z0-9_-]{12,}$")
+_UNSAFE_ANSWER_LINE_RE = re.compile(
+    r"^(?:return\b|RuntimeError\s*:|KeyError\s*:|REASONING\s*:)|"
+    r"internal\s+stack|\blog\s+output\b|(?:^|\s)[A-Za-z]:[/\\](?:private|secret)(?:[/\\]|$)",
+    re.IGNORECASE,
 )
 
 
@@ -260,32 +268,59 @@ def _safe_field_value(value: str) -> str:
     value = re.sub(r"[\x00-\x1f\x7f]", "", value)
     value = re.sub(r"\s+", " ", value).strip().replace("`", "")
     if _contains_sensitive_material(value):
-        return "技術細節已省略；可明確要求詳細說明。"
+        return "敏感內容已遮蔽。"
     if not value or _UNSAFE_VALUE_RE.search(value) or not _SAFE_VALUE_RE.fullmatch(value):
-        return "技術細節已省略；可明確要求詳細說明。" if value else ""
+        return "不安全內容已遮蔽。" if value else ""
     return value[: _MAX_FIELD_CHARS - 1] + "…" if len(value) > _MAX_FIELD_CHARS else value
+
+
+def _normalized_secret_stream(lines: list[str]) -> str:
+    """Join only credential-like line fragments for cross-line screening."""
+    fragments: list[str] = []
+    for line in lines:
+        candidate = _MARKDOWN_PREFIX_RE.sub("", line.strip())
+        candidate = candidate.strip("|* `")
+        if _TOKEN_FRAGMENT_RE.fullmatch(candidate):
+            fragments.append(candidate)
+    return "".join(fragments)
 
 
 def _sanitize_brief_response(text: str) -> str:
     original = str(text or "")
     fields: dict[str, str] = {}
+    answer_lines: list[str] = []
+    blocked = {"敏感內容已遮蔽。", "不安全內容已遮蔽。"}
     for raw_line in original.splitlines():
-        match = _FIELD_RE.match(raw_line.strip())
+        stripped = raw_line.strip()
+        match = _FIELD_RE.match(stripped)
         if match and match.group(1) not in fields:
             value = _safe_field_value(match.group(2))
             if value:
                 fields[match.group(1)] = value
+        elif (
+            stripped
+            and not stripped.startswith(("MEDIA:", "[[audio_as_voice]]", "[[as_document]]"))
+            and not _UNSAFE_ANSWER_LINE_RE.search(stripped)
+        ):
+            value = _safe_field_value(stripped)
+            if value and value not in blocked:
+                answer_lines.append(value)
 
-    if "結果" not in fields:
-        fields = {
-            "結果": "部分完成",
-            "變更": "任務已結束，但最終摘要未符合 brief 格式。",
-            "下一步": "如需查看技術內容，請明確要求詳細說明。",
-        }
-    lines = [f"{name}：{fields[name]}" for name in _FIELD_ORDER if name in fields][:_MAX_BRIEF_LINES]
+    secret_stream = _normalized_secret_stream(answer_lines)
+    if secret_stream and _contains_sensitive_material(secret_stream):
+        answer_lines = ["敏感內容已遮蔽。"]
+
+    if fields:
+        lines = [f"{name}：{fields[name]}" for name in _FIELD_ORDER if name in fields]
+        lines.extend(answer_lines)
+    else:
+        # Brief is a presentation preference, not a schema gate. Preserve every
+        # safe answer when the model used prose, values, lists, or tables.
+        lines = answer_lines
+    lines = lines[:_MAX_BRIEF_LINES]
     while lines and len("\n".join(lines)) > _MAX_BRIEF_CHARS:
         lines.pop()
-    summary = "\n".join(lines) or "結果：部分完成\n變更：最終摘要未符合 brief 格式。"
+    summary = "\n".join(lines) or "結果：無法安全顯示\n變更：回覆未包含可安全傳送的文字。"
 
     # Canonical parser is the sole media syntax allowlist. Bound paths, count,
     # aggregate size, and final serialized size before reconstructing tags.

--- a/plugins/telegram-brief/plugin.yaml
+++ b/plugins/telegram-brief/plugin.yaml
@@ -1,0 +1,12 @@
+name: telegram-brief
+version: 1.0.0
+description: "Telegram final-answer-first reporting with /brief, /detail, and mode-aware /status."
+author: "David Lin / Hermes"
+hooks:
+  - pre_gateway_transport
+  - pre_llm_call
+  - finalize_llm_output
+  - validate_llm_output
+  - finalize_gateway_output
+  - validate_gateway_output
+  - extend_gateway_status

--- a/tests/agent/test_turn_finalizer_cleanup_guard.py
+++ b/tests/agent/test_turn_finalizer_cleanup_guard.py
@@ -164,3 +164,67 @@ def test_clean_turn_has_no_cleanup_errors_key():
     assert "cleanup_errors" not in result
 
 
+def test_required_final_output_hook_failure_does_not_leak_original(monkeypatch):
+    import hermes_cli.plugins as plugins_mod
+    from hermes_cli.plugins import PluginManager
+
+    manager = PluginManager()
+
+    def _boom(**kwargs):
+        raise RuntimeError("final safety failed")
+
+    manager._hooks["finalize_llm_output"] = [_boom]
+    monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: manager)
+    agent = _StubAgent(raise_in=())
+    agent.platform = "telegram"
+
+    result = _run(agent)
+
+    assert result["final_response"] != "PARTIAL SUMMARY FROM MODEL"
+    assert "無法安全顯示" in result["final_response"]
+    assert result["response_transformed"] is True
+
+
+def test_required_finalizer_runs_after_legacy_transform(monkeypatch):
+    import hermes_cli.plugins as plugins_mod
+    from hermes_cli.plugins import PluginManager
+
+    manager = PluginManager()
+    manager._hooks["transform_llm_output"] = [
+        lambda **kwargs: kwargs["response_text"] + " legacy-added-detail"
+    ]
+    manager._hooks["finalize_llm_output"] = [lambda **kwargs: "SAFE FINAL"]
+    monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: manager)
+    agent = _StubAgent(raise_in=())
+    agent.platform = "telegram"
+
+    result = _run(agent)
+
+    assert result["final_response"] == "SAFE FINAL"
+
+
+def test_terminal_validator_blocks_post_sanitizer_callback_mutation(monkeypatch):
+    import hermes_cli.plugins as plugins_mod
+    from hermes_cli.plugins import PluginManager
+
+    manager = PluginManager()
+    manager._hooks["finalize_llm_output"] = [
+        lambda **kwargs: "SAFE FINAL",
+        lambda **kwargs: kwargs["response_text"] + "\n" + "sk-" + "proj-unsafe-appended-value",
+    ]
+
+    def _terminal_validator(**kwargs):
+        if "sk-proj-" in kwargs["response_text"]:
+            raise RuntimeError("terminal validation rejected output")
+        return True
+
+    manager._hooks["validate_llm_output"] = [_terminal_validator]
+    monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: manager)
+    agent = _StubAgent(raise_in=())
+    agent.platform = "telegram"
+
+    result = _run(agent)
+
+    assert "sk-proj-" not in result["final_response"]
+    assert "無法安全顯示" in result["final_response"]
+    assert result["response_transformed"] is True

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -116,7 +116,12 @@ class TestRunBackgroundTask:
         # Should have sent an error message
         mock_adapter.send.assert_called_once()
         call_args = mock_adapter.send.call_args
-        assert "failed" in call_args[1].get("content", call_args[0][1] if len(call_args[0]) > 1 else "").lower()
+        content = call_args[1].get("content", call_args[0][1] if len(call_args[0]) > 1 else "")
+        assert content == (
+            "結果：背景任務未執行\n"
+            "變更：目前無法安全啟動背景任務。\n"
+            "下一步：請檢查模型供應商設定後重試。"
+        )
 
     @pytest.mark.asyncio
     async def test_successful_task_sends_result(self):
@@ -170,6 +175,312 @@ class TestRunBackgroundTask:
         mock_agent_instance.shutdown_memory_provider.assert_called_once()
         mock_agent_instance.close.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_telegram_result_error_omits_internal_error_details(self, monkeypatch):
+        from gateway import run as gateway_run
+
+        runner = _make_runner()
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("test-model", {"api_key": "test-key"})
+        )
+        runner._resolve_session_reasoning_config = MagicMock(return_value=None)
+        runner._load_service_tier = MagicMock(return_value=None)
+        runner._resolve_turn_agent_config = MagicMock(
+            return_value={
+                "model": "test-model",
+                "runtime": {"api_key": "test-key"},
+                "request_overrides": None,
+            }
+        )
+        runner._run_in_executor_with_context = AsyncMock(
+            return_value={"final_response": "", "error": "internal-sensitive-detail"}
+        )
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(side_effect=lambda text: ([], text))
+        mock_adapter.extract_images = MagicMock(side_effect=lambda text: ([], text))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+        source = SessionSource(platform=Platform.TELEGRAM, user_id="12345", chat_id="67890")
+
+        await runner._run_background_task("private prompt", source, "bg_test")
+
+        content = mock_adapter.send.call_args.kwargs["content"]
+        assert content == (
+            "結果：背景任務失敗\n"
+            "變更：背景處理未能安全完成。\n"
+            "下一步：請重試；若持續失敗，再檢查 Gateway 日誌。"
+        )
+        assert "internal-sensitive-detail" not in content
+
+    @pytest.mark.asyncio
+    async def test_telegram_empty_extracted_response_is_canonical(self, monkeypatch):
+        from gateway import run as gateway_run
+
+        runner = _make_runner()
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("test-model", {"api_key": "test-key"})
+        )
+        runner._resolve_session_reasoning_config = MagicMock(return_value=None)
+        runner._load_service_tier = MagicMock(return_value=None)
+        runner._resolve_turn_agent_config = MagicMock(
+            return_value={
+                "model": "test-model",
+                "runtime": {"api_key": "test-key"},
+                "request_overrides": None,
+            }
+        )
+        runner._run_in_executor_with_context = AsyncMock(
+            return_value={"final_response": "removed during extraction", "messages": []}
+        )
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], ""))
+        mock_adapter.extract_images = MagicMock(return_value=([], ""))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+        source = SessionSource(platform=Platform.TELEGRAM, user_id="12345", chat_id="67890")
+
+        await runner._run_background_task("private prompt", source, "bg_test")
+
+        assert mock_adapter.send.call_args.kwargs["content"] == (
+            "結果：背景任務已完成\n"
+            "變更：任務沒有產生可顯示的文字或附件。\n"
+            "下一步：如有需要，請調整要求後重試。"
+        )
+
+    @pytest.mark.asyncio
+    async def test_telegram_exception_delivery_omits_exception_and_task_details(self, monkeypatch):
+        from gateway import run as gateway_run
+
+        runner = _make_runner()
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("test-model", {"api_key": "test-key"})
+        )
+        runner._resolve_session_reasoning_config = MagicMock(return_value=None)
+        runner._load_service_tier = MagicMock(return_value=None)
+        runner._resolve_turn_agent_config = MagicMock(
+            return_value={
+                "model": "test-model",
+                "runtime": {"api_key": "test-key"},
+                "request_overrides": None,
+            }
+        )
+        runner._run_in_executor_with_context = AsyncMock(
+            side_effect=RuntimeError("credential-shaped-internal-detail")
+        )
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+        )
+
+        await runner._run_background_task("private prompt", source, "bg_secret_task")
+
+        content = mock_adapter.send.call_args.kwargs["content"]
+        assert content == (
+            "結果：背景任務失敗\n"
+            "變更：背景處理未能安全完成。\n"
+            "下一步：請重試；若持續失敗，再檢查 Gateway 日誌。"
+        )
+        assert "credential-shaped" not in content
+        assert "private prompt" not in content
+        assert "bg_secret_task" not in content
+
+    @pytest.mark.asyncio
+    async def test_media_files_routed_by_type(self, monkeypatch):
+        """Result media is routed to the type-specific sender, not send_document.
+
+        A TTS clip should arrive as a voice bubble, a video as a video, an
+        image as a native image, and everything else as a document.
+        """
+        from gateway import run as gateway_run
+
+        runner = _make_runner()
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("test-model", {"api_key": "test-key"})
+        )
+        runner._resolve_session_reasoning_config = MagicMock(return_value=None)
+        runner._load_service_tier = MagicMock(return_value=None)
+        runner._resolve_turn_agent_config = MagicMock(
+            return_value={
+                "model": "test-model",
+                "runtime": {"api_key": "test-key"},
+                "request_overrides": None,
+            }
+        )
+        runner._run_in_executor_with_context = AsyncMock(
+            return_value={"final_response": "see attached", "messages": []}
+        )
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+
+        # Four real files so the media-delivery path validator accepts them
+        # (default mode requires the file to exist as a regular file).
+        import os as _os
+        import tempfile as _tempfile
+        _tmpdir = _tempfile.mkdtemp(prefix="bg_media_")
+        _ogg = _os.path.join(_tmpdir, "clip.ogg")
+        _mp4 = _os.path.join(_tmpdir, "render.mp4")
+        _png = _os.path.join(_tmpdir, "chart.png")
+        _pdf = _os.path.join(_tmpdir, "report.pdf")
+        for _p in (_ogg, _mp4, _png, _pdf):
+            with open(_p, "wb") as _fh:
+                _fh.write(b"x")
+        # ogg flagged as voice, mp4 video, png image, pdf doc.
+        media = [
+            (_ogg, True),
+            (_mp4, False),
+            (_png, False),
+            (_pdf, False),
+        ]
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.send_voice = AsyncMock()
+        mock_adapter.send_video = AsyncMock()
+        mock_adapter.send_image_file = AsyncMock()
+        mock_adapter.send_document = AsyncMock()
+        mock_adapter.send_image = AsyncMock()
+        # No text, no markdown images — just the four media attachments.
+        mock_adapter.extract_media = MagicMock(return_value=(media, ""))
+        mock_adapter.extract_images = MagicMock(return_value=([], ""))
+        # Non-telegram platform so every audio ext routes through send_voice.
+        runner.adapters[Platform.DISCORD] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        try:
+            await runner._run_background_task("make stuff", source, "bg_test")
+
+            mock_adapter.send_voice.assert_called_once()
+            assert mock_adapter.send_voice.call_args.kwargs["audio_path"] == _ogg
+            mock_adapter.send_video.assert_called_once()
+            assert mock_adapter.send_video.call_args.kwargs["video_path"] == _mp4
+            mock_adapter.send_image_file.assert_called_once()
+            assert mock_adapter.send_image_file.call_args.kwargs["image_path"] == _png
+            mock_adapter.send_document.assert_called_once()
+            assert mock_adapter.send_document.call_args.kwargs["file_path"] == _pdf
+        finally:
+            import shutil as _shutil
+            _shutil.rmtree(_tmpdir, ignore_errors=True)
+
+    @pytest.mark.asyncio
+    async def test_telegram_dm_topic_completion_preserves_reply_anchor_metadata(self, monkeypatch):
+        """Background completion metadata must let Telegram send thread id plus reply id."""
+        from gateway import run as gateway_run
+
+        runner = _make_runner()
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("test-model", {"api_key": "test-key"})
+        )
+        runner._resolve_session_reasoning_config = MagicMock(return_value=None)
+        runner._load_service_tier = MagicMock(return_value=None)
+        runner._resolve_turn_agent_config = MagicMock(
+            return_value={
+                "model": "test-model",
+                "runtime": {"api_key": "test-key"},
+                "request_overrides": None,
+            }
+        )
+        runner._run_in_executor_with_context = AsyncMock(
+            return_value={"final_response": "done", "messages": []}
+        )
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "done"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "done"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            chat_type="dm",
+            thread_id="20197",
+        )
+
+        await runner._run_background_task(
+            "say hello",
+            source,
+            "bg_test",
+            event_message_id="463",
+        )
+
+        mock_adapter.send.assert_called_once()
+        assert mock_adapter.send.call_args.kwargs["metadata"] == {
+            "thread_id": "20197",
+            "telegram_dm_topic_reply_fallback": True,
+            "direct_messages_topic_id": "20197",
+            "telegram_reply_to_message_id": "463",
+        }
+
+    @pytest.mark.asyncio
+    async def test_agent_cleanup_runs_when_background_agent_raises(self):
+        """Temporary background agents must be cleaned up on error paths too."""
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+            mock_agent_instance.run_conversation.side_effect = RuntimeError("boom")
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task("say hello", source, "bg_test")
+
+        mock_adapter.send.assert_called_once()
+        mock_agent_instance.shutdown_memory_provider.assert_called_once()
+        mock_agent_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_exception_sends_error_message(self):
+        """When the agent raises an exception, an error message is sent."""
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", side_effect=RuntimeError("boom")):
+            await runner._run_background_task("test prompt", source, "bg_test")
+
+        mock_adapter.send.assert_called_once()
+        call_args = mock_adapter.send.call_args
+        content = call_args[1].get("content", call_args[0][1] if len(call_args[0]) > 1 else "")
+        assert content == (
+            "結果：背景任務失敗\n"
+            "變更：背景處理未能安全完成。\n"
+            "下一步：請重試；若持續失敗，再檢查 Gateway 日誌。"
+        )
+        assert "boom" not in content
 
 # ---------------------------------------------------------------------------
 # /background in help and known_commands

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -165,8 +165,7 @@ class TestRunBackgroundTask:
         mock_adapter.send.assert_called_once()
         call_args = mock_adapter.send.call_args
         content = call_args[1].get("content", call_args[0][1] if len(call_args[0]) > 1 else "")
-        assert "Background task complete" in content
-        assert "Hello from background!" in content
+        assert content == "Hello from background!"
         agent_kwargs = MockAgent.call_args.kwargs
         assert agent_kwargs["checkpoints_enabled"] is True
         assert agent_kwargs["checkpoint_max_snapshots"] == 8

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -85,6 +85,22 @@ class TestCommandBypassActiveSession:
     """Commands that must bypass the active-session guard."""
 
     @pytest.mark.asyncio
+    async def test_plugin_command_bypasses_guard(self, monkeypatch):
+        """Registered plugin commands must dispatch, never become agent input."""
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_plugin_command_handler",
+            lambda name: (lambda args: "ok") if name == "brief" else None,
+        )
+        adapter = _make_adapter()
+        sk = _session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        await adapter.handle_message(_make_event("/brief"))
+
+        assert sk not in adapter._pending_messages
+        assert any("handled:brief" in response for response in adapter.sent_responses)
+
+    @pytest.mark.asyncio
     async def test_stop_bypasses_guard(self):
         """/stop must be dispatched directly, not queued."""
         adapter = _make_adapter()

--- a/tests/gateway/test_gateway_final_output.py
+++ b/tests/gateway/test_gateway_final_output.py
@@ -1,0 +1,68 @@
+"""Tests for the true gateway final-egress plugin boundary."""
+
+from types import SimpleNamespace
+
+from gateway.config import Platform
+from gateway.run import _build_auto_reset_notice, _finalize_gateway_output
+
+
+def test_gateway_final_output_transforms_then_validates(monkeypatch):
+    calls = []
+
+    def _transform(name, *, response_text, **kwargs):
+        calls.append(("transform", name, response_text, kwargs))
+        return "結果：無法安全顯示\n變更：已移除內部錯誤。\n下一步：請重試。", True
+
+    def _validate(name, *, response_text, **kwargs):
+        calls.append(("validate", name, response_text, kwargs))
+        assert "private/project" not in response_text
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_text_hook", _transform)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_validation_hook", _validate)
+    source = SimpleNamespace(platform=Platform.TELEGRAM, user_id="u1")
+
+    gateway = object()
+    result = _finalize_gateway_output(
+        source,
+        "The request failed: internal stack at C:/private/project\n"
+        "MEDIA:C:/private/project/opaque.txt\nmodel · C:/private/project",
+        user_message="run it",
+        gateway=gateway,
+        force_brief=True,
+    )
+
+    assert result.startswith("結果：")
+    assert [call[0] for call in calls] == ["transform", "validate"]
+    assert calls[0][1] == "finalize_gateway_output"
+    assert calls[1][1] == "validate_gateway_output"
+    assert calls[0][3]["gateway"] is gateway
+    assert calls[0][3]["force_brief"] is True
+
+
+def test_telegram_auto_reset_notice_omits_session_metadata():
+    notice = _build_auto_reset_notice(
+        Platform.TELEGRAM,
+        "inactive for 2h",
+        "Model: provider/model\nEndpoint: http://local.private:9000\nCWD: C:/private",
+    )
+
+    assert notice.startswith("結果：工作階段已自動重設")
+    assert "provider/model" not in notice
+    assert "local.private" not in notice
+    assert "C:/private" not in notice
+
+
+def test_gateway_final_output_hook_failure_is_safe(monkeypatch):
+    def _raise(*args, **kwargs):
+        raise RuntimeError("internal terminal failure")
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_text_hook", _raise)
+    source = SimpleNamespace(platform=Platform.TELEGRAM, user_id="u1")
+
+    result = _finalize_gateway_output(
+        source, "raw output that must not be delivered", user_message="run it"
+    )
+
+    assert result.startswith("結果：無法安全顯示")
+    assert "raw output" not in result
+    assert "internal terminal failure" not in result

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -61,16 +61,107 @@ def _make_runner(platform: Platform):
 
 
 @pytest.mark.asyncio
-async def test_internal_events_bypass_hook(monkeypatch):
-    """Internal events (event.internal=True) skip the plugin hook entirely."""
+async def test_hook_skip_short_circuits_dispatch(monkeypatch):
+    """A plugin returning {'action': 'skip'} drops the message before auth."""
+    _clear_auth_env(monkeypatch)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_dispatch":
+            return [{"action": "skip", "reason": "plugin-handled"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, adapter = _make_runner(Platform.WHATSAPP)
+
+    result = await runner._handle_message(_make_event("hi"))
+
+    assert result is None
+    adapter.send.assert_not_awaited()
+    runner.pairing_store.generate_code.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_hook_rewrite_replaces_event_text(monkeypatch):
+    """A plugin returning {'action': 'rewrite', 'text': ...} mutates event.text."""
     _clear_auth_env(monkeypatch)
     monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
 
-    called = {"count": 0}
+    seen_text = {}
 
     def _fake_hook(name, **kwargs):
-        called["count"] += 1
-        return [{"action": "skip"}]
+        if name == "pre_gateway_dispatch":
+            return [{"action": "rewrite", "text": "REWRITTEN"}]
+        return []
+
+    async def _capture(event, source, _quick_key, _run_generation):
+        seen_text["value"] = event.text
+        return "ok"
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, _adapter = _make_runner(Platform.WHATSAPP)
+    runner._handle_message_with_agent = _capture  # noqa: SLF001
+
+    await runner._handle_message(_make_event("original"))
+
+    assert seen_text.get("value") == "REWRITTEN"
+
+
+@pytest.mark.asyncio
+async def test_hook_allow_falls_through_to_auth(monkeypatch):
+    """A plugin returning {'action': 'allow'} continues to normal dispatch."""
+    _clear_auth_env(monkeypatch)
+    # No allowed users set → auth fails → pairing flow triggers.
+    monkeypatch.delenv("WHATSAPP_ALLOWED_USERS", raising=False)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_dispatch":
+            return [{"action": "allow"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, adapter = _make_runner(Platform.WHATSAPP)
+    runner.pairing_store.generate_code.return_value = "12345"
+
+    result = await runner._handle_message(_make_event("hi"))
+
+    # auth chain ran → pairing code was generated
+    assert result is None
+    runner.pairing_store.generate_code.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_hook_exception_does_not_break_dispatch(monkeypatch):
+    """A raising plugin hook does not break the gateway."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.delenv("WHATSAPP_ALLOWED_USERS", raising=False)
+
+    def _fake_hook(name, **kwargs):
+        raise RuntimeError("plugin blew up")
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, _adapter = _make_runner(Platform.WHATSAPP)
+    runner.pairing_store.generate_code.return_value = None
+
+    # Should not raise; falls through to auth chain.
+    result = await runner._handle_message(_make_event("hi"))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_internal_events_run_transport_hook_but_bypass_user_hook(monkeypatch):
+    """Internal events run safety hooks while skipping user interception."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+
+    called = []
+
+    def _fake_hook(name, **kwargs):
+        called.append((name, kwargs.get("fail_closed")))
+        return [{"action": "skip"}] if name == "pre_gateway_dispatch" else []
 
     async def _capture(event, source, _quick_key, _run_generation):
         return "ok"
@@ -83,9 +174,8 @@ async def test_internal_events_bypass_hook(monkeypatch):
     event = _make_event("hi")
     event.internal = True
 
-    # Even though the hook would say skip, internal events bypass it.
     await runner._handle_message(event)
-    assert called["count"] == 0
+    assert called == [("pre_gateway_transport", True)]
 
 @pytest.mark.asyncio
 async def test_hook_fires_without_session_store_attribute(monkeypatch):
@@ -118,3 +208,42 @@ async def test_hook_fires_without_session_store_attribute(monkeypatch):
     # Hook actually fired (skip short-circuited before auth) with a None store.
     assert seen == {"session_store": None}
     adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_real_transport_callback_failure_blocks_internal_telegram(monkeypatch):
+    """PluginManager callback isolation still surfaces strict transport failure."""
+    from hermes_cli.plugins import PluginManager
+
+    manager = PluginManager()
+
+    def _boom(**kwargs):
+        raise RuntimeError("transport safety failed")
+
+    manager._hooks["pre_gateway_transport"] = [_boom]
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+    runner, _adapter = _make_runner(Platform.TELEGRAM)
+    runner._handle_message_with_agent = AsyncMock(return_value="must-not-run")
+    event = _make_event("internal task", platform=Platform.TELEGRAM)
+    event.internal = True
+
+    assert await runner._handle_message(event) is None
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_internal_telegram_event_can_be_blocked_by_transport_safety(monkeypatch):
+    """Unsafe internal Telegram agent turns fail closed before dispatch."""
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_transport":
+            return [{"action": "skip", "reason": "unsafe-display"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    runner, _adapter = _make_runner(Platform.TELEGRAM)
+    runner._handle_message_with_agent = AsyncMock(return_value="must-not-run")
+    event = _make_event("internal task", platform=Platform.TELEGRAM)
+    event.internal = True
+
+    assert await runner._handle_message(event) is None
+    runner._handle_message_with_agent.assert_not_awaited()

--- a/tests/gateway/test_status_plugin_extensions.py
+++ b/tests/gateway/test_status_plugin_extensions.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from gateway.slash_commands import _apply_status_extensions
+
+
+def test_status_extensions_append_without_changing_canonical_dispatch_or_auth():
+    event = SimpleNamespace(text="/status", source=SimpleNamespace(platform="telegram"))
+    with patch("hermes_cli.plugins.invoke_hook") as invoke:
+        invoke.return_value = ["Base status\n回報模式：brief"]
+        result = _apply_status_extensions("Base status", event=event, gateway=object())
+
+    assert result == "Base status\n回報模式：brief"
+    assert event.text == "/status"
+    invoke.assert_called_once()
+    kwargs = invoke.call_args.kwargs
+    assert kwargs["status"] == "Base status"
+    assert kwargs["event"] is event
+
+
+def test_status_extensions_ignore_non_string_or_empty_plugin_results():
+    event = SimpleNamespace(text="/status", source=SimpleNamespace(platform="telegram"))
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[None, {}, "", "extended"]):
+        assert _apply_status_extensions("base", event=event, gateway=object()) == "extended"

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -120,6 +120,88 @@ async def test_unknown_slash_command_returns_guidance(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_unknown_slash_command_underscored_form_also_guarded(monkeypatch):
+    """Telegram may send /foo_bar — same guard must trigger for underscored
+    commands that normalize to unknown hyphenated names."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError(
+            "unknown slash command leaked through to the agent"
+        )
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/made_up_thing"))
+
+    assert result is not None
+    assert "Unknown command" in result
+    assert "/made_up_thing" in result
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_idle_plugin_command_failure_is_consumed(monkeypatch):
+    """Cold-path plugin failures must not fall through to unknown-command routing."""
+    runner = _make_runner()
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_command_handler", lambda name: object()
+    )
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("internal plugin detail")
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_plugin_command", _raise)
+    result = await runner._handle_message(_make_event("/brief"))
+
+    assert result
+    assert "internal plugin detail" not in result
+    assert "Unknown command" not in result
+
+
+@pytest.mark.asyncio
+async def test_active_plugin_command_failure_is_consumed(monkeypatch):
+    """A recognized plugin command must never fall through as agent input."""
+    import gateway.run as gateway_run
+    from hermes_cli import plugins as plugins_mod
+
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    runner._running_agents[session_key] = MagicMock()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("failed plugin command leaked to agent")
+    )
+    runner._handle_active_session_busy_message = AsyncMock(
+        side_effect=AssertionError("failed plugin command reached busy routing")
+    )
+
+    def _raise_command(*args, **kwargs):
+        raise RuntimeError("internal-command-detail")
+
+    monkeypatch.setattr(
+        plugins_mod,
+        "get_plugin_command_handler",
+        lambda name: _raise_command if name == "brief" else None,
+    )
+    monkeypatch.setattr(plugins_mod, "invoke_plugin_command", _raise_command)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "test-key"}
+    )
+
+    result = await runner._handle_message(_make_event("/brief"))
+
+    assert result is not None
+    assert "internal-command-detail" not in str(result)
+    assert session_key not in runner._pending_messages
+    runner._run_agent.assert_not_called()
+    runner._handle_active_session_busy_message.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_known_slash_command_not_flagged_as_unknown(monkeypatch):
     """A real built-in like /status must NOT hit the unknown-command guard."""
     runner = _make_runner()

--- a/tests/hermes_cli/test_plugin_command_context.py
+++ b/tests/hermes_cli/test_plugin_command_context.py
@@ -1,0 +1,17 @@
+from types import SimpleNamespace
+
+import hermes_cli.plugins as plugins
+
+
+def test_invoke_plugin_command_preserves_legacy_one_argument_handler(monkeypatch):
+    monkeypatch.setattr(plugins, "get_plugin_command_handler", lambda _name: lambda args: f"legacy:{args}")
+    assert plugins.invoke_plugin_command("demo", "x", event=object(), gateway=object()) == "legacy:x"
+
+
+def test_invoke_plugin_command_passes_event_context_when_accepted(monkeypatch):
+    def handler(args, *, event=None):
+        return f"{event.source.platform.value}:{args}"
+
+    monkeypatch.setattr(plugins, "get_plugin_command_handler", lambda _name: handler)
+    event = SimpleNamespace(source=SimpleNamespace(platform=SimpleNamespace(value="telegram")))
+    assert plugins.invoke_plugin_command("demo", "x", event=event, gateway=object()) == "telegram:x"

--- a/tests/hermes_cli/test_plugin_hook_fail_closed.py
+++ b/tests/hermes_cli/test_plugin_hook_fail_closed.py
@@ -1,0 +1,63 @@
+import pytest
+
+from hermes_cli.plugins import PluginManager
+
+
+def _boom(**kwargs):
+    raise RuntimeError("transport safety failed")
+
+
+def test_fail_closed_hook_surfaces_callback_failure_as_skip():
+    manager = PluginManager()
+    manager._hooks["pre_gateway_transport"] = [_boom]
+
+    assert manager.invoke_hook(
+        "pre_gateway_transport", fail_closed=True
+    ) == [{"action": "skip", "reason": "hook-callback-error"}]
+
+
+def test_legacy_hook_callback_failure_remains_isolated():
+    manager = PluginManager()
+    manager._hooks["pre_gateway_dispatch"] = [_boom]
+
+    assert manager.invoke_hook("pre_gateway_dispatch") == []
+
+
+def test_required_text_hooks_chain_in_registration_order():
+    manager = PluginManager()
+    seen = []
+
+    def _first(**kwargs):
+        seen.append(kwargs["response_text"])
+        return kwargs["response_text"] + " first"
+
+    def _second(**kwargs):
+        seen.append(kwargs["response_text"])
+        return kwargs["response_text"] + " second"
+
+    manager._hooks["finalize_llm_output"] = [_first, _second]
+
+    assert manager.invoke_text_hook(
+        "finalize_llm_output", response_text="original", platform="telegram"
+    ) == ("original first second", True)
+    assert seen == ["original", "original first"]
+
+
+def test_required_text_hook_callback_failure_is_raised():
+    manager = PluginManager()
+    manager._hooks["finalize_llm_output"] = [_boom]
+
+    with pytest.raises(RuntimeError, match="transport safety failed"):
+        manager.invoke_text_hook(
+            "finalize_llm_output", response_text="must not leak", platform="telegram"
+        )
+
+
+def test_terminal_validation_hooks_cannot_modify_output():
+    manager = PluginManager()
+    manager._hooks["validate_llm_output"] = [lambda **kwargs: "unsafe append"]
+
+    with pytest.raises(TypeError, match="must return None or True"):
+        manager.invoke_validation_hook(
+            "validate_llm_output", response_text="safe", platform="telegram"
+        )

--- a/tests/plugins/test_telegram_brief_plugin.py
+++ b/tests/plugins/test_telegram_brief_plugin.py
@@ -155,7 +155,7 @@ def test_brief_transform_is_conservative_allowlist_for_code_diff_commands_and_lo
         "pytest -q", "Traceback", 'File "x.py"', "tool result", "RuntimeError: boom",
     ):
         assert forbidden not in transformed
-    assert "阻礙：技術細節已省略" in transformed
+    assert "阻礙：RuntimeError；測試未完成" in transformed
     assert "print(secret_token)" not in plugin._sanitize_brief_response(
         "結果：完成\n變更：print(secret_token)"
     )
@@ -176,6 +176,175 @@ def test_safe_english_punctuation_remains_usable():
         assert plugin._safe_field_value(value) == value
 
 
+def test_requested_hardware_values_survive_brief_projection():
+    plugin = _load_plugin()
+    response = "\n".join(
+        (
+            "結果：完成",
+            "變更：已即時讀取家中電腦硬體。",
+            "驗證：以下為實際數值：",
+            "- CPU：AMD Ryzen 5 5600X 6-Core Processor",
+            "- 記憶體：總量 16.0 GB；目前可用 6.5 GB",
+            "- GPU：NVIDIA GeForce RTX 3060 Ti",
+            "- 專用 GPU 記憶體：8.0 GB",
+            "- C 槽：總容量 952.9 GB；已用 895.4 GB；剩餘 57.5 GB",
+            "- D 槽：總容量 953.9 GB；已用 681.6 GB；剩餘 272.3 GB",
+        )
+    )
+
+    delivered = plugin._sanitize_brief_response(response)
+
+    for expected in (
+        "AMD Ryzen 5 5600X 6-Core Processor",
+        "總量 16.0 GB",
+        "目前可用 6.5 GB",
+        "NVIDIA GeForce RTX 3060 Ti",
+        "專用 GPU 記憶體：8.0 GB",
+        "C 槽：總容量 952.9 GB",
+        "D 槽：總容量 953.9 GB",
+    ):
+        assert expected in delivered
+    assert "技術細節已省略" not in delivered
+
+
+def test_plain_hardware_answer_without_brief_schema_is_preserved_verbatim():
+    plugin = _load_plugin()
+    response = (
+        "CPU：AMD Ryzen 5 5600X 6-Core Processor\n"
+        "RAM 總量：15.91 GiB；可用：2.87 GiB\n"
+        "GPU：NVIDIA GeForce RTX 3060 Ti\n"
+        "專用 VRAM：8192 MiB；shared memory 不計入\n"
+        "C: 總量 952.90 GiB；剩餘 57.08 GiB"
+    )
+
+    assert plugin._sanitize_brief_response(response) == response
+
+
+def test_non_schema_final_answer_keeps_safe_prose_instead_of_generic_fallback():
+    plugin = _load_plugin()
+    response = "答案是 42。\n這是使用者明確要求的完整正文。"
+
+    delivered = plugin._sanitize_brief_response(response)
+
+    assert delivered == response
+    assert "最終摘要未符合 brief 格式" not in delivered
+    assert "明確要求詳細說明" not in delivered
+
+
+def test_fragmented_secret_across_answer_lines_is_redacted_as_a_whole():
+    plugin = _load_plugin()
+    left = "Ab9xY7zQ2mN8pL4r"
+    right = "T6uV0wK3sJ5hG1fD7cB"
+    response = f"結果：完成\n- {left}\n- {right}"
+
+    delivered = plugin._sanitize_brief_response(response)
+
+    assert left not in delivered
+    assert right not in delivered
+    assert "敏感內容已遮蔽" in delivered
+
+
+def test_telegram_text_delivery_keeps_required_body_alongside_voice_media():
+    plugin = _load_plugin()
+    response = (
+        "CPU：AMD Ryzen 5 5600X\n"
+        "專用 VRAM：8 GiB\n"
+        "[[audio_as_voice]]\nMEDIA:C:\\Users\\User\\memo.ogg"
+    )
+
+    delivered = plugin._sanitize_brief_response(response)
+    files, text = BasePlatformAdapter.extract_media(delivered)
+
+    assert "CPU：AMD Ryzen 5 5600X" in text
+    assert "專用 VRAM：8 GiB" in text
+    assert files == [("C:\\Users\\User\\memo.ogg", True)]
+    assert "最終摘要未符合 brief 格式" not in delivered
+
+
+def test_explicit_detailed_data_request_keeps_body_instead_of_omission_placeholder():
+    plugin = _load_plugin()
+    event = _telegram_event("請詳細列出 CPU、記憶體、GPU 專用記憶體與磁碟空間")
+    _bind_event(plugin, event)
+    plugin._on_pre_llm_call(
+        platform="telegram", sender_id="u1", user_message=event.text
+    )
+    response = (
+        "結果：完成\n"
+        "驗證：硬體資料如下：\n"
+        "- CPU：AMD Ryzen 5 5600X\n"
+        "- 記憶體：16 GB\n"
+        "- 專用 GPU 記憶體：8 GB\n"
+        "- C 槽剩餘：57.5 GB"
+    )
+    delivered = plugin._transform_llm_output(
+        platform="telegram", response_text=response
+    ) or response
+
+    assert "CPU：AMD Ryzen 5 5600X" in delivered
+    assert "專用 GPU 記憶體：8 GB" in delivered
+    assert "C 槽剩餘：57.5 GB" in delivered
+    assert "技術細節已省略" not in delivered
+    assert "明確要求詳細說明" not in delivered
+
+
+def test_simple_success_operation_remains_compact():
+    plugin = _load_plugin()
+    response = "結果：完成\n變更：設定已儲存。\n驗證：回讀值一致。"
+    assert plugin._sanitize_brief_response(response) == response
+
+
+def test_markdown_heading_and_requested_list_survive_projection():
+    plugin = _load_plugin()
+    response = (
+        "結果：完成\n"
+        "驗證：實際硬體如下：\n"
+        "**硬體數值**\n"
+        "- CPU：AMD Ryzen 5 5600X\n"
+        "- 專用 GPU 記憶體：8 GB"
+    )
+    delivered = plugin._sanitize_brief_response(response)
+
+    assert "**硬體數值**" in delivered
+    assert "CPU：AMD Ryzen 5 5600X" in delivered
+    assert "專用 GPU 記憶體：8 GB" in delivered
+
+
+def test_long_requested_list_is_preserved_for_telegram_adapter_chunking():
+    plugin = _load_plugin()
+    rows = [f"- 磁碟 {index:03d}：總容量 1000 GB；已用 400 GB；剩餘 600 GB；檔案系統 NTFS；狀態正常；已完成容量與可用空間實際回讀驗證，數值可供使用者直接採用" for index in range(55)]
+    response = "結果：完成\n驗證：完整清單如下：\n" + "\n".join(rows)
+
+    delivered = plugin._sanitize_brief_response(response)
+    chunks = BasePlatformAdapter.truncate_message(delivered, 4096)
+
+    assert len(delivered) > 4096
+    assert rows[0] in delivered
+    assert rows[-1] in delivered
+    assert len(chunks) > 1
+    assert all(len(chunk) <= 4096 for chunk in chunks)
+
+
+def test_actionable_error_reason_survives_without_stack_trace():
+    plugin = _load_plugin()
+    response = "\n".join(
+        (
+            "結果：失敗",
+            "阻礙：連線逾時，無法連上本機服務 127.0.0.1:9332。",
+            "Traceback (most recent call last):",
+            "RuntimeError: connection timed out",
+            "下一步：確認服務已啟動並檢查 9332 連接埠後重試。",
+        )
+    )
+    delivered = plugin._sanitize_brief_response(response)
+
+    assert "連線逾時" in delivered
+    assert "127.0.0.1:9332" in delivered
+    assert "確認服務已啟動" in delivered
+    assert "Traceback" not in delivered
+    assert "RuntimeError" not in delivered
+    assert "技術細節已省略" not in delivered
+
+
 @pytest.mark.parametrize(
     "secret",
     (
@@ -192,7 +361,7 @@ def test_credential_shaped_values_are_forcibly_redacted(secret):
     plugin = _load_plugin()
     result = plugin._sanitize_brief_response(f"結果：完成\n變更：{secret}")
     assert secret not in result
-    assert "技術細節已省略" in result
+    assert "敏感內容已遮蔽" in result
 
 
 def test_unlabelled_high_entropy_values_are_redacted():
@@ -208,7 +377,7 @@ def test_unlabelled_high_entropy_values_are_redacted():
     for value in opaque_values:
         result = plugin._sanitize_brief_response(f"結果：完成\n變更：{value}")
         assert value not in result
-        assert "技術細節已省略" in result
+        assert "敏感內容已遮蔽" in result
 
 
 def test_control_character_fragments_cannot_reconstruct_secret_after_screening():
@@ -224,7 +393,7 @@ def test_control_character_fragments_cannot_reconstruct_secret_after_screening()
             f"結果：完成\n變更：{fragmented}"
         )
         assert reconstructed not in result
-        assert "技術細節已省略" in result
+        assert "敏感內容已遮蔽" in result
 
 
 def test_high_entropy_media_basename_is_rejected():
@@ -300,7 +469,7 @@ def test_unstructured_long_output_fails_closed_without_leaking_details():
     transformed = plugin._transform_llm_output(
         response_text=raw, platform="telegram", session_id="s1"
     )
-    assert transformed.startswith("結果：部分完成")
+    assert transformed.startswith("結果：無法安全顯示")
     assert "def secret" not in transformed
     assert "token" not in transformed
     assert "log output" not in transformed

--- a/tests/plugins/test_telegram_brief_plugin.py
+++ b/tests/plugins/test_telegram_brief_plugin.py
@@ -1,0 +1,523 @@
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.platforms.base import BasePlatformAdapter
+
+
+PLUGIN_PATH = Path(__file__).parents[2] / "plugins" / "telegram-brief" / "__init__.py"
+
+
+def _load_plugin():
+    spec = importlib.util.spec_from_file_location("telegram_brief_test_plugin", PLUGIN_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    module._reset_state_for_tests()
+    return module
+
+
+def _telegram_event(text="hello", user_id="u1", chat_id="c1", thread_id=None, profile=None):
+    source = SimpleNamespace(
+        platform=SimpleNamespace(value="telegram"),
+        user_id=user_id,
+        user_id_alt=None,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        profile=profile,
+    )
+    return SimpleNamespace(
+        text=text,
+        source=source,
+        get_command=lambda: text.lstrip("/").split()[0] if text.startswith("/") else None,
+    )
+
+
+def _bind_event(plugin, event):
+    plugin._turn_identity.set(plugin._identity_from_source(event.source))
+
+
+def test_default_brief_prompt_has_required_final_schema():
+    plugin = _load_plugin()
+    _bind_event(plugin, _telegram_event())
+    result = plugin._on_pre_llm_call(
+        platform="telegram", sender_id="u1", session_id="s1", user_message="finish the task"
+    )
+    context = result["context"]
+    for label in ("結果：", "變更：", "驗證：", "交付：", "阻礙：", "下一步："):
+        assert label in context
+    assert "10" in context
+    assert "code fence" in context
+
+
+def test_brief_and_detail_commands_switch_mode_for_current_identity():
+    plugin = _load_plugin()
+    detail_event = _telegram_event("/detail")
+    _bind_event(plugin, detail_event)
+    assert "detail" in plugin._handle_detail("", event=detail_event).lower()
+    detail = plugin._on_pre_llm_call(
+        platform="telegram", sender_id="u1", session_id="s1", user_message="normal request"
+    )
+    assert "DETAIL" in detail["context"]
+    assert plugin._transform_llm_output(
+        response_text="```python\nprint(1)\n```", platform="telegram", session_id="s1"
+    ) is None
+
+    brief_event = _telegram_event("/brief")
+    _bind_event(plugin, brief_event)
+    assert "brief" in plugin._handle_brief("", event=brief_event).lower()
+    brief = plugin._on_pre_llm_call(
+        platform="telegram", sender_id="u1", session_id="s2", user_message="normal request"
+    )
+    assert "BRIEF" in brief["context"]
+
+
+def test_identityless_senders_are_isolated_by_chat_and_thread():
+    plugin = _load_plugin()
+    detail_event = _telegram_event("/detail", user_id=None, chat_id="admin-chat", thread_id="1")
+    _bind_event(plugin, detail_event)
+    plugin._handle_detail("", event=detail_event)
+    assert plugin._mode_for_identity("default:telegram:chat:admin-chat:thread:1") == "detail"
+
+    _bind_event(plugin, _telegram_event("hello", user_id=None, chat_id="other-chat", thread_id="2"))
+    result = plugin._on_pre_llm_call(
+        platform="telegram", sender_id=None, session_id="s2", user_message="normal request"
+    )
+    assert "BRIEF" in result["context"]
+
+
+def test_explicit_detail_request_is_one_turn_exception_without_mode_switch():
+    plugin = _load_plugin()
+    _bind_event(plugin, _telegram_event())
+    result = plugin._on_pre_llm_call(
+        platform="telegram", sender_id="u1", session_id="s1", user_message="請顯示 diff"
+    )
+    assert "DETAIL" in result["context"]
+    original = "```python\nprint('ok')\n```\ndiff --git a/x b/x"
+    assert plugin._transform_llm_output(
+        response_text=original, platform="telegram", session_id="s1"
+    ) is None
+    assert plugin._turn_allows_detail.get() is False
+
+    next_turn = plugin._on_pre_llm_call(
+        platform="telegram", sender_id="u1", session_id="s2", user_message="normal request"
+    )
+    assert "BRIEF" in next_turn["context"]
+
+
+def test_negated_or_quoted_detail_phrases_do_not_enable_exception():
+    plugin = _load_plugin()
+    _bind_event(plugin, _telegram_event())
+    for message in (
+        "不要貼程式碼，也不用詳細說明",
+        "do not show the code or show the diff",
+        "請分析這段文字：『show the diff』，但維持精簡",
+        "show the diff is a phrase to classify, not a request",
+    ):
+        result = plugin._on_pre_llm_call(
+            platform="telegram", sender_id="u1", session_id="s1", user_message=message
+        )
+        assert "BRIEF" in result["context"]
+
+
+def test_brief_transform_is_conservative_allowlist_for_code_diff_commands_and_logs():
+    plugin = _load_plugin()
+    _bind_event(plugin, _telegram_event())
+    plugin._on_pre_llm_call(
+        platform="telegram", sender_id="u1", session_id="s1", user_message="do it"
+    )
+    response = "\n".join([
+        "結果：部分完成",
+        "變更：updated several files",
+        "def leaked_function():",
+        "    return 'code'",
+        "~~~python",
+        "print('tilde fence')",
+        "~~~",
+        "diff --git a/a b/a",
+        "+added_line()",
+        "pytest -q",
+        "Traceback (most recent call last):",
+        "  File \"x.py\", line 1, in <module>",
+        "RuntimeError: boom",
+        "tool result contained private output",
+        "阻礙：RuntimeError；測試未完成",
+        "下一步：檢查本機完整 log 路徑",
+    ])
+    transformed = plugin._transform_llm_output(
+        response_text=response, platform="telegram", session_id="s1"
+    )
+    assert transformed is not None
+    for forbidden in (
+        "def leaked", "return 'code'", "~~~", "diff --git", "+added_line",
+        "pytest -q", "Traceback", 'File "x.py"', "tool result", "RuntimeError: boom",
+    ):
+        assert forbidden not in transformed
+    assert "阻礙：技術細節已省略" in transformed
+    assert "print(secret_token)" not in plugin._sanitize_brief_response(
+        "結果：完成\n變更：print(secret_token)"
+    )
+    assert "private_payload" not in plugin._sanitize_brief_response(
+        "結果：完成\n變更：MEDIA:/tmp/private_payload.unknown"
+    )
+    assert len(transformed.splitlines()) <= 10
+    assert len(transformed) <= 3500
+
+
+def test_safe_english_punctuation_remains_usable():
+    plugin = _load_plugin()
+    for value in (
+        "Updated parser (tests passed)",
+        "Changed Bob's report safely; validation passed.",
+        'Changed the “final report” — tests passed.',
+    ):
+        assert plugin._safe_field_value(value) == value
+
+
+@pytest.mark.parametrize(
+    "secret",
+    (
+        "sk-proj-" + "A" * 36,
+        "ghp_" + "B" * 36,
+        "xoxb-1234567890-" + "C" * 26,
+        "hf_" + "D" * 36,
+        "eyJhbGciOiJIUzI1NiJ9." + "eyJzdWIiOiIxMjM0NTY3ODkwIn0.signaturevalue",
+        "Bearer " + "E" * 36,
+        "api_key=" + "F" * 36,
+    ),
+)
+def test_credential_shaped_values_are_forcibly_redacted(secret):
+    plugin = _load_plugin()
+    result = plugin._sanitize_brief_response(f"結果：完成\n變更：{secret}")
+    assert secret not in result
+    assert "技術細節已省略" in result
+
+
+def test_unlabelled_high_entropy_values_are_redacted():
+    plugin = _load_plugin()
+    opaque_values = (
+        "9f4a8c2e7b1d6f3a0c5e9b2d7a4f8c1e9d6b3a7f2c5e8d1a0b4f7c9e2d6a3b8f",
+        "Ab9_xY7-" + "zQ2mN8pL4rT6uV0w" + "K3sJ5hG1fD7cB9eX" + "2aP8nM6qR4tZ",
+        "a4ayc/80/OGda4BO/1o/" + "V0etpOqiLx1JwB5S3beH",
+        "Ab9xY7zQ2mN8pL4r:" + "T6uV0wK3sJ5hG1fD7cB",
+        "Ab9xY7zQ2mN8pL4r|" + "T6uV0wK3sJ5hG1fD7cB",
+        "9f4a8c2e7b1d6f3a:" + "0c5e9b2d7a4f8c1e:" + "9d6b3a7f2c5e8d1a",
+    )
+    for value in opaque_values:
+        result = plugin._sanitize_brief_response(f"結果：完成\n變更：{value}")
+        assert value not in result
+        assert "技術細節已省略" in result
+
+
+def test_control_character_fragments_cannot_reconstruct_secret_after_screening():
+    plugin = _load_plugin()
+    left = "Ab9xY7zQ2mN8pL4r"
+    right = "T6uV0wK3sJ5hG1fD7cB"
+    reconstructed = left + right
+
+    for separator in ("\t", "\x00", "\x1f", "\x7f"):
+        fragmented = f"{left}{separator}{right}"
+        assert plugin._contains_sensitive_material(fragmented) is True
+        result = plugin._sanitize_brief_response(
+            f"結果：完成\n變更：{fragmented}"
+        )
+        assert reconstructed not in result
+        assert "技術細節已省略" in result
+
+
+def test_high_entropy_media_basename_is_rejected():
+    plugin = _load_plugin()
+    opaque_names = (
+        "Ab9_xY7-" + "zQ2mN8pL4rT6uV0w" + "K3sJ5hG1fD7cB9eX" + "2aP8nM6qR4tZ",
+        "a4ayc/80/OGda4BO/1o/" + "V0etpOqiLx1JwB5S3beH",
+        "Ab9xY7zQ2mN8pL4r:" + "T6uV0wK3sJ5hG1fD7cB",
+        "Ab9xY7zQ2mN8pL4r|" + "T6uV0wK3sJ5hG1fD7cB",
+        "9f4a8c2e7b1d6f3a:" + "0c5e9b2d7a4f8c1e:" + "9d6b3a7f2c5e8d1a",
+    )
+    for opaque_name in opaque_names:
+        _bind_event(plugin, _telegram_event())
+        plugin._on_pre_llm_call(
+            platform="telegram", sender_id="u1", session_id="s1", user_message="do it"
+        )
+        delivered = plugin._transform_llm_output(
+            response_text=f"結果：完成\nMEDIA:/tmp/{opaque_name}.txt",
+            platform="telegram",
+            session_id="s1",
+        )
+        assert delivered is not None
+        assert opaque_name not in delivered
+        files, _cleaned = BasePlatformAdapter.extract_media(delivered)
+        assert files == []
+
+
+def test_brief_transform_preserves_bounded_media_separately_from_text_limit():
+    plugin = _load_plugin()
+    _bind_event(plugin, _telegram_event())
+    plugin._on_pre_llm_call(
+        platform="telegram", sender_id="u1", session_id="s1", user_message="make attachments"
+    )
+    media = [f"MEDIA:C:\\Users\\User\\report-{i}.txt" for i in range(12)]
+    response = "結果：完成\n變更：已建立附件\n驗證：實際檔案檢查完成\n" + "\n".join(media)
+    transformed = plugin._transform_llm_output(
+        response_text=response, platform="telegram", session_id="s1"
+    )
+    delivered = transformed or response
+    files, cleaned = BasePlatformAdapter.extract_media(delivered)
+    assert len(files) == 10
+    assert all(item in delivered for item in media[:10])
+    assert media[10] not in delivered and media[11] not in delivered
+    assert len(delivered) <= 3900
+    assert len(cleaned) <= 3500
+    assert len(cleaned.splitlines()) <= 10
+
+
+def test_media_directives_use_canonical_parser_and_preserve_delivery_semantics():
+    plugin = _load_plugin()
+    voice = plugin._sanitize_brief_response(
+        "結果：完成\n[[audio_as_voice]]\nMEDIA:C:\\Users\\User\\memo.ogg\n"
+        "MEDIA:<sensitive tool output>"
+    )
+    assert "[[audio_as_voice]]" in voice
+    assert "MEDIA:C:\\Users\\User\\memo.ogg" in voice
+    assert "sensitive tool output" not in voice
+
+    document = plugin._sanitize_brief_response(
+        "結果：完成\n[[as_document]]\nMEDIA:C:\\Users\\User\\chart.png"
+    )
+    assert "[[as_document]]" in document
+    assert "MEDIA:C:\\Users\\User\\chart.png" in document
+
+
+def test_unstructured_long_output_fails_closed_without_leaking_details():
+    plugin = _load_plugin()
+    _bind_event(plugin, _telegram_event())
+    plugin._on_pre_llm_call(
+        platform="telegram", sender_id="u1", session_id="s1", user_message="do it"
+    )
+    raw = "\n".join(["def secret():", "  return token"] + ["log output" for _ in range(50)])
+    transformed = plugin._transform_llm_output(
+        response_text=raw, platform="telegram", session_id="s1"
+    )
+    assert transformed.startswith("結果：部分完成")
+    assert "def secret" not in transformed
+    assert "token" not in transformed
+    assert "log output" not in transformed
+
+
+def test_non_telegram_commands_are_rejected_without_mutating_telegram_mode():
+    plugin = _load_plugin()
+    event = _telegram_event("/detail")
+    event.source.platform = SimpleNamespace(value="discord")
+    assert "僅適用於 Telegram" in plugin._handle_detail("", event=event)
+    assert plugin._modes_by_identity == {}
+    plugin._turn_identity.set("default:telegram:user:stale")
+    plugin._on_pre_gateway_dispatch(event=event, gateway=object(), session_store=object())
+    assert plugin._turn_identity.get() is None
+
+
+def test_non_telegram_output_is_untouched():
+    plugin = _load_plugin()
+    assert plugin._transform_llm_output(
+        response_text="```python\nprint(1)\n```", platform="cli", session_id="s1"
+    ) is None
+
+
+def test_status_extension_reports_mode_without_rewriting_command():
+    plugin = _load_plugin()
+    event = _telegram_event("/status")
+    _bind_event(plugin, event)
+    status = plugin._extend_gateway_status(status="Hermes status", event=event, gateway=object())
+    assert status == "Hermes status\n回報模式：brief"
+    assert event.text == "/status"
+
+
+def test_normal_messages_attachments_and_project_commands_are_not_rewritten(monkeypatch):
+    plugin = _load_plugin()
+    monkeypatch.setattr(plugin, "_transport_is_safe", lambda source, gateway: True)
+    gateway = object()
+    for text in ("normal task", "/status", "/focus C:\\Users\\User\\Dev\\folio", "/new"):
+        event = _telegram_event(text)
+        event.media_urls = ["C:\\Users\\User\\report.txt"]
+        before = (event.text, list(event.media_urls))
+        assert plugin._on_pre_gateway_dispatch(
+            event=event, gateway=gateway, session_store=object()
+        ) is None
+        assert (event.text, event.media_urls) == before
+
+
+def test_transport_safety_is_read_only_profile_scoped_and_revalidated(monkeypatch):
+    from contextlib import contextmanager
+
+    plugin = _load_plugin()
+    safe = dict(plugin._REQUIRED_TELEGRAM_DISPLAY)
+    configs = {
+        "default": {"display": {"platforms": {"telegram": dict(safe)}}},
+        "work": {"display": {"platforms": {"telegram": dict(safe)}}},
+    }
+    active = []
+
+    @contextmanager
+    def profile_scope(profile_home):
+        active.append(str(profile_home))
+        try:
+            yield
+        finally:
+            active.pop()
+
+    monkeypatch.setattr("gateway.run._profile_runtime_scope", profile_scope)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: configs[active[-1]])
+
+    class Gateway:
+        @staticmethod
+        def _resolve_profile_home_for_source(source):
+            return source.profile
+
+    gateway = Gateway()
+    default_source = _telegram_event(profile="default").source
+    work_source = _telegram_event(profile="work").source
+    assert plugin._transport_is_safe(default_source, gateway) is True
+    assert plugin._transport_is_safe(work_source, gateway) is True
+
+    configs["work"]["display"]["platforms"]["telegram"]["streaming"] = True
+    snapshot = repr(configs["work"])
+    assert plugin._transport_is_safe(work_source, gateway) is False
+    assert repr(configs["work"]) == snapshot
+    configs["work"]["display"]["platforms"]["telegram"]["streaming"] = False
+    assert plugin._transport_is_safe(work_source, gateway) is True
+
+    configs["work"]["display"]["runtime_footer"] = {"enabled": True}
+    assert plugin._transport_is_safe(work_source, gateway) is False
+    plugin._modes_by_identity[plugin._identity_from_source(work_source)] = "detail"
+    with pytest.raises(RuntimeError, match="transport"):
+        plugin._transform_gateway_output(
+            platform="telegram",
+            source=work_source,
+            gateway=gateway,
+            user_message="show detail",
+            response_text="REASONING: hidden deliberation about tool calls",
+        )
+    configs["work"]["display"]["platforms"]["telegram"]["runtime_footer"] = {
+        "enabled": False
+    }
+    assert plugin._transport_is_safe(work_source, gateway) is True
+
+
+def test_transport_safety_failure_skips_message_before_dispatch(monkeypatch):
+    plugin = _load_plugin()
+    monkeypatch.setattr(plugin, "_transport_is_safe", lambda source, gateway: False)
+    result = plugin._on_pre_gateway_dispatch(
+        event=_telegram_event(), gateway=object(), session_store=object()
+    )
+    assert result["action"] == "skip"
+
+
+def test_gateway_terminal_boundary_preserves_authorized_detail():
+    plugin = _load_plugin()
+    event = _telegram_event("run it")
+    plugin._handle_detail("", event=event)
+    detail = "Detailed explanation\n```python\nprint('ok')\n```"
+
+    assert plugin._transform_gateway_output(
+        platform="telegram",
+        source=event.source,
+        user_message=event.text,
+        response_text=detail,
+    ) is None
+    assert plugin._validate_gateway_output(
+        platform="telegram",
+        source=event.source,
+        user_message=event.text,
+        response_text=detail,
+    ) is True
+
+    forced = plugin._transform_gateway_output(
+        platform="telegram",
+        source=event.source,
+        user_message=event.text,
+        response_text="REASONING: gateway-added hidden deliberation",
+        force_brief=True,
+    )
+    assert forced is not None
+    assert "hidden deliberation" not in forced
+
+
+def test_gateway_terminal_boundary_rechecks_post_agent_mutations():
+    plugin = _load_plugin()
+    event = _telegram_event("run it")
+    raw = (
+        "The request failed: internal stack detail at C:/private/project\n"
+        "MEDIA:C:/private/project/Ab9xY7zQ2mN8pL4rT6uV0wK3sJ5hG1fD7cB.txt\n"
+        "model-name · C:/private/project"
+    )
+
+    transformed = plugin._transform_gateway_output(
+        platform="telegram",
+        source=event.source,
+        user_message=event.text,
+        response_text=raw,
+    )
+
+    assert transformed.startswith("結果：")
+    assert "internal stack" not in transformed
+    assert "MEDIA:" not in transformed
+    assert "private/project" not in transformed
+    assert plugin._validate_gateway_output(
+        platform="telegram",
+        source=event.source,
+        user_message=event.text,
+        response_text=transformed,
+    ) is True
+
+
+def test_terminal_validator_rejects_post_sanitizer_append():
+    plugin = _load_plugin()
+    event = _telegram_event("hello")
+    _bind_event(plugin, event)
+    plugin._on_pre_llm_call(
+        platform="telegram", user_message="hello", sender_id="u1"
+    )
+    safe = plugin._transform_llm_output(
+        platform="telegram",
+        response_text="結果：完成\n變更：無\n下一步：無",
+    )
+    assert safe is None
+
+    with pytest.raises(RuntimeError, match="terminal validation"):
+        plugin._validate_llm_output(
+            platform="telegram",
+            response_text=(
+                "結果：完成\n變更：無\n下一步：無\n"
+                + "sk-"
+                + "proj-unsafe-appended-value"
+            ),
+        )
+
+
+def test_registration_adds_only_mode_commands_and_presentation_hooks_not_tools():
+    plugin = _load_plugin()
+
+    class Context:
+        def __init__(self):
+            self.commands = []
+            self.hooks = []
+
+        def register_command(self, name, handler, description="", args_hint=""):
+            self.commands.append(name)
+
+        def register_hook(self, name, handler):
+            self.hooks.append(name)
+
+    ctx = Context()
+    plugin.register(ctx)
+    assert set(ctx.commands) == {"brief", "detail"}
+    assert set(ctx.hooks) == {
+        "pre_gateway_transport",
+        "pre_llm_call",
+        "finalize_llm_output",
+        "validate_llm_output",
+        "finalize_gateway_output",
+        "validate_gateway_output",
+        "extend_gateway_status",
+    }


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `telegram-brief` plugin that keeps Telegram delivery final-answer-first while leaving tools, approvals, authorization, credentials, project selection, and execution behavior under Hermes core control.

The plugin provides per-identity `/brief` and `/detail` modes plus mode-aware `/status`. Brief mode validates and sanitizes final output at both the LLM and gateway boundaries, preserves explicitly requested answer bodies, and fails closed when Telegram transport settings or output safety cannot be verified.

## Related Issue

No linked issue. Searched open and closed issues/PRs for `telegram brief`; no duplicate was found.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add the `plugins/telegram-brief` plugin with bounded, fail-closed output validation and secret-shaped material screening.
- Add generic plugin/gateway hooks needed for pre-dispatch transport checks, final-output validation, command handling, and status extensions.
- Preserve explicitly requested answers and detail-mode responses without exposing progress narration, tool output, or private reasoning.
- Add focused coverage for finalization cleanup, gateway dispatch/commands, plugin hook failure behavior, status extensions, and Telegram brief output handling.

## How to Test

1. Install CI-parity dependencies with `uv sync --locked --python 3.11 --extra all --extra dev --extra anthropic --extra mistral --extra fal --extra modal --extra daytona --extra hindsight --extra parallel-web`.
2. Run the ten changed test files through `scripts/run_tests.sh`; current result is 124 passed, 0 failed.
3. Enable the plugin in a Telegram profile, verify `/brief`, `/detail`, and `/status`, and confirm non-Telegram platforms are unchanged.
4. Run `python scripts/check-windows-footguns.py --diff origin/main`; current result is 0 findings across 16 scanned Python files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: native Windows, Python 3.11

The full local wrapper was attempted after installing the exact CI dependency set. It is not all-green on native Windows because unrelated upstream tests currently hit IOCP pipe errors, `file://`/WSL path translation, symlink privilege (`WinError 1314`), SQLite cleanup locking (`WinError 32`), and timing thresholds. The feature's ten directly affected test files pass 124/124; this Draft PR leaves the full Linux suite to GitHub Actions.

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys added
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no model tool schema changed

## Screenshots / Logs

```text
Targeted wrapper: 10 files, 124 tests passed, 0 failed
Windows footguns: No Windows footguns found (16 files scanned)
Range-diff: both rebased commits patch-equivalent to the reviewed originals
```