### PR TITLE
feat(desktop): add searchable Lucide project icons

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -128,6 +128,7 @@
     "hast-util-to-text": "4.0.2",
     "ignore": "7.0.6",
     "katex": "0.16.47",
+    "lucide-react": "0.577.0",
     "mermaid": "11.16.1",
     "motion": "12.42.2",
     "nanostores": "1.4.2",

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
@@ -87,6 +87,16 @@ describe('ProjectOverviewRow', () => {
     expect(onNewSession).toHaveBeenCalledWith(null)
   })
 
+  it('renders a Lucide project icon stored by the appearance picker', async () => {
+    const lucideProject = { ...project, icon: 'lucide:briefcase-business' } as SidebarProjectTree
+    const { container } = render(<ProjectOverviewRow project={lucideProject} />)
+
+    expect(await screen.findByLabelText('Enter Test D')).toBeTruthy()
+    await vi.waitFor(() =>
+      expect(container.querySelector('svg[data-project-icon="lucide:briefcase-business"]')).toBeTruthy()
+    )
+  })
+
   it('tags the row with data-sessions-project so a skin can target one project', () => {
     const { container } = render(<ProjectOverviewRow project={project} />)
 

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -20,6 +20,7 @@ import {
 } from '../chrome'
 
 import { latestProjectSessions, PROJECT_PREVIEW_COUNT, useWorkspaceNodeOpen } from './model'
+import { ProjectIcon } from './project-icon'
 import { ProjectContextMenu, ProjectMenu } from './project-menu'
 import type { SidebarProjectTree } from './workspace-groups'
 import { WorkspaceAddButton } from './workspace-header'
@@ -37,7 +38,7 @@ export function projectIcon({ color, icon, isNoProject }: SidebarProjectTree) {
 
   return (
     <SidebarRowLeadGlyph style={color ? { color } : undefined}>
-      <Codicon name={icon || (isNoProject ? 'home' : 'folder-library')} size={SIDEBAR_LEAD_ICON_SIZE} />
+      <ProjectIcon fallback={isNoProject ? 'home' : 'folder-library'} name={icon} size={SIDEBAR_LEAD_ICON_SIZE} />
     </SidebarRowLeadGlyph>
   )
 }

--- a/apps/desktop/src/app/chat/sidebar/projects/project-appearance.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-appearance.test.tsx
@@ -1,0 +1,46 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ProjectAppearancePicker } from './project-appearance'
+
+afterEach(cleanup)
+
+describe('ProjectAppearancePicker', () => {
+  it('finds and selects any Lucide icon by name', async () => {
+    const onIcon = vi.fn()
+
+    render(
+      <ProjectAppearancePicker color={null} icon={null} noColorLabel="No color" onColor={vi.fn()} onIcon={onIcon} />
+    )
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search' }), { target: { value: 'briefcase business' } })
+    fireEvent.click(await screen.findByRole('button', { name: 'briefcase-business' }))
+
+    expect(onIcon).toHaveBeenCalledWith('lucide:briefcase-business')
+  })
+
+  it('keeps the selected Lucide icon visible when the search is cleared', async () => {
+    render(
+      <ProjectAppearancePicker
+        color="#ff0000"
+        icon="lucide:zodiac-virgo"
+        noColorLabel="No color"
+        onColor={vi.fn()}
+        onIcon={vi.fn()}
+      />
+    )
+
+    expect(await screen.findByRole('button', { name: 'zodiac-virgo' })).toBeTruthy()
+  })
+
+  it('caps broad searches so typing does not mount the full dynamic catalogue', async () => {
+    const { container } = render(
+      <ProjectAppearancePicker color={null} icon={null} noColorLabel="No color" onColor={vi.fn()} onIcon={vi.fn()} />
+    )
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search' }), { target: { value: 'a' } })
+    await screen.findByRole('button', { name: 'a-arrow-down' })
+
+    expect(container.querySelectorAll('[data-slot="project-icon-results"] button')).toHaveLength(36)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/project-appearance.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-appearance.tsx
@@ -1,12 +1,20 @@
-import { Codicon } from '@/components/ui/codicon'
+import { useMemo, useState } from 'react'
+
+import { useDebounced } from '@/app/hooks/use-debounced'
 import { ColorSwatches } from '@/components/ui/color-swatches'
+import { SearchField } from '@/components/ui/search-field'
 import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
 import { PROFILE_SWATCHES } from '@/lib/profile-color'
 import { cn } from '@/lib/utils'
 
-// Curated codicons for a project glyph (tinted by the chosen color). Shared by
-// the kebab's Appearance popover and the right-click menu's Appearance submenu
-// so both offer the same picker.
+import { LUCIDE_PROJECT_ICON_NAMES, lucideProjectIconValue, ProjectIcon, projectLucideIconName } from './project-icon'
+
+const LUCIDE_RESULTS_LIMIT = 36
+
+// Keep the familiar curated Codicons as the zero-query view. Searching switches
+// to Lucide's complete dynamic catalogue; a selected Lucide icon is pinned here
+// too, so clearing the search never makes the current choice disappear.
 export const PROJECT_ICONS = [
   'folder-library',
   'repo',
@@ -49,6 +57,27 @@ interface ProjectAppearancePickerProps {
 /** Color swatches + icon grid for a project's appearance — one component so the
  *  kebab popover and the right-click submenu render an identical picker. */
 export function ProjectAppearancePicker({ color, icon, noColorLabel, onColor, onIcon }: ProjectAppearancePickerProps) {
+  const { t } = useI18n()
+  const [query, setQuery] = useState('')
+  const debouncedQuery = useDebounced(query, 120)
+  const selectedLucideName = projectLucideIconName(icon)
+
+  const displayedIcons = useMemo(() => {
+    const terms = debouncedQuery
+      .trim()
+      .toLowerCase()
+      .split(/[\s_-]+/)
+      .filter(Boolean)
+
+    if (terms.length) {
+      return LUCIDE_PROJECT_ICON_NAMES.filter(name => terms.every(term => name.includes(term)))
+        .slice(0, LUCIDE_RESULTS_LIMIT)
+        .map(lucideProjectIconValue)
+    }
+
+    return selectedLucideName ? [lucideProjectIconValue(selectedLucideName), ...PROJECT_ICONS] : PROJECT_ICONS
+  }, [debouncedQuery, selectedLucideName])
+
   return (
     <>
       <ColorSwatches
@@ -58,25 +87,36 @@ export function ProjectAppearancePicker({ color, icon, noColorLabel, onColor, on
         swatches={PROFILE_SWATCHES}
         value={color ?? null}
       />
-      {/* Same 6 columns + gap as the swatch grid so the picker keeps the
-          profile picker's width (icons flex to fill, not fixed-width). */}
-      <div className="mt-2 grid grid-cols-6 gap-1.5">
-        {PROJECT_ICONS.map(name => (
-          <Tip key={name} label={name}>
-            <button
-              aria-label={name}
-              className={cn(
-                'grid aspect-square place-items-center rounded-md text-(--ui-text-tertiary) transition hover:bg-(--ui-control-hover-background)',
-                icon === name && 'bg-(--ui-control-active-background) text-foreground'
-              )}
-              onClick={() => onIcon(icon === name ? null : name)}
-              style={icon === name && color ? { color } : undefined}
-              type="button"
-            >
-              <Codicon name={name} size="0.8125rem" />
-            </button>
-          </Tip>
-        ))}
+      <SearchField
+        aria-label={t.titlebar.search}
+        containerClassName="mt-2 w-full"
+        onChange={setQuery}
+        placeholder={t.titlebar.search}
+        value={query}
+      />
+      {/* Debouncing plus a six-row cap avoids an import storm while typing;
+          every Lucide name remains reachable as soon as the query narrows. */}
+      <div className="mt-1 grid max-h-48 grid-cols-6 gap-1.5 overflow-y-auto pr-0.5" data-slot="project-icon-results">
+        {displayedIcons.map(value => {
+          const name = projectLucideIconName(value) ?? value
+
+          return (
+            <Tip key={value} label={name}>
+              <button
+                aria-label={name}
+                className={cn(
+                  'grid aspect-square place-items-center rounded-md text-(--ui-text-tertiary) transition hover:bg-(--ui-control-hover-background)',
+                  icon === value && 'bg-(--ui-control-active-background) text-foreground'
+                )}
+                onClick={() => onIcon(icon === value ? null : value)}
+                style={icon === value && color ? { color } : undefined}
+                type="button"
+              >
+                <ProjectIcon name={value} size="0.8125rem" />
+              </button>
+            </Tip>
+          )
+        })}
       </div>
     </>
   )

--- a/apps/desktop/src/app/chat/sidebar/projects/project-icon.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-icon.test.tsx
@@ -1,0 +1,40 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { ProjectIcon, projectIconComponent } from './project-icon'
+
+afterEach(cleanup)
+
+describe('ProjectIcon', () => {
+  it('keeps rendering legacy Codicon project values', () => {
+    const { container } = render(<ProjectIcon name="folder-library" size={16} />)
+
+    expect(container.querySelector('.codicon-folder-library')).toBeTruthy()
+  })
+
+  it('renders a namespaced Lucide icon', async () => {
+    const { container } = render(<ProjectIcon name="lucide:briefcase-business" size={16} />)
+
+    await waitFor(() =>
+      expect(container.querySelector('svg[data-project-icon="lucide:briefcase-business"]')).toBeTruthy()
+    )
+    const glyph = container.querySelector('svg[data-project-icon="lucide:briefcase-business"]')
+
+    expect(glyph?.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  it('falls back when a persisted Lucide name is unknown', () => {
+    const { container } = render(<ProjectIcon fallback="folder-library" name="lucide:not-a-real-icon" size={16} />)
+
+    expect(container.querySelector('.codicon-folder-library')).toBeTruthy()
+  })
+
+  it('adapts project icons for palette rows', async () => {
+    const Icon = projectIconComponent('lucide:briefcase-business', 'folder-library')
+
+    const { container } = render(<Icon aria-label="Project" />)
+
+    await waitFor(() => expect(screen.getByLabelText('Project')).toBeTruthy())
+    expect(container.querySelector('svg[data-project-icon="lucide:briefcase-business"]')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/project-icon.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-icon.tsx
@@ -1,0 +1,84 @@
+import type { Icon } from '@tabler/icons-react'
+import { DynamicIcon, type IconName, iconNames } from 'lucide-react/dynamic'
+import type * as React from 'react'
+
+import { Codicon } from '@/components/ui/codicon'
+
+export const LUCIDE_PROJECT_ICON_PREFIX = 'lucide:'
+export const LUCIDE_PROJECT_ICON_NAMES = iconNames as readonly IconName[]
+
+const lucideIconNames = new Set<string>(LUCIDE_PROJECT_ICON_NAMES)
+
+export function lucideProjectIconValue(name: IconName): string {
+  return `${LUCIDE_PROJECT_ICON_PREFIX}${name}`
+}
+
+export function projectLucideIconName(value: null | string | undefined): IconName | null {
+  if (!value?.startsWith(LUCIDE_PROJECT_ICON_PREFIX)) {
+    return null
+  }
+
+  const name = value.slice(LUCIDE_PROJECT_ICON_PREFIX.length)
+
+  return lucideIconNames.has(name) ? (name as IconName) : null
+}
+
+interface ProjectIconProps {
+  name?: null | string
+  fallback?: string
+  size?: number | string
+  className?: string
+  style?: React.CSSProperties
+  'aria-label'?: string
+}
+
+/** Render persisted project icons while keeping legacy Codicon values valid. */
+export function ProjectIcon({
+  name,
+  fallback = 'folder-library',
+  size,
+  className,
+  style,
+  'aria-label': ariaLabel
+}: ProjectIconProps) {
+  const lucideName = projectLucideIconName(name)
+
+  if (lucideName) {
+    return (
+      <DynamicIcon
+        aria-hidden={ariaLabel ? undefined : true}
+        aria-label={ariaLabel}
+        className={className}
+        data-project-icon={lucideProjectIconValue(lucideName)}
+        name={lucideName}
+        size={size}
+        style={style}
+      />
+    )
+  }
+
+  const codiconName = name?.startsWith(LUCIDE_PROJECT_ICON_PREFIX) ? fallback : name || fallback
+
+  return <Codicon aria-label={ariaLabel} className={className} name={codiconName} size={size} style={style} />
+}
+
+/** Adapt a persisted project glyph to palette rows that expect a Tabler-shaped component. */
+export function projectIconComponent(name: null | string | undefined, fallback = 'folder-library'): Icon {
+  function ProjectIconComponent({
+    className,
+    size,
+    'aria-label': ariaLabel
+  }: {
+    className?: string
+    size?: number | string
+    'aria-label'?: string
+  }) {
+    return (
+      <ProjectIcon aria-label={ariaLabel} className={className} fallback={fallback} name={name} size={size ?? '1em'} />
+    )
+  }
+
+  ProjectIconComponent.displayName = `ProjectIcon(${name || fallback})`
+
+  return ProjectIconComponent as Icon
+}

--- a/apps/desktop/src/app/chat/sidebar/projects/project-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-menu.test.tsx
@@ -25,6 +25,7 @@ vi.mock('@/i18n', () => ({
   useI18n: () => ({
     t: {
       common: { cancel: 'Cancel', confirm: 'Confirm', done: 'Done', loading: 'Loading…' },
+      titlebar: { search: 'Search' },
       sidebar: {
         projects: {
           copyPath: 'Copy path',

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -4,6 +4,7 @@ import { Dialog as DialogPrimitive } from 'radix-ui'
 import { memo, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 
+import { projectIconComponent } from '@/app/chat/sidebar/projects/project-icon'
 import {
   HUD_HEADING,
   HUD_ITEM,
@@ -766,7 +767,7 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
     // from the palette. Plain select is a pure scope switch (sidebar enters the
     // project — never spends main); ⌘-Enter / ⌘-click also starts a new session
     // at the project root (stacked as a tab when main holds a chat), previewed
-    // by the label swap while ⌘ is held. Rows carry the project's own codicon,
+    // by the label swap while ⌘ is held. Rows carry the project's own glyph,
     // matching the sidebar. The pinned "Open folder…" row is the ⌘O upsert.
     const projectGroup: PaletteGroup = {
       heading: cc.projects,
@@ -781,7 +782,7 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
         },
         ...filterVisibleProjects(projectTree, dismissedAutoProjects).map(project => ({
           comboHint: 'mod+enter',
-          icon: codiconIcon(project.icon || (project.isNoProject ? 'home' : 'folder-library')),
+          icon: projectIconComponent(project.icon, project.isNoProject ? 'home' : 'folder-library'),
           id: `project-${project.id}`,
           keywords: ['project', 'workspace', 'go to', project.label, ...(project.path ? [project.path] : [])],
           label: project.label,

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,6 +114,7 @@
         "hast-util-to-text": "4.0.2",
         "ignore": "7.0.6",
         "katex": "0.16.47",
+        "lucide-react": "0.577.0",
         "mermaid": "11.16.1",
         "motion": "12.42.2",
         "nanostores": "1.4.2",


### PR DESCRIPTION
## Summary

- add a searchable Lucide icon catalogue to project appearance controls
- persist Lucide selections as namespaced `lucide:<name>` values while preserving existing Codicon values
- render project icons consistently in the sidebar and command palette
- load Lucide glyphs dynamically, debounce searches, and cap broad results at 36 icons to avoid import storms

## Testing

- `npx vitest run --project ui src/app/chat/sidebar/projects/project-icon.test.tsx src/app/chat/sidebar/projects/project-appearance.test.tsx src/app/chat/sidebar/projects/project-menu.test.tsx src/app/chat/sidebar/projects/overview-row.test.tsx`
- `npm run typecheck`
- targeted ESLint on all changed TypeScript files
- `npm run build`
- `LC_ALL=C LANG=C npm run test:ui`

## Compatibility

Existing project icon values remain Codicon names and continue to render unchanged. Unknown namespaced Lucide values fall back to the project's default Codicon.
