### PR TITLE
fix(cli): label standalone dashboard holders correctly in the venv message

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3702,8 +3702,15 @@ def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> 
     for pid, name, cmdline in matches[:6]:
         hint = ""
         low = cmdline.lower()
-        if "serve" in low or "dashboard" in low:
+        if "serve" in low:
+            # `hermes serve` is the headless backend the Electron app
+            # spawns — closing the desktop app clears it.
             hint = "  ← Hermes Desktop backend (close the desktop app)"
+        elif "dashboard" in low:
+            # `hermes dashboard` is the STANDALONE browser UI a user starts
+            # themselves (port 9119) — not the desktop app. Point at the
+            # command that actually clears this holder (#90778).
+            hint = "  ← standalone dashboard (stop with: hermes dashboard --stop)"
         elif "gateway" in low:
             hint = "  ← gateway"
         lines.append(f"  PID {pid}  {name}  {cmdline[:120]}{hint}")
@@ -3717,7 +3724,8 @@ def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> 
         "  dependency update would fail partway and leave a broken install."
     )
     lines.append(
-        "  Close the Hermes desktop app / other Hermes terminals, then re-run:"
+        "  Close the Hermes desktop app / stop the dashboard"
+        " (`hermes dashboard --stop`) / close other Hermes terminals, then re-run:"
     )
     lines.append("    hermes update")
     lines.append("  (or use `hermes update --force-venv` to proceed anyway at your own risk)")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3694,6 +3694,27 @@ def _defer_update_for_self_lock(loaded: list[str]) -> None:
     _m()._write_update_incomplete_marker()
 
 
+def _cmdline_runs_hermes_subcommand(cmdline: str, subcommand: str) -> bool:
+    """True when *cmdline* launches the hermes entrypoint with *subcommand*.
+
+    Token-based so a cmdline that merely *contains* the word (``npm run
+    serve``, ``my-dashboard-monitor.exe``) is not mislabeled — the same
+    class of misclassification #90778 fixed, one step down (review
+    feedback on #90791). Covers both launch shapes: the console-script
+    entrypoint (``.../bin/hermes serve``, ``...\\Scripts\\hermes.exe
+    serve``) and the module forms (``-m hermes_cli serve``,
+    ``-m hermes_cli.main serve``).
+    """
+    tokens = cmdline.lower().split()
+    for i, tok in enumerate(tokens[:-1]):
+        if tokens[i + 1] != subcommand:
+            continue
+        base = tok.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+        if base in {"hermes", "hermes.exe"} or tok in {"hermes_cli", "hermes_cli.main"}:
+            return True
+    return False
+
+
 def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> str:
     """Explain which venv processes block the update and how to clear them."""
     lines = [
@@ -3701,17 +3722,16 @@ def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> 
     ]
     for pid, name, cmdline in matches[:6]:
         hint = ""
-        low = cmdline.lower()
-        if "serve" in low:
+        if _cmdline_runs_hermes_subcommand(cmdline, "serve"):
             # `hermes serve` is the headless backend the Electron app
             # spawns — closing the desktop app clears it.
             hint = "  ← Hermes Desktop backend (close the desktop app)"
-        elif "dashboard" in low:
+        elif _cmdline_runs_hermes_subcommand(cmdline, "dashboard"):
             # `hermes dashboard` is the STANDALONE browser UI a user starts
             # themselves (port 9119) — not the desktop app. Point at the
             # command that actually clears this holder (#90778).
             hint = "  ← standalone dashboard (stop with: hermes dashboard --stop)"
-        elif "gateway" in low:
+        elif _cmdline_runs_hermes_subcommand(cmdline, "gateway"):
             hint = "  ← gateway"
         lines.append(f"  PID {pid}  {name}  {cmdline[:120]}{hint}")
     if len(matches) > 6:

--- a/tests/hermes_cli/test_update_venv_holders_message.py
+++ b/tests/hermes_cli/test_update_venv_holders_message.py
@@ -1,0 +1,44 @@
+"""Tests for the venv-holder message's per-process classification (#90778).
+
+`hermes serve` (the headless backend the Electron app spawns) and
+`hermes dashboard` (the standalone browser UI on port 9119) used to share
+one classification branch, so a standalone dashboard was labeled "Hermes
+Desktop backend (close the desktop app)" — advice that points at a
+program that may not even be running, while the actual holder stays
+locked. The remedy line also never mentioned `hermes dashboard --stop`.
+"""
+
+from hermes_cli.update_cmd import _format_venv_python_holders_message
+
+
+def test_serve_holder_keeps_desktop_backend_hint():
+    msg = _format_venv_python_holders_message(
+        [(4242, "python.exe", r"C:\h\venv\Scripts\python.exe -m hermes_cli serve")]
+    )
+    assert "Hermes Desktop backend (close the desktop app)" in msg
+
+
+def test_dashboard_holder_is_labeled_standalone_with_stop_hint():
+    msg = _format_venv_python_holders_message(
+        [(4243, "python.exe", r"C:\h\venv\Scripts\python.exe -m hermes_cli dashboard")]
+    )
+    # NOT the desktop backend — that program may not even be running.
+    assert "Hermes Desktop backend" not in msg
+    assert "standalone dashboard" in msg
+    assert "hermes dashboard --stop" in msg
+
+
+def test_gateway_holder_hint_unchanged():
+    msg = _format_venv_python_holders_message(
+        [(4244, "python.exe", r"C:\h\venv\Scripts\python.exe -m hermes_cli gateway run")]
+    )
+    assert "← gateway" in msg
+
+
+def test_remedy_line_mentions_dashboard_stop():
+    msg = _format_venv_python_holders_message(
+        [(4243, "python.exe", r"C:\h\venv\Scripts\python.exe -m hermes_cli dashboard")]
+    )
+    # The remedy paragraph must name the command that clears this holder.
+    assert "hermes dashboard --stop" in msg
+    assert "hermes update --force-venv" in msg

--- a/tests/hermes_cli/test_update_venv_holders_message.py
+++ b/tests/hermes_cli/test_update_venv_holders_message.py
@@ -42,3 +42,42 @@ def test_remedy_line_mentions_dashboard_stop():
     # The remedy paragraph must name the command that clears this holder.
     assert "hermes dashboard --stop" in msg
     assert "hermes update --force-venv" in msg
+
+
+def test_cmdline_that_merely_contains_serve_is_not_mislabeled():
+    # `npm run serve` contains "serve" but is not the hermes backend —
+    # bare substring matching mislabeled it (review feedback on #90791).
+    msg = _format_venv_python_holders_message(
+        [(5001, "node.exe", r"C:\Program Files\nodejs\node.exe npm run serve")]
+    )
+    assert "Desktop backend" not in msg
+    assert "standalone dashboard" not in msg
+    assert "← gateway" not in msg
+
+
+def test_cmdline_that_merely_contains_dashboard_is_not_mislabeled():
+    msg = _format_venv_python_holders_message(
+        [(5002, "monitor.exe", r"C:\tools\my-dashboard-monitor.exe --watch")]
+    )
+    assert "standalone dashboard" not in msg
+
+
+def test_hermes_cli_main_module_form_is_classified():
+    # The desktop app spawns `-m hermes_cli.main serve|dashboard`.
+    msg = _format_venv_python_holders_message(
+        [(5003, "python.exe", r"C:\h\venv\Scripts\python.exe -m hermes_cli.main serve")]
+    )
+    assert "Hermes Desktop backend (close the desktop app)" in msg
+    msg = _format_venv_python_holders_message(
+        [(5004, "python.exe", r"C:\h\venv\Scripts\python.exe -m hermes_cli.main dashboard")]
+    )
+    assert "standalone dashboard" in msg
+
+
+def test_console_script_entrypoint_form_is_classified():
+    # `.../bin/hermes dashboard` (macOS/Linux entrypoint) — the token
+    # before the subcommand ends with "hermes".
+    msg = _format_venv_python_holders_message(
+        [(5005, "hermes", "/home/u/.hermes/venv/bin/hermes dashboard")]
+    )
+    assert "standalone dashboard" in msg


### PR DESCRIPTION
## What does this PR do?

When `hermes update` refuses the dependency step because something else runs from the install's venv, the holder list mislabeled a standalone `hermes dashboard` process as **"Hermes Desktop backend (close the desktop app)"** (#90778). `serve` and `dashboard` shared one classification branch, but they are different things: `hermes serve` is the headless backend the Electron app spawns (closing the desktop app clears it), while `hermes dashboard` is the standalone browser UI on port 9119 that a user starts themselves — only the first is "the desktop app". The advice therefore pointed at a program that may not even be running while the actual holder kept the venv locked, and the remedy line never mentioned `hermes dashboard --stop`, the only thing that clears this holder.

This PR splits the branch: `serve` keeps the desktop-backend hint, `dashboard` gets a standalone label naming `hermes dashboard --stop`, and the remedy paragraph now lists the stop command alongside closing the desktop app.

## Related Issue

Fixes #90778

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd.py` — `_format_venv_python_holders_message`: `serve` and `dashboard` get separate classification branches with per-branch comments; the remedy paragraph mentions `hermes dashboard --stop`
- `tests/hermes_cli/test_update_venv_holders_message.py` — four regression tests: serve keeps the desktop-backend hint; dashboard is labeled standalone (and NOT desktop backend) with the stop command; gateway hint unchanged; the remedy line names both `hermes dashboard --stop` and `hermes update --force-venv`

## How to Test

1. `python -m pytest tests/hermes_cli/test_update_venv_holders_message.py -q` — should pass (4 passed)
2. Observed result: with the update_cmd change stashed, the dashboard-classification and remedy-line tests fail (standalone dashboard inherits the desktop-backend label, no stop command anywhere); with the fix, all four pass
3. Manual equivalence: run `hermes dashboard` in one terminal and `hermes update` in another on Windows — the holder list now reads "← standalone dashboard (stop with: hermes dashboard --stop)" instead of the desktop-app advice

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (why serve and dashboard are different programs)
- [x] Tests added that prove the fix is effective or prevent regression (all three classifications + remedy line)
- [x] All new and existing tests pass locally (4/4)
- [x] Platform: macOS (pure message-formatting logic; the Windows .pyd locking behavior it explains is unchanged)
