### PR TITLE
fix(state): prevent live SQLite restore and FTS rebuild corruption

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -19,7 +19,7 @@ import tempfile
 import threading
 import time
 import zipfile
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -36,6 +36,7 @@ from utils import (
 # Shared formatter; the private alias is kept because claw.py and the backup
 # tests import ``_format_size`` from this module.
 from hermes_cli.sizefmt import format_bytes as _format_size
+from hermes_cli.sqlite_safe_read import LiveConnectionError, offline_file_access
 
 logger = logging.getLogger(__name__)
 
@@ -157,6 +158,10 @@ class _SQLiteSnapshotError(RuntimeError):
 
 class _SQLiteBackupTimeout(RuntimeError):
     """Raised when a SQLite snapshot remains busy past its deadline."""
+
+
+class _SQLiteRestoreValidationError(OSError):
+    """A staged SQLite restore candidate failed integrity validation."""
 
 
 @contextmanager
@@ -621,6 +626,108 @@ def copy_db_and_verify(src: Path, dst: Path) -> bool:
     return True
 
 
+def _validate_sqlite_restore_candidate(path: Path) -> None:
+    """Fail closed unless a staged database is structurally healthy.
+
+    Empty files are accepted as brand-new SQLite stores; SQLite will
+    initialise them on first open. Non-empty restore candidates always run
+    the full check, regardless of size: restores are rare, and the bounded
+    update-time shortcut previously missed the repeated ``messages`` b-tree
+    damage seen in the August 2026 incidents.
+    """
+    try:
+        if path.stat().st_size == 0:
+            return
+    except OSError as exc:
+        raise _SQLiteRestoreValidationError(str(exc)) from exc
+
+    result = verify_sqlite_integrity(path, run_pragma=True, max_bytes=0)
+    if not result.get("valid"):
+        raise _SQLiteRestoreValidationError(
+            f"refusing to install corrupt SQLite snapshot {path}: "
+            f"{result.get('message') or 'integrity validation failed'}"
+        )
+
+    conn = None
+    try:
+        conn = sqlite3.connect(str(path), timeout=5.0)
+        foreign_key_errors = conn.execute("PRAGMA foreign_key_check").fetchmany(5)
+        if foreign_key_errors:
+            raise _SQLiteRestoreValidationError(
+                f"refusing to install SQLite snapshot {path}: "
+                f"foreign key check failed ({foreign_key_errors!r})"
+            )
+
+        # PRAGMA integrity_check does not validate an FTS5 inverted index.
+        # Ask each FTS5 virtual table to validate its shadow tables too; this
+        # catches the recurring "malformed inverted index" restore shape.
+        fts_tables = conn.execute(
+            "SELECT name FROM sqlite_schema "
+            "WHERE type = 'table' "
+            "AND lower(sql) LIKE 'create virtual table%using fts5%'"
+        ).fetchall()
+        for (name,) in fts_tables:
+            quoted = '"' + str(name).replace('"', '""') + '"'
+            conn.execute(
+                f"INSERT INTO {quoted}({quoted}) VALUES('integrity-check')"
+            )
+        conn.rollback()
+
+        # Prove the candidate can take a canonical main-schema write before
+        # publishing it. Rollback keeps the restored schema byte-for-byte
+        # logical-equivalent while exercising the actual writable path.
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            "CREATE TABLE __hermes_restore_write_probe "
+            "(id INTEGER PRIMARY KEY)"
+        )
+        conn.execute("DROP TABLE __hermes_restore_write_probe")
+        conn.rollback()
+    except _SQLiteRestoreValidationError:
+        raise
+    except sqlite3.DatabaseError as exc:
+        raise _SQLiteRestoreValidationError(
+            f"refusing to install corrupt SQLite snapshot {path}: {exc}"
+        ) from exc
+    finally:
+        if conn is not None:
+            try:
+                conn.rollback()
+                conn.close()
+            except sqlite3.Error:
+                pass
+
+
+def _remove_stale_db_sidecars(path: Path) -> None:
+    """Remove journals belonging to the retired DB generation (offline only)."""
+    for suffix in ("-wal", "-shm", "-journal"):
+        path.with_name(path.name + suffix).unlink(missing_ok=True)
+
+
+def _restore_database_file_atomically(source: Path, target: Path) -> None:
+    """Validate and publish one DB while exclusively owning its lifecycle."""
+    fd, temp_name = tempfile.mkstemp(
+        dir=str(target.parent),
+        prefix=f".{target.name[:80]}.",
+        suffix=".restore-partial",
+    )
+    os.close(fd)
+    try:
+        shutil.copy2(source, temp_name)
+        with open(temp_name, "rb") as handle:
+            os.fsync(handle.fileno())
+        _validate_sqlite_restore_candidate(Path(temp_name))
+        with offline_file_access(target, what="restore"):
+            _remove_stale_db_sidecars(target)
+            atomic_replace(temp_name, target)
+    except BaseException:
+        try:
+            os.unlink(temp_name)
+        except OSError:
+            pass
+        raise
+
+
 # ---------------------------------------------------------------------------
 # Backup
 # ---------------------------------------------------------------------------
@@ -1013,13 +1120,30 @@ def _extract_member_atomically(
                 shutil.copyfileobj(src, dst)
             dst.flush()
             os.fsync(dst.fileno())
-        real_path = Path(atomic_replace(tmp_name, target))
-        # Owner first, mode second — the ordering ``atomic_yaml_write`` uses,
-        # because chown drops setuid/setgid and a mode restore that ran first
-        # would be partly undone.  Here ``mode`` no longer carries those bits,
-        # so the two agree: neither step can re-elevate the restored file.
-        _restore_file_owner(real_path, owner)
-        _restore_file_mode(real_path, mode)
+        db_restore = target.suffix == ".db"
+        guard = (
+            offline_file_access(target, what="restore")
+            if db_restore
+            else nullcontext()
+        )
+        with guard:
+            if db_restore:
+                _validate_sqlite_restore_candidate(Path(tmp_name))
+            # A WAL/SHM belongs to one exact database generation. Keeping an
+            # old sidecar beside a newly published main file can replay pages
+            # from the retired generation and corrupt an otherwise clean
+            # restore on its first open. Retire sidecars before publishing so
+            # there is no post-publish window where a raw legacy opener could
+            # pair the clean main with the old WAL.
+            if db_restore:
+                _remove_stale_db_sidecars(target)
+            real_path = Path(atomic_replace(tmp_name, target))
+            # Owner first, mode second — the ordering ``atomic_yaml_write``
+            # uses, because chown drops setuid/setgid and a mode restore that
+            # ran first would be partly undone. Here ``mode`` no longer
+            # carries those bits, so neither step can re-elevate the file.
+            _restore_file_owner(real_path, owner)
+            _restore_file_mode(real_path, mode)
     except BaseException:
         try:
             os.unlink(tmp_name)
@@ -1117,7 +1241,7 @@ def run_import(args) -> None:
                             pass
                     restored += 1
                     restored_external += 1
-                except (PermissionError, OSError) as exc:
+                except (PermissionError, OSError, LiveConnectionError) as exc:
                     errors.append(f"  {member}: {exc}")
                 if restored % 500 == 0:
                     print(f"  {restored}/{file_count} files ...")
@@ -1157,7 +1281,7 @@ def run_import(args) -> None:
                 if target.name in _SECRET_FILE_NAMES:
                     os.chmod(target, 0o600)
                 restored += 1
-            except (PermissionError, OSError) as exc:
+            except (PermissionError, OSError, LiveConnectionError) as exc:
                 errors.append(f"  {rel}: {exc}")
 
             if restored % 500 == 0:
@@ -1649,14 +1773,16 @@ def restore_quick_snapshot(
 
         try:
             if dst.suffix == ".db":
-                # Atomic-ish replace for databases
-                tmp = dst.parent / f".{dst.name}.snap_restore"
-                shutil.copy2(src, tmp)
-                dst.unlink(missing_ok=True)
-                shutil.move(str(tmp), str(dst))
+                _restore_database_file_atomically(src, dst)
             else:
                 shutil.copy2(src, dst)
             restored += 1
+        except (LiveConnectionError, _SQLiteRestoreValidationError):
+            # These are safety refusals, not per-file best-effort failures.
+            # Surface them to /snapshot so the operator sees the exact stop-
+            # services or corrupt-candidate action instead of a misleading
+            # "snapshot not found" message.
+            raise
         except (OSError, PermissionError) as exc:
             logger.error("Failed to restore %s: %s", rel, exc)
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -322,6 +322,7 @@ class CLICommandsMixin:
             create_quick_snapshot, list_quick_snapshots,
             restore_quick_snapshot, prune_quick_snapshots,
         )
+        from hermes_cli.sqlite_safe_read import LiveConnectionError
         from hermes_constants import display_hermes_home
 
         parts = command.split()
@@ -375,9 +376,21 @@ class CLICommandsMixin:
                     return
             except ValueError:
                 pass
-            if restore_quick_snapshot(snap_id):
+            try:
+                restored = restore_quick_snapshot(snap_id)
+            except (LiveConnectionError, OSError) as exc:
+                # Database restores intentionally fail closed while any
+                # gateway/dashboard/CLI still owns the live generation. Do
+                # not misreport that safety refusal as "snapshot not found".
+                print(f"  Restore refused: {exc}")
+                print(
+                    "  Stop every Hermes process using this profile and run "
+                    "the restore from a fresh shell."
+                )
+                return
+            if restored:
                 print(f"  Restored state from: {snap_id}")
-                print("  Restart recommended for state.db changes to take effect.")
+                print("  Restart Hermes services before opening the database.")
             else:
                 print(f"  Snapshot not found: {snap_id}")
 

--- a/hermes_cli/sqlite_safe_read.py
+++ b/hermes_cli/sqlite_safe_read.py
@@ -65,9 +65,11 @@ import contextlib
 import logging
 import os
 import sqlite3
+import sys
 import threading
 from pathlib import Path
 from typing import Optional
+from urllib.parse import unquote, urlsplit
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +83,124 @@ _HEADER_PAGE_COUNT_OFFSET = 28
 _live_lock = threading.RLock()
 # canonical path -> number of live connections opened by this process
 _live_connections: dict[str, int] = {}
+
+
+def _lifecycle_lock_path(path: Path | str) -> Path:
+    """Return the sidecar used to coordinate DB opens with offline surgery."""
+    canonical = Path(_key(path))
+    return canonical.with_name(canonical.name + ".lifecycle.lock")
+
+
+def _filesystem_path_hint(
+    path: Path | str,
+    tracking_path: Path | str | None,
+) -> Optional[Path | str]:
+    """Resolve the on-disk path before connect, including SQLite file URIs."""
+    if tracking_path is not None:
+        return tracking_path
+    raw = str(path)
+    if raw == ":memory:":
+        return None
+    if not raw.startswith("file:"):
+        return path
+    parsed = urlsplit(raw)
+    if "mode=memory" in parsed.query.lower():
+        return None
+    return unquote(parsed.path)
+
+
+def _acquire_lifecycle_lock(
+    path: Path | str,
+    *,
+    exclusive: bool,
+    nonblocking: bool,
+):
+    """Acquire a process-spanning lifecycle lease for *path* on POSIX.
+
+    SQLite's own locks protect transactions, but they do not make replacing
+    the database pathname safe: an already-open connection keeps the old
+    inode while a new opener sees the replacement, and a stale ``-wal`` can
+    then be paired with the wrong main database. A shared lease is held for
+    every tracked connection; raw copy/restore/repair paths require the
+    exclusive form.
+
+    Returns an open lock-file handle, or ``None`` on platforms without
+    ``fcntl``. Callers must keep the handle alive for the whole lease.
+    """
+    if os.name != "posix":
+        return None
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - non-POSIX defensive fallback
+        return None
+
+    lock_path = _lifecycle_lock_path(path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = lock_path.open("a+b")
+    operation = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+    if nonblocking:
+        operation |= fcntl.LOCK_NB
+    try:
+        fcntl.flock(handle.fileno(), operation)
+    except BaseException:
+        handle.close()
+        raise
+    return handle
+
+
+def _release_lifecycle_lock(handle) -> None:
+    if handle is None:
+        return
+    try:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except (ImportError, OSError):  # pragma: no cover - defensive cleanup
+        pass
+    finally:
+        try:
+            handle.close()
+        except OSError:
+            pass
+
+
+def database_holder_pids(path: Path | str) -> Optional[set[int]]:
+    """Return Linux PIDs with *path* open, or ``None`` when unavailable.
+
+    This catches legacy/untracked SQLite clients that do not yet participate
+    in the lifecycle lease. The result is a lower bound when ``/proc`` hides
+    other users' descriptors, but Hermes services normally run as one user.
+    A descriptor to an inode replaced earlier is reported by Linux with a
+    ``" (deleted)"`` suffix; strip it so dangerous split-generation holders
+    are still detected.
+    """
+    if not sys.platform.startswith("linux"):
+        return None
+    target = os.path.realpath(str(path))
+    holders: set[int] = set()
+    try:
+        pids = os.listdir("/proc")
+    except OSError:
+        return None
+    for raw_pid in pids:
+        if not raw_pid.isdigit():
+            continue
+        fd_dir = f"/proc/{raw_pid}/fd"
+        try:
+            fds = os.listdir(fd_dir)
+        except OSError:
+            continue
+        for fd in fds:
+            try:
+                resolved = os.readlink(f"{fd_dir}/{fd}")
+            except OSError:
+                continue
+            if resolved.endswith(" (deleted)"):
+                resolved = resolved[: -len(" (deleted)")]
+            if os.path.realpath(resolved) == target:
+                holders.add(int(raw_pid))
+                break
+    return holders
 
 
 class UntrackableConnectionError(RuntimeError):
@@ -150,6 +270,7 @@ class _TrackingMixin:
     """Untrack-on-close behaviour, mixable into any Connection subclass."""
 
     _hermes_tracked_path: str | None = None
+    _hermes_lifecycle_lock = None
 
     def close(self) -> None:  # type: ignore[misc]
         with _live_lock:
@@ -162,6 +283,10 @@ class _TrackingMixin:
             if path is not None:
                 self._hermes_tracked_path = None
                 untrack_connection(path)
+            lifecycle_lock = getattr(self, "_hermes_lifecycle_lock", None)
+            if lifecycle_lock is not None:
+                self._hermes_lifecycle_lock = None
+                _release_lifecycle_lock(lifecycle_lock)
 
 
 class TrackedConnection(_TrackingMixin, sqlite3.Connection):
@@ -243,7 +368,25 @@ def connect_tracked(
     kwargs["factory"] = _tracking_factory(kwargs.get("factory", sqlite3.Connection))
 
     with _live_lock:
-        conn = opener(str(path), **kwargs)
+        # Acquire the shared lifecycle lease BEFORE SQLite opens the file.
+        # Otherwise an offline restorer can publish a new database generation
+        # between sqlite3.connect() and registration, leaving this connection
+        # attached to the retired inode.
+        lifecycle_path = _filesystem_path_hint(path, tracking_path)
+        lifecycle_lock = (
+            _acquire_lifecycle_lock(
+                lifecycle_path,
+                exclusive=False,
+                nonblocking=False,
+            )
+            if lifecycle_path is not None
+            else None
+        )
+        try:
+            conn = opener(str(path), **kwargs)
+        except BaseException:
+            _release_lifecycle_lock(lifecycle_lock)
+            raise
         try:
             resolved = (
                 _key(tracking_path)
@@ -252,6 +395,7 @@ def connect_tracked(
             )
             if resolved is None:
                 # In-memory / unnamed: nothing on disk to byte-probe.
+                _release_lifecycle_lock(lifecycle_lock)
                 return conn
             if not isinstance(conn, _TrackingMixin):
                 # The opener substituted its own factory and discarded ours
@@ -261,6 +405,7 @@ def connect_tracked(
                 # connection whose database has silently lost probe safety.
                 conn = _retrofit_tracking(conn, resolved)
             conn._hermes_tracked_path = resolved
+            conn._hermes_lifecycle_lock = lifecycle_lock
             _live_connections[resolved] = _live_connections.get(resolved, 0) + 1
             return conn
         except Exception:
@@ -270,6 +415,7 @@ def connect_tracked(
                 sqlite3.Connection.close(conn)
             except Exception:
                 pass
+            _release_lifecycle_lock(lifecycle_lock)
             raise
 
 
@@ -412,4 +558,29 @@ def offline_file_access(path: Path | str, *, what: str = "read"):
                 "connection's POSIX advisory locks. Close all database "
                 "handles (stop the gateway/dashboard) and retry."
             )
-        yield
+        lifecycle_lock = None
+        try:
+            try:
+                lifecycle_lock = _acquire_lifecycle_lock(
+                    path,
+                    exclusive=True,
+                    nonblocking=True,
+                )
+            except (BlockingIOError, OSError) as exc:
+                raise LiveConnectionError(
+                    f"Refusing to {what} {path}: another process holds a "
+                    "database lifecycle lease. Stop every gateway, dashboard, "
+                    "CLI, and worker using this profile, then retry."
+                ) from exc
+
+            holder_pids = database_holder_pids(path)
+            if holder_pids:
+                formatted = ", ".join(str(pid) for pid in sorted(holder_pids))
+                raise LiveConnectionError(
+                    f"Refusing to {what} {path}: database holder PID(s) "
+                    f"{formatted} are still active. Stop every gateway, "
+                    "dashboard, CLI, and worker using this profile, then retry."
+                )
+            yield
+        finally:
+            _release_lifecycle_lock(lifecycle_lock)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2340,7 +2340,31 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
                 "schema surgery to avoid racing it"
             )
             return report
-        result = _repair_state_db_schema_locked(db_path, backup=backup, report=report)
+        # The repair lock serialises repairers, not ordinary SessionDB,
+        # gateway, dashboard, or CLI connections. In-place FTS rebuild,
+        # REINDEX, writable_schema surgery, and VACUUM must never run while
+        # another process owns this database generation. Doing so is how an
+        # apparently successful restore can be re-corrupted by an old open
+        # inode or stale WAL. Require the shared SQLite lifecycle layer's
+        # exclusive offline lease before any probe, raw backup, or mutation.
+        try:
+            from hermes_cli.sqlite_safe_read import (
+                LiveConnectionError,
+                offline_file_access,
+            )
+
+            with offline_file_access(db_path, what="repair"):
+                result = _repair_state_db_schema_locked(
+                    db_path,
+                    backup=backup,
+                    report=report,
+                )
+        except LiveConnectionError as exc:
+            report["error"] = str(exc)
+            logger.error("state.db repair refused: %s", exc)
+            # Ownership contention is not a failed repair attempt against the
+            # bytes, so do not consume the persistent corruption budget.
+            return report
         # Persist the outcome AFTER surgery, keyed on the post-attempt
         # fingerprint — that is the file state the NEXT attempt's exhaustion
         # probe will observe. Failures count toward the cross-restart cap;

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -2403,22 +2403,34 @@ class SessionSearchMixin:
         Safe to call when FTS tables don't exist (skips them).
         Returns the number of FTS indexes that were rebuilt.
         """
+        # ``self._lock`` only protects threads sharing this SessionDB. FTS
+        # rebuild rewrites several shadow tables, so independent gateway/cron
+        # processes must also serialize the maintenance pass.
+        from hermes_state import _cross_process_repair_lock
+
         rebuilt = 0
-        with self._lock:
-            for tbl in self._FTS_TABLES:
-                if not self._fts_table_exists(tbl):
-                    continue
-                try:
-                    self._conn.execute(
-                        f"INSERT INTO {tbl}({tbl}) VALUES('rebuild')"
-                    )
-                    self._conn.commit()
-                    rebuilt += 1
-                except sqlite3.OperationalError as exc:
-                    self._conn.rollback()
-                    logger.warning(
-                        "FTS rebuild failed for %s: %s", tbl, exc
-                    )
+        with _cross_process_repair_lock(self.db_path) as holding_lock:
+            if not holding_lock:
+                logger.warning(
+                    "state.db FTS rebuild skipped: repair lock is held by "
+                    "another process"
+                )
+                return 0
+            with self._lock:
+                for tbl in self._FTS_TABLES:
+                    if not self._fts_table_exists(tbl):
+                        continue
+                    try:
+                        self._conn.execute(
+                            f"INSERT INTO {tbl}({tbl}) VALUES('rebuild')"
+                        )
+                        self._conn.commit()
+                        rebuilt += 1
+                    except sqlite3.OperationalError as exc:
+                        self._conn.rollback()
+                        logger.warning(
+                            "FTS rebuild failed for %s: %s", tbl, exc
+                        )
         return rebuilt
 
     def _merge_fts_incrementally(

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -4,6 +4,7 @@ import json
 import os
 import sqlite3
 import stat
+import sys
 import zipfile
 from argparse import Namespace
 from pathlib import Path
@@ -432,11 +433,16 @@ class TestImport:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         zip_path = tmp_path / "backup.zip"
+        sqlite_fixture = tmp_path / "state-fixture.db"
+        fixture_conn = sqlite3.connect(str(sqlite_fixture))
+        fixture_conn.execute("CREATE TABLE marker(value TEXT)")
+        fixture_conn.commit()
+        fixture_conn.close()
         self._make_backup_zip(zip_path, {
             "config.yaml": "model: openrouter\n",
             ".env": "OPENROUTER_API_KEY=sk-secret\n",
             "auth.json": '{"providers": {"nous": "token"}}',
-            "state.db": b"SQLite format 3\x00",
+            "state.db": sqlite_fixture.read_bytes(),
             "profiles/coder/.env": "ANTHROPIC_API_KEY=sk-ant-secret\n",
         })
 
@@ -1708,5 +1714,80 @@ class TestMemoryProviderExternalPaths:
         assert not (hermes_home / "_external").exists()
 
 
+class TestDatabaseRestoreLifecycleSafety:
+    """A restore must never mix a new main DB with old holders/sidecars."""
 
+    @staticmethod
+    def _seed(path: Path, value: str) -> None:
+        conn = sqlite3.connect(str(path))
+        conn.execute("CREATE TABLE IF NOT EXISTS marker(value TEXT NOT NULL)")
+        conn.execute("DELETE FROM marker")
+        conn.execute("INSERT INTO marker VALUES (?)", (value,))
+        conn.commit()
+        conn.close()
+
+    @staticmethod
+    def _value(path: Path) -> str:
+        conn = sqlite3.connect(str(path))
+        try:
+            return str(conn.execute("SELECT value FROM marker").fetchone()[0])
+        finally:
+            conn.close()
+
+    def test_snapshot_restore_retires_stale_wal_bundle(self, tmp_path):
+        from hermes_cli.backup import create_quick_snapshot, restore_quick_snapshot
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        db = home / "state.db"
+        self._seed(db, "snapshot-generation")
+        snap_id = create_quick_snapshot(hermes_home=home)
+        assert snap_id is not None
+
+        self._seed(db, "retired-live-generation")
+        for suffix in ("-wal", "-shm", "-journal"):
+            db.with_name(db.name + suffix).write_bytes(b"stale-generation")
+
+        assert restore_quick_snapshot(snap_id, hermes_home=home) is True
+        assert self._value(db) == "snapshot-generation"
+        for suffix in ("-wal", "-shm", "-journal"):
+            assert not db.with_name(db.name + suffix).exists()
+
+    @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="uses /proc")
+    def test_snapshot_restore_refuses_live_untracked_connection(self, tmp_path):
+        from hermes_cli.backup import create_quick_snapshot, restore_quick_snapshot
+        from hermes_cli.sqlite_safe_read import LiveConnectionError
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        db = home / "state.db"
+        self._seed(db, "snapshot-generation")
+        snap_id = create_quick_snapshot(hermes_home=home)
+        assert snap_id is not None
+        self._seed(db, "must-remain-live")
+
+        holder = sqlite3.connect(str(db))
+        try:
+            with pytest.raises(LiveConnectionError, match=str(os.getpid())):
+                restore_quick_snapshot(snap_id, hermes_home=home)
+        finally:
+            holder.close()
+        assert self._value(db) == "must-remain-live"
+
+    def test_snapshot_restore_rejects_corrupt_candidate_before_publish(self, tmp_path):
+        from hermes_cli.backup import create_quick_snapshot, restore_quick_snapshot
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        db = home / "state.db"
+        self._seed(db, "snapshot-generation")
+        snap_id = create_quick_snapshot(hermes_home=home)
+        assert snap_id is not None
+        self._seed(db, "must-survive-validation")
+
+        snapshot_db = home / "state-snapshots" / snap_id / "state.db"
+        snapshot_db.write_bytes(b"not a sqlite database" * 20)
+        with pytest.raises(OSError, match="refusing to install corrupt SQLite"):
+            restore_quick_snapshot(snap_id, hermes_home=home)
+        assert self._value(db) == "must-survive-validation"
 

--- a/tests/test_sqlite_lock_safe_inspection.py
+++ b/tests/test_sqlite_lock_safe_inspection.py
@@ -23,12 +23,15 @@ import subprocess
 import sys
 import textwrap
 import threading
+from pathlib import Path
 
 import pytest
 
 from hermes_cli.sqlite_safe_read import (
+    LiveConnectionError,
     file_length_matches_header,
     has_live_connection,
+    offline_file_access,
     page_count_bytes,
     read_header_bytes_preopen,
     track_connection,
@@ -161,6 +164,78 @@ def test_tracking_registry_does_not_leak_across_close_paths(tmp_path, clean_regi
         connect_tracked(db).close()
     assert not has_live_connection(db)
 
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="uses /proc")
+def test_offline_access_refuses_untracked_external_holder(tmp_path, clean_registry):
+    """Recovery must see legacy/Rust/raw sqlite clients, not only our registry."""
+    db = tmp_path / "state.db"
+    _make_db(db, "WAL")
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sqlite3,sys; "
+                "c=sqlite3.connect(sys.argv[1]); "
+                "print('READY',flush=True); sys.stdin.read(1); c.close()"
+            ),
+            str(db),
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert holder.stdout is not None
+        assert holder.stdout.readline().strip() == "READY"
+        with pytest.raises(LiveConnectionError, match=str(holder.pid)):
+            with offline_file_access(db, what="restore"):
+                pytest.fail("live external holder was not rejected")
+    finally:
+        if holder.stdin is not None:
+            holder.stdin.write("x")
+            holder.stdin.close()
+        holder.wait(timeout=30)
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="uses flock")
+def test_lifecycle_lease_refuses_external_tracked_holder(
+    tmp_path, clean_registry, monkeypatch
+):
+    """The lease remains load-bearing even when /proc discovery is unavailable."""
+    import hermes_cli.sqlite_safe_read as ssr
+
+    db = tmp_path / "state.db"
+    _make_db(db, "WAL")
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "from hermes_cli.sqlite_safe_read import connect_tracked; "
+                "c=connect_tracked(sys.argv[1]); "
+                "print('READY',flush=True); sys.stdin.read(1); c.close()"
+            ),
+            str(db),
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+        cwd=str(Path(__file__).resolve().parents[1]),
+    )
+    try:
+        assert holder.stdout is not None
+        assert holder.stdout.readline().strip() == "READY"
+        monkeypatch.setattr(ssr, "database_holder_pids", lambda _path: set())
+        with pytest.raises(LiveConnectionError, match="lifecycle lease"):
+            with offline_file_access(db, what="repair"):
+                pytest.fail("exclusive access bypassed the shared lease")
+    finally:
+        if holder.stdin is not None:
+            holder.stdin.write("x")
+            holder.stdin.close()
+        holder.wait(timeout=30)
 
 def test_failed_close_keeps_connection_tracked(tmp_path, clean_registry):
     """A raising close must not release the registry (#75629).

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -91,6 +91,44 @@ def test_repaired_db_search_works(tmp_path):
         db.close()
 
 
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="uses flock")
+def test_fts_rebuild_respects_cross_process_repair_lock(tmp_path, monkeypatch):
+    """FTS recovery must not run beside another process's rebuild/repair."""
+    import hermes_state
+
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    lock_path = db_path.with_name(db_path.name + ".repair.lock")
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import fcntl,sys; "
+                "f=open(sys.argv[1], 'a+b'); "
+                "fcntl.flock(f.fileno(), fcntl.LOCK_EX); "
+                "print('READY', flush=True); sys.stdin.read(1)"
+            ),
+            str(lock_path),
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    db = None
+    try:
+        assert holder.stdout is not None
+        assert holder.stdout.readline().strip() == "READY"
+        monkeypatch.setattr(hermes_state, "_REPAIR_LOCK_TIMEOUT_SECONDS", 0.05)
+        db = SessionDB(db_path=db_path)
+        assert db.rebuild_fts() == 0
+    finally:
+        if db is not None:
+            db.close()
+        if holder.stdin is not None:
+            holder.stdin.write("x")
+            holder.stdin.close()
+        holder.wait(timeout=30)
 
 
 def test_auto_heal_attempted_once_per_process(tmp_path, monkeypatch):

--- a/tests/test_state_db_repair_loop_cap.py
+++ b/tests/test_state_db_repair_loop_cap.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
+import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -125,7 +127,6 @@ class TestBackupDedupeAndCap:
         # reused instead of copying another ~900MB.
         assert second == first
         assert len(_existing_malformed_backups(db)) == 1
-
     def test_changed_file_gets_a_new_backup(self, tmp_path):
         db = _make_unrepairable_db(tmp_path)
         first, _ = _backup_db_file(db)
@@ -161,3 +162,37 @@ class TestBackupDedupeAndCap:
         for _ in range(_MAX_PERSISTENT_REPAIR_ATTEMPTS):
             repair_state_db_schema(db)
         assert len(_existing_malformed_backups(db)) == 1
+
+
+def test_schema_repair_refuses_while_external_holder_is_live(tmp_path):
+    """The repair mutex alone must not authorize surgery against live users."""
+    if not sys.platform.startswith("linux"):
+        return
+    db = _make_healthy_db(tmp_path)
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sqlite3,sys; c=sqlite3.connect(sys.argv[1]); "
+                "print('READY',flush=True); sys.stdin.read(1); c.close()"
+            ),
+            str(db),
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert holder.stdout is not None
+        assert holder.stdout.readline().strip() == "READY"
+        report = repair_state_db_schema(db)
+        assert report["repaired"] is False
+        assert str(holder.pid) in str(report["error"])
+        assert not _repair_ledger_path(db).exists()
+        assert not _existing_malformed_backups(db)
+    finally:
+        if holder.stdin is not None:
+            holder.stdin.write("x")
+            holder.stdin.close()
+        holder.wait(timeout=30)


### PR DESCRIPTION
Kanban: t_cf46d5c6

## Summary
- Require offline ownership for destructive SQLite restore/repair operations.
- Serialize SessionDB FTS rebuilds across gateway, cron, CLI, and dashboard processes using the existing kernel-backed repair lock.
- Add regression coverage for live-holder refusal and concurrent FTS recovery.

## Evidence
- Active /home/solo/.hermes/state.db: PRAGMA integrity_check = ok; WAL mode; 2,642 sessions, 110,645 messages.
- Gateway and cron logs showed repeated FTS corruption/rebuild attempts from separate Hermes processes (PID 678930 and PID 358086) during the incident window.
- Running Hermes interpreter links SQLite 3.53.1; system /usr/bin/python3 links SQLite 3.45.1 and is vulnerable, supporting a runtime/process-path distinction rather than filesystem failure.
- Bounded 4-process x 3-rebuild stress: all exit 0, integrity_check ok, FTS MATCH returned 20 rows.

## Tests
- scripts/run_tests.sh tests/test_state_db_malformed_repair.py -q (17 passed)
- scripts/run_tests.sh tests/state/test_fts_runtime_rebuild.py tests/test_state_db_repair_loop_cap.py tests/test_sqlite_lock_safe_inspection.py -q (30 passed)