### PR TITLE
feat(buzz): improve threads, images, and live channel refresh

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -37,16 +37,19 @@ environment and is never logged.
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
 import re
 import shutil
+import tempfile
 import time
+import unicodedata
 from collections import OrderedDict
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 from urllib.parse import urlsplit, urlunsplit
 
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
@@ -74,12 +77,37 @@ def _get_scoped_secret(name, default=None):
 
 
 logger = logging.getLogger(__name__)
+_MEMBER_MENTION_ERROR = re.compile(
+    r"mention '(@.+?)' (?:does not match a current channel member|is ambiguous)",
+    re.IGNORECASE,
+)
+_MAX_MENTIONS_ERROR = "too many unique message mentions"
+_OUTBOUND_MENTION_MARKER = re.compile(r"(?<![\w@])@(?=[^\s@])")
+_MENTION_FALLBACK_MAX_RETRIES = 3
+_BUZZ_MARKDOWN_IMAGE_RE = re.compile(r"!\[[^\]\r\n]*\]\((https?://[^)\s]+)\)")
+_BUZZ_MEDIA_IMAGE_PATH_RE = re.compile(
+    r"/media/([0-9a-f]{64})\.(png|jpe?g|gif|webp|bmp)",
+    re.IGNORECASE,
+)
+_BUZZ_IMAGE_MIME = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "webp": "image/webp",
+    "bmp": "image/bmp",
+}
+_MAX_BUZZ_IMAGES_PER_MESSAGE = 4
+_BUZZ_MEDIA_RETRY_DELAYS = (0.25, 0.75)
+_BUZZ_MEDIA_TOTAL_TIMEOUT = 30.0
 
 from gateway.platforms.base import (
     BasePlatformAdapter,
     SendResult,
     MessageEvent,
     MessageType,
+    cache_image_from_bytes,
+    validate_inbound_media_size,
 )
 from gateway.config import Platform
 
@@ -95,6 +123,124 @@ _SEEN_CAP = 500
 # Re-run DM discovery (``dms list`` plus the channels-list fallback) every
 # N poll sweeps to pick up conversations opened mid-run.
 _DM_DISCOVERY_EVERY = 5
+_CHANNEL_DISCOVERY_EVERY = 5
+
+
+def _detected_image_family(data: bytes) -> Optional[str]:
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "jpeg"
+    if data.startswith((b"GIF87a", b"GIF89a")):
+        return "gif"
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "webp"
+    if data.startswith(b"BM"):
+        return "bmp"
+    return None
+
+
+def _cli_failure_is_retryable(stderr: str, returncode: int) -> bool:
+    try:
+        data = json.loads((stderr or "").strip())
+    except ValueError:
+        data = None
+    if isinstance(data, dict) and isinstance(data.get("retryable"), bool):
+        return data["retryable"]
+    return returncode == 2
+
+
+def _is_mention_continuation(char: str) -> bool:
+    return bool(
+        char
+        and (
+            char.isalnum()
+            or char == "_"
+            or char in ".-"
+            or unicodedata.category(char).startswith("M")
+        )
+    )
+
+
+def _complete_mention_spans(content: str, mention: str) -> List[Tuple[int, int]]:
+    target = mention if mention.startswith("@") else f"@{mention}"
+    normalized_target = target.casefold()
+    spans = []
+    for start, char in enumerate(content or ""):
+        if char != "@":
+            continue
+        if start and (
+            content[start - 1] == "@" or _is_mention_continuation(content[start - 1])
+        ):
+            continue
+        for end in range(start + 2, len(content) + 1):
+            normalized_candidate = content[start:end].casefold()
+            if len(normalized_candidate) > len(normalized_target):
+                break
+            if normalized_candidate != normalized_target:
+                continue
+            if end < len(content) and _is_mention_continuation(content[end]):
+                continue
+            spans.append((start, end))
+            break
+    return spans
+
+
+def unresolved_mention_fallback(
+    content: str,
+    error: str,
+    protected_mentions: Optional[Set[str]] = None,
+) -> Optional[str]:
+    """Neutralize only the mention marker rejected by Buzz."""
+    error = error or ""
+    protected_mentions = protected_mentions or set()
+    match = _MEMBER_MENTION_ERROR.search(error)
+    if match:
+        mention = match.group(1)
+        if mention.casefold() in protected_mentions:
+            return None
+        spans = _complete_mention_spans(content or "", mention)
+        if not spans:
+            return None
+        pieces = []
+        cursor = 0
+        for start, end in spans:
+            pieces.extend((content[cursor:start], content[start + 1 : end]))
+            cursor = end
+        pieces.append(content[cursor:])
+        fallback = "".join(pieces)
+    elif _MAX_MENTIONS_ERROR in error.lower() and not protected_mentions:
+        fallback = _OUTBOUND_MENTION_MARKER.sub("", content or "")
+    else:
+        return None
+    return fallback if fallback != content else None
+
+
+def buzz_event_thread_root(event: dict) -> Optional[str]:
+    """Return the NIP-10 root, falling back to the direct reply target."""
+
+    tags = event.get("tags")
+    if not isinstance(tags, list):
+        return None
+    root = None
+    reply = None
+    unmarked = []
+    for tag in tags:
+        if not isinstance(tag, list) or len(tag) < 2 or tag[0] != "e":
+            continue
+        target = str(tag[1] or "").strip()
+        if not target:
+            continue
+        marker = str(tag[3] or "") if len(tag) > 3 else ""
+        if marker == "root":
+            root = target
+        elif marker == "reply":
+            reply = target
+        elif marker == "":
+            unmarked.append(target)
+    # Legacy positional NIP-10: first unmarked e tag is the stable root and,
+    # when two or more exist, the last is the direct reply target.
+    return root or (unmarked[0] if unmarked else None) or reply
 
 _DEFAULT_POLL_INTERVAL = 4.0
 _MIN_POLL_INTERVAL = 1.0
@@ -105,6 +251,7 @@ _CLI_TIMEOUT = 30.0
 _WS_AUTH_TIMEOUT = 20.0
 _WS_MAX_MESSAGE_BYTES = 2_000_000
 _WS_MEMBERSHIP_KIND = 44100
+_WS_MEMBERSHIP_REMOVED_KIND = 44101
 _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
 
 # Where to look for a credentials JSON (keys: nsec / private_key_hex) when
@@ -223,6 +370,29 @@ def _normalize_user_ref(ref: str) -> Optional[str]:
     if re.fullmatch(r"[0-9a-f]{64}", ref):
         return ref
     return None
+
+
+def _parse_outbound_mention_pubkeys(value) -> Dict[str, Tuple[str, str]]:
+    if value in (None, ""):
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError("Buzz outbound_mention_pubkeys must be a mapping")
+    parsed = {}
+    for raw_name, raw_pubkey in value.items():
+        name = str(raw_name or "").strip().lstrip("@").strip()
+        pubkey = _normalize_user_ref(str(raw_pubkey or ""))
+        if not name or not pubkey:
+            raise ValueError(
+                "Buzz outbound_mention_pubkeys entries require a display name "
+                "and a valid hex or npub identity"
+            )
+        normalized_name = name.casefold()
+        if normalized_name in parsed:
+            raise ValueError(
+                "Buzz outbound_mention_pubkeys contains a duplicate display name"
+            )
+        parsed[normalized_name] = (name, pubkey)
+    return parsed
 
 
 # ---------------------------------------------------------------------------
@@ -344,6 +514,17 @@ def _parse_json_list(stdout: str) -> List[dict]:
     return [item for item in data if isinstance(item, dict)]
 
 
+def _is_valid_authoritative_channel_row(channel: object) -> bool:
+    """Validate required fields before an authoritative roster is applied."""
+    return bool(
+        isinstance(channel, dict)
+        and isinstance(channel.get("channel_id"), str)
+        and channel["channel_id"].strip()
+        and isinstance(channel.get("type"), str)
+        and channel["type"].strip()
+    )
+
+
 # ---------------------------------------------------------------------------
 # Buzz Adapter
 # ---------------------------------------------------------------------------
@@ -360,6 +541,9 @@ class BuzzAdapter(BasePlatformAdapter):
 
         extra = getattr(config, "extra", {}) or {}
         self._extra = extra
+        self.outbound_mention_pubkeys = _parse_outbound_mention_pubkeys(
+            extra.get("outbound_mention_pubkeys")
+        )
 
         # Connection settings (env vars override config.yaml)
         self.relay_url = (os.getenv("BUZZ_RELAY_URL") or extra.get("relay_url", "")).strip()
@@ -430,6 +614,7 @@ class BuzzAdapter(BasePlatformAdapter):
         self._lock_key: Optional[str] = None
         # channel_id -> {"chat_type", "last_ts", "seen": OrderedDict[event_id, None]}
         self._channel_state: Dict[str, dict] = {}
+        self._joined_channel_ids: Set[str] = set()
         self._channel_names: Dict[str, str] = {}
         # channel_id -> raw ``channels list`` entry; drives DM-vs-channel
         # classification (see _may_reclassify_as_dm).
@@ -477,16 +662,56 @@ class BuzzAdapter(BasePlatformAdapter):
         code, out, err = await self._run_cli(["users", "get"])
         if code != 0:
             message = _cli_error_message(err, code)
+            retryable = _cli_failure_is_retryable(err, code)
             logger.error("Buzz: failed to fetch own profile from %s — %s", self.relay_url, message)
-            self._set_fatal_error("connect_failed", message, retryable=code == 2)
+            self._set_fatal_error(
+                "network_error" if retryable else "connect_failed",
+                message,
+                retryable=retryable,
+            )
             return False
-        profiles = _parse_json_list(out)
-        if not profiles or not profiles[0].get("pubkey"):
+        if not out.strip():
+            raw_profiles = []
+        else:
+            try:
+                raw_profiles = json.loads(out)
+            except (json.JSONDecodeError, TypeError):
+                raw_profiles = None
+        if not isinstance(raw_profiles, list):
+            logger.error("Buzz: 'users get' returned a malformed profile payload")
+            self._set_fatal_error(
+                "connect_failed",
+                "buzz users get returned malformed profile payload",
+                retryable=False,
+            )
+            return False
+        if not raw_profiles:
             logger.error("Buzz: 'users get' returned no profile — is the key a member of this community?")
-            self._set_fatal_error("connect_failed", "buzz users get returned no profile", retryable=True)
+            self._set_fatal_error(
+                "connect_failed", "buzz users get returned no profile", retryable=True
+            )
             return False
-        self._self_pubkey = str(profiles[0]["pubkey"]).lower()
-        self._display_name = str(profiles[0].get("display_name") or "").strip()
+        if not all(isinstance(item, dict) for item in raw_profiles):
+            logger.error("Buzz: 'users get' returned a malformed profile object")
+            self._set_fatal_error(
+                "connect_failed",
+                "buzz users get returned malformed profile object",
+                retryable=False,
+            )
+            return False
+        profile = raw_profiles[0]
+        raw_pubkey = profile.get("pubkey")
+        pubkey = raw_pubkey.strip().lower() if isinstance(raw_pubkey, str) else ""
+        if not re.fullmatch(r"[0-9a-f]{64}", pubkey):
+            logger.error("Buzz: 'users get' returned an incomplete profile object")
+            self._set_fatal_error(
+                "connect_failed",
+                "buzz users get returned incomplete profile object",
+                retryable=False,
+            )
+            return False
+        self._self_pubkey = pubkey
+        self._display_name = str(profile.get("display_name") or "").strip()
         self._self_npub = hex_to_npub(self._self_pubkey) or ""
 
         # Prevent two profiles from driving the same Buzz identity on the
@@ -496,7 +721,8 @@ class BuzzAdapter(BasePlatformAdapter):
             from gateway.status import acquire_scoped_lock
 
             lock_key = f"{self.relay_url}:{self._self_pubkey}"
-            if not acquire_scoped_lock("buzz", lock_key):
+            acquired, _existing = acquire_scoped_lock("buzz", lock_key)
+            if not acquired:
                 logger.error(
                     "Buzz: identity %s… on %s already in use by another profile",
                     self._self_pubkey[:8],
@@ -510,33 +736,82 @@ class BuzzAdapter(BasePlatformAdapter):
         except ImportError:
             self._lock_key = None  # status module not available (e.g. tests)
 
-        # Map channel ids to names and pick the watch set.
-        code, out, err = await self._run_cli(["channels", "list"])
+        connected = False
+        try:
+            connected = await self._connect_after_identity_lock()
+            return connected
+        finally:
+            if not connected:
+                await self.disconnect()
+
+    async def _connect_after_identity_lock(self) -> bool:
+        """Finish setup while the caller owns the scoped identity lock."""
+
+        # Fetch the authoritative joined-channel roster and apply any explicit
+        # configured restriction before seeding history.
+        code, out, err = await self._run_cli(["channels", "list", "--member"])
         if code != 0:
             message = _cli_error_message(err, code)
-            logger.error("Buzz: failed to list channels — %s", message)
-            self._set_fatal_error("connect_failed", message, retryable=code == 2)
+            retryable = _cli_failure_is_retryable(err, code)
+            logger.error("Buzz: failed to list joined channels — %s", message)
+            self._set_fatal_error(
+                "network_error" if retryable else "connect_failed",
+                message,
+                retryable=retryable,
+            )
+            self._release_identity_lock()
             return False
-        listed = _parse_json_list(out)
-        self._channel_names = {
-            str(ch.get("channel_id")): str(ch.get("name") or ch.get("channel_id"))
-            for ch in listed
-            if ch.get("channel_id")
+        try:
+            listed = json.loads(out)
+        except (json.JSONDecodeError, TypeError):
+            listed = None
+        if not isinstance(listed, list) or not all(
+            _is_valid_authoritative_channel_row(channel) for channel in listed
+        ):
+            logger.error("Buzz: joined-channel query returned a malformed payload")
+            self._set_fatal_error(
+                "connect_failed",
+                "buzz channels list returned malformed joined-channel payload",
+                retryable=False,
+            )
+            self._release_identity_lock()
+            return False
+        configured_ids = set(self.channels)
+        joined = [
+            channel
+            for channel in listed
+            if channel.get("channel_id")
+            and (
+                not configured_ids
+                or str(channel.get("channel_id")) in configured_ids
+            )
+        ]
+        self._joined_channel_ids = {
+            str(channel["channel_id"]) for channel in joined
         }
-        for ch in listed:
-            if ch.get("channel_id"):
-                self._channel_meta[str(ch["channel_id"])] = ch
-        watch = self.channels or list(self._channel_names)
-        if not watch:
-            logger.error("Buzz: no channels to watch (configure BUZZ_CHANNELS or join a channel)")
-            self._set_fatal_error("config_missing", "no Buzz channels to watch", retryable=False)
-            return False
-
+        self._channel_names = {
+            str(channel["channel_id"]): str(
+                channel.get("name") or channel["channel_id"]
+            )
+            for channel in joined
+        }
+        self._channel_meta = {
+            str(channel["channel_id"]): channel for channel in joined
+        }
         # Seed high-water marks from the newest events so a (re)start never
         # replays channel history into the agent.
-        for channel_id in watch:
+        for channel_id in self._joined_channel_ids:
             await self._seed_channel(channel_id, chat_type="group")
         await self._discover_dms(seed=True)
+
+        if not self._channel_state:
+            logger.error("Buzz: no joined channels or direct messages are available")
+            self._set_fatal_error(
+                "config_missing",
+                "no joined Buzz channels or direct messages to watch",
+                retryable=False,
+            )
+            return False
 
         # Inbound transport: prefer the NIP-42-authenticated WebSocket
         # subscription (push, near-zero latency); fall back to CLI polling
@@ -570,15 +845,7 @@ class BuzzAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Stop the inbound transport and drop runtime state."""
         self._mark_disconnected()
-        lock_key = getattr(self, "_lock_key", None)
-        if lock_key:
-            try:
-                from gateway.status import release_scoped_lock
-
-                release_scoped_lock("buzz", lock_key)
-            except Exception:
-                pass
-            self._lock_key = None
+        self._release_identity_lock()
         self._ws_active = False
         if self._ws_task and not self._ws_task.done():
             self._ws_task.cancel()
@@ -597,6 +864,18 @@ class BuzzAdapter(BasePlatformAdapter):
         self._channel_state = {}
         self._poll_count = 0
 
+    def _release_identity_lock(self) -> None:
+        """Release the scoped Buzz identity lock when this adapter owns it."""
+        lock_key = getattr(self, "_lock_key", None)
+        if lock_key:
+            try:
+                from gateway.status import release_scoped_lock
+
+                release_scoped_lock("buzz", lock_key)
+            except Exception:
+                pass
+            self._lock_key = None
+
     # ── Sending ───────────────────────────────────────────────────────────
 
     async def send(
@@ -609,15 +888,43 @@ class BuzzAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
+        configured_mentions = [
+            (name, pubkey)
+            for name, pubkey in self.outbound_mention_pubkeys.values()
+            if _complete_mention_spans(content or "", name)
+        ]
+        for _name, pubkey in configured_mentions:
+            args += ["--mention", pubkey]
+        protected_mentions = {
+            f"@{name}".casefold() for name, _pubkey in configured_mentions
+        }
         reply_target = reply_to or (metadata or {}).get("thread_id")
+        state = self._channel_state.get(str(chat_id))
+        if reply_target and state is not None:
+            reply_target = self._resolve_thread_root(state, str(reply_target))
         if reply_target:
             args += ["--reply-to", str(reply_target)]
-        code, out, err = await self._run_cli(args, input_text=content)
+        send_content = content
+        code, out, err = await self._run_cli(args, input_text=send_content)
+        for _ in range(_MENTION_FALLBACK_MAX_RETRIES):
+            fallback = (
+                unresolved_mention_fallback(
+                    send_content,
+                    err,
+                    protected_mentions,
+                )
+                if code != 0
+                else None
+            )
+            if fallback is None:
+                break
+            send_content = fallback
+            code, out, err = await self._run_cli(args, input_text=send_content)
         if code != 0:
             return SendResult(
                 success=False,
                 error=_cli_error_message(err, code),
-                retryable=code == 2,
+                retryable=_cli_failure_is_retryable(err, code),
             )
         try:
             data = json.loads(out or "{}")
@@ -628,6 +935,8 @@ class BuzzAdapter(BasePlatformAdapter):
             # Belt-and-braces echo suppression: the poll loop already skips
             # our own pubkey, but marking the id seen makes de-dupe explicit.
             self._mark_seen(str(chat_id), str(event_id))
+            if state is not None and reply_target:
+                self._remember_thread_root(state, str(event_id), str(reply_target))
         return SendResult(
             success=bool(data.get("accepted", True)),
             message_id=str(event_id) if event_id else None,
@@ -681,11 +990,42 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--file", str(local),
                 "--content", "-",
             ]
-            if reply_to:
-                args += ["--reply-to", str(reply_to)]
-            code, out, err = await self._run_cli(args, input_text=caption or "")
+            configured_mentions = [
+                (name, pubkey)
+                for name, pubkey in self.outbound_mention_pubkeys.values()
+                if _complete_mention_spans(caption or "", name)
+            ]
+            for _name, pubkey in configured_mentions:
+                args += ["--mention", pubkey]
+            protected_mentions = {
+                f"@{name}".casefold() for name, _pubkey in configured_mentions
+            }
+            reply_target = reply_to or (metadata or {}).get("thread_id")
+            state = self._channel_state.get(str(chat_id))
+            if reply_target and state is not None:
+                reply_target = self._resolve_thread_root(state, str(reply_target))
+            if reply_target:
+                args += ["--reply-to", str(reply_target)]
+            send_caption = caption or ""
+            code, out, err = await self._run_cli(args, input_text=send_caption)
+            for _ in range(_MENTION_FALLBACK_MAX_RETRIES):
+                fallback = (
+                    unresolved_mention_fallback(
+                        send_caption, err, protected_mentions
+                    )
+                    if code != 0 and send_caption
+                    else None
+                )
+                if fallback is None:
+                    break
+                send_caption = fallback
+                code, out, err = await self._run_cli(args, input_text=send_caption)
             if code != 0:
-                return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
+                return SendResult(
+                    success=False,
+                    error=_cli_error_message(err, code),
+                    retryable=_cli_failure_is_retryable(err, code),
+                )
             try:
                 data = json.loads(out or "{}")
             except ValueError:
@@ -693,6 +1033,8 @@ class BuzzAdapter(BasePlatformAdapter):
             event_id = data.get("event_id")
             if event_id:
                 self._mark_seen(str(chat_id), str(event_id))
+                if state is not None and reply_target:
+                    self._remember_thread_root(state, str(event_id), str(reply_target))
             return SendResult(
                 success=bool(data.get("accepted", True)),
                 message_id=str(event_id) if event_id else None,
@@ -701,6 +1043,35 @@ class BuzzAdapter(BasePlatformAdapter):
         # Markdown renders in Buzz, so a URL arrives as a clickable image link.
         text = f"{caption}\n{image_url}" if caption else image_url
         return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **_kwargs,
+    ) -> SendResult:
+        """Send a local image through Buzz's native attachment path."""
+
+        local = Path(image_path).expanduser()
+        if not local.is_file():
+            notice = "⚠️ Couldn't deliver the image attachment."
+            content = f"{caption}\n{notice}" if caption else notice
+            return await self.send(
+                chat_id,
+                content,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+        return await self.send_image(
+            chat_id,
+            str(local),
+            caption=caption,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         chat_id = str(chat_id)
@@ -813,7 +1184,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 "REQ",
                 _WS_MEMBERSHIP_SUB_ID,
                 {
-                    "kinds": [_WS_MEMBERSHIP_KIND],
+                    "kinds": [_WS_MEMBERSHIP_KIND, _WS_MEMBERSHIP_REMOVED_KIND],
                     "#p": [self._self_pubkey],
                     "since": max(self._membership_since - 1, 0),
                 },
@@ -823,18 +1194,47 @@ class BuzzAdapter(BasePlatformAdapter):
         return subscriptions
 
     async def _handle_membership_event(self, websocket, subscriptions: Dict[str, Optional[str]], event: dict) -> None:
-        """A membership event p-tagged to us: rediscover conversations and
-        subscribe to any new ones (fresh DMs dispatch from their beginning)."""
-        self._membership_since = max(self._membership_since, int(event.get("created_at") or 0))
+        """Reconcile live subscriptions from the authoritative joined roster."""
+        created_at = int(event.get("created_at") or 0)
+        self._membership_since = max(self._membership_since, created_at)
+        target_channel_id = ""
+        for tag in event.get("tags") or []:
+            if isinstance(tag, list) and len(tag) > 1 and tag[0] == "h":
+                target_channel_id = str(tag[1] or "")
+                break
         before = set(self._channel_state)
+        await self._discover_joined_channels(
+            since=created_at,
+            target_channel_id=target_channel_id,
+        )
+        for subscription_id, channel_id in list(subscriptions.items()):
+            if channel_id is not None and channel_id not in self._channel_state:
+                await websocket.send(
+                    json.dumps(["CLOSE", subscription_id], separators=(",", ":"))
+                )
+                subscriptions.pop(subscription_id, None)
+
+        async def subscribe_discovered() -> None:
+            for channel_id in self._channel_state:
+                if channel_id in before:
+                    continue
+                subscription_index = len(subscriptions)
+                subscription_id = f"hermes-buzz-{subscription_index}"
+                while subscription_id in subscriptions:
+                    subscription_index += 1
+                    subscription_id = f"hermes-buzz-{subscription_index}"
+                subscriptions[subscription_id] = channel_id
+                await self._send_channel_subscription(
+                    websocket,
+                    subscription_id,
+                    channel_id,
+                )
+                before.add(channel_id)
+                logger.info("Buzz: subscribed to new conversation %s", channel_id)
+
+        await subscribe_discovered()
         await self._discover_dms(seed=False)
-        for channel_id in self._channel_state:
-            if channel_id in before:
-                continue
-            subscription_id = f"hermes-buzz-dm-{len(subscriptions)}"
-            subscriptions[subscription_id] = channel_id
-            await self._send_channel_subscription(websocket, subscription_id, channel_id)
-            logger.info("Buzz: subscribed to new conversation %s", channel_id)
+        await subscribe_discovered()
 
     async def _websocket_loop(self) -> None:
         """Persistent authenticated subscription with bounded reconnect
@@ -907,7 +1307,10 @@ class BuzzAdapter(BasePlatformAdapter):
                 await asyncio.sleep(self.poll_interval)
                 self._poll_count += 1
                 try:
-                    if self._poll_count % _DM_DISCOVERY_EVERY == 0:
+                    if self._poll_count % _CHANNEL_DISCOVERY_EVERY == 0:
+                        await self._discover_joined_channels()
+                        await self._discover_dms(seed=False)
+                    elif self._poll_count % _DM_DISCOVERY_EVERY == 0:
                         await self._discover_dms(seed=False)
                     for channel_id in list(self._channel_state):
                         await self._poll_channel(channel_id)
@@ -917,6 +1320,67 @@ class BuzzAdapter(BasePlatformAdapter):
                     logger.warning("Buzz: poll sweep failed", exc_info=True)
         except asyncio.CancelledError:
             raise
+
+    async def _discover_joined_channels(
+        self,
+        *,
+        since: int = 0,
+        target_channel_id: str = "",
+    ) -> Optional[bool]:
+        code, out, _err = await self._run_cli(["channels", "list", "--member"])
+        if code != 0:
+            return None
+        try:
+            channels = json.loads(out)
+        except (TypeError, ValueError):
+            return None
+        if not isinstance(channels, list) or not all(
+            _is_valid_authoritative_channel_row(channel) for channel in channels
+        ):
+            return None
+        listed_ids = {
+            str(channel.get("channel_id") or "") for channel in channels
+        }
+        listed_ids.discard("")
+        configured_ids = set(self.channels)
+        joined_ids = listed_ids & configured_ids if configured_ids else listed_ids
+        before = set(self._joined_channel_ids)
+        if (
+            target_channel_id
+            and target_channel_id not in joined_ids
+            and target_channel_id not in self._channel_state
+        ):
+            return None
+        self._joined_channel_ids = joined_ids
+        changed = False
+        for watched_channel_id, state in list(self._channel_state.items()):
+            if (
+                state.get("chat_type") == "group"
+                and watched_channel_id not in joined_ids
+                and not self._may_reclassify_as_dm(watched_channel_id)
+            ):
+                self._channel_state.pop(watched_channel_id, None)
+                self._channel_names.pop(watched_channel_id, None)
+                self._channel_meta.pop(watched_channel_id, None)
+                changed = True
+        for channel in channels:
+            channel_id = str(channel.get("channel_id") or "")
+            if not channel_id or channel_id not in joined_ids:
+                continue
+            self._channel_names[channel_id] = str(channel.get("name") or channel_id)
+            self._channel_meta[channel_id] = channel
+            if channel_id in self._channel_state:
+                continue
+            if target_channel_id and channel_id == target_channel_id and since > 0:
+                self._channel_state[channel_id] = {
+                    "chat_type": "group",
+                    "last_ts": int(since),
+                    "seen": OrderedDict(),
+                }
+            else:
+                await self._seed_channel(channel_id, chat_type="group")
+            changed = True
+        return changed or joined_ids != before
 
     async def _seed_channel(self, channel_id: str, chat_type: str) -> None:
         """Initialize a channel's high-water mark from its newest events."""
@@ -943,6 +1407,7 @@ class BuzzAdapter(BasePlatformAdapter):
             # leaked in via ``channels list`` latches to chat_type="dm" here,
             # so it bypasses the mention gate from the very first poll.
             self._maybe_latch_dm(channel_id, state, event)
+            self._remember_event_thread_root(state, event)
         self._trim_seen(state)
 
     async def _discover_dms(self, *, seed: bool) -> None:
@@ -1021,6 +1486,8 @@ class BuzzAdapter(BasePlatformAdapter):
         if not pubkey or not isinstance(content, str) or not content.strip():
             return
 
+        self._remember_event_thread_root(state, event)
+
         # Suppress self-echo: never dispatch our own messages back to the agent.
         if pubkey == self._self_pubkey:
             return
@@ -1056,6 +1523,7 @@ class BuzzAdapter(BasePlatformAdapter):
             user_name=await self._resolve_user_name(pubkey),
             message_id=event_id,
             created_at=created_at,
+            thread_id=buzz_event_thread_root(event),
         )
 
     # ── DM classification (issue #68871) ──────────────────────────────────
@@ -1092,6 +1560,8 @@ class BuzzAdapter(BasePlatformAdapter):
         p-tags us.  A conversation with no metadata at all is trusted only
         when the user did not explicitly configure it as a watched channel.
         """
+        if channel_id in self._joined_channel_ids:
+            return False
         meta = self._channel_meta.get(channel_id)
         if meta is None:
             return channel_id not in self.channels
@@ -1144,7 +1614,7 @@ class BuzzAdapter(BasePlatformAdapter):
         if self._self_npub and self._self_npub in lowered:
             return True
         if self._display_name:
-            pattern = rf"(?<!\w)@?{re.escape(self._display_name.lower())}(?!\w)"
+            pattern = rf"(?<!\w)@{re.escape(self._display_name.lower())}(?!\w)"
             if re.search(pattern, lowered):
                 return True
         return False
@@ -1204,11 +1674,181 @@ class BuzzAdapter(BasePlatformAdapter):
         while len(seen) > _SEEN_CAP:
             seen.popitem(last=False)
 
+    @staticmethod
+    def _remember_thread_root(state: dict, event_id: str, reply_target: str) -> None:
+        if not event_id or not reply_target:
+            return
+        roots = state.setdefault("thread_roots", OrderedDict())
+        root = str(reply_target)
+        visited = set()
+        while root in roots and root not in visited:
+            visited.add(root)
+            root = str(roots[root])
+        roots[str(event_id)] = root
+        roots.move_to_end(str(event_id))
+        while len(roots) > _SEEN_CAP:
+            roots.popitem(last=False)
+
+    @staticmethod
+    def _resolve_thread_root(state: dict, event_id: str) -> str:
+        roots = state.get("thread_roots", {})
+        root = str(event_id)
+        visited = set()
+        while root in roots and root not in visited:
+            visited.add(root)
+            root = str(roots[root])
+        return root
+
+    def _remember_event_thread_root(self, state: dict, event: dict) -> None:
+        self._remember_thread_root(
+            state,
+            str(event.get("id") or ""),
+            buzz_event_thread_root(event) or "",
+        )
+
     def _mark_seen(self, channel_id: str, event_id: str) -> None:
         state = self._channel_state.get(channel_id)
         if state is not None:
             state["seen"][event_id] = None
             self._trim_seen(state)
+
+    def _media_sender_authorized(self, user_id: str) -> bool:
+        allow_all = str(
+            os.getenv("BUZZ_ALLOW_ALL_USERS")
+            or self._extra.get("allow_all_users", "")
+        ).lower() in {"true", "1", "yes"}
+        if allow_all:
+            return True
+        return bool(self._allowed_pubkeys and user_id in self._allowed_pubkeys)
+
+    def _buzz_image_metadata(self, url: str) -> Optional[Tuple[str, str, str]]:
+        relay = urlsplit(self.relay_url)
+        candidate = urlsplit(url)
+        relay_scheme = {"ws": "http", "wss": "https"}.get(
+            relay.scheme.lower(), relay.scheme.lower()
+        )
+        if (
+            candidate.scheme.lower() != relay_scheme
+            or candidate.netloc.lower() != relay.netloc.lower()
+            or candidate.username is not None
+            or candidate.password is not None
+            or candidate.query
+            or candidate.fragment
+        ):
+            return None
+        match = _BUZZ_MEDIA_IMAGE_PATH_RE.fullmatch(candidate.path)
+        if match is None:
+            return None
+        digest, extension = match.groups()
+        extension = extension.lower()
+        return digest.lower(), f".{extension}", _BUZZ_IMAGE_MIME[extension]
+
+    @staticmethod
+    def _buzz_image_removal_span(
+        text: str, span: Tuple[int, int]
+    ) -> Tuple[int, int]:
+        start, end = span
+        line_start = text.rfind("\n", 0, start) + 1
+        line_end = text.find("\n", end)
+        if line_end < 0:
+            line_end = len(text)
+        if text[line_start:start].strip() or text[end:line_end].strip():
+            return span
+        if line_end < len(text):
+            return line_start, line_end + 1
+        if line_start > 0:
+            return line_start - 1, line_end
+        return line_start, line_end
+
+    async def _ingest_buzz_images(
+        self, text: str
+    ) -> Tuple[str, List[str], List[str]]:
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        consumed_spans: List[Tuple[int, int]] = []
+        download_attempts = 0
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _BUZZ_MEDIA_TOTAL_TIMEOUT
+        for match in _BUZZ_MARKDOWN_IMAGE_RE.finditer(text):
+            if loop.time() >= deadline:
+                logger.warning("Buzz: inbound image deadline exhausted")
+                break
+            url = match.group(1)
+            metadata = self._buzz_image_metadata(url)
+            if metadata is None:
+                continue
+            if download_attempts >= _MAX_BUZZ_IMAGES_PER_MESSAGE:
+                break
+            download_attempts += 1
+            expected_digest, extension, mime = metadata
+            fd, temporary_path = tempfile.mkstemp(
+                prefix="hermes_buzz_media_", suffix=extension
+            )
+            os.close(fd)
+            cached_path: Optional[str] = None
+            try:
+                code = 4
+                error_text = ""
+                for delay in (0, *_BUZZ_MEDIA_RETRY_DELAYS):
+                    remaining = deadline - loop.time()
+                    if remaining <= 0:
+                        raise TimeoutError
+                    if delay:
+                        await asyncio.wait_for(asyncio.sleep(delay), timeout=remaining)
+                    remaining = deadline - loop.time()
+                    if remaining <= 0:
+                        raise TimeoutError
+                    code, _out, error_text = await asyncio.wait_for(
+                        self._run_cli(
+                            ["media", "get", url, "--output", temporary_path]
+                        ),
+                        timeout=remaining,
+                    )
+                    if code == 0 or not _cli_failure_is_retryable(error_text, code):
+                        break
+                if code != 0:
+                    logger.warning("Buzz: authenticated inbound image download failed")
+                    continue
+                path = Path(temporary_path)
+                validate_inbound_media_size(path.stat().st_size, media_type="image")
+                data = path.read_bytes()
+                if hashlib.sha256(data).hexdigest() != expected_digest:
+                    logger.warning("Buzz: inbound image hash did not match media URL")
+                    continue
+                family = _detected_image_family(data)
+                expected_family = extension.lstrip(".").lower()
+                if expected_family == "jpg":
+                    expected_family = "jpeg"
+                if family != expected_family:
+                    logger.warning("Buzz: inbound image content did not match URL extension")
+                    continue
+                cached_path = cache_image_from_bytes(data, ext=extension)
+                os.chmod(cached_path, 0o600)
+                media_urls.append(cached_path)
+                media_types.append(mime)
+                consumed_spans.append(
+                    self._buzz_image_removal_span(text, match.span())
+                )
+            except TimeoutError:
+                logger.warning("Buzz: inbound image deadline exhausted")
+            except (OSError, ValueError) as exc:
+                logger.warning(
+                    "Buzz: could not cache authenticated inbound image (%s)",
+                    type(exc).__name__,
+                )
+            finally:
+                if cached_path and cached_path not in media_urls:
+                    try:
+                        Path(cached_path).unlink()
+                    except OSError:
+                        pass
+                try:
+                    Path(temporary_path).unlink()
+                except OSError:
+                    pass
+        for start, end in reversed(sorted(consumed_spans)):
+            text = text[:start] + text[end:]
+        return text, media_urls, media_types
 
     async def _dispatch_message(
         self,
@@ -1219,6 +1859,7 @@ class BuzzAdapter(BasePlatformAdapter):
         user_name: str,
         message_id: str,
         created_at: int,
+        thread_id: str | None = None,
     ) -> None:
         """Build a MessageEvent and hand it to the base class handler."""
         if not self._message_handler:
@@ -1230,13 +1871,21 @@ class BuzzAdapter(BasePlatformAdapter):
             chat_type=chat_type,
             user_id=user_id,
             user_name=user_name,
+            thread_id=thread_id or (message_id if chat_type != "dm" else None),
         )
+        dispatch_text = text
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        if not getattr(source, "profile_route_rejected", False) and self._media_sender_authorized(user_id):
+            dispatch_text, media_urls, media_types = await self._ingest_buzz_images(text)
 
         event = MessageEvent(
-            text=text,
-            message_type=MessageType.TEXT,
+            text=dispatch_text,
+            message_type=MessageType.PHOTO if media_urls else MessageType.TEXT,
             source=source,
             message_id=message_id,
+            media_urls=media_urls,
+            media_types=media_types,
             timestamp=datetime.fromtimestamp(created_at) if created_at else datetime.now(),
         )
 
@@ -1385,15 +2034,56 @@ async def _standalone_send(
     if not target:
         return {"error": "Buzz standalone send: no target channel (set BUZZ_HOME_CHANNEL)"}
 
+    try:
+        outbound_mentions = _parse_outbound_mention_pubkeys(
+            extra.get("outbound_mention_pubkeys")
+        )
+    except ValueError:
+        return {"error": "Buzz standalone send: invalid outbound_mention_pubkeys"}
+    configured_mentions = [
+        (name, pubkey)
+        for name, pubkey in outbound_mentions.values()
+        if _complete_mention_spans(message or "", name)
+    ]
+    protected_mentions = {
+        f"@{name}".casefold() for name, _pubkey in configured_mentions
+    }
     args = ["messages", "send", "--channel", target, "--content", "-"]
+    for _name, pubkey in configured_mentions:
+        args += ["--mention", pubkey]
     if thread_id:
         args += ["--reply-to", str(thread_id)]
     for path in media_files or []:
         args += ["--file", str(path)]
+    send_content = message
     try:
         code, out, err = await _exec_buzz(
-            cli_path, args, relay_url=relay, private_key=private_key, input_text=message
+            cli_path,
+            args,
+            relay_url=relay,
+            private_key=private_key,
+            input_text=send_content,
         )
+        for _ in range(_MENTION_FALLBACK_MAX_RETRIES):
+            fallback = (
+                unresolved_mention_fallback(
+                    send_content,
+                    err,
+                    protected_mentions,
+                )
+                if code != 0
+                else None
+            )
+            if fallback is None:
+                break
+            send_content = fallback
+            code, out, err = await _exec_buzz(
+                cli_path,
+                args,
+                relay_url=relay,
+                private_key=private_key,
+                input_text=send_content,
+            )
     except asyncio.CancelledError:
         raise
     except OSError as e:
@@ -1523,6 +2213,9 @@ def register(ctx):
             "You are collaborating in a Buzz workspace (Block's Nostr-based "
             "human+agent platform). Markdown IS supported. Users address you "
             "by @-mentioning your name or npub in channels; direct messages "
-            "reach you without a mention. Keep responses conversational."
+            "reach you without a mention. Keep responses conversational. "
+            "You can send local images natively. When the user supplies the path "
+            "to an existing local image, respond with MEDIA:/absolute/path to that "
+            "image directly; do not use Computer Use or open a UI."
         ),
     )

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -1,7 +1,11 @@
 """Tests for the Buzz platform adapter plugin."""
 
 import asyncio
+import hashlib
 import json
+import stat
+from collections import OrderedDict
+from pathlib import Path
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
@@ -113,6 +117,297 @@ class TestBech32Helpers:
         assert npub_to_hex(SELF_NPUB) == SELF_PUBKEY
 
 
+    def test_unresolved_mention_fallback_uses_unicode_casefold_boundaries(self):
+        fallback = getattr(_buzz_mod, "unresolved_mention_fallback", None)
+        assert callable(fallback)
+        assert fallback(
+            "Ask @Straße now, not bob@example.com.",
+            "mention '@STRASSE' is ambiguous",
+        ) == "Ask Straße now, not bob@example.com."
+
+
+@pytest.mark.asyncio
+async def test_joined_channel_discovery_adds_and_seeds_authoritative_membership():
+    adapter = _make_adapter()
+    cli = _ScriptedCli()
+    cli.script(
+        "channels",
+        "list",
+        [
+            {
+                "channel_id": "joined-channel",
+                "type": "community",
+                "name": "Project",
+            }
+        ],
+    )
+    cli.script(
+        "messages",
+        "get",
+        [
+            {
+                "id": "historical-event",
+                "kind": 9,
+                "pubkey": OTHER_PUBKEY,
+                "content": "old",
+                "created_at": 41,
+                "tags": [],
+            }
+        ],
+    )
+    adapter._run_cli = cli
+
+    changed = await adapter._discover_joined_channels()
+
+    assert changed is True
+    assert adapter._joined_channel_ids == {"joined-channel"}
+    assert adapter._channel_state["joined-channel"]["last_ts"] == 41
+    assert "historical-event" in adapter._channel_state["joined-channel"]["seen"]
+    assert cli.calls[0][0] == ["channels", "list", "--member"]
+
+
+@pytest.mark.asyncio
+async def test_joined_channel_discovery_removes_departed_group():
+    adapter = _make_adapter()
+    adapter._joined_channel_ids = {"kept-channel", "departed-channel"}
+    adapter._channel_state = {
+        "kept-channel": {"chat_type": "group", "last_ts": 1, "seen": OrderedDict()},
+        "departed-channel": {"chat_type": "group", "last_ts": 1, "seen": OrderedDict()},
+    }
+    adapter._channel_names = {
+        "kept-channel": "Kept",
+        "departed-channel": "Departed",
+    }
+    adapter._channel_meta = {
+        "kept-channel": {"channel_id": "kept-channel", "name": "Kept"},
+        "departed-channel": {"channel_id": "departed-channel", "name": "Departed"},
+    }
+    cli = _ScriptedCli()
+    cli.script(
+        "channels",
+        "list",
+        [{"channel_id": "kept-channel", "type": "community", "name": "Kept"}],
+    )
+    adapter._run_cli = cli
+
+    changed = await adapter._discover_joined_channels()
+
+    assert changed is True
+    assert set(adapter._channel_state) == {"kept-channel"}
+    assert "departed-channel" not in adapter._channel_names
+    assert "departed-channel" not in adapter._channel_meta
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "malformed_roster",
+    [
+        [{"type": "community", "name": "Missing id"}],
+        [{"channel_id": "new-channel", "name": "Missing type"}],
+        [{"channel_id": "new-channel", "type": "community"}, "not-an-object"],
+    ],
+)
+async def test_malformed_joined_refresh_preserves_prior_snapshot(malformed_roster):
+    adapter = _make_adapter()
+    prior_state = {"chat_type": "group", "last_ts": 7, "seen": OrderedDict()}
+    prior_meta = {
+        "channel_id": "prior-channel",
+        "type": "community",
+        "name": "Prior",
+    }
+    adapter._joined_channel_ids = {"prior-channel"}
+    adapter._channel_state = {"prior-channel": prior_state}
+    adapter._channel_names = {"prior-channel": "Prior"}
+    adapter._channel_meta = {"prior-channel": prior_meta}
+    cli = _ScriptedCli()
+    cli.script("channels", "list", malformed_roster)
+    adapter._run_cli = cli
+
+    assert await adapter._discover_joined_channels() is None
+    assert adapter._joined_channel_ids == {"prior-channel"}
+    assert adapter._channel_state == {"prior-channel": prior_state}
+    assert adapter._channel_names == {"prior-channel": "Prior"}
+    assert adapter._channel_meta == {"prior-channel": prior_meta}
+
+
+@pytest.mark.asyncio
+async def test_valid_empty_joined_refresh_clears_prior_group_snapshot():
+    adapter = _make_adapter()
+    adapter._joined_channel_ids = {"prior-channel"}
+    adapter._channel_state = {
+        "prior-channel": {"chat_type": "group", "last_ts": 7, "seen": OrderedDict()}
+    }
+    adapter._channel_names = {"prior-channel": "Prior"}
+    adapter._channel_meta = {
+        "prior-channel": {
+            "channel_id": "prior-channel",
+            "type": "community",
+            "name": "Prior",
+        }
+    }
+    cli = _ScriptedCli()
+    cli.script("channels", "list", [])
+    adapter._run_cli = cli
+
+    assert await adapter._discover_joined_channels() is True
+    assert adapter._joined_channel_ids == set()
+    assert adapter._channel_state == {}
+    assert adapter._channel_names == {}
+    assert adapter._channel_meta == {}
+
+
+@pytest.mark.asyncio
+async def test_explicit_channels_restrict_dynamic_join_discovery():
+    adapter = _make_adapter(extra={"channels": [CHANNEL]})
+    cli = _ScriptedCli()
+    cli.script(
+        "channels",
+        "list",
+        [
+            {"channel_id": CHANNEL, "type": "community", "name": "Configured"},
+            {
+                "channel_id": "unconfigured",
+                "type": "community",
+                "name": "Other",
+            },
+        ],
+    )
+    cli.script("messages", "get", [])
+    adapter._run_cli = cli
+
+    await adapter._discover_joined_channels()
+
+    assert set(adapter._channel_state) == {CHANNEL}
+    assert adapter._joined_channel_ids == {CHANNEL}
+
+
+@pytest.mark.asyncio
+async def test_irrelevant_targeted_refresh_preserves_joined_snapshot():
+    adapter = _make_adapter()
+    adapter._joined_channel_ids = {"prior-channel"}
+    adapter._channel_state = {
+        "prior-channel": {
+            "chat_type": "group",
+            "last_ts": 1,
+            "seen": OrderedDict(),
+        }
+    }
+    adapter._channel_names = {"prior-channel": "Prior"}
+    adapter._channel_meta = {
+        "prior-channel": {
+            "channel_id": "prior-channel",
+            "type": "community",
+            "name": "Prior",
+        }
+    }
+    cli = _ScriptedCli()
+    cli.script(
+        "channels",
+        "list",
+        [{"channel_id": "other-channel", "type": "community", "name": "Other"}],
+    )
+    adapter._run_cli = cli
+
+    result = await adapter._discover_joined_channels(
+        target_channel_id="unrelated-channel"
+    )
+
+    assert result is None
+    assert adapter._joined_channel_ids == {"prior-channel"}
+    assert set(adapter._channel_state) == {"prior-channel"}
+
+
+@pytest.mark.asyncio
+async def test_explicit_channel_filter_keeps_new_dm_discovery_independent():
+    adapter = _make_adapter(extra={"channels": [CHANNEL]})
+    adapter._joined_channel_ids = {CHANNEL}
+    adapter._channel_state = {
+        CHANNEL: {"chat_type": "group", "last_ts": 1, "seen": OrderedDict()}
+    }
+    direct_dm = "direct-dm"
+    fallback_dm = "fallback-dm"
+    unconfigured_community = "unconfigured-community"
+    cli = _ScriptedCli()
+    cli.script("dms", "list", [{"dm_id": direct_dm}])
+    cli.script(
+        "channels",
+        "list",
+        [
+            {
+                "channel_id": fallback_dm,
+                "type": "community",
+                "name": "DM",
+                "description": "",
+            },
+            {
+                "channel_id": unconfigured_community,
+                "type": "community",
+                "name": "Other",
+                "description": "Community channel",
+            },
+        ],
+    )
+    adapter._run_cli = cli
+
+    await adapter._discover_dms(seed=False)
+
+    assert set(adapter._channel_state) == {CHANNEL, direct_dm, fallback_dm}
+    assert adapter._channel_state[direct_dm]["chat_type"] == "dm"
+    assert adapter._channel_state[fallback_dm]["chat_type"] == "group"
+    assert unconfigured_community not in adapter._channel_state
+
+
+@pytest.mark.asyncio
+async def test_membership_subscription_and_reconciliation_cover_add_and_remove():
+    adapter = _make_adapter()
+    adapter._self_pubkey = SELF_PUBKEY
+    adapter._channel_state = {
+        "departed": {"chat_type": "group", "last_ts": 1, "seen": OrderedDict()}
+    }
+
+    class WebSocket:
+        def __init__(self):
+            self.frames = []
+
+        async def send(self, frame):
+            self.frames.append(json.loads(frame))
+
+    websocket = WebSocket()
+    subscriptions = await adapter._subscribe_websocket(websocket)
+    membership_request = websocket.frames[-1]
+    assert membership_request[2]["kinds"] == [
+        _buzz_mod._WS_MEMBERSHIP_KIND,
+        _buzz_mod._WS_MEMBERSHIP_REMOVED_KIND,
+    ]
+
+    async def discover_joined_channels(**_kwargs):
+        adapter._channel_state.pop("departed")
+        adapter._channel_state["joined"] = {
+            "chat_type": "group",
+            "last_ts": 50,
+            "seen": OrderedDict(),
+        }
+        return True
+
+    async def discover_dms(*, seed):
+        assert "joined" in subscriptions.values()
+
+    adapter._discover_joined_channels = discover_joined_channels
+    adapter._discover_dms = discover_dms
+    websocket.frames.clear()
+
+    await adapter._handle_membership_event(
+        websocket,
+        subscriptions,
+        {"created_at": 50, "kind": 44101, "tags": [["h", "departed"]]},
+    )
+
+    assert "departed" not in subscriptions.values()
+    assert "joined" in subscriptions.values()
+    assert any(frame[:2] == ["CLOSE", "hermes-buzz-0"] for frame in websocket.frames)
+    assert any(frame[0] == "REQ" and frame[2]["#h"] == ["joined"] for frame in websocket.frames)
+
+
 # ── Adapter init / config precedence ──────────────────────────────────────
 
 
@@ -152,6 +447,770 @@ class TestCliErrorContract:
         msg = _cli_error_message('{"error":"relay_error","message":"boom","retryable":false}', 2)
         assert "relay_error" in msg and "boom" in msg and "exit 2" in msg
 
+    @pytest.mark.parametrize(
+        ("returncode", "retryable", "expected"),
+        [(1, True, True), (2, False, False)],
+    )
+    def test_structured_retryable_field_overrides_exit_code(
+        self, returncode, retryable, expected
+    ):
+        stderr = json.dumps(
+            {"error": "relay_error", "message": "production failure", "retryable": retryable}
+        )
+        assert _buzz_mod._cli_failure_is_retryable(stderr, returncode) is expected
+
+    @pytest.mark.parametrize(
+        ("stderr", "returncode", "expected"),
+        [("relay unavailable", 2, True), ("not-json", 1, False), ("{", 2, True)],
+    )
+    def test_legacy_or_malformed_stderr_uses_exit_code_fallback(
+        self, stderr, returncode, expected
+    ):
+        assert _buzz_mod._cli_failure_is_retryable(stderr, returncode) is expected
+
+
+@pytest.mark.asyncio
+async def test_top_level_channel_message_becomes_its_stable_thread_root():
+    adapter = _make_adapter()
+    received = []
+
+    async def capture(event):
+        received.append(event)
+
+    adapter.set_message_handler(capture)
+    adapter.handle_message = capture
+
+    await adapter._dispatch_message(
+        text="hello",
+        chat_id=CHANNEL,
+        chat_type="group",
+        user_id=OTHER_PUBKEY,
+        user_name="Alice",
+        message_id="root-event",
+        created_at=1,
+    )
+
+    assert len(received) == 1
+    assert received[0].source.thread_id == "root-event"
+
+
+@pytest.mark.asyncio
+async def test_channel_reply_keeps_the_explicit_thread_root():
+    adapter = _make_adapter()
+    received = []
+
+    async def capture(event):
+        received.append(event)
+
+    adapter.set_message_handler(capture)
+    adapter.handle_message = capture
+
+    await adapter._dispatch_message(
+        text="follow-up",
+        chat_id=CHANNEL,
+        chat_type="group",
+        user_id=OTHER_PUBKEY,
+        user_name="Alice",
+        message_id="reply-event",
+        created_at=2,
+        thread_id="root-event",
+    )
+
+    assert len(received) == 1
+    assert received[0].source.thread_id == "root-event"
+
+
+@pytest.mark.asyncio
+async def test_nip10_root_tag_reaches_plugin_dispatch_as_thread_root():
+    adapter = _make_adapter(extra={"require_mention": False})
+    adapter.require_mention = False
+    adapter._user_names[OTHER_PUBKEY] = "Alice"
+    received = []
+
+    async def capture(event):
+        received.append(event)
+
+    adapter.set_message_handler(capture)
+    adapter.handle_message = capture
+    state = {"seen": OrderedDict(), "last_ts": 0, "chat_type": "group"}
+    event = {
+        "id": "reply-event",
+        "kind": 9,
+        "pubkey": OTHER_PUBKEY,
+        "content": "follow-up",
+        "created_at": 2,
+        "tags": [
+            ["h", CHANNEL],
+            ["e", "root-event", "", "root"],
+            ["e", "parent-event", "", "reply"],
+        ],
+    }
+
+    await adapter._handle_event(CHANNEL, state, event)
+
+    assert len(received) == 1
+    assert received[0].source.thread_id == "root-event"
+
+
+@pytest.mark.asyncio
+async def test_legacy_two_unmarked_e_tags_use_first_as_stable_root():
+    adapter = _make_adapter(extra={"require_mention": False})
+    adapter.require_mention = False
+    adapter._user_names[OTHER_PUBKEY] = "Alice"
+    received = []
+
+    async def capture(event):
+        received.append(event)
+
+    adapter.set_message_handler(capture)
+    adapter.handle_message = capture
+    state = {"seen": OrderedDict(), "last_ts": 0, "chat_type": "group"}
+
+    await adapter._handle_event(
+        CHANNEL,
+        state,
+        {
+            "id": "nested-reply",
+            "kind": 9,
+            "pubkey": OTHER_PUBKEY,
+            "content": "legacy positional reply",
+            "created_at": 3,
+            "tags": [["e", "root-event"], ["e", "parent-event"]],
+        },
+    )
+
+    assert received[0].source.thread_id == "root-event"
+
+
+@pytest.mark.asyncio
+async def test_newest_first_seed_canonicalizes_legacy_positional_thread_root():
+    adapter = _make_adapter()
+    cli = _ScriptedCli()
+    cli.script(
+        "messages",
+        "get",
+        [
+            {
+                "id": "nested-reply",
+                "created_at": 3,
+                "kind": 9,
+                "tags": [["e", "root-event"], ["e", "parent-event"]],
+            },
+            {
+                "id": "parent-event",
+                "created_at": 2,
+                "kind": 9,
+                "tags": [["e", "root-event"]],
+            },
+        ],
+    )
+    cli.script("messages", "send", {"accepted": True, "event_id": "answer"})
+    adapter._run_cli = cli
+
+    await adapter._seed_channel(CHANNEL, chat_type="group")
+    result = await adapter.send(CHANNEL, "answer", reply_to="nested-reply")
+
+    assert result.success is True
+    assert adapter._channel_state[CHANNEL]["thread_roots"]["nested-reply"] == "root-event"
+    send_args, _stdin = cli.calls[-1]
+    assert send_args[send_args.index("--reply-to") + 1] == "root-event"
+
+
+@pytest.mark.asyncio
+async def test_nested_reply_send_targets_original_nip10_root():
+    adapter = _make_adapter(extra={"require_mention": False})
+    adapter.require_mention = False
+    adapter._user_names[OTHER_PUBKEY] = "Alice"
+    state = {"seen": OrderedDict(), "last_ts": 0, "chat_type": "group"}
+    adapter._channel_state[CHANNEL] = state
+
+    for event in (
+        {
+            "id": "first-reply",
+            "kind": 9,
+            "pubkey": OTHER_PUBKEY,
+            "content": "first",
+            "created_at": 2,
+            "tags": [["e", "root-event", "", "root"]],
+        },
+        {
+            "id": "nested-reply",
+            "kind": 9,
+            "pubkey": OTHER_PUBKEY,
+            "content": "nested",
+            "created_at": 3,
+            "tags": [["e", "first-reply", "", "reply"]],
+        },
+    ):
+        await adapter._handle_event(CHANNEL, state, event)
+
+    cli = _ScriptedCli()
+    cli.script("messages", "send", {"accepted": True, "event_id": "agent-reply"})
+    adapter._run_cli = cli
+
+    await adapter.send(CHANNEL, "answer", reply_to="nested-reply")
+
+    assert cli.calls[-1][0][-2:] == ["--reply-to", "root-event"]
+
+
+@pytest.mark.asyncio
+async def test_seed_reconstructs_nested_reply_root_without_dispatch():
+    adapter = _make_adapter(extra={"require_mention": False})
+    adapter.require_mention = False
+    received = []
+
+    async def capture(event):
+        received.append(event)
+
+    adapter.set_message_handler(capture)
+    adapter.handle_message = capture
+    cli = _ScriptedCli()
+    cli.script(
+        "messages",
+        "get",
+        [
+            {
+                "id": "first-reply",
+                "kind": 9,
+                "pubkey": OTHER_PUBKEY,
+                "content": "first",
+                "created_at": 2,
+                "tags": [["e", "root-event", "", "root"]],
+            },
+            {
+                "id": "nested-reply",
+                "kind": 9,
+                "pubkey": OTHER_PUBKEY,
+                "content": "nested",
+                "created_at": 3,
+                "tags": [["e", "first-reply", "", "reply"]],
+            },
+        ],
+    )
+    adapter._run_cli = cli
+
+    await adapter._seed_channel(CHANNEL, chat_type="group")
+    cli.script("messages", "send", {"accepted": True, "event_id": "agent-reply"})
+    await adapter.send(CHANNEL, "answer", reply_to="nested-reply")
+
+    assert received == []
+    assert cli.calls[-1][0][-2:] == ["--reply-to", "root-event"]
+
+
+def test_event_to_root_mapping_is_bounded():
+    adapter = _make_adapter()
+    state = {"seen": OrderedDict(), "last_ts": 0, "chat_type": "group"}
+
+    for index in range(_buzz_mod._SEEN_CAP + 1):
+        adapter._remember_thread_root(state, f"event-{index}", "root-event")
+
+    assert len(state["thread_roots"]) == _buzz_mod._SEEN_CAP
+    assert "event-0" not in state["thread_roots"]
+
+
+@pytest.mark.asyncio
+async def test_top_level_dm_uses_message_anchor_without_fragmenting_dm_session():
+    adapter = _make_adapter()
+    received = []
+
+    async def capture(event):
+        received.append(event)
+
+    adapter.set_message_handler(capture)
+    adapter.handle_message = capture
+
+    await adapter._dispatch_message(
+        text="hello",
+        chat_id=DM_CHANNEL,
+        chat_type="dm",
+        user_id=OTHER_PUBKEY,
+        user_name="Alice",
+        message_id="dm-root",
+        created_at=1,
+    )
+
+    assert len(received) == 1
+    assert received[0].source.thread_id is None
+    assert received[0].message_id == "dm-root"
+
+
+@pytest.mark.asyncio
+async def test_dm_follow_up_keeps_the_original_root():
+    adapter = _make_adapter()
+    adapter._user_names[OTHER_PUBKEY] = "Alice"
+    received = []
+
+    async def capture(event):
+        received.append(event)
+
+    adapter.set_message_handler(capture)
+    adapter.handle_message = capture
+    state = {"seen": OrderedDict(), "last_ts": 0, "chat_type": "dm"}
+    event = {
+        "id": "dm-follow-up",
+        "kind": 9,
+        "pubkey": OTHER_PUBKEY,
+        "content": "more",
+        "created_at": 2,
+        "tags": [
+            ["e", "dm-root", "", "root"],
+            ["e", "dm-parent", "", "reply"],
+        ],
+    }
+
+    await adapter._handle_event(DM_CHANNEL, state, event)
+
+    assert len(received) == 1
+    assert received[0].source.thread_id == "dm-root"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_channel_messages_cannot_exchange_thread_roots():
+    adapter = _make_adapter(extra={"require_mention": False})
+    adapter.require_mention = False
+    received = []
+    both_resolving = asyncio.Event()
+    resolver_count = 0
+
+    async def resolve_name(_pubkey):
+        nonlocal resolver_count
+        resolver_count += 1
+        if resolver_count == 2:
+            both_resolving.set()
+        await both_resolving.wait()
+        return "Alice"
+
+    async def capture(event):
+        received.append(event)
+
+    adapter._resolve_user_name = resolve_name
+    adapter.set_message_handler(capture)
+    adapter.handle_message = capture
+
+    def inbound(message_id, root_id, sender):
+        return {
+            "id": message_id,
+            "kind": 9,
+            "pubkey": sender,
+            "content": "follow-up",
+            "created_at": 2,
+            "tags": [["e", root_id, "", "root"]],
+        }
+
+    await asyncio.gather(
+        adapter._handle_event(
+            "channel-a",
+            {"seen": OrderedDict(), "last_ts": 0, "chat_type": "group"},
+            inbound("reply-a", "root-a", "a" * 64),
+        ),
+        adapter._handle_event(
+            "channel-b",
+            {"seen": OrderedDict(), "last_ts": 0, "chat_type": "group"},
+            inbound("reply-b", "root-b", "c" * 64),
+        ),
+    )
+
+    roots = {event.message_id: event.source.thread_id for event in received}
+    assert roots == {"reply-a": "root-a", "reply-b": "root-b"}
+
+
+@pytest.mark.asyncio
+async def test_repository_path_containing_display_name_does_not_address_agent():
+    adapter = _make_adapter(extra={"require_mention": True})
+    adapter.require_mention = True
+    adapter._user_names[OTHER_PUBKEY] = "Alice"
+    received = []
+
+    async def capture(event):
+        received.append(event)
+
+    adapter.set_message_handler(capture)
+    adapter.handle_message = capture
+    state = {"seen": OrderedDict(), "last_ts": 0, "chat_type": "group"}
+
+    await adapter._handle_event(
+        CHANNEL,
+        state,
+        {
+            "id": "path-message",
+            "kind": 9,
+            "pubkey": OTHER_PUBKEY,
+            "content": "Inspect /srv/example-project before release.",
+            "created_at": 1,
+            "tags": [],
+        },
+    )
+
+    assert received == []
+
+    await adapter._handle_event(
+        CHANNEL,
+        state,
+        {
+            "id": "explicit-mention",
+            "kind": 9,
+            "pubkey": OTHER_PUBKEY,
+            "content": "@Chip inspect the release.",
+            "created_at": 2,
+            "tags": [],
+        },
+    )
+
+    assert [event.message_id for event in received] == ["explicit-mention"]
+
+
+
+@pytest.mark.asyncio
+async def test_protected_relay_image_is_authenticated_cached_and_dispatched(
+    monkeypatch, tmp_path
+):
+    image_bytes = b"\x89PNG\r\n\x1a\nprotected-image"
+    image_hash = hashlib.sha256(image_bytes).hexdigest()
+    image_url = f"https://relay.invalid/media/{image_hash}.png"
+    monkeypatch.setenv("IMAGE_CACHE_DIR", str(tmp_path / "images"))
+    adapter = _make_adapter(
+        extra={
+            "relay_url": "https://relay.invalid",
+            "allowed_users": [OTHER_PUBKEY],
+            "require_mention": True,
+        }
+    )
+    received = []
+    calls = []
+
+    async def run_cli(args, **_kwargs):
+        calls.append(list(args))
+        assert args[:3] == ["media", "get", image_url]
+        Path(args[args.index("--output") + 1]).write_bytes(image_bytes)
+        return 0, "", ""
+
+    async def capture(event):
+        received.append(event)
+
+    adapter._run_cli = run_cli
+    adapter._user_names[OTHER_PUBKEY] = "Alice"
+    adapter.set_message_handler(capture)
+    adapter.handle_message = capture
+    state = {"chat_type": "group", "last_ts": 0, "seen": OrderedDict()}
+
+    await adapter._handle_event(
+        CHANNEL,
+        state,
+        {
+            "id": "image-event",
+            "kind": 9,
+            "pubkey": OTHER_PUBKEY,
+            "content": f"@Chip inspect this\n![image]({image_url})",
+            "created_at": 1,
+            "tags": [],
+        },
+    )
+
+    assert len(received) == 1
+    assert received[0].message_type is _buzz_mod.MessageType.PHOTO
+    assert received[0].source.thread_id == "image-event"
+    assert received[0].text == "inspect this"
+    assert received[0].media_types == ["image/png"]
+    assert len(received[0].media_urls) == 1
+    cached_path = Path(received[0].media_urls[0])
+    assert cached_path.read_bytes() == image_bytes
+    assert stat.S_IMODE(cached_path.stat().st_mode) == 0o600
+    media_calls = [call for call in calls if call[:2] == ["media", "get"]]
+    assert media_calls == [
+        ["media", "get", image_url, "--output", media_calls[0][-1]]
+    ]
+    assert not Path(calls[0][-1]).exists()
+
+
+@pytest.mark.asyncio
+async def test_chmod_failure_unlinks_uncommitted_protected_cache(monkeypatch, tmp_path):
+    image_bytes = b"\x89PNG\r\n\x1a\nprotected-image"
+    image_hash = hashlib.sha256(image_bytes).hexdigest()
+    image_url = f"https://relay.invalid/media/{image_hash}.png"
+    adapter = _make_adapter(extra={"relay_url": "https://relay.invalid"})
+    cached_path = tmp_path / "cached.png"
+    cli_temp_paths = []
+
+    async def run_cli(args, **_kwargs):
+        temporary_path = Path(args[args.index("--output") + 1])
+        cli_temp_paths.append(temporary_path)
+        temporary_path.write_bytes(image_bytes)
+        return 0, "", ""
+
+    def cache_image(data, *, ext):
+        assert data == image_bytes
+        cached_path.write_bytes(data)
+        return str(cached_path)
+
+    def fail_chmod(path, mode):
+        assert Path(path) == cached_path
+        assert mode == 0o600
+        raise OSError("chmod failed")
+
+    monkeypatch.setattr(_buzz_mod, "cache_image_from_bytes", cache_image)
+    monkeypatch.setattr(_buzz_mod.os, "chmod", fail_chmod)
+    adapter._run_cli = run_cli
+
+    original = f"inspect ![image]({image_url})"
+    text, media_urls, media_types = await adapter._ingest_buzz_images(original)
+
+    assert text == original
+    assert media_urls == []
+    assert media_types == []
+    assert not cached_path.exists()
+    assert cli_temp_paths and not cli_temp_paths[0].exists()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.invalid/media/" + ("a" * 64) + ".png",
+        "https://user@relay.invalid/media/" + ("a" * 64) + ".png",
+        "https://relay.invalid/media/" + ("a" * 64) + ".png?token=secret",
+        "https://relay.invalid/media/" + ("a" * 64) + ".png#fragment",
+        "https://relay.invalid/media/" + ("a" * 64) + ".svg",
+    ],
+)
+def test_only_exact_relay_image_urls_are_eligible_for_authenticated_fetch(url):
+    adapter = _make_adapter(extra={"relay_url": "https://relay.invalid"})
+    assert adapter._buzz_image_metadata(url) is None
+
+
+def test_wss_relay_accepts_same_origin_https_protected_image():
+    digest = "a" * 64
+    adapter = _make_adapter(extra={"relay_url": "wss://relay.invalid"})
+
+    assert adapter._buzz_image_metadata(
+        f"https://relay.invalid/media/{digest}.png"
+    ) == (digest, ".png", "image/png")
+
+
+def test_buzz_docs_state_protected_images_require_authorized_senders():
+    docs = (
+        Path(__file__).parents[2]
+        / "website/docs/user-guide/messaging/buzz.md"
+    ).read_text()
+
+    assert "Protected images are fetched only for authorized senders" in docs
+
+
+@pytest.mark.asyncio
+async def test_retryable_protected_image_failure_retries_before_dispatch(
+    monkeypatch, tmp_path
+):
+    image_bytes = b"\x89PNG\r\n\x1a\nprotected-after-retry"
+    image_hash = hashlib.sha256(image_bytes).hexdigest()
+    image_url = f"https://relay.invalid/media/{image_hash}.png"
+    monkeypatch.setenv("IMAGE_CACHE_DIR", str(tmp_path / "images"))
+    monkeypatch.setattr(_buzz_mod, "_BUZZ_MEDIA_RETRY_DELAYS", (0,))
+    adapter = _make_adapter(extra={"relay_url": "https://relay.invalid"})
+    attempts = 0
+
+    async def run_cli(args, **_kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return (
+                4,
+                "",
+                '{"error":"server_error","message":"unavailable","retryable":true}',
+            )
+        Path(args[args.index("--output") + 1]).write_bytes(image_bytes)
+        return 0, "", ""
+
+    adapter._run_cli = run_cli
+    text, media_urls, media_types = await adapter._ingest_buzz_images(
+        f"inspect\n![image]({image_url})"
+    )
+
+    assert attempts == 2
+    assert text == "inspect"
+    assert media_types == ["image/png"]
+    assert Path(media_urls[0]).read_bytes() == image_bytes
+
+
+@pytest.mark.asyncio
+async def test_protected_media_ingest_has_one_bounded_message_deadline(monkeypatch):
+    image_url = "https://relay.invalid/media/" + ("a" * 64) + ".png"
+    monkeypatch.setattr(_buzz_mod, "_BUZZ_MEDIA_TOTAL_TIMEOUT", 0.01)
+    adapter = _make_adapter(extra={"relay_url": "https://relay.invalid"})
+    output_paths = []
+
+    async def run_cli(args, **_kwargs):
+        output_paths.append(Path(args[args.index("--output") + 1]))
+        await asyncio.sleep(60)
+
+    adapter._run_cli = run_cli
+    original = f"inspect\n![image]({image_url})"
+    text, media_urls, media_types = await adapter._ingest_buzz_images(original)
+
+    assert text == original
+    assert media_urls == []
+    assert media_types == []
+    assert output_paths and all(not path.exists() for path in output_paths)
+
+
+@pytest.mark.asyncio
+async def test_protected_image_downloads_are_bounded_per_message(monkeypatch, tmp_path):
+    payloads = [
+        b"\x89PNG\r\n\x1a\nimage-" + str(index).encode() for index in range(5)
+    ]
+    urls = [
+        f"https://relay.invalid/media/{hashlib.sha256(data).hexdigest()}.png"
+        for data in payloads
+    ]
+    payload_by_url = dict(zip(urls, payloads, strict=True))
+    monkeypatch.setenv("IMAGE_CACHE_DIR", str(tmp_path / "images"))
+    adapter = _make_adapter(extra={"relay_url": "https://relay.invalid"})
+    calls = []
+
+    async def run_cli(args, **_kwargs):
+        url = args[2]
+        calls.append(url)
+        Path(args[args.index("--output") + 1]).write_bytes(payload_by_url[url])
+        return 0, "", ""
+
+    adapter._run_cli = run_cli
+    original = "inspect\n" + "\n".join(f"![image]({url})" for url in urls)
+    text, media_urls, media_types = await adapter._ingest_buzz_images(original)
+
+    assert calls == urls[:4]
+    assert len(media_urls) == 4
+    assert media_types == ["image/png"] * 4
+    assert urls[4] in text
+    assert all(url not in text for url in urls[:4])
+
+
+@pytest.mark.asyncio
+async def test_hash_mismatch_preserves_protected_image_link(monkeypatch, tmp_path):
+    expected_url = "https://relay.invalid/media/" + ("a" * 64) + ".png"
+    wrong_bytes = b"\x89PNG\r\n\x1a\nwrong-image"
+    monkeypatch.setenv("IMAGE_CACHE_DIR", str(tmp_path / "images"))
+    adapter = _make_adapter(extra={"relay_url": "https://relay.invalid"})
+
+    async def run_cli(args, **_kwargs):
+        Path(args[args.index("--output") + 1]).write_bytes(wrong_bytes)
+        return 0, "", ""
+
+    adapter._run_cli = run_cli
+    original = f"inspect\n![image]({expected_url})"
+    text, media_urls, media_types = await adapter._ingest_buzz_images(original)
+
+    assert text == original
+    assert media_urls == []
+    assert media_types == []
+
+
+@pytest.mark.asyncio
+async def test_url_extension_must_match_downloaded_image_family(monkeypatch, tmp_path):
+    png_bytes = b"\x89PNG\r\n\x1a\nactual-png"
+    image_hash = hashlib.sha256(png_bytes).hexdigest()
+    image_url = f"https://relay.invalid/media/{image_hash}.gif"
+    monkeypatch.setenv("IMAGE_CACHE_DIR", str(tmp_path / "images"))
+    adapter = _make_adapter(extra={"relay_url": "https://relay.invalid"})
+
+    async def run_cli(args, **_kwargs):
+        Path(args[args.index("--output") + 1]).write_bytes(png_bytes)
+        return 0, "", ""
+
+    adapter._run_cli = run_cli
+    original = f"inspect\n![image]({image_url})"
+    text, media_urls, media_types = await adapter._ingest_buzz_images(original)
+
+    assert text == original
+    assert media_urls == []
+    assert media_types == []
+
+
+@pytest.mark.asyncio
+async def test_jpg_extension_accepts_detected_jpeg_family(monkeypatch, tmp_path):
+    jpeg_bytes = b"\xff\xd8\xff\xe0actual-jpeg"
+    image_hash = hashlib.sha256(jpeg_bytes).hexdigest()
+    image_url = f"https://relay.invalid/media/{image_hash}.jpg"
+    monkeypatch.setenv("IMAGE_CACHE_DIR", str(tmp_path / "images"))
+    adapter = _make_adapter(extra={"relay_url": "https://relay.invalid"})
+
+    async def run_cli(args, **_kwargs):
+        Path(args[args.index("--output") + 1]).write_bytes(jpeg_bytes)
+        return 0, "", ""
+
+    adapter._run_cli = run_cli
+    text, media_urls, media_types = await adapter._ingest_buzz_images(
+        f"inspect\n![image]({image_url})"
+    )
+
+    assert text == "inspect"
+    assert len(media_urls) == 1
+    assert Path(media_urls[0]).read_bytes() == jpeg_bytes
+    assert media_types == ["image/jpeg"]
+
+
+@pytest.mark.asyncio
+async def test_oversized_protected_image_is_not_cached_or_removed(monkeypatch, tmp_path):
+    image_bytes = b"\x89PNG\r\n\x1a\noversized"
+    image_hash = hashlib.sha256(image_bytes).hexdigest()
+    image_url = f"https://relay.invalid/media/{image_hash}.png"
+    monkeypatch.setenv("IMAGE_CACHE_DIR", str(tmp_path / "images"))
+    monkeypatch.setattr(
+        _buzz_mod,
+        "validate_inbound_media_size",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("too large")),
+    )
+    adapter = _make_adapter(extra={"relay_url": "https://relay.invalid"})
+
+    async def run_cli(args, **_kwargs):
+        Path(args[args.index("--output") + 1]).write_bytes(image_bytes)
+        return 0, "", ""
+
+    adapter._run_cli = run_cli
+    original = f"inspect\n![image]({image_url})"
+    text, media_urls, media_types = await adapter._ingest_buzz_images(original)
+
+    assert text == original
+    assert media_urls == []
+    assert media_types == []
+    assert not (tmp_path / "images").exists()
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_image_message_is_not_downloaded():
+    sender = "a" * 64
+    image_url = "https://relay.invalid/media/" + ("b" * 64) + ".png"
+    adapter = _make_adapter(
+        extra={
+            "relay_url": "https://relay.invalid",
+            "allowed_users": ["c" * 64],
+            "require_mention": True,
+        }
+    )
+    adapter._user_names[sender] = "Alice"
+    received = []
+
+    async def run_cli(args, **_kwargs):
+        raise AssertionError(f"unauthorized media must not be fetched: {args}")
+
+    async def capture(event):
+        received.append(event)
+
+    adapter._run_cli = run_cli
+    adapter.set_message_handler(capture)
+    adapter.handle_message = capture
+    state = {"chat_type": "group", "last_ts": 0, "seen": OrderedDict()}
+
+    await adapter._handle_event(
+        CHANNEL,
+        state,
+        {
+            "id": "unauthorized-image",
+            "kind": 9,
+            "pubkey": sender,
+            "content": f"@Chip inspect\n![image]({image_url})",
+            "created_at": 1,
+            "tags": [],
+        },
+    )
+
+    assert received == []
 
 # ── Seeding / high-water mark / de-dupe ───────────────────────────────────
 
@@ -386,6 +1445,167 @@ class TestDmClassification:
 
 class TestBuzzAdapterSend:
 
+    def test_configured_agent_handoff_accepts_npub_identity(self):
+        target_pubkey = "d" * 64
+        adapter = _make_adapter(
+            extra={
+                "outbound_mention_pubkeys": {
+                    "ClaudeCode": _buzz_mod.hex_to_npub(target_pubkey)
+                }
+            }
+        )
+
+        assert adapter.outbound_mention_pubkeys == {
+            "claudecode": ("ClaudeCode", target_pubkey)
+        }
+
+    def test_configured_handoffs_reject_invalid_or_ambiguous_configuration(self):
+        with pytest.raises(ValueError, match="must be a mapping"):
+            _make_adapter(extra={"outbound_mention_pubkeys": ["not", "a", "mapping"]})
+
+        with pytest.raises(ValueError, match="duplicate display name"):
+            _make_adapter(
+                extra={
+                    "outbound_mention_pubkeys": {
+                        "ClaudeCode": "c" * 64,
+                        "claudecode": "d" * 64,
+                    }
+                }
+            )
+
+    @pytest.mark.asyncio
+    async def test_configured_agent_handoff_uses_exact_structural_pubkey(self):
+        target_pubkey = "c" * 64
+        adapter = _make_adapter(
+            extra={"outbound_mention_pubkeys": {"ClaudeCode": target_pubkey}}
+        )
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "handoff-event"},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "@ClaudeCode review this target.",
+            metadata={"thread_id": "root-event"},
+        )
+
+        assert result.success is True
+        assert len(cli.calls) == 1
+        args, stdin_text = cli.calls[0]
+        assert args[args.index("--mention") + 1] == target_pubkey
+        assert args[args.index("--reply-to") + 1] == "root-event"
+        assert stdin_text == "@ClaudeCode review this target."
+
+    @pytest.mark.asyncio
+    async def test_configured_handoff_is_never_downgraded_to_plain_text(self):
+        target_pubkey = "c" * 64
+        adapter = _make_adapter(
+            extra={"outbound_mention_pubkeys": {"ClaudeCode": target_pubkey}}
+        )
+        calls = []
+
+        async def run_cli(args, *, input_text=None):
+            calls.append((list(args), input_text))
+            return (
+                1,
+                "",
+                "mention '@ClaudeCode' does not match a current channel member",
+            )
+
+        adapter._run_cli = run_cli
+
+        result = await adapter.send(CHANNEL, "@ClaudeCode review this target.")
+
+        assert result.success is False
+        assert len(calls) == 1
+        assert calls[0][0][calls[0][0].index("--mention") + 1] == target_pubkey
+        assert calls[0][1] == "@ClaudeCode review this target."
+
+    @pytest.mark.asyncio
+    async def test_configured_handoff_protects_itself_while_falling_back_other_mentions(self):
+        target_pubkey = "c" * 64
+        adapter = _make_adapter(
+            extra={"outbound_mention_pubkeys": {"ClaudeCode": target_pubkey}}
+        )
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="mention '@ghost' does not match a current channel member",
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "mixed-event"},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "@ClaudeCode ask @ghost to review.",
+            reply_to="root-event",
+        )
+
+        assert result.success is True
+        assert len(cli.calls) == 2
+        assert cli.calls[0][0] == cli.calls[1][0]
+        assert cli.calls[0][0][cli.calls[0][0].index("--mention") + 1] == target_pubkey
+        assert cli.calls[0][1] == "@ClaudeCode ask @ghost to review."
+        assert cli.calls[1][1] == "@ClaudeCode ask ghost to review."
+
+    @pytest.mark.asyncio
+    async def test_configured_handoff_requires_a_complete_display_name(self):
+        adapter = _make_adapter(
+            extra={"outbound_mention_pubkeys": {"Claude": "c" * 64}}
+        )
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "plain-event"},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "@ClaudeCode review this target.")
+
+        assert result.success is True
+        assert "--mention" not in cli.calls[0][0]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("returncode", "retryable"), [(1, True), (2, False)]
+    )
+    async def test_send_uses_structured_retryability_over_exit_code(
+        self, returncode, retryable
+    ):
+        adapter = _make_adapter()
+
+        async def run_cli(args, *, input_text=None):
+            return (
+                returncode,
+                "",
+                json.dumps(
+                    {
+                        "error": "relay_error",
+                        "message": "production failure",
+                        "retryable": retryable,
+                    }
+                ),
+            )
+
+        adapter._run_cli = run_cli
+
+        result = await adapter.send(CHANNEL, "hello")
+
+        assert result.success is False
+        assert result.retryable is retryable
+
     @pytest.mark.asyncio
     async def test_send_success_via_stdin(self):
         adapter = _make_adapter()
@@ -407,6 +1627,213 @@ class TestBuzzAdapterSend:
         # Our own event id is marked seen for echo suppression
         assert "evt123" in adapter._channel_state[CHANNEL]["seen"]
 
+    @pytest.mark.asyncio
+    async def test_unresolved_outbound_mention_retries_as_readable_text(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="user_error: mention '@ghost' does not match a current channel member",
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "delivered"},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "Ask @ghost to review, but preserve bob@example.com.",
+            metadata={"thread_id": "root-event"},
+        )
+
+        assert result.success is True
+        assert [text for _args, text in cli.calls] == [
+            "Ask @ghost to review, but preserve bob@example.com.",
+            "Ask ghost to review, but preserve bob@example.com.",
+        ]
+        assert cli.calls[0][0] == cli.calls[1][0]
+        retry_args = cli.calls[1][0]
+        assert retry_args[retry_args.index("--reply-to") + 1] == "root-event"
+
+    @pytest.mark.asyncio
+    async def test_sequential_unresolved_mentions_are_bounded_and_delivered(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="mention '@first' does not match a current channel member",
+        )
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="mention '@second' is ambiguous",
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "delivered"},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "Ask @first, then @second please.")
+
+        assert result.success is True
+        assert [text for _args, text in cli.calls] == [
+            "Ask @first, then @second please.",
+            "Ask first, then @second please.",
+            "Ask first, then second please.",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_mention_limit_fallback_neutralizes_only_mention_markers(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="user_error: too many unique message mentions",
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "delivered"},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "Notify @Alice and @Bob; preserve bob@example.com.",
+        )
+
+        assert result.success is True
+        assert [text for _args, text in cli.calls] == [
+            "Notify @Alice and @Bob; preserve bob@example.com.",
+            "Notify Alice and Bob; preserve bob@example.com.",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_local_image_caption_retries_unresolved_mention(self, tmp_path):
+        image = tmp_path / "report.png"
+        image.write_bytes(b"not-a-real-image")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="mention '@ghost' does not match a current channel member",
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "image-event"},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send_image_file(
+            CHANNEL,
+            str(image),
+            caption="Evidence for @ghost to review",
+            reply_to="root-event",
+        )
+
+        assert result.success is True
+        assert [text for _args, text in cli.calls] == [
+            "Evidence for @ghost to review",
+            "Evidence for ghost to review",
+        ]
+        assert cli.calls[0][0] == cli.calls[1][0]
+        assert cli.calls[0][0][cli.calls[0][0].index("--file") + 1] == str(image)
+
+    @pytest.mark.asyncio
+    async def test_missing_local_image_file_uses_safe_notice_without_path_leak(
+        self, tmp_path
+    ):
+        missing = tmp_path / "private-render.png"
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "notice-event"},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send_image_file(
+            CHANNEL,
+            str(missing),
+            caption="Evidence",
+            metadata={"thread_id": "root-event"},
+        )
+
+        assert result.success is True
+        assert len(cli.calls) == 1
+        args, stdin_text = cli.calls[0]
+        assert "--file" not in args
+        assert args[args.index("--reply-to") + 1] == "root-event"
+        assert stdin_text == "Evidence\n⚠️ Couldn't deliver the image attachment."
+        assert str(missing) not in stdin_text
+
+    @pytest.mark.asyncio
+    async def test_image_batch_preserves_metadata_thread_root(self, tmp_path):
+        image = tmp_path / "report.png"
+        image.write_bytes(b"not-a-real-image")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "image-event"},
+        )
+        adapter._run_cli = cli
+
+        await adapter.send_multiple_images(
+            CHANNEL,
+            [(image.as_uri(), "Evidence")],
+            metadata={"thread_id": "root-event"},
+        )
+
+        args, _stdin_text = cli.calls[0]
+        assert args[args.index("--file") + 1] == str(image)
+        assert args[args.index("--reply-to") + 1] == "root-event"
+
+
+    @pytest.mark.asyncio
+    async def test_local_image_caption_uses_configured_structural_mention(self, tmp_path):
+        target_pubkey = "c" * 64
+        image = tmp_path / "report.png"
+        image.write_bytes(b"not-a-real-image")
+        adapter = _make_adapter(
+            extra={"outbound_mention_pubkeys": {"ClaudeCode": target_pubkey}}
+        )
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "image-handoff"})
+        adapter._run_cli = cli
+
+        result = await adapter.send_image(
+            CHANNEL,
+            str(image),
+            caption="@ClaudeCode review this image.",
+        )
+
+        assert result.success is True
+        assert len(cli.calls) == 1
+        args, stdin_text = cli.calls[0]
+        assert args[args.index("--mention") + 1] == target_pubkey
+        assert stdin_text == "@ClaudeCode review this image."
 
     @pytest.mark.asyncio
     async def test_send_image_local_file_uses_file_flag(self, tmp_path):
@@ -446,12 +1873,210 @@ class TestBuzzAdapterLifecycle:
         assert adapter._lock_key is None
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("channels_result", "extra"),
+        [
+            ((2, "", '{"error":"relay_error","message":"down","retryable":true}'), {}),
+            ((0, "{}", ""), {}),
+            ((0, "[]", ""), {}),
+            ((0, json.dumps([{"channel_id": "other", "type": "community"}]), ""), {"channels": [CHANNEL]}),
+        ],
+        ids=["cli-failure", "malformed-payload", "empty-roster", "nonmatching-roster"],
+    )
+    async def test_unsuccessful_post_lock_connect_releases_identity_lock(
+        self, monkeypatch, channels_result, extra
+    ):
+        import gateway.status as gateway_status
+
+        released = []
+        monkeypatch.setattr(
+            gateway_status, "acquire_scoped_lock", lambda platform, key: (True, None)
+        )
+        monkeypatch.setattr(
+            gateway_status,
+            "release_scoped_lock",
+            lambda platform, key: released.append((platform, key)),
+        )
+        monkeypatch.setattr(_buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1test")
+        adapter = _make_adapter(extra=extra)
+        adapter.cli_path = "/fake/buzz"
+
+        async def run_cli(args, *, input_text=None):
+            if args == ["users", "get"]:
+                return 0, json.dumps([{"pubkey": SELF_PUBKEY, "display_name": "Chip"}]), ""
+            if args == ["channels", "list", "--member"]:
+                return channels_result
+            if args in (["dms", "list"], ["channels", "list"]):
+                return 0, "[]", ""
+            raise AssertionError(args)
+
+        adapter._run_cli = run_cli
+
+        assert await adapter.connect() is False
+        lock_key = f"{adapter.relay_url}:{SELF_PUBKEY}"
+        assert released == [("buzz", lock_key)]
+        assert adapter._lock_key is None
+
+    @pytest.mark.asyncio
+    async def test_cancelled_post_lock_connect_releases_identity_lock(self, monkeypatch):
+        import gateway.status as gateway_status
+
+        released = []
+        monkeypatch.setattr(
+            gateway_status, "acquire_scoped_lock", lambda platform, key: (True, None)
+        )
+        monkeypatch.setattr(
+            gateway_status,
+            "release_scoped_lock",
+            lambda platform, key: released.append((platform, key)),
+        )
+        monkeypatch.setattr(_buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1test")
+        adapter = _make_adapter()
+        adapter.cli_path = "/fake/buzz"
+
+        async def run_cli(args, *, input_text=None):
+            if args == ["users", "get"]:
+                return 0, json.dumps([{"pubkey": SELF_PUBKEY}]), ""
+            raise asyncio.CancelledError
+
+        adapter._run_cli = run_cli
+
+        with pytest.raises(asyncio.CancelledError):
+            await adapter.connect()
+        lock_key = f"{adapter.relay_url}:{SELF_PUBKEY}"
+        assert released == [("buzz", lock_key)]
+        assert adapter._lock_key is None
+
+    @pytest.mark.asyncio
+    async def test_raised_post_lock_seed_failure_releases_identity_lock(self, monkeypatch):
+        import gateway.status as gateway_status
+
+        released = []
+        monkeypatch.setattr(
+            gateway_status, "acquire_scoped_lock", lambda platform, key: (True, None)
+        )
+        monkeypatch.setattr(
+            gateway_status,
+            "release_scoped_lock",
+            lambda platform, key: released.append((platform, key)),
+        )
+        monkeypatch.setattr(_buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1test")
+        adapter = _make_adapter()
+        adapter.cli_path = "/fake/buzz"
+        cli = _ScriptedCli()
+        cli.script("users", "get", [{"pubkey": SELF_PUBKEY}])
+        cli.script(
+            "channels",
+            "list",
+            [{"channel_id": CHANNEL, "type": "community", "name": "General"}],
+        )
+        adapter._run_cli = cli
+        adapter._seed_channel = AsyncMock(side_effect=OSError("seed failed"))
+
+        with pytest.raises(OSError, match="seed failed"):
+            await adapter.connect()
+        lock_key = f"{adapter.relay_url}:{SELF_PUBKEY}"
+        assert released == [("buzz", lock_key)]
+        assert adapter._lock_key is None
+
+    @pytest.mark.asyncio
+    async def test_connect_accepts_direct_dm_only_account(self, monkeypatch):
+        monkeypatch.setattr(_buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1test")
+        adapter = _make_adapter(extra={"transport": "poll"})
+        adapter.cli_path = "/fake/buzz"
+        dm_id = "direct-dm"
+        cli = _ScriptedCli()
+        cli.script("users", "get", [{"pubkey": SELF_PUBKEY}])
+        cli.script("channels", "list", [])
+        cli.script("dms", "list", [{"dm_id": dm_id}])
+        cli.script("messages", "get", [])
+        cli.script("channels", "list", [])
+        adapter._run_cli = cli
+
+        assert await adapter.connect() is True
+        assert adapter._channel_state[dm_id]["chat_type"] == "dm"
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_accepts_dm_fallback_when_configured_community_is_absent(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(_buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1test")
+        adapter = _make_adapter(
+            extra={"transport": "poll", "channels": [CHANNEL]}
+        )
+        adapter.cli_path = "/fake/buzz"
+        dm_id = "fallback-dm"
+        cli = _ScriptedCli()
+        cli.script("users", "get", [{"pubkey": SELF_PUBKEY}])
+        cli.script(
+            "channels",
+            "list",
+            [{"channel_id": "other", "type": "community", "name": "Other"}],
+        )
+        cli.script("dms", "list", [])
+        cli.script(
+            "channels",
+            "list",
+            [
+                {
+                    "channel_id": dm_id,
+                    "type": "community",
+                    "name": "DM",
+                    "description": "",
+                }
+            ],
+        )
+        cli.script("messages", "get", [])
+        adapter._run_cli = cli
+
+        assert await adapter.connect() is True
+        assert set(adapter._channel_state) == {dm_id}
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_successful_connect_keeps_identity_lock_until_disconnect(self, monkeypatch):
+        import gateway.status as gateway_status
+
+        released = []
+        monkeypatch.setattr(
+            gateway_status, "acquire_scoped_lock", lambda platform, key: (True, None)
+        )
+        monkeypatch.setattr(
+            gateway_status,
+            "release_scoped_lock",
+            lambda platform, key: released.append((platform, key)),
+        )
+        monkeypatch.setattr(_buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1test")
+        adapter = _make_adapter(extra={"transport": "poll"})
+        adapter.cli_path = "/fake/buzz"
+        cli = _ScriptedCli()
+        cli.script("users", "get", [{"pubkey": SELF_PUBKEY, "display_name": "Chip"}])
+        cli.script(
+            "channels", "list", [{"channel_id": CHANNEL, "type": "community", "name": "General"}]
+        )
+        cli.script("messages", "get", [])
+        cli.script("dms", "list", [])
+        cli.script("channels", "list", [])
+        adapter._run_cli = cli
+
+        assert await adapter.connect() is True
+        lock_key = f"{adapter.relay_url}:{SELF_PUBKEY}"
+        assert adapter._lock_key == lock_key
+        assert released == []
+
+        await adapter.disconnect()
+        assert released == [("buzz", lock_key)]
+
+    @pytest.mark.asyncio
     async def test_connect_fails_when_identity_lock_held(self, monkeypatch):
         """A second profile using the same relay+pubkey must fail fast."""
         import gateway.status as gateway_status
 
         monkeypatch.setattr(
-            gateway_status, "acquire_scoped_lock", lambda platform, key: False
+            gateway_status,
+            "acquire_scoped_lock",
+            lambda platform, key: (False, {"pid": 4242}),
         )
         adapter = _make_adapter()
         adapter.cli_path = "/fake/buzz"
@@ -464,6 +2089,143 @@ class TestBuzzAdapterLifecycle:
         adapter._run_cli = cli
         assert await adapter.connect() is False
         assert adapter._lock_key is None
+        assert adapter.fatal_error_code == "lock_conflict"
+        assert adapter.fatal_error_retryable is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("profile_output", "returncode", "expected_code", "retryable"),
+        [
+            ("", 0, "connect_failed", True),
+            ("[]", 0, "connect_failed", True),
+            (json.dumps([{"display_name": "Chip"}]), 0, "connect_failed", False),
+            (json.dumps([{"pubkey": "abc"}]), 0, "connect_failed", False),
+            (json.dumps([{"pubkey": "g" * 64}]), 0, "connect_failed", False),
+            (json.dumps([{"pubkey": {"hex": SELF_PUBKEY}}]), 0, "connect_failed", False),
+            (json.dumps(["not-an-object"]), 0, "connect_failed", False),
+            ("not-json", 0, "connect_failed", False),
+            ("{}", 0, "connect_failed", False),
+            (
+                '{"error":"auth_error","message":"denied","retryable":true}',
+                1,
+                "network_error",
+                True,
+            ),
+            (
+                '{"error":"relay_error","message":"down","retryable":false}',
+                2,
+                "connect_failed",
+                False,
+            ),
+            ("relay unavailable", 2, "network_error", True),
+            ("invalid credentials", 1, "connect_failed", False),
+        ],
+    )
+    async def test_profile_failure_classification(
+        self,
+        monkeypatch,
+        profile_output,
+        returncode,
+        expected_code,
+        retryable,
+    ):
+        adapter = _make_adapter()
+        adapter.cli_path = "/fake/buzz"
+        monkeypatch.setattr(_buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1test")
+
+        async def run_cli(args, *, input_text=None):
+            assert args == ["users", "get"]
+            if returncode:
+                return returncode, "", profile_output
+            return 0, profile_output, ""
+
+        adapter._run_cli = run_cli
+
+        assert await adapter.connect() is False
+        assert adapter.fatal_error_code == expected_code
+        assert adapter.fatal_error_retryable is retryable
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("returncode", "stderr", "expected_code", "retryable"),
+        [
+            (
+                1,
+                '{"error":"relay_error","message":"down","retryable":true}',
+                "network_error",
+                True,
+            ),
+            (
+                2,
+                '{"error":"auth_error","message":"denied","retryable":false}',
+                "connect_failed",
+                False,
+            ),
+            (2, "relay unavailable", "network_error", True),
+            (1, "invalid credentials", "connect_failed", False),
+        ],
+    )
+    async def test_joined_channel_failure_classification(
+        self,
+        monkeypatch,
+        returncode,
+        stderr,
+        expected_code,
+        retryable,
+    ):
+        import gateway.status as gateway_status
+
+        adapter = _make_adapter()
+        adapter.cli_path = "/fake/buzz"
+        monkeypatch.setattr(_buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1test")
+        monkeypatch.setattr(
+            gateway_status,
+            "acquire_scoped_lock",
+            lambda platform, key: (True, None),
+        )
+
+        async def run_cli(args, *, input_text=None):
+            if args == ["users", "get"]:
+                return 0, json.dumps(
+                    [{"pubkey": SELF_PUBKEY, "display_name": "Chip"}]
+                ), ""
+            assert args == ["channels", "list", "--member"]
+            return returncode, "", stderr
+
+        adapter._run_cli = run_cli
+
+        assert await adapter.connect() is False
+        assert adapter.fatal_error_code == expected_code
+        assert adapter.fatal_error_retryable is retryable
+
+    @pytest.mark.asyncio
+    async def test_malformed_joined_channel_payload_is_non_retryable_connect_failure(
+        self, monkeypatch
+    ):
+        import gateway.status as gateway_status
+
+        adapter = _make_adapter()
+        adapter.cli_path = "/fake/buzz"
+        monkeypatch.setattr(_buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1test")
+        monkeypatch.setattr(
+            gateway_status,
+            "acquire_scoped_lock",
+            lambda platform, key: (True, None),
+        )
+
+        async def run_cli(args, *, input_text=None):
+            if args == ["users", "get"]:
+                return 0, json.dumps(
+                    [{"pubkey": SELF_PUBKEY, "display_name": "Chip"}]
+                ), ""
+            assert args == ["channels", "list", "--member"]
+            return 0, "{}", ""
+
+        adapter._run_cli = run_cli
+
+        assert await adapter.connect() is False
+        assert adapter.fatal_error_code == "connect_failed"
+        assert adapter.fatal_error_retryable is False
 
 
 # ── Credentials / requirements ────────────────────────────────────────────
@@ -508,6 +2270,11 @@ class TestBuzzPluginRegistration:
         assert callable(kwargs["standalone_sender_fn"])
         assert callable(kwargs["env_enablement_fn"])
         assert set(kwargs["required_env"]) == {"BUZZ_RELAY_URL", "BUZZ_PRIVATE_KEY"}
+        platform_hint = kwargs["platform_hint"]
+        assert "existing local image" in platform_hint
+        assert "MEDIA:/absolute/path" in platform_hint
+        assert "do not use Computer Use" in platform_hint
+        assert "document" not in platform_hint.lower()
 
 
 class TestStandaloneSend:
@@ -536,5 +2303,107 @@ class TestStandaloneSend:
         assert captured["input_text"] == "cron says hi"
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
+
+    @pytest.mark.asyncio
+    async def test_standalone_mention_fallback_keeps_thread_and_media(
+        self, monkeypatch, tmp_path
+    ):
+        from gateway.config import PlatformConfig
+
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        calls = []
+        outcomes = [
+            (
+                1,
+                "",
+                "mention '@ghost' does not match a current channel member",
+            ),
+            (0, json.dumps({"accepted": True, "event_id": "delivered"}), ""),
+        ]
+
+        async def fake_exec(
+            cli_path,
+            args,
+            *,
+            relay_url,
+            private_key,
+            input_text=None,
+            timeout=30.0,
+        ):
+            calls.append((list(args), input_text))
+            return outcomes.pop(0)
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            CHANNEL,
+            "Ask @ghost to review.",
+            thread_id="root-event",
+            media_files=["report.png"],
+            force_document=True,
+        )
+
+        assert result == {"success": True, "message_id": "delivered"}
+        assert [call[1] for call in calls] == [
+            "Ask @ghost to review.",
+            "Ask ghost to review.",
+        ]
+        assert calls[0][0] == calls[1][0]
+        assert calls[0][0][calls[0][0].index("--reply-to") + 1] == "root-event"
+        assert calls[0][0][calls[0][0].index("--file") + 1] == "report.png"
+
+    @pytest.mark.asyncio
+    async def test_standalone_configured_handoff_keeps_exact_pubkey_and_media(
+        self, monkeypatch, tmp_path
+    ):
+        from gateway.config import PlatformConfig
+
+        target_pubkey = "c" * 64
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        calls = []
+
+        async def fake_exec(
+            cli_path,
+            args,
+            *,
+            relay_url,
+            private_key,
+            input_text=None,
+            timeout=30.0,
+        ):
+            calls.append((list(args), input_text))
+            return 0, json.dumps({"accepted": True, "event_id": "handoff"}), ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+        pconfig = PlatformConfig(
+            enabled=True,
+            extra={"outbound_mention_pubkeys": {"ClaudeCode": target_pubkey}},
+        )
+
+        result = await _standalone_send(
+            pconfig,
+            CHANNEL,
+            "@ClaudeCode review this artifact.",
+            thread_id="root-event",
+            media_files=["report.png"],
+            force_document=True,
+        )
+
+        assert result == {"success": True, "message_id": "handoff"}
+        assert len(calls) == 1
+        args, stdin_text = calls[0]
+        assert args[args.index("--mention") + 1] == target_pubkey
+        assert args[args.index("--reply-to") + 1] == "root-event"
+        assert args[args.index("--file") + 1] == "report.png"
+        assert stdin_text == "@ClaudeCode review this artifact."
 
 

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -2,9 +2,9 @@
 
 The Buzz adapter connects Hermes to a [Buzz](https://github.com/block/buzz) community — Block's open-source human+agent collaboration platform built on the Nostr protocol — and relays messages between Buzz channels (or DMs) and the agent. Outbound traffic shells out to the `buzz` CLI binary ("JSON in, JSON out"); inbound uses a native Nostr WebSocket subscription (via the already-bundled `websockets` package) with CLI polling as fallback. **No extra Python packages are required** — just the `buzz` binary.
 
-Buzz renders markdown, so agent replies keep their formatting. Images are delivered as uploads (local files) or links (URLs). Replies can thread onto an existing message via its event id.
+Buzz renders markdown, so agent replies keep their formatting. Images are delivered as native uploads (local files) or links (URLs). Replies use the stable NIP-10 thread root: a response to a root message opens one thread, and responses to nested replies stay attached to that original root instead of creating deeper subthreads. Recent event-to-root relationships are rebuilt from history after a gateway restart.
 
-Inbound messages arrive over a persistent NIP-42-authenticated Nostr WebSocket subscription by default (near-instant delivery), with automatic fallback to CLI polling when the WebSocket can't be established. Outbound messages always go through the `buzz` CLI. Control it with `transport` / `BUZZ_TRANSPORT`: `auto` (default), `websocket` (require WS, fail otherwise), or `poll`. If your relay membership uses NIP-OA owner attestation, set `BUZZ_AUTH_TAG` to the four-string auth tag JSON.
+Inbound messages arrive over a persistent NIP-42-authenticated Nostr WebSocket subscription by default (near-instant delivery), with CLI polling as a startup fallback when `auto` cannot establish the WebSocket. An established WebSocket reconnects with bounded backoff if it disconnects; it does not switch to polling mid-connection. Outbound messages always go through the `buzz` CLI. Control inbound transport with `transport` / `BUZZ_TRANSPORT`: `auto` (default), `websocket` (require WS at startup), or `poll`. If your relay membership uses NIP-OA owner attestation, set `BUZZ_AUTH_TAG` to the four-string auth tag JSON.
 
 > Run `hermes gateway setup` and pick **Buzz** for a guided walk-through.
 
@@ -97,9 +97,15 @@ gateway:
 
 ## Mentions, channels, and DMs
 
-- In shared channels the agent only responds when **addressed** — by `@name`, its npub, or its hex pubkey. Everything else is ignored.
+- In shared channels the agent only responds when **explicitly addressed**. A display-name mention must include the `@` marker (for example, `@Chip`); a bare name in prose, a path, or a URL does not count. The agent's npub and hex pubkey identity forms are also recognized.
 - Direct messages always reach the agent, no mention needed.
+- Configuring `channels` restricts joined community channel discovery; DM discovery remains independent. New DMs can still be discovered through the DM roster or the relay's DM-shaped channel fallback, while other unconfigured community channels are not watched.
 - The agent's own messages are never dispatched back to it (self-echo suppression by pubkey), and every event is de-duplicated by event id against a per-channel high-water mark.
+
+## Images
+
+- When you supply an existing local image path and ask Hermes to send it, Hermes can return `MEDIA:/absolute/path/to/image.png`; the Buzz adapter uploads that image through the native CLI attachment path. It does not need to open Computer Use or another UI.
+- For inbound protected Buzz images, the adapter recognizes exact image URLs on the configured relay and fetches them with the configured Buzz identity. Protected images are fetched only for authorized senders. It validates the size, content hash, image type, and filename extension before placing the file in a private local cache. URLs on other hosts, malformed URLs, failed downloads, or failed validation remain links in the message.
 
 ## Access control
 
@@ -117,7 +123,8 @@ Check status with `hermes gateway status` — Buzz connection state is reported 
 
 ## Notes and limitations
 
-- **Inbound is polled, not streamed.** The `buzz` CLI is request/response, so the adapter polls `buzz messages get` per watched channel every `poll_interval` seconds (default 4). Expect up to one interval of latency on inbound messages. A future optimization is a websocket transport (the Buzz repo ships `buzz-ws-client` for true streaming).
+- Inbound defaults to an authenticated WebSocket subscription. Poll mode uses `buzz messages get` per watched conversation every `poll_interval` seconds (default 4), so poll-mode delivery can take up to one interval.
 - On (re)connect the adapter seeds its high-water mark from the newest events, so channel history is never replayed into the agent.
-- New DM conversations are discovered automatically (every few poll sweeps).
+- The adapter reconciles WebSocket subscriptions from the authoritative joined-channel roster when Buzz emits membership add/remove events. Poll mode refreshes the same roster periodically. An explicit `channels` / `BUZZ_CHANNELS` list remains a restrictive watch list and is never broadened by discovery.
+- New DM conversations are discovered automatically. Joined community channels are kept distinct from DM-shaped fallback metadata.
 - The private key is passed to the CLI via the subprocess environment — it never appears in argv or logs.


### PR DESCRIPTION
## What this improves

This makes Hermes's bundled Buzz adapter more dependable in everyday conversations:

- replies stay attached to the original Buzz thread instead of creating nested or drifting conversations;
- shared-channel messages address the agent through explicit `@DisplayName` mentions, avoiding false activations from bare names in paths, URLs, or prose;
- an existing local image path can be sent through Hermes's native media response instead of opening Computer Use or another UI;
- authorized protected images from the configured Buzz relay are downloaded, validated, and exposed to the model safely;
- joined-community additions and removals refresh while the gateway is running, while direct-message discovery remains independent;
- reconnect and startup behavior handles malformed profiles, malformed rosters, retryable relay errors, cancellation, and identity-lock cleanup consistently.

## Thread and image behavior

Buzz thread roots are reconstructed from marked and legacy NIP-10 tags, bounded in memory, and preserved across nested replies and history seeding. Polling and WebSocket delivery use the same event path, so they produce the same thread identity.

For protected inbound images, the adapter:

- requires an authorized sender before downloading;
- accepts only the configured relay origin, including the transport-equivalent `ws→http` and `wss→https` forms;
- validates the exact media path, size, SHA-256 digest, image family, and extension;
- uses private cache permissions and removes incomplete temporary or cached files on failure.

For outbound images, a user-supplied existing local path is sent through the native Buzz CLI attachment path. Configured structural mentions are preserved in image captions.

## Live channel reconciliation

The adapter watches the authoritative joined-community roster and reconciles additions and removals without requiring a gateway restart. Explicitly configured community IDs remain restrictive. Direct messages are still discovered independently through the DM roster or Buzz's DM-shaped channel fallback.

## Security and failure handling

- Profile identities must be normalized 64-character hexadecimal pubkeys before lock or transport startup.
- Authoritative channel rows are validated before any roster state is mutated.
- Structured Buzz CLI `retryable` values take precedence over legacy exit-code fallback.
- Duplicate Buzz profiles now fail closed through the scoped identity lock.
- Every unsuccessful, exceptional, or cancelled connection path releases that lock and cleans up partially started transport tasks.

## Relationship to existing PRs

This current-main contribution fully supersedes:

- #74823 — dynamic joined-channel discovery;
- #77734 — authenticated protected inbound images;
- #77647 — delivery of messages containing unresolved mentions.

It also carries forward #75049’s stable thread-root and reconstruction behavior. #91020 carries forward that PR’s live channel/thread mention-policy configuration. Agent-participated-thread admission and pending-follow-up behavior remain outside both contributions.

It also overlaps the stable-thread problem space discussed in #84492, #89868, and #90555. This implementation keeps one canonical NIP-10 root across nested replies, restart/history reconstruction, polling, and WebSocket delivery.

#74823, #75049, and #77734 are now closed in favor of focused current-main contributions.

#91020 is the independent follow-up for live profile-scoped Buzz access and mention settings, including the Buzz panel under Config.

The two PRs are based separately on `main` and can be reviewed or merged in either order.

## Deliberately out of scope

This PR does not include:

- live profile-policy/settings infrastructure and Dashboard UI, proposed independently in #91020;
- signed agent-directory publication;
- generic turn-observer, activity, clarification, or route-scope infrastructure;
- generic non-image document delivery;
- configurable flat-versus-threaded outbound reply placement (`reply_to_mode`), proposed separately in #85613;

Those are independent review and rollback boundaries.

## Verification

Canonical affected suites:

```text
HERMES_PYTHON=/tmp/buzz-pr1-venv/bin/python \
  scripts/run_tests.sh \
  tests/gateway/test_buzz_adapter.py \
  tests/gateway/test_buzz_websocket.py -q

116 passed
```