### PR TITLE
feat(skills): make DESIGN.md the mandatory first step for every UI build

### DIFF
--- a/skills/creative/claude-design/SKILL.md
+++ b/skills/creative/claude-design/SKILL.md
@@ -17,7 +17,7 @@ Use this skill when the user asks for design work that would normally fit Claude
 
 The goal is to preserve Claude Design's useful design behavior and taste while removing hosted-tool plumbing that does not exist in normal agent environments.
 
-**Before starting, check for other web-design skills like `popular-web-designs` (ready-to-paste design systems for Stripe, Linear, Vercel, Notion, etc.) and `design-md` (Google's DESIGN.md token spec format).** If the user wants a known brand's look, load `popular-web-designs` alongside this one and let it supply the visual vocabulary. If the deliverable is a token spec file rather than a rendered artifact, use `design-md` instead. Full decision table below.
+**Before starting, author a `DESIGN.md` in the project root via the `design-md` skill — it is the mandatory first step for any UI build.** Extract real tokens from the existing project/brand when they exist; never invent a palette that already exists. If the user wants a known brand's look, load `popular-web-designs` alongside this one and let it supply the visual vocabulary, then encode the chosen system into `DESIGN.md` before building. Build every artifact strictly from the DESIGN.md tokens. Full decision table below.
 
 ## When To Use This Skill vs `popular-web-designs` vs `design-md`
 
@@ -27,15 +27,15 @@ Hermes has three design-related skills under `skills/creative/`. They do differe
 |---|---|---|
 | **claude-design** (this one) | Design *process and taste* — how to scope a brief, gather context, produce variants, verify a local HTML artifact, avoid AI-design slop | a from-scratch designed artifact (landing page, prototype, deck, component lab, motion study) with no specific brand or token system dictated |
 | **popular-web-designs** | 54 ready-to-paste design systems — exact colors, typography, components, CSS values for sites like Stripe, Linear, Vercel, Notion, Airbnb | "make it look like Stripe / Linear / Vercel", a page styled after a known brand, or a visual starting point pulled from a real product |
-| **design-md** | Google's DESIGN.md spec format — author/validate/diff/export design-token files, WCAG contrast checking, Tailwind/DTCG export | a formal, persistent, machine-readable design-system *spec file* (tokens + rationale) that lives in a repo and gets consumed by agents over time |
+| **design-md** | Google's DESIGN.md spec format — author/validate/diff/export design-token files, WCAG contrast checking, Tailwind/DTCG export | **EVERY UI build** — the mandatory first step: author the DESIGN.md in the project root, lint it, then build from its tokens |
 
 Rule of thumb:
 
-- **Process + taste, one-off artifact** → claude-design
-- **Match a known brand's look** → popular-web-designs (and let claude-design drive the process)
-- **Author the tokens spec itself** → design-md
+- **Always: DESIGN.md first** → design-md (author + lint in project root)
+- **Process + taste, one-off artifact** → claude-design builds from the DESIGN.md
+- **Match a known brand's look** → popular-web-designs (let claude-design drive the process), encode the chosen system into DESIGN.md
 
-These compose: use `popular-web-designs` for the visual vocabulary, `claude-design` for how to turn a brief into a thoughtful local HTML file, and `design-md` when the output is the token file rather than a rendered artifact.
+These compose: author the DESIGN.md first (design-md), use `popular-web-designs` for the visual vocabulary, `claude-design` for how to turn a brief into a thoughtful local HTML file — the DESIGN.md is the contract everything gets built from.
 
 ## Runtime Mode
 
@@ -107,7 +107,7 @@ Use this skill for:
 - settings, command palettes, modals, cards, forms, empty states
 - redesigns based on screenshots, repos, brand docs, or UI kits
 
-Do not use this skill for pure DESIGN.md token authoring unless the user specifically asks for a DESIGN.md file. Use `design-md` for that.
+This skill always follows DESIGN.md: author the spec first via the `design-md` skill, then build with this skill's process and taste from its tokens.
 
 ## Design Principle: Start From Context, Not Vibes
 

--- a/skills/creative/design-md/SKILL.md
+++ b/skills/creative/design-md/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: design-md
-description: Author/validate/export Google's DESIGN.md token spec files.
-version: 1.1.0
+description: "Use when the user designs or builds an app, website, or UI. DESIGN.md is the mandatory first step: author, lint, then build from tokens."
+version: 2.0.0
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
@@ -11,7 +11,7 @@ metadata:
     related_skills: [popular-web-designs, claude-design, excalidraw, architecture-diagram]
 ---
 
-# DESIGN.md Skill
+# DESIGN.md — Mandatory Design Workflow
 
 DESIGN.md is Google's open spec (Apache-2.0, `google-labs-code/design.md`) for
 describing a visual identity to coding agents. One file combines:
@@ -19,22 +19,41 @@ describing a visual identity to coding agents. One file combines:
 - **YAML front matter** — machine-readable design tokens (normative values)
 - **Markdown body** — human-readable rationale, organized into canonical sections
 
-Tokens give exact values. Prose tells agents *why* those values exist and how to
-apply them. The CLI (`npx @google/design.md`) lints structure + WCAG contrast,
-diffs versions for regressions, and exports to Tailwind or W3C DTCG JSON.
+This skill is the **mandatory entry point for every design or UI build** —
+app, website, page, landing, dashboard, or component. It is NOT optional and
+not just for "formal spec" requests. Pair it with an AGENTS.md or SOUL.md rule
+to make it sticky in every session; this skill is how to execute it.
 
-## When to use this skill
+## The rule (always)
 
-- User asks for a DESIGN.md file, design tokens, or a design system spec
-- User wants consistent UI/brand across multiple projects or tools
-- User pastes an existing DESIGN.md and asks to lint, diff, export, or extend it
-- User asks to port a style guide into a format agents can consume
-- User wants contrast / WCAG accessibility validation on their color palette
+1. **Author `DESIGN.md` in the project root before writing any UI.** If a
+   DESIGN.md already exists — read it first and build from its tokens.
+2. **Extract real tokens.** If the project/brand/client already has a site,
+   style, or materials, pull the actual palette, type, and radii from the code
+   or brand kit. Never invent a palette when the real one exists.
+   (For an existing project, extract straight from its own stylesheet — e.g.
+   `src/app/globals.css`.)
+3. **Lint it** with the CLI (below). Fix broken refs and WCAG failures before
+   building.
+4. **Build every screen strictly from the DESIGN.md tokens.** Colors, type,
+   radii, spacing all resolve to the spec. Extend the spec before violating it.
+5. **One DESIGN.md per project/brand identity.** Client work gets its own file
+   per client. For direction sketches (see `sketch` skill), the winning variant
+   gets encoded into DESIGN.md before it becomes a real build.
+6. For a specific brand/design-system look, `popular-web-designs` supplies the
+   vocabulary (sourced from VoltAgent/awesome-design-md) — encode the chosen
+   system into DESIGN.md, then build. Want a DESIGN.md that already exists for a
+   known brand? The awesome collection has 73 ready-made files:
+   https://github.com/VoltAgent/awesome-design-md (each brand also at
+   `getdesign.md/<brand>/design-md`). Missing one? Request it at
+   https://getdesign.md/request.
 
-For purely visual inspiration or layout examples, use `popular-web-designs`
-instead. For *process and taste* when designing a one-off HTML artifact
-from scratch (prototype, deck, landing page, component lab), use
-`claude-design`. This skill is for the *formal spec file* itself.
+## When this skill is NOT the design workflow
+
+Only `sketch` (throwaway comparison mockups, nothing built for real) and pure
+motion/illustration work skip the DESIGN.md-first step — and even sketches
+become DESIGN.md before a real build. `claude-design` and HTML artifact work
+follow this skill, not around it.
 
 ## File anatomy
 
@@ -129,9 +148,9 @@ if the value type is valid. Unknown component properties produce a warning.
 
 ## Workflow: authoring a new DESIGN.md
 
-1. **Ask the user** (or infer) the brand tone, accent color, and typography
-   direction. If they provided a site, image, or vibe, translate it to the
-   token shape above.
+1. **Extract real tokens** if the brand/site/project already has them (CSS,
+   brand kit, client materials). Otherwise ask the user (or infer) brand tone,
+   accent color, and typography direction.
 2. **Write `DESIGN.md`** in their project root using `write_file`. Always
    include `name:` and `colors:`; other sections optional but encouraged.
 3. **Use token references** (`{colors.primary}`) in the `components:` section
@@ -174,7 +193,7 @@ On Windows, the `design.md` bin name can collide with the `.md` file
 association (silent no-op or the file opens in an editor). Use the dot-free
 alias: `npx -y -p @google/design.md designmd lint DESIGN.md`.
 
-### Lint rule reference (the 9 rules, as of CLI 0.3.0)
+### Lint rule reference (as of CLI 0.4.0 — verify with `spec --rules-only`)
 
 - `broken-ref` (error) — `{colors.missing}` points at a non-existent token
 - `contrast-ratio` (warning) — component `textColor` vs `backgroundColor`
@@ -202,13 +221,13 @@ summary — WCAG findings are the most load-bearing reason to use the CLI.
 - **Section order matters even though the linter only warns.** If the user
   gives you prose in a random order, reorder it to match the canonical list
   before saving — spec-compliant consumers expect it.
-- **Typography sub-property typos are silently dropped.** As of CLI 0.3.0 a
-  typo like `fontwight:` produces no finding and the value vanishes from
-  exports — double-check sub-property names against the schema
-  (`fontFamily`, `fontSize`, `fontWeight`, `lineHeight`, `letterSpacing`,
-  `fontFeature`, `fontVariation`).
-- **`version: alpha` is the current spec version** (as of Jul 2026, CLI
-  0.3.0). The spec is marked alpha — watch for breaking changes.
+- **Typography sub-property typos are silently dropped.** A typo like
+  `fontwight:` produces no finding and the value vanishes from exports —
+  double-check sub-property names against the schema (`fontFamily`,
+  `fontSize`, `fontWeight`, `lineHeight`, `letterSpacing`, `fontFeature`,
+  `fontVariation`).
+- **`version: alpha` is the current spec version.** The spec is marked alpha —
+  watch for breaking changes.
 - **Token references resolve by dotted path.** `{colors.primary}` works;
   `{primary}` does not.
 
@@ -216,5 +235,6 @@ summary — WCAG findings are the most load-bearing reason to use the CLI.
 
 - Repo: https://github.com/google-labs-code/design.md (Apache-2.0)
 - CLI: `@google/design.md` on npm
+- Curated ready-made files (73 brands): https://github.com/VoltAgent/awesome-design-md
 - License of generated DESIGN.md files: whatever the user's project uses;
   the spec itself is Apache-2.0.

--- a/skills/creative/popular-web-designs/SKILL.md
+++ b/skills/creative/popular-web-designs/SKILL.md
@@ -31,15 +31,19 @@ system, shadows, responsive behavior, and practical agent prompts with exact CSS
   Pair it with this skill when the user wants a thoughtfully-designed page styled
   after a known brand: `claude-design` drives the workflow, this skill supplies
   the visual vocabulary.
-- **`design-md`** — use when the deliverable is a formal DESIGN.md token spec
-  file, not a rendered artifact.
+- **`design-md`** — **mandatory first step for every UI build**: encode the
+  chosen design system into a `DESIGN.md` in the project root, lint it, then
+  build from its tokens. It is not optional — it is the contract every
+  artifact is built from.
 
 ## How to Use
 
 1. Pick a design from the catalog below
 2. Load it: `skill_view(name="popular-web-designs", file_path="templates/<site>.md")`
-3. Use the design tokens and component specs when generating HTML
-4. Pair with the `generative-widgets` skill to serve the result via cloudflared tunnel
+3. Author `DESIGN.md` in the project root from the chosen system's tokens
+   (design-md skill), then lint it
+4. Use the design tokens and component specs when generating HTML
+5. Pair with the `generative-widgets` skill to serve the result via cloudflared tunnel
 
 Each template includes a **Hermes Implementation Notes** block at the top with:
 - CDN font substitute and Google Fonts `<link>` tag (ready to paste)

--- a/skills/creative/sketch/SKILL.md
+++ b/skills/creative/sketch/SKILL.md
@@ -174,6 +174,8 @@ If the user has an existing theme (colors, fonts, tokens), put shared tokens in 
 
 Don't over-tokenize a throwaway sketch — three colors and one font is usually enough.
 
+When the user picks a winner, encode the chosen direction into `DESIGN.md` in the project root via the `design-md` skill before it becomes a real build. The sketch becomes the spec.
+
 ## Interactivity bar
 
 A sketch is interactive enough when the user can:


### PR DESCRIPTION
Make DESIGN.md the mandatory first step for every UI build.

## What & why

DESIGN.md (Google's open spec, `google-labs-code/design.md`) is the cleanest
way to hand an agent a visual identity: one markdown file, no tooling, tokens
with WCAG validation. Until now Hermes treated it as an optional format tool —
relevant only when the user explicitly asked for a spec file.

This changes the posture: **any** app/website/UI build starts by authoring a
`DESIGN.md` in the project root, linting it, then building every screen from
its tokens. Rationale:

- **Consistency by construction.** The spec file becomes the contract every
  artifact is built from, instead of each build re-deriving style from a
  short-lived prompt.
- **Real tokens, not vibes.** The workflow mandates extracting the actual
  palette/type/radii from an existing site or brand kit, not inventing one.
- **Accessibility gating.** The CLI runs WCAG contrast checks before any UI is
  written.

## Changes

- **`skills/creative/design-md`** → v2.0. Repurposed as the mandatory design
  workflow: author → extract real tokens → lint → build from tokens. Adds the
  VoltAgent/awesome-design-md collection (73 ready-made brand specs) as the
  style source and getdesign.md for requested specs.
- **`skills/creative/claude-design`** → DESIGN.md is now the required first
  step before any artifact; decision table updated.
- **`skills/creative/popular-web-designs`** → chosen design system is encoded
  into DESIGN.md before building (the file is now the contract).
- **`skills/creative/sketch`** → a picked sketch variant gets encoded into
  DESIGN.md before it becomes a real build.

## Verification

- `@google/design.md` CLI 0.4.0
- A real DESIGN.md extracted from an existing project's stylesheet lints at
  **0 errors / 0 warnings** (`exit 0`).

No core-tool footprint: skills-only change, no model tools, no config keys.
