### PR TITLE
feat(desktop): add copy action to user prompts

### DIFF
--- a/apps/desktop/e2e/user-message-copy.spec.ts
+++ b/apps/desktop/e2e/user-message-copy.spec.ts
@@ -1,0 +1,52 @@
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { expect, test } from './test'
+
+let fixture: MockBackendFixture | null = null
+
+test.beforeAll(async () => {
+  fixture = await setupMockBackend()
+  await waitForAppReady(fixture, 120_000)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+test('copies a sent user prompt without opening the edit composer', async () => {
+  const page = fixture!.page
+  const prompt = 'copy this prompt `verbatim` 한글'
+  const composer = page.locator('[data-slot="composer-rich-input"]').first()
+
+  await composer.fill(prompt)
+  await expect(composer).toHaveText(prompt)
+  await page.keyboard.press('Enter')
+  await page.waitForFunction(() => (document.body.textContent ?? '').includes('mock inference server'), undefined, {
+    timeout: 60_000
+  })
+
+  const userMessage = page.locator('[data-slot="aui_user-message-root"]').first()
+  const copy = userMessage.getByRole('button', { name: 'Copy' })
+
+  const readClipboard = () =>
+    page.evaluate(() =>
+      (window as unknown as { hermesDesktop: { readClipboard: () => Promise<string> } }).hermesDesktop.readClipboard()
+    )
+
+  const sentinel = 'clipboard-before-user-message-copy'
+
+  await page.evaluate(
+    value =>
+      (
+        window as unknown as { hermesDesktop: { writeClipboard: (text: string) => Promise<boolean> } }
+      ).hermesDesktop.writeClipboard(value),
+    sentinel
+  )
+  await expect.poll(readClipboard, { timeout: 10_000 }).toBe(sentinel)
+
+  await userMessage.hover()
+  await copy.click()
+
+  await expect.poll(readClipboard, { timeout: 10_000 }).toBe(prompt)
+  await expect(page.locator('[data-slot="aui_edit-composer-root"]')).toHaveCount(0)
+})

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-copy.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-copy.test.tsx
@@ -1,0 +1,64 @@
+import { AssistantRuntimeProvider, ExportedMessageRepository, type ThreadMessage } from '@assistant-ui/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
+
+import { assistantMessage, stubThreadEnvironment, stubThreadViewportSize, userMessage } from '../test-utils'
+
+import { Thread } from '.'
+
+stubThreadEnvironment()
+stubThreadViewportSize()
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+function Harness({ prompt }: { prompt: string }) {
+  const repository = ExportedMessageRepository.fromArray([userMessage('user-1', prompt), assistantMessage()])
+
+  const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
+    messageRepository: repository,
+    isRunning: false,
+    setMessages: () => {},
+    onNew: async () => {},
+    onEdit: async () => {},
+    onCancel: async () => {},
+    onReload: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
+describe('user message copy action', () => {
+  it('copies the exact prompt without opening the edit composer', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    const prompt = 'first line\n`literal code` and 한글'
+
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText }
+    })
+
+    const { container } = render(<Harness prompt={prompt} />)
+
+    const userMessageRoot = await waitFor(() => {
+      const node = container.querySelector('[data-slot="aui_user-message-root"]')
+      expect(node).toBeTruthy()
+
+      return node as HTMLElement
+    })
+
+    fireEvent.click(within(userMessageRoot).getByRole('button', { name: 'Copy' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(prompt))
+    expect(container.querySelector('[data-slot="aui_edit-composer-root"]')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Edit message' })).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-copy.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-copy.test.tsx
@@ -14,6 +14,7 @@ stubThreadViewportSize()
 afterEach(() => {
   cleanup()
   vi.restoreAllMocks()
+  vi.unstubAllGlobals()
 })
 
 function Harness({ prompt }: { prompt: string }) {
@@ -37,10 +38,15 @@ function Harness({ prompt }: { prompt: string }) {
 }
 
 describe('user message copy action', () => {
-  it('copies the exact prompt without opening the edit composer', async () => {
+  it('copies the exact prompt through the desktop clipboard bridge without opening the edit composer', async () => {
+    const writeClipboard = vi.fn().mockResolvedValue(true)
     const writeText = vi.fn().mockResolvedValue(undefined)
     const prompt = 'first line\n`literal code` and 한글'
 
+    // Electron exposes `hermesDesktop.writeClipboard`; the renderer's
+    // `navigator.clipboard` can throw once the document loses focus, so the
+    // bridge must win whenever it is present.
+    vi.stubGlobal('hermesDesktop', { writeClipboard })
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
       value: { writeText }
@@ -57,7 +63,8 @@ describe('user message copy action', () => {
 
     fireEvent.click(within(userMessageRoot).getByRole('button', { name: 'Copy' }))
 
-    await waitFor(() => expect(writeText).toHaveBeenCalledWith(prompt))
+    await waitFor(() => expect(writeClipboard).toHaveBeenCalledWith(prompt))
+    expect(writeText).not.toHaveBeenCalled()
     expect(container.querySelector('[data-slot="aui_edit-composer-root"]')).toBeNull()
     expect(screen.getByRole('button', { name: 'Edit message' })).toBeTruthy()
   })

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -9,6 +9,7 @@ import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/type
 import { useMessageReactions } from '@/components/assistant-ui/thread/use-message-reactions'
 import { UserMessageText } from '@/components/assistant-ui/thread/user-message-text'
 import { Codicon } from '@/components/ui/codicon'
+import { CopyButton } from '@/components/ui/copy-button'
 import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
@@ -407,7 +408,8 @@ export const UserMessage: FC<{
 
   const bubbleClassName = cn(
     USER_BUBBLE_BASE_CLASS,
-    'cursor-pointer pr-9 text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground/95 transition-colors',
+    'cursor-pointer text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground/95 transition-colors',
+    showStop || showRestore ? 'pr-16' : 'pr-9',
     'border-(--ui-stroke-tertiary) hover:border-(--ui-stroke-secondary)'
   )
 
@@ -527,8 +529,17 @@ export const UserMessage: FC<{
                     </button>
                   </ActionBarPrimitive.Edit>
                 )}
-                {(showStop || showRestore) && (
-                  <div className="pointer-events-none absolute right-2 bottom-2 z-10 flex items-center justify-center opacity-0 transition-opacity group-hover/user-message:opacity-100 group-focus-within/user-message:opacity-100">
+                {hasBody && (
+                  <div className="pointer-events-none absolute right-2 bottom-2 z-10 flex items-center justify-center gap-0.5 opacity-0 transition-opacity group-hover/user-message:opacity-100 group-focus-within/user-message:opacity-100">
+                    <CopyButton
+                      appearance="icon"
+                      buttonSize="icon-xs"
+                      className="pointer-events-auto"
+                      label={copy.copy}
+                      preventDefault
+                      stopPropagation
+                      text={messageText}
+                    />
                     {showStop ? (
                       <button
                         aria-label={copy.stop}
@@ -543,7 +554,7 @@ export const UserMessage: FC<{
                       >
                         {StopGlyph}
                       </button>
-                    ) : (
+                    ) : showRestore ? (
                       <button
                         aria-label={copy.restoreCheckpoint}
                         className={cn('pointer-events-auto size-6', USER_ACTION_ICON_BUTTON_CLASS)}
@@ -565,7 +576,7 @@ export const UserMessage: FC<{
                       >
                         <Codicon name="discard" size="0.875rem" />
                       </button>
-                    )}
+                    ) : null}
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Summary

- add a hover/focus copy action to sent user-message bubbles
- reuse the existing localized `CopyButton` and Electron clipboard bridge
- preserve click-to-edit, Stop, Restore, and drag-selection behavior
- copy the raw prompt text exactly, including line breaks and inline Markdown

## Why

User prompts are rendered as edit buttons. Although Desktop has selection guards, drag-select remains a fragile way to copy an entire prompt on Windows Chromium. Assistant messages already expose a dedicated copy action; user messages do not.

This change adds the same reliable one-click path without replacing arbitrary text selection.

Related to #52457. Complementary to #80270 (selectable user text) and #58996 (copy prompt + response together); this PR is limited to copying one user prompt.

## Implementation

The copy control is a sibling of the edit button inside the existing user-message action overlay, so it does not create nested buttons or trigger the edit composer. When Stop or Restore shares the corner, the bubble reserves enough right padding for both controls.

## Validation

- TDD: new unit test failed before implementation because no user-message Copy button existed
- `npm run test:ui` — 555 files, 5,293 tests passed
- `npm run typecheck`
- targeted ESLint and Prettier checks
- `npm run build`
- Electron E2E with mock backend: send prompt → hover user bubble → click Copy → verify OS clipboard exact match and edit composer remains closed
