### PR TITLE
fix(aux): apply per-provider extra_headers on auxiliary clients

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1042,7 +1042,7 @@ _OR_HEADERS_BASE = {
 _TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
 
 
-def _apply_user_default_headers(headers: dict | None) -> dict | None:
+def _apply_user_default_headers(headers: dict | None, base_url: str | None = None) -> dict | None:
     """Merge user-configured ``model.default_headers`` onto resolved headers.
 
     User values take precedence over provider/SDK defaults, mirroring the main
@@ -1052,6 +1052,10 @@ def _apply_user_default_headers(headers: dict | None) -> dict | None:
     ``X-Stainless-*``) override them for auxiliary calls too — otherwise the
     main turn would succeed but title/compression/vision calls to the same
     endpoint would still fail. (#40033)
+
+    When *base_url* is given, per-provider ``custom_providers[].extra_headers``
+    matching that route are merged on top (most specific wins), mirroring the
+    main client's ``apply_custom_provider_extra_headers_to_client_kwargs``.
 
     Returns the merged dict, or the original ``headers`` (possibly ``None``)
     when nothing is configured. No allocation when there are no overrides.
@@ -1073,13 +1077,45 @@ def _apply_user_default_headers(headers: dict | None) -> dict | None:
             user_headers = merged_user
     except Exception:
         return headers
-    if not isinstance(user_headers, dict) or not user_headers:
+
+    # Per-provider extra_headers lookup is kept outside the user_headers
+    # try/except so its own failures can't cause us to discard user_headers.
+    # The block below has its own try/except for defence-in-depth.
+    provider_headers: dict = {}
+    if base_url:
+        try:
+            from hermes_cli.config import get_custom_provider_extra_headers
+            provider_headers = get_custom_provider_extra_headers(base_url, config=_cfg)
+        except Exception as exc:
+            # Never let a lookup failure break auxiliary client
+            # construction or discard the user_headers merge above, but
+            # leave a breadcrumb so operators can tell why their
+            # custom_providers[].extra_headers didn't apply. Neither
+            # header values nor the base_url are logged — both can be
+            # sensitive (credentials, internal topology).
+            logger.warning(
+                "aux headers: custom-provider extra_headers lookup failed: %s",
+                type(exc).__name__,
+            )
+            provider_headers = {}
+        if not isinstance(provider_headers, dict):
+            provider_headers = {}
+
+    if (not isinstance(user_headers, dict) or not user_headers) and not provider_headers:
         return headers
     merged = dict(headers or {})
-    for key, value in user_headers.items():
+    if isinstance(user_headers, dict):
+        for key, value in user_headers.items():
+            if value is None:
+                continue
+            merged[str(key)] = str(value)
+    # Per-provider extra_headers are the most specific level — applied last.
+    for key, value in provider_headers.items():
         if value is None:
             continue
         merged[str(key)] = str(value)
+    if not merged:
+        return headers
     return merged or headers
 
 
@@ -2769,7 +2805,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                         extra["default_headers"] = dict(_ph_aux.default_headers)
                 except Exception:
                     pass
-            _merged_aux = _apply_user_default_headers(extra.get("default_headers"))
+            _merged_aux = _apply_user_default_headers(extra.get("default_headers"), base_url=base_url)
             if _merged_aux:
                 extra["default_headers"] = _merged_aux
             _client = _create_openai_client(api_key=api_key, base_url=base_url, **extra)
@@ -2809,7 +2845,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                     extra["default_headers"] = dict(_ph_aux2.default_headers)
             except Exception:
                 pass
-        _merged_aux2 = _apply_user_default_headers(extra.get("default_headers"))
+        _merged_aux2 = _apply_user_default_headers(extra.get("default_headers"), base_url=base_url)
         if _merged_aux2:
             extra["default_headers"] = _merged_aux2
         _client = _create_openai_client(api_key=api_key, base_url=base_url, **extra)
@@ -3671,7 +3707,7 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
     # headers (User-Agent: OpenAI/Python ..., X-Stainless-*) on this custom
     # endpoint's auxiliary calls too — matching the main agent client so the
     # whole session reaches a gateway/WAF that rejects the SDK fingerprint. (#40033)
-    _custom_headers = _apply_user_default_headers(None)
+    _custom_headers = _apply_user_default_headers(None, base_url=_clean_base)
     if _custom_headers:
         _extra["default_headers"] = _custom_headers
     if custom_mode == "codex_responses":
@@ -6186,7 +6222,7 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
                     async_kwargs["default_headers"] = dict(_ph_async.default_headers)
         except Exception:
             pass
-    _merged_async = _apply_user_default_headers(async_kwargs.get("default_headers"))
+    _merged_async = _apply_user_default_headers(async_kwargs.get("default_headers"), base_url=sync_base_url)
     if _merged_async:
         async_kwargs["default_headers"] = _merged_async
     async_kwargs = {
@@ -6575,7 +6611,7 @@ def resolve_provider_client(
                         extra["default_headers"] = dict(_ph_custom.default_headers)
                 except Exception:
                     pass
-            _merged_custom = _apply_user_default_headers(extra.get("default_headers"))
+            _merged_custom = _apply_user_default_headers(extra.get("default_headers"), base_url=_clean_base)
             if _merged_custom:
                 extra["default_headers"] = _merged_custom
             client = _create_openai_client(api_key=custom_key, base_url=_clean_base, **extra)
@@ -6665,7 +6701,7 @@ def resolve_provider_client(
                     raw_base_for_wrap = custom_base
                 _clean_base2, _dq2 = _extract_url_query_params(openai_base)
                 _extra2 = {"default_query": _dq2} if _dq2 else {}
-                _headers2 = _apply_user_default_headers(_extra2.get("default_headers"))
+                _headers2 = _apply_user_default_headers(_extra2.get("default_headers"), base_url=_clean_base2)
                 if _headers2:
                     _extra2["default_headers"] = _headers2
                 logger.debug(
@@ -6690,7 +6726,7 @@ def resolve_provider_client(
                         _fallback_base = _to_openai_base_url(custom_base)
                         _fb_clean, _fb_dq = _extract_url_query_params(_fallback_base)
                         _fb_extra = {"default_query": _fb_dq} if _fb_dq else {}
-                        _fb_headers = _apply_user_default_headers(_fb_extra.get("default_headers"))
+                        _fb_headers = _apply_user_default_headers(_fb_extra.get("default_headers"), base_url=_fb_clean)
                         if _fb_headers:
                             _fb_extra["default_headers"] = _fb_headers
                         client = _create_openai_client(api_key=custom_key, base_url=_fb_clean, **_fb_extra)
@@ -6877,7 +6913,7 @@ def resolve_provider_client(
                     headers.update(_ph_main.default_headers)
             except Exception:
                 pass
-        _merged_main = _apply_user_default_headers(headers)
+        _merged_main = _apply_user_default_headers(headers, base_url=base_url)
         if _merged_main:
             headers = _merged_main
         client = _create_openai_client(api_key=api_key, base_url=base_url,

--- a/tests/agent/test_auxiliary_provider_extra_headers.py
+++ b/tests/agent/test_auxiliary_provider_extra_headers.py
@@ -1,0 +1,303 @@
+"""Tests for per-provider ``custom_providers[].extra_headers`` in the auxiliary client.
+
+The main agent client merges ``custom_providers[].extra_headers`` into
+``default_headers`` by matching ``base_url`` (see
+``hermes_cli.config.apply_custom_provider_extra_headers_to_client_kwargs``).
+The auxiliary client (title generation, compression, vision, web_extract)
+builds separate OpenAI clients and must apply the same merge — otherwise an
+OpenAI-compatible gateway/WAF that filters on the SDK's identifying
+``User-Agent`` lets the main turn through while every auxiliary call to the
+same endpoint gets rejected (403). Per-provider headers are the most specific
+configuration level: they override both provider/SDK defaults and the global
+``model.default_headers`` merge.
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """Redirect HERMES_HOME so load_config() reads our test config.yaml."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / "config.yaml").write_text("model:\n  default: test-model\n")
+
+
+def _write_config(tmp_path, config_dict):
+    import yaml
+    (tmp_path / ".hermes" / "config.yaml").write_text(yaml.dump(config_dict))
+
+
+class TestProviderExtraHeadersHelper:
+    """Direct unit tests for the base_url-aware merge helper."""
+
+    def test_provider_extra_headers_applied_on_base_url_match(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "m"},
+            "custom_providers": [
+                {
+                    "name": "my-gw",
+                    "base_url": "http://my-gw.local/v1",
+                    "api_key": "k",
+                    "extra_headers": {"User-Agent": "curl/8.7.1"},
+                },
+            ],
+        })
+        from agent.auxiliary_client import _apply_user_default_headers
+        merged = _apply_user_default_headers({}, base_url="http://my-gw.local/v1")
+        assert merged["User-Agent"] == "curl/8.7.1"
+
+    def test_no_matching_provider_injects_nothing(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "m"},
+            "custom_providers": [
+                {
+                    "name": "my-gw",
+                    "base_url": "http://my-gw.local/v1",
+                    "api_key": "k",
+                    "extra_headers": {"User-Agent": "curl/8.7.1"},
+                },
+            ],
+        })
+        from agent.auxiliary_client import _apply_user_default_headers
+        merged = _apply_user_default_headers(None, base_url="http://other.local/v1")
+        assert merged is None
+
+    def test_provider_extra_headers_beat_global_default_headers(self, tmp_path):
+        """Per-provider extra_headers are the most specific level and win."""
+        _write_config(tmp_path, {
+            "model": {
+                "default": "m",
+                "default_headers": {"User-Agent": "global-ua/1.0", "X-Global": "g"},
+            },
+            "custom_providers": [
+                {
+                    "name": "my-gw",
+                    "base_url": "http://my-gw.local/v1",
+                    "api_key": "k",
+                    "extra_headers": {"User-Agent": "curl/8.7.1"},
+                },
+            ],
+        })
+        from agent.auxiliary_client import _apply_user_default_headers
+        merged = _apply_user_default_headers({}, base_url="http://my-gw.local/v1")
+        assert merged["User-Agent"] == "curl/8.7.1"  # provider wins over global
+        assert merged["X-Global"] == "g"  # unrelated global keys still merge
+
+    def test_default_base_url_none_preserves_legacy_behavior(self, tmp_path):
+        """Omitting base_url must behave exactly as before (global merge only)."""
+        _write_config(tmp_path, {
+            "model": {
+                "default": "m",
+                "default_headers": {"User-Agent": "global-ua/1.0"},
+            },
+            "custom_providers": [
+                {
+                    "name": "my-gw",
+                    "base_url": "http://my-gw.local/v1",
+                    "api_key": "k",
+                    "extra_headers": {"User-Agent": "curl/8.7.1"},
+                },
+            ],
+        })
+        from agent.auxiliary_client import _apply_user_default_headers
+        merged = _apply_user_default_headers({})
+        assert merged == {"User-Agent": "global-ua/1.0"}
+
+    def test_lookup_exception_falls_back_to_global_headers(self, tmp_path):
+        """Lookup exception must be swallowed, defaulting provider_headers to {} while keeping global headers."""
+        _write_config(tmp_path, {
+            "model": {
+                "default": "m",
+                "default_headers": {"User-Agent": "global-ua/1.0", "X-Global": "g"},
+            },
+            "custom_providers": [
+                {
+                    "name": "my-gw",
+                    "base_url": "http://my-gw.local/v1",
+                    "api_key": "k",
+                    "extra_headers": {"User-Agent": "curl/8.7.1"},
+                },
+            ],
+        })
+        from agent.auxiliary_client import _apply_user_default_headers
+        with patch("hermes_cli.config.get_custom_provider_extra_headers", side_effect=RuntimeError("lookup failure")):
+            merged = _apply_user_default_headers({}, base_url="http://my-gw.local/v1")
+        assert merged is not None
+        assert merged["User-Agent"] == "global-ua/1.0"
+        assert merged["X-Global"] == "g"
+
+    def test_non_dict_return_falls_back_to_global_headers(self, tmp_path):
+        """Non-dict return from lookup must fall back to {} while keeping global headers."""
+        _write_config(tmp_path, {
+            "model": {
+                "default": "m",
+                "default_headers": {"User-Agent": "global-ua/1.0", "X-Global": "g"},
+            },
+            "custom_providers": [
+                {
+                    "name": "my-gw",
+                    "base_url": "http://my-gw.local/v1",
+                    "api_key": "k",
+                    "extra_headers": {"User-Agent": "curl/8.7.1"},
+                },
+            ],
+        })
+        from agent.auxiliary_client import _apply_user_default_headers
+        with patch("hermes_cli.config.get_custom_provider_extra_headers", return_value="not-a-dict"):
+            merged = _apply_user_default_headers({}, base_url="http://my-gw.local/v1")
+        assert merged is not None
+        assert merged["User-Agent"] == "global-ua/1.0"
+        assert merged["X-Global"] == "g"
+
+
+class TestAuxClientHonorsProviderExtraHeaders:
+    """Integration: resolve_provider_client must pass per-provider headers to OpenAI."""
+
+    def test_anonymous_custom_provider_gets_extra_headers(self, tmp_path):
+        """Anonymous ``model.provider: custom`` branch (base_url match)."""
+        _write_config(tmp_path, {
+            "model": {
+                "default": "my-custom-model",
+                "provider": "custom",
+                "base_url": "http://my-gw.local/v1",
+            },
+            "custom_providers": [
+                {
+                    "name": "my-gw",
+                    "base_url": "http://my-gw.local/v1",
+                    "api_key": "k",
+                    "extra_headers": {"User-Agent": "curl/8.7.1"},
+                },
+            ],
+        })
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client("main", "my-custom-model")
+
+        assert client is not None
+        assert mock_openai.called
+        headers = mock_openai.call_args.kwargs.get("default_headers", {}) or {}
+        assert headers.get("User-Agent") == "curl/8.7.1"
+
+    def test_named_custom_provider_gets_extra_headers(self, tmp_path):
+        """Named custom provider branch (L6653 path)."""
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "custom_providers": [
+                {
+                    "name": "my-gw",
+                    "base_url": "http://my-gw.local/v1",
+                    "api_key": "k",
+                    "extra_headers": {"User-Agent": "curl/8.7.1"},
+                },
+            ],
+        })
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client("my-gw", "test-model")
+
+        assert client is not None
+        headers = mock_openai.call_args.kwargs.get("default_headers", {}) or {}
+        assert headers.get("User-Agent") == "curl/8.7.1"
+
+    def test_anthropic_fallback_branch_gets_extra_headers(self, tmp_path):
+        """anthropic_messages with SDK missing falls back to OpenAI-wire (L6678)."""
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "custom_providers": [
+                {
+                    "name": "my-gw",
+                    "base_url": "http://my-gw.local/v1",
+                    "api_key": "k",
+                    "api_mode": "anthropic_messages",
+                    "extra_headers": {"User-Agent": "curl/8.7.1"},
+                },
+            ],
+        })
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai, \
+             patch.dict("sys.modules", {"agent.anthropic_adapter": None}):
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client("my-gw", "test-model")
+
+        assert client is not None
+        assert mock_openai.called
+        headers = mock_openai.call_args.kwargs.get("default_headers", {}) or {}
+        assert headers.get("User-Agent") == "curl/8.7.1"
+
+    def test_no_matching_provider_sends_no_user_agent(self, tmp_path):
+        """A custom_providers entry for a DIFFERENT base_url must not leak in."""
+        _write_config(tmp_path, {
+            "model": {
+                "default": "my-custom-model",
+                "provider": "custom",
+                "base_url": "http://unrelated.local/v1",
+            },
+            "custom_providers": [
+                {
+                    "name": "my-gw",
+                    "base_url": "http://my-gw.local/v1",
+                    "api_key": "k",
+                    "extra_headers": {"User-Agent": "curl/8.7.1"},
+                },
+            ],
+        })
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client("main", "my-custom-model")
+
+        assert client is not None
+        headers = mock_openai.call_args.kwargs.get("default_headers", {}) or {}
+        assert "User-Agent" not in headers
+
+    @pytest.mark.asyncio
+    async def test_async_path_gets_extra_headers(self, tmp_path):
+        """The sync->async conversion (L6174) must carry provider headers too."""
+        _write_config(tmp_path, {
+            "model": {
+                "default": "my-custom-model",
+                "provider": "custom",
+                "base_url": "http://my-gw.local/v1",
+            },
+            "custom_providers": [
+                {
+                    "name": "my-gw",
+                    "base_url": "http://my-gw.local/v1",
+                    "api_key": "k",
+                    "extra_headers": {"User-Agent": "curl/8.7.1"},
+                },
+            ],
+        })
+        sync_instance = MagicMock()
+        sync_instance.api_key = "k"
+        sync_instance.base_url = "http://my-gw.local/v1"
+        captured_async_kwargs = {}
+        real_async_openai = None
+        with patch("agent.auxiliary_client.OpenAI", return_value=sync_instance):
+            import openai as _openai_mod
+            real_async_openai = _openai_mod.AsyncOpenAI
+
+            def _capture_async(**kwargs):
+                captured_async_kwargs.update(kwargs)
+                return MagicMock()
+
+            _openai_mod.AsyncOpenAI = _capture_async
+            try:
+                from agent.auxiliary_client import resolve_provider_client
+                client, model = resolve_provider_client(
+                    "main", "my-custom-model", async_mode=True
+                )
+            finally:
+                _openai_mod.AsyncOpenAI = real_async_openai
+
+        assert client is not None
+        assert captured_async_kwargs, "AsyncOpenAI constructor was not called"
+        headers = captured_async_kwargs.get("default_headers", {}) or {}
+        assert headers.get("User-Agent") == "curl/8.7.1"


### PR DESCRIPTION
## Problem

Auxiliary clients (session title generation, background model calls) created by `auxiliary_client.py` ignored `custom_providers[].extra_headers`, always sending the OpenAI SDK's default `User-Agent`. Gateways fronted by Cloudflare WAF reject this default UA with HTTP 403 at the edge — the request never reaches the origin server. The main client already passes per-provider headers correctly; only the auxiliary paths were affected.

## Root Cause

`_apply_user_default_headers()` merges `model.default_headers` into the client config, but:
- `base_url` was not threaded through to this function, so per-provider header lookup by base_url never matched
- `custom_providers[].extra_headers` were not merged at all — only `model.default_headers` was consulted

## Fix

Thread `base_url` through `_apply_user_default_headers()` and merge `custom_providers[].extra_headers` the same way the main client does, so auxiliary clients inherit the same per-provider header set (including custom `User-Agent`).

## Testing

- New test suite: `tests/agent/test_auxiliary_provider_extra_headers.py` (303 lines) — covers header merging for all auxiliary client paths, base_url matching, None/empty edge cases, and thread safety
- Real-path smoke test: auxiliary client → WAF-fronted gateway returned HTTP 200 (was 403 before fix)
- 3 rounds of code review completed (0 confirmed findings)

## Files Changed

| File | Changes |
|------|---------|
| `agent/auxiliary_client.py` | +58 / -11 |
| `tests/agent/test_auxiliary_provider_extra_headers.py` | +303 (new) |

