### PR TITLE
fix(process): make background lifecycle outcomes truthful

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25714,7 +25714,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             while True:
                 await asyncio.sleep(interval)
                 session = process_registry.get(session_id)
-                if session is None or session.exited:
+                if (
+                    session is None
+                    or process_registry.terminal_snapshot(session)["exited"]
+                ):
                     break
             logger.debug("Process watcher ended (silent): %s", session_id)
             return
@@ -25731,12 +25734,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             has_new_output = current_output_len > last_output_len
             last_output_len = current_output_len
 
-            if session.exited:
+            from tools.process_registry import process_registry as _pr_check
+            terminal = _pr_check.terminal_snapshot(session)
+            if terminal["exited"]:
                 # --- Agent-triggered completion: inject synthetic message ---
                 # Skip if the agent already consumed the result via wait/log.
                 # poll() is read-only and intentionally does NOT mark consumed
                 # (#10156) — a status check must not suppress this delivery turn.
-                from tools.process_registry import format_process_notification, process_registry as _pr_check
+                from tools.process_registry import format_process_notification
                 if agent_notify and not _pr_check.is_completion_consumed(session_id):
                     from agent.redact import redact_terminal_output
                     from tools.ansi_strip import strip_ansi
@@ -25770,9 +25775,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "message_id": message_id,
                         "started_at": getattr(session, "started_at", None),
                         "command": _command,
-                        "exit_code": session.exit_code,
-                        "completion_reason": getattr(session, "completion_reason", "exited"),
-                        "termination_source": getattr(session, "termination_source", ""),
+                        "exit_code": terminal["exit_code"],
+                        "completion_reason": terminal["completion_reason"],
+                        "termination_source": terminal["termination_source"],
                         "output": _out,
                         # Spawning conversation's session-db id (stamped at
                         # spawn time in terminal_tool). Lets the delivery
@@ -25817,7 +25822,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Decide whether to notify based on mode
                 should_notify = (
                     notify_mode in {"concise", "all", "result"}
-                    or (notify_mode == "error" and session.exit_code not in {0, None})
+                    or (
+                        notify_mode == "error"
+                        and (
+                            terminal["completion_reason"] == "lost"
+                            or terminal["exit_code"] not in {0, None}
+                        )
+                    )
                 )
                 if should_notify:
                     new_output = session.output_buffer[-1000:] if session.output_buffer else ""
@@ -25842,13 +25853,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         message_text = _format_concise_process_notification(
                             session_id,
                             _cmd_disp,
-                            session.exit_code,
+                            terminal["exit_code"],
                             new_output,
                             duration_seconds=_dur,
                         )
                     else:
                         message_text = (
-                            f"[Background process {session_id} finished with exit code {session.exit_code}~ "
+                            f"[Background process {session_id} finished with exit code {terminal['exit_code']}~ "
                             f"Here's the final output:\n{new_output}]"
                         )
                     adapter = None

--- a/hermes_cli/session_lost_and_found.py
+++ b/hermes_cli/session_lost_and_found.py
@@ -104,6 +104,7 @@ def _cli_supports_recover(binary: str) -> bool:
         probe = subprocess.run(
             [binary, "-readonly", str(scratch), ".recover"],
             capture_output=True,
+            cwd=scratch_dir,
             timeout=30,
         )
         if probe.returncode != 0:

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -39,21 +39,23 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # ── Locate python ───────────────────────────────────────────────────────────
 # Probe local venvs first; fall back to the Nix devShell's editable venv
-# (HERMES_PYTHON is exported by the devShell hook and ships [dev] extras:
-# pytest, pytest-asyncio, pytest-timeout, ruff, ty).
+# (HERMES_PYTHON is exported by the devShell hook and ships [dev] extras).
 #
-# A candidate must have pytest INSTALLED, not merely exist. The release venv
-# at ~/.hermes/hermes-agent/venv has bin/activate but no pytest, so an
-# existence-only probe selected it in checkouts/worktrees without a local
-# .venv — every file then died with "No module named pytest" and the run
-# reported "0 tests passed" (which reads green at a glance even though the
-# exit code is 1). Skip such a venv and keep probing instead.
+# ``pytest`` alone is not a usable Hermes development test runtime. The
+# release venv can acquire pytest incidentally while still lacking
+# pytest-asyncio; selecting it makes every async test fail before product code
+# runs and turns one environment error into thousands of false failures.
 VENV=""
 VENV_PYTHON=""
 SKIPPED_VENVS=""
+
+has_test_runtime() {
+  "$1" -c 'import pytest, pytest_asyncio, prompt_toolkit' >/dev/null 2>&1
+}
+
 for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
   if [ -f "$candidate/bin/activate" ]; then
-    if "$candidate/bin/python" -c 'import pytest' 2>/dev/null; then
+    if has_test_runtime "$candidate/bin/python"; then
       VENV="$candidate"
       VENV_PYTHON="$candidate/bin/python"
       break
@@ -65,7 +67,7 @@ for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agen
   # Git Bash / MSYS with a `python -m venv`- or uv-created venv hits
   # this branch — without it the canonical runner refuses to start.
   if [ -f "$candidate/Scripts/activate" ]; then
-    if "$candidate/Scripts/python.exe" -c 'import pytest' 2>/dev/null; then
+    if has_test_runtime "$candidate/Scripts/python.exe"; then
       VENV="$candidate"
       VENV_PYTHON="$candidate/Scripts/python.exe"
       break
@@ -76,24 +78,34 @@ done
 
 if [ -n "$SKIPPED_VENVS" ]; then
   for skipped in $SKIPPED_VENVS; do
-    echo "▶ skipping venv without pytest: $skipped" >&2
+    echo "▶ skipping venv without Hermes dev test runtime (pytest + pytest-asyncio + prompt-toolkit): $skipped" >&2
   done
 fi
 
+SYSTEM_PYTHON=""
+for command_name in python3 python; do
+  command_path="$(command -v "$command_name" 2>/dev/null || true)"
+  if [ -n "$command_path" ] && has_test_runtime "$command_path"; then
+    SYSTEM_PYTHON="$command_path"
+    break
+  fi
+done
+
 if [ -n "$VENV" ]; then
   PYTHON="$VENV_PYTHON"
-elif [ -n "${HERMES_PYTHON:-}" ] && [ -x "$HERMES_PYTHON" ] \
-    && "$HERMES_PYTHON" -c 'import pytest' 2>/dev/null; then
-  # Guard with an import check: HERMES_PYTHON may point at the RELEASE
-  # venv (no pytest) when inherited from a wrapped `hermes` binary rather
-  # than the devShell hook.
+elif [ -n "${HERMES_PYTHON:-}" ] && [ -x "$HERMES_PYTHON" ]     && has_test_runtime "$HERMES_PYTHON"; then
+  # HERMES_PYTHON may point at the release venv when inherited from a wrapped
+  # `hermes` binary rather than the development shell; apply the same gate.
   PYTHON="$HERMES_PYTHON"
   echo "▶ no local venv — using Nix dev venv via HERMES_PYTHON: $PYTHON"
+elif [ -n "$SYSTEM_PYTHON" ]; then
+  PYTHON="$SYSTEM_PYTHON"
+  echo "▶ no dev venv — using PATH interpreter with Hermes test runtime: $PYTHON"
 else
-  echo "error: no virtualenv with pytest found in $REPO_ROOT/.venv or $REPO_ROOT/venv," >&2
-  echo "       and HERMES_PYTHON is not a python with pytest (enter the Nix devShell or create a venv)" >&2
+  echo "error: no virtualenv with the Hermes dev test runtime found in $REPO_ROOT/.venv or $REPO_ROOT/venv," >&2
+  echo "       and neither HERMES_PYTHON nor PATH python has pytest + pytest-asyncio + prompt-toolkit" >&2
   if [ -n "$SKIPPED_VENVS" ]; then
-    echo "       (skipped for missing pytest:$SKIPPED_VENVS — install dev extras there, or create $REPO_ROOT/.venv)" >&2
+    echo "       (skipped for missing dev test runtime:$SKIPPED_VENVS — install dev extras there, or create $REPO_ROOT/.venv)" >&2
   fi
   exit 1
 fi

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -103,6 +103,56 @@ _DEFAULT_FILE_RETRIES = 1
 _DURATIONS_FILE = "test_durations.json"
 
 
+def _write_result_json(path_value: str, payload: dict) -> None:
+    """Atomically persist the bounded machine-readable run result."""
+    path = Path(path_value).expanduser().resolve()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _worktree_status(repo_root: Path) -> set[str] | None:
+    """Return bounded Git status entries, or None outside a usable checkout."""
+    try:
+        proc = subprocess.run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            cwd=repo_root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return {
+        line
+        for line in proc.stdout.splitlines()
+        if line and line[3:] != _DURATIONS_FILE
+    }
+
+
+def _git_head(repo_root: Path) -> str | None:
+    """Return the source HEAD used by this run, or None outside Git."""
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    head = proc.stdout.strip()
+    return head if proc.returncode == 0 and head else None
+
+
 def _split_pathspec(value: str) -> List[str]:
     """Split a separator-joined path list (``--paths``/``--files``/
     ``HERMES_TEST_PATHS``) into individual paths.
@@ -797,6 +847,14 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--result-json",
+        metavar="PATH",
+        help=(
+            "Atomically write a bounded machine-readable completion record "
+            "with return code, counts, duration, and failed files."
+        ),
+    )
+    parser.add_argument(
         "--slice",
         metavar="I/N",
         help=(
@@ -858,6 +916,7 @@ def main() -> int:
     OUR_FLAGS = {
         "-j", "--jobs", "--paths", "--include-integration",
         "--file-timeout", "--file-retries", "--slice", "--generate-slices", "--files",
+        "--result-json",
     }
     # pytest short flags that consume the NEXT token as their value.
     PYTEST_VALUE_FLAGS = {"-k", "-m", "-p", "-o", "-c", "-r", "-W"}
@@ -958,6 +1017,9 @@ def main() -> int:
             sys.exit(2)
 
     repo_root = Path(__file__).resolve().parent.parent
+    initial_worktree_status = _worktree_status(repo_root)
+    source_git_head = _git_head(repo_root)
+    invocation = [sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]]
 
     # --files: explicit file list from the CI generate job — skip discovery.
     if args.files:
@@ -1195,6 +1257,16 @@ def main() -> int:
         for f, t in slowest:
             print(f"    {t:>6.2f}s  {_format_file(f, repo_root)}")
 
+    final_worktree_status = _worktree_status(repo_root)
+    checkout_pollution = sorted(
+        final_worktree_status - initial_worktree_status
+    ) if initial_worktree_status is not None and final_worktree_status is not None else []
+    if checkout_pollution:
+        print()
+        print("=== ✗ CHECKOUT POLLUTION — the test run introduced Git status entries ===")
+        for entry in checkout_pollution:
+            print(f"  {entry}")
+
     if failures:
         print()
         print("=== Failure output ===")
@@ -1223,12 +1295,42 @@ def main() -> int:
             print(f"=== {len(no_tests_ran)} file{'s' if len(no_tests_ran) != 1 else ''} where no tests ran (collection/import error, timeout before collection, etc.) ===")
             for file, s in no_tests_ran:
                 print(f"  {_format_file(file, repo_root)}")
-        return 1
+    return_code = 1 if failures or no_tests_ran_at_all or checkout_pollution else 0
+    if args.result_json:
+        _write_result_json(
+            args.result_json,
+            {
+                "schema_version": 1,
+                "command": invocation,
+                "git_head": source_git_head,
+                "worktree_clean_before": initial_worktree_status == set(),
+                "returncode": return_code,
+                "duration_seconds": round(elapsed, 6),
+                "workers": args.jobs,
+                "files_total": len(files),
+                "files_passed": pass_count,
+                "files_failed": fail_count,
+                "tests_passed": tests_passed,
+                "tests_failed": tests_failed,
+                "tests_skipped": tests_skipped,
+                "tests_collected": tests_collected,
+                "no_tests_ran": no_tests_ran_at_all,
+                "checkout_pollution": checkout_pollution,
+                "failed_files": [
+                    {
+                        "path": _format_file(file, repo_root),
+                        "summary": summary,
+                    }
+                    for file, _output, summary in failures
+                ],
+                "flaky_files": [
+                    _format_file(file, repo_root)
+                    for file, _output in _FLAKY_RESULTS
+                ],
+            },
+        )
 
-    if no_tests_ran_at_all:
-        return 1
-
-    return 0
+    return return_code
 
 
 if __name__ == "__main__":

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -38,6 +38,15 @@ class _FakeRegistry:
     def is_completion_consumed(self, session_id):
         return self._consumed
 
+    def terminal_snapshot(self, session):
+        """Mirror the terminal fields consumed by the gateway watcher."""
+        return {
+            "exited": session.exited,
+            "exit_code": session.exit_code,
+            "completion_reason": getattr(session, "completion_reason", "exited"),
+            "termination_source": getattr(session, "termination_source", ""),
+        }
+
 
 def _build_runner(monkeypatch, tmp_path, mode: str) -> GatewayRunner:
     """Create a GatewayRunner with a fake config for the given mode."""

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -7,6 +7,7 @@ state (when available) is acknowledged through its authoritative SQLite API.
 """
 
 import asyncio
+import signal
 import json
 import queue
 from collections import OrderedDict
@@ -217,6 +218,7 @@ def test_explicit_kill_returns_output_before_consuming_notification(monkeypatch)
     )
     session.process = MagicMock()
     session.process.pid = 4242
+    session.process.wait.return_value = -signal.SIGTERM
     registry._running[session.id] = session
     monkeypatch.setattr(registry, "_terminate_host_pid", lambda *_a, **_kw: None)
     monkeypatch.setattr(registry, "_write_checkpoint", lambda: None)
@@ -884,3 +886,39 @@ def test_sibling_claimed_by_other_consumer_is_not_double_delivered(
     assert "Result for deleg_owned_1" not in delivered.text
     row = async_delegation.get_durable_delegation(events[1]["delegation_id"])
     assert row["delivery_state"] == "pending"
+
+
+def test_error_mode_delivers_lost_process_completion(monkeypatch):
+    """Lost custody is an error even though its exit code is unavailable."""
+    import tools.process_registry as pr_module
+
+    registry = ProcessRegistry()
+    session = ProcessSession(
+        id="proc_lost_error_mode",
+        command="opaque-worker",
+        started_at=1.0,
+        output_buffer="result unavailable",
+    )
+    registry._record_terminal_observation(
+        session, None, unavailable_source="backend_lost"
+    )
+    registry._finished[session.id] = session
+    monkeypatch.setattr(pr_module, "process_registry", registry)
+
+    adapter = SimpleNamespace(handle_message=AsyncMock(), send=AsyncMock())
+    runner = _runner(adapter)
+    runner._load_background_notifications_mode = lambda: "error"
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+    asyncio.run(runner._run_process_watcher({
+        "session_id": session.id,
+        "check_interval": 0,
+        "platform": "telegram",
+        "chat_id": "123",
+    }))
+
+    adapter.send.assert_awaited_once()
+    assert "result unavailable" in adapter.send.await_args.args[1]

--- a/tests/gateway/test_internal_event_bypass_pairing.py
+++ b/tests/gateway/test_internal_event_bypass_pairing.py
@@ -39,6 +39,15 @@ class _FakeRegistry:
     def is_completion_consumed(self, session_id):
         return session_id in self._completion_consumed
 
+    def terminal_snapshot(self, session):
+        """Mirror the terminal fields consumed by the gateway watcher."""
+        return {
+            "exited": session.exited,
+            "exit_code": session.exit_code,
+            "completion_reason": getattr(session, "completion_reason", "exited"),
+            "termination_source": getattr(session, "termination_source", ""),
+        }
+
 
 def _build_runner(monkeypatch, tmp_path) -> GatewayRunner:
     """Create a GatewayRunner with notifications set to 'all'."""

--- a/tests/hermes_cli/test_session_lost_and_found_probe.py
+++ b/tests/hermes_cli/test_session_lost_and_found_probe.py
@@ -1,0 +1,30 @@
+"""Isolation regressions for the sqlite3 .recover capability probe."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hermes_cli.session_lost_and_found import _cli_supports_recover
+
+
+def test_incompatible_sqlite_shim_cannot_pollute_caller_cwd(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A shim that treats ``-readonly`` as a DB path stays in scratch cwd."""
+    shim = tmp_path / "sqlite3-shim"
+    shim.write_text(
+        "#!/usr/bin/python3\n"
+        "import sqlite3, sys\n"
+        "sqlite3.connect(sys.argv[1]).close()\n"
+        "raise SystemExit(1)\n",
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    caller_cwd = tmp_path / "checkout"
+    caller_cwd.mkdir()
+    monkeypatch.chdir(caller_cwd)
+
+    assert _cli_supports_recover(str(shim)) is False
+    assert not (caller_cwd / "-readonly").exists()
+    assert list(caller_cwd.iterdir()) == []

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -460,3 +460,103 @@ def test_drive_letter_colon_is_not_a_path_separator(tmp_path: Path) -> None:
         f"drive letter split off as a phantom root:\n{proc.stdout}"
     )
     assert "Discovered 1 test files" in proc.stdout, proc.stdout
+
+
+# ── Machine-readable completion contract ────────────────────────────────────
+
+def _run_with_result_json(probe: Path, result_path: Path) -> subprocess.CompletedProcess:
+    repo_root = Path(__file__).resolve().parent.parent
+    runner = repo_root / "scripts" / "run_tests_parallel.py"
+    return subprocess.run(
+        [
+            sys.executable,
+            str(runner),
+            "--files",
+            str(probe),
+            "--result-json",
+            str(result_path),
+            "--file-retries",
+            "0",
+            "-j",
+            "1",
+            "-q",
+        ],
+        cwd=repo_root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_result_json_records_success_atomically(tmp_path: Path) -> None:
+    probe = tmp_path / "test_result_success.py"
+    probe.write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+    result_path = tmp_path / "nested" / "result.json"
+
+    proc = _run_with_result_json(probe, result_path)
+
+    assert proc.returncode == 0, proc.stdout
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 1
+    assert payload["command"][0] == sys.executable
+    assert str(probe) in payload["command"]
+    assert payload["git_head"] == subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=Path(__file__).resolve().parent.parent,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert isinstance(payload["worktree_clean_before"], bool)
+    assert payload["returncode"] == 0
+    assert payload["files_total"] == 1
+    assert payload["files_passed"] == 1
+    assert payload["files_failed"] == 0
+    assert payload["tests_passed"] == 1
+    assert payload["tests_failed"] == 0
+    assert payload["failed_files"] == []
+    assert not list(result_path.parent.glob(".*.tmp"))
+
+
+def test_result_json_records_failure_without_test_output(tmp_path: Path) -> None:
+    probe = tmp_path / "test_result_failure.py"
+    probe.write_text(
+        "def test_bad():\n    assert False, 'sensitive failure detail'\n",
+        encoding="utf-8",
+    )
+    result_path = tmp_path / "result.json"
+
+    proc = _run_with_result_json(probe, result_path)
+
+    assert proc.returncode == 1
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["returncode"] == 1
+    assert payload["files_failed"] == 1
+    assert payload["tests_failed"] == 1
+    assert payload["failed_files"][0]["path"] == str(probe)
+    assert payload["failed_files"][0]["summary"]["failed"] == 1
+    assert "sensitive failure detail" not in result_path.read_text(encoding="utf-8")
+    assert not list(result_path.parent.glob(".*.tmp"))
+
+
+def test_runner_fails_on_new_checkout_pollution(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    pollution = repo_root / f".runner-pollution-{os.getpid()}"
+    probe = tmp_path / "test_pollution_probe.py"
+    probe.write_text(
+        "from pathlib import Path\n\n"
+        f"def test_pollutes_checkout():\n    Path({str(pollution)!r}).touch()\n",
+        encoding="utf-8",
+    )
+    result_path = tmp_path / "result.json"
+
+    try:
+        proc = _run_with_result_json(probe, result_path)
+        assert proc.returncode == 1, proc.stdout
+        assert "CHECKOUT POLLUTION" in proc.stdout
+        payload = json.loads(result_path.read_text(encoding="utf-8"))
+        assert payload["returncode"] == 1
+        assert any(str(pollution.name) in entry for entry in payload["checkout_pollution"])
+    finally:
+        pollution.unlink(missing_ok=True)

--- a/tests/test_run_tests_shell.py
+++ b/tests/test_run_tests_shell.py
@@ -1,0 +1,111 @@
+"""Behavioral tests for scripts/run_tests.sh interpreter admission."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+import subprocess
+import sys
+
+
+def _sandbox_runner(tmp_path: Path) -> tuple[Path, Path]:
+    """Copy the shell runner away from any real checkout-local virtualenv."""
+    source_root = Path(__file__).resolve().parent.parent
+    repo_root = tmp_path / "repo"
+    scripts = repo_root / "scripts"
+    scripts.mkdir(parents=True)
+    runner = scripts / "run_tests.sh"
+    shutil.copy2(source_root / "scripts" / "run_tests.sh", runner)
+    (scripts / "run_tests_parallel.py").write_text("# selected by fixture shim\n")
+    return repo_root, runner
+
+
+def test_release_venv_without_async_plugin_fails_closed(tmp_path: Path) -> None:
+    """An incidental pytest install must not admit a release-only venv."""
+    repo_root, runner = _sandbox_runner(tmp_path)
+
+    fake_home = tmp_path / "home"
+    fake_bin = fake_home / ".hermes" / "hermes-agent" / "venv" / "bin"
+    fake_bin.mkdir(parents=True)
+    (fake_bin / "activate").write_text("# test fixture\n", encoding="utf-8")
+
+    fake_python = fake_bin / "python"
+    fake_python.write_text(
+        "#!/bin/sh\n"
+        "case \"${2-}\" in\n"
+        "  *pytest_asyncio*) exit 1 ;;\n"
+        "esac\n"
+        f"exec {sys.executable!r} \"$@\"\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+
+    fake_tools = tmp_path / "tools"
+    fake_tools.mkdir()
+    (fake_tools / "dirname").symlink_to("/usr/bin/dirname")
+
+    env = os.environ.copy()
+    env["HOME"] = str(fake_home)
+    env["HERMES_PYTHON"] = str(fake_python)
+    env["PATH"] = str(fake_tools)
+    proc = subprocess.run(
+        ["/bin/bash", str(runner), "--help"],
+        cwd=repo_root,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=30,
+    )
+
+    assert proc.returncode == 1, proc.stdout
+    assert "skipping venv without Hermes dev test runtime" in proc.stdout
+    assert "neither HERMES_PYTHON nor PATH python has pytest + pytest-asyncio + prompt-toolkit" in proc.stdout
+    assert "launching test runner" not in proc.stdout
+
+
+def test_usable_path_python_is_selected_without_dev_venv(tmp_path: Path) -> None:
+    """A validated system interpreter is a legitimate final fallback."""
+    repo_root, runner = _sandbox_runner(tmp_path)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    selected = tmp_path / "selected"
+
+    fake_python = fake_bin / "python3"
+    fake_python.write_text(
+        "#!/bin/sh\n"
+        f"touch {str(selected)!r}\n"
+        "case \"${1-}\" in\n"
+        "  -c) exit 0 ;;\n"
+        "  -m) exit 0 ;;\n"
+        "  */run_tests_parallel.py) exit 0 ;;\n"
+        "esac\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+
+    env = os.environ.copy()
+    env["HOME"] = os.environ["HOME"]
+    env["HERMES_PYTHON"] = str(tmp_path / "missing-python")
+    env["PATH"] = f"{fake_bin}:/usr/bin:/bin"
+    proc = subprocess.run(
+        [
+            "/bin/bash",
+            str(runner),
+            "tests/test_run_tests_parallel_stdio.py",
+            "-q",
+        ],
+        cwd=repo_root,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=30,
+    )
+
+    assert proc.returncode == 0, proc.stdout
+    assert selected.exists()
+    assert "using PATH interpreter with Hermes test runtime" in proc.stdout
+    assert "launching test runner" in proc.stdout

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -299,8 +299,10 @@ def _silent_bg_harness(monkeypatch, tmp_path):
 
     config = _silent_bg_base_config(tmp_path)
     dummy_env = SimpleNamespace(env={})
+    spawn_kwargs = {}
 
     def fake_spawn_local(**kwargs):
+        spawn_kwargs.update(kwargs)
         return SimpleNamespace(
             id="proc_silent_test",
             pid=4242,
@@ -320,6 +322,7 @@ def _silent_bg_harness(monkeypatch, tmp_path):
     monkeypatch.setattr(process_registry_module.process_registry, "spawn_local", fake_spawn_local)
     monkeypatch.setitem(terminal_tool_module._active_environments, "default", dummy_env)
     monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
+    terminal_tool_module._test_spawn_kwargs = spawn_kwargs
     return terminal_tool_module
 
 
@@ -348,6 +351,26 @@ def test_background_without_notify_emits_silent_process_hint(monkeypatch, tmp_pa
         "Hint must explain the failure mode, not just suggest the fix"
     )
 
+
+
+def test_background_notification_flags_are_forwarded_before_spawn(monkeypatch, tmp_path):
+    tt = _silent_bg_harness(monkeypatch, tmp_path)
+    try:
+        json.loads(
+            tt.terminal_tool(
+                command="pytest tests/",
+                background=True,
+                notify_on_complete=True,
+                watch_patterns=["DONE"],
+            )
+        )
+    finally:
+        tt._active_environments.pop("default", None)
+        tt._last_activity.pop("default", None)
+
+    assert tt._test_spawn_kwargs["notify_on_complete"] is True
+    # notify_on_complete wins the documented mutual-exclusion rule.
+    assert tt._test_spawn_kwargs["watch_patterns"] == []
 
 def test_background_with_notify_does_not_emit_hint(monkeypatch, tmp_path):
     """The correct shape — bg+notify together — must not nag."""

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -729,6 +729,35 @@ class TestOrphanedPipeReconciliation:
         except (ProcessLookupError, PermissionError):
             pass
 
+    def test_reconcile_combines_kill_intent_with_concrete_signal_once(self, registry):
+        """A poll/reconcile race must not publish a requested kill as exited."""
+        proc = MagicMock()
+        proc.poll.return_value = -signal.SIGTERM
+        proc.stdout = None
+
+        s = _make_session(sid="proc_reconcile_kill_race")
+        s.process = proc
+        s.pid = 12345
+        s.notify_on_complete = True
+        s._kill_requested_source = "process.kill"
+        registry._running[s.id] = s
+
+        registry._reconcile_local_exit(s)
+        registry._reconcile_local_exit(s)
+
+        assert s.exited is True
+        assert s.exit_code == -signal.SIGTERM
+        assert s.completion_reason == "killed"
+        assert s.termination_source == "process.kill"
+        assert s.id in registry._finished
+        assert s.id not in registry._running
+
+        event = registry.completion_queue.get_nowait()
+        assert registry.completion_queue.empty()
+        assert event["exit_code"] == -signal.SIGTERM
+        assert event["completion_reason"] == "killed"
+        assert event["termination_source"] == "process.kill"
+
     def test_wait_returns_when_reader_blocked(self, registry):
         """wait() must also reconcile — not just poll()."""
         proc = subprocess.Popen(

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1,5 +1,6 @@
 """Tests for tools/process_registry.py — ProcessRegistry query methods, pruning, checkpoint."""
 
+import io
 import json
 import os
 import signal
@@ -577,6 +578,94 @@ def test_pty_reader_unknown_exit_status_is_explicitly_lost(registry, monkeypatch
     assert completion["completion_reason"] == "lost"
 
 
+def test_pty_reader_signal_status_is_concrete_killed_result(registry, monkeypatch):
+    """A reaped PTY signal status is evidence, not a lost exit result."""
+
+    class _FakePty:
+        exitstatus = None
+        signalstatus = signal.SIGTERM
+
+        def isalive(self):
+            return False
+
+        def wait(self):
+            return None
+
+    session = _make_session(sid="proc_pty_sigterm")
+    session._pty = _FakePty()
+    session.notify_on_complete = True
+    registry._running[session.id] = session
+    monkeypatch.setattr(registry, "_check_watch_patterns", lambda _s, _c: None)
+    monkeypatch.setattr(registry, "_emit_output", lambda _s, _c: None)
+
+    registry._pty_reader_loop(session)
+
+    assert session.exited is True
+    assert session.exit_code == -signal.SIGTERM
+    assert session.completion_reason == "killed"
+    assert session.termination_source == "pty_signal"
+    completion = registry.completion_queue.get_nowait()
+    assert completion["exit_code"] == -signal.SIGTERM
+    assert completion["completion_reason"] == "killed"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX PTY signal semantics")
+def test_real_pty_sigterm_is_killed_not_lost(registry):
+    """ptyprocess exposes signalstatus when exitstatus is None."""
+    from ptyprocess import PtyProcess
+
+    pty = PtyProcess.spawn([sys.executable, "-c", "import time; time.sleep(30)"])
+    session = _make_session(sid="proc_real_pty_sigterm")
+    session._pty = pty
+    session.notify_on_complete = True
+    registry._running[session.id] = session
+
+    try:
+        os.kill(pty.pid, signal.SIGTERM)
+        registry._pty_reader_loop(session)
+    finally:
+        if pty.isalive():
+            pty.terminate(force=True)
+
+    assert session.exit_code == -signal.SIGTERM
+    assert session.completion_reason == "killed"
+    assert session.termination_source == "pty_signal"
+    completion = registry.completion_queue.get_nowait()
+    assert completion["exit_code"] == -signal.SIGTERM
+    assert completion["completion_reason"] == "killed"
+
+
+def test_reader_combines_concrete_exit_with_kill_intent(registry):
+    """A reader that wins the kill race must publish killed with real status."""
+
+    class _KilledProcess:
+        def __init__(self):
+            self.stdout = io.BytesIO(b"")
+            self.returncode = None
+
+        def poll(self):
+            return self.returncode
+
+        def wait(self):
+            self.returncode = -signal.SIGKILL
+            return self.returncode
+
+    session = _make_session(sid="proc_reader_kill_race")
+    session.process = _KilledProcess()
+    session._kill_requested_source = "process.kill"
+    session.notify_on_complete = True
+    registry._running[session.id] = session
+
+    registry._reader_loop(session)
+
+    assert session.exit_code == -signal.SIGKILL
+    assert session.completion_reason == "killed"
+    assert session.termination_source == "process.kill"
+    completion = registry.completion_queue.get_nowait()
+    assert completion["exit_code"] == -signal.SIGKILL
+    assert completion["completion_reason"] == "killed"
+
+
 # =========================================================================
 # Orphaned-pipe reconciliation (issue #17327)
 # =========================================================================
@@ -969,6 +1058,43 @@ class TestSpawnEnvSanitization:
         assert env.commands[1][0] == "kill -0 \"$(cat '/path with spaces/hermes_bg.pid' 2>/dev/null)\" 2>/dev/null; echo $?"
         assert env.commands[2][0] == "cat '/path with spaces/hermes_bg.exit' 2>/dev/null"
 
+    def test_env_poller_missing_exit_status_is_explicitly_lost(self, registry):
+        session = _make_session(sid="proc_env_no_status")
+
+        class FakeEnv:
+            def __init__(self):
+                self._responses = iter([
+                    {"output": ""},
+                    {"output": "1\n"},
+                    {"output": ""},
+                ])
+
+            def execute(self, command, **kwargs):
+                return next(self._responses)
+
+        with patch("tools.process_registry.time.sleep", return_value=None):
+            registry._env_poller_loop(session, FakeEnv(), "/log", "/pid", "/exit")
+
+        assert session.exited is True
+        assert session.exit_code is None
+        assert session.completion_reason == "lost"
+        assert session.termination_source == "backend_exit_status_unavailable"
+
+    def test_env_poller_backend_disappearance_is_explicitly_lost(self, registry):
+        session = _make_session(sid="proc_env_gone")
+
+        class GoneEnv:
+            def execute(self, command, **kwargs):
+                raise RuntimeError("backend disappeared")
+
+        with patch("tools.process_registry.time.sleep", return_value=None):
+            registry._env_poller_loop(session, GoneEnv(), "/log", "/pid", "/exit")
+
+        assert session.exited is True
+        assert session.exit_code is None
+        assert session.completion_reason == "lost"
+        assert session.termination_source == "backend_lost"
+
 
 # =========================================================================
 # Popen leak prevention
@@ -1223,6 +1349,46 @@ class TestKillProcess:
         result = registry.kill_process(s.id)
         assert result["status"] == "already_exited"
 
+
+    def test_kill_intent_precedes_termination_and_preserves_observed_code(
+        self, registry, monkeypatch
+    ):
+        class FakeProcess:
+            pid = 4242
+
+            def poll(self):
+                return None
+
+        session = _make_session(sid="proc_kill_race")
+        session.process = FakeProcess()
+        registry._running[session.id] = session
+
+        def terminate(pid, expected_start):
+            assert session._kill_requested_source == "process.kill"
+            # Simulate the reader reaping SIGKILL before kill_process resumes.
+            session.exited = True
+            session.exit_code = -signal.SIGKILL
+            session.completion_reason = "killed"
+            session.termination_source = session._kill_requested_source
+
+        monkeypatch.setattr(registry, "_terminate_host_pid", terminate)
+        result = registry.kill_process(session.id)
+
+        assert result["status"] == "killed"
+        assert session.exit_code == -signal.SIGKILL
+        assert session.completion_reason == "killed"
+        assert session.termination_source == "process.kill"
+
+    def test_unsupported_recovered_kill_clears_intent_and_consumption(self, registry):
+        session = _make_session(sid="proc_recovered_without_handle")
+        registry._running[session.id] = session
+
+        result = registry.kill_process(session.id, consume_output=True)
+
+        assert result["status"] == "error"
+        assert session._kill_requested_source == ""
+        assert session.id not in registry._completion_consumed
+        assert session.id in registry._running
 
     def test_kill_detached_session_uses_host_pid(self, registry):
         s = _make_session(sid="proc_detached", command="sleep 999")

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -313,6 +313,99 @@ def test_reader_loop_streams_incremental_chunks_from_read1(registry, monkeypatch
     assert moved == ["proc_reader_live"]
 
 
+def test_reader_failure_waits_for_real_child_exit_before_completion(registry, monkeypatch):
+    """A broken stdout reader must not publish an exited/null completion.
+
+    The child can close or lose its stdout pipe while continuing to run. A
+    bounded lifecycle wait used to time out after five seconds and the reader
+    then unconditionally marked the session exited with ``returncode=None``.
+    Completion must instead wait for the real child terminal state.
+    """
+
+    class _BrokenBuffer:
+        def read1(self, _n):
+            raise OSError("simulated reader failure")
+
+    class _BrokenStdout:
+        def __init__(self):
+            self.buffer = _BrokenBuffer()
+
+    class _StillRunningProcess:
+        def __init__(self):
+            self.stdout = _BrokenStdout()
+            self.returncode = None
+            self.wait_calls = []
+
+        def wait(self, timeout=None):
+            self.wait_calls.append(timeout)
+            if timeout is not None:
+                raise subprocess.TimeoutExpired("watcher", timeout)
+            self.returncode = 0
+            return 0
+
+        def poll(self):
+            return self.returncode
+
+    session = _make_session(sid="proc_reader_failure")
+    process = _StillRunningProcess()
+    session.process = process
+    session.notify_on_complete = True
+    registry._running[session.id] = session
+
+    registry._reader_loop(session)
+
+    assert process.wait_calls == [None]
+    assert session.exited is True
+    assert session.exit_code == 0
+    assert session.completion_reason == "exited"
+    assert session.id in registry._finished
+    assert session.id not in registry._running
+    completion = registry.completion_queue.get_nowait()
+    assert completion["type"] == "completion"
+    assert completion["session_id"] == session.id
+    assert completion["exit_code"] == 0
+
+
+def test_reader_unreapable_child_is_explicitly_lost(registry):
+    """A failed wait/poll is classified, never serialized as plain exited/null."""
+
+    class _BrokenBuffer:
+        def read1(self, _n):
+            raise OSError("simulated reader failure")
+
+    class _BrokenStdout:
+        def __init__(self):
+            self.buffer = _BrokenBuffer()
+
+    class _UnreapableProcess:
+        def __init__(self):
+            self.stdout = _BrokenStdout()
+            self.returncode = None
+
+        def wait(self, timeout=None):
+            raise OSError("simulated wait failure")
+
+        def poll(self):
+            return None
+
+    session = _make_session(sid="proc_reader_unreapable")
+    session.process = _UnreapableProcess()
+    session.notify_on_complete = True
+    registry._running[session.id] = session
+
+    registry._reader_loop(session)
+
+    assert session.exited is True
+    assert session.exit_code is None
+    assert session.completion_reason == "lost"
+    assert session.termination_source == "reader_wait_failed"
+    completion = registry.completion_queue.get_nowait()
+    assert completion["type"] == "completion"
+    assert completion["exit_code"] is None
+    assert completion["completion_reason"] == "lost"
+    assert completion["termination_source"] == "reader_wait_failed"
+
+
 # =========================================================================
 # Incremental UTF-8 decoding across chunk boundaries
 # (ported from openclaw/openclaw#112325)
@@ -412,6 +505,36 @@ def test_pty_reader_loop_reassembles_multibyte_char_split_across_chunks(registry
 
     assert session.output_buffer == "café\n"
     assert "\ufffd" not in session.output_buffer
+
+
+def test_pty_reader_unknown_exit_status_is_explicitly_lost(registry, monkeypatch):
+    """A PTY without an exit status must not be reported as plain exited."""
+
+    class _FakePty:
+        exitstatus = None
+
+        def isalive(self):
+            return False
+
+        def wait(self):
+            return None
+
+    session = _make_session(sid="proc_pty_lost")
+    session._pty = _FakePty()
+    session.notify_on_complete = True
+    registry._running[session.id] = session
+    monkeypatch.setattr(registry, "_check_watch_patterns", lambda _s, _c: None)
+    monkeypatch.setattr(registry, "_emit_output", lambda _s, _c: None)
+
+    registry._pty_reader_loop(session)
+
+    assert session.exited is True
+    assert session.exit_code is None
+    assert session.completion_reason == "lost"
+    assert session.termination_source == "pty_exit_status_unavailable"
+    completion = registry.completion_queue.get_nowait()
+    assert completion["exit_code"] is None
+    assert completion["completion_reason"] == "lost"
 
 
 # =========================================================================
@@ -1117,6 +1240,21 @@ class TestProcessToolHandler:
 from tools.process_registry import format_process_notification
 
 
+def test_format_lost_completion_omits_fake_null_exit_code():
+    text = format_process_notification({
+        "type": "completion",
+        "session_id": "proc_lost",
+        "command": "gh pr checks --watch",
+        "exit_code": None,
+        "completion_reason": "lost",
+        "termination_source": "detached_pid_unavailable",
+        "output": "",
+    })
+
+    assert "marked lost (detached_pid_unavailable)" in text
+    assert "exit code None" not in text
+
+
 def test_drain_notifications_completion_callback_exception_fails_closed(registry):
     event = {
         "type": "completion",
@@ -1381,7 +1519,13 @@ class TestPidReuseGuard:
         registry._running[s.id] = s
         refreshed = registry._refresh_detached_session(s)
         assert refreshed.exited is True
+        assert refreshed.exit_code is None
+        assert refreshed.completion_reason == "lost"
+        assert refreshed.termination_source == "detached_pid_unavailable"
         assert s.id in registry._finished
+        entry = next(item for item in registry.list_sessions() if item["session_id"] == s.id)
+        assert entry["completion_reason"] == "lost"
+        assert entry["termination_source"] == "detached_pid_unavailable"
 
 
 @pytest.mark.skipif(sys.platform == "win32",
@@ -2169,6 +2313,11 @@ class TestSystemdCgroupIsolation:
         assert stopped == ["hermes-worker-proc_recovered_scope.scope"]
         assert terminated == []
         assert session.exited is True
+        assert session.exit_code is None
+        assert session.completion_reason == "lost"
+        assert session.termination_source == "detached_pid_unavailable"
+        assert result["completion_reason"] == "lost"
+        assert result["termination_source"] == "detached_pid_unavailable"
         assert session.id in registry._finished
         assert session.id not in registry._running
 

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -437,12 +437,12 @@ def test_reader_unreapable_child_is_explicitly_lost(registry):
     registry._reader_loop(session)
 
     assert session.exited is True
-    assert session.exit_code is None
+    assert session.exit_code == -1
     assert session.completion_reason == "lost"
     assert session.termination_source == "reader_wait_failed"
     completion = registry.completion_queue.get_nowait()
     assert completion["type"] == "completion"
-    assert completion["exit_code"] is None
+    assert completion["exit_code"] == -1
     assert completion["completion_reason"] == "lost"
     assert completion["termination_source"] == "reader_wait_failed"
 
@@ -570,16 +570,16 @@ def test_pty_reader_unknown_exit_status_is_explicitly_lost(registry, monkeypatch
     registry._pty_reader_loop(session)
 
     assert session.exited is True
-    assert session.exit_code is None
+    assert session.exit_code == -1
     assert session.completion_reason == "lost"
     assert session.termination_source == "pty_exit_status_unavailable"
     completion = registry.completion_queue.get_nowait()
-    assert completion["exit_code"] is None
+    assert completion["exit_code"] == -1
     assert completion["completion_reason"] == "lost"
 
 
-def test_pty_reader_signal_status_is_concrete_killed_result(registry, monkeypatch):
-    """A reaped PTY signal status is evidence, not a lost exit result."""
+def test_pty_reader_external_signal_is_concrete_exit_result(registry, monkeypatch):
+    """A reaped external PTY signal is known, but not a Hermes kill."""
 
     class _FakePty:
         exitstatus = None
@@ -602,16 +602,17 @@ def test_pty_reader_signal_status_is_concrete_killed_result(registry, monkeypatc
 
     assert session.exited is True
     assert session.exit_code == -signal.SIGTERM
-    assert session.completion_reason == "killed"
-    assert session.termination_source == "pty_signal"
+    assert session.completion_reason == "exited"
+    assert session.termination_source == "external_signal"
     completion = registry.completion_queue.get_nowait()
     assert completion["exit_code"] == -signal.SIGTERM
-    assert completion["completion_reason"] == "killed"
+    assert completion["completion_reason"] == "exited"
+    assert completion["termination_source"] == "external_signal"
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX PTY signal semantics")
-def test_real_pty_sigterm_is_killed_not_lost(registry):
-    """ptyprocess exposes signalstatus when exitstatus is None."""
+def test_real_external_pty_sigterm_is_exited_not_lost(registry):
+    """ptyprocess exposes a known external signal without kill intent."""
     from ptyprocess import PtyProcess
 
     pty = PtyProcess.spawn([sys.executable, "-c", "import time; time.sleep(30)"])
@@ -628,11 +629,12 @@ def test_real_pty_sigterm_is_killed_not_lost(registry):
             pty.terminate(force=True)
 
     assert session.exit_code == -signal.SIGTERM
-    assert session.completion_reason == "killed"
-    assert session.termination_source == "pty_signal"
+    assert session.completion_reason == "exited"
+    assert session.termination_source == "external_signal"
     completion = registry.completion_queue.get_nowait()
     assert completion["exit_code"] == -signal.SIGTERM
-    assert completion["completion_reason"] == "killed"
+    assert completion["completion_reason"] == "exited"
+    assert completion["termination_source"] == "external_signal"
 
 
 def test_reader_combines_concrete_exit_with_kill_intent(registry):
@@ -664,6 +666,50 @@ def test_reader_combines_concrete_exit_with_kill_intent(registry):
     completion = registry.completion_queue.get_nowait()
     assert completion["exit_code"] == -signal.SIGKILL
     assert completion["completion_reason"] == "killed"
+
+
+def test_clean_exit_is_not_relabelled_by_kill_intent(registry):
+    """Intent is not effect evidence when the child exits cleanly."""
+    session = _make_session(sid="proc_clean_kill_race")
+    session._kill_requested_source = "process.kill"
+
+    terminal = registry._record_terminal_observation(session, 0)
+
+    assert terminal == {
+        "exited": True,
+        "exit_code": 0,
+        "completion_reason": "exited",
+        "termination_source": "",
+    }
+
+
+def test_terminal_snapshot_waits_for_coherent_writer_tuple(registry):
+    """Readers cannot observe fields while a writer holds the session lock."""
+    session = _make_session(sid="proc_snapshot_lock")
+    snapshot = {}
+    completed = threading.Event()
+
+    def read_snapshot():
+        snapshot.update(registry.terminal_snapshot(session))
+        completed.set()
+
+    with session._lock:
+        reader = threading.Thread(target=read_snapshot)
+        reader.start()
+        assert not completed.wait(0.05)
+        session.exited = True
+        session.exit_code = -signal.SIGTERM
+        session.completion_reason = "exited"
+        session.termination_source = "external_signal"
+
+    reader.join(timeout=1)
+    assert completed.is_set()
+    assert snapshot == {
+        "exited": True,
+        "exit_code": -signal.SIGTERM,
+        "completion_reason": "exited",
+        "termination_source": "external_signal",
+    }
 
 
 # =========================================================================
@@ -832,6 +878,20 @@ class TestReadLog:
         registry._running[s.id] = s
         result = registry.read_log(s.id, offset=10, limit=5)
         assert "5 lines" in result["showing"]
+
+    def test_terminal_log_includes_reason_code_and_source(self, registry):
+        s = _make_session(output="partial output")
+        registry._record_terminal_observation(
+            s, None, unavailable_source="reader_wait_failed"
+        )
+        registry._finished[s.id] = s
+
+        result = registry.read_log(s.id)
+
+        assert result["status"] == "exited"
+        assert result["exit_code"] == -1
+        assert result["completion_reason"] == "lost"
+        assert result["termination_source"] == "reader_wait_failed"
 
 
 # =========================================================================
@@ -1105,7 +1165,7 @@ class TestSpawnEnvSanitization:
             registry._env_poller_loop(session, FakeEnv(), "/log", "/pid", "/exit")
 
         assert session.exited is True
-        assert session.exit_code is None
+        assert session.exit_code == -1
         assert session.completion_reason == "lost"
         assert session.termination_source == "backend_exit_status_unavailable"
 
@@ -1120,7 +1180,7 @@ class TestSpawnEnvSanitization:
             registry._env_poller_loop(session, GoneEnv(), "/log", "/pid", "/exit")
 
         assert session.exited is True
-        assert session.exit_code is None
+        assert session.exit_code == -1
         assert session.completion_reason == "lost"
         assert session.termination_source == "backend_lost"
 
@@ -1408,6 +1468,34 @@ class TestKillProcess:
         assert session.completion_reason == "killed"
         assert session.termination_source == "process.kill"
 
+    def test_kill_return_preserves_clean_exit_observed_after_intent(
+        self, registry, monkeypatch
+    ):
+        """Kill intent cannot fabricate a killed API result over observed exit 0."""
+
+        class FakeProcess:
+            pid = 4242
+
+            def poll(self):
+                return None
+
+        session = _make_session(sid="proc_kill_clean_exit")
+        session.process = FakeProcess()
+        registry._running[session.id] = session
+
+        def terminate(pid, expected_start):
+            assert session._kill_requested_source == "process.kill"
+            registry._record_terminal_observation(session, 0)
+
+        monkeypatch.setattr(registry, "_terminate_host_pid", terminate)
+
+        result = registry.kill_process(session.id)
+
+        assert result["status"] == "exited"
+        assert result["exit_code"] == 0
+        assert result["completion_reason"] == "exited"
+        assert result["termination_source"] == ""
+
     def test_unsupported_recovered_kill_clears_intent_and_consumption(self, registry):
         session = _make_session(sid="proc_recovered_without_handle")
         registry._running[session.id] = session
@@ -1451,7 +1539,14 @@ class TestKillProcess:
                  patch.object(_psutil, "Process", side_effect=lambda pid: FakeProcess(pid)):
                 result = registry.kill_process(s.id)
 
-            assert result["status"] == "killed"
+            assert result["status"] == "lost"
+            assert result["completion_reason"] == "lost"
+            assert result["exit_code"] == -1
+            assert result["termination_source"] == "detached_kill_result_unavailable"
+            assert s.completion_reason == "lost"
+            assert s.exit_code == -1
+            assert s.id in registry._finished
+            assert s.id not in registry._running
             assert ("terminate", 424242) in terminate_calls
         finally:
             registry._running.pop(s.id, None)
@@ -1475,12 +1570,12 @@ class TestProcessToolHandler:
 from tools.process_registry import format_process_notification
 
 
-def test_format_lost_completion_omits_fake_null_exit_code():
+def test_format_lost_completion_omits_sentinel_exit_code():
     text = format_process_notification({
         "type": "completion",
         "session_id": "proc_lost",
         "command": "gh pr checks --watch",
-        "exit_code": None,
+        "exit_code": -1,
         "completion_reason": "lost",
         "termination_source": "detached_pid_unavailable",
         "output": "",
@@ -1755,7 +1850,7 @@ class TestPidReuseGuard:
         registry._running[s.id] = s
         refreshed = registry._refresh_detached_session(s)
         assert refreshed.exited is True
-        assert refreshed.exit_code is None
+        assert refreshed.exit_code == -1
         assert refreshed.completion_reason == "lost"
         assert refreshed.termination_source == "detached_pid_unavailable"
         assert s.id in registry._finished
@@ -1763,7 +1858,7 @@ class TestPidReuseGuard:
         assert entry["completion_reason"] == "lost"
         assert entry["termination_source"] == "detached_pid_unavailable"
         completion = registry.completion_queue.get_nowait()
-        assert completion["exit_code"] is None
+        assert completion["exit_code"] == -1
         assert completion["completion_reason"] == "lost"
         assert completion["termination_source"] == "detached_pid_unavailable"
 
@@ -2553,7 +2648,7 @@ class TestSystemdCgroupIsolation:
         assert stopped == ["hermes-worker-proc_recovered_scope.scope"]
         assert terminated == []
         assert session.exited is True
-        assert session.exit_code is None
+        assert session.exit_code == -1
         assert session.completion_reason == "lost"
         assert session.termination_source == "detached_pid_unavailable"
         assert result["completion_reason"] == "lost"

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -366,6 +366,46 @@ def test_reader_failure_waits_for_real_child_exit_before_completion(registry, mo
     assert completion["exit_code"] == 0
 
 
+def test_reader_waits_for_real_subprocess_after_stdout_closes(registry):
+    """Real child closure of stdout is not the same as child completion."""
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import os, sys, time; "
+                "os.close(sys.stdout.fileno()); "
+                "time.sleep(0.2); "
+                "raise SystemExit(7)"
+            ),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    session = _make_session(sid="proc_reader_real_child")
+    session.process = proc
+    session.pid = proc.pid
+    session.notify_on_complete = True
+    registry._running[session.id] = session
+
+    started = time.monotonic()
+    try:
+        registry._reader_loop(session)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
+
+    elapsed = time.monotonic() - started
+    assert elapsed >= 0.15
+    assert session.exited is True
+    assert session.exit_code == 7
+    assert session.completion_reason == "exited"
+    completion = registry.completion_queue.get_nowait()
+    assert completion["exit_code"] == 7
+    assert completion["completion_reason"] == "exited"
+
+
 def test_reader_unreapable_child_is_explicitly_lost(registry):
     """A failed wait/poll is classified, never serialized as plain exited/null."""
 

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1556,6 +1556,7 @@ class TestPidReuseGuard:
         s.pid_scope = "host"
         s.detached = True
         s.host_start_time = wrong_start  # ...identity no longer matches
+        s.notify_on_complete = True
         registry._running[s.id] = s
         refreshed = registry._refresh_detached_session(s)
         assert refreshed.exited is True
@@ -1566,6 +1567,10 @@ class TestPidReuseGuard:
         entry = next(item for item in registry.list_sessions() if item["session_id"] == s.id)
         assert entry["completion_reason"] == "lost"
         assert entry["termination_source"] == "detached_pid_unavailable"
+        completion = registry.completion_queue.get_nowait()
+        assert completion["exit_code"] is None
+        assert completion["completion_reason"] == "lost"
+        assert completion["termination_source"] == "detached_pid_unavailable"
 
 
 @pytest.mark.skipif(sys.platform == "win32",

--- a/tests/tools/test_process_registry_notification_races.py
+++ b/tests/tools/test_process_registry_notification_races.py
@@ -1,0 +1,42 @@
+"""Regression tests for completion-notification ordering and canonical identity."""
+
+import sys
+import time
+
+from tools.process_registry import ProcessRegistry, ProcessSession
+
+
+def test_prefix_poll_deduplicates_canonical_completion_event():
+    registry = ProcessRegistry()
+    session = ProcessSession(
+        id="proc_abcdef123456",
+        command="true",
+        started_at=time.time(),
+        notify_on_complete=True,
+    )
+    registry._running[session.id] = session
+    registry._record_terminal_observation(session, 0)
+    registry._move_to_finished(session)
+
+    result = registry.poll("abcdef")
+
+    assert result["session_id"] == session.id
+    assert registry.drain_notifications() == []
+
+
+def test_fast_exit_notify_on_complete_is_configured_before_reader_starts(monkeypatch):
+    monkeypatch.setattr(
+        "tools.process_registry._is_supervised_gateway_process",
+        lambda: False,
+    )
+    registry = ProcessRegistry()
+
+    session = registry.spawn_local(
+        f'{sys.executable} -c "pass"',
+        cwd="/tmp",
+        notify_on_complete=True,
+    )
+
+    assert session._completion_event.wait(timeout=5)
+    notifications = registry.drain_notifications(skip_poll_observed=False)
+    assert [event[0]["session_id"] for event in notifications] == [session.id]

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -170,6 +170,8 @@ def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
         "session_key": task_id,
         "env_vars": {},
         "use_pty": False,
+        "notify_on_complete": False,
+        "watch_patterns": [],
     }]
 
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -377,9 +377,9 @@ class ProcessSession:
     started_at: float = 0.0                     # time.time() of spawn (wall clock)
     host_start_time: Optional[int] = None       # kernel start ticks (/proc/<pid>/stat f22) — PID-reuse guard
     exited: bool = False                        # Whether the process has finished
-    exit_code: Optional[int] = None             # Exit code (None if still running)
+    exit_code: Optional[int] = None             # None only while running or when reason=lost
     completion_reason: str = "exited"           # exited|killed|lost|failed_start|already_exited
-    termination_source: str = ""                # process.kill|kill_all|backend_lost|failed_start
+    termination_source: str = ""                # process.kill|backend_lost|*_unavailable|failed_start
     output_buffer: str = ""                     # Rolling output (last MAX_OUTPUT_CHARS)
     max_output_chars: int = MAX_OUTPUT_CHARS
     detached: bool = False                      # True if recovered from crash (no pipe)
@@ -792,6 +792,8 @@ class ProcessRegistry:
             # Recovered sessions no longer have a waitable handle, so the real
             # exit code is unavailable once the original process object is gone.
             session.exit_code = None
+            session.completion_reason = "lost"
+            session.termination_source = "detached_pid_unavailable"
 
         self._move_to_finished(session)
         return session
@@ -1432,15 +1434,30 @@ class ProcessRegistry:
                     _append_chunk(tail)
             except Exception:
                 pass
-            # Always reap the child to prevent zombie processes.
+            # Always reap the child to prevent zombie processes. This reader
+            # already runs in a daemon thread, so lifecycle truth is more
+            # important than a bounded wait here: stdout can close or fail
+            # while the child is still running. A timed-out wait followed by
+            # unconditional completion used to publish ``exited`` with
+            # ``returncode=None`` for a live process.
+            wait_failed = False
             try:
-                session.process.wait(timeout=5)
+                session.process.wait()
             except Exception as e:
-                logger.debug("Process wait timed out or failed: %s", e)
+                logger.debug("Process wait failed: %s", e)
+                try:
+                    wait_failed = session.process.poll() is None
+                except Exception:
+                    wait_failed = True
             session.exited = True
             if session.completion_reason != "killed":
-                session.exit_code = session.process.returncode
-                session.completion_reason = "exited"
+                if wait_failed:
+                    session.exit_code = None
+                    session.completion_reason = "lost"
+                    session.termination_source = "reader_wait_failed"
+                else:
+                    session.exit_code = session.process.returncode
+                    session.completion_reason = "exited"
             self._move_to_finished(session)
 
     def _env_poller_loop(
@@ -1548,8 +1565,13 @@ class ProcessRegistry:
             logger.debug("PTY wait timed out or failed: %s", e)
         session.exited = True
         if session.completion_reason != "killed":
-            session.exit_code = pty.exitstatus if hasattr(pty, 'exitstatus') else -1
-            session.completion_reason = "exited"
+            exit_code = pty.exitstatus if hasattr(pty, "exitstatus") else None
+            session.exit_code = exit_code
+            if exit_code is None:
+                session.completion_reason = "lost"
+                session.termination_source = "pty_exit_status_unavailable"
+            else:
+                session.completion_reason = "exited"
         self._move_to_finished(session)
 
     def _move_to_finished(self, session: ProcessSession):
@@ -2139,6 +2161,8 @@ class ProcessRegistry:
                     with session._lock:
                         session.exited = True
                         session.exit_code = None
+                        session.completion_reason = "lost"
+                        session.termination_source = "detached_pid_unavailable"
                         output = strip_ansi(session.output_buffer[-2000:])
                     if consume_output:
                         self._completion_consumed.add(session_id)
@@ -2146,6 +2170,8 @@ class ProcessRegistry:
                     return {
                         "status": "already_exited",
                         "exit_code": session.exit_code,
+                        "completion_reason": session.completion_reason,
+                        "termination_source": session.termination_source,
                         "output": output,
                     }
                 self._terminate_host_pid(session.pid, session.host_start_time)
@@ -2362,6 +2388,9 @@ class ProcessRegistry:
                 entry["notify_on_complete"] = True
             if s.exited:
                 entry["exit_code"] = s.exit_code
+                entry["completion_reason"] = s.completion_reason
+                if s.termination_source:
+                    entry["termination_source"] = s.termination_source
             if s.detached:
                 entry["detached"] = True
             result.append(entry)
@@ -2965,16 +2994,16 @@ def format_process_notification(evt: dict) -> "str | None":
     if _reason == "killed":
         _status = f"terminated by {_source or 'Hermes'}"
     elif _reason == "lost":
-        _status = "marked lost because the process backend disappeared"
+        _status = f"marked lost ({_source or 'exit result unavailable'})"
     elif _reason == "failed_start":
         _status = "failed to start"
     elif _exit == 0:
         _status = "completed normally"
     else:
         _status = "exited"
+    _exit_suffix = "" if _reason == "lost" and _exit is None else f" (exit code {_exit}{_signal})"
     text = (
-        f"[IMPORTANT: Background process {_sid} {_status} "
-        f"(exit code {_exit}{_signal}).\n"
+        f"[IMPORTANT: Background process {_sid} {_status}{_exit_suffix}.\n"
     )
     if _attribution:
         text += f"{_attribution}\n"

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -377,9 +377,9 @@ class ProcessSession:
     started_at: float = 0.0                     # time.time() of spawn (wall clock)
     host_start_time: Optional[int] = None       # kernel start ticks (/proc/<pid>/stat f22) — PID-reuse guard
     exited: bool = False                        # Whether the process has finished
-    exit_code: Optional[int] = None             # None only while running or when reason=lost
-    completion_reason: str = "exited"           # exited|killed|lost|failed_start|already_exited
-    termination_source: str = ""                # process.kill|backend_lost|*_unavailable|failed_start
+    exit_code: Optional[int] = None             # None only while running; lost publishes -1
+    completion_reason: str = "exited"           # exited|killed|lost|failed_start
+    termination_source: str = ""                # process.kill|external_signal|backend_lost|*_unavailable|failed_start
     output_buffer: str = ""                     # Rolling output (last MAX_OUTPUT_CHARS)
     max_output_chars: int = MAX_OUTPUT_CHARS
     detached: bool = False                      # True if recovered from crash (no pipe)
@@ -794,7 +794,7 @@ class ProcessRegistry:
             session.exited = True
             # Recovered sessions no longer have a waitable handle, so the real
             # exit code is unavailable once the original process object is gone.
-            session.exit_code = None
+            session.exit_code = -1
             session.completion_reason = "lost"
             session.termination_source = "detached_pid_unavailable"
 
@@ -984,6 +984,8 @@ class ProcessRegistry:
         session_key: str = "",
         env_vars: dict = None,
         use_pty: bool = False,
+        notify_on_complete: bool = False,
+        watch_patterns: Optional[List[str]] = None,
     ) -> ProcessSession:
         """
         Spawn a background process locally.
@@ -1011,6 +1013,8 @@ class ProcessRegistry:
             session_key=session_key,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
+            notify_on_complete=notify_on_complete,
+            watch_patterns=list(watch_patterns or []),
         )
 
         pty_scope_attempted = False
@@ -1069,11 +1073,15 @@ class ProcessRegistry:
                     name=f"proc-pty-reader-{session.id}",
                 )
                 session._reader_thread = reader
-                reader.start()
-
                 with self._lock:
                     self._prune_if_needed()
                     self._running[session.id] = session
+                try:
+                    reader.start()
+                except Exception:
+                    with self._lock:
+                        self._running.pop(session.id, None)
+                    raise
 
                 self._write_checkpoint()
                 return session
@@ -1175,14 +1183,15 @@ class ProcessRegistry:
                 name=f"proc-reader-{session.id}",
             )
             session._reader_thread = reader
-            reader.start()
-
             with self._lock:
                 self._prune_if_needed()
                 self._running[session.id] = session
+            reader.start()
 
             self._write_checkpoint()
         except Exception:
+            with self._lock:
+                self._running.pop(session.id, None)
             # Post-Popen setup failed — kill the orphaned subprocess (and any
             # descendants spawned via setsid) before re-raising so they do not
             # leak as untracked background processes.
@@ -1222,6 +1231,8 @@ class ProcessRegistry:
         task_id: str = "",
         session_key: str = "",
         timeout: int = 10,
+        notify_on_complete: bool = False,
+        watch_patterns: Optional[List[str]] = None,
     ) -> ProcessSession:
         """
         Spawn a background process through a non-local environment backend.
@@ -1243,6 +1254,8 @@ class ProcessRegistry:
             started_at=time.time(),
             env_ref=env,
             pid_scope="sandbox",
+            notify_on_complete=notify_on_complete,
+            watch_patterns=list(watch_patterns or []),
         )
 
         # Run the command in the sandbox with output capture
@@ -1294,7 +1307,8 @@ class ProcessRegistry:
             session.output_buffer = f"Failed to start: {e}"
 
         if not session.exited:
-            # Start a poller thread that periodically reads the log file
+            # Register before the poller starts so an immediate completion is
+            # still the first authoritative running-to-finished transition.
             reader = threading.Thread(
                 target=self._env_poller_loop,
                 args=(session, env, log_path, pid_path, exit_path),
@@ -1302,19 +1316,69 @@ class ProcessRegistry:
                 name=f"proc-poller-{session.id}",
             )
             session._reader_thread = reader
-            reader.start()
-
-        with self._lock:
-            self._prune_if_needed()
-            if not session.exited:
+            with self._lock:
+                self._prune_if_needed()
                 self._running[session.id] = session
-
-        if not session.exited:
+            try:
+                reader.start()
+            except Exception:
+                with self._lock:
+                    self._running.pop(session.id, None)
+                raise
             self._write_checkpoint()
 
         return session
 
     # ----- Reader / Poller Threads -----
+
+    @staticmethod
+    def _record_terminal_observation(
+        session: ProcessSession,
+        exit_code: Optional[int],
+        *,
+        unavailable_source: str = "",
+        external_signal: bool = False,
+    ) -> Dict[str, Any]:
+        """Atomically classify one observed terminal result.
+
+        Kill intent is not itself proof of effect: a clean code-0 exit remains
+        ``exited``.  A non-zero result observed after a successful kill request
+        is ``killed``.  Missing custody/result data is explicit ``lost`` and
+        must name its source.
+        """
+        if exit_code is None and not unavailable_source:
+            raise ValueError("unavailable terminal result requires a source")
+        with session._lock:
+            session.exited = True
+            session.exit_code = -1 if exit_code is None else exit_code
+            if exit_code is None:
+                session.completion_reason = "lost"
+                session.termination_source = unavailable_source
+            elif session._kill_requested_source and exit_code != 0:
+                session.completion_reason = "killed"
+                session.termination_source = session._kill_requested_source
+            else:
+                session.completion_reason = "exited"
+                session.termination_source = (
+                    "external_signal" if external_signal else ""
+                )
+            return {
+                "exited": session.exited,
+                "exit_code": session.exit_code,
+                "completion_reason": session.completion_reason,
+                "termination_source": session.termination_source,
+            }
+
+    @staticmethod
+    def terminal_snapshot(session: ProcessSession) -> Dict[str, Any]:
+        """Read the terminal tuple under the same lock used by writers."""
+        with session._lock:
+            return {
+                "exited": session.exited,
+                "exit_code": session.exit_code,
+                "completion_reason": session.completion_reason,
+                "termination_source": session.termination_source,
+            }
 
     def _reader_loop(self, session: ProcessSession):
         """Background thread: read stdout from a local Popen process.
@@ -1452,19 +1516,14 @@ class ProcessRegistry:
                     wait_failed = session.process.poll() is None
                 except Exception:
                     wait_failed = True
-            with session._lock:
-                session.exited = True
-                if wait_failed:
-                    session.exit_code = None
-                    session.completion_reason = "lost"
-                    session.termination_source = "reader_wait_failed"
-                else:
-                    session.exit_code = session.process.returncode
-                    if session._kill_requested_source:
-                        session.completion_reason = "killed"
-                        session.termination_source = session._kill_requested_source
-                    elif session.completion_reason != "killed":
-                        session.completion_reason = "exited"
+            if wait_failed:
+                self._record_terminal_observation(
+                    session, None, unavailable_source="reader_wait_failed"
+                )
+            else:
+                self._record_terminal_observation(
+                    session, session.process.returncode
+                )
             self._move_to_finished(session)
 
     def _env_poller_loop(
@@ -1510,17 +1569,14 @@ class ProcessRegistry:
                         exit_code = int(exit_str.splitlines()[-1].strip())
                     except (ValueError, IndexError):
                         exit_code = None
-                    with session._lock:
-                        session.exited = True
-                        session.exit_code = exit_code
-                        if exit_code is None:
-                            session.completion_reason = "lost"
-                            session.termination_source = "backend_exit_status_unavailable"
-                        elif session._kill_requested_source:
-                            session.completion_reason = "killed"
-                            session.termination_source = session._kill_requested_source
-                        elif session.completion_reason != "killed":
-                            session.completion_reason = "exited"
+                    self._record_terminal_observation(
+                        session,
+                        exit_code,
+                        unavailable_source=(
+                            "backend_exit_status_unavailable"
+                            if exit_code is None else ""
+                        ),
+                    )
                     self._move_to_finished(session)
                     return
 
@@ -1528,11 +1584,9 @@ class ProcessRegistry:
                 # Environment might be gone (sandbox reaped, etc.). A kill
                 # request is intent, not proof of effect; unavailable custody
                 # therefore remains an explicit lost result.
-                with session._lock:
-                    session.exited = True
-                    session.exit_code = None
-                    session.completion_reason = "lost"
-                    session.termination_source = "backend_lost"
+                self._record_terminal_observation(
+                    session, None, unavailable_source="backend_lost"
+                )
                 self._move_to_finished(session)
                 return
 
@@ -1581,27 +1635,20 @@ class ProcessRegistry:
             pty.wait()
         except Exception as e:
             logger.debug("PTY wait timed out or failed: %s", e)
-        with session._lock:
-            session.exited = True
-            exit_code = getattr(pty, "exitstatus", None)
-            signal_status = getattr(pty, "signalstatus", None)
-            if isinstance(signal_status, int):
-                session.exit_code = -signal_status
-                session.completion_reason = "killed"
-                session.termination_source = (
-                    session._kill_requested_source or "pty_signal"
-                )
-            elif isinstance(exit_code, int):
-                session.exit_code = exit_code
-                if session._kill_requested_source:
-                    session.completion_reason = "killed"
-                    session.termination_source = session._kill_requested_source
-                elif session.completion_reason != "killed":
-                    session.completion_reason = "exited"
-            else:
-                session.exit_code = None
-                session.completion_reason = "lost"
-                session.termination_source = "pty_exit_status_unavailable"
+        exit_code = getattr(pty, "exitstatus", None)
+        signal_status = getattr(pty, "signalstatus", None)
+        if isinstance(signal_status, int) and signal_status > 0:
+            self._record_terminal_observation(
+                session,
+                -signal_status,
+                external_signal=not bool(session._kill_requested_source),
+            )
+        elif isinstance(exit_code, int):
+            self._record_terminal_observation(session, exit_code)
+        else:
+            self._record_terminal_observation(
+                session, None, unavailable_source="pty_exit_status_unavailable"
+            )
         self._move_to_finished(session)
 
     def _move_to_finished(self, session: ProcessSession):
@@ -1614,7 +1661,6 @@ class ProcessRegistry:
         with self._lock:
             was_running = self._running.pop(session.id, None) is not None
             self._finished[session.id] = session
-        session._completion_event.set()
         self._write_checkpoint()
 
         # Only enqueue completion notification on the FIRST move.  Without
@@ -1640,6 +1686,11 @@ class ProcessRegistry:
             }
             _redact_process_result(notification)
             self.completion_queue.put(notification)
+
+        # Completion becomes externally observable only after checkpoint and
+        # notification publication are complete. Otherwise waiters can wake and
+        # drain the queue in the gap before the event is enqueued.
+        session._completion_event.set()
 
     # ----- Query Methods -----
 
@@ -1900,13 +1951,7 @@ class ProcessRegistry:
                 session.output_buffer += drained
                 if len(session.output_buffer) > session.max_output_chars:
                     session.output_buffer = session.output_buffer[-session.max_output_chars:]
-            session.exited = True
-            session.exit_code = rc
-            if session._kill_requested_source:
-                session.completion_reason = "killed"
-                session.termination_source = session._kill_requested_source
-            elif session.completion_reason != "killed":
-                session.completion_reason = "exited"
+        self._record_terminal_observation(session, rc)
         logger.info(
             "Reconciled session %s: direct child exited with code %s but reader "
             "was still blocked (orphaned pipe). Flipped to exited.",
@@ -1928,19 +1973,20 @@ class ProcessRegistry:
 
         with session._lock:
             output_preview = strip_ansi(session.output_buffer[-1000:]) if session.output_buffer else ""
+        terminal = self.terminal_snapshot(session)
 
         result = {
             "session_id": session.id,
             "command": session.command,
-            "status": "exited" if session.exited else "running",
+            "status": "exited" if terminal["exited"] else "running",
             "pid": session.pid,
             "uptime_seconds": int(time.time() - session.started_at),
             "output_preview": output_preview,
         }
-        if session.exited:
-            result["exit_code"] = session.exit_code
-            result["completion_reason"] = session.completion_reason
-            result["termination_source"] = session.termination_source
+        if terminal["exited"]:
+            result["exit_code"] = terminal["exit_code"]
+            result["completion_reason"] = terminal["completion_reason"]
+            result["termination_source"] = terminal["termination_source"]
             # NOTE: poll() is a read-only status query and deliberately does
             # NOT mark the session _completion_consumed. wait()/read_log()
             # represent actual output consumption and do mark it. Marking
@@ -1951,7 +1997,7 @@ class ProcessRegistry:
             # dedups (the agent already saw the exit in this turn's poll result)
             # without affecting the gateway/tui watchers, which only consult
             # _completion_consumed.
-            self._poll_observed.add(session_id)
+            self._poll_observed.add(session.id)
         if session.detached:
             result["detached"] = True
             result["note"] = "Process recovered after restart -- output history unavailable"
@@ -1987,16 +2033,21 @@ class ProcessRegistry:
                 total_lines == 0 or (bool(selected) and stop == total_lines)
             )
 
+        terminal = self.terminal_snapshot(session)
         result = {
             "session_id": session.id,
             "command": session.command,
-            "status": "exited" if session.exited else "running",
+            "status": "exited" if terminal["exited"] else "running",
             "output": "\n".join(selected),
             "total_lines": total_lines,
             "showing": f"{len(selected)} lines",
         }
-        if session.exited and observed_completion_output:
-            self._completion_consumed.add(session_id)
+        if terminal["exited"]:
+            result["exit_code"] = terminal["exit_code"]
+            result["completion_reason"] = terminal["completion_reason"]
+            result["termination_source"] = terminal["termination_source"]
+        if terminal["exited"] and observed_completion_output:
+            self._completion_consumed.add(session.id)
         return result
 
     def wait(self, session_id: str, timeout: int = None) -> dict:
@@ -2056,14 +2107,15 @@ class ProcessRegistry:
             # pipe reader hangs where the reader is blocked but the direct
             # child has already exited (issue #17327).
             self._reconcile_local_exit(session)
-            if session.exited:
-                self._completion_consumed.add(session_id)
+            terminal = self.terminal_snapshot(session)
+            if terminal["exited"]:
+                self._completion_consumed.add(session.id)
                 result = {
                     "status": "exited",
                     "command": session.command,
-                    "exit_code": session.exit_code,
-                    "completion_reason": session.completion_reason,
-                    "termination_source": session.termination_source,
+                    "exit_code": terminal["exit_code"],
+                    "completion_reason": terminal["completion_reason"],
+                    "termination_source": terminal["termination_source"],
                     "output": strip_ansi(session.output_buffer[-2000:]),
                 }
                 if timeout_note:
@@ -2160,7 +2212,7 @@ class ProcessRegistry:
             # Only suppress the autonomous turn after its output is present in
             # the explicit kill result, matching wait/log consumption.
             if consume_output:
-                self._completion_consumed.add(session_id)
+                self._completion_consumed.add(session.id)
             return result
 
         # Record kill intent before the potentially blocking termination call.
@@ -2169,7 +2221,7 @@ class ProcessRegistry:
         with session._lock:
             session._kill_requested_source = source
             if consume_output:
-                self._completion_consumed.add(session_id)
+                self._completion_consumed.add(session.id)
 
         # Kill via PTY, Popen (local), or env execute (non-local)
         try:
@@ -2181,10 +2233,18 @@ class ProcessRegistry:
                     if session.pid:
                         os.kill(session.pid, signal.SIGTERM)
             elif session.process:
-                # Local process -- kill the process tree. On Windows this
-                # must be taskkill /T /F; Popen.terminate() only kills the
-                # shell wrapper and leaves Git Bash descendants behind.
+                # Local process -- kill the process tree, then ask the owned
+                # Popen for the real child status. Never fabricate SIGTERM:
+                # escalation may have produced SIGKILL and the reader's
+                # notification must agree with this synchronous path.
                 self._terminate_host_pid(session.process.pid, session.host_start_time)
+                try:
+                    observed_code = session.process.wait(timeout=2)
+                except (subprocess.TimeoutExpired, OSError, AttributeError):
+                    observed_code = session.process.poll()
+                if isinstance(observed_code, int):
+                    self._record_terminal_observation(session, observed_code)
+                    self._move_to_finished(session)
             elif session.env_ref and session.pid:
                 # Non-local -- kill inside sandbox
                 session.env_ref.execute(f"kill {session.pid} 2>/dev/null", timeout=5)
@@ -2201,12 +2261,12 @@ class ProcessRegistry:
                         _stop_systemd_unit(session.systemd_unit)
                     with session._lock:
                         session.exited = True
-                        session.exit_code = None
+                        session.exit_code = -1
                         session.completion_reason = "lost"
                         session.termination_source = "detached_pid_unavailable"
                         output = strip_ansi(session.output_buffer[-2000:])
                     if consume_output:
-                        self._completion_consumed.add(session_id)
+                        self._completion_consumed.add(session.id)
                     self._move_to_finished(session)
                     return {
                         "status": "already_exited",
@@ -2216,11 +2276,17 @@ class ProcessRegistry:
                         "output": output,
                     }
                 self._terminate_host_pid(session.pid, session.host_start_time)
+                self._record_terminal_observation(
+                    session,
+                    None,
+                    unavailable_source="detached_kill_result_unavailable",
+                )
+                self._move_to_finished(session)
             else:
                 with session._lock:
                     session._kill_requested_source = ""
                 if consume_output:
-                    self._completion_consumed.discard(session_id)
+                    self._completion_consumed.discard(session.id)
                 return {
                     "status": "error",
                     "error": (
@@ -2238,32 +2304,41 @@ class ProcessRegistry:
             # above already handled the main process; this catches stragglers.
             if session.systemd_unit:
                 _stop_systemd_unit(session.systemd_unit)
-            # Capture output before marking consumed, then mark consumed before
-            # exposing ``exited`` to watcher tasks. This closes the delayed
-            # notification race without discarding the terminal transcript.
+            # Capture output before marking consumed. Terminal completion is
+            # published only by a path holding concrete result evidence above
+            # or by the owning reader/poller; the kill acknowledgement itself
+            # is not permission to invent an exit code.
             with session._lock:
                 output = strip_ansi(session.output_buffer[-2000:])
                 if consume_output:
-                    self._completion_consumed.add(session_id)
-                session.exited = True
-                if session.exit_code is None:
-                    session.exit_code = -15  # Best available result without reader status.
-                session.completion_reason = "killed"
-                session.termination_source = source
-            self._move_to_finished(session)
+                    self._completion_consumed.add(session.id)
+            terminal = self.terminal_snapshot(session)
             self._write_checkpoint()
-            return {
-                "status": "killed",
-                "session_id": session.id,
-                "completion_reason": session.completion_reason,
-                "termination_source": session.termination_source,
-                "output": output,
-            }
+            if terminal["exited"]:
+                # Return the same observed tuple that is canonical state. Kill
+                # intent is provenance, never permission to fabricate outcome.
+                result = {
+                    "status": terminal["completion_reason"],
+                    "session_id": session.id,
+                    "exit_code": terminal["exit_code"],
+                    "completion_reason": terminal["completion_reason"],
+                    "termination_source": terminal["termination_source"],
+                    "output": output,
+                }
+            else:
+                # The owning reader/poller still has custody of the eventual
+                # result. Acknowledge intent without claiming terminal state.
+                result = {
+                    "status": "kill_requested",
+                    "session_id": session.id,
+                    "output": output,
+                }
+            return result
         except Exception as e:
             with session._lock:
                 session._kill_requested_source = ""
             if consume_output:
-                self._completion_consumed.discard(session_id)
+                self._completion_consumed.discard(session.id)
             return {"status": "error", "error": str(e)}
 
     def write_stdin(self, session_id: str, data: str) -> dict:
@@ -2413,6 +2488,7 @@ class ProcessRegistry:
 
         result = []
         for s in all_sessions:
+            terminal = self.terminal_snapshot(s)
             entry = {
                 "session_id": s.id,
                 "command": s.command[:200],
@@ -2420,7 +2496,7 @@ class ProcessRegistry:
                 "pid": s.pid,
                 "started_at": time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(s.started_at)),
                 "uptime_seconds": int(time.time() - s.started_at),
-                "status": "exited" if s.exited else "running",
+                "status": "exited" if terminal["exited"] else "running",
                 "output_preview": s.output_buffer[-200:] if s.output_buffer else "",
             }
             # Flag processes surfaced only because they share the gateway
@@ -2436,11 +2512,11 @@ class ProcessRegistry:
                 entry["watch_hit"] = s._watch_hits > 0
             if s.notify_on_complete:
                 entry["notify_on_complete"] = True
-            if s.exited:
-                entry["exit_code"] = s.exit_code
-                entry["completion_reason"] = s.completion_reason
-                if s.termination_source:
-                    entry["termination_source"] = s.termination_source
+            if terminal["exited"]:
+                entry["exit_code"] = terminal["exit_code"]
+                entry["completion_reason"] = terminal["completion_reason"]
+                if terminal["termination_source"]:
+                    entry["termination_source"] = terminal["termination_source"]
             if s.detached:
                 entry["detached"] = True
             result.append(entry)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1901,8 +1901,11 @@ class ProcessRegistry:
                 if len(session.output_buffer) > session.max_output_chars:
                     session.output_buffer = session.output_buffer[-session.max_output_chars:]
             session.exited = True
-            if session.completion_reason != "killed":
-                session.exit_code = rc
+            session.exit_code = rc
+            if session._kill_requested_source:
+                session.completion_reason = "killed"
+                session.termination_source = session._kill_requested_source
+            elif session.completion_reason != "killed":
                 session.completion_reason = "exited"
         logger.info(
             "Reconciled session %s: direct child exited with code %s but reader "

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -419,6 +419,9 @@ class ProcessSession:
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
     _pty: Any = field(default=None, repr=False)  # ptyprocess handle (when use_pty=True)
+    # Non-terminal intent set before a potentially blocking kill operation.
+    # Readers use it only after observing a concrete child terminal status.
+    _kill_requested_source: str = field(default="", repr=False)
 
 
 class ProcessRegistry:
@@ -1449,15 +1452,19 @@ class ProcessRegistry:
                     wait_failed = session.process.poll() is None
                 except Exception:
                     wait_failed = True
-            session.exited = True
-            if session.completion_reason != "killed":
+            with session._lock:
+                session.exited = True
                 if wait_failed:
                     session.exit_code = None
                     session.completion_reason = "lost"
                     session.termination_source = "reader_wait_failed"
                 else:
                     session.exit_code = session.process.returncode
-                    session.completion_reason = "exited"
+                    if session._kill_requested_source:
+                        session.completion_reason = "killed"
+                        session.termination_source = session._kill_requested_source
+                    elif session.completion_reason != "killed":
+                        session.completion_reason = "exited"
             self._move_to_finished(session)
 
     def _env_poller_loop(
@@ -1500,21 +1507,32 @@ class ProcessRegistry:
                     )
                     exit_str = exit_result.get("output", "").strip()
                     try:
-                        session.exit_code = int(exit_str.splitlines()[-1].strip())
+                        exit_code = int(exit_str.splitlines()[-1].strip())
                     except (ValueError, IndexError):
-                        session.exit_code = -1
-                    session.exited = True
-                    if session.completion_reason != "killed":
-                        session.completion_reason = "exited"
+                        exit_code = None
+                    with session._lock:
+                        session.exited = True
+                        session.exit_code = exit_code
+                        if exit_code is None:
+                            session.completion_reason = "lost"
+                            session.termination_source = "backend_exit_status_unavailable"
+                        elif session._kill_requested_source:
+                            session.completion_reason = "killed"
+                            session.termination_source = session._kill_requested_source
+                        elif session.completion_reason != "killed":
+                            session.completion_reason = "exited"
                     self._move_to_finished(session)
                     return
 
             except Exception:
-                # Environment might be gone (sandbox reaped, etc.)
-                session.exited = True
-                session.exit_code = -1
-                session.completion_reason = "lost"
-                session.termination_source = "backend_lost"
+                # Environment might be gone (sandbox reaped, etc.). A kill
+                # request is intent, not proof of effect; unavailable custody
+                # therefore remains an explicit lost result.
+                with session._lock:
+                    session.exited = True
+                    session.exit_code = None
+                    session.completion_reason = "lost"
+                    session.termination_source = "backend_lost"
                 self._move_to_finished(session)
                 return
 
@@ -1563,15 +1581,27 @@ class ProcessRegistry:
             pty.wait()
         except Exception as e:
             logger.debug("PTY wait timed out or failed: %s", e)
-        session.exited = True
-        if session.completion_reason != "killed":
-            exit_code = pty.exitstatus if hasattr(pty, "exitstatus") else None
-            session.exit_code = exit_code
-            if exit_code is None:
+        with session._lock:
+            session.exited = True
+            exit_code = getattr(pty, "exitstatus", None)
+            signal_status = getattr(pty, "signalstatus", None)
+            if isinstance(signal_status, int):
+                session.exit_code = -signal_status
+                session.completion_reason = "killed"
+                session.termination_source = (
+                    session._kill_requested_source or "pty_signal"
+                )
+            elif isinstance(exit_code, int):
+                session.exit_code = exit_code
+                if session._kill_requested_source:
+                    session.completion_reason = "killed"
+                    session.termination_source = session._kill_requested_source
+                elif session.completion_reason != "killed":
+                    session.completion_reason = "exited"
+            else:
+                session.exit_code = None
                 session.completion_reason = "lost"
                 session.termination_source = "pty_exit_status_unavailable"
-            else:
-                session.completion_reason = "exited"
         self._move_to_finished(session)
 
     def _move_to_finished(self, session: ProcessSession):
@@ -2130,6 +2160,14 @@ class ProcessRegistry:
                 self._completion_consumed.add(session_id)
             return result
 
+        # Record kill intent before the potentially blocking termination call.
+        # Reader/poller threads may observe the concrete exit first; they combine
+        # that observed status with this intent rather than publishing `exited`.
+        with session._lock:
+            session._kill_requested_source = source
+            if consume_output:
+                self._completion_consumed.add(session_id)
+
         # Kill via PTY, Popen (local), or env execute (non-local)
         try:
             if session._pty:
@@ -2176,6 +2214,10 @@ class ProcessRegistry:
                     }
                 self._terminate_host_pid(session.pid, session.host_start_time)
             else:
+                with session._lock:
+                    session._kill_requested_source = ""
+                if consume_output:
+                    self._completion_consumed.discard(session_id)
                 return {
                     "status": "error",
                     "error": (
@@ -2201,7 +2243,8 @@ class ProcessRegistry:
                 if consume_output:
                     self._completion_consumed.add(session_id)
                 session.exited = True
-                session.exit_code = -15  # SIGTERM
+                if session.exit_code is None:
+                    session.exit_code = -15  # Best available result without reader status.
                 session.completion_reason = "killed"
                 session.termination_source = source
             self._move_to_finished(session)
@@ -2214,6 +2257,10 @@ class ProcessRegistry:
                 "output": output,
             }
         except Exception as e:
+            with session._lock:
+                session._kill_requested_source = ""
+            if consume_output:
+                self._completion_consumed.discard(session_id)
             return {"status": "error", "error": str(e)}
 
     def write_stdin(self, session_id: str, data: str) -> dict:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3073,6 +3073,23 @@ def terminal_tool(
                 session_key=session_key,
                 env_type=env_type,
             )
+            # Resolve notification semantics before execution starts. Reader and
+            # poller threads may finish an instant command before this function
+            # returns, so intent and patterns must be part of session creation.
+            watch_patterns, conflict_note = _resolve_notification_flag_conflict(
+                notify_on_complete=bool(notify_on_complete),
+                watch_patterns=watch_patterns,
+                background=bool(background),
+            )
+            notification_unsupported = False
+            if notify_on_complete or watch_patterns:
+                from gateway.session_context import async_delivery_supported as _async_ok
+
+                if not _async_ok():
+                    notify_on_complete = False
+                    watch_patterns = None
+                    notification_unsupported = True
+
             try:
                 if env_type == "local":
                     proc_session = process_registry.spawn_local(
@@ -3082,6 +3099,8 @@ def terminal_tool(
                         session_key=session_key,
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
+                        notify_on_complete=bool(notify_on_complete),
+                        watch_patterns=list(watch_patterns or []),
                     )
                 else:
                     proc_session = process_registry.spawn_via_env(
@@ -3090,6 +3109,8 @@ def terminal_tool(
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
+                        notify_on_complete=bool(notify_on_complete),
+                        watch_patterns=list(watch_patterns or []),
                     )
 
                 result_data = {
@@ -3212,80 +3233,42 @@ def terminal_tool(
                             else canonical_hint
                         )
 
-                # Populate routing metadata on the session so that
-                # watch-pattern and completion notifications can be
-                # routed back to the correct chat/thread.
-                if background and (notify_on_complete or watch_patterns):
-                    from gateway.session_context import (
-                        async_delivery_supported as _async_ok,
-                        get_session_env as _gse,
+                # Populate routing metadata after the configured session exists.
+                # Notification intent itself was already fixed before spawn.
+                if notification_unsupported:
+                    result_data["notify_on_complete"] = False
+                    result_data["notify_unsupported"] = (
+                        "notify_on_complete / watch_patterns are not available in "
+                        "this session — it cannot receive an async completion after "
+                        "the turn ends (a one-shot runner such as `hermes -z`, a "
+                        "cron job, a Kanban worker, or a stateless HTTP endpoint). "
+                        "The process is running in the background; retrieve its result "
+                        "with process(action='poll') or process(action='wait')."
                     )
+                    logger.info(
+                        "background proc %s: async delivery unsupported on this "
+                        "session; notify_on_complete/watch_patterns disabled",
+                        proc_session.id,
+                    )
+                elif notify_on_complete or watch_patterns:
+                    from gateway.session_context import get_session_env as _gse
 
-                    # Finite sessions (stateless HTTP requests and one-shot
-                    # Kanban workers) cannot route a completion back to the
-                    # agent after the turn/process ends. Refuse the promise:
-                    # drop the flags and tell the agent to poll.
-                    if not _async_ok():
-                        notify_on_complete = False
-                        watch_patterns = None
-                        result_data["notify_on_complete"] = False
-                        result_data["notify_unsupported"] = (
-                            "notify_on_complete / watch_patterns are not available in "
-                            "this session — it cannot receive an async completion after "
-                            "the turn ends (a one-shot runner such as `hermes -z`, a "
-                            "cron job, a Kanban worker, or a stateless HTTP endpoint). "
-                            "The process is "
-                            "running in the background; retrieve its result with "
-                            "process(action='poll') or process(action='wait')."
-                        )
-                        logger.info(
-                            "background proc %s: async delivery unsupported on this "
-                            "session; notify_on_complete/watch_patterns disabled",
-                            proc_session.id,
-                        )
-                    else:
-                        _gw_platform = _gse("HERMES_SESSION_PLATFORM", "")
-                        if _gw_platform:
-                            _gw_chat_id = _gse("HERMES_SESSION_CHAT_ID", "")
-                            _gw_thread_id = _gse("HERMES_SESSION_THREAD_ID", "")
-                            _gw_user_id = _gse("HERMES_SESSION_USER_ID", "")
-                            _gw_user_name = _gse("HERMES_SESSION_USER_NAME", "")
-                            _gw_message_id = _gse("HERMES_SESSION_MESSAGE_ID", "")
-                            proc_session.watcher_platform = _gw_platform
-                            proc_session.watcher_chat_id = _gw_chat_id
-                            proc_session.watcher_user_id = _gw_user_id
-                            proc_session.watcher_user_name = _gw_user_name
-                            proc_session.watcher_thread_id = _gw_thread_id
-                            proc_session.watcher_message_id = _gw_message_id
-                            # Stamp the spawning conversation's session-db id
-                            # so the gateway's completion pre-flight
-                            # (_classify_completion_target) can drop the
-                            # notification when the user closes this session
-                            # (/new) before the process finishes, instead of
-                            # injecting it into the chat's NEW session.
-                            proc_session.parent_session_id = _gse(
-                                "HERMES_SESSION_ID", ""
-                            )
+                    _gw_platform = _gse("HERMES_SESSION_PLATFORM", "")
+                    if _gw_platform:
+                        proc_session.watcher_platform = _gw_platform
+                        proc_session.watcher_chat_id = _gse("HERMES_SESSION_CHAT_ID", "")
+                        proc_session.watcher_user_id = _gse("HERMES_SESSION_USER_ID", "")
+                        proc_session.watcher_user_name = _gse("HERMES_SESSION_USER_NAME", "")
+                        proc_session.watcher_thread_id = _gse("HERMES_SESSION_THREAD_ID", "")
+                        proc_session.watcher_message_id = _gse("HERMES_SESSION_MESSAGE_ID", "")
+                        proc_session.parent_session_id = _gse("HERMES_SESSION_ID", "")
 
-                # Mutual exclusion: if both notify_on_complete and watch_patterns
-                # are set, drop watch_patterns. The combination produces duplicate
-                # notifications (one per match + one on exit) that deliver
-                # asynchronously and can spam the user long after the process ends.
-                # notify_on_complete is the more useful signal for "let me know
-                # when the task finishes"; watch_patterns should be reserved for
-                # standalone mid-process signals on long-lived processes.
-                watch_patterns, conflict_note = _resolve_notification_flag_conflict(
-                    notify_on_complete=bool(notify_on_complete),
-                    watch_patterns=watch_patterns,
-                    background=bool(background),
-                )
                 if conflict_note:
                     logger.warning("background proc %s: %s", proc_session.id, conflict_note)
                     result_data["watch_patterns_ignored"] = conflict_note
 
                 # Mark for agent notification on completion
                 if notify_on_complete and background:
-                    proc_session.notify_on_complete = True
                     result_data["notify_on_complete"] = True
 
                     # In gateway mode, auto-register a fast watcher so the
@@ -3309,8 +3292,7 @@ def terminal_tool(
 
                 # Set watch patterns for output monitoring
                 if watch_patterns and background:
-                    proc_session.watch_patterns = list(watch_patterns)
-                    result_data["watch_patterns"] = proc_session.watch_patterns
+                    result_data["watch_patterns"] = list(watch_patterns)
 
                 return json.dumps(result_data, ensure_ascii=False)
             except Exception as e:


### PR DESCRIPTION
## What does this PR do?

Repairs Hermes background-process lifecycle truthfulness. Kill intent is recorded as provenance, but only observed terminal process evidence determines the published outcome.

Primary semantics:

```text
clean exit 0
→ exited / 0
→ no fabricated kill source

verified signal termination following a Hermes kill request
→ killed / actual observed exit code
→ verified kill provenance

terminal result irrecoverably unavailable
→ lost / -1 / non-empty source

terminal result still owned by reader/poller
→ kill_requested
→ no fabricated terminal tuple
```

The repair also makes terminal snapshots lock-coherent, preserves concrete PTY and child return codes, installs notification policy before fast completion can race it, deduplicates completion by canonical session identity, and makes focused-test evidence atomic and source-bound.

## Related Issue

Fixes #86416.

Related reports #47864 and #62118 concern dashboard action-state persistence across restart and are not closed by this ProcessRegistry repair.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Reap owned children and preserve their observed integer return codes.
- Publish unavailable terminal evidence as `lost/-1/<source>` instead of `exited/None`.
- Keep successful kill requests as provenance; a raced clean exit remains `exited/0`.
- Return `kill_process()` results from the same lock-protected terminal snapshot that becomes canonical state.
- Distinguish external PTY signals from verified Hermes kills.
- Make terminal publication, active-to-finished movement, completion enqueue, and notification exactly once.
- Resolve prefix/full-ID aliases to canonical session identity for completion bookkeeping.
- Install notification policy before fast readers or children can finish.
- Add dependency-aware test-runner selection, atomic result evidence, and checkout-pollution rejection.
- Isolate SQLite `.recover` probing so incompatible shims cannot create checkout artifacts.

## How to Test

1. Run the focused 16-path selection recorded below with the repository `.venv`.
2. Verify the critical real-process race: a child that handles SIGTERM and exits 0 produces `exited/0` from both `kill_process()` and `terminal_snapshot()`.
3. Run `tests/tools/test_process_registry.py -q`; expected result is `103 passed, 4 skipped`.
4. Run the full suite and exact-base comparison. Preserve the classification `FAIL_WITH_PROVEN_BASELINE_DEBT`; do not interpret it as a full-suite pass.

## Exact head and manifest

```text
head_sha: 964514f7e6377b855931ec208ffafdbec4965b6f
parent_sha: c676184fed43e2dae323c568d1328e014851a8cd
manifest_sha256: 3cdca1c0ea4e484f840dbac9e393bfa22624794f016bbfd057a951f5b734d889
entries_digest_sha256: ec4e8a7cc42c94cb674c7aab44c2810e4851f8e03497d09bd8642e961196888a
changed_path_count: 16
```

Any head mutation invalidates this review epoch. Do not amend, rebase, squash, or add follow-up work to the sealed head.

| Path | SHA-256 | Bytes |
|---|---|---:|
| `gateway/run.py` | `9555e97212807d082c39382ee3d11ddf1b4bd2d60e1cc265b2020d31cbbaf4e3` | 1496042 |
| `hermes_cli/session_lost_and_found.py` | `214fb7a3dcc291b085663a8253cac6b9de222189fde193e6e62e919e1d2fbb10` | 22271 |
| `scripts/run_tests.sh` | `a393ea5dc77262de930cdfb1fb268c58fb3484ec76e4d9cd93e45ad36176cdc2` | 9336 |
| `scripts/run_tests_parallel.py` | `95df807306be605f677bb4e8eac2f016b2d0bc7ca599e869ac1e6516d8d1e3d9` | 55354 |
| `tests/gateway/test_background_process_notifications.py` | `4489d00c24ad498dbb2668ac7b1f804b331407f29c72e1dbf8a40ac44f4bd2e1` | 22669 |
| `tests/gateway/test_completion_delivery.py` | `ff8a30c085d2d906d0589136d11ece51e39b92f32dfc285a90baefb54aadf762` | 33218 |
| `tests/gateway/test_internal_event_bypass_pairing.py` | `43f2d66ea4a0dcce168a42282f32e2f2213d970740289451041209e28dfb81e5` | 7259 |
| `tests/hermes_cli/test_session_lost_and_found_probe.py` | `7ebde06ccbe3c7a512fcd5f91b9364ece85ecaee367a2f7a4571dc0b739d420c` | 893 |
| `tests/test_run_tests_parallel.py` | `cd44bc98a19eaa7ad320470626baeaf79ba2b12d509d79641e87b5a467d04b5c` | 21591 |
| `tests/test_run_tests_shell.py` | `6edb69ad85d6a34462a39ae9d90638c6586b1af449f35b4bfbe58ae36c76da61` | 3528 |
| `tests/tools/test_notify_on_complete.py` | `6eb700b99408febe2524e5751556aa5c309b9c2fa201da4bc34c1cb6a22c5da5` | 17641 |
| `tests/tools/test_process_registry.py` | `2c35e5528941f1710bd933ce6f87e19800a68d0138a00b1cf2bddb77645c6717` | 114256 |
| `tests/tools/test_process_registry_notification_races.py` | `5255fb08a4065a9324f806cb921aa02d9b7303c443eb86135eaed1074003c27f` | 1287 |
| `tests/tools/test_terminal_task_cwd.py` | `b3b10b899df17e5389be2e50c51631c17503ca5d6ad1cd854dbd34cb63b9cf15` | 6732 |
| `tools/process_registry.py` | `ee6f976d404d07c994eec4e4c17bdab514f65cd9f4d2b87665d47d1ee7e6bf11` | 148199 |
| `tools/terminal_tool.py` | `46780861d478b978830dbc8067e813360dea6a7b94c81c8cafc22fd91ef55760` | 175549 |

## Validation

Focused validation:

```text
274 passed
5 skipped
0 failed
checkout_pollution=[]
```

Registry validation:

```text
103 passed
4 skipped
```

Static validation:

```text
ruff: PASS
compile: PASS
shell syntax: PASS
git diff --check: PASS
```

Full-suite classification:

```text
FAIL_WITH_PROVEN_BASELINE_DEBT

candidate:
35,502 passed
321 skipped
10 failed across 6 files

fresh exact base, same six files:
84 passed
10 failed

candidate-attributable failures:
0
```

This is neither `FULL_SUITE_PASS` nor evidence that this candidate introduced ten failures. All ten residual failures reproduced against exact parent/base code under the same locked interpreter.

Evidence hashes:

```text
FOCUSED-RESULT.json: 770fbd14b79f68645420a3e337832bf9265fd4e50f64feb120f4aeffe73a4aef
FULL-SUITE-RESULT.json: ed32050da44d3117539f103a26a3c6d13f90c7dddd3a4310b6df263834616735
BASELINE-ATTRIBUTION.json: 2cbb7b989be2401a4bd4d335909e578846e4774fce326f57874b8653a27fb5c6
BASELINE-ATTRIBUTION.log: 7befb816dca956396e02f03c8aaa66b7b6bbdc11bf01e6e736b8ed378463b0cc
SOURCE-COMMIT-BINDING.json: 4e4c4cf5368884ce414658fe937f8c946271f65034ef1e0b8e660a7fe7964d71
FINAL-REVIEW-FANIN.json: 3b6b24e7857fcae56aa44c18dd0abd467a0245dd2b426f2017a0b1e774aa888c
```

## Review evidence

Binding reviews on the identical manifest and prompt:

- DeepSeek V4 Pro: `APPROVE`, 0 blockers.
- Grok 4.5: `APPROVE`, 0 blockers.

Advisory reviews:

- lifecycle adversarial: `APPROVE`;
- compatibility/concurrency: `APPROVE`;
- evidence/harness: `APPROVE`.

The earlier four-turn DeepSeek and Grok attempts are retained as lineage only:

```text
INCOMPLETE
NON_BINDING
SUPERSEDED_BY_COMPLETED_REVIEW
```

Reviewer agreement is quality evidence, not merge or activation authority.

## Proven

- The exact 16-path source candidate is committed at `964514f7e6377b855931ec208ffafdbec4965b6f`.
- All committed blobs match the reviewed manifest.
- Focused and registry regressions pass with the counts above.
- The ten full-suite residual failures reproduce on the exact base; candidate-attributable failures are zero.
- Linux real-process probes reproduce clean-exit, concrete-signal, lost-result, notification-ordering, and exactly-once semantics.

## Not Proven

- Windows runtime: NOT_PROVEN.
- production_ready: false.
- vertical_complete: false.
- runtime activation: NOT_AUTHORIZED.
- merge authority: NOT_GRANTED.
- P2 observations are follow-up debt and are not bundled here.

## Risk

The change touches central process lifecycle and notification paths. Risk is bounded by lock-protected snapshots, concrete return-code preservation, exactly-once regressions, fake-registry compatibility tests, focused real-process probes, and exact-base attribution. Windows runtime behavior remains explicitly unproven.

## Rollback

After merge, rollback is a `git revert` of this PR. Reverting restores the previous lifecycle ambiguity and cannot recover historical process evidence.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs for this branch; none exist.
- [x] My PR contains only the exact 16-path lifecycle repair denominator.
- [ ] I've run `pytest tests/ -q` and all tests pass. Full suite is intentionally disclosed as `FAIL_WITH_PROVEN_BASELINE_DEBT`; all 10 residual failures reproduce at exact base.
- [x] I've added tests for the repaired behavior.
- [x] I've tested on Linux.

### Documentation & Housekeeping

- [x] Relevant docstrings and test contracts are updated; README/docs changes are N/A.
- [x] `cli-config.yaml.example` changes are N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A.
- [x] Cross-platform impact was considered; Windows runtime remains NOT_PROVEN.
- [x] Tool schema changes are additive and covered by compatibility tests.
