### PR TITLE
fix: disbanded Bot Mode group chats no longer resurface as empty roster rows

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -316,9 +316,24 @@ function handleSessionsGatewayTransition() {
  *  { [botName]: { shape, color, title } } */
 const $botMeta = atom({})
 
+/** Freshness fence for the server-meta overlay: the last moment each bot's
+ *  local meta was written (stamped again once the server write settles).
+ *  mergeServerMeta refuses to overlay a roster snapshot FETCHED BEFORE this
+ *  moment — such a snapshot still carries the pre-write ui_meta, and
+ *  spreading it over local meta resurrects state the user just changed
+ *  (disbanded groups reappearing as empty roster rows, renames reverting,
+ *  unpins undoing). Runtime-only by design: on a fresh window there are no
+ *  in-flight local writes for a stale snapshot to clobber. */
+const botMetaWriteAt = new Map()
+
+function noteBotMetaWrite(name) {
+  botMetaWriteAt.set(name, Date.now())
+}
+
 async function saveBotMeta(name, patch) {
   const prevMeta = $botMeta.get()[name] || {}
   const next = { ...$botMeta.get(), [name]: { ...prevMeta, ...patch } }
+  noteBotMetaWrite(name)
   $botMeta.set(next)
 
   // Local plugin storage: instant, and the fallback for older gateways.
@@ -382,6 +397,10 @@ async function saveBotMeta(name, patch) {
     } catch {
       /* older/unavailable gateway — the local fallback remains saved */
     }
+    // Re-stamp now that the server write settled: a roster snapshot fetched
+    // while profiles.configure was still in flight predates the new ui_meta
+    // just as surely as one fetched before the local write.
+    noteBotMetaWrite(name)
   }
 
   return { serverPersisted: serverOutcome === 'persisted', serverOutcome }
@@ -703,8 +722,16 @@ function pullServerAvatars(roster) {
  *  pet icon) are PRESERVED — the server copy never includes them, so a
  *  naive replace would wipe a just-saved image avatar on the next roster
  *  paint. When server bot metadata exists, an omitted chat is authoritative
- *  deletion; local still fills all gaps for older gateways with no metadata. */
-function mergeServerMeta(roster) {
+ *  deletion; local still fills all gaps for older gateways with no metadata.
+ *
+ *  `fetchedAt` (the snapshot's issue time) fences the overlay: a bot whose
+ *  local meta was written AFTER the snapshot was fetched is skipped — that
+ *  snapshot's ui_meta predates the write, and spreading it back over local
+ *  meta resurrects state the user just changed (a disbanded group's
+ *  membership reappearing as an empty roster row, a rename reverting, an
+ *  unpin undoing). The next roster fetch post-dates the write and overlays
+ *  normally, so server truth still gets the last word. */
+function mergeServerMeta(roster, fetchedAt = 0) {
   const local = $botMeta.get()
   let changed = false
   const next = { ...local }
@@ -712,6 +739,9 @@ function mergeServerMeta(roster) {
   for (const bot of roster) {
     const server = bot.ui_meta?.['hermes-bots']
     if (server && typeof server === 'object') {
+      if (fetchedAt && fetchedAt < (botMetaWriteAt.get(bot.name) || 0)) {
+        continue
+      }
       const mine = next[bot.name] || {}
       const merged = { ...mine, ...server }
 
@@ -2760,6 +2790,11 @@ function useRoster() {
   return useQuery({
     queryKey: [...ROSTER_KEY, activeConnectionId],
     queryFn: async () => {
+      // Stamp the ISSUE time on the snapshot: mergeServerMeta compares it
+      // against each bot's last local meta write, and a fetch issued before
+      // a write can only carry pre-write ui_meta. (Issue time is the
+      // conservative bound — the server answered no earlier than this.)
+      const issuedAt = Date.now()
       // Rich rows (last_session, ui_meta, has_avatar) come from the ACTIVE
       // gateway's profiles.list — unchanged single-source behavior.
       const pins = preferredSessionIds($botMeta.get())
@@ -2780,13 +2815,13 @@ function useRoster() {
       if (typeof host.agents === 'function') {
         try {
           const union = await host.agents()
-          return mergeMultiSourceRoster(local, union, activeConnectionId, $lastRoster.get())
+          return { ...mergeMultiSourceRoster(local, union, activeConnectionId, $lastRoster.get()), fetchedAt: issuedAt }
         } catch {
           /* older build or roster failure — single-source list stands */
         }
       }
 
-      return local
+      return { ...(local && typeof local === 'object' ? local : {}), fetchedAt: issuedAt }
     },
     refetchInterval: 5000,
     staleTime: 5000,
@@ -4182,6 +4217,13 @@ async function disbandGroupChat(group, members) {
     const meta = $botMeta.get()[member.name] || {}
     await saveBotMeta(member.name, groupMembershipPatch(meta, group, false))
   }
+
+  // Converge on server truth: the cached roster still carries the pre-disband
+  // ui_meta (the write-fence in mergeServerMeta keeps it from resurrecting
+  // the membership, but a fresh snapshot is what makes every surface agree).
+  if (typeof queryClient !== 'undefined' && queryClient?.invalidateQueries) {
+    queryClient.invalidateQueries({ queryKey: ROSTER_KEY })
+  }
 }
 
 /** Set or clear a group chat's room picture (small data URL, normalized by
@@ -4273,6 +4315,12 @@ async function renameGroupChat(oldName, newName, members) {
   if (groupChatMainTabs.has(oldName)) {
     closeGroupChatMainTab(oldName)
     openGroupChat(next)
+  }
+
+  // Same convergence as disband: drop the pre-rename roster snapshot so the
+  // old name can't linger anywhere the fence doesn't cover.
+  if (typeof queryClient !== 'undefined' && queryClient?.invalidateQueries) {
+    queryClient.invalidateQueries({ queryKey: ROSTER_KEY })
   }
 
   return next
@@ -10100,7 +10148,7 @@ function BotsPane() {
 
   if (live) {
     $lastRoster.set(roster)
-    mergeServerMeta(activeSourceRoster)
+    mergeServerMeta(activeSourceRoster, data?.fetchedAt || 0)
     pullServerAvatars(activeSourceRoster)
     trackInboundActivity(activeSourceRoster)
     backfillMessagingProtocol(activeSourceRoster)

--- a/apps/desktop/src/plugins/hermes-bots/tests/bot-meta-sync.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bot-meta-sync.test.mjs
@@ -31,6 +31,8 @@ globalThis.__botMetaSync = {
   get: () => $botMeta.get(),
   set: value => $botMeta.set(value),
   mergeServerMeta,
+  noteBotMetaWrite,
+  saveBotMeta,
   setPluginCtx: value => { pluginCtx = value }
 };
 `)
@@ -97,4 +99,41 @@ test('compatibility: local canonical chat survives when gateway has no server bo
 
   assert.equal(sync.get().default.chat, 'local-chat')
   assert.equal(writes.length, 0)
+})
+
+test('regression (#disband-resurrection): a roster snapshot fetched BEFORE a local write cannot overlay it back', async () => {
+  const writes = []
+  const sync = load()
+  sync.set({ builder: { groups: ['Team'], group: 'Team', title: 'Builder' } })
+  sync.setPluginCtx({ storage: { set: (key, value) => writes.push({ key, value }) } })
+
+  // Snapshot fetched now — its ui_meta still names the group.
+  const staleFetchedAt = Date.now()
+  const staleRow = { name: 'builder', ui_meta: { 'hermes-bots': { groups: ['Team'], group: 'Team', title: 'Builder' } } }
+
+  // Disband path: saveBotMeta removes the membership AFTER the fetch.
+  await new Promise(resolve => setTimeout(resolve, 5))
+  await sync.saveBotMeta('builder', { groups: [], group: null })
+  assert.deepEqual(sync.get().builder.groups, [])
+
+  // The stale snapshot must NOT resurrect the membership...
+  sync.mergeServerMeta([staleRow], staleFetchedAt)
+  assert.deepEqual(sync.get().builder.groups, [])
+  assert.deepEqual(writes.at(-1).value.builder.groups, [])
+
+  // ...but a FRESH snapshot (fetched after the write) still gets the last
+  // word — server truth wins once it actually post-dates the local change.
+  sync.mergeServerMeta([staleRow], Date.now() + 5)
+  assert.deepEqual(sync.get().builder.groups, ['Team'])
+})
+
+test('compatibility: mergeServerMeta without fetchedAt overlays as before (no fence)', async () => {
+  const sync = load()
+  sync.set({})
+  sync.setPluginCtx({ storage: { set: () => undefined } })
+
+  await sync.saveBotMeta('builder', { groups: [], group: null })
+  sync.mergeServerMeta([{ name: 'builder', ui_meta: { 'hermes-bots': { groups: ['Team'] } } }])
+
+  assert.deepEqual(sync.get().builder.groups, ['Team'])
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/hide-bots.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/hide-bots.test.mjs
@@ -212,7 +212,7 @@ test('shape: hiding never filters mentions, group flows, or the meta/activity sw
   // avatar pulls, and activity tracking all run on activeSourceRoster —
   // which is derived from the unfiltered roster, not visibleRoster.
   assert.match(pluginSource, /const activeSourceRoster = roster\.filter\(bot => !bot\.remoteSource\)/)
-  assert.match(pluginSource, /mergeServerMeta\(activeSourceRoster\)/)
+  assert.match(pluginSource, /mergeServerMeta\(activeSourceRoster, data\?\.fetchedAt \|\| 0\)/)
   assert.match(pluginSource, /trackInboundActivity\(activeSourceRoster\)/)
   // Mention resolution never consults the hidden flag.
   const mentions = pluginSource.slice(


### PR DESCRIPTION
## Summary
Disbanding a Bot Mode group chat now removes it for good — the group no longer reappears as an empty roster row after the messages are cleared (reported by @iamlukethedev).

Root cause: `BotsPane` overlays server `ui_meta['hermes-bots']` from the cached roster snapshot onto local bot meta on every paint (`mergeServerMeta`: `{ ...mine, ...server }`). Disband cleared the membership locally and server-side, but the still-cached snapshot — fetched *before* the disband — carried the old `groups` array and immediately spread the membership back into local meta, re-listing the group as an empty row. Any later meta write for that bot (pin, title, chat pointer) then re-uploaded the resurrected membership to the server, making the ghost permanent. The same stale-overlay class could revert group renames, undo pins/hides, and re-group members who just left.

## Changes
- `plugin.js` (`saveBotMeta`): stamps a per-bot last-local-write time in a runtime `botMetaWriteAt` map; re-stamped once the `profiles.configure` write settles.
- `plugin.js` (`useRoster`): each roster snapshot carries `fetchedAt` (its fetch issue time — the conservative bound).
- `plugin.js` (`mergeServerMeta(roster, fetchedAt)`): skips overlaying any bot whose local meta write post-dates the snapshot. The next fresh fetch overlays normally, so server truth still gets the last word. Callers without `fetchedAt` behave exactly as before.
- `plugin.js` (`disbandGroupChat`, `renameGroupChat`): invalidate the roster query after the mutation so every surface converges on a fresh snapshot immediately.
- `tests/bot-meta-sync.test.mjs`: regression test (stale snapshot cannot resurrect a disbanded membership; fresh snapshot still wins) + no-fence compatibility test; `tests/hide-bots.test.mjs`: updated pinned call-shape regex.

This is the class fix the existing per-field carve-outs in `mergeServerMeta` (`chat` deletion-sync, `group` scalar sync) were symptom-patching around.

## Validation
| Check | Result |
|---|---|
| Plugin test suite (`node --test tests/*.test.mjs`) | 341/341 pass |
| Sabotage run (fence removed) | new regression test fails, exactly as intended |
| Live desktop E2E (built renderer, real gateway, scratch HERMES_HOME) | create "Squad" (2 bots) → message room → Disband → group gone and **stays gone across 30s of 5s roster polls** |
| Full window reload after disband | no rehydration; member profile.yaml shows `groups: []` server-side |
| Fresh-snapshot precedence | verified in test: post-write snapshot still overlays (cross-machine sync intact) |

## Infographic

![Ghost groups exorcised — stale roster snapshots can no longer overwrite fresh local state](https://v3b.fal.media/files/b/0aa718a2/rAy3Y8IIn4MgOK1bXa9T0_StbuzQtl.png)
