### PR TITLE
fix(cron): forward attach_to_session through tool handler

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -389,6 +389,37 @@ class TestUnifiedCronjobTool:
 
 
 # =========================================================================
+# Agent-facing registry handler
+# =========================================================================
+
+
+@pytest.mark.parametrize("action", ["create", "update"])
+def test_handler_forwards_attach_to_session(monkeypatch, action):
+    """The schema-exposed flag must reach cronjob() through the registry."""
+    from tools import cronjob_tools
+    from tools.registry import registry
+
+    captured = {}
+
+    def fake_cronjob(**kwargs):
+        captured.update(kwargs)
+        return json.dumps({"success": True})
+
+    monkeypatch.setattr(cronjob_tools, "cronjob", fake_cronjob)
+
+    raw_result = registry.dispatch(
+        "cronjob",
+        {"action": action, "attach_to_session": True},
+    )
+    assert isinstance(raw_result, str)
+    result = json.loads(raw_result)
+
+    assert result["success"] is True
+    assert captured["action"] == action
+    assert captured["attach_to_session"] is True
+
+
+# =========================================================================
 # Agent-facing surface: per-job model pins are user-owned
 # =========================================================================
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1805,6 +1805,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        attach_to_session=args.get("attach_to_session"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),
         task_id=kw.get("task_id"),


### PR DESCRIPTION
Agent-issued cron create and update calls can now enable `attach_to_session`. Previously, the schema exposed the flag but the registered tool handler silently discarded it, so updates could report success without persisting continuable delivery.

The handler now forwards the flag, and a parameterized registry-dispatch regression test covers both create and update. Validation passed: the focused cases passed, 97 adjacent cron tests passed, and Ruff reported no issues.
