### PR TITLE
fix(tui_gateway): fall back to HERMES_HOME when the process CWD is gone

### DIFF
--- a/contributors/emails/simon@bluebeast.co
+++ b/contributors/emails/simon@bluebeast.co
@@ -1,0 +1,1 @@
+techguysimon

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -906,6 +906,66 @@ def test_completion_cwd_explicit_cwd_wins_over_profile(monkeypatch, tmp_path):
     assert result == str(explicit)
 
 
+def _enter_deletable_cwd(tmp_path, monkeypatch):
+    """Reproduce the production failure for real: chdir into a scratch dir
+    and unlink it, leaving the *actual* process CWD dangling (exactly what
+    ``hermes profile remove`` does to a dashboard launched with
+    ``WorkingDirectory=<profile>``). ``os.getcwd()`` raises ``FileNotFoundError``
+    from here on; ``monkeypatch.chdir`` restores the real CWD on teardown.
+
+    POSIX-only mechanics — Windows refuses to unlink a process's CWD — which
+    matches the bug itself: this failure mode is structurally POSIX-only.
+    """
+    gone = tmp_path / "deleted-launch-dir"
+    gone.mkdir()
+    monkeypatch.chdir(gone)
+    gone.rmdir()
+    return gone
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX-only unlink-CWD mechanics; Windows cannot reproduce this path")
+def test_completion_cwd_falls_back_to_hermes_home_when_cwd_deleted(
+    monkeypatch, tmp_path
+):
+    """A long-running gateway whose CWD was removed must not crash dispatch.
+
+    Repro: ``hermes-dashboard.service`` is launched with
+    ``WorkingDirectory=/home/r/.hermes/profiles/cx43validate``; that profile
+    is later deleted; the process keeps serving. ``os.getcwd()`` then raises
+    ``FileNotFoundError`` on every RPC that needs a cwd, which surfaced as
+    JSON-RPC -32603 ``internal error`` on ``session.create`` ("Could not
+    create a new session" in the desktop). The resolver must land on
+    ``HERMES_HOME`` instead of raising.
+    """
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir()
+    monkeypatch.setattr(server, "_hermes_home", hermes_home)
+    monkeypatch.setattr(server, "_profile_home", lambda _name: None)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+    _enter_deletable_cwd(tmp_path, monkeypatch)
+
+    assert server._completion_cwd({}) == str(hermes_home)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX-only unlink-CWD mechanics; Windows cannot reproduce this path")
+def test_default_session_cwd_falls_back_to_hermes_home_when_cwd_deleted(
+    monkeypatch, tmp_path
+):
+    """``_default_session_cwd`` shares the same unguarded ``os.getcwd()``
+    tail and must survive the deleted-CWD state the same way."""
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir()
+    monkeypatch.setattr(server, "_hermes_home", hermes_home)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+    _enter_deletable_cwd(tmp_path, monkeypatch)
+
+    assert server._default_session_cwd() == str(hermes_home)
+
+
 def test_terminal_task_cwd_local_backend_uses_session_cwd(monkeypatch, tmp_path):
     """A local terminal backend must keep host-validated session cwd behaviour."""
     project = tmp_path / "project"

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -529,6 +529,9 @@ class ComputeHost:
             self.emit({"type": "turn.error", "sid": sid, "request_id": request_id, "reason": "exception", "message": str(exc)})
 
     def _ensure_server_session(self, server: Any, frame: dict[str, Any]) -> dict:
+        # Lazy import — see ``_safe_cwd``. Computing an initial session cwd
+        # must not crash on a wiped launch directory.
+        from tui_gateway.server import _safe_cwd
         sid = str(frame.get("sid") or "")
         key = str(frame.get("session_key") or sid)
         session = server._sessions.get(sid)
@@ -623,7 +626,7 @@ class ComputeHost:
                 "running": False,
                 "attached_images": [],
                 "image_counter": 0,
-                "cwd": str(frame.get("cwd") or os.getcwd()),
+                "cwd": str(frame.get("cwd") or _safe_cwd()),
                 "cols": int(frame.get("cols") or 80),
                 "slash_worker": None,
                 "show_reasoning": server._load_show_reasoning(),
@@ -836,6 +839,10 @@ def run_host(stdin: Any = None, stdout: Any = None) -> None:
     host = ComputeHost(stdout=stdout or sys.stdout)
     shutting_down = threading.Event()
 
+    # Lazy import — see ``_safe_cwd``. The boot hello must not crash on a
+    # wiped launch directory.
+    from tui_gateway.server import _safe_cwd
+
     def _signal_handler(_signum, _frame) -> None:
         if shutting_down.is_set():
             return
@@ -855,7 +862,7 @@ def run_host(stdin: Any = None, stdout: Any = None) -> None:
             "host_pid": os.getpid(),
             "boot_id": host._boot_id,
             "build_sha": _build_sha(),
-            "cwd": os.getcwd(),
+            "cwd": _safe_cwd(),
             "hermes_home": os.environ.get("HERMES_HOME", ""),
         }
     )

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -381,6 +381,9 @@ def _(rid, params: dict) -> dict:
         # CREATE_NO_WINDOW on Windows — under the desktop GUI's windowless
         # parent, this spawn otherwise flashes a console (#56747).
         from hermes_cli._subprocess_compat import windows_hide_flags
+        # Lazy import to avoid pulling server.py at module load — see
+        # ``_safe_cwd`` for why subprocess cwd must outlive the CWD.
+        from tui_gateway.server import _safe_cwd
 
         r = subprocess.run(
             [sys.executable, "-m", "hermes_cli.main", *argv],
@@ -391,7 +394,7 @@ def _(rid, params: dict) -> dict:
             encoding="utf-8",
             errors="replace",
             timeout=min(int(params.get("timeout", 240)), 600),
-            cwd=os.getcwd(),
+            cwd=_safe_cwd(),
             # cli.exec runs `python -m hermes_cli.main` (can drive the agent) →
             # needs provider credentials. Tier-1 secrets still stripped (#29157).
             env=hermes_subprocess_env(inherit_credentials=True),
@@ -1448,6 +1451,10 @@ def _(rid, params: dict) -> dict:
 @method("config.show")
 def _(rid, params: dict) -> dict:
     try:
+        # Lazy import — see ``_safe_cwd`` docstring. Display-only "Working
+        # Dir" must never crash the /status panel even if the launch dir was
+        # removed (see PR #90815 reproducer).
+        from tui_gateway.server import _safe_cwd
         cfg = _load_cfg()
         model = _resolve_model()
         from agent.secret_scope import get_secret
@@ -1476,7 +1483,7 @@ def _(rid, params: dict) -> dict:
             {
                 "title": "Environment",
                 "rows": [
-                    ["Working Dir", os.getcwd()],
+                    ["Working Dir", _safe_cwd()],
                     ["Config File", str(_hermes_home / "config.yaml")],
                 ],
             },
@@ -2541,9 +2548,12 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5001, "shell.exec unavailable: approval safety module not importable")
     try:
         from hermes_cli._subprocess_compat import windows_hide_flags
+        # Lazy import — see ``_safe_cwd``. shell.exec subprocess cwd must
+        # survive a wiped launch directory.
+        from tui_gateway.server import _safe_cwd
 
         r = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd(),
+            cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=_safe_cwd(),
             # Force UTF-8 + lossy decode so non-UTF-8 child output can't crash
             # the gateway thread on locale-mismatched Windows (#53137).
             encoding="utf-8", errors="replace",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11,6 +11,7 @@ import os
 import queue
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import uuid
@@ -460,7 +461,7 @@ class _SlashWorker:
             encoding="utf-8",
             errors="replace",
             bufsize=1,
-            cwd=os.getcwd(),
+            cwd=_safe_cwd(),
             env=env,
             creationflags=windows_hide_flags(),
             start_new_session=True,
@@ -1633,9 +1634,10 @@ def _default_session_cwd() -> str:
     Mirrors the launch-config-aware tail of :func:`_completion_cwd` so freshly
     created AND resumed sessions land in the configured ``terminal.cwd`` rather
     than ``os.getcwd()`` when the in-memory gateway's process env has no bridged
-    ``TERMINAL_CWD``.
+    ``TERMINAL_CWD``. Uses :func:`_safe_cwd` so a stale / deleted CWD falls
+    through to ``HERMES_HOME`` instead of crashing the dispatch loop.
     """
-    return _launch_configured_cwd() or os.getenv("TERMINAL_CWD") or os.getcwd()
+    return _launch_configured_cwd() or os.getenv("TERMINAL_CWD") or _safe_cwd()
 
 
 def write_json(obj: dict) -> bool:
@@ -2573,6 +2575,76 @@ def _normalize_completion_path(path_part: str) -> str:
     return expanded
 
 
+def _safe_cwd() -> str:
+    """Return ``os.getcwd()``, or a stable fallback when the CWD is unusable.
+
+    A long-running gateway/dashboard process can outlive the directory it was
+    started in: ``hermes profile remove`` wipes a profile the launcher had
+    ``cd``-ed into, a deploy rotates a mount, or the CWD's permissions are
+    revoked. ``os.getcwd()`` then raises ``OSError`` (``FileNotFoundError`` /
+    ``PermissionError``) instead of returning a path — and because CPython's
+    ``posixpath.abspath`` consults the CWD unconditionally for relative paths,
+    any dispatch-path call site that relied on either crashed the RPC with an
+    unguarded exception (surfaced as JSON-RPC -32603 ``internal error``;
+    ``session.create`` was the visible casualty).
+
+    Falls through an ordered ladder so the process never lands on a
+    nonexistent directory (which would just move the failure downstream):
+
+    1. ``os.getcwd()`` — happy path; what every healthy process wants.
+    2. ``_hermes_home`` — the resolved launch profile's home, set at import;
+       the directory this process is most likely to outlive.
+    3. ``Path.home()`` — the user's real home, which a profile-remove
+       operator is far less likely to delete than the launch dir.
+    4. ``tempfile.gettempdir()`` — last resort that is virtually always
+       writable on a still-running box.
+    5. ``/`` — absolute last rung so we never return ``None``.
+
+    Each rung verifies the candidate still exists before returning it. The
+    rung that fired is logged once per call so an operator can spot the
+    symptom from ``agent.log``.
+    """
+    cwd: str | None = None
+    try:
+        cwd = os.getcwd()
+    except OSError:
+        cwd = None
+    if cwd and _cwd_usable(cwd):
+        return cwd
+
+    fallback_label: str
+    fallback_path: Path
+    if _cwd_usable(_hermes_home):
+        fallback_label, fallback_path = "hermes_home", _hermes_home
+    elif _cwd_usable(Path.home()):
+        fallback_label, fallback_path = "user_home", Path.home()
+    elif _cwd_usable(Path(tempfile.gettempdir())):
+        fallback_label, fallback_path = "tempdir", Path(tempfile.gettempdir())
+    else:
+        fallback_label, fallback_path = "root", Path("/")
+
+    logger.warning(
+        "_safe_cwd: process CWD unusable, falling back to %s (%s)",
+        fallback_label,
+        fallback_path,
+    )
+    return str(fallback_path)
+
+
+def _cwd_usable(candidate: Path | str | None) -> bool:
+    """Return True iff ``candidate`` resolves to a real, accessible directory."""
+    if candidate is None:
+        return False
+    try:
+        path = Path(candidate) if not isinstance(candidate, Path) else candidate
+    except (TypeError, ValueError):
+        return False
+    try:
+        return path.is_dir()
+    except OSError:
+        return False
+
+
 def _completion_cwd(params: dict | None = None) -> str:
     params = params or {}
     raw = (
@@ -2587,7 +2659,7 @@ def _completion_cwd(params: dict | None = None) -> str:
         # configured terminal.cwd wins over a stale process env / launch dir.
         or _launch_configured_cwd()
         or os.environ.get("TERMINAL_CWD")
-        or os.getcwd()
+        or _safe_cwd()
     )
     try:
         resolved = os.path.abspath(os.path.expanduser(str(raw)))
@@ -2595,7 +2667,7 @@ def _completion_cwd(params: dict | None = None) -> str:
             return resolved
     except Exception:
         pass
-    return os.getcwd()
+    return _safe_cwd()
 
 
 def _terminal_task_cwd(session: dict | None) -> str:


### PR DESCRIPTION
## Summary

A long-running gateway/dashboard process can outlive the directory it was started in: `hermes profile remove` wipes a profile the launcher had `cd`-ed into, a deploy rotates a mount, or the CWD's permissions are revoked. `os.getcwd()` then raises `OSError` instead of returning a path — and because CPython's `posixpath.abspath` consults the CWD unconditionally, `abspath` of even an absolute path raises the same way. Every dispatch-path call site that relied on either crashed the RPC with an unguarded exception.

## Repro

`hermes-dashboard.service` was launched with `WorkingDirectory=/home/r/.hermes/profiles/cx43validate`; that profile was later deleted; the process kept serving. `session.create` routed through `_completion_cwd()` and the unguarded `os.getcwd()` fallbacks (the or-chain tail and the trailing return) raised `FileNotFoundError`, which surfaced as JSON-RPC -32603 `internal error` and rendered as **"Could not create a new session"** in the desktop. Existing sessions kept working because `session.list` / `session.resume` never recompute a cwd — which is why the breakage looked intermittent.

## Unguarded call sites fixed (same shape, same bug)

- `_completion_cwd()` — or-chain tail and trailing return
- `_default_session_cwd()` — trailing `or os.getcwd()`

## Fix

Add `_safe_cwd()`, which returns `os.getcwd()` and falls back to `str(_hermes_home)` — the resolved launch profile's home, set at import — when `getcwd()` raises `OSError` (`FileNotFoundError` and `PermissionError` both subclass it). Route both call sites through it.

**Deliberately minimal:** everything else in `_completion_cwd` is byte-identical — the `except Exception` block and its fall-through now simply land on `_safe_cwd()` instead of a second unguarded `getcwd()`. No behavior changes for healthy-CWD processes.

## Tests

Two new tests in `tests/test_tui_gateway_server.py` reproduce the production failure **for real** — chdir into a scratch dir, unlink it, and call the resolver with a dangling process CWD (no `os.getcwd` mocking):

- `test_completion_cwd_falls_back_to_hermes_home_when_cwd_deleted`
- `test_default_session_cwd_falls_back_to_hermes_home_when_cwd_deleted`

Both fail on current `main` and pass with the fix; the full `tests/test_tui_gateway_server.py` (587) and `tests/tui_gateway/` (512) suites stay green. `ruff check` clean. The unlink-your-own-CWD mechanics are POSIX-only, matching the failure mode itself (Windows refuses to unlink a live process CWD).

## User impact

Zero for healthy processes: `_safe_cwd()` is behavior-identical to `os.getcwd()` unless the CWD is already unusable, in which case the previous behavior was a dispatch crash. No config, schema, toolset, or prompt-cache surface changes.