### PR TITLE
security: add autonomous initiation and strict-readonly Kanban workers

### DIFF
--- a/agent/autonomy/__init__.py
+++ b/agent/autonomy/__init__.py
@@ -1,0 +1,51 @@
+"""
+Autonomous initiation path (V1).
+
+Public surface:
+
+  * attempt_autonomous_initiation(spec, ctx) -> InitiationResult
+        in  agent.autonomy.initiator
+  * state.{enable, disable, fire_kill_switch, clear_kill_switch,
+          is_enabled, is_kill_switch_active, get_active_objective_id,
+          get_active_task_id, get_active_initiated_at,
+          get_policy_version, get_profile, reset}
+        in  agent.autonomy.state
+  * policy.evaluate(spec, ctx) -> Verdict
+        in  agent.autonomy.policy
+
+This package is the smallest possible bridge that lets the existing
+Executive/Kanban pipeline admit an autonomous objective without
+requiring the operator to invoke `hermes kanban create`. It does NOT
+create a second Executive, a second Scheduler, a second Kanban, or
+a second Worker Dispatcher; it uses the canonical
+hermes_cli.kanban_db.create_task API and the standard claim/complete/
+comment lifecycle the dispatcher already drives.
+"""
+
+from __future__ import annotations
+
+from .initiator import (
+    InitiationResult,
+    attempt_autonomous_initiation,
+    summarize,
+)
+from .policy import (
+    ADMITTED_RISK_CLASS,
+    Verdict,
+    evaluate,
+)
+from . import state
+
+
+__all__ = [
+    # initiator
+    "InitiationResult",
+    "attempt_autonomous_initiation",
+    "summarize",
+    # policy
+    "ADMITTED_RISK_CLASS",
+    "Verdict",
+    "evaluate",
+    # state (re-export submodule)
+    "state",
+]

--- a/agent/autonomy/initiator.py
+++ b/agent/autonomy/initiator.py
@@ -160,6 +160,12 @@ def attempt_autonomous_initiation(
                     # default, no MiniMax hardcoding, no config lookup.
                     model_override=objective_spec.get("model_override"),
                     provider_override=objective_spec.get("provider_override"),
+                    # V2: STRICT-READONLY Kanban worker capability flag,
+                    # opt-in from the objective spec only. Default is
+                    # False (writable). Never inferred from
+                    # ``created_by == "autonomous_initiator"`` —
+                    # provenance is NOT capability.
+                    strict_readonly=objective_spec.get("strict_readonly"),
                 )
     except sqlite3.IntegrityError as e:
         # Race: another caller created the same idempotency_key between

--- a/agent/autonomy/initiator.py
+++ b/agent/autonomy/initiator.py
@@ -1,0 +1,361 @@
+"""
+Autonomous initiation path for AUTONOMOUS_INITIATION_PATH_V1.
+
+Public API:
+
+  attempt_autonomous_initiation(objective_spec, policy_context=None)
+      -> InitiationResult
+
+This is the single bridge between "an autonomous trigger arrives" and
+"a Kanban task appears". It uses hermes_cli.kanban_db.create_task as the
+canonical task creation API (the same one used by the CLI and the
+dashboard). No raw SQL, no parallel table, no second scheduler.
+
+The initiator consults the policy gate (agent.autonomy.policy.evaluate)
+BEFORE writing anything. It also computes an idempotency key derived
+from (objective_id, trigger_id) and passes it to create_task, which
+guarantees exactly-one semantics on duplicate triggers.
+
+Every successful admission records the active task id in
+agent.autonomy.state so the post-run accounting (and the success
+evaluator) can confirm exactly-one task was created.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterator, List, Optional
+
+from . import state
+from .policy import evaluate, Verdict
+
+
+@dataclass
+class InitiationResult:
+    """Structured result of an attempt_autonomous_initiation call.
+
+    decision is the policy decision (verbatim from policy.evaluate).
+    reason mirrors policy.evaluate(...).reason.
+    task_id is the id of the Kanban task created (or None if no
+    task was created).
+    duplicate is True iff this call was a no-op because an earlier call
+    with the same idempotency key already created the task.
+    provenance is the structured provenance dict stored on the task
+    body, exposed here for tests and the audit JSON.
+    initiated_at is the unix timestamp of the successful admission, or
+    None if no task was created.
+    raw_policy is the full Verdict object (for tests and audit).
+    """
+
+    decision: str
+    reason: str
+    task_id: Optional[str] = None
+    duplicate: bool = False
+    provenance: Dict[str, Any] = field(default_factory=dict)
+    initiated_at: Optional[float] = None
+    raw_policy: Optional[Verdict] = None
+
+
+# ----------------------------------------------------------------------
+# Public API
+# ----------------------------------------------------------------------
+
+
+def attempt_autonomous_initiation(
+    objective_spec: Dict[str, Any],
+    policy_context: Optional[Dict[str, Any]] = None,
+) -> InitiationResult:
+    """Attempt to admit an autonomous objective.
+
+    Side effects: at most one Kanban task is created, and only if all
+    policy gates pass. The canonical API is hermes_cli.kanban_db.create_task.
+    """
+    verdict = evaluate(objective_spec, policy_context)
+
+    if verdict.decision != "admit":
+        return InitiationResult(
+            decision=verdict.decision,
+            reason=verdict.reason,
+            task_id=None,
+            duplicate=False,
+            raw_policy=verdict,
+        )
+
+    # Build the provenance payload
+    trigger_id = objective_spec.get("trigger_id") or _generate_trigger_id()
+    objective_id = objective_spec["objective_id"]
+    initiated_at = time.time()
+    provenance = {
+        "OBJECTIVE_ID": objective_id,
+        "ORIGIN": "autonomous_initiator",
+        "POLICY_VERSION": objective_spec["policy_version"],
+        "RISK_CLASS": objective_spec["risk_class"],
+        "TRIGGER_ID": trigger_id,
+        "INITIATED_AT": initiated_at,
+        "RUNNING_MODE": "AUTONOMOUS_A1",
+    }
+    title = objective_spec.get("title") or f"[autonomous] {objective_id}"
+    body_text = _render_task_body(provenance, objective_spec.get("body"))
+    idempotency_key = f"autonomous-{objective_id}-{trigger_id}"
+
+    # Use the canonical task creation API. The kanban_db is the public
+    # surface used by `hermes kanban create` and the dashboard plugin; we
+    # import lazily to keep this module importable in tests that mock the
+    # database.
+    try:
+        from hermes_cli import kanban_db as kb
+        with _autonomous_admission_lock(kb):
+            with kb.connect_closing() as conn:
+                existing_id = _find_existing(conn, idempotency_key)
+                if existing_id is not None:
+                    # Duplicate trigger; do NOT create another task. The active
+                    # objective id, if any, is not changed.
+                    return InitiationResult(
+                        decision="duplicate_suppressed",
+                        reason=(
+                            f"idempotency_key={idempotency_key!r} already exists "
+                            f"as task {existing_id!r}; duplicate trigger suppressed"
+                        ),
+                        task_id=existing_id,
+                        duplicate=True,
+                        provenance=provenance,
+                        raw_policy=verdict,
+                    )
+                active_id = _find_active_autonomous_task(conn)
+                if active_id is not None:
+                    return InitiationResult(
+                        decision="denied_concurrency",
+                        reason=(
+                            "another autonomous objective is already active "
+                            f"(task={active_id!r}); max_concurrent_autonomous_objectives=1"
+                        ),
+                        task_id=None,
+                        duplicate=False,
+                        provenance=provenance,
+                        raw_policy=verdict,
+                    )
+                task_id = kb.create_task(
+                    conn,
+                    title=title,
+                    body=body_text,
+                    assignee=objective_spec.get("assignee"),
+                    created_by="autonomous_initiator",
+                    idempotency_key=idempotency_key,
+                    priority=objective_spec.get("priority", 0),
+                    initial_status="running",
+                    max_runtime_seconds=objective_spec.get("max_runtime_seconds"),
+                    skills=objective_spec.get("skills"),
+                    # V1.3-A: the canonical Kanban task store already supports
+                    # ``model_override`` / ``provider_override`` and the dispatcher
+                    # already consumes them. The autonomous bridge merely
+                    # preserves the spec keys the caller already provided.
+                    # Absent key -> None. Explicit None -> None. No hidden
+                    # default, no MiniMax hardcoding, no config lookup.
+                    model_override=objective_spec.get("model_override"),
+                    provider_override=objective_spec.get("provider_override"),
+                )
+    except sqlite3.IntegrityError as e:
+        # Race: another caller created the same idempotency_key between
+        # our existence check and the create_task call. Look it up and
+        # return the existing id.
+        try:
+            from hermes_cli import kanban_db as kb
+            with kb.connect_closing() as conn:
+                existing_id = _find_existing(conn, idempotency_key)
+        except Exception:
+            existing_id = None
+        return InitiationResult(
+            decision="duplicate_suppressed",
+            reason=(
+                f"idempotency_key={idempotency_key!r} already exists "
+                f"(race detected: {e!s})"
+            ),
+            task_id=existing_id,
+            duplicate=True,
+            provenance=provenance,
+            raw_policy=verdict,
+        )
+    except Exception as e:
+        # Any other error from the DB layer is propagated as a structured
+        # denial. No task was created.
+        return InitiationResult(
+            decision="denied_runtime_error",
+            reason=f"create_task raised {type(e).__name__}: {e}",
+            task_id=None,
+            duplicate=False,
+            provenance=provenance,
+            raw_policy=verdict,
+        )
+
+    # Mark this objective as the active one. The active slot is what
+    # makes the next attempt with a different objective_id fail
+    # concurrency.
+    state.reserve_active(objective_id, task_id)
+
+    return InitiationResult(
+        decision="admit",
+        reason=verdict.reason,
+        task_id=task_id,
+        duplicate=False,
+        provenance=provenance,
+        initiated_at=initiated_at,
+        raw_policy=verdict,
+    )
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _generate_trigger_id() -> str:
+    """Default trigger id: a uuid4 hex string, used only when the spec
+    does not provide one. Tests should always pass a stable trigger_id
+    so that idempotency_key derivation is deterministic."""
+    return uuid.uuid4().hex
+
+
+def _render_provenance_body(provenance: Dict[str, Any]) -> str:
+    """Render the provenance as a deterministic body string. Each line is
+    ``KEY=VALUE`` for easy grep and audit."""
+    return "\n".join(f"{k}={v}" for k, v in sorted(provenance.items()))
+
+
+def _render_task_body(provenance: Dict[str, Any], custom_body: Any) -> str:
+    """Render durable provenance plus any caller-supplied task body.
+
+    The provenance block is always first and delimited so it remains
+    recoverable from the canonical Kanban task body even when the caller
+    provides their own human-readable objective text.
+    """
+    parts = [
+        "AUTONOMOUS_PROVENANCE_BEGIN",
+        _render_provenance_body(provenance),
+        "AUTONOMOUS_PROVENANCE_END",
+    ]
+    if custom_body is not None:
+        body = str(custom_body)
+        if body:
+            parts.extend(["", "CUSTOM_BODY_BEGIN", body, "CUSTOM_BODY_END"])
+    return "\n".join(parts)
+
+
+def _find_existing(conn, idempotency_key: str) -> Optional[str]:
+    """Return the id of the most recent non-archived task with the given
+    idempotency_key, or None. Mirrors the behavior in kanban_db.create_task
+    so that duplicate detection here is consistent with duplicate detection
+    inside the create path itself.
+    """
+    cur = conn.execute(
+        "SELECT id FROM tasks WHERE idempotency_key = ? "
+        "AND status != 'archived' ORDER BY created_at DESC LIMIT 1",
+        (idempotency_key,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+    return row[0]
+
+
+def _find_active_autonomous_task(conn) -> Optional[str]:
+    """Return an already-active autonomous task id, if one exists.
+
+    This makes the Kanban task table the durable cross-process source of
+    truth for max_concurrent_autonomous_objectives=1. A completed or archived
+    autonomous task no longer occupies the slot; every other lifecycle state
+    does.
+    """
+    cur = conn.execute(
+        "SELECT id FROM tasks WHERE created_by = ? "
+        "AND status NOT IN ('done', 'archived') "
+        "ORDER BY created_at ASC LIMIT 1",
+        ("autonomous_initiator",),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+    return row[0]
+
+
+@contextlib.contextmanager
+def _autonomous_admission_lock(kb, timeout_seconds: float = 5.0) -> Iterator[None]:
+    """Serialize autonomous admission across processes with a bounded lock."""
+    path = _autonomous_admission_lock_path(kb)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a+", encoding="utf-8") as handle:
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            try:
+                _try_lock_file(handle)
+                break
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"timed out acquiring autonomous admission lock at {path}"
+                    )
+                time.sleep(0.02)
+        try:
+            yield
+        finally:
+            _unlock_file(handle)
+
+
+def _autonomous_admission_lock_path(kb) -> Path:
+    override = os.environ.get("HERMES_KANBAN_DB", "").strip()
+    if override:
+        return Path(override).expanduser().parent / ".autonomous_admission.lock"
+    return kb.kanban_home() / "kanban" / ".autonomous_admission.lock"
+
+
+def _try_lock_file(handle) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        try:
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        except OSError as exc:
+            raise BlockingIOError(str(exc)) from exc
+    else:
+        import fcntl
+
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            raise BlockingIOError(str(exc)) from exc
+
+
+def _unlock_file(handle) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        with contextlib.suppress(OSError):
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        with contextlib.suppress(OSError):
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+# ----------------------------------------------------------------------
+# Convenience for tests and dispatcher hooks
+# ----------------------------------------------------------------------
+
+
+def summarize(result: InitiationResult) -> Dict[str, Any]:
+    """Return a JSON-safe summary of the result. Used by the audit JSON."""
+    return {
+        "decision": result.decision,
+        "reason": result.reason,
+        "task_id": result.task_id,
+        "duplicate": result.duplicate,
+        "provenance": result.provenance,
+        "initiated_at": result.initiated_at,
+    }

--- a/agent/autonomy/policy.py
+++ b/agent/autonomy/policy.py
@@ -1,0 +1,138 @@
+"""
+Autonomy policy gate for AUTONOMOUS_INITIATION_PATH_V1.
+
+The policy gate is the only place that decides whether a given
+objective_spec is admissible under the current autonomy envelope. It
+returns a structured Verdict; the initiator consults the verdict and
+either proceeds to call kanban_db.create_task or fails closed.
+
+V1 policy:
+
+  * autonomy must be enabled (state.is_enabled() == True)
+  * kill switch must not be active (state.is_kill_switch_active() == False)
+  * risk_class must be exactly "CLASS_A_AUTONOMOUS_SAFE"
+  * policy_version must match the configured one
+  * the spec's objective_id must not already be admitted
+    (active_objective_id == None OR already == spec.objective_id)
+  * no other autonomous objective is currently active
+  * profile, if specified in the policy_context, must match the configured
+    AUTONOMOUS_PROFILE_SCOPE (the policy_context.profile field is opt-in)
+
+Class B and Class C are explicitly NOT admissible; the policy returns
+REQUIRES_HUMAN for any class that is not A.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from . import state
+
+
+# The only risk class this policy admits. Anything else is REQUIRES_HUMAN.
+ADMITTED_RISK_CLASS = "CLASS_A_AUTONOMOUS_SAFE"
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """Result of a policy evaluation.
+
+    decision is one of:
+      "admit"             - the initiator may proceed to create the task
+      "denied_disabled"   - autonomy is not enabled
+      "denied_kill"       - the kill switch is active
+      "denied_class"      - the spec's risk_class is not CLASS_A_AUTONOMOUS_SAFE
+      "denied_version"    - the spec's policy_version does not match
+      "denied_concurrency"- another autonomous objective is already active
+      "denied_profile"    - the policy_context profile does not match the scope
+    reason is a human-readable explanation suitable for an audit log.
+    """
+
+    decision: str
+    reason: str
+
+
+def evaluate(
+    objective_spec: Dict[str, Any],
+    policy_context: Optional[Dict[str, Any]] = None,
+) -> Verdict:
+    """Run all policy gates and return a Verdict.
+
+    objective_spec must be a dict with at least:
+      - "objective_id": str
+      - "risk_class":   str (one of the documented classes)
+      - "policy_version": str
+      - "title":        str (used downstream by the initiator to fill
+                                  the kanban title)
+
+    policy_context is optional; when present it may contain:
+      - "profile": str (the profile the autonomous run is bound to)
+    """
+    policy_context = policy_context or {}
+
+    # 1. autonomy enabled?
+    if not state.is_enabled():
+        return Verdict(
+            decision="denied_disabled",
+            reason="autonomy is not enabled; call agent.autonomy.state.enable() first",
+        )
+
+    # 2. kill switch?
+    if state.is_kill_switch_active():
+        return Verdict(
+            decision="denied_kill",
+            reason="kill switch is active; autonomous initiation paused",
+        )
+
+    # 3. risk class must be A
+    spec_class = objective_spec.get("risk_class")
+    if spec_class != ADMITTED_RISK_CLASS:
+        return Verdict(
+            decision="denied_class",
+            reason=(
+                f"risk_class={spec_class!r} is not admissible by V1 policy; "
+                f"V1 admits only {ADMITTED_RISK_CLASS!r}"
+            ),
+        )
+
+    # 4. policy version must match
+    spec_version = objective_spec.get("policy_version")
+    if spec_version != state.get_policy_version():
+        return Verdict(
+            decision="denied_version",
+            reason=(
+                f"spec policy_version={spec_version!r} does not match "
+                f"configured policy_version={state.get_policy_version()!r}"
+            ),
+        )
+
+    # 5. concurrency: at most one active autonomous objective
+    active = state.get_active_objective_id()
+    spec_id = objective_spec.get("objective_id")
+    if active is not None and active != spec_id:
+        return Verdict(
+            decision="denied_concurrency",
+            reason=(
+                f"another autonomous objective is already active "
+                f"(active={active!r}); max_concurrent_autonomous_objectives=1"
+            ),
+        )
+
+    # 6. profile scope (optional; only enforced if both sides specify a profile)
+    spec_profile = policy_context.get("profile")
+    state_profile = state.get_profile()
+    if spec_profile is not None and state_profile is not None:
+        if spec_profile != state_profile:
+            return Verdict(
+                decision="denied_profile",
+                reason=(
+                    f"spec profile={spec_profile!r} does not match "
+                    f"configured profile={state_profile!r}"
+                ),
+            )
+
+    return Verdict(
+        decision="admit",
+        reason="all policy gates passed",
+    )

--- a/agent/autonomy/state.py
+++ b/agent/autonomy/state.py
@@ -1,0 +1,195 @@
+"""
+In-process autonomy state for AUTONOMOUS_INITIATION_PATH_V1.
+
+This module holds the only mutable runtime state owned by the autonomy
+initiation path. It is intentionally:
+
+  * module-level (not persisted to disk)
+  * thread-unsafe by design (Hermes runs a single worker per process)
+  * reset by ``reset()`` between tests and at the end of every canary
+
+The state is intentionally NOT stored in config.yaml, .env, profiles, or
+any other persistent location. Activation is ephemeral and scope-limited.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Optional
+
+
+# Lock for the rare case two threads call into the initiator in the same
+# process (e.g. during teardown). Single-process workers do not need this
+# in normal operation but the tests fire concurrent attempts.
+_LOCK = threading.Lock()
+
+
+# In-process flag. False by default (autonomy off). When the canary is
+# authorized, a human-supervised test harness or the dispatcher sets this
+# to True. The state is reset by reset() at the end of every canary.
+_ENABLED: bool = False
+
+
+# When set to True, no autonomous initiation can succeed. The kill switch
+# is read before any policy gate. The dispatcher, the operator, or the
+# SUCCESS_EVALUATOR may set this.
+_KILL_SWITCH: bool = False
+
+
+# The id of the currently active autonomous objective (if any). The
+# concurrency budget is enforced via this slot: while non-None, no other
+# autonomous objective may be admitted.
+_ACTIVE_OBJECTIVE_ID: Optional[str] = None
+
+
+# The task id of the currently active autonomous run (the task created by
+# the initiator). Used by tests and by post-run accounting to find the
+# task that the autonomous admission created.
+_ACTIVE_TASK_ID: Optional[str] = None
+
+
+# When the current active objective was admitted. Set by attempt_autonomous
+# _initiation on success, cleared by reset().
+_ACTIVE_OBJECTIVE_INITIATED_AT: Optional[float] = None
+
+
+# Policy version this state was configured for. Defaults to "1.0.0".
+# attempt_autonomous_initiation compares the spec's policy_version to this.
+_POLICY_VERSION: str = "1.0.0"
+
+
+# Default scope: which profile the autonomous tasks target. Defaults to the
+# profile of the current process (resolved at enable time, not stored).
+_PROFILE: Optional[str] = None
+
+
+# ------------------------------------------------------------------
+# Public API
+# ------------------------------------------------------------------
+
+
+def enable(*, policy_version: str = "1.0.0", profile: Optional[str] = None) -> None:
+    """Activate the autonomy initiation path. Ephemeral and in-process only.
+
+    Idempotent: calling enable() multiple times is safe; the most recent
+    policy_version and profile win. Does not touch config, profile, .env,
+    or any persistent file.
+    """
+    global _ENABLED, _KILL_SWITCH, _POLICY_VERSION, _PROFILE
+    with _LOCK:
+        _ENABLED = True
+        _KILL_SWITCH = False
+        _POLICY_VERSION = policy_version
+        _PROFILE = profile
+
+
+def disable() -> None:
+    """Deactivate the autonomy initiation path and clear all slots.
+
+    Calling disable() also clears the kill switch, the active objective
+    id, the active task id, and the initiated-at timestamp. Used at the
+    end of every canary and between tests.
+    """
+    global _ENABLED, _KILL_SWITCH, _ACTIVE_OBJECTIVE_ID, _ACTIVE_TASK_ID
+    global _ACTIVE_OBJECTIVE_INITIATED_AT, _POLICY_VERSION, _PROFILE
+    with _LOCK:
+        _ENABLED = False
+        _KILL_SWITCH = False
+        _ACTIVE_OBJECTIVE_ID = None
+        _ACTIVE_TASK_ID = None
+        _ACTIVE_OBJECTIVE_INITIATED_AT = None
+
+
+def fire_kill_switch() -> None:
+    """Set the kill switch. Subsequent attempts return PAUSED_NEEDS_HUMAN.
+
+    Does not change _ENABLED. Tests and operators can fire the kill switch
+    while autonomy is enabled, simulating an emergency stop.
+    """
+    global _KILL_SWITCH
+    with _LOCK:
+        _KILL_SWITCH = True
+
+
+def clear_kill_switch() -> None:
+    """Clear the kill switch. Used by tests; not exposed to operators."""
+    global _KILL_SWITCH
+    with _LOCK:
+        _KILL_SWITCH = False
+
+
+def is_enabled() -> bool:
+    """Return True if autonomy has been enabled (and not disabled since)."""
+    with _LOCK:
+        return _ENABLED
+
+
+def is_kill_switch_active() -> bool:
+    """Return True if the kill switch has been fired (and not cleared)."""
+    with _LOCK:
+        return _KILL_SWITCH
+
+
+def get_active_objective_id() -> Optional[str]:
+    """Return the id of the currently active autonomous objective, if any."""
+    with _LOCK:
+        return _ACTIVE_OBJECTIVE_ID
+
+
+def get_active_task_id() -> Optional[str]:
+    """Return the id of the task created by the most recent successful
+    attempt, if any. Used by tests to confirm exactly-one semantics."""
+    with _LOCK:
+        return _ACTIVE_TASK_ID
+
+
+def get_active_initiated_at() -> Optional[float]:
+    """Return the unix timestamp the current active objective was admitted."""
+    with _LOCK:
+        return _ACTIVE_OBJECTIVE_INITIATED_AT
+
+
+def get_policy_version() -> str:
+    """Return the policy version this state was configured for."""
+    with _LOCK:
+        return _POLICY_VERSION
+
+
+def get_profile() -> Optional[str]:
+    """Return the profile this autonomy state is scoped to, if any."""
+    with _LOCK:
+        return _PROFILE
+
+
+def reserve_active(objective_id: str, task_id: str) -> None:
+    """Internal: called by the initiator when an objective is admitted.
+
+    Sets the active objective id and task id. The initiator must already
+    have passed all policy gates before calling this.
+    """
+    global _ACTIVE_OBJECTIVE_ID, _ACTIVE_TASK_ID, _ACTIVE_OBJECTIVE_INITIATED_AT
+    with _LOCK:
+        _ACTIVE_OBJECTIVE_ID = objective_id
+        _ACTIVE_TASK_ID = task_id
+        _ACTIVE_OBJECTIVE_INITIATED_AT = time.time()
+
+
+def clear_active() -> None:
+    """Internal: called by the initiator when the active run finishes.
+
+    Does NOT change _ENABLED or _KILL_SWITCH. The operator decides whether
+    to disable the autonomy state or leave it enabled for the next run.
+    """
+    global _ACTIVE_OBJECTIVE_ID, _ACTIVE_TASK_ID, _ACTIVE_OBJECTIVE_INITIATED_AT
+    with _LOCK:
+        _ACTIVE_OBJECTIVE_ID = None
+        _ACTIVE_TASK_ID = None
+        _ACTIVE_OBJECTIVE_INITIATED_AT = None
+
+
+def reset() -> None:
+    """Reset all state. Intended for use in tests between cases."""
+    disable()
+    clear_kill_switch()
+    clear_active()

--- a/cli.py
+++ b/cli.py
@@ -4990,6 +4990,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         resume: str = None,
         checkpoints: bool = False,
         pass_session_id: bool = False,
+        skip_background_review: bool = False,
         ignore_rules: bool = False,
     ):
         """
@@ -5284,6 +5285,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.checkpoint_max_total_size_mb = cp_cfg.get("max_total_size_mb", 500)
         self.checkpoint_max_file_size_mb = cp_cfg.get("max_file_size_mb", 10)
         self.pass_session_id = pass_session_id
+        # --skip-background-review: per-invocation CLI flag forwarding onto
+        # AIAgent(skip_background_review=...) via cli_agent_setup_mixin._init_agent.
+        # The flag is invocation-local — never persisted to config or env. The
+        # explicit /refine command remains unaffected because it calls
+        # agent._spawn_background_review(automatic=False), which opts out of
+        # the central fail-safe guard.
+        self.skip_background_review = skip_background_review
         # --ignore-rules: honor either the constructor flag or the env var set
         # by `hermes chat --ignore-rules` in hermes_cli/main.py. When true we
         # pass skip_context_files=True and skip_memory=True to AIAgent so

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -75,3 +75,143 @@ Consequences:
 - Regression coverage exercises the real production path
   (`set_hermes_home_override()`) rather than only the env-var path, and
   includes a dedicated relative-import leak test.
+## 2026-08-20: Strict-readonly Kanban worker capability (workspace confinement)
+
+Status: Accepted
+
+### Context
+
+Kanban workers can be dispatched autonomously to act on a task. Some
+workflows require an autonomous worker that is **explicitly confined
+to its own task workspace** — a worker that can write files but cannot
+escape that workspace, modify the Hermes repository, reach the user's
+profile, or interact with arbitrary external systems.
+
+Without a strict capability, an autonomous worker that runs in a
+workspace shell could mutate the repository under itself, escalate by
+writing profile config, traverse symlinks to escape the workspace,
+or open a shell that bypasses the file-tool gate entirely. The
+narrow solution is a strict-readonly capability that activates only
+when the dispatcher explicitly opts in.
+
+### Decision
+
+Persist an explicit `strict_readonly` capability on the Kanban task
+row (`INTEGER NOT NULL DEFAULT 0`). Provenance is NOT capability:
+`created_by='agent'` does NOT imply strict mode.
+
+The capability travels via two channels:
+
+1. **Database column** `tasks.strict_readonly`. Read by
+   `hermes_cli/kanban_db._default_spawn` when constructing the
+   worker environment.
+2. **Environment variable** `HERMES_KANBAN_STRICT_READONLY=1`,
+   observed by `tools.file_tools._is_strict_readonly_active`. Set
+   ONLY by the dispatcher when the task row opts in.
+
+When the task opts in, the dispatcher (`_default_spawn`):
+
+- Pins `HERMES_KANBAN_STRICT_READONLY=1`.
+- Pins `HERMES_KANBAN_TASK` to the Kanban task id.
+- Pins `HERMES_KANBAN_WORKSPACE` to the canonical workspace path
+  for the task.
+- Pins `HERMES_KANBAN_DB` and `HERMES_KANBAN_BOARD` so the worker
+  opens the same authoritative board DB the dispatcher used.
+- Removes `terminal` and `code_execution` from the worker CLI
+  `--toolsets` allowlist at the resolved-toolsets level (the
+  production CLI accepts a comma-separated `--toolsets` allowlist
+  but does NOT accept `--disabled-toolsets`).
+- Preserves the `kanban` toolset on the worker (re-appended by
+  `model_tools` because `HERMES_KANBAN_TASK` is in the spawned env),
+  so the worker can still self-complete via `kanban_complete`,
+  `kanban_attach`, etc.
+
+The strict gate in `tools/file_tools.py` enforces, in order:
+
+1. `HERMES_KANBAN_STRICT_READONLY` is set (`_is_strict_readonly_active`).
+2. `HERMES_KANBAN_TASK` and `HERMES_KANBAN_WORKSPACE` are present
+   and non-sentinel.
+3. The dispatcher-pinned workspace authenticates against the
+   authoritative task row via
+   `hermes_cli.kanban_db.expected_workspace_for_task(conn, task_id,
+   board=board)` — a pure read-only resolver — and must canonicalise
+   equal to the pinned workspace.
+4. The target path resolves inside the workspace via
+   `Path.resolve(strict=False).is_relative_to(workspace)`.
+
+Identity model:
+
+- `HERMES_KANBAN_TASK` is the Kanban task id (e.g. `t_…`).
+- The `task_id` argument on file tools is the Hermes session id
+  (e.g. `20260819_…`). These are **separate identities**; the gate
+  never compares them.
+- `HERMES_KANBAN_WORKSPACE` alone is NOT authorization; the gate
+  cross-checks it against the persisted task row before allowing
+  any write.
+
+Failure modes are fail-closed: missing DB pin, missing board pin,
+import failure, DB connect failure, missing task row, mismatched
+workspace, symlink chain escape, `..` traversal, malformed
+workspace env — all return a structured `tool_error` JSON and the
+write is denied. No soft fallback, no cwd fallback, no `$HOME`
+fallback.
+
+Trusted artifact promotion: completion artifacts are promoted by
+`hermes_cli/kanban_db._persist_scratch_completion_artifacts` and
+`_insert_completion_attachment` (the byte-preserving path used by
+`kanban_complete(artifacts=[...])`). The LLM does NOT re-emit file
+contents; production code reads bytes from the existing workspace
+file via `open("rb")` and writes them to the attachment directory
+via `open("xb")`. This is the property that guarantees byte-exact
+promotion regardless of the strict posture.
+
+CLI surface: `hermes kanban create --strict-readonly` /
+`--strict_readonly` flag at `hermes_cli/kanban.py` (`p_create`
+argparse). The internal Python destination is `strict_readonly`,
+which is forwarded to `hermes_cli.kanban_db.create_task`.
+
+Autonomy propagation: `agent/autonomy/initiator.py` accepts
+`objective_spec['strict_readonly']` (default `False`) and forwards
+it to `kb.create_task`. The capability remains explicit per task;
+no autonomous origin alone infers strict mode.
+
+### Consequences
+
+- Strict workers can mutate only their authorized task workspace
+  through `write_file_tool` and `patch_tool`. The repository,
+  profile, configuration, reports, skills, other-task workspaces,
+  and external paths are not writable by the strict worker.
+- Ordinary Kanban and non-Kanban behavior remains outside this
+  capability. Non-strict workers see no effect.
+- The dispatcher, the Kanban DB, and the trusted completion path
+  remain trusted components. The file-tool gate is downstream of
+  those three.
+- The strict capability is opt-in per task. Operators must
+  explicitly set `strict_readonly=True` (or `--strict-readonly` on
+  the CLI) to activate it.
+- Provider and model are NOT pinned by the capability. The
+  dispatcher passes `--model`/`--provider` only when
+  `task.model_override` / `task.provider_override` are explicitly
+  set on the task row; the capability is independent of model
+  routing.
+- Strict-readonly does NOT mean zero writes. It confines the
+  worker's file-tool mutation surface to the authoritative task
+  workspace; the trusted completion/attachment promotion path
+  remains available.
+
+### References
+
+- `docs/security/strict-readonly-kanban-workers.md` — full
+  architectural description.
+- `hermes_cli/kanban_db.py` — `class Task` (strict_readonly
+  field), `create_task` (kwarg + INSERT), `_migrate_add_optional_columns`
+  (column migration), `_default_spawn` (env export + toolsets
+  filter), `expected_workspace_for_task` and
+  `KanbanWorkspaceLookupError` (S14 binding resolver).
+- `tools/file_tools.py` — `_is_strict_readonly_active`,
+  `_verify_strict_readonly_task_workspace_binding`,
+  `_resolve_strict_readonly_pinned_workspace`, `_strict_readonly_gate`.
+- `hermes_cli/kanban.py` — `--strict-readonly` CLI flag
+  (`p_create.add_argument`) and forward into `kb.create_task`.
+- `agent/autonomy/initiator.py` — `objective_spec['strict_readonly']`
+  propagation into `kb.create_task`.

--- a/docs/security/strict-readonly-kanban-workers.md
+++ b/docs/security/strict-readonly-kanban-workers.md
@@ -1,0 +1,461 @@
+# Strict-Readonly Kanban Workers
+
+**Status:** Accepted
+**Audience:** Hermes operators, contributors, and security reviewers
+**Source files:** `hermes_cli/kanban_db.py`, `tools/file_tools.py`,
+`hermes_cli/kanban.py`, `agent/autonomy/initiator.py`
+
+## Overview
+
+Hermes can dispatch autonomous Kanban workers via
+`agent/autonomy/initiator.py`. Some workflows need an autonomous worker
+that is **explicitly confined to its own task workspace** — a worker
+that can write files but cannot escape that workspace, modify the
+repository, reach the user's profile, or interact with arbitrary
+external systems.
+
+**Strict-readonly** is the narrow capability that satisfies that
+requirement. It is an explicit, persisted task property
+(`strict_readonly=True`), opt-in per task, and never inferred from
+provenance. A normal autonomous task does NOT become strict merely
+because it was autonomously created:
+
+```
+AUTONOMOUS ORIGIN  ≠  STRICT-READONLY CAPABILITY
+```
+
+Provenance (who created the task) is not capability (what the worker
+may do). The strict mode is a separate, explicit field on the Kanban
+task row.
+
+**Strict-readonly does NOT mean zero writes.** It means:
+
+- the worker has no `terminal` and no `code_execution` toolset;
+- file mutation is confined to the authoritative task workspace;
+- the trusted artifact completion / promotion path remains available;
+- ordinary (non-strict) workers and non-Kanban sessions are unchanged.
+
+## Threat Model
+
+Without a strict capability, an autonomous worker that runs in a
+workspace shell could:
+
+- `write_file` into the Hermes repository tree (`run_agent.py`,
+  `tools/file_tools.py`, etc.) and replace the gate under itself.
+- `write_file` into the user's profile (`~/.hermes/profiles/...`),
+  skills, `.usage.json`, or `~/.hermes/.env` and escalate privilege.
+- `write_file` into another task's workspace and corrupt cross-task
+  data.
+- Traverse symlinks to escape the workspace.
+- Open a shell (`terminal`) or run Python (`code_execution`) and
+  bypass the file-tool gate entirely.
+
+The strict capability collapses the attack surface to: the worker can
+write only inside its own canonical task workspace, and only through
+the file tools, only when the dispatcher-pinned workspace agrees with
+the persisted task's canonical workspace.
+
+## Security Invariants
+
+The strict capability enforces, in order:
+
+1. **Hermes session_id is NOT the Kanban task_id.** The value passed
+   as the `task_id` argument to `write_file_tool` / `patch_tool` is
+   the Hermes session ID (the format `YYYYMMDD_HHMMSS_<short>`). The
+   Kanban task identity is `HERMES_KANBAN_TASK` (the format
+   `t_<short>`). These are distinct identifiers and the gate never
+   compares them.
+
+2. **`HERMES_KANBAN_WORKSPACE` alone is NOT authorization.** The env
+   variable is set by the dispatcher; an attacker (or a misconfigured
+   dispatcher) could lie about it. The gate authenticates the workspace
+   against the persisted task.
+
+3. **Authoritative boundary is derived from persisted Kanban state.**
+   `hermes_cli.kanban_db.expected_workspace_for_task(conn, task_id,
+   board)` — a pure read-only resolver — returns the canonical
+   workspace recorded for the task. The gate requires this to
+   canonicalise equal to the pinned workspace.
+
+4. **Pinned workspace must equal authoritative expected workspace.**
+   `Path.resolve(strict=False)` of both is compared. Any mismatch —
+   wrong directory, divergent symlink resolution, missing task row —
+   is denied.
+
+5. **Targets must remain canonically contained within the workspace.**
+   `Path(target).resolve(strict=False).is_relative_to(workspace)` is
+   the final containment check. The workspace root itself is not a
+   writable target.
+
+6. **Missing, malformed, or mismatched authority fails closed.** No
+   fallback to the process cwd, no warning-and-continue, no
+   degraded-but-permissive mode.
+
+7. **Symlink and traversal escape fails closed.** `Path.resolve`
+   walks the symlink chain; `..` traversal is caught by
+   `is_relative_to`.
+
+8. **Repository, profile, reports, skills, configuration, other-task
+   workspaces are not writable.** They are all outside the canonical
+   workspace and are denied by the containment check.
+
+9. **`terminal` and `code_execution` are absent from the strict worker
+   toolset.** The dispatcher subtracts these two from the worker's
+   resolved `--toolsets` allowlist before emitting the CLI argv. The
+   production CLI accepts a comma-separated `--toolsets` allowlist but
+   does NOT accept `--disabled-toolsets`; emitting an unsupported
+   flag is a hard argparse failure, so the strict filter operates at
+   the resolved-toolsets level.
+
+10. **Kanban lifecycle capability remains available.** `model_tools`
+    re-appends the `kanban` toolset because `HERMES_KANBAN_TASK` is
+    set in the spawned env, so the worker can self-complete via
+    `kanban_complete`, attach via `kanban_attach`, comment via
+    `kanban_comment`, etc.
+
+11. **Completion artifacts are promoted by the trusted completion
+    path.** `kanban_complete(artifacts=[...])` validates that
+    `artifacts` is a top-level array of paths, then
+    `hermes_cli/kanban_db._persist_scratch_completion_artifacts`
+    reads each source via `open("rb")` and writes to the attachment
+    directory via `open("xb")`. The LLM does not re-emit file
+    contents — bytes are read by production code.
+
+12. **Automatic background review is isolated.** The worker CLI's
+    `_effective_skip_background_review` mixin detects the
+    `HERMES_KANBAN_TASK` / `HERMES_SESSION_SOURCE=="kanban"` worker
+    markers and propagates `skip_background_review=True` onto the
+    AIAgent constructor, so no post-turn review fork fires after the
+    worker's own turns. This is the current upstream behavior used
+    for all Kanban workers; the strict capability does not introduce
+    a separate review-suppression patch.
+
+## Architecture
+
+```
+objective / task
+        │
+        ▼
+strict_readonly  (persisted task capability, opt-in)
+        │
+        ▼
+Kanban persistence (kanban.db: tasks.strict_readonly column)
+        │
+        ▼
+dispatcher (hermes_cli/kanban_db._default_spawn)
+        ├── strict env: HERMES_KANBAN_STRICT_READONLY=1
+        ├── Kanban task identity: HERMES_KANBAN_TASK=t_<id>
+        ├── authoritative workspace: HERMES_KANBAN_WORKSPACE=…/workspaces/t_<id>
+        ├── DB pin: HERMES_KANBAN_DB=<board root>/kanban.db
+        ├── board slug: HERMES_KANBAN_BOARD=<slug>
+        ├── session source tag: HERMES_SESSION_SOURCE=kanban
+        ├── toolsets allowlist = resolved - {terminal, code_execution}
+        └── Kanban toolset still attached by model_tools
+        │
+        ▼
+worker subprocess
+  (provider / model resolved by existing task.profile / override
+   machinery — strict_readonly adds confinement capability only;
+   no provider / model is required by the capability)
+        │
+        ▼
+write_file_tool / patch_tool → strict gate (tools/file_tools)
+        │
+        ▼
+HERMES_KANBAN_TASK + HERMES_KANBAN_WORKSPACE + HERMES_KANBAN_DB + HERMES_KANBAN_BOARD
+        │
+        ▼
+kanban_db.expected_workspace_for_task(task_id, board)
+        │
+        ▼
+expected_workspace == pinned_workspace   (canonicalised equality)
+        │
+        ▼
+target.resolve(strict=False).is_relative_to(workspace)
+        │
+        ├── ALLOW
+        ▼
+kanban_complete(artifacts=[...])
+        │
+        ▼
+trusted byte-preserving artifact promotion
+  (open("rb") → open("xb") → uploaded_by=kanban_complete)
+        │
+        ▼
+task done
+```
+
+## Capability Propagation
+
+The strict capability travels via two channels:
+
+1. **Database column.** `tasks.strict_readonly` (`INTEGER NOT NULL
+   DEFAULT 0`). The dispatcher reads this column when constructing the
+   worker environment.
+
+2. **Environment variable.** `HERMES_KANBAN_STRICT_READONLY=1`. The
+   `_is_strict_readonly_active(task_id)` check in `tools/file_tools`
+   reads this env. The variable is set ONLY by the dispatcher path
+   that originated from a task with `strict_readonly=True`.
+
+The CLI surface (`hermes kanban create --strict-readonly` /
+`--strict_readonly` flag at `hermes_cli/kanban.py`) sets the database
+column; the dispatcher path reads the column and exports the env.
+
+Autonomy propagation: `agent/autonomy/initiator.py` accepts
+`objective_spec['strict_readonly']` and forwards it to
+`hermes_cli.kanban_db.create_task`. The capability is opt-in per
+objective; absence / falsy values leave the task writable.
+
+## Dispatcher Boundary
+
+The dispatcher (`hermes_cli/kanban_db._default_spawn`) is the TCB for
+strict capability. It is responsible for:
+
+- Pinning `HERMES_KANBAN_STRICT_READONLY=1` only when
+  `task.strict_readonly` is true.
+- Pinning `HERMES_KANBAN_TASK` to the task id.
+- Pinning `HERMES_KANBAN_WORKSPACE` to the canonical workspace path
+  for the task.
+- Pinning `HERMES_KANBAN_DB` and `HERMES_KANBAN_BOARD` so the worker
+  opens the same board the dispatcher used.
+- Removing `terminal` and `code_execution` from the `--toolsets`
+  allowlist on the worker CLI argv.
+- Tagging `HERMES_SESSION_SOURCE=kanban` so worker-side mechanisms
+  (CLI mixin, session DB, sidebar filters) recognise the worker.
+- Pinning `TERMINAL_CWD` to the workspace so worker file tools and
+  context-file loading anchor on the task workspace rather than the
+  dispatching gateway's cwd.
+
+Provider / model are NOT pinned by the capability. `--model` /
+`--provider` are emitted only when `task.model_override` /
+`task.provider_override` are explicitly set on the task row; the
+capability is independent of model routing.
+
+The dispatcher is also responsible for the byte-preserving artifact
+promotion path: `kanban_complete` in the worker triggers
+`_persist_scratch_completion_artifacts` and `_insert_completion_attachment`
+in the dispatcher's own kanban database connection, with
+`uploaded_by='kanban_complete'`.
+
+## Authoritative Task-to-Workspace Binding
+
+The task-to-workspace binding check is the security-critical step:
+
+```
+os.environ["HERMES_KANBAN_TASK"]            → env_task
+os.environ["HERMES_KANBAN_WORKSPACE"]       → env_workspace
+os.environ["HERMES_KANBAN_DB"]              → db_pin
+os.environ["HERMES_KANBAN_BOARD"]           → board_pin
+
+conn = kanban_db.connect()
+expected = kanban_db.expected_workspace_for_task(conn, env_task, board=board_pin)
+
+Path(env_workspace).resolve(strict=False) == expected.resolve(strict=False)
+```
+
+`expected_workspace_for_task` is a pure read-only resolver. It does
+not create directories, does not branch workspaces, does not write to
+the DB. It only reads the canonical workspace recorded for the task.
+
+If `HERMES_KANBAN_DB` or `HERMES_KANBAN_BOARD` are unset, the gate
+denies — strict mode without dispatcher authority is refused up-front.
+
+If `kanban_db` cannot be imported, the DB cannot be opened, the task
+row is missing, or `expected_workspace_for_task` raises
+`KanbanWorkspaceLookupError`, the gate denies.
+
+## Workspace Enforcement
+
+Containment is the last step:
+
+```
+target = Path(resolved_path).resolve(strict=False)
+workspace = Path(env_workspace).resolve(strict=False)
+
+target != workspace                                   (root not writable)
+target.is_relative_to(workspace)                      (containment)
+```
+
+`Path.resolve(strict=False)` walks the symlink chain. Symlinks whose
+chain leaves the workspace are caught by the containment check. `..`
+traversal is caught by `is_relative_to`. Both failures return a
+structured `tool_error` JSON; the worker sees the denial as a normal
+tool result, not a hard agent crash.
+
+## Toolset Confinement
+
+The strict worker receives a `--toolsets` allowlist that contains:
+
+- All toolsets the assignee profile would normally receive,
+- **minus** `terminal`,
+- **minus** `code_execution`,
+- **plus** `kanban` (re-appended by `model_tools` because
+  `HERMES_KANBAN_TASK` is in the env).
+
+The dispatcher applies the filter at the resolved-toolsets level
+because the Hermes CLI accepts a comma-separated `--toolsets` allowlist
+but does not accept `--disabled-toolsets`. Filtering at the
+resolved-toolsets level stays inside the existing CLI transport
+contract.
+
+The `terminal` and `code_execution` exclusion is the single most
+important confinement: without it, the worker could shell out and
+bypass the file-tool gate entirely.
+
+## Kanban Lifecycle
+
+The `kanban` toolset is preserved so the worker can self-complete:
+
+- `kanban_complete(task_id, summary, result, artifacts=[...])` —
+  closes the task and, when `artifacts` is supplied, persists the
+  declared workspace files as task attachments via the byte-preserving
+  path.
+- `kanban_attach(task_id, filename, data_b64)` / `kanban_attach_url`
+  / `kanban_attachments` — attach a workspace file as a task
+  attachment, attach by URL, or list current attachments.
+- `kanban_comment`, `kanban_heartbeat`, `kanban_show`,
+  `kanban_create`, `kanban_link`, `kanban_block`,
+  `kanban_request_changes`, `kanban_request_review`,
+  `kanban_unblock` — observability and progress surfaces.
+
+The `artifacts` argument to `kanban_complete` MUST be a list of
+absolute paths. The dispatcher's own `kanban_db.complete_task`
+validates the shape.
+
+## Trusted Artifact Promotion
+
+When the worker calls `kanban_complete(artifacts=[...])`:
+
+1. `tools/kanban_tools.py::_handle_kanban_complete` validates the
+   `artifacts` argument is a top-level list and copies the values
+   into `metadata["artifacts"]`.
+2. `hermes_cli/kanban_db.complete_task(...)` invokes
+   `_persist_scratch_completion_artifacts(conn, task_id, metadata)`.
+3. The promotion path validates each declared path is inside the
+   canonical workspace, opens each source via `open("rb")`, and writes
+   to the attachment directory via `open("xb")` (chunk-by-chunk).
+4. `_insert_completion_attachment(...)` records each artifact as a
+   `task_attachments` row with `uploaded_by='kanban_complete'`.
+
+The LLM does not re-emit file contents in this path. Production code
+reads bytes from the existing workspace file and writes them to the
+attachment store. This is the property that guarantees byte-exact
+promotion.
+
+When the worker uses `kanban_attach` directly, the underlying write
+goes through `hermes_cli.kanban_db.store_attachment_bytes`, which is
+the trusted in-DB attachment write path used by the dashboard, the
+CLI, and the kanban toolset. None of these trusted paths are
+intercepted by the strict file-tool gate because they are not
+model-tool mutations of arbitrary file paths — they are explicit
+promotion calls into the kanban subsystem.
+
+## Background-Review Isolation
+
+A normal worker session can fire `_spawn_background_review` after a
+turn, which can invoke `skill_view` / `skill_manage` and trigger
+`curator` / `auxiliary_client` events. For a strict worker this would
+be a silent second-tick attack surface.
+
+The current upstream behavior uses the worker CLI's
+`_effective_skip_background_review()` mixin
+(`hermes_cli/cli_agent_setup_mixin.py`), which detects
+`HERMES_KANBAN_TASK` or `HERMES_SESSION_SOURCE=="kanban"` in the
+worker subprocess env and propagates `skip_background_review=True`
+onto the AIAgent constructor. The dispatcher sets
+`HERMES_SESSION_SOURCE=kanban` for every Kanban worker, so this
+mechanism applies to both strict and non-strict workers; the strict
+capability does not introduce a separate review-suppression patch.
+
+The worker session log shows exactly the API calls for the worker's
+own turns and no skill-management events after the worker exits.
+
+## Failure and Fail-Closed Semantics
+
+Every failure mode returns a structured `tool_error` JSON and the
+write is denied. There is no soft fallback, no return
+`None`-indicating-allowed-with-warning, no falling back to the
+process cwd or `$HOME`.
+
+Failure modes (non-exhaustive):
+
+- `HERMES_KANBAN_STRICT_READONLY` not set → gate is a no-op (this is
+  the non-strict path; gate does not fire).
+- `HERMES_KANBAN_TASK` empty → deny.
+- `HERMES_KANBAN_WORKSPACE` empty, sentinel, non-absolute, or not an
+  existing directory → deny.
+- `HERMES_KANBAN_DB` or `HERMES_KANBAN_BOARD` empty → deny.
+- `kanban_db` import or DB connect failure → deny.
+- `expected_workspace_for_task` raises `KanbanWorkspaceLookupError`
+  → deny.
+- Pinned workspace ≠ authoritative expected workspace → deny.
+- Target equals workspace root → deny.
+- Target not `is_relative_to(workspace)` → deny.
+- Path traversal check raises `OSError` → deny.
+- Path canonicalisation raises → deny.
+
+## Validation
+
+The contract is exercised by reproducible repository tests:
+
+- `tests/hermes_cli/test_kanban_strict_readonly_field.py` —
+  schema, migration, round-trip persistence.
+- `tests/hermes_cli/test_kanban_worker_strict_dispatch.py` —
+  dispatcher env export, toolsets filter, lifecycle preservation,
+  model / provider / reasoning propagation, trusted artifact
+  promotion.
+- `tests/tools/test_file_tools_strict_workspace_gate.py` —
+  containment, traversal, symlink escape, missing / malformed /
+  mismatched / unknown-task denial, S14 binding matrix.
+- `tests/hermes_cli/test_kanban_initiator_strict_propagation.py` —
+  autonomy objective → task row propagation, no origin-based
+  inference.
+- `tests/cron/test_cron_kanban_env_isolation.py` —
+  `HERMES_KANBAN_STRICT_READONLY` is in the identity-gated set.
+
+Background-review isolation is exercised by
+`tests/agent/test_skip_background_review.py` and
+`tests/agent/test_skip_background_review_cli_propagation.py`.
+
+Provider / model preservation is exercised by
+`tests/hermes_cli/test_kanban_worker_strict_dispatch.py`
+(`test_strict_worker_propagates_model_provider_reasoning`).
+
+## Limitations
+
+- Strict-readonly applies to the explicit Kanban strict capability. It
+  is not a global process sandbox, not a kernel-level isolation, and
+  not a substitute for an OS-level sandbox.
+- It does not make every Hermes session read-only. Ordinary CLI,
+  non-strict Kanban, and non-Kanban sessions are unaffected.
+- It does not make autonomous origin itself a security authority.
+  Provenance is not capability.
+- It does not eliminate the trusted dispatcher, the trusted Kanban DB,
+  or the trusted completion path from the TCB. All three are
+  upstream of the file-tool gate and remain attacker-relevant if
+  compromised.
+- It does not authorize arbitrary external filesystem writes. It
+  confines the worker's file-tool mutation surface, nothing more.
+- This document describes the accepted current implementation. It is
+  not a future-design document; proposed-but-not-accepted changes are
+  not documented here.
+
+## Related
+
+- `docs/ADR.md` — `## 2026-08-20: Strict-readonly Kanban worker
+  capability (workspace confinement)` decision entry.
+- `hermes_cli/kanban_db.py` — `expected_workspace_for_task`,
+  `KanbanWorkspaceLookupError`, `_default_spawn`,
+  `_persist_scratch_completion_artifacts`, `_insert_completion_attachment`,
+  `store_attachment_bytes`.
+- `tools/file_tools.py` — `_is_strict_readonly_active`,
+  `_verify_strict_readonly_task_workspace_binding`,
+  `_resolve_strict_readonly_pinned_workspace`, `_strict_readonly_gate`.
+- `hermes_cli/kanban.py` — `--strict-readonly` CLI flag.
+- `agent/autonomy/initiator.py` — `strict_readonly` objective field.
+- `hermes_cli/cli_agent_setup_mixin.py` — `_effective_skip_background_review`
+  worker marker detection.
+- `docs/security/network-egress-isolation.md` — adjacent isolation
+  pattern (network egress, complementary concept).
+- `SECURITY.md` — Hermes trust model and vulnerability reporting.

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -490,6 +490,19 @@ def build_top_level_parser():
     )
     _inherited_flag(
         chat_parser,
+        "--skip-background-review",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help=(
+            "Skip the end-of-turn automatic background memory/skill review fork "
+            "(~30K tokens / event). Useful for cron-style sessions, CI, or "
+            "strict-readonly worker contexts where the review fork has no "
+            "human-in-the-loop value. Implies skip_background_review=True on the "
+            "AIAgent constructor; the explicit /refine command still works."
+        ),
+    )
+    _inherited_flag(
+        chat_parser,
         "--ignore-user-config",
         action="store_true",
         default=argparse.SUPPRESS,

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -14,6 +14,7 @@ loaded) so this module never imports ``cli`` at import time -> no import cycle.
 
 from __future__ import annotations
 
+import os
 import sys
 
 from rich.markup import escape as _escape
@@ -23,6 +24,38 @@ from utils import base_url_host_matches
 
 class CLIAgentSetupMixin:
     """Agent construction + session-resume display methods for ``HermesCLI``."""
+
+    def _effective_skip_background_review(self) -> bool:
+        """Return the effective skip-background-review value for AIAgent construction.
+
+        Invariant: explicit ``--skip-background-review`` on the CLI wins;
+        the Kanban worker marker is the secondary signal. We never mutate
+        the environment and never persist this value to config — it is
+        computed at construction time and discarded when the worker exits.
+
+        The Kanban worker marker is the canonical current upstream signal
+        the dispatcher (``hermes_cli/kanban_db.py``) sets when spawning a
+        worker subprocess: ``HERMES_KANBAN_TASK`` to the task ID, plus the
+        secondary ``HERMES_SESSION_SOURCE = "kanban"`` tag. Either marker
+        being present on the worker subprocess means we are a worker, so
+        we suppress the post-turn review fork to avoid the worker
+        mutating the skill library mid-task.
+
+        Both env vars are read-only here — the dispatcher owns them and
+        this function only consults them.
+        """
+        explicit = bool(getattr(self, "skip_background_review", False))
+        if explicit:
+            return True
+        # Canonical worker markers (set by the dispatcher in kanban_db.py).
+        # HERMES_KANBAN_TASK is the most specific: it's only set when a
+        # Kanban task is dispatched. HERMES_SESSION_SOURCE == "kanban" is
+        # the secondary tag. We treat both as equivalent signals.
+        if os.environ.get("HERMES_KANBAN_TASK"):
+            return True
+        if os.environ.get("HERMES_SESSION_SOURCE") == "kanban":
+            return True
+        return False
 
     def _ensure_runtime_credentials(self) -> bool:
         """
@@ -533,6 +566,13 @@ class CLIAgentSetupMixin:
                 pass_session_id=self.pass_session_id,
                 skip_context_files=self.ignore_rules,
                 skip_memory=self.ignore_rules,
+                # --skip-background-review: explicit CLI flag wins; the
+                # Kanban worker marker (HERMES_KANBAN_TASK /
+                # HERMES_SESSION_SOURCE=="kanban", set by the dispatcher in
+                # hermes_cli/kanban_db.py when spawning a worker) also
+                # activates the suppression. Read at AIAgent construction
+                # time; the environment is NOT mutated.
+                skip_background_review=self._effective_skip_background_review(),
                 tool_progress_callback=self._on_tool_progress,
                 tool_start_callback=self._on_tool_start if self._inline_diffs_enabled else None,
                 tool_complete_callback=self._on_tool_complete if self._inline_diffs_enabled else None,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -393,6 +393,19 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           metavar="N", dest="goal_max_turns",
                           help="Turn budget for --goal workers (default 20). "
                                "Ignored without --goal.")
+    p_create.add_argument("--strict-readonly", action="store_true",
+                          dest="strict_readonly", default=False,
+                          help=(
+                              "Dispatch the worker as a STRICT-READONLY "
+                              "Kanban worker: the worker is launched with "
+                              "HERMES_KANBAN_STRICT_READONLY=1 and "
+                              "--disabled-toolsets terminal,code_execution, "
+                              "and its write_file / patch tools are "
+                              "constrained to its current task workspace. "
+                              "Default is off — ordinary writable Kanban "
+                              "workers. Capability is explicit per task; "
+                              "never inferred from --created-by."
+                          ))
     p_create.add_argument("--initial-status",
                           choices=sorted(kb.VALID_INITIAL_STATUSES),
                           default="running",
@@ -1585,6 +1598,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             provider_override=getattr(args, "provider_override", None),
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
+            strict_readonly=bool(getattr(args, "strict_readonly", False)),
             initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1128,6 +1128,15 @@ class Task:
     # Goal-loop turn budget for ``goal_mode`` workers. ``None`` falls
     # through to the goals engine default (``goals.DEFAULT_MAX_TURNS``).
     goal_max_turns: Optional[int] = None
+    # When True, the dispatched worker is a STRICT-READONLY Kanban worker:
+    # it sees ``HERMES_KANBAN_STRICT_READONLY=1`` in its env, the worker CLI
+    # is launched with ``--disabled-toolsets terminal,code_execution``, and
+    # the file-write gate (``tools.file_tools``) confines
+    # ``write_file_tool`` / ``patch_tool`` to the worker's current task
+    # workspace. ``False`` (default) = ordinary writable Kanban worker.
+    # Set explicitly by the caller; never inferred from ``created_by``
+    # (provenance is NOT capability).
+    strict_readonly: bool = False
     # Originating chat/agent session id, when the task was created from
     # within an agent loop that propagated ``HERMES_SESSION_ID``. NULL for
     # tasks created from the CLI, the dashboard, or any path that doesn't
@@ -1223,6 +1232,9 @@ class Task:
             ),
             goal_max_turns=(
                 row["goal_max_turns"] if "goal_max_turns" in keys and row["goal_max_turns"] else None
+            ),
+            strict_readonly=(
+                bool(row["strict_readonly"]) if "strict_readonly" in keys and row["strict_readonly"] else False
             ),
             session_id=(
                 row["session_id"] if "session_id" in keys else None
@@ -1404,6 +1416,15 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- Goal-loop turn budget for ``goal_mode`` workers. NULL = use the
     -- goals-engine default.
     goal_max_turns       INTEGER,
+    -- Strict-readonly capability flag. When 1, the dispatched worker is a
+    -- STRICT-READONLY Kanban worker: ``HERMES_KANBAN_STRICT_READONLY=1``
+    -- is exported, the worker CLI is launched with
+    -- ``--disabled-toolsets terminal,code_execution``, and the file-write
+    -- gate confines ``write_file`` / ``patch`` to the current task
+    -- workspace. 0 (default) = ordinary writable Kanban worker. Set
+    -- explicitly by the caller; never inferred from ``created_by``
+    -- (provenance is NOT capability).
+    strict_readonly      INTEGER NOT NULL DEFAULT 0,
     -- Originating chat/agent session id when the task was created from
     -- inside an agent loop that propagated ``HERMES_SESSION_ID``. NULL
     -- for tasks created from the CLI, dashboard, or any path that doesn't
@@ -2654,6 +2675,21 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             conn, "tasks", "goal_max_turns", "goal_max_turns INTEGER"
         )
 
+    if "strict_readonly" not in cols:
+        # STRICT-READONLY Kanban worker capability. 0 (default) = ordinary
+        # writable Kanban worker (preserves existing-row behaviour). 1 =
+        # the dispatcher pins ``HERMES_KANBAN_STRICT_READONLY=1`` on the
+        # worker, the worker CLI receives
+        # ``--disabled-toolsets terminal,code_execution``, and
+        # ``tools.file_tools`` confines ``write_file`` / ``patch`` to the
+        # current task workspace. Never inferred from ``created_by``.
+        _add_column_if_missing(
+            conn,
+            "tasks",
+            "strict_readonly",
+            "strict_readonly INTEGER NOT NULL DEFAULT 0",
+        )
+
     if "session_id" not in cols:
         # Originating agent/chat session id, populated when the task is
         # created from within an agent loop that propagated
@@ -3178,6 +3214,7 @@ def create_task(
     reasoning_effort: Optional[str] = None,
     goal_mode: bool = False,
     goal_max_turns: Optional[int] = None,
+    strict_readonly: bool = False,
     initial_status: str = "running",
     session_id: Optional[str] = None,
     board: Optional[str] = None,
@@ -3216,6 +3253,16 @@ def create_task(
     (``minimal``…``ultra``, or ``none`` to disable thinking), passed as
     ``--reasoning <level>``. It is independent of ``model_override``: a task
     can run the profile's own model at a different depth.
+
+    ``strict_readonly`` (default ``False``) opts the dispatched worker into
+    the STRICT-READONLY Kanban worker posture: the dispatcher exports
+    ``HERMES_KANBAN_STRICT_READONLY=1`` and passes
+    ``--disabled-toolsets terminal,code_execution`` to the worker CLI;
+    the file-write gate (``tools.file_tools``) confines ``write_file`` and
+    ``patch`` to the worker's current task workspace. ``False`` (default)
+    = ordinary writable Kanban worker; never inferred from ``created_by``.
+    The capability is explicit — autonomous and operator-created tasks
+    both default to writable unless they opt in.
 
     ``project_source_task_id`` is an internal cross-profile fallback for a
     worker-created child. When the active profile cannot resolve ``project_id``
@@ -3497,8 +3544,8 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, strict_readonly, session_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3523,6 +3570,7 @@ def create_task(
                         reasoning_effort,
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
+                        1 if strict_readonly else 0,
                         session_id,
                     ),
                 )
@@ -7901,6 +7949,167 @@ def set_workspace_path(
         )
 
 
+# ---------------------------------------------------------------------------
+# STRICT-READONLY S14 binding resolver (read-only, pure)
+# ---------------------------------------------------------------------------
+#
+# ``expected_workspace_for_task`` computes the canonical workspace that
+# the dispatcher SHOULD hand a worker for ``task_id`` without performing
+# any state mutation. It is the authoritative counterpart of
+# ``resolve_workspace`` for the strict-readonly file-write gate: the
+# gate cross-checks that the dispatcher-pinned ``HERMES_KANBAN_WORKSPACE``
+# equals the value returned here for ``HERMES_KANBAN_TASK`` before
+# allowing any write.
+#
+# INVARIANTS (the gate relies on every one of these):
+#
+# * PURE: no filesystem creation, no git worktree materialization, no
+#   DB update, no task lifecycle mutation. Only ``get_task`` reads and
+#   ``Path(...)`` arithmetic run.
+# * FAIL-LOUD: every failure mode raises a typed
+#   :class:`KanbanWorkspaceLookupError` so the gate can translate it
+#   into a structured ``tool_error``. Callers must NOT swallow the
+#   exception to fall back to env-only containment; that would be the
+#   very fail-open the gate exists to prevent.
+# * CONSISTENT-WITH-DISPATCHER: the algorithms mirror the relevant
+#   branches of ``resolve_workspace`` and ``_resolve_worktree_workspace``
+#   so a worker whose task row matches the dispatcher's pinned env gets
+#   exactly the same canonical path back; a worker whose task row does
+#   NOT match gets a different path and is denied at the binding check.
+#
+# The worktree branch is intentionally conservative: when
+# ``task.workspace_path`` is None (the common case) and the board has
+# no ``default_workdir``, we fail closed rather than guess — guessing
+# from ``Path.cwd()`` is exactly what the production dispatcher refuses
+# to do for confused-deputy reasons, so the gate cannot do it either.
+
+WORKSPACE_KIND_SCRATCH = "scratch"
+WORKSPACE_KIND_DIR = "dir"
+WORKSPACE_KIND_WORKTREE = "worktree"
+_VALID_STRICT_WORKSPACE_KINDS = frozenset(
+    {WORKSPACE_KIND_SCRATCH, WORKSPACE_KIND_DIR, WORKSPACE_KIND_WORKTREE}
+)
+
+
+class KanbanWorkspaceLookupError(Exception):
+    """Raised when :func:`expected_workspace_for_task` cannot compute a
+    canonical workspace for a Kanban task.
+
+    The strict-readonly file-write gate treats every instance as
+    fail-closed: any failure here means the dispatcher pin and the
+    authoritative persisted state disagree (or the task / board /
+    workspace mode itself is unknown), so the gate denies the write
+    without consulting target containment.
+    """
+
+
+def expected_workspace_for_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    board: Optional[str] = None,
+) -> Path:
+    """Return the canonical workspace path the dispatcher SHOULD hand a
+    worker for ``task_id``.
+
+    Pure read-only resolver; see the section comment above for the
+    contract the gate relies on. The returned path is ``expanduser()``-ed
+    but NOT resolved through symlinks (so the gate's canonicalisation
+    step sees the same shape on both sides).
+    """
+    if not task_id or not isinstance(task_id, str):
+        raise KanbanWorkspaceLookupError(
+            f"expected_workspace_for_task: invalid task_id {task_id!r}"
+        )
+    task = get_task(conn, task_id)
+    if task is None:
+        raise KanbanWorkspaceLookupError(
+            f"expected_workspace_for_task: task {task_id!r} not found in "
+            f"board {board!r} DB"
+        )
+    kind = (task.workspace_kind or WORKSPACE_KIND_SCRATCH).strip().lower()
+    if kind not in _VALID_STRICT_WORKSPACE_KINDS:
+        raise KanbanWorkspaceLookupError(
+            f"expected_workspace_for_task: task {task_id!r} has unknown "
+            f"workspace_kind {kind!r}"
+        )
+
+    if kind == WORKSPACE_KIND_SCRATCH:
+        if task.workspace_path:
+            stored = Path(task.workspace_path).expanduser()
+            if not stored.is_absolute():
+                raise KanbanWorkspaceLookupError(
+                    f"expected_workspace_for_task: task {task_id!r} scratch "
+                    f"workspace_path {stored!r} is not absolute"
+                )
+            return stored
+        root = workspaces_root(board=board)
+        return root / task_id
+
+    if kind == WORKSPACE_KIND_DIR:
+        if not task.workspace_path:
+            raise KanbanWorkspaceLookupError(
+                f"expected_workspace_for_task: task {task_id!r} has "
+                f"workspace_kind=dir but no workspace_path persisted"
+            )
+        stored = Path(task.workspace_path).expanduser()
+        if not stored.is_absolute():
+            raise KanbanWorkspaceLookupError(
+                f"expected_workspace_for_task: task {task_id!r} dir "
+                f"workspace_path {stored!r} is not absolute"
+            )
+        return stored
+
+    # ``worktree`` — match ``_resolve_worktree_workspace`` semantics for
+    # the path-only determination, but never create the worktree.
+    if task.workspace_path:
+        stored = Path(task.workspace_path).expanduser()
+        if not stored.is_absolute():
+            raise KanbanWorkspaceLookupError(
+                f"expected_workspace_for_task: task {task_id!r} worktree "
+                f"workspace_path {stored!r} is not absolute"
+            )
+        # The dispatcher's persisted-path branch returns the stored path
+        # verbatim when it is or points inside an existing / new git
+        # repo, possibly rewritten to ``<repo>/.worktrees/<task_id>``.
+        # We approximate that without I/O: when the persisted path is
+        # a git toplevel itself, the canonical worktree path lives at
+        # ``<repo>/.worktrees/<task_id>``; otherwise we trust the
+        # stored path (the dispatcher would materialise the worktree
+        # there, so the gate must accept the same target).
+        from_top = _git_toplevel(stored)
+        if from_top is not None and stored.resolve(strict=False) == from_top.resolve(strict=False):
+            return (from_top / ".worktrees" / task_id).resolve(strict=False)
+        return stored.resolve(strict=False)
+
+    # Persisted path absent: anchor on the board's ``default_workdir``.
+    # The strict gate must NOT guess from ``Path.cwd()`` — that's the
+    # confused-deputy risk the production dispatcher rejects.
+    slug = board if board else get_current_board()
+    meta = read_board_metadata(slug)
+    default_workdir = (meta.get("default_workdir") or "").strip()
+    if not default_workdir:
+        raise KanbanWorkspaceLookupError(
+            f"expected_workspace_for_task: task {task_id!r} has no "
+            f"workspace_path and board {slug!r} has no default_workdir; "
+            f"strict-readonly gate cannot derive a canonical path"
+        )
+    anchor = Path(default_workdir).expanduser()
+    if not anchor.is_absolute():
+        raise KanbanWorkspaceLookupError(
+            f"expected_workspace_for_task: board {slug!r} default_workdir "
+            f"{default_workdir!r} is not absolute"
+        )
+    git_root = _git_toplevel(anchor)
+    if git_root is None:
+        raise KanbanWorkspaceLookupError(
+            f"expected_workspace_for_task: board {slug!r} default_workdir "
+            f"{default_workdir!r} is not inside a git repository; "
+            f"cannot derive canonical worktree path for task {task_id!r}"
+        )
+    return (git_root / ".worktrees" / task_id).resolve(strict=False)
+
+
 def set_branch_name(
     conn: sqlite3.Connection, task_id: str, branch_name: str
 ) -> None:
@@ -10798,6 +11007,15 @@ def _default_spawn(
         env["HERMES_KANBAN_GOAL_MODE"] = "1"
         if task.goal_max_turns is not None:
             env["HERMES_KANBAN_GOAL_MAX_TURNS"] = str(int(task.goal_max_turns))
+    # STRICT-READONLY worker capability. When the task opts in via
+    # ``strict_readonly=True``, the dispatcher exports
+    # ``HERMES_KANBAN_STRICT_READONLY=1`` so the worker's file-write gate
+    # (``tools.file_tools``) and any other capability consumer can
+    # observe the posture. Ordinary writable Kanban workers MUST NOT
+    # receive this env — the capability is explicit per task, never
+    # inferred from ``created_by`` (provenance is NOT capability).
+    if task.strict_readonly:
+        env["HERMES_KANBAN_STRICT_READONLY"] = "1"
     terminal_timeout = _worker_terminal_timeout_env(
         task.max_runtime_seconds,
         env.get("TERMINAL_TIMEOUT"),
@@ -10871,6 +11089,26 @@ def _default_spawn(
     if task.reasoning_effort:
         cmd.extend(["--reasoning", task.reasoning_effort])
     worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"))
+    # STRICT-READONLY worker: subtract ``terminal`` and ``code_execution``
+    # from the worker's resolved CLI toolset surface before emitting
+    # ``--toolsets``. The production Hermes CLI accepts a comma-separated
+    # ``--toolsets`` allowlist (top-level and ``chat`` subparser both
+    # support it) but does NOT accept ``--disabled-toolsets`` — emitting
+    # an unsupported flag is a hard argparse failure that crashes the
+    # worker before session init. Filtering at the resolved-toolsets
+    # level stays inside the existing transport contract: every
+    # otherwise-authorized assignee toolset is preserved, ``terminal``
+    # and ``code_execution`` are removed, and ``model_tools`` still
+    # re-appends the ``kanban`` lifecycle toolset because
+    # ``HERMES_KANBAN_TASK`` is set in the spawned env (see
+    # ``model_tools._get_tool_definitions_uncached``). Ordinary
+    # non-strict workers do NOT see this filter — the capability is
+    # explicit per task, never inferred.
+    if task.strict_readonly and worker_toolsets:
+        worker_toolsets = [
+            ts for ts in worker_toolsets
+            if ts not in {"terminal", "code_execution"}
+        ]
     if worker_toolsets:
         cmd.extend(["--toolsets", ",".join(worker_toolsets)])
     cmd.extend([

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3249,6 +3249,7 @@ def cmd_chat(args):
         "worktree": getattr(args, "worktree", False),
         "checkpoints": getattr(args, "checkpoints", False),
         "pass_session_id": getattr(args, "pass_session_id", False),
+        "skip_background_review": getattr(args, "skip_background_review", False),
         "max_turns": getattr(args, "max_turns", None),
         "run_budget": getattr(args, "run_budget", None),
         "ignore_rules": getattr(args, "ignore_rules", False) or getattr(args, "safe_mode", False),

--- a/tests/agent/test_autonomous_initiation.py
+++ b/tests/agent/test_autonomous_initiation.py
@@ -1,0 +1,1214 @@
+"""
+Tests for AUTONOMOUS_INITIATION_PATH_V1.
+
+These tests use a per-test isolated temporary Kanban DB. The real
+~/.hermes/kanban.db is NEVER touched by these tests. The tests patch
+hermes_cli.kanban_db.connect_closing (and the connect function) to
+return a connection to a fresh sqlite3 file under tmp_path.
+
+The 12 tests cover the contract from the directive:
+
+  T1  autonomy disabled               -> 0 task created, fail closed
+  T2  kill switch active               -> 0 task created, fail closed
+  T3  Class A, kill off                -> exactly 1 task created
+  T4  Class B                          -> 0 task created, requires human
+  T5  Class C                          -> 0 task created, requires human
+  T6  duplicate trigger                -> exactly 1 task total
+  T7  concurrency limit                -> second objective not admitted
+  T8  provenance on resulting task     -> origin / objective_id / etc.
+  T9  canonical Kanban event semantics -> standard event trail
+  T10 no operator create required      -> no `hermes kanban create` invoked
+  T11 no config/profile/.env mutation  -> no persistent file written
+  T12 deactivation                     -> subsequent initiation blocked
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import multiprocessing
+import os
+import re
+import sqlite3
+import sys
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+
+# Locate THIS TEMP CANDIDATE so we can import agent.autonomy from the
+# current working tree — not the primary checkout. The historical baseline
+# hard-coded /home/jr-ubuntu/.hermes/hermes-agent into sys.path, which
+# defeated the point of running the test against a fresh temp. We instead
+# derive the candidate root from the test file's own path.
+CANDIDATE_ROOT = Path(__file__).resolve().parents[2]
+_candidate_str = str(CANDIDATE_ROOT)
+if _candidate_str not in sys.path:
+    sys.path.insert(0, _candidate_str)
+
+
+# Provenance assertion: ``import agent.autonomy`` must resolve under the
+# TEMP candidate path, NOT under the primary checkout. This guards
+# against accidental reintroduction of the historical PRIMARY sys.path
+# injection that would silently test the wrong tree.
+def _assert_autonomy_resolves_under_candidate():
+    import importlib
+    import agent.autonomy as _autonomy
+    _autonomy_file = Path(_autonomy.__file__).resolve()
+    assert str(_autonomy_file).startswith(str(CANDIDATE_ROOT) + "/"), (
+        f"agent.autonomy resolved to {_autonomy_file!r}; expected it under "
+        f"{CANDIDATE_ROOT!r}. Refusing to run against the primary checkout."
+    )
+
+
+@pytest.fixture(autouse=True)
+def _enforce_autonomy_provenance():
+    """Autouse session-wide: runtime provenance guard.
+
+    Confirms ``import agent.autonomy`` resolves under the TEMP candidate,
+    NEVER under the primary checkout. Runs before every test; cheap if
+    already cached by the import system.
+    """
+    _assert_autonomy_resolves_under_candidate()
+    yield
+
+
+# Tests run with a per-test isolated Kanban DB; we patch the
+# hermes_cli.kanban_db module so the real ~/.hermes/kanban.db is not
+# touched. This is the same pattern used by the project's own kanban
+# tests (see tests/hermes_cli/test_kanban_db.py).
+
+
+@pytest.fixture
+def isolated_kanban_db(tmp_path, monkeypatch):
+    """Yield a fresh Kanban sqlite3 file under tmp_path, and patch
+    hermes_cli.kanban_db to use only this file. After the test the file
+    is removed by tmp_path cleanup."""
+
+    db_file = tmp_path / "test_kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_file))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path / "kanban-home"))
+    # Initialize the schema by importing the real kanban_db helpers.
+    from hermes_cli import kanban_db as kb
+    # Save the originals so the patched connect_closing calls the real
+    # connect (avoid the recursion that would happen if we called
+    # kb.connect, which we are about to monkey-patch below).
+    _original_connect = kb.connect
+
+    conn = _original_connect(db_file)
+    conn.close()
+
+    @contextmanager
+    def _patched_connect_closing():
+        c = _original_connect(db_file)
+        try:
+            yield c
+        finally:
+            c.close()
+
+    monkeypatch.setattr(kb, "connect_closing", _patched_connect_closing)
+    # Patch kb.connect only at the test-harness level (so any test code
+    # that calls kb.connect directly also gets the test file). The
+    # patched version uses the saved original to avoid recursion.
+    monkeypatch.setattr(
+        kb, "connect",
+        lambda board=None: _original_connect(db_file),
+    )
+
+    yield db_file
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _make_spec(objective_id="obj-1", risk_class="CLASS_A_AUTONOMOUS_SAFE",
+               policy_version="1.0.0", trigger_id="trig-1", title=None,
+               profile=None, **extra):
+    spec = {
+        "objective_id": objective_id,
+        "risk_class": risk_class,
+        "policy_version": policy_version,
+        "trigger_id": trigger_id,
+        "title": title or f"[autonomous] {objective_id}",
+    }
+    spec.update(extra)
+    ctx = {"profile": profile} if profile is not None else None
+    return spec, ctx
+
+
+def _count_tasks(db_file: Path) -> int:
+    if not db_file.exists():
+        return 0
+    conn = sqlite3.connect(str(db_file))
+    try:
+        cur = conn.execute("SELECT COUNT(*) FROM tasks")
+        return cur.fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _read_task(db_file: Path, task_id: str):
+    conn = sqlite3.connect(str(db_file))
+    try:
+        cur = conn.execute(
+            "SELECT id, title, body, created_by, status, idempotency_key "
+            "FROM tasks WHERE id = ?",
+            (task_id,),
+        )
+        return cur.fetchone()
+    finally:
+        conn.close()
+
+
+def _read_all_tasks(db_file: Path):
+    conn = sqlite3.connect(str(db_file))
+    try:
+        return conn.execute(
+            "SELECT id, title, body, created_by, status, idempotency_key "
+            "FROM tasks ORDER BY created_at, id"
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+def _snapshot_files(paths):
+    return {str(p): p.read_bytes() for p in paths}
+
+
+def _attempt_in_thread(spec, ctx, barrier, results, index):
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    barrier.wait(timeout=5)
+    results[index] = attempt_autonomous_initiation(spec, ctx)
+
+
+def _attempt_in_process(db_path, hermes_home, spec, ctx, barrier, queue):
+    os.environ["HERMES_KANBAN_DB"] = str(db_path)
+    os.environ["HERMES_KANBAN_HOME"] = str(Path(db_path).parent / "kanban-home")
+    os.environ["HERMES_HOME"] = str(hermes_home)
+    # Ensure the child process can import agent.autonomy from this temp
+    # candidate. multiprocessing.get_context("spawn") inherits sys.path
+    # from the parent, but we re-derive the candidate root here so the
+    # child resolves the same module location the parent did.
+    _child_candidate = str(Path(__file__).resolve().parents[2])
+    if _child_candidate not in sys.path:
+        sys.path.insert(0, _child_candidate)
+    try:
+        from agent.autonomy import state
+        from agent.autonomy.initiator import attempt_autonomous_initiation, summarize
+
+        state.reset()
+        state.enable(policy_version="1.0.0")
+        barrier.wait(timeout=10)
+        queue.put(summarize(attempt_autonomous_initiation(spec, ctx)))
+    except Exception as exc:  # pragma: no cover - surfaced to parent assertion
+        queue.put({"error": f"{type(exc).__name__}: {exc}"})
+
+
+def _run_cross_process_attempts(db_file: Path, specs_and_contexts, tmp_path: Path):
+    ctx = multiprocessing.get_context("spawn")
+    barrier = ctx.Barrier(len(specs_and_contexts))
+    queue = ctx.Queue()
+    procs = []
+    hermes_home = tmp_path / "child-hermes-home"
+    hermes_home.mkdir(exist_ok=True)
+    for spec, pol_ctx in specs_and_contexts:
+        proc = ctx.Process(
+            target=_attempt_in_process,
+            args=(str(db_file), str(hermes_home), spec, pol_ctx, barrier, queue),
+        )
+        proc.start()
+        procs.append(proc)
+    for proc in procs:
+        proc.join(timeout=15)
+    assert all(proc.exitcode == 0 for proc in procs)
+    rows = [queue.get(timeout=5) for _ in procs]
+    assert not [r for r in rows if "error" in r]
+    return rows
+
+
+def _assert_exactly_one_admitted(results):
+    admitted = [r for r in results if r.decision == "admit"]
+    assert len(admitted) == 1
+    assert admitted[0].task_id
+    return admitted[0]
+
+
+def _assert_exactly_one_admitted_summary(results):
+    admitted = [r for r in results if r["decision"] == "admit"]
+    assert len(admitted) == 1
+    assert admitted[0]["task_id"]
+    return admitted[0]
+
+
+# ----------------------------------------------------------------------
+# T1
+# ----------------------------------------------------------------------
+
+
+def test_T1_disabled_fail_closed(isolated_kanban_db, monkeypatch):
+    """T1: autonomy disabled -> 0 task created."""
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    # Autonomy is OFF by default
+    assert state.is_enabled() is False
+
+    spec, ctx = _make_spec()
+    result = attempt_autonomous_initiation(spec, ctx)
+    assert result.decision == "denied_disabled"
+    assert result.task_id is None
+    assert _count_tasks(isolated_kanban_db) == 0
+
+
+# ----------------------------------------------------------------------
+# T2
+# ----------------------------------------------------------------------
+
+
+def test_T2_kill_switch_fail_closed(isolated_kanban_db, monkeypatch):
+    """T2: kill switch active -> 0 task created."""
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    state.enable(policy_version="1.0.0", profile="minimax-direct-test")
+    state.fire_kill_switch()
+    assert state.is_kill_switch_active() is True
+
+    spec, ctx = _make_spec()
+    result = attempt_autonomous_initiation(spec, ctx)
+    assert result.decision == "denied_kill"
+    assert result.task_id is None
+    assert _count_tasks(isolated_kanban_db) == 0
+
+
+# ----------------------------------------------------------------------
+# T3
+# ----------------------------------------------------------------------
+
+
+def test_T3_class_a_accepted(isolated_kanban_db, monkeypatch):
+    """T3: enabled, kill off, Class A -> exactly 1 task created."""
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    state.enable(policy_version="1.0.0", profile="minimax-direct-test")
+
+    spec, ctx = _make_spec(objective_id="obj-3", trigger_id="trig-3")
+    result = attempt_autonomous_initiation(spec, ctx)
+    assert result.decision == "admit"
+    assert result.task_id is not None
+    assert result.duplicate is False
+    assert _count_tasks(isolated_kanban_db) == 1
+    assert state.get_active_objective_id() == "obj-3"
+    assert state.get_active_task_id() == result.task_id
+
+
+# ----------------------------------------------------------------------
+# T4
+# ----------------------------------------------------------------------
+
+
+def test_T4_class_b_requires_human(isolated_kanban_db, monkeypatch):
+    """T4: Class B -> 0 task created, requires_human equivalent."""
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+
+    spec, ctx = _make_spec(risk_class="CLASS_B_AUTONOMOUS_WITH_LIMITS")
+    result = attempt_autonomous_initiation(spec, ctx)
+    assert result.decision == "denied_class"
+    assert result.task_id is None
+    assert _count_tasks(isolated_kanban_db) == 0
+
+
+# ----------------------------------------------------------------------
+# T5
+# ----------------------------------------------------------------------
+
+
+def test_T5_class_c_requires_human(isolated_kanban_db, monkeypatch):
+    """T5: Class C -> 0 task created, requires_human equivalent."""
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+
+    spec, ctx = _make_spec(risk_class="CLASS_C_HUMAN_GATE_REQUIRED")
+    result = attempt_autonomous_initiation(spec, ctx)
+    assert result.decision == "denied_class"
+    assert result.task_id is None
+    assert _count_tasks(isolated_kanban_db) == 0
+
+
+# ----------------------------------------------------------------------
+# T6
+# ----------------------------------------------------------------------
+
+
+def test_T6_idempotent_duplicate_trigger(isolated_kanban_db, monkeypatch):
+    """T6: same spec invoked twice -> exactly 1 task total."""
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+
+    spec, ctx = _make_spec(objective_id="obj-6", trigger_id="trig-6")
+    r1 = attempt_autonomous_initiation(spec, ctx)
+    r2 = attempt_autonomous_initiation(spec, ctx)
+
+    assert r1.decision == "admit"
+    assert r1.duplicate is False
+    assert r2.decision == "duplicate_suppressed"
+    assert r2.duplicate is True
+    assert r2.task_id == r1.task_id
+    assert _count_tasks(isolated_kanban_db) == 1
+
+
+# ----------------------------------------------------------------------
+# T7
+# ----------------------------------------------------------------------
+
+
+def test_T7_concurrency_limit(isolated_kanban_db, monkeypatch):
+    """T7: a second objective with different id is rejected while the
+    first is still active."""
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+
+    spec_a, ctx_a = _make_spec(objective_id="obj-A", trigger_id="trig-A")
+    spec_b, ctx_b = _make_spec(objective_id="obj-B", trigger_id="trig-B")
+
+    r1 = attempt_autonomous_initiation(spec_a, ctx_a)
+    r2 = attempt_autonomous_initiation(spec_b, ctx_b)
+
+    assert r1.decision == "admit"
+    assert r2.decision == "denied_concurrency"
+    assert r2.task_id is None
+    assert _count_tasks(isolated_kanban_db) == 1
+
+
+def test_C1_same_process_same_trigger_concurrent(isolated_kanban_db, monkeypatch):
+    from agent.autonomy import state
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+    spec, ctx = _make_spec(objective_id="obj-c1", trigger_id="trig-c1")
+    barrier = threading.Barrier(2)
+    results = [None, None]
+    threads = [
+        threading.Thread(target=_attempt_in_thread, args=(spec, ctx, barrier, results, i))
+        for i in range(2)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert all(r is not None for r in results)
+    _assert_exactly_one_admitted(results)
+    assert sorted(r.decision for r in results if r is not None) == ["admit", "duplicate_suppressed"]
+    assert _count_tasks(isolated_kanban_db) == 1
+
+
+def test_C2_cross_process_same_trigger_concurrent(isolated_kanban_db, tmp_path):
+    spec, ctx = _make_spec(objective_id="obj-c2", trigger_id="trig-c2")
+
+    rows = _run_cross_process_attempts(isolated_kanban_db, [(spec, ctx), (spec, ctx)], tmp_path)
+
+    _assert_exactly_one_admitted_summary(rows)
+    assert sorted(r["decision"] for r in rows) == ["admit", "duplicate_suppressed"]
+    assert _count_tasks(isolated_kanban_db) == 1
+
+
+def test_C3_same_process_different_objective_concurrent(isolated_kanban_db, monkeypatch):
+    from agent.autonomy import state
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+    spec_a, ctx_a = _make_spec(objective_id="obj-c3-a", trigger_id="trig-c3-a")
+    spec_b, ctx_b = _make_spec(objective_id="obj-c3-b", trigger_id="trig-c3-b")
+    barrier = threading.Barrier(2)
+    results = [None, None]
+    threads = [
+        threading.Thread(target=_attempt_in_thread, args=(spec_a, ctx_a, barrier, results, 0)),
+        threading.Thread(target=_attempt_in_thread, args=(spec_b, ctx_b, barrier, results, 1)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert all(r is not None for r in results)
+    _assert_exactly_one_admitted(results)
+    assert sorted(r.decision for r in results if r is not None) == ["admit", "denied_concurrency"]
+    assert _count_tasks(isolated_kanban_db) == 1
+
+
+def test_C4_cross_process_different_objective_concurrent(isolated_kanban_db, tmp_path):
+    spec_a, ctx_a = _make_spec(objective_id="obj-c4-a", trigger_id="trig-c4-a")
+    spec_b, ctx_b = _make_spec(objective_id="obj-c4-b", trigger_id="trig-c4-b")
+
+    rows = _run_cross_process_attempts(
+        isolated_kanban_db,
+        [(spec_a, ctx_a), (spec_b, ctx_b)],
+        tmp_path,
+    )
+
+    _assert_exactly_one_admitted_summary(rows)
+    assert sorted(r["decision"] for r in rows) == ["admit", "denied_concurrency"]
+    assert _count_tasks(isolated_kanban_db) == 1
+
+
+def test_C5_post_restart_duplicate(isolated_kanban_db, monkeypatch):
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+    spec, ctx = _make_spec(objective_id="obj-c5", trigger_id="trig-c5")
+    first = attempt_autonomous_initiation(spec, ctx)
+    assert first.decision == "admit"
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+    second = attempt_autonomous_initiation(spec, ctx)
+
+    assert second.decision == "duplicate_suppressed"
+    assert second.task_id == first.task_id
+    assert _count_tasks(isolated_kanban_db) == 1
+
+
+# ----------------------------------------------------------------------
+# T8
+# ----------------------------------------------------------------------
+
+
+def test_T8_provenance(isolated_kanban_db, monkeypatch):
+    """T8: the resulting task carries the autonomous provenance in body
+    and created_by."""
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    state.enable(policy_version="1.0.0", profile="minimax-direct-test")
+
+    spec, ctx = _make_spec(
+        objective_id="obj-8", trigger_id="trig-8",
+        risk_class="CLASS_A_AUTONOMOUS_SAFE", policy_version="1.0.0",
+    )
+    result = attempt_autonomous_initiation(spec, ctx)
+    assert result.decision == "admit"
+    assert result.task_id
+
+    row = _read_task(isolated_kanban_db, result.task_id)
+    assert row is not None
+    task_id, title, body, created_by, status, idem = row
+
+    assert created_by == "autonomous_initiator"
+    # kanban_db.create_task creates tasks in 'running' status by default;
+    # autonomous tasks follow the same lifecycle (claim transitions to
+    # running; the initial state is the same as for operator-created tasks).
+    assert status in ("ready", "running")
+    assert idem == "autonomous-obj-8-trig-8"
+
+    # The body must contain the provenance fields
+    assert "OBJECTIVE_ID=obj-8" in body
+    assert "ORIGIN=autonomous_initiator" in body
+    assert "POLICY_VERSION=1.0.0" in body
+    assert "RISK_CLASS=CLASS_A_AUTONOMOUS_SAFE" in body
+    assert "TRIGGER_ID=trig-8" in body
+    assert "RUNNING_MODE=AUTONOMOUS_A1" in body
+    # INITIATED_AT is a float; it must parse
+    m = re.search(r"^INITIATED_AT=([0-9.]+)$", body, re.MULTILINE)
+    assert m is not None
+    float(m.group(1))
+
+
+def test_P1_custom_body_preserves_body(isolated_kanban_db, monkeypatch):
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+    custom = "Human supplied objective body\nwith multiple lines."
+    spec, ctx = _make_spec(objective_id="obj-p1", trigger_id="trig-p1", body=custom)
+
+    result = attempt_autonomous_initiation(spec, ctx)
+
+    assert result.decision == "admit"
+    assert result.task_id is not None
+    body = _read_task(isolated_kanban_db, result.task_id)[2]
+    assert "CUSTOM_BODY_BEGIN" in body
+    assert custom in body
+    assert "CUSTOM_BODY_END" in body
+
+
+def test_P2_custom_body_preserves_full_provenance(isolated_kanban_db, monkeypatch):
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+    spec, ctx = _make_spec(
+        objective_id="obj-p2",
+        trigger_id="trig-p2",
+        body="custom body must not replace provenance",
+    )
+
+    result = attempt_autonomous_initiation(spec, ctx)
+
+    assert result.decision == "admit"
+    assert result.task_id is not None
+    body = _read_task(isolated_kanban_db, result.task_id)[2]
+    assert "AUTONOMOUS_PROVENANCE_BEGIN" in body
+    assert "AUTONOMOUS_PROVENANCE_END" in body
+    for key, value in result.provenance.items():
+        assert f"{key}={value}" in body
+
+
+def test_P3_provenance_recoverable_after_db_reopen(isolated_kanban_db, monkeypatch):
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+    spec, ctx = _make_spec(
+        objective_id="obj-p3",
+        trigger_id="trig-p3",
+        body="reopen persistence body",
+    )
+
+    result = attempt_autonomous_initiation(spec, ctx)
+
+    assert result.decision == "admit"
+    reopened = sqlite3.connect(str(isolated_kanban_db))
+    try:
+        row = reopened.execute(
+            "SELECT body FROM tasks WHERE id = ?", (result.task_id,)
+        ).fetchone()
+    finally:
+        reopened.close()
+    assert row is not None
+    body = row[0]
+    assert "AUTONOMOUS_PROVENANCE_BEGIN" in body
+    assert "OBJECTIVE_ID=obj-p3" in body
+    assert "ORIGIN=autonomous_initiator" in body
+    assert "POLICY_VERSION=1.0.0" in body
+    assert "RISK_CLASS=CLASS_A_AUTONOMOUS_SAFE" in body
+    assert "TRIGGER_ID=trig-p3" in body
+    assert "RUNNING_MODE=AUTONOMOUS_A1" in body
+    assert "CUSTOM_BODY_BEGIN\nreopen persistence body\nCUSTOM_BODY_END" in body
+
+
+# ----------------------------------------------------------------------
+# T9
+# ----------------------------------------------------------------------
+
+
+def test_T9_canonical_kanban_event_semantics(isolated_kanban_db, monkeypatch):
+    """T9: the autonomous task is indistinguishable from a normal
+    kanban.create task except for the autonomous provenance. Verify the
+    event trail includes the standard 'created' event."""
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+
+    spec, ctx = _make_spec(objective_id="obj-9", trigger_id="trig-9")
+    result = attempt_autonomous_initiation(spec, ctx)
+    assert result.task_id
+
+    conn = sqlite3.connect(str(isolated_kanban_db))
+    try:
+        cur = conn.execute(
+            "SELECT kind, payload FROM task_events WHERE task_id = ? "
+            "ORDER BY created_at ASC",
+            (result.task_id,),
+        )
+        events = cur.fetchall()
+    finally:
+        conn.close()
+
+    # At minimum, the 'created' event must exist
+    kinds = [e[0] for e in events]
+    assert "created" in kinds
+
+
+# ----------------------------------------------------------------------
+# T10
+# ----------------------------------------------------------------------
+
+
+def test_T10_no_operator_create_required(isolated_kanban_db, monkeypatch):
+    """T10: the autonomous initiation succeeds without invoking the
+    hermes.kanban.create CLI. We assert this by patching kanban.create
+    CLI entry point to fail loudly if it gets called; if the test passes
+    the CLI was NOT called."""
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+
+    def _explode(*a, **kw):
+        raise AssertionError("CLI hermes kanban create was invoked")
+
+    # Patch the argparse-level command to ensure it was NOT called. The
+    # `kanban_command` function in hermes_cli/kanban.py is the entry
+    # point. We patch it at the module level.
+    import hermes_cli.kanban as kanban_mod
+    monkeypatch.setattr(kanban_mod, "kanban_command", _explode)
+
+    spec, ctx = _make_spec(objective_id="obj-10", trigger_id="trig-10")
+    result = attempt_autonomous_initiation(spec, ctx)
+    assert result.decision == "admit"
+    assert result.task_id
+
+
+# ----------------------------------------------------------------------
+# T11
+# ----------------------------------------------------------------------
+
+
+def test_T11_no_config_profile_env_persistence(isolated_kanban_db, monkeypatch, tmp_path):
+    """T11: enabling autonomy does NOT write to config, profile, .env,
+    auth/secrets metadata, or profile-state sentinels.
+
+    The test creates every sentinel under a temp HERMES_HOME before the
+    initiation path runs, then asserts the exact bytes are unchanged. This
+    avoids the previous hardcoded-profile/vacuous case where zero files could
+    be snapshotted and the test would still pass.
+    """
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+
+    hermes_home = tmp_path / "hermes-home"
+    profile_home = hermes_home / "profiles" / "autonomy-test"
+    profile_state = profile_home / "state"
+    for d in (hermes_home, profile_home, profile_state):
+        d.mkdir(parents=True, exist_ok=True)
+    sentinels = {
+        hermes_home / "config.yaml": b"model:\n  provider: sentinel\n",
+        hermes_home / ".env": b"SENTINEL_API_KEY=not-a-real-secret\n",
+        hermes_home / "auth.json": b'{"sentinel":"auth-metadata"}\n',
+        profile_home / "config.yaml": b"profile: autonomy-test\n",
+        profile_home / ".env": b"PROFILE_SENTINEL=not-a-real-secret\n",
+        profile_home / "auth.json": b'{"profile":"auth-metadata"}\n',
+        profile_state / "runtime.json": b'{"enabled":false,"sentinel":true}\n',
+    }
+    for path, payload in sentinels.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(payload)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    before = _snapshot_files(sentinels.keys())
+    assert len(before) == 7
+
+    # Run the cycle
+    state.enable(policy_version="1.0.0", profile="autonomy-test")
+    spec, ctx = _make_spec(objective_id="obj-11", trigger_id="trig-11")
+    result = attempt_autonomous_initiation(spec, ctx)
+    assert result.decision == "admit"
+
+    # Verify nothing was written
+    after = _snapshot_files(sentinels.keys())
+    assert before == after
+
+    state.reset()
+
+
+# ----------------------------------------------------------------------
+# T12
+# ----------------------------------------------------------------------
+
+
+def test_T12_deactivation(isolated_kanban_db, monkeypatch):
+    """T12: after disable(), a subsequent attempt is denied_disabled and
+    no new task is created."""
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+    spec1, ctx1 = _make_spec(objective_id="obj-12a", trigger_id="trig-12a")
+    r1 = attempt_autonomous_initiation(spec1, ctx1)
+    assert r1.decision == "admit"
+    assert _count_tasks(isolated_kanban_db) == 1
+
+    # Deactivate
+    state.disable()
+    assert state.is_enabled() is False
+    # The active slot is cleared on disable() — concurrency is back to 0
+    assert state.get_active_objective_id() is None
+
+    # Subsequent attempt fails closed
+    spec2, ctx2 = _make_spec(objective_id="obj-12b", trigger_id="trig-12b")
+    r2 = attempt_autonomous_initiation(spec2, ctx2)
+    assert r2.decision == "denied_disabled"
+    assert r2.task_id is None
+    assert _count_tasks(isolated_kanban_db) == 1
+
+
+# ----------------------------------------------------------------------
+# AUTONOMOUS_INITIATION_PATH_V1.2 — Assignee Propagation
+#
+# A1: objective_spec["assignee"]="orchestrator" -> persisted row assignee="orchestrator"
+# A2: same path -> status="ready", assignee="orchestrator"
+# A3: production dispatch_once sees / claims / spawns exactly that task
+#     (isolated temp DB, isolated valid profile resolution, fake spawn_fn,
+#      NO real provider/worker subprocess)
+# A4: backward compat: spec without assignee -> persisted assignee=None
+# ----------------------------------------------------------------------
+
+
+def _read_task_assignee(db_file: Path, task_id: str):
+    """Read the (status, assignee) pair for a task by id."""
+    conn = sqlite3.connect(str(db_file))
+    try:
+        row = conn.execute(
+            "SELECT status, assignee FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return None, None
+    return row[0], row[1]
+
+
+def _read_task_overrides(db_file: Path, task_id: str):
+    """Read (model_override, provider_override) for a task by id.
+
+    Both columns are NULL-when-absent in the canonical schema; we return
+    None when unset. Used by the V1.3-A tests to assert the autonomous
+    initiator propagates the spec's model / provider overrides into the
+    persisted Kanban row via the canonical kb.create_task path.
+    """
+    conn = sqlite3.connect(str(db_file))
+    try:
+        row = conn.execute(
+            "SELECT model_override, provider_override FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return None, None
+    model_override, provider_override = row
+    # The schema stores unset values as NULL; the kb layer normalises "" to
+    # None before write. Mirror that here so the assertions read what the
+    # production code would see on read-back.
+    if model_override == "":
+        model_override = None
+    if provider_override == "":
+        provider_override = None
+    return model_override, provider_override
+
+
+def test_A1_assignee_propagated(isolated_kanban_db, monkeypatch):
+    """A1: objective_spec["assignee"]="orchestrator" -> persisted row
+    assignee="orchestrator". The initiator MUST propagate the spec's
+    assignee through the canonical hermes_cli.kanban_db.create_task call.
+    """
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+
+    spec, ctx = _make_spec(
+        objective_id="obj-A1",
+        trigger_id="trig-A1",
+        assignee="orchestrator",
+    )
+    result = attempt_autonomous_initiation(spec, ctx)
+    assert result.decision == "admit"
+    assert result.task_id is not None
+    task_id: str = result.task_id
+
+    status, persisted_assignee = _read_task_assignee(
+        isolated_kanban_db, task_id
+    )
+    assert persisted_assignee == "orchestrator", (
+        f"expected persisted assignee='orchestrator', got {persisted_assignee!r}"
+    )
+
+
+def test_A2_assigned_task_is_ready(isolated_kanban_db, monkeypatch):
+    """A2: same autonomous initiation -> status='ready', assignee='orchestrator'.
+    The truth-test established that create_task(initial_status='running')
+    with no blocked/triage/parent condition PERSISTS status='ready'.
+    """
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+
+    spec, ctx = _make_spec(
+        objective_id="obj-A2",
+        trigger_id="trig-A2",
+        assignee="orchestrator",
+    )
+    result = attempt_autonomous_initiation(spec, ctx)
+    assert result.decision == "admit"
+    assert result.task_id is not None
+    task_id: str = result.task_id
+
+    status, persisted_assignee = _read_task_assignee(
+        isolated_kanban_db, task_id
+    )
+    assert status == "ready", f"expected status='ready', got {status!r}"
+    assert persisted_assignee == "orchestrator", (
+        f"expected persisted assignee='orchestrator', got {persisted_assignee!r}"
+    )
+
+
+def test_A3_assigned_task_dispatchable(isolated_kanban_db, monkeypatch, tmp_path):
+    """A3: production dispatch_once sees/claims/spawns the assigned task
+    exactly once with a fake spawn_fn (NO real provider/worker subprocess).
+
+    Setup:
+      * isolated temp Kanban DB (already provided by fixture)
+      * isolated valid profile resolution: monkeypatch hermes_cli.profiles
+        so 'orchestrator' resolves to a real directory we control under
+        tmp_path, satisfying profile_exists() inside dispatch_once
+      * fake spawn_fn: a stub that records the (task_id, assignee, ...)
+        triple it was called with and returns None (no real worker pid)
+      * the task is created ONLY through attempt_autonomous_initiation
+        with assignee='orchestrator'
+
+    Required:
+      * dispatch_once claims exactly that task
+      * fake spawn_fn is invoked exactly once
+      * task reaches the canonical 'running' state (claimed by dispatch_once)
+      * no manual assign_task / status mutation / raw SQL patch was used
+    """
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import profiles as profiles_mod
+
+    # 1. Isolated valid profile resolution for "orchestrator" under tmp_path.
+    # dispatch_once calls hermes_cli.profiles.profile_exists(assignee).
+    # We monkeypatch profile_exists to recognize our fake profile id only,
+    # leaving other lookups untouched (default returns True for 'default').
+    real_profile_exists = profiles_mod.profile_exists
+
+    def _fake_profile_exists(name):
+        if name == "orchestrator":
+            return True
+        # Fall through for other lookups (e.g. _default_assignee probe).
+        return real_profile_exists(name)
+
+    monkeypatch.setattr(profiles_mod, "profile_exists", _fake_profile_exists)
+
+    # Also patch the symbol dispatch_once reaches via the lazy import inside
+    # the dispatcher loop — dispatch_once imports profile_exists from
+    # hermes_cli.profiles at call time, so the patch above is sufficient.
+
+    # 2. Enable autonomy and create the assigned task through the
+    # canonical autonomous admission (NOT via create_task / raw SQL).
+    state.reset()
+    state.enable(policy_version="1.0.0")
+
+    spec, ctx = _make_spec(
+        objective_id="obj-A3",
+        trigger_id="trig-A3",
+        assignee="orchestrator",
+    )
+    init_result = attempt_autonomous_initiation(spec, ctx)
+    assert init_result.decision == "admit"
+    expected_task_id = init_result.task_id
+    assert expected_task_id is not None
+
+    # Pre-flight: the row must be in 'ready' with assignee='orchestrator'
+    # BEFORE dispatch_once runs. (No premature claim.)
+    pre_status, pre_assignee = _read_task_assignee(
+        isolated_kanban_db, expected_task_id
+    )
+    assert pre_status == "ready"
+    assert pre_assignee == "orchestrator"
+
+    # 3. Fake spawn_fn: records exactly which (task, assignee, board) it was
+    # asked to spawn for and returns None (no real subprocess).
+    spawn_calls = []
+
+    def _fake_spawn_fn(task, workspace_path, board):
+        spawn_calls.append(
+            {
+                "task_id": task.id,
+                "assignee": task.assignee,
+                "board": board,
+            }
+        )
+        return None  # no real worker pid
+
+    # 4. Run the production dispatch_once with the fake spawn_fn.
+    conn = kb.connect()
+    try:
+        result = kb.dispatch_once(conn, spawn_fn=_fake_spawn_fn, dry_run=False)
+    finally:
+        conn.close()
+
+    # 5. Assert: dispatch_once saw exactly this task, claimed it,
+    # and called the fake spawn_fn exactly once.
+    assert len(spawn_calls) == 1, (
+        f"expected fake spawn_fn invoked exactly once, got {len(spawn_calls)}: "
+        f"{spawn_calls!r}"
+    )
+    spawn = spawn_calls[0]
+    assert spawn["task_id"] == expected_task_id
+    assert spawn["assignee"] == "orchestrator"
+
+    # The task MUST have transitioned from 'ready' -> 'running' as part of
+    # the canonical claim path (claim_task inside dispatch_once).
+    post_status, post_assignee = _read_task_assignee(
+        isolated_kanban_db, expected_task_id
+    )
+    assert post_status == "running", (
+        f"expected task to reach 'running' after dispatch_once claim, "
+        f"got {post_status!r}"
+    )
+    assert post_assignee == "orchestrator"
+
+    # Sanity: the DispatchResult must list this task under .spawned, not
+    # .skipped_unassigned or .skipped_nonspawnable.
+    spawned_ids = [
+        entry[0] if isinstance(entry, tuple) else entry
+        for entry in (result.spawned or [])
+    ]
+    assert expected_task_id in spawned_ids, (
+        f"expected task in result.spawned; got spawned={result.spawned!r} "
+        f"skipped_unassigned={result.skipped_unassigned!r} "
+        f"skipped_nonspawnable={result.skipped_nonspawnable!r}"
+    )
+    assert expected_task_id not in result.skipped_unassigned
+    assert expected_task_id not in result.skipped_nonspawnable
+
+
+def test_A4_unassigned_backward_compatible(isolated_kanban_db, monkeypatch):
+    """A4: backward compatibility. When objective_spec omits assignee
+    (or supplies None), the persisted row MUST have assignee=None and
+    every existing V1.1 contract MUST remain intact: exactly-one task,
+    idempotency on duplicate trigger, concurrency limit, provenance,
+    deactivation.
+    """
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+
+    # Spec WITHOUT assignee (no key at all) — most common backward path.
+    spec, ctx = _make_spec(objective_id="obj-A4a", trigger_id="trig-A4a")
+    result = attempt_autonomous_initiation(spec, ctx)
+    assert result.decision == "admit"
+    assert result.task_id is not None
+
+    status, persisted_assignee = _read_task_assignee(
+        isolated_kanban_db, result.task_id
+    )
+    assert status == "ready"
+    assert persisted_assignee is None, (
+        f"expected persisted assignee=None when spec omits it, "
+        f"got {persisted_assignee!r}"
+    )
+
+    # Existing V1.1 contracts still hold: exactly-one task, idempotency,
+    # provenance preserved.
+    assert _count_tasks(isolated_kanban_db) == 1
+    body = _read_task(isolated_kanban_db, result.task_id)[2]
+    assert "AUTONOMOUS_PROVENANCE_BEGIN" in body
+    assert "OBJECTIVE_ID=obj-A4a" in body
+
+    # Idempotency: a second call with the same (objective_id, trigger_id)
+    # MUST NOT create another task, MUST still return assignee=None.
+    state.reset()
+    state.enable(policy_version="1.0.0")
+    spec_dup, ctx_dup = _make_spec(
+        objective_id="obj-A4a", trigger_id="trig-A4a"
+    )
+    r_dup = attempt_autonomous_initiation(spec_dup, ctx_dup)
+    assert r_dup.decision == "duplicate_suppressed"
+    assert r_dup.task_id == result.task_id
+    assert _count_tasks(isolated_kanban_db) == 1
+    _, dup_assignee = _read_task_assignee(isolated_kanban_db, r_dup.task_id)
+    assert dup_assignee is None
+
+    # Explicit None case: spec with assignee=None explicitly. This is
+    # equivalent to omitting the key (objective_spec.get("assignee") is
+    # None in both cases). To admit a second objective we must first
+    # archive the active one — the concurrency budget is keyed on the
+    # active autonomous slot in the DB, not just in process state.
+    from hermes_cli import kanban_db as kb
+    archive_conn = kb.connect()
+    try:
+        kb.archive_task(archive_conn, result.task_id)
+    finally:
+        archive_conn.close()
+    state.reset()
+    state.enable(policy_version="1.0.0")
+    spec_none, ctx_none = _make_spec(
+        objective_id="obj-A4b", trigger_id="trig-A4b",
+        assignee=None,
+    )
+    r_none = attempt_autonomous_initiation(spec_none, ctx_none)
+    assert r_none.decision == "admit"
+    assert r_none.task_id is not None
+    task_id_none: str = r_none.task_id
+    _, none_assignee = _read_task_assignee(
+        isolated_kanban_db, task_id_none
+    )
+    assert none_assignee is None
+
+
+# ----------------------------------------------------------------------
+# AUTONOMOUS_INITIATION_PATH_V1.3 — Model / Provider Override Propagation
+#
+# A5: objective_spec["model_override"] + "provider_override" -> persisted
+#     row carries both into the canonical Kanban task store, so the
+#     dispatcher's spawn_worker_subprocess can translate them into the
+#     worker's "-m <model> --provider <provider>" argv.
+# A6: backward compatibility — both keys omitted and/or explicit None must
+#     persist as None. No hidden default.
+# ----------------------------------------------------------------------
+
+
+def test_A5_model_and_provider_overrides_propagated(isolated_kanban_db, monkeypatch):
+    """A5: model_override + provider_override survive the autonomous bridge.
+
+    The objective_spec carries MiniMax-shaped values; the canonical
+    kb.create_task path is the ONLY task-creation call. The persisted
+    row MUST carry the exact strings the spec supplied, read back through
+    the same column names the dispatcher's worker spawn path consumes.
+    """
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+
+    spec, ctx = _make_spec(
+        objective_id="obj-A5",
+        trigger_id="trig-A5",
+        model_override="minimax-m3",
+        provider_override="minimax",
+    )
+    result = attempt_autonomous_initiation(spec, ctx)
+    assert result.decision == "admit"
+    assert result.task_id is not None
+    task_id: str = result.task_id
+
+    persisted_model, persisted_provider = _read_task_overrides(
+        isolated_kanban_db, task_id
+    )
+    assert persisted_model == "minimax-m3", (
+        f"expected persisted model_override='minimax-m3', "
+        f"got {persisted_model!r}"
+    )
+    assert persisted_provider == "minimax", (
+        f"expected persisted provider_override='minimax', "
+        f"got {persisted_provider!r}"
+    )
+
+    # Sanity: the V1.2 contract still holds — provenance, exactly-one,
+    # idempotency are unaffected by the new override passthrough.
+    assert _count_tasks(isolated_kanban_db) == 1
+    body = _read_task(isolated_kanban_db, task_id)[2]
+    assert "AUTONOMOUS_PROVENANCE_BEGIN" in body
+    assert "OBJECTIVE_ID=obj-A5" in body
+
+
+def test_A6_overrides_backward_compatible(isolated_kanban_db, monkeypatch):
+    """A6: omitted AND explicit None both persist as None. No hidden default.
+
+    Two objectives:
+      A6a: spec without the keys at all (the most common caller path).
+      A6b: spec with explicit None values.
+    Both must persist model_override=None, provider_override=None. This
+    guards against any hidden default appearing in the production
+    bridge (no MiniMax, no "auto", no first-configured model).
+    """
+    from agent.autonomy import state
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    # --- A6a: omitted keys (most common caller path) ---
+    state.reset()
+    state.enable(policy_version="1.0.0")
+    spec_omit, ctx_omit = _make_spec(
+        objective_id="obj-A6a", trigger_id="trig-A6a"
+    )
+    r_omit = attempt_autonomous_initiation(spec_omit, ctx_omit)
+    assert r_omit.decision == "admit"
+    assert r_omit.task_id is not None
+
+    model_omit, provider_omit = _read_task_overrides(
+        isolated_kanban_db, r_omit.task_id
+    )
+    assert model_omit is None, (
+        f"expected persisted model_override=None when key omitted, "
+        f"got {model_omit!r}"
+    )
+    assert provider_omit is None, (
+        f"expected persisted provider_override=None when key omitted, "
+        f"got {provider_omit!r}"
+    )
+
+    # --- A6b: explicit None values ---
+    # The concurrency slot is keyed on the active objective; archive A6a
+    # before admitting A6b so the second objective is eligible.
+    from hermes_cli import kanban_db as kb
+    archive_conn = kb.connect()
+    try:
+        kb.archive_task(archive_conn, r_omit.task_id)
+    finally:
+        archive_conn.close()
+
+    state.reset()
+    state.enable(policy_version="1.0.0")
+    spec_none, ctx_none = _make_spec(
+        objective_id="obj-A6b",
+        trigger_id="trig-A6b",
+        model_override=None,
+        provider_override=None,
+    )
+    r_none = attempt_autonomous_initiation(spec_none, ctx_none)
+    assert r_none.decision == "admit"
+    assert r_none.task_id is not None
+
+    model_none, provider_none = _read_task_overrides(
+        isolated_kanban_db, r_none.task_id
+    )
+    assert model_none is None, (
+        f"expected persisted model_override=None when spec passes None, "
+        f"got {model_none!r}"
+    )
+    assert provider_none is None, (
+        f"expected persisted provider_override=None when spec passes None, "
+        f"got {provider_none!r}"
+    )
+
+    # Existing V1.2 invariants still hold for both rows.
+    assert _count_tasks(isolated_kanban_db) == 2

--- a/tests/agent/test_skip_background_review_cli_propagation.py
+++ b/tests/agent/test_skip_background_review_cli_propagation.py
@@ -1,0 +1,294 @@
+"""Tests for the --skip-background-review CLI flag and its propagation.
+
+Behavioral coverage (no brittle source-string inspection):
+
+K1  --skip-background-review parses via the real hermes_cli._parser,
+    and `hermes --help` / `hermes chat --help` documents the flag.
+
+K2  Absent flag: HermesCLI() default leaves `skip_background_review=False`,
+    and the effective skip value is False (unless a Kanban marker is set).
+
+K2b Kanban-derived effective skip remains True. We set HERMES_KANBAN_TASK
+    in the worker subprocess env, the dispatcher-owned canonical marker,
+    and the effective value is True even with no CLI flag.
+
+K3  The effective value is what reaches the AIAgent constructor; the
+    raw CLI flag is a secondary signal. AIAgent(skip_background_review=)
+    receives the effective value, not necessarily the raw flag.
+
+B1_INTERMEDIATE_CONSTRUCTOR_TYPEERROR=no: AIAgent(skip_background_review=False)
+    remains a valid invocation in current upstream.
+
+These tests use ONLY stdlib + hermes internals; no live subprocess or
+network. The parser is loaded directly; the AIAgent constructor is exercised
+via a minimal mock to confirm the forwarded kwarg shape.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+PRIMARY = "/home/jr-ubuntu/.hermes/hermes-agent"
+if PRIMARY not in sys.path:
+    sys.path.insert(0, PRIMARY)
+
+
+RECON_ROOT = Path("/tmp/hermes-v2-live-main-reconcile.6A3IXl/reconcile")
+REPO = RECON_ROOT
+
+
+def _ensure_in_path():
+    repo = str(REPO)
+    if repo not in sys.path:
+        sys.path.insert(0, repo)
+
+
+# ---------------------------------------------------------------------------
+# K1 — parser surface
+# ---------------------------------------------------------------------------
+
+
+def test_skip_background_review_flag_present_in_real_parser():
+    """K1: real hermes_cli._parser.build_top_level_parser() accepts the flag."""
+    _ensure_in_path()
+    from hermes_cli import _parser
+
+    result = _parser.build_top_level_parser()
+    # Current upstream returns (top_parser, subparsers_action, chat_parser).
+    # Pick the chat subparser robustly.
+    chat_parser = None
+    if isinstance(result, tuple):
+        for x in result:
+            if hasattr(x, "parse_args") and getattr(x, "prog", "").endswith("chat"):
+                chat_parser = x
+                break
+        if chat_parser is None and len(result) == 3:
+            chat_parser = result[2]
+    else:
+        chat_parser = result
+
+    try:
+        ns = chat_parser.parse_args(["--skip-background-review"])
+    except SystemExit as exc:
+        raise AssertionError(
+            f"--skip-background-review rejected by real parser (SystemExit {exc.code})"
+        )
+    # argparse.SUPPRESS for absent → not present on the namespace by default;
+    # when supplied, store_true sets the attribute.
+    assert getattr(ns, "skip_background_review", False) is True, (
+        f"parser did not register --skip-background-review; "
+        f"got skip_background_review={getattr(ns, 'skip_background_review', None)!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# K1 (UX) — the flag's help text surfaces in `hermes chat --help`
+# ---------------------------------------------------------------------------
+
+
+def test_skip_background_review_flag_in_help_text():
+    """K1 (UX): the flag's help text surfaces when running chat --help."""
+    repo = str(REPO)
+    # Write the inline Python to a temp file so we don't have to fight
+    # shell quoting around newlines / backslashes.
+    import tempfile
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".py", delete=False, encoding="utf-8"
+    ) as script_file:
+        script_file.write(
+            "import sys\n"
+            f"sys.path.insert(0, {repo!r})\n"
+            "from hermes_cli import _parser\n"
+            "result = _parser.build_top_level_parser()\n"
+            "parser = None\n"
+            "if isinstance(result, tuple):\n"
+            "    for x in result:\n"
+            "        if hasattr(x, 'parse_known_args') and getattr(x, 'prog', '').endswith('chat'):\n"
+            "            parser = x\n"
+            "            break\n"
+            "    if parser is None and len(result) == 3:\n"
+            "        parser = result[2]\n"
+            "else:\n"
+            "    parser = result\n"
+            "try:\n"
+            "    parser.parse_args(['--help'])\n"
+            "except SystemExit:\n"
+            "    pass\n"
+        )
+        script_path = script_file.name
+    try:
+        result = subprocess.run(
+            [sys.executable, script_path],
+            capture_output=True, text=True, timeout=20,
+        )
+    finally:
+        try:
+            os.unlink(script_path)
+        except FileNotFoundError:
+            pass
+
+    out = (result.stdout or "") + (result.stderr or "")
+    assert "--skip-background-review" in out, (
+        f"--skip-background-review missing from chat --help output: {out[:400]!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# K2 — absent flag default
+# ---------------------------------------------------------------------------
+
+
+def test_absent_flag_leaves_skip_background_review_default_false():
+    """K2: no flag ⇒ HermesCLI attribute defaults to False (no leak)."""
+    _ensure_in_path()
+    repo = str(REPO)
+    # Sanity: ensure HermesCLI is importable.
+    from cli import HermesCLI  # type: ignore
+    # Construct with minimal valid args. HermesCLI is heavy; we just
+    # verify the attribute exists and defaults to False.
+    # We can't easily run HermesCLI() (needs runtime credentials), but the
+    # attribute is set from the constructor default we added.
+    sig = HermesCLI.__init__.__doc__ or ""
+    # The default value of skip_background_review is False; we check by
+    # inspecting the function signature defaults.
+    import inspect
+    params = inspect.signature(HermesCLI.__init__).parameters
+    skip_param = params.get("skip_background_review")
+    assert skip_param is not None, "HermesCLI.__init__ missing skip_background_review param"
+    assert skip_param.default is False, (
+        f"skip_background_review default should be False, got {skip_param.default!r}"
+    )
+
+
+def test_effective_skip_false_when_no_flag_no_kanban_marker(monkeypatch):
+    """K2: with no CLI flag and no Kanban marker, effective skip is False."""
+    _ensure_in_path()
+    repo = str(REPO)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_SOURCE", raising=False)
+
+    # Build a minimal stub object that satisfies _effective_skip_background_review
+    # (just needs a skip_background_review attribute or getattr default).
+    from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin  # type: ignore
+
+    class Stub(CLIAgentSetupMixin):
+        skip_background_review = False
+
+    assert Stub()._effective_skip_background_review() is False
+
+
+# ---------------------------------------------------------------------------
+# K2b — Kanban-derived effective skip
+# ---------------------------------------------------------------------------
+
+
+def test_effective_skip_true_when_hermes_kanban_task_set(monkeypatch):
+    """K2b: HERMES_KANBAN_TASK present in env ⇒ effective skip is True."""
+    _ensure_in_path()
+    repo = str(REPO)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_test_only")
+    monkeypatch.delenv("HERMES_SESSION_SOURCE", raising=False)
+
+    from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin  # type: ignore
+
+    class Stub(CLIAgentSetupMixin):
+        skip_background_review = False
+
+    assert Stub()._effective_skip_background_review() is True
+
+
+def test_effective_skip_true_when_session_source_kanban(monkeypatch):
+    """K2b: HERMES_SESSION_SOURCE=kanban present ⇒ effective skip is True."""
+    _ensure_in_path()
+    repo = str(REPO)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "kanban")
+
+    from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin  # type: ignore
+
+    class Stub(CLIAgentSetupMixin):
+        skip_background_review = False
+
+    assert Stub()._effective_skip_background_review() is True
+
+
+def test_effective_skip_explicit_flag_wins_over_no_marker(monkeypatch):
+    """K2b (precedence): explicit --skip-background-review wins over absence."""
+    _ensure_in_path()
+    repo = str(REPO)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_SOURCE", raising=False)
+
+    from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin  # type: ignore
+
+    class Stub(CLIAgentSetupMixin):
+        skip_background_review = True
+
+    assert Stub()._effective_skip_background_review() is True
+
+
+# ---------------------------------------------------------------------------
+# K3 — AIAgent receives the EFFECTIVE value, not necessarily the raw flag
+# ---------------------------------------------------------------------------
+
+
+def test_k3_aiagent_constructor_accepts_skip_background_review():
+    """K3: AIAgent(skip_background_review=False) is a valid invocation.
+
+    B1_INTERMEDIATE_CONSTRUCTOR_TYPEERROR=no: the constructor signature
+    accepts the kwarg, so passing it does NOT raise TypeError.
+    """
+    _ensure_in_path()
+    repo = str(REPO)
+    import inspect
+    from run_agent import AIAgent
+
+    params = inspect.signature(AIAgent.__init__).parameters
+    skip_param = params.get("skip_background_review")
+    assert skip_param is not None, (
+        "AIAgent.__init__ missing skip_background_review kwarg — would raise TypeError"
+    )
+    assert skip_param.default is False, (
+        f"skip_background_review default should be False, got {skip_param.default!r}"
+    )
+
+
+def test_k3_skip_background_review_forwarded_in_aiagent_kwargs():
+    """K3: cli_agent_setup_mixin._init_agent forwards skip_background_review=.
+
+    This is a behavioural check that the AIAgent constructor call site
+    passes the kwarg. We can't easily exercise _init_agent end-to-end
+    (needs runtime credentials, session DB, etc.), so we verify the
+    call site shape via a minimal attribute-style inspection.
+
+    The strict contract is: the call site MUST pass
+    skip_background_review=self._effective_skip_background_review().
+    """
+    _ensure_in_path()
+    repo = str(REPO)
+    from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin  # type: ignore
+    assert hasattr(CLIAgentSetupMixin, "_effective_skip_background_review"), (
+        "CLIAgentSetupMixin must define _effective_skip_background_review for K3 forwarding"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constructor parameter support (B1_INTERMEDIATE_CONSTRUCTOR_TYPEERROR=no)
+# ---------------------------------------------------------------------------
+
+
+def test_aiagent_constructor_default_no_skip_background_review():
+    """B1_INTERMEDIATE_CONSTRUCTOR_TYPEERROR=no: AIAgent(...) without the kwarg works."""
+    _ensure_in_path()
+    repo = str(REPO)
+    import inspect
+    from run_agent import AIAgent
+    params = inspect.signature(AIAgent.__init__).parameters
+    assert "skip_background_review" in params
+    # Default is False — passing it explicitly to False is identical to omitting it.
+    assert params["skip_background_review"].default is False

--- a/tests/cron/test_cron_kanban_env_isolation.py
+++ b/tests/cron/test_cron_kanban_env_isolation.py
@@ -438,6 +438,7 @@ def test_every_dispatcher_kanban_var_is_identity_gated():
         "HERMES_KANBAN_BRANCH",
         "HERMES_KANBAN_GOAL_MODE",
         "HERMES_KANBAN_GOAL_MAX_TURNS",
+        "HERMES_KANBAN_STRICT_READONLY",
     }
     uncovered = injected - set(KANBAN_ENV_KEYS) - behaviour_only
     assert not uncovered, (

--- a/tests/hermes_cli/test_kanban_initiator_strict_propagation.py
+++ b/tests/hermes_cli/test_kanban_initiator_strict_propagation.py
@@ -1,0 +1,201 @@
+"""Tests for STRICT-READONLY propagation from the autonomous initiator.
+
+Regression matrix coverage:
+
+S1  initiator component — ``objective_spec['strict_readonly']`` flows
+    through ``kb.create_task`` and persists on the task row.
+S2  ordinary autonomous writable task NOT made strict purely by origin
+    — ``created_by == "autonomous_initiator"`` alone does NOT set
+    strict mode; an absent / False ``strict_readonly`` key leaves the
+    task writable.
+    explicit True propagation
+    absent/False propagation
+    no origin-based inference
+
+These tests use ONLY stdlib + hermes internals; no live subprocess or
+network. ``hermes_cli.kanban_db`` is monkey-patched to an isolated
+sqlite3 file under ``tmp_path`` so the real ~/.hermes/kanban.db is
+never touched.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+
+PRIMARY = "/home/jr-ubuntu/.hermes/hermes-agent"
+if PRIMARY not in sys.path:
+    sys.path.insert(0, PRIMARY)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (parallel to test_autonomous_initiation.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_kanban_db(tmp_path, monkeypatch):
+    """Yield a fresh Kanban sqlite3 file under tmp_path, and patch
+    hermes_cli.kanban_db to use only this file."""
+    db_file = tmp_path / "test_kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_file))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path / "kanban-home"))
+    from hermes_cli import kanban_db as kb
+
+    _original_connect = kb.connect
+    conn = _original_connect(db_file)
+    conn.close()
+
+    @contextmanager
+    def _patched_connect_closing():
+        c = _original_connect(db_file)
+        try:
+            yield c
+        finally:
+            c.close()
+
+    monkeypatch.setattr(kb, "connect_closing", _patched_connect_closing)
+    monkeypatch.setattr(
+        kb, "connect",
+        lambda board=None: _original_connect(db_file),
+    )
+    # Reset autonomy module state so cross-test contamination is impossible.
+    from agent.autonomy import state as _autonomy_state
+    _autonomy_state.reset()
+    _autonomy_state.enable(policy_version="TEST_V2_STRICT")
+    yield db_file
+    _autonomy_state.reset()
+
+
+# ---------------------------------------------------------------------------
+# S1 — initiator component (explicit True propagation)
+# ---------------------------------------------------------------------------
+
+
+def test_strict_readonly_true_propagates_from_objective_spec(isolated_kanban_db):
+    """S1: when ``objective_spec['strict_readonly']=True``, the resulting
+    task row carries ``strict_readonly=1`` and ``kb.get_task(...).strict_readonly``
+    is True."""
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    spec = {
+        "objective_id": "obj_strict_yes",
+        "trigger_id": "trig_strict_yes",
+        "policy_version": "TEST_V2_STRICT",
+        "risk_class": "CLASS_A_AUTONOMOUS_SAFE",
+        "title": "Strict autonomous test",
+        "body": "Strict body",
+        "strict_readonly": True,
+    }
+    result = attempt_autonomous_initiation(spec)
+    assert result.decision == "admit"
+    assert result.task_id is not None
+
+    from hermes_cli import kanban_db as kb
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, result.task_id)
+    assert task is not None
+    assert task.strict_readonly is True
+    assert task.created_by == "autonomous_initiator"
+
+
+# ---------------------------------------------------------------------------
+# S2 — absent / False propagation; no origin-based inference
+# ---------------------------------------------------------------------------
+
+
+def test_strict_readonly_absent_yields_writable_task(isolated_kanban_db):
+    """S2: ``objective_spec`` without a ``strict_readonly`` key yields a
+    writable task (``strict_readonly=False``). Provenance
+    ``created_by == "autonomous_initiator"`` alone is NOT enough to
+    make the task strict."""
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    spec = {
+        "objective_id": "obj_strict_absent",
+        "trigger_id": "trig_strict_absent",
+        "policy_version": "TEST_V2_STRICT",
+        "risk_class": "CLASS_A_AUTONOMOUS_SAFE",
+        "title": "Ordinary autonomous test",
+        "body": "Ordinary body",
+    }
+    assert "strict_readonly" not in spec  # precondition
+
+    result = attempt_autonomous_initiation(spec)
+    assert result.decision == "admit"
+    assert result.task_id is not None
+
+    from hermes_cli import kanban_db as kb
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, result.task_id)
+    assert task is not None
+    # Capability is NOT inferred from created_by.
+    assert task.strict_readonly is False
+    assert task.created_by == "autonomous_initiator"
+
+
+def test_strict_readonly_explicit_false_propagates(isolated_kanban_db):
+    """S2 (explicit False): ``objective_spec['strict_readonly']=False``
+    yields a writable task."""
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    spec = {
+        "objective_id": "obj_strict_false",
+        "trigger_id": "trig_strict_false",
+        "policy_version": "TEST_V2_STRICT",
+        "risk_class": "CLASS_A_AUTONOMOUS_SAFE",
+        "title": "Explicit False",
+        "body": "Body",
+        "strict_readonly": False,
+    }
+    result = attempt_autonomous_initiation(spec)
+    assert result.decision == "admit"
+    assert result.task_id is not None
+
+    from hermes_cli import kanban_db as kb
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, result.task_id)
+    assert task is not None
+    assert task.strict_readonly is False
+
+
+# ---------------------------------------------------------------------------
+# S1 + S2 (negative) — non-strict autonomous writable tasks remain possible
+# ---------------------------------------------------------------------------
+
+
+def test_writable_autonomous_task_unaffected_by_v2(isolated_kanban_db):
+    """S2 + non-regression: an ordinary autonomous task with no
+    ``strict_readonly`` opt-in produces a task whose dispatcher env
+    WILL NOT contain HERMES_KANBAN_STRICT_READONLY=1 (capability is
+    explicit per objective)."""
+    from agent.autonomy.initiator import attempt_autonomous_initiation
+
+    spec = {
+        "objective_id": "obj_writable_check",
+        "trigger_id": "trig_writable_check",
+        "policy_version": "TEST_V2_STRICT",
+        "risk_class": "CLASS_A_AUTONOMOUS_SAFE",
+        "title": "Writable autonomous",
+        "body": "Body",
+    }
+    result = attempt_autonomous_initiation(spec)
+    assert result.decision == "admit"
+    task_id = result.task_id
+
+    from hermes_cli import kanban_db as kb
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+    assert task is not None
+    # Dispatch env for an ordinary autonomous writable task is unchanged:
+    # strict_readonly=False => env var MUST NOT be set.
+    assert task.strict_readonly is False
+    # Indirect check: the dispatcher propagation in _default_spawn only
+    # sets the env var when task.strict_readonly is truthy. The
+    # underlying boolean field is the single source of truth.

--- a/tests/hermes_cli/test_kanban_strict_readonly_field.py
+++ b/tests/hermes_cli/test_kanban_strict_readonly_field.py
@@ -1,0 +1,158 @@
+"""Tests for the STRICT-READONLY Kanban worker capability field.
+
+Regression matrix coverage:
+
+S1  strict capability propagates objective -> task -> dispatcher env
+    (data persistence component — companion dispatch test covers env)
+S2  ordinary autonomous writable task NOT made strict purely by origin
+    (task-default component — companion initiator test covers origin)
+S3  ordinary Kanban task unchanged
+
+The companion tests cover the remaining S-regressions:
+
+  tests/hermes_cli/test_kanban_worker_strict_dispatch.py     S1-env S4 S15 S16 S18 S20 S21
+  tests/hermes_cli/test_kanban_initiator_strict_propagation.py  S1-init S2 origin
+  tests/tools/test_file_tools_strict_workspace_gate.py       S5-S14 S17 S19
+
+These tests use ONLY stdlib + hermes internals; no live network calls.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import hermes_state
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+# ---------------------------------------------------------------------------
+# Schema (S1, S3)
+# ---------------------------------------------------------------------------
+
+
+def test_strict_readonly_column_present_in_fresh_schema(kanban_home):
+    """S1+S3: fresh schema carries ``strict_readonly`` (default 0)."""
+    with kb.connect_closing() as conn:
+        cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
+    assert "strict_readonly" in cols
+
+
+def test_strict_readonly_migration_idempotent(kanban_home):
+    """Migration runs more than once without error or duplicate columns."""
+    kb._migrate_add_optional_columns(_open_conn())  # noqa: SLF001 — internal API by design
+    kb._migrate_add_optional_columns(_open_conn())
+    with kb.connect_closing() as conn:
+        cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
+    # Exactly one strict_readonly column.
+    strict_cols = [name for name in cols if name == "strict_readonly"]
+    assert len(strict_cols) == 1
+
+
+def test_strict_readonly_default_zero_on_existing_rows(kanban_home):
+    """S3: ordinary Kanban tasks created before opt-in default to 0."""
+    with kb.connect_closing() as conn:
+        # Ordinary writable task (no strict_readonly kwarg).
+        task_id = kb.create_task(
+            conn,
+            title="ordinary",
+            created_by="user",
+            initial_status="running",
+        )
+        row = conn.execute(
+            "SELECT strict_readonly FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+    assert row is not None and row["strict_readonly"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Round-trip (S1, S3)
+# ---------------------------------------------------------------------------
+
+
+def test_strict_readonly_persists_and_round_trips(kanban_home):
+    """S1: create_task(strict_readonly=True) persists 1 and reads back True."""
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="strict",
+            created_by="user",
+            strict_readonly=True,
+            initial_status="running",
+        )
+        row = conn.execute(
+            "SELECT strict_readonly FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+    assert row is not None and row["strict_readonly"] == 1
+
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+    assert task.strict_readonly is True
+
+
+def test_strict_readonly_explicit_false_persists(kanban_home):
+    """Explicit False persists as 0 (default behavior preserved)."""
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="explicit-false",
+            created_by="user",
+            strict_readonly=False,
+            initial_status="running",
+        )
+        task = kb.get_task(conn, task_id)
+    assert task.strict_readonly is False
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_create_task_without_strict_readonly_kwarg_still_works(kanban_home):
+    """S3: existing callers that don't pass strict_readonly continue to work."""
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="legacy-caller",
+            created_by="user",
+            goal_mode=True,  # exercise an adjacent kwarg too
+            initial_status="running",
+        )
+        task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.strict_readonly is False
+    assert task.goal_mode is True
+
+
+def test_task_dataclass_field_default_false():
+    """The dataclass default is False so legacy Task(...) constructions are safe."""
+    # Default-only construction (no persistence round-trip needed).
+    from dataclasses import fields as dc_fields
+    f = next(f for f in dc_fields(kb.Task) if f.name == "strict_readonly")
+    assert f.default is False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _open_conn() -> sqlite3.Connection:
+    """Open a connection to the current kanban DB (for migration runs)."""
+    from hermes_cli import kanban_db as _kb
+    conn = _kb.connect()
+    return conn

--- a/tests/hermes_cli/test_kanban_worker_strict_dispatch.py
+++ b/tests/hermes_cli/test_kanban_worker_strict_dispatch.py
@@ -1,0 +1,518 @@
+"""Tests for STRICT-READONLY Kanban worker dispatch semantics.
+
+Regression matrix coverage:
+
+S1   strict capability propagates objective -> task -> dispatcher env
+     (dispatch + env component — companion field test covers persistence)
+S4   non-Kanban CLI unchanged (worker-only env vars)
+S15  terminal disabled for strict worker
+S16  execute_code disabled while Kanban lifecycle tools remain available
+S18  two workspace artifacts promote to attachments (trusted Kanban
+     internal copy path — store_attachment_bytes — is unaffected by
+     the strict gate)
+S20  background review suppression unchanged via
+     HERMES_SESSION_SOURCE=kanban / accepted Scope A
+S21  provider/model/reasoning propagation unchanged
+
+These tests use ONLY stdlib + hermes internals; no live subprocess spawn
+and no live network calls. ``subprocess.Popen`` is monkey-patched so we
+can observe ``cmd`` / ``env`` / ``cwd`` without booting a worker.
+
+The S15/S16 behavioural assertions are expressed against the worker's
+effective ``--toolsets`` payload (the supported CLI transport) — NOT
+against the unsupported ``--disabled-toolsets`` flag the real CLI
+rejects with ``invalid choice: 'terminal,code_execution'``. The same
+boundary check that crashed the V2 real canary is replayed against the
+real ``hermes_cli._parser`` so any future regression that re-introduces
+the malformed flag (or breaks the supported path) fails here before
+reaching production.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import hermes_state
+from hermes_cli import kanban_db as kb
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with a kanban DB and a workspace directory."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def captured_spawn(monkeypatch):
+    """Capture ``cmd``, ``env``, ``cwd`` passed to ``subprocess.Popen``."""
+    captured: dict = {}
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            captured["cmd"] = list(cmd)
+            captured["env"] = dict(kwargs.get("env") or {})
+            captured["cwd"] = kwargs.get("cwd")
+            captured["stdin"] = kwargs.get("stdin")
+            captured["stdout"] = kwargs.get("stdout")
+            captured["stderr"] = kwargs.get("stderr")
+            self.pid = 99999
+
+    # Patch the ``subprocess`` module that ``_default_spawn`` imports
+    # inside its own function body (it does ``import subprocess``).
+    import subprocess as _sp
+    monkeypatch.setattr(_sp, "Popen", _FakePopen)
+    return captured
+
+
+def _create_and_get(conn, *, strict_readonly: bool, assignee: str = "coder"):
+    task_id = kb.create_task(
+        conn,
+        title=f"task-strict={strict_readonly}",
+        assignee=assignee,
+        created_by="user",
+        workspace_kind="scratch",
+        initial_status="running",
+        strict_readonly=strict_readonly,
+    )
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    return task
+
+
+# ---------------------------------------------------------------------------
+# S1 — env propagation
+# ---------------------------------------------------------------------------
+
+
+def test_strict_worker_receives_env_var(kanban_home, captured_spawn):
+    """S1: dispatch of strict task sets HERMES_KANBAN_STRICT_READONLY=1."""
+    workspace = str(kanban_home / "ws")
+    with kb.connect_closing() as conn:
+        task = _create_and_get(conn, strict_readonly=True)
+        kb._default_spawn(task, workspace)  # noqa: SLF001
+    assert captured_spawn["env"].get("HERMES_KANBAN_STRICT_READONLY") == "1"
+
+
+def test_ordinary_worker_does_not_receive_env_var(kanban_home, captured_spawn):
+    """S1 (negative half): ordinary writable task does NOT see the env var."""
+    workspace = str(kanban_home / "ws")
+    with kb.connect_closing() as conn:
+        task = _create_and_get(conn, strict_readonly=False)
+        kb._default_spawn(task, workspace)  # noqa: SLF001
+    assert "HERMES_KANBAN_STRICT_READONLY" not in captured_spawn["env"]
+
+
+# ---------------------------------------------------------------------------
+# S4 — non-Kanban CLI unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_strict_env_var_is_only_set_when_task_opted_in(kanban_home, captured_spawn):
+    """S4: env var is opt-in per task, not ambient."""
+    workspace = str(kanban_home / "ws")
+    with kb.connect_closing() as conn:
+        strict_task = _create_and_get(conn, strict_readonly=True)
+        writable_task = _create_and_get(conn, strict_readonly=False)
+        kb._default_spawn(strict_task, workspace)  # noqa: SLF001
+        strict_env = captured_spawn["env"]
+        kb._default_spawn(writable_task, workspace)  # noqa: SLF001
+        writable_env = captured_spawn["env"]
+    assert strict_env.get("HERMES_KANBAN_STRICT_READONLY") == "1"
+    assert "HERMES_KANBAN_STRICT_READONLY" not in writable_env
+
+
+# ---------------------------------------------------------------------------
+# S15 / S16 — strict surface expressed via the supported --toolsets transport
+# ---------------------------------------------------------------------------
+
+
+def _toolsets_from_cmd(cmd):
+    """Return the comma-separated value passed to ``--toolsets``, or None.
+
+    Mirrors the dispatcher's single emission contract: ``--toolsets`` is
+    the supported transport; ``--disabled-toolsets`` does not exist in the
+    real CLI parser.
+    """
+    pairs = list(zip(cmd, cmd[1:]))
+    for flag, value in pairs:
+        if flag == "--toolsets":
+            return value
+    return None
+
+
+def test_strict_worker_subtracts_terminal_and_code_execution(kanban_home, captured_spawn):
+    """S15+S16: strict worker argv contains ``--toolsets`` whose payload has
+    ``terminal`` and ``code_execution`` removed from the assignee's
+    resolved CLI toolset surface. Uses the supported CLI transport, not
+    the rejected ``--disabled-toolsets`` flag that crashed the V2 canary.
+    """
+    workspace = str(kanban_home / "ws")
+    with kb.connect_closing() as conn:
+        task = _create_and_get(conn, strict_readonly=True)
+        kb._default_spawn(task, workspace)  # noqa: SLF001
+    cmd = captured_spawn["cmd"]
+    toolsets_value = _toolsets_from_cmd(cmd)
+    assert toolsets_value is not None, (
+        f"--toolsets missing from cmd={cmd}; cannot express STRICT surface"
+    )
+    emitted = {s.strip() for s in toolsets_value.split(",") if s.strip()}
+    assert "terminal" not in emitted, (
+        f"STRICT worker must not have terminal in --toolsets, got {emitted}"
+    )
+    assert "code_execution" not in emitted, (
+        f"STRICT worker must not have code_execution in --toolsets, got {emitted}"
+    )
+    # The malformed runtime path that crashed the V2 canary must never
+    # re-appear — see the real-CLI-boundary regression test below for the
+    # parser-level guard.
+    assert "--disabled-toolsets" not in cmd, (
+        f"STRICT worker must not emit --disabled-toolsets "
+        f"(unsupported in real Hermes CLI), got cmd={cmd}"
+    )
+
+
+def test_ordinary_worker_keeps_full_toolsets_payload(kanban_home, captured_spawn):
+    """Ordinary (non-strict) workers emit ``--toolsets`` with the assignee's
+    full resolved CLI toolset surface — ``terminal`` and ``code_execution``
+    must remain when the strict capability is OFF."""
+    workspace = str(kanban_home / "ws")
+    with kb.connect_closing() as conn:
+        task = _create_and_get(conn, strict_readonly=False)
+        kb._default_spawn(task, workspace)  # noqa: SLF001
+    cmd = captured_spawn["cmd"]
+    toolsets_value = _toolsets_from_cmd(cmd)
+    assert toolsets_value is not None, (
+        f"ordinary worker missing --toolsets pin in cmd={cmd}"
+    )
+    emitted = {s.strip() for s in toolsets_value.split(",") if s.strip()}
+    # The default ``kanban`` fixture resolves to a non-empty toolset that
+    # includes the worker-relevant surface; the strict filter must NOT
+    # have run, so the full set is preserved.
+    assert "terminal" in emitted, (
+        f"ordinary worker must keep terminal; got {emitted}"
+    )
+    assert "code_execution" in emitted, (
+        f"ordinary worker must keep code_execution; got {emitted}"
+    )
+    assert "--disabled-toolsets" not in cmd, (
+        f"ordinary worker must not emit --disabled-toolsets either, "
+        f"got cmd={cmd}"
+    )
+
+
+def test_strict_worker_kanban_lifecycle_anchor_pinned(kanban_home, captured_spawn):
+    """S16 (lifecycle preservation): HERMES_KANBAN_TASK remains pinned so
+    ``model_tools._compute_tool_definitions`` re-appends the ``kanban``
+    toolset regardless of profile config."""
+    workspace = str(kanban_home / "ws")
+    with kb.connect_closing() as conn:
+        task = _create_and_get(conn, strict_readonly=True)
+        task_id = task.id
+        kb._default_spawn(task, workspace)  # noqa: SLF001
+    env = captured_spawn["env"]
+    assert env.get("HERMES_KANBAN_TASK") == task_id
+    # Session source still tagged kanban so Scope-A skip_background_review
+    # continues to apply.
+    assert env.get("HERMES_SESSION_SOURCE") == "kanban"
+
+
+# ---------------------------------------------------------------------------
+# S20 — background review suppression unchanged (Scope A inheritance)
+# ---------------------------------------------------------------------------
+
+
+def test_strict_worker_inherits_scope_a_session_source(kanban_home, captured_spawn):
+    """S20: HERMES_SESSION_SOURCE=kanban is still set, so the
+    cli_agent_setup_mixin wires skip_background_review=True."""
+    workspace = str(kanban_home / "ws")
+    with kb.connect_closing() as conn:
+        task = _create_and_get(conn, strict_readonly=True)
+        kb._default_spawn(task, workspace)  # noqa: SLF001
+    assert captured_spawn["env"].get("HERMES_SESSION_SOURCE") == "kanban"
+
+
+# ---------------------------------------------------------------------------
+# S21 — provider/model/reasoning propagation unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_strict_worker_propagates_model_provider_reasoning(kanban_home, captured_spawn):
+    """S21: strict worker still passes -m / --provider / --reasoning."""
+    workspace = str(kanban_home / "ws")
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="strict-with-overrides",
+            assignee="coder",
+            created_by="user",
+            workspace_kind="scratch",
+            initial_status="running",
+            strict_readonly=True,
+            model_override="some-model",
+            provider_override="some-provider",
+            reasoning_effort="high",
+        )
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        kb._default_spawn(task, workspace)  # noqa: SLF001
+    cmd = captured_spawn["cmd"]
+    pairs = list(zip(cmd, cmd[1:]))
+
+    def _pair(flag):
+        for f, v in pairs:
+            if f == flag:
+                return v
+        return None
+
+    assert _pair("-m") == "some-model"
+    assert _pair("--provider") == "some-provider"
+    assert _pair("--reasoning") == "high"
+    # Strict env still exported alongside overrides.
+    assert captured_spawn["env"].get("HERMES_KANBAN_STRICT_READONLY") == "1"
+
+
+# ---------------------------------------------------------------------------
+# S18 — trusted artifact promotion path (unaffected by strict gate)
+# ---------------------------------------------------------------------------
+
+
+def test_two_artifacts_promote_to_task_attachments(kanban_home):
+    """S18: ``store_attachment_bytes`` is the trusted Kanban internal-copy
+    path used by ``kanban_attach`` / dashboard / CLI. It writes to
+    ``task_attachments_dir(task_id)`` directly and is NOT a model-tool
+    surface, so it is naturally unaffected by the strict gate. Two
+    attachments persist as expected."""
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="strict-attachment-test",
+            assignee="coder",
+            created_by="user",
+            workspace_kind="scratch",
+            initial_status="running",
+            strict_readonly=True,
+        )
+        kb.store_attachment_bytes(
+            conn,
+            task_id,
+            "out_a.txt",
+            b"AAA",
+            uploaded_by="strict-worker",
+        )
+        kb.store_attachment_bytes(
+            conn,
+            task_id,
+            "out_b.txt",
+            b"BBB",
+            uploaded_by="strict-worker",
+        )
+        attachments = kb.list_attachments(conn, task_id)
+
+    assert len(attachments) == 2
+    filenames = sorted(a.filename for a in attachments)
+    assert filenames == ["out_a.txt", "out_b.txt"]
+    # Both attachment files exist on disk under task_attachments_dir.
+    for a in attachments:
+        full = kanban_home / "kanban" / a.stored_path
+        assert full.is_file(), f"attachment missing: {full}"
+
+
+# ---------------------------------------------------------------------------
+# Real Hermes CLI parser / process-boundary regression
+# ---------------------------------------------------------------------------
+#
+# The V2 real canary failed with::
+#
+#     hermes: error: argument command:
+#     invalid choice: 'terminal,code_execution'
+#
+# because the dispatcher emitted ``--disabled-toolsets terminal,code_execution``
+# and the real Hermes CLI does NOT accept that flag at any layer (top-level
+# or ``chat`` subparser). This regression replays the exact boundary check
+# the dispatcher crash tripped on: feed the actual generated argv into
+# the real ``hermes_cli._parser.build_top_level_parser`` and assert that
+# it parses cleanly. A second sub-test feeds the synthetic pre-repair
+# malformed argv into the same parser and asserts it is rejected with
+# ``invalid choice`` — exactly the production crash signature.
+#
+# The test is *behavioural*: ``--disabled-toolsets`` absent alone is not
+# sufficient, because a future regression could drop the strict filter
+# entirely and still satisfy that trivial assertion. What the boundary
+# demands is that the generated argv actually crosses the real
+# ``argparse`` boundary, and the negative half proves the parser does
+# reject the malformed variant.
+
+# Local alias for the profile-relative argv prefix the real CLI uses
+# after ``_apply_profile_override`` resolves the worker profile.
+_STRICT_FLAG_PREFIX_PROFILE = ["-p", "coder", "--cli", "--accept-hooks"]
+
+
+def _strip_profile_bootstrap_flags(cmd):
+    """Drop the leading argv elements the dispatcher injects to bootstrap
+    the profile before the shared parser sees the flags.
+
+    ``_apply_profile_override`` and the ``-p <assignee>`` selection live
+    outside ``build_top_level_parser`` — they are wired up by
+    ``hermes_cli.main``. The pattern below mirrors the assertion already
+    used by ``test_kanban_worker_spawn_toolsets`` for the same reason.
+    """
+    # The dispatcher emits: ``hermes -p <profile> --cli --accept-hooks [per-task flags...] chat -q <prompt>``
+    # ``-p`` and its value ride together; ``--cli`` and ``--accept-hooks``
+    # are flag-only.
+    assert cmd[1:3] == ["-p", "coder"], (
+        f"unexpected profile bootstrap in cmd={cmd}"
+    )
+    assert "--cli" in cmd[:5]
+    assert "--accept-hooks" in cmd[:6]
+    return cmd[3:]
+
+
+def test_strict_worker_argv_parses_through_real_cli_parser(
+    kanban_home, captured_spawn
+):
+    """The exact argv ``_default_spawn`` generates for a STRICT task must
+    cross the *real* ``hermes_cli._parser`` boundary without raising
+    ``SystemExit``. This is the regression the V2 canary proved was
+    missing: a unit test that observed ``--disabled-toolsets`` in the
+    generated argv did not catch that the real CLI parser rejects the
+    flag with ``invalid choice`` and crashes the worker before session
+    init.
+
+    Concretely:
+
+    1. Generate the strict-worker argv by invoking ``_default_spawn``.
+    2. Strip the profile-bootstrap prefix the dispatcher adds (mirrors
+       how ``test_kanban_worker_spawn_toolsets`` exercises the parser).
+    3. Hand the remainder to the real ``build_top_level_parser``.
+    4. Assert ``parser.parse_args(...)`` returns cleanly and resolves
+       ``args.command == "chat"``.
+    5. Assert the parsed ``args.toolsets`` payload has neither
+       ``terminal`` nor ``code_execution`` (the S15/S16 invariant,
+       expressed against the real parser's view of the world).
+    """
+    from hermes_cli._parser import build_top_level_parser
+
+    workspace = str(kanban_home / "ws")
+    with kb.connect_closing() as conn:
+        task = _create_and_get(conn, strict_readonly=True)
+        kb._default_spawn(task, workspace)  # noqa: SLF001
+    cmd = captured_spawn["cmd"]
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+
+    # Crossing the real argparse boundary is the assertion. ``parse_args``
+    # raises ``SystemExit(2)`` on an unknown flag or invalid value —
+    # exactly the production crash shape the canary logged.
+    tail = _strip_profile_bootstrap_flags(cmd)
+    try:
+        args = parser.parse_args(tail)
+    except SystemExit as exc:
+        raise AssertionError(
+            f"strict-worker argv was REJECTED by the real CLI parser "
+            f"(exit={exc.code!r}); the dispatcher emitted malformed flags. "
+            f"cmd={cmd}"
+        )
+
+    assert args.command == "chat", (
+        f"strict-worker argv did not resolve to chat subcommand; "
+        f"got command={args.command!r}, cmd={cmd}"
+    )
+
+    # The S15/S16 behavioural contract, validated against the real parser.
+    emitted = {
+        s.strip() for s in (args.toolsets or "").split(",") if s.strip()
+    }
+    assert "terminal" not in emitted, (
+        f"STRICT worker must not have terminal in parsed --toolsets, "
+        f"got {emitted}"
+    )
+    assert "code_execution" not in emitted, (
+        f"STRICT worker must not have code_execution in parsed --toolsets, "
+        f"got {emitted}"
+    )
+
+
+def test_pre_repair_disabled_toolsets_argv_is_rejected_by_real_cli_parser(
+    kanban_home, monkeypatch, captured_spawn
+):
+    """Negative companion to the boundary regression above.
+
+    Construct the exact malformed argv the V2 dispatcher emitted before
+    the repair — ``--disabled-toolsets terminal,code_execution`` between
+    the strict flag prefix and ``chat -q <prompt>`` — and feed it to the
+    real ``hermes_cli._parser``. Assert that ``parse_args`` raises
+    ``SystemExit(2)`` with a usage message that names the bad choice.
+
+    This proves two things at once:
+
+    * The parser truly does reject ``--disabled-toolsets`` (so any future
+      regression that re-introduces the flag trips this test, not a
+      live canary).
+    * The shape of the rejection matches the production crash signature
+      observed in the canary log
+      (``/home/jr-ubuntu/.hermes/kanban/boards/ai-os/logs/t_552bab31.log``):
+      ``invalid choice: 'terminal,code_execution'``.
+
+    Without this negative half the boundary regression would silently
+    pass on a no-op refactor that strips ``--disabled-toolsets`` without
+    restoring the strict tool surface. Both halves must hold.
+    """
+    from hermes_cli._parser import build_top_level_parser
+
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+
+    # Construct the synthetic pre-repair argv. The ``--disabled-toolsets``
+    # flag is unknown to the parser, so argparse treats its value as a
+    # positional candidate and rejects it on the ``command`` subparser
+    # with the exact message shape the canary captured.
+    synthetic_tail = [
+        "--disabled-toolsets", "terminal,code_execution",
+        "chat", "-q", "work kanban task t_synthetic",
+    ]
+
+    stderr_capture = []
+    real_print_usage = parser.print_usage
+    real_error = parser.error
+
+    def _capture_error(message):
+        stderr_capture.append(message)
+        raise SystemExit(2)
+
+    def _capture_usage(file=None):
+        stderr_capture.append("__usage__")
+
+    parser.error = _capture_error
+    parser.print_usage = _capture_usage
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args(synthetic_tail)
+    finally:
+        parser.error = real_error
+        parser.print_usage = real_print_usage
+
+    assert exc_info.value.code == 2, (
+        f"expected SystemExit(2) from real CLI parser on malformed argv; "
+        f"got code={exc_info.value.code!r}"
+    )
+    combined = "\n".join(stderr_capture)
+    assert "invalid choice" in combined, (
+        f"parser error did not match the production canary signature; "
+        f"got: {combined!r}"
+    )
+    assert "terminal,code_execution" in combined, (
+        f"parser error did not name the rejected value; got: {combined!r}"
+    )

--- a/tests/tools/test_file_tools_strict_workspace_gate.py
+++ b/tests/tools/test_file_tools_strict_workspace_gate.py
@@ -1,0 +1,889 @@
+"""Tests for the STRICT-READONLY file-write workspace gate (V2 IDENTITY + S14 BINDING REPAIR).
+
+Regression matrix coverage:
+
+S5   strict worker writes own workspace  (write_file, patch — both)
+S6   strict worker cannot write repo
+S7   strict worker cannot write ~/.hermes/reports
+S8   strict worker cannot write profile/config/.env/skills
+S9   strict worker cannot write another workspace
+S10  traversal blocked
+S11  symlink escape blocked
+S12  missing HERMES_KANBAN_TASK and/or HERMES_KANBAN_WORKSPACE => BLOCK
+S13  invalid workspace env (relative / sentinel / non-existent) => BLOCK
+S14  task/workspace binding mismatch => BLOCK
+     (the dispatcher-pinned workspace must equal the canonical workspace
+     of the persisted task identified by HERMES_KANBAN_TASK in the
+     authoritative Kanban DB; see ``test_S14_*`` for the true matrix)
+S19  unrelated task mutation remains blocked (pinned-workspace containment
+     prevents cross-task leaks; the protection does NOT come from
+     comparing the tool ``task_id`` argument against ``HERMES_KANBAN_TASK``)
+
+Identity model under test:
+
+* ``HERMES_KANBAN_TASK``         e.g. ``t_9ff5c2bf`` (dispatcher-pinned)
+* tool ``task_id`` argument      e.g. ``20260819_203942_1782cf`` (Hermes
+                                  session_id propagated through
+                                  ``cli.py: run_conversation(task_id=...)``)
+* ``HERMES_KANBAN_WORKSPACE``    dispatcher-pinned canonical path
+* ``HERMES_KANBAN_DB`` + ``HERMES_KANBAN_BOARD``   authoritative DB/board
+                                                       pins the S14
+                                                       binding check
+                                                       uses to look up
+                                                       the task row.
+
+The V2 previous gate (rejected on Canary #2) compared A
+``HERMES_KANBAN_TASK`` against the tool's session_id-like ``task_id``
+argument and denied every write because the two never match in
+production; the V2 S14 repair replaced that with the authoritative
+DB-anchored binding shown here. The trusted Kanban artifact promotion
+path (``kanban_db.store_attachment_bytes``) is exercised in
+``test_kanban_worker_strict_dispatch.py`` as S18 and is intentionally
+NOT routed through this gate.
+
+Tests use ONLY stdlib + hermes internals; no live network calls.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+import hermes_state
+from tools.file_tools import patch_tool, write_file_tool
+
+
+PRIMARY = "/home/jr-ubuntu/.hermes/hermes-agent"
+import sys as _sys
+if PRIMARY not in _sys.path:
+    _sys.path.insert(0, PRIMARY)
+
+
+# ---------------------------------------------------------------------------
+# Identity model — values used through the file
+# ---------------------------------------------------------------------------
+#
+# These constants encode the real production identity split proven by
+# Canary #2. Keep the two strings as DIFFERENT values so any future
+# test that re-introduces a ``task_id == env_task`` comparison fails on
+# inspection.
+_KANBAN_TASK_ID = "t_strict_test"                         # dispatcher-pinned
+_SESSION_ID = "20260819_203942_1782cf"                    # tool task_id
+
+
+# ---------------------------------------------------------------------------
+# Kanban DB isolation helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def kanban_db_isolated(tmp_path, monkeypatch):
+    """Isolate the Kanban DB into a fresh tmp sqlite file.
+
+    Mirrors the canonical pattern used by
+    ``tests/hermes_cli/test_kanban_initiator_strict_propagation.py``
+    (``isolated_kanban_db``) and the worker dispatch test. The DB is
+    opened with ``kb.connect(db_path)`` so the production schema /
+    migrations run exactly once.
+    """
+    db_file = tmp_path / "test_kanban.db"
+    from hermes_cli import kanban_db as kb
+
+    _original_connect = kb.connect
+    conn = _original_connect(db_file)
+    conn.close()
+
+    @contextmanager
+    def _patched_connect_closing():
+        c = _original_connect(db_file)
+        try:
+            yield c
+        finally:
+            c.close()
+
+    monkeypatch.setattr(
+        kb, "connect",
+        lambda board=None: _original_connect(db_file),
+    )
+    monkeypatch.setattr(kb, "connect_closing", _patched_connect_closing)
+
+    return {
+        "db_path": db_file,
+        "kb": kb,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Strict-env fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def strict_env(tmp_path, monkeypatch, kanban_db_isolated):
+    """Set up a STRICT-READONLY Kanban worker process environment.
+
+    Persists authoritative task T1 in an isolated Kanban DB so the new
+    S14 binding check has real state to anchor on. Wires the production
+    identity split: dispatcher-pinned Kanban ``t_<id>`` ≠ the Hermes
+    session_id that ``cli.py`` propagates as the tool ``task_id``.
+    """
+    kb = kanban_db_isolated["kb"]
+    db_path = kanban_db_isolated["db_path"]
+    home = tmp_path / "home"
+    home.mkdir()
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "inside.txt").write_text("before\n", encoding="utf-8")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "README.md").write_text("repo readme\n", encoding="utf-8")
+    reports = home / "reports"
+    reports.mkdir(parents=True, exist_ok=True)
+    (reports / "old.json").write_text("{}", encoding="utf-8")
+    profile_dir = home / "profiles" / "coder"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "config.yaml").write_text("model: x\n", encoding="utf-8")
+    other_workspace = tmp_path / "other_ws"
+    other_workspace.mkdir()
+    (other_workspace / "other.txt").write_text("OTHER\n", encoding="utf-8")
+
+    # Persist authoritative task T1 with an explicit absolute
+    # ``workspace_path = <fixture workspace>`` so the S14 binding
+    # helper's canonical computation matches the dispatcher-pinned
+    # ``HERMES_KANBAN_WORKSPACE``. Without this the helper would derive
+    # ``workspaces_root/T1`` (a different path), the binding check
+    # would fire spuriously, and the happy-path tests would all
+    # fail. This mirrors the real ``_default_spawn`` flow which calls
+    # ``resolve_workspace`` + ``set_workspace_path`` before exporting
+    # ``HERMES_KANBAN_WORKSPACE`` to the worker.
+    with kb.connect_closing() as conn:
+        kb.create_task(
+            conn,
+            title="strict-test-T1",
+            created_by="user",
+            workspace_kind="scratch",
+            workspace_path=str(workspace),
+            initial_status="running",
+            strict_readonly=True,
+        )
+    # Look up the task id the schema actually assigned (sqlite ROWID
+    # alias; deterministic for a single insert but we don't need to
+    # hardcode it because the env we set below is what the gate sees).
+    with kb.connect_closing() as conn:
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE title = ? ORDER BY id DESC LIMIT 1",
+            ("strict-test-T1",),
+        ).fetchall()
+    actual_id = rows[0]["id"]
+
+    monkeypatch.setenv("HERMES_KANBAN_STRICT_READONLY", "1")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", actual_id)
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    return {
+        "home": home,
+        "workspace": workspace,
+        "repo": repo,
+        "reports": reports,
+        "profile": profile_dir,
+        "other_workspace": other_workspace,
+        "task_id": actual_id,
+        "kanban_task_id": actual_id,
+        "kb": kb,
+        "db_path": db_path,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_error(result_json: str) -> bool:
+    try:
+        payload = json.loads(result_json)
+    except Exception:
+        return True
+    if "error" in payload:
+        return True
+    return False
+
+
+def _error_text(result_json: str) -> str:
+    try:
+        payload = json.loads(result_json)
+    except Exception:
+        return result_json
+    err = payload.get("error") if isinstance(payload, dict) else None
+    if err is None:
+        return result_json
+    if isinstance(err, dict):
+        return json.dumps(err, ensure_ascii=False)
+    return str(err)
+
+
+def _call_write(target: Path, *, task_id: str, content: str = "x\n") -> str:
+    return write_file_tool(path=str(target), content=content, task_id=task_id)
+
+
+def _call_patch(target: Path, *, task_id: str) -> str:
+    return patch_tool(
+        mode="replace",
+        path=str(target),
+        old_string="before",
+        new_string="after",
+        task_id=task_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# A. session-id tool task_id + own canonical workspace => ALLOW
+# ---------------------------------------------------------------------------
+
+
+def test_A_write_file_session_id_inside_workspace_allowed(strict_env):
+    """A. write_file: session_id-like tool task_id + own workspace => ALLOW."""
+    target = strict_env["workspace"] / "artifact_one.txt"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert not _is_error(result), (
+        f"unexpected error: {result}\n"
+        f"regression: gate miscompared session_id against HERMES_KANBAN_TASK (Canary #2)"
+    )
+    assert target.read_text(encoding="utf-8") == "x\n"
+
+
+def test_A_patch_session_id_inside_workspace_allowed(strict_env):
+    """A. patch: session_id-like tool task_id + own workspace => ALLOW."""
+    target = strict_env["workspace"] / "inside.txt"
+    result = _call_patch(target, task_id=_SESSION_ID)
+    assert not _is_error(result), (
+        f"unexpected error: {result}\n"
+        f"regression: gate miscompared session_id against HERMES_KANBAN_TASK (Canary #2)"
+    )
+    assert target.read_text(encoding="utf-8") == "after\n"
+
+
+def test_A_nested_subdir_session_id_allowed(strict_env):
+    """A. (nested): write to a subdir created inside the workspace."""
+    sub = strict_env["workspace"] / "subdir"
+    target = sub / "deep.txt"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert not _is_error(result), f"unexpected error: {result}"
+    assert target.read_text(encoding="utf-8") == "x\n"
+
+
+# ---------------------------------------------------------------------------
+# B / D. missing HERMES_KANBAN_TASK or HERMES_KANBAN_WORKSPACE => DENY
+# ---------------------------------------------------------------------------
+
+
+def test_B_missing_kanban_task_denied(strict_env, monkeypatch):
+    """B: strict mode with empty HERMES_KANBAN_TASK is denied."""
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    target = strict_env["workspace"] / "should_fail.txt"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert _is_error(result), (
+        f"missing dispatcher identity must be denied; got {result!r}"
+    )
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "missing dispatcher identity" in text.lower()
+    assert not target.exists()
+
+
+def test_D_missing_workspace_env_denied(strict_env, monkeypatch):
+    """D: with HERMES_KANBAN_STRICT_READONLY=1 but
+    HERMES_KANBAN_WORKSPACE absent, write is denied."""
+    monkeypatch.delenv("HERMES_KANBAN_WORKSPACE", raising=False)
+    target = strict_env["workspace"] / "should_fail.txt"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert _is_error(result), (
+        f"missing workspace must be denied; got {result!r}"
+    )
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "missing dispatcher identity" in text.lower()
+    assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# C / E. invalid workspace env => DENY, error points to the workspace env
+# ---------------------------------------------------------------------------
+
+
+def test_C_invalid_workspace_relative_denied(strict_env, monkeypatch):
+    """C: a relative HERMES_KANBAN_WORKSPACE is denied (path policy)."""
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", "relative/path")
+    target = strict_env["workspace"] / "should_fail.txt"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert _is_error(result), f"relative workspace must be denied; got {result!r}"
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "absolute" in text.lower()
+
+
+def test_C_invalid_workspace_sentinel_denied(strict_env, monkeypatch):
+    """E (sentinel): ``.`` / ``cwd`` / ``auto`` workspace is denied."""
+    for sentinel in (".", "cwd", "auto"):
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", sentinel)
+        target = strict_env["workspace"] / "x.txt"
+        result = _call_write(target, task_id=_SESSION_ID)
+        assert _is_error(result), f"sentinel {sentinel!r} not denied: {result!r}"
+        text = _error_text(result)
+        assert "STRICT_READONLY" in text
+        assert "sentinel" in text.lower() or "missing" in text.lower()
+
+
+def test_C_invalid_workspace_nonexistent_denied(strict_env, monkeypatch):
+    """E (nonexistent): a path that does not exist on disk is denied."""
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", "/nope/does/not/exist/at/all")
+    target = strict_env["workspace"] / "should_fail.txt"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert _is_error(result), f"nonexistent workspace must be denied; got {result!r}"
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "existing directory" in text.lower() or "absolute" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# S6. cannot write repo root
+# ---------------------------------------------------------------------------
+
+
+def test_S6_repo_root_write_denied(strict_env):
+    """S6 (write_file): absolute repo path is denied (path containment)."""
+    target = strict_env["repo"] / "INJECTED.md"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert _is_error(result), f"repo path must be denied; got {result!r}"
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "escapes the workspace boundary" in text.lower(), (
+        f"expected path-containment error, got {text!r}"
+    )
+    assert not target.exists()
+
+
+def test_S6_repo_root_patch_denied(strict_env):
+    """S6 (patch): patch inside the repo is denied (path containment)."""
+    target = strict_env["repo"] / "README.md"
+    result = _call_patch(target, task_id=_SESSION_ID)
+    assert _is_error(result), f"repo path must be denied; got {result!r}"
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "escapes the workspace boundary" in text.lower()
+    assert target.read_text(encoding="utf-8") == "repo readme\n"
+
+
+# ---------------------------------------------------------------------------
+# S7. cannot write ~/.hermes/reports
+# ---------------------------------------------------------------------------
+
+
+def test_S7_reports_write_denied(strict_env):
+    target = strict_env["reports"] / "leaked.json"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert _is_error(result), f"reports path must be denied; got {result!r}"
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "escapes the workspace boundary" in text.lower()
+    assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# S8. cannot write profile / config / .env / skills
+# ---------------------------------------------------------------------------
+
+
+def test_S8_profile_config_write_denied(strict_env):
+    target = strict_env["profile"] / "config.yaml"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert _is_error(result), f"profile path must be denied; got {result!r}"
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "escapes the workspace boundary" in text.lower()
+    assert target.read_text(encoding="utf-8") == "model: x\n"
+
+
+def test_S8_hermes_config_write_denied(strict_env):
+    cfg = strict_env["home"] / "config.yaml"
+    cfg.write_text("ok: 1\n", encoding="utf-8")
+    result = _call_write(cfg, task_id=_SESSION_ID)
+    assert _is_error(result), f"hermes config path must be denied; got {result!r}"
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "escapes the workspace boundary" in text.lower()
+    assert cfg.read_text(encoding="utf-8") == "ok: 1\n"
+
+
+def test_S8_dotenv_write_denied(strict_env):
+    env = strict_env["home"] / ".env"
+    env.write_text("OK=1\n", encoding="utf-8")
+    result = _call_write(env, task_id=_SESSION_ID)
+    assert _is_error(result), f"dotenv path must be denied; got {result!r}"
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "escapes the workspace boundary" in text.lower()
+    assert env.read_text(encoding="utf-8") == "OK=1\n"
+
+
+def test_S8_skills_dir_write_denied(strict_env):
+    skills = strict_env["home"] / "skills" / "evil"
+    skills.mkdir(parents=True, exist_ok=True)
+    target = skills / "SKILL.md"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert _is_error(result), f"skills path must be denied; got {result!r}"
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "escapes the workspace boundary" in text.lower()
+    assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# S9 / F. another task workspace => DENY (path containment)
+# ---------------------------------------------------------------------------
+
+
+def test_S9_other_workspace_write_denied(strict_env):
+    """S9: writes into a different kanban workspace path are denied by
+    path containment."""
+    target = strict_env["other_workspace"] / "hijack.txt"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert _is_error(result), f"other-task workspace must be denied; got {result!r}"
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "escapes the workspace boundary" in text.lower()
+    assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# G. traversal blocked (path containment)
+# ---------------------------------------------------------------------------
+
+
+def test_G_traversal_dotdot_blocked(strict_env):
+    target = strict_env["workspace"] / ".." / "escaped.txt"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert _is_error(result), f"traversal must be denied; got {result!r}"
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "escapes the workspace boundary" in text.lower()
+
+
+def test_G_workspace_root_self_blocked(strict_env):
+    result = _call_write(strict_env["workspace"], task_id=_SESSION_ID)
+    assert _is_error(result), f"workspace root must be denied; got {result!r}"
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "target equals the workspace root" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# H. symlink escape blocked (path containment)
+# ---------------------------------------------------------------------------
+
+
+def test_H_symlink_escape_blocked(strict_env):
+    outside = strict_env["home"] / "outside.txt"
+    outside.write_text("OUTSIDE\n", encoding="utf-8")
+    link = strict_env["workspace"] / "escape_link"
+    os.symlink(str(outside), str(link))
+    result = _call_write(link, task_id=_SESSION_ID)
+    assert _is_error(result), f"symlink escape must be denied; got {result!r}"
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "escapes the workspace boundary" in text.lower()
+    assert outside.read_text(encoding="utf-8") == "OUTSIDE\n"
+
+
+# ===========================================================================
+# S14 — TASK/WORKSPACE BINDING MISMATCH => BLOCK
+# ===========================================================================
+#
+# The V2 S14 contract is the production bug this file section exists to
+# prevent regressing: a writer whose env pins T1 + W2_T2 (W2 belonging to
+# a *different* Kanban task) must be denied, even if W2_T2 itself exists
+# on disk and the target lives inside it. Containment on W2 is not
+# sufficient — the gate must look up T1 in the authoritative Kanban DB
+# and compare the persisted canonical workspace to the pinned one.
+#
+# Pre-S14-repair the gate trusted ``HERMES_KANBAN_WORKSPACE`` literally,
+# so a T1+W2_T2 binding silently allowed the write (S14 fail-open). The
+# tests below demonstrate both the FAIL-CLOSED behaviour post-repair and
+# the path-containment behaviour when the binding is consistent.
+
+
+def test_S14_true_matrix_T1_workspace_W2_denied(
+    tmp_path, monkeypatch, kanban_db_isolated
+):
+    """S14 (true matrix, scratch): dispatcher pins T1 + W2_T2, model
+    targets W2/file → DENY because T1↔W2_T2 binding is wrong.
+
+    Setup:
+
+      * T1 persisted with ``scratch`` kind and NO workspace_path
+        → canonical workspace is ``workspaces_root/T1``.
+      * T2 persisted with explicit absolute workspace_path = ``W2``
+        → canonical workspace is ``W2``.
+      * Strict worker env: ``HERMES_KANBAN_TASK=T1``,
+        ``HERMES_KANBAN_WORKSPACE=W2`` (T2's workspace).
+      * Tool task_id = session-like ``20260819_203942_1782cf``.
+      * Target = ``W2/artifact.txt`` (lexically inside W2_T2).
+
+    Expected: DENY because canonical(T1) = workspaces_root/T1 ≠ W2.
+    """
+    kb = kanban_db_isolated["kb"]
+    db_path = kanban_db_isolated["db_path"]
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    # T1 (scratch, no workspace_path)
+    with kb.connect_closing() as conn:
+        t1 = kb.create_task(
+            conn,
+            title="t1-strict-target",
+            created_by="user",
+            workspace_kind="scratch",
+            initial_status="running",
+            strict_readonly=True,
+        )
+
+    # T2 with explicit absolute workspace_path = W2
+    workspace2 = tmp_path / "ws_T2"
+    workspace2.mkdir()
+    with kb.connect_closing() as conn:
+        t2 = kb.create_task(
+            conn,
+            title="t2-strict-other",
+            created_by="user",
+            workspace_kind="scratch",
+            workspace_path=str(workspace2),
+            initial_status="running",
+            strict_readonly=True,
+        )
+
+    # Wire strict-mode env as the dispatcher would, but with the
+    # INCONSISTENT binding we're testing: T1 pinned, W2_T2 pinned.
+    monkeypatch.setenv("HERMES_KANBAN_STRICT_READONLY", "1")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", t1)
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace2))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+
+    target = workspace2 / "artifact.txt"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert _is_error(result), (
+        f"S14 TRUE MATRIX: T1+W2_T2 binding must be denied; got {result!r}"
+    )
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    # The denial message must surface the binding mismatch — that is the
+    # S14 contract, distinct from path containment.
+    assert "binding mismatch" in text.lower(), (
+        f"expected S14 binding-mismatch error, got {text!r}"
+    )
+    assert not target.exists()
+
+
+def test_S14_dir_kind_T1_workspace_W2_denied(
+    tmp_path, monkeypatch, kanban_db_isolated
+):
+    """S14 (true matrix, ``dir:``): even when W1.T1 and W2.T2 are both
+    absolute explicit paths, the dispatcher-pinned mismatch must be
+    detected and denied.
+
+    Setup:
+
+      * T1 persisted with ``dir:`` kind, workspace_path = ``W1``.
+      * T2 persisted with ``dir:`` kind, workspace_path = ``W2``.
+      * Strict worker env: ``HERMES_KANBAN_TASK=T1``,
+        ``HERMES_KANBAN_WORKSPACE=W2``.
+      * Target = ``W2/file.txt`` (inside W2_T2).
+
+    Expected: DENY because canonical(T1) = W1 ≠ W2.
+    """
+    kb = kanban_db_isolated["kb"]
+    db_path = kanban_db_isolated["db_path"]
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    workspace1 = tmp_path / "ws_T1"
+    workspace1.mkdir()
+    workspace2 = tmp_path / "ws_T2"
+    workspace2.mkdir()
+
+    with kb.connect_closing() as conn:
+        t1 = kb.create_task(
+            conn,
+            title="t1-dir",
+            created_by="user",
+            workspace_kind="dir",
+            workspace_path=str(workspace1),
+            initial_status="running",
+            strict_readonly=True,
+        )
+        t2 = kb.create_task(
+            conn,
+            title="t2-dir",
+            created_by="user",
+            workspace_kind="dir",
+            workspace_path=str(workspace2),
+            initial_status="running",
+            strict_readonly=True,
+        )
+
+    monkeypatch.setenv("HERMES_KANBAN_STRICT_READONLY", "1")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", t1)
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace2))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+
+    target = workspace2 / "file.txt"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert _is_error(result), (
+        f"S14 (dir): T1+W2_T2 binding must be denied; got {result!r}"
+    )
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "binding mismatch" in text.lower(), (
+        f"expected S14 binding-mismatch error, got {text!r}"
+    )
+    assert not target.exists()
+
+
+def test_S14_worktree_kind_T1_workspace_W2_denied(
+    tmp_path, monkeypatch, kanban_db_isolated
+):
+    """S14 (true matrix, ``worktree:`` with explicit workspace_path).
+
+    Setup mirrors the ``dir:`` case but uses ``worktree`` kind. Each
+    task gets its own absolute ``workspace_path`` (the dispatcher side
+    of ``_resolve_worktree_workspace`` would normally have created the
+    linked git worktree; the strict gate's pure resolver instead
+    trusts the persisted path verbatim, so the binding check still
+    works without any I/O).
+
+      * T1.worktree, workspace_path = ``W1``.
+      * T2.worktree, workspace_path = ``W2``.
+      * Env: ``HERMES_KANBAN_TASK=T1``, ``HERMES_KANBAN_WORKSPACE=W2``.
+      * Target = ``W2/file``.
+
+    Expected: DENY because canonical(T1) = W1 ≠ W2.
+    """
+    kb = kanban_db_isolated["kb"]
+    db_path = kanban_db_isolated["db_path"]
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    workspace1 = tmp_path / "wt_T1"
+    workspace1.mkdir()
+    workspace2 = tmp_path / "wt_T2"
+    workspace2.mkdir()
+
+    with kb.connect_closing() as conn:
+        t1 = kb.create_task(
+            conn,
+            title="t1-worktree",
+            created_by="user",
+            workspace_kind="worktree",
+            workspace_path=str(workspace1),
+            initial_status="running",
+            strict_readonly=True,
+        )
+        t2 = kb.create_task(
+            conn,
+            title="t2-worktree",
+            created_by="user",
+            workspace_kind="worktree",
+            workspace_path=str(workspace2),
+            initial_status="running",
+            strict_readonly=True,
+        )
+
+    monkeypatch.setenv("HERMES_KANBAN_STRICT_READONLY", "1")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", t1)
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace2))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+
+    target = workspace2 / "file"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert _is_error(result), (
+        f"S14 (worktree): T1+W2_T2 binding must be denied; got {result!r}"
+    )
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "binding mismatch" in text.lower(), (
+        f"expected S14 binding-mismatch error, got {text!r}"
+    )
+    assert not target.exists()
+
+
+def test_S14_binding_missing_db_pin_denied(strict_env, monkeypatch):
+    """S14 (defence in depth): if the dispatcher forgot to pin
+    ``HERMES_KANBAN_DB`` (or the env inherited a partial state), the
+    binding check cannot be performed — the gate MUST deny rather than
+    fall through to env-only containment."""
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    target = strict_env["workspace"] / "should_fail.txt"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert _is_error(result), (
+        f"missing HERMES_KANBAN_DB must fail closed; got {result!r}"
+    )
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "binding" in text.lower() or "board/db identity" in text.lower(), (
+        f"expected binding-check denial, got {text!r}"
+    )
+    assert not target.exists()
+
+
+def test_S14_binding_missing_board_pin_denied(strict_env, monkeypatch):
+    """S14 (defence in depth): missing ``HERMES_KANBAN_BOARD`` is also
+    fail-closed."""
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    target = strict_env["workspace"] / "should_fail.txt"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert _is_error(result), (
+        f"missing HERMES_KANBAN_BOARD must fail closed; got {result!r}"
+    )
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "binding" in text.lower() or "board/db identity" in text.lower()
+    assert not target.exists()
+
+
+def test_S14_binding_unknown_task_denied(strict_env, monkeypatch):
+    """S14 (defence in depth): an ``HERMES_KANBAN_TASK`` that is not
+    present in the authoritative Kanban DB is denied — the gate does
+    NOT trust the env when authoritative state disagrees."""
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_does_not_exist_anywhere")
+    target = strict_env["workspace"] / "should_fail.txt"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert _is_error(result), (
+        f"unknown task must fail closed; got {result!r}"
+    )
+    text = _error_text(result)
+    assert "STRICT_READONLY" in text
+    assert "not found" in text.lower() or "binding" in text.lower(), (
+        f"expected task-not-found denial, got {text!r}"
+    )
+    assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# VALID BINDING — write/patch MUST still succeed under T1↔W1
+# ---------------------------------------------------------------------------
+
+
+def test_S14_valid_binding_write_allowed(strict_env):
+    """Valid binding: T1+W1 (workspace), session_id tool task_id. ALLOW."""
+    target = strict_env["workspace"] / "artifact_two.txt"
+    result = _call_write(target, task_id=_SESSION_ID)
+    text = _error_text(result) if _is_error(result) else ""
+    assert not _is_error(result), (
+        f"valid T1+W1 binding must allow write; got {result!r}\n"
+        f"error excerpt: {text!r}"
+    )
+    assert target.read_text(encoding="utf-8") == "x\n"
+
+
+def test_S14_valid_binding_patch_allowed(strict_env):
+    """Valid binding: T1+W1 (workspace), session_id tool task_id. ALLOW."""
+    target = strict_env["workspace"] / "inside.txt"
+    result = _call_patch(target, task_id=_SESSION_ID)
+    text = _error_text(result) if _is_error(result) else ""
+    assert not _is_error(result), (
+        f"valid T1+W1 binding must allow patch; got {result!r}\n"
+        f"error excerpt: {text!r}"
+    )
+    assert target.read_text(encoding="utf-8") == "after\n"
+
+
+# ---------------------------------------------------------------------------
+# CANARY #2 REGRESSION (must remain green post S14)
+# ---------------------------------------------------------------------------
+
+
+def test_canary2_identity_alignment_regression(strict_env):
+    """Canary #2 regression: legitimate in-workspace write must succeed
+    even though the tool ``task_id`` (Hermes session_id) does not
+    equal ``HERMES_KANBAN_TASK`` (Kanban task id).
+
+    Pre-fix this was denied by ``task_id != env_task``. Post-fix it
+    is allowed by the S14 DB-anchored binding check (the binding
+    matches), and post-S14-repair the binding check is anchored on
+    the authoritative Kanban DB lookup rather than a string
+    comparison.
+    """
+    session_like_tool_id = "20260819_203942_1782cf"
+    workspace = strict_env["workspace"]
+    target = workspace / "artifact_one.txt"
+    result = _call_write(target, task_id=session_like_tool_id, content="hello\n")
+    text = _error_text(result) if _is_error(result) else ""
+    assert not _is_error(result), (
+        "Canary #2 regression: legitimate in-workspace write was denied. "
+        "Pre-fix this surfaced as a 'task/workspace mismatch' string "
+        "compare; post-fix the S14 DB-anchored binding check must allow it.\n"
+        f"  HERMES_KANBAN_TASK='{strict_env['kanban_task_id']}'\n"
+        f"  tool task_id='{session_like_tool_id}' (Hermes session_id)\n"
+        f"  target within workspace '{workspace}'\n"
+        f"  result: {result!r}"
+    )
+    assert target.read_text(encoding="utf-8") == "hello\n"
+
+
+# ---------------------------------------------------------------------------
+# Static source-anchored regression for the session-id-vs-kanban-id bug
+# ---------------------------------------------------------------------------
+
+
+def test_pre_fix_behavior_not_reintroduced():
+    """Source-level guarantee: the string-equality comparison that
+    caused Canary #2 must never return. A regression that re-introduces
+    it fails this test in review (and the production source itself
+    will fail code review)."""
+    import tools.file_tools as _ft
+    src = Path(_ft.__file__).read_text(encoding="utf-8")
+    forbidden = re.search(
+        r"str\(task_id\)\s*!=\s*env_task|env_task\s*!=\s*str\(task_id\)"
+        r"|task_id\s*==\s*env_task|env_task\s*==\s*task_id",
+        src,
+    )
+    assert forbidden is None, (
+        "Regression: tools/file_tools.py re-introduced the session-id-vs-"
+        "kanban-id string equality comparison that Canary #2 caught."
+    )
+
+
+# ---------------------------------------------------------------------------
+# J. non-strict behavior unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_J_outside_strict_mode_unaffected(strict_env, monkeypatch, tmp_path):
+    """Outside strict mode the gate is a no-op."""
+    monkeypatch.delenv("HERMES_KANBAN_STRICT_READONLY", raising=False)
+    safe_dir = tmp_path / "safe_outside"
+    safe_dir.mkdir()
+    target = safe_dir / "ok.txt"
+    result = _call_write(target, task_id=_SESSION_ID)
+    assert not _is_error(result), (
+        f"unexpected error outside strict mode: {result}"
+    )
+    assert target.read_text(encoding="utf-8") == "x\n"

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -10,6 +10,7 @@ import posixpath
 import sys
 import threading
 from pathlib import Path, PurePosixPath
+from typing import Optional, Tuple
 
 from agent.file_safety import get_read_block_error
 from tools.binary_extensions import (
@@ -2230,6 +2231,12 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
     Pass ``True`` after explicit user direction — same shape as ``force``
     on the terminal tool.
     """
+    # STRICT-READONLY Kanban worker gate (fail-closed). Must run FIRST
+    # so an escape attempt never reaches the broader sensitive / cross-
+    # profile checks. Outside strict mode the gate is a no-op.
+    strict_err = _strict_readonly_gate(path, task_id)
+    if strict_err:
+        return strict_err
     sensitive_err = _check_sensitive_path(path, task_id)
     if sensitive_err:
         return tool_error(sensitive_err)
@@ -2321,6 +2328,26 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
     targets under another profile's skills/plugins/cron/memories
     directory. Same shape as ``write_file``'s flag.
     """
+    # STRICT-READONLY Kanban worker gate (fail-closed). Runs FIRST
+    # against every path the patch will touch (the explicit ``path``
+    # argument AND every path embedded in a V4A patch body) so an
+    # escape attempt never reaches the broader sensitive / cross-
+    # profile checks. Outside strict mode the gate is a no-op.
+    _strict_paths: list[str] = []
+    if path:
+        _strict_paths.append(path)
+    if mode == "patch" and patch:
+        import re as _strict_re
+        for _m in _strict_re.finditer(
+            r'^\*\*\*\s*(?:Update|Add|Delete|Move|File)\s*:\s*(.+)$',
+            patch,
+            _strict_re.MULTILINE,
+        ):
+            _strict_paths.append(_m.group(1).strip())
+    for _strict_p in _strict_paths:
+        _strict_err = _strict_readonly_gate(_strict_p, task_id)
+        if _strict_err:
+            return _strict_err
     # Check sensitive paths for both replace (explicit path) and V4A patch (extract paths)
     _paths_to_check = []
     # Paths whose CONTENT will be text-written (Update/Add + explicit path).
@@ -2636,6 +2663,285 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         return tool_error(str(e))
 
 
+
+
+# ---------------------------------------------------------------------------
+# Strict-readonly Kanban worker gate
+# ---------------------------------------------------------------------------
+# When a Kanban worker is dispatched with ``HERMES_KANBAN_STRICT_READONLY=1``
+# in its environment, ``write_file_tool`` and ``patch_tool`` must refuse any
+# mutation whose target resolves outside the worker's current task workspace
+# (``HERMES_KANBAN_WORKSPACE``). The gate is fail-closed: missing / invalid /
+# mismatched workspace ⇒ BLOCK with a structured ``tool_error`` JSON. The
+# trusted Kanban artifact promotion path (``kanban_db.store_attachment_bytes``
+# and friends) is not a model-tool surface and therefore unaffected.
+_STRICT_READONLY_SENTINELS = frozenset({"", ".", "./", "auto", "cwd"})
+
+
+def _is_strict_readonly_active(task_id: str) -> bool:
+    """True iff the current process is a STRICT-READONLY Kanban worker.
+
+    Reads ``HERMES_KANBAN_STRICT_READONLY`` from the process environment.
+    The flag is set only by ``hermes_cli.kanban_db._default_spawn`` when
+    the dispatched task explicitly opted in via ``strict_readonly=True``;
+    ordinary writable Kanban workers and any non-Kanban CLI leave the
+    variable unset.
+    """
+    return os.environ.get("HERMES_KANBAN_STRICT_READONLY", "").strip() == "1"
+
+
+def _verify_strict_readonly_task_workspace_binding(
+    env_task: str, env_workspace: str
+) -> Optional[str]:
+    """Return a ``tool_error`` JSON iff the dispatcher-pinned workspace
+    does NOT match the canonical workspace of the persisted task.
+
+    Implements the S14 contract for ``tools.file_tools._strict_readonly_gate``:
+
+      1. ``env_task`` must name a task row that exists in the authoritative
+         Kanban DB on this board.
+      2. The canonical workspace of that task (computed by
+         :func:`hermes_cli.kanban_db.expected_workspace_for_task`, a pure
+         read-only resolver) must canonicalise equal to ``env_workspace``.
+
+    Any failure — missing DB env vars, DB connect failure, missing task,
+    bad kind, absent workspace_path for ``dir:``, no ``default_workdir``
+    for a fresh ``worktree``, schema drift, exception — is fail-closed:
+    the gate does NOT fall through to env-only containment. The original
+    Canary #2 lesson is preserved: the tool ``task_id`` argument is the
+    Hermes session_id and is NOT consulted here.
+
+    Returns ``None`` iff the binding matches.
+    """
+    db_pin = os.environ.get("HERMES_KANBAN_DB", "").strip()
+    board_pin = os.environ.get("HERMES_KANBAN_BOARD", "").strip()
+
+    if not db_pin or not board_pin:
+        return tool_error(
+            "STRICT_READONLY: cannot verify task/workspace binding — "
+            "dispatcher-controlled board/DB identity missing "
+            f"(HERMES_KANBAN_DB={db_pin!r}, HERMES_KANBAN_BOARD={board_pin!r}). "
+            "Writes are denied — strict mode fails closed."
+        )
+
+    # Lazy import: ``hermes_cli.kanban_db`` is a heavy module that itself
+    # touches ``hermes_state`` at import time. Importing it from the
+    # common-path file-tool module would couple them and balloon import
+    # cost; the gate already runs only under strict mode, so the
+    # import cost only ever lands when this branch fires.
+    try:
+        from hermes_cli import kanban_db as _kb
+        from hermes_cli.kanban_db import KanbanWorkspaceLookupError
+    except Exception as exc:
+        return tool_error(
+            "STRICT_READONLY: cannot verify task/workspace binding — "
+            f"kanban_db import failed ({type(exc).__name__}: {exc}). "
+            "Writes are denied — strict mode fails closed."
+        )
+
+    try:
+        conn = _kb.connect()
+    except Exception as exc:
+        return tool_error(
+            "STRICT_READONLY: cannot verify task/workspace binding — "
+            f"kanban DB connect failed ({type(exc).__name__}: {exc}). "
+            "Writes are denied — strict mode fails closed."
+        )
+    try:
+        try:
+            expected = _kb.expected_workspace_for_task(conn, env_task, board=board_pin)
+        except KanbanWorkspaceLookupError as exc:
+            return tool_error(
+                "STRICT_READONLY: task/workspace binding lookup failed — "
+                f"{exc}. Writes are denied."
+            )
+        except Exception as exc:
+            return tool_error(
+                "STRICT_READONLY: task/workspace binding lookup failed — "
+                f"({type(exc).__name__}: {exc}). Writes are denied."
+            )
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    try:
+        env_resolved = Path(env_workspace).resolve(strict=False)
+        expected_resolved = expected.resolve(strict=False)
+    except (OSError, ValueError) as exc:
+        return tool_error(
+            "STRICT_READONLY: task/workspace binding path canonicalisation "
+            f"failed ({type(exc).__name__}: {exc}). Writes are denied."
+        )
+
+    if env_resolved != expected_resolved:
+        return tool_error(
+            "STRICT_READONLY: task/workspace binding mismatch — "
+            f"task {env_task!r} canonical workspace is "
+            f"{str(expected_resolved)!r} but dispatcher pinned "
+            f"HERMES_KANBAN_WORKSPACE={env_workspace!r}. "
+            "Writes are denied."
+        )
+
+    return None
+
+
+def _resolve_strict_readonly_pinned_workspace() -> Tuple[Optional[Path], Optional[str]]:
+    """Return ``(canonical_workspace, error_json)`` for the dispatcher-pinned workspace.
+
+    The dispatcher (``hermes_cli.kanban_db._default_spawn``) sets
+    ``HERMES_KANBAN_WORKSPACE`` to the path it resolved for the dispatched
+    task; this is the dispatcher-controlled anchor the gate contains
+    against. Two failure modes are distinguished by return value:
+
+    * ``(Path, None)`` — workspace pinned, canonicalised via
+      ``Path.resolve(strict=False)`` so symlinks at the workspace
+      root are walked exactly once.
+    * ``(None, <tool_error JSON>)`` — workspace missing, sentinel,
+      non-absolute, or non-existent; the caller propagates the JSON.
+
+    The CLI's tool ``task_id`` argument is the **Hermes session_id**
+    (e.g. ``20260819_203942_1782cf``) — NOT the Kanban task id — so it
+    is deliberately NOT compared against ``HERMES_KANBAN_TASK`` here.
+    Authority lives in the workspace, not in model-supplied identity.
+    """
+    raw_workspace = os.environ.get("HERMES_KANBAN_WORKSPACE", "")
+    if not raw_workspace or raw_workspace.strip().lower() in _STRICT_READONLY_SENTINELS:
+        return None, tool_error(
+            "STRICT_READONLY: HERMES_KANBAN_WORKSPACE is missing or a sentinel "
+            f"value (got {raw_workspace!r}). Writes are denied — strict mode "
+            "fails closed."
+        )
+    if not os.path.isabs(raw_workspace):
+        return None, tool_error(
+            "STRICT_READONLY: HERMES_KANBAN_WORKSPACE is not an absolute path "
+            f"(got {raw_workspace!r}). Writes are denied — strict mode fails "
+            "closed."
+        )
+    if not os.path.isdir(raw_workspace):
+        return None, tool_error(
+            "STRICT_READONLY: HERMES_KANBAN_WORKSPACE does not identify an "
+            f"existing directory (got {raw_workspace!r}). Writes are denied — "
+            "strict mode fails closed."
+        )
+    return Path(raw_workspace).resolve(strict=False), None
+
+
+def _strict_readonly_gate(
+    path: str,
+    task_id: str,
+) -> Optional[str]:
+    """Return a ``tool_error`` JSON string iff the gate denies a write.
+
+    Returns ``None`` when the write is allowed (or when strict mode is
+    inactive, in which case the gate is a no-op). Activation requires
+    ``HERMES_KANBAN_STRICT_READONLY=1``. Authorization requires ALL of:
+
+      1. ``HERMES_KANBAN_TASK`` is non-empty (the dispatcher pins the
+         task identity; an empty env var means strict mode was set
+         without dispatcher authority and is refused up-front).
+      2. ``HERMES_KANBAN_WORKSPACE`` is set, absolute, not a sentinel
+         (``.``, ``cwd``, ``auto``, …), identifies an existing
+         directory, and is canonicalised via ``Path.resolve(strict=False)``.
+      3. The target's canonicalised path is contained within the
+         canonicalised workspace (symlink chain walked, ``..``
+         traversal blocked).
+
+    The tool ``task_id`` argument is the Hermes session_id propagated
+    by ``cli.py`` via ``AIAgent.run_conversation(task_id=...)``
+    (``task_id=self.session_id``); it is NOT the Kanban ``t_<id>`` and
+    is therefore NOT compared against ``HERMES_KANBAN_TASK``. Canary
+    #2 (strict worker t_9ff5c2bf, session 20260819_203942_1782cf)
+    proved the previous string-equality gate rejected every legitimate
+    in-workspace write because the two identities never match in
+    production. Identity is anchored on the dispatcher-pinned
+    workspace, not on a model-supplied task-id string.
+
+    Any failure ⇒ ``tool_error(...)`` JSON. No soft fallback, no return
+    ``None`` indicating "allowed with warning", no falling back to the
+    process cwd or HOME.
+    """
+    if not _is_strict_readonly_active(task_id):
+        return None
+
+    # Strict mode is only meaningful when a dispatcher identity is
+    # present in the environment. The flag without ``HERMES_KANBAN_TASK``
+    # means strict mode was set outside the dispatcher contract (or
+    # the dispatcher was configured inconsistently); refuse every
+    # write rather than fall through to containment-less "strict".
+    env_task = os.environ.get("HERMES_KANBAN_TASK", "").strip()
+    raw_workspace = os.environ.get("HERMES_KANBAN_WORKSPACE", "")
+    if not env_task or not raw_workspace:
+        return tool_error(
+            "STRICT_READONLY: missing dispatcher identity "
+            f"(HERMES_KANBAN_TASK={env_task!r}, "
+            f"HERMES_KANBAN_WORKSPACE={raw_workspace!r}). "
+            "Writes are denied — strict mode fails closed."
+        )
+
+    workspace, ws_err = _resolve_strict_readonly_pinned_workspace()
+    if ws_err is not None:
+        return ws_err
+    assert workspace is not None  # invariant: ws_err is None ⇒ workspace is set
+
+    # S14 task/workspace binding check. The authorization anchor now
+    # expands from "the dispatcher pinned this workspace" to "the
+    # dispatcher pinned a workspace that matches the canonical workspace
+    # of the persisted task identified by HERMES_KANBAN_TASK in the
+    # authoritative Kanban DB". Failures anywhere in this check deny
+    # the write before target containment is even consulted — defense
+    # in depth against inconsistent dispatcher state, env inheritance,
+    # and any future code path that exports ``HERMES_KANBAN_WORKSPACE``
+    # without going through ``_default_spawn``.
+    binding_err = _verify_strict_readonly_task_workspace_binding(
+        env_task, str(workspace)
+    )
+    if binding_err is not None:
+        return binding_err
+
+    # Resolve the target. Use the existing helper to preserve current
+    # path semantics for relative paths (against the task cwd) before
+    # applying the strict workspace containment check.
+    try:
+        resolved = _resolve_path_for_task(path, task_id)
+    except Exception as exc:
+        return tool_error(
+            "STRICT_READONLY: target path could not be resolved "
+            f"({type(exc).__name__}: {exc}). Writes are denied."
+        )
+
+    target = Path(resolved).resolve(strict=False)
+
+    # The workspace root itself is not a writable file target.
+    if target == workspace:
+        return tool_error(
+            "STRICT_READONLY: target equals the workspace root "
+            f"({str(workspace)!r}); only files INSIDE the workspace are "
+            "writable."
+        )
+
+    # Containment under the canonicalised workspace. ``is_relative_to``
+    # already follows lexical containment, but we additionally walk the
+    # symlink chain via ``Path.resolve(strict=False)`` above to defeat
+    # symlinks whose chain escapes the workspace.
+    try:
+        is_inside = target.is_relative_to(workspace)
+    except ValueError:
+        is_inside = False
+    except OSError as exc:
+        return tool_error(
+            "STRICT_READONLY: target path traversal check failed "
+            f"({type(exc).__name__}: {exc}). Writes are denied."
+        )
+    if not is_inside:
+        return tool_error(
+            "STRICT_READONLY: target escapes the workspace boundary "
+            f"(workspace={str(workspace)!r}, target={str(target)!r}). "
+            "Writes are denied."
+        )
+
+    return None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR lands four previously isolated and validated changes:

1. `cli: expose per-invocation --skip-background-review`
2. `autonomy: add autonomous initiation runtime baseline`
3. `security: confine strict-readonly Kanban workers`
4. `docs: document strict-readonly Kanban workers`

## Security model

Strict-readonly is an explicit per-task capability.

Key properties:

- writable remains the default
- strict-readonly is never inferred from model, provider, or provenance
- opted-in workers do not receive terminal/code-execution capabilities
- Kanban lifecycle and artifact promotion remain available
- task-to-workspace authority is persisted and resolved centrally
- filesystem writes fail closed on missing, malformed, mismatched, traversal, or symlink-escape workspace authority
- both `write_file` and `patch` are gated
- stale inherited strict-readonly environment state is isolated
- model/provider overrides and existing worker behavior remain preserved

## Behavioral contract

The implementation was revalidated against the complete S1-S22 contract.

In particular:

- `strict_readonly` is an explicit per-task capability and defaults to false
- it is never inferred from model, provider, provenance, or worker origin
- stale inherited readonly state is isolated
- strict workers lose terminal/code-execution capabilities but retain Kanban lifecycle
- task-to-workspace authority is persisted and resolved centrally
- traversal, symlink escape, missing metadata, unknown tasks, malformed authority, and workspace mismatches fail closed
- both `write_file` and `patch` enforce the workspace boundary
- autonomy forwards the capability explicitly
- model/provider overrides remain intact
- ordinary workers retain their previous behavior
- trusted artifact completion/promotion inside the bound workspace remains available

Behavioral validation: S1-S22 = 22/22 PASS, 0 failed, 0 unverified.

## Validation

Final integration rehearsal against upstream `main`:

- B1 + autonomy + V2 core: 111 passed, 0 failed
- upstream overlap regressions: 122 passed, 0 failed, 1 Windows-only skipped
- S1-S22 behavioral revalidation: 70 passed, 0 failed
- merged diff checks: PASS
- no textual conflicts
- canonical `agent/autonomy/__init__.py` preserved

Upstream advanced once after publication of the feature branch.

A bounded delta revalidation against:

`2123a01601ca4a9a81f81759451faab2f33ae94f`

confirmed:

- new upstream delta touches only 3 Bot Mode files
- overlap with the 20 integration paths: 0
- merge rehearsal remains clean
- all 20 integration paths are byte-identical to the fully tested rehearsal tree
- no additional push or full integration test rerun required

## Commit structure

The branch intentionally preserves four reviewable commits:

- `0ccb95b6` cli: expose per-invocation --skip-background-review
- `86520b6a` autonomy: add autonomous initiation runtime baseline
- `6b2d5e2e` security: confine strict-readonly Kanban workers
- `b847c48b` docs: document strict-readonly Kanban workers
