### PR TITLE
fix(opencode-go): route Muse models through Responses API

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -5283,6 +5283,10 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
             # per the published Go endpoint table, same as GPT on Zen:
             # https://opencode.ai/docs/go/#endpoints
             return "codex_responses"
+        if normalized.startswith("muse-"):
+            # Muse Spark models on Go use /v1/responses (same as GPT).
+            # Includes muse-spark-1.2 and muse-spark-1.2-contributor.
+            return "codex_responses"
         if normalized.startswith("minimax-"):
             return "anthropic_messages"
         if normalized.startswith("qwen"):

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -272,6 +272,11 @@ class TestCopilotNormalization:
         # GPT models on Go are Responses-only (Go endpoint table).
         assert opencode_model_api_mode("opencode-go", "gpt-5.6-luna") == "codex_responses"
         assert opencode_model_api_mode("opencode-go", "opencode-go/gpt-5.6-luna") == "codex_responses"
+        # Muse models on Go are Responses-only (same as GPT).
+        assert opencode_model_api_mode("opencode-go", "muse-spark-1.2") == "codex_responses"
+        assert opencode_model_api_mode("opencode-go", "muse-spark-1.2-contributor") == "codex_responses"
+        assert opencode_model_api_mode("opencode-go", "opencode-go/muse-spark-1.2") == "codex_responses"
+        assert opencode_model_api_mode("opencode-go", "opencode-go/muse-spark-1.2-contributor") == "codex_responses"
 
 
 class TestNormalizeOpencodeBaseUrl:


### PR DESCRIPTION
Summary

OpenCode Go Muse models require the Responses API, but currently fall through to `chat_completions`.

This adds Muse family routing to `codex_responses`.

Why

Without this routing, models such as:

- `muse-spark-1.2`
- `muse-spark-1.2-contributor`

are sent through the wrong API surface.

Change

- route `muse-*` to `codex_responses` in `opencode_model_api_mode()` (opencode-go branch)
- add regression coverage for standard and Contributor variants (with/without `opencode-go/` prefix)

Verification

```
python -m pytest tests/hermes_cli/test_model_validation.py -v
# 29 passed
```

Matrix:

- `muse-spark-1.2` → `codex_responses`
- `muse-spark-1.2-contributor` → `codex_responses`
- `deepseek-v4-flash` → `chat_completions` (unchanged)
- `mimo-v2.5` → `chat_completions` (unchanged)
- `gpt-5.6-luna` → `codex_responses` (unchanged)
- `minimax-m3` → `anthropic_messages` (unchanged)
- `qwen3.7-max` → `anthropic_messages` (unchanged)
