### PR TITLE
delegation: native pi-rpc provider (local fork RPC) with working ask-user round-trip

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import copy
 import json
 import logging
+import os
 import re
 import threading
 import time
@@ -2483,7 +2484,60 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     httpx_verify = resolve_httpx_verify(ca_bundle=ssl_ca_cert, ssl_verify=ssl_verify_cfg)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
+    if agent.provider == "pi-rpc" or str(client_kwargs.get("base_url", "")).startswith("pi://"):
+        # First-class pi delegation: drive pi's native JSONL RPC directly.
+        # Unlike ACP, the native protocol exposes extension_ui_request, so
+        # delegated pi agents can ask the parent questions and receive real
+        # free-text answers.
+        from agent.copilot_acp_client import _resolve_command
+        from agent.pi_rpc_client import PI_RPC_MARKER_BASE_URL, PiRPCClient
+
+        _pi_cmd = str(
+            client_kwargs.get("acp_command")
+            or client_kwargs.get("command")
+            or os.getenv("HERMES_PI_BIN", "").strip()
+            or "pi"
+        ).strip()
+        if Path(_pi_cmd).name in ("pi", "pi-acp") or not _pi_cmd:
+            client_kwargs.pop("base_url", None)
+            client_kwargs.pop("acp_command", None)
+            client_kwargs.pop("command", None)
+            client = PiRPCClient(**client_kwargs, base_url=PI_RPC_MARKER_BASE_URL)
+            _ra().logger.info(
+                "Pi RPC client created (%s, shared=%s) %s",
+                reason,
+                shared,
+                agent._client_log_context(),
+            )
+            return client
+        raise RuntimeError(
+            f"pi-rpc provider requires the pi binary (got command '{_pi_cmd}'). "
+            "Install pi or set HERMES_PI_BIN."
+        )
     if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
+        # When the ACP transport is actually pi (directly or via the pi-acp
+        # bridge), drive pi's native JSONL RPC instead. Unlike ACP, the
+        # native protocol exposes extension_ui_request, so delegated pi
+        # agents can ask the parent questions and receive real answers.
+        from agent.copilot_acp_client import _resolve_command
+
+        _acp_cmd = str(
+            client_kwargs.get("acp_command")
+            or client_kwargs.get("command")
+            or _resolve_command()
+        ).strip()
+        if Path(_acp_cmd).name in ("pi", "pi-acp"):
+            from agent.pi_rpc_client import PI_RPC_MARKER_BASE_URL, PiRPCClient
+
+            client_kwargs.pop("base_url", None)
+            client = PiRPCClient(**client_kwargs, base_url=PI_RPC_MARKER_BASE_URL)
+            _ra().logger.info(
+                "Pi RPC client created (%s, shared=%s) %s",
+                reason,
+                shared,
+                agent._client_log_context(),
+            )
+            return client
         from agent.copilot_acp_client import CopilotACPClient
 
         client = CopilotACPClient(**client_kwargs)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6886,6 +6886,18 @@ def resolve_provider_client(
             or _read_main_model_for_aux(),
             provider,
         )
+        if provider == "pi-rpc":
+            from agent.pi_rpc_client import PI_RPC_MARKER_BASE_URL, PiRPCClient
+
+            client = PiRPCClient(
+                api_key=str(creds.get("api_key", "")).strip() or "pi-rpc",
+                base_url=PI_RPC_MARKER_BASE_URL,
+                command=str(creds.get("command", "")).strip() or None,
+                args=list(creds.get("args") or []),
+            )
+            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                    else (client, final_model))
         if provider == "copilot-acp":
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -60,8 +60,29 @@ def _is_gh_copilot_deprecation_message(stderr_text: str) -> bool:
 
 
 def _resolve_command() -> str:
+    # Re-read .env at call time so changing HERMES_COPILOT_ACP_COMMAND
+    # applies to the next delegation without a gateway restart.
+    env_val = os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+    if not env_val:
+        for candidate in (
+            Path(os.path.expanduser("~/.hermes/.env")),
+            Path(os.path.expanduser("~/.hermes/hermes-agent/.env")),
+        ):
+            try:
+                if not candidate.is_file():
+                    continue
+                for line in candidate.read_text().splitlines():
+                    line = line.strip()
+                    if line.startswith("HERMES_COPILOT_ACP_COMMAND="):
+                        env_val = line.split("=", 1)[1].strip().strip("'\"")
+                        if env_val:
+                            break
+                if env_val:
+                    break
+            except OSError:
+                continue
     return (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+        env_val
         or os.getenv("COPILOT_CLI_PATH", "").strip()
         or "copilot"
     )

--- a/agent/extensions/hermes_ask_user.ts
+++ b/agent/extensions/hermes_ask_user.ts
@@ -1,0 +1,63 @@
+/**
+ * hermes_ask_user — first-party pi extension for Hermes pi-rpc delegation.
+ *
+ * Exposes an `hermes_ask_user` tool to the pi agent. When called, it raises a
+ * blocking UI dialog over the RPC channel (extension_ui_request). Hermes'
+ * PiRPCClient holds the question open, surfaces it to the user as
+ * [pi-question], and the user's steering reply is delivered back as the
+ * answer.
+ *
+ * Uses the documented ExtensionUIContext API: ctx.ui.input() / ctx.ui.select(),
+ * both of which resolve to string | undefined (undefined = cancelled/timeout).
+ */
+export default function (pi: any) {
+  pi.registerTool({
+    name: "hermes_ask_user",
+    label: "Ask User (Hermes)",
+    description:
+      "Ask the supervising human a question and block until they answer. " +
+      "Use when you genuinely need information or a decision before proceeding.",
+    executionMode: "sequential",
+    parameters: {
+      type: "object",
+      properties: {
+        question: { type: "string", description: "The question, self-contained." },
+        options: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional choices; the human may also answer freely.",
+        },
+      },
+      required: ["question"],
+    },
+    async execute(toolCallId: string, args: { question: string; options?: string[] }, signal: any, onUpdate: any, ctx: any) {
+      const question = (args?.question ?? "").trim() || "(no question)";
+      const options = (args?.options ?? []).map((o) => String(o).trim()).filter(Boolean);
+      const ui = ctx && ctx.ui ? ctx.ui : (pi as any).ui;
+      if (!ui || typeof ui.input !== "function") {
+        return {
+          content: [{ type: "text", text: "(no answer provided — proceed with a safe default and note it)" }],
+        };
+      }
+
+      let answer: string | undefined;
+      if (options.length > 0 && typeof ui.select === "function") {
+        // Prepend an explicit freeform escape so the human is never locked in.
+        answer = await ui.select(question, [...options, "Other (type a custom answer)"]);
+        if (answer === "Other (type a custom answer)") {
+          answer = await ui.input(question, "Type your answer...");
+        }
+      } else {
+        answer = await ui.input(question, "Type your answer...");
+      }
+
+      const text = (answer ?? "").trim();
+      if (!text) {
+        return {
+          content: [{ type: "text", text: "(no answer provided — proceed with a safe default and note it)" }],
+        };
+      }
+      return { content: [{ type: "text", text: `User answered: ${text}` }] };
+    },
+  });
+}

--- a/agent/pi_rpc_client.py
+++ b/agent/pi_rpc_client.py
@@ -60,11 +60,12 @@ pending_questions: dict[str, "PendingQuestion"] = {}
 class PendingQuestion:
     """One unanswered extension_ui_request from a pi child."""
 
-    def __init__(self, method: str, title: str, options: list[str] | None):
+    def __init__(self, method: str, title: str, options: list[str] | None, owner: "PiRPCClient | None" = None):
         self.id = f"q_{int(time.time() * 1000)}_{id(self):x}"
         self.method = method
         self.title = title
         self.options = list(options or [])
+        self.owner = owner  # owning client; questions die with their client
         self.answered = threading.Event()
         self.answer: dict[str, Any] | None = None
         self.created_at = time.time()
@@ -111,11 +112,17 @@ class PendingQuestion:
 def answer_oldest_pending_question(text: str) -> bool:
     """Route free text to the oldest pending pi question, if any.
 
+    Questions whose owning client has closed are skipped (their run is
+    gone; answering them would steal the text from a live question).
     Returns True when the text was consumed as a question answer.
     """
     with _registry_lock:
         oldest = None
-        for question in pending_questions.values():
+        for question in list(pending_questions.values()):
+            if question.owner is not None and question.owner.is_closed:
+                pending_questions.pop(question.id, None)
+                question.answered.set()  # unblock the dead waiter if any
+                continue
             if oldest is None or question.created_at < oldest.created_at:
                 oldest = question
         if oldest is None:
@@ -266,6 +273,18 @@ class PiRPCClient:
         tools = os.getenv("HERMES_PI_TOOLS", "").strip()
         if tools:
             argv += ["--tools", tools]
+        # Auto-load pi-ask-user (interactive questions) if installed; users can
+        # force extra extensions with HERMES_PI_EXTENSIONS (colon-separated).
+        ask_user = os.path.join(
+            os.path.expanduser("~"), ".pi", "agent", "npm", "node_modules",
+            "pi-ask-user", "index.ts",
+        )
+        exts = []
+        if os.path.isfile(ask_user):
+            exts.append(ask_user)
+        exts += [p for p in os.getenv("HERMES_PI_EXTENSIONS", "").split(":") if p]
+        for ext in exts:
+            argv += ["-e", ext]
         try:
             proc = subprocess.Popen(
                 argv,
@@ -414,7 +433,7 @@ class PiRPCClient:
             except Exception:
                 pass
             return
-        question = PendingQuestion(method, title, options)
+        question = PendingQuestion(method, title, options, owner=self)
         with _registry_lock:
             pending_questions[question.id] = question
 

--- a/agent/pi_rpc_client.py
+++ b/agent/pi_rpc_client.py
@@ -1,0 +1,537 @@
+"""Native Pi JSONL RPC client for delegated agents (no ACP bridge).
+
+Option C replacement for the pi-acp bridge: Hermes speaks pi's own
+``--mode rpc`` protocol directly, which exposes ``extension_ui_request``
+(confirm / select / input / editor). Unlike ACP — which has no free-text
+question channel — this lets a delegated pi agent ask the parent a
+question and receive a real answer.
+
+Contract parity with the pi-acp bridge is preserved:
+- tool activity inside the child is surfaced as ``[pi-tool ...]`` /
+  ``[pi-tool:ok|FAILED] ...`` markers in the reasoning stream (parsed by
+  ``copilot_acp_client.parse_pi_tool_markers``), and
+- every run appends a fenced ``pi-delegation-result`` JSON footer to the
+  final message (parsed by ``parse_pi_result_footer``).
+
+Interactive questions:
+- An incoming ``extension_ui_request`` is registered in a module-level
+  registry (``pending_questions``) and surfaced as a ``[pi-question]``
+  marker in the reasoning stream plus the question text in the message
+  stream, so the live delegation transcript shows it.
+- The run then blocks (up to ``question_timeout_seconds``, default 600)
+  waiting for an answer. ``tools.delegate_tool.steer_subagent`` checks
+  the registry and routes a steer message to the oldest pending question
+  as free text (``{"text": ...}`` for input/editor, option matching for
+  select, yes/no parsing for confirm).
+- On timeout the old auto-answer policy applies (confirm=true,
+  select=first, input/editor=cancelled) so a delegation never hangs
+  forever.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import threading
+import time
+from collections import deque
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from agent.copilot_acp_client import (
+    _completion_to_stream_chunks,
+    _extract_tool_calls_from_text,
+    _format_messages_as_prompt,
+)
+from tools.environments.local import hermes_subprocess_env
+
+PI_RPC_MARKER_BASE_URL = "pi://rpc"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+_DEFAULT_QUESTION_TIMEOUT = float(os.getenv("HERMES_PI_QUESTION_TIMEOUT", "600"))
+
+# Module-level registry of live questions from all running pi children.
+# Key: unique question id. Value: PendingQuestion.
+_registry_lock = threading.Lock()
+pending_questions: dict[str, "PendingQuestion"] = {}
+
+
+class PendingQuestion:
+    """One unanswered extension_ui_request from a pi child."""
+
+    def __init__(self, method: str, title: str, options: list[str] | None):
+        self.id = f"q_{int(time.time() * 1000)}_{id(self):x}"
+        self.method = method
+        self.title = title
+        self.options = list(options or [])
+        self.answered = threading.Event()
+        self.answer: dict[str, Any] | None = None
+        self.created_at = time.time()
+
+    def answer_with(self, text: str) -> dict[str, Any]:
+        """Map free text to the response payload pi expects."""
+        cleaned = (text or "").strip()
+        low = cleaned.lower()
+        if self.method == "confirm":
+            if low in ("y", "yes", "true", "ok", "confirm"):
+                payload = {"confirmed": True}
+            elif low in ("n", "no", "false", "cancel"):
+                payload = {"confirmed": False}
+            else:
+                # Non-boolean answer to a confirm: treat non-empty as yes.
+                payload = {"confirmed": bool(cleaned)}
+        elif self.method == "select":
+            match = None
+            for option in self.options:
+                if option and option.lower() == low:
+                    match = option
+                    break
+            if match is None and low.isdigit():
+                idx = int(low)
+                if 1 <= idx <= len(self.options):
+                    match = self.options[idx - 1]
+            if match is None and self.options:
+                match = self.options[0]
+            payload = {"value": match} if match is not None else {"cancelled": True}
+        else:  # input, editor — free text is exactly what these want
+            payload = {"text": cleaned} if cleaned else {"cancelled": True}
+        self.answer = payload
+        self.answered.set()
+        return payload
+
+    def auto_answer(self) -> dict[str, Any]:
+        if self.method == "confirm":
+            return {"confirmed": True}
+        if self.method == "select":
+            return {"value": self.options[0]} if self.options else {"cancelled": True}
+        return {"cancelled": True}
+
+
+def answer_oldest_pending_question(text: str) -> bool:
+    """Route free text to the oldest pending pi question, if any.
+
+    Returns True when the text was consumed as a question answer.
+    """
+    with _registry_lock:
+        oldest = None
+        for question in pending_questions.values():
+            if oldest is None or question.created_at < oldest.created_at:
+                oldest = question
+        if oldest is None:
+            return False
+        pending_questions.pop(oldest.id, None)
+    oldest.answer_with(text)
+    return True
+
+
+def _resolve_pi_bin() -> str:
+    return (
+        os.getenv("HERMES_PI_BIN", "").strip()
+        or os.getenv("PI_BIN", "").strip()
+        or "pi"
+    )
+
+
+def _resolve_acp_command(kwargs_command: str | None) -> str:
+    # When wired through the copilot-acp plumbing, the command may be
+    # ``pi`` or ``pi-acp``; either way we drive pi natively.
+    return _resolve_pi_bin()
+
+
+class _PiChatCompletions:
+    def __init__(self, client: "PiRPCClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _PiChatNamespace:
+    def __init__(self, client: "PiRPCClient"):
+        self.completions = _PiChatCompletions(client)
+
+
+class PiRPCClient:
+    """Minimal OpenAI-client-compatible facade over `pi --mode rpc`."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        acp_command: str | None = None,
+        acp_args: list[str] | None = None,
+        acp_cwd: str | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        **_: Any,
+    ) -> None:
+        self.api_key = api_key or "pi-rpc"
+        self.base_url = base_url or PI_RPC_MARKER_BASE_URL
+        self._pi_bin = _resolve_acp_command(command or acp_command)
+        self._cwd = str(Path(acp_cwd or os.getcwd()).resolve())
+        self.chat = _PiChatNamespace(self)
+        self.is_closed = False
+        self._proc: subprocess.Popen[str] | None = None
+        self._stdin_lock = threading.Lock()
+        self._pending: dict[int, list] = {}
+        self._pending_lock = threading.Lock()
+        self._next_id = 0
+        self._stderr_tail: deque[str] = deque(maxlen=40)
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def close(self) -> None:
+        self.is_closed = True
+        proc = self._proc
+        self._proc = None
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+            proc.wait(timeout=2)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    # -- shim entrypoint ---------------------------------------------------
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        stream: bool = False,
+        **_: Any,
+    ) -> Any:
+        prompt_text = _format_messages_as_prompt(
+            messages or [], model=model, tools=tools, tool_choice=tool_choice
+        )
+        if timeout is None:
+            effective_timeout = _DEFAULT_TIMEOUT_SECONDS
+        elif isinstance(timeout, (int, float)):
+            effective_timeout = float(timeout)
+        else:
+            candidates = [
+                getattr(timeout, attr, None)
+                for attr in ("read", "write", "connect", "pool", "timeout")
+            ]
+            numeric = [float(v) for v in candidates if isinstance(v, (int, float))]
+            effective_timeout = max(numeric) if numeric else _DEFAULT_TIMEOUT_SECONDS
+
+        response_text, reasoning_text = self._run_prompt(
+            prompt_text, timeout_seconds=effective_timeout
+        )
+        tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
+        usage = SimpleNamespace(
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+        )
+        assistant_message = SimpleNamespace(
+            content=cleaned_text,
+            tool_calls=tool_calls,
+            reasoning=reasoning_text or None,
+            reasoning_content=reasoning_text or None,
+            reasoning_details=None,
+        )
+        finish_reason = "tool_calls" if tool_calls else "stop"
+        choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
+        completion = SimpleNamespace(
+            choices=[choice], usage=usage, model=model or "pi-rpc"
+        )
+        if stream:
+            return _completion_to_stream_chunks(completion)
+        return completion
+
+    # -- pi protocol -------------------------------------------------------
+
+    def _spawn(self) -> subprocess.Popen[str]:
+        argv = [self._pi_bin, "--mode", "rpc", "--no-session"]
+        model = os.getenv("HERMES_PI_MODEL", "").strip()
+        if model:
+            argv += ["--model", model]
+        tools = os.getenv("HERMES_PI_TOOLS", "").strip()
+        if tools:
+            argv += ["--tools", tools]
+        try:
+            proc = subprocess.Popen(
+                argv,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                bufsize=1,
+                cwd=self._cwd,
+                env=hermes_subprocess_env(),
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Could not start pi binary '{self._pi_bin}'. Install pi or set HERMES_PI_BIN."
+            ) from exc
+        if proc.stdin is None or proc.stdout is None:
+            proc.kill()
+            raise RuntimeError("pi rpc process did not expose stdin/stdout pipes.")
+        self._proc = proc
+        threading.Thread(target=self._reader, daemon=True).start()
+        threading.Thread(target=self._stderr_reader, daemon=True).start()
+        return proc
+
+    def _reader(self) -> None:
+        proc = self._proc
+        if proc is None or proc.stdout is None:
+            return
+        try:
+            for line in proc.stdout:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line)
+                except ValueError:
+                    continue
+                self._dispatch(msg)
+        except Exception:
+            pass
+
+    def _stderr_reader(self) -> None:
+        proc = self._proc
+        if proc is None or proc.stderr is None:
+            return
+        for line in proc.stderr:
+            self._stderr_tail.append(line.rstrip("\n"))
+
+    def _send_pi(self, command: dict) -> None:
+        proc = self._proc
+        if proc is None or proc.stdin is None:
+            raise RuntimeError("pi rpc child is not running")
+        with self._stdin_lock:
+            proc.stdin.write(json.dumps(command) + "\n")
+            proc.stdin.flush()
+
+    def _request_pi(self, command: dict, timeout: float = 60.0) -> dict:
+        with self._pending_lock:
+            self._next_id += 1
+            request_id = self._next_id
+            waiter = threading.Event()
+            slot: list = [None]
+            self._pending[request_id] = [waiter, slot]
+        self._send_pi(dict(command, id=request_id))
+        if not waiter.wait(timeout):
+            with self._pending_lock:
+                self._pending.pop(request_id, None)
+            raise TimeoutError(f"pi did not answer command {command.get('type')!r}")
+        return slot[0] or {}
+
+    def _dispatch(self, msg: dict) -> None:
+        msg_type = msg.get("type")
+
+        if msg_type == "response":
+            request_id = msg.get("id")
+            with self._pending_lock:
+                entry = (
+                    self._pending.pop(request_id, None)
+                    if isinstance(request_id, int)
+                    else None
+                )
+            if entry is not None:
+                entry[1][0] = msg
+                entry[0].set()
+            return
+
+        if msg_type == "extension_ui_request":
+            self._handle_ui_request(msg)
+            return
+
+        if msg_type in ("tool_execution_start", "tool_execution_end"):
+            name = str(msg.get("toolName") or "tool")
+            if msg_type == "tool_execution_start":
+                args = msg.get("args")
+                args_txt = (
+                    args
+                    if isinstance(args, str)
+                    else json.dumps(args, ensure_ascii=False, default=str)
+                )
+                line = f"[pi-tool] {name} {args_txt}".strip()
+            else:
+                result = msg.get("result")
+                details = result.get("details") if isinstance(result, dict) else None
+                ok = details.get("success") if isinstance(details, dict) else None
+                mark = "ok" if ok is not False else "FAILED"
+                size = (
+                    len(result)
+                    if isinstance(result, str)
+                    else len(json.dumps(result, default=str))
+                )
+                line = f"[pi-tool:{mark}] {name} -> result {size} bytes"
+            self._reasoning_parts.append(line[:400] + "\n")
+            return
+
+        if msg_type == "message_update":
+            event = msg.get("assistantMessageEvent") or {}
+            kind = event.get("type")
+            delta = event.get("delta")
+            if not isinstance(delta, str) or not delta:
+                return
+            if kind == "text_delta":
+                self.text_streamed = True
+                self._text_parts.append(delta)
+            elif kind == "thinking_delta":
+                self._reasoning_parts.append(delta)
+            return
+
+        if msg_type == "agent_settled":
+            self._settled.set()
+            return
+
+    # -- interactive questions ----------------------------------------------
+
+    def _handle_ui_request(self, msg: dict) -> None:
+        method = str(msg.get("method") or "input")
+        request_id = msg.get("id")
+        title = str(msg.get("title") or "")
+        options = msg.get("options") or []
+        if method not in ("input", "select", "confirm", "editor"):
+            # setStatus / notify / setWidget and similar are fire-and-forget
+            # UI notifications from extensions, not questions. Acknowledge
+            # immediately so the child never blocks on them.
+            try:
+                self._send_pi({"type": "extension_ui_response", "id": request_id, "ok": True})
+            except Exception:
+                pass
+            return
+        question = PendingQuestion(method, title, options)
+        with _registry_lock:
+            pending_questions[question.id] = question
+
+        self._reasoning_parts.append(
+            f"[pi-question] {method}: {title}"
+            + (f" options={options}" if options else "")
+            + "\n"
+        )
+        self._text_parts.append(
+            f"\n[Question from pi delegate — steer this delegation with your answer"
+            f" (timeout {int(_DEFAULT_QUESTION_TIMEOUT)}s)]: {title}\n"
+        )
+
+        try:
+            answered = question.answered.wait(_DEFAULT_QUESTION_TIMEOUT)
+        finally:
+            with _registry_lock:
+                pending_questions.pop(question.id, None)
+
+        payload = question.answer if answered else question.auto_answer()
+
+        if not answered:
+            self._reasoning_parts.append(
+                f"[pi-question] timed out; auto-answered {method} -> {payload}\n"
+            )
+        else:
+            self._reasoning_parts.append(
+                f"[pi-question] answered with user text -> {payload}\n"
+            )
+        try:
+            self._send_pi(
+                {"type": "extension_ui_response", "id": request_id, **payload}
+            )
+        except Exception:
+            pass
+
+    # -- run ------------------------------------------------------------------
+
+    def _git_status_snapshot(self) -> dict[str, str] | None:
+        try:
+            proc = subprocess.run(
+                ["git", "-C", self._cwd, "status", "--porcelain"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+        except Exception:
+            return None
+        if proc.returncode != 0:
+            return None
+        return {
+            line[3:]: line for line in proc.stdout.splitlines() if len(line) > 3
+        }
+
+    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+        self._spawn()
+        self._text_parts: list[str] = []
+        self._reasoning_parts: list[str] = []
+        self._settled = threading.Event()
+        self.text_streamed = False
+
+        before_status = self._git_status_snapshot()
+        started = time.monotonic()
+
+        policy = (
+            "[Delegation policy] You are a delegated implementer. Make the "
+            "requested changes in the working tree, but do NOT run git "
+            "commit or git push — leave all changes uncommitted for the "
+            "reviewing agent to review and land."
+        )
+
+        status = "end_turn"
+        try:
+            response = self._request_pi(
+                {"type": "prompt", "message": policy + "\n\n" + prompt_text},
+                timeout=timeout_seconds,
+            )
+            if not response.get("success"):
+                error = response.get("error") or "prompt rejected"
+                self._text_parts.append(f"\n[pi-rpc error] prompt rejected: {error}\n")
+                status = "error"
+            else:
+                self._settled.wait(timeout_seconds)
+                if not self._settled.is_set():
+                    try:
+                        self._send_pi({"type": "abort"})
+                    except Exception:
+                        pass
+                    self._settled.wait(10)
+                    self._text_parts.append(
+                        f"\n[pi-rpc error] timed out after {timeout_seconds:.0f}s\n"
+                    )
+                    status = "error"
+        except TimeoutError as exc:
+            self._text_parts.append(f"\n[pi-rpc error] {exc}\n")
+            status = "error"
+
+        if status == "end_turn" and not self.text_streamed:
+            try:
+                last = self._request_pi({"type": "get_last_assistant_text"})
+                text = (last.get("data") or {}).get("text")
+                if isinstance(text, str) and text:
+                    self._text_parts.append(text)
+            except Exception:
+                pass
+
+        after_status = self._git_status_snapshot()
+        touched = sorted(
+            line
+            for path, line in (after_status or {}).items()
+            if (before_status or {}).get(path) != line
+        ) if before_status is not None and after_status is not None else []
+        footer = {
+            "status": status,
+            "duration_s": round(time.monotonic() - started, 1),
+            "git_repo": after_status is not None,
+            "touched_files": touched,
+        }
+        self._text_parts.append(
+            "\n```pi-delegation-result\n"
+            + json.dumps(footer, ensure_ascii=False)
+            + "\n```\n"
+        )
+        return "".join(self._text_parts), "".join(self._reasoning_parts)

--- a/agent/pi_rpc_client.py
+++ b/agent/pi_rpc_client.py
@@ -134,8 +134,12 @@ def _resolve_pi_bin() -> str:
 
 
 def _resolve_acp_command(kwargs_command: str | None) -> str:
-    # When wired through the copilot-acp plumbing, the command may be
-    # ``pi`` or ``pi-acp``; either way we drive pi natively.
+    # An explicitly passed command that exists on disk wins (lets callers
+    # and tests pin the exact binary). Bare names (``pi`` / ``pi-acp`` from
+    # the copilot-acp plumbing) resolve through env so HERMES_PI_BIN still
+    # overrides; we drive pi natively either way.
+    if kwargs_command and Path(kwargs_command).exists():
+        return kwargs_command
     return _resolve_pi_bin()
 
 

--- a/agent/pi_rpc_client.py
+++ b/agent/pi_rpc_client.py
@@ -71,15 +71,22 @@ class PendingQuestion:
         self.created_at = time.time()
 
     def answer_with(self, text: str) -> dict[str, Any]:
-        """Map free text to the pi-ask-user response shape (AskResponse)."""
+        """Map free text onto pi's extension_ui_response dialog shapes.
+
+        Pi's RPC dialogs resolve via:
+          input/select -> ``r.cancelled ? undefined : r.value``
+          confirm      -> ``r.cancelled ? false : r.confirmed``
+        So the wire payload is ``{value}`` / ``{confirmed}`` / ``{cancelled}``
+        — NOT the third-party pi-ask-user ``{kind: ...}`` shape.
+        """
         cleaned = (text or "").strip()
         low = cleaned.lower()
         if self.method == "confirm":
-            # yes/no/true/false → selection with "yes" or "no".
             is_yes = low in ("y", "yes", "true", "ok", "confirm", "t", "1", "yeah", "yep")
-            payload = {"kind": "selection", "selections": ["yes"] if is_yes else ["no"]}
+            payload = {"confirmed": is_yes}
         elif self.method == "select":
-            # Match by option text first, then by 1‑based index.
+            # Match by option text first, then by 1‑based index, else pass the
+            # raw text through as a freeform selection.
             match = None
             for option in self.options:
                 if option and option.lower() == low:
@@ -89,12 +96,9 @@ class PendingQuestion:
                 idx = int(low)
                 if 1 <= idx <= len(self.options):
                     match = self.options[idx - 1]
-            if match is None and self.options:
-                match = self.options[0]
-            selections = [match] if match is not None else (self.options[:1] if self.options else [cleaned])
-            payload = {"kind": "selection", "selections": selections}
+            payload = {"value": match if match is not None else cleaned} if (match is not None or cleaned) else {"cancelled": True}
         else:  # input, editor — free text.
-            payload = {"kind": "freeform", "text": cleaned} if cleaned else {"cancelled": True}
+            payload = {"value": cleaned} if cleaned else {"cancelled": True}
         self.answer = payload
         self.answered.set()
         return payload
@@ -102,9 +106,9 @@ class PendingQuestion:
     def auto_answer(self) -> dict[str, Any]:
         """Default answer for fallback policy."""
         if self.method == "confirm":
-            return {"kind": "selection", "selections": ["yes"]}
+            return {"confirmed": True}
         if self.method == "select":
-            return {"kind": "selection", "selections": self.options[:1]} if self.options else {"cancelled": True}
+            return {"value": self.options[0]} if self.options else {"cancelled": True}
         return {"cancelled": True}
 
 
@@ -272,13 +276,19 @@ class PiRPCClient:
         tools = os.getenv("HERMES_PI_TOOLS", "").strip()
         if tools:
             argv += ["--tools", tools]
-        # Auto-load pi-ask-user (interactive questions) if installed; users can
-        # force extra extensions with HERMES_PI_EXTENSIONS (colon-separated).
+        # Auto-load the first-party hermes_ask_user extension (ships with this
+        # repo) and optionally pi-ask-user; users can force extra extensions
+        # with HERMES_PI_EXTENSIONS (colon-separated).
+        exts = []
+        first_party = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "extensions", "hermes_ask_user.ts"
+        )
+        if os.path.isfile(first_party):
+            exts.append(first_party)
         ask_user = os.path.join(
             os.path.expanduser("~"), ".pi", "agent", "npm", "node_modules",
             "pi-ask-user", "index.ts",
         )
-        exts = []
         if os.path.isfile(ask_user):
             exts.append(ask_user)
         exts += [p for p in os.getenv("HERMES_PI_EXTENSIONS", "").split(":") if p]

--- a/agent/pi_rpc_client.py
+++ b/agent/pi_rpc_client.py
@@ -71,18 +71,15 @@ class PendingQuestion:
         self.created_at = time.time()
 
     def answer_with(self, text: str) -> dict[str, Any]:
-        """Map free text to the response payload pi expects."""
+        """Map free text to the pi-ask-user response shape (AskResponse)."""
         cleaned = (text or "").strip()
         low = cleaned.lower()
         if self.method == "confirm":
-            if low in ("y", "yes", "true", "ok", "confirm"):
-                payload = {"confirmed": True}
-            elif low in ("n", "no", "false", "cancel"):
-                payload = {"confirmed": False}
-            else:
-                # Non-boolean answer to a confirm: treat non-empty as yes.
-                payload = {"confirmed": bool(cleaned)}
+            # yes/no/true/false → selection with "yes" or "no".
+            is_yes = low in ("y", "yes", "true", "ok", "confirm", "t", "1", "yeah", "yep")
+            payload = {"kind": "selection", "selections": ["yes"] if is_yes else ["no"]}
         elif self.method == "select":
+            # Match by option text first, then by 1‑based index.
             match = None
             for option in self.options:
                 if option and option.lower() == low:
@@ -94,18 +91,20 @@ class PendingQuestion:
                     match = self.options[idx - 1]
             if match is None and self.options:
                 match = self.options[0]
-            payload = {"value": match} if match is not None else {"cancelled": True}
-        else:  # input, editor — free text is exactly what these want
-            payload = {"text": cleaned} if cleaned else {"cancelled": True}
+            selections = [match] if match is not None else (self.options[:1] if self.options else [cleaned])
+            payload = {"kind": "selection", "selections": selections}
+        else:  # input, editor — free text.
+            payload = {"kind": "freeform", "text": cleaned} if cleaned else {"cancelled": True}
         self.answer = payload
         self.answered.set()
         return payload
 
     def auto_answer(self) -> dict[str, Any]:
+        """Default answer for fallback policy."""
         if self.method == "confirm":
-            return {"confirmed": True}
+            return {"kind": "selection", "selections": ["yes"]}
         if self.method == "select":
-            return {"value": self.options[0]} if self.options else {"cancelled": True}
+            return {"kind": "selection", "selections": self.options[:1]} if self.options else {"cancelled": True}
         return {"cancelled": True}
 
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2154,11 +2154,19 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if hass_token:
         if Platform.HOMEASSISTANT not in config.platforms:
             config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
-        config.platforms[Platform.HOMEASSISTANT].enabled = True
-        config.platforms[Platform.HOMEASSISTANT].token = hass_token
+        # A secondary multiplex profile may need HASS_TOKEN for the built-in
+        # Home Assistant toolset while explicitly disabling the HA messaging
+        # adapter to avoid consuming the same credential twice. Mirror the API
+        # server's explicit-disable semantics: env presence wires the token
+        # through but must not override platforms.homeassistant.enabled: false.
+        hass_config = config.platforms[Platform.HOMEASSISTANT]
+        hass_explicit = bool(hass_config.extra.get("_enabled_explicit", False))
+        if not hass_explicit or hass_config.enabled:
+            hass_config.enabled = True
+        hass_config.token = hass_token
         hass_url = getenv("HASS_URL")
         if hass_url:
-            config.platforms[Platform.HOMEASSISTANT].extra["url"] = hass_url
+            hass_config.extra["url"] = hass_url
 
     # Email
     email_addr = getenv("EMAIL_ADDRESS")

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -305,6 +305,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "pi-rpc": ProviderConfig(
+        id="pi-rpc",
+        name="Pi (native JSONL RPC)",
+        auth_type="external_process",
+        inference_base_url="pi://rpc",
+        base_url_env_var="",  # fixed internal marker; not configurable
+    ),
     "gemini": ProviderConfig(
         id="gemini",
         name="Google AI Studio",
@@ -7349,6 +7356,28 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             provider=provider_id,
             code="invalid_provider",
         )
+
+    if provider_id == "pi-rpc":
+        # Pi speaks its native JSONL RPC protocol directly — no ACP bridge,
+        # no Copilot CLI env vars. The client builds its own argv
+        # (``pi --mode rpc --no-session``); command/args are resolved for
+        # liveness only.
+        command = os.getenv("HERMES_PI_BIN", "").strip() or "pi"
+        resolved_command = shutil.which(command)
+        if not resolved_command:
+            raise AuthError(
+                f"Could not find the pi binary '{command}'. Install pi or set HERMES_PI_BIN.",
+                provider=provider_id,
+                code="missing_pi_binary",
+            )
+        return {
+            "provider": provider_id,
+            "api_key": "pi-rpc",
+            "base_url": "pi://rpc",
+            "command": resolved_command,
+            "args": ["--mode", "rpc", "--no-session"],
+            "source": "process",
+        }
 
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -2099,6 +2099,19 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
+    if provider == "pi-rpc":
+        creds = resolve_external_process_provider_credentials(provider)
+        return {
+            "provider": "pi-rpc",
+            "api_mode": "chat_completions",
+            "base_url": creds.get("base_url", "").rstrip("/"),
+            "api_key": creds.get("api_key", ""),
+            "command": creds.get("command", ""),
+            "args": list(creds.get("args") or []),
+            "source": creds.get("source", "process"),
+            "requested_provider": requested_provider,
+        }
+
     # Anthropic (native Messages API)
     if provider == "anthropic":
         # Allow base URL override from config.yaml model.base_url, but only

--- a/plugins/model-providers/pi-rpc/__init__.py
+++ b/plugins/model-providers/pi-rpc/__init__.py
@@ -1,0 +1,40 @@
+"""Pi RPC provider profile.
+
+pi-rpc drives the local ``pi`` coding agent over its native JSONL RPC
+protocol (``pi --mode rpc``) — no ACP bridge. The native protocol exposes
+``extension_ui_request``, so delegated pi agents can ask the parent
+questions and receive real free-text answers.
+
+The profile captures auth + endpoint metadata for registry migration;
+client construction is handled in run_agent.py / auxiliary_client.py,
+which build ``PiRPCClient`` for ``provider == "pi-rpc"``.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class PiRPCProfile(ProviderProfile):
+    """Pi coding agent — external JSONL RPC process, no REST endpoint."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Model listing is owned by the pi subprocess config."""
+        return None
+
+
+pi_rpc = PiRPCProfile(
+    name="pi-rpc",
+    aliases=("pi", "pi-agent"),
+    api_mode="chat_completions",  # JSONL RPC is routed via chat_completions plumbing
+    env_vars=(),  # Managed by the pi subprocess
+    base_url="pi://rpc",  # internal marker scheme
+    auth_type="external_process",
+)
+
+register_provider(pi_rpc)

--- a/plugins/model-providers/pi-rpc/plugin.yaml
+++ b/plugins/model-providers/pi-rpc/plugin.yaml
@@ -1,0 +1,5 @@
+name: pi-rpc-provider
+kind: model-provider
+version: 1.0.0
+description: Pi coding agent via native JSONL RPC
+author: local

--- a/tests/agent/test_pi_rpc_client.py
+++ b/tests/agent/test_pi_rpc_client.py
@@ -13,7 +13,6 @@ the real binary or network. Pins the behaviors the parent relies on:
 
 import stat
 import sys
-import textwrap
 import threading
 import time
 
@@ -29,41 +28,45 @@ from agent.pi_rpc_client import (
 
 # ---------------------------------------------------------------- fake pi
 
-FAKE_PI = textwrap.dedent(
-    """
-    import json, sys
-    def send(o): sys.stdout.write(json.dumps(o) + "\\n"); sys.stdout.flush()
-    send({"type": "ready"})
-    prompt_id = None
-    while True:
-        line = sys.stdin.readline()
-        if not line:
-            break
-        line = line.strip()
-        if not line:
-            continue
-        msg = json.loads(line)
-        if msg.get("type") == "prompt":
-            prompt_id = msg["id"]
-            # 1) tool-call markers (reasoning), 2) a question, 3) block
-            # here (NOT in the for-loop) until answered, 4) final answer
-            # echoing the response payload + footer.
-            send({"type": "assistant", "thought":
-                  '[pi-tool] bash {"cmd": "ls"}\n'
-                  "[pi-tool:ok] bash -> result 12 bytes"})
-            send({"type": "extension_ui_request", "id": 9001,
-                  "method": "input", "title": "Which DB port?"})
-            while True:
-                r = json.loads(sys.stdin.readline())
-                if r.get("type") == "extension_ui_response":
-                    ans = r.get("text")
-                    break
-            footer = "{\"status\": \"end_turn\", \"duration_s\": 1.5, \"touched_files\": []}"
-            send({"type": "assistant",
-                  "text": "answered with: %s\n```pi-delegation-result\n%s\n```" % (ans, footer)})
-            send({"type": "prompt_done", "id": prompt_id})
-    """
-)
+# The fake pi script. Built as a plain string (not a triple-quoted blob)
+# so indentation is explicit and a stray margin can never break dedent.
+FAKE_PI = "\n".join([
+    "import json, sys",
+    "last_text = ''",
+    "def send(o): sys.stdout.write(json.dumps(o) + chr(10)); sys.stdout.flush()",
+    'send({"type": "ready"})',
+    "while True:",
+    "    line = sys.stdin.readline()",
+    "    if not line: break",
+    "    line = line.strip()",
+    "    if not line: continue",
+    "    msg = json.loads(line)",
+    '    if msg.get("type") == "get_last_assistant_text":',
+    '        send({"type": "response", "id": msg["id"], "success": True,',
+    '              "data": {"text": last_text}})',
+    '        continue',
+    '    if msg.get("type") != "prompt": continue',
+    '    # acknowledge the request, then run the scripted exchange:',
+    '    # 1) tool-call markers (reasoning), 2) a question, 3) block',
+    '    # until answered, 4) final answer echoing the answer + footer.',
+    '    send({"type": "response", "id": msg["id"], "success": True})',
+    '    send({"type": "assistant", "thought":',
+    '          \'[pi-tool] bash {"cmd": "ls"}\\n[pi-tool:ok] bash -> result 12 bytes\'})',
+    '    send({"type": "message_update", "assistantMessageEvent":',
+    '          {"type": "thinking_delta", "delta":',
+    '           \'[pi-tool] bash {"cmd": "ls"}\\n[pi-tool:ok] bash -> result 12 bytes\\n\'}})',
+    '    send({"type": "extension_ui_request", "id": 9001,',
+    '          "method": "input", "title": "Which DB port?"})',
+    "    while True:",
+    "        r = json.loads(sys.stdin.readline())",
+    '        if r.get("type") == "extension_ui_response":',
+    '            ans = r.get("text"); break',
+    '    footer = \'{"status": "end_turn", "duration_s": 1.5, "touched_files": []}\'',
+    '    send({"type": "assistant", "text": "answered with: %s\\n```pi-delegation-result\\n%s\\n```" % (ans, footer)})',
+    '    last_text = "answered with: %s" % ans',
+    '    send({"type": "prompt_done", "id": msg["id"]})',
+    '    send({"type": "agent_settled"})',
+])
 
 
 @pytest.fixture
@@ -85,9 +88,11 @@ def make_client(fake_pi):
     return PiRPCClient(acp_command=fake_pi, base_url="pi://rpc-test")
 
 
-def create(client, content):
+def create(client, content, timeout=120):
     return client.chat.completions.create(
-        model="test-model", messages=[{"role": "user", "content": content}]
+        model="test-model",
+        messages=[{"role": "user", "content": content}],
+        timeout=timeout,
     )
 
 
@@ -156,14 +161,17 @@ def test_round_trip_markers_question_footer(fake_pi, clean_registry):
     # Background answerer stands in for steer_subagent's routing: as soon
     # as the child's question registers, answer it with free text.
     def answerer():
-        for _ in range(200):
+        # Poll far longer than the 600s file-level budget: under heavy
+        # parallel load the fake-pi spawn can take a while, and if this
+        # thread gives up the question waits on the full default timeout.
+        for _ in range(2000):
             if pending_questions:
                 answer_oldest_pending_question("5432")
                 return
-            time.sleep(0.05)
+            time.sleep(0.1)
     t = threading.Thread(target=answerer, daemon=True)
     t.start()
-    completion = create(client, "delegate this")
+    completion = create(client, "delegate this", timeout=180)
     t.join(timeout=5)
     msg = completion.choices[0].message
     # free-text answer reached the child and is echoed in its final text
@@ -179,7 +187,7 @@ def test_question_timeout_auto_answers(fake_pi, clean_registry, monkeypatch):
     monkeypatch.setattr("agent.pi_rpc_client._DEFAULT_QUESTION_TIMEOUT", 1.0)
     client = make_client(fake_pi)
     start = time.time()
-    completion = create(client, "go")
+    completion = create(client, "go", timeout=180)
     elapsed = time.time() - start
     # No steer ever arrives: after ~1s the input question is auto-answered
     # (cancelled policy), the run still completes with a footer.

--- a/tests/agent/test_pi_rpc_client.py
+++ b/tests/agent/test_pi_rpc_client.py
@@ -1,0 +1,199 @@
+"""PiRPCClient — native pi --mode rpc delegate contract.
+
+Hermetic: exercises the JSONL protocol against a fake pi subprocess, never
+the real binary or network. Pins the behaviors the parent relies on:
+(1) tool markers + result footer surface on the shim message exactly like
+    the pi-acp bridge's, so existing parsing in conversation_loop /
+    delegate_tool is shared unchanged;
+(2) extension_ui_request questions register as pending and free-text
+    answers map per method (input/editor -> text, select -> option match
+    or index, confirm -> yes/no), with safe auto-answer fallback;
+(3) the pi-rpc provider resolves without any ACP env vars set.
+"""
+
+import stat
+import sys
+import textwrap
+import threading
+import time
+
+import pytest
+
+from agent.pi_rpc_client import (
+    PiRPCClient,
+    PendingQuestion,
+    answer_oldest_pending_question,
+    pending_questions,
+)
+
+
+# ---------------------------------------------------------------- fake pi
+
+FAKE_PI = textwrap.dedent(
+    """
+    import json, sys
+    def send(o): sys.stdout.write(json.dumps(o) + "\\n"); sys.stdout.flush()
+    send({"type": "ready"})
+    prompt_id = None
+    while True:
+        line = sys.stdin.readline()
+        if not line:
+            break
+        line = line.strip()
+        if not line:
+            continue
+        msg = json.loads(line)
+        if msg.get("type") == "prompt":
+            prompt_id = msg["id"]
+            # 1) tool-call markers (reasoning), 2) a question, 3) block
+            # here (NOT in the for-loop) until answered, 4) final answer
+            # echoing the response payload + footer.
+            send({"type": "assistant", "thought":
+                  '[pi-tool] bash {"cmd": "ls"}\n'
+                  "[pi-tool:ok] bash -> result 12 bytes"})
+            send({"type": "extension_ui_request", "id": 9001,
+                  "method": "input", "title": "Which DB port?"})
+            while True:
+                r = json.loads(sys.stdin.readline())
+                if r.get("type") == "extension_ui_response":
+                    ans = r.get("text")
+                    break
+            footer = "{\"status\": \"end_turn\", \"duration_s\": 1.5, \"touched_files\": []}"
+            send({"type": "assistant",
+                  "text": "answered with: %s\n```pi-delegation-result\n%s\n```" % (ans, footer)})
+            send({"type": "prompt_done", "id": prompt_id})
+    """
+)
+
+
+@pytest.fixture
+def fake_pi(tmp_path):
+    p = tmp_path / "fake-pi"
+    p.write_text("#!%s\n%s" % (sys.executable, FAKE_PI))
+    p.chmod(p.stat().st_mode | stat.S_IEXEC)
+    return str(p)
+
+
+@pytest.fixture
+def clean_registry():
+    pending_questions.clear()
+    yield
+    pending_questions.clear()
+
+
+def make_client(fake_pi):
+    return PiRPCClient(acp_command=fake_pi, base_url="pi://rpc-test")
+
+
+def create(client, content):
+    return client.chat.completions.create(
+        model="test-model", messages=[{"role": "user", "content": content}]
+    )
+
+
+# ------------------------------------------------- answer text mapping
+
+@pytest.mark.parametrize(
+    "method,steer,expected",
+    [
+        ("input", "PostgreSQL on 5432", {"text": "PostgreSQL on 5432"}),
+        ("editor", "line1\nline2", {"text": "line1\nline2"}),
+        ("input", "  trimmed  ", {"text": "trimmed"}),
+        ("select", "2", {"value": "Use REST"}),
+        ("select", "use grpc", {"value": "Use gRPC"}),
+        ("confirm", "yes", {"confirmed": True}),
+        ("confirm", "no", {"confirmed": False}),
+        ("confirm", "cancel", {"confirmed": False}),
+    ],
+)
+def test_answer_with_maps_per_method(method, steer, expected):
+    q = PendingQuestion(method, "q", ["Use gRPC", "Use REST"])
+    assert q.answer_with(steer) == expected
+
+
+def test_select_fallbacks_never_crash():
+    # non-matching, non-numeric text -> first option; empty options -> cancel
+    q = PendingQuestion("select", "t", ["a", "b"])
+    assert q.answer_with("whatever") == {"value": "a"}
+    q2 = PendingQuestion("select", "t", [])
+    assert q2.answer_with("anything") == {"cancelled": True}
+
+
+def test_empty_input_is_cancelled_not_empty_text():
+    q = PendingQuestion("input", "t", None)
+    assert q.answer_with("   ") == {"cancelled": True}
+
+
+def test_auto_answer_policy():
+    assert PendingQuestion("confirm", "t", None).auto_answer() == {"confirmed": True}
+    assert PendingQuestion("select", "t", ["a"]).auto_answer() == {"value": "a"}
+    assert PendingQuestion("input", "t", None).auto_answer() == {"cancelled": True}
+
+
+# ---------------------------------------------------------------- registry
+
+def test_answer_oldest_routes_to_oldest(clean_registry):
+    old = PendingQuestion("input", "old", None)
+    old.created_at -= 10
+    new = PendingQuestion("input", "new", None)
+    pending_questions[old.id] = old
+    pending_questions[new.id] = new
+    assert answer_oldest_pending_question("the answer") is True
+    assert old.id not in pending_questions
+    assert new.id in pending_questions
+    assert old.answer == {"text": "the answer"}
+    assert old.answered.is_set()
+
+
+def test_answer_oldest_empty_registry(clean_registry):
+    assert answer_oldest_pending_question("x") is False
+
+
+# ------------------------------------------------------- e2e over fake pi
+
+def test_round_trip_markers_question_footer(fake_pi, clean_registry):
+    client = make_client(fake_pi)
+    # Background answerer stands in for steer_subagent's routing: as soon
+    # as the child's question registers, answer it with free text.
+    def answerer():
+        for _ in range(200):
+            if pending_questions:
+                answer_oldest_pending_question("5432")
+                return
+            time.sleep(0.05)
+    t = threading.Thread(target=answerer, daemon=True)
+    t.start()
+    completion = create(client, "delegate this")
+    t.join(timeout=5)
+    msg = completion.choices[0].message
+    # free-text answer reached the child and is echoed in its final text
+    assert "answered with: 5432" in msg.content
+    # footer contract intact on the final message
+    assert "pi-delegation-result" in msg.content
+    # tool markers ride the reasoning field for shared parsing
+    assert "[pi-tool:ok] bash" in (msg.reasoning or "")
+    client.close()
+
+
+def test_question_timeout_auto_answers(fake_pi, clean_registry, monkeypatch):
+    monkeypatch.setattr("agent.pi_rpc_client._DEFAULT_QUESTION_TIMEOUT", 1.0)
+    client = make_client(fake_pi)
+    start = time.time()
+    completion = create(client, "go")
+    elapsed = time.time() - start
+    # No steer ever arrives: after ~1s the input question is auto-answered
+    # (cancelled policy), the run still completes with a footer.
+    assert elapsed < 30
+    assert "pi-delegation-result" in completion.choices[0].message.content
+    assert pending_questions == {}
+    client.close()
+
+
+# ---------------------------------------------------------------- provider
+
+def test_pi_rpc_provider_resolves_without_acp_env(monkeypatch):
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+    monkeypatch.delenv("HERMES_COPILOT_ACP_COMMAND", raising=False)
+    monkeypatch.delenv("HERMES_COPILOT_ACP_ARGS", raising=False)
+    r = resolve_runtime_provider(requested="pi-rpc")
+    assert r is not None

--- a/tests/agent/test_pi_rpc_client.py
+++ b/tests/agent/test_pi_rpc_client.py
@@ -60,7 +60,7 @@ FAKE_PI = "\n".join([
     "    while True:",
     "        r = json.loads(sys.stdin.readline())",
     '        if r.get("type") == "extension_ui_response":',
-    '            ans = r.get("text"); break',
+    '            ans = r.get("value"); break',
     '    footer = \'{"status": "end_turn", "duration_s": 1.5, "touched_files": []}\'',
     '    send({"type": "assistant", "text": "answered with: %s\\n```pi-delegation-result\\n%s\\n```" % (ans, footer)})',
     '    last_text = "answered with: %s" % ans',
@@ -101,9 +101,9 @@ def create(client, content, timeout=120):
 @pytest.mark.parametrize(
     "method,steer,expected",
     [
-        ("input", "PostgreSQL on 5432", {"text": "PostgreSQL on 5432"}),
-        ("editor", "line1\nline2", {"text": "line1\nline2"}),
-        ("input", "  trimmed  ", {"text": "trimmed"}),
+        ("input", "PostgreSQL on 5432", {"value": "PostgreSQL on 5432"}),
+        ("editor", "line1\nline2", {"value": "line1\nline2"}),
+        ("input", "  trimmed  ", {"value": "trimmed"}),
         ("select", "2", {"value": "Use REST"}),
         ("select", "use grpc", {"value": "Use gRPC"}),
         ("confirm", "yes", {"confirmed": True}),
@@ -117,11 +117,11 @@ def test_answer_with_maps_per_method(method, steer, expected):
 
 
 def test_select_fallbacks_never_crash():
-    # non-matching, non-numeric text -> first option; empty options -> cancel
+    # non-matching, non-numeric text passes through as freeform value; empty text -> cancel
     q = PendingQuestion("select", "t", ["a", "b"])
-    assert q.answer_with("whatever") == {"value": "a"}
+    assert q.answer_with("whatever") == {"value": "whatever"}
     q2 = PendingQuestion("select", "t", [])
-    assert q2.answer_with("anything") == {"cancelled": True}
+    assert q2.answer_with("  ") == {"cancelled": True}
 
 
 def test_empty_input_is_cancelled_not_empty_text():
@@ -146,7 +146,7 @@ def test_answer_oldest_routes_to_oldest(clean_registry):
     assert answer_oldest_pending_question("the answer") is True
     assert old.id not in pending_questions
     assert new.id in pending_questions
-    assert old.answer == {"text": "the answer"}
+    assert old.answer == {"value": "the answer"}
     assert old.answered.is_set()
 
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1203,3 +1203,29 @@ class TestApiServerEnvOverride:
         assert config.platforms[Platform.API_SERVER].enabled is False
         # The key is still wired through for the shared listener.
         assert config.platforms[Platform.API_SERVER].extra.get("key") == api_server_key
+
+
+class TestHomeAssistantEnvOverride:
+    def test_env_token_does_not_reenable_explicitly_disabled_homeassistant(self):
+        """A multiplex secondary profile can keep HASS_TOKEN for HA tools while
+        explicitly disabling the Home Assistant messaging adapter.
+        """
+        config = GatewayConfig(
+            platforms={
+                Platform.HOMEASSISTANT: PlatformConfig(
+                    enabled=False,
+                    extra={"_enabled_explicit": True},
+                ),
+            },
+        )
+
+        with patch.dict(
+            os.environ,
+            {"HASS_TOKEN": "ha-token", "HASS_URL": "http://homeassistant:8123"},
+            clear=True,
+        ):
+            _apply_env_overrides(config)
+
+        assert config.platforms[Platform.HOMEASSISTANT].enabled is False
+        assert config.platforms[Platform.HOMEASSISTANT].token == "ha-token"
+        assert config.platforms[Platform.HOMEASSISTANT].extra.get("url") == "http://homeassistant:8123"

--- a/tests/tools/test_homeassistant_tool.py
+++ b/tests/tools/test_homeassistant_tool.py
@@ -198,6 +198,32 @@ class TestEntityIdValidation:
             None,
         )
 
+    @patch("tools.homeassistant_tool._async_call_service", new_callable=AsyncMock)
+    def test_call_service_accepts_entity_id_array(self, mock_call_service):
+        mock_call_service.return_value = {"success": True}
+        result = json.loads(_handle_call_service({
+            "domain": "light",
+            "service": "turn_off",
+            "entity_id": ["light.bedroom", "light.kitchen"],
+        }))
+        assert result["result"]["success"] is True
+        mock_call_service.assert_awaited_once_with(
+            "light", "turn_off", ["light.bedroom", "light.kitchen"], None
+        )
+
+    @patch("tools.homeassistant_tool._async_call_service", new_callable=AsyncMock)
+    def test_call_service_normalizes_comma_separated_entity_ids(self, mock_call_service):
+        mock_call_service.return_value = {"success": True}
+        result = json.loads(_handle_call_service({
+            "domain": "light",
+            "service": "turn_off",
+            "entity_id": "light.bedroom, light.kitchen",
+        }))
+        assert result["result"]["success"] is True
+        mock_call_service.assert_awaited_once_with(
+            "light", "turn_off", ["light.bedroom", "light.kitchen"], None
+        )
+
 
 # ---------------------------------------------------------------------------
 # String-data deserialization (XML tool calling workaround)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -328,6 +328,18 @@ def steer_subagent(
         agent = record.get("agent")
         if agent is None:
             return False
+        # A delegated pi (native RPC) child may be blocked on an
+        # extension_ui_request. Route the steer text to the oldest pending
+        # question first — that IS the answer — before falling back to the
+        # normal next-request injection.
+        try:
+            from agent.pi_rpc_client import answer_oldest_pending_question
+
+            if answer_oldest_pending_question(text):
+                logger.debug("steer routed to pending pi question for %s", subagent_id)
+                return True
+        except Exception as exc:
+            logger.debug("pi question routing unavailable: %s", exc)
         try:
             return bool(agent.steer(text))
         except Exception as exc:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -333,8 +333,21 @@ def steer_subagent(
         # question first — that IS the answer — before falling back to the
         # normal next-request injection.
         try:
-            from agent.pi_rpc_client import answer_oldest_pending_question
+            from agent.pi_rpc_client import answer_oldest_pending_question, pending_questions, _registry_lock
+            import time
 
+            # If no question is registered yet, wait up to 2 seconds for one
+            # to appear — the child may have just sent the request but the
+            # parent hasn't registered it yet. This avoids the race where a
+            # steer sent immediately after the question marker is seen bypasses
+            # into the child instead of answering the question.
+            if not pending_questions:
+                deadline = time.time() + 2.0
+                while time.time() < deadline:
+                    time.sleep(0.05)
+                    with _registry_lock:
+                        if pending_questions:
+                            break
             if answer_oldest_pending_question(text):
                 logger.debug("steer routed to pending pi question for %s", subagent_id)
                 return True

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -141,7 +141,7 @@ async def _async_get_state(entity_id: str) -> Dict[str, Any]:
 
 
 def _build_service_payload(
-    entity_id: Optional[str] = None,
+    entity_id: Optional[str | list[str]] = None,
     data: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build the JSON payload for a HA service call."""
@@ -178,7 +178,7 @@ def _parse_service_response(
 async def _async_call_service(
     domain: str,
     service: str,
-    entity_id: Optional[str] = None,
+    entity_id: Optional[str | list[str]] = None,
     data: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Call a Home Assistant service."""
@@ -271,8 +271,23 @@ def _handle_call_service(args: dict, **kw) -> str:
         )
 
     entity_id = args.get("entity_id")
-    if entity_id and not _ENTITY_ID_RE.match(entity_id):
-        return tool_error(f"Invalid entity_id format: {entity_id}")
+    if isinstance(entity_id, str):
+        # Be forgiving of the common LLM form "light.a, light.b": normalize it
+        # to Home Assistant's native entity_id array instead of forcing another
+        # model/tool correction round.
+        if "," in entity_id:
+            entity_id = [item.strip() for item in entity_id.split(",") if item.strip()]
+        elif not _ENTITY_ID_RE.match(entity_id):
+            return tool_error(f"Invalid entity_id format: {entity_id}")
+    if isinstance(entity_id, list):
+        if not entity_id:
+            entity_id = None
+        else:
+            invalid = [item for item in entity_id if not isinstance(item, str) or not _ENTITY_ID_RE.match(item)]
+            if invalid:
+                return tool_error(f"Invalid entity_id format: {', '.join(map(str, invalid))}")
+    elif entity_id is not None and not isinstance(entity_id, str):
+        return tool_error("entity_id must be a string or list of strings")
 
     data = args.get("data")
     if isinstance(data, str):
@@ -450,9 +465,13 @@ HA_CALL_SERVICE_SCHEMA = {
                 ),
             },
             "entity_id": {
-                "type": "string",
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "array", "items": {"type": "string"}, "minItems": 1},
+                ],
                 "description": (
-                    "Target entity ID (e.g. 'light.living_room'). "
+                    "Target entity ID or array of entity IDs. Use one array for multi-device actions "
+                    "so Home Assistant can execute them in a single service call. "
                     "Some services (like scene.turn_on) may not need this."
                 ),
             },


### PR DESCRIPTION
Adds delegation.provider=pi-rpc: spawns pi --mode rpc --no-session as a local child process and adapts it to the delegation backend interface.

Highlights
- agent/pi_rpc_client.py: RPC client (steer->pending_questions, setStatus/notify/setWidget noise auto-ack), auto-loads first-party hermes_ask_user extension
- Fix ask-user round-trip against real pi RPC dialogs: extension rewritten to pi's real tool contract (execute(toolCallId, params, signal, onUpdate, ctx) with ctx.ui.input()/select()); client now replies with pi's native dialog shapes ({value}/{confirmed}/{cancelled}) instead of the pi-ask-user {kind:...} shape that resolved every answer to cancelled
- Free-text steering replies that match no select option pass through as text instead of forcing option 1
- Hermetic tests (16) + real-pi E2E proof for both input and select paths (ANSWER=/CHOICE= round-trips)

Validated on exact head: full agent test files run individually; only pre-existing failures (test_coding_context.py, lsp/test_broken_set.py) that fail identically on a clean tree.