### PR TITLE
fix(install): disclose an install that lost hash verification

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -4389,6 +4389,25 @@ function Write-Completion {
     Write-Host "|              [OK] Installation Complete!                |" -ForegroundColor Green
     Write-Host "+---------------------------------------------------------+" -ForegroundColor Green
     Write-Host ""
+
+    # $script:InstalledTier has been recorded at both install sites since the
+    # tiered cascade landed, and nothing ever read it, so a run that lost hash
+    # verification signed off exactly like a run that kept it (#90650, #82446).
+    if ($script:InstalledTier -ne "hash-verified (uv.lock)") {
+        $tierUsed = if ($script:InstalledTier) { $script:InstalledTier } else { "unknown" }
+        Write-Host "[!] Dependencies were installed WITHOUT hash verification" -ForegroundColor Yellow
+        Write-Host ""
+        Write-Host "   Tier used: $tierUsed" -ForegroundColor Yellow
+        Write-Host ""
+        Write-Host "   The hash-verified tier (uv sync --locked against uv.lock) did not"
+        Write-Host "   run, so package contents were not checked against the hashes this"
+        Write-Host "   release shipped. The install is usable; its supply-chain posture"
+        Write-Host "   is weaker than a verified one."
+        Write-Host ""
+        Write-Host "   Verify at any time:"
+        Write-Host "     cd '$InstallDir'; `$env:UV_PROJECT_ENVIRONMENT='$InstallDir\venv'; uv sync --extra all --locked"
+        Write-Host ""
+    }
     
     # Show file locations
     Write-Host "* Your files:" -ForegroundColor Cyan

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1475,6 +1475,31 @@ setup_venv() {
     log_success "Virtual environment ready (Python $PYTHON_VERSION)"
 }
 
+# Which dependency tier actually installed. Set by install_deps() and read by
+# print_success() so the final banner cannot imply a verified install when the
+# hash-verified tier did not run.
+INSTALLED_DEP_TIER=""
+HASH_VERIFIED_DEP_TIER="hash-verified (uv.lock)"
+
+# Announce a fall back to the unverified PyPI resolve. The tiers below keep an
+# install working, which is why the fallback exists, but only the uv.lock tier
+# checks each package against a recorded SHA256. One passing log line was not
+# enough of a signal: the run still ends on a green "Installation Complete"
+# banner, so every install that quietly lost hash verification looked identical
+# to one that kept it (#90650, #82446).
+warn_unverified_dependency_resolve() {
+    local reason="$1"
+    echo ""
+    log_warn "Dependencies will NOT be hash-verified for this install."
+    log_warn "Reason: $reason"
+    log_info "The tiers below re-resolve every dependency fresh from PyPI. Nothing"
+    log_info "checks a package against the SHA256 recorded in uv.lock, so a"
+    log_info "compromised transitive would not be rejected."
+    log_info "To install with verification once the cause is resolved:"
+    log_info "    cd $INSTALL_DIR && UV_PROJECT_ENVIRONMENT=$INSTALL_DIR/venv $UV_CMD sync --extra all --locked"
+    echo ""
+}
+
 install_deps() {
     log_info "Installing dependencies..."
 
@@ -1614,13 +1639,16 @@ install_deps() {
         # uv's own progress UI handles TTY detection and downgrades
         # gracefully when stdout/stderr aren't terminals.
         if UV_PROJECT_ENVIRONMENT="$INSTALL_DIR/venv" $UV_CMD sync --extra all --locked; then
+            INSTALLED_DEP_TIER="hash-verified (uv.lock)"
             log_success "Main package installed (hash-verified via uv.lock)"
             log_success "All dependencies installed"
             return 0
         fi
         log_warn "uv.lock sync failed (see uv output above), falling back to PyPI resolve..."
+        warn_unverified_dependency_resolve "the uv.lock sync above failed"
     else
         log_info "uv.lock not found — falling back to PyPI resolve (no hash verification)"
+        warn_unverified_dependency_resolve "uv.lock is not present in this checkout"
     fi
 
     # Multi-tier fallback. The point of the tiers is that ONE compromised
@@ -1698,6 +1726,7 @@ PY
             log_success "Main package installed ($name)"
             _installed=true
             _tier_name="$name"
+            INSTALLED_DEP_TIER="$name"
             return 0
         fi
         log_warn "Tier '$name' failed. Top of pip output:"
@@ -2764,6 +2793,26 @@ print_success() {
     echo "└─────────────────────────────────────────────────────────┘"
     echo -e "${NC}"
     echo ""
+
+    # A degraded install has to say so where the user is actually looking. The
+    # warning at downgrade time scrolls away behind minutes of dependency
+    # output; this is the last thing on screen.
+    if [ "$INSTALLED_DEP_TIER" != "$HASH_VERIFIED_DEP_TIER" ]; then
+        echo -e "${YELLOW}${BOLD}⚠ Dependencies were installed WITHOUT hash verification${NC}"
+        echo ""
+        echo -e "   ${YELLOW}Tier used:${NC} ${INSTALLED_DEP_TIER:-unknown}"
+        echo ""
+        echo -e "   The hash-verified tier (uv sync --locked against uv.lock) did not"
+        echo -e "   run, so package contents were not checked against the hashes this"
+        echo -e "   release shipped. The install is usable; its supply-chain posture is"
+        echo -e "   weaker than a verified one."
+        echo ""
+        echo -e "   Verify at any time:"
+        echo -e "     cd $INSTALL_DIR && UV_PROJECT_ENVIRONMENT=$INSTALL_DIR/venv uv sync --extra all --locked"
+        echo ""
+        echo -e "${CYAN}─────────────────────────────────────────────────────────${NC}"
+        echo ""
+    fi
 
     # Show file locations
     echo -e "${CYAN}${BOLD}📁 Your files:${NC}"

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -188,6 +188,10 @@ SETUP_PYTHON="$SCRIPT_DIR/venv/bin/python"
 # Dependencies
 # ============================================================================
 
+# Read by the completion banner below so a run that lost hash verification
+# does not sign off with an unqualified "Setup complete!" (#90650, #82446).
+HASH_VERIFIED_DEPS=false
+
 echo -e "${CYAN}→${NC} Installing dependencies..."
 
 if is_termux; then
@@ -252,6 +256,7 @@ else
         # Also: stream stderr through directly so the user sees uv's
         # progress UI instead of staring at a frozen prompt.
         if UV_PROJECT_ENVIRONMENT="$SCRIPT_DIR/venv" $UV_CMD sync --extra all --locked; then
+            HASH_VERIFIED_DEPS=true
             echo -e "${GREEN}✓${NC} Dependencies installed (hash-verified via uv.lock)"
         else
             echo -e "${YELLOW}⚠${NC} Lockfile sync failed (see uv output above)."
@@ -421,6 +426,13 @@ fi
 echo ""
 echo -e "${GREEN}✓ Setup complete!${NC}"
 echo ""
+if [ "$HASH_VERIFIED_DEPS" != true ]; then
+    echo -e "${YELLOW}⚠ Dependencies were installed WITHOUT hash verification.${NC}"
+    echo "  Package contents were not checked against the hashes in uv.lock."
+    echo "  Verify at any time:"
+    echo "    cd $SCRIPT_DIR && UV_PROJECT_ENVIRONMENT=$SCRIPT_DIR/venv uv sync --extra all --locked"
+    echo ""
+fi
 echo "Next steps:"
 echo ""
 if is_termux; then

--- a/tests/test_install_unverified_dependency_disclosure.py
+++ b/tests/test_install_unverified_dependency_disclosure.py
@@ -1,0 +1,187 @@
+"""Regression: an install that lost hash verification has to say so at the end.
+
+Only the ``uv sync --locked`` tier checks each package against the SHA256 that
+``uv.lock`` records. The ``uv pip install`` tiers below it exist to keep an
+install working when the lockfile is stale or unreadable, and they re-resolve
+every transitive fresh from PyPI with nothing verifying it.
+
+The downgrade used to be a single ``log_warn`` line in the middle of several
+minutes of dependency output, after which the run still finished on an
+unqualified "Installation Complete!" banner. A run that silently lost hash
+verification was therefore indistinguishable from one that kept it, which is
+how #90650 and #82446 both came to be filed against a tier that had not been
+applying for some time.
+
+These tests pin the disclosure: the fallback announces itself where it happens,
+and the completion banner refuses to sign off clean unless the hash-verified
+tier is what actually ran.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+SETUP_SH = REPO_ROOT / "setup-hermes.sh"
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+HASH_VERIFIED = "hash-verified (uv.lock)"
+DISCLOSURE = "WITHOUT hash verification"
+GUARD = 'if [ "$INSTALLED_DEP_TIER" != "$HASH_VERIFIED_DEP_TIER" ]; then'
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="needs bash to execute installer functions"
+)
+
+# Everything the extracted shell reaches for that it does not define itself.
+# Kept deliberately small: if the disclosure grows a new dependency, these
+# tests should fail loudly rather than quietly exercise a different path.
+_STUBS = """
+GREEN=''; YELLOW=''; CYAN=''; BOLD=''; NC=''
+INSTALL_DIR=/tmp/hermes-install
+UV_CMD=uv
+log_info() { echo "$1"; }
+log_warn() { echo "$1"; }
+"""
+
+
+def _run(script: str) -> str:
+    # shutil.which rather than a bare "bash": on a Windows dev box PATH can
+    # resolve bash to the WSL launcher, which accepts -c, exits 0, and drops
+    # the arguments passed to shell functions -- every assertion below would
+    # then fail against empty output for a reason that has nothing to do with
+    # the installer.
+    proc = subprocess.run(
+        [shutil.which("bash"), "-c", script], capture_output=True, text=True, check=False
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout
+
+
+def _extract_sh_function(path: Path, name: str) -> str:
+    text = path.read_text(encoding="utf-8")
+    match = re.search(rf"^{name}\(\) \{{.*?^\}}", text, re.DOTALL | re.MULTILINE)
+    assert match is not None, f"{name}() not found in {path.name}"
+    return match.group(0)
+
+
+def _disclosure_block() -> str:
+    """The tier guard out of print_success(), verbatim.
+
+    Only this block is executed rather than the whole banner. print_success()
+    prints the command list, which includes `hermes update`, and conftest's
+    live-system guard rejects any subprocess whose argv looks like that -- a
+    guard worth leaving alone rather than tunnelling around. The block is real
+    shipped code either way, and test_the_disclosure_lives_in_the_banner below
+    pins the fact that it is reached from print_success().
+    """
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    start = text.index(GUARD)
+    end = text.index("\n    fi\n", start) + len("\n    fi\n")
+    return text[start:end]
+
+
+def _banner(tier: str) -> str:
+    script = (
+        _STUBS
+        + 'INSTALLED_DEP_TIER="' + tier + '"\n'
+        + 'HASH_VERIFIED_DEP_TIER="' + HASH_VERIFIED + '"\n'
+        + _disclosure_block()
+    )
+    return _run(script)
+
+
+class TestCompletionBanner:
+    def test_a_fallback_tier_is_disclosed(self):
+        out = _banner("core only (no extras)")
+        assert DISCLOSURE in out
+        assert "core only (no extras)" in out
+        # The remedy has to be in the message, not just the diagnosis.
+        assert "uv sync --extra all --locked" in out
+
+    def test_a_hash_verified_install_says_nothing(self):
+        assert _banner(HASH_VERIFIED).strip() == ""
+
+    def test_an_unrecorded_tier_is_disclosed_rather_than_assumed(self):
+        # Fail closed. A tier nobody recorded is not evidence of verification,
+        # and defaulting the other way is how this went unnoticed to begin with.
+        out = _banner("")
+        assert DISCLOSURE in out
+        assert "unknown" in out
+
+    def test_the_disclosure_lives_in_the_banner(self):
+        # Guards the wiring the block test cannot: this has to run on the way
+        # out of the installer, not somewhere the user has already scrolled past.
+        body = _extract_sh_function(INSTALL_SH, "print_success")
+        assert GUARD in body
+        assert body.index("Installation Complete") < body.index(GUARD)
+
+
+class TestDowngradeAnnouncement:
+    def test_the_fallback_announces_itself_with_its_reason(self):
+        body = _extract_sh_function(INSTALL_SH, "warn_unverified_dependency_resolve")
+        out = _run(
+            _STUBS
+            + body
+            + '\nwarn_unverified_dependency_resolve "the uv.lock sync above failed"\n'
+        )
+        assert "NOT be hash-verified" in out
+        assert "the uv.lock sync above failed" in out
+        assert "uv sync --extra all --locked" in out
+
+    def test_both_routes_into_the_unverified_tiers_announce(self):
+        text = INSTALL_SH.read_text(encoding="utf-8")
+        calls = re.findall(r"warn_unverified_dependency_resolve \"", text)
+        # One for the failed lockfile sync, one for a checkout with no
+        # lockfile at all. Both land in the same unverified resolve.
+        assert len(calls) == 2, f"expected both fallback routes to announce, found {len(calls)}"
+
+    def test_the_tiers_record_which_one_ran(self):
+        text = INSTALL_SH.read_text(encoding="utf-8")
+        assert f'INSTALLED_DEP_TIER="{HASH_VERIFIED}"' in text
+        assert 'INSTALLED_DEP_TIER="$name"' in text
+
+
+class TestSetupHermesScript:
+    def test_the_flag_defaults_to_unverified(self):
+        text = SETUP_SH.read_text(encoding="utf-8")
+        assert "HASH_VERIFIED_DEPS=false" in text
+        assert text.index("HASH_VERIFIED_DEPS=false") < text.index("HASH_VERIFIED_DEPS=true")
+
+    def test_only_the_locked_sync_may_set_it(self):
+        text = SETUP_SH.read_text(encoding="utf-8")
+        assert text.count("HASH_VERIFIED_DEPS=true") == 1
+        before = text[: text.index("HASH_VERIFIED_DEPS=true")]
+        assert before.rstrip().endswith("--extra all --locked; then"), (
+            "the verified flag must be set by the locked sync succeeding, nothing else"
+        )
+
+    def test_the_completion_message_is_gated_on_it(self):
+        text = SETUP_SH.read_text(encoding="utf-8")
+        gate = 'if [ "$HASH_VERIFIED_DEPS" != true ]; then'
+        assert gate in text
+        assert text.index("Setup complete!") < text.index(gate)
+
+
+class TestWindowsInstaller:
+    def test_the_recorded_tier_is_actually_read(self):
+        # $script:InstalledTier was written at both install sites and read
+        # nowhere, so the Windows banner had the same blind spot.
+        text = INSTALL_PS1.read_text(encoding="utf-8")
+        completion = text[text.index("function Write-Completion"):]
+        assert "$script:InstalledTier" in completion
+        assert DISCLOSURE in completion
+
+    def test_the_windows_disclosure_stays_ascii(self):
+        # install.ps1 is ASCII-only (see test_install_ps1_ascii_only.py); this
+        # keeps the specific block honest even if that guard is relaxed.
+        text = INSTALL_PS1.read_text(encoding="utf-8")
+        completion = text[text.index("function Write-Completion"):]
+        block = completion[: completion.index("* Your files:")]
+        assert block.isascii(), "the disclosure block must not introduce non-ASCII"


### PR DESCRIPTION
## What does this PR do?

`uv sync --locked` is the only tier that checks each package against the SHA256 recorded in `uv.lock`. Its own comment in `install.sh` calls it "the *only* path that protects against the 'direct dep is fine, but the dep's dep got worm-poisoned overnight' failure mode". When it fails, the installer drops to a fresh PyPI resolve of every transitive with nothing verifying it. That fallback is correct and should stay, because a stale lockfile should not brick an install. What was wrong is how quietly it happened:

- one `log_warn` line, in the middle of several minutes of dependency output;
- then the run finished on an unqualified `Installation Complete!` banner.

So an install that silently lost hash verification was indistinguishable from one that kept it. That is not hypothetical: #82446 and #90650 are two reports of this same tier not applying, filed eleven days apart, and in both cases the tier had been skipped for some time before anyone noticed.

This PR announces the downgrade twice: once where it happens, with the reason, and once in the completion banner where the user is actually looking. It records which tier installed so the banner can tell the difference, and it fails closed, reporting a tier nobody recorded as unverified rather than assuming it was verified.

`scripts/install.ps1` turned out to already record `$script:InstalledTier` at both install sites and read it nowhere, so Windows had the same blind spot with the answer already in hand. Its banner now reads what was already being written.

**This is not the fix for either report, and deliberately does not close them.** The cause is `UV_NO_CONFIG=1` at `scripts/install.sh:33`, which suppresses this checkout's own `[tool.uv]` along with the ambient config it was aimed at, so uv computes no global `exclude-newer`, disagrees with the lockfile that records one, and rejects a pristine lock. #82450 fixes that and has been open since 2026-08-09. This PR is the backstop that would have made it visible in the first place, and it stays useful afterwards for every other reason Tier 0 can fail: a genuinely stale lock, a network failure mid-sync, a checkout with no `uv.lock` at all.

## Related Issue

Related to #90650 and #82446. Not `Fixes`, on purpose: #82450 is the fix, this is disclosure.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh` - `INSTALLED_DEP_TIER` / `HASH_VERIFIED_DEP_TIER` globals; new `warn_unverified_dependency_resolve()` called from both routes into the unverified tiers (failed lockfile sync, no lockfile present); tier recorded on the hash-verified path and in `install_tier`; a disclosure block in `print_success()` gated on the tier.
- `setup-hermes.sh` - `HASH_VERIFIED_DEPS` defaulting to `false`, set `true` only by the locked sync succeeding, and a matching note under `Setup complete!`.
- `scripts/install.ps1` - `Write-Completion` now reads the `$script:InstalledTier` it was already recording. ASCII only, per `tests/test_install_ps1_ascii_only.py`.
- `tests/test_install_unverified_dependency_disclosure.py` - new.

No behaviour change to what gets installed. This only changes what the installer says.

## How to Test

1. `pytest tests/test_install_unverified_dependency_disclosure.py -q` - 12 passed.
2. Proof the tests bite. With the three installer files reverted to `upstream/main` and the test file kept, **11 of 12 fail**. The one that still passes is `test_the_windows_disclosure_stays_ascii`, which is a guard rather than a restatement of the change, so it is supposed to pass either way.
3. The behavioural tests execute the shipped shell rather than pattern-matching it: the disclosure block and `warn_unverified_dependency_resolve()` are extracted from `install.sh` and run under `bash` with the log helpers stubbed, then asserted on their real output for three tier values (a fallback tier, the hash-verified tier, and an unrecorded one).
4. To see it by hand, run the installer against a checkout where the locked sync cannot succeed, for example by exporting `UV_NO_CONFIG=1` before `uv sync --extra all --locked` in the install directory. The install still completes; the banner now says it was not hash-verified and gives the command to verify.

Two notes on the test harness, both Windows-local and both commented in the file. `shutil.which("bash")` is used rather than a bare `"bash"`, because PATH on a Windows dev box can resolve `bash` to the WSL launcher, which accepts `-c`, exits 0, and drops the arguments passed to shell functions; every assertion then fails against empty output for a reason unrelated to the installer. And only the disclosure block is executed rather than the whole of `print_success()`, because that function prints the command list including `hermes update`, which `tests/conftest.py`'s live-system guard rejects on sight. That guard is worth leaving alone rather than tunnelling around, so a separate static test pins the fact that the block is reached from `print_success()`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

On the test checkbox, the honest detail: the new file is 12 passed, and `tests/test_install_ps1_ascii_only.py`, `tests/test_packaging_metadata.py` and `tests/test_project_metadata.py` pass alongside it. `tests/test_install_lockfile_churn.py` has 2 failures, and they reproduce identically with this diff reverted: they are `UnicodeDecodeError: 'charmap' codec` from a `read_text()` without an explicit encoding, which is a Windows default-codepage issue in that file rather than anything this PR touches. `bash -n` is clean on both shell scripts and the PowerShell parser reports 0 errors on `install.ps1`.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, the user-facing text is the change itself and there is no doc claiming the old behaviour.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - all three installers are covered, the PowerShell text is ASCII only, and the shell additions use no non-POSIX constructs beyond what the surrounding bash already relies on.
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A.

## Screenshots / Logs

What a degraded install now ends with, colours stripped:

```
┌─────────────────────────────────────────────────────────┐
│              ✓ Installation Complete!                   │
└─────────────────────────────────────────────────────────┘

⚠ Dependencies were installed WITHOUT hash verification

   Tier used: core only (no extras)

   The hash-verified tier (uv sync --locked against uv.lock) did not
   run, so package contents were not checked against the hashes this
   release shipped. The install is usable; its supply-chain posture is
   weaker than a verified one.

   Verify at any time:
     cd <install dir> && UV_PROJECT_ENVIRONMENT=<install dir>/venv uv sync --extra all --locked
```

A hash-verified install prints nothing extra.

## Open questions for maintainers

1. **Should a lost Tier 0 be fatal under an opt-in flag?** Something like `--require-hash-verified` that exits non-zero rather than falling back. I did not add it because it is a policy decision about what an installer owes a user who did not ask, and it belongs to whoever owns that call, not to me.
2. **Would you rather this were folded into #82450?** It is small and would sit naturally on top. I kept it separate so the fix can land on its own timeline, and because it outlives the fix.
3. The `hermes update` path has the same tier ladder. I did not touch it here to keep this reviewable, but if the disclosure is wanted there too I am happy to send it as a follow-up.
