### PR TITLE
fix(opencode-go): route Muse Spark models through the Responses API

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -5262,6 +5262,8 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
 
     - GPT-5 / Codex models on Zen use ``/v1/responses``
     - GPT models on Go (gpt-5.6-luna) use ``/v1/responses``
+    - Muse Spark models on Go and Zen use ``/v1/responses``
+      (chat/completions streams empty chunks on Go — 503/empty assistant)
     - Claude models on Zen use ``/v1/messages``
     - MiniMax and Qwen models on Go use ``/v1/messages``
     - GLM / Kimi / DeepSeek / MiMo on Go use ``/v1/chat/completions``
@@ -5283,6 +5285,14 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
             # per the published Go endpoint table, same as GPT on Zen:
             # https://opencode.ai/docs/go/#endpoints
             return "codex_responses"
+        if normalized.startswith("muse-spark"):
+            # Muse Spark (standard + contributor) on Go uses /v1/responses.
+            # /v1/chat/completions returns HTTP 200 but streams empty
+            # choices (no content, no finish_reason), surfacing as an
+            # empty/broken conversation. Verified live 2026-08-20:
+            # muse-spark-1.2-contributor completes via /v1/responses only.
+            # https://opencode.ai/docs/go/#endpoints
+            return "codex_responses"
         if normalized.startswith("minimax-"):
             return "anthropic_messages"
         if normalized.startswith("qwen"):
@@ -5295,6 +5305,10 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
         if normalized.startswith("claude-"):
             return "anthropic_messages"
         if normalized.startswith("gpt-"):
+            return "codex_responses"
+        if normalized.startswith("muse-spark"):
+            # Standard Muse Spark on Zen is served via /v1/responses,
+            # same as GPT: https://opencode.ai/docs/zen/#endpoints
             return "codex_responses"
         if normalized.startswith("qwen"):
             # Qwen models on Zen moved to /v1/messages per the published

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -1,10 +1,10 @@
 """OpenCode provider profiles (Zen + Go).
 
 Both use per-model api_mode routing:
-  - OpenCode Zen: Claude → anthropic_messages, GPT-5/Codex → codex_responses,
-    everything else → chat_completions (this profile)
-  - OpenCode Go: GPT → codex_responses, MiniMax/Qwen → anthropic_messages,
-    GLM/Kimi/DeepSeek/MiMo → chat_completions (this profile)
+  - OpenCode Zen: Claude → anthropic_messages, GPT-5/Codex/Muse Spark →
+    codex_responses, everything else → chat_completions (this profile)
+  - OpenCode Go: GPT / Muse Spark → codex_responses, MiniMax/Qwen →
+    anthropic_messages, GLM/Kimi/DeepSeek/MiMo → chat_completions (this profile)
 """
 
 from __future__ import annotations

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -272,6 +272,13 @@ class TestCopilotNormalization:
         # GPT models on Go are Responses-only (Go endpoint table).
         assert opencode_model_api_mode("opencode-go", "gpt-5.6-luna") == "codex_responses"
         assert opencode_model_api_mode("opencode-go", "opencode-go/gpt-5.6-luna") == "codex_responses"
+        # Muse Spark on Go is Responses-only too — /v1/chat/completions returns
+        # HTTP 200 but streams empty choices (no content, no finish_reason).
+        assert opencode_model_api_mode("opencode-go", "muse-spark-1.2") == "codex_responses"
+        assert opencode_model_api_mode("opencode-go", "muse-spark-1.2-contributor") == "codex_responses"
+        assert opencode_model_api_mode("opencode-go", "opencode-go/muse-spark-1.2-contributor") == "codex_responses"
+        # Standard Muse Spark on Zen is served via /v1/responses too.
+        assert opencode_model_api_mode("opencode-zen", "muse-spark-1.2") == "codex_responses"
 
 
 class TestNormalizeOpencodeBaseUrl:


### PR DESCRIPTION
## Summary

Muse Spark models (`muse-spark-1.2`, `muse-spark-1.2-contributor`) on OpenCode **Go** return HTTP 200 from `/v1/chat/completions` but stream **empty `choices:[]` chunks** — no content, no `finish_reason`. Hermes' streaming path sees an empty stream and surfaces a broken/empty conversation (the symptom behind #89836). `/v1/responses` completes normally.

**Verified live 2026-08-20** with a real `OPENCODE_GO_API_KEY` against `opencode.ai/zen/go`:

| Endpoint | `muse-spark-1.2-contributor` streaming behavior |
|---|---|
| `POST /v1/responses` | full Responses SSE (`response.created` → `response.content` → `response.completed`), 200, complete output |
| `POST /v1/chat/completions` | HTTP 200 but `choices:[]` on every chunk, no delta, no `finish_reason` → Hermes EmptyStream |

So the fix routes all `muse-spark*` variants to `codex_responses` (`/v1/responses`) on Go, and the standard variant on Zen (per the published Zen endpoint table), mirroring how GPT is already routed.

## Comparison to the three competing PRs

| PR | Routes muse → | Contributor variant | Verdict |
|---|---|---|---|
| #89877 | `muse-*` → responses, **but `-contributor` → chat_completions** | chat_completions | ⚠️ Contributor exception is **wrong** — live test shows `-contributor` completes via `/v1/responses`; chat_completions is the broken path |
| #90176 | `muse-spark*` → responses (Go **and** Zen) | responses | ✅ Core direction correct (Go side confirmed here; Zen side adopted per its claim + docs) |
| #90823 | `muse-*` → responses (Go only) | responses | ✅ Direction correct |
| **This PR** | `muse-spark*` → responses (Go + Zen) | responses | Combines #90176's Zen coverage with live-verification that `-contributor` must NOT be special-cased back to chat_completions |

Key judgment call: #89877's `-contributor` → `chat_completions` exception targets exactly the model most users hit (`muse-spark-1.2-contributor`) and sends it to the *only* broken path. Rejected on direct live evidence.

## Changes
- `hermes_cli/models.py` — `opencode_model_api_mode`: Go `muse-spark*` → `codex_responses`; Zen `muse-spark*` → `codex_responses`; docstring
- `plugins/model-providers/opencode-zen/__init__.py` — routing summary doc
- `tests/hermes_cli/test_model_validation.py` — Go (bare + prefixed + contributor) and Zen assertions

## Test Plan
- `scripts/run_tests.sh tests/hermes_cli/test_model_validation.py -k opencode` → 3 passed
- Live curl verification table above

Credits: builds on #90176 (kadiratesdev) and #90823 (guoyutw); deliberately does **not** take #89877's contributor exception.