### PR TITLE
fix(desktop): re-hydrate pinned session states after gateway reconnect

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -36,7 +36,7 @@ import {
   setSessions,
   setSessionsLoading
 } from '@/store/session'
-import { $workingSessionIds, getRecentlySettledSessionIds } from '@/store/session-states'
+import { $workingSessionIds, getRecentlySettledSessionIds, restorePinnedSessionStates } from '@/store/session-states'
 
 import { refreshCronJobs as refreshCronJobsStore } from '../../cron/cron-actions'
 
@@ -291,6 +291,13 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
           return sameCronSignature(prev, next) ? prev : next
         })
+        // Re-hydrate pinned session states after the list refresh: a
+        // gateway reconnect wiped runtime state for pinned/idle sessions
+        // (detached_sessions), and $sessionStates is only repopulated by
+        // live gateway events. Without this, clicking a pinned session
+        // shows a blank chat despite the session existing in both the
+        // sidebar list and in state.db.
+        restorePinnedSessionStates($sessions.get())
         // "Is there another page?" instead of an exact total: the backend
         // reports which profiles filled their window, which costs nothing on
         // top of the rows it already read (the old exact totals ran a COUNT(*)

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -33,6 +33,7 @@ import { stableArray } from '@/lib/stable-array'
 import { readJson, writeJson } from '@/lib/storage'
 import type { SessionInfo } from '@/types/hermes'
 
+import { $pinnedSessionIds } from '@/store/layout'
 import { $activeGatewayProfile, normalizeProfileKey } from './profile'
 import { clearAllProviderWaits, clearSessionProviderWait } from './provider-wait'
 import {
@@ -44,6 +45,7 @@ import {
   lineageAliases,
   markSessionRead,
   sessionMatchesStoredId,
+  sessionPinId,
   setActiveSessionStoredIdRotation,
   setSessions
 } from './session'
@@ -371,6 +373,84 @@ export function clearAllSessionStates() {
   sessionScopeByRuntimeId.clear()
   $stalledSessionIds.set([])
   $sessionStates.set({})
+}
+
+/**
+ * After a gateway disconnect/reconnect, re-hydrate lightweight placeholder states
+ * for pinned sessions that no longer have runtime state entries.
+ *
+ * When the backend detaches sessions from a stale WebSocket (`detached_sessions`
+ * in agent.log), those sessions' runtime ids become invalid. The frontend's
+ * session list ($sessions) and pins ($pinnedSessionIds) survive because they're
+ * re-fetched from the backend, but $sessionStates only gets populated by live
+ * gateway events — so pinned/idle sessions end up with no state. Clicking them
+ * in the sidebar navigates to a session whose runtime has no transcript.
+ *
+ * This creates minimal idle states for pinned sessions that lack one, so the UI
+ * shows them as valid conversations rather than blank/empty chat views.
+ * The placeholder will be replaced by a real state on the first gateway event
+ * for that session.
+ */
+export function restorePinnedSessionStates(rows: readonly SessionInfo[]): void {
+  const current = $sessionStates.get()
+  const pinned = $pinnedSessionIds.get()
+  const pinnedIds = new Set(pinned)
+
+  // Collect runtime ids that already have a state for any stored session
+  const activeStoredIds = new Set<string>()
+  for (const state of Object.values(current)) {
+    if (state.storedSessionId) {
+      activeStoredIds.add(state.storedSessionId)
+    }
+  }
+
+  const entries: [string, ClientSessionState][] = []
+
+  for (const row of rows) {
+    const pinId = sessionPinId(row)
+
+    if (!pinnedIds.has(pinId)) {
+      continue
+    }
+
+    // Already has state — skip
+    if (current[row.id] || activeStoredIds.has(row.id) || (row._lineage_root_id && activeStoredIds.has(row._lineage_root_id))) {
+      continue
+    }
+
+    entries.push([
+      row.id,
+      {
+        storedSessionId: row.id,
+        messages: [],
+        branch: '',
+        cwd: '',
+        model: '',
+        provider: '',
+        reasoningEffort: '',
+        serviceTier: '',
+        fast: false,
+        yolo: false,
+        personality: '',
+        busy: false,
+        awaitingResponse: false,
+        streamId: null,
+        sawAssistantPayload: false,
+        adoptedRunningTurn: false,
+        pendingBranchGroup: null,
+        interrupted: false,
+        interimBoundaryPending: false,
+        needsInput: false,
+        turnStartedAt: null,
+        turnLive: false,
+        usage: null
+      }
+    ])
+  }
+
+  if (entries.length > 0) {
+    $sessionStates.set({ ...current, ...Object.fromEntries(entries) })
+  }
 }
 
 // Derived per-session status sets — pure projections of `$sessionStates` (which


### PR DESCRIPTION
## Bug
When the backend WebSocket disconnects (logged as `detached_sessions` in agent.log), runtime session ids become stale. The frontend's session list (``) and pinned ids (``) survive because they're re-fetched from the backend, but `` is only repopulated by **live gateway events** — so pinned/idle sessions end up with no runtime state. Clicking them in the sidebar navigates to a blank/empty chat despite valid data in `state.db`.

## Root Cause
The `clearAllSessionStates()` wipe (called during gateway mode switches) + the backend's `detached_sessions` on reconnect leave pinned sessions without a `ClientSessionState` entry. No subsequent code re-creates one for idle/pinned sessions.

## Fix
New function `restorePinnedSessionStates()` in `session-states.ts`: after every sidebar list refresh (`refreshSessions()`), creates lightweight idle placeholder states for every pinned session that lacks a runtime state entry. The placeholder is replaced by a real state on the first gateway event for that session.

## Verification
- ✅ `tsc --noEmit`: 0 errors
- ✅ All 76 related tests pass (session-states, gateway-switch, watchdog, session-pin-sync, use-session-list-actions)
- ✅ Test files: `session-states-scopes.test.ts`, `gateway-switch.test.ts`, `session-watchdog.test.ts`, `active-work.test.ts`, `session-pin-sync.test.ts`, `use-session-list-actions.test.tsx`

## Files changed
- `store/session-states.ts` — +80 lines: `restorePinnedSessionStates()`
- `app/session/hooks/use-session-list-actions.ts` — +9 lines: call after `setSessions`