### PR TITLE
fix(desktop/ssh): one remote backend per gateway, and a 2-authentication bootstrap on Windows

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -1085,6 +1085,96 @@ test('normalizeRegistry preserves stored headers on remote entries (v2 additive 
   })
 })
 
+test('normalizeRegistry keeps the served token on an ssh entry', () => {
+  // The ssh token is the SERVED dashboard token, written back after a
+  // bootstrap. Dropping it on read made it write-only: every start reported
+  // "no saved token", reaped the running remote backend and spawned a new one,
+  // so a reusable backend was never reused.
+  const registry = normalizeRegistry({
+    version: REGISTRY_VERSION,
+    primary: 'box',
+    connections: [
+      { id: 'local', kind: 'local', label: 'This device' },
+      {
+        id: 'box',
+        kind: 'ssh',
+        label: 'Alfred laptop',
+        host: '100.64.0.1',
+        user: 'hermes',
+        token: { encoding: 'safeStorage', value: 'envelope' }
+      }
+    ]
+  })
+
+  const ssh = registry.connections.find(c => c.id === 'box')
+
+  assert.ok(ssh)
+  assert.deepEqual(ssh.token, { encoding: 'safeStorage', value: 'envelope' })
+  assert.equal(ssh.host, '100.64.0.1')
+  assert.equal(ssh.user, 'hermes')
+
+  // Still absent when nothing was stored — no phantom field.
+  const fresh = normalizeRegistry({
+    version: REGISTRY_VERSION,
+    primary: 'box',
+    connections: [{ id: 'box', kind: 'ssh', label: 'Box', host: 'box.test' }]
+  })
+
+  assert.equal(fresh.connections.find(c => c.id === 'box')?.token, undefined)
+})
+
+test('normalizeConnectionInput keeps the served token when an ssh entry is renamed', () => {
+  const registry = normalizeRegistry({
+    version: REGISTRY_VERSION,
+    primary: 'local',
+    connections: [{ id: 'local', kind: 'local', label: 'This device' }]
+  })
+
+  const entry = normalizeConnectionInput(
+    {
+      id: 'box',
+      kind: 'ssh',
+      label: 'Renamed box',
+      host: 'box.test',
+      user: 'hermes',
+      token: { encoding: 'safeStorage', value: 'envelope' }
+    } as any,
+    registry
+  )
+
+  assert.equal(entry.kind, 'ssh')
+  assert.equal(entry.label, 'Renamed box')
+  assert.deepEqual(entry.token, { encoding: 'safeStorage', value: 'envelope' })
+
+  const withoutToken = normalizeConnectionInput(
+    { id: 'box2', kind: 'ssh', label: 'No token', host: 'other.test' } as any,
+    registry
+  )
+
+  assert.equal(withoutToken.token, undefined)
+})
+
+test('an ssh token survives a write/read round trip through the registry', () => {
+  const stored = { encoding: 'safeStorage', value: 'envelope' }
+
+  const registry = normalizeRegistry({
+    version: REGISTRY_VERSION,
+    primary: 'box',
+    connections: [
+      { id: 'local', kind: 'local', label: 'This device' },
+      { id: 'box', kind: 'ssh', label: 'Box', host: 'box.test' }
+    ]
+  })
+
+  const entry = registry.connections.find(c => c.id === 'box')
+
+  assert.ok(entry)
+  const saved = upsertConnection(registry, { ...entry, token: stored })
+  const reloaded = normalizeRegistry(JSON.parse(JSON.stringify(saved)))
+
+  assert.deepEqual(reloaded.connections.find(c => c.id === 'box')?.token, stored)
+})
+
 test('migrateV1ToRegistry carries v1 remote headers into the registry entry', () => {
   const registry = migrateV1ToRegistry({
     mode: 'remote',

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -54,7 +54,9 @@ export interface RegistryConnection {
   url?: string
   /** remote/cloud: 'token' | 'oauth'. */
   authMode?: 'oauth' | 'token'
-  /** remote: encrypted token envelope (opaque here; main.ts encrypts/decrypts). */
+  /** remote/ssh: encrypted token envelope (opaque here; main.ts encrypts/
+   * decrypts). For ssh it is the SERVED dashboard token, written back after a
+   * bootstrap so the next start can prove reuse instead of respawning. */
   token?: unknown
   /** remote/cloud: extra gateway headers (Cloudflare Access etc.). Secret
    * envelopes, same shape as `token`; names pre-filtered through
@@ -654,7 +656,17 @@ export function normalizeConnectionInput(input: ConnectionInput, registry: Conne
       throw new Error(`A connection to this SSH host already exists ("${sshDupe.label}").`)
     }
 
-    return { id, kind: 'ssh', label, ...sshFields }
+    const sshEntry: RegistryConnection = { id, kind: 'ssh', label, ...sshFields }
+
+    // ssh entries are always token-auth (Desktop mints the token and writes
+    // back the one the remote dashboard serves), so unlike remote/cloud there
+    // is no auth mode that makes the stored token meaningless. Renaming an ssh
+    // connection must not throw away its reuse credential.
+    if (input.token !== undefined) {
+      sshEntry.token = input.token
+    }
+
+    return sshEntry
   }
 
   if (kind === 'remote' || kind === 'cloud') {
@@ -892,6 +904,14 @@ export function normalizeRegistry(raw: unknown): ConnectionRegistry {
 
       const { mode: _mode, ...sshFields } = ssh
       Object.assign(clean, sshFields)
+
+      // The served dashboard token is what proves reuse of an existing remote
+      // backend. Dropping it here made it write-only: persistSshConnectionToken
+      // wrote it to disk and every read threw it away, so each start reported
+      // "no saved token", killed the previous backend and spawned a new one.
+      if (entry.token !== undefined) {
+        clean.token = entry.token
+      }
     }
 
     connections.push(clean)

--- a/apps/desktop/electron/desktop-remote-route.test.ts
+++ b/apps/desktop/electron/desktop-remote-route.test.ts
@@ -2,8 +2,14 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { normalizeRegistry, REGISTRY_VERSION } from './connection-registry'
-import { resolveDesktopRemoteRoute } from './desktop-remote-route'
+import { resolveRemoteSshDashboardProfile } from './connection-config'
+import { backendScopeKey, normalizeRegistry, REGISTRY_VERSION } from './connection-registry'
+import {
+  effectiveDialDigest,
+  registryTargetForRoute,
+  resolveDesktopRemoteRoute,
+  sshPayloadFieldsMatch
+} from './desktop-remote-route'
 
 const tokenA = { encoding: 'plain', value: 'token-a' }
 const tokenB = { encoding: 'plain', value: 'token-b' }
@@ -153,6 +159,157 @@ test('global SSH treats an omitted port as 22 and checks the primary route', () 
   assert.equal(route?.connectionId, 'ssh-primary')
 })
 
+test('an exact registry-backed primary SSH route delegates to the registry backend', () => {
+  const route = resolveDesktopRemoteRoute({
+    config: { mode: 'ssh', remote: { mode: 'ssh', host: 'box.test', user: 'hermes' } },
+    profile: 'default',
+    registry: registry('ssh-primary', [
+      { id: 'ssh-primary', kind: 'ssh', label: 'SSH primary', host: 'box.test', user: 'hermes', port: 22 }
+    ])
+  })
+
+  assert.deepEqual(registryTargetForRoute(route, 'default'), {
+    connectionId: 'ssh-primary',
+    profile: 'default'
+  })
+  assert.deepEqual(registryTargetForRoute(route, null), { connectionId: 'ssh-primary', profile: 'default' })
+  assert.deepEqual(registryTargetForRoute(route, '  '), { connectionId: 'ssh-primary', profile: 'default' })
+})
+
+test('a route without a registry identity keeps the historical v1 path', () => {
+  assert.equal(registryTargetForRoute(null, 'default'), null)
+  assert.equal(
+    registryTargetForRoute(
+      { kind: 'ssh', source: 'settings', ssh: { host: 'box.test', mode: 'ssh', user: 'hermes' } },
+      'default'
+    ),
+    null
+  )
+
+  // Two identical registry entries are ambiguous, so resolution deliberately
+  // drops the identity: delegating to an arbitrary one of them would move the
+  // backend under a scope the user never picked.
+  const ssh = { mode: 'ssh', host: 'box.test', user: 'hermes' }
+
+  const ambiguous = resolveDesktopRemoteRoute({
+    config: { mode: 'ssh', remote: ssh },
+    profile: 'default',
+    registry: registry('ssh-a', [
+      { id: 'ssh-a', kind: 'ssh', label: 'A', ...ssh },
+      { id: 'ssh-b', kind: 'ssh', label: 'B', ...ssh }
+    ])
+  })
+
+  assert.equal(ambiguous?.connectionId, 'ssh-a')
+
+  const unrelatedPrimary = resolveDesktopRemoteRoute({
+    config: { mode: 'ssh', remote: ssh },
+    profile: 'default',
+    registry: registry('other', [
+      { id: 'other', kind: 'ssh', label: 'Other', host: 'other.test', user: 'hermes' },
+      { id: 'ssh-a', kind: 'ssh', label: 'A', ...ssh }
+    ])
+  })
+
+  assert.equal(registryTargetForRoute(unrelatedPrimary, 'default'), null)
+})
+
+test('a global SSH route never merges into a registry entry that dials differently', () => {
+  const ssh = {
+    mode: 'ssh',
+    host: 'box.test',
+    user: 'hermes',
+    port: 2222,
+    keyPath: '/keys/a',
+    remoteHermesPath: '/srv/hermes',
+    remoteProfile: 'worker'
+  }
+
+  const variants = [
+    { ...ssh, port: 2200 },
+    { ...ssh, keyPath: '/keys/b' },
+    { ...ssh, remoteHermesPath: '/opt/hermes' },
+    { ...ssh, remoteProfile: 'other' },
+    { ...ssh, user: 'other' },
+    { ...ssh, host: 'other.test' }
+  ]
+
+  for (const [index, variant] of variants.entries()) {
+    const route = resolveDesktopRemoteRoute({
+      config: { mode: 'ssh', remote: ssh },
+      profile: 'default',
+      registry: registry(`ssh-${index}`, [{ id: `ssh-${index}`, kind: 'ssh', label: `SSH ${index}`, ...variant }])
+    })
+
+    assert.equal(registryTargetForRoute(route, 'default'), null)
+  }
+})
+
+test('a v1 route and a direct registry call join one bootstrap for the same pair', async () => {
+  const route = resolveDesktopRemoteRoute({
+    config: { mode: 'ssh', remote: { mode: 'ssh', host: 'box.test', user: 'hermes' } },
+    profile: 'default',
+    registry: registry('ssh-primary', [
+      { id: 'ssh-primary', kind: 'ssh', label: 'SSH primary', host: 'box.test', user: 'hermes', port: 22 }
+    ])
+  })
+
+  // Mirrors ensureRegistryBackend()'s pool: one composite key, one in-flight
+  // connection promise. The point of the delegation is that the legacy route
+  // now lands on that key instead of minting a second SSH scope.
+  const pool = new Map<string, Promise<string>>()
+  let bootstraps = 0
+
+  const ensureRegistryBackend = (connectionId: string, profile: string) => {
+    const key = backendScopeKey(connectionId, profile)
+    const existing = pool.get(key)
+
+    if (existing) {
+      return existing
+    }
+
+    bootstraps += 1
+    const promise = Promise.resolve(key)
+    pool.set(key, promise)
+
+    return promise
+  }
+
+  const target = registryTargetForRoute(route, 'default')
+
+  assert.ok(target)
+
+  const [viaV1, viaRegistry] = await Promise.all([
+    ensureRegistryBackend(target.connectionId, target.profile),
+    ensureRegistryBackend('ssh-primary', 'default')
+  ])
+
+  assert.equal(bootstraps, 1)
+  assert.equal(viaV1, viaRegistry)
+  assert.equal(viaV1, 'conn:ssh-primary::default')
+})
+
+test('the delegated default profile stays the remote root profile', () => {
+  const route = resolveDesktopRemoteRoute({
+    config: { mode: 'ssh', remote: { mode: 'ssh', host: 'box.test', user: 'hermes' } },
+    profile: 'default',
+    registry: registry('ssh-primary', [
+      { id: 'ssh-primary', kind: 'ssh', label: 'SSH primary', host: 'box.test', user: 'hermes', port: 22 }
+    ])
+  })
+
+  const target = registryTargetForRoute(route, 'default')
+
+  assert.ok(target)
+  const poolKey = backendScopeKey(target.connectionId, target.profile)
+
+  assert.equal(poolKey, 'conn:ssh-primary::default')
+  // The composite pool key is a DESKTOP routing label. What reaches the remote
+  // `hermes serve` must stay the root profile — never `conn:<id>::default`.
+  assert.equal(resolveRemoteSshDashboardProfile('', poolKey), '')
+  assert.equal(resolveRemoteSshDashboardProfile('', backendScopeKey(target.connectionId, 'writer')), 'writer')
+})
+
 test('profile route omits identity when two registry entries match exactly', () => {
   const block = { mode: 'remote', url: 'https://worker.test', authMode: 'token', token: tokenA }
 
@@ -230,6 +387,60 @@ test('URL route fails closed for different token, headers, kind, or Cloud org', 
 
     assert.equal(route?.connectionId, undefined)
   }
+})
+
+// A real `ssh -G` dump, trimmed to the keywords that decide the destination.
+function dump(overrides: Record<string, string> = {}) {
+  const fields: Record<string, string> = {
+    host: 'galaxybook2',
+    hostname: '100.124.139.54',
+    user: 'thibaut-roux',
+    port: '22',
+    addressfamily: 'any',
+    identityfile: '~/.ssh/id_ed25519',
+    proxyjump: 'none',
+    ...overrides
+  }
+
+  return Object.entries(fields)
+    .map(([key, value]) => `${key} ${value}`)
+    .join('\n')
+}
+
+test('an ssh.config alias and its resolved host have the same effective dial', () => {
+  // This is the shape that shipped two backends: connection.json kept the
+  // ~/.ssh/config alias while the registry entry stored the resolved host+user.
+  assert.equal(
+    effectiveDialDigest(dump({ host: 'galaxybook2' })),
+    effectiveDialDigest(dump({ host: '100.124.139.54' }))
+  )
+  assert.equal(effectiveDialDigest(dump()), effectiveDialDigest(`${dump()}\r\n`))
+})
+
+test('anything that changes where or as whom ssh connects breaks the dial match', () => {
+  const base = effectiveDialDigest(dump())
+
+  for (const override of [
+    { hostname: '10.0.0.9' },
+    { user: 'someone-else' },
+    { port: '2222' },
+    { identityfile: '~/.ssh/other' },
+    { proxyjump: 'bastion.test' }
+  ]) {
+    assert.notEqual(base, effectiveDialDigest(dump(override)), JSON.stringify(override))
+  }
+
+  // `hostname` must survive the `host ` filter, or every target on the same
+  // config file would look identical.
+  assert.notEqual(effectiveDialDigest('hostname a'), effectiveDialDigest('hostname b'))
+  assert.equal(effectiveDialDigest('host a\nhostname z'), effectiveDialDigest('host b\nhostname z'))
+})
+
+test('remote Hermes path and remote profile are never resolved by ssh -G', () => {
+  assert.equal(sshPayloadFieldsMatch({}, { remoteHermesPath: '', remoteProfile: '' }), true)
+  assert.equal(sshPayloadFieldsMatch({ remoteHermesPath: '/srv/hermes' }, { remoteHermesPath: '/srv/hermes' }), true)
+  assert.equal(sshPayloadFieldsMatch({ remoteHermesPath: '/srv/hermes' }, { remoteHermesPath: '/opt/hermes' }), false)
+  assert.equal(sshPayloadFieldsMatch({ remoteProfile: 'writer' }, { remoteProfile: '' }), false)
 })
 
 test('local config without overrides returns null', () => {

--- a/apps/desktop/electron/desktop-remote-route.ts
+++ b/apps/desktop/electron/desktop-remote-route.ts
@@ -4,6 +4,8 @@
  * discard dial details. Environment routes deliberately remain unregistered.
  */
 
+import crypto from 'node:crypto'
+
 import {
   connectionScopeKey,
   modeIsRemoteLike,
@@ -52,6 +54,74 @@ export interface DesktopRemoteRouteInput {
   env?: { token?: null | string; url?: null | string }
   profile?: null | string
   registry: ConnectionRegistry
+}
+
+export interface RegistryBackendTarget {
+  connectionId: string
+  profile: string
+}
+
+/**
+ * An exact v2 registry identity is authoritative for backend ownership.
+ * Returning it here lets the primary v1-compatible route delegate to the
+ * registry pool instead of opening the same SSH gateway a second time under
+ * the legacy global scope — two scopes meant two ownership ids, so one gateway
+ * spawned two identical `hermes serve --isolated` backends for one profile.
+ *
+ * `connectionId` is only ever set by resolveDesktopRemoteRoute() when the
+ * stored v1 route matches ONE registry entry byte-for-byte (host, user, port,
+ * key path, remote Hermes path, remote profile — or URL/auth/headers/org for
+ * gateway routes). An ambiguous or partial match leaves it undefined and this
+ * returns null, so the caller keeps the historical v1 path.
+ */
+export function registryTargetForRoute(
+  route: DesktopRemoteRoute | null,
+  profile?: null | string
+): null | RegistryBackendTarget {
+  const connectionId = String(route?.connectionId || '').trim()
+
+  if (!connectionId) {
+    return null
+  }
+
+  return {
+    connectionId,
+    profile: String(profile ?? '').trim() || 'default'
+  }
+}
+
+/**
+ * Digest of one `ssh -G` dump, ignoring the echoed `host <alias>` line.
+ *
+ * Two routes that resolve to the same effective configuration dial the SAME
+ * machine even when they are spelled differently - typically an ~/.ssh/config
+ * alias on one side and the resolved host/user on the other. Everything that
+ * decides WHERE and AS WHOM ssh connects (hostname, user, port, identityfile,
+ * proxyjump, ...) stays in the digest; only the alias the caller typed is
+ * dropped, because that is spelling, not destination.
+ *
+ * `hostname <resolved>` is deliberately NOT filtered: the pattern requires
+ * whitespace directly after `host`.
+ */
+export function effectiveDialDigest(sshConfigDump: string): string {
+  const lines = String(sshConfigDump || '')
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line && !/^host\s/i.test(line))
+
+  return crypto.createHash('sha256').update(lines.join('\n')).digest('hex')
+}
+
+/**
+ * Fields that `ssh -G` cannot answer for: they describe what Hermes does ONCE
+ * connected, not how to connect. Two routes may only be treated as one gateway
+ * when these agree exactly.
+ */
+export function sshPayloadFieldsMatch(left: any, right: any): boolean {
+  return (
+    String(left?.remoteHermesPath || '') === String(right?.remoteHermesPath || '') &&
+    String(left?.remoteProfile || '') === String(right?.remoteProfile || '')
+  )
 }
 
 type StoredRoute =

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -121,7 +121,12 @@ import { describeCrashReason, installCrashForensics } from './crash-forensics'
 import { adoptServedDashboardToken } from './dashboard-token'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
 import { formatDesktopLogLine } from './desktop-log-line'
-import { resolveDesktopRemoteRoute } from './desktop-remote-route'
+import {
+  effectiveDialDigest,
+  registryTargetForRoute,
+  resolveDesktopRemoteRoute,
+  sshPayloadFieldsMatch
+} from './desktop-remote-route'
 import {
   buildPosixCleanupScript,
   buildWindowsCleanupScript,
@@ -9001,7 +9006,10 @@ async function reachablePreviewUrl(rawUrl: string): Promise<string> {
   }
 }
 
-function effectiveSshConfigFingerprint(sshConfig) {
+// `ssh -G` resolves ~/.ssh/config for a target WITHOUT connecting: no network,
+// no key, no agent prompt. It is the only way to tell whether two differently
+// spelled targets are the same machine.
+function sshEffectiveConfigDump(sshConfig) {
   const ssh =
     process.platform === 'win32'
       ? path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'OpenSSH', 'ssh.exe')
@@ -9018,9 +9026,67 @@ function effectiveSshConfigFingerprint(sshConfig) {
   }
 
   args.push('--', sshConfig.user ? `${sshConfig.user}@${sshConfig.host}` : sshConfig.host)
-  const output = execFileSync(ssh, args, { encoding: 'utf8', timeout: 10_000, windowsHide: true })
 
-  return crypto.createHash('sha256').update(output).digest('hex')
+  return execFileSync(ssh, args, { encoding: 'utf8', timeout: 10_000, windowsHide: true })
+}
+
+function effectiveSshConfigFingerprint(sshConfig) {
+  return crypto.createHash('sha256').update(sshEffectiveConfigDump(sshConfig)).digest('hex')
+}
+
+// A leftover v1 global SSH block can SPELL the same gateway differently from
+// the registry entry the roster dials - an ~/.ssh/config alias on one side, the
+// resolved host/user on the other. resolveDesktopRemoteRoute() compares the
+// STORED fields, so it cannot see through the alias, and the two spellings mint
+// two ssh scopes, two ownership ids, and two identical
+// `hermes serve --isolated` backends for one profile (#observed on Windows:
+// 78 authentications and two remote backends per cold start).
+//
+// `ssh -G` resolves both sides to their effective dial. Identical dial AND
+// identical remote Hermes path/profile means one gateway, so the legacy route
+// delegates to the registry pool instead of opening its own. Anything less -
+// a different port, user, key, jump host, remote path or remote profile - keeps
+// the historical behaviour. Deliberately limited to the GLOBAL v1 route and the
+// registry PRIMARY: a per-profile override is a deliberate choice by the user,
+// and two registry entries are never merged into each other.
+function registryPrimarySharingSshRoute(route, registry) {
+  if (route?.kind !== 'ssh' || route.connectionId || route.source !== 'settings') {
+    return null
+  }
+
+  const primary = registry.connections.find(connection => connection.id === registry.primary)
+
+  if (!primary || primary.kind !== 'ssh') {
+    return null
+  }
+
+  const entry = normalizeSshConfig({
+    mode: 'ssh',
+    host: primary.host,
+    user: primary.user,
+    port: primary.port,
+    keyPath: primary.keyPath,
+    remoteHermesPath: primary.remoteHermesPath,
+    remoteProfile: primary.remoteProfile
+  })
+
+  if (!entry || !sshPayloadFieldsMatch(entry, route.ssh)) {
+    return null
+  }
+
+  try {
+    if (effectiveDialDigest(sshEffectiveConfigDump(route.ssh)) !== effectiveDialDigest(sshEffectiveConfigDump(entry))) {
+      return null
+    }
+  } catch (error: any) {
+    // No ssh binary, an unreadable ~/.ssh/config, a malformed target: we cannot
+    // prove they are the same gateway, so we do not claim it.
+    sshRememberLog(`[ssh] could not compare effective SSH dials (${error?.message || error}); keeping the v1 route`)
+
+    return null
+  }
+
+  return primary.id
 }
 
 async function bootstrapSshConnection(profile, sshConfig, reuseToken, source) {
@@ -9212,8 +9278,9 @@ function persistSshConnectionToken(profile, source, token) {
 //   3. global remote (connection.json `mode: 'remote'`)
 // A null/empty profile resolves the env/global remote, so legacy callers and
 // the connection test (which pass no profile) are unchanged.
-async function resolveRemoteBackend(profile) {
+async function resolveRemoteBackend(profile: any): Promise<any> {
   const config = readDesktopConnectionConfig()
+  const registry = readDesktopConnectionsRegistry()
 
   const route = resolveDesktopRemoteRoute({
     config,
@@ -9222,11 +9289,44 @@ async function resolveRemoteBackend(profile) {
       url: process.env.HERMES_DESKTOP_REMOTE_URL
     },
     profile,
-    registry: readDesktopConnectionsRegistry()
+    registry
   })
 
   if (!route) {
     return null
+  }
+
+  // A v1 route that resolves to exactly one registry entry is the SAME gateway
+  // the v2 roster dials. Bootstrapping it here under the legacy global ssh
+  // scope minted a second ownership id, so one connection ended up with two
+  // remote `hermes serve --isolated` backends for one profile. Delegate to the
+  // registry pool so both entry points join a single bootstrap.
+  let registryTarget = registryTargetForRoute(route, profile)
+  let delegationBasis = 'stored identity'
+
+  if (!registryTarget) {
+    const sharedPrimaryId = registryPrimarySharingSshRoute(route, registry)
+
+    if (sharedPrimaryId) {
+      registryTarget = registryTargetForRoute({ ...route, connectionId: sharedPrimaryId }, profile)
+      delegationBasis = 'effective ssh dial'
+    }
+  }
+
+  if (registryTarget) {
+    sshRememberLog(
+      `[ssh] route delegated connection=${registryTarget.connectionId} profile=${registryTarget.profile} ` +
+        `source=${route.source} kind=${route.kind} basis="${delegationBasis}"`
+    )
+
+    return ensureRegistryBackend(registryTarget.connectionId, registryTarget.profile)
+  }
+
+  if (route.kind === 'ssh') {
+    sshRememberLog(
+      `[ssh] route not delegated (no registry entry proves the same gateway) source=${route.source} ` +
+        `scope=${JSON.stringify(sshScopeKey(route.source === 'profile' ? profile : null))}`
+    )
   }
 
   let connection
@@ -9786,7 +9886,7 @@ async function ensureBackend(profile) {
 // a genuinely-local child when the v1 mode says remote; non-local connections
 // pool under the composite key from backendScopeKey() and reuse the same pool
 // entry lifecycle (LRU, idle reaper, touch) as per-profile local backends.
-async function ensureRegistryBackend(connectionId, profile) {
+async function ensureRegistryBackend(connectionId: any, profile: any): Promise<any> {
   const registry = readDesktopConnectionsRegistry()
   const id = String(connectionId || '').trim() || registry.primary
   const source = registry.connections.find(c => c.id === id)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -225,6 +225,7 @@ import {
 import { selectPoolEvictions } from './pool-eviction'
 import { createPoolStopper } from './pool-stop'
 import { poolTouchKeys } from './pool-touch-scope'
+import { connectBatched, shouldFallBackToLegacy } from './posix-remote-bootstrap'
 import { createKeepAwake } from './power-save'
 import { PreviewReachRegistry } from './preview-reach'
 import {
@@ -9095,6 +9096,15 @@ async function bootstrapSshConnection(profile, sshConfig, reuseToken, source) {
   const resolvedConfig = { ...sshConfig, effectiveConfigFingerprint }
   const fingerprint = sshConfigFingerprint(scope, resolvedConfig)
 
+  // "joined" means a concurrent caller (v1 route + registry roster, or several
+  // windows) landed on the SAME (scope, fingerprint) and shares one bootstrap
+  // instead of dialling a second time.
+  const joined = sshBootstrapCoordinator.pending.get(scope)?.fingerprint === fingerprint
+
+  sshRememberLog(
+    `[ssh] bootstrap ${joined ? 'joined' : 'started'} scope=${JSON.stringify(scope)} source=${String(source || '')}`
+  )
+
   return sshBootstrapCoordinator.start(scope, fingerprint, lease =>
     bootstrapSshConnectionInner(profile, resolvedConfig, reuseToken, source, fingerprint, lease)
   )
@@ -9109,9 +9119,30 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
     await teardownSshConnection(profile)
   }
 
+  // Windows OpenSSH has no ControlMaster, so EVERY ssh invocation is a fresh
+  // key authentication (and, with a vault-backed agent, a user-visible
+  // approval). On that platform the whole remote lifecycle runs as one batched
+  // exec instead of ~15 calls plus a two-call readiness poll.
+  const batched = process.platform === 'win32'
+  const remoteDashboardProfile = resolveRemoteSshDashboardProfile(sshConfig.remoteProfile, profile)
+
+  const connectionLabel =
+    typeof source === 'string' && source.startsWith('registry:')
+      ? source.slice('registry:'.length)
+      : `v1-${String(source || 'settings')}`
+
+  const phases: Record<string, number> = {}
+
+  const recordPhase = (name: string, ms: number) => {
+    phases[name] = (phases[name] || 0) + ms
+  }
+
   let ssh = sshConnections.get(scope)?.ssh
 
-  if (ssh && !(await ssh.isAlive())) {
+  // Without mux there is no master to interrogate: the batched bootstrap exec
+  // that follows IS the liveness test, and its failure path already tears the
+  // scope down. Probing here would just buy one more authentication.
+  if (ssh && !batched && !(await ssh.isAlive())) {
     try {
       await ssh.close()
     } catch {
@@ -9125,6 +9156,7 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
   const created = !ssh
 
   let removeForceCleanup = () => {}
+  const cycleStartedAt = Date.now()
 
   if (created) {
     ssh = new SshConnection(
@@ -9137,17 +9169,21 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
       }
     )
     removeForceCleanup = lease.onForceCleanup(() => ssh.close())
-    await ssh.open({ signal: lease.signal })
+    const openStartedAt = Date.now()
+    await ssh.open({ lazy: batched, signal: lease.signal })
+    recordPhase('open', Date.now() - openStartedAt)
   }
 
+  const invocationsAtStart = ssh.invocations || 0
   let result
 
-  try {
+  const runLegacyLifecycle = async () => {
     const platform = await detectRemotePlatform(ssh, sshConfig.remoteHermesPath || '')
     const lifecycle = platform.os === 'Windows' ? connectWindowsRemote : remoteLifecycle.connect
-    result = await lifecycle({
+
+    return lifecycle({
       ssh,
-      profile: resolveRemoteSshDashboardProfile(sshConfig.remoteProfile, profile),
+      profile: remoteDashboardProfile,
       remoteHermesPath: sshConfig.remoteHermesPath || '',
       ownershipId: sshOwnershipKey(profile),
       reuseToken: reuseToken || '',
@@ -9160,6 +9196,46 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
       rememberLog: sshRememberLog,
       signal: lease.signal
     })
+  }
+
+  try {
+    if (batched) {
+      try {
+        result = await connectBatched({
+          adoptServedToken: adoptServedDashboardToken,
+          cancelForward: (localPort, remotePort) => ssh.cancelForward(localPort, remotePort),
+          forward: (localPort, remotePort, options) => ssh.forward(localPort, remotePort, '127.0.0.1', options),
+          onPhase: recordPhase,
+          ownershipId: sshOwnershipKey(profile),
+          pickLocalPort,
+          probeReuseProof: sshProbeReuseProof,
+          probeWebSocket: wsUrl => probeGatewayWebSocket(wsUrl, { WebSocketImpl: globalThis.WebSocket }),
+          profile: remoteDashboardProfile,
+          rememberLog: sshRememberLog,
+          remoteHermesPath: sshConfig.remoteHermesPath || '',
+          reuseToken: reuseToken || '',
+          signal: lease.signal,
+          ssh,
+          waitForHermes: (baseUrl, token) => waitForHermes(baseUrl, token, lease.signal, 'token')
+        })
+      } catch (error: any) {
+        if (!shouldFallBackToLegacy(error)) {
+          throw error
+        }
+
+        // The remote could not run the batched program at all (no python3, a
+        // Windows remote, a mangled response). Take the slow path rather than
+        // failing the connection - and say exactly why, since this is the one
+        // case where the authentication count goes back up.
+        sshRememberLog(
+          `[ssh] batched bootstrap unavailable, falling back to the per-call lifecycle: ${error?.message || error}`
+        )
+        recordPhase('fallback', 0)
+        result = await runLegacyLifecycle()
+      }
+    } else {
+      result = await runLegacyLifecycle()
+    }
   } catch (error: any) {
     if (created) {
       try {
@@ -9221,6 +9297,17 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
   sshRememberLog(
     `[ssh] connection ${result.reused ? 'REUSED' : 'spawned'} dashboard: ` +
       `${result.hermesVersion || 'hermes (version unknown)'} at ${result.hermesPath || '?'}`
+  )
+
+  const phaseTrace = Object.entries(phases)
+    .map(([name, ms]) => `${name}Ms=${ms}`)
+    .join(' ')
+
+  sshRememberLog(
+    `[ssh] ready connection=${connectionLabel} profile=${remoteDashboardProfile || 'default'} ` +
+      `scope=${JSON.stringify(scope)} reused=${Boolean(result.reused)} ` +
+      `sshInvocations=${(ssh.invocations || 0) - invocationsAtStart} totalMs=${Date.now() - cycleStartedAt}` +
+      `${phaseTrace ? ` ${phaseTrace}` : ''}`
   )
 
   const connection = await buildRemoteConnection(
@@ -12756,7 +12843,10 @@ async function probeSshProfileInventory(connection) {
   )
 
   try {
-    await ssh.open()
+    // The listing exec below is itself the reachability check, so on a
+    // no-ControlMaster client we skip the separate `ssh true` handshake rather
+    // than pay a second authentication for the same answer.
+    await ssh.open({ lazy: process.platform === 'win32' })
     const profiles = await remoteLifecycle.listRemoteHermesProfiles(ssh)
 
     if (profiles.length > 0) {

--- a/apps/desktop/electron/posix-remote-bootstrap.test.ts
+++ b/apps/desktop/electron/posix-remote-bootstrap.test.ts
@@ -1,0 +1,571 @@
+import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
+
+import { test } from 'vitest'
+
+import {
+  bootstrapParams,
+  buildBootstrapCommand,
+  buildRestampCommand,
+  connectBatched,
+  fingerprintToken,
+  parseBootstrapResponse,
+  REMOTE_BOOTSTRAP_PY,
+  RESPONSE_MARKER,
+  shouldFallBackToLegacy
+} from './posix-remote-bootstrap'
+import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
+import { baseSshOptions, SshConnection } from './ssh-connection'
+
+const OWNERSHIP_ID = 'a'.repeat(32)
+
+function decodeParams(command: string) {
+  const parts = command.trim().split(/\s+/)
+  const encoded = parts[parts.length - 1].replace(/^'|'$/g, '')
+
+  return JSON.parse(Buffer.from(encoded, 'base64').toString('utf8'))
+}
+
+function remoteResponse(params: any, overrides: Record<string, unknown> = {}) {
+  const nonce = String(overrides.spawnNonce ?? params.spawnNonce)
+
+  return {
+    arch: 'x86_64',
+    hermesHome: '/home/remote/.hermes',
+    hermesPath: '/home/remote/.local/bin/hermes',
+    hermesVersion: 'Hermes Agent v0.20.4',
+    logPath: `~/.hermes/desktop-ssh/${params.ownershipId}/${nonce}.log`,
+    ok: true,
+    os: 'Linux',
+    ownershipId: params.ownershipId,
+    pid: 4242,
+    port: 35691,
+    profile: params.profile,
+    reused: false,
+    spawnNonce: nonce,
+    timings: { totalMs: 1200 },
+    tokenFingerprint: params.tokenFingerprint,
+    ...overrides
+  }
+}
+
+function line(payload: unknown) {
+  return `${RESPONSE_MARKER} ${JSON.stringify(payload)}\n`
+}
+
+/**
+ * A scripted stand-in for SshConnection. Every ssh process the real class would
+ * spawn shows up in `calls`, so a test can assert the invocation BUDGET, not
+ * just the outcome.
+ */
+function fakeSsh(respond: (command: string, options: any) => Promise<string> | string) {
+  const calls: { command?: string; kind: string; options?: any }[] = []
+
+  return {
+    calls,
+    async cancelForward(localPort: number, remotePort: number) {
+      calls.push({ kind: 'cancelForward', options: { localPort, remotePort } })
+    },
+    async exec(command: string, options: any = {}) {
+      calls.push({ command, kind: 'exec', options })
+
+      return respond(command, options)
+    },
+    async forward(localPort: number, remotePort: number, remoteHost: string, options: any = {}) {
+      calls.push({ kind: 'forward', options: { localPort, remoteHost, remotePort, ...options } })
+    },
+    get invocations() {
+      return calls.filter(call => call.kind === 'exec' || call.kind === 'forward').length
+    }
+  }
+}
+
+function connectDeps(ssh: any, overrides: Record<string, unknown> = {}) {
+  return {
+    adoptServedToken: async (_baseUrl: string, token: string) => token,
+    cancelForward: (localPort: number, remotePort: number) => ssh.cancelForward(localPort, remotePort),
+    forward: (localPort: number, remotePort: number, options: any) =>
+      ssh.forward(localPort, remotePort, '127.0.0.1', options),
+    ownershipId: OWNERSHIP_ID,
+    pickLocalPort: async () => 51234,
+    probeReuseProof: async () => 'authenticated-ok',
+    profile: '',
+    rememberLog: () => {},
+    remoteHermesPath: '',
+    reuseToken: '',
+    ssh,
+    waitForHermes: async () => ({ ok: true }),
+    ...overrides
+  } as any
+}
+
+// --- the remote program itself ---
+
+test('the remote program keeps its regexes and NUL split intact through the TS literal', () => {
+  // String.raw is load-bearing: a normal template literal would eat the
+  // backslashes and ship a program that matches "d+" and splits on "0".
+  assert.match(REMOTE_BOOTSTRAP_PY, /READY port=\(\\d\+\)/)
+  assert.match(REMOTE_BOOTSTRAP_PY, /raw\.split\(b"\\0"\)/)
+  assert.match(REMOTE_BOOTSTRAP_PY, /\^\[0-9a-f\]\{32\}\$/)
+  // argv[1] is the program the loader exec'd; argv[2] is the parameter block.
+  // Reading argv[1] for the parameters made every start fail with a JSON error
+  // on the program's own source, and no mocked-ssh test could see it.
+  assert.match(REMOTE_BOOTSTRAP_PY, /json\.loads\(base64\.b64decode\(sys\.argv\[2\]\)/)
+  assert.match(
+    buildBootstrapCommand(bootstrapParams({ ownershipId: OWNERSHIP_ID } as any, false).params),
+    /sys\.argv\[1\]/
+  )
+  // The backend must stay loopback-only on the remote.
+  assert.match(REMOTE_BOOTSTRAP_PY, /"--host",\s*\n?\s*"127\.0\.0\.1"/)
+  assert.doesNotMatch(REMOTE_BOOTSTRAP_PY, /0\.0\.0\.0/)
+})
+
+// --- 6. the token is never an argument and never logged ---
+
+test('the session token travels on stdin only, never in argv or the log', async () => {
+  const logs: string[] = []
+  let seenStdin = ''
+  let seenCommand = ''
+
+  const ssh = fakeSsh((command, options) => {
+    seenCommand = command
+    seenStdin = options.stdinData
+    const params = decodeParams(command)
+
+    return line(remoteResponse(params))
+  })
+
+  const result: any = await connectBatched(connectDeps(ssh, { rememberLog: (m: string) => logs.push(m) }))
+
+  assert.equal(result.token, seenStdin)
+  assert.ok(seenStdin.length >= 64)
+  assert.ok(!seenCommand.includes(seenStdin), 'token must not appear in the remote command')
+
+  const decoded = Buffer.from(seenCommand.trim().split(/\s+/).slice(-1)[0].replace(/'/g, ''), 'base64').toString('utf8')
+
+  assert.ok(!decoded.includes(seenStdin), 'token must not appear in the encoded parameters')
+  assert.equal(decoded.includes(fingerprintToken(seenStdin)), true, 'only the fingerprint is sent')
+
+  for (const message of logs) {
+    assert.ok(!message.includes(seenStdin), `token leaked into a log line: ${message}`)
+  }
+
+  assert.ok(!buildRestampCommand(OWNERSHIP_ID, 'b'.repeat(16), fingerprintToken(seenStdin)).includes(seenStdin))
+})
+
+// --- 1. bounded ssh invocations ---
+
+test('a cold start costs exactly one exec and one tunnel', async () => {
+  const ssh = fakeSsh(command => line(remoteResponse(decodeParams(command))))
+  const result: any = await connectBatched(connectDeps(ssh))
+
+  assert.equal(result.reused, false)
+  assert.equal(ssh.invocations, 2)
+  assert.deepEqual(
+    ssh.calls.map(call => call.kind),
+    ['exec', 'forward']
+  )
+})
+
+// --- 3. a valid lock reuses the backend ---
+
+test('a reusable lock costs the same two invocations and spawns nothing', async () => {
+  const reuseToken = 'r'.repeat(64)
+  let sentParams: any
+
+  const ssh = fakeSsh(command => {
+    sentParams = decodeParams(command)
+
+    return line(
+      remoteResponse(sentParams, {
+        pid: 1556269,
+        reused: true,
+        spawnNonce: 'c'.repeat(16),
+        tokenFingerprint: fingerprintToken(reuseToken)
+      })
+    )
+  })
+
+  const result: any = await connectBatched(connectDeps(ssh, { reuseToken }))
+
+  assert.equal(sentParams.allowReuse, true)
+  assert.equal(sentParams.reuseFingerprint, fingerprintToken(reuseToken))
+  assert.equal(result.reused, true)
+  assert.equal(result.pid, 1556269)
+  assert.equal(result.token, reuseToken)
+  assert.equal(ssh.invocations, 2)
+})
+
+test('no saved token means the remote is never allowed to reuse a lock', async () => {
+  let sentParams: any
+
+  const ssh = fakeSsh(command => {
+    sentParams = decodeParams(command)
+
+    return line(remoteResponse(sentParams))
+  })
+
+  await connectBatched(connectDeps(ssh, { reuseToken: '' }))
+  assert.equal(sentParams.allowReuse, false)
+  assert.equal(sentParams.reuseFingerprint, '')
+})
+
+// --- 4. a stale or unowned lock never kills a foreign process ---
+
+test('a stale reuse proof respawns once and never trusts the first answer', async () => {
+  const reuseToken = 'r'.repeat(64)
+  const commands: any[] = []
+  const proofs = ['authenticated-stale', 'authenticated-ok']
+
+  const ssh = fakeSsh(command => {
+    const params = decodeParams(command)
+    commands.push(params)
+
+    return line(
+      params.allowReuse
+        ? remoteResponse(params, {
+            reused: true,
+            spawnNonce: 'c'.repeat(16),
+            tokenFingerprint: fingerprintToken(reuseToken)
+          })
+        : remoteResponse(params)
+    )
+  })
+
+  const result: any = await connectBatched(
+    connectDeps(ssh, { probeReuseProof: async () => proofs.shift(), reuseToken })
+  )
+
+  assert.equal(commands.length, 2)
+  assert.equal(commands[0].allowReuse, true)
+  // The retry forbids reuse, so the remote script takes its cleanup-then-spawn
+  // branch instead of adopting a backend the dashboard just disowned.
+  assert.equal(commands[1].allowReuse, false)
+  assert.equal(commands[1].reuseFingerprint, '')
+  assert.equal(result.reused, false)
+  // The tunnel opened for the stale backend is closed before the retry.
+  assert.equal(ssh.calls.filter(call => call.kind === 'cancelForward').length, 1)
+})
+
+test('a retry that still claims reuse is rejected instead of trusted', async () => {
+  // The retry forbids reuse. A remote that answers `reused: true` anyway is
+  // not describing a backend we asked for, so it is refused rather than
+  // adopted - and refused BEFORE any credential is handed to it.
+  const ssh = fakeSsh(command =>
+    line(
+      remoteResponse(decodeParams(command), {
+        reused: true,
+        spawnNonce: 'c'.repeat(16),
+        tokenFingerprint: fingerprintToken('r'.repeat(64))
+      })
+    )
+  )
+
+  await assert.rejects(
+    connectBatched(
+      connectDeps(ssh, { probeReuseProof: async () => 'authenticated-stale', reuseToken: 'r'.repeat(64) })
+    ),
+    /unusable response \(reuse fingerprint mismatch\)/
+  )
+  assert.equal(ssh.calls.filter(call => call.kind === 'cancelForward').length, 1)
+})
+
+test('the remote program only terminates a pid whose argv proves it is ours', () => {
+  // The ownership proof is the guard that keeps a foreign pid alive: cleanup
+  // is gated on `owned`, which is gated on the argv check.
+  assert.match(
+    REMOTE_BOOTSTRAP_PY,
+    /def cleanup_stale\(oid, lock, alive, owned\):\n {4}if lock and alive and owned:\n {8}terminate\(lock\["pid"\]\)/
+  )
+  assert.match(REMOTE_BOOTSTRAP_PY, /owned = alive and is_our_backend\(/)
+  assert.match(REMOTE_BOOTSTRAP_PY, /args\[owner \+ 1\] == nonce/)
+})
+
+// --- 2. strict validation of the single JSON response ---
+
+test('the bootstrap response is validated field by field', () => {
+  const { params } = bootstrapParams({ ownershipId: OWNERSHIP_ID } as any, false)
+  const good = remoteResponse(params)
+
+  assert.equal(parseBootstrapResponse(line(good), params).port, 35691)
+
+  const rejected: [string, unknown][] = [
+    ['port 0', { ...good, port: 0 }],
+    ['port out of range', { ...good, port: 70000 }],
+    ['pid 0', { ...good, pid: 0 }],
+    ['other ownership', { ...good, ownershipId: 'b'.repeat(32) }],
+    ['other profile', { ...good, profile: 'someone-else' }],
+    ['bad nonce', { ...good, spawnNonce: 'zz' }],
+    ['bad fingerprint', { ...good, tokenFingerprint: 'nope' }],
+    ['missing reuse flag', { ...good, reused: 'yes' }],
+    ['foreign spawn nonce', { ...good, spawnNonce: 'd'.repeat(16) }],
+    ['foreign token fingerprint', { ...good, tokenFingerprint: 'e'.repeat(32) }],
+    ['log path escape', { ...good, logPath: '~/.hermes/desktop-ssh/other/x.log' }]
+  ]
+
+  for (const [label, payload] of rejected) {
+    assert.throws(() => parseBootstrapResponse(line(payload), params), /unusable response/, label)
+  }
+
+  assert.throws(() => parseBootstrapResponse('', params), /no response line/)
+  assert.throws(() => parseBootstrapResponse(`${RESPONSE_MARKER} not-json`, params), /not JSON/)
+  // Remote chatter before the response line must not break parsing.
+  assert.equal(parseBootstrapResponse(`motd\nwarning: x\n${line(good)}`, params).pid, 4242)
+})
+
+test('a reported remote failure keeps its kind and never falls back', () => {
+  const { params } = bootstrapParams({ ownershipId: OWNERSHIP_ID } as any, false)
+
+  const error: any = (() => {
+    try {
+      parseBootstrapResponse(line({ error: 'Hermes is not installed', kind: 'hermes-not-found', ok: false }), params)
+    } catch (caught) {
+      return caught
+    }
+  })()
+
+  assert.equal(error.kind, 'hermes-not-found')
+  assert.equal(shouldFallBackToLegacy(error), false)
+  // An unlisted kind is not trusted verbatim.
+  assert.throws(
+    () => parseBootstrapResponse(line({ error: 'x', kind: 'made-up', ok: false }), params),
+    (thrown: any) => thrown.kind === 'unknown'
+  )
+})
+
+test('a transport failure is surfaced, a missing python3 falls back', () => {
+  for (const kind of ['auth-failed', 'host-key-changed', 'superseded', 'timeout', 'unreachable']) {
+    assert.equal(shouldFallBackToLegacy(Object.assign(new Error('x'), { kind })), false)
+  }
+
+  assert.equal(shouldFallBackToLegacy(new Error('python3: command not found')), true)
+  assert.equal(shouldFallBackToLegacy(Object.assign(new Error('x'), { kind: 'batched-unavailable' })), true)
+})
+
+// --- 5. a backend that never announces its port ---
+
+test('a ready timeout arrives as an actionable error, not a hang', async () => {
+  const ssh = fakeSsh(() =>
+    line({
+      error: 'Timed out waiting for the remote dashboard to announce its port (45000ms).',
+      kind: 'ready-timeout',
+      ok: false
+    })
+  )
+
+  await assert.rejects(connectBatched(connectDeps(ssh)), (error: any) => {
+    assert.equal(error.kind, 'ready-timeout')
+    assert.match(error.message, /Timed out waiting for the remote dashboard/)
+
+    return true
+  })
+
+  // The exec is bounded by the remote readiness budget plus a margin, so a
+  // wedged remote cannot pin the ssh child forever.
+  const params = bootstrapParams({ ownershipId: OWNERSHIP_ID, readyTimeoutMs: 45_000 } as any, false).params
+  assert.equal(params.readyTimeoutMs, 45_000)
+  assert.ok(ssh.calls[0].options.timeoutMs > params.readyTimeoutMs)
+  // Nothing was forwarded, so nothing leaks.
+  assert.equal(ssh.calls.filter(call => call.kind === 'forward').length, 0)
+})
+
+// --- 7. the tunnel is closed when HTTP or WebSocket fails ---
+
+test('an HTTP failure closes the tunnel', async () => {
+  const ssh = fakeSsh(command => line(remoteResponse(decodeParams(command))))
+
+  await assert.rejects(
+    connectBatched(
+      connectDeps(ssh, {
+        waitForHermes: async () => {
+          throw new Error('backend never answered /api/status')
+        }
+      })
+    ),
+    /never answered/
+  )
+
+  assert.equal(ssh.calls.filter(call => call.kind === 'cancelForward').length, 1)
+})
+
+test('a WebSocket rejection closes the tunnel and reports the reason', async () => {
+  const ssh = fakeSsh(command => line(remoteResponse(decodeParams(command))))
+
+  await assert.rejects(
+    connectBatched(connectDeps(ssh, { probeWebSocket: async () => ({ ok: false, reason: '401 unauthorized' }) })),
+    /WebSocket \(\/api\/ws\) rejected the session token: 401 unauthorized/
+  )
+
+  assert.equal(ssh.calls.filter(call => call.kind === 'cancelForward').length, 1)
+})
+
+test('a backend serving a foreign ownership nonce is refused', async () => {
+  const ssh = fakeSsh(command => line(remoteResponse(decodeParams(command))))
+
+  await assert.rejects(
+    connectBatched(connectDeps(ssh, { probeReuseProof: async () => 'authenticated-stale' })),
+    (error: any) => {
+      assert.equal(error.kind, 'foreign-backend')
+
+      return true
+    }
+  )
+
+  assert.equal(ssh.calls.filter(call => call.kind === 'cancelForward').length, 1)
+})
+
+test('served-token drift costs exactly one extra exec to re-stamp the lockfile', async () => {
+  const served = 's'.repeat(64)
+
+  const ssh = fakeSsh(command => {
+    if (command.includes('restamp')) {
+      return 'OK'
+    }
+
+    return line(remoteResponse(decodeParams(command)))
+  })
+
+  const result: any = await connectBatched(connectDeps(ssh, { adoptServedToken: async () => served }))
+
+  assert.equal(result.token, served)
+  assert.equal(result.tokenFingerprint, fingerprintToken(served))
+  assert.equal(ssh.invocations, 3)
+})
+
+// --- 9. cancellation leaves nothing behind ---
+
+test('a cancelled bootstrap aborts the ssh child and opens no tunnel', async () => {
+  const controller = new AbortController()
+
+  const ssh = fakeSsh((_command, options) => {
+    assert.equal(options.signal, controller.signal, 'the abort signal must reach the ssh child')
+    controller.abort()
+    const error: any = new Error('SSH operation was cancelled.')
+    error.kind = 'superseded'
+
+    throw error
+  })
+
+  await assert.rejects(connectBatched(connectDeps(ssh, { signal: controller.signal })), (error: any) => {
+    assert.equal(error.kind, 'superseded')
+
+    return true
+  })
+
+  assert.equal(ssh.calls.filter(call => call.kind === 'forward').length, 0)
+  assert.equal(shouldFallBackToLegacy({ kind: 'superseded' }), false)
+})
+
+test('an abort raised after the tunnel is up still closes the tunnel', async () => {
+  const controller = new AbortController()
+  const ssh = fakeSsh(command => line(remoteResponse(decodeParams(command))))
+
+  await assert.rejects(
+    connectBatched(
+      connectDeps(ssh, {
+        signal: controller.signal,
+        waitForHermes: async () => {
+          controller.abort()
+        }
+      })
+    ),
+    (error: any) => {
+      assert.equal(error.kind, 'superseded')
+
+      return true
+    }
+  )
+
+  assert.equal(ssh.calls.filter(call => call.kind === 'cancelForward').length, 1)
+})
+
+// --- 8. concurrent callers join one bootstrap ---
+
+test('two callers for the same connection and profile join one bootstrap', async () => {
+  const coordinator = createBootstrapCoordinator()
+  const scope = 'conn:alfred-laptop::default'
+  const config = { host: 'box.test', port: 22, remoteProfile: '', user: 'hermes' }
+  const fingerprint = sshConfigFingerprint(scope, config)
+  let runs = 0
+
+  const start = () =>
+    coordinator.start(scope, fingerprint, async () => {
+      runs += 1
+      await new Promise(resolve => setTimeout(resolve, 5))
+
+      return 'connection'
+    })
+
+  const [a, b] = await Promise.all([start(), start()])
+
+  assert.equal(runs, 1)
+  assert.equal(a, b)
+})
+
+// --- 10. POSIX clients keep ControlMaster ---
+
+test('POSIX keeps one multiplexed connection and ignores the lazy shortcut', async () => {
+  const spawned: string[][] = []
+
+  // `-O check` fails: no master is up yet, so open() must establish one.
+  const spawnFn = (_cmd: string, args: string[]) => {
+    spawned.push(args)
+    const code = args.includes('check') ? 255 : 0
+
+    return {
+      on: (event: string, handler: any) => {
+        if (event === 'close') {
+          setTimeout(() => handler(code), 0)
+        }
+      },
+      stderr: { on: () => {} },
+      stdout: { on: () => {} }
+    } as any
+  }
+
+  const conn: any = new SshConnection(
+    { host: 'box.test', user: 'hermes' },
+    { controlDir: '/tmp/hermes-test-sockets', mux: true, spawnFn }
+  )
+
+  assert.ok(conn.controlPath, 'a multiplexed connection owns a control socket')
+  assert.deepEqual(baseSshOptions(conn.controlPath).slice(0, 6), [
+    '-o',
+    `ControlPath=${conn.controlPath}`,
+    '-o',
+    'ControlMaster=auto',
+    '-o',
+    'ControlPersist=300'
+  ])
+
+  // `lazy` is a no-mux-only shortcut: on POSIX the master is still opened, so
+  // exec/forward keep sharing that single authentication.
+  await conn.open({ lazy: true })
+  assert.ok(spawned.length > 0, 'the master handshake still runs')
+  assert.ok(
+    spawned.some(args => args.includes('-M')),
+    'ControlMaster is still established'
+  )
+
+  const noMux: any = new SshConnection({ host: 'box.test', user: 'hermes' }, { mux: false, spawnFn })
+  const before = noMux.invocations
+  await noMux.open({ lazy: true })
+
+  assert.equal(noMux.controlPath, '')
+  assert.equal(noMux.invocations - before, 0, 'the lazy no-mux open costs no authentication')
+})
+
+test('the batched command carries no secret and stays a single python3 invocation', () => {
+  const { params, token } = bootstrapParams(
+    { ownershipId: OWNERSHIP_ID, profile: 'writer', remoteHermesPath: '/srv/hermes' } as any,
+    true,
+    () => crypto.randomBytes(32).toString('hex')
+  )
+
+  const command = buildBootstrapCommand(params)
+
+  assert.equal(command.startsWith('python3 -c '), true)
+  assert.equal(command.split('python3').length, 2, 'exactly one remote interpreter invocation')
+  assert.ok(!command.includes(token))
+  assert.deepEqual(decodeParams(command), params)
+})

--- a/apps/desktop/electron/posix-remote-bootstrap.ts
+++ b/apps/desktop/electron/posix-remote-bootstrap.ts
@@ -1,0 +1,1155 @@
+/**
+ * posix-remote-bootstrap.ts
+ *
+ * ONE remote round-trip bootstrap of a POSIX Hermes backend over SSH.
+ *
+ * Why this exists
+ * ---------------
+ * remote-lifecycle.ts walks the remote lifecycle as ~15 separate `ssh.exec()`
+ * calls plus a readiness poll that adds two more every 750ms. With
+ * ControlMaster (Linux/macOS clients) those all ride one authenticated
+ * connection, so the cost is a round-trip each. Windows OpenSSH has no
+ * ControlMaster — mux sockets were never implemented on Win32 — so on a Windows
+ * client every single one of those calls is a full TCP connect + key
+ * authentication against the agent. With a hardware/vault-backed agent
+ * (1Password, YubiKey) that is 1-3s and a user-visible approval each time; a
+ * cold start measured 43 authentications and minutes of wall clock.
+ *
+ * The fix is not to make the calls faster, it is to stop making them. This
+ * module ships the ENTIRE remote lifecycle as one Python program executed by a
+ * single `ssh` invocation:
+ *
+ *   1. one ssh exec  -> platform, hermes location/version, HERMES_HOME, lock
+ *                       read + ownership proof, reuse-or-spawn, local wait for
+ *                       HERMES_BACKEND_READY, lockfile write. One JSON line back.
+ *   2. one ssh -N -L -> the tunnel.
+ *   3. HTTP + WebSocket checks run THROUGH that tunnel, with no further ssh.
+ *
+ * Cold start: 2 authentications. Warm restart: 2. A served token that drifts
+ * from the spawn token costs one extra exec to re-stamp the lockfile.
+ *
+ * Compatibility
+ * -------------
+ * The lockfile schema, ownership proof, token-file handling and spawn argv are
+ * byte-compatible with remote-lifecycle.ts, so a backend started by either path
+ * is reusable and reapable by the other. Whatever this module cannot do (a
+ * Windows remote, a host without python3) reports itself as unavailable and the
+ * caller falls back to the legacy per-call path.
+ *
+ * Security
+ * --------
+ *   - The session token travels on stdin, never in argv, never in a log. Only
+ *     its SHA256 fingerprint is passed as a parameter, exactly as the lockfile
+ *     already stores it on the remote.
+ *   - The remote script writes the token to a 0600 file in a 0700 directory it
+ *     verifies it owns, with O_EXCL|O_NOFOLLOW.
+ *   - A backend is only ever reused or terminated after its argv proves our
+ *     ownership nonce + token path. A pid we cannot prove is ours is left
+ *     alone.
+ *   - The backend binds 127.0.0.1 on the remote and the tunnel binds 127.0.0.1
+ *     locally.
+ *
+ * No `import 'electron'`: main.ts injects the SshConnection, the HTTP probes
+ * and the token adoption.
+ */
+
+import crypto from 'node:crypto'
+
+import { assertBootstrapNotSuperseded } from './ssh-connection'
+
+const LOCKFILE_SCHEMA_VERSION = 2
+const PROTOCOL_VERSION = 1
+const DEFAULT_READY_TIMEOUT_MS = 45_000
+// The remote script owns the readiness wait, so the ssh exec has to outlive it.
+// This margin covers login shell + `hermes --version` + `serve --help` on a
+// cold page cache.
+const EXEC_MARGIN_MS = 60_000
+const REMOTE_NOFILE_SOFT_LIMIT = 65_536
+const RESPONSE_MARKER = 'HERMES_DESKTOP_BOOTSTRAP'
+
+// Error kinds that mean "the transport is broken", not "the bootstrap failed".
+// Falling back to the legacy path for these would just repeat the failure at
+// 20x the authentication cost.
+const TRANSPORT_KINDS = new Set(['auth-failed', 'host-key-changed', 'superseded', 'timeout', 'unreachable'])
+
+// Kinds the remote script is allowed to report. Anything else is treated as a
+// malformed response rather than silently trusted.
+const REMOTE_ERROR_KINDS = new Set([
+  'hermes-not-found',
+  'ready-timeout',
+  'spawn-failed',
+  'transient-transport-error',
+  'unknown',
+  'unsafe-path',
+  'unsupported-platform',
+  'update-required'
+])
+
+// The remote program. Kept as a raw string so backslashes survive into Python.
+const REMOTE_BOOTSTRAP_PY = String.raw`
+import base64
+import errno
+import json
+import os
+import re
+import shlex
+import signal
+import stat
+import subprocess
+import sys
+import time
+
+MARKER = "HERMES_DESKTOP_BOOTSTRAP"
+READY_RE = re.compile(r"^HERMES_(?:BACKEND|DASHBOARD)_READY port=(\d+)", re.M)
+SUPPORTED_OS = ("Darwin", "Linux")
+LOCK_ROOT = "~/.hermes/desktop-ssh"
+POLL_SECONDS = 0.2
+LOG_TAIL_BYTES = 65536
+HOME = os.path.expanduser("~")
+
+
+class Failure(Exception):
+    def __init__(self, kind, message):
+        Exception.__init__(self, message)
+        self.kind = kind
+
+
+def emit(payload):
+    sys.stdout.write(MARKER + " " + json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def real(p):
+    return os.path.expanduser(p)
+
+
+def owner_dir(oid):
+    return LOCK_ROOT + "/" + oid
+
+
+def lock_path(oid):
+    return owner_dir(oid) + "/backend.lock.json"
+
+
+def token_path(oid, nonce):
+    return owner_dir(oid) + "/" + nonce + ".token"
+
+
+def log_path(oid, nonce):
+    return owner_dir(oid) + "/" + nonce + ".log"
+
+
+def capture(argv, timeout):
+    proc = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL)
+    try:
+        out = proc.communicate(timeout=timeout)[0]
+    except Exception:
+        try:
+            proc.kill()
+            proc.communicate()
+        except Exception:
+            pass
+        raise
+    return out.decode("utf-8", "replace")
+
+
+def executable(candidate):
+    try:
+        target = real(candidate)
+        return os.path.isfile(target) and os.access(target, os.X_OK)
+    except OSError:
+        return False
+
+
+def locate_hermes(explicit):
+    if explicit:
+        if executable(explicit):
+            return explicit
+        raise Failure(
+            "hermes-not-found",
+            'The Hermes path you set is not an executable on the remote host: "%s". '
+            "Check the path (it must be the full path to the hermes binary on the remote, e.g. "
+            "~/hermes-agent/.venv/bin/hermes), or clear it to auto-detect." % explicit,
+        )
+    candidates = []
+    try:
+        found = capture(["bash", "-lc", "command -v hermes"], 30).strip().split("\n")
+        if found and found[-1].strip():
+            candidates.append(found[-1].strip())
+    except Exception:
+        pass
+    candidates.append("~/.local/bin/hermes")
+    candidates.append("/usr/local/bin/hermes")
+    candidates.append("~/.hermes/hermes-agent/venv/bin/hermes")
+    for candidate in candidates:
+        if candidate and executable(candidate):
+            return candidate
+    raise Failure(
+        "hermes-not-found",
+        "Hermes is not installed on the remote host (could not find a hermes executable). "
+        "Install it on the remote with:  curl -fsSL https://hermes-agent.nousresearch.com/install.sh | sh  "
+        "- or set the Hermes path explicitly in the SSH connection settings.",
+    )
+
+
+def hermes_version(hermes):
+    try:
+        return capture([real(hermes), "--version"], 120).strip().split("\n")[0].strip()
+    except Exception:
+        return ""
+
+
+def supports_ssh_ownership(hermes):
+    try:
+        text = capture([real(hermes), "serve", "--help"], 120)
+    except Exception:
+        return False
+    return "ssh-session-token-file" in text and "ssh-owner-nonce" in text
+
+
+def read_lock(oid, protocol_version, schema_version):
+    try:
+        with open(real(lock_path(oid)), "rb") as handle:
+            raw = handle.read()
+    except OSError:
+        return None
+    try:
+        parsed = json.loads(raw.decode("utf-8", "replace"))
+    except ValueError:
+        return None
+    if not isinstance(parsed, dict) or parsed.get("schemaVersion") != schema_version:
+        return None
+    if parsed.get("protocolVersion") != protocol_version:
+        return None
+    pid = parsed.get("pid")
+    port = parsed.get("port")
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0 or pid > 4194304:
+        return None
+    if not isinstance(port, int) or isinstance(port, bool) or port < 0 or port > 65535:
+        return None
+    if parsed.get("ownershipId") != oid:
+        return None
+    if not re.match(r"^[0-9a-f]{16}$", str(parsed.get("spawnNonce") or "")):
+        return None
+    if not re.match(r"^[0-9a-f]{32}$", str(parsed.get("tokenFingerprint") or "")):
+        return None
+    if parsed.get("logPath") != log_path(oid, parsed["spawnNonce"]):
+        return None
+    for field in ("profile", "hermesPath", "hermesHome", "logPath", "startedAt"):
+        value = parsed.get(field)
+        if not isinstance(value, str) or len(value) > 1024:
+            return None
+    return parsed
+
+
+def pid_alive(pid):
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError as error:
+        # EPERM: the pid exists but belongs to someone else. Report it alive so
+        # the ownership proof (which will say FOREIGN) decides, never a kill.
+        return error.errno == errno.EPERM
+
+
+def process_args(pid):
+    try:
+        with open("/proc/%d/cmdline" % pid, "rb") as handle:
+            raw = handle.read()
+        return [x.decode("utf-8", "surrogateescape") for x in raw.split(b"\0") if x]
+    except OSError:
+        pass
+    try:
+        line = capture(["ps", "-ww", "-o", "command=", "-p", str(pid)], 30).strip()
+    except Exception:
+        return None
+    if not line:
+        return None
+    try:
+        return shlex.split(line)
+    except ValueError:
+        return None
+
+
+def is_our_backend(pid, nonce, hermes_path, hermes_home, oid, profile):
+    if not pid or not re.match(r"^[0-9a-f]{16}$", str(nonce or "")) or not hermes_path:
+        return False
+    args = process_args(pid)
+    if not args:
+        return False
+    expected = real(hermes_path)
+    entries = set([expected])
+    if hermes_home:
+        entries.add(os.path.join(real(hermes_home), "hermes-agent", "venv", "bin", "hermes"))
+    expected_token = real(token_path(oid, nonce)) if oid else ""
+    try:
+        serve = args.index("serve")
+        owner = args.index("--ssh-owner-nonce", serve + 1)
+        token = args.index("--ssh-session-token-file", serve + 1) if expected_token else -1
+        isolated = args.index("--isolated", serve + 1)
+        profile_arg = args.index("--profile") if profile else -1
+        serve_count = args.count("serve")
+        owner_count = args.count("--ssh-owner-nonce")
+        token_count = args.count("--ssh-session-token-file")
+        isolated_count = args.count("--isolated")
+        profile_count = args.count("--profile")
+        direct = args[0] in entries
+        python_entry = len(args) > 1 and args[1] in entries and os.path.basename(args[0]).startswith("python")
+        token_ok = (not expected_token) or args[token + 1] == expected_token
+        isolated_ok = isolated_count == 1 and isolated > serve
+        if profile:
+            profile_ok = profile_count == 1 and profile_arg < serve and args[profile_arg + 1] == profile
+        else:
+            profile_ok = profile_count == 0
+        spawn_proof = bool(expected_token) and owner_count == 1 and token_count == 1 and token_ok and profile_ok
+        return bool(
+            (direct or python_entry or spawn_proof)
+            and serve_count == 1
+            and isolated_ok
+            and owner_count == 1
+            and args[owner + 1] == nonce
+            and token_ok
+            and profile_ok
+        )
+    except (IndexError, ValueError):
+        return False
+
+
+def unlink(path):
+    try:
+        os.unlink(real(path))
+    except OSError:
+        pass
+
+
+def terminate(pid):
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError:
+        return
+    for _ in range(50):
+        if not pid_alive(pid):
+            return
+        time.sleep(0.1)
+    raise Failure("transient-transport-error", "Could not terminate the stale SSH backend.")
+
+
+def cleanup_stale(oid, lock, alive, owned):
+    if lock and alive and owned:
+        terminate(lock["pid"])
+    if lock and lock.get("logPath") == log_path(oid, lock.get("spawnNonce") or ""):
+        unlink(lock["logPath"])
+    if lock and lock.get("spawnNonce"):
+        unlink(token_path(oid, lock["spawnNonce"]))
+    unlink(lock_path(oid))
+
+
+def write_lock(oid, lock):
+    directory = real(owner_dir(oid))
+    previous = os.umask(0o077)
+    try:
+        if not os.path.isdir(directory):
+            os.makedirs(directory, 0o700)
+        temporary = os.path.join(directory, "." + binhex(os.urandom(8)) + ".lock.tmp")
+        with open(temporary, "w") as handle:
+            handle.write(json.dumps(lock))
+        os.replace(temporary, real(lock_path(oid)))
+    finally:
+        os.umask(previous)
+
+
+def binhex(raw):
+    return "".join("%02x" % byte for byte in bytearray(raw))
+
+
+def write_token(oid, nonce, data):
+    path = real(token_path(oid, nonce))
+    directory = os.path.dirname(path)
+    name = os.path.basename(path)
+    if not os.path.isdir(directory):
+        os.makedirs(directory, 0o700)
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    handle = os.open(directory, flags)
+    try:
+        info = os.fstat(handle)
+        if not stat.S_ISDIR(info.st_mode):
+            raise Failure("unsafe-path", "unsafe token directory")
+        if hasattr(os, "getuid") and info.st_uid != os.getuid():
+            raise Failure("unsafe-path", "token directory owner mismatch")
+        if (info.st_mode & 0o777) != 0o700:
+            os.fchmod(handle, 0o700)
+        now = time.time()
+        for stale in os.listdir(handle):
+            if stale.endswith(".token") and len(stale) == 22:
+                try:
+                    info2 = os.stat(stale, dir_fd=handle, follow_symlinks=False)
+                    if stat.S_ISREG(info2.st_mode) and now - info2.st_mtime > 3600:
+                        os.unlink(stale, dir_fd=handle)
+                except OSError:
+                    pass
+        create = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(name, create, 0o600, dir_fd=handle)
+        try:
+            os.write(fd, data)
+        except BaseException:
+            try:
+                os.unlink(name, dir_fd=handle)
+            except OSError:
+                pass
+            raise
+        finally:
+            os.close(fd)
+    finally:
+        os.close(handle)
+
+
+def raise_nofile(limit):
+    try:
+        import resource
+
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        target = limit if hard == resource.RLIM_INFINITY else min(limit, hard)
+        if soft < target:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (target, hard))
+    except Exception:
+        pass
+
+
+def spawn_backend(hermes, profile, oid, nonce, nofile):
+    argv = [real(hermes)]
+    if profile:
+        argv += ["--profile", profile]
+    argv += [
+        "serve",
+        "--isolated",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "0",
+        "--ssh-session-token-file",
+        real(token_path(oid, nonce)),
+        "--ssh-owner-nonce",
+        nonce,
+    ]
+    log = real(log_path(oid, nonce))
+    directory = os.path.dirname(log)
+    if not os.path.isdir(directory):
+        os.makedirs(directory, 0o700)
+    env = dict(os.environ)
+    env["HERMES_DESKTOP"] = "1"
+    raise_nofile(nofile)
+    sink = open(log, "ab", 0)
+    devnull = open(os.devnull, "rb")
+    try:
+        return subprocess.Popen(
+            argv,
+            close_fds=True,
+            cwd=HOME,
+            env=env,
+            start_new_session=True,
+            stderr=subprocess.STDOUT,
+            stdin=devnull,
+            stdout=sink,
+        )
+    finally:
+        sink.close()
+        devnull.close()
+
+
+def read_log_tail(path):
+    try:
+        with open(real(path), "rb") as handle:
+            try:
+                handle.seek(-LOG_TAIL_BYTES, os.SEEK_END)
+            except OSError:
+                handle.seek(0)
+            return handle.read().decode("utf-8", "replace")
+    except OSError:
+        return ""
+
+
+def wait_ready(proc, path, timeout_ms):
+    deadline = time.time() + (timeout_ms / 1000.0)
+    while time.time() < deadline:
+        tail = read_log_tail(path)
+        port = None
+        for match in READY_RE.finditer(tail):
+            port = int(match.group(1))
+        if port:
+            return port
+        if proc.poll() is not None:
+            raise Failure(
+                "spawn-failed",
+                "Remote dashboard process exited before announcing its port (exit=%s). %s"
+                % (proc.returncode, tail[-2000:]),
+            )
+        time.sleep(POLL_SECONDS)
+    raise Failure("ready-timeout", "Timed out waiting for the remote dashboard to announce its port (%dms)." % timeout_ms)
+
+
+def reuse_blockers(lock, alive, owned, profile, hermes, hermes_home, reuse_fingerprint, params):
+    """Why an existing lock could not be adopted, in stable machine-readable
+    tokens. Never carries a secret: the token fingerprints are compared, not
+    reported."""
+    blockers = []
+    if not params.get("allowReuse"):
+        blockers.append("reuse-not-allowed")
+    if not alive:
+        blockers.append("pid-dead")
+    elif not owned:
+        blockers.append("pid-not-ours")
+    if lock["port"] <= 0:
+        blockers.append("spawn-in-progress")
+    if lock["profile"] != profile:
+        blockers.append("profile-changed")
+    if not reuse_fingerprint:
+        blockers.append("no-saved-token")
+    elif lock["tokenFingerprint"] != reuse_fingerprint:
+        blockers.append("saved-token-mismatch")
+    if lock["hermesPath"] != hermes:
+        blockers.append("hermes-path-changed")
+    if lock["hermesHome"] != hermes_home:
+        blockers.append("hermes-home-changed")
+    return blockers or ["none"]
+
+
+def bootstrap(params, token):
+    started = time.time()
+    oid = str(params.get("ownershipId") or "")
+    if not re.match(r"^[0-9a-f]{32}$", oid):
+        raise Failure("unknown", "SSH ownership ID is invalid.")
+    nonce = str(params.get("spawnNonce") or "")
+    if not re.match(r"^[0-9a-f]{16}$", nonce):
+        raise Failure("unknown", "SSH spawn nonce is invalid.")
+    fingerprint = str(params.get("tokenFingerprint") or "")
+    if not re.match(r"^[0-9a-f]{32}$", fingerprint):
+        raise Failure("unknown", "SSH token fingerprint is invalid.")
+    profile = str(params.get("profile") or "")
+    protocol_version = params.get("protocolVersion")
+    schema_version = params.get("schemaVersion")
+    uname = os.uname()
+    if uname.sysname not in SUPPORTED_OS:
+        raise Failure(
+            "unsupported-platform",
+            'Unsupported remote platform "%s". Hermes Desktop SSH mode supports Linux, macOS, '
+            "and Windows remote hosts." % (uname.sysname or "unknown"),
+        )
+    hermes = locate_hermes(str(params.get("remoteHermesPath") or ""))
+    hermes_home = os.environ.get("HERMES_HOME") or os.path.join(HOME, ".hermes")
+    located = time.time()
+    lock = read_lock(oid, protocol_version, schema_version)
+    reuse_fingerprint = str(params.get("reuseFingerprint") or "")
+    alive = False
+    owned = False
+    respawn_reason = "no-lock"
+    if lock:
+        alive = pid_alive(lock["pid"])
+        owned = alive and is_our_backend(
+            lock["pid"], lock["spawnNonce"], lock["hermesPath"], lock["hermesHome"], oid, lock["profile"]
+        )
+        respawn_reason = ",".join(
+            reuse_blockers(lock, alive, owned, profile, hermes, hermes_home, reuse_fingerprint, params)
+        )
+        reusable = (
+            bool(params.get("allowReuse"))
+            and alive
+            and owned
+            and lock["port"] > 0
+            and lock["profile"] == profile
+            and bool(reuse_fingerprint)
+            and lock["tokenFingerprint"] == reuse_fingerprint
+            and lock["hermesPath"] == hermes
+            and lock["hermesHome"] == hermes_home
+        )
+        if reusable:
+            version = str(lock.get("hermesVersion") or "") or hermes_version(hermes)
+            return {
+                "arch": uname.machine,
+                "hermesHome": hermes_home,
+                "hermesPath": hermes,
+                "hermesVersion": version,
+                "logPath": lock["logPath"],
+                "os": uname.sysname,
+                "ownershipId": oid,
+                "pid": lock["pid"],
+                "port": lock["port"],
+                "profile": profile,
+                "protocolVersion": protocol_version,
+                "respawnReason": "",
+                "reused": True,
+                "schemaVersion": schema_version,
+                "spawnNonce": lock["spawnNonce"],
+                "timings": {
+                    "locateMs": int((located - started) * 1000),
+                    "readyMs": 0,
+                    "spawnMs": 0,
+                    "totalMs": int((time.time() - started) * 1000),
+                },
+                "tokenFingerprint": lock["tokenFingerprint"],
+            }
+        cleanup_stale(oid, lock, alive, owned)
+    if not supports_ssh_ownership(hermes):
+        raise Failure(
+            "update-required",
+            "The remote Hermes install does not support --ssh-session-token-file and --ssh-owner-nonce. "
+            "Update Hermes on the remote host to continue using Desktop SSH mode.",
+        )
+    version = hermes_version(hermes)
+    probed = time.time()
+    write_token(oid, nonce, token)
+    record = {
+        "hermesHome": hermes_home,
+        "hermesPath": hermes,
+        "hermesVersion": version,
+        "logPath": log_path(oid, nonce),
+        "ownershipId": oid,
+        "pid": 0,
+        "port": 0,
+        "profile": profile,
+        "protocolVersion": protocol_version,
+        "schemaVersion": schema_version,
+        "spawnNonce": nonce,
+        "startedAt": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()) + "Z",
+        "tokenFingerprint": fingerprint,
+    }
+    proc = None
+    try:
+        proc = spawn_backend(hermes, profile, oid, nonce, params.get("nofileSoftLimit") or 65536)
+        record["pid"] = proc.pid
+        # Written with port=0 BEFORE readiness: if this attempt is superseded
+        # and cleanup cannot reach the box, the next connect still finds the
+        # record and reaps the process by exact ownership.
+        write_lock(oid, record)
+        spawned = time.time()
+        port = wait_ready(proc, record["logPath"], params.get("readyTimeoutMs") or 45000)
+    except BaseException:
+        if proc is not None and proc.poll() is None:
+            try:
+                terminate(proc.pid)
+            except Exception:
+                pass
+        unlink(record["logPath"])
+        unlink(token_path(oid, nonce))
+        unlink(lock_path(oid))
+        raise
+    record["port"] = port
+    write_lock(oid, record)
+    finished = time.time()
+    return {
+        "arch": uname.machine,
+        "hermesHome": hermes_home,
+        "hermesPath": hermes,
+        "hermesVersion": version,
+        "logPath": record["logPath"],
+        "os": uname.sysname,
+        "ownershipId": oid,
+        "pid": record["pid"],
+        "port": port,
+        "profile": profile,
+        "protocolVersion": protocol_version,
+        "respawnReason": respawn_reason,
+        "reused": False,
+        "schemaVersion": schema_version,
+        "spawnNonce": nonce,
+        "timings": {
+            "locateMs": int((located - started) * 1000),
+            "probeMs": int((probed - located) * 1000),
+            "readyMs": int((finished - spawned) * 1000),
+            "spawnMs": int((spawned - probed) * 1000),
+            "totalMs": int((finished - started) * 1000),
+        },
+        "tokenFingerprint": fingerprint,
+    }
+
+
+def main():
+    try:
+        # argv[1] is this program (the loader already exec'd it); argv[2] is
+        # the parameter block. The session token is on stdin, never in argv.
+        params = json.loads(base64.b64decode(sys.argv[2]).decode("utf-8"))
+    except Exception as error:
+        emit({"error": "invalid bootstrap parameters: %s" % error, "kind": "unknown", "ok": False})
+        return
+    try:
+        token = sys.stdin.buffer.read()
+    except Exception as error:
+        emit({"error": "could not read the session token: %s" % error, "kind": "unknown", "ok": False})
+        return
+    try:
+        result = bootstrap(params, token)
+        result["ok"] = True
+        emit(result)
+    except Failure as error:
+        emit({"error": str(error), "kind": error.kind, "ok": False})
+    except Exception as error:
+        emit({"error": "%s: %s" % (type(error).__name__, error), "kind": "unknown", "ok": False})
+
+
+main()
+`
+
+// shell-single-quote a value for safe interpolation into a remote command.
+function shq(value: string): string {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`
+}
+
+function fingerprintToken(token: string): string {
+  return crypto
+    .createHash('sha256')
+    .update(String(token || ''))
+    .digest('hex')
+    .slice(0, 32)
+}
+
+export interface BootstrapParams {
+  allowReuse: boolean
+  nofileSoftLimit?: number
+  ownershipId: string
+  profile: string
+  protocolVersion: number
+  readyTimeoutMs: number
+  remoteHermesPath: string
+  reuseFingerprint: string
+  schemaVersion: number
+  spawnNonce: string
+  tokenFingerprint: string
+}
+
+/**
+ * The one remote command. The program and its parameters travel base64-encoded
+ * in argv so no quoting rule of the remote login shell can corrupt them; the
+ * SESSION TOKEN is deliberately absent — it goes on stdin.
+ */
+export function buildBootstrapCommand(params: BootstrapParams): string {
+  const source = Buffer.from(REMOTE_BOOTSTRAP_PY, 'utf8').toString('base64')
+  const encoded = Buffer.from(JSON.stringify(params), 'utf8').toString('base64')
+
+  return (
+    'python3 -c ' +
+    shq('import base64,sys;exec(compile(base64.b64decode(sys.argv[1]),"<hermes-desktop-bootstrap>","exec"))') +
+    ` ${shq(source)} ${shq(encoded)}`
+  )
+}
+
+export interface BootstrapResponse {
+  arch: string
+  error?: string
+  hermesHome: string
+  hermesPath: string
+  hermesVersion: string
+  kind?: string
+  logPath: string
+  ok: boolean
+  os: string
+  ownershipId: string
+  pid: number
+  port: number
+  profile: string
+  respawnReason?: string
+  reused: boolean
+  spawnNonce: string
+  timings?: Record<string, number>
+  tokenFingerprint: string
+}
+
+function malformed(detail: string): Error {
+  const error: any = new Error(`The remote bootstrap returned an unusable response (${detail}).`)
+  error.kind = 'batched-unavailable'
+
+  return error
+}
+
+/**
+ * Strictly validate the single JSON line the remote program prints. Everything
+ * here is remote-controlled, so nothing is trusted by shape alone: ids, paths,
+ * ports and pids are re-checked against the same rules the lockfile reader
+ * uses. A response that fails validation is reported as `batched-unavailable`
+ * so the caller can fall back instead of connecting to something unverified.
+ */
+export function parseBootstrapResponse(stdout: string, expected: BootstrapParams): BootstrapResponse {
+  const line = String(stdout || '')
+    .split(/\r?\n/)
+    .filter(text => text.startsWith(`${RESPONSE_MARKER} `))
+    .pop()
+
+  if (!line) {
+    throw malformed('no response line')
+  }
+
+  let parsed: any
+
+  try {
+    parsed = JSON.parse(line.slice(RESPONSE_MARKER.length + 1))
+  } catch {
+    throw malformed('not JSON')
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw malformed('not an object')
+  }
+
+  if (parsed.ok !== true) {
+    const kind = REMOTE_ERROR_KINDS.has(parsed.kind) ? parsed.kind : 'unknown'
+    const detail = String(parsed.error || 'the remote bootstrap failed')
+    // eslint-disable-next-line no-control-regex -- remote output is headed for the UI
+    const error: any = new Error(detail.replace(/[\x00-\x1f\x7f]/g, ' ').slice(0, 2000))
+    error.kind = kind
+
+    throw error
+  }
+
+  const port = Number(parsed.port)
+  const pid = Number(parsed.pid)
+
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw malformed('invalid port')
+  }
+
+  if (!Number.isInteger(pid) || pid < 1 || pid > 4194304) {
+    throw malformed('invalid pid')
+  }
+
+  if (parsed.ownershipId !== expected.ownershipId) {
+    throw malformed('ownership id mismatch')
+  }
+
+  if (parsed.profile !== expected.profile) {
+    throw malformed('profile mismatch')
+  }
+
+  if (!/^[0-9a-f]{16}$/.test(String(parsed.spawnNonce || ''))) {
+    throw malformed('invalid spawn nonce')
+  }
+
+  if (!/^[0-9a-f]{32}$/.test(String(parsed.tokenFingerprint || ''))) {
+    throw malformed('invalid token fingerprint')
+  }
+
+  if (typeof parsed.reused !== 'boolean') {
+    throw malformed('missing reuse flag')
+  }
+
+  // A fresh spawn MUST report the nonce and token we just minted; anything else
+  // means the response does not describe the process we own.
+  if (!parsed.reused) {
+    if (parsed.spawnNonce !== expected.spawnNonce || parsed.tokenFingerprint !== expected.tokenFingerprint) {
+      throw malformed('spawn identity mismatch')
+    }
+  }
+
+  if (parsed.reused && parsed.tokenFingerprint !== expected.reuseFingerprint) {
+    throw malformed('reuse fingerprint mismatch')
+  }
+
+  for (const field of ['hermesPath', 'hermesHome', 'logPath', 'os', 'arch'] as const) {
+    if (typeof parsed[field] !== 'string' || parsed[field].length > 1024) {
+      throw malformed(`invalid ${field}`)
+    }
+  }
+
+  if (parsed.logPath !== `~/.hermes/desktop-ssh/${expected.ownershipId}/${parsed.spawnNonce}.log`) {
+    throw malformed('log path outside the ownership directory')
+  }
+
+  return {
+    arch: parsed.arch,
+    hermesHome: parsed.hermesHome,
+    hermesPath: parsed.hermesPath,
+    hermesVersion: typeof parsed.hermesVersion === 'string' ? parsed.hermesVersion.slice(0, 300) : '',
+    logPath: parsed.logPath,
+    ok: true,
+    os: parsed.os,
+    ownershipId: parsed.ownershipId,
+    pid,
+    port,
+    profile: parsed.profile,
+    respawnReason: typeof parsed.respawnReason === 'string' ? parsed.respawnReason.slice(0, 200) : '',
+    reused: parsed.reused,
+    spawnNonce: parsed.spawnNonce,
+    timings: parsed.timings && typeof parsed.timings === 'object' ? parsed.timings : undefined,
+    tokenFingerprint: parsed.tokenFingerprint
+  }
+}
+
+export function isTransportError(error: any): boolean {
+  return TRANSPORT_KINDS.has(error?.kind)
+}
+
+/** True when the caller should fall back to the legacy per-call lifecycle. */
+export function shouldFallBackToLegacy(error: any): boolean {
+  if (isTransportError(error)) {
+    return false
+  }
+
+  // A kind the remote program itself reported is a real verdict about the
+  // remote, not a limitation of this transport — do not repeat it 20x slower.
+  if (REMOTE_ERROR_KINDS.has(error?.kind)) {
+    return false
+  }
+
+  return true
+}
+
+export interface BatchedConnectDeps {
+  adoptServedToken: (baseUrl: string, token: string, options: any) => Promise<string>
+  cancelForward: (localPort: number, remotePort: number) => Promise<void>
+  forward: (localPort: number, remotePort: number, options?: any) => Promise<void>
+  onPhase?: (phase: string, ms: number) => void
+  ownershipId: string
+  pickLocalPort: () => Promise<number>
+  probeReuseProof: (baseUrl: string, token: string, spawnNonce: string) => Promise<string>
+  probeWebSocket?: (wsUrl: string) => Promise<{ ok: boolean; reason?: string }>
+  profile?: string
+  readyTimeoutMs?: number
+  rememberLog?: (message: string) => void
+  remoteHermesPath?: string
+  reuseToken?: string
+  signal?: AbortSignal
+  ssh: any
+  waitForHermes?: (baseUrl: string, token: string) => Promise<unknown>
+}
+
+/**
+ * Mint the spawn credential and the parameter block. The token stays OUT of
+ * the block on purpose: the block is base64'd into argv (visible in the remote
+ * process list), the token is written to stdin.
+ */
+export function bootstrapParams(
+  deps: Pick<BatchedConnectDeps, 'ownershipId' | 'profile' | 'readyTimeoutMs' | 'remoteHermesPath' | 'reuseToken'>,
+  allowReuse: boolean,
+  mint: () => string = () => crypto.randomBytes(32).toString('hex'),
+  nonce: () => string = () => crypto.randomBytes(8).toString('hex')
+): { params: BootstrapParams; token: string } {
+  const token = mint()
+
+  return {
+    params: {
+      allowReuse,
+      nofileSoftLimit: REMOTE_NOFILE_SOFT_LIMIT,
+      ownershipId: deps.ownershipId,
+      profile: String(deps.profile || ''),
+      protocolVersion: PROTOCOL_VERSION,
+      readyTimeoutMs: deps.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
+      remoteHermesPath: String(deps.remoteHermesPath || ''),
+      reuseFingerprint: allowReuse && deps.reuseToken ? fingerprintToken(deps.reuseToken) : '',
+      schemaVersion: LOCKFILE_SCHEMA_VERSION,
+      spawnNonce: nonce(),
+      tokenFingerprint: fingerprintToken(token)
+    },
+    token
+  }
+}
+
+async function runRemoteBootstrap(deps: BatchedConnectDeps, allowReuse: boolean) {
+  const { params, token } = bootstrapParams(deps, allowReuse)
+
+  assertBootstrapNotSuperseded(deps.signal)
+
+  const stdout = await deps.ssh.exec(buildBootstrapCommand(params), {
+    signal: deps.signal,
+    stdinData: token,
+    timeoutMs: params.readyTimeoutMs + EXEC_MARGIN_MS
+  })
+
+  return { response: parseBootstrapResponse(stdout, params), token }
+}
+
+/**
+ * Bring up (or adopt) the remote backend and its tunnel with a bounded number
+ * of ssh invocations. Returns the same descriptor shape as
+ * remote-lifecycle.connect so main.ts does not care which path ran.
+ */
+export async function connectBatched(deps: BatchedConnectDeps) {
+  const log = (message: string) => deps.rememberLog?.(`[ssh-lifecycle] ${message}`)
+  const phase = (name: string, startedAt: number) => deps.onPhase?.(name, Date.now() - startedAt)
+
+  let allowReuse = Boolean(deps.reuseToken)
+  let attempt = 0
+
+  for (;;) {
+    attempt += 1
+    const bootstrapStartedAt = Date.now()
+    const { response, token: spawnToken } = await runRemoteBootstrap(deps, allowReuse)
+    phase('bootstrap', bootstrapStartedAt)
+    log(
+      `remote platform ${response.os}/${response.arch}; hermes ${response.hermesPath}` +
+        `${response.hermesVersion ? ` (${response.hermesVersion})` : ''}`
+    )
+    log(
+      `${response.reused ? 'backend reused' : 'backend spawned'} pid=${response.pid} port=${response.port} ` +
+        `remoteMs=${response.timings?.totalMs ?? '?'}` +
+        `${response.reused ? '' : ` respawnReason=${response.respawnReason || 'unknown'}`}`
+    )
+
+    const tunnelStartedAt = Date.now()
+    const localPort = await deps.pickLocalPort()
+    await deps.forward(localPort, response.port, { signal: deps.signal })
+    phase('tunnel', tunnelStartedAt)
+    const baseUrl = `http://127.0.0.1:${localPort}`
+
+    try {
+      assertBootstrapNotSuperseded(deps.signal)
+      const httpStartedAt = Date.now()
+      const reuseToken = String(deps.reuseToken || '')
+      let token = response.reused ? reuseToken : spawnToken
+
+      if (!response.reused && deps.waitForHermes) {
+        await deps.waitForHermes(baseUrl, token)
+        assertBootstrapNotSuperseded(deps.signal)
+      }
+
+      if (response.reused) {
+        const classification = await deps.probeReuseProof(baseUrl, reuseToken, response.spawnNonce)
+
+        if (classification === 'authenticated-stale') {
+          // The lock says ours, the backend says otherwise. Drop the tunnel and
+          // make ONE more attempt that is forbidden from reusing anything.
+          log('reuse proof stale; respawning the remote backend')
+          await deps.cancelForward(localPort, response.port)
+
+          if (attempt >= 2) {
+            const error: any = new Error('The remote SSH backend could not be verified after a respawn.')
+            error.kind = 'transient-transport-error'
+            throw error
+          }
+
+          allowReuse = false
+
+          continue
+        }
+
+        if (classification !== 'authenticated-ok') {
+          const error: any = new Error('SSH reuse proof returned an invalid classification.')
+          error.kind = 'transient-transport-error'
+          throw error
+        }
+      }
+
+      token = await deps.adoptServedToken(baseUrl, token, {
+        childAlive: () => true,
+        label: response.reused ? 'reused remote dashboard' : 'remote dashboard'
+      })
+
+      // Ownership proof over the ADOPTED token: it authenticates AND returns
+      // the owner nonce, so a port squatter or a foreign backend fails here
+      // without costing another ssh round-trip.
+      assertBootstrapNotSuperseded(deps.signal)
+      const proof = await deps.probeReuseProof(baseUrl, token, response.spawnNonce)
+
+      if (proof !== 'authenticated-ok') {
+        const error: any = new Error(
+          `${baseUrl} is served by a process that does not carry our SSH ownership nonce; refusing it.`
+        )
+
+        error.kind = 'foreign-backend'
+        throw error
+      }
+
+      phase('http', httpStartedAt)
+
+      if (deps.probeWebSocket) {
+        const wsStartedAt = Date.now()
+        const wsUrl = `ws://127.0.0.1:${localPort}/api/ws?token=${encodeURIComponent(token)}`
+        const probe = await deps.probeWebSocket(wsUrl)
+        phase('ws', wsStartedAt)
+
+        if (!probe.ok) {
+          const error: any = new Error(
+            `The remote Hermes backend is HTTP-reachable through the tunnel but the WebSocket (/api/ws) ` +
+              `rejected the session token: ${probe.reason || 'unknown reason'}`
+          )
+
+          error.kind = 'spawn-failed'
+          throw error
+        }
+      }
+
+      const tokenFingerprint = fingerprintToken(token)
+
+      // Served-token drift (the dashboard regenerated its own) is the ONLY case
+      // that needs a third ssh call: the lockfile has to record the credential
+      // that actually authenticates, or the next start cannot prove reuse.
+      if (tokenFingerprint !== response.tokenFingerprint) {
+        assertBootstrapNotSuperseded(deps.signal)
+        log('served token differs from the spawn token; re-stamping the remote lockfile')
+        await restampLockFingerprint(deps, response, tokenFingerprint)
+      }
+
+      assertBootstrapNotSuperseded(deps.signal)
+
+      return {
+        baseUrl,
+        hermesHome: response.hermesHome,
+        hermesPath: response.hermesPath,
+        hermesVersion: response.hermesVersion,
+        localPort,
+        logPath: response.logPath,
+        ownershipId: response.ownershipId,
+        pid: response.pid,
+        platform: { arch: response.arch, os: response.os },
+        remotePort: response.port,
+        reused: response.reused,
+        spawnNonce: response.spawnNonce,
+        token,
+        tokenFingerprint
+      }
+    } catch (error) {
+      // Any failure past the forward leaves the tunnel behind unless we say so.
+      try {
+        await deps.cancelForward(localPort, response.port)
+      } catch {
+        void 0
+      }
+
+      throw error
+    }
+  }
+}
+
+// Rewrite ONLY the token fingerprint of a lockfile we already proved is ours.
+// Python again (not sed/jq) so the rewrite is atomic and the ownership id is
+// re-checked on the remote side before anything is written.
+function buildRestampCommand(ownershipId: string, spawnNonce: string, fingerprint: string): string {
+  const script = [
+    'import json,os,sys',
+    `oid=${JSON.stringify(ownershipId)}`,
+    `nonce=${JSON.stringify(spawnNonce)}`,
+    `fp=${JSON.stringify(fingerprint)}`,
+    'p=os.path.expanduser("~/.hermes/desktop-ssh/"+oid+"/backend.lock.json")',
+    'raw=open(p,"rb").read()',
+    'lock=json.loads(raw.decode("utf-8"))',
+    'assert lock.get("ownershipId")==oid and lock.get("spawnNonce")==nonce',
+    'lock["tokenFingerprint"]=fp',
+    'd=os.path.dirname(p)',
+    'prev=os.umask(0o077)',
+    't=os.path.join(d,"."+nonce+".restamp.tmp")',
+    'open(t,"w").write(json.dumps(lock))',
+    'os.replace(t,p)',
+    'os.umask(prev)',
+    'sys.stdout.write("OK")'
+  ].join('\n')
+
+  return `python3 -c ${shq(script)}`
+}
+
+async function restampLockFingerprint(deps: BatchedConnectDeps, response: BootstrapResponse, fingerprint: string) {
+  const out = await deps.ssh.exec(buildRestampCommand(response.ownershipId, response.spawnNonce, fingerprint), {
+    signal: deps.signal
+  })
+
+  if (String(out || '').trim() !== 'OK') {
+    throw Object.assign(new Error('Could not update the remote SSH backend ownership record.'), {
+      kind: 'transient-transport-error'
+    })
+  }
+}
+
+export {
+  buildRestampCommand,
+  DEFAULT_READY_TIMEOUT_MS,
+  fingerprintToken,
+  LOCKFILE_SCHEMA_VERSION,
+  PROTOCOL_VERSION,
+  REMOTE_BOOTSTRAP_PY,
+  RESPONSE_MARKER
+}

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -9,6 +9,7 @@ import { test } from 'vitest'
 
 import { profileSshOverride } from './connection-config'
 import {
+  buildRemoteProfileInventoryCommand,
   buildSpawnCommand,
   cleanupStale,
   connect,
@@ -87,10 +88,14 @@ function fakeSsh(rules: any[] = []) {
   }
 }
 
+// The remote answer: home, separator, then the listing.
+function inventoryOutput(home: string, listing = '') {
+  return `${home}\n--- hermes-desktop-profiles ---\n${listing}`
+}
+
 test('listRemoteHermesProfiles inventories Mini-style profile dirs without spawning a dashboard', async () => {
   const ssh = fakeSsh([
-    [/HERMES_HOME/, '/Users/zillajr/.hermes\n'],
-    [/ls -1/, 'bob\ndixie\ngoose\nrambo\nbob.rollback-old\n']
+    [/HERMES_HOME/, inventoryOutput('/Users/zillajr/.hermes', 'bob\ndixie\ngoose\nrambo\nbob.rollback-old\n')]
   ])
 
   assert.deepEqual(await listRemoteHermesProfiles(ssh), ['default', 'bob', 'dixie', 'goose', 'rambo'])
@@ -98,10 +103,13 @@ test('listRemoteHermesProfiles inventories Mini-style profile dirs without spawn
     ssh.calls.some(cmd => cmd.includes('serve') || cmd.includes('dashboard')),
     false
   )
+  // One exec: on a no-ControlMaster client each extra call is a whole extra
+  // key authentication, and this runs on every roster poll.
+  assert.equal(ssh.calls.length, 1)
 })
 
 test('listRemoteHermesProfiles rejects a hostile HERMES_HOME', async () => {
-  const ssh = fakeSsh([[/HERMES_HOME/, '/tmp/x; echo pwned\n']])
+  const ssh = fakeSsh([[/HERMES_HOME/, inventoryOutput('/tmp/x; echo pwned', 'bob\n')]])
 
   await assert.rejects(
     () => listRemoteHermesProfiles(ssh),
@@ -111,9 +119,26 @@ test('listRemoteHermesProfiles rejects a hostile HERMES_HOME', async () => {
       return true
     }
   )
-  assert.equal(
-    ssh.calls.some(cmd => cmd.includes('ls -1')),
-    false
+})
+
+test('the inventory command interpolates nothing and stays quoted on the remote', () => {
+  const command = buildRemoteProfileInventoryCommand()
+
+  assert.match(command, /home="\$\{HERMES_HOME:-\$HOME\/\.hermes\}"/)
+  assert.match(command, /ls -1 "\$home\/profiles"/)
+  assert.equal(command.includes('--- hermes-desktop-profiles ---'), true)
+})
+
+test('a remote answer without the separator is a transport error, not an empty roster', async () => {
+  const ssh = fakeSsh([[/HERMES_HOME/, 'bash: HERMES_HOME: command not found\n']])
+
+  await assert.rejects(
+    () => listRemoteHermesProfiles(ssh),
+    (err: any) => {
+      assert.equal(err.kind, 'transient-transport-error')
+
+      return true
+    }
   )
 })
 

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -37,6 +37,7 @@ const LOCKFILE_SCHEMA_VERSION = 2
 const PROTOCOL_VERSION = 1
 const READY_RE = /^HERMES_(?:BACKEND|DASHBOARD)_READY port=(\d+)/m
 const REMOTE_LOCK_DIR = '~/.hermes/desktop-ssh'
+const NEWLINE = '\n'
 const SUPPORTED_REMOTE_OS = new Set(['Linux', 'Darwin'])
 const DEFAULT_READY_TIMEOUT_MS = 45_000
 const READY_POLL_INTERVAL_MS = 750
@@ -261,13 +262,28 @@ async function probeRemoteHermesHome(ssh) {
   }
 }
 
+const REMOTE_INVENTORY_SEPARATOR = '--- hermes-desktop-profiles ---'
+
+// Home resolution + listing in ONE exec. This runs on every roster poll until
+// it succeeds, and a client without ControlMaster (Windows) pays a full key
+// authentication per exec — two calls here is two authentications for one
+// answer. $HERMES_HOME is expanded and quoted by the REMOTE shell, so nothing
+// untrusted is interpolated into the command; the home is still validated
+// locally afterwards and an unsafe one still discards the listing.
+function buildRemoteProfileInventoryCommand() {
+  return (
+    'home="${HERMES_HOME:-$HOME/.hermes}"; ' +
+    `printf '%s${NEWLINE}' "$home"; ` +
+    `printf '%s${NEWLINE}' ${shq(REMOTE_INVENTORY_SEPARATOR)}; ` +
+    'if [ -d "$home/profiles" ]; then ls -1 "$home/profiles"; fi'
+  )
+}
+
 async function listRemoteHermesProfiles(ssh) {
-  const home = assertSafeRemoteHome(await probeRemoteHermesHome(ssh))
-  const dir = expandRemotePath(`${home}/profiles`)
-  let listing = ''
+  let output = ''
 
   try {
-    listing = await ssh.exec(`if [ -d ${dir} ]; then ls -1 ${dir}; fi`)
+    output = await ssh.exec(buildRemoteProfileInventoryCommand())
   } catch (cause) {
     const error: any = new Error('Could not list remote Hermes profiles.')
     error.kind = 'transient-transport-error'
@@ -275,7 +291,23 @@ async function listRemoteHermesProfiles(ssh) {
     throw error
   }
 
-  return parseRemoteProfileListing(listing)
+  const index = String(output || '').indexOf(REMOTE_INVENTORY_SEPARATOR)
+
+  if (index < 0) {
+    const error: any = new Error('Could not resolve the remote Hermes home.')
+    error.kind = 'transient-transport-error'
+    throw error
+  }
+
+  // Throws `unsafe-path` on a hostile HERMES_HOME, before any listing is used.
+  assertSafeRemoteHome(
+    String(output.slice(0, index) || '')
+      .trim()
+      .split(NEWLINE)
+      .pop()
+  )
+
+  return parseRemoteProfileListing(output.slice(index + REMOTE_INVENTORY_SEPARATOR.length))
 }
 
 function assertSafeRemoteHome(home) {
@@ -956,6 +988,7 @@ async function connect(deps) {
 
 export {
   adoptOwnedServedToken,
+  buildRemoteProfileInventoryCommand,
   buildSpawnCommand,
   cleanupStale,
   connect,

--- a/apps/desktop/electron/ssh-connection.ts
+++ b/apps/desktop/electron/ssh-connection.ts
@@ -550,6 +550,11 @@ class SshConnection {
   _opened: boolean
   _mux: boolean
   _tunnels: Map<string, any>
+  // Every element of this counter is one spawned `ssh` process. On Windows
+  // (no ControlMaster) that is also one authentication against the agent, so
+  // the bootstrap logs it to prove the batched path did not regress into a
+  // per-operation auth storm.
+  _invocations: number
 
   constructor(cfg, opts: any = {}) {
     if (!cfg || !cfg.host) {
@@ -589,6 +594,20 @@ class SshConnection {
     this._execTimeoutMs = opts.execTimeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS
     this._forwardTimeoutMs = opts.forwardTimeoutMs ?? DEFAULT_FORWARD_TIMEOUT_MS
     this._opened = false
+    this._invocations = 0
+  }
+
+  // Count of ssh processes this connection has spawned. Read as a delta around
+  // one bootstrap cycle.
+  get invocations() {
+    return this._invocations
+  }
+
+  // Single funnel for every ssh spawn so the counter cannot drift from reality.
+  _run(args, options: any = {}) {
+    this._invocations += 1
+
+    return runSsh(args, { spawnFn: this._spawnFn, ...options })
   }
 
   // Lifecycle logging — ALWAYS through redaction.
@@ -619,7 +638,20 @@ class SshConnection {
   // Open the connection. Mux: start the persistent ControlMaster (idempotent —
   // a live master is a no-op). No-mux: there is no master; validate auth +
   // reachability with a one-shot `ssh true` so failures classify identically.
-  async open({ signal }: any = {}) {
+  //
+  // `lazy` (no-mux only): skip the `ssh true` reachability probe and let the
+  // FIRST real operation classify auth/reachability instead. Without mux that
+  // probe is a whole extra authentication — on Windows, where every ssh call
+  // re-authenticates through the agent, it doubles the cost of a two-call
+  // bootstrap for no added signal.
+  async open({ lazy, signal }: any = {}) {
+    if (!this._mux && lazy) {
+      this._opened = true
+      this._logLine(`deferred connect (no-mux, lazy) to ${target(this.user, this.host)}:${this.port}`)
+
+      return
+    }
+
     if (await this.isAlive({ signal })) {
       // -O check passing is not proof the master works: a ControlPersist master
       // can survive a failed teardown with wedged channels (observed on macOS
@@ -640,9 +672,8 @@ class SshConnection {
       let result
 
       try {
-        result = await runSsh(buildExecArgs(this, 'exit 0', this._connectTimeoutMs), {
+        result = await this._run(buildExecArgs(this, 'exit 0', this._connectTimeoutMs), {
           timeoutMs: this._connectTimeoutMs,
-          spawnFn: this._spawnFn,
           signal
         })
       } catch (error) {
@@ -692,7 +723,7 @@ class SshConnection {
     let result
 
     try {
-      result = await runSsh(args, { timeoutMs: this._connectTimeoutMs, spawnFn: this._spawnFn, signal })
+      result = await this._run(args, { timeoutMs: this._connectTimeoutMs, signal })
     } catch (error) {
       throw this._fail(error, SSH_ERROR.UNREACHABLE)
     }
@@ -717,7 +748,7 @@ class SshConnection {
       : buildExecArgs(this, 'exit 0', this._connectTimeoutMs)
 
     try {
-      const result: any = await runSsh(args, { timeoutMs: this._connectTimeoutMs, spawnFn: this._spawnFn, signal })
+      const result: any = await this._run(args, { timeoutMs: this._connectTimeoutMs, signal })
 
       return result.code === 0
     } catch (error: any) {
@@ -733,9 +764,8 @@ class SshConnection {
   // cmd.exe); a wedged mux hangs to the timeout.
   async _verifyMuxChannel({ signal }: any = {}) {
     try {
-      const result: any = await runSsh(buildExecArgs(this, 'exit 0', this._connectTimeoutMs), {
+      const result: any = await this._run(buildExecArgs(this, 'exit 0', this._connectTimeoutMs), {
         timeoutMs: this._connectTimeoutMs,
-        spawnFn: this._spawnFn,
         signal
       })
 
@@ -755,9 +785,8 @@ class SshConnection {
   // inert.)
   async _evictStaleMaster() {
     try {
-      await runSsh(buildControlArgs(this, 'exit', [], this._connectTimeoutMs), {
-        timeoutMs: this._connectTimeoutMs,
-        spawnFn: this._spawnFn
+      await this._run(buildControlArgs(this, 'exit', [], this._connectTimeoutMs), {
+        timeoutMs: this._connectTimeoutMs
       })
     } catch {
       void 0
@@ -774,14 +803,17 @@ class SshConnection {
 
   // One-shot remote command over the control connection. Resolves stdout;
   // rejects with a classified error on non-zero exit or timeout.
-  async exec(remoteCommand, { timeoutMs, stdinData }: any = {}) {
+  //
+  // `signal` aborts the spawned ssh: a bootstrap superseded (or an app quit)
+  // mid-exec must not leave the child running to completion.
+  async exec(remoteCommand, { signal, stdinData, timeoutMs }: any = {}) {
     const args = buildExecArgs(this, remoteCommand, this._connectTimeoutMs)
     let result
 
     try {
-      result = await runSsh(args, {
+      result = await this._run(args, {
         timeoutMs: timeoutMs ?? this._execTimeoutMs,
-        spawnFn: this._spawnFn,
+        ...(signal ? { signal } : {}),
         ...(stdinData != null ? { stdinData } : {})
       })
     } catch (error) {
@@ -799,7 +831,7 @@ class SshConnection {
   // No-mux: spawn a persistent `ssh -N -L` child that IS the tunnel; ready when
   // the local port accepts. The child dying = tunnel down (isAlive of the
   // backend catches it upstream).
-  async forward(localPort, remotePort, remoteHost = '127.0.0.1') {
+  async forward(localPort, remotePort, remoteHost = '127.0.0.1', { signal }: any = {}) {
     const spec = forwardSpec(localPort, remotePort, remoteHost)
     this._logLine(`forwarding 127.0.0.1:${localPort} -> ${remoteHost}:${remotePort}`)
 
@@ -815,6 +847,7 @@ class SshConnection {
         target(this.user, this.host)
       ]
 
+      this._invocations += 1
       const child = this._spawnFn('ssh', args, { stdio: ['ignore', 'ignore', 'pipe'] })
       const tunnel = { child, alive: true }
       this._tunnels.set(spec, tunnel)
@@ -827,6 +860,17 @@ class SshConnection {
         readyResolve = resolve
         readyReject = reject
       })
+
+      const onAbort = () => {
+        tunnel.alive = false
+        readyReject(Object.assign(new Error('SSH operation was cancelled.'), { kind: 'superseded' }))
+      }
+
+      signal?.addEventListener('abort', onAbort, { once: true })
+
+      if (signal?.aborted) {
+        onAbort()
+      }
 
       const readyPattern = new RegExp(`Local forwarding listening on .* port ${localPort}\\b`)
       child.stderr?.on('data', d => {
@@ -873,9 +917,14 @@ class SshConnection {
           throw this._fail(stopError, SSH_ERROR.UNKNOWN)
         }
 
+        if (error?.kind === 'superseded') {
+          throw error
+        }
+
         throw this._fail(stderr || error, SSH_ERROR.UNKNOWN)
       } finally {
         clearTimeout(readyTimeout)
+        signal?.removeEventListener('abort', onAbort)
       }
 
       return
@@ -885,7 +934,7 @@ class SshConnection {
     let result
 
     try {
-      result = await runSsh(args, { timeoutMs: this._forwardTimeoutMs, spawnFn: this._spawnFn })
+      result = await this._run(args, { timeoutMs: this._forwardTimeoutMs })
     } catch (error) {
       throw this._fail(error)
     }
@@ -915,7 +964,7 @@ class SshConnection {
     const args = buildControlArgs(this, 'cancel', ['-L', spec], this._connectTimeoutMs)
 
     try {
-      await runSsh(args, { timeoutMs: this._forwardTimeoutMs, spawnFn: this._spawnFn })
+      await this._run(args, { timeoutMs: this._forwardTimeoutMs })
       this._logLine(`cancelled forward 127.0.0.1:${localPort}`)
     } catch (error: any) {
       this._logLine(`cancelForward failed (ignored): ${error.message}`)
@@ -944,7 +993,7 @@ class SshConnection {
     const args = buildControlArgs(this, 'exit', [], this._connectTimeoutMs)
 
     try {
-      const result: any = await runSsh(args, { timeoutMs: this._connectTimeoutMs, spawnFn: this._spawnFn })
+      const result: any = await this._run(args, { timeoutMs: this._connectTimeoutMs })
 
       if (result.code !== 0) {
         throw this._fail(result.stderr)
@@ -972,8 +1021,8 @@ class SshConnection {
 // kernel-assigned port, release. The benign TOCTOU window (release → forward
 // grabs it) is caught upstream and retried with a fresh port.
 
-function pickLocalPort() {
-  return new Promise((resolve, reject) => {
+function pickLocalPort(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
     const server = net.createServer()
     server.unref()
     server.on('error', reject)

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -63,6 +63,7 @@
     "fix": "npm run lint:fix && npm run fmt",
     "test:ui": "vitest run --project ui",
     "test:desktop:platforms": "vitest run --project electron",
+    "test:ssh-bootstrap": "node scripts/ssh-bootstrap-selftest.mjs",
     "test:find-in-page-native": "electron electron/find-in-page-native-fixture",
     "test": "vitest run",
     "preview": "node scripts/assert-root-install.mjs && vite preview --host 127.0.0.1 --port 4174",

--- a/apps/desktop/scripts/ssh-bootstrap-selftest.mjs
+++ b/apps/desktop/scripts/ssh-bootstrap-selftest.mjs
@@ -1,0 +1,250 @@
+/**
+ * End-to-end self-test of the remote program in electron/posix-remote-bootstrap.ts.
+ *
+ *   node scripts/ssh-bootstrap-selftest.mjs <ssh-host>
+ *
+ * The unit tests mock ssh, so they answer whatever command they are given and
+ * cannot see a mistake in the program that actually runs on the remote (an
+ * off-by-one argv index shipped past a full green suite exactly that way).
+ * This drives the real program over a real ssh connection, against a throw-away
+ * HOME under /tmp with a FAKE hermes, and checks what the remote host actually
+ * did: cold spawn, reuse, an owned respawn, a foreign pid left alone, a bounded
+ * ready-timeout with full cleanup, 0600/0700 token handling, and the token
+ * never appearing in argv or the process list.
+ *
+ * It touches nothing real on the remote: no ~/.hermes, no running backend, no
+ * repo. Everything it creates lives under /tmp and is removed at the end.
+ *
+ * Requires: passwordless ssh to <ssh-host>, and python3 + bash there.
+ */
+import { spawn } from 'node:child_process'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const HOST = process.argv[2] || ''
+
+if (!HOST) {
+  console.error('usage: node scripts/ssh-bootstrap-selftest.mjs <ssh-host>')
+  process.exit(2)
+}
+
+const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'electron')
+const SANDBOX = '/tmp/hermes-bootstrap-selftest'
+
+// Pull REMOTE_BOOTSTRAP_PY out of the TS source without a TS toolchain.
+function remotePython() {
+  const src = fs.readFileSync(path.join(REPO, 'posix-remote-bootstrap.ts'), 'utf8')
+  const start = src.indexOf('const REMOTE_BOOTSTRAP_PY = String.raw`')
+  if (start < 0) throw new Error('REMOTE_BOOTSTRAP_PY not found')
+  const from = src.indexOf('`', start) + 1
+  const end = src.indexOf('`\n', from)
+  if (end < 0) throw new Error('unterminated REMOTE_BOOTSTRAP_PY')
+  return src.slice(from, end)
+}
+
+function shq(v) {
+  return `'${String(v).replace(/'/g, `'\\''`)}'`
+}
+
+function fingerprint(token) {
+  return crypto.createHash('sha256').update(String(token)).digest('hex').slice(0, 32)
+}
+
+function ssh(command, { stdinData, timeoutMs = 120000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const args = [
+      '-o', 'BatchMode=yes',
+      '-o', 'StrictHostKeyChecking=accept-new',
+      '-o', 'ConnectTimeout=15',
+      '--', HOST, command
+    ]
+    const child = spawn('ssh', args, { stdio: [stdinData == null ? 'ignore' : 'pipe', 'pipe', 'pipe'] })
+    if (stdinData != null) child.stdin.end(stdinData)
+    let out = ''
+    let err = ''
+    const timer = setTimeout(() => { child.kill('SIGKILL'); reject(new Error(`ssh timed out: ${command.slice(0, 80)}`)) }, timeoutMs)
+    child.stdout.on('data', d => { out += d })
+    child.stderr.on('data', d => { err += d })
+    child.on('close', code => { clearTimeout(timer); resolve({ code, out, err }) })
+    child.on('error', e => { clearTimeout(timer); reject(e) })
+  })
+}
+
+const PY_B64 = Buffer.from(remotePython(), 'utf8').toString('base64')
+
+async function bootstrap(params, token, { home = SANDBOX } = {}) {
+  const encoded = Buffer.from(JSON.stringify(params), 'utf8').toString('base64')
+  const inner = 'import base64,sys;exec(compile(base64.b64decode(sys.argv[1]),"<hermes-desktop-bootstrap>","exec"))'
+  const command = `HOME=${shq(home)} python3 -c ${shq(inner)} ${shq(PY_B64)} ${shq(encoded)}`
+  const res = await ssh(command, { stdinData: token })
+  const line = res.out.split(/\r?\n/).filter(l => l.startsWith('HERMES_DESKTOP_BOOTSTRAP ')).pop()
+  if (!line) throw new Error(`no response line. code=${res.code}\nSTDOUT:${res.out}\nSTDERR:${res.err}`)
+  return { command, parsed: JSON.parse(line.slice('HERMES_DESKTOP_BOOTSTRAP '.length)), raw: res }
+}
+
+const FAKE_HERMES = [
+  '#!/usr/bin/env bash',
+  'if [ "$1" = "--version" ]; then echo "Hermes Agent v9.9.9 (fake)"; exit 0; fi',
+  'if [ "$1" = "serve" ] && [ "$2" = "--help" ]; then',
+  '  echo "  --ssh-session-token-file PATH"; echo "  --ssh-owner-nonce NONCE"; exit 0',
+  'fi',
+  'sleep 1',
+  'echo "HERMES_BACKEND_READY port=45999"',
+  'sleep 600'
+].join('\n')
+
+const results = []
+function check(label, ok, detail = '') {
+  results.push({ detail, label, ok })
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? ` -- ${detail}` : ''}`)
+}
+
+async function remoteProcCount(nonce) {
+  const res = await ssh(`ps -eo pid,cmd | grep -F -- '--ssh-owner-nonce ${nonce}' | grep -v grep | wc -l`)
+  return Number(res.out.trim())
+}
+
+async function main() {
+  const OID = crypto.randomBytes(16).toString('hex')
+
+  // --- sandbox ---
+  await ssh(`rm -rf ${shq(SANDBOX)}; mkdir -p ${shq(SANDBOX)}/bin`)
+  await ssh(`cat > ${shq(SANDBOX)}/bin/hermes && chmod 755 ${shq(SANDBOX)}/bin/hermes`, { stdinData: FAKE_HERMES })
+
+  const hermesPath = `${SANDBOX}/bin/hermes`
+  const baseParams = {
+    allowReuse: false,
+    nofileSoftLimit: 65536,
+    ownershipId: OID,
+    profile: '',
+    protocolVersion: 1,
+    readyTimeoutMs: 30000,
+    remoteHermesPath: hermesPath,
+    reuseFingerprint: '',
+    schemaVersion: 2,
+    spawnNonce: '',
+    tokenFingerprint: ''
+  }
+
+  // --- 1. a bad hermes path fails cleanly and spawns nothing ---
+  {
+    const token = crypto.randomBytes(32).toString('hex')
+    const p = { ...baseParams, remoteHermesPath: `${SANDBOX}/nope`, spawnNonce: crypto.randomBytes(8).toString('hex'), tokenFingerprint: fingerprint(token) }
+    const { parsed } = await bootstrap(p, token)
+    check('a non-executable hermes path is reported, not guessed around', parsed.ok === false && parsed.kind === 'hermes-not-found', parsed.kind)
+  }
+
+  // --- 2. cold spawn ---
+  const token1 = crypto.randomBytes(32).toString('hex')
+  const nonce1 = crypto.randomBytes(8).toString('hex')
+  const first = await bootstrap({ ...baseParams, spawnNonce: nonce1, tokenFingerprint: fingerprint(token1) }, token1)
+  check('cold start spawns a backend and reports its announced port', first.parsed.ok === true && first.parsed.port === 45999 && first.parsed.reused === false, JSON.stringify({ pid: first.parsed.pid, port: first.parsed.port, timings: first.parsed.timings }))
+  check('the spawn is not reported as a reuse', first.parsed.reused === false)
+  check('the version comes from the located binary', first.parsed.hermesVersion === 'Hermes Agent v9.9.9 (fake)', first.parsed.hermesVersion)
+  check('a cold start names its reason as no-lock', first.parsed.respawnReason === 'no-lock', first.parsed.respawnReason)
+
+  // token file permissions
+  {
+    const res = await ssh(`stat -c '%a %U' ${shq(SANDBOX)}/.hermes/desktop-ssh/${OID}/${nonce1}.token ${shq(SANDBOX)}/.hermes/desktop-ssh/${OID}`)
+    const lines = res.out.trim().split(/\r?\n/)
+    check('the token file is 0600 in a 0700 directory', lines[0]?.startsWith('600 ') && lines[1]?.startsWith('700 '), res.out.trim().replace(/\n/g, ' | '))
+  }
+
+  // the token never appears in the remote process list or the command line
+  {
+    const res = await ssh(`ps -ww -eo cmd | grep -F ${shq(token1)} | grep -v grep | wc -l`)
+    check('the token is absent from the remote process list', res.out.trim() === '0', res.out.trim())
+    check('the token is absent from the ssh command line', !first.command.includes(token1))
+  }
+
+  // --- 3. reuse ---
+  {
+    const p = { ...baseParams, allowReuse: true, reuseFingerprint: fingerprint(token1), spawnNonce: crypto.randomBytes(8).toString('hex'), tokenFingerprint: fingerprint('unused') }
+    const { parsed } = await bootstrap(p, 'unused')
+    check('a valid lock is reused instead of spawning again', parsed.ok === true && parsed.reused === true && parsed.pid === first.parsed.pid, JSON.stringify({ pid: parsed.pid, reused: parsed.reused }))
+    check('a reuse reports no respawn reason', parsed.respawnReason === '', JSON.stringify(parsed.respawnReason))
+    check('reuse costs no second backend', (await remoteProcCount(nonce1)) === 1)
+  }
+
+  // --- 3b. reuse explicitly forbidden ---
+  {
+    const p = { ...baseParams, allowReuse: false, reuseFingerprint: '', spawnNonce: crypto.randomBytes(8).toString('hex'), tokenFingerprint: fingerprint('t') }
+    const { parsed } = await bootstrap(p, 't')
+    check('forbidding reuse names both blockers', String(parsed.respawnReason).includes('reuse-not-allowed') && String(parsed.respawnReason).includes('no-saved-token'), parsed.respawnReason)
+    await ssh(`pkill -f -- '--ssh-owner-nonce ${p.spawnNonce}' 2>/dev/null; true`)
+  }
+
+  // --- 4. a wrong reuse fingerprint reaps OUR backend and spawns a new one ---
+  const token2 = crypto.randomBytes(32).toString('hex')
+  const nonce2 = crypto.randomBytes(8).toString('hex')
+  const second = await bootstrap({ ...baseParams, allowReuse: true, reuseFingerprint: fingerprint('a-different-token'), spawnNonce: nonce2, tokenFingerprint: fingerprint(token2) }, token2)
+  check('a lock we own but cannot authenticate is respawned', second.parsed.ok === true && second.parsed.reused === false && second.parsed.pid !== first.parsed.pid, JSON.stringify({ newPid: second.parsed.pid, oldPid: first.parsed.pid }))
+  check('the respawn names the saved-token mismatch', String(second.parsed.respawnReason).includes('saved-token-mismatch'), second.parsed.respawnReason)
+  check('the superseded backend we owned is terminated', (await remoteProcCount(nonce1)) === 0)
+  check('exactly one backend remains', (await remoteProcCount(nonce2)) === 1)
+
+  // --- 5. a lock pointing at a FOREIGN pid must never be killed ---
+  {
+    const victim = await ssh(`nohup sleep 900 >/dev/null 2>&1 & echo $!`)
+    const victimPid = Number(victim.out.trim())
+    const lockPath = `${SANDBOX}/.hermes/desktop-ssh/${OID}/backend.lock.json`
+    // Repoint OUR lock at an unrelated process, keeping every other field valid.
+    await ssh(`python3 -c "import json,sys;p=sys.argv[1];d=json.load(open(p));d['pid']=${victimPid};json.dump(d,open(p,'w'))" ${shq(lockPath)}`)
+    const token3 = crypto.randomBytes(32).toString('hex')
+    const nonce3 = crypto.randomBytes(8).toString('hex')
+    const third = await bootstrap({ ...baseParams, allowReuse: true, reuseFingerprint: fingerprint(token2), spawnNonce: nonce3, tokenFingerprint: fingerprint(token3) }, token3)
+    const stillAlive = await ssh(`kill -0 ${victimPid} 2>/dev/null && echo ALIVE || echo DEAD`)
+    check('a lock pointing at a foreign pid does not kill it', stillAlive.out.trim() === 'ALIVE', stillAlive.out.trim())
+    check('an unowned lock still leads to a clean respawn', third.parsed.ok === true && third.parsed.reused === false, JSON.stringify({ kind: third.parsed.kind, reused: third.parsed.reused }))
+    check('the respawn names the foreign pid', String(third.parsed.respawnReason).includes('pid-not-ours'), third.parsed.respawnReason)
+    await ssh(`kill ${victimPid} 2>/dev/null; true`)
+    await ssh(`pkill -f -- '--ssh-owner-nonce ${nonce3}' 2>/dev/null; true`)
+  }
+
+  // --- 6. a backend that never announces its port times out and cleans up ---
+  {
+    const silent = ['#!/usr/bin/env bash',
+      'if [ "$1" = "--version" ]; then echo "Hermes Agent v9.9.9 (silent)"; exit 0; fi',
+      'if [ "$1" = "serve" ] && [ "$2" = "--help" ]; then echo "--ssh-session-token-file"; echo "--ssh-owner-nonce"; exit 0; fi',
+      'sleep 600'].join('\n')
+    await ssh(`cat > ${shq(SANDBOX)}/bin/hermes-silent && chmod 755 ${shq(SANDBOX)}/bin/hermes-silent`, { stdinData: silent })
+    const OID2 = crypto.randomBytes(16).toString('hex')
+    const token4 = crypto.randomBytes(32).toString('hex')
+    const nonce4 = crypto.randomBytes(8).toString('hex')
+    const started = Date.now()
+    const { parsed } = await bootstrap({ ...baseParams, ownershipId: OID2, readyTimeoutMs: 6000, remoteHermesPath: `${SANDBOX}/bin/hermes-silent`, spawnNonce: nonce4, tokenFingerprint: fingerprint(token4) }, token4)
+    const elapsed = Date.now() - started
+    check('a backend that never announces its port times out with an actionable error', parsed.ok === false && parsed.kind === 'ready-timeout', `${parsed.kind}: ${String(parsed.error).slice(0, 90)}`)
+    check('the timeout is bounded by readyTimeoutMs, not the ssh timeout', elapsed < 40000, `${elapsed}ms`)
+    check('the timed-out process is reaped', (await remoteProcCount(nonce4)) === 0)
+    const leftovers = await ssh(`ls -1 ${shq(SANDBOX)}/.hermes/desktop-ssh/${OID2} 2>/dev/null | wc -l`)
+    check('no lock, token or log is left behind after a failed spawn', leftovers.out.trim() === '0', leftovers.out.trim())
+  }
+
+  // --- 7. an unsupported/unknown parameter set is refused, not guessed ---
+  {
+    const { parsed } = await bootstrap({ ...baseParams, ownershipId: 'not-an-id', spawnNonce: 'x' }, 'tok')
+    check('a malformed ownership id is refused', parsed.ok === false && parsed.kind === 'unknown', parsed.kind)
+  }
+
+  // --- cleanup ---
+  await ssh(`pkill -f -- '${SANDBOX}/bin/hermes' 2>/dev/null; pkill -f -- '--ssh-owner-nonce ${nonce2}' 2>/dev/null; true`)
+  await ssh(`rm -rf ${shq(SANDBOX)}`)
+  const strays = await ssh(`ps -eo cmd | grep -F -- 'hermes-bootstrap-selftest' | grep -v grep | wc -l`)
+  check('the sandbox leaves no process behind', strays.out.trim() === '0', strays.out.trim())
+
+  const failed = results.filter(r => !r.ok)
+  console.log(`\n${results.length - failed.length}/${results.length} checks passed`)
+  if (failed.length) {
+    process.exitCode = 1
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error('SELFTEST ERROR:', error)
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
## What does this PR do?

A Windows Desktop connecting to a Linux host over SSH took **5+ minutes and dozens of key
authentications** to start, and left **two identical `hermes serve --isolated` backends** running on
the remote for a single profile. On the box this was found on, a cold start was measured at
**35 SSH authentications and 75s of SSH lifecycle**; after this PR the same start is
**2 authentications and 8.8s**, with a warm restart at **5.1s**, and exactly one remote backend.

Three independent defects were involved.

**1. One gateway, two owners.** The legacy v1 global SSH route and the v2 registry entry for the
same host each bootstrapped under their own ssh scope. A different scope means a different
ownership id, a different lockfile, and therefore a second remote backend for the same profile —
each start reaping and respawning the other's work, taking its MCP servers and language servers
with it. `registryTargetForRoute()` lets a v1 route that resolves to exactly one registry entry
delegate to that entry's pooled backend, so both entry points join a single bootstrap under
`conn:<id>::<profile>`.

Stored fields alone are not enough to recognise one gateway: a v1 block holding an
`~/.ssh/config` alias and a registry entry holding the resolved `user@host` describe the same
machine and compare as different. `effectiveDialDigest()` compares the two sides' `ssh -G` output —
which resolves the alias locally, without connecting, without a key and without an agent prompt —
ignoring only the echoed `host <alias>` line, since that is spelling, not destination. The global v1
route delegates to the registry primary when that digest *and* the remote Hermes path/profile all
match. Anything less keeps the historical path, and two registry entries are never merged into each
other.

**2. One authentication per remote operation on Windows.** `remote-lifecycle.ts` walks the remote
lifecycle as ~15 separate `ssh.exec()` calls plus a readiness poll that adds two more every 750ms.
Under ControlMaster those all ride one authenticated connection, so the cost is a round-trip each.
Windows OpenSSH has no ControlMaster — mux sockets were never implemented on Win32 — so on a
Windows client every one of them is a full TCP connect plus a key authentication. With a
vault-backed agent (1Password, YubiKey) that is seconds each, and a user-visible approval.

The fix is not to make those calls faster, it is to stop making them. `posix-remote-bootstrap.ts`
ships the whole remote lifecycle as **one Python program run by a single exec**: platform, hermes
location/version, `HERMES_HOME`, lock read plus ownership proof, reuse-or-spawn, the readiness wait,
the lockfile write — answered with one strictly validated JSON line. The tunnel is the second and
last ssh process; the HTTP readiness probe, the ownership proof and the WebSocket check all run
through it. A served token that drifts from the spawn token costs a third exec to re-stamp the
lockfile.

**3. The registry threw away every ssh connection's saved token.** `normalizeRegistry()` rebuilt an
ssh entry from `normalizeSshConfig()`, which returns dial fields only, so `token` was dropped on
**every read** of `connections.json` while `persistSshConnectionToken()` kept writing it — a
write-only field. Every start therefore reported "no saved token", killed the running remote backend
(provably ours, so the reaper was right to) and spawned a fresh one. **A reusable SSH backend was
never reused, on any platform.** `normalizeConnectionInput()` dropped it the same way, so renaming an
ssh connection in Settings also cleared its reuse credential.

This one is independent of the Windows work and reviewable on its own — happy to split it out if
you'd rather take it separately.

### Why this approach

No Node SSH library: the system `ssh` client is what gives Desktop `~/.ssh/config`, the agent,
`ProxyJump` and hardware keys for free, exactly as `tools/environments/ssh.py` argues. Replacing it
would trade those away for the same result.

The lockfile schema, ownership proof, token handling and spawn argv stay **byte-compatible** with
`remote-lifecycle.ts`, so a backend started by either path is reusable and reapable by the other —
mixed-version fleets and rollbacks keep working. Anything the batched path cannot do (a Windows
remote, a host without `python3`, a mangled response) falls back to the legacy lifecycle with a log
line naming the cause. **POSIX clients are untouched and keep their ControlMaster multiplexing.**

Security posture is preserved or tightened: the session token still travels on stdin into a `0600`
file inside a `0700` directory the remote verifies it owns (`O_EXCL|O_NOFOLLOW`), and only its
fingerprint is ever a parameter; `StrictHostKeyChecking=accept-new` and the host-key-change
detection are unchanged; the backend binds `127.0.0.1` remotely and the tunnel binds `127.0.0.1`
locally; a backend is reused or terminated only after its argv proves our ownership nonce and token
path, so a pid that cannot be proven ours is left alone. Cancellation now reaches the ssh child and
the tunnel, so a superseded or quitting bootstrap leaves no orphan.

## Related Issue

No existing issue or PR found for this (searched open PRs for ControlMaster / desktop ssh / ssh
backend). Happy to open one first if you'd prefer that order.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

Four commits, each self-contained and typechecking on its own:

- **`fix(desktop/ssh): one gateway, one backend`**
  - `apps/desktop/electron/desktop-remote-route.ts` — `registryTargetForRoute()`,
    `effectiveDialDigest()`, `sshPayloadFieldsMatch()`
  - `apps/desktop/electron/main.ts` — `resolveRemoteBackend()` delegates;
    `sshEffectiveConfigDump()` split out of `effectiveSshConfigFingerprint()`;
    `registryPrimarySharingSshRoute()`
- **`perf(desktop/ssh): bootstrap a POSIX remote in one ssh call on Windows`**
  - `apps/desktop/electron/posix-remote-bootstrap.ts` — new; the remote program, its strict response
    validation, and `connectBatched()`
  - `apps/desktop/electron/ssh-connection.ts` — invocation counter, `signal` plumbed through
    `exec()`/`forward()`, `open({ lazy })` for the no-mux path
  - `apps/desktop/electron/remote-lifecycle.ts` — the roster profile inventory resolves
    `HERMES_HOME` and lists profiles in one exec instead of two (home still validated locally, a
    hostile one still refused)
  - `apps/desktop/electron/main.ts` — wiring, fallback, instrumentation
- **`fix(desktop/connections): stop discarding an ssh connection's saved token`**
  - `apps/desktop/electron/connection-registry.ts` — `normalizeRegistry()` and
    `normalizeConnectionInput()` keep `token` on ssh entries
- **`test(desktop/ssh): drive the real remote bootstrap program over a real ssh`**
  - `apps/desktop/scripts/ssh-bootstrap-selftest.mjs` — new; `npm run test:ssh-bootstrap -- <host>`

New instrumentation, secret-free: `bootstrap joined/started`, `backend reused/spawned` with the
exact reason a lock could not be adopted, the fallback cause, and a closing line:

```
[ssh] ready connection=alfred-laptop profile=default scope="conn:alfred-laptop::default" \
      reused=true sshInvocations=2 totalMs=5108 openMs=0 bootstrapMs=2545 tunnelMs=2100 \
      httpMs=414 wsMs=46
```

## How to Test

**Reproduction (before this PR), Windows client + Linux remote:**

1. Configure an SSH connection in the v2 registry, and leave a v1 `connection.json` in `mode: "ssh"`
   pointing at the same host (an `~/.ssh/config` alias on one side and the resolved `user@host` on
   the other reproduces it exactly).
2. Start Desktop. On the remote: `ps -eo pid,cmd | grep 'hermes serve --isolated'` → **two**
   backends, both without `--profile`, under two different `~/.hermes/desktop-ssh/<id>/` directories.
3. Count authentications on the remote:
   `journalctl -u ssh --since '<start>' | grep -c 'Accepted publickey'` → dozens.
4. Quit and restart: the previously running backend is killed and respawned every single time.

**After:** one backend, one ownership directory, `sshInvocations=2` in `desktop.log`, and a restart
reuses the same pid.

**Automated:**

```
cd apps/desktop
npm run typecheck
npm run lint
npm run test:desktop:platforms
npm run test:ssh-bootstrap -- <an-ssh-host>     # needs passwordless ssh + python3/bash there
```

`test:ssh-bootstrap` runs the real remote program over a real ssh connection against a throw-away
`HOME` under `/tmp` with a fake `hermes`, and asserts what the remote host actually did: cold spawn,
reuse of a valid lock, an owned respawn, **a foreign pid left alone**, a bounded ready-timeout that
reaps its process and leaves no lock/token/log, a `0600` token in a `0700` directory, and the token
absent from argv and from the remote process list. It creates nothing outside `/tmp` and cleans up.

It exists because the mocked-ssh unit tests could not catch a real defect: reading the parameter
block from `sys.argv[1]` instead of `argv[2]` shipped past a fully green suite and only failed on a
real host.

## Results

| | before | after |
|---|---|---|
| SSH authentications, cold start | 35 | **2** |
| SSH authentications, warm restart | 35 | **2** |
| SSH lifecycle, cold start | 75.1s | **8.8s** |
| SSH lifecycle, warm restart | 75.1s | **5.1s** |
| remote backends for one profile | 2 | **1** |
| reuses an existing remote backend | never | yes |

Authentications counted on the remote with a `journalctl --show-cursor` / `--after-cursor` window
(clock-skew proof), minus the measuring call itself.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (a separate window-close-behaviour change
      that shared a branch locally is deliberately **not** included here)
- [ ] I've run `pytest tests/ -q` — **not run: this PR touches no Python.** I ran the desktop suites
      instead (see below).
- [x] I've added tests for my changes
- [x] I've tested on my platform: **Windows 11 client → Ubuntu (Linux 7.0) remote**, real hardware,
      1Password SSH agent, Tailscale link.

`npm run test:desktop:platforms` on this branch: **27 failed | 1511 passed**. On unmodified `main`
from the same machine: **27 failed | 1477 passed** — the same 27 pre-existing failures (they are
Windows-host artefacts in tests that assume POSIX `chmod`/`umask`, symlinks, `/proc`, `ssh_config`
`Include`, `pyvenv.cfg`, ControlMaster socket paths, plus one WSL probe that does not answer here),
**+34 passing tests and zero new failures.** A Linux/macOS CI run should be clean.

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing config or CLI surface changed)
- [x] `cli-config.yaml.example` — N/A (no config keys added or changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change; the new module
      documents its own rationale in its header)
- [x] Cross-platform impact considered: the batched path is gated on `process.platform === 'win32'`;
      POSIX keeps ControlMaster with no behaviour change, and there is a regression test asserting
      that the `lazy` shortcut is ignored when mux is on. A Windows *remote* still routes to the
      existing `connectWindowsRemote` path.
- [x] Tool descriptions/schemas — N/A

## Notes for reviewers

- The remote program is held in a `String.raw` template literal so backslashes survive into Python;
  there is a test asserting the regexes and the NUL split are intact, because a plain template
  literal would silently ship a program that matches `d+` and splits on `0`.
- The program and its parameters travel base64-encoded in argv so no remote login-shell quoting rule
  can corrupt them. The session token is deliberately absent from that payload.
- `effectiveDialDigest()` filters lines starting with `host` **followed by whitespace**, so
  `hostname <resolved>` is deliberately kept — without it every target sharing a config file would
  digest identically.
