### PR TITLE
fix(bot-mode): wrap prose text blocks in group chat

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -75,6 +75,33 @@ const SkillsView = typeof sdk === 'undefined' ? undefined : sdk.SkillsView
 // so those builds keep the staged checklists for remote targets.
 const skillsViewRoutesConnections = Boolean(SkillsView && SkillsView.supportsFixedConnection)
 const Streamdown = typeof sdk === 'undefined' ? undefined : sdk.Streamdown
+const isLikelyStructuredText = typeof sdk === 'undefined' ? undefined : sdk.isLikelyStructuredText
+
+function GroupChatPre({ children, node: _node, ...props }) {
+  const code =
+    children &&
+    typeof children === 'object' &&
+    !Array.isArray(children) &&
+    children.type === 'code'
+      ? children
+      : null
+  const codeClass = typeof code?.props?.className === 'string' ? code.props.className : ''
+  const language = /(?:^|\s)language-([^\s]+)/.exec(codeClass)?.[1]
+  const body = typeof code?.props?.children === 'string' ? code.props.children : null
+  const shouldWrap =
+    language === 'text' &&
+    body !== null &&
+    typeof isLikelyStructuredText === 'function' &&
+    !isLikelyStructuredText(body)
+
+  return jsx('pre', {
+    ...props,
+    className: cn(props.className, shouldWrap ? 'whitespace-pre-wrap wrap-anywhere' : 'overflow-x-auto'),
+    children
+  })
+}
+
+const GROUP_CHAT_MARKDOWN_COMPONENTS = { pre: GroupChatPre }
 // Deterministic blob avatars (name → face). Feature-detected: older SDKs
 // without the export fall back to the legacy math-face shapes below.
 const blobatarSvg = typeof sdk === 'undefined' ? undefined : sdk.blobatarSvg
@@ -9536,11 +9563,13 @@ function GroupChatWorkspace({ group, members, onBack }) {
                           }),
                           jsx('div', {
                             className:
-                              'text-xs text-(--ui-text-secondary) [&_p]:mb-1 [&_p:last-child]:mb-0 [&_ul]:mb-1 [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:mb-1 [&_ol]:list-decimal [&_ol]:pl-4 [&_pre]:overflow-x-auto',
+                              'text-xs text-(--ui-text-secondary) [&_p]:mb-1 [&_p:last-child]:mb-0 [&_ul]:mb-1 [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:mb-1 [&_ol]:list-decimal [&_ol]:pl-4',
                             // The app shell sets user-select: none globally; message bodies opt
                             // back in so drag-select and ⌘C work in group chat logs.
                             'data-selectable-text': 'true',
-                            children: Streamdown ? jsx(Streamdown, { children: entry.text }) : entry.text
+                            children: Streamdown
+                              ? jsx(Streamdown, { components: GROUP_CHAT_MARKDOWN_COMPONENTS, children: entry.text })
+                              : entry.text
                           }),
                           // User attachments: what every responding bot was
                           // shown — image previews, or a named chip for

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat-markdown-wrap.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat-markdown-wrap.test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadPreRenderer(isLikelyStructuredText) {
+  const start = pluginSource.indexOf('const Streamdown =')
+  const end = pluginSource.indexOf('\nconst ID =', start)
+
+  assert.ok(start >= 0 && end > start, 'optional SDK capability section exists')
+
+  const context = {
+    cn: (...values) => values.filter(Boolean).join(' '),
+    jsx: (type, props) => ({ props, type }),
+    sdk: {
+      Streamdown: () => null,
+      ...(isLikelyStructuredText ? { isLikelyStructuredText } : {})
+    }
+  }
+  const source = `${pluginSource.slice(start, end)}\nglobalThis.__markdown = { GroupChatPre, GROUP_CHAT_MARKDOWN_COMPONENTS };\n`
+
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+
+  return context.__markdown
+}
+
+function code(language, body) {
+  return { props: { children: body, className: `language-${language}` }, type: 'code' }
+}
+
+test('plain text prose wraps while preserving the pre element contract', () => {
+  const calls = []
+  const markdown = loadPreRenderer(body => {
+    calls.push(body)
+    return false
+  })
+  const body =
+    'Please review this ordinary group-chat update. It contains several natural-language sentences with spaces and should remain readable when the chat becomes narrow.'
+  const children = code('text', body)
+  const rendered = markdown.GroupChatPre({
+    children,
+    className: 'existing',
+    node: { internal: true },
+    title: 'message'
+  })
+
+  assert.equal(rendered.type, 'pre')
+  assert.equal(rendered.props.children, children)
+  assert.equal(rendered.props.title, 'message')
+  assert.equal(Object.hasOwn(rendered.props, 'node'), false)
+  assert.match(rendered.props.className, /whitespace-pre-wrap/)
+  assert.match(rendered.props.className, /wrap-anywhere/)
+  assert.doesNotMatch(rendered.props.className, /overflow-x-auto/)
+  assert.deepEqual(calls, [body])
+  assert.equal(markdown.GROUP_CHAT_MARKDOWN_COMPONENTS.pre, markdown.GroupChatPre)
+})
+
+test('structured text keeps horizontal scroll', () => {
+  const body =
+    'Host production\n  HostName example.internal\n  IdentityFile ~/.ssh/id_ed25519\n  StrictHostKeyChecking yes'
+  const markdown = loadPreRenderer(value => value === body)
+  const rendered = markdown.GroupChatPre({ children: code('text', body) })
+
+  assert.match(rendered.props.className, /overflow-x-auto/)
+  assert.doesNotMatch(rendered.props.className, /whitespace-pre-wrap|wrap-anywhere/)
+})
+
+test('other languages and unexpected Streamdown trees fail closed to scroll', () => {
+  let calls = 0
+  const markdown = loadPreRenderer(() => {
+    calls += 1
+    return false
+  })
+  const javascript = markdown.GroupChatPre({ children: code('javascript', 'const value = 1') })
+  const nonCodeElement = markdown.GroupChatPre({
+    children: { props: { children: 'ordinary prose', className: 'language-text' }, type: 'span' }
+  })
+  const unexpected = markdown.GroupChatPre({ children: 'plain child' })
+
+  assert.match(javascript.props.className, /overflow-x-auto/)
+  assert.match(nonCodeElement.props.className, /overflow-x-auto/)
+  assert.match(unexpected.props.className, /overflow-x-auto/)
+  assert.equal(calls, 0)
+})
+
+test('legacy SDK without the classifier loads and keeps text scrolling', () => {
+  const markdown = loadPreRenderer(undefined)
+  const rendered = markdown.GroupChatPre({ children: code('text', 'Ordinary prose from an older Desktop build.') })
+
+  assert.match(rendered.props.className, /overflow-x-auto/)
+  assert.doesNotMatch(rendered.props.className, /whitespace-pre-wrap|wrap-anywhere/)
+})

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1034,6 +1034,9 @@ export type { HermesOpenTarget } from '@/lib/hermes-open-target'
 export * as icons from '@/lib/icons'
 export { type KeybindContribution, KEYBINDS_AREA } from '@/lib/keybinds/actions'
 export { formatModifierToken } from '@/lib/keybinds/combo'
+/** Distinguish config-like fenced text (SSH, .env, INI) from prose without
+ *  duplicating the renderer's heuristics in plugins. */
+export { isLikelyStructuredText } from '@/lib/markdown-code'
 /** The app's deterministic identity color for a name (profiles, assignees,
  *  authors) + its translucent tag fill — so plugin-rendered identities read
  *  the same hue as everywhere else. */


### PR DESCRIPTION
## Summary
- Wrap only non-structured `text` fences in Bot Mode group chat logs.
- Re-export the existing structured-text classifier through the SDK; older SDKs and unexpected Streamdown trees retain the current horizontal-scroll fallback.
- Preserve horizontal scrolling for SSH/.env-style configuration and every non-`text` language.

## Verification
- TDD: 0/4 RED before the renderer existed; 4/4 GREEN after.
- Group/SDK regression tests: 61/61.
- Desktop plugin suite: 345/345.
- Authoritative classifier tests: 12/12.
- Typecheck, applicable lint/format, and `git diff --check` pass.
- Synthetic narrow-width visual check: prose has `clientWidth=scrollWidth=300` with wrapping; SSH config keeps `scrollWidth=563 > 300` and `overflow-x:auto`.

## Scope
No changes to the main Markdown renderer, `markdown-code.ts`, CRONJOBS/layout, or PR #77258. User-provided screenshots and group-chat content were not included.