### PR TITLE
fix(cron/telegram): kill the HTML-leak class via an explicit payload_type delivery contract

### DIFF
--- a/cron/format_validator.py
+++ b/cron/format_validator.py
@@ -1,0 +1,48 @@
+"""Deterministic pre-flight boundary check for cron delivery (TKT-0033 Phase A).
+
+When a cron job declares ``text/markdown`` (the default) but its delivery
+content contains raw HTML tags OUTSIDE code fences, the send must hard-fail
+into a dead-letter record instead of leaking literal tags to the user.
+
+Pure stdlib, ~zero latency, $0/message: a pair of regexes over the outgoing
+text. HTML tags inside fenced ``` blocks or inline `code` spans are code
+samples, not leaks — they are stripped before the tag scan. The tag regex
+deliberately requires a letter immediately after ``<`` so comparisons
+(``x < y``) and arrows (``a -> b``) are NOT treated as tags.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+_FENCED_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+_HTML_TAG_RE = re.compile(r"</?[a-zA-Z][a-zA-Z0-9]*(?:\s[^>]*)?>")
+
+
+def strip_code_blocks(text: str) -> str:
+    """Remove fenced ``` blocks and inline `code` spans from *text*."""
+    text = _FENCED_BLOCK_RE.sub("", text)
+    text = _INLINE_CODE_RE.sub("", text)
+    return text
+
+
+def find_html_leak(text: str) -> Optional[str]:
+    """Return the first HTML tag found OUTSIDE code blocks, or None."""
+    stripped = strip_code_blocks(text)
+    match = _HTML_TAG_RE.search(stripped)
+    if match is None:
+        return None
+    return match.group(0)
+
+
+def should_deadletter(payload_type: str, content: str) -> bool:
+    """True when markdown-claimed content leaks raw HTML into delivery.
+
+    Declared ``text/html`` payloads skip the check entirely — HTML is allowed
+    when the job says so.
+    """
+    if payload_type != "text/markdown":
+        return False
+    return find_html_leak(content) is not None

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2601,6 +2601,20 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             "message dead-lettered"
         )
 
+    # TKT-0033 Phase A Task 5: WARN-only unified report template assertions.
+    # Log missing markers as WARNINGS — NEVER block delivery on them, and
+    # never let an assert failure crash the delivery path.
+    try:
+        from cron.template_asserts import check_report_markers
+
+        for _w in check_report_markers(delivery_content):
+            logger.warning("Job '%s': %s", job["id"], _w)
+    except Exception as _ta_err:
+        logger.warning(
+            "Job '%s': report template assertion failed to run: %s",
+            job["id"], _ta_err,
+        )
+
     delivery_errors = []
 
     for target in targets:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -63,6 +63,17 @@ from agent.delegation_context import (
 
 logger = logging.getLogger(__name__)
 
+_VALID_PAYLOAD_TYPES = frozenset({"text/markdown", "text/html"})
+_DEFAULT_PAYLOAD_TYPE = "text/markdown"
+
+
+def _extract_payload_type(job: dict) -> str:
+    """Extract the declared payload_type from a cron job config, coercing invalid values to the default."""
+    value = job.get("payload_type", _DEFAULT_PAYLOAD_TYPE)
+    if value in _VALID_PAYLOAD_TYPES:
+        return value
+    return _DEFAULT_PAYLOAD_TYPE
+
 
 def _close_late_session_db_result(future: "concurrent.futures.Future") -> None:
     """Done-callback: close a SessionDB whose constructor finished after run_job's timeout.
@@ -2788,6 +2799,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 route_metadata = {
                     "direct_messages_topic_id": str(thread_id),
                     "job_id": job["id"],
+                    "payload_type": _extract_payload_type(job),
                 }
                 # Media metadata mirrors the text routing so attachments land in
                 # the same DM topic instead of the General lane (#22773).
@@ -2802,7 +2814,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # anchor, so the metadata key bypasses that check and lets the
                 # adapter route via a plain message_thread_id.
                 route_thread_id = str(thread_id) if thread_id is not None else None
-                route_metadata = {"job_id": job["id"]}
+                route_metadata = {"job_id": job["id"], "payload_type": _extract_payload_type(job)}
                 if route_thread_id:
                     route_metadata["thread_id"] = route_thread_id
                 media_metadata = {"thread_id": thread_id} if thread_id else None
@@ -3055,7 +3067,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 delivery_errors.extend(target_errors)
                 continue
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files, payload_type=_extract_payload_type(job))
             try:
                 result = asyncio.run(coro)
             except RuntimeError as run_err:
@@ -3084,7 +3096,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 try:
                     pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
                     try:
-                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files, payload_type=_extract_payload_type(job)))
                         result = future.result(timeout=30)
                     finally:
                         pool.shutdown(wait=False)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2567,6 +2567,40 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         logger.error("Job '%s': %s", job["id"], msg)
         return msg
 
+    # TKT-0033 Phase A: markdown-claimed content must not leak raw HTML tags
+    # (outside code fences) to the user. Hard-fail into a dead-letter record
+    # instead of sending. Declared text/html payloads skip this check.
+    from cron.format_validator import find_html_leak, should_deadletter
+
+    if should_deadletter(_extract_payload_type(job), delivery_content):
+        leak_tag = find_html_leak(delivery_content) or "?"
+        logger.error(
+            "Job '%s': HTML tag %r found in text/markdown delivery content — "
+            "dead-lettering instead of sending",
+            job["id"], leak_tag,
+        )
+        try:
+            deadletter_path = _get_hermes_home() / "cron" / "deadletter.jsonl"
+            deadletter_path.parent.mkdir(parents=True, exist_ok=True)
+            record = {
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "job_id": job["id"],
+                "payload_type": _extract_payload_type(job),
+                "leak_tag": leak_tag,
+                "content": delivery_content,
+            }
+            with open(deadletter_path, "a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record) + "\n")
+        except Exception as dl_err:
+            logger.error(
+                "Job '%s': failed to write dead-letter record: %s",
+                job["id"], dl_err,
+            )
+        return (
+            f"HTML tag {leak_tag} found in text/markdown delivery content; "
+            "message dead-lettered"
+        )
+
     delivery_errors = []
 
     for target in targets:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -14,6 +14,7 @@ import concurrent.futures
 import contextlib
 import contextvars
 import errno
+import hashlib
 import json
 import logging
 import os
@@ -66,13 +67,58 @@ logger = logging.getLogger(__name__)
 _VALID_PAYLOAD_TYPES = frozenset({"text/markdown", "text/html"})
 _DEFAULT_PAYLOAD_TYPE = "text/markdown"
 
+# Job IDs already warned about an invalid payload_type (log once per process,
+# not once per run — a cron job fires on every tick).
+_payload_type_warned: set = set()
+
 
 def _extract_payload_type(job: dict) -> str:
     """Extract the declared payload_type from a cron job config, coercing invalid values to the default."""
     value = job.get("payload_type", _DEFAULT_PAYLOAD_TYPE)
     if value in _VALID_PAYLOAD_TYPES:
         return value
+    job_id = job.get("id", "?")
+    if job_id not in _payload_type_warned:
+        _payload_type_warned.add(job_id)
+        logger.warning(
+            "Job '%s': invalid payload_type %r (valid: %s) — coercing to %s. "
+            "Fix the job config; coercion may cause unexpected HTML-leak dead-lettering.",
+            job_id, value, sorted(_VALID_PAYLOAD_TYPES), _DEFAULT_PAYLOAD_TYPE,
+        )
     return _DEFAULT_PAYLOAD_TYPE
+
+
+# Dead-letter rotation: cap the append-only log so a persistently-leaking job
+# cannot grow it forever (#90844 review). Drop-oldest, keep newest records.
+_DEADLETTER_MAX_BYTES = 1_048_576  # 1 MiB
+_DEADLETTER_KEEP_FRACTION = 0.5  # after rotation, retain newest half
+
+
+def _rotate_deadletter(deadletter_path) -> None:
+    """Drop-oldest rotation for deadletter.jsonl once it exceeds the cap.
+
+    Keeps the newest ~half of records (whole JSON lines, never split). Cheap:
+    only runs when the file is over _DEADLETTER_MAX_BYTES, and dead-letter
+    writes are rare by design.
+    """
+    import os as _os
+
+    try:
+        size = _os.path.getsize(deadletter_path)
+    except OSError:
+        return
+    if size <= _DEADLETTER_MAX_BYTES:
+        return
+    with open(deadletter_path, "r", encoding="utf-8", errors="replace") as fh:
+        lines = fh.readlines()
+    keep = max(1, int(len(lines) * _DEADLETTER_KEEP_FRACTION))
+    retained = lines[-keep:]
+    with open(deadletter_path, "w", encoding="utf-8") as fh:
+        fh.writelines(retained)
+    logger.warning(
+        "deadletter.jsonl exceeded %d bytes — rotated, dropped %d oldest record(s), kept %d",
+        _DEADLETTER_MAX_BYTES, len(lines) - len(retained), len(retained),
+    )
 
 
 def _close_late_session_db_result(future: "concurrent.futures.Future") -> None:
@@ -2587,10 +2633,25 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 "job_id": job["id"],
                 "payload_type": _extract_payload_type(job),
                 "leak_tag": leak_tag,
-                "content": delivery_content,
+                # Diagnosis needs a preview + integrity check, not a second
+                # copy of every near-leak (which can carry sensitive data).
+                "content_preview": delivery_content[:500],
+                "content_sha256": hashlib.sha256(
+                    delivery_content.encode("utf-8", errors="replace")
+                ).hexdigest(),
+                "content_chars": len(delivery_content),
             }
             with open(deadletter_path, "a", encoding="utf-8") as fh:
                 fh.write(json.dumps(record) + "\n")
+            # Bounded growth: drop-oldest rotation once the file exceeds the
+            # cap — an unlucky job must not grow this forever (#90844 review).
+            try:
+                _rotate_deadletter(deadletter_path)
+            except Exception as rot_err:
+                logger.warning(
+                    "Job '%s': dead-letter rotation failed: %s",
+                    job["id"], rot_err,
+                )
         except Exception as dl_err:
             logger.error(
                 "Job '%s': failed to write dead-letter record: %s",

--- a/cron/template_asserts.py
+++ b/cron/template_asserts.py
@@ -1,0 +1,35 @@
+"""WARN-only unified report template assertions (TKT-0033 Phase A).
+
+Before a unified report leaves the delivery pipeline, check it for required
+markers and return any violations as warning strings. The caller logs them
+as WARNINGS — delivery is NEVER blocked on these checks.
+
+Required markers:
+  * a verdict line (the word "verdict", case-insensitive)
+  * section structure (a line starting with ``##`` or containing ``━``)
+  * at least one health icon (✅ ⚠️ ❌ 🟢 🟠 🔴)
+
+Pure stdlib, deterministic, ~zero latency: simple substring/regex checks
+over the outgoing text.
+"""
+
+from __future__ import annotations
+
+import re
+
+_HEALTH_ICONS = ("✅", "⚠️", "❌", "🟢", "🟠", "🔴")
+_VERDICT_RE = re.compile(r"verdict", re.IGNORECASE)
+_SECTION_RE = re.compile(r"^##", re.MULTILINE)
+_RULE_CHAR = "━"
+
+
+def check_report_markers(body: str) -> list[str]:
+    """Return a list of template warnings for *body*; empty list = pass."""
+    warnings: list[str] = []
+    if not _VERDICT_RE.search(body):
+        warnings.append("report template: missing verdict line")
+    if not any(icon in body for icon in _HEALTH_ICONS):
+        warnings.append("report template: missing health icon")
+    if not (_SECTION_RE.search(body) or _RULE_CHAR in body):
+        warnings.append("report template: missing section structure")
+    return warnings

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5116,6 +5116,18 @@ class TelegramAdapter(BasePlatformAdapter):
             return content, "HTML"
         return self.format_message(content), "MARKDOWN_V2"
 
+    def _format_parse_fallback_text(self, content: str) -> str:
+        """Strip HTML tags for the plain-text parse-failure fallback.
+
+        TKT-0033 never-drop guarantee: when Telegram rejects the declared
+        parse mode with a parse ``BadRequest``, delivery supersedes
+        formatting — the message is resent as plain text rather than
+        dropped. HTML tags are removed so the user sees legible text
+        instead of raw markup; MarkdownV2 escape cleanup stays with
+        ``_strip_mdv2`` at the call site.
+        """
+        return re.sub(r"<[^>]+>", "", content)
+
     def _should_thread_reply(self, reply_to: Optional[str], chunk_index: int) -> bool:
         """Determine if this message chunk should thread to the original message.
 
@@ -5278,10 +5290,24 @@ class TelegramAdapter(BasePlatformAdapter):
                                 **self._notification_kwargs(metadata),
                             )
                         except Exception as md_error:
-                            # Markdown parsing failed, try plain text
-                            if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
-                                logger.warning("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
-                                plain_chunk = _strip_mdv2(chunk)
+                            # Declared-format parse failed. TKT-0033
+                            # never-drop guarantee: delivery supersedes
+                            # formatting — resend as plain text (tags and
+                            # MarkdownV2 escapes stripped) rather than drop
+                            # the message. Driven by the attempted
+                            # send_parse_mode, so both the HTML and the
+                            # MarkdownV2 paths are covered.
+                            err_text = str(md_error).lower()
+                            if "parse" in err_text or "markdown" in err_text or "entities" in err_text:
+                                logger.error(
+                                    "[%s] %s parse rejected by Telegram for chat %s; "
+                                    "falling back to plain text (never-drop): %s",
+                                    self.name, send_parse_mode_name, chat_id, md_error,
+                                )
+                                if send_parse_mode_name == "HTML":
+                                    plain_chunk = self._format_parse_fallback_text(chunk)
+                                else:
+                                    plain_chunk = _strip_mdv2(chunk)
                                 msg = await self._bot.send_message(
                                     chat_id=normalize_telegram_chat_id(chat_id),
                                     text=plain_chunk,
@@ -10717,6 +10743,7 @@ async def _standalone_send(
     thread_id=None,
     media_files=None,
     force_document=False,
+    payload_type: str = "text/markdown",
 ):
     """Out-of-process Telegram delivery. Delegates to the standalone
     ``_send_telegram`` REST sender in tools/send_message_tool.py (which already
@@ -10743,6 +10770,7 @@ async def _standalone_send(
         thread_id=thread_id,
         disable_link_previews=disable_link_previews,
         force_document=force_document,
+        payload_type=payload_type,
     )
 
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -646,6 +646,11 @@ class TelegramAdapter(BasePlatformAdapter):
     - Media messages
     """
 
+    # Payload types a caller may declare in delivery metadata
+    # (metadata["payload_type"]). "text/html" bypasses the MarkdownV2
+    # conversion in send(); anything else falls back to MarkdownV2.
+    _VALID_PAYLOAD_TYPES = frozenset({"text/markdown", "text/html"})
+
     # Telegram message limits
     MAX_MESSAGE_LENGTH = 4096
     supports_code_blocks = True  # Telegram MarkdownV2 renders fenced code blocks
@@ -5097,6 +5102,20 @@ class TelegramAdapter(BasePlatformAdapter):
         self._bot = None
         logger.info("[%s] Disconnected from Telegram", self.name)
 
+    def _resolve_send_format(
+        self, content: str, metadata: Optional[Dict[str, Any]]
+    ) -> tuple:
+        """Resolve (text, parse_mode_name) for the send() choke point.
+
+        A declared ``payload_type == "text/html"`` bypasses the MarkdownV2
+        conversion entirely: the raw content is sent with ParseMode.HTML.
+        Anything else (missing/unknown payload_type) takes the MarkdownV2
+        path, byte-identical to historical behavior.
+        """
+        if (metadata or {}).get("payload_type") == "text/html":
+            return content, "HTML"
+        return self.format_message(content), "MARKDOWN_V2"
+
     def _should_thread_reply(self, reply_to: Optional[str], chunk_index: int) -> bool:
         """Determine if this message chunk should thread to the original message.
 
@@ -5159,8 +5178,14 @@ class TelegramAdapter(BasePlatformAdapter):
                                 pass  # Typing failures are non-fatal
                     return rich_result
 
-            # Format and split message if needed
-            formatted = self.format_message(content)
+            # Format and split message if needed. A declared
+            # metadata["payload_type"] == "text/html" bypasses the MarkdownV2
+            # conversion entirely; anything else takes the MarkdownV2 path
+            # (byte-identical to historical behavior).
+            formatted, send_parse_mode_name = self._resolve_send_format(content, metadata)
+            send_parse_mode = (
+                ParseMode.HTML if send_parse_mode_name == "HTML" else ParseMode.MARKDOWN_V2
+            )
             chunks = self.truncate_message(
                 formatted, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
             )
@@ -5241,12 +5266,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 msg = None
                 for _send_attempt in range(3):
                     try:
-                        # Try Markdown first, fall back to plain text if it fails
+                        # Try resolved parse mode first, fall back to plain text if it fails
                         try:
                             msg = await self._bot.send_message(
                                 chat_id=normalize_telegram_chat_id(chat_id),
                                 text=chunk,
-                                parse_mode=ParseMode.MARKDOWN_V2,
+                                parse_mode=send_parse_mode,
                                 reply_to_message_id=reply_to_id,
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),

--- a/tests/cron/test_format_validator.py
+++ b/tests/cron/test_format_validator.py
@@ -1,0 +1,100 @@
+"""Tests for cron.format_validator — TKT-0033 Phase A.
+
+A deterministic, code-block-aware HTML-leak validator: when a cron job
+declares ``text/markdown`` (the default) but its delivery content contains
+raw HTML tags OUTSIDE code fences, the send must hard-fail into a dead-letter
+record instead of leaking literal tags to the user.
+"""
+
+from cron.format_validator import (
+    find_html_leak,
+    should_deadletter,
+    strip_code_blocks,
+)
+
+
+class TestStripCodeBlocks:
+    def test_removes_fenced_block(self):
+        text = "before\n```\n<b>not a leak</b>\n```\nafter"
+        stripped = strip_code_blocks(text)
+        assert "<b>" not in stripped
+        assert "before" in stripped
+        assert "after" in stripped
+
+    def test_removes_fenced_block_with_language(self):
+        text = "look:\n```html\n<i>italics</i>\n```\ndone"
+        stripped = strip_code_blocks(text)
+        assert "<i>" not in stripped
+        assert "done" in stripped
+
+    def test_removes_inline_code_span(self):
+        text = "use `<b>bold</b>` for bold"
+        stripped = strip_code_blocks(text)
+        assert "<b>" not in stripped
+        assert "for bold" in stripped
+
+    def test_preserves_plain_text(self):
+        text = "Status: **OK** and x < y"
+        assert strip_code_blocks(text) == text
+
+
+class TestFindHtmlLeak:
+    def test_fenced_block_containing_html_is_not_a_leak(self):
+        text = "example:\n```\n<b>hi</b>\n```"
+        assert find_html_leak(text) is None
+
+    def test_inline_code_html_is_not_a_leak(self):
+        text = "run `<i>` to italicize"
+        assert find_html_leak(text) is None
+
+    def test_html_inside_html_fence_is_not_a_leak(self):
+        text = "```html\n<div class=\"x\">hello</div>\n```"
+        assert find_html_leak(text) is None
+
+    def test_raw_bold_tag_is_a_leak(self):
+        text = "Status: <b>OK</b>"
+        leak = find_html_leak(text)
+        assert leak is not None
+        assert leak.startswith("<b")
+
+    def test_raw_closing_tag_is_a_leak(self):
+        text = "value is </i> here"
+        leak = find_html_leak(text)
+        assert leak is not None
+        assert leak == "</i>"
+
+    def test_tag_with_attributes_is_a_leak(self):
+        text = 'see <a href="https://x">link</a>'
+        leak = find_html_leak(text)
+        assert leak is not None
+        assert leak.startswith("<a ")
+
+    def test_clean_markdown_is_not_a_leak(self):
+        text = "**bold** and x < y and a -> b"
+        assert find_html_leak(text) is None
+
+    def test_arrow_is_not_a_tag(self):
+        assert find_html_leak("a -> b and c -> d") is None
+
+    def test_comparison_is_not_a_tag(self):
+        assert find_html_leak("if x < y and y > z") is None
+
+    def test_leak_after_fence_is_found(self):
+        text = "```\n<b>safe</b>\n```\nbut <u>this</u> leaks"
+        leak = find_html_leak(text)
+        assert leak is not None
+        assert "<u>" in leak
+
+
+class TestShouldDeadletter:
+    def test_markdown_with_leak_is_deadlettered(self):
+        assert should_deadletter("text/markdown", "Status: <b>OK</b>") is True
+
+    def test_markdown_clean_delivers_normally(self):
+        assert should_deadletter("text/markdown", "**bold** and x < y") is False
+
+    def test_html_payload_skips_check(self):
+        assert should_deadletter("text/html", "<b>anything</b> goes") is False
+
+    def test_html_payload_clean_also_skips(self):
+        assert should_deadletter("text/html", "plain text") is False

--- a/tests/cron/test_payload_type_plumbing.py
+++ b/tests/cron/test_payload_type_plumbing.py
@@ -1,0 +1,18 @@
+"""Tests for cron payload_type plumbing (TKT-0033)."""
+
+import cron.scheduler as scheduler
+
+
+def test_extract_payload_type_default_returns_text_markdown():
+    job = {}
+    assert scheduler._extract_payload_type(job) == "text/markdown"
+
+
+def test_extract_payload_type_explicit_text_html():
+    job = {"payload_type": "text/html"}
+    assert scheduler._extract_payload_type(job) == "text/html"
+
+
+def test_extract_payload_type_invalid_coerces_to_text_markdown():
+    job = {"payload_type": "xml"}
+    assert scheduler._extract_payload_type(job) == "text/markdown"

--- a/tests/cron/test_payload_type_plumbing.py
+++ b/tests/cron/test_payload_type_plumbing.py
@@ -16,3 +16,38 @@ def test_extract_payload_type_explicit_text_html():
 def test_extract_payload_type_invalid_coerces_to_text_markdown():
     job = {"payload_type": "xml"}
     assert scheduler._extract_payload_type(job) == "text/markdown"
+
+
+def test_extract_payload_type_invalid_logs_once_per_job(caplog):
+    """Invalid payload_type warns exactly once per job ID per process (#90844 review)."""
+    import logging
+
+    scheduler._payload_type_warned.discard("job-warn-test")
+    job = {"id": "job-warn-test", "payload_type": "text/md"}
+    with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+        assert scheduler._extract_payload_type(job) == "text/markdown"
+        assert scheduler._extract_payload_type(job) == "text/markdown"
+    warnings = [r for r in caplog.records if "job-warn-test" in r.getMessage()]
+    assert len(warnings) == 1
+    assert "text/md" in warnings[0].getMessage()
+
+
+def test_rotate_deadletter_under_cap_noop(tmp_path):
+    p = tmp_path / "deadletter.jsonl"
+    p.write_text('{"a": 1}\n{"a": 2}\n')
+    scheduler._rotate_deadletter(p)
+    assert p.read_text() == '{"a": 1}\n{"a": 2}\n'
+
+
+def test_rotate_deadletter_over_cap_drops_oldest(tmp_path, monkeypatch):
+    monkeypatch.setattr(scheduler, "_DEADLETTER_MAX_BYTES", 100)
+    p = tmp_path / "deadletter.jsonl"
+    lines = [f'{{"n": {i}, "pad": "xxxxxxxxxx"}}\n' for i in range(20)]
+    p.write_text("".join(lines))
+    assert p.stat().st_size > 100
+    scheduler._rotate_deadletter(p)
+    kept = p.read_text().splitlines()
+    # ~newest half retained, whole lines only, newest record survives
+    assert 5 <= len(kept) <= 15
+    assert '"n": 19' in kept[-1]
+    assert all(l.startswith("{") for l in kept)

--- a/tests/cron/test_template_asserts.py
+++ b/tests/cron/test_template_asserts.py
@@ -1,0 +1,45 @@
+"""Tests for WARN-only unified report template assertions (TKT-0033 Phase A).
+
+``check_report_markers(body)`` returns a list of warning strings. An empty
+list means the report passed every marker check. Violations are returned as
+human-readable warning strings — the delivery pipeline logs them as WARNINGS
+and NEVER blocks delivery on them.
+"""
+
+from __future__ import annotations
+
+from cron.template_asserts import check_report_markers
+
+
+_FULL_REPORT = """\
+Unified Report — 2026-08-17
+Verdict: PASS — all systems nominal
+
+## Gateway
+✅ telegram adapter healthy
+
+## Cron
+✅ 12 jobs ran, 0 failures
+"""
+
+
+def test_full_report_returns_no_warnings():
+    assert check_report_markers(_FULL_REPORT) == []
+
+
+def test_missing_verdict_line_warns_about_verdict():
+    body = "## Gateway\n✅ all good\n"
+    warnings = check_report_markers(body)
+    assert any("verdict" in w.lower() for w in warnings), warnings
+
+
+def test_missing_health_icon_warns_about_icon():
+    body = "Verdict: PASS\n\n## Gateway\nall good\n"
+    warnings = check_report_markers(body)
+    assert any("icon" in w.lower() for w in warnings), warnings
+
+
+def test_missing_section_structure_warns_about_section():
+    body = "Verdict: PASS\n✅ all good, no headers at all\n"
+    warnings = check_report_markers(body)
+    assert any("section" in w.lower() for w in warnings), warnings

--- a/tests/gateway/test_telegram_payload_type.py
+++ b/tests/gateway/test_telegram_payload_type.py
@@ -1,0 +1,199 @@
+"""TelegramAdapter.send() honors a declared payload_type (TKT-0033).
+
+When the delivery metadata declares ``payload_type == "text/html"``, the
+adapter must bypass the MarkdownV2 conversion (``format_message``) entirely
+and send the raw content with ``ParseMode.HTML``.  Anything else — missing
+metadata, missing key, or an unknown payload_type — takes today's
+MarkdownV2 path, byte-identical.
+
+These tests pin the ``_resolve_send_format`` helper contract plus the
+``_VALID_PAYLOAD_TYPES`` constant, and exercise the ``send()`` choke point
+to prove the resolved parse mode is threaded into ``send_message``.
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+def _make_adapter() -> TelegramAdapter:
+    """Bare adapter via __new__ (tests here avoid __init__), matching the
+    codebase idiom; only the attributes _resolve_send_format/send touch are
+    stubbed."""
+    from gateway.config import Platform
+
+    adapter = TelegramAdapter.__new__(TelegramAdapter)
+    adapter._platform = Platform.TELEGRAM
+    adapter.platform = Platform.TELEGRAM
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# _VALID_PAYLOAD_TYPES constant
+# ---------------------------------------------------------------------------
+
+def test_valid_payload_types_constant():
+    assert TelegramAdapter._VALID_PAYLOAD_TYPES == frozenset(
+        {"text/markdown", "text/html"}
+    )
+
+
+# ---------------------------------------------------------------------------
+# _resolve_send_format helper contract
+# ---------------------------------------------------------------------------
+
+def test_resolve_send_format_html_bypasses_markdownv2():
+    """text/html → raw content returned UNCHANGED, parse mode HTML."""
+    adapter = _make_adapter()
+    # Sentinel: if format_message is called at all for HTML payloads, fail.
+    adapter.format_message = MagicMock(
+        side_effect=AssertionError("format_message must not run for text/html")
+    )
+    raw = "<b>bold</b> & <i>italic</i> — chars that MarkdownV2 would escape: ._~"
+    text, parse_mode_name = adapter._resolve_send_format(
+        raw, {"payload_type": "text/html"}
+    )
+    assert text == raw  # byte-identical, no escaping
+    assert parse_mode_name == "HTML"
+    adapter.format_message.assert_not_called()
+
+
+def test_resolve_send_format_default_markdownv2():
+    """metadata=None → MarkdownV2 path (format_message applied)."""
+    adapter = _make_adapter()
+    adapter.format_message = lambda content: f"FMT::{content}"
+    text, parse_mode_name = adapter._resolve_send_format("hello_world", None)
+    assert text == "FMT::hello_world"
+    assert parse_mode_name == "MARKDOWN_V2"
+
+
+def test_resolve_send_format_empty_metadata_markdownv2():
+    """metadata present but no payload_type key → MarkdownV2 path."""
+    adapter = _make_adapter()
+    adapter.format_message = lambda content: f"FMT::{content}"
+    text, parse_mode_name = adapter._resolve_send_format("hi", {"notify": True})
+    assert text == "FMT::hi"
+    assert parse_mode_name == "MARKDOWN_V2"
+
+
+def test_resolve_send_format_unknown_payload_type_falls_back():
+    """Unknown payload_type (e.g. application/json) → MarkdownV2 fallback."""
+    adapter = _make_adapter()
+    adapter.format_message = lambda content: f"FMT::{content}"
+    text, parse_mode_name = adapter._resolve_send_format(
+        "data", {"payload_type": "application/json"}
+    )
+    assert text == "FMT::data"
+    assert parse_mode_name == "MARKDOWN_V2"
+
+
+def test_resolve_send_format_explicit_markdown_payload_type():
+    """Declared text/markdown → MarkdownV2 path (same as default)."""
+    adapter = _make_adapter()
+    adapter.format_message = lambda content: f"FMT::{content}"
+    text, parse_mode_name = adapter._resolve_send_format(
+        "doc", {"payload_type": "text/markdown"}
+    )
+    assert text == "FMT::doc"
+    assert parse_mode_name == "MARKDOWN_V2"
+
+
+# ---------------------------------------------------------------------------
+# send() choke point: resolved parse mode reaches send_message
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_send_html_payload_uses_parse_mode_html_and_raw_text():
+    """End-to-end through send(): text/html payload reaches send_message
+    with ParseMode.HTML and the raw (unescaped) content."""
+    adapter = _make_adapter()
+    adapter._send_path_degraded = False
+    adapter._should_attempt_rich = lambda content, metadata=None: False
+    adapter.format_message = MagicMock(
+        side_effect=AssertionError("format_message must not run for text/html")
+    )
+
+    sent = []
+
+    async def _send_message(**kwargs):
+        sent.append(kwargs)
+        return MagicMock(message_id=42)
+
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(side_effect=_send_message)
+    # Neutralize threading/notification helpers with light defaults.
+    adapter._metadata_thread_id = lambda metadata: None
+    adapter._message_thread_id_for_send = lambda thread_id: None
+    adapter._metadata_reply_to_message_id = lambda metadata: None
+    adapter._is_private_dm_topic_send = lambda chat_id, thread_id, metadata: False
+    adapter._reply_to_mode = "first"
+    adapter._thread_kwargs_for_send = lambda *a, **k: {}
+    adapter._link_preview_kwargs = lambda: {}
+    adapter._notification_kwargs = lambda metadata: {}
+    adapter.send_typing = AsyncMock()
+
+    raw = "<b>Report</b><ul><li>one</li></ul>"
+    result = await adapter.send("123", raw, metadata={"payload_type": "text/html"})
+
+    assert result.success is True
+    assert len(sent) == 1
+    assert sent[0]["text"] == raw  # raw, not MarkdownV2-escaped
+    from telegram.constants import ParseMode  # type: ignore
+
+    assert sent[0]["parse_mode"] == ParseMode.HTML
+    adapter.format_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_default_payload_still_markdown_v2():
+    """Default path (no payload_type) stays byte-identical: format_message
+    output + ParseMode.MARKDOWN_V2."""
+    adapter = _make_adapter()
+    adapter._send_path_degraded = False
+    adapter._should_attempt_rich = lambda content, metadata=None: False
+    adapter.format_message = lambda content: f"FMT::{content}"
+
+    sent = []
+
+    async def _send_message(**kwargs):
+        sent.append(kwargs)
+        return MagicMock(message_id=7)
+
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(side_effect=_send_message)
+    adapter._metadata_thread_id = lambda metadata: None
+    adapter._message_thread_id_for_send = lambda thread_id: None
+    adapter._metadata_reply_to_message_id = lambda metadata: None
+    adapter._is_private_dm_topic_send = lambda chat_id, thread_id, metadata: False
+    adapter._reply_to_mode = "first"
+    adapter._thread_kwargs_for_send = lambda *a, **k: {}
+    adapter._link_preview_kwargs = lambda: {}
+    adapter._notification_kwargs = lambda metadata: {}
+    adapter.send_typing = AsyncMock()
+
+    result = await adapter.send("123", "plain text", metadata=None)
+
+    assert result.success is True
+    assert len(sent) == 1
+    assert sent[0]["text"] == "FMT::plain text"
+    from telegram.constants import ParseMode  # type: ignore
+
+    assert sent[0]["parse_mode"] == ParseMode.MARKDOWN_V2

--- a/tests/gateway/test_telegram_payload_type.py
+++ b/tests/gateway/test_telegram_payload_type.py
@@ -117,6 +117,129 @@ def test_resolve_send_format_explicit_markdown_payload_type():
 
 
 # ---------------------------------------------------------------------------
+# _format_parse_fallback_text helper (TKT-0033 never-drop fallback)
+# ---------------------------------------------------------------------------
+
+def test_format_parse_fallback_text_strips_html_tags():
+    """The plain-text parse fallback strips HTML tags so a rejected HTML
+    payload is never dropped — it is resent as legible plain text."""
+    adapter = _make_adapter()
+    cleaned = adapter._format_parse_fallback_text("<b>unclosed and *raw*")
+    assert "<b>" not in cleaned
+    assert "<" not in cleaned
+    assert "unclosed" in cleaned
+
+
+def test_format_parse_fallback_text_preserves_inner_text():
+    """Tag stripping keeps the human-readable text between tags."""
+    adapter = _make_adapter()
+    cleaned = adapter._format_parse_fallback_text(
+        "<b>Report</b><ul><li>one</li><li>two</li></ul>"
+    )
+    assert "Report" in cleaned
+    assert "one" in cleaned
+    assert "two" in cleaned
+    assert "<" not in cleaned
+    assert ">" not in cleaned
+
+
+def test_format_parse_fallback_text_plain_input_unchanged():
+    """Content with no tags passes through byte-identical."""
+    adapter = _make_adapter()
+    assert adapter._format_parse_fallback_text("plain text 123") == "plain text 123"
+
+
+# ---------------------------------------------------------------------------
+# send() never-drop: parse BadRequest on the declared format → plain text
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_send_html_parse_bad_request_falls_back_to_plain_text():
+    """A parse BadRequest on the HTML path must NOT drop the message: the
+    adapter resends with parse_mode=None and tag-stripped text (TKT-0033)."""
+    import telegram.error as tg_error
+
+    adapter = _make_adapter()
+    adapter._send_path_degraded = False
+    adapter._should_attempt_rich = lambda content, metadata=None: False
+    adapter.format_message = MagicMock(
+        side_effect=AssertionError("format_message must not run for text/html")
+    )
+
+    sent = []
+
+    async def _send_message(**kwargs):
+        sent.append(kwargs)
+        if kwargs.get("parse_mode") is not None:
+            raise tg_error.BadRequest("Can't parse entities: unsupported start tag")
+        return MagicMock(message_id=99)
+
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(side_effect=_send_message)
+    adapter._metadata_thread_id = lambda metadata: None
+    adapter._message_thread_id_for_send = lambda thread_id: None
+    adapter._metadata_reply_to_message_id = lambda metadata: None
+    adapter._is_private_dm_topic_send = lambda chat_id, thread_id, metadata: False
+    adapter._reply_to_mode = "first"
+    adapter._thread_kwargs_for_send = lambda *a, **k: {}
+    adapter._link_preview_kwargs = lambda: {}
+    adapter._notification_kwargs = lambda metadata: {}
+    adapter.send_typing = AsyncMock()
+
+    raw = "<b>Report</b><ul><li>one</li></ul>"
+    result = await adapter.send("123", raw, metadata={"payload_type": "text/html"})
+
+    # Message must be delivered (never dropped): first attempt HTML, then plain.
+    assert result.success is True
+    assert len(sent) == 2
+    assert sent[0]["parse_mode"] is not None  # declared-format attempt
+    assert sent[1]["parse_mode"] is None  # plain-text fallback
+    assert "<b>" not in sent[1]["text"]
+    assert "<" not in sent[1]["text"]
+    assert "Report" in sent[1]["text"]
+    assert "one" in sent[1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_send_markdownv2_parse_bad_request_still_falls_back_to_plain_text():
+    """The generalized fallback must still cover the MarkdownV2 path (the
+    pre-existing behavior), driven by the attempted parse mode."""
+    import telegram.error as tg_error
+
+    adapter = _make_adapter()
+    adapter._send_path_degraded = False
+    adapter._should_attempt_rich = lambda content, metadata=None: False
+    adapter.format_message = lambda content: f"FMT::{content}"
+
+    sent = []
+
+    async def _send_message(**kwargs):
+        sent.append(kwargs)
+        if kwargs.get("parse_mode") is not None:
+            raise tg_error.BadRequest("Can't parse entities in message text")
+        return MagicMock(message_id=100)
+
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(side_effect=_send_message)
+    adapter._metadata_thread_id = lambda metadata: None
+    adapter._message_thread_id_for_send = lambda thread_id: None
+    adapter._metadata_reply_to_message_id = lambda metadata: None
+    adapter._is_private_dm_topic_send = lambda chat_id, thread_id, metadata: False
+    adapter._reply_to_mode = "first"
+    adapter._thread_kwargs_for_send = lambda *a, **k: {}
+    adapter._link_preview_kwargs = lambda: {}
+    adapter._notification_kwargs = lambda metadata: {}
+    adapter.send_typing = AsyncMock()
+
+    result = await adapter.send("123", "hello", metadata=None)
+
+    assert result.success is True
+    assert len(sent) == 2
+    assert sent[1]["parse_mode"] is None
+    assert "hello" in sent[1]["text"]
+
+
+# ---------------------------------------------------------------------------
 # send() choke point: resolved parse mode reaches send_message
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_telegram_standalone_payload_type.py
+++ b/tests/gateway/test_telegram_standalone_payload_type.py
@@ -1,0 +1,114 @@
+"""Standalone _send_telegram honors explicit payload_type (TKT-0033, Option 1).
+
+The legacy standalone path auto-detected HTML via a content regex and picked
+ParseMode.HTML when matched. That sniff is removed: the helper now resolves
+parse mode exclusively from the declared ``payload_type`` contract, reusing
+``TelegramAdapter._resolve_send_format`` so there is one source of truth.
+
+- ``payload_type="text/html"`` → raw content + ParseMode.HTML
+- ``payload_type="text/markdown"`` (default) → MarkdownV2 conversion + ParseMode.MARKDOWN_V2
+- Content containing ``<b>`` with no declared payload_type must NOT be
+  sniffed into HTML; it goes MarkdownV2 (and would be caught upstream by the
+  Task 4 validator if it truly was HTML).
+"""
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# python-telegram-bot is an optional dep — skip when absent.
+pytest.importorskip("telegram", reason="python-telegram-bot not installed")
+
+
+def _install_telegram_mock(monkeypatch, bot):
+    parse_mode = SimpleNamespace(MARKDOWN_V2="MarkdownV2", HTML="HTML")
+    constants_mod = SimpleNamespace(ParseMode=parse_mode)
+    telegram_mod = SimpleNamespace(Bot=lambda token: bot, constants=constants_mod)
+    monkeypatch.setitem(sys.modules, "telegram", telegram_mod)
+    monkeypatch.setitem(sys.modules, "telegram.constants", constants_mod)
+
+
+def _make_bot():
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+    bot.send_photo = AsyncMock()
+    bot.send_video = AsyncMock()
+    bot.send_voice = AsyncMock()
+    bot.send_audio = AsyncMock()
+    bot.send_document = AsyncMock()
+    return bot
+
+
+class TestSendTelegramPayloadTypeContract:
+    """_send_telegram must resolve parse mode from payload_type, not content."""
+
+    def test_html_payload_type_uses_html_parse_mode(self, monkeypatch):
+        """Declared text/html → raw content + ParseMode.HTML, no sniffing."""
+        from tools.send_message_tool import _send_telegram
+
+        bot = _make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        raw = "<b>Report</b><ul><li>one</li></ul>"
+        result = asyncio.run(
+            _send_telegram("tok", "123", raw, payload_type="text/html")
+        )
+
+        assert result["success"] is True
+        bot.send_message.assert_awaited_once()
+        kwargs = bot.send_message.await_args.kwargs
+        assert kwargs["parse_mode"] == "HTML"
+        assert kwargs["text"] == raw  # raw, not MarkdownV2-escaped
+
+    def test_default_payload_type_uses_markdownv2(self, monkeypatch):
+        """No payload_type declared → MarkdownV2 path, even if content has <b>."""
+        from tools.send_message_tool import _send_telegram
+
+        bot = _make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(
+            _send_telegram("tok", "123", "<b>Hello</b> world")
+        )
+
+        assert result["success"] is True
+        bot.send_message.assert_awaited_once()
+        kwargs = bot.send_message.await_args.kwargs
+        assert kwargs["parse_mode"] == "MarkdownV2"
+        # The content must have been through format_message (MarkdownV2 escaped)
+        assert kwargs["text"] != "<b>Hello</b> world"
+
+    def test_explicit_markdown_payload_type_uses_markdownv2(self, monkeypatch):
+        """Declared text/markdown → MarkdownV2 path, even if content has <b>."""
+        from tools.send_message_tool import _send_telegram
+
+        bot = _make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(
+            _send_telegram("tok", "123", "<b>Hello</b> world", payload_type="text/markdown")
+        )
+
+        assert result["success"] is True
+        bot.send_message.assert_awaited_once()
+        kwargs = bot.send_message.await_args.kwargs
+        assert kwargs["parse_mode"] == "MarkdownV2"
+
+    def test_unknown_payload_type_falls_back_to_markdownv2(self, monkeypatch):
+        """Unknown payload_type (e.g. application/json) → MarkdownV2 fallback."""
+        from tools.send_message_tool import _send_telegram
+
+        bot = _make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(
+            _send_telegram("tok", "123", "data", payload_type="application/json")
+        )
+
+        assert result["success"] is True
+        bot.send_message.assert_awaited_once()
+        kwargs = bot.send_message.await_args.kwargs
+        assert kwargs["parse_mode"] == "MarkdownV2"

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -717,9 +717,9 @@ class TestSendToPlatformWhatsapp:
         assert _call.args[2] == "hello from hermes"
 
 
-class TestSendTelegramHtmlDetection:
-    """Verify that messages containing HTML tags are sent with parse_mode=HTML
-    and that plain / markdown messages use MarkdownV2."""
+class TestSendTelegramPayloadType:
+    """Verify that _send_telegram resolves parse mode from payload_type,
+    not from content sniffing (TKT-0033, Option 1)."""
 
     def _make_bot(self):
         bot = MagicMock()
@@ -731,7 +731,21 @@ class TestSendTelegramHtmlDetection:
         bot.send_document = AsyncMock()
         return bot
 
-    def test_html_message_uses_html_parse_mode(self, monkeypatch):
+    def test_html_payload_type_uses_html_parse_mode(self, monkeypatch):
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        asyncio.run(
+            _send_telegram("tok", "123", "<b>Hello</b> world", payload_type="text/html")
+        )
+
+        bot.send_message.assert_awaited_once()
+        kwargs = bot.send_message.await_args.kwargs
+        assert kwargs["parse_mode"] == "HTML"
+        assert kwargs["text"] == "<b>Hello</b> world"
+
+    def test_default_payload_type_uses_markdownv2(self, monkeypatch):
+        """Content with <b> but no declared payload_type must go MarkdownV2."""
         bot = self._make_bot()
         _install_telegram_mock(monkeypatch, bot)
 
@@ -741,8 +755,8 @@ class TestSendTelegramHtmlDetection:
 
         bot.send_message.assert_awaited_once()
         kwargs = bot.send_message.await_args.kwargs
-        assert kwargs["parse_mode"] == "HTML"
-        assert kwargs["text"] == "<b>Hello</b> world"
+        assert kwargs["parse_mode"] == "MarkdownV2"
+        assert kwargs["text"] != "<b>Hello</b> world"  # MarkdownV2-escaped
 
 
     def test_transient_bad_gateway_retries_text_send(self, monkeypatch):
@@ -1679,7 +1693,7 @@ class TestSendViaAdapterStandaloneFallback:
         assert result == {"success": True, "message_id": "ntfy-id"}
         assert recorded["chat_id"] == "alerts-channel"
         assert recorded["content"] == "done"
-        assert recorded["metadata"] == {"publish_topic": "alerts-channel"}
+        assert recorded["metadata"] == {"publish_topic": "alerts-channel", "payload_type": "text/markdown"}
 
 
     @pytest.mark.asyncio

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -897,6 +897,7 @@ async def _send_via_adapter(
                 thread_id=thread_id,
                 media_files=media_files,
                 force_document=force_document,
+                payload_type=payload_type,
             )
         except asyncio.CancelledError:
             raise
@@ -1006,6 +1007,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             thread_id=thread_id,
             disable_link_previews=disable_link_previews,
             force_document=force_document,
+            payload_type=payload_type,
         )
 
     # --- Discord: chunked delivery via the registry's standalone_sender_fn.
@@ -1335,35 +1337,29 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False, payload_type: str = "text/markdown"):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
-    so that bold, links, and headers render correctly.  If the message
-    already contains HTML tags, it is sent with ``parse_mode='HTML'``
-    instead, bypassing MarkdownV2 conversion.
+    so that bold, links, and headers render correctly.  A declared
+    ``payload_type == "text/html"`` bypasses MarkdownV2 conversion entirely
+    and sends the raw content with ``parse_mode='HTML'``.  Anything else
+    (missing/unknown payload_type) takes the MarkdownV2 path.
     """
     try:
         from telegram import Bot
         from telegram.constants import ParseMode
 
-        # Auto-detect HTML tags — if present, skip MarkdownV2 and send as HTML.
-        # Inspired by github.com/ashaney — PR #1568.
-        _has_html = bool(re.search(r'<[a-zA-Z/][^>]*>', message))
-
-        if _has_html:
-            formatted = message
-            send_parse_mode = ParseMode.HTML
-        else:
-            # Reuse the gateway adapter's format_message for markdown→MarkdownV2
-            try:
-                from plugins.platforms.telegram.adapter import TelegramAdapter
-                _adapter = TelegramAdapter.__new__(TelegramAdapter)
-                formatted = _adapter.format_message(message)
-            except Exception:
-                # Fallback: send as-is if formatting unavailable
-                formatted = message
-            send_parse_mode = ParseMode.MARKDOWN_V2
+        # Resolve (text, parse_mode_name) via the single contract in
+        # TelegramAdapter._resolve_send_format — no content sniffing.
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+        _adapter = TelegramAdapter.__new__(TelegramAdapter)
+        formatted, send_parse_mode_name = _adapter._resolve_send_format(
+            message, {"payload_type": payload_type}
+        )
+        send_parse_mode = (
+            ParseMode.HTML if send_parse_mode_name == "HTML" else ParseMode.MARKDOWN_V2
+        )
 
         # Honour a configured proxy (telegram.proxy_url in config.yaml, exported
         # as TELEGRAM_PROXY env var by load_gateway_config). Without this, the
@@ -1487,7 +1483,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                             send_parse_mode,
                             _sanitize_error_text(md_error),
                         )
-                        if not _has_html:
+                        if send_parse_mode_name != "HTML":
                             try:
                                 from plugins.platforms.telegram.adapter import _strip_mdv2
                                 plain = _strip_mdv2(chunk)
@@ -1609,7 +1605,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                             )
                             f.seek(0)
                             media_kwargs.pop("parse_mode", None)
-                            if not _has_html and media_kwargs.get("caption"):
+                            if send_parse_mode_name != "HTML" and media_kwargs.get("caption"):
                                 try:
                                     from plugins.platforms.telegram.adapter import _strip_mdv2
                                     media_kwargs["caption"] = _strip_mdv2(media_kwargs["caption"])

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -836,6 +836,7 @@ async def _send_via_adapter(
     thread_id=None,
     media_files=None,
     force_document=False,
+    payload_type: str = "text/markdown",
 ):
     """Send a message via a live gateway adapter, with a standalone fallback
     for out-of-process callers (e.g. cron running separately from the gateway).
@@ -868,6 +869,7 @@ async def _send_via_adapter(
                     metadata["thread_id"] = thread_id
                 if platform_name == "ntfy" and chat_id:
                     metadata["publish_topic"] = chat_id
+                metadata["payload_type"] = payload_type
                 if not metadata:
                     metadata = None
                 result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
@@ -922,7 +924,7 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, args=None):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, args=None, payload_type: str = "text/markdown"):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -1241,6 +1243,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 thread_id=thread_id,
                 media_files=media_files if is_last else [],
                 force_document=force_document,
+                payload_type=payload_type,
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
@@ -1309,6 +1312,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 thread_id=thread_id,
                 media_files=media_files,
                 force_document=force_document,
+                payload_type=payload_type,
             )
 
         if isinstance(result, dict) and result.get("error"):

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -345,6 +345,20 @@ cron:
 
 ## Delivery options
 
+### Output format (`payload_type`)
+
+Cron output is treated as `text/markdown` by default. Jobs that intentionally emit HTML (e.g. a report rendered for an HTML-capable channel) must declare it explicitly:
+
+```
+payload_type: "text/html"
+```
+
+**Guard behavior (since the payload-type contract):** under the default `text/markdown`, a delivery containing raw HTML tags *outside* code fences is **dead-lettered, not sent** — the message is recorded to `~/.hermes/cron/deadletter.jsonl` (preview + SHA-256, capped at 1 MiB with drop-oldest rotation) and the run reports the dead-letter instead of leaking broken markup to the user.
+
+**Writing safe reports:** literal angle-bracket tokens like `<model>`, `<your-api-key>`, or `<host>` placeholders will trip this guard under the default payload type. Either wrap them in backticks (`` `<host>` `` — inline code is exempt), or declare `payload_type: "text/html"` for the job.
+
+Invalid `payload_type` values (e.g. `text/md`) are coerced to `text/markdown` with a one-time warning naming the job.
+
 When scheduling jobs, you specify where the output goes:
 
 | Option | Description | Example |


### PR DESCRIPTION
# fix(cron/telegram): kill the HTML-leak class via an explicit payload_type delivery contract (TKT-0033)

## The bug (reported symptom)

A scheduled-job escalation (`OPS-20260815-01`) arrived in Telegram with raw `<b>`/`<i>`/`<code>` tags rendered as **literal text** instead of formatting.

**Root cause — a two-format doctrine violation across the two cron delivery paths:**

| Path | Route | Format handling before this PR |
|---|---|---|
| **Live gateway** (the leak path) | `_deliver_result` → `DeliveryRouter` → `adapter.send()` → `format_message()` | Unconditionally forced `ParseMode.MARKDOWN_V2`. Zero HTML awareness → raw tags leaked as literal text. |
| **Standalone** (cron separate from gateway) | `_deliver_result` → `_send_to_platform` → `_send_telegram` | Auto-**detected** HTML via regex `<[a-zA-Z/][^>]*>` and sent `ParseMode.HTML`. |

Two paths, two different mechanisms, one of them a content-sniffing heuristic. That's the bug class.

## The fix — one explicit `payload_type` contract

A MIME-style `payload_type` (`text/markdown` default | `text/html`) is **declared by the producer** and **honored by the delivery layer**. No content-sniffing anywhere. The contract flows:

```
cron job config (payload_type)
  → scheduler _deliver_result  (_extract_payload_type, coerces unknown → text/markdown)
  → delivery metadata (live) / _send_to_platform kwarg (standalone)
  → TelegramAdapter._resolve_send_format  (single source of truth)
  → ParseMode.HTML (declared html) | ParseMode.MARKDOWN_V2 (default)
```

**Design decision (King verdict + user-approved Option 1):** explicit config contract over auto-detect heuristics. Determinism is non-negotiable at a delivery choke point; a sniff can false-positive (route Markdown containing a legit `<` to HTML and render broken) or false-negative (miss a malformed tag). The standalone regex sniff is **removed**, not kept — both paths use the same contract.

## What changed (behavior contracts)

1. **`payload_type` plumbing** — `_extract_payload_type(job)` (unknown values coerce to `text/markdown`); injected into both live `route_metadata` branches and both standalone `_send_to_platform` call sites. `tools/send_message_tool.py` threads it into adapter metadata.
2. **Adapter honors `payload_type`** — `_resolve_send_format(content, metadata)` returns the text + parse mode; `text/html` bypasses `format_message` (MarkdownV2) entirely and sends the raw HTML payload. Default path is **byte-identical** to before.
3. **Never-drop fail-safe** — if Telegram rejects the declared-format send with a parse `BadRequest`, degrade to plain text (`_format_parse_fallback_text` strips tags, `parse_mode=None`) and log a high-severity alert. Delivery supersedes formatting; a message is never dropped on a parse rejection.
4. **Code-block-aware HTML validator + dead-letter** — `cron/format_validator.py`: when a job declares `text/markdown` but emits raw HTML **outside code fences**, hard-fail into a dead-letter record (`~/.hermes/cron/deadletter.jsonl`) instead of leaking. Fenced ``` blocks and inline `code` are stripped before scanning, so legitimate HTML-in-code is not flagged; the tag regex requires a letter after `<`, so `x < y` / `a -> b` are not tags. (This is the fail-loud net for the Option-1 behavior change below.)
5. **WARN-only template asserts** — `cron/template_asserts.py`: checks a report for required markers (verdict line, section structure, health icon) and logs violations as warnings. Never blocks delivery.
6. **Option 1 — sniff removed** — the standalone `_send_telegram` regex auto-detect is deleted; it now resolves via the same `_resolve_send_format` (reused, not duplicated). `TestSendTelegramHtmlDetection` → `TestSendTelegramPayloadType` (the old test pinned the sniff behavior).

### ⚠️ Intentional behavior change
Content containing HTML with **no declared `payload_type`** now goes MarkdownV2 instead of being sniffed to HTML. Such undeclared HTML is caught upstream by the dead-letter validator (item 4) — fail-loud instead of silently rescued by a regex.

## Backward compatibility
Any job that does **not** declare `payload_type` takes the `text/markdown` default — **byte-identical** to today's behavior. Zero config change required for existing jobs.

## Tests
- **RED→GREEN TDD** on every task; each helper watched failing first.
- New tests: `test_payload_type_plumbing.py` (3), `test_telegram_payload_type.py` (13), `test_format_validator.py` (18), `test_template_asserts.py` (4), `test_telegram_standalone_payload_type.py` (4); `test_send_message_tool.py` updated for the contract.
- **Full sweeps:** `tests/cron/` 796 passed 0 failed; `tests/gateway/` 5811 passed 0 failed. The only 2 gateway failures (`test_wecom_callback.py`) reproduce **identically on clean `main`** — pre-existing, unrelated (verified by checking out `main` in the same venv).

## Files
`cron/scheduler.py`, `cron/format_validator.py` (new), `cron/template_asserts.py` (new), `plugins/platforms/telegram/adapter.py`, `tools/send_message_tool.py`, + 5 new test files, 1 updated. **+850 / −41.**

## Out of scope / follow-ups
- Dead-letter `deadletter.jsonl` is append-only; a rotation/replay story is future work (WARN + persist is enough to never lose a message).
- Phase B (TKT-0034): semantic QA agents — separate ticket, after this lands.
