### PR TITLE
feat(web): keyless ring exhaustion falls back to a keyed backstop, never sticky

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -360,6 +360,16 @@ DEFAULT_CONFIG = {
         # keyless ring; the next call tries the chosen backend again (no sticky failover). Off when
         # keyless_fallback is false.
         "keyless_rescue": True,
+        # One-shot keyed backstop (mirror of keyless_rescue): when a call rode the keyless ring and
+        # EVERY vendor came back throttled, retry that one call on the vendor's keyed path if an API
+        # key is present. The next call starts on the free ring again (no sticky failover).
+        # OPT-IN (default false): it is the only path in the web stack that can spend money the
+        # operator did not ask to spend. The single reachable population is a vendor pinned "free"
+        # WITH a key on file -- tier "auto" with a key routes keyed and never touches the ring, so it
+        # can't reach the backstop at all. A free pin is the strongest available signal that the user
+        # wants the free endpoint, so turning this on has to be their decision. Off when
+        # keyless_fallback is false.
+        "keyed_backstop": False,
         # Per-vendor tier for vendors with both a keyless free endpoint and a keyed paid path (exa,
         # parallel, firecrawl, keenable; tavily is opt-in keyless via `hermes tools`, not a ring
         # member). Set by the `hermes tools` picker. "free" = always anonymous endpoint even with a

--- a/plugins/web/keyless_mcp.py
+++ b/plugins/web/keyless_mcp.py
@@ -11,6 +11,8 @@ import json
 import logging
 import threading
 import uuid
+from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import Any, Callable, Dict, List, Optional
 
 from plugins.web._common import document as _page, page_error as _page_error, search_fail, search_ok, web_hit as _row
@@ -39,6 +41,46 @@ _VENDOR_HINTS = {
     "exa": ("Exa", "EXA_API_KEY", "https://exa.ai"), "parallel": ("Parallel", "PARALLEL_API_KEY", "https://parallel.ai"),
     "firecrawl": ("Firecrawl", "FIRECRAWL_API_KEY", "https://firecrawl.dev"), "keenable": ("Keenable", "KEENABLE_API_KEY", "https://keenable.ai"),
 }
+
+# Emitted by search_with_failover() once every eligible vendor answered with
+# a rate-limit-shaped error, and matched by ring_exhausted(). Single source
+# of truth so the producer and the consumer can never drift apart.
+_RING_EXHAUSTED_MARKER = "all keyless vendors throttled"
+
+# Names the one vendor whose keyless routing is suspended for the current
+# call. A ContextVar (not a module global) so concurrent web calls on other
+# threads/tasks are unaffected, and so the override cannot leak past the
+# `with` block that set it.
+_forced_keyed: "ContextVar[Optional[str]]" = ContextVar(
+    "hermes_web_forced_keyed", default=None
+)
+
+
+@contextmanager
+def force_keyed(name: str):
+    """Temporarily force provider *name* onto its keyed path.
+
+    Used by the keyed backstop so it can re-run a provider's own
+    ``search``/``extract`` without duplicating that provider's SDK logic.
+    Scoped to the calling context and always reset, including on error.
+
+    **Non-reentrancy contract.** The override is keyed on the vendor *name*,
+    so an unrelated provider running inside the block is unaffected. It is
+    inherited, however, by any nested call for the *same* vendor. No shipped
+    provider does this: every vendor's ``use_keyless`` gate returns
+    immediately on the keyless branch, and the keyed branch calls the vendor
+    SDK directly rather than re-entering the ring. A provider that ever
+    nests a same-vendor ring dispatch inside its keyed path would spend a
+    second time on one backstop, so that condition is pinned by
+    ``TestForcedKeyedReentrancy`` in
+    ``tests/tools/test_web_keyed_backstop.py`` — clear and restore the
+    ContextVar around such a boundary if one is ever introduced.
+    """
+    token = _forced_keyed.set(name)
+    try:
+        yield
+    finally:
+        _forced_keyed.reset(token)
 
 
 def _is_rate_limitish(message: str) -> bool:
@@ -108,8 +150,11 @@ def provider_tier(name: str) -> str:
 
 
 def use_keyless(name: str, api_key: str) -> bool:
-    """Single chokepoint for search + extract: ``free`` → keyless even with a key; ``paid`` → keyed even
-    without one (the keyed path raises its usual missing-key error); ``auto`` → keyless only when no key + tier enabled."""
+    """Single chokepoint for search + extract: a :func:`force_keyed` override for *name* → keyed;
+    ``free`` → keyless even with a key; ``paid`` → keyed even without one (the keyed path raises its
+    usual missing-key error); ``auto`` → keyless only when no key + tier enabled."""
+    if _forced_keyed.get() == name:
+        return False
     tier = provider_tier(name)
     if tier in ("free", "paid"):
         return tier == "free"
@@ -366,10 +411,39 @@ def search_with_failover(name: str, query: str, limit: int = 5) -> Dict[str, Any
     if not order:
         return search_fail(_ALL_PAID_MSG)
     if exhausted:
-        result["error"] = f"{result.get('error', '')} (all keyless vendors throttled: {', '.join(order)})"
+        # Use the constant, not a literal: ring_exhausted() greps for this exact
+        # marker to decide whether a keyed backstop is warranted, so the two must
+        # not drift apart.
+        result["error"] = f"{result.get('error', '')} ({_RING_EXHAUSTED_MARKER}: {', '.join(order)})"
     elif result.get("success") and vendor != name:
         result.setdefault("data", {})["served_by"] = vendor
     return result
+
+
+def ring_exhausted(error: str) -> bool:
+    """True when *error* is the ring's own "every vendor throttled" verdict.
+
+    :func:`search_with_failover` appends a fixed marker once it has walked
+    every eligible vendor and each answered with a rate-limit-shaped error.
+    That exact condition — and only that one — means the free tier has no
+    capacity left to offer, so a keyed backstop is worth attempting. A
+    single vendor's 500, a malformed query, or a partial walk all stop the
+    ring early and must NOT be treated as exhaustion.
+    """
+    return _RING_EXHAUSTED_MARKER in (error or "").lower()
+
+
+def extract_ring_exhausted(results: List[Dict[str, Any]]) -> bool:
+    """True when every extract result carries a rate-limit-shaped error.
+
+    The extract ring returns per-URL dicts rather than a single error
+    string, so exhaustion is "the whole batch came back throttled" — the
+    same condition that made :func:`extract_with_failover` advance past
+    its final vendor. An empty batch is not exhaustion.
+    """
+    if not results:
+        return False
+    return all(_is_rate_limitish(r.get("error", "")) for r in results)
 
 
 def extract_with_failover(name: str, urls: List[str]) -> List[Dict[str, Any]]:

--- a/tests/tools/test_web_keyed_backstop.py
+++ b/tests/tools/test_web_keyed_backstop.py
@@ -1,0 +1,503 @@
+"""One-shot keyed backstop: a keyless call whose ring came back fully
+throttled retries ONCE on the vendor's keyed path; the NEXT call starts on
+the free ring again.
+
+Mirror image of the keyless rescue in test_web_keyless_rescue.py.
+
+Covers:
+- eligibility: only fires on the ring's own exhaustion verdict, only for a
+  keyless-mode ring vendor that actually has an API key, never for a vendor
+  pinned "free", and never when a keyed call failed (that's the other
+  rescue's job)
+- search dispatcher: exhausted ring → keyed retry, annotated with
+  backstopped_from + backend_error
+- statelessness: the next dispatch goes back to the keyless ring
+- force_keyed: scoped, resets on exit AND on exception, and does not leak
+  to other vendors
+- extract dispatcher: whole-batch throttling backstops; a partial failure
+  and a policy block do not
+- backstop failure: the original ring error survives with a note appended
+"""
+
+import asyncio
+import json
+from unittest.mock import patch
+
+import pytest
+
+import tools.web_tools as web_tools
+from tools import web_tools_rescue
+from plugins.web import keyless_mcp
+
+RING_EXHAUSTED = (
+    "429 rate limit (all keyless vendors throttled: exa, parallel, tavily, "
+    "firecrawl, keenable)"
+)
+
+
+class _KeylessExhaustedProvider:
+    """Ring vendor whose keyless path reports every vendor throttled.
+
+    Models the real dispatcher shape: the provider routes keyless by
+    default and only takes its keyed branch while :func:`force_keyed` is
+    active — which is exactly what the backstop does. Its keyed path
+    succeeds, so the backstop has something real to fall back to.
+    """
+
+    name = "exa"
+    display_name = "Exa"
+
+    def __init__(self):
+        self.search_calls = []
+        self.extract_calls = []
+
+    def supports_search(self):
+        return True
+
+    def supports_extract(self):
+        return True
+
+    def is_available(self):
+        return True
+
+    def _keyed(self):
+        """True only under an active force_keyed override for this vendor.
+
+        The real providers ask ``use_keyless()``; here we read the override
+        directly so the double stays honest regardless of how the ambient
+        tier resolves in a given test.
+        """
+        return keyless_mcp._forced_keyed.get() == self.name
+
+    def search(self, query, limit=5):
+        keyed = self._keyed()
+        self.search_calls.append("keyed" if keyed else "keyless")
+        if keyed:
+            return {
+                "success": True,
+                "data": {"web": [{"url": "https://k", "title": "keyed result"}]},
+            }
+        return {"success": False, "error": RING_EXHAUSTED}
+
+    def extract(self, urls, **kwargs):
+        keyed = self._keyed()
+        self.extract_calls.append("keyed" if keyed else "keyless")
+        if keyed:
+            return [
+                {"url": u, "title": "keyed", "content": "body", "error": ""}
+                for u in urls
+            ]
+        return [
+            {"url": u, "title": "", "content": "", "error": "429 rate limit"}
+            for u in urls
+        ]
+
+
+@pytest.fixture(autouse=True)
+def _keyless_exa_env(monkeypatch):
+    """Exa pinned to the free tier with a key on file, backstop opted in.
+
+    This is the backstop's real domain: a ``free`` pin is the only config
+    that runs the keyless ring while an API key exists to fall back to.
+
+    ``keyed_backstop`` is set True explicitly because the feature ships
+    OPT-IN (default false). Tests that assert the default itself override
+    this fixture with an empty config -- see ``TestOptInDefault``.
+    """
+    monkeypatch.setattr(
+        "agent.web_search_provider.get_provider_env",
+        lambda var: "sk-test-key" if var == "EXA_API_KEY" else "",
+        raising=True,
+    )
+    monkeypatch.setattr(
+        web_tools, "_load_web_config", lambda: {"keyed_backstop": True}
+    )
+    monkeypatch.setattr(web_tools_rescue, "_backstop_key_for",
+                        lambda name: "sk-test-key" if name == "exa" else "")
+    monkeypatch.setattr(keyless_mcp, "provider_tier", lambda name: "free")
+    monkeypatch.setattr(keyless_mcp, "keyless_enabled", lambda: True)
+    monkeypatch.setattr(
+        "agent.web_search_registry._keyless_tier_enabled", lambda: True
+    )
+    monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+
+
+def _dispatch_search(monkeypatch, provider, query="q", limit=2):
+    monkeypatch.setattr(
+        "agent.web_search_registry.get_provider", lambda name: provider
+    )
+    return json.loads(web_tools.web_search_tool(query, limit=limit))
+
+
+def _dispatch_extract(monkeypatch, provider, urls):
+    monkeypatch.setattr(
+        "agent.web_search_registry.get_provider", lambda name: provider
+    )
+
+    async def _allow_all(url, **kwargs):
+        return True
+
+    monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_all)
+    return asyncio.run(web_tools.web_extract_tool(urls))
+
+
+# ── force_keyed contextvar ───────────────────────────────────────────────
+
+def test_force_keyed_scopes_and_resets():
+    assert keyless_mcp.use_keyless("exa", "") is True
+    with keyless_mcp.force_keyed("exa"):
+        assert keyless_mcp.use_keyless("exa", "") is False
+    assert keyless_mcp.use_keyless("exa", "") is True
+
+
+def test_force_keyed_resets_on_exception():
+    with pytest.raises(RuntimeError):
+        with keyless_mcp.force_keyed("exa"):
+            raise RuntimeError("boom")
+    assert keyless_mcp.use_keyless("exa", "") is True, "override leaked"
+
+
+def test_force_keyed_does_not_affect_other_vendors():
+    with keyless_mcp.force_keyed("exa"):
+        assert keyless_mcp.use_keyless("parallel", "") is True
+
+
+# ── exhaustion detection ─────────────────────────────────────────────────
+
+def test_ring_exhausted_matches_only_the_real_verdict():
+    assert keyless_mcp.ring_exhausted(RING_EXHAUSTED) is True
+    assert keyless_mcp.ring_exhausted("429 rate limit") is False
+    assert keyless_mcp.ring_exhausted("HTTP 500 boom") is False
+    assert keyless_mcp.ring_exhausted("") is False
+
+
+def test_extract_ring_exhausted_requires_all_throttled():
+    throttled = [{"error": "429 rate limit"}, {"error": "too many requests"}]
+    mixed = [{"error": "429 rate limit"}, {"error": "404 not found"}]
+    assert keyless_mcp.extract_ring_exhausted(throttled) is True
+    assert keyless_mcp.extract_ring_exhausted(mixed) is False
+    assert keyless_mcp.extract_ring_exhausted([]) is False
+
+
+# ── eligibility ──────────────────────────────────────────────────────────
+
+def test_eligible_for_exhausted_keyless_ring_vendor():
+    assert web_tools_rescue._backstop_eligible(
+        _KeylessExhaustedProvider(), RING_EXHAUSTED
+    ) is True
+
+
+def test_not_eligible_for_a_single_vendor_error():
+    assert web_tools_rescue._backstop_eligible(
+        _KeylessExhaustedProvider(), "HTTP 500 upstream exploded"
+    ) is False
+
+
+def test_not_eligible_without_an_api_key(monkeypatch):
+    monkeypatch.setattr(web_tools_rescue, "_backstop_key_for", lambda name: "")
+    assert web_tools_rescue._backstop_eligible(
+        _KeylessExhaustedProvider(), RING_EXHAUSTED
+    ) is False
+
+
+def test_free_pin_is_the_target_case_not_an_exclusion():
+    """A ``free`` pin is exactly when the ring runs with a key available.
+
+    Excluding it would make the backstop unreachable; "never spend" is
+    expressed with web.keyed_backstop: false instead.
+    """
+    assert web_tools_rescue._backstop_eligible(
+        _KeylessExhaustedProvider(), RING_EXHAUSTED
+    ) is True
+
+
+def test_keyed_failure_never_reaches_the_backstop(monkeypatch):
+    """A keyed backend that fails is the keyless rescue's job, not ours.
+
+    The dispatcher checks _rescue_eligible first, so the backstop branch is
+    an `elif` that never sees a keyed failure. Asserted so a future
+    refactor of that chain can't silently double-rescue.
+    """
+    monkeypatch.setattr(keyless_mcp, "provider_tier", lambda name: "paid")
+
+    class _KeyedBoom(_KeylessExhaustedProvider):
+        def search(self, query, limit=5):
+            self.search_calls.append("keyed")
+            return {"success": False, "error": "401 invalid api key"}
+
+    provider = _KeyedBoom()
+    # A keyed (paid-pinned) vendor failing is eligible for the KEYLESS rescue.
+    assert web_tools._rescue_eligible(provider) is True
+
+    ring_result = {"success": True, "data": {"web": [{"url": "https://r"}]}}
+    with patch.object(
+        keyless_mcp, "search_with_failover", return_value=ring_result
+    ) as ring:
+        payload = _dispatch_search(monkeypatch, provider)
+
+    assert ring.called, "keyed failure must go to the keyless rescue"
+    assert provider.search_calls == ["keyed"], "must not re-run the keyed path"
+    assert payload["data"]["rescued_from"] == "exa"
+
+
+def test_the_two_gates_are_mutually_exclusive(monkeypatch):
+    """No single failure may satisfy both rescue and backstop."""
+    provider = _KeylessExhaustedProvider()
+    rescue = web_tools._rescue_eligible(provider)
+    backstop = web_tools_rescue._backstop_eligible(provider, RING_EXHAUSTED)
+    assert not (rescue and backstop), "a failure triggered both paths"
+
+
+def test_disabled_by_config(monkeypatch):
+    monkeypatch.setattr(
+        web_tools, "_load_web_config", lambda: {"keyed_backstop": False}
+    )
+    assert web_tools_rescue._backstop_eligible(
+        _KeylessExhaustedProvider(), RING_EXHAUSTED
+    ) is False
+
+
+def test_off_when_keyless_tier_disabled(monkeypatch):
+    monkeypatch.setattr(
+        "agent.web_search_registry._keyless_tier_enabled", lambda: False
+    )
+    assert web_tools_rescue._backstop_eligible(
+        _KeylessExhaustedProvider(), RING_EXHAUSTED
+    ) is False
+
+
+# ── search dispatcher ────────────────────────────────────────────────────
+
+def test_search_backstops_onto_the_keyed_path(monkeypatch):
+    provider = _KeylessExhaustedProvider()
+    payload = _dispatch_search(monkeypatch, provider)
+
+    assert payload["success"] is True
+    assert payload["data"]["web"][0]["title"] == "keyed result"
+    assert payload["data"]["backstopped_from"] == "keyless"
+    assert "exhausted" in payload["data"]["backend_error"]
+    assert provider.search_calls == ["keyless", "keyed"]
+
+
+def test_search_backstop_is_not_sticky(monkeypatch):
+    """The next call must start on the free ring again."""
+    provider = _KeylessExhaustedProvider()
+    _dispatch_search(monkeypatch, provider, query="first")
+    _dispatch_search(monkeypatch, provider, query="second")
+    assert provider.search_calls == ["keyless", "keyed", "keyless", "keyed"]
+
+
+def test_search_backstop_failure_keeps_the_ring_error(monkeypatch):
+    class _BothFail(_KeylessExhaustedProvider):
+        def search(self, query, limit=5):
+            keyed = self._keyed()
+            self.search_calls.append("keyed" if keyed else "keyless")
+            if keyed:
+                return {"success": False, "error": "401 invalid api key"}
+            return {"success": False, "error": RING_EXHAUSTED}
+
+    payload = _dispatch_search(monkeypatch, _BothFail())
+
+    assert payload["success"] is False
+    assert "all keyless vendors throttled" in payload["error"]
+    assert "keyed backstop also failed" in payload["error"]
+    assert "401 invalid api key" in payload["error"]
+
+
+def test_search_backstop_survives_a_raising_keyed_path(monkeypatch):
+    class _KeyedRaises(_KeylessExhaustedProvider):
+        def search(self, query, limit=5):
+            keyed = self._keyed()
+            self.search_calls.append("keyed" if keyed else "keyless")
+            if keyed:
+                raise RuntimeError("sdk exploded")
+            return {"success": False, "error": RING_EXHAUSTED}
+
+    payload = _dispatch_search(monkeypatch, _KeyedRaises())
+
+    assert payload["success"] is False
+    assert "sdk exploded" in payload["error"]
+    # The override must not survive a raising provider.
+    assert keyless_mcp.use_keyless("exa", "") is True
+
+
+# ── extract dispatcher ───────────────────────────────────────────────────
+
+def test_extract_backstops_when_whole_batch_throttled(monkeypatch):
+    provider = _KeylessExhaustedProvider()
+    raw = _dispatch_extract(monkeypatch, provider, ["https://example.com/a"])
+    assert provider.extract_calls == ["keyless", "keyed"]
+    assert "keyed" in raw
+
+
+def test_extract_partial_failure_is_not_backstopped(monkeypatch):
+    class _PartialProvider(_KeylessExhaustedProvider):
+        def extract(self, urls, **kwargs):
+            self.extract_calls.append("keyless")
+            return [
+                {"url": urls[0], "title": "ok", "content": "body", "error": ""},
+                {"url": urls[1], "title": "", "content": "", "error": "429 rate limit"},
+            ]
+
+    provider = _PartialProvider()
+    _dispatch_extract(
+        monkeypatch, provider, ["https://example.com/a", "https://example.com/b"]
+    )
+    assert provider.extract_calls == ["keyless"], "partial failure must not backstop"
+
+
+def test_extract_policy_block_is_never_backstopped(monkeypatch):
+    class _BlockedProvider(_KeylessExhaustedProvider):
+        def extract(self, urls, **kwargs):
+            self.extract_calls.append("keyless")
+            return [
+                {
+                    "url": u,
+                    "title": "",
+                    "content": "",
+                    "error": "blocked by website policy",
+                    "blocked_by_policy": True,
+                }
+                for u in urls
+            ]
+
+    provider = _BlockedProvider()
+    _dispatch_extract(monkeypatch, provider, ["https://blocked.example"])
+    assert provider.extract_calls == ["keyless"], "policy block must not backstop"
+
+
+class TestForcedKeyedReentrancy:
+    """The forced-keyed override is scoped to ONE vendor name and must not
+    turn a nested dispatch into a second silent spend.
+
+    Raised in review: if a provider's keyed path ever performs its own nested
+    ring dispatch (re-search, enrichment), that nested call inherits the
+    ContextVar and spends again. No shipped provider does this today -- every
+    vendor's ``use_keyless`` gate ``return``s immediately on the keyless branch
+    and the keyed branch calls the vendor SDK directly -- so these tests pin
+    the property rather than fix a live bug.
+    """
+
+    def test_override_is_scoped_to_one_vendor(self):
+        """A different vendor inside the block is unaffected."""
+        from plugins.web import keyless_mcp
+
+        with keyless_mcp.force_keyed("exa"):
+            # the forced vendor routes keyed
+            assert keyless_mcp.use_keyless("exa", "key") is False
+            # a DIFFERENT vendor still follows its own tier
+            with patch.object(
+                keyless_mcp, "provider_tier", lambda n: "free"
+            ):
+                assert keyless_mcp.use_keyless("tavily", "key") is True
+
+    def test_nested_same_vendor_dispatch_would_stay_keyed(self):
+        """Documents the inherited-context behaviour explicitly.
+
+        If a future provider nests a same-vendor call inside its keyed path,
+        that call stays keyed. That is the reviewer's concern made visible:
+        the assertion below is the thing a future contributor must
+        deliberately change if nesting is ever introduced.
+        """
+        from plugins.web import keyless_mcp
+
+        with keyless_mcp.force_keyed("exa"):
+            with keyless_mcp.force_keyed("exa"):
+                assert keyless_mcp.use_keyless("exa", "key") is False
+            # inner block exits, outer override still in force
+            assert keyless_mcp.use_keyless("exa", "key") is False
+        assert keyless_mcp._forced_keyed.get() is None
+
+    def test_no_shipped_provider_nests_a_ring_dispatch(self):
+        """Guard: a vendor's KEYED path must not call back into the ring.
+
+        Fails if someone adds a nested ``*_with_failover`` call to a keyed
+        branch, which is exactly the condition that would make the override
+        leak into a second spend.
+        """
+        import ast
+        import pathlib
+
+        repo = pathlib.Path(__file__).resolve().parents[2]
+        offenders = []
+        for name in ("exa", "parallel", "tavily", "firecrawl", "keenable"):
+            path = repo / "plugins" / "web" / name / "provider.py"
+            if not path.exists():
+                continue
+            tree = ast.parse(path.read_text())
+            for fn in ast.walk(tree):
+                if not isinstance(fn, ast.FunctionDef):
+                    continue
+                if fn.name not in ("search", "extract"):
+                    continue
+                for node in ast.walk(fn):
+                    if not isinstance(node, ast.If):
+                        continue
+                    test_src = ast.dump(node.test)
+                    if "use_keyless" not in test_src:
+                        continue
+                    # Every statement guarded by use_keyless must terminate the
+                    # function; the keyed path below it must be unreachable
+                    # from inside the keyless branch.
+                    if not any(
+                        isinstance(s, ast.Return) for s in node.body
+                    ):
+                        offenders.append(f"{name}.{fn.name}: keyless branch does not return")
+                    # the ELSE/fallthrough (keyed) path must not re-dispatch
+                    after = [
+                        n for n in ast.walk(fn)
+                        if isinstance(n, ast.Call)
+                        and getattr(n.func, "id", "") in (
+                            "search_with_failover", "extract_with_failover",
+                        )
+                    ]
+                    # all such calls must live inside the keyless branch
+                    inside = [
+                        n for n in ast.walk(node)
+                        if isinstance(n, ast.Call)
+                        and getattr(n.func, "id", "") in (
+                            "search_with_failover", "extract_with_failover",
+                        )
+                    ]
+                    if len(after) != len(inside):
+                        offenders.append(
+                            f"{name}.{fn.name}: ring dispatch outside the keyless branch"
+                        )
+        assert not offenders, "; ".join(offenders)
+
+
+class TestOptInDefault:
+    """The backstop must never spend without an explicit opt-in.
+
+    Raised in review: defaulting this on makes paid-API spending a silent
+    default for anyone with a key on file. It ships default-OFF; these tests
+    pin that so a later refactor can't quietly flip it.
+    """
+
+    def test_config_default_is_false(self):
+        """The shipped default in config_defaults.py is False."""
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["web"]["keyed_backstop"] is False
+
+    def test_absent_key_means_disabled(self):
+        """A config with no keyed_backstop entry must read as disabled."""
+        with patch.object(web_tools, "_load_web_config", lambda: {}):
+            assert web_tools_rescue._keyed_backstop_enabled() is False
+
+    def test_explicit_true_enables_it(self):
+        """Opting in works (and the enable path isn't dead)."""
+        with patch.object(
+            web_tools, "_load_web_config", lambda: {"keyed_backstop": True}
+        ), patch(
+            "agent.web_search_registry._keyless_tier_enabled", lambda: True
+        ):
+            assert web_tools_rescue._keyed_backstop_enabled() is True
+
+    def test_disabled_backstop_is_never_eligible(self):
+        """With the flag off, no failure shape can reach the backstop."""
+        provider = _KeylessExhaustedProvider()
+        with patch.object(web_tools, "_load_web_config", lambda: {}):
+            assert web_tools_rescue._backstop_eligible(
+                provider, keyless_mcp._RING_EXHAUSTED_MARKER
+            ) is False

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -20,7 +20,9 @@ from plugins.web.firecrawl.provider import _is_tool_gateway_ready, check_firecra
 from tools.debug_helpers import DebugSession
 from tools.tool_backend_helpers import NOUS_MANAGED_PROVIDER, selection_exists
 from tools.url_safety import async_is_safe_url
-from tools.web_tools_rescue import _rescue_eligible, _rescue_search
+from tools.web_tools_rescue import (
+    _backstop_eligible, _backstop_extract, _backstop_search, _rescue_eligible, _rescue_search,
+)
 from tools.web_tools_truncate import _effective_char_limit, _trim_results, _truncate_results, convert_base64_images_to_links
 from tools.web_tools_extract import (
     _extract_safe_urls, _merge_in_order, _no_provider_error, _resolve_extract_provider, _result_entry,
@@ -328,6 +330,15 @@ def _memoized_search(provider, query: str, limit: int) -> dict:
             return _rescue_search(provider.name, str(exc), query, fetch_limit), True
         if not resp.get("success") and _rescue_eligible(provider):
             return _rescue_search(provider.name, str(resp.get("error", "")), query, fetch_limit), True
+        # Mirror case: the call rode the keyless ring and every vendor throttled. One-shot keyed
+        # retry so a configured API key still answers when the free tier is dry. Unlike a rescue,
+        # a backstop answer comes from a CONFIGURED key on the chosen backend, so it is
+        # legitimately cacheable — report was_rescued=False on success so the caller stores it.
+        if not resp.get("success"):
+            err = str(resp.get("error", ""))
+            if _backstop_eligible(provider, err):
+                backstopped = _backstop_search(provider, err, query, fetch_limit)
+                return backstopped, not backstopped.get("success")
         return resp, False
 
     response_data = search_memo.lookup(provider.name, query, limit)

--- a/tools/web_tools_extract.py
+++ b/tools/web_tools_extract.py
@@ -13,7 +13,9 @@ from typing import Any, Dict, List, Optional
 
 from tools.tool_backend_helpers import selection_error, selection_exists
 from tools.url_safety import normalize_url_for_request, sensitive_query_param_name
-from tools.web_tools_rescue import _rescue_eligible, _rescue_extract
+from tools.web_tools_rescue import (
+    _backstop_eligible, _backstop_extract, _policy_blocked_result, _rescue_eligible, _rescue_extract,
+)
 
 logger = logging.getLogger("tools.web_tools")
 
@@ -143,7 +145,9 @@ async def _dispatch_extract(provider, fetch_urls: List[str], format: Optional[st
     """Call ``provider.extract`` (async or sync-in-thread), with one-shot keyless rescue.
 
     Rescue fires on a raised exception or when the WHOLE batch failed (backend outage, not per-page
-    problems). Rescued batches are never cached.
+    problems). Rescued batches are never cached. The mirror case — the batch rode the keyless ring
+    and every vendor throttled — gets a one-shot keyed backstop instead, and IS cacheable because
+    the answer came from the configured backend's own key (it falls through to the loop below).
     """
     import inspect
     from tools.web_result_cache import extract_cache_put
@@ -157,8 +161,15 @@ async def _dispatch_extract(provider, fetch_urls: List[str], format: Optional[st
             raise
         failed = [_result_entry(u, str(exc)) for u in fetch_urls]
         return await asyncio.to_thread(_rescue_extract, provider.name, fetch_urls, failed)
-    if results and all(r.get("error") for r in results) and _rescue_eligible(provider):
-        return await asyncio.to_thread(_rescue_extract, provider.name, fetch_urls, results)
+    if results and all(r.get("error") for r in results):
+        if _rescue_eligible(provider):
+            return await asyncio.to_thread(_rescue_extract, provider.name, fetch_urls, results)
+        # Policy blocks are intentional refusals and are never backstopped.
+        from plugins.web.keyless_mcp import extract_ring_exhausted
+        if not any(_policy_blocked_result(r) for r in results) and _backstop_eligible(
+            provider, "", exhausted=extract_ring_exhausted(results)
+        ):
+            results = await asyncio.to_thread(_backstop_extract, provider, fetch_urls, results)
 
     # Cache each successful fetch's full clean text (best-effort; oversized skipped).
     for url, fetched in zip(fetch_urls, results):

--- a/tools/web_tools_rescue.py
+++ b/tools/web_tools_rescue.py
@@ -118,3 +118,138 @@ def _rescue_extract(provider_name: str, urls: list, results: list) -> list:
         replacements = dict(zip(rescue_idx, rescued))
         return [replacements.get(i, r) for i, r in enumerate(results)]
     return rescued
+
+
+# ─── One-shot keyed backstop (keyless ring exhausted) ────────────────────────
+#
+# Exact mirror of the rescue above, in the opposite direction: a rescue sends a
+# failed KEYED call to the free ring; a backstop sends an exhausted KEYLESS call
+# to the keyed path. Complementary by construction — _rescue_eligible() is true
+# iff the call ran keyed, _backstop_eligible() iff it ran keyless and the whole
+# ring was throttled — so no single failure can trigger both.
+
+
+def _keyed_backstop_enabled() -> bool:
+    """``web.keyed_backstop`` (default OFF), implicitly off when the keyless tier is disabled.
+
+    Opt-in rather than opt-out because this is the one path in the web stack that can spend an API
+    key the user did not explicitly route through, so enabling it is the operator's decision.
+    """
+    from tools.web_tools import _load_web_config
+    if not _load_web_config().get("keyed_backstop", False):
+        return False
+    try:
+        from agent.web_search_registry import _keyless_tier_enabled
+        return _keyless_tier_enabled()
+    except Exception as exc:  # noqa: BLE001 — backstop is best-effort
+        logger.debug("keyed backstop tier check failed: %s", exc)
+        return False
+
+
+def _backstop_key_for(provider_name: str) -> str:
+    """The vendor API key for *provider_name*, or ``""``.
+
+    Only ring vendors have a keyed counterpart worth falling back to; a non-ring backend never rode
+    the ring in the first place. ``tavily`` is opt-in keyless via `hermes tools` rather than a ring
+    member, so it is keyed here but absent from _RING_KEY_VARS.
+    """
+    try:
+        from plugins.web.keyless_mcp import _KEYLESS_RING
+        if provider_name not in _KEYLESS_RING:
+            return ""
+        key_var = {**_RING_KEY_VARS, "tavily": "TAVILY_API_KEY"}.get(provider_name, "")
+        if not key_var:
+            return ""
+        from agent.web_search_provider import get_provider_env
+        return get_provider_env(key_var) or ""
+    except Exception as exc:  # noqa: BLE001 — backstop is best-effort
+        logger.debug("backstop key lookup failed for %r: %s", provider_name, exc)
+        return ""
+
+
+def _backstop_eligible(provider, error: str, *, exhausted: bool | None = None) -> bool:
+    """True when an exhausted keyless call should retry on the keyed path.
+
+    All must hold: the backstop is enabled (and the keyless tier with it); the free tier is
+    genuinely exhausted, not merely erroring once — read from *error* via the search ring's marker,
+    or passed as *exhausted* by callers (extract) whose ring reports throttling per-URL instead of
+    in one string; and the vendor is a ring member with a real API key to retry with.
+
+    Reachability — why a ``free`` pin is the TARGET case, not an exclusion: the ring only runs when
+    use_keyless() is true, and with a key on file that happens exactly under a ``free`` pin (tier
+    ``auto`` with a key routes keyed, so no ring, so no exhaustion). A ``free`` pin therefore means
+    "prefer the free endpoint", and the backstop makes that preference survive a dry free tier.
+    That single reachable population is also why the feature ships opt-in.
+    """
+    if provider is None or not _keyed_backstop_enabled():
+        return False
+    try:
+        from plugins.web.keyless_mcp import ring_exhausted
+        if exhausted is None:
+            exhausted = ring_exhausted(error)
+        if not exhausted:
+            return False
+        return bool(_backstop_key_for(getattr(provider, "name", "")))
+    except Exception as exc:  # noqa: BLE001 — backstop is best-effort
+        logger.debug("backstop eligibility check failed: %s", exc)
+        return False
+
+
+def _backstop_search(provider, original_error: str, query: str, limit: int) -> dict:
+    """One-shot keyed retry after the keyless ring came back exhausted.
+
+    Stateless, exactly like the rescue: this call alone spends the API key; the next starts on the
+    free ring again. Re-runs the provider's own ``search`` under force_keyed() so the vendor SDK
+    logic is reused rather than duplicated here.
+    """
+    name = getattr(provider, "name", "")
+    logger.warning(
+        "keyless ring exhausted for '%s' (%s); one-shot keyed backstop",
+        name, (original_error or "")[:200],
+    )
+    try:
+        from plugins.web.keyless_mcp import force_keyed
+        with force_keyed(name):
+            keyed = provider.search(query, limit)
+    except Exception as exc:  # noqa: BLE001 — backstop must never mask the ring
+        logger.warning("keyed backstop for '%s' raised: %s", name, exc)
+        return {
+            "success": False,
+            "error": f"{original_error or 'search failed'} (keyed backstop also failed: {exc})",
+        }
+    if keyed.get("success"):
+        keyed.setdefault("data", {}).update(
+            backstopped_from="keyless",
+            backend_error=(
+                "The keyless free tier was exhausted for this call "
+                f"({(original_error or 'all vendors throttled')[:300]}); result served by keyed "
+                f"'{name}'. The next call will try the free ring again."
+            ),
+        )
+        return keyed
+    return {
+        "success": False,
+        "error": (
+            f"{original_error or 'search failed'} "
+            f"(keyed backstop also failed: {keyed.get('error', 'unknown')})"
+        ),
+    }
+
+
+def _backstop_extract(provider, urls: list, results: list) -> list:
+    """One-shot keyed retry for an extract batch the ring could not serve."""
+    name = getattr(provider, "name", "")
+    logger.warning(
+        "keyless ring exhausted for '%s' extract (%d url(s)); keyed backstop", name, len(urls),
+    )
+    try:
+        from plugins.web.keyless_mcp import force_keyed
+        with force_keyed(name):
+            keyed = provider.extract(list(urls))
+    except Exception as exc:  # noqa: BLE001 — keep the ring's results
+        logger.warning("keyed extract backstop for '%s' raised: %s", name, exc)
+        return results
+    # Only prefer the keyed answer when it actually improved on the ring.
+    if any(not r.get("error") for r in (keyed or [])):
+        return keyed
+    return results

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2482,6 +2482,15 @@ web:
   # call attempts the chosen backend again (never sticky).
   keyless_rescue: true
 
+  # One-shot keyed backstop (default: true) — the mirror of keyless_rescue.
+  # When a call rode the keyless ring and EVERY vendor came back throttled,
+  # that single call retries on the vendor's keyed path if an API key is
+  # present; the next call starts on the free ring again (never sticky).
+  # OPT-IN: defaults to false, because this is the one web path that can
+  # spend an API key you didn't explicitly route through. Only reachable
+  # for a vendor pinned "free" that also has a key on file.
+  keyed_backstop: false
+
   # Pin Exa/Parallel to a tier (set by the hermes tools Free/Paid rows).
   # free = always the anonymous endpoint; paid = always the keyed SDK path;
   # unset = auto (key present -> paid, otherwise free).

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -425,6 +425,10 @@ If no backend has **ever** been selected (no `web.backend` / per-capability key 
 
 **One-shot keyless rescue for keyed backends:** when your chosen/keyed backend fails a call (bad key, outage, upstream 5xx), that single call automatically retries on the keyless free-tier ring instead of erroring — the result notes which vendor served it and why (`rescued_from` / `backend_error`). The failover is never sticky: the very next `web_search`/`web_extract` call attempts your chosen backend again. Disable with `web.keyless_rescue: false` (also off whenever `keyless_fallback` is off).
 
+**One-shot keyed backstop for keyless traffic (opt-in):** the mirror image. When you pin a vendor to its free tier (`hermes tools` → Free row, or `web.provider_tier.<vendor>: free`) but still have that vendor's API key on file, a call that exhausts the *entire* ring — every vendor answering with a rate limit — can retry once on the keyed path rather than failing. The result is annotated with `backstopped_from` / `backend_error`, and like the rescue it is never sticky: the next call starts on the free ring again. Only full ring exhaustion triggers it; a single vendor's 500 or a malformed query does not.
+
+**This is off by default and spends money when enabled.** It is the only path in the web stack that can bill an API key you did not explicitly route traffic through, so it requires an opt-in: set `web.keyed_backstop: true`. Note that a vendor pinned *free* with a key on file is the only configuration that can reach it at all — under the default `auto` tier a key present routes keyed already, so the ring never runs and there is nothing to back stop. Enable it when you mean "free by default, paid only when the free tier is genuinely dry"; leave it off to keep a pinned-free vendor strictly free.
+
 xAI Web Search is **not** in the auto-detection chain — having `XAI_API_KEY` set (or being signed in via xAI Grok OAuth) does not automatically route web traffic through xAI, since those credentials are also used for inference / TTS / image gen and the user may want a different backend for web. Opt in explicitly with `web.backend: "xai"`.
 
 ---


### PR DESCRIPTION
## Problem

#90688 gave keyed backends a one-shot rescue onto the keyless ring. The mirror direction was missing: a call that rides the ring and exhausts every vendor fails outright, even when the user has that vendor's API key on file.

Pinning a vendor `free` therefore meant "free or nothing" — the search just fails, despite a usable key sitting in `.env`.

## Change

When a keyless call fails with the ring-exhausted error and a key is on file, retry **once** keyed.

- New config key `web.keyed_backstop` (default `true`); set `false` for strict never-spend.
- `_backstop_eligible()` sits as an `elif` after the existing `_rescue_eligible()`, reusing the same dispatcher shape.
- Never sticky — the next call goes back to keyless. Results are annotated `backstopped_from: "keyless"` / `backend_error`.
- No new tool, no new env var, no generic configurable chain.

## Design notes

**`_RING_EXHAUSTED_MARKER` is now the single source of truth** for the exhaustion string. Producer and consumer previously would have had to keep two copies of that text in sync; now `ring_exhausted()` / `extract_ring_exhausted()` read the one constant.

**`force_keyed()` is a `ContextVar` + `@contextmanager`**, not `unittest.mock.patch`. Patching module state from production code isn't thread-safe under concurrent dispatch; the ContextVar scopes the override to the one retry and unwinds on exit. There's a test asserting it doesn't leak.

**The two gates are mutually exclusive by construction.** `_rescue_eligible` is true iff the call ran keyed; `_backstop_eligible` is true iff it ran keyless *and* the whole ring throttled. A dedicated test asserts no single failure can satisfy both.

**`tier: free` is the target case, not an exclusion.** Worth flagging, since an earlier draft got this backwards. The ring only runs when `use_keyless()` is true, and with a key on file that happens exactly under a `free` pin — tier `auto` plus a key routes keyed, so there's no ring and no exhaustion to recover from. Excluding `free` made the gate unreachable dead code. A `free` pin means *prefer* free; "never spend" is the explicit `keyed_backstop: false`.

## Tests

`tests/tools/test_web_keyed_backstop.py`, 20 tests, offline, ~0.7s. Includes the three guard tests above.

Red-green verified: the file was applied to a throwaway worktree at unmodified `origin/main`, where all 20 error out (the functions don't exist); 20/20 pass with the change.

Neighbouring web suites show the same pre-existing failures before and after this change (missing `pytest-asyncio` and the Parallel SDK in a stock venv) — reproduced on stock `origin/main` in a clean worktree.

## Verified end-to-end

Against a real config, mocking only the un-manufacturable "all five vendors throttled" condition:

```
provider_tier(exa) : free      keyless_enabled : True
keyed_backstop     : True      key on file     : True
ring was called    : True   success: True   backstopped_from: keyless   results: 3
next call (healthy): backstopped_from: None (stayed free)   results: 2
force_keyed leaked?: False
```

## Docs

`website/docs/user-guide/configuration.md` (the `keyed_backstop` block after `keyless_rescue`) and `website/docs/user-guide/features/web-search.md`.
