### PR TITLE
fix(opencode): route Muse Spark models through the Responses API

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -5283,6 +5283,16 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
             # per the published Go endpoint table, same as GPT on Zen:
             # https://opencode.ai/docs/go/#endpoints
             return "codex_responses"
+        if normalized.startswith("muse-"):
+            # Muse Spark models on Go (muse-spark-1.2, muse-spark-1.2-contributor)
+            # are served via /v1/responses. Verified live: /v1/chat/completions
+            # streams HTTP 200 with empty choices:[] chunks (no delta, no
+            # finish_reason) against muse-spark-1.2-contributor, while
+            # /v1/responses completes with full content and encrypted reasoning.
+            # Without this routing the model falls into the chat_completions
+            # branch below, where the empty stream surfaces as a truncated /
+            # "4 continuation attempts" error in the conversation loop.
+            return "codex_responses"
         if normalized.startswith("minimax-"):
             return "anthropic_messages"
         if normalized.startswith("qwen"):
@@ -5295,6 +5305,11 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
         if normalized.startswith("claude-"):
             return "anthropic_messages"
         if normalized.startswith("gpt-"):
+            return "codex_responses"
+        if normalized.startswith("muse-"):
+            # Muse Spark models on Zen are also served via /v1/responses (the
+            # published Zen endpoint table lists muse-spark* on /v1/responses),
+            # mirroring the Go routing above and the existing GPT handling.
             return "codex_responses"
         if normalized.startswith("qwen"):
             # Qwen models on Zen moved to /v1/messages per the published

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -273,6 +273,31 @@ class TestCopilotNormalization:
         assert opencode_model_api_mode("opencode-go", "gpt-5.6-luna") == "codex_responses"
         assert opencode_model_api_mode("opencode-go", "opencode-go/gpt-5.6-luna") == "codex_responses"
 
+    def test_opencode_go_muse_spark_routes_to_responses(self):
+        # Muse Spark on Go must go through /v1/responses. Verified live
+        # (2026-08-20): streaming /v1/chat/completions for
+        # muse-spark-1.2-contributor returns HTTP 200 with empty choices:[]
+        # chunks — no delta, no finish_reason — while /v1/responses completes
+        # with full content and encrypted reasoning. Without this routing the
+        # empty stream surfaces as a truncated "4 continuation attempts" error.
+        assert opencode_model_api_mode("opencode-go", "muse-spark-1.2") == "codex_responses"
+        assert opencode_model_api_mode("opencode-go", "opencode-go/muse-spark-1.2") == "codex_responses"
+        assert opencode_model_api_mode("opencode-go", "muse-spark-1.2-contributor") == "codex_responses"
+        assert opencode_model_api_mode("opencode-go", "opencode-go/muse-spark-1.2-contributor") == "codex_responses"
+        assert opencode_model_api_mode("opencode-go", "muse-glimmer-30b") == "codex_responses"
+
+    def test_opencode_zen_muse_spark_routes_to_responses(self):
+        # Muse Spark on Zen is served via /v1/responses per the published Zen
+        # endpoint table, mirroring the Go routing and the GPT handling.
+        assert opencode_model_api_mode("opencode-zen", "muse-spark-1.2") == "codex_responses"
+        assert opencode_model_api_mode("opencode-zen", "opencode-zen/muse-spark-1.2") == "codex_responses"
+        assert opencode_model_api_mode("opencode-zen", "muse-spark-1.2-contributor") == "codex_responses"
+        assert opencode_model_api_mode("opencode-zen", "opencode-zen/muse-spark-1.2-contributor") == "codex_responses"
+        # Non-Muse Zen models keep their existing routing.
+        assert opencode_model_api_mode("opencode-zen", "deepseek-v4-flash") == "chat_completions"
+        assert opencode_model_api_mode("opencode-zen", "claude-sonnet-4.6") == "anthropic_messages"
+        assert opencode_model_api_mode("opencode-zen", "qwen3.7-max") == "anthropic_messages"
+
 
 class TestNormalizeOpencodeBaseUrl:
     """Symmetric /v1 normalization for OpenCode Zen / Go base URLs.


### PR DESCRIPTION
## Summary

Muse Spark models on **OpenCode Go** (`muse-spark-1.2`, `muse-spark-1.2-contributor`) fall into the `chat_completions` branch of `opencode_model_api_mode()`, but the upstream serves them **only on `/v1/responses`** (the same situation GPT already has on Go, fixed in #81595). The result is a broken/truncated stream in the Hermes conversation loop.

This routes `muse-*` to `codex_responses` on both `opencode-go` and `opencode-zen`, mirroring the existing `gpt-*` handling.

## Reproduction (verified live 2026-08-20 against `opencode.ai/zen/go/v1`)

With a real `OPENCODE_GO_API_KEY` and `muse-spark-1.2-contributor`:

| Endpoint | Behavior |
|---|---|
| `POST /v1/chat/completions` with `stream:true` | HTTP 200 but **every chunk is `{"choices":[]}`** — no `delta`, no `finish_reason` |
| `POST /v1/chat/completions` non-stream | full text but `finish_reason: None`, no reasoning surface |
| `POST /v1/responses` | full Responses SSE (`response.created` → content → `response.completed`), `status: completed`, encrypted reasoning |

Because the stream delivers empty chunks with no `finish_reason`, the Hermes streaming path treats it as truncated and fires `Response still truncated after 4 continuation attempts` (`agent/conversation_loop.py`) — 4 futile auto-continuation retries against the same broken path.

`resolve_runtime_provider(requested='opencode-go', target_model='muse-spark-1.2-contributor')` now returns `api_mode=codex_responses` with this change.

## Changes

- `hermes_cli/models.py` — `opencode_model_api_mode()` routes `muse-*` → `codex_responses` on `opencode-go` and `opencode-zen`
- `tests/hermes_cli/test_model_validation.py` — regression coverage for standard + Contributor variants (with/without `opencode-*/` prefix), and assertions that non-Muse routing is unchanged

## Verification

- `tests/hermes_cli/test_model_validation.py` — **31 passed**
- `test_runtime_provider_resolution.py` + model_switch custom-providers/opencode-anthropic suites — **131 passed**
- E2E: `resolve_runtime_provider(...)` returns `api_mode=codex_responses` for the user's live config

## Related PRs

- #90827 — same fix (Muse → Responses on Go + Zen), Contributor verified live; this PR independently confirms that result
- #90176 — same direction (Muse Spark → Responses)
- #90823 — same direction, Go-only
- #89877 — opposite claim (`-contributor` → chat_completions). **Contradicted by live testing**: `/v1/responses` for `muse-spark-1.2-contributor` returns 200 + full output; `/v1/chat/completions` streaming returns empty `choices:[]` chunks.
- #81595 (merged) — precedent: route `gpt-*` on opencode-go to `/v1/responses`

## Why Responses API, not chat_completions

Muse Spark is a reasoning model. On the React-compatible surface `/v1/responses` Hermes gets typed output items (`reasoning`, `message`, `function_call`), honest `incomplete_details.reason` on truncation, and encrypted reasoning replay across turns. On `/v1/chat/completions` Muse loses reasoning continuity, truncation is indistinguishable from a graceful stop (empty `choices:[]` chunks, `finish_reason=None`), and the loop burns 4 continuation retries before giving up. The endpoint table (https://opencode.ai/docs/go/, https://opencode.ai/docs/zen/) lists `muse-spark*` under `/v1/responses`.
