### PR TITLE
fix(agent): drop continuation nudge/fragments on recovered turn

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -8039,11 +8039,39 @@ def run_conversation(
                     final_response = _join_truncated_parts([*truncated_response_parts, final_response])
                     truncated_response_parts = []
                     length_continue_retries = 0
-                    # The continuation recovered, so the fragments stay in the transcript.
-                    for _frag in messages:
-                        if isinstance(_frag, dict):
-                            _frag.pop("_length_continuation_fragment", None)
-                            _frag.pop("_length_continuation_nudge", None)
+                    # The continuation recovered. The partial-fragment rows and
+                    # the "[System: ...]" continuation nudge were scaffolding
+                    # that only drove the retry — they must not persist. The
+                    # nudge in particular would otherwise survive as a plain
+                    # role=user row and render as a user bubble in desktop/TUI
+                    # transcripts (and confuse the model on replay). Drop both
+                    # and carry the full stitched answer on the final assistant
+                    # row so the durable transcript reads as one clean turn.
+                    # Scoped to the CURRENT turn, mirroring the ceiling exit
+                    # above: a mark that reached disk mid-crash and was
+                    # reloaded on a PRIOR turn's message must never be deleted
+                    # by this turn's cleanup.
+                    _stitched = final_response
+                    _turn_start = (
+                        current_turn_user_idx + 1
+                        if isinstance(current_turn_user_idx, int)
+                        and current_turn_user_idx >= 0
+                        else 0
+                    )
+                    messages[_turn_start:] = [
+                        m
+                        for m in messages[_turn_start:]
+                        if not (
+                            isinstance(m, dict)
+                            and (
+                                m.get("_length_continuation_fragment")
+                                or m.get("_length_continuation_nudge")
+                            )
+                        )
+                    ]
+                    agent._session_messages = messages
+                    if isinstance(assistant_message.content, str):
+                        assistant_message.content = _stitched
                 
                 final_response = agent._strip_think_blocks(final_response).strip()
                 

--- a/tests/run_agent/test_continuation_ceiling_wedge.py
+++ b/tests/run_agent/test_continuation_ceiling_wedge.py
@@ -230,6 +230,80 @@ class TestContinuationCeilingWedge:
         assert "second turn partial" in result2["final_response"]
         assert "and the rest." in result2["final_response"]
 
+    def test_successful_continuation_drops_nudge_and_fragments(self, loop_agent):
+        """A continuation that RECOVERS must not leave the "[System: ...]"
+        nudge (or the partial-fragment rows) in the durable transcript.
+
+        The nudge is role=user scaffolding that only drives the retry; if it
+        persists it renders as a user bubble in desktop/TUI transcripts and
+        confuses the model on replay. The recovered turn must collapse to one
+        clean assistant row carrying the full stitched answer."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _stub("part one "),
+            _mock_response(content="the rest.", finish_reason="stop"),
+        ]
+        result = _run(loop_agent, "write me a long report")
+
+        assert result["completed"] is True
+        msgs = [m for m in result["messages"] if isinstance(m, dict)]
+
+        nudges = [
+            m for m in msgs
+            if m.get("role") == "user"
+            and "Continue exactly where you left off" in (m.get("content") or "")
+        ]
+        assert nudges == [], (
+            "The continuation nudge must not survive a recovered turn — it "
+            "renders as a user bubble and steers replay."
+        )
+
+        assistants = [m for m in msgs if m.get("role") == "assistant"]
+        assert len(assistants) == 1, (
+            "The fragment trail must collapse into one settled assistant turn."
+        )
+        content = assistants[0].get("content") or ""
+        assert "part one" in content, "Stitched answer must keep the partial."
+        assert "the rest." in content, "Stitched answer must keep the continuation."
+
+        # No scaffolding marks may remain on any durable row.
+        for m in msgs:
+            assert not m.get("_length_continuation_fragment")
+            assert not m.get("_length_continuation_nudge")
+
+    def test_successful_continuation_keeps_prior_turn_marked_rows(self, loop_agent):
+        """The success-path cleanup is scoped to the current turn: a marked
+        row reloaded from a prior turn's crash must survive (mirrors
+        test_prior_turn_marked_message_survives_later_ceiling)."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        reloaded_history = [
+            {"role": "user", "content": "earlier question"},
+            {
+                "role": "assistant",
+                "content": "earlier answer fragment",
+                "_length_continuation_fragment": True,
+            },
+        ]
+        loop_agent.client.chat.completions.create.side_effect = [
+            _stub("part one "),
+            _mock_response(content="the rest.", finish_reason="stop"),
+        ]
+        result = _run(loop_agent, "write me a long report", history=reloaded_history)
+
+        assert result["completed"] is True
+        prior = [
+            m for m in result["messages"]
+            if isinstance(m, dict)
+            and m.get("role") == "assistant"
+            and "earlier answer fragment" in (m.get("content") or "")
+        ]
+        assert len(prior) == 1, (
+            "The prior turn's reloaded message must survive the success-path "
+            "cleanup."
+        )
+
 
 class TestTruncatedPartJoining:
     """#78577 — parts joined with no separator glued text together."""


### PR DESCRIPTION
## Symptom

A mid-stream network cut (e.g. a reasoning model idling with no SSE keepalive) triggers a length-continuation retry. When the retry **recovers**, the internal `[System: The previous response was cut off ... Continue ...]` nudge and the partial-fragment rows survive in the durable transcript as plain `role=user` rows. They render as a **user bubble** in the desktop/TUI transcript and get replayed to the model on the next turn as if the user had typed them.

Reproduced on `main` with a real user report (screenshots of the stray bubble in the desktop transcript).

## Root cause

`agent/conversation_loop.py` — on the recovered-continuation path, the cleanup only stripped the `_length_continuation_fragment` / `_length_continuation_nudge` metadata keys and left the rows in place, so they persisted as plain user rows. The ceiling-exit path already deletes the rows; the recovered path did not.

## Fix

Mirror the ceiling-exit behavior on the recovered path: drop the nudge and fragment rows, scoped to the **current turn**, and carry the full stitched answer on the final assistant row so the durable transcript reads as one clean `user -> assistant` turn. Prior-turn marked rows reloaded from a crash are never deleted (same discipline as the existing ceiling exit).

## Tests

Two regression tests added to `tests/run_agent/test_continuation_ceiling_wedge.py`:

- `test_successful_continuation_drops_nudge_and_fragments` — recovered turn leaves no nudge, collapses to one assistant row, and keeps the full stitched content.
- `test_successful_continuation_keeps_prior_turn_marked_rows` — a marked row reloaded from a prior turn's crash survives the success-path cleanup.

Target file: **29 passed**. Broader continuation/truncation/length/persist/flush suite: **369 passed**; the only failures are two pre-existing environment flakes (dashboard tests missing `fastapi`, and a SQLite WAL/`rmtree` teardown race on macOS) that also fail on clean `main`.
