### PR TITLE
fix(cli): honor approved pattern keys in approvals test

### DIFF
--- a/hermes_cli/approvals_test.py
+++ b/hermes_cli/approvals_test.py
@@ -10,8 +10,9 @@ guard (``check_all_command_guards``) applies them:
     3. sudo-stdin guard (unconditional),
     4. user ``approvals.deny`` rules (fire before yolo/off),
     5. yolo / ``approvals.mode: off`` bypass,
-    6. permanent ``command_allowlist``,
-    7. dangerous-pattern detection → would ask for approval.
+    6. permanent ``command_allowlist`` command-text patterns,
+    7. dangerous-pattern detection,
+    8. permanent approval for the detected pattern key → allow, otherwise ask.
 
 Because the same functions run — including ``_command_detection_variants``'s
 normalization/de-obfuscation path — an obfuscated command (``r\\m -rf /``)
@@ -130,9 +131,18 @@ def evaluate_command(command: str, env_type: str = "local") -> dict:
                    "(permanently approved)",
         )
 
-    # 7. Dangerous-pattern detection → would prompt.
+    # 7. Dangerous-pattern detection.  The runtime passes the detected key
+    # through _run_approval_gate(), whose first decision is whether that key
+    # has already been approved.  Mirror that short-circuit before reporting
+    # that an interactive prompt would occur.
     is_dangerous, pattern_key, description = approval.detect_dangerous_command(command)
     if is_dangerous:
+        if approval.is_approved("", pattern_key):
+            return result(
+                "allow", rule=pattern_key,
+                detail="detected dangerous-pattern key is present in "
+                       "command_allowlist (permanently approved)",
+            )
         return result(
             "ask-approval", rule=description,
             detail="matches a dangerous-command pattern; the runtime would "

--- a/tests/hermes_cli/test_approvals_test.py
+++ b/tests/hermes_cli/test_approvals_test.py
@@ -68,6 +68,43 @@ class TestVerdicts:
         assert "ask-approval" in out
         assert "recursive delete" in out
 
+    @pytest.mark.parametrize(
+        "stored_key",
+        [
+            "delete in root path",
+            next(
+                key
+                for key in A._approval_key_aliases("delete in root path")
+                if key != "delete in root path"
+            ),
+        ],
+        ids=["canonical-key", "legacy-key"],
+    )
+    def test_dangerous_pattern_allowlist_matches_runtime(
+        self, isolated_approvals, stored_key
+    ):
+        command = "rm /tmp/approvals-test-probe"
+        isolated_approvals._permanent_approved.add(stored_key)
+
+        runtime = isolated_approvals.check_dangerous_command(command, "local")
+        verdict = at.evaluate_command(command)
+
+        assert runtime["approved"] is True
+        assert verdict["verdict"] == "allow"
+        assert verdict["exit_code"] == 0
+        assert verdict["rule"] == "delete in root path"
+        assert "permanently approved" in verdict["detail"]
+
+    def test_pattern_allowlist_cannot_bypass_hardline(
+        self, isolated_approvals
+    ):
+        isolated_approvals._permanent_approved.add("delete in root path")
+
+        verdict = at.evaluate_command("rm -rf /")
+
+        assert verdict["verdict"] == "hardline-deny"
+        assert verdict["exit_code"] == 3
+
     def test_user_deny_rule_from_config_honored(self, isolated_approvals, capsys,
                                                 monkeypatch):
         monkeypatch.setattr(


### PR DESCRIPTION
## What does this PR do?

Makes `hermes approvals test` honor permanent approvals stored under dangerous-pattern keys, matching the runtime approval gate.

Previously, a persisted pattern key such as `delete in root path` allowed the matching command at runtime, while the dry-run diagnostic incorrectly reported that the command would prompt for approval. The diagnostic now checks the detected pattern key through the same alias-aware approval lookup used by the runtime before returning `ask-approval`.

Hardline and user-deny rules retain their existing precedence.

## Related Issue

No related issue found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `hermes_cli/approvals_test.py` to check a detected dangerous-pattern key for an existing permanent approval before reporting that a prompt would occur.
- Add regression coverage for canonical and legacy stored pattern keys.
- Confirm that pattern-key approvals cannot bypass the hardline blocklist.

## How to Test

1. Put either `delete in root path` or its legacy regex-derived alias in `command_allowlist` inside an isolated `HERMES_HOME`.
2. Run `hermes approvals test -- rm /tmp/approvals-test-probe`; it should report `allow` with exit code 0, matching `check_dangerous_command()`.
3. Run `hermes approvals test -- rm -rf /`; it should still report `hardline-deny` with exit code 3.
4. Run `HERMES_PYTHON=/path/to/dev/python scripts/run_tests.sh tests/hermes_cli/test_approvals_test.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused regression suite:

```text
19 passed in 0.22s
```

Manual isolated-home verification:

```text
canonical pattern key: allow (exit 0)
legacy pattern key:    allow (exit 0)
hardline command:      hardline-deny (exit 3)
```
