### PR TITLE
refactor: unify conversation turn finalization path

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -91,7 +91,13 @@ from agent.repetition_guard import is_repetition_dominated
 from agent.trajectory import has_incomplete_scratchpad
 # Bind before the turn starts so a source-tree swap cannot load a skewed
 # finalizer at turn end.
-from agent.turn_finalizer import finalize_turn
+from agent.turn_finalizer import (
+    _begin_turn_finalization,
+    _complete_turn_finalization,
+    _record_turn_exit_reason,
+    _reset_turn_finalization,
+    finalize_turn,
+)
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent import empty_response_guard as _empty_guard
 from hermes_constants import PARTIAL_STREAM_STUB_ID
@@ -1759,7 +1765,7 @@ def _notify_context_engine_turn_complete(
         )
 
 
-def run_conversation(
+def _run_conversation_impl(
     agent,
     user_message: Any,
     system_message: str = None,
@@ -1932,7 +1938,7 @@ def run_conversation(
     max_compression_attempts = getattr(agent, "max_compression_attempts", 3)
     _last_preflight_pressure: Optional[int] = None
     _preflight_compression_blocked = _ctx.preflight_compression_blocked
-    _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
+    _turn_exit_reason = _record_turn_exit_reason("unknown")  # Diagnostic: why the loop ended
     # Last composed answer intentionally held back by a verification gate. If
     # that continuation consumes the remaining budget, this is the best
     # user-facing result available; it must not be confused with error or
@@ -1994,7 +2000,7 @@ def run_conversation(
         # Check for interrupt request (e.g., user sent new message)
         if agent._interrupt_requested:
             interrupted = True
-            _turn_exit_reason = "interrupted_by_user"
+            _turn_exit_reason = _record_turn_exit_reason("interrupted_by_user")
             if not agent.quiet_mode:
                 agent._safe_print("\n⚡ Breaking out of tool loop due to interrupt...")
             break
@@ -2009,7 +2015,7 @@ def run_conversation(
         if agent._budget_grace_call:
             agent._budget_grace_call = False
         elif not agent.iteration_budget.consume():
-            _turn_exit_reason = "budget_exhausted"
+            _turn_exit_reason = _record_turn_exit_reason("budget_exhausted")
             if not agent.quiet_mode:
                 agent._safe_print(f"\n⚠️  Iteration budget exhausted ({agent.iteration_budget.used}/{agent.iteration_budget.max_total} iterations used)")
             break
@@ -2555,7 +2561,7 @@ def run_conversation(
         if _runtime_context_error:
             final_response = _runtime_context_error
             failed = True
-            _turn_exit_reason = "ollama_runtime_context_too_small"
+            _turn_exit_reason = _record_turn_exit_reason("ollama_runtime_context_too_small")
             append_message(messages, {"role": "assistant", "content": final_response})
             agent._emit_status("❌ Ollama runtime context is too small for Hermes tool use")
             api_call_count -= 1
@@ -2736,7 +2742,7 @@ def run_conversation(
                     )
                     if not final_response:
                         final_response = _HANDOFF_SKIP_FINAL_RESPONSE
-                    _turn_exit_reason = "compaction_handoff_not_actionable"
+                    _turn_exit_reason = _record_turn_exit_reason("compaction_handoff_not_actionable")
                     break
                 continue
         elif (
@@ -6574,7 +6580,7 @@ def run_conversation(
 
         # If the API call was interrupted, skip response processing
         if interrupted:
-            _turn_exit_reason = "interrupted_during_api_call"
+            _turn_exit_reason = _record_turn_exit_reason("interrupted_during_api_call")
             break
 
         if _retry.restart_with_compressed_messages:
@@ -6594,7 +6600,7 @@ def run_conversation(
                 )
                 if not final_response:
                     final_response = _HANDOFF_SKIP_FINAL_RESPONSE
-                _turn_exit_reason = "compaction_handoff_not_actionable"
+                _turn_exit_reason = _record_turn_exit_reason("compaction_handoff_not_actionable")
                 break
             # In-loop compression rebuilt `messages` with fresh compaction
             # copies, so the pre-compression current-turn index is stale.
@@ -6649,7 +6655,7 @@ def run_conversation(
         # (e.g. repeated context-length errors that exhausted retry_count),
         # the `response` variable is still None. Break out cleanly.
         if response is None:
-            _turn_exit_reason = "all_retries_exhausted_no_response"
+            _turn_exit_reason = _record_turn_exit_reason("all_retries_exhausted_no_response")
             print(f"{agent.log_prefix}❌ All API retries exhausted with no successful response.")
             agent._persist_session(messages, conversation_history)
             break
@@ -7325,7 +7331,7 @@ def run_conversation(
                     # nothing was recorded, the cause is genuinely unknown.
                     if getattr(agent, "_last_persistence_error_cause", None) is None:
                         agent._last_persistence_error_cause = "unknown"
-                    _turn_exit_reason = "session_persistence_failed"
+                    _turn_exit_reason = _record_turn_exit_reason("session_persistence_failed")
                     final_response = ""
                     failed = True
                     break
@@ -7354,14 +7360,14 @@ def run_conversation(
                     # A tool result could not be made canonical. Do not send
                     # the in-memory result back to the model or project any
                     # later events from this turn.
-                    _turn_exit_reason = "session_persistence_failed"
+                    _turn_exit_reason = _record_turn_exit_reason("session_persistence_failed")
                     final_response = ""
                     failed = True
                     break
 
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
-                    _turn_exit_reason = "guardrail_halt"
+                    _turn_exit_reason = _record_turn_exit_reason("guardrail_halt")
                     final_response = agent._toolguard_controlled_halt_response(decision)
                     agent._emit_status(
                         f"⚠️ Tool guardrail halted {decision.tool_name}: {decision.code}"
@@ -7488,7 +7494,7 @@ def run_conversation(
                             )
                             if not final_response:
                                 final_response = _HANDOFF_SKIP_FINAL_RESPONSE
-                            _turn_exit_reason = "compaction_handoff_not_actionable"
+                            _turn_exit_reason = _record_turn_exit_reason("compaction_handoff_not_actionable")
                             break
                 elif agent.compression_enabled:
                     # Over threshold but compression is blocked (summary-LLM
@@ -7593,7 +7599,7 @@ def run_conversation(
                         getattr(agent, "_current_streamed_assistant_text", "") or ""
                     )
                     if agent._has_content_after_think_block(_partial_streamed):
-                        _turn_exit_reason = "partial_stream_recovery"
+                        _turn_exit_reason = _record_turn_exit_reason("partial_stream_recovery")
                         _recovered = agent._strip_think_blocks(_partial_streamed).strip()
                         logger.info(
                             "Partial stream content delivered (%d chars) "
@@ -7624,7 +7630,7 @@ def run_conversation(
                     # post-tool nudge below handle that instead of exiting early.
                     fallback = getattr(agent, '_last_content_with_tools', None)
                     if fallback and getattr(agent, '_last_content_tools_all_housekeeping', False):
-                        _turn_exit_reason = "fallback_prior_turn_content"
+                        _turn_exit_reason = _record_turn_exit_reason("fallback_prior_turn_content")
                         logger.info("Empty follow-up after tool calls — using prior turn content as final response")
                         agent._emit_status("↻ Empty response after tool calls — using earlier content as final answer")
                         agent._last_content_with_tools = None
@@ -7904,7 +7910,7 @@ def run_conversation(
                             f"per attempt even when no answer is produced)"
                         )
                     agent._flush_status_buffer()
-                    _turn_exit_reason = "empty_response_exhausted"
+                    _turn_exit_reason = _record_turn_exit_reason("empty_response_exhausted")
                     reasoning_text = agent._extract_reasoning(assistant_message)
                     agent._drop_trailing_empty_response_scaffolding(messages)
                     assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
@@ -8310,7 +8316,9 @@ def run_conversation(
                         exc_info=True,
                     )
 
-                _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
+                _turn_exit_reason = _record_turn_exit_reason(
+                    f"text_response(finish_reason={finish_reason})"
+                )
                 if not agent.quiet_mode:
                     agent._safe_print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")
                 break
@@ -8400,10 +8408,14 @@ def run_conversation(
                 or api_call_count >= agent.max_iterations - 1
             ):
                 if _is_local_processing_error:
-                    _turn_exit_reason = f"local_processing_error({error_msg[:80]})"
+                    _turn_exit_reason = _record_turn_exit_reason(
+                        f"local_processing_error({error_msg[:80]})"
+                    )
                     final_response = f"I apologize, but I encountered an error while processing the model response: {error_msg}"
                 else:
-                    _turn_exit_reason = f"error_near_max_iterations({error_msg[:80]})"
+                    _turn_exit_reason = _record_turn_exit_reason(
+                        f"error_near_max_iterations({error_msg[:80]})"
+                    )
                     final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
                 # Append as assistant so the history stays valid for
                 # session resume (avoids consecutive user messages).
@@ -8431,6 +8443,45 @@ def run_conversation(
         _pending_verification_response_previewed=_pending_verification_response_previewed,
     )
 
+
+def run_conversation(
+    agent,
+    user_message: Any,
+    system_message: str = None,
+    conversation_history: List[Dict[str, Any]] = None,
+    task_id: str = None,
+    stream_callback: Optional[callable] = None,
+    persist_user_message: Optional[Any] = None,
+    persist_user_timestamp: Optional[float] = None,
+    persist_user_display_kind: Optional[str] = None,
+    persist_user_display_metadata: Optional[Dict[str, Any]] = None,
+    moa_config: Optional[dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Run one turn through a single behavior-neutral finalization path."""
+    token = _begin_turn_finalization()
+    error: BaseException | None = None
+    try:
+        return _run_conversation_impl(
+            agent,
+            user_message,
+            system_message=system_message,
+            conversation_history=conversation_history,
+            task_id=task_id,
+            stream_callback=stream_callback,
+            persist_user_message=persist_user_message,
+            persist_user_timestamp=persist_user_timestamp,
+            persist_user_display_kind=persist_user_display_kind,
+            persist_user_display_metadata=persist_user_display_metadata,
+            moa_config=moa_config,
+        )
+    except BaseException as exc:
+        error = exc
+        raise
+    finally:
+        try:
+            _complete_turn_finalization(agent, error)
+        finally:
+            _reset_turn_finalization(token)
 
 
 __all__ = ["run_conversation"]

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -22,13 +22,78 @@ keep the exact logger name (``"agent.conversation_loop"``).
 
 from __future__ import annotations
 
+from contextvars import ContextVar, Token
 import logging
 import os
+from typing import Any
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.message_content import flatten_message_text
 from agent.message_metadata import append_message, stamp_message_timestamp
 from agent.message_sanitization import _sanitize_surrogates
+
+
+_TURN_EXIT_REASON: ContextVar[str] = ContextVar(
+    "hermes_turn_exit_reason", default="unknown"
+)
+
+
+def _begin_turn_finalization() -> Token[str]:
+    """Start an isolated reason scope for one public conversation turn."""
+    return _TURN_EXIT_REASON.set("unknown")
+
+
+def _record_turn_exit_reason(reason: str) -> str:
+    """Publish the existing loop-local reason without changing its value."""
+    _TURN_EXIT_REASON.set(reason)
+    return reason
+
+
+def _current_turn_exit_reason() -> str:
+    """Return the reason associated with the current execution context."""
+    return _TURN_EXIT_REASON.get()
+
+
+def _log_turn_finalization(agent: Any, reason: str, error: BaseException | None) -> None:
+    """Emit the behavior-neutral breadcrumb consumed by future accounting work."""
+    try:
+        from agent.redact import redact_sensitive_text
+
+        safe_session_id = redact_sensitive_text(
+            str(getattr(agent, "session_id", None) or "-"), force=True
+        )
+        safe_reason = redact_sensitive_text(str(reason), force=True)
+    except Exception:
+        # Fail closed: diagnostics must not leak a reason or session identifier
+        # when the central redactor is unavailable.
+        safe_session_id = "[REDACTED]"
+        safe_reason = "[REDACTED]"
+    logging.getLogger("agent.conversation_loop").info(
+        "Turn finalization path reached: session=%s reason=%s exception=%s",
+        safe_session_id,
+        safe_reason,
+        type(error).__name__ if error is not None else "none",
+    )
+
+
+def _complete_turn_finalization(agent: Any, error: BaseException | None) -> None:
+    """Observe one terminal path without replacing its return or exception."""
+    reason = _current_turn_exit_reason()
+    if error is not None and reason == "unknown":
+        reason = f"exception({type(error).__name__})"
+    try:
+        _log_turn_finalization(agent, reason, error)
+    except Exception:
+        # The new observer is diagnostic only. It must never replace a result
+        # or mask the original exception.
+        logging.getLogger("agent.conversation_loop").warning(
+            "Turn finalization path logging failed", exc_info=True
+        )
+
+
+def _reset_turn_finalization(token: Token[str]) -> None:
+    """Restore the caller's ContextVar state after one public turn."""
+    _TURN_EXIT_REASON.reset(token)
 
 
 def _is_pure_tool_call_tail(msg: dict) -> bool:
@@ -172,14 +237,18 @@ def finalize_turn(
         # response-loss blocker)
         if _pending_verification_response_previewed:
             agent._response_was_previewed = True
-        _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
+        _turn_exit_reason = _record_turn_exit_reason(
+            f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
+        )
         iteration_limit_fallback = True
         preserved_verification_fallback = True
     elif final_response is None and budget_fallback_eligible:
         # Budget exhausted — ask the model for a summary via one extra
         # API call with tools stripped.  _handle_max_iterations injects a
         # user message and makes a single toolless request.
-        _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
+        _turn_exit_reason = _record_turn_exit_reason(
+            f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
+        )
         agent._emit_status(
             f"⚠️ Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
             "— asking model to summarise"

--- a/tests/agent/test_turn_finalization_path.py
+++ b/tests/agent/test_turn_finalization_path.py
@@ -1,0 +1,206 @@
+"""Parity tests for the single run_conversation finalization path."""
+
+from __future__ import annotations
+
+import inspect
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier, Lock
+from types import SimpleNamespace
+
+import pytest
+
+from agent import conversation_loop, turn_finalizer
+
+
+_COUNTER_NAMES = (
+    "session_input_tokens",
+    "session_output_tokens",
+    "session_total_tokens",
+    "session_estimated_cost_usd",
+)
+
+
+def _agent(session_id: str = "session-test", *, reason: str = "unknown") -> SimpleNamespace:
+    return SimpleNamespace(
+        session_id=session_id,
+        reason=reason,
+        session_input_tokens=101,
+        session_output_tokens=23,
+        session_total_tokens=124,
+        session_estimated_cost_usd=0.0123,
+    )
+
+
+def _totals(agent: SimpleNamespace) -> tuple[object, ...]:
+    return tuple(getattr(agent, name) for name in _COUNTER_NAMES)
+
+
+@pytest.mark.parametrize(
+    ("nature", "reason", "result"),
+    [
+        (
+            "normal",
+            "text_response(finish_reason=stop)",
+            {"final_response": "ok", "messages": [], "api_calls": 1, "completed": True},
+        ),
+        (
+            "partial",
+            "partial_stream_recovery",
+            {
+                "final_response": "partial",
+                "messages": [],
+                "api_calls": 2,
+                "completed": False,
+                "partial": True,
+            },
+        ),
+        (
+            "interrupted",
+            "interrupted_by_user",
+            {
+                "final_response": None,
+                "messages": [],
+                "api_calls": 1,
+                "completed": False,
+                "interrupted": True,
+            },
+        ),
+        (
+            "budget_exhausted",
+            "budget_exhausted",
+            {
+                "final_response": "budget summary",
+                "messages": [],
+                "api_calls": 4,
+                "completed": False,
+                "partial": True,
+            },
+        ),
+        (
+            "error",
+            "all_retries_exhausted_no_response",
+            {
+                "final_response": "failed",
+                "messages": [],
+                "api_calls": 3,
+                "completed": False,
+                "failed": True,
+                "error": "failed",
+            },
+        ),
+    ],
+)
+def test_public_turn_result_and_totals_are_unchanged_and_finalized_once(
+    monkeypatch: pytest.MonkeyPatch,
+    nature: str,
+    reason: str,
+    result: dict[str, object],
+) -> None:
+    agent = _agent()
+    before = _totals(agent)
+    calls: list[tuple[str, str, BaseException | None]] = []
+
+    def fake_impl(_agent: SimpleNamespace, *_args, **_kwargs) -> dict[str, object]:
+        turn_finalizer._record_turn_exit_reason(reason)
+        return result
+
+    def capture(_agent: SimpleNamespace, observed_reason: str, error: BaseException | None) -> None:
+        calls.append((_agent.session_id, observed_reason, error))
+
+    monkeypatch.setattr(conversation_loop, "_run_conversation_impl", fake_impl)
+    monkeypatch.setattr(turn_finalizer, "_log_turn_finalization", capture)
+
+    observed = conversation_loop.run_conversation(agent, f"case:{nature}")
+
+    assert observed is result
+    assert observed == result
+    assert _totals(agent) == before
+    assert calls == [(agent.session_id, reason, None)]
+    assert turn_finalizer._current_turn_exit_reason() == "unknown"
+
+
+def test_exception_is_finalized_once_reraised_by_identity_and_context_is_restored(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _agent()
+    before = _totals(agent)
+    sentinel = RuntimeError("sentinel")
+    calls: list[tuple[str, str, BaseException | None]] = []
+
+    def fake_impl(_agent: SimpleNamespace, *_args, **_kwargs) -> dict[str, object]:
+        raise sentinel
+
+    def capture(_agent: SimpleNamespace, reason: str, error: BaseException | None) -> None:
+        calls.append((_agent.session_id, reason, error))
+
+    monkeypatch.setattr(conversation_loop, "_run_conversation_impl", fake_impl)
+    monkeypatch.setattr(turn_finalizer, "_log_turn_finalization", capture)
+
+    with pytest.raises(RuntimeError) as raised:
+        conversation_loop.run_conversation(agent, "exception")
+
+    assert raised.value is sentinel
+    assert _totals(agent) == before
+    assert calls == [(agent.session_id, "exception(RuntimeError)", sentinel)]
+    assert turn_finalizer._current_turn_exit_reason() == "unknown"
+
+
+def test_contextvar_keeps_concurrent_turn_reasons_isolated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    barrier = Barrier(2)
+    lock = Lock()
+    calls: list[tuple[str, str]] = []
+
+    def fake_impl(agent: SimpleNamespace, *_args, **_kwargs) -> dict[str, object]:
+        turn_finalizer._record_turn_exit_reason(agent.reason)
+        barrier.wait(timeout=5)
+        return {"final_response": agent.reason, "completed": True}
+
+    def capture(agent: SimpleNamespace, reason: str, _error: BaseException | None) -> None:
+        with lock:
+            calls.append((agent.session_id, reason))
+
+    monkeypatch.setattr(conversation_loop, "_run_conversation_impl", fake_impl)
+    monkeypatch.setattr(turn_finalizer, "_log_turn_finalization", capture)
+
+    agents = [_agent("session-a", reason="reason-a"), _agent("session-b", reason="reason-b")]
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda item: conversation_loop.run_conversation(item, "go"), agents))
+
+    assert results == [
+        {"final_response": "reason-a", "completed": True},
+        {"final_response": "reason-b", "completed": True},
+    ]
+    assert sorted(calls) == [("session-a", "reason-a"), ("session-b", "reason-b")]
+    assert turn_finalizer._current_turn_exit_reason() == "unknown"
+
+
+def test_finalization_log_redacts_dynamic_reason(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from agent import redact
+
+    sensitive = "dynamic-sensitive-value"
+    calls: list[tuple[str, bool]] = []
+
+    def fake_redact(value: str, *, force: bool = False) -> str:
+        calls.append((value, force))
+        return value.replace(sensitive, "[REDACTED]")
+
+    monkeypatch.setattr(redact, "redact_sensitive_text", fake_redact)
+    with caplog.at_level("INFO", logger="agent.conversation_loop"):
+        turn_finalizer._log_turn_finalization(
+            _agent(), f"local_processing_error({sensitive})", None
+        )
+
+    assert sensitive not in caplog.text
+    assert "local_processing_error([REDACTED])" in caplog.text
+    assert all(force for _value, force in calls)
+
+
+def test_public_signature_matches_private_implementation() -> None:
+    assert inspect.signature(conversation_loop.run_conversation) == inspect.signature(
+        conversation_loop._run_conversation_impl
+    )


### PR DESCRIPTION
## Summary
- preserve the legacy conversation loop as `_run_conversation_impl` behind a public `try/finally` wrapper
- carry the existing turn exit reason through a per-execution `ContextVar`, finalize exactly once, restore context, and re-raise exceptions unchanged
- redact finalization diagnostics with the central forced redactor and leave usage/cost accounting untouched

## Parity and safety
- public signature matches the pre-refactor signature
- normalized AST of the legacy implementation is identical after stripping only the reason observer
- return dictionaries retain object identity and session totals remain identical for normal, partial, interrupted, budget-exhausted, and error paths
- propagated exception retains object identity
- concurrent-turn test verifies ContextVar isolation

## Tests
- `scripts/run_tests.sh` on the seven affected finalizer suites: **67 passed**
- new parity suite: **9 passed**
- `ruff 0.15.10 check` on changed files: **passed**
- full local suite was attempted but the available system test environment lacked optional dependencies (`acp`, `mcp`, `openai`, `fal-client`, `pytest-asyncio`) and timed out at 86.5%; targeted failures reproduced before reaching this diff. CI should provide the authoritative full-suite result.

No merge or deployment performed.