### PR TITLE
fix(web_tools): remove duplicate Firecrawl Client section comment

### DIFF
--- a/contributors/emails/bot@blut-agent.dev
+++ b/contributors/emails/bot@blut-agent.dev
@@ -1,0 +1,1 @@
+blut-agent

--- a/contributors/emails/edrayoca+agent@gmail.com
+++ b/contributors/emails/edrayoca+agent@gmail.com
@@ -1,0 +1,2 @@
+edrayoca-agent
+# hermes-agent PR contributor

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -579,8 +579,6 @@ def _rescue_extract(provider_name: str, urls: list, results: list) -> list:
 
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
-
-# ─── Firecrawl Client ────────────────────────────────────────────────────────
 # After PR #25182, the firecrawl client, lazy SDK proxy, dual-auth config
 # resolution, response normalizers, and check_firecrawl_api_key() all live
 # in plugins.web.firecrawl.provider and are re-exported at the top of this


### PR DESCRIPTION
The Firecrawl Client section comment in tools/web_tools.py was duplicated - a standalone header appeared before the annotated comment block with the same header. This is a merge artifact from the keyless rescue PR. Removed the stale standalone line while keeping the annotated block.