### PR TITLE
fix(discord): rebase thread backfill continue onto current main

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7010,11 +7010,22 @@ class DiscordAdapter(BasePlatformAdapter):
                     or _looks_like_nonconversational_history_message(_content)
                 ):
                     continue
-                # Stop at our own (conversational) message — this is the
-                # partition point.  Everything before this is already in the
-                # session transcript.  (Redundant when _after_obj is set, but
-                # needed for cold start.)
+                # In regular channels: stop at our own (conversational)
+                # message — this is the partition point.  Everything before
+                # this is already in the session transcript.  (Redundant when
+                # _after_obj is set, but needed for cold start.)
+                #
+                # In threads: skip our own messages instead of breaking.
+                # Threads with thread_require_mention=false process every
+                # message, so bot responses sit between user messages.  A new
+                # trigger after a bot response would scan backwards and
+                # immediately break at the bot's last reply, collecting zero
+                # user messages.  After a gateway restart the session
+                # transcript may also be fresh, so the partition rule cannot
+                # assume prior context already exists.
                 if msg.author == self._client.user:
+                    if isinstance(channel, discord.Thread):
+                        continue
                     break
                 line = _keep(msg)
                 if line is None:

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -184,6 +184,22 @@ class FakeHistoryChannel(FakeTextChannel):
         return _iter()
 
 
+class FakeHistoryThread(FakeThread):
+    """Thread flavour of FakeHistoryChannel.
+
+    ``isinstance(channel, discord.Thread)`` drives the thread-specific
+    partition rule, and the ``adapter`` fixture patches ``discord.Thread``
+    to ``FakeThread`` — so backfill tests that need thread semantics must
+    inherit from it rather than from ``FakeTextChannel``.
+    """
+
+    def __init__(self, history_messages, **kwargs):
+        super().__init__(**kwargs)
+        self._history_messages = list(history_messages)
+
+    history = FakeHistoryChannel.history
+
+
 @pytest.mark.asyncio
 async def test_discord_free_response_in_server_channels(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
@@ -680,6 +696,69 @@ async def test_fetch_channel_context_ignores_stale_cache(adapter, monkeypatch):
     assert result == "[Recent channel messages]\n[Alice] hello"
     # Cache should have been ignored — after= should be None
     assert recorded_after["value"] is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_context_thread_keeps_humans_around_own_message(adapter, monkeypatch):
+    """Regression: in threads the scan must skip our own message, not break at it.
+
+    With ``thread_require_mention=false`` every thread message is processed, so
+    our replies sit between human turns.  Breaking at the first self-authored
+    message collects zero human context — and after a gateway restart the
+    session transcript is fresh, so nothing else supplies it either.
+    """
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    human = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+
+    channel = FakeHistoryThread(
+        [
+            make_history_message(author=human, content="earlier human turn", msg_id=1),
+            make_history_message(author=adapter._client.user, content="hermes reply", msg_id=2),
+            make_history_message(author=human, content="recent human turn", msg_id=3),
+        ],
+        channel_id=888,
+    )
+
+    result = await adapter._fetch_channel_context(
+        channel, before=make_message(channel=channel, content="trigger"),
+    )
+
+    # Both sides of our own message survive; our own reply is skipped, not kept.
+    assert "[Alice] earlier human turn" in result
+    assert "[Alice] recent human turn" in result
+    assert "hermes reply" not in result
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_context_regular_channel_still_partitions_at_own_message(adapter, monkeypatch):
+    """Control for the thread carve-out: normal channels must still break.
+
+    Outside threads the self-authored message remains the partition point —
+    everything before it is already in the session transcript.
+    """
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    human = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+
+    channel = FakeHistoryChannel(
+        [
+            make_history_message(author=human, content="earlier human turn", msg_id=1),
+            make_history_message(author=adapter._client.user, content="hermes reply", msg_id=2),
+            make_history_message(author=human, content="recent human turn", msg_id=3),
+        ],
+        channel_id=889,
+    )
+
+    result = await adapter._fetch_channel_context(
+        channel, before=make_message(channel=channel, content="trigger"),
+    )
+
+    assert "[Alice] recent human turn" in result
+    assert "[Alice] earlier human turn" not in result
+    assert "hermes reply" not in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Salvage of #42075 onto current `main`. Original authorship preserved via cherry-pick (`Pruthvi Patel`).

Fixes the Discord thread history partition in `_fetch_channel_context`: in threads, skip Hermes-authored messages instead of `break`ing at them. Regular channels keep the existing self-message partition.

This is the exact remaining hole in #42079. Without a Discord reply, a follow-up in an existing bot thread collected only messages *after* the last Hermes reply, so short continuations (`ok`, `fix it`, `the other one`) arrived with no target.

## Why a rebase PR

#42075 is still open and still the right change. Sweeper review asked to:

- keep the thread-only `continue`
- drop the unrelated auto-thread `channel_context` hunk
- add a FakeThread regression test

The current #42075 commit already matches that. It did not apply onto today's `main` as a merge from the original head, so this PR cherry-picks that commit onto `origin/main` (`f43eabee5f`). Please treat this as the landable form of #42075, not a competing design.

Closes #42079.

## Tests

```bash
scripts/run_tests.sh tests/gateway/test_discord_free_response.py \
  tests/gateway/test_discord_thread_persistence.py \
  tests/gateway/test_discord_missed_message_backfill.py \
  tests/gateway/test_discord_reply_mode.py -q
```

Result on this branch: **54 passed, 0 failed**.

Same diff previously also passed the full `tests/gateway/test_discord_*.py` set: **261 passed, 0 failed**.

Red/green on current main before cherry-pick:

- `test_fetch_channel_context_thread_keeps_humans_around_own_message` **failed** (earlier human turn dropped at the self-message `break`)
- `test_fetch_channel_context_regular_channel_still_partitions_at_own_message` **passed**
- after the cherry-pick, both pass
