### PR TITLE
fix(cli): stop plugins doctor from copying a non-plugin directory

### DIFF
--- a/hermes_cli/plugin_dev.py
+++ b/hermes_cli/plugin_dev.py
@@ -16,7 +16,7 @@ import sys
 import tempfile
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePath
 from types import SimpleNamespace
 from typing import Any, Literal
 from unittest.mock import patch
@@ -178,33 +178,88 @@ class DoctorReport:
         return "\n".join(lines)
 
 
+_MANIFEST_NAMES = ("plugin.yaml", "plugin.yml", "plugin.json")
+
+
+def _has_manifest(path: Path) -> bool:
+    return any(
+        (path / name).exists() or (path / name).is_symlink()
+        for name in _MANIFEST_NAMES
+    )
+
+
+def _holds_plugin(path: Path) -> bool:
+    """True when plugin discovery would find a manifest under *path*.
+
+    Mirrors ``PluginManager._scan_directory``: a manifest in *path* itself
+    (flat layout) or in one immediate subdirectory (category layout, where
+    the category directory carries no manifest of its own).
+
+    Doctor copies the resolved directory wholesale before the runtime gets
+    to reject it, so an unvalidated resolve is a disk-usage bug, not just a
+    confusing error: ``hermes plugins doctor`` with no argument defaults to
+    ``.``, and any directory used to satisfy that.
+    """
+    if not path.is_dir():
+        return False
+    if _has_manifest(path):
+        return True
+    try:
+        children = sorted(path.iterdir())
+    except OSError:
+        return False
+    return any(child.is_dir() and _has_manifest(child) for child in children)
+
+
+def _is_plugin_id(raw: str) -> bool:
+    """True when *raw* can name an installed plugin rather than a path.
+
+    Ids are relative and may carry one category segment
+    (``image_gen/openai``). Dot components are excluded: joining ``.``
+    onto a plugins root yields the root itself, which would hand Doctor
+    every installed plugin at once instead of one.
+    """
+    if not raw or PurePath(raw).is_absolute():
+        return False
+    parts = PurePath(raw).parts
+    return bool(parts) and all(part not in {os.curdir, os.pardir} for part in parts)
+
+
 def resolve_plugin_path(target: str | os.PathLike[str] | None = None) -> Path:
     """Resolve an explicit path or an installed/bundled plugin id."""
     raw = os.fspath(target or ".")
     direct = Path(raw).expanduser()
-    if direct.is_dir():
+    direct_is_dir = direct.is_dir()
+    if direct_is_dir and _holds_plugin(direct):
         return direct.resolve()
 
     candidates: list[Path] = []
-    user_root = get_hermes_home() / "plugins"
-    candidates.append(user_root / raw)
-    try:
-        from hermes_cli.plugins import get_bundled_plugins_dir
+    if _is_plugin_id(raw):
+        user_root = get_hermes_home() / "plugins"
+        candidates.append(user_root / raw)
+        try:
+            from hermes_cli.plugins import get_bundled_plugins_dir
 
-        bundled = get_bundled_plugins_dir()
-        candidates.extend(
-            [
-                bundled / raw,
-                bundled / "platforms" / raw,
-                bundled / "model-providers" / raw,
-            ]
-        )
-    except Exception:
-        pass
-    candidates.append(Path.cwd() / ".hermes" / "plugins" / raw)
+            bundled = get_bundled_plugins_dir()
+            candidates.extend(
+                [
+                    bundled / raw,
+                    bundled / "platforms" / raw,
+                    bundled / "model-providers" / raw,
+                ]
+            )
+        except Exception:
+            pass
+        candidates.append(Path.cwd() / ".hermes" / "plugins" / raw)
     for candidate in candidates:
-        if candidate.is_dir():
+        if _holds_plugin(candidate):
             return candidate.resolve()
+    if direct_is_dir:
+        raise FileNotFoundError(
+            f"{direct.resolve()} holds no plugin manifest "
+            f"({', '.join(_MANIFEST_NAMES)}), and {raw!r} is not an installed "
+            "plugin id. Point Doctor at a plugin directory."
+        )
     raise FileNotFoundError(
         f"Plugin {raw!r} was not found as a path or installed plugin id"
     )

--- a/tests/hermes_cli/test_plugin_dev.py
+++ b/tests/hermes_cli/test_plugin_dev.py
@@ -134,3 +134,84 @@ def test_doctor_blocks_live_network(tmp_path: Path) -> None:
     report = doctor_plugin(plugin)
     assert report.ok is False
     assert "network access is disabled while Plugin Doctor runs" in report.format_text()
+
+
+def test_resolve_rejects_directory_without_manifest(tmp_path: Path) -> None:
+    """A non-plugin directory must not resolve — Doctor copies what it resolves."""
+    import pytest
+
+    from hermes_cli.plugin_dev import resolve_plugin_path
+
+    not_a_plugin = tmp_path / "home"
+    (not_a_plugin / "Documents").mkdir(parents=True)
+    (not_a_plugin / "Documents" / "notes.txt").write_text("x", encoding="utf-8")
+
+    with pytest.raises(FileNotFoundError) as excinfo:
+        resolve_plugin_path(not_a_plugin)
+
+    assert "holds no plugin manifest" in str(excinfo.value)
+
+
+def test_doctor_default_target_does_not_copy_cwd(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """``hermes plugins doctor`` with no argument defaults to ``.``.
+
+    Before the manifest guard, that copied the whole working directory into
+    a temporary HERMES_HOME — running it from ``$HOME`` copied the home
+    directory, cloud-storage placeholders included.
+    """
+    import os
+    import shutil
+
+    from hermes_cli import plugin_dev
+
+    workdir = tmp_path / "workdir"
+    (workdir / "big").mkdir(parents=True)
+    (workdir / "big" / "payload.bin").write_text("x" * 1024, encoding="utf-8")
+    monkeypatch.chdir(workdir)
+
+    copied: list[tuple[str, str]] = []
+    real_copytree = shutil.copytree
+
+    def _tracking_copytree(src, dst, *args, **kwargs):
+        copied.append((os.fspath(src), os.fspath(dst)))
+        return real_copytree(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(plugin_dev.shutil, "copytree", _tracking_copytree)
+
+    report = plugin_dev.doctor_plugin()
+
+    assert report.ok is False
+    assert copied == []
+
+
+def test_resolve_accepts_category_layout(tmp_path: Path) -> None:
+    """A category directory holds no manifest itself but discovery finds one."""
+    from hermes_cli.plugin_dev import resolve_plugin_path
+
+    category = tmp_path / "image_gen"
+    plugin = category / "openai"
+    plugin.mkdir(parents=True)
+    (plugin / "plugin.yaml").write_text("name: openai\n", encoding="utf-8")
+
+    assert resolve_plugin_path(category) == category.resolve()
+
+
+def test_resolve_prefers_installed_id_over_unrelated_local_dir(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A same-named local directory must not shadow the installed plugin."""
+    from hermes_cli import plugin_dev
+
+    hermes_home = tmp_path / "hermes-home"
+    installed = hermes_home / "plugins" / "sample"
+    installed.mkdir(parents=True)
+    (installed / "plugin.yaml").write_text("name: sample\n", encoding="utf-8")
+
+    workdir = tmp_path / "workdir"
+    (workdir / "sample").mkdir(parents=True)
+    monkeypatch.chdir(workdir)
+    monkeypatch.setattr(plugin_dev, "get_hermes_home", lambda: hermes_home)
+
+    assert plugin_dev.resolve_plugin_path("sample") == installed.resolve()


### PR DESCRIPTION
## What does this PR do?

`hermes plugins doctor` copied its target directory into a temporary
`HERMES_HOME` before checking that the target was a plugin. Since the `target`
argument defaults to `.`, running the command from any non-plugin directory
copied that whole tree.

On macOS run from `$HOME` this copies the home directory, and because
`Library/CloudStorage` is not excluded it also materializes every cloud-only
Google Drive / iCloud placeholder — so the copy grows past the size of the
source. I measured 461 GB written to `/private/var/folders`, still growing at
~6 GB/min when I killed it, on a machine that had 49 GB left.

The fix moves the plugin check ahead of the copy: `resolve_plugin_path` now
requires a manifest before it returns a path.

## Related Issue

Fixes #90858

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

**`hermes_cli/plugin_dev.py`**

- Added `_has_manifest()` / `_holds_plugin()`. `_holds_plugin` mirrors
  `PluginManager._scan_directory` so both discovery layouts keep resolving:
  a manifest in the directory itself (flat), or in one immediate subdirectory
  (category layout such as `image_gen/openai`, where the category directory
  carries no manifest of its own). Manifest names match the scanner:
  `plugin.yaml`, `plugin.yml`, `plugin.json`, including the dangling-symlink
  case the scanner already handles.
- `resolve_plugin_path` requires `_holds_plugin` for both the direct-path
  branch and the id candidates.
- Added `_is_plugin_id()`, and only build id candidates when `raw` can be an
  id. This matters: candidates are formed by joining `raw` onto a plugins
  root, so `raw == "."` makes `bundled / "."` the bundled plugins root itself.
  Without this guard, tightening the direct branch just moves the over-broad
  copy from the working directory to the whole bundled plugins tree — my first
  attempt at this patch did exactly that, and the new
  `test_doctor_default_target_does_not_copy_cwd` caught it.
- A directory target that holds no manifest now names the missing files and
  says what to point Doctor at, instead of the generic not-found message.

**`tests/hermes_cli/test_plugin_dev.py`** — four regression tests:

- `test_resolve_rejects_directory_without_manifest`
- `test_doctor_default_target_does_not_copy_cwd` — wraps `shutil.copytree` and
  asserts it is never called; this is the disk-filling regression
- `test_resolve_accepts_category_layout`
- `test_resolve_prefers_installed_id_over_unrelated_local_dir`

## How to Test

Reproduce on `main` (**this fills your disk** — use a scratch user or a VM, or
wrap `shutil.copytree` first):

```bash
cd ~
hermes plugins doctor
# in another shell:
du -sh /private/var/folders/*/*/T/hermes-plugin-doctor-*   # macOS
```

With this branch:

```bash
$ cd ~ && hermes plugins doctor
Plugin Doctor: .
  ERROR: /Users/<you> holds no plugin manifest (plugin.yaml, plugin.yml, plugin.json), and '.' is not an installed plugin id. Point Doctor at a plugin directory.
  registrations: 0 tool(s), 0 hook(s)
```

Nothing is copied — verified by wrapping `shutil.copytree` with a call that
raises, then running `doctor_plugin()` from `$HOME`.

Valid targets are unaffected:

```bash
hermes plugins doctor memory/honcho        # category layout
hermes plugins doctor platforms/telegram
hermes plugins doctor <installed-id>       # ~/.hermes/plugins/<id>
hermes plugins doctor ./path/to/plugin     # explicit path
```

Tests:

```bash
pytest tests/hermes_cli/test_plugin_dev.py -v   # 9 passed
```

I could not get a clean full-suite run in my environment — `pytest tests/ -q`
has 68 pre-existing failures here from missing CI-only test dependencies. I
verified they are unrelated by running the plugin suites with and without this
patch: the failure list is byte-identical both ways (68 before, 68 after), and
the patched run adds exactly the 4 new passing tests.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — see note above; the
      targeted suites pass and the pre-existing failures are unchanged by this
      patch
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 27.0, Python 3.11.16

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — the new helpers carry
      the rationale
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — the fix is `pathlib` only, no new
      platform assumptions. The cloud-placeholder amplification is macOS
      specific, but the unbounded copy itself affects every platform.
- [x] Tool descriptions/schemas — N/A

## Notes for reviewers

Two things I deliberately left out of this PR, happy to follow up separately:

1. **`copytree` is still unbounded for a legitimate plugin.** A plugin
   directory carrying a `.venv` or `node_modules` is copied in full; the
   `ignore_patterns` list is only `.git`, `__pycache__`, `.pytest_cache`,
   `*.pyc`. Worth widening, and worth excluding `Library/CloudStorage` and
   `~/Library/Mobile Documents` outright so cloud placeholders can never be
   materialized by a copy.
2. **Running Doctor from inside a plugins root** (e.g. `~/.hermes/plugins`)
   still copies every installed plugin before failing with "Expected one
   plugin manifest, discovered N". That is bounded and pre-existing behavior,
   so I did not change it here.
