### PR TITLE
feat(desktop): notify when local cron runs finish

### DIFF
--- a/apps/desktop/src/app/cron/cron-actions.test.ts
+++ b/apps/desktop/src/app/cron/cron-actions.test.ts
@@ -2,12 +2,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const getCronJobs = vi.fn()
 const getApiRequestConnection = vi.fn<() => null | string>(() => null)
+const observeCronCompletions = vi.fn().mockResolvedValue(undefined)
 const triggerCronJob = vi.fn()
 
 vi.mock('@/hermes', () => ({
   getApiRequestConnection: () => getApiRequestConnection(),
   getCronJobs: (...args: unknown[]) => getCronJobs(...args),
   triggerCronJob: (...args: unknown[]) => triggerCronJob(...args)
+}))
+
+vi.mock('@/store/cron-completion-notifications', () => ({
+  observeCronCompletions: (...args: unknown[]) => observeCronCompletions(...args)
 }))
 
 import { beginCronJobsRequest } from '@/store/cron'
@@ -21,7 +26,18 @@ describe('triggerAndRefreshCronJobs', () => {
     getApiRequestConnection.mockReset()
     getApiRequestConnection.mockReturnValue(null)
     getCronJobs.mockReset()
+    observeCronCompletions.mockClear()
     triggerCronJob.mockReset()
+  })
+
+  it('observes only an authoritative accepted cron snapshot', async () => {
+    const jobs = [{ id: 'daily', last_run_at: '2026-08-20T10:00:00+00:00' }]
+    getApiRequestConnection.mockReturnValue('gateway-a')
+    getCronJobs.mockResolvedValue(jobs)
+
+    await refreshCronJobs('work')
+
+    expect(observeCronCompletions).toHaveBeenCalledWith('gateway-a\0work', jobs)
   })
 
   it('replaces the local cache with the authoritative list after a trigger', async () => {

--- a/apps/desktop/src/app/cron/cron-actions.ts
+++ b/apps/desktop/src/app/cron/cron-actions.ts
@@ -7,6 +7,7 @@ import {
   isCronJobsRequestCurrent,
   isCronJobsScopeCurrent
 } from '@/store/cron'
+import { observeCronCompletions } from '@/store/cron-completion-notifications'
 
 export interface CronTriggerRefreshResult {
   jobs: CronJob[] | null
@@ -29,6 +30,10 @@ async function refreshForGeneration(profile: string, request: CronJobsRequest): 
     if (!commitCronJobsRequest(request, jobs)) {
       return { jobs: null, refreshError: null, stale: true }
     }
+
+    // Compare only authoritative, request-fenced snapshots. The observer
+    // hydrates silently, then resolves the exact run session for click-through.
+    void observeCronCompletions(request.scope, jobs)
 
     return { jobs, refreshError: null, stale: false }
   } catch (refreshError) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/lifecycle.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/lifecycle.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ingestBackendSkin = vi.fn()
+const resetCronCompletionNotifications = vi.fn()
+const setChangeEventsAvailable = vi.fn()
+
+vi.mock('@/store/cron-completion-notifications', () => ({
+  resetCronCompletionNotifications: () => resetCronCompletionNotifications()
+}))
+
+vi.mock('@/store/live-sync', () => ({
+  notifyCronChanged: vi.fn(),
+  notifyPairingChanged: vi.fn(),
+  notifyPetChanged: vi.fn(),
+  notifyPlatformsChanged: vi.fn(),
+  notifySessionsChanged: vi.fn(),
+  setChangeEventsAvailable: (available: boolean) => setChangeEventsAvailable(available)
+}))
+
+vi.mock('@/store/session-states', () => ({
+  dropSessionState: vi.fn(),
+  unbindTileRuntime: vi.fn()
+}))
+
+vi.mock('@/themes/backend-sync', () => ({
+  ingestBackendSkin: (...args: unknown[]) => ingestBackendSkin(...args)
+}))
+
+import { handleLifecycleEvent } from './lifecycle'
+
+function readyContext(fromActiveSource: boolean) {
+  return {
+    deps: {},
+    event: { payload: { change_events: true }, type: 'gateway.ready' },
+    fromActiveSource: () => fromActiveSource,
+    payload: { change_events: true }
+  } as never
+}
+
+describe('gateway.ready cron completion baseline', () => {
+  beforeEach(() => {
+    ingestBackendSkin.mockClear()
+    resetCronCompletionNotifications.mockClear()
+    setChangeEventsAvailable.mockClear()
+  })
+
+  it('resets the completion baseline for the active source reconnect', () => {
+    expect(handleLifecycleEvent(readyContext(true))).toBe(true)
+    expect(resetCronCompletionNotifications).toHaveBeenCalledOnce()
+  })
+
+  it('does not reset the active baseline for a background source reconnect', () => {
+    expect(handleLifecycleEvent(readyContext(false))).toBe(true)
+    expect(resetCronCompletionNotifications).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/lifecycle.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/lifecycle.ts
@@ -1,5 +1,6 @@
 import type { HermesSkin } from '@hermes/shared/skin'
 
+import { resetCronCompletionNotifications } from '@/store/cron-completion-notifications'
 import {
   notifyCronChanged,
   notifyPairingChanged,
@@ -21,6 +22,13 @@ export function handleLifecycleEvent(ctx: GatewayEventContext): boolean {
   const { deps, event, payload, fromActiveSource } = ctx
 
   if (event.type === 'gateway.ready') {
+    // A reconnect may replay a jobs snapshot whose last_run_at advanced while
+    // the desktop was offline. Treat the active source's snapshot as hydration,
+    // not a fresh completion; background profile sockets must not reset it.
+    if (fromActiveSource()) {
+      resetCronCompletionNotifications()
+    }
+
     // Seed the active skin into the desktop theme registry without applying,
     // so a fresh connect never overrides the user's persisted desktop theme.
     ingestBackendSkin((payload as { skin?: HermesSkin } | undefined)?.skin, { apply: false })

--- a/apps/desktop/src/store/cron-completion-notifications.test.ts
+++ b/apps/desktop/src/store/cron-completion-notifications.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { CronJob, SessionInfo } from '@/hermes'
+
+import { createCronCompletionNotifier } from './cron-completion-notifications'
+
+const run = { id: 'cron_daily_1720000000' } as SessionInfo
+
+function job(updates: Partial<CronJob> = {}): CronJob {
+  return {
+    deliver: 'local',
+    enabled: true,
+    id: 'daily',
+    last_run_at: null,
+    name: 'Daily briefing',
+    ...updates
+  }
+}
+
+describe('cron completion notifications', () => {
+  it('notifies once when a locally delivered job completes after hydration', async () => {
+    const getRuns = vi.fn().mockResolvedValue([run])
+    const notify = vi.fn()
+    const observer = createCronCompletionNotifier({ getRuns, notify })
+
+    await observer.observe('local\0default', [job()])
+    await observer.observe('local\0default', [job({ last_run_at: '2026-08-20T10:00:00+00:00' })])
+    await observer.observe('local\0default', [job({ last_run_at: '2026-08-20T10:00:00+00:00' })])
+
+    expect(getRuns).toHaveBeenCalledTimes(1)
+    expect(getRuns).toHaveBeenCalledWith('daily', 5)
+    expect(notify).toHaveBeenCalledOnce()
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        global: true,
+        kind: 'backgroundDone',
+        sessionId: run.id
+      })
+    )
+  })
+
+  it('uses the first accepted snapshot as a silent hydration baseline', async () => {
+    const getRuns = vi.fn().mockResolvedValue([run])
+    const notify = vi.fn()
+    const observer = createCronCompletionNotifier({ getRuns, notify })
+
+    await observer.observe('local\0default', [job({ last_run_at: '2026-08-20T10:00:00+00:00' })])
+
+    expect(getRuns).not.toHaveBeenCalled()
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it('silently re-baselines when the connection or profile scope changes', async () => {
+    const getRuns = vi.fn().mockResolvedValue([run])
+    const notify = vi.fn()
+    const observer = createCronCompletionNotifier({ getRuns, notify })
+
+    await observer.observe('local\0default', [job()])
+    await observer.observe('remote\0work', [job({ last_run_at: '2026-08-20T10:00:00+00:00' })])
+
+    expect(getRuns).not.toHaveBeenCalled()
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it('does not notify for a remote-only delivery target', async () => {
+    const getRuns = vi.fn().mockResolvedValue([run])
+    const notify = vi.fn()
+    const observer = createCronCompletionNotifier({ getRuns, notify })
+
+    await observer.observe('local\0default', [job({ deliver: 'telegram' })])
+    await observer.observe('local\0default', [
+      job({ deliver: 'telegram', last_run_at: '2026-08-20T10:00:00+00:00' })
+    ])
+
+    expect(getRuns).not.toHaveBeenCalled()
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it('notifies once for a multi-target job that includes local delivery', async () => {
+    const getRuns = vi.fn().mockResolvedValue([run])
+    const notify = vi.fn()
+    const observer = createCronCompletionNotifier({ getRuns, notify })
+
+    await observer.observe('local\0default', [job({ deliver: 'local,telegram' })])
+    await observer.observe('local\0default', [
+      job({ deliver: 'local,telegram', last_run_at: '2026-08-20T10:00:00+00:00' })
+    ])
+
+    expect(notify).toHaveBeenCalledOnce()
+  })
+
+  it('labels failed runs and retains the exact completed run session target', async () => {
+    const getRuns = vi.fn().mockResolvedValue([run])
+    const notify = vi.fn()
+    const observer = createCronCompletionNotifier({ getRuns, notify })
+
+    await observer.observe('local\0default', [job()])
+    await observer.observe('local\0default', [
+      job({
+        last_error: 'provider timed out',
+        last_run_at: '2026-08-20T10:00:00+00:00',
+        last_status: 'error'
+      })
+    ])
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: 'provider timed out',
+        sessionId: run.id,
+        title: expect.stringMatching(/failed/i)
+      })
+    )
+  })
+
+  it('matches the notification to the run nearest the accepted completion timestamp', async () => {
+    const completedRun = { ended_at: 1_777_000_000, id: 'cron_daily_completed' } as SessionInfo
+    const newerRun = { ended_at: 1_777_000_120, id: 'cron_daily_newer' } as SessionInfo
+    const getRuns = vi.fn().mockResolvedValue([newerRun, completedRun])
+    const notify = vi.fn()
+    const observer = createCronCompletionNotifier({ getRuns, notify })
+    const completedAt = new Date(completedRun.ended_at! * 1000).toISOString()
+
+    await observer.observe('local\0default', [job()])
+    await observer.observe('local\0default', [job({ last_run_at: completedAt })])
+
+    expect(notify).toHaveBeenCalledWith(expect.objectContaining({ sessionId: completedRun.id }))
+  })
+
+  it('keeps the dedupe watermark monotonic when overlapping completions resolve out of order', async () => {
+    let resolveFirst!: (runs: SessionInfo[]) => void
+    let resolveSecond!: (runs: SessionInfo[]) => void
+
+    const firstRuns = new Promise<SessionInfo[]>(resolve => {
+      resolveFirst = resolve
+    })
+
+    const secondRuns = new Promise<SessionInfo[]>(resolve => {
+      resolveSecond = resolve
+    })
+
+    const firstRun = { ended_at: 1_777_000_000, id: 'cron_daily_first' } as SessionInfo
+    const secondRun = { ended_at: 1_777_000_120, id: 'cron_daily_second' } as SessionInfo
+    const firstAt = new Date(firstRun.ended_at! * 1000).toISOString()
+    const secondAt = new Date(secondRun.ended_at! * 1000).toISOString()
+    const getRuns = vi.fn().mockReturnValueOnce(firstRuns).mockReturnValueOnce(secondRuns)
+    const notify = vi.fn()
+    const observer = createCronCompletionNotifier({ getRuns, notify })
+
+    await observer.observe('local\0default', [job()])
+    const firstObservation = observer.observe('local\0default', [job({ last_run_at: firstAt })])
+    const secondObservation = observer.observe('local\0default', [job({ last_run_at: secondAt })])
+
+    resolveSecond([secondRun, firstRun])
+    await secondObservation
+    resolveFirst([secondRun, firstRun])
+    await firstObservation
+    await observer.observe('local\0default', [job({ last_run_at: secondAt })])
+
+    expect(getRuns).toHaveBeenCalledTimes(2)
+    expect(notify).toHaveBeenCalledTimes(2)
+    expect(notify.mock.calls.map(([input]) => input.sessionId)).toEqual([secondRun.id, firstRun.id])
+  })
+
+  it('retries run lookup after the run session is not yet visible', async () => {
+    const getRuns = vi.fn().mockResolvedValueOnce([]).mockResolvedValueOnce([run])
+    const notify = vi.fn()
+    const observer = createCronCompletionNotifier({ getRuns, notify })
+    const completed = job({ last_run_at: '2026-08-20T10:00:00+00:00' })
+
+    await observer.observe('local\0default', [job()])
+    await observer.observe('local\0default', [completed])
+    await observer.observe('local\0default', [completed])
+
+    expect(getRuns).toHaveBeenCalledTimes(2)
+    expect(notify).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/store/cron-completion-notifications.test.ts
+++ b/apps/desktop/src/store/cron-completion-notifications.test.ts
@@ -112,6 +112,26 @@ describe('cron completion notifications', () => {
     )
   })
 
+  it('does not label unknown successful statuses as failures', async () => {
+    const getRuns = vi.fn().mockResolvedValue([run])
+    const notify = vi.fn()
+    const observer = createCronCompletionNotifier({ getRuns, notify })
+
+    await observer.observe('local\0default', [job()])
+    await observer.observe('local\0default', [
+      job({
+        last_run_at: '2026-08-20T10:00:00+00:00',
+        last_status: 'completed'
+      })
+    ])
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.not.stringMatching(/failed/i)
+      })
+    )
+  })
+
   it('matches the notification to the run nearest the accepted completion timestamp', async () => {
     const completedRun = { ended_at: 1_777_000_000, id: 'cron_daily_completed' } as SessionInfo
     const newerRun = { ended_at: 1_777_000_120, id: 'cron_daily_newer' } as SessionInfo
@@ -173,5 +193,37 @@ describe('cron completion notifications', () => {
 
     expect(getRuns).toHaveBeenCalledTimes(2)
     expect(notify).toHaveBeenCalledOnce()
+  })
+
+  it('stops retrying when the completed run never becomes visible', async () => {
+    const getRuns = vi.fn().mockResolvedValue([])
+    const notify = vi.fn()
+    const observer = createCronCompletionNotifier({ getRuns, notify })
+    const completed = job({ last_run_at: '2026-08-20T10:00:00+00:00' })
+
+    await observer.observe('local\0default', [job()])
+    await observer.observe('local\0default', [completed])
+    await observer.observe('local\0default', [completed])
+    await observer.observe('local\0default', [completed])
+    await observer.observe('local\0default', [completed])
+
+    expect(getRuns).toHaveBeenCalledTimes(3)
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it('stops retrying after repeated run lookup failures', async () => {
+    const getRuns = vi.fn().mockRejectedValue(new Error('route removed'))
+    const notify = vi.fn()
+    const observer = createCronCompletionNotifier({ getRuns, notify })
+    const completed = job({ last_run_at: '2026-08-20T10:00:00+00:00' })
+
+    await observer.observe('local\0default', [job()])
+    await observer.observe('local\0default', [completed])
+    await observer.observe('local\0default', [completed])
+    await observer.observe('local\0default', [completed])
+    await observer.observe('local\0default', [completed])
+
+    expect(getRuns).toHaveBeenCalledTimes(3)
+    expect(notify).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/store/cron-completion-notifications.ts
+++ b/apps/desktop/src/store/cron-completion-notifications.ts
@@ -1,0 +1,189 @@
+import { type CronJob, getCronJobRuns, type SessionInfo } from '@/hermes'
+import { translateNow } from '@/i18n'
+
+import { dispatchNativeNotification, type NativeNotificationInput } from './native-notifications'
+
+interface CronCompletionNotifierDependencies {
+  getRuns: (jobId: string, limit?: number) => Promise<SessionInfo[]>
+  notify: (input: NativeNotificationInput) => boolean | void
+}
+
+export interface CronCompletionNotifier {
+  observe: (scope: string, jobs: CronJob[]) => Promise<void>
+  reset: () => void
+}
+
+function deliversLocally(job: CronJob): boolean {
+  const targets = (job.deliver ?? 'local')
+    .split(',')
+    .map(target => target.trim())
+    .filter(Boolean)
+
+  return targets.length === 0 || targets.includes('local')
+}
+
+function runFailed(job: CronJob): boolean {
+  return Boolean(job.last_error) || (Boolean(job.last_status) && job.last_status !== 'ok')
+}
+
+function runNearestCompletion(runs: SessionInfo[], completedAt: string): SessionInfo | undefined {
+  const completedMs = Date.parse(completedAt)
+
+  if (Number.isNaN(completedMs)) {
+    return runs[0]
+  }
+
+  let nearest: SessionInfo | undefined
+  let nearestDistance = Number.POSITIVE_INFINITY
+
+  for (const run of runs) {
+    const runSeconds = run.ended_at ?? run.last_active ?? run.started_at
+    const distance = Math.abs(runSeconds * 1000 - completedMs)
+
+    if (distance < nearestDistance) {
+      nearest = run
+      nearestDistance = distance
+    }
+  }
+
+  return nearest ?? runs[0]
+}
+
+function advanceSeenRun(seenRuns: Map<string, null | string>, jobId: string, completedAt: string): void {
+  const current = seenRuns.get(jobId)
+
+  if (current) {
+    const currentMs = Date.parse(current)
+    const completedMs = Date.parse(completedAt)
+
+    if (!Number.isNaN(currentMs) && !Number.isNaN(completedMs) && completedMs < currentMs) {
+      return
+    }
+  }
+
+  seenRuns.set(jobId, completedAt)
+}
+
+export function createCronCompletionNotifier({
+  getRuns,
+  notify
+}: CronCompletionNotifierDependencies): CronCompletionNotifier {
+  let activeScope: null | string = null
+  let generation = 0
+  const seenRuns = new Map<string, null | string>()
+  const inFlight = new Set<string>()
+
+  const reset = () => {
+    activeScope = null
+    generation += 1
+    seenRuns.clear()
+    inFlight.clear()
+  }
+
+  const observe = async (scope: string, jobs: CronJob[]) => {
+    if (scope !== activeScope) {
+      activeScope = scope
+      generation += 1
+      seenRuns.clear()
+      inFlight.clear()
+
+      for (const job of jobs) {
+        seenRuns.set(job.id, job.last_run_at ?? null)
+      }
+
+      return
+    }
+
+    const liveJobIds = new Set(jobs.map(job => job.id))
+
+    for (const jobId of seenRuns.keys()) {
+      if (!liveJobIds.has(jobId)) {
+        seenRuns.delete(jobId)
+      }
+    }
+
+    const observedGeneration = generation
+
+    const candidates = jobs.flatMap(job => {
+      const completedAt = job.last_run_at ?? null
+
+      if (!seenRuns.has(job.id)) {
+        seenRuns.set(job.id, completedAt)
+
+        return []
+      }
+
+      if (seenRuns.get(job.id) === completedAt) {
+        return []
+      }
+
+      if (!completedAt || !deliversLocally(job)) {
+        seenRuns.set(job.id, completedAt)
+
+        return []
+      }
+
+      const key = `${observedGeneration}\u0000${job.id}\u0000${completedAt}`
+
+      if (inFlight.has(key)) {
+        return []
+      }
+
+      inFlight.add(key)
+
+      return [{ completedAt, job, key }]
+    })
+
+    await Promise.all(
+      candidates.map(async ({ completedAt, job, key }) => {
+        try {
+          const runs = await getRuns(job.id, 5)
+          const run = runNearestCompletion(runs, completedAt)
+
+          if (!run || generation !== observedGeneration || activeScope !== scope) {
+            return
+          }
+
+          // Two accepted snapshots can advance the same job while the first
+          // run lookup is still in flight. Never let the older lookup resolve
+          // last and move the dedupe watermark backwards.
+          advanceSeenRun(seenRuns, job.id, completedAt)
+          const failed = runFailed(job)
+
+          notify({
+            body: job.last_error || job.name || job.id,
+            global: true,
+            kind: 'backgroundDone',
+            sessionId: run.id,
+            tag: `cron:${job.id}:${completedAt}`,
+            title: translateNow(
+              failed
+                ? 'notifications.native.backgroundFailedTitle'
+                : 'notifications.native.backgroundDoneTitle'
+            )
+          })
+        } catch {
+          // The jobs file can become visible just before its session row. Keep
+          // the timestamp unconsumed so the next cron refresh retries quietly.
+        } finally {
+          inFlight.delete(key)
+        }
+      })
+    )
+  }
+
+  return { observe, reset }
+}
+
+const cronCompletionNotifier = createCronCompletionNotifier({
+  getRuns: getCronJobRuns,
+  notify: dispatchNativeNotification
+})
+
+export function observeCronCompletions(scope: string, jobs: CronJob[]): Promise<void> {
+  return cronCompletionNotifier.observe(scope, jobs)
+}
+
+export function resetCronCompletionNotifications(): void {
+  cronCompletionNotifier.reset()
+}

--- a/apps/desktop/src/store/cron-completion-notifications.ts
+++ b/apps/desktop/src/store/cron-completion-notifications.ts
@@ -3,6 +3,9 @@ import { translateNow } from '@/i18n'
 
 import { dispatchNativeNotification, type NativeNotificationInput } from './native-notifications'
 
+const FAILED_RUN_STATUSES = new Set(['error', 'failed', 'timeout'])
+const MAX_RUN_LOOKUP_MISSES = 3
+
 interface CronCompletionNotifierDependencies {
   getRuns: (jobId: string, limit?: number) => Promise<SessionInfo[]>
   notify: (input: NativeNotificationInput) => boolean | void
@@ -23,7 +26,13 @@ function deliversLocally(job: CronJob): boolean {
 }
 
 function runFailed(job: CronJob): boolean {
-  return Boolean(job.last_error) || (Boolean(job.last_status) && job.last_status !== 'ok')
+  const status = job.last_status?.trim().toLowerCase()
+
+  return Boolean(job.last_error) || Boolean(status && FAILED_RUN_STATUSES.has(status))
+}
+
+function runLookupKey(jobId: string, completedAt: string): string {
+  return `${jobId}\u0000${completedAt}`
 }
 
 function runNearestCompletion(runs: SessionInfo[], completedAt: string): SessionInfo | undefined {
@@ -72,12 +81,14 @@ export function createCronCompletionNotifier({
   let generation = 0
   const seenRuns = new Map<string, null | string>()
   const inFlight = new Set<string>()
+  const runLookupMisses = new Map<string, number>()
 
   const reset = () => {
     activeScope = null
     generation += 1
     seenRuns.clear()
     inFlight.clear()
+    runLookupMisses.clear()
   }
 
   const observe = async (scope: string, jobs: CronJob[]) => {
@@ -86,6 +97,7 @@ export function createCronCompletionNotifier({
       generation += 1
       seenRuns.clear()
       inFlight.clear()
+      runLookupMisses.clear()
 
       for (const job of jobs) {
         seenRuns.set(job.id, job.last_run_at ?? null)
@@ -99,6 +111,14 @@ export function createCronCompletionNotifier({
     for (const jobId of seenRuns.keys()) {
       if (!liveJobIds.has(jobId)) {
         seenRuns.delete(jobId)
+      }
+    }
+
+    for (const lookupKey of runLookupMisses.keys()) {
+      const jobId = lookupKey.split('\u0000', 1)[0]
+
+      if (!liveJobIds.has(jobId)) {
+        runLookupMisses.delete(lookupKey)
       }
     }
 
@@ -140,9 +160,26 @@ export function createCronCompletionNotifier({
           const runs = await getRuns(job.id, 5)
           const run = runNearestCompletion(runs, completedAt)
 
-          if (!run || generation !== observedGeneration || activeScope !== scope) {
+          if (generation !== observedGeneration || activeScope !== scope) {
             return
           }
+
+          const lookupKey = runLookupKey(job.id, completedAt)
+
+          if (!run) {
+            const missCount = (runLookupMisses.get(lookupKey) ?? 0) + 1
+
+            if (missCount >= MAX_RUN_LOOKUP_MISSES) {
+              advanceSeenRun(seenRuns, job.id, completedAt)
+              runLookupMisses.delete(lookupKey)
+            } else {
+              runLookupMisses.set(lookupKey, missCount)
+            }
+
+            return
+          }
+
+          runLookupMisses.delete(lookupKey)
 
           // Two accepted snapshots can advance the same job while the first
           // run lookup is still in flight. Never let the older lookup resolve
@@ -163,8 +200,24 @@ export function createCronCompletionNotifier({
             )
           })
         } catch {
+          if (generation !== observedGeneration || activeScope !== scope) {
+            return
+          }
+
+          const lookupKey = runLookupKey(job.id, completedAt)
+          const missCount = (runLookupMisses.get(lookupKey) ?? 0) + 1
+
+          if (missCount >= MAX_RUN_LOOKUP_MISSES) {
+            advanceSeenRun(seenRuns, job.id, completedAt)
+            runLookupMisses.delete(lookupKey)
+          } else {
+            runLookupMisses.set(lookupKey, missCount)
+          }
+
           // The jobs file can become visible just before its session row. Keep
-          // the timestamp unconsumed so the next cron refresh retries quietly.
+          // the timestamp unconsumed for a bounded retry window, then consume it
+          // silently so a removed or unavailable runs endpoint cannot hot-loop
+          // forever on every cron refresh.
         } finally {
           inFlight.delete(key)
         }

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -843,6 +843,7 @@ export interface CronJob {
   id: string
   last_error?: null | string
   last_run_at?: null | string
+  last_status?: null | string
   model?: null | string
   name?: null | string
   next_run_at?: null | string


### PR DESCRIPTION
## Summary

- notify through the existing native `backgroundDone` channel when a locally delivered cron job advances to a new completed run
- silently baseline initial hydration, profile changes, and active-source reconnects so stale runs are not replayed
- resolve the timestamp-correlated cron run session for notification click-through and keep dedupe state monotonic across overlapping completions
- skip remote-only delivery while notifying once for multi-target jobs that include `local`

## Behavior

The change intentionally reuses **Settings → Notifications → Background task finished** rather than adding another preference. Existing native-notification focus, baseline, throttle, and preference gates remain authoritative.

## Tests

- `npm run test:ui` — 556 files, 5,304 tests passed
- `npm run typecheck`
- targeted ESLint for all changed Desktop files
- `git diff --check`

Added behavioral coverage for hydration/reconnect suppression, local vs remote delivery, failures, exact run targeting, duplicate refreshes, overlapping out-of-order completions, lookup retry, accepted request fencing, and active-vs-background gateway reconnects.