### PR TITLE
fix(desktop): use Windows translucency defaults on Win10

### DIFF
--- a/apps/desktop/src/store/translucency.ts
+++ b/apps/desktop/src/store/translucency.ts
@@ -116,7 +116,7 @@ export function setAppearance(appearance: Appearance): void {
 
 /** The resolved state for the painted appearance — the shape every consumer reads. */
 export const $translucency = computed([$translucencyBook, $appearance], (book, appearance) =>
-  resolveTranslucency(book, appearance, GLASS_IS_WINDOWS)
+  resolveTranslucency(book, appearance, isWindowsPlatform())
 )
 
 /** Write an edit against the appearance being painted. */

--- a/apps/desktop/src/store/translucency.win10.test.ts
+++ b/apps/desktop/src/store/translucency.win10.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+
+vi.hoisted(() => {
+  Object.defineProperty(globalThis.navigator, 'platform', { configurable: true, value: 'Win32' })
+  ;(globalThis.window as Window).hermesDesktop = {
+    glassSupported: false,
+    translucencySupported: true
+  } as Window['hermesDesktop']
+})
+
+import {
+  $translucency,
+  defaultTranslucencyValues,
+  GLASS_SUPPORTED,
+  TRANSLUCENCY_SUPPORTED
+} from './translucency'
+
+describe('Windows 10 translucency defaults', () => {
+  it('uses Windows defaults even when glass is unsupported', () => {
+    expect(GLASS_SUPPORTED).toBe(false)
+    expect(TRANSLUCENCY_SUPPORTED).toBe(true)
+    expect($translucency.get()).toEqual({
+      ...defaultTranslucencyValues('dark', true),
+      mode: 'clear'
+    })
+  })
+})


### PR DESCRIPTION
Summary
Windows 10 renderer sessions could resolve the macOS translucency defaults because the store passed the glass-capability flag into the platform-family default resolver. This changes the renderer to use the actual Windows platform family for default resolution while keeping the glass-capability flag for feature availability, so unsupported-glass Windows builds start from the Windows clear defaults instead of a partially transparent macOS default.

Changes
apps/desktop/src/store/translucency.ts: Pass isWindowsPlatform() to resolveTranslucency so Windows defaults are selected independently of glass support.
apps/desktop/src/store/translucency.win10.test.ts: Add a jsdom regression test for Win32 with glassSupported=false, asserting the untouched store resolves Windows clear defaults.

How to Test
npm run test:ui -- src/store/translucency.win10.test.ts src/store/translucency.test.ts
# Local Termux blocker: vitest: Permission denied
npm run typecheck
# Local Termux blocker: tsc: Permission denied
git diff --check
# ✅ passed
node fallback logic shim
# ✅ passed — pre-fix resolves mac dark defaults; fixed path resolves Windows dark clear defaults

Checklist
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Windows desktop only)
- [x] profile-safe paths not touched
- [x] .env not used for non-credential settings
- [ ] Local Vitest/typecheck pass — blocked by Termux desktop runner permissions

Risk & Impact
Low. The change only separates platform-family default selection from the glass-capability flag and leaves glass feature gating unchanged.
Type: Bug fix
Closes: #90824
