### PR TITLE
feat(skills): include quoted history in Gmail replies

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -189,8 +189,10 @@ $GAPI gmail send --to user@example.com --subject "Hello" --body "Message text"
 $GAPI gmail send --to user@example.com --subject "Report" --body "<h1>Q4</h1><p>Details...</p>" --html
 $GAPI gmail send --to user@example.com --subject "Hello" --from '"Research Agent" <user@example.com>' --body "Message text"
 
-# Reply (automatically threads and sets In-Reply-To)
+# Reply (threads and includes visible quoted history by default)
 $GAPI gmail reply MESSAGE_ID --body "Thanks, that works for me."
+$GAPI gmail reply MESSAGE_ID --body "<p>Thanks, that works for me.</p>" --html
+$GAPI gmail reply MESSAGE_ID --body "Thanks" --no-quote-original
 $GAPI gmail reply MESSAGE_ID --from '"Support Bot" <user@example.com>' --body "Thanks"
 
 # Labels

--- a/skills/productivity/google-workspace/scripts/gmail_reply_formatting.py
+++ b/skills/productivity/google-workspace/scripts/gmail_reply_formatting.py
@@ -41,6 +41,16 @@ _QUOTE_CLASSES = {"gmail_extra", "gmail_quote", "moz-cite-prefix", "protonmail_q
 _QUOTE_IDS = {"appendonsend", "divreplyfwdmsg", "isforwardcontent"}
 
 
+def _is_prior_quote(tag: str, attrs: dict[str, str]) -> bool:
+    classes = set(attrs.get("class", "").lower().split())
+    return (
+        bool(classes & _QUOTE_CLASSES)
+        or attrs.get("id", "").lower() in _QUOTE_IDS
+        or "data-hermes-quote" in attrs
+        or (tag == "blockquote" and attrs.get("type", "").lower() == "cite")
+    )
+
+
 def _decode_body_data(data: str, charset: str = "utf-8") -> str:
     raw = base64.urlsafe_b64decode(data + "=" * (-len(data) % 4))
     try:
@@ -124,21 +134,23 @@ class _SanitizingHTMLParser(HTMLParser):
         self.open_tags: list[tuple[str, bool]] = []
         self.stopped = False
 
+    def _close_open_safe_tags(self) -> None:
+        for tag, dropped in reversed(self.open_tags):
+            if not dropped and tag in _SAFE_TAGS and tag not in _VOID_TAGS:
+                self.output.append(f"</{tag}>")
+        self.open_tags.clear()
+        self.drop_depth = 0
+
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         if self.stopped:
             return
         tag = tag.lower()
         attrs_dict = {name.lower(): value or "" for name, value in attrs}
-        classes = set(attrs_dict.get("class", "").lower().split())
-        is_prior_quote = (
-            bool(classes & _QUOTE_CLASSES)
-            or attrs_dict.get("id", "").lower() in _QUOTE_IDS
-            or "data-hermes-quote" in attrs_dict
-            or (tag == "blockquote" and attrs_dict.get("type", "").lower() == "cite")
-        )
-        if is_prior_quote:
+        if _is_prior_quote(tag, attrs_dict):
+            self._close_open_safe_tags()
             self.stopped = True
-        dropped = self.drop_depth > 0 or tag in _DROP_CONTENT_TAGS or is_prior_quote
+            return
+        dropped = self.drop_depth > 0 or tag in _DROP_CONTENT_TAGS
         is_void = tag in _VOID_TAGS
         if not is_void:
             self.open_tags.append((tag, dropped))
@@ -222,9 +234,13 @@ class _HTMLToTextParser(HTMLParser):
         self.open_tags: list[tuple[str, bool]] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
         attrs_dict = {name.lower(): value or "" for name, value in attrs}
-        classes = set(attrs_dict.get("class", "").lower().split())
-        dropped = self.drop_depth > 0 or tag in _DROP_CONTENT_TAGS or "gmail_quote" in classes
+        dropped = (
+            self.drop_depth > 0
+            or tag in _DROP_CONTENT_TAGS
+            or _is_prior_quote(tag, attrs_dict)
+        )
         is_void = tag in _VOID_TAGS
         if not is_void:
             self.open_tags.append((tag, dropped))

--- a/skills/productivity/google-workspace/scripts/gmail_reply_formatting.py
+++ b/skills/productivity/google-workspace/scripts/gmail_reply_formatting.py
@@ -1,0 +1,329 @@
+"""MIME extraction and visible quoted-history formatting for Gmail replies."""
+
+from __future__ import annotations
+
+import base64
+import html
+import re
+from html.parser import HTMLParser
+
+
+_BLOCK_TAGS = {
+    "address", "blockquote", "div", "h1", "h2", "h3", "h4", "h5", "h6",
+    "li", "ol", "p", "pre", "table", "tbody", "td", "th", "thead", "tr", "ul",
+}
+_SAFE_TAGS = _BLOCK_TAGS | {
+    "a", "b", "br", "code", "del", "em", "hr", "i", "s", "small", "span",
+    "strong", "sub", "sup", "u",
+}
+_DROP_CONTENT_TAGS = {"embed", "form", "head", "iframe", "object", "script", "style", "svg"}
+_VOID_TAGS = {"area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "source", "track", "wbr"}
+_SAFE_ATTRS = {
+    "a": {"href", "title"},
+    "blockquote": {"type"},
+    "td": {"colspan", "rowspan"},
+    "th": {"colspan", "rowspan"},
+}
+_SAFE_STYLE_PROPERTIES = {
+    "background-color", "border", "border-bottom", "border-left", "border-right",
+    "border-top", "color", "font-family", "font-size", "font-style", "font-weight",
+    "line-height", "margin", "margin-bottom", "margin-left", "margin-right", "margin-top",
+    "padding", "padding-bottom", "padding-left", "padding-right", "padding-top",
+    "text-align", "text-decoration", "white-space",
+}
+_UNSAFE_STYLE_RE = re.compile(r"url\s*\(|expression\s*\(|@import|javascript:", re.I)
+_MESSAGE_ID_RE = re.compile(r"<[^<>\s]+>")
+_PLAIN_QUOTE_MARKER_RE = re.compile(
+    r"^\s*(?:>+|On .+ wrote:\s*$|-{2,}\s*(?:Original Message|Forwarded message)\s*-{2,}\s*$)",
+    re.I,
+)
+_QUOTE_CLASSES = {"gmail_extra", "gmail_quote", "moz-cite-prefix", "protonmail_quote", "yahoo_quoted"}
+_QUOTE_IDS = {"appendonsend", "divreplyfwdmsg", "isforwardcontent"}
+
+
+def _decode_body_data(data: str, charset: str = "utf-8") -> str:
+    raw = base64.urlsafe_b64decode(data + "=" * (-len(data) % 4))
+    try:
+        return raw.decode(charset or "utf-8", errors="replace")
+    except LookupError:
+        return raw.decode("utf-8", errors="replace")
+
+
+def _part_headers(part: dict) -> dict[str, str]:
+    return {
+        header.get("name", "").lower(): header.get("value", "")
+        for header in part.get("headers", [])
+        if header.get("name")
+    }
+
+
+def _part_charset(part: dict) -> str:
+    content_type = _part_headers(part).get("content-type", "")
+    match = re.search(r"charset\s*=\s*[\"']?([^;\s\"']+)", content_type, re.I)
+    return match.group(1) if match else "utf-8"
+
+
+def extract_reply_bodies(message: dict, fetch_attachment=None) -> tuple[str, str]:
+    """Return the first non-attachment plain and HTML bodies in a Gmail payload."""
+    found: dict[str, str] = {}
+    message_id = message.get("id", "")
+
+    def walk(part: dict) -> None:
+        headers = _part_headers(part)
+        disposition = headers.get("content-disposition", "").lower()
+        if part.get("filename") or disposition.startswith("attachment"):
+            return
+
+        mime_type = part.get("mimeType", "").lower()
+        if mime_type in {"text/plain", "text/html"} and mime_type not in found:
+            body = part.get("body", {})
+            data = body.get("data", "")
+            attachment_id = body.get("attachmentId", "")
+            if not data and attachment_id and fetch_attachment:
+                attachment = fetch_attachment(message_id, attachment_id) or {}
+                data = attachment.get("data", "")
+            if data:
+                found[mime_type] = _decode_body_data(data, _part_charset(part))
+
+        for child in part.get("parts", []) or []:
+            walk(child)
+
+    walk(message.get("payload", {}))
+    return found.get("text/plain", ""), found.get("text/html", "")
+
+
+def _safe_style(value: str) -> str:
+    if _UNSAFE_STYLE_RE.search(value):
+        return ""
+    declarations = []
+    for declaration in value.split(";"):
+        if ":" not in declaration:
+            continue
+        name, raw_value = declaration.split(":", 1)
+        name = name.strip().lower()
+        raw_value = raw_value.strip()
+        if name in _SAFE_STYLE_PROPERTIES and raw_value:
+            declarations.append(f"{name}: {raw_value}")
+    return "; ".join(declarations)
+
+
+def _safe_href(value: str) -> str:
+    stripped = value.strip()
+    if stripped.startswith("#"):
+        return stripped
+    if re.match(r"^(?:https?://|mailto:)", stripped, re.I):
+        return stripped
+    return ""
+
+
+class _SanitizingHTMLParser(HTMLParser):
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.output: list[str] = []
+        self.drop_depth = 0
+        self.open_tags: list[tuple[str, bool]] = []
+        self.stopped = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if self.stopped:
+            return
+        tag = tag.lower()
+        attrs_dict = {name.lower(): value or "" for name, value in attrs}
+        classes = set(attrs_dict.get("class", "").lower().split())
+        is_prior_quote = (
+            bool(classes & _QUOTE_CLASSES)
+            or attrs_dict.get("id", "").lower() in _QUOTE_IDS
+            or "data-hermes-quote" in attrs_dict
+            or (tag == "blockquote" and attrs_dict.get("type", "").lower() == "cite")
+        )
+        if is_prior_quote:
+            self.stopped = True
+        dropped = self.drop_depth > 0 or tag in _DROP_CONTENT_TAGS or is_prior_quote
+        is_void = tag in _VOID_TAGS
+        if not is_void:
+            self.open_tags.append((tag, dropped))
+        if dropped:
+            if not is_void:
+                self.drop_depth += 1
+            return
+        if tag not in _SAFE_TAGS:
+            return
+
+        safe_attrs = []
+        for name, value in attrs:
+            name = name.lower()
+            value = value or ""
+            if name.startswith("on"):
+                continue
+            if name == "style":
+                value = _safe_style(value)
+                if value:
+                    safe_attrs.append((name, value))
+                continue
+            if name not in _SAFE_ATTRS.get(tag, set()):
+                continue
+            if name == "href":
+                value = _safe_href(value)
+                if not value:
+                    continue
+            safe_attrs.append((name, value))
+
+        rendered_attrs = "".join(
+            f' {name}="{html.escape(value, quote=True)}"' for name, value in safe_attrs
+        )
+        self.output.append(f"<{tag}{rendered_attrs}>")
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.handle_starttag(tag, attrs)
+        self.handle_endtag(tag)
+
+    def handle_endtag(self, tag: str) -> None:
+        if self.stopped:
+            return
+        tag = tag.lower()
+        matching = next(
+            (index for index in range(len(self.open_tags) - 1, -1, -1) if self.open_tags[index][0] == tag),
+            None,
+        )
+        if matching is None:
+            return
+        opened_tag, dropped = self.open_tags.pop(matching)
+        if dropped:
+            self.drop_depth = max(0, self.drop_depth - 1)
+            return
+        if opened_tag in _SAFE_TAGS and opened_tag not in {"br", "hr"}:
+            self.output.append(f"</{opened_tag}>")
+
+    def handle_data(self, data: str) -> None:
+        if not self.drop_depth and not self.stopped:
+            self.output.append(html.escape(data))
+
+    def handle_entityref(self, name: str) -> None:
+        if not self.drop_depth and not self.stopped:
+            self.output.append(f"&{name};")
+
+    def handle_charref(self, name: str) -> None:
+        if not self.drop_depth and not self.stopped:
+            self.output.append(f"&#{name};")
+
+
+def sanitize_quoted_html(value: str) -> str:
+    parser = _SanitizingHTMLParser()
+    parser.feed(value)
+    parser.close()
+    return "".join(parser.output).strip()
+
+
+class _HTMLToTextParser(HTMLParser):
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.output: list[str] = []
+        self.drop_depth = 0
+        self.open_tags: list[tuple[str, bool]] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attrs_dict = {name.lower(): value or "" for name, value in attrs}
+        classes = set(attrs_dict.get("class", "").lower().split())
+        dropped = self.drop_depth > 0 or tag in _DROP_CONTENT_TAGS or "gmail_quote" in classes
+        is_void = tag in _VOID_TAGS
+        if not is_void:
+            self.open_tags.append((tag, dropped))
+        if dropped:
+            if not is_void:
+                self.drop_depth += 1
+            return
+        if tag == "br":
+            self.output.append("\n")
+        elif tag == "li":
+            self.output.append("\n- ")
+        elif tag in _BLOCK_TAGS:
+            self.output.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        matching = next(
+            (index for index in range(len(self.open_tags) - 1, -1, -1) if self.open_tags[index][0] == tag),
+            None,
+        )
+        if matching is None:
+            return
+        _, dropped = self.open_tags.pop(matching)
+        if dropped:
+            self.drop_depth = max(0, self.drop_depth - 1)
+        elif tag in _BLOCK_TAGS:
+            self.output.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if not self.drop_depth:
+            self.output.append(data)
+
+
+def html_to_text(value: str) -> str:
+    parser = _HTMLToTextParser()
+    parser.feed(value)
+    parser.close()
+    lines = [re.sub(r"[ \t]+", " ", line).strip() for line in "".join(parser.output).splitlines()]
+    compact: list[str] = []
+    for line in lines:
+        if line or (compact and compact[-1]):
+            compact.append(line)
+    return "\n".join(compact).strip()
+
+
+def strip_plain_quote_chain(value: str) -> str:
+    lines = value.splitlines()
+    kept = []
+    for line in lines:
+        if _PLAIN_QUOTE_MARKER_RE.match(line):
+            break
+        kept.append(line)
+    return "\n".join(kept).rstrip()
+
+
+def build_references(headers: dict[str, str]) -> str:
+    candidates: list[str] = []
+    for name in ("references", "in-reply-to", "message-id"):
+        value = headers.get(name, "")
+        ids = _MESSAGE_ID_RE.findall(value)
+        if not ids and value.strip():
+            ids = value.split()
+        for message_id in ids:
+            if message_id not in candidates:
+                candidates.append(message_id)
+    return " ".join(candidates)
+
+
+def compose_quoted_reply(
+    reply_body: str,
+    *,
+    reply_is_html: bool,
+    original_plain: str,
+    original_html: str,
+    original_from: str,
+    original_date: str,
+) -> tuple[str, bool]:
+    """Compose a reply and its visible original-message quote."""
+    attribution = f"On {original_date}, {original_from} wrote:" if original_date else f"{original_from} wrote:"
+    use_html = reply_is_html or bool(original_html)
+
+    if use_html:
+        new_html = reply_body if reply_is_html else html.escape(reply_body).replace("\n", "<br>\n")
+        quoted_html = sanitize_quoted_html(original_html)
+        if not quoted_html and original_plain:
+            quoted_html = html.escape(strip_plain_quote_chain(original_plain)).replace("\n", "<br>\n")
+        if not quoted_html:
+            return new_html, True
+        quote = (
+            '<div class="gmail_quote" data-hermes-quote="original">'
+            f'<div class="gmail_attr">{html.escape(attribution)}</div>'
+            '<blockquote style="margin:0 0 0 .8ex;border-left:1px solid #ccc;'
+            f'padding-left:1ex">{quoted_html}</blockquote></div>'
+        )
+        return f"{new_html}<br><br>{quote}", True
+
+    original_text = strip_plain_quote_chain(original_plain)
+    if not original_text and original_html:
+        original_text = html_to_text(original_html)
+    if not original_text:
+        return reply_body, False
+    quoted = "\n".join(f"> {line}" if line else ">" for line in original_text.splitlines())
+    return f"{reply_body.rstrip()}\n\n{attribution}\n{quoted}", False

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -9,7 +9,7 @@ Usage:
   python google_api.py gmail search "is:unread" [--max 10]
   python google_api.py gmail get MESSAGE_ID
   python google_api.py gmail send --to user@example.com --subject "Hi" --body "Hello"
-  python google_api.py gmail reply MESSAGE_ID --body "Thanks"
+  python google_api.py gmail reply MESSAGE_ID --body "Thanks" [--html] [--no-quote-original]
   python google_api.py calendar list [--from DATE] [--to DATE] [--calendar primary]
   python google_api.py calendar create --summary "Meeting" --start DATETIME --end DATETIME
   python google_api.py drive search "budget report" [--max 10]
@@ -37,6 +37,11 @@ if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
 from _hermes_home import get_hermes_home
+from gmail_reply_formatting import (
+    build_references,
+    compose_quoted_reply,
+    extract_reply_bodies,
+)
 
 HERMES_HOME = get_hermes_home()
 TOKEN_PATH = HERMES_HOME / "google_token.json"
@@ -359,14 +364,20 @@ def gmail_send(args):
 
 
 def gmail_reply(args):
+    quote_original = not getattr(args, "no_quote_original", False)
+    message_format = "full" if quote_original else "metadata"
+    metadata_headers = [
+        "From", "Subject", "Date", "Message-ID", "In-Reply-To", "References",
+    ]
+
     if _gws_binary():
         original = _run_gws(
             ["gmail", "users", "messages", "get"],
             params={
                 "userId": "me",
                 "id": args.message_id,
-                "format": "metadata",
-                "metadataHeaders": ["From", "Subject", "Message-ID"],
+                "format": message_format,
+                **({"metadataHeaders": metadata_headers} if not quote_original else {}),
             },
         )
         headers = _headers_dict(original)
@@ -375,14 +386,35 @@ def gmail_reply(args):
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
 
-        message = MIMEText(args.body)
+        body_text = args.body
+        use_html = getattr(args, "html", False)
+        if quote_original:
+            def fetch_attachment(message_id, attachment_id):
+                return _run_gws(
+                    ["gmail", "users", "messages", "attachments", "get"],
+                    params={"userId": "me", "messageId": message_id, "id": attachment_id},
+                )
+
+            original_plain, original_html = extract_reply_bodies(original, fetch_attachment)
+            body_text, use_html = compose_quoted_reply(
+                args.body,
+                reply_is_html=use_html,
+                original_plain=original_plain,
+                original_html=original_html,
+                original_from=headers.get("from", ""),
+                original_date=headers.get("date", ""),
+            )
+
+        message = MIMEText(body_text, "html" if use_html else "plain", "utf-8")
         message["To"] = headers.get("from", "")
         message["Subject"] = subject
         if args.from_header:
             message["From"] = args.from_header
         if headers.get("message-id"):
             message["In-Reply-To"] = headers["message-id"]
-            message["References"] = headers["message-id"]
+        references = build_references(headers)
+        if references:
+            message["References"] = references
 
         raw = base64.urlsafe_b64encode(message.as_bytes()).decode()
         result = _run_gws(
@@ -395,8 +427,8 @@ def gmail_reply(args):
 
     service = build_service("gmail", "v1")
     original = service.users().messages().get(
-        userId="me", id=args.message_id, format="metadata",
-        metadataHeaders=["From", "Subject", "Message-ID"],
+        userId="me", id=args.message_id, format=message_format,
+        **({"metadataHeaders": metadata_headers} if not quote_original else {}),
     ).execute()
     headers = _headers_dict(original)
 
@@ -404,14 +436,34 @@ def gmail_reply(args):
     if not subject.startswith("Re:"):
         subject = f"Re: {subject}"
 
-    message = MIMEText(args.body)
+    body_text = args.body
+    use_html = getattr(args, "html", False)
+    if quote_original:
+        def fetch_attachment(message_id, attachment_id):
+            return service.users().messages().attachments().get(
+                userId="me", messageId=message_id, id=attachment_id,
+            ).execute()
+
+        original_plain, original_html = extract_reply_bodies(original, fetch_attachment)
+        body_text, use_html = compose_quoted_reply(
+            args.body,
+            reply_is_html=use_html,
+            original_plain=original_plain,
+            original_html=original_html,
+            original_from=headers.get("from", ""),
+            original_date=headers.get("date", ""),
+        )
+
+    message = MIMEText(body_text, "html" if use_html else "plain", "utf-8")
     message["To"] = headers.get("from", "")
     message["Subject"] = subject
     if args.from_header:
         message["From"] = args.from_header
     if headers.get("message-id"):
         message["In-Reply-To"] = headers["message-id"]
-        message["References"] = headers["message-id"]
+    references = build_references(headers)
+    if references:
+        message["References"] = references
 
     raw = base64.urlsafe_b64encode(message.as_bytes()).decode()
     body = {"raw": raw, "threadId": original["threadId"]}
@@ -1082,6 +1134,8 @@ def main():
     p.add_argument("message_id", help="Message ID to reply to")
     p.add_argument("--body", required=True)
     p.add_argument("--from", dest="from_header", default="", help="Custom From header (e.g. '\"Agent Name\" <user@example.com>')")
+    p.add_argument("--html", action="store_true", help="Treat the new reply body as HTML")
+    p.add_argument("--no-quote-original", action="store_true", help="Do not include visible quoted history")
     p.set_defaults(func=gmail_reply)
 
     p = gmail_sub.add_parser("labels")

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -1,11 +1,14 @@
 """Tests for Google Workspace gws bridge and CLI wrapper."""
 
+import base64
 import importlib.util
 import json
 import subprocess
 import sys
 import types
 from datetime import datetime, timedelta, timezone
+from email import policy
+from email.parser import BytesParser
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -66,6 +69,67 @@ def _write_token(path: Path, *, token="ya29.test", expiry=None, **extra):
     if expiry is not None:
         data["expiry"] = expiry
     path.write_text(json.dumps(data))
+
+
+def _gmail_data(value: str, encoding="utf-8") -> str:
+    return base64.urlsafe_b64encode(value.encode(encoding)).decode().rstrip("=")
+
+
+def _decoded_message(raw: str):
+    data = base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4))
+    return BytesParser(policy=policy.default).parsebytes(data)
+
+
+def _reply_args(api_module, **overrides):
+    values = {
+        "message_id": "orig-123",
+        "body": "Thanks for the update.",
+        "from_header": "",
+        "html": False,
+        "no_quote_original": False,
+        "func": api_module.gmail_reply,
+    }
+    values.update(overrides)
+    return api_module.argparse.Namespace(**values)
+
+
+def _original_message(*, subject="Status", sender="Sender <sender@example.com>", parts=None):
+    return {
+        "id": "orig-123",
+        "threadId": "thread-456",
+        "payload": {
+            "mimeType": "multipart/alternative" if parts else "text/plain",
+            "headers": [
+                {"name": "From", "value": sender},
+                {"name": "Date", "value": "Wed, 19 Aug 2026 14:30:00 +0000"},
+                {"name": "Subject", "value": subject},
+                {"name": "Message-ID", "value": "<current@example.com>"},
+                {"name": "In-Reply-To", "value": "<parent@example.com>"},
+                {"name": "References", "value": "<root@example.com> <parent@example.com>"},
+            ],
+            **({"parts": parts} if parts else {"body": {"data": _gmail_data("Original body")}}),
+        },
+    }
+
+
+def _run_gws_reply(api_module, original, args, attachments=None):
+    captured = {}
+    attachments = attachments or {}
+
+    def fake_run(parts, *, params=None, body=None):
+        if parts[-2:] == ["messages", "get"]:
+            captured["get_params"] = params
+            return original
+        if parts[-2:] == ["attachments", "get"]:
+            return attachments[params["id"]]
+        if parts[-2:] == ["messages", "send"]:
+            captured["send_body"] = body
+            return {"id": "reply-789", "threadId": original["threadId"]}
+        raise AssertionError(parts)
+
+    api_module._run_gws = fake_run
+    api_module.gmail_reply(args)
+    return captured, _decoded_message(captured["send_body"]["raw"])
 
 
 def test_bridge_returns_valid_token(bridge_module, tmp_path):
@@ -134,6 +198,202 @@ def test_api_calendar_list_uses_events_list(api_module):
     assert "timeMin" in params
     assert "timeMax" in params
     assert params["calendarId"] == "primary"
+
+
+def test_api_gmail_reply_quotes_plain_body_and_preserves_thread_ancestry(api_module):
+    captured, message = _run_gws_reply(
+        api_module,
+        _original_message(sender="Jöhn Döe <sender@example.com>"),
+        _reply_args(api_module),
+    )
+
+    assert captured["get_params"]["format"] == "full"
+    assert captured["send_body"]["threadId"] == "thread-456"
+    assert message.get_content_type() == "text/plain"
+    assert message.get_content_charset() == "utf-8"
+    assert "sender@example.com" in str(message["To"])
+    assert message["Subject"] == "Re: Status"
+    assert message.get_content() == (
+        "Thanks for the update.\n\n"
+        "On Wed, 19 Aug 2026 14:30:00 +0000, Jöhn Döe <sender@example.com> wrote:\n"
+        "> Original body"
+    )
+    assert message["In-Reply-To"] == "<current@example.com>"
+    assert message["References"] == (
+        "<root@example.com> <parent@example.com> <current@example.com>"
+    )
+
+
+def test_api_gmail_reply_trims_existing_plain_quote_chain(api_module):
+    original = _original_message()
+    original["payload"]["body"]["data"] = _gmail_data(
+        "Immediate reply\n\n  -----Original Message-----\nOld chain"
+    )
+    _, message = _run_gws_reply(api_module, original, _reply_args(api_module))
+
+    assert "> Immediate reply" in message.get_content()
+    assert "Old chain" not in message.get_content()
+
+
+def test_api_gmail_reply_preserves_sanitized_html_by_default(api_module):
+    original_html = """
+        <div><p style="color: blue; position: fixed">Formatted <strong>history</strong>.</p>
+        <table><tr><td>Cell</td></tr></table>
+        <a href="javascript:alert(1)" onclick="alert(1)">unsafe link</a>
+        <img src="https://tracker.example/pixel.gif">
+        <script>alert(1)</script>
+        <div class="gmail_quote">Older quoted chain</div></div>
+    """
+    parts = [{"mimeType": "text/html", "body": {"data": _gmail_data(original_html)}}]
+    _, message = _run_gws_reply(
+        api_module,
+        _original_message(parts=parts),
+        _reply_args(api_module, body="Line one\nLine two"),
+    )
+
+    body = message.get_content()
+    assert message.get_content_type() == "text/html"
+    assert body.startswith("Line one<br>\nLine two<br><br>")
+    assert '<div class="gmail_quote" data-hermes-quote="original">' in body
+    assert '<p style="color: blue">Formatted <strong>history</strong>.</p>' in body
+    assert "<table><tr><td>Cell</td></tr></table>" in body
+    assert "position" not in body
+    assert "javascript:" not in body
+    assert "onclick" not in body
+    assert "<img" not in body
+    assert "<script" not in body
+    assert "Older quoted chain" not in body
+
+
+def test_api_gmail_reply_fetches_attachment_backed_nested_body(api_module):
+    parts = [{
+        "mimeType": "multipart/mixed",
+        "parts": [{
+            "mimeType": "text/plain",
+            "filename": "private-notes.txt",
+            "body": {"data": _gmail_data("Do not quote this attachment")},
+        }, {
+            "mimeType": "multipart/alternative",
+            "parts": [
+                {
+                    "mimeType": "text/plain",
+                    "headers": [{"name": "Content-Type", "value": "text/plain; charset=iso-8859-1"}],
+                    "body": {"attachmentId": "plain-part"},
+                },
+                {
+                    "mimeType": "application/pdf",
+                    "headers": [{"name": "Content-Disposition", "value": "attachment; filename=report.pdf"}],
+                    "body": {"attachmentId": "pdf-part"},
+                },
+            ],
+        }],
+    }]
+    encoded = base64.urlsafe_b64encode("Résumé original".encode("iso-8859-1")).decode().rstrip("=")
+    _, message = _run_gws_reply(
+        api_module,
+        _original_message(parts=parts),
+        _reply_args(api_module),
+        attachments={"plain-part": {"data": encoded}},
+    )
+
+    assert "> Résumé original" in message.get_content()
+    assert "private-notes" not in message.get_content()
+
+
+def test_api_gmail_reply_no_quote_uses_metadata_and_body_only(api_module):
+    captured, message = _run_gws_reply(
+        api_module,
+        _original_message(),
+        _reply_args(api_module, no_quote_original=True),
+    )
+
+    assert captured["get_params"]["format"] == "metadata"
+    assert captured["get_params"]["metadataHeaders"] == [
+        "From", "Subject", "Date", "Message-ID", "In-Reply-To", "References",
+    ]
+    assert message.get_content() == "Thanks for the update."
+    assert message["References"] == (
+        "<root@example.com> <parent@example.com> <current@example.com>"
+    )
+
+
+def test_api_gmail_reply_python_backend_supports_authored_html(api_module):
+    original = _original_message()
+    messages = MagicMock()
+    messages.get.return_value.execute.return_value = original
+    messages.send.return_value.execute.return_value = {
+        "id": "reply-789", "threadId": "thread-456",
+    }
+    users = MagicMock()
+    users.messages.return_value = messages
+    service = MagicMock()
+    service.users.return_value = users
+    api_module._gws_binary = lambda: None
+    api_module.build_service = lambda *_args: service
+
+    api_module.gmail_reply(_reply_args(api_module, body="<strong>Thanks</strong>", html=True))
+
+    get_kwargs = messages.get.call_args.kwargs
+    send_body = messages.send.call_args.kwargs["body"]
+    message = _decoded_message(send_body["raw"])
+    assert get_kwargs == {"userId": "me", "id": "orig-123", "format": "full"}
+    assert send_body["threadId"] == "thread-456"
+    assert message.get_content_type() == "text/html"
+    assert message.get_content().startswith("<strong>Thanks</strong><br><br>")
+    assert "&gt; Original body" not in message.get_content()
+    assert "Original body" in message.get_content()
+
+
+def test_api_gmail_reply_python_backend_fetches_inline_body(api_module):
+    original = _original_message(parts=[{
+        "mimeType": "text/plain",
+        "body": {"attachmentId": "body-part"},
+    }])
+    messages = MagicMock()
+    messages.get.return_value.execute.return_value = original
+    messages.attachments.return_value.get.return_value.execute.return_value = {
+        "data": _gmail_data("Python backend original"),
+    }
+    messages.send.return_value.execute.return_value = {
+        "id": "reply-789", "threadId": "thread-456",
+    }
+    users = MagicMock()
+    users.messages.return_value = messages
+    service = MagicMock()
+    service.users.return_value = users
+    api_module._gws_binary = lambda: None
+    api_module.build_service = lambda *_args: service
+
+    api_module.gmail_reply(_reply_args(api_module))
+
+    message = _decoded_message(messages.send.call_args.kwargs["body"]["raw"])
+    assert "> Python backend original" in message.get_content()
+    messages.attachments.return_value.get.assert_called_once_with(
+        userId="me", messageId="orig-123", id="body-part",
+    )
+
+
+def test_api_gmail_reply_cli_parses_html_and_quote_opt_out(api_module, monkeypatch):
+    captured = {}
+
+    def fake_reply(args):
+        captured["args"] = args
+
+    monkeypatch.setattr(api_module, "gmail_reply", fake_reply)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "google_api.py", "gmail", "reply", "orig-123",
+            "--body", "<p>Thanks</p>", "--html", "--no-quote-original",
+        ],
+    )
+
+    api_module.main()
+
+    assert captured["args"].message_id == "orig-123"
+    assert captured["args"].html is True
+    assert captured["args"].no_quote_original is True
 
 
 

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -23,6 +23,10 @@ API_PATH = (
     Path(__file__).resolve().parents[2]
     / "skills/productivity/google-workspace/scripts/google_api.py"
 )
+FORMATTING_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills/productivity/google-workspace/scripts/gmail_reply_formatting.py"
+)
 
 
 @pytest.fixture
@@ -54,6 +58,17 @@ def api_module(monkeypatch, tmp_path):
     module._gws_binary = lambda: "/usr/bin/gws"
     # Bypass authentication check — no real token file in CI.
     module._ensure_authenticated = lambda: None
+    return module
+
+
+@pytest.fixture
+def formatting_module():
+    spec = importlib.util.spec_from_file_location(
+        "gmail_reply_formatting_test", FORMATTING_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
     return module
 
 
@@ -233,6 +248,32 @@ def test_api_gmail_reply_trims_existing_plain_quote_chain(api_module):
 
     assert "> Immediate reply" in message.get_content()
     assert "Old chain" not in message.get_content()
+
+
+def test_html_sanitizer_closes_safe_ancestors_before_prior_quote(formatting_module):
+    value = (
+        "<div><table><tbody><tr><td>Current reply"
+        '<div id="divreplyfwdmsg">Older quoted chain</div>'
+        "</td></tr></tbody></table></div>"
+    )
+
+    assert formatting_module.sanitize_quoted_html(value) == (
+        "<div><table><tbody><tr><td>Current reply"
+        "</td></tr></tbody></table></div>"
+    )
+
+
+@pytest.mark.parametrize(
+    "prior_quote",
+    [
+        '<div id="divreplyfwdmsg">Outlook quoted chain</div>',
+        '<div class="protonmail_quote">ProtonMail quoted chain</div>',
+    ],
+)
+def test_html_to_text_uses_all_prior_quote_markers(formatting_module, prior_quote):
+    value = f"<p>Current reply</p>{prior_quote}"
+
+    assert formatting_module.html_to_text(value) == "Current reply"
 
 
 def test_api_gmail_reply_preserves_sanitized_html_by_default(api_module):

--- a/website/docs/user-guide/skills/bundled/productivity/productivity-google-workspace.md
+++ b/website/docs/user-guide/skills/bundled/productivity/productivity-google-workspace.md
@@ -201,8 +201,10 @@ $GAPI gmail send --to user@example.com --subject "Hello" --body "Message text"
 $GAPI gmail send --to user@example.com --subject "Report" --body "<h1>Q4</h1><p>Details...</p>" --html
 $GAPI gmail send --to user@example.com --subject "Hello" --from '"Research Agent" <user@example.com>' --body "Message text"
 
-# Reply (automatically threads and sets In-Reply-To)
+# Reply (threads and includes visible quoted history by default)
 $GAPI gmail reply MESSAGE_ID --body "Thanks, that works for me."
+$GAPI gmail reply MESSAGE_ID --body "<p>Thanks, that works for me.</p>" --html
+$GAPI gmail reply MESSAGE_ID --body "Thanks" --no-quote-original
 $GAPI gmail reply MESSAGE_ID --from '"Support Bot" <user@example.com>' --body "Thanks"
 
 # Labels

--- a/website/docs/user-guide/skills/google-workspace.md
+++ b/website/docs/user-guide/skills/google-workspace.md
@@ -92,9 +92,15 @@ $GAPI gmail reply MESSAGE_ID \
 
 ```bash
 $GAPI gmail reply MESSAGE_ID --body "Thanks, that works for me."
+$GAPI gmail reply MESSAGE_ID --body "<p>Thanks, that works for me.</p>" --html
+$GAPI gmail reply MESSAGE_ID --body "Thanks" --no-quote-original
 ```
 
-Automatically threads the reply (sets `In-Reply-To` and `References` headers) and uses the original message's thread ID.
+Replies automatically include visible quoted history and preserve the original
+message's `threadId`, `In-Reply-To`, and complete `References` ancestry. If the
+original contains HTML, its safe formatting is retained automatically; `--html`
+controls whether the new reply body is interpreted as HTML. Use
+`--no-quote-original` when only the new body should be sent.
 
 ### Labels
 


### PR DESCRIPTION
## What does this PR do?

Adds Gmail-composer-style visible quoted history to the bundled Google Workspace `gmail reply` helper. Quoting is default-on, with `--no-quote-original` preserving the prior body-only behavior.

The implementation fetches full MIME only when quoting, recursively extracts non-attachment text bodies, retains sanitized HTML formatting automatically, collapses recognized prior quote chains, and preserves complete RFC/Gmail threading ancestry across both `gws` and Python-client backends.

## Related Issue

Fixes #90864

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `skills/productivity/google-workspace/scripts/gmail_reply_formatting.py` for recursive MIME extraction, safe HTML retention, plain/HTML quote composition, chain trimming, and `References` construction.
- Updated `google_api.py` so both backends use `format=full` by default, support `--html` and `--no-quote-original`, and emit the same raw MIME contract.
- Added decoded raw-MIME regression coverage in `tests/skills/test_google_workspace_api.py`.
- Updated the skill and Google Workspace user guide.

## How to Test

1. Run `scripts/run_tests.sh tests/skills/test_google_workspace_api.py -q`.
2. Run `scripts/run_tests.sh tests/skills/`.
3. Run `ruff check .` and `git diff --check`.
4. Decode the captured `raw` payloads in the focused tests and verify body, content type, charset, `threadId`, `In-Reply-To`, and complete `References` ancestry.

No live Gmail token or mailbox is used by these tests.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: Ubuntu 24.04, Python 3.11

The repository-prescribed wrapper was used instead of direct pytest. Results:

- Google Workspace tests: 12 passed.
- Entire skills suite: 1,597 passed.
- `ruff check .`: passed.
- A repository-wide run was attempted after installing all locked extras. It encountered unrelated current-main LSP failures in `test_broken_set.py` and `test_install_and_lint_fixes.py`; both reproduce in isolation and no LSP files are changed here. Upstream CI remains authoritative for the complete matrix.

### Documentation & Housekeeping

- [x] I have updated relevant documentation
- [x] `cli-config.yaml.example` changes: N/A, no config keys added
- [x] `CONTRIBUTING.md` or `AGENTS.md` changes: N/A, no architecture or workflow change
- [x] I have considered cross-platform impact; the formatter uses the Python standard library only
- [x] I have updated the CLI help and skill command documentation

## Screenshots / Logs

The no-network tests decode the generated Gmail API `raw` MIME and prove:

- Plain original: `text/plain; charset=utf-8`, new body followed by an attribution and `> Original body`.
- HTML original: `text/html; charset=utf-8`, escaped new plain text plus a sanitized `<div class="gmail_quote">` block retaining paragraphs, emphasis, and tables.
- Threading: original `threadId`, `In-Reply-To: <current@example.com>`, and `References: <root@example.com> <parent@example.com> <current@example.com>`.
- Multipart bodies: attachment-backed inline text is decoded while filename-bearing text/HTML attachments are excluded.