### PR TITLE
fix(desktop): include unread flag in session signatures

### DIFF
--- a/apps/desktop/src/lib/session-signatures.test.ts
+++ b/apps/desktop/src/lib/session-signatures.test.ts
@@ -51,6 +51,23 @@ describe('sameCronSignature', () => {
     const b = [session('a', 't', { archived: false, pinned: true })]
     expect(sameCronSignature(a, b)).toBe(true)
   })
+
+  // Read-state-only pages must swap in: opening a session clears `unread`
+  // backend-side, and the refresh page whose only delta is that flag is the
+  // one that clears the emerald dot. Gating it out froze the stale `unread:
+  // true` row, and the dot survived navigation until some content field
+  // moved too (mirror of the #76919 pin-signature fix).
+  it('is false when only the unread flag changed', () => {
+    const a = [session('a', 't', { unread: true })]
+    const b = [session('a', 't', { unread: false })]
+    expect(sameCronSignature(a, b)).toBe(false)
+  })
+
+  it('is true when the unread flag matches', () => {
+    const a = [session('a', 't', { unread: true })]
+    const b = [session('a', 't', { unread: true })]
+    expect(sameCronSignature(a, b)).toBe(true)
+  })
 })
 
 describe('sessionMessagesSignature', () => {

--- a/apps/desktop/src/lib/session-signatures.ts
+++ b/apps/desktop/src/lib/session-signatures.ts
@@ -29,8 +29,13 @@ export function sameCronSignature(a: SessionInfo[], b: SessionInfo[]): boolean {
       // whose only delta is a flag has to swap in or the reconciler reads a
       // frozen copy forever. An idle conversation never moves any of the
       // fields above again, which is exactly when a pin gets toggled (#76919).
+      // `unread` is the backend read-state watermark: opening a session
+      // clears it backend-side, and only a read-state-only page delivers the
+      // false — if the signature misses it, the stale emerald dot survives
+      // navigation until some content field moves too.
       session.pinned === other.pinned &&
-      session.archived === other.archived
+      session.archived === other.archived &&
+      session.unread === other.unread
     )
   })
 }


### PR DESCRIPTION
## What does this PR do?

Fixes a stale "unread" (emerald dot) indicator in the desktop session list. `sameCronSignature` compares session fields to decide whether a refresh page should swap into the store, but it omitted `unread`. Opening a session clears `unread` backend-side, so the read-state-only refresh page — the one whose *only* delta is that flag — was being gated out. The stale `unread: true` row survived navigation until some unrelated content field happened to move.

## Related Issue

Mirror of the existing pin-signature fix (#76919), same class of bug on the sibling field.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/session-signatures.ts` — add `session.unread === other.unread` to the `sameCronSignature` comparison.
- `apps/desktop/src/lib/session-signatures.test.ts` — two cases: signature is false when only `unread` differs, true when it matches.

## How to Test

1. Open a session that shows an unread dot.
2. Navigate away and back; confirm the dot clears without any other content change.
3. `npm test -- session-signatures` passes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally
