### PR TITLE
fix(state): stop live FTS rebuilds from corrupting shared state.db

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4210,6 +4210,59 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         msg = str(exc).lower()
         return "fts5" in msg and "corrupt" in msg
 
+    def _foreign_state_db_holders(self) -> List[Tuple[int, str]]:
+        """Return foreign processes holding this DB or its WAL sidecars.
+
+        Automatic FTS repair is structural maintenance, not an ordinary WAL
+        write.  It must not run while another process remains attached: a
+        sidecar reset under that holder can leave the two processes writing
+        through different WAL inodes.  ``psutil`` reads the kernel's open-file
+        table, including Linux ``(deleted)`` descriptors, so this also catches
+        a split brain already in progress.
+
+        A scan failure is represented as an unknown holder.  Skipping optional
+        automatic maintenance is safer than assuming quiescence; canonical
+        writes continue through the stale-FTS fail-open path.
+        """
+        # The split-brain mechanism requires POSIX unlink semantics: Windows
+        # refuses to replace SQLite sidecars while another process has them
+        # open.  Avoid psutil.open_files() there; querying arbitrary Windows
+        # processes can block for minutes on device-backed handles.
+        if _IS_WINDOWS:
+            return []
+        if psutil is None:
+            return [(-1, "open-file scan unavailable")]
+
+        def _canonical(path: str) -> str:
+            clean = path.removesuffix(" (deleted)")
+            return os.path.normcase(os.path.abspath(clean))
+
+        db_path = os.path.abspath(os.fspath(self.db_path))
+        watched = {
+            _canonical(db_path),
+            _canonical(db_path + "-wal"),
+            _canonical(db_path + "-shm"),
+        }
+        holders: List[Tuple[int, str]] = []
+        try:
+            for process in psutil.process_iter(["pid", "open_files"]):
+                info = process.info
+                pid = int(info["pid"])
+                if pid == os.getpid():
+                    continue
+                for opened in info.get("open_files") or ():
+                    path = getattr(opened, "path", "")
+                    if path and _canonical(path) in watched:
+                        holders.append((pid, path))
+        except Exception as exc:
+            logger.warning(
+                "Could not prove state.db has no foreign holders; deferring "
+                "automatic FTS maintenance: %s",
+                exc,
+            )
+            return holders or [(-1, f"open-file scan failed: {exc}")]
+        return holders
+
     def _try_runtime_fts_rebuild(self, exc: sqlite3.DatabaseError) -> bool:
         """One-shot in-place FTS rebuild after a corrupt-index write failure.
 
@@ -4233,6 +4286,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if not self._is_fts_write_corruption_error(exc):
             return False
         self._fts_runtime_rebuild_attempted = True
+        foreign_holders = self._foreign_state_db_holders()
+        if foreign_holders:
+            logger.warning(
+                "Skipping automatic state.db FTS rebuild while foreign "
+                "processes hold the database or WAL sidecars (%s); detaching "
+                "FTS sync so canonical writes can continue.",
+                foreign_holders,
+            )
+            return False
         logger.warning(
             "state.db write failed with an FTS-corruption error (%s) — "
             "attempting one-shot in-place FTS rebuild; canonical message "

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -368,6 +368,15 @@ class SessionSchemaMixin:
 
     def _recover_stale_fts(self, cursor: sqlite3.Cursor, *, legacy: bool) -> bool:
         """Atomically rebuild stale base/trigram indexes and resume syncing."""
+        foreign_holders = self._foreign_state_db_holders()
+        if foreign_holders:
+            logger.warning(
+                "Deferred stale state.db FTS rebuild while foreign processes "
+                "hold the database or WAL sidecars (%s); canonical writes and "
+                "LIKE search remain available.",
+                foreign_holders,
+            )
+            return False
         try:
             trigram_status = self._fts_table_probe(cursor, "messages_fts_trigram")
         except sqlite3.DatabaseError:

--- a/tests/state/test_fts_runtime_rebuild.py
+++ b/tests/state/test_fts_runtime_rebuild.py
@@ -14,9 +14,11 @@ until a later open atomically rebuilds the index and restores the triggers.
 """
 
 import sqlite3
+from types import SimpleNamespace
 
 import pytest
 
+import hermes_state
 from hermes_state import (
     FTS_STALE_KEY,
     LEGACY_FTS_SQL,
@@ -84,6 +86,47 @@ def _base_fts_triggers(db_path):
 
 
 class TestRuntimeFtsRebuild:
+    def test_foreign_holder_detection_includes_deleted_wal(
+        self, db, tmp_path, monkeypatch
+    ):
+        db_path = tmp_path / "state.db"
+
+        class FakePsutil:
+            @staticmethod
+            def process_iter(_attrs):
+                return iter(
+                    (
+                        SimpleNamespace(
+                            info={
+                                "pid": 111,
+                                "open_files": [SimpleNamespace(path=str(db_path))],
+                            }
+                        ),
+                        SimpleNamespace(
+                            info={
+                                "pid": 222,
+                                "open_files": [
+                                    SimpleNamespace(path=f"{db_path}-wal (deleted)")
+                                ],
+                            }
+                        ),
+                        SimpleNamespace(
+                            info={
+                                "pid": 333,
+                                "open_files": [SimpleNamespace(path=str(tmp_path / "other.db"))],
+                            }
+                        ),
+                    )
+                )
+
+        monkeypatch.setattr(hermes_state, "psutil", FakePsutil)
+        monkeypatch.setattr(hermes_state, "_IS_WINDOWS", False)
+        monkeypatch.setattr(hermes_state.os, "getpid", lambda: 111)
+
+        assert db._foreign_state_db_holders() == [
+            (222, f"{db_path}-wal (deleted)")
+        ]
+
     def test_corruption_error_classification_covers_both_sqlite_messages(self):
         """SQLite's message for a corrupt FTS index varies by version: older
         builds raise the generic malformed-image error, newer builds raise an
@@ -242,6 +285,30 @@ class TestRuntimeFtsRebuild:
         assert _meta_value(db_path, FTS_STALE_KEY) == "1"
         assert _base_fts_triggers(db_path) == set()
 
+    def test_foreign_holder_skips_runtime_rebuild_and_fails_open(
+        self, db, tmp_path, monkeypatch
+    ):
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db_path = tmp_path / "state.db"
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "seed")
+        _corrupt_fts(db_path)
+
+        monkeypatch.setattr(
+            db,
+            "_foreign_state_db_holders",
+            lambda: [(4242, str(db_path) + "-wal")],
+            raising=False,
+        )
+
+        db.append_message("s1", "user", "canonical survives foreign holder")
+
+        assert _message_contents(db_path)[-1] == "canonical survives foreign holder"
+        assert db._fts_stale is True
+        assert _meta_value(db_path, FTS_STALE_KEY) == "1"
+        assert _base_fts_triggers(db_path) == set()
+
     def test_stale_search_preserves_not_semantics(self, db, tmp_path, monkeypatch):
         if not db._fts_enabled:
             pytest.skip("FTS5 unavailable in this build")
@@ -321,6 +388,39 @@ class TestRuntimeFtsRebuild:
             reopened.append_message("s1", "user", "after failed recovery")
             assert _message_contents(db_path)[-1] == "after failed recovery"
             assert reopened.search_messages("failed recovery")
+        finally:
+            reopened.close()
+
+    def test_foreign_holder_defers_startup_stale_rebuild(
+        self, db, tmp_path, monkeypatch
+    ):
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db_path = tmp_path / "state.db"
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "seed")
+        _corrupt_fts(db_path)
+        monkeypatch.setattr(
+            db,
+            "rebuild_fts",
+            lambda: (_ for _ in ()).throw(sqlite3.DatabaseError("still corrupt")),
+        )
+        db.append_message("s1", "user", "before restart")
+        db.close()
+
+        monkeypatch.setattr(
+            SessionDB,
+            "_foreign_state_db_holders",
+            lambda self: [(4242, str(db_path) + "-wal")],
+            raising=False,
+        )
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert reopened._fts_stale is True
+            assert _meta_value(db_path, FTS_STALE_KEY) == "1"
+            assert _base_fts_triggers(db_path) == set()
+            reopened.append_message("s1", "user", "after deferred recovery")
+            assert _message_contents(db_path)[-1] == "after deferred recovery"
         finally:
             reopened.close()
 


### PR DESCRIPTION
## What does this PR do?

When `gateway run` and `hermes serve` both keep `state.db` open, an automatic FTS rebuild can replace the WAL sidecars while the other process still holds the old inodes. The two writers then commit through different WAL files and the database comes back as structurally malformed (`2nd reference to page N`). This change skips those automatic rebuilds whenever another process holds the DB or its `-wal`/`-shm` files (including already-deleted descriptors) and keeps canonical transcript writes on the existing fail-open path.

### Symptom

`state.db` becomes `database disk image is malformed` after a live FTS-corruption rebuild or a startup "Rebuilt stale state.db FTS indexes" pass, even on SQLite 3.53.1 where the WAL-reset bug is already classified as fixed. A concurrent process can be observed holding deleted `state.db-wal` / `state.db-shm` file descriptors.

### Impact

Gateway and desktop (`hermes serve`) users who share one `state.db` can lose or corrupt session history. Offline recovery can re-corrupt within hours if the same live rebuild path runs again. Blast radius beyond that dual-process topology was not measured here.

### Bug Cause

**Trigger:** `SessionDB._try_runtime_fts_rebuild` (`hermes_state.py`) and `SessionSchemaMixin._recover_stale_fts` (`hermes_state_schema.py`) when another process still holds `state.db` or its WAL sidecars.

**Causal chain:**
1. Two Hermes processes open the same WAL `state.db` (typically gateway + desktop backend).
2. An FTS-corruption write error (or a stale-FTS marker at the next open) starts an in-place FTS rebuild.
3. Rebuild / reconnect / WAL-init unlinks and recreates `-wal`/`-shm` while the other process still holds the old inodes.
4. Integrity check reports cross-linked pages across sessions, messages, and turn-lease indexes.

**Why it is wrong:** WAL sidecars belong to one database generation. Replacing them under a live holder is split-brain, and the existing WAL-reset defenses do not gate this FTS-maintenance path.

**Working sibling / contrast:** `_apply_delete_for_wal_reset_bug` and the read-only journal probe already refuse WAL-init that would unlink files other connections hold. Automatic FTS rebuild did not.

**Ruled out:** The SQLite 3.50 WAL-reset bug (`is_sqlite_wal_reset_vulnerable()` is false on 3.53.1). Reporter also ruled out NFS, disk-full, kernel I/O errors, and non-Hermes holders.

### Fix

Before a one-shot runtime FTS rebuild or a startup stale-FTS rebuild, scan for foreign holders of `state.db`, `state.db-wal`, and `state.db-shm`, including Linux `(deleted)` descriptors. If any holder exists (or the scan cannot prove quiescence), skip the rebuild, detach FTS sync, and continue canonical writes. Windows is left unchanged: NTFS will not replace those sidecars while they are open, and a process-wide `open_files()` scan can stall there.

## Related Issue

Fixes #90806

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: skip `_try_runtime_fts_rebuild` when foreign processes hold the DB or WAL sidecars.
- `hermes_state_schema.py`: defer `_recover_stale_fts` under the same holder check.
- `tests/state/test_fts_runtime_rebuild.py`: cover deleted-WAL detection, runtime skip + fail-open, and deferred startup rebuild.

## How to Test

1. `scripts/run_tests.sh tests/state/test_fts_runtime_rebuild.py -q`
2. Confirm a mocked foreign holder of `state.db-wal` (including a `(deleted)` path) skips the in-place rebuild, keeps canonical message rows, and leaves FTS detached.
3. Confirm reopening a stale-FTS database while a foreign holder is present does not log "Rebuilt stale state.db FTS indexes" and still accepts new canonical writes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/state/test_fts_runtime_rebuild.py -q`
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (unit tests for the holder guard; the reported Linux `/proc` split-brain was reproduced by the issue reporter)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, existing method docs cover the new guard
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - unit coverage for the holder guard. The original incident logs remain on #90806.
