### PR TITLE
fix(cli): double Ctrl+C guard for idle exit path

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5688,6 +5688,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # not the background process_loop thread.
         self._pending_relaunch: list[str] | None = None
         self._last_ctrl_c_time = 0
+        self._last_idle_ctrl_c_time = 0
         self._clarify_state = None
         self._clarify_freetext = False
         self._clarify_deadline = 0
@@ -18288,6 +18289,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._last_turn_interrupted = False
         self._should_exit = False
         self._last_ctrl_c_time = 0  # Track double Ctrl+C for force exit
+        self._last_idle_ctrl_c_time = 0  # Idle-path double Ctrl+C timer (separate from agent path)
 
         # Give plugin manager a CLI reference so plugins can inject messages
         from hermes_cli.plugins import get_plugin_manager
@@ -19236,7 +19238,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             0. Cancel active voice recording
             1. Cancel active sudo/approval/clarify prompt
             2. Interrupt the running agent (first press)
-            3. Force exit (second press within 2s, or when idle)
+            3. Force exit (second press within 2s)
             """
             now = time.time()
 
@@ -19256,6 +19258,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 threading.Thread(
                     target=_recorder_ref.cancel, daemon=True
                 ).start()
+                self._last_idle_ctrl_c_time = 0
                 event.app.invalidate()
                 return
 
@@ -19264,6 +19267,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if self._slash_confirm_state:
                 self._submit_slash_confirm_response("cancel")
                 event.app.current_buffer.reset()
+                self._last_idle_ctrl_c_time = 0
                 event.app.invalidate()
                 return
 
@@ -19271,6 +19275,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if self._model_picker_state:
                 self._close_model_picker()
                 event.app.current_buffer.reset()
+                self._last_idle_ctrl_c_time = 0
                 event.app.invalidate()
                 return
 
@@ -19302,6 +19307,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # If we only cleared overlays and the agent is NOT running, stop here
             # (don't fall through to the interrupt/exit path).
             if _overlay_cleared and not (self._agent_running and self.agent):
+                self._last_idle_ctrl_c_time = 0
                 return
 
             if self._agent_running and self.agent:
@@ -19315,14 +19321,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 print("\n⚡ Interrupting agent... (press Ctrl+C again to force exit)")
                 request_hard_interrupt(self.agent)
             # If there's text or images, clear them (like bash).
-            # If everything is already empty, exit.
+            # If everything is already empty, exit (with double Ctrl+C guard).
             elif event.app.current_buffer.text or self._attached_images:
                 event.app.current_buffer.reset()
                 self._attached_images.clear()
+                self._last_idle_ctrl_c_time = 0
                 event.app.invalidate()
             else:
-                self._should_exit = True
-                event.app.exit()
+                if now - self._last_idle_ctrl_c_time < 2.0:
+                    print("\n⚡ Force exiting...")
+                    self._should_exit = True
+                    event.app.exit()
+                    return
+                self._last_idle_ctrl_c_time = now
+                _cprint(f"\n{_DIM}Press Ctrl+C again to exit.{_RST}")
+                event.app.invalidate()
 
         # Ctrl+Shift+C: no binding needed. Terminal emulators (GNOME Terminal,
         # iTerm2, kitty, Windows Terminal, etc.) intercept Ctrl+Shift+C before

--- a/cli.py
+++ b/cli.py
@@ -5193,6 +5193,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     # on this attribute and is enqueued after the fresh queue exists.
     _seeded_first_message: Optional["_SeededQueryMessage"] = None
 
+    # Ctrl+C double-press guard. Never-armed sentinel is -inf, not 0: the
+    # window clock is time.monotonic(), which starts at boot, so 0 is a
+    # *live* value in the first 2s of uptime and would make the very first
+    # Ctrl+C look like a double-press (force-exit).
+    _CTRL_C_NEVER_ARMED = float("-inf")
+    _CTRL_C_WINDOW_S = 2.0
     def __init__(
         self,
         model: str = None,
@@ -5687,8 +5693,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # _handle_update_command() so the relaunch happens on the main thread,
         # not the background process_loop thread.
         self._pending_relaunch: list[str] | None = None
-        self._last_ctrl_c_time = 0
-        self._last_idle_ctrl_c_time = 0
+        self._last_ctrl_c_time = self._CTRL_C_NEVER_ARMED
+        self._last_idle_ctrl_c_time = self._CTRL_C_NEVER_ARMED
         self._clarify_state = None
         self._clarify_freetext = False
         self._clarify_deadline = 0
@@ -18081,6 +18087,152 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             ] if item is not None
         ]
 
+    def _disarm_ctrl_c_timers(self) -> None:
+        """Disarm both double-press timers (sentinel ``_CTRL_C_NEVER_ARMED``).
+
+        Every intervening Ctrl+C press disarms the other path's timer (see
+        the ``_handle_ctrl_c`` docstring) so a stale arm from one path can
+        never combine with a later press on the other path. This is the
+        only place both timers are disarmed together after construction
+        (``__init__`` sets the initial sentinels); the agent branch (idle
+        only) and the idle arm (arms idle, disarms agent) set theirs
+        explicitly.
+        """
+        self._last_ctrl_c_time = self._CTRL_C_NEVER_ARMED
+        self._last_idle_ctrl_c_time = self._CTRL_C_NEVER_ARMED
+
+    def _handle_ctrl_c(self, event: Any) -> None:
+        """Handle Ctrl+C - cancel interactive prompts, interrupt agent, or exit.
+
+        Priority (in branch order):
+        0. Cancel active voice recording
+        1. Cancel slash-confirm prompt
+        2. Cancel /model picker
+        3. Cancel command palette
+        4. Clear agent-blocking overlays (approval/clarify/sudo/secret)
+           (falls through to 5 if the agent is running)
+        5. Interrupt the running agent (first press; force exit on the
+           second press within 2s)
+        6. Clear text/images at the prompt
+        7. Idle exit: arm on first press, force exit on the second within 2s
+
+        Extracted from the ``run()`` keybinding closure (PR #90874) so the
+        full state machine — idle double-press timer, agent-path timer, and
+        every intervening-press disarm — is reachable from unit tests with
+        a mocked ``event.app``.
+
+        Disarm contract (symmetric): a press is only "part of a double-press"
+        if it lands in the same branch as the previous one. Every press that
+        takes any other path disarms the other path's timer — the cancel/
+        clear branches disarm both, while an idle arm or an agent interrupt
+        arms its own path and disarms only the other — so a stale arm from
+        one path can never combine with a later press on the other path
+        into an accidental force-exit.
+        """
+        now = time.monotonic()  # elapsed-time window: wall clock can step backwards
+
+        # Cancel active voice recording.
+        # Run cancel() in a background thread to prevent blocking the
+        # event loop if AudioRecorder._lock or CoreAudio takes time.
+        _should_cancel_voice = False
+        _recorder_ref = None
+        with self._voice_lock:
+            if self._voice_recording and self._voice_recorder:
+                _recorder_ref = self._voice_recorder
+                self._voice_recording = False
+                self._voice_continuous = False
+                _should_cancel_voice = True
+        if _should_cancel_voice:
+            _cprint(f"\n{_DIM}Recording cancelled.{_RST}")
+            threading.Thread(
+                target=_recorder_ref.cancel, daemon=True
+            ).start()
+            self._disarm_ctrl_c_timers()
+            event.app.invalidate()
+            return
+
+        # Cancel slash confirmation prompt (foreground UI, not an
+        # agent-blocking overlay — cancel and stop here).
+        if self._slash_confirm_state:
+            self._submit_slash_confirm_response("cancel")
+            event.app.current_buffer.reset()
+            self._disarm_ctrl_c_timers()
+            event.app.invalidate()
+            return
+
+        # Cancel /model picker (foreground UI — cancel and stop here).
+        if self._model_picker_state:
+            self._close_model_picker()
+            event.app.current_buffer.reset()
+            self._disarm_ctrl_c_timers()
+            event.app.invalidate()
+            return
+
+        # Cancel command palette (foreground UI — cancel and stop here).
+        if self._command_palette_state:
+            self._close_command_palette()
+            event.app.current_buffer.reset()
+            self._disarm_ctrl_c_timers()
+            event.app.invalidate()
+            return
+
+        # Clear all agent-blocking overlays (approval/clarify/sudo/secret)
+        # in one shot.  We do NOT return after clearing — we fall through so
+        # that if the agent is also running we fire the interrupt on the same
+        # Ctrl+C press.  This fixes the case where a stale/orphaned overlay
+        # (left behind by a previous interrupt) consumes the press without
+        # ever reaching the agent-interrupt branch, leaving the chat frozen
+        # (#14026).
+        _overlay_cleared = bool(
+            self._sudo_state
+            or self._secret_state
+            or self._approval_state
+            or self._clarify_state
+        )
+        if _overlay_cleared:
+            self._clear_active_overlays_for_interrupt()
+            event.app.current_buffer.reset()
+            event.app.invalidate()
+
+        # If we only cleared overlays and the agent is NOT running, stop here
+        # (don't fall through to the interrupt/exit path).
+        if _overlay_cleared and not (self._agent_running and self.agent):
+            self._disarm_ctrl_c_timers()
+            return
+
+        if self._agent_running and self.agent:
+            # Any Ctrl+C press while the agent runs is an intervening press:
+            # disarm the idle-path timer so a stale idle arm can't combine
+            # with a later idle press into an accidental force-exit.
+            self._last_idle_ctrl_c_time = self._CTRL_C_NEVER_ARMED
+            if now - self._last_ctrl_c_time < self._CTRL_C_WINDOW_S:
+                print("\n⚡ Force exiting...")
+                self._should_exit = True
+                event.app.exit()
+                return
+
+            self._last_ctrl_c_time = now
+            print("\n⚡ Interrupting agent... (press Ctrl+C again to force exit)")
+            request_hard_interrupt(self.agent)
+        # If there's text or images, clear them (like bash).
+        # If everything is already empty, exit (with double Ctrl+C guard).
+        elif event.app.current_buffer.text or self._attached_images:
+            event.app.current_buffer.reset()
+            self._attached_images.clear()
+            self._disarm_ctrl_c_timers()
+            event.app.invalidate()
+        else:
+            if now - self._last_idle_ctrl_c_time < self._CTRL_C_WINDOW_S:
+                print("\n⚡ Force exiting...")
+                self._should_exit = True
+                event.app.exit()
+                return
+            self._last_idle_ctrl_c_time = now
+            # Idle arm is itself an intervening press for the agent path.
+            self._last_ctrl_c_time = self._CTRL_C_NEVER_ARMED
+            _cprint(f"\n{_DIM}Press Ctrl+C again to exit.{_RST}")
+            event.app.invalidate()
+
     def run(self):
         """Run the interactive CLI loop with persistent input at bottom."""
         if not self._claim_active_session("cli"):
@@ -18288,8 +18440,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # the earlier __init__ branch.
         self._last_turn_interrupted = False
         self._should_exit = False
-        self._last_ctrl_c_time = 0  # Track double Ctrl+C for force exit
-        self._last_idle_ctrl_c_time = 0  # Idle-path double Ctrl+C timer (separate from agent path)
+        # Fresh session: both double-press timers start never-armed.
+        self._disarm_ctrl_c_timers()
 
         # Give plugin manager a CLI reference so plugins can inject messages
         from hermes_cli.plugins import get_plugin_manager
@@ -19232,110 +19384,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         @kb.add('c-c')
         def handle_ctrl_c(event):
-            """Handle Ctrl+C - cancel interactive prompts, interrupt agent, or exit.
-            
-            Priority:
-            0. Cancel active voice recording
-            1. Cancel active sudo/approval/clarify prompt
-            2. Interrupt the running agent (first press)
-            3. Force exit (second press within 2s)
-            """
-            now = time.time()
-
-            # Cancel active voice recording.
-            # Run cancel() in a background thread to prevent blocking the
-            # event loop if AudioRecorder._lock or CoreAudio takes time.
-            _should_cancel_voice = False
-            _recorder_ref = None
-            with cli_ref._voice_lock:
-                if cli_ref._voice_recording and cli_ref._voice_recorder:
-                    _recorder_ref = cli_ref._voice_recorder
-                    cli_ref._voice_recording = False
-                    cli_ref._voice_continuous = False
-                    _should_cancel_voice = True
-            if _should_cancel_voice:
-                _cprint(f"\n{_DIM}Recording cancelled.{_RST}")
-                threading.Thread(
-                    target=_recorder_ref.cancel, daemon=True
-                ).start()
-                self._last_idle_ctrl_c_time = 0
-                event.app.invalidate()
-                return
-
-            # Cancel slash confirmation prompt (foreground UI, not an
-            # agent-blocking overlay — cancel and stop here).
-            if self._slash_confirm_state:
-                self._submit_slash_confirm_response("cancel")
-                event.app.current_buffer.reset()
-                self._last_idle_ctrl_c_time = 0
-                event.app.invalidate()
-                return
-
-            # Cancel /model picker (foreground UI — cancel and stop here).
-            if self._model_picker_state:
-                self._close_model_picker()
-                event.app.current_buffer.reset()
-                self._last_idle_ctrl_c_time = 0
-                event.app.invalidate()
-                return
-
-            # Cancel command palette (foreground UI — cancel and stop here).
-            if self._command_palette_state:
-                self._close_command_palette()
-                event.app.current_buffer.reset()
-                event.app.invalidate()
-                return
-
-            # Clear all agent-blocking overlays (approval/clarify/sudo/secret)
-            # in one shot.  We do NOT return after clearing — we fall through so
-            # that if the agent is also running we fire the interrupt on the same
-            # Ctrl+C press.  This fixes the case where a stale/orphaned overlay
-            # (left behind by a previous interrupt) consumes the press without
-            # ever reaching the agent-interrupt branch, leaving the chat frozen
-            # (#14026).
-            _overlay_cleared = bool(
-                self._sudo_state
-                or self._secret_state
-                or self._approval_state
-                or self._clarify_state
-            )
-            if _overlay_cleared:
-                self._clear_active_overlays_for_interrupt()
-                event.app.current_buffer.reset()
-                event.app.invalidate()
-
-            # If we only cleared overlays and the agent is NOT running, stop here
-            # (don't fall through to the interrupt/exit path).
-            if _overlay_cleared and not (self._agent_running and self.agent):
-                self._last_idle_ctrl_c_time = 0
-                return
-
-            if self._agent_running and self.agent:
-                if now - self._last_ctrl_c_time < 2.0:
-                    print("\n⚡ Force exiting...")
-                    self._should_exit = True
-                    event.app.exit()
-                    return
-                
-                self._last_ctrl_c_time = now
-                print("\n⚡ Interrupting agent... (press Ctrl+C again to force exit)")
-                request_hard_interrupt(self.agent)
-            # If there's text or images, clear them (like bash).
-            # If everything is already empty, exit (with double Ctrl+C guard).
-            elif event.app.current_buffer.text or self._attached_images:
-                event.app.current_buffer.reset()
-                self._attached_images.clear()
-                self._last_idle_ctrl_c_time = 0
-                event.app.invalidate()
-            else:
-                if now - self._last_idle_ctrl_c_time < 2.0:
-                    print("\n⚡ Force exiting...")
-                    self._should_exit = True
-                    event.app.exit()
-                    return
-                self._last_idle_ctrl_c_time = now
-                _cprint(f"\n{_DIM}Press Ctrl+C again to exit.{_RST}")
-                event.app.invalidate()
+            """Ctrl+C keybinding — see HermesCLI._handle_ctrl_c."""
+            self._handle_ctrl_c(event)
 
         # Ctrl+Shift+C: no binding needed. Terminal emulators (GNOME Terminal,
         # iTerm2, kitty, Windows Terminal, etc.) intercept Ctrl+Shift+C before
@@ -21072,7 +21122,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         n = len(submit_images)
                         _cprint(f"  {_DIM}📎 {n} image{'s' if n > 1 else ''} attached{_RST}")
 
-                    # Regular chat - run agent
+                    # Regular chat - run agent. A new run starts both
+                    # double-press state machines clean: a stale arm from a
+                    # previous run (interrupt, idle arm, or a half-finished
+                    # force-exit attempt) must never make the FIRST Ctrl+C
+                    # against this run force-exit the session.
+                    self._disarm_ctrl_c_timers()
                     self._agent_running = True
                     self._interactive_turn = True
                     self._pet_turn_error = False

--- a/tests/cli/test_cli_idle_ctrl_c_guard.py
+++ b/tests/cli/test_cli_idle_ctrl_c_guard.py
@@ -1,0 +1,448 @@
+"""Regression tests for the idle-path double Ctrl+C guard (PR #90874).
+
+First Ctrl+C at an empty prompt (no agent running, no text/images) must
+arm a 2s timer instead of exiting; a second press within the window
+force-exits. The idle and agent-running state machines are independent,
+and the disarm contract is symmetric: every intervening Ctrl+C press
+disarms the other path's timer (cancel/clear branches disarm both), so
+only consecutive same-path presses arm-then-exit.
+
+``_handle_ctrl_c`` was extracted from the ``run()`` keybinding closure so
+the branches are reachable from unit tests with a mocked ``event.app``.
+
+The complementary half of the contract — a new agent run starts both
+timers clean via ``_disarm_ctrl_c_timers()`` at the single
+``_agent_running = True`` site in ``run()`` — lives in the run loop; the
+helper itself is pinned by ``test_disarm_ctrl_c_timers_disarms_both`` and
+the call site is covered by inspection. Likewise the ``@kb.add('c-c')``
+binding site (a one-line delegate to ``_handle_ctrl_c``) is covered by
+inspection: the tests drive the method directly.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_cli():
+    """Build a HermesCLI instance with prompt_toolkit stubbed out.
+
+    Returns ``(cli_module, cli_instance)``. The module is returned so tests
+    can patch module-level names (``request_hard_interrupt``,
+    ``threading``) on the exact object the instance uses. Note: ``reload``
+    re-executes cli.py in place, so the stubbed prompt_toolkit bindings
+    stick to that module object for the rest of the session — this is the
+    established pattern of ``test_cli_interrupt_drain_regression.py`` /
+    ``test_cli_steer_busy_path.py`` and is NOT a guarantee of isolation;
+    patching by name would additionally hit a *fresh* module the instance
+    never closes over, which is why we hold the module object itself.
+    """
+    _clean_config = {
+        "model": {
+            "default": "anthropic/claude-opus-4.6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        "display": {"compact": False, "tool_progress": "all"},
+        "agent": {},
+        "terminal": {"env_type": "local"},
+    }
+    clean_env = {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+        "prompt_toolkit.auto_suggest": MagicMock(),
+    }
+    with patch.dict(sys.modules, prompt_toolkit_stubs), patch.dict(
+        "os.environ", clean_env, clear=False
+    ):
+        import cli as _cli_mod
+
+        _cli_mod = importlib.reload(_cli_mod)
+        with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), patch.dict(
+            _cli_mod.__dict__, {"CLI_CONFIG": _clean_config}
+        ):
+            return _cli_mod, _cli_mod.HermesCLI()
+
+
+@pytest.fixture()
+def cli():
+    """(cli_module, HermesCLI) with the __init__ timer contract pinned.
+
+    Asserts rather than assigns: if a timer attribute were ever dropped
+    from ``__init__``, the real keybinding path would raise AttributeError
+    on the first Ctrl+C — the fixture must fail here, not mask it.
+    """
+    mod, c = _make_cli()
+    assert c._last_ctrl_c_time == float("-inf")  # never-armed sentinel
+    assert c._last_idle_ctrl_c_time == float("-inf")
+    assert c._should_exit is False
+    # Branch-guard attributes must come from __init__ too: if one were
+    # dropped, the real keybinding path AttributeErrors on the first
+    # Ctrl+C while these tests stay green (tests below assign to them).
+    assert c._voice_recording is False
+    assert c._voice_recorder is None
+    assert c._voice_continuous is False
+    assert c._slash_confirm_state is None
+    assert c._model_picker_state is None
+    assert c._sudo_state is None
+    assert c._secret_state is None
+    assert c._approval_state is None
+    assert c._clarify_state is None
+    assert c._agent_running is False
+    assert c.agent is None
+    assert c._voice_lock is not None
+    assert c._attached_images == []
+    return mod, c
+
+
+def _fake_event(text: str = ""):
+    app = SimpleNamespace(
+        current_buffer=SimpleNamespace(text=text, reset=MagicMock()),
+        invalidate=MagicMock(),
+        exit=MagicMock(),
+    )
+    return SimpleNamespace(app=app)
+
+
+def _press(c, t: float, text: str = ""):
+    """Run one Ctrl+C press at fake time ``t``; returns the fake event."""
+    event = _fake_event(text)
+    with patch("time.monotonic", return_value=t):
+        c._handle_ctrl_c(event)
+    return event
+
+
+class TestIdleDoublePress:
+    """The empty-prompt state machine: arm -> arm-then-exit within 2s."""
+
+    def test_single_idle_press_arms_timer_without_exiting(self, cli):
+        mod, c = cli
+        with patch.object(mod, "_cprint") as cprint:
+            event = _press(c, t=1000.0)
+
+        assert c._last_idle_ctrl_c_time == 1000.0
+        assert c._should_exit is False
+        event.app.exit.assert_not_called()
+        event.app.invalidate.assert_called_once()
+        # The user-visible arm hint is the point of the PR: without it a
+        # first press would look like a silent no-op.
+        cprint.assert_called_once()
+        assert "Press Ctrl+C again to exit." in cprint.call_args.args[0]
+
+    def test_second_idle_press_within_window_force_exits(self, cli, capsys):
+        _, c = cli
+        _press(c, t=1000.0)
+        event = _press(c, t=1001.0)
+
+        assert c._should_exit is True
+        event.app.exit.assert_called_once()
+        event.app.invalidate.assert_not_called()
+        assert "Force exiting..." in capsys.readouterr().out
+
+    def test_idle_press_at_exactly_2s_rearms_instead_of_exiting(self, cli):
+        """The window is strict (< 2.0s): a press at t+2.0s must not exit.
+
+        The literals are deliberately exact: 1000.0 and 1002.0 are both
+        exactly representable in IEEE-754, so the difference is exactly
+        2.0 and the strict-inequality check is exercised without float
+        flakiness.
+        """
+        _, c = cli
+        _press(c, t=1000.0)
+        event = _press(c, t=1002.0)
+
+        assert c._should_exit is False
+        assert c._last_idle_ctrl_c_time == 1002.0
+        event.app.exit.assert_not_called()
+        event.app.invalidate.assert_called_once()
+
+    def test_idle_press_just_under_2s_force_exits(self, cli):
+        """The other side of the boundary: 1001.999 - 1000.0 < 2.0 exits."""
+        _, c = cli
+        _press(c, t=1000.0)
+        event = _press(c, t=1001.999)
+
+        assert c._should_exit is True
+        event.app.exit.assert_called_once()
+
+    def test_boot_window_first_idle_press_arms_not_exits(self, cli):
+        """time.monotonic() starts at boot: within the first 2s of uptime
+        the clock is in [0, 2.0). The never-armed sentinel is -inf, so the
+        very first press must ARM — with a 0 sentinel it would force-exit."""
+        _, c = cli
+        event = _press(c, t=0.5)  # fresh instance, boot window
+
+        assert c._should_exit is False
+        assert c._last_idle_ctrl_c_time == 0.5
+        event.app.exit.assert_not_called()
+
+        # And the double-press still works inside the boot window.
+        event = _press(c, t=1.0)
+        assert c._should_exit is True
+        event.app.exit.assert_called_once()
+
+
+class TestInterveningPressDisarms:
+    """Any non-empty-prompt Ctrl+C press must disarm the other path's timer.
+
+    Cancel/clear branches disarm both timers; the arm branches (idle arm,
+    agent interrupt) arm their own path and disarm only the other. Either
+    way, a stale arm from one path can never combine with a later press on
+    the other path into an accidental force-exit.
+    """
+
+    def test_disarm_ctrl_c_timers_disarms_both(self, cli):
+        """The helper is the only place both timers are disarmed together
+        after construction (__init__ sets the initial sentinels) — pinned
+        so a future edit can't drop one half of the pair."""
+        _, c = cli
+        c._last_ctrl_c_time = 999.5
+        c._last_idle_ctrl_c_time = 999.5
+
+        c._disarm_ctrl_c_timers()
+
+        assert c._last_ctrl_c_time == float("-inf")
+        assert c._last_idle_ctrl_c_time == float("-inf")
+
+    def test_buffer_clear_disarms_both_timers(self, cli):
+        _, c = cli
+        c._last_idle_ctrl_c_time = 999.5  # stale idle arm
+        c._last_ctrl_c_time = 999.7  # stale agent arm
+        event = _press(c, t=1000.0, text="typed text")  # buffer-clear branch
+
+        assert c._last_idle_ctrl_c_time == float("-inf")
+        assert c._last_ctrl_c_time == float("-inf")
+        event.app.current_buffer.reset.assert_called_once()  # "like bash"
+
+    def test_images_only_clear_disarms_both_timers_and_clears_images(self, cli):
+        _, c = cli
+        c._last_idle_ctrl_c_time = 999.5
+        c._last_ctrl_c_time = 999.7
+        c._attached_images = [Path("img.png")]
+        event = _press(c, t=1000.0)  # empty buffer, images present
+
+        assert c._attached_images == []
+        assert c._last_idle_ctrl_c_time == float("-inf")
+        assert c._last_ctrl_c_time == float("-inf")
+        event.app.current_buffer.reset.assert_called_once()
+
+    def test_slash_confirm_cancel_disarms_both_timers(self, cli):
+        _, c = cli
+        c._last_idle_ctrl_c_time = 999.5
+        c._last_ctrl_c_time = 999.7
+        c._slash_confirm_state = {"prompt": "confirm?"}
+        with patch.object(c, "_submit_slash_confirm_response") as submit:
+            _press(c, t=1000.0)
+
+        submit.assert_called_once_with("cancel")
+        assert c._last_idle_ctrl_c_time == float("-inf")
+        assert c._last_ctrl_c_time == float("-inf")
+
+    def test_model_picker_cancel_disarms_both_timers(self, cli):
+        _, c = cli
+        c._last_idle_ctrl_c_time = 999.5
+        c._last_ctrl_c_time = 999.7
+        c._model_picker_state = {"open": True}
+        with patch.object(c, "_close_model_picker") as close:
+            _press(c, t=1000.0)
+
+        close.assert_called_once()
+        assert c._last_idle_ctrl_c_time == float("-inf")
+        assert c._last_ctrl_c_time == float("-inf")
+
+    def test_command_palette_cancel_disarms_both_timers(self, cli):
+        _, c = cli
+        c._last_idle_ctrl_c_time = 999.5
+        c._last_ctrl_c_time = 999.7
+        c._command_palette_state = {"open": True}
+        with patch.object(c, "_close_command_palette") as close:
+            _press(c, t=1000.0)
+
+        close.assert_called_once()
+        assert c._last_idle_ctrl_c_time == float("-inf")
+        assert c._last_ctrl_c_time == float("-inf")
+
+    def test_voice_cancel_disarms_both_timers_and_uses_daemon_thread(self, cli):
+        mod, c = cli
+        c._last_idle_ctrl_c_time = 999.5
+        c._last_ctrl_c_time = 999.7
+        c._voice_recording = True
+        c._voice_continuous = True
+        c._voice_recorder = MagicMock()
+        with patch.object(mod, "threading") as mock_threading:
+            _press(c, t=1000.0)
+
+        assert c._last_idle_ctrl_c_time == float("-inf")
+        assert c._last_ctrl_c_time == float("-inf")
+        # "Don't block the event loop" intent: cancel runs on a daemon thread.
+        mock_threading.Thread.assert_called_once_with(
+            target=c._voice_recorder.cancel, daemon=True
+        )
+        mock_threading.Thread.return_value.start.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "state_attr",
+        ["_sudo_state", "_secret_state", "_approval_state", "_clarify_state"],
+    )
+    def test_overlay_clear_without_agent_disarms_both_timers(self, cli, state_attr):
+        _, c = cli
+        c._last_idle_ctrl_c_time = 999.5
+        c._last_ctrl_c_time = 999.7
+        setattr(c, state_attr, {"response_queue": MagicMock()})
+        with patch.object(c, "_clear_active_overlays_for_interrupt") as clear:
+            _press(c, t=1000.0)
+
+        clear.assert_called_once()
+        assert c._last_idle_ctrl_c_time == float("-inf")
+        assert c._last_ctrl_c_time == float("-inf")
+
+    def test_agent_interrupt_press_disarms_idle_timer(self, cli):
+        mod, c = cli
+        _press(c, t=1000.0)  # idle arm
+        c._agent_running = True
+        c.agent = MagicMock()
+        with patch.object(mod, "request_hard_interrupt") as hard_interrupt:
+            _press(c, t=1000.5)  # agent-interrupt press
+        assert c._last_idle_ctrl_c_time == float("-inf")  # disarmed by the interrupt
+        hard_interrupt.assert_called_once_with(c.agent)
+
+        # Back at the empty prompt, a quick press must ARM, not exit.
+        c._agent_running = False
+        c.agent = None
+        event = _press(c, t=1001.0)
+        assert c._should_exit is False
+        assert c._last_idle_ctrl_c_time == 1001.0
+        event.app.exit.assert_not_called()
+
+    def test_overlay_with_running_agent_clears_and_interrupts(self, cli):
+        """#14026 fall-through: one press clears overlays AND interrupts."""
+        mod, c = cli
+        c._sudo_state = {"response_queue": MagicMock()}
+        c._agent_running = True
+        c.agent = MagicMock()
+        with patch.object(c, "_clear_active_overlays_for_interrupt") as clear, patch.object(
+            mod, "request_hard_interrupt"
+        ) as hard_interrupt:
+            event = _press(c, t=1000.0)
+
+        clear.assert_called_once()
+        hard_interrupt.assert_called_once_with(c.agent)
+        assert c._last_idle_ctrl_c_time == float("-inf")  # agent branch disarms idle
+        assert c._last_ctrl_c_time == 1000.0  # interrupt armed agent path
+        assert c._should_exit is False
+        event.app.exit.assert_not_called()
+
+        # Second press inside the window (overlay still present, agent still
+        # running): must force-exit, not re-interrupt.
+        with patch.object(c, "_clear_active_overlays_for_interrupt") as clear2, patch.object(
+            mod, "request_hard_interrupt"
+        ) as hard_interrupt2:
+            event = _press(c, t=1000.5)
+
+        clear2.assert_called_once()
+        hard_interrupt2.assert_not_called()
+        assert c._should_exit is True
+        event.app.exit.assert_called_once()
+
+
+class TestAgentPathIndependence:
+    """The agent-running double-press machine is untouched and separate."""
+
+    def test_agent_path_force_exit_uses_own_timer(self, cli):
+        mod, c = cli
+        c._agent_running = True
+        c.agent = MagicMock()
+        with patch.object(mod, "request_hard_interrupt"):
+            _press(c, t=1000.0)  # first press: interrupt
+        assert c._last_ctrl_c_time == 1000.0
+        assert c._last_idle_ctrl_c_time == float("-inf")
+
+        event = _press(c, t=1001.0)  # second press: force exit
+        assert c._should_exit is True
+        event.app.exit.assert_called_once()
+
+    def test_agent_path_press_at_exactly_2s_interrupts_instead_of_exiting(self, cli):
+        """Agent window is strict (< 2.0s) too: a press at t+2.0s must
+        interrupt, not force-exit (mirror of the idle boundary test)."""
+        mod, c = cli
+        c._agent_running = True
+        c.agent = MagicMock()
+        c._last_ctrl_c_time = 998.0  # armed exactly 2.0s ago
+        with patch.object(mod, "request_hard_interrupt") as hard_interrupt:
+            event = _press(c, t=1000.0)
+
+        hard_interrupt.assert_called_once_with(c.agent)
+        assert c._should_exit is False
+        event.app.exit.assert_not_called()
+
+    def test_boot_window_first_agent_press_interrupts_not_exits(self, cli):
+        """Boot-window variant for the agent path: with a 0 sentinel the
+        first press against a fresh run inside 2s of boot would force-exit."""
+        mod, c = cli
+        c._agent_running = True
+        c.agent = MagicMock()
+        with patch.object(mod, "request_hard_interrupt") as hard_interrupt:
+            event = _press(c, t=0.5)
+
+        hard_interrupt.assert_called_once_with(c.agent)
+        assert c._should_exit is False
+        event.app.exit.assert_not_called()
+
+    def test_idle_arm_does_not_leak_into_agent_path(self, cli):
+        mod, c = cli
+        _press(c, t=1000.0)  # idle arm
+        c._agent_running = True
+        c.agent = MagicMock()
+        with patch.object(mod, "request_hard_interrupt") as hard_interrupt:
+            _press(c, t=1000.5)  # agent first press: must INTERRUPT, not exit
+
+        hard_interrupt.assert_called_once_with(c.agent)
+        assert c._should_exit is False
+        assert c._last_ctrl_c_time == 1000.5
+
+    def test_idle_press_disarms_stale_agent_arm(self, cli):
+        """Symmetric leak: interrupt -> agent ends -> idle press -> new run.
+
+        A stale agent arm must be disarmed by the idle press, so the first
+        Ctrl+C against the NEW agent run interrupts instead of force-exiting
+        the session.
+        """
+        mod, c = cli
+        c._agent_running = True
+        c.agent = MagicMock()
+        with patch.object(mod, "request_hard_interrupt"):
+            _press(c, t=1000.0)  # interrupt agent, agent timer = 1000.0
+        assert c._last_ctrl_c_time == 1000.0
+
+        c._agent_running = False
+        c.agent = None
+        _press(c, t=1000.5)  # idle arm: must disarm the stale agent arm
+        assert c._last_ctrl_c_time == float("-inf")
+
+        c._agent_running = True
+        c.agent = MagicMock()
+        with patch.object(mod, "request_hard_interrupt") as hard_interrupt:
+            event = _press(c, t=1001.0)  # first press on the new run
+
+        assert c._should_exit is False
+        hard_interrupt.assert_called_once_with(c.agent)  # interrupt, NOT exit
+        event.app.exit.assert_not_called()


### PR DESCRIPTION
Closes #90873

**Summary**
First Ctrl+C on an empty prompt (no agent running, no text/images) now shows "Press Ctrl+C again to exit." instead of exiting immediately; a second press within 2s force-exits. The handler docstring already promised a double-press contract — this aligns the idle path with it.

**What changed**
- The idle path uses its own `_last_idle_ctrl_c_time` field so the idle and agent-running double-press state machines can't cross-trigger (an idle warning press can no longer make the next Ctrl+C force-exit the whole session instead of interrupting a running agent).
- The timer is disarmed by every intervening Ctrl+C press — voice/slash-confirm/model-picker/overlay cancel and buffer clear — so only consecutive empty-prompt presses arm-then-exit.
- The dim hint renders via `_cprint`/`_DIM`/`_RST` (prompt_toolkit-safe under `patch_stdout`), matching the voice-cancel branch in the same handler.

**Scope**
- The pre-existing agent-running branch is untouched.
- Ctrl+Q and ESC handlers are not modified: Ctrl+Q explicitly has no double-press feature (per its docstring) and ESC is a separate key. The idle-exit contract is Ctrl+C-specific.

**Testing**
- `py_compile` clean.
- No upstream test harness exists for key bindings; behavior verified by scenario analysis across the handler's branches (agent running, text/images present, all cancel paths, overlay states).

**Review**
Passed 2/2 reviewers across 4 rounds (Claude Code opus-5 + Antigravity CLI); all findings addressed or rebutted with code evidence.
