### PR TITLE
fix(sms): add missing re import so standalone sends don't NameError

### DIFF
--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -24,6 +24,7 @@ import hashlib
 import hmac
 import logging
 import os
+import re
 import urllib.parse
 from typing import Any, Dict, Optional
 

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -321,3 +321,102 @@ class TestWebhookSignatureEnforcement:
         request = self._mock_request(oversized, content_length=None)
         resp = await adapter._handle_webhook(request)
         assert resp.status == 413
+
+
+# ── Standalone send: markdown stripping ────────────────────────────
+
+class TestStandaloneSendMarkdownStripping:
+    """_strip_markdown_for_sms and the standalone send path must work.
+
+    Regression: the helper was added in the plugin migration (560010547)
+    using ``re.sub`` without importing ``re``, so every out-of-process SMS
+    delivery (cron jobs, the standalone sender contract) crashed with
+    ``NameError: name 're' is not defined`` before reaching Twilio.
+    """
+
+    def test_strips_bold_italic_headings(self):
+        from plugins.platforms.sms.adapter import _strip_markdown_for_sms
+
+        result = _strip_markdown_for_sms(
+            "# Title\n**bold** and *italic*\n__under__ and _em_"
+        )
+        assert result == "Title\nbold and italic\nunder and em"
+
+    def test_strips_code_and_links_keeps_text(self):
+        from plugins.platforms.sms.adapter import _strip_markdown_for_sms
+
+        result = _strip_markdown_for_sms("run `cmd` then [docs](https://x.com/y)")
+        assert result == "run cmd then docs"
+
+    def test_collapses_excess_newlines(self):
+        from plugins.platforms.sms.adapter import _strip_markdown_for_sms
+
+        assert _strip_markdown_for_sms("a\n\n\n\nb") == "a\n\nb"
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_delivers_stripped_body(self):
+        """The out-of-process send path strips markdown from the SMS body.
+
+        Before the missing-import fix this failed with NameError before the
+        Twilio request was ever built.
+        """
+        from plugins.platforms.sms import adapter as sms_adapter_mod
+
+        captured = {}
+
+        class _FakeForm:
+            def add_field(self, name, value):
+                captured[name] = value
+
+        class _FakeResp:
+            status = 201
+
+            async def json(self):
+                return {"sid": "SM123"}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+        class _FakeSession:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            def post(self, *a, **kw):
+                return _FakeResp()
+
+        pc = PlatformConfig(enabled=True, api_key="tok")
+        fake_secrets = {
+            "TWILIO_ACCOUNT_SID": "ACtest",
+            "TWILIO_AUTH_TOKEN": "tok",
+        }
+        with patch.dict(
+            os.environ, {"TWILIO_PHONE_NUMBER": "+15550001111"}, clear=False
+        ), patch.object(
+            sms_adapter_mod, "_get_scoped_secret", lambda name, default=None: fake_secrets.get(name, default)
+        ), patch(
+            "aiohttp.ClientSession", _FakeSession
+        ), patch(
+            "aiohttp.FormData", _FakeForm
+        ):
+            result = await sms_adapter_mod._standalone_send(
+                pc, "+15559876543", "**urgent** cron `status` report"
+            )
+
+        assert result == {
+            "success": True,
+            "platform": "sms",
+            "chat_id": "+15559876543",
+            "message_id": "SM123",
+        }
+        assert captured["From"] == "+15550001111"
+        assert captured["To"] == "+15559876543"
+        assert captured["Body"] == "urgent cron status report"


### PR DESCRIPTION
Fixes #90875

## What

`_strip_markdown_for_sms()` in `plugins/platforms/sms/adapter.py` calls `re.sub` eight times, but the module never imports `re`. Every **out-of-process SMS delivery** — cron jobs with `deliver: sms`, or any caller of the plugin's `standalone_sender_fn` — failed with:

```
{"error": "Plugin standalone send failed: name 're' is not defined"}
```

The call site (`_standalone_send` → `_strip_markdown_for_sms(message)`) sits *before* the function's `try:` block, so the `NameError` aborted the delivery instead of being wrapped into a Twilio-API-style error result.

## Root cause

The helper landed in the plugin migration (560010547, 2026-06-19) which created the file; the `import re` was simply left out. The function has been untouched since.

## Fix

One line — `import re` in the stdlib import block (alphabetical order, between `os` and `urllib.parse`).

## Tests

Adds `TestStandaloneSendMarkdownStripping` to `tests/gateway/test_sms.py`:

- Direct `_strip_markdown_for_sms` behavior tests (bold/italic/underline/headings, inline code + links, newline collapse)
- An async `_standalone_send` test that mocks the Twilio POST (aiohttp session + form) and asserts the delivered `Body` field is the markdown-stripped text — proving the full standalone path now reaches the request

**Reverse-verified:** with the one-line fix reverted, all four new tests fail with exactly `NameError: name 're' is not defined` at the `re.sub` line; with the fix, the whole file is green via `scripts/run_tests.sh tests/gateway/test_sms.py` (19 passed / 0 failed).

cc @teknium1 — you authored the original plugin migration; could you take a look when you get a chance?
