### PR TITLE
fix(agent): clamp chat-completions output cap to fit the context window

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2012,6 +2012,30 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     except Exception:
         pass
 
+    # Output-token ceiling: largest cap that still fits the context window
+    # alongside the (roughly estimated) input.  Recomputed per request so it
+    # tracks input growth and compression.  See compute_output_token_ceiling
+    # for why this must happen up front (strict servers like vLLM 400 on
+    # input + max_tokens > window, deterministically).
+    _output_ceiling = None
+    try:
+        from agent.model_metadata import (
+            compute_output_token_ceiling,
+            estimate_request_tokens_rough,
+        )
+        _ctx_len = getattr(
+            getattr(agent, "context_compressor", None), "context_length", None
+        )
+        if _ctx_len:
+            _output_ceiling = compute_output_token_ceiling(
+                _ctx_len,
+                estimate_request_tokens_rough(
+                    api_messages, tools=tools_for_api or None
+                ),
+            )
+    except Exception:
+        _output_ceiling = None
+
     # Qwen session metadata
     _qwen_meta = None
     if _is_qwen:
@@ -2047,6 +2071,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             timeout=agent._resolved_api_call_timeout(),
             max_tokens=agent.max_tokens,
             ephemeral_max_output_tokens=_ephemeral_out,
+            output_token_ceiling=_output_ceiling,
             max_tokens_param_fn=agent._max_tokens_param,
             reasoning_config=agent.reasoning_config,
             request_overrides=agent.request_overrides,
@@ -2080,6 +2105,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         timeout=agent._resolved_api_call_timeout(),
         max_tokens=agent.max_tokens,
         ephemeral_max_output_tokens=_ephemeral_out,
+        output_token_ceiling=_output_ceiling,
         max_tokens_param_fn=agent._max_tokens_param,
         reasoning_config=agent.reasoning_config,
         request_overrides=agent.request_overrides,

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1772,6 +1772,42 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     return None
 
 
+def compute_output_token_ceiling(
+    context_length: Optional[int],
+    estimated_input_tokens: int,
+    *,
+    margin: int = 256,
+) -> Optional[int]:
+    """Return the largest output cap that still fits the context window.
+
+    Strict OpenAI-compatible servers (vLLM among them) reject any request
+    where ``input_tokens + max_tokens > context_window`` — deterministically,
+    on every call carrying the same oversized cap.  A full-window default cap
+    (e.g. CustomProfile's 65536 against a 65536-token vLLM server) therefore
+    fails EVERY request, and a one-shot post-error correction death-loops the
+    turn: each tool-loop call re-fails, re-compresses (1-3 min), and
+    max_compression_attempts kills the session (2026-08-19 vllm-metal outage).
+
+    Clamping at request-build time prevents the 400 up front and recomputes
+    per request, so it adapts as input grows or compression shrinks it, and
+    mutates no session state (fallback switches, /model, continuation boosts,
+    and compressor accounting are untouched).
+
+    Returns None when no clamp should be applied: unknown window, or the
+    estimated input already at/over the window (that is an input-overflow
+    problem — let the provider report it so compression handles it).
+    """
+    if not context_length or context_length <= 0:
+        return None
+    remaining = context_length - max(0, estimated_input_tokens)
+    if remaining < 1:
+        return None
+    # Margin applies only when room allows — a prompt that fits but leaves
+    # less than the margin still needs a clamp (floor 1), otherwise the
+    # unclamped full-window default goes out and deterministically 400s.
+    return max(1, remaining - margin)
+
+
 def is_output_cap_error(error_msg: str) -> bool:
     """Return True if a 400 is about the OUTPUT cap (max_tokens) being too large.
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -555,20 +555,31 @@ class ChatCompletionsTransport(ProviderTransport):
         is_tokenhub = params.get("is_tokenhub", False)
         reasoning_config = _reasoning_config_for_model(model, params.get("reasoning_config"))
 
+        _resolved_cap = None
+        _use_fn = False
         if ephemeral is not None and max_tokens_fn:
-            api_kwargs.update(
-                max_tokens_fn(
-                    _raise_gemini_thinking_max_tokens(model, reasoning_config, ephemeral)
-                )
+            _resolved_cap = _raise_gemini_thinking_max_tokens(
+                model, reasoning_config, ephemeral
             )
+            _use_fn = True
         elif max_tokens is not None and max_tokens_fn:
-            api_kwargs.update(
-                max_tokens_fn(
-                    _raise_gemini_thinking_max_tokens(model, reasoning_config, max_tokens)
-                )
+            _resolved_cap = _raise_gemini_thinking_max_tokens(
+                model, reasoning_config, max_tokens
             )
+            _use_fn = True
         elif anthropic_max_out is not None:
-            api_kwargs["max_tokens"] = anthropic_max_out
+            _resolved_cap = anthropic_max_out
+        # Clamp so input + output fits the context window — strict servers
+        # (vLLM) deterministically 400 otherwise. See
+        # model_metadata.compute_output_token_ceiling.
+        _ceiling = params.get("output_token_ceiling")
+        if _resolved_cap is not None and _ceiling:
+            _resolved_cap = min(_resolved_cap, _ceiling)
+        if _resolved_cap is not None:
+            if _use_fn:
+                api_kwargs.update(max_tokens_fn(_resolved_cap))
+            else:
+                api_kwargs["max_tokens"] = _resolved_cap
 
         # Kimi: top-level reasoning_effort (unless thinking disabled)
         if is_kimi:
@@ -773,26 +784,36 @@ class ChatCompletionsTransport(ProviderTransport):
         profile_max = profile.get_max_tokens(model)
         reasoning_config = _reasoning_config_for_model(model, params.get("reasoning_config"))
 
+        _resolved_cap = None
+        _use_fn = False
         if ephemeral is not None and max_tokens_fn:
-            api_kwargs.update(
-                max_tokens_fn(
-                    _raise_gemini_thinking_max_tokens(model, reasoning_config, ephemeral)
-                )
+            _resolved_cap = _raise_gemini_thinking_max_tokens(
+                model, reasoning_config, ephemeral
             )
+            _use_fn = True
         elif user_max is not None and max_tokens_fn:
-            api_kwargs.update(
-                max_tokens_fn(
-                    _raise_gemini_thinking_max_tokens(model, reasoning_config, user_max)
-                )
+            _resolved_cap = _raise_gemini_thinking_max_tokens(
+                model, reasoning_config, user_max
             )
+            _use_fn = True
         elif profile_max and max_tokens_fn:
-            api_kwargs.update(
-                max_tokens_fn(
-                    _raise_gemini_thinking_max_tokens(model, reasoning_config, profile_max)
-                )
+            _resolved_cap = _raise_gemini_thinking_max_tokens(
+                model, reasoning_config, profile_max
             )
+            _use_fn = True
         elif anthropic_max is not None:
-            api_kwargs["max_tokens"] = anthropic_max
+            _resolved_cap = anthropic_max
+        # Clamp so input + output fits the context window — strict servers
+        # (vLLM) deterministically 400 otherwise. See
+        # model_metadata.compute_output_token_ceiling.
+        _ceiling = params.get("output_token_ceiling")
+        if _resolved_cap is not None and _ceiling:
+            _resolved_cap = min(_resolved_cap, _ceiling)
+        if _resolved_cap is not None:
+            if _use_fn:
+                api_kwargs.update(max_tokens_fn(_resolved_cap))
+            else:
+                api_kwargs["max_tokens"] = _resolved_cap
 
         # Provider-specific api_kwargs extras (reasoning_effort, metadata, etc.)
         extra_body_from_profile, top_level_from_profile = (

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -224,6 +224,30 @@ class TestChatCompletionsBuildKwargs:
 
 
 
+    def test_no_callback_falls_through_to_anthropic_max(self, transport):
+        """Without max_tokens_param_fn, ephemeral/user caps are ignored and
+        the anthropic_max_output fallback is emitted as plain max_tokens —
+        the pre-clamp fallthrough semantics must be preserved."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o",
+            messages=msgs,
+            ephemeral_max_output_tokens=123,
+            max_tokens=456,
+            anthropic_max_output=789,
+        )
+        assert kw["max_tokens"] == 789
+
+    def test_no_callback_anthropic_max_is_still_clamped(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o",
+            messages=msgs,
+            anthropic_max_output=789,
+            output_token_ceiling=100,
+        )
+        assert kw["max_tokens"] == 100
+
     def test_tools_included(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         tools = [{"type": "function", "function": {"name": "test", "parameters": {}}}]

--- a/tests/test_output_cap_clamp.py
+++ b/tests/test_output_cap_clamp.py
@@ -1,0 +1,125 @@
+"""Output caps must fit the context window at request-build time (2026-08-19).
+
+Live failure mode: a provider whose default output cap equals the full context
+window (CustomProfile.default_max_tokens=65536 against a 65536-token vLLM
+server) makes EVERY request fail with a deterministic 400 — strict servers
+reject input + max_tokens > window.  The post-error remediation
+(_ephemeral_max_output_tokens) is one-shot, so each subsequent tool-loop call
+re-failed, re-compressed (1-3 min each), and after max_compression_attempts
+the turn died.
+
+The fix: build_api_kwargs computes an output-token ceiling
+(context_length - estimated input - margin) per request and the transport
+clamps whatever cap was resolved (ephemeral / user / profile default) to it.
+No session state is mutated, so fallback switches, /model, continuation
+boosts, and compressor accounting are unaffected.
+"""
+
+from unittest.mock import MagicMock
+
+from agent.model_metadata import compute_output_token_ceiling
+
+
+def _make_agent(max_tokens=None, context_length=65536):
+    """Minimal chat_completions AIAgent aimed at a vLLM-style custom provider."""
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    attrs = dict(
+        api_mode="chat_completions",
+        provider="custom",
+        base_url="http://127.0.0.1:8000/v1",
+        model="qwen3.8-27b",
+        tools=[],
+        max_tokens=max_tokens,
+        reasoning_config=None,
+        request_overrides={},
+        session_id="t",
+        _ephemeral_max_output_tokens=None,
+        _ollama_num_ctx=None,
+        openrouter_min_coding_score=None,
+        providers_allowed=None,
+        providers_denied=None,
+        providers_ignored=None,
+        providers_order=None,
+        providers_quantizations=None,
+        provider_sort=None,
+        provider_require_parameters=None,
+        provider_data_collection=None,
+        api_key="x",
+    )
+    for name, value in attrs.items():
+        setattr(agent, name, value)
+    compressor = MagicMock()
+    compressor.context_length = context_length
+    agent.context_compressor = compressor
+    agent._prepare_messages_for_non_vision_model = lambda m: m
+    agent._resolved_api_call_timeout = lambda: 60
+    agent._supports_reasoning_extra_body = lambda: False
+    return agent
+
+
+def _built_cap(agent, messages):
+    kwargs = agent._build_api_kwargs(messages)
+    return kwargs.get("max_tokens") or kwargs.get("max_completion_tokens")
+
+
+SMALL = [{"role": "user", "content": "hi"}]
+# ~120K chars — the shape of the real outage: input alone leaves far less
+# than the provider-default 65536 output cap inside a 65536-token window.
+BIG = [{"role": "user", "content": "x" * 120_000}]
+
+
+class TestComputeOutputTokenCeiling:
+    def test_basic_headroom(self):
+        assert compute_output_token_ceiling(65536, 30000) == 65536 - 30000 - 256
+
+    def test_unknown_window_returns_none(self):
+        assert compute_output_token_ceiling(None, 1000) is None
+        assert compute_output_token_ceiling(0, 1000) is None
+
+    def test_near_window_prompt_still_gets_a_clamp(self):
+        # A prompt that fits but leaves less than the margin must NOT escape
+        # unclamped — the full-window default would deterministically 400.
+        assert compute_output_token_ceiling(65536, 65535) == 1
+        assert compute_output_token_ceiling(65536, 65400) == 1
+        assert compute_output_token_ceiling(65536, 65280) == 1
+        assert compute_output_token_ceiling(65536, 65279) == 1
+
+    def test_input_at_or_over_window_returns_none(self):
+        # Input overflow is compression's job — no clamp, let the provider
+        # report the real error.
+        assert compute_output_token_ceiling(65536, 65536) is None
+        assert compute_output_token_ceiling(65536, 80000) is None
+
+
+class TestRequestBuildClamping:
+    def test_full_window_provider_default_is_clamped(self):
+        """The regression: the CustomProfile 65536 default must shrink so the
+        request fits, on EVERY build — no error round-trip required."""
+        agent = _make_agent(max_tokens=None)
+        cap = _built_cap(agent, BIG)
+        est_input_upper = 65536  # any clamp beats the old full-window cap
+        assert cap < est_input_upper
+        # And the request actually fits the window per the same estimator.
+        from agent.model_metadata import estimate_request_tokens_rough
+        assert cap + estimate_request_tokens_rough(BIG) <= 65536
+
+    def test_clamp_repeats_on_subsequent_builds(self):
+        agent = _make_agent(max_tokens=None)
+        first = _built_cap(agent, BIG)
+        assert _built_cap(agent, BIG) == first
+
+    def test_small_prompt_keeps_user_cap(self):
+        agent = _make_agent(max_tokens=16384)
+        assert _built_cap(agent, SMALL) == 16384
+
+    def test_ephemeral_override_is_clamped_too(self):
+        agent = _make_agent(max_tokens=None)
+        agent._ephemeral_max_output_tokens = 65536
+        cap = _built_cap(agent, BIG)
+        assert cap < 65536
+
+    def test_large_window_provider_is_unaffected(self):
+        agent = _make_agent(max_tokens=16384, context_length=200_000)
+        assert _built_cap(agent, BIG) == 16384


### PR DESCRIPTION
## Problem

Strict OpenAI-compatible servers (vLLM among them) deterministically reject any request where `input_tokens + max_tokens > context_window` with a 400. `CustomProfile.default_max_tokens` is 65536 — the full window on a 65536-token vLLM server — so with no user-configured `model.max_tokens`, **every** request fails:

```
This model's maximum context length is 65536 tokens. However, you requested
65536 output tokens and your prompt contains 131039 characters (more than 0
characters, which is the upper bound for 0 input tokens)...
```

The existing remediation (`_ephemeral_max_output_tokens`) is one-shot: the immediate retry succeeds, but the next tool-loop call in the same turn reverts to the oversized default, re-fails, re-compresses (1–3 min each), and after `max_compression_attempts` the turn dies with "Try /new". Reproduced live 2026-08-19 against vllm-metal serving Qwen3.8-27B.

## Fix

`build_api_kwargs` computes an output-token ceiling per request — `context_length − estimate_request_tokens_rough(messages, tools) − 256` via new `compute_output_token_ceiling()` — and both chat-completions transport branches clamp the resolved cap (ephemeral > user > profile default > anthropic fallback) to it. This mirrors the clamp the Anthropic Messages path already performs.

Design notes:
- Recomputed per request, so it adapts as input grows or compression shrinks it. No session state is mutated (a sticky `agent.max_tokens` design was considered and rejected in adversarial review: it contaminated fallback switches, `/model`, continuation boosts, and compressor accounting).
- Ceiling is `None` (no clamp) when the window is unknown, or when estimated input is already at/over the window — input overflow remains compression's job.
- A prompt that fits but leaves less than the margin still gets a clamp (floor 1) rather than escaping unclamped.
- No-callback fallthrough semantics preserved (ephemeral/user resolve only when `max_tokens_param_fn` is present; `anthropic_max_output` still emits plain `max_tokens`), with regression tests.
- Residual risk: a systematic estimator undershoot > 256 tokens (very token-dense content) can still 400; the one-shot ephemeral path still catches those.

## Test plan

- `scripts/run_tests.sh tests/test_output_cap_clamp.py` — new coverage: ceiling math incl. near-window boundaries, request-build clamping for a vLLM-style custom provider, ephemeral clamping, large-window providers unaffected
- `scripts/run_tests.sh tests/agent/transports/` — incl. new no-callback fallthrough regressions; Gemini thinking max_tokens raise preserved in both branches
- Full `tests/agent/ tests/run_agent/` suites pass on the fork (5,595 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLBH7WcsrDrqCGuqD8wFD5