### PR TITLE
fix(kanban): enforce parent cap at claim boundary

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2092,6 +2092,24 @@ def _cmd_claim(args: argparse.Namespace) -> int:
             if existing is None:
                 print(f"no such task: {args.task_id}", file=sys.stderr)
                 return 1
+            rejected = conn.execute(
+                "SELECT kind, payload FROM task_events "
+                "WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+                (args.task_id,),
+            ).fetchone()
+            if rejected and rejected["kind"] == "claim_rejected" and rejected["payload"]:
+                try:
+                    payload = json.loads(rejected["payload"])
+                except (json.JSONDecodeError, TypeError):
+                    payload = {}
+                if payload.get("reason") == "max_in_progress":
+                    print(
+                        f"cannot claim {args.task_id}: max_in_progress "
+                        f"capacity exhausted (observed={payload.get('observed')} "
+                        f"cap={payload.get('cap')})",
+                        file=sys.stderr,
+                    )
+                    return 1
             print(
                 f"cannot claim {args.task_id}: status={existing.status} "
                 f"lock={existing.claim_lock or '(none)'}",
@@ -2686,6 +2704,14 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 {"task_id": tid, "assignee": who, "current": current}
                 for (tid, who, current) in res.skipped_per_profile_capped
             ],
+            "capacity_exhausted": (
+                {
+                    "observed": res.capacity_exhausted[0],
+                    "cap": res.capacity_exhausted[1],
+                }
+                if res.capacity_exhausted is not None
+                else None
+            ),
             "auto_assigned_default": res.auto_assigned_default,
         }, indent=2))
         return 0
@@ -2723,6 +2749,12 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         print(
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
+        )
+    if res.capacity_exhausted is not None:
+        observed, cap = res.capacity_exhausted
+        print(
+            "Deferred (max_in_progress capacity exhausted): "
+            f"observed={observed} cap={cap}"
         )
     return 0
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4603,6 +4603,74 @@ def recompute_ready(
 # Claim / complete / block
 # ---------------------------------------------------------------------------
 
+# ``None`` remains an explicit opt-out for internal setup/recovery callers.
+# Normal claim callers use the configured board cap by default, while dispatcher
+# callers pass their already-resolved cap (which may include the memory-derived
+# default).  A sentinel is required so those two meanings stay distinct.
+_CONFIGURED_PARENT_CAP = object()
+
+
+def _claim_rejected_for_capacity(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    expected_status: str,
+    max_in_progress: object,
+) -> bool:
+    """Reject an eligible parent claim at capacity inside its write txn.
+
+    The count and the later status transition run under the same SQLite
+    ``BEGIN IMMEDIATE`` transaction.  Independent gateway, API, CLI, and review
+    owners therefore serialize on the board DB and cannot both consume the
+    final slot.
+    """
+    if max_in_progress is _CONFIGURED_PARENT_CAP:
+        cap = configured_max_in_progress()
+    elif isinstance(max_in_progress, int) and not isinstance(max_in_progress, bool):
+        cap = max_in_progress if max_in_progress > 0 else None
+    else:
+        cap = None
+    if cap is None:
+        return False
+
+    candidate = conn.execute(
+        "SELECT status, claim_lock FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if (
+        candidate is None
+        or candidate["status"] != expected_status
+        or candidate["claim_lock"] is not None
+    ):
+        return False
+
+    observed = int(conn.execute(
+        "SELECT COUNT(*) AS n FROM tasks WHERE status = 'running'"
+    ).fetchone()["n"])
+    if observed < cap:
+        return False
+
+    _append_event(
+        conn,
+        task_id,
+        "claim_rejected",
+        {
+            "reason": "max_in_progress",
+            "observed": observed,
+            "cap": cap,
+            "source_status": expected_status,
+        },
+    )
+    _log.warning(
+        "kanban claim refused: parent worker capacity exhausted "
+        "(observed=%d cap=%d task=%s source=%s)",
+        observed,
+        cap,
+        task_id,
+        expected_status,
+    )
+    return True
+
 def _parents_satisfied(conn: sqlite3.Connection, task_id: str) -> bool:
     """Return whether every direct parent is terminal for dependency gating."""
     return conn.execute(
@@ -4620,6 +4688,7 @@ def claim_task(
     *,
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    max_in_progress: object = _CONFIGURED_PARENT_CAP,
 ) -> Optional[Task]:
     """Atomically transition ``ready -> running``.
 
@@ -4654,6 +4723,13 @@ def claim_task(
                 conn, task_id, "claim_rejected",
                 {"reason": "parents_not_done"},
             )
+            return None
+        if _claim_rejected_for_capacity(
+            conn,
+            task_id,
+            expected_status="ready",
+            max_in_progress=max_in_progress,
+        ):
             return None
         # Defensive: if a prior run somehow leaked (invariant violation from
         # an unknown code path), close it as 'reclaimed' so we don't strand
@@ -4742,6 +4818,7 @@ def claim_review_task(
     *,
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    max_in_progress: object = _CONFIGURED_PARENT_CAP,
 ) -> Optional[Task]:
     """Atomically transition ``review -> running``.
 
@@ -4774,6 +4851,13 @@ def claim_review_task(
                         "source_status": "review",
                     },
                 )
+            return None
+        if _claim_rejected_for_capacity(
+            conn,
+            task_id,
+            expected_status="review",
+            max_in_progress=max_in_progress,
+        ):
             return None
         cur = conn.execute(
             """
@@ -8075,6 +8159,11 @@ class DispatchResult:
     DB writes this tick — the lock holder is making progress on the same
     board. This is the steady-state signal that a single-writer guard is
     actively preventing two dispatchers from racing on ``kanban.db``."""
+    capacity_exhausted: Optional[tuple[int, int]] = None
+    """``(observed_parent_workers, cap)`` when no parent launch was allowed.
+
+    This content-free diagnostic is shared by CLI, gateway, and Desktop/API
+    serialization of ``DispatchResult``. Active workers are preserved."""
     memory_pressure: Optional[str] = None
     """System memory pressure observed at spawn time when the memory guard
     restricted this tick (OOF-30/OOF-77): ``"critical"`` — no new workers
@@ -10004,6 +10093,13 @@ def _dispatch_once_locked(
     if max_in_progress is not None:
         total_running = running_count + count_running_tasks_other_boards(board)
         if total_running >= max_in_progress:
+            result.capacity_exhausted = (total_running, max_in_progress)
+            _log.warning(
+                "kanban dispatch refused: parent worker capacity exhausted "
+                "(observed=%d cap=%d)",
+                total_running,
+                max_in_progress,
+            )
             return result
         remaining = max_in_progress - total_running
         if spawn_budget is None or spawn_budget > remaining:
@@ -10227,7 +10323,12 @@ def _dispatch_once_locked(
                     _per_profile_running.get(row_assignee, 0) + 1
                 )
             continue
-        claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
+        claimed = claim_task(
+            conn,
+            row["id"],
+            ttl_seconds=ttl_seconds,
+            max_in_progress=max_in_progress,
+        )
         if claimed is None:
             continue
         try:
@@ -10354,7 +10455,12 @@ def _dispatch_once_locked(
                     _per_profile_running.get(row["assignee"], 0) + 1
                 )
             continue
-        claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
+        claimed = claim_review_task(
+            conn,
+            row["id"],
+            ttl_seconds=ttl_seconds,
+            max_in_progress=max_in_progress,
+        )
         if claimed is None:
             continue
         try:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2287,8 +2287,15 @@ def dispatch(
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
+        max_in_progress = kanban_db.resolve_max_in_progress(
+            kanban_db.configured_max_in_progress()
+        )
         result = kanban_db.dispatch_once(
-            conn, dry_run=dry_run, max_spawn=max_n, board=board,
+            conn,
+            dry_run=dry_run,
+            max_spawn=max_n,
+            max_in_progress=max_in_progress,
+            board=board,
         )
         # DispatchResult is a dataclass.
         try:

--- a/tests/hermes_cli/test_kanban_atomic_parent_cap.py
+++ b/tests/hermes_cli/test_kanban_atomic_parent_cap.py
@@ -1,0 +1,205 @@
+"""Atomic board-wide parent-worker capacity enforcement.
+
+The cap belongs at the claim boundary, not only in dispatcher budgeting: gateway,
+Desktop/API, CLI/manual, and review owners can race through different entry
+points while sharing one board.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _running_ids(conn):
+    return {
+        row["id"]
+        for row in conn.execute("SELECT id FROM tasks WHERE status = 'running'")
+    }
+
+
+def test_simultaneous_claim_owners_share_the_last_parent_slot(kanban_home):
+    """Two independent owners racing from 2/3 capacity claim exactly one task."""
+    with kb.connect() as conn:
+        existing = [
+            kb.create_task(conn, title=f"running-{i}", assignee="default")
+            for i in range(2)
+        ]
+        for task_id in existing:
+            assert kb.claim_task(conn, task_id) is not None
+        candidates = [
+            kb.create_task(conn, title=f"candidate-{i}", assignee="default")
+            for i in range(2)
+        ]
+
+    barrier = threading.Barrier(2)
+    outcomes: list[tuple[str, bool]] = []
+    errors: list[BaseException] = []
+
+    def attempt(task_id: str, owner: str) -> None:
+        try:
+            with kb.connect() as conn:
+                barrier.wait(timeout=5)
+                claimed = kb.claim_task(
+                    conn,
+                    task_id,
+                    claimer=owner,
+                    max_in_progress=3,
+                )
+                outcomes.append((task_id, claimed is not None))
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=attempt, args=(task_id, f"owner-{i}:1"))
+        for i, task_id in enumerate(candidates)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert errors == []
+    assert all(not thread.is_alive() for thread in threads)
+    assert sorted(success for _, success in outcomes) == [False, True]
+    with kb.connect() as conn:
+        assert len(_running_ids(conn)) == 3
+
+
+def test_manual_claim_uses_the_configured_parent_cap(kanban_home, monkeypatch):
+    """The direct/manual claim path cannot bypass configured max_in_progress."""
+    monkeypatch.setattr(kb, "configured_max_in_progress", lambda: 3)
+    with kb.connect() as conn:
+        running = [
+            kb.create_task(conn, title=f"running-{i}", assignee="default")
+            for i in range(3)
+        ]
+        for task_id in running:
+            assert kb.claim_task(conn, task_id, max_in_progress=None) is not None
+        candidate = kb.create_task(conn, title="manual", assignee="default")
+
+        assert kb.claim_task(conn, candidate, claimer="manual:1") is None
+        assert kb.get_task(conn, candidate).status == "ready"
+        event = conn.execute(
+            "SELECT kind, payload FROM task_events WHERE task_id = ? "
+            "ORDER BY id DESC LIMIT 1",
+            (candidate,),
+        ).fetchone()
+
+    assert event["kind"] == "claim_rejected"
+    assert '"reason": "max_in_progress"' in event["payload"]
+    assert '"observed": 3' in event["payload"]
+    assert '"cap": 3' in event["payload"]
+
+
+def test_manual_claim_cli_reports_capacity_diagnostic(
+    kanban_home, monkeypatch,
+):
+    from hermes_cli import kanban as kanban_cli
+
+    monkeypatch.setattr(kb, "configured_max_in_progress", lambda: 3)
+    with kb.connect() as conn:
+        running = [
+            kb.create_task(conn, title=f"running-{i}", assignee="default")
+            for i in range(3)
+        ]
+        for task_id in running:
+            assert kb.claim_task(conn, task_id, max_in_progress=None) is not None
+        candidate = kb.create_task(conn, title="manual-cli", assignee="default")
+
+    output = kanban_cli.run_slash(f"claim {candidate}")
+
+    assert "max_in_progress" in output
+    assert "observed=3" in output
+    assert "cap=3" in output
+
+
+def test_cli_dispatch_reports_configured_capacity(
+    kanban_home, monkeypatch,
+):
+    from hermes_cli import config as config_module
+    from hermes_cli import kanban as kanban_cli
+
+    monkeypatch.setattr(
+        config_module,
+        "load_config",
+        lambda *args, **kwargs: {"kanban": {"max_in_progress": 3}},
+    )
+    with kb.connect() as conn:
+        for i in range(3):
+            task_id = kb.create_task(
+                conn, title=f"running-{i}", assignee="default"
+            )
+            assert kb.claim_task(conn, task_id, max_in_progress=None) is not None
+        kb.create_task(conn, title="waiting", assignee="default")
+
+    output = kanban_cli.run_slash("dispatch --json")
+
+    assert '"capacity_exhausted"' in output
+    assert "3" in output
+
+
+def test_review_claim_shares_parent_cap_without_reclaiming_active_work(
+    kanban_home,
+):
+    """Review dispatch is refused at capacity and preserves active workers."""
+    with kb.connect() as conn:
+        running = [
+            kb.create_task(conn, title=f"running-{i}", assignee="default")
+            for i in range(3)
+        ]
+        for task_id in running:
+            assert kb.claim_task(conn, task_id) is not None
+        review_id = kb.create_task(conn, title="review", assignee="reviewer")
+        conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (review_id,))
+        conn.commit()
+
+        assert kb.claim_review_task(
+            conn,
+            review_id,
+            claimer="review-owner:1",
+            max_in_progress=3,
+        ) is None
+        assert kb.get_task(conn, review_id).status == "review"
+        assert _running_ids(conn) == set(running)
+        reclaimed = conn.execute(
+            "SELECT COUNT(*) AS n FROM task_events WHERE kind = 'reclaimed'"
+        ).fetchone()["n"]
+
+    assert reclaimed == 0
+
+
+def test_dispatch_reports_full_capacity_without_reclaiming(kanban_home):
+    with kb.connect() as conn:
+        running = [
+            kb.create_task(conn, title=f"running-{i}", assignee="default")
+            for i in range(3)
+        ]
+        for task_id in running:
+            assert kb.claim_task(conn, task_id) is not None
+        waiting = kb.create_task(conn, title="waiting", assignee="default")
+
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: pytest.fail("must not spawn"),
+            max_in_progress=3,
+        )
+
+        assert result.capacity_exhausted == (3, 3)
+        assert kb.get_task(conn, waiting).status == "ready"
+        assert _running_ids(conn) == set(running)

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -515,6 +515,26 @@ def test_dispatch_dry_run(client):
     assert isinstance(body, dict)
 
 
+def test_dispatch_uses_configured_parent_cap(client, monkeypatch):
+    """Desktop/API dispatch returns the same full-cap diagnostic as gateway/CLI."""
+    monkeypatch.setattr(kb, "configured_max_in_progress", lambda: 3)
+    with kb.connect() as conn:
+        for i in range(3):
+            task_id = kb.create_task(
+                conn, title=f"running-{i}", assignee="researcher"
+            )
+            assert kb.claim_task(conn, task_id, max_in_progress=None) is not None
+    client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "waiting", "assignee": "researcher"},
+    )
+
+    response = client.post("/api/plugins/kanban/dispatch?max=8")
+
+    assert response.status_code == 200
+    assert response.json()["capacity_exhausted"] == [3, 3]
+
+
 # ---------------------------------------------------------------------------
 # Triage column (new v1 status)
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1491,6 +1491,13 @@ class TestAsyncCapUnified(unittest.TestCase):
         from tools.delegate_tool import _get_max_async_children
         self.assertEqual(_get_max_async_children(), 15)
 
+
+class TestConfiguredThreeChildCap(unittest.TestCase):
+    @patch("tools.delegate_tool._load_config",
+           return_value={"max_concurrent_children": 3})
+    def test_three_child_cap_is_enforced_independently(self, mock_cfg):
+        self.assertEqual(_get_max_concurrent_children(), 3)
+
 # =========================================================================
 # max_spawn_depth clamping
 # =========================================================================


### PR DESCRIPTION
## Root cause

`max_in_progress` was enforced only as a pre-loop budget in `dispatch_once`. Direct/manual and review claims bypassed it, while the dashboard `/dispatch` path omitted the cap entirely. Concurrent owners could therefore claim past the configured board capacity.

## Fix

- Recheck parent-worker capacity inside the same SQLite `BEGIN IMMEDIATE` transaction as every ready/review claim.
- Pass the resolved cap through dispatcher and dashboard paths.
- Return content-free observed/cap diagnostics in CLI/API results and claim events.
- Preserve active workers; capacity refusal never reclaims.
- Keep delegated-child accounting separate; the operational child cap remains config-driven.

## Verification

- Deterministic two-owner last-slot race: exactly one claim succeeds from 2/3.
- Atomic parent-cap + CLI/manual/review diagnostics: 6 passed.
- Host-cap/dispatch-lock: 13 passed.
- Review lifecycle: 41 passed.
- Dashboard plugin: 39 passed.
- Core Kanban regression slice: 57 passed, 1 unrelated live-system guard failure in the pre-existing zombie test.
- Ruff checks, `py_compile`, and `git diff --check` passed.