### PR TITLE
fix(delegate): defer timed-out child teardown

### DIFF
--- a/tests/tools/test_delegate_timeout_cleanup.py
+++ b/tests/tools/test_delegate_timeout_cleanup.py
@@ -1,0 +1,90 @@
+"""Regression coverage for timed-out delegation teardown."""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+from tools import delegate_tool
+
+
+class _SlowUnwindingChild:
+    def __init__(self) -> None:
+        self.tool_progress_callback = None
+        self._credential_pool = None
+        self._delegate_saved_tool_names = []
+        self._delegate_role = "leaf"
+        self._delegate_depth = 1
+        self._subagent_id = None
+        self.model = "test-model"
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_estimated_cost_usd = 0.0
+        self.session_cost_status = "unknown"
+        self.started = threading.Event()
+        self.interrupted = threading.Event()
+        self.unwinding = threading.Event()
+        self.allow_finish = threading.Event()
+        self.finished = threading.Event()
+        self.closed = threading.Event()
+        self.close_while_running = False
+
+    def run_conversation(self, **_kwargs):
+        self.started.set()
+        assert self.interrupted.wait(timeout=1)
+        # Model the real child turn's finally path: it still performs session
+        # activity/SQLite cleanup after the parent requests interruption.
+        self.unwinding.set()
+        assert self.allow_finish.wait(timeout=2)
+        self.finished.set()
+        return {
+            "final_response": "",
+            "completed": False,
+            "interrupted": True,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+    def hard_interrupt(self, _reason=None):
+        self.interrupted.set()
+
+    def get_activity_summary(self):
+        return {"api_call_count": 1}
+
+    def close(self):
+        if not self.finished.is_set():
+            self.close_while_running = True
+        self.closed.set()
+
+
+def test_timeout_does_not_close_child_while_worker_is_unwinding(monkeypatch):
+    child = _SlowUnwindingChild()
+    parent = SimpleNamespace(
+        session_id="parent-timeout-test",
+        _current_task_id=None,
+        _active_children=[child],
+        _active_children_lock=threading.Lock(),
+    )
+    monkeypatch.setattr(delegate_tool, "_get_child_timeout", lambda: 0.5)
+    monkeypatch.setattr(delegate_tool, "_get_worktree_isolation", lambda: False)
+
+    result = delegate_tool._run_single_child(
+        task_index=0,
+        goal="exercise timeout teardown",
+        child=child,
+        parent_agent=parent,
+    )
+
+    assert result["status"] == "timeout"
+    assert child.unwinding.wait(timeout=1)
+    try:
+        assert not child.closed.is_set(), (
+            "timed-out child.close() ran before its conversation thread unwound"
+        )
+    finally:
+        child.allow_finish.set()
+    assert child.finished.wait(timeout=1)
+    assert child.closed.wait(timeout=1)
+    assert not child.close_while_running, (
+        "timed-out child.close() raced its still-running conversation thread"
+    )

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2439,6 +2439,12 @@ def _run_single_child(
     Returns a structured result dict.
     """
     child_start = time.monotonic()
+    # A timed-out Future may still be unwinding on its daemon worker. Closing
+    # the child from this owner thread before that Future settles races every
+    # resource the conversation's finally path still touches (notably its
+    # owned SessionDB). The timeout branch flips this when close ownership is
+    # handed to a Future done-callback instead.
+    _child_close_deferred = False
 
     # Get the progress callback from the child agent
     child_progress_cb = getattr(child, "tool_progress_callback", None)
@@ -2916,6 +2922,28 @@ def _run_single_child(
                     f"{_late_pending_steer}]"
                 )
             _attach_worktree(_error_entry)
+            if is_timeout and not _child_future.done():
+                # request_hard_interrupt() is cooperative: the worker still
+                # executes run_conversation's finally path before its Future
+                # becomes done. child.close() tears down that same agent's
+                # clients, messages, and owned SQLite handle, so calling it in
+                # our outer finally while the worker is alive can close SQLite
+                # underneath its final activity write. Future callbacks run
+                # only after the worker has fully returned (or raised), which
+                # is the first safe close boundary.
+                def _close_after_timed_out_worker(_done_future) -> None:
+                    try:
+                        close = getattr(child, "close", None)
+                        if callable(close):
+                            close()
+                    except Exception:
+                        logger.debug(
+                            "Failed to close timed-out child after worker exit",
+                            exc_info=True,
+                        )
+
+                _child_future.add_done_callback(_close_after_timed_out_worker)
+                _child_close_deferred = True
             return _error_entry
         finally:
             # Shut down executor without waiting — if the child thread
@@ -3339,11 +3367,13 @@ def _run_single_child(
         # Close tool resources (terminal sandboxes, browser daemons,
         # background processes, httpx clients) so subagent subprocesses
         # don't outlive the delegation.
-        try:
-            if hasattr(child, "close"):
-                child.close()
-        except Exception:
-            logger.debug("Failed to close child agent after delegation")
+        if not _child_close_deferred:
+            try:
+                close = getattr(child, "close", None)
+                if callable(close):
+                    close()
+            except Exception:
+                logger.debug("Failed to close child agent after delegation")
 
         # The AIAgent turn boundary normally closes the child scope itself. This
         # fallback covers failures before that boundary starts, but must not pop


### PR DESCRIPTION
## What does this PR do?

Prevents timed-out delegated children from being closed while their conversation thread is still unwinding.

`_run_single_child()` waits on a child `Future`. On timeout it requests a cooperative hard interrupt, but the function's outer `finally` immediately called `child.close()` even when the `Future` was still running. `AIAgent.close()` closes the child's owned `SessionDB`; meanwhile `run_conversation()` can still be executing its final activity-label write on the worker thread. That cross-thread close/use race matches the observed gateway segfault stack.

When a timed-out child `Future` is still running, this change transfers close ownership to a `Future` done-callback. Normal completion and already-settled failure paths keep their existing synchronous close behavior.

## Related Issue

No existing issue found. This was reproduced on current `main` after a gateway crash involving two simultaneous delegated-child timeouts.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Defer `child.close()` until the timed-out worker `Future` has fully settled.
- Preserve synchronous teardown for normal and already-settled paths.
- Add a deterministic regression test that holds the fake child inside its unwind phase and asserts teardown cannot race it.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_delegate_timeout_cleanup.py -q`.
2. Temporarily restore the old unconditional `child.close()` path; the regression test fails with `timed-out child.close() ran before its conversation thread unwound`.
3. Run the delegation/subagent family:
   `scripts/run_tests.sh tests/tools/test_delegate*.py tests/tools/test_subagent*.py tests/agent/test_subagent*.py tests/test_delegate_cascade_49148.py tests/cli/test_cli_delegate_background_notice.py tests/cli/test_cli_interrupt_subagent.py -q`

Local results:
- Regression test with fix: `1 passed`
- Sabotage run against old behavior: `1 failed` at the intended assertion
- Delegation/subagent suite: `255 passed, 0 failed`
- `ruff 0.15.10`: clean
- `git diff --check`: clean

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (affected 255-test family passed; full suite delegated to CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; internal lifecycle fix
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure `concurrent.futures` lifecycle change
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Observed failure shape before the fix:

```text
Subagent timed out
owner thread -> child.close() -> SessionDB.close()
worker thread -> run_conversation() finally -> clear_session_activity_labels()
Fatal Python error: Segmentation fault
```
