### PR TITLE
fix(config): accept supported toolset passthroughs

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2403,8 +2403,24 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         from toolsets import validate_toolset
         from hermes_cli.toolset_validation import validate_platform_toolsets
 
+        raw_config = read_raw_config()
+        known_plugin_map = raw_config.get("known_plugin_toolsets") or {}
+        extra_valid_toolsets = {"no_mcp"}
+        if isinstance(known_plugin_map, dict):
+            for names in known_plugin_map.values():
+                if isinstance(names, list):
+                    extra_valid_toolsets.update(
+                        name for name in names if isinstance(name, str) and name
+                    )
+        raw_mcp_servers = raw_config.get("mcp_servers") or {}
+        if isinstance(raw_mcp_servers, dict):
+            extra_valid_toolsets.update(
+                name for name in raw_mcp_servers if isinstance(name, str) and name
+            )
         ts_warnings = validate_platform_toolsets(
-            read_raw_config().get("platform_toolsets"), validate_toolset
+            raw_config.get("platform_toolsets"),
+            validate_toolset,
+            extra_valid_toolsets=extra_valid_toolsets,
         )
         for w in ts_warnings:
             results["warnings"].append(w)

--- a/hermes_cli/toolset_validation.py
+++ b/hermes_cli/toolset_validation.py
@@ -12,12 +12,14 @@ significant debugging to find. Surfacing invalid toolset names (and the
 zero-tools end state) loudly turns that silent failure into an actionable one.
 """
 
-from typing import Callable, List
+from typing import Callable, Iterable, List
 
 
 def validate_platform_toolsets(
     platform_toolsets: object,
     is_valid_toolset: Callable[[str], bool],
+    *,
+    extra_valid_toolsets: Iterable[str] = (),
 ) -> List[str]:
     """Return human-readable warnings for a ``platform_toolsets`` mapping.
 
@@ -43,6 +45,7 @@ def validate_platform_toolsets(
         A list of warning strings (empty when everything is valid).
     """
     warnings: List[str] = []
+    extra_valid = set(extra_valid_toolsets)
     if not isinstance(platform_toolsets, dict) or not platform_toolsets:
         return warnings
 
@@ -52,7 +55,7 @@ def validate_platform_toolsets(
         for name in names:
             if not isinstance(name, str) or not name:
                 continue
-            if is_valid_toolset(name):
+            if name in extra_valid or is_valid_toolset(name):
                 valid_count += 1
                 continue
             suggestion = f"hermes-{platform}"

--- a/tests/hermes_cli/test_toolset_validation.py
+++ b/tests/hermes_cli/test_toolset_validation.py
@@ -46,5 +46,14 @@ def test_mixed_valid_and_invalid_flags_only_the_invalid():
     assert "unknown toolset 'bogus'" in warnings[0]
 
 
+def test_registered_plugin_and_supported_sentinel_are_valid_passthroughs():
+    warnings = validate_platform_toolsets(
+        {"webhook": ["beca-webhook"], "cron": ["no_mcp"]},
+        _is_valid,
+        extra_valid_toolsets={"beca-webhook", "no_mcp"},
+    )
+
+    assert warnings == []
+
 
 


### PR DESCRIPTION
## Summary
- treat the supported no_mcp sentinel as valid during platform toolset validation
- accept registered plugin toolsets and configured MCP server names
- keep warnings for genuinely unknown toolsets

## Proof
- regression test fails before the change
- tests/hermes_cli/test_toolset_validation.py: 3 passed
- config v38 migration/check no longer warns for a registered Beca plugin or no_mcp