### PR TITLE
fix(state): make state.db synchronous configurable on every platform

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -22,8 +22,9 @@ database:
   # (or 0-3). Unset leaves SQLite's default, which is baked in at compile time
   # (SQLITE_DEFAULT_WAL_SYNCHRONOUS) and therefore differs between the bundled
   # interpreter, a distro python3 and a Homebrew one. Set it if you need to
-  # know which one you are running rather than infer it. macOS is always held
-  # at FULL regardless: Darwin's fsync() does not guarantee write ordering.
+  # know which one you are running rather than infer it. On macOS this is a
+  # floor, not a pin: values below FULL are refused because Darwin's fsync()
+  # does not guarantee write ordering, while EXTRA is honored normally.
   # synchronous: FULL
 
 # =============================================================================

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -17,6 +17,14 @@ database:
   # Optional WAL sizing pragmas (integers). Unset = SQLite defaults.
   # wal_autocheckpoint: 1000     # pages between automatic checkpoints
   # journal_size_limit: 67108864 # cap the WAL/journal file size in bytes
+  #
+  # Durability level for every state.db connection: OFF, NORMAL, FULL, EXTRA
+  # (or 0-3). Unset leaves SQLite's default, which is baked in at compile time
+  # (SQLITE_DEFAULT_WAL_SYNCHRONOUS) and therefore differs between the bundled
+  # interpreter, a distro python3 and a Homebrew one. Set it if you need to
+  # know which one you are running rather than infer it. macOS is always held
+  # at FULL regardless: Darwin's fsync() does not guarantee write ordering.
+  # synchronous: FULL
 
 # =============================================================================
 # Runtime Limits

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1444,6 +1444,91 @@ def _log_wal_fallback_once(db_label: str, exc: Exception) -> None:
 # ---------------------------------------------------------------------------
 # Config-driven database pragmas
 # ---------------------------------------------------------------------------
+# PRAGMA synchronous accepts either an integer or a symbolic name, and operators
+# write the names. Mapped here rather than passed through so a typo becomes a
+# warning instead of a silently different durability level.
+_SYNCHRONOUS_LEVELS: Dict[str, int] = {
+    "OFF": 0,
+    "NORMAL": 1,
+    "FULL": 2,
+    "EXTRA": 3,
+}
+_SYNCHRONOUS_NAMES: Dict[int, str] = {v: k for k, v in _SYNCHRONOUS_LEVELS.items()}
+_SYNCHRONOUS_FULL = 2
+
+
+def resolve_synchronous_level(raw_value: Any) -> Optional[int]:
+    """Map a configured ``database.synchronous`` value to its PRAGMA integer.
+
+    Accepts the symbolic names SQLite documents (``OFF``/``NORMAL``/``FULL``/
+    ``EXTRA``, any case) and the equivalent integers ``0``-``3``. Returns None
+    for anything else so the caller can warn and leave the level untouched —
+    guessing at a malformed durability setting is worse than ignoring it.
+    """
+    if isinstance(raw_value, bool):
+        # bool is an int subclass, and YAML turns a bare `on`/`off` into one.
+        # "off" as a durability level is a real choice; True is meaningless.
+        return 0 if raw_value is False else None
+    if isinstance(raw_value, int):
+        return raw_value if raw_value in _SYNCHRONOUS_NAMES else None
+    text = str(raw_value).strip()
+    if not text:
+        return None
+    upper = text.upper()
+    if upper in _SYNCHRONOUS_LEVELS:
+        return _SYNCHRONOUS_LEVELS[upper]
+    try:
+        value = int(text)
+    except (TypeError, ValueError):
+        return None
+    return value if value in _SYNCHRONOUS_NAMES else None
+
+
+def _apply_synchronous_pragma(
+    conn: sqlite3.Connection,
+    raw_value: Any,
+    *,
+    db_label: str,
+) -> None:
+    """Set ``PRAGMA synchronous`` from config, never below FULL on macOS.
+
+    Split out of the integer loop in :func:`apply_database_pragmas` because
+    this PRAGMA is not interchangeable with the sizing ones around it. Those
+    trade memory or disk for speed; this one decides whether a commit is on
+    the platter, so an unrecognised value must not fall through to "SQLite
+    default" the way a bad ``cache_size`` harmlessly can.
+
+    The Darwin floor exists because :func:`_enforce_macos_synchronous_full`
+    runs during ``apply_wal_with_fallback()`` and this function runs after it,
+    so a configured ``NORMAL`` would otherwise silently undo the macOS btree
+    protection that fix put there deliberately. Raising the level on macOS is
+    allowed; lowering it is refused out loud.
+    """
+    level = resolve_synchronous_level(raw_value)
+    if level is None:
+        logger.warning(
+            "%s: ignoring unrecognized database.synchronous=%r "
+            "(expected OFF, NORMAL, FULL, EXTRA, or 0-3)",
+            db_label,
+            raw_value,
+        )
+        return
+    if sys.platform == "darwin" and level < _SYNCHRONOUS_FULL:
+        logger.warning(
+            "%s: refusing database.synchronous=%s on macOS; keeping FULL. "
+            "Darwin's fsync() does not guarantee write ordering, so a lower "
+            "level readmits the half-written btree pages FULL exists to "
+            "prevent.",
+            db_label,
+            _SYNCHRONOUS_NAMES[level],
+        )
+        return
+    try:
+        conn.execute(f"PRAGMA synchronous={level}")
+    except sqlite3.OperationalError:
+        pass
+
+
 def apply_database_pragmas(
     conn: sqlite3.Connection,
     *,
@@ -1466,6 +1551,11 @@ def apply_database_pragmas(
     * ``temp_store`` — 0=DEFAULT(file), 1=FILE, 2=MEMORY, 3=ALWAYS
     * ``wal_autocheckpoint`` — WAL auto-checkpoint threshold in pages
     * ``journal_size_limit`` — max journal/WAL size in bytes
+    * ``synchronous`` — durability level: ``OFF``/``NORMAL``/``FULL``/``EXTRA``
+      or ``0``-``3``. Unset leaves SQLite's own default, which is a
+      *compile-time* constant (``SQLITE_DEFAULT_WAL_SYNCHRONOUS``) and so
+      differs between the bundled, distro and Homebrew builds an operator
+      might be running. Setting it explicitly is the only way to know.
 
     Best-effort: config load or pragma failures are ignored so DB init
     never breaks on a malformed ``database:`` section.
@@ -1504,6 +1594,14 @@ def apply_database_pragmas(
             conn.execute(f"PRAGMA {pragma_name}={value}")
         except sqlite3.OperationalError:
             pass
+
+    # Last, so it wins over nothing and loses to nothing: the sizing pragmas
+    # above cannot change durability, and the macOS enforcement ran earlier
+    # during WAL activation (see _apply_synchronous_pragma for why that
+    # ordering needs an explicit floor rather than an explicit override).
+    raw_synchronous = cfg_get(cfg, "database", "synchronous", default=None)
+    if raw_synchronous is not None:
+        _apply_synchronous_pragma(conn, raw_synchronous, db_label=db_label)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_state_synchronous_pragma.py
+++ b/tests/test_state_synchronous_pragma.py
@@ -1,0 +1,228 @@
+"""``database.synchronous`` is configurable, validated, and floored on macOS.
+
+Before this, `apply_database_pragmas()` accepted five sizing pragmas and no
+durability one, and `_enforce_macos_synchronous_full()` returned early off
+Darwin. So on Linux and Windows nothing in the process ever executed
+`PRAGMA synchronous` against state.db, and the effective level was whichever
+`SQLITE_DEFAULT_WAL_SYNCHRONOUS` the interpreter's SQLite happened to be
+compiled with -- invisible from config, unpinnable, and different between
+builds. See #90837, where three weeks of corruption forensics were carried out
+under the stated assumption of `synchronous=FULL` on Ubuntu.
+"""
+
+import sqlite3
+import sys
+
+import pytest
+
+import hermes_state
+from hermes_state import (
+    apply_database_pragmas,
+    resolve_synchronous_level,
+)
+
+
+def _wal_conn(tmp_path):
+    conn = sqlite3.connect(str(tmp_path / "state.db"), isolation_level=None)
+    conn.execute("PRAGMA journal_mode=WAL")
+    return conn
+
+
+def _level(conn):
+    return conn.execute("PRAGMA synchronous").fetchone()[0]
+
+
+def _config(monkeypatch, database_section):
+    """Point apply_database_pragmas at an in-memory config.
+
+    It imports `hermes_cli.config` lazily inside the function body, so the
+    patch has to land on that module rather than on a name in this one.
+    """
+    import hermes_cli.config as config_mod
+
+    cfg = {"database": database_section}
+    monkeypatch.setattr(config_mod, "load_config_readonly", lambda *a, **k: cfg)
+    return cfg
+
+
+class TestResolveSynchronousLevel:
+    """The parser, in isolation -- a wrong answer here is a silent downgrade."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("OFF", 0),
+            ("NORMAL", 1),
+            ("FULL", 2),
+            ("EXTRA", 3),
+            ("full", 2),
+            ("Full", 2),
+            ("  FULL  ", 2),
+            (0, 0),
+            (1, 1),
+            (2, 2),
+            (3, 3),
+            ("2", 2),
+            (" 2 ", 2),
+        ],
+    )
+    def test_accepts_documented_spellings(self, raw, expected):
+        assert resolve_synchronous_level(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "PARANOID",
+            "",
+            "   ",
+            4,
+            -1,
+            "4",
+            None,
+            [],
+            {},
+            2.5,
+            "2.0",
+        ],
+    )
+    def test_rejects_everything_else(self, raw):
+        assert resolve_synchronous_level(raw) is None
+
+    def test_yaml_off_is_a_level_but_yaml_on_is_not(self):
+        """`synchronous: off` is bool False in YAML and means OFF.
+
+        `synchronous: on` is bool True and means nothing -- there is no
+        durability level it could map to, so it must be rejected rather than
+        coerced to 1 by int(True).
+        """
+        assert resolve_synchronous_level(False) == 0
+        assert resolve_synchronous_level(True) is None
+
+
+class TestAppliedFromConfig:
+    def test_configured_level_reaches_the_connection(self, tmp_path, monkeypatch):
+        _config(monkeypatch, {"synchronous": "NORMAL"})
+        conn = _wal_conn(tmp_path)
+        try:
+            monkeypatch.setattr(sys, "platform", "linux")
+            apply_database_pragmas(conn, db_label="state.db")
+            assert _level(conn) == 1
+        finally:
+            conn.close()
+
+    def test_full_reaches_the_connection(self, tmp_path, monkeypatch):
+        """The #90837 case: an operator asking for FULL on Linux gets FULL.
+
+        Fails without the patch -- the pragma was never executed at all, so the
+        connection kept whatever the build's default was.
+        """
+        _config(monkeypatch, {"synchronous": "FULL"})
+        conn = _wal_conn(tmp_path)
+        try:
+            monkeypatch.setattr(sys, "platform", "linux")
+            conn.execute("PRAGMA synchronous=0")
+            assert _level(conn) == 0
+            apply_database_pragmas(conn, db_label="state.db")
+            assert _level(conn) == 2
+        finally:
+            conn.close()
+
+    def test_unset_leaves_the_level_alone(self, tmp_path, monkeypatch):
+        """No config key must mean no write -- this is the default path."""
+        _config(monkeypatch, {"wal_autocheckpoint": 1000})
+        conn = _wal_conn(tmp_path)
+        try:
+            monkeypatch.setattr(sys, "platform", "linux")
+            conn.execute("PRAGMA synchronous=0")
+            apply_database_pragmas(conn, db_label="state.db")
+            assert _level(conn) == 0
+            assert conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0] == 1000
+        finally:
+            conn.close()
+
+    def test_garbage_warns_and_changes_nothing(self, tmp_path, monkeypatch, caplog):
+        """A typo must not fall through to a different durability level."""
+        _config(monkeypatch, {"synchronous": "PARANOID"})
+        conn = _wal_conn(tmp_path)
+        try:
+            monkeypatch.setattr(sys, "platform", "linux")
+            conn.execute("PRAGMA synchronous=2")
+            with caplog.at_level("WARNING"):
+                apply_database_pragmas(conn, db_label="state.db")
+            assert _level(conn) == 2
+            assert "PARANOID" in caplog.text
+        finally:
+            conn.close()
+
+    def test_the_other_pragmas_still_apply(self, tmp_path, monkeypatch):
+        """Guardrail for #77630's five keys -- they share the same function."""
+        _config(
+            monkeypatch,
+            {"synchronous": "FULL", "wal_autocheckpoint": 250, "mmap_size": 0},
+        )
+        conn = _wal_conn(tmp_path)
+        try:
+            monkeypatch.setattr(sys, "platform", "linux")
+            apply_database_pragmas(conn, db_label="state.db")
+            assert _level(conn) == 2
+            assert conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0] == 250
+            assert conn.execute("PRAGMA mmap_size").fetchone()[0] == 0
+        finally:
+            conn.close()
+
+
+class TestMacOSFloor:
+    """#64355 enforced FULL on Darwin. Config must not be able to undo it.
+
+    `_enforce_macos_synchronous_full()` runs inside `apply_wal_with_fallback()`,
+    which is earlier than `apply_database_pragmas()`, so without an explicit
+    floor the config value would simply win by running last.
+    """
+
+    def test_lowering_below_full_is_refused_on_darwin(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        _config(monkeypatch, {"synchronous": "NORMAL"})
+        conn = _wal_conn(tmp_path)
+        try:
+            monkeypatch.setattr(sys, "platform", "darwin")
+            hermes_state._enforce_macos_synchronous_full(conn)
+            assert _level(conn) == 2
+            with caplog.at_level("WARNING"):
+                apply_database_pragmas(conn, db_label="state.db")
+            assert _level(conn) == 2, "config lowered the macOS btree protection"
+            assert "macOS" in caplog.text
+        finally:
+            conn.close()
+
+    def test_raising_above_full_is_allowed_on_darwin(self, tmp_path, monkeypatch):
+        """The floor is a floor, not a pin -- EXTRA is strictly safer."""
+        _config(monkeypatch, {"synchronous": "EXTRA"})
+        conn = _wal_conn(tmp_path)
+        try:
+            monkeypatch.setattr(sys, "platform", "darwin")
+            apply_database_pragmas(conn, db_label="state.db")
+            assert _level(conn) == 3
+        finally:
+            conn.close()
+
+    def test_the_floor_does_not_apply_off_darwin(self, tmp_path, monkeypatch):
+        """Linux operators may deliberately choose NORMAL for write volume."""
+        _config(monkeypatch, {"synchronous": "NORMAL"})
+        conn = _wal_conn(tmp_path)
+        try:
+            monkeypatch.setattr(sys, "platform", "linux")
+            conn.execute("PRAGMA synchronous=2")
+            apply_database_pragmas(conn, db_label="state.db")
+            assert _level(conn) == 1
+        finally:
+            conn.close()
+
+
+def test_example_config_documents_the_key():
+    """An unpinnable durability level is the bug; docs are half the fix."""
+    from pathlib import Path
+
+    text = Path(__file__).resolve().parents[1] / "cli-config.yaml.example"
+    body = text.read_text(encoding="utf-8")
+    assert "synchronous: FULL" in body

--- a/tests/test_state_synchronous_pragma.py
+++ b/tests/test_state_synchronous_pragma.py
@@ -226,3 +226,22 @@ def test_example_config_documents_the_key():
     text = Path(__file__).resolve().parents[1] / "cli-config.yaml.example"
     body = text.read_text(encoding="utf-8")
     assert "synchronous: FULL" in body
+
+
+def test_example_config_calls_the_darwin_rule_a_floor_not_a_pin():
+    """The macOS wording has to match _apply_synchronous_pragma's actual rule.
+
+    Saying macOS is "always held at FULL" reads as "your setting is ignored
+    here", which would talk an operator out of choosing EXTRA -- the one level
+    that IS honored on Darwin. Only sub-FULL values are refused. The wording
+    is the whole interface for a key nobody can otherwise observe, so pin the
+    distinction rather than just the key's presence.
+    """
+    from pathlib import Path
+
+    body = (
+        Path(__file__).resolve().parents[1] / "cli-config.yaml.example"
+    ).read_text(encoding="utf-8")
+    assert "floor, not a pin" in body
+    assert "EXTRA is honored" in body
+    assert "always held" not in body


### PR DESCRIPTION
## What does this PR do?

Makes `database.synchronous` a supported config key, so the durability level of `state.db` can be set and read back on every platform instead of being inherited invisibly from the SQLite build.

Today two things are true at once:

- `apply_database_pragmas()` reads five keys from `database:` (`cache_size`, `mmap_size`, `temp_store`, `wal_autocheckpoint`, `journal_size_limit`). `synchronous` is not one of them, and the loop only warns about a non-integer value of a key it already knows, so `synchronous: FULL` in `config.yaml` is not rejected. It is never read.
- `_enforce_macos_synchronous_full()` opens with `if sys.platform != "darwin": return`.

So on Linux and Windows, nothing in the process ever executes `PRAGMA synchronous` against `state.db`. The effective level is `SQLITE_DEFAULT_WAL_SYNCHRONOUS`, a compile-time constant of whichever SQLite the interpreter links. Debian and Ubuntu builds commonly ship that as NORMAL; the bundled build and a plain source build use FULL. I checked on this box (Windows, bundled 3.x): a fresh WAL connection reports `2`, and `apply_database_pragmas()` leaves it at `2` because it never touches the pragma at all.

The result is that the durability of `state.db` is decided by which `python3` the installer happened to find, is invisible from config, and cannot be pinned.

That is the reason this is filed now. #90837 is three weeks of corruption forensics on Ubuntu, eleven incidents, every other cause eliminated live one per incident, conducted throughout under the stated premise `synchronous=FULL`. That premise was not something the reporter could have checked: there was no key to set it with and no line to read it back from. I am **not** claiming this is the cause of #90837 and the PR does not say `Fixes` it. I am claiming the environment table in that report contains a value the code cannot currently produce on that platform, which is worth being able to establish before more suspects are eliminated against it.

## Related Issue

Related to #90837

(Deliberately not a closing keyword. #90837 asks whether a single-authoritative-writer consolidation would be accepted upstream, which is a maintainer decision and a much larger change. This is the observability gap underneath it.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` `resolve_synchronous_level()` maps the spellings operators actually write (`OFF`/`NORMAL`/`FULL`/`EXTRA`, any case, or `0`-`3`) to the PRAGMA integer, and returns `None` for anything else. It is deliberately not folded into the existing integer loop: an unrecognised `cache_size` harmlessly falls back to a default, an unrecognised durability level must not, so this one warns and leaves the level alone rather than passing a value through to SQLite.
  - `bool` is handled ahead of `int`, because YAML turns a bare `synchronous: off` into `False`. `False` means OFF, which is a real choice. `True` means nothing, so it is rejected instead of becoming `1` via `int(True)`.
- `hermes_state.py` `_apply_synchronous_pragma()` applies the resolved level, and on Darwin refuses to lower it below FULL. This floor is load-bearing rather than defensive: `_enforce_macos_synchronous_full()` runs inside `apply_wal_with_fallback()`, and `apply_database_pragmas()` runs after it, so without the floor a configured `NORMAL` would undo #64355 purely by running last. Raising to `EXTRA` on macOS is allowed, since the floor is a floor and not a pin.
- `hermes_state.py` the call site sits at the end of `apply_database_pragmas()`, and only fires when the key is present. Unset changes nothing, so no existing install moves.
- `cli-config.yaml.example` documents the key, the accepted values, why unset is not the same as a known default, and the macOS floor.
- `tests/test_state_synchronous_pragma.py` 34 tests.

## How to Test

Reproduce the gap on any non-macOS box, before the patch:

```python
import sqlite3, tempfile, os, hermes_state
p = os.path.join(tempfile.mkdtemp(), "state.db")
c = sqlite3.connect(p, isolation_level=None)
c.execute("PRAGMA journal_mode=WAL")
c.execute("PRAGMA synchronous=0")                 # pretend the build default is OFF
hermes_state.apply_database_pragmas(c, db_label="state.db")
print(c.execute("PRAGMA synchronous").fetchone()[0])
```

With `database: {synchronous: FULL}` in `config.yaml` this prints `0` before the patch and `2` after it.

To see which level you are actually running today, on any install:

```bash
python3 -c "import sqlite3;c=sqlite3.connect(':memory:');c.execute('PRAGMA journal_mode=WAL');print(c.execute('PRAGMA synchronous').fetchone()[0])"
```

Test suite:

```
pytest tests/test_state_synchronous_pragma.py -q          # 34 passed
pytest tests/test_hermes_state.py tests/test_session_db_read_conn_pool.py -q
```

**Proof the tests bite.** Two mutations against the patched tree:

| Mutation | Result |
|---|---|
| Remove the call site from `apply_database_pragmas()`, keep both helpers | **6 failed**, 28 passed |
| Replace the Darwin floor condition with `if False:` | **1 failed** (`test_lowering_below_full_is_refused_on_darwin`), 33 passed |

The 28 that survive the first mutation are the parser cases and the guardrail that #77630's five sizing keys still apply, which is the intended split: they are not testing the wiring.

**Pre-existing failure, not from this PR.** `tests/test_hermes_state.py::TestFTS5Search::test_search_projection_skips_context_enrichment_queries` fails on my machine. I confirmed it fails identically on an untouched checkout of `upstream/main` at the same SHA (`f43eabee5f`) in a separate worktree, so it is unrelated to this change.

## Relationship to the other open state.db PRs

I read these before writing anything, since `hermes_state.py` is busy right now:

- **#90747** (macOS write barriers on every repair connection) is the closest neighbour and is complementary, not overlapping. It routes the six bare `sqlite3.connect()` calls on the *repair* path through the existing barriers, and stays `darwin`-gated. This PR does not touch repair connections and does not change macOS behaviour except to refuse a config value that would weaken it.
- **#64355** (merged) introduced the macOS enforcement this floor protects.
- **#77630** (merged) introduced `apply_database_pragmas()` and its five keys. This adds a sixth, and the guardrail test asserts the other five still land.
- **#90871** and **#89073** are about live FTS rebuilds. Worth noting for #90837 specifically that its reporter ran incidents 9 through 11 with FTS **fully off**, no shadow tables and no triggers, so neither of those can be the mechanism for that report even if both are correct fixes on their own terms.

## A maintainer call I did not make

The Darwin floor refuses to lower below FULL and logs a warning. The alternative is to honour the operator's explicit value on every platform on the grounds that an explicit config key should mean what it says, and treat #64355's protection as a default rather than a minimum. I took the conservative reading because #64355 exists to stop real btree corruption and a config file is an easy place to lose that by accident, but it is genuinely a policy choice about whether config outranks a platform safety floor, and I will switch it if you prefer the other reading.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.13, bundled SQLite. The Darwin-specific behaviour is covered by patching `sys.platform`, not by running on macOS, which I have called out rather than implied.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the `apply_database_pragmas()` docstring lists the new key and explains why unset is not a known default
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — this change is specifically about a platform divergence, and the macOS path is tested in both directions
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
