### PR TITLE
fix(nous): restore native Anthropic reasoning controls

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1896,7 +1896,31 @@ def nous_model_reasoning_capabilities(
         caps_by_id = _fetch_nous_reasoning_caps(timeout=timeout)
     if caps_by_id is None:
         return None
-    return caps_by_id.get(model)
+    detail = caps_by_id.get(model)
+
+    # Portal's native Anthropic Messages routes currently publish an empty
+    # OpenAI-style ``supported_parameters`` list on their base model rows.
+    # That list describes the chat-completions surface, not the native
+    # ``/v1/messages`` request Hermes selects for every ``anthropic/*`` model,
+    # so parsing it literally produces a false ``supports_reasoning=False``.
+    #
+    # The same catalog publishes the model-level reasoning contract on the
+    # corresponding ``:batch`` row, including whether reasoning is mandatory.
+    # Reuse that live Portal verdict for the native row rather than hiding a
+    # working effort control. Haiku stays on the exact-row verdict because the
+    # Anthropic adapter deliberately does not emit thinking parameters for it.
+    if (
+        detail
+        and not detail.get("supports_reasoning")
+        and model.lower().startswith("anthropic/")
+        and ":" not in model
+        and "haiku" not in model.lower()
+    ):
+        batch_detail = caps_by_id.get(f"{model}:batch")
+        if batch_detail and batch_detail.get("supports_reasoning"):
+            return batch_detail
+
+    return detail
 
 
 _nous_caps_disk_checked = False

--- a/tests/hermes_cli/test_inventory_reasoning_caps.py
+++ b/tests/hermes_cli/test_inventory_reasoning_caps.py
@@ -9,6 +9,7 @@ the Portal honors levels a route doesn't advertise, so publishing it would
 invite a picker filter that hides working levels.
 """
 
+import agent.models_dev as models_dev
 import hermes_cli.inventory as inv
 import hermes_cli.models as models_mod
 
@@ -95,6 +96,34 @@ def test_reasoning_mandatory_route_cannot_disable(monkeypatch):
     inv._apply_capabilities(rows)
 
     assert rows[0]["capabilities"]["z-ai/glm-5.3"]["can_disable_reasoning"] is False
+
+
+def test_native_fable_keeps_effort_but_hides_the_off_switch(monkeypatch):
+    """Portal's empty base row must not erase its native Messages contract."""
+    monkeypatch.setattr(models_mod, "model_supports_fast_mode", lambda model: False)
+    monkeypatch.setattr(models_mod, "warm_nous_reasoning_caps_async", lambda: None)
+    monkeypatch.setattr(models_dev, "get_model_capabilities", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        models_mod,
+        "_nous_reasoning_caps_cache",
+        {
+            "anthropic/claude-fable-5": {"supports_reasoning": False},
+            "anthropic/claude-fable-5:batch": {
+                "supports_reasoning": True,
+                "supported_efforts": ["max", "xhigh", "high"],
+                "mandatory": True,
+            },
+        },
+    )
+    monkeypatch.setattr(models_mod, "_nous_caps_disk_checked", True)
+
+    rows = [{"slug": "nous", "models": ["anthropic/claude-fable-5"]}]
+    inv._apply_capabilities(rows)
+
+    caps = rows[0]["capabilities"]["anthropic/claude-fable-5"]
+    assert caps["reasoning"] is True
+    assert caps["can_disable_reasoning"] is False
+    assert "supported_efforts" not in caps
 
 
 def test_unlisted_model_states_no_restriction(monkeypatch):

--- a/tests/hermes_cli/test_nous_reasoning_metadata.py
+++ b/tests/hermes_cli/test_nous_reasoning_metadata.py
@@ -34,6 +34,25 @@ _CATALOG = (
 )
 
 
+_NATIVE_ANTHROPIC_CATALOG = (
+    b'{"data": ['
+    b'{"id": "anthropic/claude-fable-5", "supported_parameters": []},'
+    b'{"id": "anthropic/claude-fable-5:batch",'
+    b' "supported_parameters": ["reasoning", "reasoning_effort"],'
+    b' "reasoning": {"mandatory": true, "supported_efforts": ["max", "xhigh", "high"]}},'
+    b'{"id": "anthropic/claude-opus-5", "supported_parameters": []},'
+    b'{"id": "anthropic/claude-opus-5:batch",'
+    b' "supported_parameters": ["reasoning", "reasoning_effort"],'
+    b' "reasoning": {"mandatory": false, "supported_efforts": ["max", "high", "low"]}},'
+    b'{"id": "anthropic/claude-haiku-4.5", "supported_parameters": []},'
+    b'{"id": "anthropic/claude-haiku-4.5:batch",'
+    b' "supported_parameters": ["reasoning"]},'
+    b'{"id": "other/model", "supported_parameters": []},'
+    b'{"id": "other/model:batch", "supported_parameters": ["reasoning"]}'
+    b']}'
+)
+
+
 @pytest.fixture
 def cold_cache(monkeypatch):
     """A freshly started process that has never mirrored a catalog to disk."""
@@ -64,6 +83,53 @@ class TestNousModelReasoningCapabilities:
 
         mandatory = nous_model_reasoning_capabilities("arcee-ai/trinity-large-thinking")
         assert mandatory["mandatory"] is True
+
+    def test_native_anthropic_base_uses_batch_reasoning_contract(
+        self, cold_cache, monkeypatch
+    ):
+        """Empty base metadata must not hide native Messages effort controls."""
+        from hermes_cli.models import nous_model_reasoning_capabilities
+
+        monkeypatch.setattr(
+            cold_cache,
+            "_urlopen_model_catalog_request",
+            lambda req, *, timeout: _mock_response(_NATIVE_ANTHROPIC_CATALOG),
+        )
+
+        fable = nous_model_reasoning_capabilities(
+            "anthropic/claude-fable-5", allow_fetch=True
+        )
+        assert fable == {
+            "supports_reasoning": True,
+            "supported_efforts": ["max", "xhigh", "high"],
+            "mandatory": True,
+        }
+
+        opus = nous_model_reasoning_capabilities("anthropic/claude-opus-5")
+        assert opus["supports_reasoning"] is True
+        assert opus["mandatory"] is False
+
+    def test_native_anthropic_fallback_is_scoped_to_supported_adapter_models(
+        self, cold_cache, monkeypatch
+    ):
+        """Do not borrow batch metadata for Haiku or non-Anthropic routes."""
+        from hermes_cli.models import nous_model_reasoning_capabilities
+
+        monkeypatch.setattr(
+            cold_cache,
+            "_urlopen_model_catalog_request",
+            lambda req, *, timeout: _mock_response(_NATIVE_ANTHROPIC_CATALOG),
+        )
+        nous_model_reasoning_capabilities(
+            "anthropic/claude-fable-5", allow_fetch=True
+        )
+
+        assert nous_model_reasoning_capabilities(
+            "anthropic/claude-haiku-4.5"
+        ) == {"supports_reasoning": False}
+        assert nous_model_reasoning_capabilities("other/model") == {
+            "supports_reasoning": False
+        }
 
     def test_catalog_read_sends_user_agent(self, cold_cache, monkeypatch):
         """The Portal 403s an anonymous catalog read."""


### PR DESCRIPTION
## What does this PR do?

Restores reasoning controls for native Anthropic models served through Nous Portal.

The Portal catalog currently publishes an explicit empty `supported_parameters` list on native Anthropic base rows, while the matching `:batch` row carries the model's reasoning contract. Treating the empty base row as a definitive negative made Desktop hide reasoning controls even though Hermes sends these models through the native `/v1/messages` adapter and supports their effort setting.

For a base `anthropic/*` model with an exact negative catalog row, this change reuses a positive `:batch` reasoning contract. The fallback is scoped away from Haiku, whose adapter path deliberately does not emit thinking parameters, and from non-Anthropic providers. This preserves the catalog as the live authority while correcting the endpoint-shape mismatch.

## Related Issue

No GitHub issue. Reported through support.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/models.py`: reconcile native Anthropic base rows with their live `:batch` reasoning contract for Nous Portal.
- `tests/hermes_cli/test_nous_reasoning_metadata.py`: cover mandatory Fable, optional Opus, Haiku, and non-Anthropic catalog behavior.
- `tests/hermes_cli/test_inventory_reasoning_caps.py`: verify the picker receives `reasoning: true` and `can_disable_reasoning: false` for Fable without forwarding the catalog's incomplete effort list.

## How to Test

1. Load a Nous catalog where `anthropic/claude-fable-5` has an empty parameter list and its `:batch` sibling advertises mandatory reasoning.
2. Resolve `nous_model_reasoning_capabilities("anthropic/claude-fable-5")` and confirm the positive mandatory contract is returned.
3. Build the provider inventory and confirm Fable reports `reasoning: true` and `can_disable_reasoning: false`, while Haiku and unrelated providers retain their exact negative verdicts.

Focused checks run locally:

- Ruff 0.15.10 lint on all three changed files: passed.
- Python compilation on all three changed files: passed.
- Direct capability and inventory behavior probe: passed.
- `git diff --check`: passed.
- Full Python tests were not run locally; the focused regression files are left to CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Direct probe result:

```json
{"detail":{"mandatory":true,"supported_efforts":["max","xhigh","high"],"supports_reasoning":true},"inventory":{"can_disable_reasoning":false,"fast":false,"reasoning":true}}
```