### PR TITLE
feat(cron): expose per-job toolset scope

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -388,6 +388,9 @@ def cron_create(args):
         repeat=getattr(args, "repeat", None),
         skill=getattr(args, "skill", None),
         skills=_normalize_skills(getattr(args, "skill", None), getattr(args, "skills", None)),
+        enabled_toolsets=_normalize_skills(
+            None, getattr(args, "enabled_toolsets", None)
+        ),
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         model=getattr(args, "model", None),
@@ -462,6 +465,9 @@ def cron_edit(args):
         deliver=getattr(args, "deliver", None),
         repeat=getattr(args, "repeat", None),
         skills=final_skills,
+        enabled_toolsets=_normalize_skills(
+            None, getattr(args, "enabled_toolsets", None)
+        ),
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         model=getattr(args, "model", None),

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -46,6 +46,12 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         help="Attach a skill. Repeat to add multiple skills.",
     )
     cron_create.add_argument(
+        "--toolset",
+        dest="enabled_toolsets",
+        action="append",
+        help="Restrict the job to this toolset. Repeat to add multiple toolsets.",
+    )
+    cron_create.add_argument(
         "--script",
         help=(
             "Path to a script under ~/.hermes/scripts/. Default mode: "
@@ -134,6 +140,12 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         dest="skills",
         action="append",
         help="Replace the job's skills with this set. Repeat to attach multiple skills.",
+    )
+    cron_edit.add_argument(
+        "--toolset",
+        dest="enabled_toolsets",
+        action="append",
+        help="Replace the job's toolset scope. Repeat to add multiple toolsets.",
     )
     cron_edit.add_argument(
         "--add-skill",

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -128,6 +128,27 @@ class TestCronCommandLifecycle:
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
 
+    def test_create_persists_repeatable_toolset_scope(self, tmp_cron_dir, capsys):
+        cron_command(
+            Namespace(
+                cron_command="create",
+                schedule="every 1h",
+                prompt="Scoped prep",
+                name="Scoped job",
+                deliver=None,
+                repeat=None,
+                skill=None,
+                skills=["beca-meeting-prep"],
+                enabled_toolsets=["file", "google_calendar", "attio"],
+                script=None,
+                workdir=None,
+                no_agent=False,
+            )
+        )
+
+        jobs = list_jobs()
+        assert jobs[0]["enabled_toolsets"] == ["file", "google_calendar", "attio"]
+
 
 
 class TestGatewayNotRunningWarning:

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -48,3 +48,16 @@ def test_cron_accept_hooks_flag_on_run_and_tick():
     assert ns.accept_hooks is True
     ns2 = parser.parse_args(["cron", "tick", "--accept-hooks"])
     assert ns2.accept_hooks is True
+
+
+def test_cron_create_and_edit_accept_repeatable_toolset_scope():
+    parser = _build()
+    created = parser.parse_args([
+        "cron", "create", "30m", "prep", "--toolset", "file", "--toolset", "attio",
+    ])
+    edited = parser.parse_args([
+        "cron", "edit", "jobid", "--toolset", "file", "--toolset", "no_mcp",
+    ])
+
+    assert created.enabled_toolsets == ["file", "attio"]
+    assert edited.enabled_toolsets == ["file", "no_mcp"]


### PR DESCRIPTION
## Summary
- add repeatable --toolset to hermes cron create
- add repeatable --toolset replacement to hermes cron edit
- persist the scope through the existing enabled_toolsets job API

## Why
The job model and agent cron tool already support per-job toolsets, but the operator CLI cannot set them. Dynamic operator-created jobs otherwise inherit every enabled MCP connector.

## Proof
- tests/hermes_cli/test_cron_parser_builder.py
- tests/hermes_cli/test_cron.py
- 19 passed