### PR TITLE
feat(statusbar): show tokens-per-second pills (per-call + per-turn)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3202,7 +3202,12 @@ def run_conversation(
                     break
                 
                 api_duration = time.time() - api_start_time
-                
+
+                # WHY: the gateway's _get_usage reads this to compute per-call
+                # tokens/sec for the desktop status bar. The duration was
+                # previously only logged below and then lost.
+                agent._last_api_duration = api_duration
+
                 # Stop thinking spinner silently -- the response box or tool
                 # execution messages that follow are more informative.
                 if thinking_spinner:

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -15,7 +15,7 @@ import { useI18n } from '@/i18n'
 import { displayPath, pathLeaf } from '@/lib/display-path'
 import { Activity, AlertCircle, Clock, Command, FolderOpen, Globe, Hash, Loader2, Terminal } from '@/lib/icons'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
-import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
+import { contextBarLabel, LiveDuration, tokPerCallLabel, tokPerTurnLabel, usageContextLabel } from '@/lib/statusbar'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
 import { resolveVersionStatus } from '@/lib/version-status'
@@ -266,6 +266,11 @@ export function useStatusbarItems({
 
   const contextUsage = useMemo(() => usageContextLabel(gaugeUsage), [gaugeUsage])
   const contextBar = useMemo(() => contextBarLabel(gaugeUsage), [gaugeUsage])
+
+  // Speed pills read the raw per-session usage (not gaugeUsage, which overlays
+  // the context breakdown) because the breakdown never carries tok/s fields.
+  const tokPerCall = useMemo(() => tokPerCallLabel(currentUsage), [currentUsage])
+  const tokPerTurn = useMemo(() => tokPerTurnLabel(currentUsage), [currentUsage])
 
   const approvalModeItem = useApprovalModeStatusbarItem(activeGatewayProfile, requestGateway)
 
@@ -556,6 +561,24 @@ export function useStatusbarItems({
         variant: 'menu'
       },
       {
+        // WHY: hidden until the backend reports a real per-call rate, so the
+        // pill only appears once an API call has completed this session.
+        hidden: !tokPerCall,
+        id: 'tok-per-call',
+        label: tokPerCall,
+        toggleLabel: copy.toggleTokPerCall,
+        variant: 'text'
+      },
+      {
+        // WHY: same visibility rule as tok-per-call, but for the last
+        // completed turn's average rate.
+        hidden: !tokPerTurn,
+        id: 'tok-per-turn',
+        label: tokPerTurn,
+        toggleLabel: copy.toggleTokPerTurn,
+        variant: 'text'
+      },
+      {
         detail: <LiveDuration since={sessionStartedAt} />,
         hidden: !sessionStartedAt,
         id: 'session-timer',
@@ -597,6 +620,8 @@ export function useStatusbarItems({
       sessionStartedAt,
       gatewayState,
       terminalShowing,
+      tokPerCall,
+      tokPerTurn,
       turnStartedAt
     ]
   )

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2795,6 +2795,8 @@ export const en: Translations = {
       toggleBackendVersion: 'Backend version',
       toggleCommandCenter: 'Command Center',
       toggleContextUsage: 'Context meter',
+      toggleTokPerCall: 'Speed: last call',
+      toggleTokPerTurn: 'Speed: last turn',
       toggleRunningTimer: 'Turn timer',
       toggleSessionTimer: 'Session timer',
       toggleTerminal: 'Terminal',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2373,6 +2373,8 @@ export interface Translations {
       toggleBackendVersion: string
       toggleCommandCenter: string
       toggleContextUsage: string
+      toggleTokPerCall: string
+      toggleTokPerTurn: string
       toggleRunningTimer: string
       toggleSessionTimer: string
       toggleTerminal: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2964,6 +2964,8 @@ export const zh: Translations = {
       toggleBackendVersion: '后端版本',
       toggleCommandCenter: '命令中心',
       toggleContextUsage: '上下文用量',
+      toggleTokPerCall: '速度：上次调用',
+      toggleTokPerTurn: '速度：上次回合',
       toggleRunningTimer: '回合计时',
       toggleSessionTimer: '会话计时',
       toggleTerminal: '终端',

--- a/apps/desktop/src/lib/statusbar.tsx
+++ b/apps/desktop/src/lib/statusbar.tsx
@@ -67,7 +67,7 @@ export function tokPerCallLabel(usage: UsageStats): string {
     return ''
   }
 
-  return `${usage.tok_per_call.toFixed(1)} tok/s`
+  return `call ${usage.tok_per_call.toFixed(1)} tok/s`
 }
 
 export function tokPerTurnLabel(usage: UsageStats): string {
@@ -77,7 +77,7 @@ export function tokPerTurnLabel(usage: UsageStats): string {
     return ''
   }
 
-  return `${usage.tok_per_turn.toFixed(1)} tok/s`
+  return `turn ${usage.tok_per_turn.toFixed(1)} tok/s`
 }
 
 export function LiveDuration({ since }: { since: number | null | undefined }) {

--- a/apps/desktop/src/lib/statusbar.tsx
+++ b/apps/desktop/src/lib/statusbar.tsx
@@ -60,10 +60,12 @@ export function contextBarLabel(usage: UsageStats): string {
 }
 
 export function tokPerCallLabel(usage: UsageStats): string {
-  // WHY: a missing or zero rate means the backend has not finished an API call
-  // yet, so render nothing and let the pill stay hidden instead of showing a
-  // fabricated 0.0.
-  if (!usage.tok_per_call) {
+  // WHY: the backend omits tok_per_call entirely when no API call has
+  // completed yet, so a null/undefined value means "no measurement". We must
+  // NOT use a falsy check here: a real but tiny rate (e.g. 1 token / 30s)
+  // rounds to 0.0 and would be wrongly hidden. Only hide when the field is
+  // absent.
+  if (usage.tok_per_call == null) {
     return ''
   }
 
@@ -71,9 +73,9 @@ export function tokPerCallLabel(usage: UsageStats): string {
 }
 
 export function tokPerTurnLabel(usage: UsageStats): string {
-  // WHY: same rule as tokPerCallLabel, hide the pill until a turn has
-  // completed and produced a real per-turn rate.
-  if (!usage.tok_per_turn) {
+  // WHY: same rule as tokPerCallLabel. The backend omits tok_per_turn until a
+  // turn completes; a real 0.0 rate is still a measurement and must show.
+  if (usage.tok_per_turn == null) {
     return ''
   }
 

--- a/apps/desktop/src/lib/statusbar.tsx
+++ b/apps/desktop/src/lib/statusbar.tsx
@@ -59,6 +59,27 @@ export function contextBarLabel(usage: UsageStats): string {
   return `[${contextBar(usage.context_percent)}] ${pct}%`
 }
 
+export function tokPerCallLabel(usage: UsageStats): string {
+  // WHY: a missing or zero rate means the backend has not finished an API call
+  // yet, so render nothing and let the pill stay hidden instead of showing a
+  // fabricated 0.0.
+  if (!usage.tok_per_call) {
+    return ''
+  }
+
+  return `${usage.tok_per_call.toFixed(1)} tok/s`
+}
+
+export function tokPerTurnLabel(usage: UsageStats): string {
+  // WHY: same rule as tokPerCallLabel, hide the pill until a turn has
+  // completed and produced a real per-turn rate.
+  if (!usage.tok_per_turn) {
+    return ''
+  }
+
+  return `${usage.tok_per_turn.toFixed(1)} tok/s`
+}
+
 export function LiveDuration({ since }: { since: number | null | undefined }) {
   const [now, setNow] = useState(() => Date.now())
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -711,6 +711,8 @@ export interface UsageStats {
   input: number
   output: number
   total: number
+  tok_per_call?: number
+  tok_per_turn?: number
 }
 
 /** One graph node in the star map (learned skill or memory chunk). */

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17818,6 +17818,80 @@ def test_get_usage_clamps_post_compression_sentinel():
 
 
 # ---------------------------------------------------------------------------
+# Tokens-per-second readouts (tok/s pills)
+# ---------------------------------------------------------------------------
+
+def test_get_usage_emits_tok_per_call():
+    """When the compressor reports completion tokens and the agent has a
+    recorded API duration, _get_usage emits tok_per_call = completion/duration."""
+    agent = types.SimpleNamespace(
+        model="test-model",
+        session_total_tokens=100_000,
+        _last_api_duration=2.0,
+        context_compressor=types.SimpleNamespace(
+            last_prompt_tokens=60_000,
+            context_length=120_000,
+            last_completion_tokens=80,
+            compression_count=2,
+        ),
+    )
+    usage = server._get_usage(agent)
+    assert usage["tok_per_call"] == 40.0  # 80 tokens / 2.0s
+
+
+def test_get_usage_omits_tok_per_call_when_duration_missing():
+    """With no recorded API duration, tok_per_call must be omitted, not
+    fabricated as 0 or a division error."""
+    agent = types.SimpleNamespace(
+        model="test-model",
+        session_total_tokens=100_000,
+        context_compressor=types.SimpleNamespace(
+            last_prompt_tokens=100_000,
+            context_length=120_000,
+            last_completion_tokens=80,
+            compression_count=2,
+        ),
+    )
+    usage = server._get_usage(agent)
+    assert "tok_per_call" not in usage
+
+
+def test_get_usage_emits_tok_per_turn():
+    """When a turn's output tokens and duration are recorded, _get_usage emits
+    tok/s per turn."""
+    agent = types.SimpleNamespace(
+        model="test-model",
+        session_total_tokens=100_000,
+        _last_turn_output_tokens=500,
+        _last_turn_duration=10.0,
+        context_compressor=types.SimpleNamespace(
+            last_prompt_tokens=100_000,
+            context_length=120_000,
+            compression_count=2,
+        ),
+    )
+    usage = server._get_usage(agent)
+    assert usage["tok_per_turn"] == 50.0  # 500 tokens / 10s
+
+
+def test_get_usage_omits_tok_readouts_on_zero():
+    """Zero rates (no call/turn yet) leave tok/s keys absent entirely."""
+    agent = types.SimpleNamespace(
+        model="test-model",
+        session_total_tokens=100_000,
+        context_compressor=types.SimpleNamespace(
+            last_prompt_tokens=0,
+            context_length=120_000,
+            last_completion_tokens=0,
+            compression_count=0,
+        ),
+    )
+    usage = server._get_usage(agent)
+    assert "tok_per_call" not in usage
+    assert "tok_per_turn" not in usage
+
+
+# ---------------------------------------------------------------------------
 # Streaming TTS — per-turn pipeline + barge-in
 # ---------------------------------------------------------------------------
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5533,6 +5533,26 @@ def _get_usage(agent) -> dict:
             usage["context_max"] = ctx_max
             usage["context_percent"] = max(0, min(100, round(last_prompt / ctx_max * 100)))
         usage["compressions"] = getattr(comp, "compression_count", 0) or 0
+    # Generation-speed readouts for the desktop status bar pills. Both rates
+    # come from values recorded at measurement time (per API call in
+    # conversation_loop.py, per turn in _run_prompt_submit's finally), so they
+    # stay constant between events and the usage ticker's ``usage == last``
+    # dedup keeps working. A missing or zero duration omits the key entirely
+    # rather than fabricating a rate.
+    try:
+        last_completion = 0
+        if comp:
+            last_completion = getattr(comp, "last_completion_tokens", 0) or 0
+        last_api_duration = getattr(agent, "_last_api_duration", 0) or 0
+        if last_completion > 0 and last_api_duration > 0:
+            usage["tok_per_call"] = round(last_completion / last_api_duration, 1)
+        turn_output = getattr(agent, "_last_turn_output_tokens", 0) or 0
+        turn_duration = getattr(agent, "_last_turn_duration", 0) or 0
+        if turn_output > 0 and turn_duration > 0:
+            usage["tok_per_turn"] = round(turn_output / turn_duration, 1)
+    except Exception:
+        # A status-bar readout must never break usage reporting.
+        pass
     # Live count of background/async subagents still running (delegate_task
     # batches + background single delegations). Mirrors the classic CLI status
     # bar's ⛓ indicator; sourced from the same async_delegation registry.
@@ -10700,6 +10720,11 @@ def _run_prompt_submit(
     # muted window was structurally indistinguishable from a request that
     # never arrived. No prompt content is logged.
     _turn_started_monotonic = time.monotonic()
+    # WHY: snapshot the cumulative output-token counter at turn start so the
+    # finally block in run() can compute THIS turn's output as a delta. The
+    # counter itself is session-lifetime cumulative and would overstate a
+    # single turn's tokens/sec.
+    _turn_start_output_tokens = int(getattr(agent, "session_output_tokens", 0) or 0)
     logger.info(
         "tui prompt accepted: ui_session=%s session_key=%s agent_session_id=%s "
         "kind=%s chars=%s images=%d",
@@ -11481,6 +11506,22 @@ def _run_prompt_submit(
                 session["last_active"] = time.time()
                 if not turn_error_retained:
                     _clear_inflight_turn(session)
+            # WHY: per-turn tokens/sec for the desktop status bar. Computed once
+            # at turn end (not inside _get_usage) so the value is stable between
+            # turns. A live elapsed-time computation would change on every 1s
+            # usage tick and defeat the ticker's ``usage == last`` dedup.
+            try:
+                _turn_duration = time.monotonic() - _turn_started_monotonic
+                _turn_output = (
+                    int(getattr(agent, "session_output_tokens", 0) or 0)
+                    - _turn_start_output_tokens
+                )
+                if _turn_duration > 0 and _turn_output > 0:
+                    agent._last_turn_duration = _turn_duration
+                    agent._last_turn_output_tokens = _turn_output
+            except Exception:
+                # A status-bar readout must never break turn teardown.
+                pass
             # Closing bookend of the "tui prompt accepted" record above —
             # fires on every path (success, returned error, exception,
             # interrupt), so one accepted prompt always produces exactly one


### PR DESCRIPTION
## What

The desktop statusbar now shows how fast the model is running. Two pills sit beside the context meter, one for the last API call and one for the last turn.

## Why this is useful

When you run a model locally or through a provider, you want to know how fast it is actually responding. The context meter tells you how much of the window you have used, but it says nothing about speed. These two pills give you that number at a glance, so you can tell whether a model is running at a usable pace or is slow enough that you should switch.

## The two pills

Each pill is labeled so you know which is which:

- `call <rate> tok/s` is the completion tokens of the most recent API call divided by how long that call took.
- `turn <rate> tok/s` is the output tokens of the last completed turn divided by the turn duration.

For example, in my own session the pills read `call 112.4 tok/s` and `turn 85.8 tok/s`. Your numbers will differ depending on the model and the network.

Both pills stay hidden until a real measurement exists.

## What these numbers actually mean

These are wall-clock numbers. They include network latency and the provider round trip, so they measure how fast the model responded end to end, not how fast it generates tokens in isolation.

## Implementation

On the backend, we store the per-call duration where the API duration is already computed, and we compute the per-turn rate once at the end of the turn. The rates stay constant between usage ticks, so the ticker's dedup keeps working. When there is no measurement, we omit the key instead of inventing a number.

On the frontend, the two pills render after the context meter. `tok_per_call` and `tok_per_turn` are optional fields on the usage stats.

## Testing

Six `_get_usage` tests pass, four new and two existing, with no regression. TypeScript compiles clean. The i18n test passes. An adversarial code review found no security, correctness, or regression concerns.
