### PR TITLE
fix(auth): accept loopback inference URLs from local Portal stacks

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2382,11 +2382,16 @@ def _migrate_stale_nous_portal_url(providers: Dict[str, Any]) -> None:
 # same reasoning that made the portal allowlist accept localhost. https
 # stays required for everything off-loopback (loopback_http carve-out
 # in the validator below).
+# Loopback spellings (IPv4 + IPv6 + name) — shared by the inference host
+# allowlist and the http-scheme carve-out so the two cannot drift apart.
+# Local dev stacks routinely bind ::1 (uvicorn/FastAPI listen on both
+# families), so an IPv6-loopback endpoint is the same "bearer to your own
+# machine" non-exfiltration surface as 127.0.0.1.
+_LOOPBACK_HOSTS: FrozenSet[str] = frozenset({"localhost", "127.0.0.1", "::1"})
+
 _ALLOWED_NOUS_INFERENCE_HOSTS: FrozenSet[str] = frozenset({
     "inference-api.nousresearch.com",
-    "localhost",
-    "127.0.0.1",
-})
+}) | _LOOPBACK_HOSTS
 
 
 def _validate_nous_inference_url_from_network(url: Optional[str]) -> Optional[str]:
@@ -2426,7 +2431,7 @@ def _validate_nous_inference_url_from_network(url: Optional[str]) -> Optional[st
         return None
     if parsed.scheme != "https" and not (
         parsed.scheme == "http"
-        and parsed.hostname in {"localhost", "127.0.0.1"}
+        and parsed.hostname in _LOOPBACK_HOSTS
     ):
         logger.warning(
             "nous: refusing non-https inference URL scheme %r from Portal response "

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2374,8 +2374,18 @@ def _migrate_stale_nous_portal_url(providers: Dict[str, Any]) -> None:
 # (NOUS_INFERENCE_BASE_URL) bypass validation — that's the documented
 # dev/staging escape hatch and the env source is already trusted (the
 # user set it themselves).
+#
+# Loopback hosts mirror _NOUS_PORTAL_ALLOWED_HOSTS' local-dev treatment:
+# a locally running Nous Portal stack (nous-account-service on
+# 127.0.0.1) hands out its own local inference endpoint, and a bearer
+# sent to the operator's own machine has no exfiltration surface — the
+# same reasoning that made the portal allowlist accept localhost. https
+# stays required for everything off-loopback (loopback_http carve-out
+# in the validator below).
 _ALLOWED_NOUS_INFERENCE_HOSTS: FrozenSet[str] = frozenset({
     "inference-api.nousresearch.com",
+    "localhost",
+    "127.0.0.1",
 })
 
 
@@ -2383,10 +2393,14 @@ def _validate_nous_inference_url_from_network(url: Optional[str]) -> Optional[st
     """Validate a Portal-returned inference URL against the host allowlist.
 
     Returns ``url`` (normalised by stripping trailing slashes) if it's a
-    well-formed ``https://<allowlisted-host>/...`` URL. Returns ``None``
-    if the URL is missing, malformed, non-https, or points at an
-    unexpected host — letting the caller fall back to the configured
-    default rather than persist or forward a poisoned value.
+    well-formed ``https://<allowlisted-host>/...`` URL — or an
+    ``http://`` one whose host is loopback, mirroring the Portal
+    allowlist's ``loopback_http`` carve-out (a local Portal stack hands
+    out its own local inference endpoint, and a bearer to the operator's
+    own machine has no exfiltration surface). Returns ``None`` if the
+    URL is missing, malformed, or points at an unexpected host or
+    scheme — letting the caller fall back to the configured default
+    rather than persist or forward a poisoned value.
 
     Defense-in-depth: a compromised refresh response from the Portal API
     (MITM, malicious response injection) could otherwise redirect every
@@ -2410,9 +2424,13 @@ def _validate_nous_inference_url_from_network(url: Optional[str]) -> Optional[st
         parsed = urlparse(cleaned)
     except Exception:
         return None
-    if parsed.scheme != "https":
+    if parsed.scheme != "https" and not (
+        parsed.scheme == "http"
+        and parsed.hostname in {"localhost", "127.0.0.1"}
+    ):
         logger.warning(
-            "nous: refusing non-https inference URL scheme %r from Portal response",
+            "nous: refusing non-https inference URL scheme %r from Portal response "
+            "(http is only trusted for loopback hosts)",
             parsed.scheme,
         )
         return None

--- a/tests/hermes_cli/test_nous_inference_url_validation.py
+++ b/tests/hermes_cli/test_nous_inference_url_validation.py
@@ -73,6 +73,17 @@ class TestValidatorRules:
             _validate_nous_inference_url_from_network("http://localhost:3114/v1")
             == "http://localhost:3114/v1"
         )
+        # IPv6 loopback: local dev stacks (uvicorn/FastAPI) listen on both
+        # families and hand out literal http://[::1]:port URLs — same
+        # "bearer to your own machine" surface as 127.0.0.1 (review on #90900).
+        assert (
+            _validate_nous_inference_url_from_network("http://[::1]:3114/v1")
+            == "http://[::1]:3114/v1"
+        )
+        assert (
+            _validate_nous_inference_url_from_network("https://[::1]:3114/v1")
+            == "https://[::1]:3114/v1"
+        )
 
 
     def test_loopback_https_accepted(self):

--- a/tests/hermes_cli/test_nous_inference_url_validation.py
+++ b/tests/hermes_cli/test_nous_inference_url_validation.py
@@ -57,6 +57,47 @@ class TestValidatorRules:
         )
 
 
+    def test_loopback_http_accepted_mirrors_portal_allowlist(self):
+        """A local Nous Portal stack hands out a loopback inference URL;
+        it must survive network-provenance validation instead of being
+        silently healed to the production default (#90895 — local-portal
+        logins degraded to prod and sent local-NAS-signed JWTs at the
+        real inference API). Same trust rationale as the portal
+        allowlist's localhost treatment: a bearer to the operator's own
+        machine has no exfiltration surface."""
+        assert (
+            _validate_nous_inference_url_from_network("http://127.0.0.1:3114/v1")
+            == "http://127.0.0.1:3114/v1"
+        )
+        assert (
+            _validate_nous_inference_url_from_network("http://localhost:3114/v1")
+            == "http://localhost:3114/v1"
+        )
+
+
+    def test_loopback_https_accepted(self):
+        assert (
+            _validate_nous_inference_url_from_network("https://localhost:3114/v1")
+            == "https://localhost:3114/v1"
+        )
+
+
+    def test_prod_host_http_still_rejected(self):
+        """Fail-closed guard on the carve-out itself: the loopback http
+        exemption must not relax the https requirement for production or
+        any other off-loopback host."""
+        assert (
+            _validate_nous_inference_url_from_network(
+                "http://inference-api.nousresearch.com/v1"
+            )
+            is None
+        )
+        assert (
+            _validate_nous_inference_url_from_network("http://attacker.com/v1")
+            is None
+        )
+
+
 
 class TestCallSiteWiring:
     """Verify the validator is actually wired into all auth.py NETWORK call sites.


### PR DESCRIPTION
## What does this PR do?

Gives the Nous inference-URL allowlist the same localhost carve-out the Portal allowlist already has. A Hermes instance logged into a locally running Nous Portal stack (nous-account-service on `http://127.0.0.1:3111`) receives an `inference_base_url` pointing at the local inference endpoint (e.g. `http://127.0.0.1:3114/v1`) — but `_validate_nous_inference_url_from_network()` rejected every non-prod host and every non-https scheme, so all three heal sites silently rewrote the stored URL back to `https://inference-api.nousresearch.com/v1`. The agent then sent a local-NAS-signed HS256 JWT at the production inference API and got confusing 401s from a host the user never configured (#90895).

The fix mirrors `_NOUS_PORTAL_ALLOWED_HOSTS`' local-dev treatment exactly: `localhost`/`127.0.0.1` join the inference allowlist, and `http` is trusted only for those loopback hosts (same `loopback_http` predicate shape the Portal path uses at auth.py's portal URL validation). This keeps the original security posture of #30611/#27612 intact: a poisoned refresh response can still never redirect the bearer to an attacker-controlled host, https stays mandatory for every off-loopback host, and a bearer sent to the operator's own machine has no exfiltration surface — the same reasoning that already made the Portal allowlist accept loopback under the same threat model. One validator change covers all three heal sites since they all funnel through it.

## Related Issue

Fixes #90895

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth.py` — `_ALLOWED_NOUS_INFERENCE_HOSTS` now includes `localhost`/`127.0.0.1` (comment documents the mirror-the-portal-allowlist rationale); `_validate_nous_inference_url_from_network()` accepts `http` only when the host is loopback, warning text updated to state that http is loopback-only
- `tests/hermes_cli/test_nous_inference_url_validation.py` — three new `TestValidatorRules` cases: loopback http accepted (the #90895 shape), loopback https accepted, and a fail-closed guard proving the carve-out does not relax https for prod or attacker hosts

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_cli/test_nous_inference_url_validation.py tests/hermes_cli/test_nous_portal_staging_allowlist.py -q` — should pass: 17 passed (13 pre-existing + 4 new/updated assertions)
2. Observed result: on unmodified main, `_validate_nous_inference_url_from_network("http://127.0.0.1:3114/v1")` returns `None` (host not in the prod-only allowlist AND scheme rejected) — the new loopback test fails; with this fix it returns the URL unchanged and the prod-http/attacker-host cases still return `None`
3. Pre-existing poisoned-value behaviors are unchanged: `test_refresh_resets_rejected_url_to_default` and the staging heal tests still pass (staging host stays rejected, healing to the prod default still fires)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (allowlist + carve-out rationale inline)
- [x] Tests added that prove the fix works (loopback accept + fail-closed off-loopback reject)
- [x] All new and existing tests pass locally (17 passed across both suites)
- [x] Platform: macOS (validator is pure URL parsing, platform-independent)
