### PR TITLE
fix(desktop): make explicit connection identity authoritative

### DIFF
--- a/apps/desktop/electron/connection-registry-authority.test.ts
+++ b/apps/desktop/electron/connection-registry-authority.test.ts
@@ -1,0 +1,278 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import type { ConnectionRegistry, RegistryConnection } from './connection-registry'
+import { LOCAL_CONNECTION_ID, REGISTRY_VERSION, resolvedConnectionId } from './connection-registry'
+
+function registryWith(...connections: RegistryConnection[]): ConnectionRegistry {
+  return {
+    version: REGISTRY_VERSION,
+    primary: connections[0]?.id ?? LOCAL_CONNECTION_ID,
+    launchMode: 'primary',
+    lastUsed: connections[0]?.id ?? LOCAL_CONNECTION_ID,
+    connections
+  }
+}
+
+const local: RegistryConnection = { id: LOCAL_CONNECTION_ID, kind: 'local', label: 'This device' }
+
+test('resolvedConnectionId accepts only a current explicit registration id', () => {
+  const remoteA: RegistryConnection = {
+    id: 'remote-a',
+    kind: 'remote',
+    label: 'Remote A',
+    url: 'https://shared.example',
+    authMode: 'token',
+    token: { encoding: 'safeStorage', value: 'token-a' },
+    headers: { 'CF-Access-Client-Id': { encoding: 'safeStorage', value: 'header-a' } }
+  }
+  const remoteB: RegistryConnection = {
+    id: 'remote-b',
+    kind: 'remote',
+    label: 'Remote B',
+    url: 'https://shared.example',
+    authMode: 'oauth',
+    headers: { 'CF-Access-Client-Id': { encoding: 'safeStorage', value: 'header-b' } }
+  }
+  const registry = registryWith(local, remoteA, remoteB)
+
+  assert.equal(
+    resolvedConnectionId(registry, {
+      authMode: 'token',
+      baseUrl: remoteA.url,
+      connectionId: remoteB.id,
+      headers: remoteA.headers,
+      mode: 'remote',
+      remoteKind: 'url',
+      token: remoteA.token
+    }),
+    remoteB.id
+  )
+
+  const misleadingLegacyShape = {
+    authMode: 'token',
+    baseUrl: remoteA.url,
+    headers: remoteA.headers,
+    mode: 'remote' as const,
+    remoteKind: 'url' as const,
+    token: remoteA.token
+  }
+  const invalidIds: Array<null | string | undefined> = ['retired-source', '', null, undefined]
+
+  for (const connectionId of invalidIds) {
+    assert.equal(resolvedConnectionId(registry, { ...misleadingLegacyShape, connectionId }), null)
+  }
+})
+
+test('resolvedConnectionId matches the complete URL and Cloud envelope', () => {
+  const sharedUrl = 'https://shared.example/gateway'
+  const remoteToken: RegistryConnection = {
+    id: 'remote-token',
+    kind: 'remote',
+    label: 'Token remote',
+    url: sharedUrl,
+    authMode: 'token',
+    token: { encoding: 'safeStorage', value: 'token-a' },
+    headers: { 'CF-Access-Client-Id': { encoding: 'safeStorage', value: 'header-a' } }
+  }
+  const remoteOauth: RegistryConnection = {
+    id: 'remote-oauth',
+    kind: 'remote',
+    label: 'OAuth remote',
+    url: `${sharedUrl}/`,
+    authMode: 'oauth',
+    headers: { 'CF-Access-Client-Id': { encoding: 'safeStorage', value: 'header-b' } }
+  }
+  const cloudNous: RegistryConnection = {
+    id: 'cloud-nous',
+    kind: 'cloud',
+    label: 'Nous cloud',
+    url: sharedUrl,
+    authMode: 'oauth',
+    headers: { 'CF-Access-Client-Id': { encoding: 'safeStorage', value: 'header-cloud' } },
+    org: 'nous'
+  }
+  const cloudLabs: RegistryConnection = {
+    ...cloudNous,
+    id: 'cloud-labs',
+    label: 'Labs cloud',
+    org: 'labs'
+  }
+  const registry = registryWith(local, remoteToken, remoteOauth, cloudNous, cloudLabs)
+
+  assert.equal(
+    resolvedConnectionId(registry, {
+      authMode: 'token',
+      baseUrl: sharedUrl,
+      headers: { 'cf-access-client-id': { value: 'header-a', encoding: 'safeStorage' } },
+      mode: 'remote',
+      remoteKind: 'url',
+      token: { value: 'token-a', encoding: 'safeStorage' }
+    }),
+    remoteToken.id
+  )
+  assert.equal(
+    resolvedConnectionId(registry, {
+      authMode: 'oauth',
+      baseUrl: sharedUrl,
+      headers: { 'CF-ACCESS-CLIENT-ID': { value: 'header-b', encoding: 'safeStorage' } },
+      mode: 'remote',
+      remoteKind: 'url'
+    }),
+    remoteOauth.id
+  )
+  assert.equal(
+    resolvedConnectionId(registry, {
+      authMode: 'oauth',
+      baseUrl: sharedUrl,
+      headers: { 'CF-Access-Client-Id': { encoding: 'safeStorage', value: 'header-cloud' } },
+      mode: 'remote',
+      org: 'nous',
+      remoteKind: 'cloud'
+    }),
+    cloudNous.id
+  )
+  assert.equal(
+    resolvedConnectionId(registry, {
+      authMode: 'oauth',
+      baseUrl: sharedUrl,
+      headers: { 'CF-Access-Client-Id': { encoding: 'safeStorage', value: 'header-cloud' } },
+      mode: 'remote',
+      org: 'labs',
+      remoteKind: 'cloud'
+    }),
+    cloudLabs.id
+  )
+
+  assert.equal(resolvedConnectionId(registry, { baseUrl: sharedUrl, mode: 'remote', remoteKind: 'url' }), null)
+  assert.equal(
+    resolvedConnectionId(registry, { baseUrl: sharedUrl, mode: 'remote', remoteKind: 'cloud' }),
+    null
+  )
+
+  const duplicate = registryWith(
+    ...registry.connections,
+    { ...remoteToken, id: 'remote-token-copy', label: 'Token remote copy' }
+  )
+
+  assert.equal(
+    resolvedConnectionId(duplicate, {
+      authMode: 'token',
+      baseUrl: sharedUrl,
+      headers: remoteToken.headers,
+      mode: 'remote',
+      remoteKind: 'url',
+      token: remoteToken.token
+    }),
+    null
+  )
+})
+
+test('resolvedConnectionId preserves only unique default legacy inference', () => {
+  const legacyRemote: RegistryConnection = {
+    id: 'legacy-remote',
+    kind: 'remote',
+    label: 'Legacy remote',
+    url: 'https://legacy.example:9443'
+  }
+  const legacySsh: RegistryConnection = {
+    id: 'legacy-ssh',
+    kind: 'ssh',
+    label: 'Legacy SSH',
+    host: 'work-host',
+    user: 'root'
+  }
+  const registry = registryWith(local, legacyRemote, legacySsh)
+
+  assert.equal(resolvedConnectionId(registry, { mode: 'local' }), local.id)
+  assert.equal(
+    resolvedConnectionId(registry, {
+      baseUrl: 'https://legacy.example:9443/',
+      mode: 'remote',
+      remoteKind: 'url'
+    }),
+    legacyRemote.id
+  )
+  assert.equal(
+    resolvedConnectionId(registry, {
+      mode: 'remote',
+      remoteHost: 'ROOT@WORK-HOST',
+      remoteKind: 'ssh'
+    }),
+    legacySsh.id
+  )
+
+  const duplicateRemote: RegistryConnection = {
+    ...legacyRemote,
+    id: 'legacy-remote-copy',
+    label: 'Legacy remote copy'
+  }
+
+  assert.equal(
+    resolvedConnectionId(registryWith(local, legacyRemote, duplicateRemote), {
+      baseUrl: legacyRemote.url,
+      mode: 'remote',
+      remoteKind: 'url'
+    }),
+    null
+  )
+  assert.equal(
+    resolvedConnectionId(
+      registryWith(local, { id: 'local-copy', kind: 'local', label: 'Local copy' }),
+      { mode: 'local' }
+    ),
+    null
+  )
+})
+
+test('resolvedConnectionId keeps complete SSH routes distinct', () => {
+  const base = {
+    host: 'work-host',
+    keyPath: '/keys/a',
+    kind: 'ssh' as const,
+    remoteHermesPath: '/srv/hermes',
+    remoteProfile: 'alpha',
+    user: 'root'
+  }
+  const registry = registryWith(
+    local,
+    { ...base, id: 'ssh-base', label: 'SSH base' },
+    { ...base, id: 'ssh-port', label: 'SSH port', port: 2222 },
+    { ...base, id: 'ssh-key', keyPath: '/keys/b', label: 'SSH key' },
+    { ...base, id: 'ssh-path', label: 'SSH path', remoteHermesPath: '/opt/hermes' },
+    { ...base, id: 'ssh-profile', label: 'SSH profile', remoteProfile: 'beta' }
+  )
+  const resolve = (ssh: NonNullable<Parameters<typeof resolvedConnectionId>[1]['ssh']>) =>
+    resolvedConnectionId(registry, { mode: 'remote', remoteKind: 'ssh', ssh })
+
+  assert.equal(resolve(base), 'ssh-base')
+  assert.equal(resolve({ ...base, port: 2222 }), 'ssh-port')
+  assert.equal(resolve({ ...base, keyPath: '/keys/b' }), 'ssh-key')
+  assert.equal(resolve({ ...base, remoteHermesPath: '/opt/hermes' }), 'ssh-path')
+  assert.equal(resolve({ ...base, remoteProfile: 'beta' }), 'ssh-profile')
+  assert.equal(
+    resolvedConnectionId(registry, {
+      mode: 'remote',
+      remoteHost: 'ROOT@WORK-HOST',
+      remoteKind: 'ssh'
+    }),
+    null
+  )
+  assert.equal(
+    resolvedConnectionId(registry, {
+      mode: 'remote',
+      remoteHost: 'ROOT@WORK-HOST',
+      remoteKind: 'ssh',
+      ssh: undefined
+    }),
+    null
+  )
+
+  const duplicate = registryWith(
+    ...registry.connections,
+    { ...base, id: 'ssh-base-copy', label: 'SSH base copy' }
+  )
+
+  assert.equal(resolvedConnectionId(duplicate, { mode: 'remote', remoteKind: 'ssh', ssh: base }), null)
+})

--- a/apps/desktop/electron/connection-registry-base.ts
+++ b/apps/desktop/electron/connection-registry-base.ts
@@ -1,0 +1,1119 @@
+/**
+ * connection-registry.ts
+ *
+ * Pure, electron-free helpers for the desktop's multi-connection registry —
+ * the v2 successor to the single global `mode` + `remote` block in
+ * connection.json. The registry is a named list of agent SOURCES (local
+ * runtime, remote gateways, Hermes Cloud instances, SSH hosts) that are all
+ * registered at once; routing/pooling changes that consume the registry land
+ * separately, so this module is deliberately storage-shaped, not
+ * transport-shaped.
+ *
+ * Design rules (agreed with Teknium, Aug 2026):
+ *  - Every connection carries a REQUIRED, registry-unique `label` (the
+ *    "device name"). Uniqueness is case-insensitive so `Homelab` and
+ *    `homelab` can't coexist and produce two identical badges.
+ *  - When two sources expose the same profile name, surfaces disambiguate as
+ *    `@<profile>-<label-slug>` — `agentHandle()` is the one place that rule
+ *    lives.
+ *  - The registry ALWAYS contains exactly one `local` connection (the app's
+ *    own runtime). It cannot be removed; it is the default primary.
+ *  - `primary` designates the connection that owns the window backend (boot
+ *    overlay, install/update machinery). Removing the primary retargets to
+ *    the local entry rather than leaving a dangling id.
+ *
+ * Kept standalone (no `import 'electron'`) so it unit-tests with `node --test`
+ * — same pattern as connection-config.ts / backend-probes.ts. main.ts wires
+ * these into the IPC layer and owns file I/O + secret encryption.
+ */
+
+import {
+  hostLabelFromBaseUrl,
+  modeIsRemoteLike,
+  normalizeRemoteBaseUrl,
+  normalizeRemoteHeaders,
+  normalizeSshConfig,
+  normAuthMode
+} from './connection-config'
+
+export const REGISTRY_VERSION = 2
+
+export const LOCAL_CONNECTION_ID = 'local'
+
+/** Connection kinds. 'cloud' is remote-shaped (see modeIsRemoteLike) but keeps
+ * its provenance so the UI can render the right card and updates can skip
+ * platform-managed instances. */
+export type ConnectionKind = 'cloud' | 'local' | 'remote' | 'ssh'
+
+export interface RegistryConnection {
+  id: string
+  kind: ConnectionKind
+  /** Required, unique (case-insensitive) display name — the "device name". */
+  label: string
+  /** remote/cloud: normalized base URL. */
+  url?: string
+  /** remote/cloud: 'token' | 'oauth'. */
+  authMode?: 'oauth' | 'token'
+  /** remote: encrypted token envelope (opaque here; main.ts encrypts/decrypts). */
+  token?: unknown
+  /** remote/cloud: extra gateway headers (Cloudflare Access etc.). Secret
+   * envelopes, same shape as `token`; names pre-filtered through
+   * normalizeRemoteHeaders. Optional and additive — v2 registries written
+   * before this field keep loading unchanged. */
+  headers?: Record<string, unknown>
+  /** cloud: portal org slug/id the instance was discovered under. */
+  org?: string
+  /** ssh fields (normalizeSshConfig shapes). */
+  host?: string
+  user?: string
+  port?: number
+  keyPath?: string
+  remoteHermesPath?: string
+  remoteProfile?: string
+}
+
+export interface ConnectionRegistry {
+  version: typeof REGISTRY_VERSION
+  /** id of the connection that owns the window/primary backend. */
+  primary: string
+  /** Which saved source Sessions should restore when the app launches. */
+  launchMode: 'last-used' | 'primary'
+  /** Last source the Sessions workspace successfully opened. Additive in v2
+   * so registries written before multi-source switching still normalize. */
+  lastUsed: string
+  connections: RegistryConnection[]
+}
+
+// ── Labels and ids ──────────────────────────────────────────────────────────
+
+const LABEL_MAX = 64
+
+/** Canonical comparison key for label uniqueness. */
+export function labelKey(label: string): string {
+  return String(label || '')
+    .trim()
+    .toLowerCase()
+}
+
+/**
+ * Derive a registry-unique label from a candidate: clamps to LABEL_MAX (a
+ * migrated URL host can exceed it, which would fail validation on any later
+ * edit) and suffixes " 2" / " 3" / … on collision. The single home of the
+ * label-dedup rule — normalizeRegistry and the migration both use it.
+ */
+export function uniqueLabel(candidate: string, taken: Iterable<string>): string {
+  const used = new Set([...taken].map(labelKey))
+
+  // Reserve room for a collision suffix so the suffixed form stays in-bounds.
+  const base = String(candidate || '')
+    .trim()
+    .slice(0, LABEL_MAX - 4)
+
+  if (!used.has(labelKey(base))) {
+    return base
+  }
+
+  for (let n = 2; ; n += 1) {
+    const suffixed = `${base} ${n}`
+
+    if (!used.has(labelKey(suffixed))) {
+      return suffixed
+    }
+  }
+}
+
+/** Kebab-slug of a label for ids and @handles. Never empty for a non-empty label. */
+export function labelSlug(label: string): string {
+  const slug = String(label || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48)
+
+  return slug || 'connection'
+}
+
+/**
+ * The one place the duplicate-agent naming rule lives: a profile that exists
+ * on several registered sources renders as `@<profile>-<label-slug>`;
+ * a profile unique across the roster keeps its bare name.
+ */
+export function agentHandle(profile: string, connectionLabel: string, duplicated: boolean): string {
+  const name = String(profile || '').trim() || 'default'
+
+  return duplicated ? `${name}-${labelSlug(connectionLabel)}` : name
+}
+
+/**
+ * Pool key for a backend serving (connection, profile). The local/primary
+ * connection keeps the BARE profile key so every legacy pool entry, reaper
+ * log line, and touch call stays byte-identical for single-source users;
+ * non-local connections get an unambiguous composite (`conn:<id>::<profile>`)
+ * that cannot collide with a plain profile name (colons are invalid in
+ * profile names).
+ *
+ * NOTE: the renderer's socket registry uses the twin implementation in
+ * apps/shared/src/backend-scope.ts (`@hermes/shared`) — tsconfig project
+ * boundaries prevent a single physical module here. The two are pinned
+ * byte-identical by the cross-copy contract test in
+ * connection-registry.test.ts; change BOTH or that test fails.
+ */
+export function backendScopeKey(connectionId: null | string | undefined, profile: null | string | undefined): string {
+  const profileKey = String(profile ?? '').trim() || 'default'
+  const connection = String(connectionId ?? '').trim()
+
+  if (!connection || connection === LOCAL_CONNECTION_ID) {
+    return profileKey
+  }
+
+  return `conn:${connection}::${profileKey}`
+}
+
+/** All pool keys owned by a connection share this prefix (used to stop them on remove). */
+export function backendScopePrefix(connectionId: string): string {
+  return `conn:${String(connectionId).trim()}::`
+}
+
+export interface RegistryLocalRoute {
+  /** Reuse the legacy v1 ensureBackend path — it already resolves to the
+   * app's own local runtime, so single-source behavior stays byte-identical. */
+  delegate: boolean
+  /** Pool key for the forced-local child when not delegating. */
+  poolKey: string
+}
+
+export interface ResolvedConnectionDescriptor {
+  baseUrl?: string
+  mode?: 'local' | 'remote'
+  remoteHost?: string
+  remoteKind?: 'cloud' | 'ssh' | 'url'
+}
+
+/**
+ * Recover registry identity for a descriptor resolved through the legacy v1
+ * profile path. Registry-scoped routes already carry `connectionId`; this
+ * bridge keeps migrated per-profile remotes truthful until v1 is retired.
+ */
+export function resolvedConnectionId(
+  registry: ConnectionRegistry,
+  descriptor: ResolvedConnectionDescriptor
+): null | string {
+  if (descriptor.mode === 'local') {
+    return registry.connections.find(connection => connection.kind === 'local')?.id ?? null
+  }
+
+  if (descriptor.mode !== 'remote') {
+    return null
+  }
+
+  if (descriptor.remoteKind === 'ssh') {
+    const remoteHost = String(descriptor.remoteHost || '')
+      .trim()
+      .toLowerCase()
+
+    if (!remoteHost) {
+      return null
+    }
+
+    return (
+      registry.connections.find(connection => {
+        if (connection.kind !== 'ssh') {
+          return false
+        }
+
+        const host = String(connection.host || '')
+          .trim()
+          .toLowerCase()
+
+        const target = connection.user ? `${String(connection.user).trim().toLowerCase()}@${host}` : host
+
+        return target === remoteHost
+      })?.id ?? null
+    )
+  }
+
+  let baseUrl = ''
+
+  try {
+    baseUrl = normalizeRemoteBaseUrl(descriptor.baseUrl)
+  } catch {
+    return null
+  }
+
+  return (
+    registry.connections.find(connection => {
+      if (connection.kind !== 'cloud' && connection.kind !== 'remote') {
+        return false
+      }
+
+      try {
+        return normalizeRemoteBaseUrl(connection.url) === baseUrl
+      } catch {
+        return false
+      }
+    })?.id ?? null
+  )
+}
+
+/**
+ * How the registry's 'local' entry resolves a backend for `profile`.
+ *
+ * The 'local' entry means THIS machine's runtime — always. The legacy
+ * ensureBackend() path instead follows the v1 connection.json routing table,
+ * where a global remote mode (or a per-profile remote override) resolves to a
+ * REMOTE descriptor. A migrated user whose v1 global mode was remote gets that
+ * remote as the registry primary AND keeps the mandatory 'local' entry, so
+ * delegating 'local' to the v1 route made the roster's "This device" rows
+ * enumerate and dial the remote box: every profile appeared twice (forcing
+ * -slug handles) and "local" agents talked to the remote.
+ *
+ * When the v1 route is already local we delegate (legacy path, byte-identical
+ * pool keys). When v1 says remote, the local entry spawns its own genuinely
+ * local child under a composite pool key: backendScopeKey('local', p) maps to
+ * the BARE profile key by design, and that slot may already hold the v1
+ * route's REMOTE descriptor — so the forced-local child pools under the
+ * `conn:local::<profile>` form instead (colons are invalid in profile names,
+ * so it cannot collide).
+ */
+export function resolveRegistryLocalRoute(
+  profile: null | string | undefined,
+  opts: { globalRemote?: boolean; profileRemoteOverride?: boolean } = {}
+): RegistryLocalRoute {
+  const profileKey = String(profile ?? '').trim() || 'default'
+
+  if (opts.globalRemote || opts.profileRemoteOverride) {
+    return { delegate: false, poolKey: `${backendScopePrefix(LOCAL_CONNECTION_ID)}${profileKey}` }
+  }
+
+  return { delegate: true, poolKey: profileKey }
+}
+
+/**
+ * Whether the roster enumeration should SKIP the registry's local entry as
+ * connect-on-demand. True when the local source is the forced-local route
+ * (primary resolves remote — enumerating would spawn a local backend the
+ * user never asked for, minting a phantom `default` agent and forcing
+ * -device handles onto the real one) AND no forced-local child is already
+ * pooled. Pure — main.ts feeds it the live route + pool keys.
+ */
+export function shouldDeferLocalEnumeration(
+  route: RegistryLocalRoute,
+  poolKeys: Iterable<string>,
+  connectionId: string = LOCAL_CONNECTION_ID
+): boolean {
+  if (route.delegate) {
+    return false
+  }
+
+  const prefix = backendScopePrefix(connectionId)
+
+  return ![...poolKeys].some(key => String(key).startsWith(prefix))
+}
+
+// ── Union agent roster ──────────────────────────────────────────────────────
+
+export interface ConnectionAgents {
+  connection: RegistryConnection
+  /** Profile names enumerated from the connection, or null when unreachable /
+   * connect-on-demand (ssh not yet dialed). */
+  profiles: null | string[]
+  /** Present when profiles is null: why enumeration was skipped. */
+  error?: string
+  /** Stable backend identity from the connection's /api/status (`install_id`).
+   * Two connections reporting the same id are the SAME physical install
+   * registered under two addresses (hostname + Tailscale IP), so the roster
+   * collapses their rows. Absent on older backends → no collapse (fully
+   * backward compatible). */
+  installId?: string
+}
+
+export interface RosterAgent {
+  connectionId: string
+  connectionKind: ConnectionKind
+  connectionLabel: string
+  profile: string
+  /** Bare profile name, or `<profile>-<label-slug>` when the profile name
+   * exists on more than one registered source (the @name-device rule). */
+  handle: string
+}
+
+/**
+ * Roster enumeration skips undialed sources (connect-on-demand) and reports
+ * unreachable ones with `profiles: null`. Reuse the last successful profile
+ * list so Bot Mode does not go empty (or drop to a partial roster) the moment
+ * a source is briefly unreachable — SSH tunnels drop on sleep/wake, and a
+ * remote gateway bounce (VPS restart) otherwise erased its bots from the
+ * roster until the next successful enumeration ("my 4 bots show as 2", Aug
+ * 2026 bundle). Never-seen SSH sources still get a `default` seed so the
+ * device is clickable; never-seen remote sources stay empty (no seed) since
+ * an unreachable URL is not evidence a backend exists there.
+ */
+export function rememberSshEnumeration(
+  enumeration: Pick<ConnectionAgents, 'error' | 'profiles'>,
+  cached: null | string[] | undefined,
+  kind: ConnectionKind
+): Pick<ConnectionAgents, 'error' | 'profiles'> {
+  if (enumeration.profiles && enumeration.profiles.length > 0) {
+    return enumeration
+  }
+
+  if (kind === 'local') {
+    return enumeration
+  }
+
+  if (cached && cached.length > 0) {
+    return { profiles: cached, error: enumeration.error }
+  }
+
+  if (kind === 'ssh' && enumeration.error === 'connect-on-demand') {
+    return { profiles: ['default'], error: 'connect-on-demand' }
+  }
+
+  return enumeration
+}
+
+/** Whether an undialed SSH source should be inventoried again. Cached
+ *  successes never retry. Failures retry after `retryAfterMs` so a cold box
+ *  does not stay seeded as `default` until the user hits Test. */
+export function shouldRetrySshInventory(
+  hasCache: boolean,
+  lastAttemptMs: null | number | undefined,
+  nowMs: number,
+  retryAfterMs = 60_000
+): boolean {
+  if (hasCache) {
+    return false
+  }
+
+  if (lastAttemptMs == null) {
+    return true
+  }
+
+  return nowMs - lastAttemptMs >= retryAfterMs
+}
+
+const PROFILE_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/
+
+/** Turn `ls ~/.hermes/profiles` output into roster names. Always includes
+ *  `default`. Drops rollback snapshots and junk lines. */
+export function parseRemoteProfileListing(text: string): string[] {
+  const names = new Set<string>(['default'])
+
+  for (const raw of String(text || '').split(/\r?\n/)) {
+    const name = raw.trim()
+
+    if (!name || name.startsWith('.') || name.endsWith('.rollback-old')) {
+      continue
+    }
+
+    if (!PROFILE_NAME_RE.test(name)) {
+      continue
+    }
+
+    names.add(name)
+  }
+
+  return ['default', ...[...names].filter(name => name !== 'default').sort()]
+}
+
+/**
+ * Flatten per-connection profile enumerations into the union roster, applying
+ * the duplicate-handle rule ONCE across all sources. Pure so the disambiguation
+ * policy is testable without IPC; main.ts feeds it live enumerations.
+ */
+export function buildAgentRoster(
+  enumerations: ConnectionAgents[],
+  opts: { primaryConnectionId?: string } = {}
+): RosterAgent[] {
+  // A connection can transiently report the same profile more than once (or
+  // arrive twice while registry state is reconciling). A roster row represents
+  // one routable identity, so collapse strictly by connection + profile before
+  // counting names for @name-device disambiguation.
+  const identities = new Map<
+    string,
+    { connection: RegistryConnection; installId?: string; order: number; profile: string }
+  >()
+
+  let order = 0
+
+  for (const { connection, installId, profiles } of enumerations) {
+    for (const profile of profiles || []) {
+      const name = String(profile || '').trim() || 'default'
+      const key = `${connection.id}\0${name}`
+
+      if (!identities.has(key)) {
+        identities.set(key, { connection, installId, order, profile: name })
+      }
+    }
+
+    order += 1
+  }
+
+  // Backend-identity collapse: two connections reporting the same install_id
+  // are the SAME physical install registered under two addresses, so their
+  // (install, profile) rows are one bot, not two. Connections without an id
+  // (older backends, undialed ssh) keep a per-connection key — no collapse.
+  const backends = new Map<string, { connection: RegistryConnection; order: number; profile: string }[]>()
+
+  for (const { connection, installId, order: rank, profile } of identities.values()) {
+    const key = installId ? `id:${installId}\0${profile}` : `conn:${connection.id}\0${profile}`
+    const group = backends.get(key)
+
+    if (group) {
+      group.push({ connection, order: rank, profile })
+    } else {
+      backends.set(key, [{ connection, order: rank, profile }])
+    }
+  }
+
+  const rows = [...backends.values()].map(group => pickCanonicalConnection(group, opts.primaryConnectionId))
+
+  // The @name-device duplicate-handle rule runs AFTER the collapse, so a
+  // profile that only *looked* duplicated (one box, two addresses) keeps its
+  // bare name once the rows are recognized as one backend.
+  const counts = new Map<string, number>()
+
+  for (const { profile } of rows) {
+    counts.set(profile, (counts.get(profile) || 0) + 1)
+  }
+
+  const roster: RosterAgent[] = []
+
+  for (const { connection, profile } of rows) {
+    roster.push({
+      connectionId: connection.id,
+      connectionKind: connection.kind,
+      connectionLabel: connection.label,
+      profile,
+      handle: agentHandle(profile, connection.label, (counts.get(profile) || 0) > 1)
+    })
+  }
+
+  return roster
+}
+
+/** Deterministic route priority for same-backend rows: local is definitionally
+ * this box; ssh beats HTTP remotes; cloud last. */
+const CANONICAL_KIND_PRIORITY: Record<ConnectionKind, number> = { cloud: 3, local: 0, remote: 2, ssh: 1 }
+
+/**
+ * Which connection represents a collapsed same-backend roster row: the ACTIVE
+ * (primary) connection when it is one of the candidates — the row should route
+ * where the window already routes — else the highest kind priority, else the
+ * earliest-registered (enumeration order follows registry order).
+ */
+function pickCanonicalConnection<T extends { connection: RegistryConnection; order: number }>(
+  candidates: T[],
+  primaryConnectionId?: string
+): T {
+  const active = primaryConnectionId ? candidates.find(c => c.connection.id === primaryConnectionId) : undefined
+
+  if (active) {
+    return active
+  }
+
+  return [...candidates].sort(
+    (a, b) =>
+      CANONICAL_KIND_PRIORITY[a.connection.kind] - CANONICAL_KIND_PRIORITY[b.connection.kind] || a.order - b.order
+  )[0]
+}
+
+// ── Fan-out update eligibility ──────────────────────────────────────────────
+
+export interface UpdateEligibility {
+  eligible: boolean
+  /** Present when not eligible: 'cloud-managed' (platform updates it). */
+  reason?: 'cloud-managed'
+}
+
+/**
+ * Whether "Update all instances" may drive this connection. Hermes Cloud
+ * instances are platform-managed — we never run `hermes update` against them.
+ * Local, remote, and ssh sources are all eligible (reachability and busy
+ * checks happen at dispatch time, not here).
+ */
+export function updateEligibility(connection: RegistryConnection): UpdateEligibility {
+  if (connection.kind === 'cloud') {
+    return { eligible: false, reason: 'cloud-managed' }
+  }
+
+  return { eligible: true }
+}
+
+/** Mint a registry-unique id from a label (slug, then -2/-3… suffixes). */
+export function connectionIdForLabel(label: string, taken: Iterable<string>): string {
+  const used = new Set([...taken])
+  const base = labelSlug(label)
+
+  if (!used.has(base) && base !== LOCAL_CONNECTION_ID) {
+    return base
+  }
+
+  for (let n = 2; ; n += 1) {
+    const candidate = `${base}-${n}`
+
+    if (!used.has(candidate) && candidate !== LOCAL_CONNECTION_ID) {
+      return candidate
+    }
+  }
+}
+
+// ── Validation ──────────────────────────────────────────────────────────────
+
+export interface ConnectionInput {
+  id?: string
+  kind: ConnectionKind
+  label: string
+  url?: string
+  authMode?: string
+  token?: unknown
+  headers?: Record<string, unknown>
+  org?: string
+  host?: string
+  user?: string
+  port?: number | string
+  keyPath?: string
+  remoteHermesPath?: string
+  remoteProfile?: string
+}
+
+/**
+ * Validate + normalize a save payload into a RegistryConnection.
+ * Throws with a user-facing message on any violation. `registry` supplies the
+ * uniqueness context; when `input.id` matches an existing entry this is an
+ * edit and that entry is excluded from the label-collision check.
+ */
+export function normalizeConnectionInput(input: ConnectionInput, registry: ConnectionRegistry): RegistryConnection {
+  const label = String(input.label || '').trim()
+
+  if (!label) {
+    throw new Error('Every connection needs a name. Give this instance a device name (e.g. "Homelab", "Work laptop").')
+  }
+
+  if (label.length > LABEL_MAX) {
+    throw new Error(`Connection name is too long (max ${LABEL_MAX} characters).`)
+  }
+
+  const key = labelKey(label)
+  const collision = registry.connections.find(c => labelKey(c.label) === key && c.id !== input.id)
+
+  if (collision) {
+    throw new Error(`A connection named "${collision.label}" already exists. Connection names must be unique.`)
+  }
+
+  const kind = input.kind
+
+  if (kind === 'local') {
+    // The local entry is managed by the app; only its label is editable.
+    return { id: LOCAL_CONNECTION_ID, kind: 'local', label }
+  }
+
+  // The reserved local id can never be claimed by a non-local entry — a
+  // crafted IPC payload ({id:'local', kind:'remote', …}) would otherwise
+  // replace the local entry via upsert and break the exactly-one-local
+  // invariant. connectionIdForLabel never mints 'local'; reject it when
+  // supplied, too.
+  if (input.id === LOCAL_CONNECTION_ID) {
+    throw new Error('The id "local" is reserved for the local connection.')
+  }
+
+  const id =
+    input.id ||
+    connectionIdForLabel(
+      label,
+      registry.connections.map(c => c.id)
+    )
+
+  if (kind === 'ssh') {
+    const ssh = normalizeSshConfig({
+      mode: 'ssh',
+      host: input.host,
+      user: input.user,
+      port: input.port,
+      keyPath: input.keyPath,
+      remoteHermesPath: input.remoteHermesPath,
+      remoteProfile: input.remoteProfile
+    })
+
+    if (!ssh) {
+      throw new Error('SSH connections need a host.')
+    }
+
+    const { mode: _mode, ...sshFields } = ssh
+
+    // Duplicate prevention (enforced here so a crafted IPC payload can't slip
+    // past the editor's check): two ssh entries collide on the same
+    // user@host:port + remote profile.
+    const sshKey = (c: { host?: string; port?: number; remoteProfile?: string; user?: string }) =>
+      `${(c.user || '').toLowerCase()}@${(c.host || '').toLowerCase()}:${c.port ?? 22}::${(c.remoteProfile || '').trim()}`
+
+    const sshDupe = registry.connections.find(c => c.kind === 'ssh' && c.id !== id && sshKey(c) === sshKey(sshFields))
+
+    if (sshDupe) {
+      throw new Error(`A connection to this SSH host already exists ("${sshDupe.label}").`)
+    }
+
+    return { id, kind: 'ssh', label, ...sshFields }
+  }
+
+  if (kind === 'remote' || kind === 'cloud') {
+    // normalizeRemoteBaseUrl throws its own user-facing message on bad input.
+    const url = normalizeRemoteBaseUrl(input.url)
+
+    // Duplicate prevention: remote/cloud entries collide on the normalized URL
+    // (trimmed, trailing slashes stripped, lowercased) regardless of kind — a
+    // cloud entry and a remote entry pointing at the same gateway are dupes.
+    const urlKey = (value: string) => value.trim().replace(/\/+$/, '').toLowerCase()
+
+    const urlDupe = registry.connections.find(
+      c => (c.kind === 'remote' || c.kind === 'cloud') && c.id !== id && urlKey(c.url || '') === urlKey(url)
+    )
+
+    if (urlDupe) {
+      throw new Error(`A connection to this gateway URL already exists ("${urlDupe.label}").`)
+    }
+
+    const authMode = normAuthMode(input.authMode)
+    const entry: RegistryConnection = { id, kind, label, url, authMode }
+
+    // A token is only meaningful for token-auth remotes. Dropping it here is
+    // what clears the stale envelope when an entry is switched token→oauth
+    // (or is a cloud entry, which authenticates via the portal session) —
+    // otherwise dead secret material rides along on the edited entry.
+    if (input.token !== undefined && kind === 'remote' && authMode === 'token') {
+      entry.token = input.token
+    }
+
+    // Extra gateway headers (access-proxy credentials) apply to any
+    // remote-shaped entry regardless of auth mode — Cloudflare Access sits in
+    // front of both token- and OAuth-gated gateways. Normalization drops
+    // transport-/Hermes-managed names; an empty result stores nothing.
+    if (input.headers !== undefined) {
+      const headers = normalizeRemoteHeaders(input.headers)
+
+      if (Object.keys(headers).length > 0) {
+        entry.headers = headers
+      }
+    }
+
+    const org = String(input.org || '').trim()
+
+    if (kind === 'cloud' && org) {
+      entry.org = org
+    }
+
+    return entry
+  }
+
+  throw new Error(`Unknown connection kind: ${String(kind)}`)
+}
+
+/**
+ * Merge a (possibly partial) edit payload over the stored entry so fields the
+ * editor doesn't carry survive a save. Renaming a migrated cloud entry must
+ * not drop its `org` (downstream update-fanout uses it to skip
+ * platform-managed instances), and renaming an ssh entry must not drop
+ * `remoteHermesPath`/`remoteProfile`. Only fields the payload explicitly
+ * carries (non-undefined) override; `token` is deliberately NOT merged here —
+ * the caller owns secret handling.
+ */
+export function mergeConnectionInput(input: ConnectionInput, existing?: null | RegistryConnection): ConnectionInput {
+  if (!existing || existing.kind !== input.kind) {
+    return input
+  }
+
+  const merged: ConnectionInput = { ...input }
+
+  const inherit = (field: keyof ConnectionInput & keyof RegistryConnection) => {
+    if (merged[field] === undefined && existing[field] !== undefined) {
+      ;(merged as unknown as Record<string, unknown>)[field] = existing[field]
+    }
+  }
+
+  inherit('url')
+  inherit('authMode')
+  inherit('org')
+  inherit('host')
+  inherit('keyPath')
+  inherit('remoteHermesPath')
+  inherit('remoteProfile')
+  // Headers inherit like other dial fields: an edit payload that omits the
+  // field keeps the stored set; an explicit payload (even {}) is
+  // authoritative so the editor can clear them.
+  inherit('headers')
+
+  // ssh user/port: the editor shows ONE composite host field (user@host:port),
+  // and normalizeSshConfig gives explicit user/port fields precedence over the
+  // parsed host string. Inheriting stored user/port alongside a NEW host string
+  // would resurrect the old values over what the user just typed — so when the
+  // payload carries a host, the host string is authoritative and stored
+  // user/port are NOT inherited.
+  if (input.host === undefined || !String(input.host).trim()) {
+    inherit('user')
+    inherit('port')
+  }
+
+  return merged
+}
+
+/**
+ * True when an edit changes how a connection is DIALED — endpoint, auth, or
+ * ssh routing fields — as opposed to a cosmetic label rename. Callers use
+ * this to decide whether live pooled backends / renderer sockets for the
+ * connection must be recycled after a save: a label-only edit keeps traffic
+ * flowing, while a url/token/host change means everything currently open
+ * points at the OLD target and must be torn down and re-dialed.
+ */
+export function connectionDialFieldsChanged(before: RegistryConnection, after: RegistryConnection): boolean {
+  if (before.kind !== after.kind) {
+    return true
+  }
+
+  const fields: (keyof RegistryConnection)[] = [
+    'url',
+    'authMode',
+    'org',
+    'host',
+    'user',
+    'port',
+    'keyPath',
+    'remoteHermesPath',
+    'remoteProfile'
+  ]
+
+  for (const field of fields) {
+    if ((before[field] ?? null) !== (after[field] ?? null)) {
+      return true
+    }
+  }
+
+  // Token envelopes are opaque here (main.ts encrypts). An edit that carries
+  // no new token inherits the stored envelope verbatim, so structural
+  // equality is exact for the label-only case.
+  if (JSON.stringify(before.token ?? null) !== JSON.stringify(after.token ?? null)) {
+    return true
+  }
+
+  // Headers are dial material too: a changed access-proxy credential means
+  // every open socket/backend authenticated with the OLD set.
+  return JSON.stringify(before.headers ?? null) !== JSON.stringify(after.headers ?? null)
+}
+
+// ── Registry-level operations (all pure: return a new registry) ────────────
+
+function localEntry(label = 'This device'): RegistryConnection {
+  return { id: LOCAL_CONNECTION_ID, kind: 'local', label }
+}
+
+/**
+ * Coerce arbitrary parsed JSON into a valid registry: version stamped, a
+ * local entry guaranteed, labels de-duplicated defensively (suffix, never
+ * drop), primary always pointing at an existing entry. A hand-edited or
+ * corrupt file degrades to a minimal local-only registry rather than
+ * throwing at boot.
+ */
+export function normalizeRegistry(raw: unknown): ConnectionRegistry {
+  const parsed = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {}
+  const rawConnections = Array.isArray(parsed.connections) ? parsed.connections : []
+  const seenLabels = new Set<string>()
+  const seenIds = new Set<string>()
+  const connections: RegistryConnection[] = []
+
+  for (const item of rawConnections) {
+    if (!item || typeof item !== 'object') {
+      continue
+    }
+
+    const entry = item as Record<string, unknown>
+    const kind = entry.kind
+
+    if (kind !== 'local' && kind !== 'remote' && kind !== 'cloud' && kind !== 'ssh') {
+      continue
+    }
+
+    let label = String(entry.label || '').trim()
+
+    if (!label) {
+      // Defensive: registry entries are always written with labels, but a
+      // hand-edited file may drop one. Derive rather than discard.
+      label =
+        kind === 'ssh' ? String(entry.host || 'ssh') : hostLabelFromBaseUrl(String(entry.url || '')) || String(kind)
+    }
+
+    label = uniqueLabel(label, seenLabels)
+
+    let id = kind === 'local' ? LOCAL_CONNECTION_ID : String(entry.id || '').trim()
+
+    if (!id || (seenIds.has(id) && kind !== 'local')) {
+      id = connectionIdForLabel(label, seenIds)
+    }
+
+    if (seenIds.has(id)) {
+      continue // second 'local' entry — first one wins
+    }
+
+    seenLabels.add(labelKey(label))
+    seenIds.add(id)
+
+    const clean: RegistryConnection = { id, kind, label }
+
+    if (kind === 'remote' || kind === 'cloud') {
+      const url = String(entry.url || '').trim()
+
+      if (!url) {
+        continue
+      }
+
+      clean.url = url
+      clean.authMode = normAuthMode(entry.authMode)
+
+      if (entry.token !== undefined) {
+        clean.token = entry.token
+      }
+
+      const storedHeaders = normalizeRemoteHeaders(entry.headers)
+
+      if (Object.keys(storedHeaders).length > 0) {
+        clean.headers = storedHeaders
+      }
+
+      const org = String(entry.org || '').trim()
+
+      if (kind === 'cloud' && org) {
+        clean.org = org
+      }
+    } else if (kind === 'ssh') {
+      const ssh = normalizeSshConfig({ ...entry, mode: 'ssh' })
+
+      if (!ssh) {
+        continue
+      }
+
+      const { mode: _mode, ...sshFields } = ssh
+      Object.assign(clean, sshFields)
+    }
+
+    connections.push(clean)
+  }
+
+  if (!connections.some(c => c.kind === 'local')) {
+    connections.unshift(localEntry())
+  }
+
+  const storedPrimary = String(parsed.primary || '').trim()
+  const primary = connections.some(c => c.id === storedPrimary) ? storedPrimary : LOCAL_CONNECTION_ID
+  const storedLastUsed = String(parsed.lastUsed || '').trim()
+
+  return {
+    version: REGISTRY_VERSION,
+    primary,
+    launchMode: parsed.launchMode === 'last-used' ? 'last-used' : 'primary',
+    lastUsed: connections.some(c => c.id === storedLastUsed) ? storedLastUsed : primary,
+    connections
+  }
+}
+
+/**
+ * One-time import of the v1 connection.json shape (global `mode` + `remote`
+ * block + per-profile `profiles` map) into a v2 registry. v1 had no labels,
+ * so they are derived (URL host, SSH host, "This device") and uniqued by
+ * suffixing. The active v1 global connection becomes the primary. The v1
+ * file is left untouched by the caller — old builds keep working.
+ *
+ * Per-profile override entries become registry connections too (deduped by
+ * URL/host against the global block), so a user who had `research` pinned to
+ * a second gateway sees both sources registered on first launch.
+ */
+export function migrateV1ToRegistry(v1: unknown): ConnectionRegistry {
+  const config = v1 && typeof v1 === 'object' ? (v1 as Record<string, any>) : {}
+  const connections: RegistryConnection[] = [localEntry()]
+  const byFingerprint = new Map<string, RegistryConnection>()
+
+  const addRemoteLike = (block: Record<string, any>, kind: 'cloud' | 'remote'): null | RegistryConnection => {
+    const url = String(block?.url || '').trim()
+
+    if (!url) {
+      return null
+    }
+
+    const fingerprint = `${kind}:${url}`
+    const existing = byFingerprint.get(fingerprint)
+
+    if (existing) {
+      return existing
+    }
+
+    const label = uniqueLabel(
+      hostLabelFromBaseUrl(url) || (kind === 'cloud' ? 'Hermes Cloud' : 'Remote gateway'),
+      connections.map(c => c.label)
+    )
+
+    const entry: RegistryConnection = {
+      id: connectionIdForLabel(
+        label,
+        connections.map(c => c.id)
+      ),
+      kind,
+      label,
+      url,
+      authMode: normAuthMode(block.authMode)
+    }
+
+    if (block.token !== undefined) {
+      entry.token = block.token
+    }
+
+    const v1Headers = normalizeRemoteHeaders(block.headers)
+
+    if (Object.keys(v1Headers).length > 0) {
+      entry.headers = v1Headers
+    }
+
+    const org = String(block.org || '').trim()
+
+    if (kind === 'cloud' && org) {
+      entry.org = org
+    }
+
+    connections.push(entry)
+    byFingerprint.set(fingerprint, entry)
+
+    return entry
+  }
+
+  const addSsh = (block: Record<string, any>): null | RegistryConnection => {
+    const ssh = normalizeSshConfig({ ...block, mode: 'ssh' })
+
+    if (!ssh) {
+      return null
+    }
+
+    const fingerprint = `ssh:${ssh.user || ''}@${ssh.host}:${ssh.port || 22}`
+    const existing = byFingerprint.get(fingerprint)
+
+    if (existing) {
+      return existing
+    }
+
+    const label = uniqueLabel(
+      ssh.host,
+      connections.map(c => c.label)
+    )
+
+    const { mode: _mode, ...sshFields } = ssh
+
+    const entry: RegistryConnection = {
+      id: connectionIdForLabel(
+        label,
+        connections.map(c => c.id)
+      ),
+      kind: 'ssh',
+      label,
+      ...sshFields
+    }
+
+    connections.push(entry)
+    byFingerprint.set(fingerprint, entry)
+
+    return entry
+  }
+
+  // Global connection → an entry + the primary designation.
+  let primary = LOCAL_CONNECTION_ID
+  const globalMode = config.mode
+
+  if (modeIsRemoteLike(globalMode)) {
+    const entry = addRemoteLike(config.remote || {}, globalMode === 'cloud' ? 'cloud' : 'remote')
+
+    if (entry) {
+      primary = entry.id
+    }
+  } else if (globalMode === 'ssh') {
+    const entry = addSsh(config.remote || {})
+
+    if (entry) {
+      primary = entry.id
+    }
+  }
+
+  // Per-profile overrides → additional registered sources (deduped).
+  const profiles = config.profiles && typeof config.profiles === 'object' ? config.profiles : {}
+
+  for (const block of Object.values(profiles) as Record<string, any>[]) {
+    if (!block || typeof block !== 'object') {
+      continue
+    }
+
+    if (modeIsRemoteLike(block.mode)) {
+      addRemoteLike(block, block.mode === 'cloud' ? 'cloud' : 'remote')
+    } else if (block.mode === 'ssh') {
+      addSsh(block)
+    } else if (block.mode === 'local' && block.savedSsh) {
+      addSsh(block.savedSsh)
+    }
+  }
+
+  return { version: REGISTRY_VERSION, primary, launchMode: 'primary', lastUsed: primary, connections }
+}
+
+/** Insert or replace by id. Input must already be normalized/validated. */
+export function upsertConnection(registry: ConnectionRegistry, entry: RegistryConnection): ConnectionRegistry {
+  const connections = registry.connections.some(c => c.id === entry.id)
+    ? registry.connections.map(c => (c.id === entry.id ? entry : c))
+    : [...registry.connections, entry]
+
+  return { ...registry, connections }
+}
+
+/**
+ * Remove a connection. The local entry is not removable; removing the
+ * current primary retargets primary to local.
+ */
+export function removeConnection(registry: ConnectionRegistry, id: string): ConnectionRegistry {
+  const target = registry.connections.find(c => c.id === id)
+
+  if (!target) {
+    return registry
+  }
+
+  if (target.kind === 'local') {
+    throw new Error('The local connection cannot be removed.')
+  }
+
+  const primary = registry.primary === id ? LOCAL_CONNECTION_ID : registry.primary
+
+  return {
+    ...registry,
+    primary,
+    lastUsed: registry.lastUsed === id ? primary : registry.lastUsed,
+    connections: registry.connections.filter(c => c.id !== id)
+  }
+}
+
+/** Point the window/primary backend at another registered connection. */
+export function setPrimaryConnection(registry: ConnectionRegistry, id: string): ConnectionRegistry {
+  if (!registry.connections.some(c => c.id === id)) {
+    throw new Error(`No connection with id "${id}".`)
+  }
+
+  return { ...registry, primary: id }
+}
+
+/** Remember the last source the Sessions workspace opened successfully. */
+export function setLastUsedConnection(registry: ConnectionRegistry, id: string): ConnectionRegistry {
+  if (!registry.connections.some(c => c.id === id)) {
+    throw new Error(`No connection with id "${id}".`)
+  }
+
+  return { ...registry, lastUsed: id }
+}
+
+/** Choose whether launch restores the explicit primary or the last-used source. */
+export function setConnectionLaunchMode(registry: ConnectionRegistry, launchMode: string): ConnectionRegistry {
+  if (launchMode !== 'last-used' && launchMode !== 'primary') {
+    throw new Error(`Unknown connection launch mode "${String(launchMode)}".`)
+  }
+
+  return { ...registry, launchMode }
+}

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -1,206 +1,68 @@
 /**
- * connection-registry.ts
+ * Authoritative connection-identity facade.
  *
- * Pure, electron-free helpers for the desktop's multi-connection registry —
- * the v2 successor to the single global `mode` + `remote` block in
- * connection.json. The registry is a named list of agent SOURCES (local
- * runtime, remote gateways, Hermes Cloud instances, SSH hosts) that are all
- * registered at once; routing/pooling changes that consume the registry land
- * separately, so this module is deliberately storage-shaped, not
- * transport-shaped.
- *
- * Design rules (agreed with Teknium, Aug 2026):
- *  - Every connection carries a REQUIRED, registry-unique `label` (the
- *    "device name"). Uniqueness is case-insensitive so `Homelab` and
- *    `homelab` can't coexist and produce two identical badges.
- *  - When two sources expose the same profile name, surfaces disambiguate as
- *    `@<profile>-<label-slug>` — `agentHandle()` is the one place that rule
- *    lives.
- *  - The registry ALWAYS contains exactly one `local` connection (the app's
- *    own runtime). It cannot be removed; it is the default primary.
- *  - `primary` designates the connection that owns the window backend (boot
- *    overlay, install/update machinery). Removing the primary retargets to
- *    the local entry rather than leaving a dangling id.
- *
- * Kept standalone (no `import 'electron'`) so it unit-tests with `node --test`
- * — same pattern as connection-config.ts / backend-probes.ts. main.ts wires
- * these into the IPC layer and owns file I/O + secret encryption.
+ * The registry's storage, migration, roster, and mutation implementation stays
+ * byte-for-byte in connection-registry-base.ts. This facade owns only the
+ * security-sensitive translation from a resolved route descriptor back to a
+ * live registry identity, so every caller imports one canonical contract.
  */
 
-import {
-  hostLabelFromBaseUrl,
-  modeIsRemoteLike,
-  normalizeRemoteBaseUrl,
-  normalizeRemoteHeaders,
-  normalizeSshConfig,
-  normAuthMode
-} from './connection-config'
+import { normalizeRemoteBaseUrl, normalizeSshConfig, normAuthMode } from './connection-config'
+import { matchingConnectionId, type StoredRoute } from './connection-route-identity'
+import type { ConnectionRegistry } from './connection-registry-base'
 
-export const REGISTRY_VERSION = 2
+export * from './connection-registry-base'
 
-export const LOCAL_CONNECTION_ID = 'local'
-
-/** Connection kinds. 'cloud' is remote-shaped (see modeIsRemoteLike) but keeps
- * its provenance so the UI can render the right card and updates can skip
- * platform-managed instances. */
-export type ConnectionKind = 'cloud' | 'local' | 'remote' | 'ssh'
-
-export interface RegistryConnection {
-  id: string
-  kind: ConnectionKind
-  /** Required, unique (case-insensitive) display name — the "device name". */
-  label: string
-  /** remote/cloud: normalized base URL. */
-  url?: string
-  /** remote/cloud: 'token' | 'oauth'. */
-  authMode?: 'oauth' | 'token'
-  /** remote: encrypted token envelope (opaque here; main.ts encrypts/decrypts). */
-  token?: unknown
-  /** remote/cloud: extra gateway headers (Cloudflare Access etc.). Secret
-   * envelopes, same shape as `token`; names pre-filtered through
-   * normalizeRemoteHeaders. Optional and additive — v2 registries written
-   * before this field keep loading unchanged. */
-  headers?: Record<string, unknown>
-  /** cloud: portal org slug/id the instance was discovered under. */
-  org?: string
-  /** ssh fields (normalizeSshConfig shapes). */
+export interface ResolvedConnectionSshDescriptor {
   host?: string
-  user?: string
-  port?: number
   keyPath?: string
+  port?: number
   remoteHermesPath?: string
   remoteProfile?: string
-}
-
-export interface ConnectionRegistry {
-  version: typeof REGISTRY_VERSION
-  /** id of the connection that owns the window/primary backend. */
-  primary: string
-  /** Which saved source Sessions should restore when the app launches. */
-  launchMode: 'last-used' | 'primary'
-  /** Last source the Sessions workspace successfully opened. Additive in v2
-   * so registries written before multi-source switching still normalize. */
-  lastUsed: string
-  connections: RegistryConnection[]
-}
-
-// ── Labels and ids ──────────────────────────────────────────────────────────
-
-const LABEL_MAX = 64
-
-/** Canonical comparison key for label uniqueness. */
-export function labelKey(label: string): string {
-  return String(label || '')
-    .trim()
-    .toLowerCase()
-}
-
-/**
- * Derive a registry-unique label from a candidate: clamps to LABEL_MAX (a
- * migrated URL host can exceed it, which would fail validation on any later
- * edit) and suffixes " 2" / " 3" / … on collision. The single home of the
- * label-dedup rule — normalizeRegistry and the migration both use it.
- */
-export function uniqueLabel(candidate: string, taken: Iterable<string>): string {
-  const used = new Set([...taken].map(labelKey))
-
-  // Reserve room for a collision suffix so the suffixed form stays in-bounds.
-  const base = String(candidate || '')
-    .trim()
-    .slice(0, LABEL_MAX - 4)
-
-  if (!used.has(labelKey(base))) {
-    return base
-  }
-
-  for (let n = 2; ; n += 1) {
-    const suffixed = `${base} ${n}`
-
-    if (!used.has(labelKey(suffixed))) {
-      return suffixed
-    }
-  }
-}
-
-/** Kebab-slug of a label for ids and @handles. Never empty for a non-empty label. */
-export function labelSlug(label: string): string {
-  const slug = String(label || '')
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 48)
-
-  return slug || 'connection'
-}
-
-/**
- * The one place the duplicate-agent naming rule lives: a profile that exists
- * on several registered sources renders as `@<profile>-<label-slug>`;
- * a profile unique across the roster keeps its bare name.
- */
-export function agentHandle(profile: string, connectionLabel: string, duplicated: boolean): string {
-  const name = String(profile || '').trim() || 'default'
-
-  return duplicated ? `${name}-${labelSlug(connectionLabel)}` : name
-}
-
-/**
- * Pool key for a backend serving (connection, profile). The local/primary
- * connection keeps the BARE profile key so every legacy pool entry, reaper
- * log line, and touch call stays byte-identical for single-source users;
- * non-local connections get an unambiguous composite (`conn:<id>::<profile>`)
- * that cannot collide with a plain profile name (colons are invalid in
- * profile names).
- *
- * NOTE: the renderer's socket registry uses the twin implementation in
- * apps/shared/src/backend-scope.ts (`@hermes/shared`) — tsconfig project
- * boundaries prevent a single physical module here. The two are pinned
- * byte-identical by the cross-copy contract test in
- * connection-registry.test.ts; change BOTH or that test fails.
- */
-export function backendScopeKey(connectionId: null | string | undefined, profile: null | string | undefined): string {
-  const profileKey = String(profile ?? '').trim() || 'default'
-  const connection = String(connectionId ?? '').trim()
-
-  if (!connection || connection === LOCAL_CONNECTION_ID) {
-    return profileKey
-  }
-
-  return `conn:${connection}::${profileKey}`
-}
-
-/** All pool keys owned by a connection share this prefix (used to stop them on remove). */
-export function backendScopePrefix(connectionId: string): string {
-  return `conn:${String(connectionId).trim()}::`
-}
-
-export interface RegistryLocalRoute {
-  /** Reuse the legacy v1 ensureBackend path — it already resolves to the
-   * app's own local runtime, so single-source behavior stays byte-identical. */
-  delegate: boolean
-  /** Pool key for the forced-local child when not delegating. */
-  poolKey: string
+  user?: string
 }
 
 export interface ResolvedConnectionDescriptor {
+  authMode?: unknown
   baseUrl?: string
+  /** Present on registry-qualified routes. Presence is authoritative even
+   * when the value is invalid: only descriptors with no such property may
+   * use legacy transport inference. */
+  connectionId?: null | string
+  headers?: Record<string, unknown>
   mode?: 'local' | 'remote'
+  org?: unknown
   remoteHost?: string
   remoteKind?: 'cloud' | 'ssh' | 'url'
+  ssh?: null | ResolvedConnectionSshDescriptor
+  token?: unknown
 }
 
 /**
  * Recover registry identity for a descriptor resolved through the legacy v1
- * profile path. Registry-scoped routes already carry `connectionId`; this
- * bridge keeps migrated per-profile remotes truthful until v1 is retired.
+ * profile path. Registry-scoped routes already carry `connectionId`; that
+ * exact identity is authoritative only while it names a current registration.
+ * Only genuinely unqualified legacy descriptors infer, and inference uses the
+ * same complete pre-dial envelope as Desktop route selection.
  */
 export function resolvedConnectionId(
   registry: ConnectionRegistry,
   descriptor: ResolvedConnectionDescriptor
 ): null | string {
+  if (Object.prototype.hasOwnProperty.call(descriptor, 'connectionId')) {
+    const connectionId = descriptor.connectionId
+
+    if (typeof connectionId !== 'string' || !connectionId) {
+      return null
+    }
+
+    return registry.connections.some(connection => connection.id === connectionId) ? connectionId : null
+  }
+
   if (descriptor.mode === 'local') {
-    return registry.connections.find(connection => connection.kind === 'local')?.id ?? null
+    const localConnections = registry.connections.filter(connection => connection.kind === 'local')
+
+    return localConnections.length === 1 ? localConnections[0].id : null
   }
 
   if (descriptor.mode !== 'remote') {
@@ -208,912 +70,107 @@ export function resolvedConnectionId(
   }
 
   if (descriptor.remoteKind === 'ssh') {
-    const remoteHost = String(descriptor.remoteHost || '')
-      .trim()
-      .toLowerCase()
+    if (Object.prototype.hasOwnProperty.call(descriptor, 'ssh')) {
+      if (!descriptor.ssh || typeof descriptor.ssh !== 'object') {
+        return null
+      }
 
-    if (!remoteHost) {
+      return matchingConnectionId(registry, { ...descriptor.ssh, kind: 'ssh' }, 'unique') ?? null
+    }
+
+    // Old descriptors expose only user@host after the tunnel has discarded
+    // port/key/path/profile. That weak shape is compatible only when exactly
+    // one registered SSH source shares the target and its defaulted route
+    // still satisfies the canonical full-envelope matcher.
+    const ssh = normalizeSshConfig({ mode: 'ssh', host: descriptor.remoteHost })
+
+    if (!ssh) {
       return null
     }
 
-    return (
-      registry.connections.find(connection => {
-        if (connection.kind !== 'ssh') {
-          return false
-        }
-
-        const host = String(connection.host || '')
-          .trim()
-          .toLowerCase()
-
-        const target = connection.user ? `${String(connection.user).trim().toLowerCase()}@${host}` : host
-
-        return target === remoteHost
-      })?.id ?? null
+    const target = normalizedSshTarget(ssh)
+    const coarseMatches = registry.connections.filter(
+      connection => connection.kind === 'ssh' && normalizedSshTarget(connection) === target
     )
+
+    if (!target || coarseMatches.length !== 1) {
+      return null
+    }
+
+    return matchingConnectionId(registry, { kind: 'ssh', ...ssh }, 'unique') ?? null
   }
 
-  let baseUrl = ''
+  const kind = descriptor.remoteKind === 'cloud' ? 'cloud' : descriptor.remoteKind === 'url' ? 'remote' : null
+
+  if (!kind) {
+    return null
+  }
+
+  let url = ''
 
   try {
-    baseUrl = normalizeRemoteBaseUrl(descriptor.baseUrl)
+    url = normalizeRemoteBaseUrl(descriptor.baseUrl)
   } catch {
     return null
   }
 
-  return (
-    registry.connections.find(connection => {
-      if (connection.kind !== 'cloud' && connection.kind !== 'remote') {
+  const authMode = normAuthMode(descriptor.authMode)
+  const route: StoredRoute = {
+    authMode,
+    headers: descriptor.headers,
+    kind,
+    org: descriptor.org,
+    token: descriptor.token,
+    url
+  }
+  const hasExactEnvelope =
+    Object.prototype.hasOwnProperty.call(descriptor, 'authMode') &&
+    Object.prototype.hasOwnProperty.call(descriptor, 'headers') &&
+    (authMode === 'oauth' || Object.prototype.hasOwnProperty.call(descriptor, 'token')) &&
+    (kind === 'remote' || Object.prototype.hasOwnProperty.call(descriptor, 'org'))
+
+  if (!hasExactEnvelope) {
+    // A URL alone cannot choose among legal registrations that differ by
+    // auth, headers, Cloud organization, or account. Require one coarse
+    // candidate before the shared full-envelope matcher may accept legacy
+    // defaults; zero or multiple candidates fail closed.
+    const coarseMatches = registry.connections.filter(connection => {
+      if (connection.kind !== kind) {
         return false
       }
 
       try {
-        return normalizeRemoteBaseUrl(connection.url) === baseUrl
+        return normalizeRemoteBaseUrl(connection.url) === url
       } catch {
         return false
       }
-    })?.id ?? null
-  )
-}
-
-/**
- * How the registry's 'local' entry resolves a backend for `profile`.
- *
- * The 'local' entry means THIS machine's runtime — always. The legacy
- * ensureBackend() path instead follows the v1 connection.json routing table,
- * where a global remote mode (or a per-profile remote override) resolves to a
- * REMOTE descriptor. A migrated user whose v1 global mode was remote gets that
- * remote as the registry primary AND keeps the mandatory 'local' entry, so
- * delegating 'local' to the v1 route made the roster's "This device" rows
- * enumerate and dial the remote box: every profile appeared twice (forcing
- * -slug handles) and "local" agents talked to the remote.
- *
- * When the v1 route is already local we delegate (legacy path, byte-identical
- * pool keys). When v1 says remote, the local entry spawns its own genuinely
- * local child under a composite pool key: backendScopeKey('local', p) maps to
- * the BARE profile key by design, and that slot may already hold the v1
- * route's REMOTE descriptor — so the forced-local child pools under the
- * `conn:local::<profile>` form instead (colons are invalid in profile names,
- * so it cannot collide).
- */
-export function resolveRegistryLocalRoute(
-  profile: null | string | undefined,
-  opts: { globalRemote?: boolean; profileRemoteOverride?: boolean } = {}
-): RegistryLocalRoute {
-  const profileKey = String(profile ?? '').trim() || 'default'
-
-  if (opts.globalRemote || opts.profileRemoteOverride) {
-    return { delegate: false, poolKey: `${backendScopePrefix(LOCAL_CONNECTION_ID)}${profileKey}` }
-  }
-
-  return { delegate: true, poolKey: profileKey }
-}
-
-/**
- * Whether the roster enumeration should SKIP the registry's local entry as
- * connect-on-demand. True when the local source is the forced-local route
- * (primary resolves remote — enumerating would spawn a local backend the
- * user never asked for, minting a phantom `default` agent and forcing
- * -device handles onto the real one) AND no forced-local child is already
- * pooled. Pure — main.ts feeds it the live route + pool keys.
- */
-export function shouldDeferLocalEnumeration(
-  route: RegistryLocalRoute,
-  poolKeys: Iterable<string>,
-  connectionId: string = LOCAL_CONNECTION_ID
-): boolean {
-  if (route.delegate) {
-    return false
-  }
-
-  const prefix = backendScopePrefix(connectionId)
-
-  return ![...poolKeys].some(key => String(key).startsWith(prefix))
-}
-
-// ── Union agent roster ──────────────────────────────────────────────────────
-
-export interface ConnectionAgents {
-  connection: RegistryConnection
-  /** Profile names enumerated from the connection, or null when unreachable /
-   * connect-on-demand (ssh not yet dialed). */
-  profiles: null | string[]
-  /** Present when profiles is null: why enumeration was skipped. */
-  error?: string
-  /** Stable backend identity from the connection's /api/status (`install_id`).
-   * Two connections reporting the same id are the SAME physical install
-   * registered under two addresses (hostname + Tailscale IP), so the roster
-   * collapses their rows. Absent on older backends → no collapse (fully
-   * backward compatible). */
-  installId?: string
-}
-
-export interface RosterAgent {
-  connectionId: string
-  connectionKind: ConnectionKind
-  connectionLabel: string
-  profile: string
-  /** Bare profile name, or `<profile>-<label-slug>` when the profile name
-   * exists on more than one registered source (the @name-device rule). */
-  handle: string
-}
-
-/**
- * Roster enumeration skips undialed sources (connect-on-demand) and reports
- * unreachable ones with `profiles: null`. Reuse the last successful profile
- * list so Bot Mode does not go empty (or drop to a partial roster) the moment
- * a source is briefly unreachable — SSH tunnels drop on sleep/wake, and a
- * remote gateway bounce (VPS restart) otherwise erased its bots from the
- * roster until the next successful enumeration ("my 4 bots show as 2", Aug
- * 2026 bundle). Never-seen SSH sources still get a `default` seed so the
- * device is clickable; never-seen remote sources stay empty (no seed) since
- * an unreachable URL is not evidence a backend exists there.
- */
-export function rememberSshEnumeration(
-  enumeration: Pick<ConnectionAgents, 'error' | 'profiles'>,
-  cached: null | string[] | undefined,
-  kind: ConnectionKind
-): Pick<ConnectionAgents, 'error' | 'profiles'> {
-  if (enumeration.profiles && enumeration.profiles.length > 0) {
-    return enumeration
-  }
-
-  if (kind === 'local') {
-    return enumeration
-  }
-
-  if (cached && cached.length > 0) {
-    return { profiles: cached, error: enumeration.error }
-  }
-
-  if (kind === 'ssh' && enumeration.error === 'connect-on-demand') {
-    return { profiles: ['default'], error: 'connect-on-demand' }
-  }
-
-  return enumeration
-}
-
-/** Whether an undialed SSH source should be inventoried again. Cached
- *  successes never retry. Failures retry after `retryAfterMs` so a cold box
- *  does not stay seeded as `default` until the user hits Test. */
-export function shouldRetrySshInventory(
-  hasCache: boolean,
-  lastAttemptMs: null | number | undefined,
-  nowMs: number,
-  retryAfterMs = 60_000
-): boolean {
-  if (hasCache) {
-    return false
-  }
-
-  if (lastAttemptMs == null) {
-    return true
-  }
-
-  return nowMs - lastAttemptMs >= retryAfterMs
-}
-
-const PROFILE_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/
-
-/** Turn `ls ~/.hermes/profiles` output into roster names. Always includes
- *  `default`. Drops rollback snapshots and junk lines. */
-export function parseRemoteProfileListing(text: string): string[] {
-  const names = new Set<string>(['default'])
-
-  for (const raw of String(text || '').split(/\r?\n/)) {
-    const name = raw.trim()
-
-    if (!name || name.startsWith('.') || name.endsWith('.rollback-old')) {
-      continue
-    }
-
-    if (!PROFILE_NAME_RE.test(name)) {
-      continue
-    }
-
-    names.add(name)
-  }
-
-  return ['default', ...[...names].filter(name => name !== 'default').sort()]
-}
-
-/**
- * Flatten per-connection profile enumerations into the union roster, applying
- * the duplicate-handle rule ONCE across all sources. Pure so the disambiguation
- * policy is testable without IPC; main.ts feeds it live enumerations.
- */
-export function buildAgentRoster(
-  enumerations: ConnectionAgents[],
-  opts: { primaryConnectionId?: string } = {}
-): RosterAgent[] {
-  // A connection can transiently report the same profile more than once (or
-  // arrive twice while registry state is reconciling). A roster row represents
-  // one routable identity, so collapse strictly by connection + profile before
-  // counting names for @name-device disambiguation.
-  const identities = new Map<
-    string,
-    { connection: RegistryConnection; installId?: string; order: number; profile: string }
-  >()
-
-  let order = 0
-
-  for (const { connection, installId, profiles } of enumerations) {
-    for (const profile of profiles || []) {
-      const name = String(profile || '').trim() || 'default'
-      const key = `${connection.id}\0${name}`
-
-      if (!identities.has(key)) {
-        identities.set(key, { connection, installId, order, profile: name })
-      }
-    }
-
-    order += 1
-  }
-
-  // Backend-identity collapse: two connections reporting the same install_id
-  // are the SAME physical install registered under two addresses, so their
-  // (install, profile) rows are one bot, not two. Connections without an id
-  // (older backends, undialed ssh) keep a per-connection key — no collapse.
-  const backends = new Map<string, { connection: RegistryConnection; order: number; profile: string }[]>()
-
-  for (const { connection, installId, order: rank, profile } of identities.values()) {
-    const key = installId ? `id:${installId}\0${profile}` : `conn:${connection.id}\0${profile}`
-    const group = backends.get(key)
-
-    if (group) {
-      group.push({ connection, order: rank, profile })
-    } else {
-      backends.set(key, [{ connection, order: rank, profile }])
-    }
-  }
-
-  const rows = [...backends.values()].map(group => pickCanonicalConnection(group, opts.primaryConnectionId))
-
-  // The @name-device duplicate-handle rule runs AFTER the collapse, so a
-  // profile that only *looked* duplicated (one box, two addresses) keeps its
-  // bare name once the rows are recognized as one backend.
-  const counts = new Map<string, number>()
-
-  for (const { profile } of rows) {
-    counts.set(profile, (counts.get(profile) || 0) + 1)
-  }
-
-  const roster: RosterAgent[] = []
-
-  for (const { connection, profile } of rows) {
-    roster.push({
-      connectionId: connection.id,
-      connectionKind: connection.kind,
-      connectionLabel: connection.label,
-      profile,
-      handle: agentHandle(profile, connection.label, (counts.get(profile) || 0) > 1)
-    })
-  }
-
-  return roster
-}
-
-/** Deterministic route priority for same-backend rows: local is definitionally
- * this box; ssh beats HTTP remotes; cloud last. */
-const CANONICAL_KIND_PRIORITY: Record<ConnectionKind, number> = { cloud: 3, local: 0, remote: 2, ssh: 1 }
-
-/**
- * Which connection represents a collapsed same-backend roster row: the ACTIVE
- * (primary) connection when it is one of the candidates — the row should route
- * where the window already routes — else the highest kind priority, else the
- * earliest-registered (enumeration order follows registry order).
- */
-function pickCanonicalConnection<T extends { connection: RegistryConnection; order: number }>(
-  candidates: T[],
-  primaryConnectionId?: string
-): T {
-  const active = primaryConnectionId ? candidates.find(c => c.connection.id === primaryConnectionId) : undefined
-
-  if (active) {
-    return active
-  }
-
-  return [...candidates].sort(
-    (a, b) =>
-      CANONICAL_KIND_PRIORITY[a.connection.kind] - CANONICAL_KIND_PRIORITY[b.connection.kind] || a.order - b.order
-  )[0]
-}
-
-// ── Fan-out update eligibility ──────────────────────────────────────────────
-
-export interface UpdateEligibility {
-  eligible: boolean
-  /** Present when not eligible: 'cloud-managed' (platform updates it). */
-  reason?: 'cloud-managed'
-}
-
-/**
- * Whether "Update all instances" may drive this connection. Hermes Cloud
- * instances are platform-managed — we never run `hermes update` against them.
- * Local, remote, and ssh sources are all eligible (reachability and busy
- * checks happen at dispatch time, not here).
- */
-export function updateEligibility(connection: RegistryConnection): UpdateEligibility {
-  if (connection.kind === 'cloud') {
-    return { eligible: false, reason: 'cloud-managed' }
-  }
-
-  return { eligible: true }
-}
-
-/** Mint a registry-unique id from a label (slug, then -2/-3… suffixes). */
-export function connectionIdForLabel(label: string, taken: Iterable<string>): string {
-  const used = new Set([...taken])
-  const base = labelSlug(label)
-
-  if (!used.has(base) && base !== LOCAL_CONNECTION_ID) {
-    return base
-  }
-
-  for (let n = 2; ; n += 1) {
-    const candidate = `${base}-${n}`
-
-    if (!used.has(candidate) && candidate !== LOCAL_CONNECTION_ID) {
-      return candidate
-    }
-  }
-}
-
-// ── Validation ──────────────────────────────────────────────────────────────
-
-export interface ConnectionInput {
-  id?: string
-  kind: ConnectionKind
-  label: string
-  url?: string
-  authMode?: string
-  token?: unknown
-  headers?: Record<string, unknown>
-  org?: string
-  host?: string
-  user?: string
-  port?: number | string
-  keyPath?: string
-  remoteHermesPath?: string
-  remoteProfile?: string
-}
-
-/**
- * Validate + normalize a save payload into a RegistryConnection.
- * Throws with a user-facing message on any violation. `registry` supplies the
- * uniqueness context; when `input.id` matches an existing entry this is an
- * edit and that entry is excluded from the label-collision check.
- */
-export function normalizeConnectionInput(input: ConnectionInput, registry: ConnectionRegistry): RegistryConnection {
-  const label = String(input.label || '').trim()
-
-  if (!label) {
-    throw new Error('Every connection needs a name. Give this instance a device name (e.g. "Homelab", "Work laptop").')
-  }
-
-  if (label.length > LABEL_MAX) {
-    throw new Error(`Connection name is too long (max ${LABEL_MAX} characters).`)
-  }
-
-  const key = labelKey(label)
-  const collision = registry.connections.find(c => labelKey(c.label) === key && c.id !== input.id)
-
-  if (collision) {
-    throw new Error(`A connection named "${collision.label}" already exists. Connection names must be unique.`)
-  }
-
-  const kind = input.kind
-
-  if (kind === 'local') {
-    // The local entry is managed by the app; only its label is editable.
-    return { id: LOCAL_CONNECTION_ID, kind: 'local', label }
-  }
-
-  // The reserved local id can never be claimed by a non-local entry — a
-  // crafted IPC payload ({id:'local', kind:'remote', …}) would otherwise
-  // replace the local entry via upsert and break the exactly-one-local
-  // invariant. connectionIdForLabel never mints 'local'; reject it when
-  // supplied, too.
-  if (input.id === LOCAL_CONNECTION_ID) {
-    throw new Error('The id "local" is reserved for the local connection.')
-  }
-
-  const id =
-    input.id ||
-    connectionIdForLabel(
-      label,
-      registry.connections.map(c => c.id)
-    )
-
-  if (kind === 'ssh') {
-    const ssh = normalizeSshConfig({
-      mode: 'ssh',
-      host: input.host,
-      user: input.user,
-      port: input.port,
-      keyPath: input.keyPath,
-      remoteHermesPath: input.remoteHermesPath,
-      remoteProfile: input.remoteProfile
     })
 
-    if (!ssh) {
-      throw new Error('SSH connections need a host.')
-    }
-
-    const { mode: _mode, ...sshFields } = ssh
-
-    // Duplicate prevention (enforced here so a crafted IPC payload can't slip
-    // past the editor's check): two ssh entries collide on the same
-    // user@host:port + remote profile.
-    const sshKey = (c: { host?: string; port?: number; remoteProfile?: string; user?: string }) =>
-      `${(c.user || '').toLowerCase()}@${(c.host || '').toLowerCase()}:${c.port ?? 22}::${(c.remoteProfile || '').trim()}`
-
-    const sshDupe = registry.connections.find(c => c.kind === 'ssh' && c.id !== id && sshKey(c) === sshKey(sshFields))
-
-    if (sshDupe) {
-      throw new Error(`A connection to this SSH host already exists ("${sshDupe.label}").`)
-    }
-
-    return { id, kind: 'ssh', label, ...sshFields }
-  }
-
-  if (kind === 'remote' || kind === 'cloud') {
-    // normalizeRemoteBaseUrl throws its own user-facing message on bad input.
-    const url = normalizeRemoteBaseUrl(input.url)
-
-    // Duplicate prevention: remote/cloud entries collide on the normalized URL
-    // (trimmed, trailing slashes stripped, lowercased) regardless of kind — a
-    // cloud entry and a remote entry pointing at the same gateway are dupes.
-    const urlKey = (value: string) => value.trim().replace(/\/+$/, '').toLowerCase()
-
-    const urlDupe = registry.connections.find(
-      c => (c.kind === 'remote' || c.kind === 'cloud') && c.id !== id && urlKey(c.url || '') === urlKey(url)
-    )
-
-    if (urlDupe) {
-      throw new Error(`A connection to this gateway URL already exists ("${urlDupe.label}").`)
-    }
-
-    const authMode = normAuthMode(input.authMode)
-    const entry: RegistryConnection = { id, kind, label, url, authMode }
-
-    // A token is only meaningful for token-auth remotes. Dropping it here is
-    // what clears the stale envelope when an entry is switched token→oauth
-    // (or is a cloud entry, which authenticates via the portal session) —
-    // otherwise dead secret material rides along on the edited entry.
-    if (input.token !== undefined && kind === 'remote' && authMode === 'token') {
-      entry.token = input.token
-    }
-
-    // Extra gateway headers (access-proxy credentials) apply to any
-    // remote-shaped entry regardless of auth mode — Cloudflare Access sits in
-    // front of both token- and OAuth-gated gateways. Normalization drops
-    // transport-/Hermes-managed names; an empty result stores nothing.
-    if (input.headers !== undefined) {
-      const headers = normalizeRemoteHeaders(input.headers)
-
-      if (Object.keys(headers).length > 0) {
-        entry.headers = headers
-      }
-    }
-
-    const org = String(input.org || '').trim()
-
-    if (kind === 'cloud' && org) {
-      entry.org = org
-    }
-
-    return entry
-  }
-
-  throw new Error(`Unknown connection kind: ${String(kind)}`)
-}
-
-/**
- * Merge a (possibly partial) edit payload over the stored entry so fields the
- * editor doesn't carry survive a save. Renaming a migrated cloud entry must
- * not drop its `org` (downstream update-fanout uses it to skip
- * platform-managed instances), and renaming an ssh entry must not drop
- * `remoteHermesPath`/`remoteProfile`. Only fields the payload explicitly
- * carries (non-undefined) override; `token` is deliberately NOT merged here —
- * the caller owns secret handling.
- */
-export function mergeConnectionInput(input: ConnectionInput, existing?: null | RegistryConnection): ConnectionInput {
-  if (!existing || existing.kind !== input.kind) {
-    return input
-  }
-
-  const merged: ConnectionInput = { ...input }
-
-  const inherit = (field: keyof ConnectionInput & keyof RegistryConnection) => {
-    if (merged[field] === undefined && existing[field] !== undefined) {
-      ;(merged as unknown as Record<string, unknown>)[field] = existing[field]
-    }
-  }
-
-  inherit('url')
-  inherit('authMode')
-  inherit('org')
-  inherit('host')
-  inherit('keyPath')
-  inherit('remoteHermesPath')
-  inherit('remoteProfile')
-  // Headers inherit like other dial fields: an edit payload that omits the
-  // field keeps the stored set; an explicit payload (even {}) is
-  // authoritative so the editor can clear them.
-  inherit('headers')
-
-  // ssh user/port: the editor shows ONE composite host field (user@host:port),
-  // and normalizeSshConfig gives explicit user/port fields precedence over the
-  // parsed host string. Inheriting stored user/port alongside a NEW host string
-  // would resurrect the old values over what the user just typed — so when the
-  // payload carries a host, the host string is authoritative and stored
-  // user/port are NOT inherited.
-  if (input.host === undefined || !String(input.host).trim()) {
-    inherit('user')
-    inherit('port')
-  }
-
-  return merged
-}
-
-/**
- * True when an edit changes how a connection is DIALED — endpoint, auth, or
- * ssh routing fields — as opposed to a cosmetic label rename. Callers use
- * this to decide whether live pooled backends / renderer sockets for the
- * connection must be recycled after a save: a label-only edit keeps traffic
- * flowing, while a url/token/host change means everything currently open
- * points at the OLD target and must be torn down and re-dialed.
- */
-export function connectionDialFieldsChanged(before: RegistryConnection, after: RegistryConnection): boolean {
-  if (before.kind !== after.kind) {
-    return true
-  }
-
-  const fields: (keyof RegistryConnection)[] = [
-    'url',
-    'authMode',
-    'org',
-    'host',
-    'user',
-    'port',
-    'keyPath',
-    'remoteHermesPath',
-    'remoteProfile'
-  ]
-
-  for (const field of fields) {
-    if ((before[field] ?? null) !== (after[field] ?? null)) {
-      return true
-    }
-  }
-
-  // Token envelopes are opaque here (main.ts encrypts). An edit that carries
-  // no new token inherits the stored envelope verbatim, so structural
-  // equality is exact for the label-only case.
-  if (JSON.stringify(before.token ?? null) !== JSON.stringify(after.token ?? null)) {
-    return true
-  }
-
-  // Headers are dial material too: a changed access-proxy credential means
-  // every open socket/backend authenticated with the OLD set.
-  return JSON.stringify(before.headers ?? null) !== JSON.stringify(after.headers ?? null)
-}
-
-// ── Registry-level operations (all pure: return a new registry) ────────────
-
-function localEntry(label = 'This device'): RegistryConnection {
-  return { id: LOCAL_CONNECTION_ID, kind: 'local', label }
-}
-
-/**
- * Coerce arbitrary parsed JSON into a valid registry: version stamped, a
- * local entry guaranteed, labels de-duplicated defensively (suffix, never
- * drop), primary always pointing at an existing entry. A hand-edited or
- * corrupt file degrades to a minimal local-only registry rather than
- * throwing at boot.
- */
-export function normalizeRegistry(raw: unknown): ConnectionRegistry {
-  const parsed = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {}
-  const rawConnections = Array.isArray(parsed.connections) ? parsed.connections : []
-  const seenLabels = new Set<string>()
-  const seenIds = new Set<string>()
-  const connections: RegistryConnection[] = []
-
-  for (const item of rawConnections) {
-    if (!item || typeof item !== 'object') {
-      continue
-    }
-
-    const entry = item as Record<string, unknown>
-    const kind = entry.kind
-
-    if (kind !== 'local' && kind !== 'remote' && kind !== 'cloud' && kind !== 'ssh') {
-      continue
-    }
-
-    let label = String(entry.label || '').trim()
-
-    if (!label) {
-      // Defensive: registry entries are always written with labels, but a
-      // hand-edited file may drop one. Derive rather than discard.
-      label =
-        kind === 'ssh' ? String(entry.host || 'ssh') : hostLabelFromBaseUrl(String(entry.url || '')) || String(kind)
-    }
-
-    label = uniqueLabel(label, seenLabels)
-
-    let id = kind === 'local' ? LOCAL_CONNECTION_ID : String(entry.id || '').trim()
-
-    if (!id || (seenIds.has(id) && kind !== 'local')) {
-      id = connectionIdForLabel(label, seenIds)
-    }
-
-    if (seenIds.has(id)) {
-      continue // second 'local' entry — first one wins
-    }
-
-    seenLabels.add(labelKey(label))
-    seenIds.add(id)
-
-    const clean: RegistryConnection = { id, kind, label }
-
-    if (kind === 'remote' || kind === 'cloud') {
-      const url = String(entry.url || '').trim()
-
-      if (!url) {
-        continue
-      }
-
-      clean.url = url
-      clean.authMode = normAuthMode(entry.authMode)
-
-      if (entry.token !== undefined) {
-        clean.token = entry.token
-      }
-
-      const storedHeaders = normalizeRemoteHeaders(entry.headers)
-
-      if (Object.keys(storedHeaders).length > 0) {
-        clean.headers = storedHeaders
-      }
-
-      const org = String(entry.org || '').trim()
-
-      if (kind === 'cloud' && org) {
-        clean.org = org
-      }
-    } else if (kind === 'ssh') {
-      const ssh = normalizeSshConfig({ ...entry, mode: 'ssh' })
-
-      if (!ssh) {
-        continue
-      }
-
-      const { mode: _mode, ...sshFields } = ssh
-      Object.assign(clean, sshFields)
-    }
-
-    connections.push(clean)
-  }
-
-  if (!connections.some(c => c.kind === 'local')) {
-    connections.unshift(localEntry())
-  }
-
-  const storedPrimary = String(parsed.primary || '').trim()
-  const primary = connections.some(c => c.id === storedPrimary) ? storedPrimary : LOCAL_CONNECTION_ID
-  const storedLastUsed = String(parsed.lastUsed || '').trim()
-
-  return {
-    version: REGISTRY_VERSION,
-    primary,
-    launchMode: parsed.launchMode === 'last-used' ? 'last-used' : 'primary',
-    lastUsed: connections.some(c => c.id === storedLastUsed) ? storedLastUsed : primary,
-    connections
-  }
-}
-
-/**
- * One-time import of the v1 connection.json shape (global `mode` + `remote`
- * block + per-profile `profiles` map) into a v2 registry. v1 had no labels,
- * so they are derived (URL host, SSH host, "This device") and uniqued by
- * suffixing. The active v1 global connection becomes the primary. The v1
- * file is left untouched by the caller — old builds keep working.
- *
- * Per-profile override entries become registry connections too (deduped by
- * URL/host against the global block), so a user who had `research` pinned to
- * a second gateway sees both sources registered on first launch.
- */
-export function migrateV1ToRegistry(v1: unknown): ConnectionRegistry {
-  const config = v1 && typeof v1 === 'object' ? (v1 as Record<string, any>) : {}
-  const connections: RegistryConnection[] = [localEntry()]
-  const byFingerprint = new Map<string, RegistryConnection>()
-
-  const addRemoteLike = (block: Record<string, any>, kind: 'cloud' | 'remote'): null | RegistryConnection => {
-    const url = String(block?.url || '').trim()
-
-    if (!url) {
+    if (coarseMatches.length !== 1) {
       return null
     }
-
-    const fingerprint = `${kind}:${url}`
-    const existing = byFingerprint.get(fingerprint)
-
-    if (existing) {
-      return existing
-    }
-
-    const label = uniqueLabel(
-      hostLabelFromBaseUrl(url) || (kind === 'cloud' ? 'Hermes Cloud' : 'Remote gateway'),
-      connections.map(c => c.label)
-    )
-
-    const entry: RegistryConnection = {
-      id: connectionIdForLabel(
-        label,
-        connections.map(c => c.id)
-      ),
-      kind,
-      label,
-      url,
-      authMode: normAuthMode(block.authMode)
-    }
-
-    if (block.token !== undefined) {
-      entry.token = block.token
-    }
-
-    const v1Headers = normalizeRemoteHeaders(block.headers)
-
-    if (Object.keys(v1Headers).length > 0) {
-      entry.headers = v1Headers
-    }
-
-    const org = String(block.org || '').trim()
-
-    if (kind === 'cloud' && org) {
-      entry.org = org
-    }
-
-    connections.push(entry)
-    byFingerprint.set(fingerprint, entry)
-
-    return entry
   }
 
-  const addSsh = (block: Record<string, any>): null | RegistryConnection => {
-    const ssh = normalizeSshConfig({ ...block, mode: 'ssh' })
-
-    if (!ssh) {
-      return null
-    }
-
-    const fingerprint = `ssh:${ssh.user || ''}@${ssh.host}:${ssh.port || 22}`
-    const existing = byFingerprint.get(fingerprint)
-
-    if (existing) {
-      return existing
-    }
-
-    const label = uniqueLabel(
-      ssh.host,
-      connections.map(c => c.label)
-    )
-
-    const { mode: _mode, ...sshFields } = ssh
-
-    const entry: RegistryConnection = {
-      id: connectionIdForLabel(
-        label,
-        connections.map(c => c.id)
-      ),
-      kind: 'ssh',
-      label,
-      ...sshFields
-    }
-
-    connections.push(entry)
-    byFingerprint.set(fingerprint, entry)
-
-    return entry
-  }
-
-  // Global connection → an entry + the primary designation.
-  let primary = LOCAL_CONNECTION_ID
-  const globalMode = config.mode
-
-  if (modeIsRemoteLike(globalMode)) {
-    const entry = addRemoteLike(config.remote || {}, globalMode === 'cloud' ? 'cloud' : 'remote')
-
-    if (entry) {
-      primary = entry.id
-    }
-  } else if (globalMode === 'ssh') {
-    const entry = addSsh(config.remote || {})
-
-    if (entry) {
-      primary = entry.id
-    }
-  }
-
-  // Per-profile overrides → additional registered sources (deduped).
-  const profiles = config.profiles && typeof config.profiles === 'object' ? config.profiles : {}
-
-  for (const block of Object.values(profiles) as Record<string, any>[]) {
-    if (!block || typeof block !== 'object') {
-      continue
-    }
-
-    if (modeIsRemoteLike(block.mode)) {
-      addRemoteLike(block, block.mode === 'cloud' ? 'cloud' : 'remote')
-    } else if (block.mode === 'ssh') {
-      addSsh(block)
-    } else if (block.mode === 'local' && block.savedSsh) {
-      addSsh(block.savedSsh)
-    }
-  }
-
-  return { version: REGISTRY_VERSION, primary, launchMode: 'primary', lastUsed: primary, connections }
+  return matchingConnectionId(registry, route, 'unique') ?? null
 }
 
-/** Insert or replace by id. Input must already be normalized/validated. */
-export function upsertConnection(registry: ConnectionRegistry, entry: RegistryConnection): ConnectionRegistry {
-  const connections = registry.connections.some(c => c.id === entry.id)
-    ? registry.connections.map(c => (c.id === entry.id ? entry : c))
-    : [...registry.connections, entry]
+function normalizedSshTarget(route: {
+  host?: unknown
+  port?: unknown
+  user?: unknown
+}): null | string {
+  const ssh = normalizeSshConfig({ ...route, mode: 'ssh' })
 
-  return { ...registry, connections }
-}
-
-/**
- * Remove a connection. The local entry is not removable; removing the
- * current primary retargets primary to local.
- */
-export function removeConnection(registry: ConnectionRegistry, id: string): ConnectionRegistry {
-  const target = registry.connections.find(c => c.id === id)
-
-  if (!target) {
-    return registry
+  if (!ssh) {
+    return null
   }
 
-  if (target.kind === 'local') {
-    throw new Error('The local connection cannot be removed.')
-  }
+  const host = String(ssh.host || '')
+    .trim()
+    .toLowerCase()
+  const user = String(ssh.user || '')
+    .trim()
+    .toLowerCase()
 
-  const primary = registry.primary === id ? LOCAL_CONNECTION_ID : registry.primary
-
-  return {
-    ...registry,
-    primary,
-    lastUsed: registry.lastUsed === id ? primary : registry.lastUsed,
-    connections: registry.connections.filter(c => c.id !== id)
-  }
-}
-
-/** Point the window/primary backend at another registered connection. */
-export function setPrimaryConnection(registry: ConnectionRegistry, id: string): ConnectionRegistry {
-  if (!registry.connections.some(c => c.id === id)) {
-    throw new Error(`No connection with id "${id}".`)
-  }
-
-  return { ...registry, primary: id }
-}
-
-/** Remember the last source the Sessions workspace opened successfully. */
-export function setLastUsedConnection(registry: ConnectionRegistry, id: string): ConnectionRegistry {
-  if (!registry.connections.some(c => c.id === id)) {
-    throw new Error(`No connection with id "${id}".`)
-  }
-
-  return { ...registry, lastUsed: id }
-}
-
-/** Choose whether launch restores the explicit primary or the last-used source. */
-export function setConnectionLaunchMode(registry: ConnectionRegistry, launchMode: string): ConnectionRegistry {
-  if (launchMode !== 'last-used' && launchMode !== 'primary') {
-    throw new Error(`Unknown connection launch mode "${String(launchMode)}".`)
-  }
-
-  return { ...registry, launchMode }
+  return user ? `${user}@${host}` : host
 }

--- a/apps/desktop/electron/connection-route-identity.ts
+++ b/apps/desktop/electron/connection-route-identity.ts
@@ -1,0 +1,136 @@
+/**
+ * Canonical registry route identity for Desktop.
+ *
+ * Identity is frozen before dialing, while the complete auth/transport
+ * envelope still exists. Compatibility callers may reuse the same contract,
+ * but must never reconstruct a stronger identity from post-dial metadata.
+ */
+
+import {
+  normalizeRemoteBaseUrl,
+  normalizeRemoteHeaders,
+  normalizeSshConfig,
+  normAuthMode
+} from './connection-config'
+import type { ConnectionRegistry, RegistryConnection } from './connection-registry'
+
+interface SshRouteConfig {
+  host: string
+  keyPath?: string
+  mode: 'ssh'
+  port?: number
+  remoteHermesPath?: string
+  remoteProfile?: string
+  user?: string
+}
+
+export type StoredRoute =
+  | {
+      authMode?: unknown
+      headers?: Record<string, unknown>
+      kind: 'cloud' | 'remote'
+      org?: unknown
+      token?: unknown
+      url?: unknown
+    }
+  | ({ kind: 'ssh' } & Partial<SshRouteConfig>)
+
+function stableValue(value: unknown): string {
+  if (!value || typeof value !== 'object') {
+    return JSON.stringify(value ?? null)
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(stableValue).join(',')}]`
+  }
+
+  return `{${Object.entries(value)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, item]) => `${JSON.stringify(key)}:${stableValue(item)}`)
+    .join(',')}}`
+}
+
+function canonicalHeaders(headers: unknown): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(normalizeRemoteHeaders(headers))
+      .map(([name, value]): [string, unknown] => [name.toLowerCase(), value])
+      .sort(([left], [right]) => left.localeCompare(right))
+  )
+}
+
+function routeIdentity(route: StoredRoute): null | string {
+  if (route.kind === 'ssh') {
+    const ssh = normalizeSshConfig({ ...route, mode: 'ssh' })
+
+    if (!ssh) {
+      return null
+    }
+
+    return stableValue({
+      host: ssh.host,
+      keyPath: ssh.keyPath || '',
+      kind: 'ssh',
+      port: ssh.port || 22,
+      remoteHermesPath: ssh.remoteHermesPath || '',
+      remoteProfile: ssh.remoteProfile || '',
+      user: ssh.user || ''
+    })
+  }
+
+  try {
+    const authMode = normAuthMode(route.authMode)
+
+    return stableValue({
+      authMode,
+      headers: canonicalHeaders(route.headers),
+      kind: route.kind,
+      org: route.kind === 'cloud' ? String(route.org || '').trim() : '',
+      token: authMode === 'token' ? (route.token ?? null) : null,
+      url: normalizeRemoteBaseUrl(route.url)
+    })
+  } catch {
+    return null
+  }
+}
+
+function registryRoute(connection: RegistryConnection): null | StoredRoute {
+  if (connection.kind === 'local') {
+    return null
+  }
+
+  return connection as StoredRoute
+}
+
+/**
+ * Match the complete pre-dial route identity used by #88922.
+ *
+ * `primary` accepts only the configured primary when its full envelope is
+ * equal. `unique` accepts exactly one full-envelope match. Zero and multiple
+ * matches deliberately remain unresolved.
+ */
+export function matchingConnectionId(
+  registry: ConnectionRegistry,
+  route: StoredRoute,
+  strategy: 'primary' | 'unique'
+): undefined | string {
+  const identity = routeIdentity(route)
+
+  if (!identity) {
+    return undefined
+  }
+
+  if (strategy === 'primary') {
+    const primary = registry.connections.find(connection => connection.id === registry.primary)
+    const candidate = primary && registryRoute(primary)
+
+    return candidate && routeIdentity(candidate) === identity ? primary.id : undefined
+  }
+
+  const matches = registry.connections.filter(connection => {
+    const candidate = registryRoute(connection)
+
+    return candidate ? routeIdentity(candidate) === identity : false
+  })
+
+  return matches.length === 1 ? matches[0].id : undefined
+}

--- a/apps/desktop/electron/desktop-remote-route.ts
+++ b/apps/desktop/electron/desktop-remote-route.ts
@@ -1,20 +1,13 @@
-/**
- * Pure route planner for Desktop's legacy v1 connection config. It preserves
- * v2 registry provenance before URL normalization, OAuth, or SSH tunnelling
- * discard dial details. Environment routes deliberately remain unregistered.
- */
-
 import {
   connectionScopeKey,
   modeIsRemoteLike,
-  normalizeRemoteBaseUrl,
-  normalizeRemoteHeaders,
   normalizeSshConfig,
   normAuthMode,
   profileRemoteOverride,
   profileSshOverride
 } from './connection-config'
-import type { ConnectionRegistry, RegistryConnection } from './connection-registry'
+import type { ConnectionRegistry } from './connection-registry'
+import { matchingConnectionId, type StoredRoute } from './connection-route-identity'
 
 type RouteSource = 'env' | 'profile' | 'settings'
 
@@ -52,110 +45,6 @@ export interface DesktopRemoteRouteInput {
   env?: { token?: null | string; url?: null | string }
   profile?: null | string
   registry: ConnectionRegistry
-}
-
-type StoredRoute =
-  | {
-      authMode?: unknown
-      headers?: Record<string, unknown>
-      kind: 'cloud' | 'remote'
-      org?: unknown
-      token?: unknown
-      url?: unknown
-    }
-  | ({ kind: 'ssh' } & Partial<SshRouteConfig>)
-
-function stableValue(value: unknown): string {
-  if (!value || typeof value !== 'object') {
-    return JSON.stringify(value ?? null)
-  }
-
-  if (Array.isArray(value)) {
-    return `[${value.map(stableValue).join(',')}]`
-  }
-
-  return `{${Object.entries(value)
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, item]) => `${JSON.stringify(key)}:${stableValue(item)}`)
-    .join(',')}}`
-}
-
-function canonicalHeaders(headers: unknown): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(normalizeRemoteHeaders(headers))
-      .map(([name, value]): [string, unknown] => [name.toLowerCase(), value])
-      .sort(([left], [right]) => left.localeCompare(right))
-  )
-}
-
-function routeIdentity(route: StoredRoute): null | string {
-  if (route.kind === 'ssh') {
-    const ssh = normalizeSshConfig({ ...route, mode: 'ssh' })
-
-    if (!ssh) {
-      return null
-    }
-
-    return stableValue({
-      host: ssh.host,
-      keyPath: ssh.keyPath || '',
-      kind: 'ssh',
-      port: ssh.port || 22,
-      remoteHermesPath: ssh.remoteHermesPath || '',
-      remoteProfile: ssh.remoteProfile || '',
-      user: ssh.user || ''
-    })
-  }
-
-  try {
-    const authMode = normAuthMode(route.authMode)
-
-    return stableValue({
-      authMode,
-      headers: canonicalHeaders(route.headers),
-      kind: route.kind,
-      org: route.kind === 'cloud' ? String(route.org || '').trim() : '',
-      token: authMode === 'token' ? (route.token ?? null) : null,
-      url: normalizeRemoteBaseUrl(route.url)
-    })
-  } catch {
-    return null
-  }
-}
-
-function registryRoute(connection: RegistryConnection): null | StoredRoute {
-  if (connection.kind === 'local') {
-    return null
-  }
-
-  return connection as StoredRoute
-}
-
-function matchingConnectionId(
-  registry: ConnectionRegistry,
-  route: StoredRoute,
-  strategy: 'primary' | 'unique'
-): undefined | string {
-  const identity = routeIdentity(route)
-
-  if (!identity) {
-    return undefined
-  }
-
-  if (strategy === 'primary') {
-    const primary = registry.connections.find(connection => connection.id === registry.primary)
-    const candidate = primary && registryRoute(primary)
-
-    return candidate && routeIdentity(candidate) === identity ? primary.id : undefined
-  }
-
-  const matches = registry.connections.filter(connection => {
-    const candidate = registryRoute(connection)
-
-    return candidate ? routeIdentity(candidate) === identity : false
-  })
-
-  return matches.length === 1 ? matches[0].id : undefined
 }
 
 function withConnectionId<T extends object>(route: T, connectionId?: string): T & { connectionId?: string } {


### PR DESCRIPTION
## Summary

Follow-up to merged #89719. The registry bridge was still inferring identity from endpoint shape even when a descriptor was already registry-qualified, and legacy inference selected the first endpoint match.

This closes that residual contract:

- an explicitly present `connectionId` is authoritative only when it exactly names a registered connection;
- explicit blank, null, undefined, or unknown IDs fail closed and never fall back to endpoint inference;
- only descriptors with no `connectionId` property use the v1 compatibility bridge;
- legacy local, SSH, and URL inference succeeds only for exactly one match; zero or multiple matches fail closed.

## Proof

Adds focused witnesses for:

- authoritative ID despite contradictory endpoint fields;
- invalid explicit qualification with a misleading inferable endpoint;
- unique legacy local/SSH/URL compatibility;
- ambiguous URL, SSH, and local matches.

Built directly on current `main` parent `f43eabee5f36e11448086ee8ee17c499958e81bf`; the commit diff is limited to the helper and a focused test file.

## Topology / provenance

Follow-up to #89719 and #88325. This does not replace the original multi-connection work or its authorship; it closes the post-merge identity-authority residual.