### PR TITLE
feat(skills): add agenda skill for goal and task queue tracking

### DIFF
--- a/skills/productivity/agenda/SKILL.md
+++ b/skills/productivity/agenda/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: agenda
+description: Track prioritized, recurring, and one-off agenda items.
+version: 0.1.0
+author: Thamer (taljeri), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Agenda, Goals, Task-Management, Priority, Productivity]
+    category: productivity
+    related_skills: [weekly-review-planning, session-librarian]
+---
+
+# Agenda Skill
+
+Manage prioritized, recurring, and one-off goal items with an SQLite-backed queue and CLI manager. The skill supports domain categorization, cooldown-based recurring schedules, post-mortem outcome logging, and spontaneous idea ("spark") tracking.
+
+Zero external dependencies: uses Python standard library `sqlite3` and stores data in the profile-aware Hermes directory (`~/.hermes/agenda.db`).
+
+## When to Use
+
+- "Add a task to my agenda / goal list"
+- "What is the next priority item on my agenda?"
+- "Mark task #42 as done with outcome notes"
+- "Show me my pending agenda items"
+- "I have a quick idea / spark to log for later review"
+- Setting up an autonomous recurring cron loop to surface high-priority goals
+
+Don't use for:
+- Session-level chat organization (use `session-librarian` instead)
+- Calendar event scheduling (use `google-workspace` or native calendar tools)
+
+## Prerequisites
+
+- Python 3.9+ with standard library `sqlite3` (no third-party pip dependencies required).
+- Database automatically initializes in `~/.hermes/agenda.db` on first execution (or customize via `HERMES_AGENDA_DB`).
+
+## How to Run
+
+Execute commands through the `terminal` tool pointing to the bundled script:
+
+```bash
+# Add a task
+python3 skills/productivity/agenda/scripts/agenda.py add "Read research paper" --domain research --priority 1 --detail "Review section 3 methodology"
+
+# Get next prioritized item and mark active
+python3 skills/productivity/agenda/scripts/agenda.py next --n 1 --json
+
+# Complete item with outcome notes
+python3 skills/productivity/agenda/scripts/agenda.py done 1 --outcome "Identified key benchmark metrics"
+
+# Capture a raw idea
+python3 skills/productivity/agenda/scripts/agenda.py spark "Build automated benchmark harness" --domain research
+```
+
+## Quick Reference
+
+| Task | Command |
+|---|---|
+| Surface next item(s) | `python3 skills/productivity/agenda/scripts/agenda.py next [--n N] [--domain D] [--json]` |
+| Add new item | `python3 skills/productivity/agenda/scripts/agenda.py add "<title>" [--priority 1-5] [--cooldown N]` |
+| List items | `python3 skills/productivity/agenda/scripts/agenda.py list [--status S] [--domain D] [--limit N]` |
+| Complete item | `python3 skills/productivity/agenda/scripts/agenda.py done <id> [--outcome "<summary>"]` |
+| Record spark idea | `python3 skills/productivity/agenda/scripts/agenda.py spark "<idea>" [--observation "<obs>"]` |
+| List sparks | `python3 skills/productivity/agenda/scripts/agenda.py sparks [--status S]` |
+| Summary status | `python3 skills/productivity/agenda/scripts/agenda.py status [--json]` |
+
+## Architecture & Data Model
+
+The database contains three interconnected tables:
+
+1. **`agenda`**: Core task records.
+   - `priority`: Integer scale (`1` = highest urgency, `5` = low urgency).
+   - `status`: Lifecycle states: `pending` → `active` → `done` (or `recurring`).
+   - `cooldown_days`: For recurring items; re-arms when completed.
+2. **`log`**: Audit trail of completed items with timestamp and execution outcome.
+3. **`sparks`**: Unstructured observations and nascent ideas evaluated for promotion into full agenda items.
+
+Reference SQL schema: [references/schema.sql](file:///skills/productivity/agenda/references/schema.sql)
+
+## Procedure
+
+### 1. Adding & Categorizing Tasks
+When a user expresses a goal or task:
+1. Determine `title`, `domain` (e.g. `research`, `skill`, `dev`, `personal`), `kind` (`paper`, `experiment`, `bugfix`, `feature`), and `priority` (1-5, default 3).
+2. For recurring tasks (e.g. weekly review), specify `--cooldown <days>`.
+3. Call `terminal(command="python3 skills/productivity/agenda/scripts/agenda.py add ...")`.
+
+### 2. Surfacing & Executing the Next Item
+1. Retrieve the top item using `terminal(command="python3 skills/productivity/agenda/scripts/agenda.py next --n 1 --json")`.
+2. Present the task details, priority, and steps to the user.
+3. Perform the requested work or delegate subtasks.
+
+### 3. Completing Tasks & Logging Outcomes
+1. Once completed, invoke `terminal(command="python3 skills/productivity/agenda/scripts/agenda.py done <id> --outcome \"<summary>\"")`.
+2. This records execution history in `log` and transitions recurring items cleanly.
+
+### 4. Capturing Raw Sparks
+When an unexpected finding or idea emerges during a session:
+1. Log it with `terminal(command="python3 skills/productivity/agenda/scripts/agenda.py spark \"<idea>\" --observation \"<context>\"")`.
+2. Review sparks during weekly planning sessions (`weekly-review-planning`).
+
+## Autonomous Loop & Cron Integration
+
+You can set up a recurring Hermes cronjob to periodically inspect and surface pending agenda items:
+
+```bash
+hermes cron create \
+  --name "Agenda Surfacer" \
+  --schedule "0 9 * * 1-5" \
+  --prompt "Check the next high-priority agenda item using python3 skills/productivity/agenda/scripts/agenda.py next --n 1, and present a morning briefing."
+```
+
+## Pitfalls
+
+- **Priority ordering:** Priority `1` is highest (top of queue), `5` is lowest. Do not invert the scale.
+- **Atomic state transition:** `next` automatically sets status to `active` so subsequent concurrent queries do not double-dispatch the same task.
+- **Recurring items:** Recurring tasks (`cooldown_days > 0`) transition back to `recurring` status upon `done`, preserving `times_done` counters.
+
+## Verification
+
+Verify functionality by running status and retrieval checks:
+```bash
+python3 skills/productivity/agenda/scripts/agenda.py status
+python3 skills/productivity/agenda/scripts/agenda.py list --limit 5
+```

--- a/skills/productivity/agenda/references/schema.sql
+++ b/skills/productivity/agenda/references/schema.sql
@@ -1,0 +1,46 @@
+-- SQLite schema for Hermes Agenda system
+CREATE TABLE IF NOT EXISTS agenda (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    domain TEXT,                  -- e.g., 'research', 'skill', 'voice', 'health', 'code'
+    kind TEXT,                    -- e.g., 'paper', 'experiment', 'bugfix', 'feature'
+    title TEXT NOT NULL,          -- short summary / task title
+    detail TEXT,                  -- steps, context, or reference links
+    priority INTEGER DEFAULT 3,   -- 1 = highest, 5 = lowest
+    status TEXT DEFAULT 'pending',-- pending | active | done | recurring
+    cooldown_days INTEGER DEFAULT 0, -- >0 => recurring, re-arms after cooldown days
+    last_done TEXT,               -- ISO-8601 timestamp when last completed
+    times_done INTEGER DEFAULT 0, -- execution count
+    created TEXT NOT NULL,        -- ISO-8601 creation timestamp
+    note TEXT,                    -- free-form execution notes
+    surfaced INTEGER DEFAULT 0    -- 1 if already surfaced in a check-in
+);
+
+CREATE TABLE IF NOT EXISTS log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts TEXT NOT NULL,             -- ISO-8601 timestamp
+    agenda_id INTEGER NOT NULL,
+    title TEXT,
+    outcome TEXT,
+    surfaced INTEGER DEFAULT 0,
+    FOREIGN KEY (agenda_id) REFERENCES agenda(id)
+);
+
+CREATE TABLE IF NOT EXISTS sparks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    observation TEXT,             -- raw observation that sparked the idea
+    idea TEXT NOT NULL,           -- the idea itself
+    domain TEXT,                  -- topical domain
+    score REAL,                   -- heuristic score (0.0 - 1.0)
+    confidence REAL,              -- confidence estimate (0.0 - 1.0)
+    decision TEXT,                -- 'pursue', 'defer', 'reject'
+    status TEXT DEFAULT 'open',   -- open | pursued | declined
+    kill_criteria TEXT,           -- falsification criteria
+    created TEXT NOT NULL,        -- ISO-8601 creation timestamp
+    note TEXT
+);
+
+-- Indexes for fast queue queries and status rollups
+CREATE INDEX IF NOT EXISTS idx_agenda_priority_status ON agenda(priority, status);
+CREATE INDEX IF NOT EXISTS idx_agenda_domain_kind ON agenda(domain, kind);
+CREATE INDEX IF NOT EXISTS idx_log_agenda_id ON log(agenda_id);
+CREATE INDEX IF NOT EXISTS idx_sparks_domain ON sparks(domain);

--- a/skills/productivity/agenda/scripts/agenda.py
+++ b/skills/productivity/agenda/scripts/agenda.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""agenda.py — Process Hermes agenda SQLite database from CLI.
+
+Usage:
+  agenda.py next [--n N] [--domain DOMAIN] [--json]
+  agenda.py list [--status STATUS] [--domain DOMAIN] [--limit N] [--json]
+  agenda.py add "<title>" [--detail "<detail>"] [--domain DOMAIN] [--kind KIND] [--priority N] [--cooldown N] [--json]
+  agenda.py done <id> [--outcome "<outcome>"] [--json]
+  agenda.py spark "<idea>" [--observation "<obs>"] [--domain DOMAIN] [--score S] [--confidence C] [--json]
+  agenda.py sparks [--status STATUS] [--json]
+  agenda.py status [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS agenda (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    domain TEXT,
+    kind TEXT,
+    title TEXT NOT NULL,
+    detail TEXT,
+    priority INTEGER DEFAULT 3,
+    status TEXT DEFAULT 'pending',
+    cooldown_days INTEGER DEFAULT 0,
+    last_done TEXT,
+    times_done INTEGER DEFAULT 0,
+    created TEXT NOT NULL,
+    note TEXT,
+    surfaced INTEGER DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts TEXT NOT NULL,
+    agenda_id INTEGER NOT NULL,
+    title TEXT,
+    outcome TEXT,
+    surfaced INTEGER DEFAULT 0,
+    FOREIGN KEY (agenda_id) REFERENCES agenda(id)
+);
+
+CREATE TABLE IF NOT EXISTS sparks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    observation TEXT,
+    idea TEXT NOT NULL,
+    domain TEXT,
+    score REAL,
+    confidence REAL,
+    decision TEXT,
+    status TEXT DEFAULT 'open',
+    kill_criteria TEXT,
+    created TEXT NOT NULL,
+    note TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_agenda_priority_status ON agenda(priority, status);
+CREATE INDEX IF NOT EXISTS idx_agenda_domain_kind ON agenda(domain, kind);
+CREATE INDEX IF NOT EXISTS idx_log_agenda_id ON log(agenda_id);
+CREATE INDEX IF NOT EXISTS idx_sparks_domain ON sparks(domain);
+"""
+
+
+def _get_default_db_path() -> Path:
+    env_override = os.environ.get("HERMES_AGENDA_DB")
+    if env_override and env_override.strip():
+        return Path(env_override.strip()).expanduser().resolve()
+
+    try:
+        from hermes_constants import get_hermes_home
+        return get_hermes_home() / "agenda.db"
+    except Exception:
+        home = Path.home()
+        hermes_dir = home / ".hermes"
+        if hermes_dir.exists() and hermes_dir.is_dir():
+            return hermes_dir / "agenda.db"
+        return home / ".hermes" / "agenda.db"
+
+
+def get_conn(db_path: Optional[Path] = None) -> sqlite3.Connection:
+    path = db_path or _get_default_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    with conn:
+        conn.executescript(SCHEMA_SQL)
+    return conn
+
+
+def now_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def add_item(
+    title: str,
+    *,
+    detail: str = "",
+    domain: str = "general",
+    kind: str = "task",
+    priority: int = 3,
+    cooldown_days: int = 0,
+    db_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    created = now_iso()
+    status = "recurring" if cooldown_days > 0 else "pending"
+    conn = get_conn(db_path)
+    with conn:
+        cur = conn.execute(
+            """
+            INSERT INTO agenda (domain, kind, title, detail, priority, status, cooldown_days, created)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (domain, kind, title, detail, priority, status, cooldown_days, created),
+        )
+        item_id = cur.lastrowid
+        cur = conn.execute("SELECT * FROM agenda WHERE id = ?", (item_id,))
+        row = dict(cur.fetchone())
+    conn.close()
+    return row
+
+
+def list_items(
+    *,
+    status: Optional[str] = None,
+    domain: Optional[str] = None,
+    limit: int = 20,
+    db_path: Optional[Path] = None,
+) -> List[Dict[str, Any]]:
+    conn = get_conn(db_path)
+    query = "SELECT * FROM agenda WHERE 1=1"
+    params: List[Any] = []
+    if status:
+        query += " AND status = ?"
+        params.append(status)
+    if domain:
+        query += " AND domain = ?"
+        params.append(domain)
+    query += " ORDER BY priority ASC, created ASC LIMIT ?"
+    params.append(limit)
+
+    cur = conn.execute(query, params)
+    rows = [dict(r) for r in cur.fetchall()]
+    conn.close()
+    return rows
+
+
+def next_items(
+    n: int = 1,
+    *,
+    domain: Optional[str] = None,
+    db_path: Optional[Path] = None,
+) -> List[Dict[str, Any]]:
+    conn = get_conn(db_path)
+    query = "SELECT * FROM agenda WHERE status IN ('pending', 'recurring')"
+    params: List[Any] = []
+    if domain:
+        query += " AND domain = ?"
+        params.append(domain)
+    query += " ORDER BY priority ASC, created ASC LIMIT ?"
+    params.append(n)
+
+    cur = conn.execute(query, params)
+    rows = [dict(r) for r in cur.fetchall()]
+    if rows:
+        ids = [r["id"] for r in rows]
+        placeholders = ",".join("?" for _ in ids)
+        with conn:
+            conn.execute(
+                f"UPDATE agenda SET status = 'active', surfaced = 1 WHERE id IN ({placeholders})",
+                ids,
+            )
+    conn.close()
+    return rows
+
+
+def done_item(
+    item_id: int,
+    *,
+    outcome: str = "",
+    db_path: Optional[Path] = None,
+) -> Optional[Dict[str, Any]]:
+    ts = now_iso()
+    conn = get_conn(db_path)
+    cur = conn.execute("SELECT * FROM agenda WHERE id = ?", (item_id,))
+    item = cur.fetchone()
+    if not item:
+        conn.close()
+        return None
+
+    item_dict = dict(item)
+    cooldown = item_dict.get("cooldown_days") or 0
+    new_status = "recurring" if cooldown > 0 else "done"
+
+    with conn:
+        conn.execute(
+            """
+            UPDATE agenda
+            SET status = ?, times_done = COALESCE(times_done, 0) + 1, last_done = ?
+            WHERE id = ?
+            """,
+            (new_status, ts, item_id),
+        )
+        conn.execute(
+            """
+            INSERT INTO log (ts, agenda_id, title, outcome)
+            VALUES (?, ?, ?, ?)
+            """,
+            (ts, item_id, item_dict["title"], outcome),
+        )
+        cur = conn.execute("SELECT * FROM agenda WHERE id = ?", (item_id,))
+        updated = dict(cur.fetchone())
+    conn.close()
+    return updated
+
+
+def add_spark(
+    idea: str,
+    *,
+    observation: str = "",
+    domain: str = "general",
+    score: Optional[float] = None,
+    confidence: Optional[float] = None,
+    kill_criteria: str = "",
+    db_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    created = now_iso()
+    conn = get_conn(db_path)
+    with conn:
+        cur = conn.execute(
+            """
+            INSERT INTO sparks (observation, idea, domain, score, confidence, decision, status, kill_criteria, created)
+            VALUES (?, ?, ?, ?, ?, 'open', 'open', ?, ?)
+            """,
+            (observation, idea, domain, score, confidence, kill_criteria, created),
+        )
+        spark_id = cur.lastrowid
+        cur = conn.execute("SELECT * FROM sparks WHERE id = ?", (spark_id,))
+        row = dict(cur.fetchone())
+    conn.close()
+    return row
+
+
+def list_sparks(
+    *,
+    status: Optional[str] = None,
+    limit: int = 20,
+    db_path: Optional[Path] = None,
+) -> List[Dict[str, Any]]:
+    conn = get_conn(db_path)
+    query = "SELECT * FROM sparks WHERE 1=1"
+    params: List[Any] = []
+    if status:
+        query += " AND status = ?"
+        params.append(status)
+    query += " ORDER BY id DESC LIMIT ?"
+    params.append(limit)
+
+    cur = conn.execute(query, params)
+    rows = [dict(r) for r in cur.fetchall()]
+    conn.close()
+    return rows
+
+
+def get_status(db_path: Optional[Path] = None) -> Dict[str, Any]:
+    conn = get_conn(db_path)
+    cur = conn.execute("SELECT status, COUNT(*) as cnt FROM agenda GROUP BY status")
+    by_status = {r["status"]: r["cnt"] for r in cur.fetchall()}
+
+    cur = conn.execute("SELECT domain, COUNT(*) as cnt FROM agenda GROUP BY domain")
+    by_domain = {r["domain"]: r["cnt"] for r in cur.fetchall()}
+
+    cur = conn.execute("SELECT COUNT(*) as cnt FROM sparks WHERE status = 'open'")
+    open_sparks = cur.fetchone()["cnt"]
+
+    cur = conn.execute("SELECT COUNT(*) as cnt FROM log")
+    logged_outcomes = cur.fetchone()["cnt"]
+    conn.close()
+
+    return {
+        "status_counts": by_status,
+        "domain_counts": by_domain,
+        "open_sparks": open_sparks,
+        "logged_outcomes": logged_outcomes,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Hermes Agenda goal and task tracking CLI.")
+    parser.add_argument("--db", type=Path, default=None, help="Custom SQLite database path.")
+    parser.add_argument("--json", action="store_true", help="Format output as JSON.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # next
+    p_next = subparsers.add_parser("next", help="Get next pending/recurring items and mark active.")
+    p_next.add_argument("--n", type=int, default=1, help="Number of items to retrieve.")
+    p_next.add_argument("--domain", type=str, default=None, help="Filter by domain.")
+
+    # list
+    p_list = subparsers.add_parser("list", help="List agenda items.")
+    p_list.add_argument("--status", type=str, default=None, help="Filter by status.")
+    p_list.add_argument("--domain", type=str, default=None, help="Filter by domain.")
+    p_list.add_argument("--limit", type=int, default=20, help="Max items to list.")
+
+    # add
+    p_add = subparsers.add_parser("add", help="Add a new agenda item.")
+    p_add.add_argument("title", type=str, help="Task title.")
+    p_add.add_argument("--detail", type=str, default="", help="Detailed instructions or context.")
+    p_add.add_argument("--domain", type=str, default="general", help="Domain area.")
+    p_add.add_argument("--kind", type=str, default="task", help="Item kind (e.g. paper, bugfix, experiment).")
+    p_add.add_argument("--priority", type=int, default=3, help="Priority (1=highest, 5=lowest).")
+    p_add.add_argument("--cooldown", type=int, default=0, help="Recurring cooldown in days.")
+
+    # done
+    p_done = subparsers.add_parser("done", help="Mark an agenda item as completed.")
+    p_done.add_argument("id", type=int, help="Agenda item ID.")
+    p_done.add_argument("--outcome", type=str, default="", help="Outcome or execution summary.")
+
+    # spark
+    p_spark = subparsers.add_parser("spark", help="Record a new idea or raw observation.")
+    p_spark.add_argument("idea", type=str, help="Idea summary.")
+    p_spark.add_argument("--observation", type=str, default="", help="Context or raw observation.")
+    p_spark.add_argument("--domain", type=str, default="general", help="Topic domain.")
+    p_spark.add_argument("--score", type=float, default=None, help="Heuristic score (0.0-1.0).")
+    p_spark.add_argument("--confidence", type=float, default=None, help="Confidence (0.0-1.0).")
+    p_spark.add_argument("--kill-criteria", type=str, default="", help="What would falsify this idea?")
+
+    # sparks
+    p_sparks = subparsers.add_parser("sparks", help="List captured sparks.")
+    p_sparks.add_argument("--status", type=str, default=None, help="Filter sparks by status.")
+    p_sparks.add_argument("--limit", type=int, default=20, help="Limit number of sparks.")
+
+    # status
+    subparsers.add_parser("status", help="Get summary status statistics.")
+
+    args = parser.parse_args()
+    db = args.db
+
+    if args.command == "next":
+        items = next_items(args.n, domain=args.domain, db_path=db)
+        if args.json:
+            print(json.dumps(items, indent=2))
+        else:
+            if not items:
+                print("No pending agenda items found.")
+            for it in items:
+                print(f"[#{it['id']}] (Priority {it['priority']}) [{it['domain']}/{it['kind']}] {it['title']}")
+                if it.get("detail"):
+                    print(f"    Detail: {it['detail']}")
+
+    elif args.command == "list":
+        items = list_items(status=args.status, domain=args.domain, limit=args.limit, db_path=db)
+        if args.json:
+            print(json.dumps(items, indent=2))
+        else:
+            if not items:
+                print("No agenda items found matching criteria.")
+            for it in items:
+                print(f"#{it['id']}: [{it['status']}] (P{it['priority']}) {it['title']}")
+
+    elif args.command == "add":
+        item = add_item(
+            args.title,
+            detail=args.detail,
+            domain=args.domain,
+            kind=args.kind,
+            priority=args.priority,
+            cooldown_days=args.cooldown,
+            db_path=db,
+        )
+        if args.json:
+            print(json.dumps(item, indent=2))
+        else:
+            print(f"Added agenda item #{item['id']}: [{item['status']}] {item['title']} (Priority {item['priority']})")
+
+    elif args.command == "done":
+        item = done_item(args.id, outcome=args.outcome, db_path=db)
+        if not item:
+            print(f"Agenda item #{args.id} not found.", file=sys.stderr)
+            sys.exit(1)
+        if args.json:
+            print(json.dumps(item, indent=2))
+        else:
+            print(f"Marked #{args.id} as {item['status']} (completed {item['times_done']}x).")
+
+    elif args.command == "spark":
+        sp = add_spark(
+            args.idea,
+            observation=args.observation,
+            domain=args.domain,
+            score=args.score,
+            confidence=args.confidence,
+            kill_criteria=args.kill_criteria,
+            db_path=db,
+        )
+        if args.json:
+            print(json.dumps(sp, indent=2))
+        else:
+            print(f"Logged spark #{sp['id']}: {sp['idea']}")
+
+    elif args.command == "sparks":
+        sparks = list_sparks(status=args.status, limit=args.limit, db_path=db)
+        if args.json:
+            print(json.dumps(sparks, indent=2))
+        else:
+            if not sparks:
+                print("No sparks found.")
+            for s in sparks:
+                print(f"#{s['id']}: [{s['status']}] {s['idea']}")
+
+    elif args.command == "status":
+        st = get_status(db_path=db)
+        if args.json:
+            print(json.dumps(st, indent=2))
+        else:
+            print("Agenda Status Summary:")
+            print(f"  Status breakdown: {st['status_counts']}")
+            print(f"  Domain breakdown: {st['domain_counts']}")
+            print(f"  Open sparks: {st['open_sparks']}")
+            print(f"  Completed logs: {st['logged_outcomes']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/skills/test_agenda_skill.py
+++ b/tests/skills/test_agenda_skill.py
@@ -1,0 +1,173 @@
+"""
+Tests for the Hermes Agenda skill (skills/productivity/agenda).
+
+Covers:
+- Database schema auto-creation
+- Adding agenda items with domains, priorities, and details
+- Priority ordering (P1 before P3, FIFO for same priority)
+- Next item retrieval and state transition (pending -> active)
+- Completing items and recording outcomes in the log table
+- Recurring items cooldown retention
+- Idea sparks creation and listing
+- Status reporting aggregation
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENDA_SCRIPT = REPO_ROOT / "skills" / "productivity" / "agenda" / "scripts" / "agenda.py"
+
+# Import functions directly from agenda.py
+sys.path.insert(0, str(AGENDA_SCRIPT.parent))
+import agenda
+
+
+@pytest.fixture
+def temp_db(tmp_path):
+    return tmp_path / "test_agenda.db"
+
+
+class TestAgendaDirectAPI:
+    def test_auto_initializes_db_and_tables(self, temp_db):
+        conn = agenda.get_conn(temp_db)
+        cur = conn.cursor()
+        cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        tables = {row[0] for row in cur.fetchall()}
+        conn.close()
+        assert "agenda" in tables
+        assert "log" in tables
+        assert "sparks" in tables
+
+    def test_add_and_list_items(self, temp_db):
+        item = agenda.add_item(
+            "Read AI benchmark paper",
+            detail="Check section 4 results",
+            domain="research",
+            kind="paper",
+            priority=1,
+            db_path=temp_db,
+        )
+        assert item["id"] == 1
+        assert item["title"] == "Read AI benchmark paper"
+        assert item["priority"] == 1
+        assert item["status"] == "pending"
+
+        items = agenda.list_items(db_path=temp_db)
+        assert len(items) == 1
+        assert items[0]["title"] == "Read AI benchmark paper"
+
+    def test_priority_ordering_in_next_items(self, temp_db):
+        agenda.add_item("Low priority chore", priority=4, db_path=temp_db)
+        agenda.add_item("Urgent bug fix", priority=1, db_path=temp_db)
+        agenda.add_item("Medium priority task", priority=2, db_path=temp_db)
+
+        next_items = agenda.next_items(n=2, db_path=temp_db)
+        assert len(next_items) == 2
+        assert next_items[0]["title"] == "Urgent bug fix"
+        assert next_items[0]["status"] == "pending"  # returned row was pending, now active in DB
+        assert next_items[1]["title"] == "Medium priority task"
+
+        # Verify DB updated to active
+        active_items = agenda.list_items(status="active", db_path=temp_db)
+        assert len(active_items) == 2
+
+    def test_done_item_and_logging(self, temp_db):
+        item = agenda.add_item("Write docs", priority=2, db_path=temp_db)
+        done = agenda.done_item(item["id"], outcome="Completed all sections", db_path=temp_db)
+        assert done is not None
+        assert done["status"] == "done"
+        assert done["times_done"] == 1
+        assert done["last_done"] is not None
+
+        conn = agenda.get_conn(temp_db)
+        cur = conn.cursor()
+        cur.execute("SELECT * FROM log WHERE agenda_id = ?", (item["id"],))
+        log_entry = cur.fetchone()
+        conn.close()
+        assert log_entry is not None
+        assert log_entry["outcome"] == "Completed all sections"
+
+    def test_recurring_item_cooldown(self, temp_db):
+        item = agenda.add_item("Weekly status review", priority=2, cooldown_days=7, db_path=temp_db)
+        assert item["status"] == "recurring"
+
+        done = agenda.done_item(item["id"], outcome="Sprint 1 review done", db_path=temp_db)
+        assert done["status"] == "recurring"
+        assert done["times_done"] == 1
+
+    def test_sparks_recording(self, temp_db):
+        spark = agenda.add_spark(
+            "Train dynamic memory retrieval agent",
+            observation="Observed high recall in test runs",
+            domain="ml",
+            score=0.9,
+            db_path=temp_db,
+        )
+        assert spark["id"] == 1
+        assert spark["idea"] == "Train dynamic memory retrieval agent"
+        assert spark["score"] == 0.9
+
+        sparks = agenda.list_sparks(db_path=temp_db)
+        assert len(sparks) == 1
+
+    def test_status_reporting(self, temp_db):
+        agenda.add_item("Task 1", domain="research", db_path=temp_db)
+        agenda.add_item("Task 2", domain="dev", db_path=temp_db)
+        agenda.add_spark("Idea 1", domain="research", db_path=temp_db)
+
+        st = agenda.get_status(db_path=temp_db)
+        assert st["status_counts"]["pending"] == 2
+        assert st["domain_counts"]["research"] == 1
+        assert st["domain_counts"]["dev"] == 1
+        assert st["open_sparks"] == 1
+
+
+class TestAgendaCLI:
+    def test_cli_add_and_next_json(self, temp_db):
+        # Add item via CLI
+        res = subprocess.run(
+            [
+                sys.executable,
+                str(AGENDA_SCRIPT),
+                "--db",
+                str(temp_db),
+                "--json",
+                "add",
+                "CLI Task Test",
+                "--priority",
+                "1",
+                "--domain",
+                "testing",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        data = json.loads(res.stdout)
+        assert data["title"] == "CLI Task Test"
+        assert data["priority"] == 1
+
+        # Next item via CLI
+        res = subprocess.run(
+            [
+                sys.executable,
+                str(AGENDA_SCRIPT),
+                "--db",
+                str(temp_db),
+                "--json",
+                "next",
+                "--n",
+                "1",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        items = json.loads(res.stdout)
+        assert len(items) == 1
+        assert items[0]["title"] == "CLI Task Test"

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -99,6 +99,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 
 | Skill | Description | Path |
 |-------|-------------|------|
+| [`agenda`](/docs/user-guide/skills/bundled/productivity/productivity-agenda) | Track prioritized, recurring, and one-off agenda items. | `productivity/agenda` |
 | [`airtable`](/docs/user-guide/skills/bundled/productivity/productivity-airtable) | Airtable REST API via curl. Records CRUD, filters, upserts. | `productivity/airtable` |
 | [`box`](/docs/user-guide/skills/bundled/productivity/productivity-box) | Box manages cloud files, sharing, search, and metadata. | `productivity/box` |
 | [`document-to-action-items`](/docs/user-guide/skills/bundled/productivity/productivity-document-to-action-items) | Extract cited obligations, deadlines, tasks from documents. | `productivity/document-to-action-items` |

--- a/website/docs/user-guide/skills/bundled/productivity/productivity-agenda.md
+++ b/website/docs/user-guide/skills/bundled/productivity/productivity-agenda.md
@@ -1,0 +1,144 @@
+---
+title: "Agenda — Track prioritized, recurring, and one-off agenda items"
+sidebar_label: "Agenda"
+description: "Track prioritized, recurring, and one-off agenda items"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Agenda
+
+Track prioritized, recurring, and one-off agenda items.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/productivity/agenda` |
+| Version | `0.1.0` |
+| Author | Thamer (taljeri), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `Agenda`, `Goals`, `Task-Management`, `Priority`, `Productivity` |
+| Related skills | [`weekly-review-planning`](/docs/user-guide/skills/bundled/productivity/productivity-weekly-review-planning), [`session-librarian`](/docs/user-guide/skills/bundled/productivity/productivity-session-librarian) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Agenda Skill
+
+Manage prioritized, recurring, and one-off goal items with an SQLite-backed queue and CLI manager. The skill supports domain categorization, cooldown-based recurring schedules, post-mortem outcome logging, and spontaneous idea ("spark") tracking.
+
+Zero external dependencies: uses Python standard library `sqlite3` and stores data in the profile-aware Hermes directory (`~/.hermes/agenda.db`).
+
+## When to Use
+
+- "Add a task to my agenda / goal list"
+- "What is the next priority item on my agenda?"
+- "Mark task #42 as done with outcome notes"
+- "Show me my pending agenda items"
+- "I have a quick idea / spark to log for later review"
+- Setting up an autonomous recurring cron loop to surface high-priority goals
+
+Don't use for:
+- Session-level chat organization (use `session-librarian` instead)
+- Calendar event scheduling (use `google-workspace` or native calendar tools)
+
+## Prerequisites
+
+- Python 3.9+ with standard library `sqlite3` (no third-party pip dependencies required).
+- Database automatically initializes in `~/.hermes/agenda.db` on first execution (or customize via `HERMES_AGENDA_DB`).
+
+## How to Run
+
+Execute commands through the `terminal` tool pointing to the bundled script:
+
+```bash
+# Add a task
+python3 skills/productivity/agenda/scripts/agenda.py add "Read research paper" --domain research --priority 1 --detail "Review section 3 methodology"
+
+# Get next prioritized item and mark active
+python3 skills/productivity/agenda/scripts/agenda.py next --n 1 --json
+
+# Complete item with outcome notes
+python3 skills/productivity/agenda/scripts/agenda.py done 1 --outcome "Identified key benchmark metrics"
+
+# Capture a raw idea
+python3 skills/productivity/agenda/scripts/agenda.py spark "Build automated benchmark harness" --domain research
+```
+
+## Quick Reference
+
+| Task | Command |
+|---|---|
+| Surface next item(s) | `python3 skills/productivity/agenda/scripts/agenda.py next [--n N] [--domain D] [--json]` |
+| Add new item | `python3 skills/productivity/agenda/scripts/agenda.py add "<title>" [--priority 1-5] [--cooldown N]` |
+| List items | `python3 skills/productivity/agenda/scripts/agenda.py list [--status S] [--domain D] [--limit N]` |
+| Complete item | `python3 skills/productivity/agenda/scripts/agenda.py done <id> [--outcome "<summary>"]` |
+| Record spark idea | `python3 skills/productivity/agenda/scripts/agenda.py spark "<idea>" [--observation "<obs>"]` |
+| List sparks | `python3 skills/productivity/agenda/scripts/agenda.py sparks [--status S]` |
+| Summary status | `python3 skills/productivity/agenda/scripts/agenda.py status [--json]` |
+
+## Architecture & Data Model
+
+The database contains three interconnected tables:
+
+1. **`agenda`**: Core task records.
+   - `priority`: Integer scale (`1` = highest urgency, `5` = low urgency).
+   - `status`: Lifecycle states: `pending` → `active` → `done` (or `recurring`).
+   - `cooldown_days`: For recurring items; re-arms when completed.
+2. **`log`**: Audit trail of completed items with timestamp and execution outcome.
+3. **`sparks`**: Unstructured observations and nascent ideas evaluated for promotion into full agenda items.
+
+Reference SQL schema: [references/schema.sql](file:///skills/productivity/agenda/references/schema.sql)
+
+## Procedure
+
+### 1. Adding & Categorizing Tasks
+When a user expresses a goal or task:
+1. Determine `title`, `domain` (e.g. `research`, `skill`, `dev`, `personal`), `kind` (`paper`, `experiment`, `bugfix`, `feature`), and `priority` (1-5, default 3).
+2. For recurring tasks (e.g. weekly review), specify `--cooldown <days>`.
+3. Call `terminal(command="python3 skills/productivity/agenda/scripts/agenda.py add ...")`.
+
+### 2. Surfacing & Executing the Next Item
+1. Retrieve the top item using `terminal(command="python3 skills/productivity/agenda/scripts/agenda.py next --n 1 --json")`.
+2. Present the task details, priority, and steps to the user.
+3. Perform the requested work or delegate subtasks.
+
+### 3. Completing Tasks & Logging Outcomes
+1. Once completed, invoke `terminal(command="python3 skills/productivity/agenda/scripts/agenda.py done <id> --outcome \"<summary>\"")`.
+2. This records execution history in `log` and transitions recurring items cleanly.
+
+### 4. Capturing Raw Sparks
+When an unexpected finding or idea emerges during a session:
+1. Log it with `terminal(command="python3 skills/productivity/agenda/scripts/agenda.py spark \"<idea>\" --observation \"<context>\"")`.
+2. Review sparks during weekly planning sessions (`weekly-review-planning`).
+
+## Autonomous Loop & Cron Integration
+
+You can set up a recurring Hermes cronjob to periodically inspect and surface pending agenda items:
+
+```bash
+hermes cron create \
+  --name "Agenda Surfacer" \
+  --schedule "0 9 * * 1-5" \
+  --prompt "Check the next high-priority agenda item using python3 skills/productivity/agenda/scripts/agenda.py next --n 1, and present a morning briefing."
+```
+
+## Pitfalls
+
+- **Priority ordering:** Priority `1` is highest (top of queue), `5` is lowest. Do not invert the scale.
+- **Atomic state transition:** `next` automatically sets status to `active` so subsequent concurrent queries do not double-dispatch the same task.
+- **Recurring items:** Recurring tasks (`cooldown_days > 0`) transition back to `recurring` status upon `done`, preserving `times_done` counters.
+
+## Verification
+
+Verify functionality by running status and retrieval checks:
+```bash
+python3 skills/productivity/agenda/scripts/agenda.py status
+python3 skills/productivity/agenda/scripts/agenda.py list --limit 5
+```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -262,6 +262,7 @@ const sidebars: SidebarsConfig = {
                   key: 'skills-bundled-productivity',
                   collapsed: true,
                   items: [
+                    'user-guide/skills/bundled/productivity/productivity-agenda',
                     'user-guide/skills/bundled/productivity/productivity-airtable',
                     'user-guide/skills/bundled/productivity/productivity-box',
                     'user-guide/skills/bundled/productivity/productivity-document-to-action-items',


### PR DESCRIPTION
## Summary
Adds the **Hermes Agenda Skill** (`agenda`) under `skills/productivity/agenda/`.

### Features
- **Priority-Based Task Queue**: Supports urgency-ranked items (`1` = highest priority, `5` = lowest) with domain categorisation (`research`, `dev`, `skill`, etc.).
- **Recurring Schedules**: Items with `cooldown_days > 0` re-arm automatically upon completion, tracking execution count (`times_done`).
- **Outcome Audit Log**: Completing an item records timestamped post-mortem execution summaries into the `log` table.
- **Sparks Table**: Captures unstructured observations and nascent ideas for later triage during weekly planning sessions.
- **Zero-Config Profile-Aware Storage**: Auto-initializes SQLite database in `~/.hermes/agenda.db` (or `HERMES_AGENDA_DB`) with zero external pip dependencies.
- **CLI & Autonomous Loop Integration**: CLI tool (`agenda.py`) with JSON output support for cron loops (`hermes cron`).

### Tests & Documentation
- Unit tests added in `tests/skills/test_agenda_skill.py` covering direct API and CLI operations.
- Compliant with all repo authoring standards (`pytest tests/skills/test_authoring_standards.py`).
- Added auto-generated documentation page and updated skills catalog + sidebar.
