### PR TITLE
feat: add hermes cloud export for Hermes Cloud migration bundles

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -22,7 +22,7 @@ import zipfile
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import AbstractSet, Any, Dict, List, Optional
 
 from hermes_constants import get_default_hermes_root, get_hermes_home, display_hermes_home
 from utils import (
@@ -306,8 +306,14 @@ def _iter_external_files(base: Path) -> List[Path]:
     return files
 
 
-def _should_exclude(rel_path: Path) -> bool:
-    """Return True if *rel_path* (relative to hermes root) should be skipped."""
+def _should_exclude(
+    rel_path: Path, extra_names: Optional[AbstractSet[str]] = None
+) -> bool:
+    """Return True if *rel_path* (relative to hermes root) should be skipped.
+
+    ``extra_names`` adds basename-level exclusions on top of the built-in
+    sets (used by ``hermes cloud export`` to drop secret files).
+    """
     parts = rel_path.parts
 
     for part in parts:
@@ -325,15 +331,23 @@ def _should_exclude(rel_path: Path) -> bool:
     if name in _EXCLUDED_NAMES:
         return True
 
+    if extra_names and name in extra_names:
+        return True
+
     if name.endswith(_EXCLUDED_SUFFIXES):
         return True
 
     return False
 
 
-def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> bool:
+def _should_skip_backup_file(
+    abs_path: Path,
+    rel_path: Path,
+    out_path: Path,
+    extra_exclude_names: Optional[AbstractSet[str]] = None,
+) -> bool:
     """Return True when a candidate file should not be written to a backup zip."""
-    if _should_exclude(rel_path):
+    if _should_exclude(rel_path, extra_names=extra_exclude_names):
         return True
 
     # zipfile.write() follows file symlinks, so skip links before any archive
@@ -641,8 +655,16 @@ def run_backup(args) -> None:
         raise SystemExit(2) from exc
 
 
-def _run_backup_locked(args, hermes_root: Path) -> None:
-    """Write a full backup while the cross-process backup slot is held."""
+def _run_backup_locked(
+    args,
+    hermes_root: Path,
+    extra_exclude_names: Optional[AbstractSet[str]] = None,
+) -> None:
+    """Write a full backup while the cross-process backup slot is held.
+
+    ``extra_exclude_names`` adds basename-level exclusions on top of the
+    built-in sets (used by ``hermes cloud export`` to drop secret files).
+    """
 
     # Determine output path
     out_path = None
@@ -697,7 +719,9 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
             fpath = dp / fname
             rel = fpath.relative_to(hermes_root)
 
-            if _should_skip_backup_file(fpath, rel, out_path):
+            if _should_skip_backup_file(
+                fpath, rel, out_path, extra_exclude_names=extra_exclude_names
+            ):
                 continue
 
             files_to_add.append((fpath, rel))

--- a/hermes_cli/cloud_migrate.py
+++ b/hermes_cli/cloud_migrate.py
@@ -1,0 +1,303 @@
+"""Cloud migration export: package HERMES_HOME for Hermes Cloud.
+
+Sits on top of ``hermes_cli.backup``: same walker, same exclusions, same
+SQLite snapshot discipline, plus three migration-specific rules:
+
+1. Secret files (``backup._SECRET_FILE_NAMES``) are excluded by default.
+   ``--include-secrets`` puts ``.env``/``auth.json`` back in the archive;
+   ``--include-history`` puts ``state.db`` back. The two flags are
+   independent.
+2. A ``migration-manifest.json`` entry sits at the archive root so the
+   importing side can refuse an incompatible bundle before mutating the
+   home directory.
+3. After the archive closes, every text entry in it is scanned for
+   recognizable secret values (API key shapes). Matches are reported, never
+   dropped: deleting a file because it contains a documentation placeholder
+   like ``ghp_xxxxxxxx`` would silently erase a skill.
+
+The import side (``hermes_cli/cloud_import``, shipping separately) discards
+secret files even when ``--include-secrets`` was used, so a secrets-bearing
+bundle can still be produced locally but cannot poison a cloud instance.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import socket
+import sys
+import zipfile
+from datetime import datetime
+from importlib import metadata
+from pathlib import Path
+from typing import Iterator, List, Optional, Tuple
+
+from hermes_cli.backup import (
+    BackupInProgressError,
+    _SECRET_FILE_NAMES,
+    _backup_operation_lock,
+    _count_cron_jobs,
+    _run_backup_locked,
+)
+from hermes_constants import display_hermes_home, get_default_hermes_root
+
+MIGRATION_SCHEMA_VERSION = 1
+
+DEFAULT_BUNDLE_PREFIX = "hermes_cloud_migration"
+
+# Secret-value shapes scanned for in included text files. Kept deliberately
+# narrow (documented prefixes and distinctive structural markers only) to
+# keep the false-positive rate near zero on doc-placeholder hits.
+_SECRET_VALUE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("openai api key", re.compile(r"sk-(?:live|proj)-[A-Za-z0-9_-]{10,}")),
+    ("anthropic api key", re.compile(r"sk-ant-[A-Za-z0-9_-]{10,}")),
+    ("github token", re.compile(r"\b(?:ghp|gho)_[A-Za-z0-9]{30,}")),
+    ("github fine-grained token", re.compile(r"github_pat_[A-Za-z0-9_]{20,}")),
+    ("slack token", re.compile(r"xox[bap]-[A-Za-z0-9-]{10,}")),
+    ("aws access key", re.compile(r"AKIA[0-9A-Z]{16}")),
+    ("private key", re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")),
+]
+
+# Text entries larger than this are skipped by the scan (state snapshots,
+# base64 blobs, vendor bundles). Config and skill files are far smaller.
+_SCAN_MAX_FILE_BYTES = 1_000_000
+
+_manifest = dict
+
+
+def _iter_env_key_names(hermes_root: Path) -> Iterator[str]:
+    """Yield secret key names from the ROOT ``.env`` (names only, no values).
+
+    Profile-level ``.env`` files are intentionally not indexed in v1: the
+    root file is the one the cloud instance will need re-provisioned.
+    """
+    env_path = hermes_root / ".env"
+    if not env_path.is_file():
+        return
+    try:
+        with open(env_path, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key = line.split("=", 1)[0].strip()
+                if key:
+                    yield key
+    except OSError:
+        return
+
+
+def _is_text_entry(data: bytes) -> bool:
+    if b"\x00" in data[:4096]:
+        return False
+    try:
+        data.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
+
+
+def _scan_archive_for_secrets(out_path: Path) -> list[tuple[str, str]]:
+    """Scan text entries of the finished archive for secret-value shapes.
+
+    Returns ``(entry_name, pattern_label)`` pairs. Read-only.
+    """
+    hits: list[tuple[str, str]] = []
+    with zipfile.ZipFile(out_path, "r") as zf:
+        for info in zf.infolist():
+            if info.is_dir() or info.filename == "migration-manifest.json":
+                continue
+            if info.file_size <= 0 or info.file_size > _SCAN_MAX_FILE_BYTES:
+                continue
+            try:
+                raw = zf.read(info)
+            except (OSError, zipfile.BadZipFile, RuntimeError):
+                continue
+            if not _is_text_entry(raw):
+                continue
+            try:
+                text = raw.decode("utf-8")
+            except UnicodeDecodeError:
+                continue
+            for label, pattern in _SECRET_VALUE_PATTERNS:
+                if pattern.search(text):
+                    hits.append((info.filename, label))
+                    break
+    return hits
+
+
+def _count_skills_in_archive(out_path: Path) -> int:
+    with zipfile.ZipFile(out_path, "r") as zf:
+        return sum(
+            1
+            for name in zf.namelist()
+            if name.endswith("/SKILL.md") and name.startswith("skills/")
+        )
+
+
+def _entry_bytes(zf: zipfile.ZipFile, name: str) -> Optional[int]:
+    try:
+        info = zf.getinfo(name)
+    except KeyError:
+        return None
+    return info.file_size
+
+
+def _build_manifest(out_path: Path, hermes_root: Path, *, args) -> _manifest:
+    with zipfile.ZipFile(out_path, "r") as zf:
+        state_db_bytes = _entry_bytes(zf, "state.db")
+        skills_count = _count_skills_in_archive(out_path)
+
+    try:
+        from hermes_cli.config import check_config_version
+
+        config_version = check_config_version()[0]
+    except Exception:
+        config_version = None
+
+    try:
+        tool_version = metadata.version("hermes-agent")
+    except metadata.PackageNotFoundError:
+        tool_version = "unknown"
+
+    cron_path = hermes_root / "cron" / "jobs.json"
+    cron_jobs = _count_cron_jobs(cron_path)
+
+    secrets_included = bool(getattr(args, "include_secrets", False))
+    secrets_excluded = (
+        [] if secrets_included else sorted(_iter_env_key_names(hermes_root))
+    )
+
+    return {
+        "schema_version": MIGRATION_SCHEMA_VERSION,
+        "tool_version": tool_version,
+        "config_version": config_version,
+        "created_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "assets": {
+            "state_db": {
+                "included": state_db_bytes is not None,
+                "bytes": state_db_bytes or 0,
+            },
+            "skills_count": skills_count,
+            "cron_jobs": cron_jobs,
+        },
+        "secrets_included": secrets_included,
+        "secrets_excluded": secrets_excluded,
+    }
+
+
+def _default_output_path() -> Path:
+    host = re.sub(r"[^A-Za-z0-9_-]", "-", socket.gethostname().split(".")[0])
+    stamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
+    return Path.cwd() / f"{DEFAULT_BUNDLE_PREFIX}_{host}_{stamp}.zip"
+
+
+def run_cloud_export(args) -> int:
+    """Write a migration bundle for ``hermes cloud export``."""
+    hermes_root = get_default_hermes_root()
+
+    if not hermes_root.is_dir():
+        print(f"Error: Hermes home directory not found at {hermes_root}")
+        return 1
+
+    # Resolve the output path. A file path is the contract here (the bundle
+    # is uploaded to the portal, not stashed next to backups), so unlike
+    # ``hermes backup`` a directory argument is not supported.
+    try:
+        if args.output:
+            out_path = Path(args.output).expanduser().resolve()
+        else:
+            out_path = _default_output_path()
+        if out_path.suffix.lower() != ".zip":
+            out_path = out_path.with_suffix(out_path.suffix + ".zip")
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        target = getattr(args, "output", None) or "-"
+        print(f"Error: cannot write bundle to {target}: {exc}")
+        return 1
+
+    if out_path.exists() and not getattr(args, "force", False):
+        print(f"Error: {out_path} already exists (use --force to overwrite)")
+        return 1
+
+    # Secret files are basename-excluded on top of the built-in backup
+    # exclusions. ``state.db`` is governed by --include-history, the
+    # credential pair by --include-secrets.
+    extra_excludes = set(_SECRET_FILE_NAMES)
+    if getattr(args, "include_history", False):
+        extra_excludes.discard("state.db")
+    if getattr(args, "include_secrets", False):
+        extra_excludes.discard(".env")
+        extra_excludes.discard("auth.json")
+
+    # The backup walker keys off args.output; hand it a minimal shim so the
+    # full-backup flow writes to our chosen path and nothing else.
+    shim = type("_CloudExportArgs", (), {"output": str(out_path)})()
+
+    try:
+        with _backup_operation_lock(hermes_root):
+            _run_backup_locked(shim, hermes_root, extra_exclude_names=extra_excludes)
+    except BackupInProgressError as exc:
+        print(f"Error: {exc}")
+        return 2
+
+    # Append the manifest, then scan the finished archive for stray secrets.
+    manifest = _build_manifest(out_path, hermes_root, args=args)
+    try:
+        with zipfile.ZipFile(
+            out_path, "a", zipfile.ZIP_DEFLATED, compresslevel=6
+        ) as zf:
+            zf.writestr("migration-manifest.json", json.dumps(manifest, indent=2))
+    except (OSError, zipfile.BadZipFile) as exc:
+        print(f"Error: could not finalize bundle manifest: {exc}")
+        return 1
+
+    scan_hits = _scan_archive_for_secrets(out_path)
+
+    print()
+    print(f"Migration bundle ready:")
+    print(f"  {out_path}")
+    print(f"  schema_version: {manifest['schema_version']}")
+    print(f"  tool_version:   {manifest['tool_version']}")
+    print(f"  config_version: {manifest['config_version']}")
+    print(f"  skills:         {manifest['assets']['skills_count']}")
+    print(f"  cron jobs:      {manifest['assets']['cron_jobs']}")
+    if manifest["secrets_included"]:
+        print()
+        print(
+            "  WARNING: secret files are included in this bundle. The cloud "
+            "importer discards them, and this archive now carries live "
+            "credentials. Handle it like a plaintext secret."
+        )
+    elif manifest["secrets_excluded"]:
+        print(
+            f"  secrets excluded ({len(manifest['secrets_excluded'])} key "
+            "names recorded in the manifest): "
+            + ", ".join(manifest["secrets_excluded"][:8])
+            + (
+                " ..."
+                if len(manifest["secrets_excluded"]) > 8
+                else ""
+            )
+        )
+    else:
+        print("  secrets:        none detected")
+
+    if scan_hits:
+        print()
+        print(
+            f"  WARNING: {len(scan_hits)} included file(s) match a known "
+            "secret-value shape:"
+        )
+        for entry_name, label in scan_hits[:10]:
+            print(f"    {entry_name}  ({label})")
+        if len(scan_hits) > 10:
+            print(f"    ... and {len(scan_hits) - 10} more")
+        print(
+            "  Nothing was dropped; review the files above before uploading. "
+            "The cloud importer will discard .env and auth.json regardless."
+        )
+
+    print()
+    print("Leaf note: this bundle is also a valid `hermes import` archive.")
+    return 0

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -465,6 +465,7 @@ from hermes_cli.subcommands.debug import build_debug_parser
 from hermes_cli.subcommands.backup import build_backup_parser
 from hermes_cli.subcommands.import_cmd import build_import_cmd_parser
 from hermes_cli.subcommands.import_agent import build_import_agent_parser
+from hermes_cli.subcommands.cloud import build_cloud_parser
 from hermes_cli.subcommands.config import build_config_parser
 from hermes_cli.subcommands.skin import build_skin_parser
 from hermes_cli.subcommands.console import build_console_parser
@@ -5700,6 +5701,22 @@ def cmd_import(args):
     from hermes_cli.backup import run_import
 
     run_import(args)
+
+
+def cmd_cloud(args):
+    """Hermes Cloud migration commands."""
+    sub = getattr(args, "cloud_command", None)
+    if sub != "export":
+        print(
+            "usage: hermes cloud export [-o FILE] [--force] "
+            "[--include-secrets] [--include-history]",
+            file=sys.stderr,
+        )
+        return 1
+
+    from hermes_cli.cloud_migrate import run_cloud_export
+
+    return run_cloud_export(args)
 
 
 def _print_version_info(*, check_updates: bool = True) -> None:
@@ -12811,6 +12828,7 @@ def main():
     # backup command  (parser built in hermes_cli/subcommands/backup.py)
     # =========================================================================
     build_backup_parser(subparsers, cmd_backup=cmd_backup)
+    build_cloud_parser(subparsers, cmd_cloud=cmd_cloud)
 
     # =========================================================================
     # checkpoints command

--- a/hermes_cli/subcommands/cloud.py
+++ b/hermes_cli/subcommands/cloud.py
@@ -1,0 +1,67 @@
+"""``hermes cloud`` subcommand parser.
+
+Hermes Cloud migration verbs. Handler injected to avoid importing ``main``
+(cycle avoidance, same shape as ``subcommands/sync.py``).
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Callable
+
+
+def build_cloud_parser(subparsers, *, cmd_cloud: Callable) -> None:
+    """Attach the ``cloud`` subcommand (and its sub-actions) to ``subparsers``."""
+    cloud_parser = subparsers.add_parser(
+        "cloud",
+        help="Migrate this Hermes setup to Hermes Cloud",
+        description=(
+            "Package this machine's Hermes setup (settings, skills, memory, "
+            "SOUL, cron jobs, and optionally chat history) for import into a "
+            "Hermes Cloud instance."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  hermes cloud export                        write a migration bundle to the current directory\n"
+            "  hermes cloud export --include-history      also include conversation history (state.db)\n"
+            "  hermes cloud export -o ~/Desktop/mv.zip    write to a specific path\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    cloud_sub = cloud_parser.add_subparsers(dest="cloud_command")
+
+    export_parser = cloud_sub.add_parser(
+        "export",
+        help="Export this Hermes setup as a migration bundle",
+        description=(
+            "Create a zip of your Hermes configuration, skills, memory, SOUL, "
+            "and cron jobs, ready to import into a Hermes Cloud instance. "
+            "Secret files (.env, auth.json) are excluded unless "
+            "--include-secrets is given; chat history (state.db) is excluded "
+            "unless --include-history is given."
+        ),
+    )
+    export_parser.add_argument(
+        "-o",
+        "--output",
+        help="Output path for the zip (default: ./hermes_cloud_migration_<host>_<timestamp>.zip)",
+    )
+    export_parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Overwrite an existing bundle at the output path",
+    )
+    export_parser.add_argument(
+        "--include-secrets",
+        action="store_true",
+        help="Include .env and auth.json in the bundle (to be used with care: "
+        "the archive then carries live credentials, and the cloud importer "
+        "still discards them)",
+    )
+    export_parser.add_argument(
+        "--include-history",
+        action="store_true",
+        help="Include chat history (state.db) in the bundle",
+    )
+    export_parser.set_defaults(func=cmd_cloud)

--- a/tests/hermes_cli/test_cloud_migrate.py
+++ b/tests/hermes_cli/test_cloud_migrate.py
@@ -1,0 +1,193 @@
+"""E2E tests for ``hermes cloud export`` (migration bundles).
+
+Runs the real export path against a synthetic HERMES_HOME (temp dir via
+monkeypatched HERMES_HOME env), then verifies the archive contract: secret
+files absent by default, re-includable by flag, a manifest at the root, a
+secret scan that reports (but never drops) planted values, and round-trip
+restorability through the real ``hermes import`` path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.cloud_migrate import (
+    MIGRATION_SCHEMA_VERSION,
+    run_cloud_export,
+)
+
+
+@pytest.fixture()
+def synth_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A minimal but real HERMES_HOME with every asset class the bundle covers."""
+    home = tmp_path / "hermes"
+    (home / "skills" / "custom-skill").mkdir(parents=True)
+    (home / "memory").mkdir()
+    (home / "cron").mkdir()
+    (home / "profiles" / "other").mkdir(parents=True)
+
+    (home / "config.yaml").write_text(
+        "_config_version: 4\nmodel:\n  provider: nous\n", encoding="utf-8"
+    )
+    (home / "skills" / "custom-skill" / "SKILL.md").write_text(
+        "---\nname: custom-skill\ndescription: test\n---\n# Body\n",
+        encoding="utf-8",
+    )
+    (home / "memory" / "memory.md").write_text("remember this", encoding="utf-8")
+    (home / "SOUL.md").write_text("be concise", encoding="utf-8")
+    (home / "cron" / "jobs.json").write_text(
+        json.dumps({"jobs": [{"id": "a"}, {"id": "b"}]}), encoding="utf-8"
+    )
+    (home / ".env").write_text(
+        "# comment\nANTHROPIC_API_KEY=sk-ant-real-value\nOPENROUTER_API_KEY=or-key\n",
+        encoding="utf-8",
+    )
+    (home / "auth.json").write_text('{"token": "x"}', encoding="utf-8")
+    # A per-profile secret file: basename exclusion must reach it too.
+    (home / "profiles" / "other" / ".env").write_text(
+        "PROFILE_KEY=value\n", encoding="utf-8"
+    )
+
+    conn = sqlite3.connect(home / "state.db")
+    conn.execute("CREATE TABLE sessions (id INTEGER PRIMARY KEY, body TEXT)")
+    conn.execute("INSERT INTO sessions (body) VALUES ('hello')")
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def _run_export(capsys, out: Path, **flags):
+    args = SimpleNamespace(output=str(out), force=True, **flags)
+    code = run_cloud_export(args)
+    captured = capsys.readouterr()
+    assert code == 0, captured.out
+    return captured
+
+
+def _namelist(zip_path: Path) -> list[str]:
+    with zipfile.ZipFile(zip_path) as zf:
+        return zf.namelist()
+
+
+def _manifest(zip_path: Path) -> dict:
+    with zipfile.ZipFile(zip_path) as zf:
+        return json.loads(zf.read("migration-manifest.json"))
+
+
+def _contains_basename(names: list[str], basename: str) -> bool:
+    return any(Path(n).name == basename for n in names)
+
+
+def test_export_defaults_exclude_secrets_and_history(synth_home, tmp_path, capsys):
+    out = tmp_path / "bundle.zip"
+    _run_export(capsys, out)
+
+    names = _namelist(out)
+    assert "config.yaml" in names
+    assert "skills/custom-skill/SKILL.md" in names
+    assert "memory/memory.md" in names
+    assert "SOUL.md" in names
+    assert "cron/jobs.json" in names
+
+    # Secret files excluded at any depth, state.db excluded by default.
+    for basename in (".env", "auth.json", "state.db"):
+        assert not _contains_basename(names, basename), basename
+
+    manifest = _manifest(out)
+    assert manifest["schema_version"] == MIGRATION_SCHEMA_VERSION
+    assert manifest["secrets_included"] is False
+    assert sorted(manifest["secrets_excluded"]) == [
+        "ANTHROPIC_API_KEY",
+        "OPENROUTER_API_KEY",
+    ]
+    assert manifest["assets"]["state_db"] == {"included": False, "bytes": 0}
+    assert manifest["assets"]["skills_count"] == 1
+    assert manifest["assets"]["cron_jobs"] == 2
+    assert manifest["config_version"] == 4
+
+
+def test_include_history_adds_state_db(synth_home, tmp_path, capsys):
+    out = tmp_path / "bundle.zip"
+    _run_export(capsys, out, include_history=True)
+
+    names = _namelist(out)
+    assert _contains_basename(names, "state.db")
+    assert not _contains_basename(names, ".env")
+
+    manifest = _manifest(out)
+    assert manifest["assets"]["state_db"]["included"] is True
+    assert manifest["assets"]["state_db"]["bytes"] > 0
+
+
+def test_include_secrets_adds_env_and_auth(synth_home, tmp_path, capsys):
+    out = tmp_path / "bundle.zip"
+    _run_export(capsys, out, include_secrets=True)
+
+    names = _namelist(out)
+    assert _contains_basename(names, ".env")
+    assert _contains_basename(names, "auth.json")
+    assert not _contains_basename(names, "state.db")
+
+    manifest = _manifest(out)
+    assert manifest["secrets_included"] is True
+    assert manifest["secrets_excluded"] == []
+
+
+def test_secret_scan_reports_but_does_not_drop(synth_home, tmp_path, capsys):
+    # Plant a recognizable secret shape inside an included skill file.
+    skill = synth_home / "skills" / "custom-skill" / "SKILL.md"
+    skill.write_text(
+        "---\nname: custom-skill\n---\n# Body\nexample: ghp_" + "A" * 36 + "\n",
+        encoding="utf-8",
+    )
+
+    out = tmp_path / "bundle.zip"
+    captured = _run_export(capsys, out)
+
+    names = _namelist(out)
+    assert "skills/custom-skill/SKILL.md" in names  # never dropped
+    assert "github token" in captured.out  # reported
+
+
+def test_refuses_overwrite_without_force(synth_home, tmp_path, capsys):
+    out = tmp_path / "bundle.zip"
+    _run_export(capsys, out)
+
+    args = SimpleNamespace(output=str(out), force=False)
+    assert run_cloud_export(args) == 1
+    assert "already exists" in capsys.readouterr().out
+
+
+def test_bundle_roundtrips_through_import(synth_home, tmp_path, capsys, monkeypatch):
+    out = tmp_path / "bundle.zip"
+    _run_export(capsys, out, include_history=True)
+
+    # Restore into a fresh home through the real import path.
+    fresh = tmp_path / "restored"
+    fresh.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(fresh))
+
+    from hermes_cli.backup import run_import
+
+    run_import(SimpleNamespace(zipfile=str(out), force=True))
+
+    for rel in (
+        "config.yaml",
+        "SOUL.md",
+        "memory/memory.md",
+        "skills/custom-skill/SKILL.md",
+        "cron/jobs.json",
+        "state.db",
+    ):
+        assert (fresh / rel).exists(), rel
+    assert not (fresh / ".env").exists()
+    assert not (fresh / "auth.json").exists()

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -71,6 +71,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes backup` | Back up Hermes home directory to a zip file. |
 | `hermes checkpoints` | Inspect / prune / clear `~/.hermes/checkpoints/` (the shadow store used by `/rollback`). Run with no args for a status overview. |
 | `hermes import` | Restore a Hermes backup from a zip file. |
+| `hermes cloud export` | Package this Hermes setup as a migration bundle for Hermes Cloud. |
 | `hermes logs` | View, tail, and filter agent/gateway/error log files. |
 | `hermes config` | Show, edit, migrate, and query configuration files. |
 | `hermes skin` | List, switch, and tweak display skins. |
@@ -923,6 +924,23 @@ hermes debug share --expire 30  # Keep paste for 30 days
 hermes debug share --nous       # Upload a private diagnostics bundle for Nous support
 hermes debug share --local      # Print report to terminal (no upload)
 ```
+
+## `hermes cloud`
+
+```bash
+hermes cloud export [options]
+```
+
+Create a migration bundle for Hermes Cloud: a zip of your configuration, custom skills, memory, SOUL, and cron jobs, ready to import into a newly provisioned cloud instance. The archive uses the same walker and SQLite snapshot discipline as `hermes backup` and is also a valid `hermes import` archive.
+
+| Option | Description |
+|--------|-------------|
+| `-o`, `--output <path>` | Output path for the zip (default: `./hermes_cloud_migration_<host>_<timestamp>.zip`). |
+| `-f`, `--force` | Overwrite an existing bundle at the output path. |
+| `--include-history` | Include chat history (`state.db`) in the bundle. Excluded by default. |
+| `--include-secrets` | Include `.env` and `auth.json` in the bundle. Excluded by default; the cloud importer discards secret files regardless. |
+
+Every bundle carries a `migration-manifest.json` at its root recording the exporting tool version, config schema version, and what the archive contains; the importing side uses it to refuse bundles it cannot safely restore before touching the home directory.
 
 ## `hermes backup`
 


### PR DESCRIPTION
## Summary

First slice of local-to-Hermes-Cloud migration. `hermes cloud export` packages HERMES_HOME into a zip migration bundle (settings, custom skills, memory, SOUL, cron jobs; chat history optional) for import into a newly provisioned Hermes Cloud instance. The archive is also a valid `hermes import` archive, so it round-trips locally today.

The export reuses `backup.py` end to end. The only shared-code change is an optional basename exclusion set on the backup walker (`_should_exclude` / `_should_skip_backup_file` / `_run_backup_locked`), default None, so `hermes backup` behavior is untouched.

## Bundle contract

- Secret files (.env, auth.json) and chat history (state.db) excluded by default. `--include-secrets` and `--include-history` re-include them independently.
- Every bundle carries `migration-manifest.json` at the root: schema_version, tool_version, config_version (read from config.yaml), created_at, asset sizes, and the names (never values) of excluded secret keys.
- After the archive closes, included text files are scanned for known secret-value shapes (sk-ant-, ghp_, AKIA, xox[bap]-, PEM headers). Matches are printed as warnings and never dropped, since doc placeholders (ghp_xxx) are common in skills.

## Verification

- 6 E2E tests exercise the real export and the real `hermes import` against a synthetic HERMES_HOME: secret exclusion at any depth (including profiles), include flags, manifest contents, scan-report-not-drop, overwrite refusal, full round-trip restore.
- `tests/hermes_cli/test_cloud_migrate.py` and `tests/hermes_cli/test_backup.py` green locally via scripts/run_tests.sh; CLI help verified with `hermes cloud export --help`.
- Docs updated in website/docs/reference/cli-commands.md (table row + section).

## Follow-ups (separate PRs)

- Instance-side importer + container-boot hook (hermes-agent).
- Portal upload/provision wiring (nous-account-service).

No telemetry, no new env-var config, no toolset or context changes.