### PR TITLE
fix(desktop): scope composer drafts per profile

### DIFF
--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { $activeGatewayProfile, $newChatProfile } from '@/store/profile'
+import { $sessions } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
+
 import {
   $composerAttachments,
   $voiceConversationStartRequest,
@@ -9,6 +13,7 @@ import {
   createComposerAttachmentOccurrenceId,
   createComposerAttachmentScope,
   migrateSessionDraft,
+  reloadPersistedDrafts,
   removeComposerAttachment,
   requestVoiceConversationStart,
   SESSION_DRAFTS_STORAGE_KEY,
@@ -233,7 +238,7 @@ describe('session drafts', () => {
     expect(takeSessionDraft('session-a').text).toBe('session draft')
   })
 
-  it('persists draft text (not attachments) to localStorage', () => {
+  it('persists draft text (not attachments) to localStorage under a profile-scoped key', () => {
     stashSessionDraft('session-a', 'survives reload', [attachment({ id: 'file:a' })])
 
     const persisted = JSON.parse(window.localStorage.getItem(SESSION_DRAFTS_STORAGE_KEY) ?? '{}') as Record<
@@ -241,7 +246,10 @@ describe('session drafts', () => {
       string
     >
 
-    expect(persisted['session-a']).toBe('survives reload')
+    expect(persisted['default:session-a']).toBe('survives reload')
+    // The bare, profile-less v3 shape must not come back: it is what let one
+    // profile's draft restore into another's composer.
+    expect(persisted['session-a']).toBeUndefined()
   })
 
   it('evicts empty drafts instead of leaving stale entries behind', () => {
@@ -290,5 +298,110 @@ describe('session drafts', () => {
 
     clearSessionDraft('from')
     clearSessionDraft('to')
+  })
+})
+
+describe('session drafts are scoped per profile', () => {
+  const session = (id: string, profile: string): SessionInfo => ({ id, profile }) as unknown as SessionInfo
+
+  afterEach(() => {
+    // The in-memory stash outlives localStorage.clear(), so drop each profile's
+    // buckets through the real API before resetting the profile atoms.
+    for (const profile of ['default', 'uwr', 'saint']) {
+      $activeGatewayProfile.set(profile)
+      $newChatProfile.set(null)
+      clearSessionDraft(null)
+
+      for (const scope of ['uwr-session', 'saint-session', 'session-a']) {
+        clearSessionDraft(scope)
+      }
+
+      $newChatProfile.set(profile)
+      clearSessionDraft(null)
+    }
+
+    $sessions.set([])
+    $activeGatewayProfile.set('default')
+    $newChatProfile.set(null)
+    window.localStorage.clear()
+  })
+
+  // Regression: a draft (text AND its staged image attachments) stashed while
+  // one profile was live could be restored into a composer belonging to
+  // another profile, and submitted there. The draft map keyed on session id
+  // alone, so one flat namespace served every profile in the renderer.
+  it("does not share a namespace between two profiles' drafts", () => {
+    $sessions.set([session('uwr-session', 'uwr'), session('saint-session', 'saint')])
+
+    $activeGatewayProfile.set('uwr')
+    stashSessionDraft('uwr-session', 'reference images prompt', [attachment({ id: 'image:ref', kind: 'image' })])
+
+    $activeGatewayProfile.set('saint')
+    stashSessionDraft('saint-session', 'saint prompt', [])
+
+    const persisted = Object.keys(
+      JSON.parse(window.localStorage.getItem(SESSION_DRAFTS_STORAGE_KEY) ?? '{}') as Record<string, string>
+    )
+
+    expect(persisted).toContain('uwr:uwr-session')
+    expect(persisted).toContain('saint:saint-session')
+    // Neither profile may reach the other's draft through the flat v3 key.
+    expect(takeSessionDraft('saint-session').attachments).toEqual([])
+  })
+
+  // The unsent `__new__` bucket was a single global slot, so every new-session
+  // composer in every profile read and wrote the same draft.
+  it("keeps each profile's unsent new-session draft in its own bucket", () => {
+    $activeGatewayProfile.set('uwr')
+    stashSessionDraft(null, 'uwr new chat', [attachment({ id: 'image:ref', kind: 'image' })])
+
+    $activeGatewayProfile.set('saint')
+
+    expect(takeSessionDraft(null)).toEqual({ attachments: [], text: '' })
+
+    stashSessionDraft(null, 'saint new chat', [])
+    $activeGatewayProfile.set('uwr')
+
+    expect(takeSessionDraft(null).text).toBe('uwr new chat')
+    expect(takeSessionDraft(null).attachments.map(a => a.id)).toEqual(['image:ref'])
+  })
+
+  // A background profile keeps streaming during a live swap, so a draft must
+  // stay keyed to the profile that OWNS its session, not whichever profile
+  // happens to be live when the composer reads it back.
+  it("keys a draft to its session's owning profile, not the live one", () => {
+    $sessions.set([session('uwr-session', 'uwr')])
+
+    $activeGatewayProfile.set('uwr')
+    stashSessionDraft('uwr-session', 'half typed', [])
+
+    $activeGatewayProfile.set('saint')
+
+    expect(takeSessionDraft('uwr-session').text).toBe('half typed')
+  })
+
+  // The new-chat picker points the composer at a profile before any session
+  // exists, so an unsent draft belongs to the picked target.
+  it('scopes a new-session draft to the new-chat picker target when set', () => {
+    $activeGatewayProfile.set('saint')
+    $newChatProfile.set('uwr')
+    stashSessionDraft(null, 'drafted for uwr', [])
+
+    $newChatProfile.set(null)
+
+    expect(takeSessionDraft(null)).toEqual({ attachments: [], text: '' })
+
+    $newChatProfile.set('uwr')
+    expect(takeSessionDraft(null).text).toBe('drafted for uwr')
+  })
+
+  it('discards the legacy profile-less v3 map instead of misattributing it', () => {
+    window.localStorage.setItem('hermes:composer-drafts:v3', JSON.stringify({ __new__: 'ambiguous', 'session-a': 'x' }))
+
+    reloadPersistedDrafts()
+
+    expect(window.localStorage.getItem('hermes:composer-drafts:v3')).toBeNull()
+    expect(takeSessionDraft('session-a')).toEqual({ attachments: [], text: '' })
+    expect(takeSessionDraft(null)).toEqual({ attachments: [], text: '' })
   })
 })

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -1,7 +1,10 @@
 import { atom } from 'nanostores'
 
+import { activeConnectionScopeSuffix } from '@/lib/connection-scoped'
 import { deriveDraftTitle } from '@/lib/draft-title'
 import { triggerHaptic } from '@/lib/haptics'
+import { $activeGatewayProfile, $newChatProfile, normalizeProfileKey } from '@/store/profile'
+import { $sessions, rememberedSessionProfile } from '@/store/session'
 
 export interface ComposerAttachment {
   id: string
@@ -172,7 +175,20 @@ export const mainComposerScope = createComposerAttachmentScope($composerAttachme
 // Per-thread draft stash for the decoupled composer. Session lifecycle never
 // touches this — only ChatBar's scope swap reads/writes it. Text mirrors to
 // localStorage; attachments are memory-only (blobs, upload state).
-export const SESSION_DRAFTS_STORAGE_KEY = 'hermes:composer-drafts:v3'
+//
+// v4 declares the PROFILE scope in each entry's own key. v3 keyed on the
+// session id alone, so one flat map served every profile in the renderer and
+// the unsent `__new__` bucket was global: a draft (text AND its staged image
+// attachments) stashed under one profile could be restored into a composer
+// belonging to another, and submitted there. Same failure family as the
+// remembered session id (#67603/#67709) and the connection scope (#77318) —
+// persisted state must declare its scope in its own key.
+export const SESSION_DRAFTS_STORAGE_KEY = 'hermes:composer-drafts:v4'
+
+/** v3's flat, profile-less map. Discarded, never migrated: ownership of a bare
+ *  session key is unknowable once several profiles have written to it, and
+ *  guessing an owner is precisely the cross-profile bleed v4 exists to stop. */
+const LEGACY_SESSION_DRAFTS_STORAGE_KEY = 'hermes:composer-drafts:v3'
 
 const NEW_SESSION_DRAFT_KEY = '__new__'
 const MAX_PERSISTED_DRAFTS = 50
@@ -183,14 +199,50 @@ export interface SessionDraft {
   text: string
 }
 
-const draftKey = (scope: string | null | undefined) => scope?.trim() || NEW_SESSION_DRAFT_KEY
+/**
+ * The profile a draft belongs to.
+ *
+ * Prefer the owning profile recorded on the session row, so a draft stays
+ * keyed to ITS profile even while a different one is live (background profiles
+ * keep streaming during a live swap). An unsent `__new__` draft has no session
+ * to own it, so it belongs to whichever profile the composer is currently
+ * pointed at: the new-chat picker's target when set, else the live gateway's.
+ */
+function draftProfile(scope: string | null | undefined): string {
+  const active = normalizeProfileKey($newChatProfile.get() ?? $activeGatewayProfile.get())
+
+  return scope?.trim()
+    ? normalizeProfileKey(rememberedSessionProfile($sessions.get(), scope, $activeGatewayProfile.get()))
+    : active
+}
+
+/**
+ * Storage identity for one draft: profile, then connection, then thread.
+ *
+ * The connection suffix rides along for the same reason `profileNavigationKey`
+ * carries it — the same profile NAME on a different gateway is a different
+ * backend with its own sessions, and windows on different gateways share this
+ * localStorage area.
+ */
+const draftKey = (scope: string | null | undefined): string =>
+  `${encodeURIComponent(draftProfile(scope))}${activeConnectionScopeSuffix()}:${scope?.trim() || NEW_SESSION_DRAFT_KEY}`
 
 const cloneDraft = (draft: SessionDraft): SessionDraft => ({
   attachments: draft.attachments.map(attachment => ({ ...attachment })),
   text: draft.text
 })
 
+function discardLegacyDraftTexts(): void {
+  try {
+    window.localStorage.removeItem(LEGACY_SESSION_DRAFTS_STORAGE_KEY)
+  } catch {
+    // Best-effort only — quota/private-mode must never break typing.
+  }
+}
+
 function loadPersistedDraftTexts(): [string, SessionDraft][] {
+  discardLegacyDraftTexts()
+
   try {
     const raw = window.localStorage.getItem(SESSION_DRAFTS_STORAGE_KEY)
 


### PR DESCRIPTION
## Summary

Composer drafts key on the session id alone, so one flat map serves every profile in the renderer and the unsent `__new__` bucket is a single global slot. A draft (its text **and** its memory-only staged image attachments) stashed while one profile is live can be restored into a composer belonging to another profile, and submitted there.

`apps/desktop/src/store/composer.ts`, before:

```ts
const NEW_SESSION_DRAFT_KEY = '__new__'
const draftKey = (scope: string | null | undefined) => scope?.trim() || NEW_SESSION_DRAFT_KEY
const draftsBySession = new Map<string, SessionDraft>(loadPersistedDraftTexts())
```

No profile namespace anywhere, which is the failure `apps/desktop/AGENTS.md` already names: *"Persisted state must declare its scope in its own key... Getting the scope wrong is how one profile's setting bleeds into another."* Same family as the remembered session id (#67603 / #67709) and the connection scope (#77318), both of which are already scoped; drafts were missed.

## Reproduction

Observed on a machine running three profiles with two backends live in parallel. The same four staged images and the same prompt text were submitted to a `uwr` session twice, then appeared in a `saint` session that had been idle for 45 minutes:

| When | Profile | Session | Msg id |
|---|---|---|---|
| 08-19 23:18:50 | uwr | 20260819_212716_2c919e | 243 |
| 08-19 23:28:38 | uwr | 20260819_212716_2c919e | 324 |
| 08-20 00:04:12 | **saint** | 20260818_202006_30f64b | 674 |

All three rows carry an identical attachment set (`composer_2026-08-20_03-14-56-887_0221b4.png` plus 3 siblings) and identical text. In the saint session, message 673 landed at 23:18:49 and 674 at 00:04:12 with nothing between: that session was idle when the uwr prompt arrived in it.

The persisted map confirms the flat shape, with no profile namespace:

```json
{"20260817_225628_e6cae5":"...","20260818_143457_9f2cc2":"...","__new__":"..."}
```

## Change

Key each draft `<profile><connection-suffix>:<session>`:

- Resolve the profile from the session's **owning** row via `rememberedSessionProfile`, so a draft stays keyed to ITS profile while another is live. Background profiles keep streaming during a live swap, so the live profile is the wrong answer here.
- For an unsent `__new__` draft, which has no session to own it, use the new-chat picker target (`$newChatProfile`) when set, else the live gateway profile.
- Carry `activeConnectionScopeSuffix()` for the same reason `profileNavigationKey` does: the same profile name on a different gateway is a different backend, and windows on different gateways share this localStorage area.

Bump `v3` to `v4` and **discard** the legacy flat map rather than migrate it. Ownership of a bare session key is unknowable once several profiles have written to it, and guessing an owner is exactly the cross-profile bleed this scoping prevents. Same reasoning as `discardLegacyRememberedNavigation` (#67709).

No new import cycle: `store/profile`, `store/session`, and `lib/connection-scoped` do not reach back into `store/composer` (verified by walking the `@/` import graph).

## Test Plan

Five regression tests in `src/store/composer.test.ts` covering: separate namespaces per profile, the per-profile `__new__` bucket, keying to the session's owning profile rather than the live one, the new-chat picker target, and discarding the legacy v3 map.

Verified they actually guard the bug by reverting the fix and re-running:

- fix reverted: **5 failed | 18 passed**
- fix applied: **23 passed**

Wider suite (`src/store`, `src/app/chat/composer`, `src/lib/chat-runtime.test.ts`): **139 files, 1447 tests, all passing**.

`tsc -p . --noEmit`: clean. `eslint` on both changed files: clean.
