### PR TITLE
feat: import migration bundles on hosted first boot

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1028,8 +1028,14 @@ def _extract_member_atomically(
         raise
 
 
-def run_import(args) -> None:
-    """Restore a Hermes backup from a zip file."""
+def run_import(args, extra_skip_names: Optional[set] = None) -> None:
+    """Restore a Hermes backup from a zip file.
+
+    ``extra_skip_names`` adds basename-level entries to the built-in
+    ``_IMPORT_SKIP_NAMES`` filter (used by the cloud importer to drop
+    ``.env``/``auth.json`` so credentials can never ride a bundle into a
+    hosted instance).
+    """
     zip_path = Path(args.zipfile).expanduser().resolve()
 
     if not zip_path.is_file():
@@ -1138,7 +1144,9 @@ def run_import(args) -> None:
             # reconciler on the target and disconnects hosted instances from the
             # Nous portal. Matched by basename so both the root profile and
             # named profiles (profiles/<name>/gateway_state.json) are covered.
-            if Path(rel).name in _IMPORT_SKIP_NAMES:
+            if Path(rel).name in _IMPORT_SKIP_NAMES or (
+                extra_skip_names and Path(rel).name in extra_skip_names
+            ):
                 skipped_runtime.append(rel)
                 continue
 

--- a/hermes_cli/cloud_import.py
+++ b/hermes_cli/cloud_import.py
@@ -1,0 +1,285 @@
+"""First-boot cloud migration importer for hosted Hermes instances.
+
+Triggered once per instance by the startup env var
+``HERMES_MIGRATION_BUNDLE_URL`` (a short-lived signed URL to a migration
+bundle produced by ``hermes cloud export``). Runs from the container-boot
+reconciler before the gateway comes up, and only when the home is fresh:
+
+- ``HERMES_MIGRATION_BUNDLE_URL`` is set
+- no import marker exists yet
+- ``state.db`` does not exist (the instance has not been used)
+
+Behavior:
+
+1. Stream the bundle to a temp file beside the home (same filesystem, and
+   ``/opt/data`` is a real disk, unlike ``/tmp`` on some images).
+2. Refuse, before touching the home, when the bundle's manifest carries a
+   ``schema_version`` this build cannot import.
+3. Extract through the real ``hermes_cli.backup.run_import`` path, with
+   ``.env`` and ``auth.json`` dropped extra on top of the built-in
+   machine-local runtime filters. A cloud instance must never absorb
+   credentials from a bundle, even when it was exported with
+   ``--include-secrets``.
+4. On success: write the import marker, delete the local bundle copy, and
+   report. On any failure: log loudly, delete the bundle copy, and let the
+   boot continue (an empty instance is better than a bricked one).
+
+``MIGRATION_SCHEMA_VERSION`` must stay in lockstep with
+``hermes_cli.cloud_migrate.MIGRATION_SCHEMA_VERSION`` (the exporting side).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+import zipfile
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Optional, Tuple
+
+from hermes_constants import get_default_hermes_root
+
+logger = logging.getLogger(__name__)
+
+MIGRATION_BUNDLE_URL_ENV = "HERMES_MIGRATION_BUNDLE_URL"
+IMPORT_MARKER_NAME = ".cloud-migration-import.json"
+
+# Must match hermes_cli.cloud_migrate.MIGRATION_SCHEMA_VERSION.
+MIGRATION_SCHEMA_VERSION = 1
+
+MAX_BUNDLE_BYTES = 512 * 1024 * 1024  # 512 MiB, mirrors the portal upload cap
+FETCH_TIMEOUT_SECONDS = 60
+FETCH_CHUNK_BYTES = 64 * 1024
+
+# Basenames the cloud importer drops beyond the built-in import filters.
+# Secrets belong to the instance's own env plumbing, never to a bundle.
+CLOUD_SKIP_NAMES = frozenset({".env", "auth.json"})
+
+
+def _marker_path(hermes_root: Path) -> Path:
+    return hermes_root / IMPORT_MARKER_NAME
+
+
+def has_import_marker(hermes_root: Path) -> bool:
+    return _marker_path(hermes_root).is_file()
+
+
+def home_is_fresh(hermes_root: Path) -> bool:
+    """True when the home has not yet accumulated session state."""
+    return not (hermes_root / "state.db").is_file()
+
+
+def _bundle_url() -> Optional[str]:
+    url = os.environ.get(MIGRATION_BUNDLE_URL_ENV, "").strip()
+    return url or None
+
+
+def _safe_hermes_root() -> Optional[Path]:
+    try:
+        root = get_default_hermes_root()
+    except Exception:
+        return None
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        return root
+    except OSError as exc:
+        logger.warning("cloud_import: cannot prepare hermes root: %s", exc)
+        return None
+
+
+def _fetch_bundle(url: str, hermes_root: Path) -> Optional[Path]:
+    """Stream the bundle to a temp file beside the home.
+
+    Returns the staged path, or None on any transport failure (the boot
+    must continue; a failed fetch is logged, not raised).
+    """
+    try:
+        req = urllib.request.Request(url, method="GET")
+        resp = urllib.request.urlopen(req, timeout=FETCH_TIMEOUT_SECONDS)
+    except (urllib.error.URLError, ValueError, OSError) as exc:
+        logger.warning("cloud_import: bundle fetch failed: %s", exc)
+        return None
+
+    content_length = resp.headers.get("Content-Length")
+    if content_length is not None:
+        try:
+            if int(content_length) > MAX_BUNDLE_BYTES:
+                logger.warning(
+                    "cloud_import: bundle too large (%s bytes, cap %d)",
+                    content_length,
+                    MAX_BUNDLE_BYTES,
+                )
+                resp.close()
+                return None
+        except ValueError:
+            pass
+
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".cloud-migration-bundle.", suffix=".zip", dir=str(hermes_root)
+    )
+    staged = Path(tmp_name)
+    total = 0
+    try:
+        with os.fdopen(fd, "wb") as out:
+            while True:
+                chunk = resp.read(FETCH_CHUNK_BYTES)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > MAX_BUNDLE_BYTES:
+                    logger.warning("cloud_import: bundle exceeded cap while streaming")
+                    resp.close()
+                    return None
+                out.write(chunk)
+    except OSError as exc:
+        logger.warning("cloud_import: bundle stream failed: %s", exc)
+        staged.unlink(missing_ok=True)
+        return None
+    finally:
+        resp.close()
+
+    if total == 0:
+        logger.warning("cloud_import: bundle is empty")
+        staged.unlink(missing_ok=True)
+        return None
+
+    logger.info("cloud_import phase=fetch status=complete bytes=%d", total)
+    return staged
+
+
+def _read_manifest_schema_version(bundle: Path) -> Tuple[bool, Optional[int]]:
+    """Return (has_manifest, schema_version_or_None)."""
+    try:
+        with zipfile.ZipFile(bundle, "r") as zf:
+            raw = zf.read("migration-manifest.json")
+    except (KeyError, OSError, zipfile.BadZipFile, RuntimeError):
+        return False, None
+    try:
+        manifest = json.loads(raw.decode("utf-8"))
+        return True, manifest.get("schema_version")
+    except (ValueError, UnicodeDecodeError):
+        return True, None
+
+
+def _schema_is_compatible(bundle: Path) -> Tuple[bool, Optional[str]]:
+    """Return (compatible, human_reason_when_not)."""
+    if not zipfile.is_zipfile(bundle):
+        return False, "not a zip archive"
+    has_manifest, schema_version = _read_manifest_schema_version(bundle)
+    if not has_manifest:
+        # A plain ``hermes backup`` zip has no manifest. It still restores
+        # through the same path; log the downgrade so support can tell the
+        # two apart in the marker trail.
+        return True, None
+    if schema_version is None:
+        return False, "migration-manifest.json is unreadable"
+    if int(schema_version) > MIGRATION_SCHEMA_VERSION:
+        return False, (
+            f"bundle schema_version {schema_version} is newer than this "
+            f"build supports ({MIGRATION_SCHEMA_VERSION})"
+        )
+    return True, None
+
+
+def _apply_bundle(bundle: Path, hermes_root: Path) -> bool:
+    from hermes_cli.backup import run_import
+
+    try:
+        run_import(
+            SimpleNamespace(zipfile=str(bundle), force=True),
+            extra_skip_names=CLOUD_SKIP_NAMES,
+        )
+    except SystemExit:
+        logger.warning("cloud_import: import aborted (see output above)")
+        return False
+    except Exception:
+        logger.exception("cloud_import: import raised unexpectedly")
+        return False
+    return True
+
+
+def _write_marker(hermes_root: Path, bundle_manifest: Optional[dict]) -> bool:
+    marker = {
+        "imported_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "manifest": bundle_manifest,
+        "skipped_secret_files": sorted(CLOUD_SKIP_NAMES),
+    }
+    try:
+        _marker_path(hermes_root).write_text(
+            json.dumps(marker, indent=2), encoding="utf-8"
+        )
+        return True
+    except OSError as exc:
+        logger.warning("cloud_import: marker write failed: %s", exc)
+        return False
+
+
+def maybe_run() -> bool:
+    """Run the first-boot migration import when the gates open.
+
+    Never raises: hosted boot must continue even when the migration path
+    fails. Returns True when an import was attempted.
+    """
+    url = _bundle_url()
+    if not url:
+        return False
+
+    hermes_root = _safe_hermes_root()
+    if hermes_root is None:
+        return False
+
+    if has_import_marker(hermes_root):
+        logger.info("cloud_import: marker present, skipping (already imported)")
+        return False
+
+    if not home_is_fresh(hermes_root):
+        # Not fresh and no marker: a previous attempt half-imported, or the
+        # instance was used before the bundle URL was injected. Importing
+        # now would overwrite live state, so we do not. This state needs a
+        # support look, not an automatic second pass.
+        logger.warning(
+            "cloud_import: home has session state but no import marker; "
+            "refusing to import over a live instance"
+        )
+        return False
+
+    logger.info("cloud_import: first boot, fetching migration bundle")
+    bundle = _fetch_bundle(url, hermes_root)
+    if bundle is None:
+        return True  # attempted; transport failure is logged
+
+    ok, reason = _schema_is_compatible(bundle)
+    if not ok:
+        logger.warning("cloud_import: refusing bundle: %s", reason)
+        bundle.unlink(missing_ok=True)
+        return True
+
+    schema_note = None
+    try:
+        with zipfile.ZipFile(bundle, "r") as zf:
+            data = zf.read("migration-manifest.json")
+            schema_note = json.loads(data.decode("utf-8"))
+    except Exception:
+        schema_note = None
+
+    success = _apply_bundle(bundle, hermes_root)
+    if success:
+        marker_ok = _write_marker(hermes_root, schema_note)
+        logger.info(
+            "cloud_import: import complete marker=%s", "ok" if marker_ok else "failed"
+        )
+    else:
+        logger.warning(
+            "cloud_import: import failed; leaving no marker so a future "
+            "provision can retry with a fresh bundle"
+        )
+
+    bundle.unlink(missing_ok=True)
+    return True

--- a/hermes_cli/cloud_import.py
+++ b/hermes_cli/cloud_import.py
@@ -221,6 +221,14 @@ def _write_marker(hermes_root: Path, bundle_manifest: Optional[dict]) -> bool:
         return False
 
 
+def _boot(msg: str) -> None:
+    """One-shot boot-visible line. Stdout is the cont-init channel
+    (container_boot.main() prints its reconcile lines the same way);
+    module-level INFO lines are invisible under the container logging
+    config, so the support-visible story must not ride on logging."""
+    print(f"[cloud-import] {msg}")
+
+
 def maybe_run() -> bool:
     """Run the first-boot migration import when the gates open.
 
@@ -233,10 +241,11 @@ def maybe_run() -> bool:
 
     hermes_root = _safe_hermes_root()
     if hermes_root is None:
+        _boot("cannot prepare hermes root; skipping")
         return False
 
     if has_import_marker(hermes_root):
-        logger.info("cloud_import: marker present, skipping (already imported)")
+        _boot("marker present, skipping (already imported)")
         return False
 
     if not home_is_fresh(hermes_root):
@@ -244,20 +253,21 @@ def maybe_run() -> bool:
         # instance was used before the bundle URL was injected. Importing
         # now would overwrite live state, so we do not. This state needs a
         # support look, not an automatic second pass.
-        logger.warning(
-            "cloud_import: home has session state but no import marker; "
+        _boot(
+            "home has session state but no import marker; "
             "refusing to import over a live instance"
         )
         return False
 
-    logger.info("cloud_import: first boot, fetching migration bundle")
+    _boot("first boot, fetching migration bundle")
     bundle = _fetch_bundle(url, hermes_root)
     if bundle is None:
+        _boot("bundle fetch failed; booting without migration")
         return True  # attempted; transport failure is logged
 
     ok, reason = _schema_is_compatible(bundle)
     if not ok:
-        logger.warning("cloud_import: refusing bundle: %s", reason)
+        _boot(f"refusing bundle: {reason}")
         bundle.unlink(missing_ok=True)
         return True
 
@@ -272,14 +282,9 @@ def maybe_run() -> bool:
     success = _apply_bundle(bundle, hermes_root)
     if success:
         marker_ok = _write_marker(hermes_root, schema_note)
-        logger.info(
-            "cloud_import: import complete marker=%s", "ok" if marker_ok else "failed"
-        )
+        _boot(f"import complete; marker={'written' if marker_ok else 'write failed'}")
     else:
-        logger.warning(
-            "cloud_import: import failed; leaving no marker so a future "
-            "provision can retry with a fresh bundle"
-        )
+        _boot("import failed; no marker written (a fresh bundle can retry)")
 
     bundle.unlink(missing_ok=True)
     return True

--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -598,6 +598,13 @@ def main() -> int:
         )
         return 0
 
+    # First-boot cloud migration import: self-gating on
+    # HERMES_MIGRATION_BUNDLE_URL and never raises, so a failed import
+    # leaves the boot to continue with an empty (working) instance.
+    from hermes_cli import cloud_import
+
+    cloud_import.maybe_run()
+
     hermes_home = Path(os.environ.get("HERMES_HOME", "/opt/data"))
     scandir = Path(os.environ.get("S6_PROFILE_GATEWAY_SCANDIR", "/run/service"))
     actions = reconcile_profile_gateways(

--- a/tests/hermes_cli/test_cloud_import.py
+++ b/tests/hermes_cli/test_cloud_import.py
@@ -1,0 +1,158 @@
+"""E2E tests for the first-boot cloud migration importer.
+
+Runs ``cloud_import.maybe_run`` against a synthetic HERMES_HOME and a
+migration bundle served over a ``file://`` URL (the same urllib transport
+the prod path uses, without a network hop).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import cloud_import
+from hermes_cli.cloud_import import (
+    IMPORT_MARKER_NAME,
+    MIGRATION_BUNDLE_URL_ENV,
+    MIGRATION_SCHEMA_VERSION,
+    maybe_run,
+)
+
+CONFIG = "_config_version: 4\nmodel:\n  provider: nous\n"
+
+
+def _make_bundle(
+    path: Path,
+    *,
+    schema_version: int = MIGRATION_SCHEMA_VERSION,
+    manifest: bool = True,
+    secrets: bool = True,
+) -> None:
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("config.yaml", CONFIG)
+        zf.writestr("SOUL.md", "be concise")
+        zf.writestr("skills/custom/SKILL.md", "---\nname: custom\n---\n# b\n")
+        if secrets:
+            zf.writestr(".env", "ANTHROPIC_API_KEY=sk-ant-secret\n")
+            zf.writestr("auth.json", '{"token": "x"}')
+        if manifest:
+            zf.writestr(
+                "migration-manifest.json",
+                json.dumps(
+                    {
+                        "schema_version": schema_version,
+                        "tool_version": "0.0.0-test",
+                        "config_version": 4,
+                        "secrets_included": secrets,
+                        "secrets_excluded": [],
+                    }
+                ),
+            )
+
+
+@pytest.fixture()
+def fresh_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def test_no_env_var_is_a_noop(fresh_home, capsys):
+    assert maybe_run() is False
+    assert "cloud_import" not in capsys.readouterr().out
+
+
+def test_imports_bundle_and_writes_marker(fresh_home, tmp_path, monkeypatch):
+    bundle = tmp_path / "bundle.zip"
+    _make_bundle(bundle)
+    monkeypatch.setenv(MIGRATION_BUNDLE_URL_ENV, bundle.as_uri())
+
+    assert maybe_run() is True
+
+    assert (fresh_home / "config.yaml").read_text() == CONFIG
+    assert (fresh_home / "SOUL.md").exists()
+    assert (fresh_home / "skills" / "custom" / "SKILL.md").exists()
+    # Secrets dropped even though the bundle carried them.
+    assert not (fresh_home / ".env").exists()
+    assert not (fresh_home / "auth.json").exists()
+    # Marker written, staged copy deleted (the source bundle is not ours).
+    marker = json.loads((fresh_home / IMPORT_MARKER_NAME).read_text())
+    assert marker["manifest"]["schema_version"] == MIGRATION_SCHEMA_VERSION
+    assert marker["skipped_secret_files"] == [".env", "auth.json"]
+    assert not list(fresh_home.glob(".cloud-migration-bundle.*"))
+
+
+def test_marker_present_skips(fresh_home, tmp_path, monkeypatch):
+    _make_bundle(tmp_path / "bundle.zip")
+    (fresh_home / IMPORT_MARKER_NAME).write_text('{"imported_at": "x"}')
+    monkeypatch.setenv(MIGRATION_BUNDLE_URL_ENV, (tmp_path / "bundle.zip").as_uri())
+
+    assert maybe_run() is False
+    assert not (fresh_home / "config.yaml").exists()
+
+
+def test_non_fresh_home_skips(fresh_home, tmp_path, monkeypatch):
+    # Instance already has session state: importing would clobber live data.
+    conn = sqlite3.connect(fresh_home / "state.db")
+    conn.execute("CREATE TABLE sessions (id INTEGER PRIMARY KEY)")
+    conn.commit()
+    conn.close()
+
+    _make_bundle(tmp_path / "bundle.zip")
+    monkeypatch.setenv(MIGRATION_BUNDLE_URL_ENV, (tmp_path / "bundle.zip").as_uri())
+
+    assert maybe_run() is False
+    assert not (fresh_home / "config.yaml").exists()
+    assert not (fresh_home / IMPORT_MARKER_NAME).exists()
+
+
+def test_newer_schema_refuses_before_mutation(fresh_home, tmp_path, monkeypatch):
+    bundle = tmp_path / "bundle.zip"
+    _make_bundle(bundle, schema_version=MIGRATION_SCHEMA_VERSION + 1)
+    monkeypatch.setenv(MIGRATION_BUNDLE_URL_ENV, bundle.as_uri())
+
+    assert maybe_run() is True  # attempted
+    assert not (fresh_home / "config.yaml").exists()
+    assert not (fresh_home / IMPORT_MARKER_NAME).exists()
+    assert not list(fresh_home.glob(".cloud-migration-bundle.*"))  # staged copy gone
+
+
+def test_unreachable_url_logs_and_continues(fresh_home, monkeypatch):
+    monkeypatch.setenv(MIGRATION_BUNDLE_URL_ENV, "https://127.0.0.1:1/nope.zip")
+    assert maybe_run() is True  # attempted, transport failure swallowed
+    assert not (fresh_home / "config.yaml").exists()
+    assert not (fresh_home / IMPORT_MARKER_NAME).exists()
+
+
+def test_plain_backup_zip_without_manifest_imports(fresh_home, tmp_path, monkeypatch):
+    bundle = tmp_path / "bundle.zip"
+    _make_bundle(bundle, manifest=False)
+    monkeypatch.setenv(MIGRATION_BUNDLE_URL_ENV, bundle.as_uri())
+
+    assert maybe_run() is True
+    assert (fresh_home / "config.yaml").exists()
+
+
+def test_schema_constant_matches_exporter_when_present():
+    cloud_migrate = pytest.importorskip("hermes_cli.cloud_migrate")
+    assert cloud_migrate.MIGRATION_SCHEMA_VERSION == MIGRATION_SCHEMA_VERSION
+
+
+def test_failed_extract_leaves_no_marker_and_no_partial_copy(
+    fresh_home, tmp_path, monkeypatch, capsys
+):
+    # A zip that is not actually a zip: schema gate refuses it, staged copy
+    # is removed, no marker is left behind.
+    bundle = tmp_path / "bundle.zip"
+    bundle.write_bytes(b"this is not a zip")
+    monkeypatch.setenv(MIGRATION_BUNDLE_URL_ENV, bundle.as_uri())
+
+    assert maybe_run() is True
+    assert not (fresh_home / "config.yaml").exists()
+    assert not (fresh_home / IMPORT_MARKER_NAME).exists()
+    assert not list(fresh_home.glob(".cloud-migration-bundle.*"))


### PR DESCRIPTION
## Summary

Instance side of local-to-Hermes-Cloud migration. When a hosted instance is provisioned with `HERMES_MIGRATION_BUNDLE_URL` in its startup env, the container-boot reconciler imports the bundle exactly once, before the gateway comes up.

## Behavior

`hermes_cli/cloud_import.py` runs only when three gates open:

1. the env var is set,
2. no import marker exists (`.cloud-migration-import.json`),
3. the home has no session state (`state.db` absent).

On open gates it streams the bundle (512 MiB cap, Content-Length preflight), refuses bundles whose `migration-manifest.json` schema_version is newer than this build (before touching the home), restores through the existing `run_import` path, writes the marker, and deletes the staged copy. It never raises: a failed fetch, refusal, or extract logs loudly and the boot continues with an empty, working instance. A non-fresh home with no marker (half-broken earlier attempt) is refused with a distinct log line rather than auto-retried over live state.

## Secret handling

`run_import` gains an optional `extra_skip_names` basename filter (default None, `hermes import` behavior unchanged). The cloud importer passes `{".env", "auth.json"}` so credentials can never ride a bundle into a hosted instance, even from an `--include-secrets` export. All existing `_IMPORT_SKIP_NAMES` protections (gateway_state.json, pids, locks) apply unchanged.

## Verification

- 8 E2E tests over the real urllib transport (file:// URLs) and real import path: no-op without env, full import + marker + staged-copy cleanup, secret dropping, marker-present skip, non-fresh skip, newer-schema refusal before mutation, unreachable-URL containment, plain-backup-without-manifest import, failed-extract cleanup.
- `tests/hermes_cli/test_backup.py` (51 tests) and `tests/hermes_cli/test_container_boot.py` (5 tests) regression-checked green locally.

## Dependencies

Depends on #90916 (`hermes cloud export`). The manifest schema constant is duplicated in this PR deliberately so it builds and tests independently before its base merges; `test_schema_constant_matches_exporter_when_present` asserts the two constants stay equal once both modules exist. The `backup.py` change here uses the plain `Optional` import already present, so the rebase onto the merged base needs no import-line conflict resolution.