### PR TITLE
fix(cli): distinguish hermes dashboard from serve in venv-holder update hints

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3792,9 +3792,18 @@ def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> 
     for pid, name, cmdline in matches[:6]:
         hint = ""
         low = cmdline.lower()
-        if "serve" in low or "dashboard" in low:
+        # Distinguish the two venv-holding server modes: ``hermes serve`` is
+        # the headless backend the Electron desktop app spawns (close the
+        # app); ``hermes dashboard`` is the standalone browser UI a user
+        # starts on port 9119 and stops with ``hermes dashboard --stop``.
+        # Matching the full ``hermes_cli.main <subcommand>`` token (not a
+        # bare substring) avoids mislabeling unrelated cmdlines that merely
+        # contain the word (e.g. ``hermes_cli.main serve`` vs ``npm serve``).
+        if "hermes_cli.main serve" in low:
             hint = "  ← Hermes Desktop backend (close the desktop app)"
-        elif "gateway" in low:
+        elif "hermes_cli.main dashboard" in low:
+            hint = "  ← hermes dashboard (run `hermes dashboard --stop` to close it)"
+        elif "hermes_cli.main gateway" in low:
             hint = "  ← gateway"
         lines.append(f"  PID {pid}  {name}  {cmdline[:120]}{hint}")
     if len(matches) > 6:
@@ -3810,6 +3819,8 @@ def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> 
         "  Close the Hermes desktop app / other Hermes terminals, then re-run:"
     )
     lines.append("    hermes update")
+    lines.append("  If a `hermes dashboard` is listed, stop it first with:")
+    lines.append("    hermes dashboard --stop")
     lines.append("  (or use `hermes update --force-venv` to proceed anyway at your own risk)")
     return "\n".join(lines)
 

--- a/tests/hermes_cli/test_update_venv_holder_hints.py
+++ b/tests/hermes_cli/test_update_venv_holder_hints.py
@@ -1,0 +1,60 @@
+"""Tests for venv-holder hint classification in `hermes update` preflight.
+
+Covers #90778: `_format_venv_python_holders_message` mislabeled `hermes
+dashboard` (standalone browser UI) as "Hermes Desktop backend (close the
+desktop app)". `hermes serve` (the Electron backend) and `hermes dashboard`
+are different things and must get different, actionable hints.
+
+Also guards the substring-matching regression: a cmdline that merely *contains*
+"serve"/"dashboard" as a substring (not a hermes_cli.main invocation) must not
+be labeled at all.
+"""
+
+from hermes_cli.update_cmd import _format_venv_python_holders_message
+
+
+def _msg(cmdline: str) -> str:
+    return _format_venv_python_holders_message([(12345, "python.exe", cmdline)])
+
+
+def test_dashboard_gets_stop_hint():
+    """`hermes dashboard` must point at `hermes dashboard --stop`, not the desktop app."""
+    out = _msg(r"C:\venv\Scripts\python.exe -m hermes_cli.main dashboard")
+    assert "hermes dashboard --stop" in out
+    assert "close the desktop app" not in out
+    assert "Hermes Desktop backend" not in out
+
+
+def test_serve_gets_desktop_hint():
+    """`hermes serve` (Electron backend) must still say close the desktop app."""
+    out = _msg(r"C:\venv\Scripts\python.exe -m hermes_cli.main serve")
+    assert "Hermes Desktop backend" in out
+    assert "close the desktop app" in out
+
+
+def test_gateway_gets_gateway_hint():
+    """`hermes_cli.main gateway` keeps its gateway hint."""
+    out = _msg(r"C:\venv\Scripts\python.exe -m hermes_cli.main gateway run")
+    assert "← gateway" in out
+
+
+def test_substring_serve_is_not_mislabeled():
+    """A non-hermes cmdline containing 'serve' must not get the desktop hint."""
+    out = _msg(r"C:\projects\myserver\bin\npm run serve")
+    assert "Hermes Desktop backend" not in out
+    assert "close the desktop app" not in out
+
+
+def test_substring_dashboard_is_not_mislabeled():
+    """A cmdline containing 'dashboard' outside hermes_cli.main must not be mislabeled."""
+    out = _msg(r"C:\tools\my-dashboard-monitor\app.exe --serve")
+    assert "Hermes Desktop backend" not in out
+    # No hint arrow at all for this cmdline (the remedy block below always
+    # mentions dashboard --stop, so only the per-process hint line is checked).
+    assert "←" not in out
+
+
+def test_remedy_text_mentions_dashboard_stop():
+    """The bottom remedy block must mention `hermes dashboard --stop`."""
+    out = _msg(r"C:\venv\Scripts\python.exe -m hermes_cli.main serve")
+    assert "hermes dashboard --stop" in out


### PR DESCRIPTION
## Summary

`hermes update` refuses the dependency step while another process holds the install's venv. The holder list's per-process hint mislabeled `hermes dashboard` — the standalone browser UI a user starts on port 9119 — as *"Hermes Desktop backend (close the desktop app)"*. Closing the desktop app cannot clear this holder; only `hermes dashboard --stop` does. The issue reporter's exact scenario is reproduced below.

`hermes serve` (the headless backend the Electron app spawns) and `hermes dashboard` are different things and must get different, actionable hints.

## Before / After

Before:
```
✗ Other Hermes processes are running from this install's venv:
  PID 27072  python.exe  ... -m hermes_cli.main dashboard  ← Hermes Desktop backend (close the desktop app)
```

After:
```
✗ Other Hermes processes are running from this install's venv:
  PID 27072  python.exe  ... -m hermes_cli.main dashboard  ← hermes dashboard (run `hermes dashboard --stop` to close it)
```

## Changes

- `hermes_cli/update_cmd.py` — `_format_venv_python_holders_message`: match the full `hermes_cli.main <subcommand>` token instead of bare `"serve"/"dashboard"` substrings, so:
  - `hermes_cli.main serve` → "Hermes Desktop backend (close the desktop app)" (unchanged, correct)
  - `hermes_cli.main dashboard` → "hermes dashboard (run `hermes dashboard --stop` to close it)" (fixed)
  - `hermes_cli.main gateway` → "gateway" (unchanged)
  - unrelated cmdlines containing "serve"/"dashboard" as a substring (e.g. `npm run serve`) get no hint
- Remedy block now mentions `hermes dashboard --stop`.
- `tests/hermes_cli/test_update_venv_holder_hints.py` — 6 tests covering all three modes plus substring false-positive guards.

## Why this matters beyond a cosmetic label

When a holder survives, the update can skip work silently and end on a green `✓ Restarting Windows gateway profile(s)` with no error and no non-zero exit. The holder message is the user's only signal for this failure mode, so it must name the right program.

## Reproduced on current main

The issue reporter's exact scenario reproduces on current  (f43eabee5):
,  (~line 3795 on main) labels any cmdline containing the substrings  or  as *"Hermes Desktop backend (close the desktop app)"*.

Local repro (dashboard process holding the venv):

The desktop app was not running; only No hermes dashboard processes running. clears this holder. Closing the (absent) desktop app changes nothing and the update keeps refusing.
