### PR TITLE
feat(desktop): carry route activation proof into file mutations

### DIFF
--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -18,6 +18,8 @@
  *     this via the public `/api/status` field `auth_required: true`.
  */
 
+import { assertApiRequestRouteGeneration } from './connection-route-generation'
+
 // Bare + prefixed variants of the session cookies the gateway may set,
 // depending on its deploy shape (HTTPS direct → __Host-, behind a path prefix
 // → __Secure-, loopback HTTP → bare). Mirrors
@@ -768,10 +770,17 @@ function pathWithProfileScope(path, profile) {
  * when the v1 route is remote, only the registry resolver can force the request
  * back to this device. Single-source users omit the id and keep the
  * byte-identical v1 route.
+ *
+ * Consequential filesystem/Git paths additionally require the current
+ * main-process registry generation. The check executes here before main calls
+ * ensureRegistryBackend(), so a stale receipt cannot be reinterpreted against
+ * a replacement source that reused the same stable id.
  */
 function apiRequestRegistryConnectionId(request): null | string {
-  const raw = request && typeof request === 'object' ? (request as { connectionId?: unknown }).connectionId : ''
-  const id = String(raw ?? '').trim()
+  const object = request && typeof request === 'object' ? (request as { connectionId?: unknown }) : null
+  const id = String(object?.connectionId ?? '').trim()
+
+  assertApiRequestRouteGeneration(request, id)
 
   if (!id) {
     return null

--- a/apps/desktop/electron/connection-registry-generation.test.ts
+++ b/apps/desktop/electron/connection-registry-generation.test.ts
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  normalizeConnectionInput,
+  normalizeRegistry,
+  removeConnection,
+  upsertConnection
+} from './connection-registry'
+import { currentRegistryRouteGeneration } from './connection-route-generation'
+
+test('new registered sources receive an opaque generation visible to the main authority map', () => {
+  const registry = normalizeRegistry(null)
+  const entry = normalizeConnectionInput(
+    { kind: 'remote', label: 'Homelab', url: 'https://homelab.test', authMode: 'oauth' },
+    registry
+  )
+
+  assert.ok(entry.generation)
+  assert.equal(currentRegistryRouteGeneration(entry.id), entry.generation)
+})
+
+test('cosmetic label edits preserve generation while dial-material edits rotate it', () => {
+  let registry = normalizeRegistry(null)
+  const original = normalizeConnectionInput(
+    {
+      kind: 'remote',
+      label: 'Homelab',
+      url: 'https://homelab.test',
+      authMode: 'token',
+      token: { encoding: 'safeStorage', value: 'ciphertext-1' }
+    },
+    registry
+  )
+  registry = upsertConnection(registry, original)
+
+  const renamed = normalizeConnectionInput(
+    {
+      id: original.id,
+      kind: 'remote',
+      label: 'Home server',
+      url: original.url,
+      authMode: original.authMode,
+      token: original.token
+    },
+    registry
+  )
+
+  assert.equal(renamed.generation, original.generation)
+
+  const moved = normalizeConnectionInput(
+    {
+      id: original.id,
+      kind: 'remote',
+      label: renamed.label,
+      url: 'https://replacement.test',
+      authMode: original.authMode,
+      token: original.token
+    },
+    upsertConnection(registry, renamed)
+  )
+
+  assert.ok(moved.generation)
+  assert.notEqual(moved.generation, original.generation)
+  assert.equal(currentRegistryRouteGeneration(original.id), moved.generation)
+})
+
+test('credential and header rotation also rotate source generation', () => {
+  let registry = normalizeRegistry(null)
+  const original = normalizeConnectionInput(
+    {
+      kind: 'remote',
+      label: 'Access gateway',
+      url: 'https://gateway.test',
+      authMode: 'token',
+      token: { encoding: 'safeStorage', value: 'ciphertext-1' },
+      headers: { 'CF-Access-Client-Id': { encoding: 'safeStorage', value: 'header-1' } }
+    },
+    registry
+  )
+  registry = upsertConnection(registry, original)
+
+  const tokenRotated = normalizeConnectionInput(
+    {
+      id: original.id,
+      kind: 'remote',
+      label: original.label,
+      url: original.url,
+      authMode: original.authMode,
+      token: { encoding: 'safeStorage', value: 'ciphertext-2' },
+      headers: original.headers
+    },
+    registry
+  )
+
+  assert.notEqual(tokenRotated.generation, original.generation)
+
+  const headerRotated = normalizeConnectionInput(
+    {
+      id: original.id,
+      kind: 'remote',
+      label: original.label,
+      url: original.url,
+      authMode: original.authMode,
+      token: tokenRotated.token,
+      headers: { 'CF-Access-Client-Id': { encoding: 'safeStorage', value: 'header-2' } }
+    },
+    upsertConnection(registry, tokenRotated)
+  )
+
+  assert.notEqual(headerRotated.generation, tokenRotated.generation)
+})
+
+test('normalization preserves persisted generations and mints missing legacy generations', () => {
+  const persisted = normalizeRegistry({
+    version: 2,
+    primary: 'homelab',
+    connections: [
+      { id: 'local', kind: 'local', label: 'This device' },
+      {
+        authMode: 'oauth',
+        generation: 'persisted-generation',
+        id: 'homelab',
+        kind: 'remote',
+        label: 'Homelab',
+        url: 'https://homelab.test'
+      },
+      {
+        authMode: 'oauth',
+        id: 'legacy',
+        kind: 'remote',
+        label: 'Legacy',
+        url: 'https://legacy.test'
+      }
+    ]
+  })
+  const homelab = persisted.connections.find(connection => connection.id === 'homelab')
+  const legacy = persisted.connections.find(connection => connection.id === 'legacy')
+
+  assert.equal(homelab?.generation, 'persisted-generation')
+  assert.ok(legacy?.generation)
+  assert.equal(currentRegistryRouteGeneration('homelab'), 'persisted-generation')
+  assert.equal(currentRegistryRouteGeneration('legacy'), legacy?.generation)
+})
+
+test('removal revokes the generation before the stable id can be reused', () => {
+  let registry = normalizeRegistry(null)
+  const entry = normalizeConnectionInput(
+    { kind: 'ssh', label: 'Build box', host: 'build.test', user: 'hermes' },
+    registry
+  )
+  registry = upsertConnection(registry, entry)
+
+  assert.equal(currentRegistryRouteGeneration(entry.id), entry.generation)
+
+  const removed = removeConnection(registry, entry.id)
+
+  assert.equal(removed.connections.some(connection => connection.id === entry.id), false)
+  assert.equal(currentRegistryRouteGeneration(entry.id), null)
+})

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -27,6 +27,8 @@
  * these into the IPC layer and owns file I/O + secret encryption.
  */
 
+import { randomUUID } from 'node:crypto'
+
 import {
   hostLabelFromBaseUrl,
   modeIsRemoteLike,
@@ -35,8 +37,13 @@ import {
   normalizeSshConfig,
   normAuthMode
 } from './connection-config'
+import {
+  forgetRegistryRouteGeneration,
+  rememberRegistryRouteGeneration,
+  replaceRegistryRouteGenerations
+} from './connection-route-generation'
 
-export const REGISTRY_VERSION = 2
+export const REGISTRY_VERSION: 2 = 2
 
 export const LOCAL_CONNECTION_ID = 'local'
 
@@ -48,6 +55,8 @@ export type ConnectionKind = 'cloud' | 'local' | 'remote' | 'ssh'
 export interface RegistryConnection {
   id: string
   kind: ConnectionKind
+  /** Opaque main-process source generation. Rotates on dial-material changes. */
+  generation?: string
   /** Required, unique (case-insensitive) display name — the "device name". */
   label: string
   /** remote/cloud: normalized base URL. */
@@ -56,7 +65,7 @@ export interface RegistryConnection {
   authMode?: 'oauth' | 'token'
   /** remote: encrypted token envelope (opaque here; main.ts encrypts/decrypts). */
   token?: unknown
-  /** remote/cloud: extra gateway headers (Cloudflare Access etc.). Secret
+  /** remote/cloud: extra gateway headers (access-proxy credentials). Secret
    * envelopes, same shape as `token`; names pre-filtered through
    * normalizeRemoteHeaders. Optional and additive — v2 registries written
    * before this field keep loading unchanged. */
@@ -87,6 +96,41 @@ export interface ConnectionRegistry {
 // ── Labels and ids ──────────────────────────────────────────────────────────
 
 const LABEL_MAX = 64
+
+function mintRouteGeneration(): string {
+  return randomUUID()
+}
+
+/**
+ * Preserve a source generation across cosmetic edits, but rotate it whenever
+ * dial material changes. The stable connection id remains UI identity; this
+ * opaque generation is mutation authority and therefore cannot be supplied by
+ * the renderer.
+ *
+ * `local` is not a replaceable remote source and local mutations never cross
+ * the registry REST bridge. Keep its historical storage/input shape intact;
+ * the fixed local generation is tracked only in main-process authority state.
+ */
+function withRouteGeneration(
+  entry: RegistryConnection,
+  existing: null | RegistryConnection | undefined
+): RegistryConnection {
+  if (entry.kind === 'local') {
+    rememberRegistryRouteGeneration(entry.id, 'local')
+
+    return entry
+  }
+
+  const generation =
+    existing && !connectionDialFieldsChanged(existing, entry)
+      ? String(existing.generation || '').trim() || mintRouteGeneration()
+      : mintRouteGeneration()
+  const versioned = { ...entry, generation }
+
+  rememberRegistryRouteGeneration(versioned.id, generation)
+
+  return versioned
+}
 
 /** Canonical comparison key for label uniqueness. */
 export function labelKey(label: string): string {
@@ -374,8 +418,8 @@ export function rememberSshEnumeration(
 }
 
 /** Whether an undialed SSH source should be inventoried again. Cached
- *  successes never retry. Failures retry after `retryAfterMs` so a cold box
- *  does not stay seeded as `default` until the user hits Test. */
+ * successes never retry. Failures retry after `retryAfterMs` so a cold box
+ * does not stay seeded as `default` until the user hits Test. */
 export function shouldRetrySshInventory(
   hasCache: boolean,
   lastAttemptMs: null | number | undefined,
@@ -595,6 +639,7 @@ export function normalizeConnectionInput(input: ConnectionInput, registry: Conne
     throw new Error(`Connection name is too long (max ${LABEL_MAX} characters).`)
   }
 
+  const existing = input.id ? registry.connections.find(c => c.id === input.id) : null
   const key = labelKey(label)
   const collision = registry.connections.find(c => labelKey(c.label) === key && c.id !== input.id)
 
@@ -606,7 +651,7 @@ export function normalizeConnectionInput(input: ConnectionInput, registry: Conne
 
   if (kind === 'local') {
     // The local entry is managed by the app; only its label is editable.
-    return { id: LOCAL_CONNECTION_ID, kind: 'local', label }
+    return withRouteGeneration({ id: LOCAL_CONNECTION_ID, kind: 'local', label }, existing)
   }
 
   // The reserved local id can never be claimed by a non-local entry — a
@@ -654,7 +699,7 @@ export function normalizeConnectionInput(input: ConnectionInput, registry: Conne
       throw new Error(`A connection to this SSH host already exists ("${sshDupe.label}").`)
     }
 
-    return { id, kind: 'ssh', label, ...sshFields }
+    return withRouteGeneration({ id, kind: 'ssh', label, ...sshFields }, existing)
   }
 
   if (kind === 'remote' || kind === 'cloud') {
@@ -703,7 +748,7 @@ export function normalizeConnectionInput(input: ConnectionInput, registry: Conne
       entry.org = org
     }
 
-    return entry
+    return withRouteGeneration(entry, existing)
   }
 
   throw new Error(`Unknown connection kind: ${String(kind)}`)
@@ -803,7 +848,7 @@ export function connectionDialFieldsChanged(before: RegistryConnection, after: R
 // ── Registry-level operations (all pure: return a new registry) ────────────
 
 function localEntry(label = 'This device'): RegistryConnection {
-  return { id: LOCAL_CONNECTION_ID, kind: 'local', label }
+  return { generation: 'local', id: LOCAL_CONNECTION_ID, kind: 'local', label }
 }
 
 /**
@@ -856,7 +901,13 @@ export function normalizeRegistry(raw: unknown): ConnectionRegistry {
     seenLabels.add(labelKey(label))
     seenIds.add(id)
 
-    const clean: RegistryConnection = { id, kind, label }
+    const storedGeneration = String(entry.generation || '').trim()
+    const clean: RegistryConnection = {
+      generation: kind === 'local' ? 'local' : storedGeneration || mintRouteGeneration(),
+      id,
+      kind,
+      label
+    }
 
     if (kind === 'remote' || kind === 'cloud') {
       const url = String(entry.url || '').trim()
@@ -904,14 +955,17 @@ export function normalizeRegistry(raw: unknown): ConnectionRegistry {
   const storedPrimary = String(parsed.primary || '').trim()
   const primary = connections.some(c => c.id === storedPrimary) ? storedPrimary : LOCAL_CONNECTION_ID
   const storedLastUsed = String(parsed.lastUsed || '').trim()
-
-  return {
+  const normalized = {
     version: REGISTRY_VERSION,
     primary,
-    launchMode: parsed.launchMode === 'last-used' ? 'last-used' : 'primary',
+    launchMode: parsed.launchMode === 'last-used' ? ('last-used' as const) : ('primary' as const),
     lastUsed: connections.some(c => c.id === storedLastUsed) ? storedLastUsed : primary,
     connections
   }
+
+  replaceRegistryRouteGenerations(connections)
+
+  return normalized
 }
 
 /**
@@ -950,6 +1004,7 @@ export function migrateV1ToRegistry(v1: unknown): ConnectionRegistry {
     )
 
     const entry: RegistryConnection = {
+      generation: mintRouteGeneration(),
       id: connectionIdForLabel(
         label,
         connections.map(c => c.id)
@@ -1004,6 +1059,7 @@ export function migrateV1ToRegistry(v1: unknown): ConnectionRegistry {
     const { mode: _mode, ...sshFields } = ssh
 
     const entry: RegistryConnection = {
+      generation: mintRouteGeneration(),
       id: connectionIdForLabel(
         label,
         connections.map(c => c.id)
@@ -1054,7 +1110,11 @@ export function migrateV1ToRegistry(v1: unknown): ConnectionRegistry {
     }
   }
 
-  return { version: REGISTRY_VERSION, primary, launchMode: 'primary', lastUsed: primary, connections }
+  const migrated = { version: REGISTRY_VERSION, primary, launchMode: 'primary' as const, lastUsed: primary, connections }
+
+  replaceRegistryRouteGenerations(connections)
+
+  return migrated
 }
 
 /** Insert or replace by id. Input must already be normalized/validated. */
@@ -1062,6 +1122,8 @@ export function upsertConnection(registry: ConnectionRegistry, entry: RegistryCo
   const connections = registry.connections.some(c => c.id === entry.id)
     ? registry.connections.map(c => (c.id === entry.id ? entry : c))
     : [...registry.connections, entry]
+
+  rememberRegistryRouteGeneration(entry.id, entry.kind === 'local' ? 'local' : entry.generation)
 
   return { ...registry, connections }
 }
@@ -1082,6 +1144,8 @@ export function removeConnection(registry: ConnectionRegistry, id: string): Conn
   }
 
   const primary = registry.primary === id ? LOCAL_CONNECTION_ID : registry.primary
+
+  forgetRegistryRouteGeneration(id)
 
   return {
     ...registry,

--- a/apps/desktop/electron/connection-route-generation.test.ts
+++ b/apps/desktop/electron/connection-route-generation.test.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict'
+
+import { beforeEach, test } from 'vitest'
+
+import { apiRequestRegistryConnectionId } from './connection-config'
+import {
+  apiRequestRequiresRouteGeneration,
+  currentRegistryRouteGeneration,
+  forgetRegistryRouteGeneration,
+  rememberRegistryRouteGeneration,
+  replaceRegistryRouteGenerations
+} from './connection-route-generation'
+
+beforeEach(() => {
+  replaceRegistryRouteGenerations([{ generation: 'generation-1', id: 'homelab' }])
+})
+
+test('main accepts an exact current generation for every protected FS/Git mutation family', () => {
+  const paths = [
+    '/api/fs/write-text',
+    '/api/git/branch/switch',
+    '/api/git/review/commit',
+    '/api/git/review/create-pr',
+    '/api/git/review/push',
+    '/api/git/review/revert',
+    '/api/git/review/stage',
+    '/api/git/review/unstage',
+    '/api/git/worktree/add',
+    '/api/git/worktree/remove'
+  ]
+
+  for (const path of paths) {
+    const request = {
+      connectionId: 'homelab',
+      method: 'POST',
+      path: `${path}?profile=research`,
+      routeGeneration: 'generation-1'
+    }
+
+    assert.equal(apiRequestRequiresRouteGeneration(request), true)
+    assert.equal(apiRequestRegistryConnectionId(request), 'homelab')
+  }
+})
+
+test('main rejects a stale receipt after dial material rotates under the same id', () => {
+  rememberRegistryRouteGeneration('homelab', 'generation-2')
+
+  assert.throws(
+    () =>
+      apiRequestRegistryConnectionId({
+        connectionId: 'homelab',
+        method: 'POST',
+        path: '/api/git/review/push',
+        routeGeneration: 'generation-1'
+      }),
+    /stale or has been replaced/
+  )
+  assert.equal(currentRegistryRouteGeneration('homelab'), 'generation-2')
+})
+
+test('main rejects missing generation and missing exact owner on protected routes', () => {
+  assert.throws(
+    () =>
+      apiRequestRegistryConnectionId({
+        connectionId: 'homelab',
+        method: 'POST',
+        path: '/api/fs/write-text'
+      }),
+    /stale or has been replaced/
+  )
+
+  assert.throws(
+    () =>
+      apiRequestRegistryConnectionId({
+        method: 'POST',
+        path: '/api/git/review/commit',
+        routeGeneration: 'generation-1'
+      }),
+    /requires an exact registered connection route/
+  )
+})
+
+test('main rejects a receipt after source removal', () => {
+  forgetRegistryRouteGeneration('homelab')
+
+  assert.throws(
+    () =>
+      apiRequestRegistryConnectionId({
+        connectionId: 'homelab',
+        method: 'POST',
+        path: '/api/git/worktree/remove',
+        routeGeneration: 'generation-1'
+      }),
+    /stale or has been replaced/
+  )
+  assert.equal(currentRegistryRouteGeneration('homelab'), null)
+})
+
+test('read-only and non-authority POST routes preserve their existing routing contract', () => {
+  const read = { connectionId: 'homelab', path: '/api/git/status?path=%2Frepo' }
+  const queryPost = {
+    body: { branches: [] },
+    connectionId: 'homelab',
+    method: 'POST',
+    path: '/api/git/review/pr-list'
+  }
+
+  assert.equal(apiRequestRequiresRouteGeneration(read), false)
+  assert.equal(apiRequestRequiresRouteGeneration(queryPost), false)
+  assert.equal(apiRequestRegistryConnectionId(read), 'homelab')
+  assert.equal(apiRequestRegistryConnectionId(queryPost), 'homelab')
+})

--- a/apps/desktop/electron/connection-route-generation.ts
+++ b/apps/desktop/electron/connection-route-generation.ts
@@ -1,0 +1,115 @@
+/**
+ * Main-process registry route-generation authority.
+ *
+ * Renderer route receipts may name a stable connection id, but that id can be
+ * edited in place to point at a different physical backend. Consequential
+ * filesystem/Git requests therefore carry the current registry generation and
+ * this module verifies it before main resolves or dials the source.
+ */
+
+interface RegistryGenerationEntry {
+  generation?: unknown
+  id?: unknown
+}
+
+interface RouteGenerationRequest {
+  connectionId?: unknown
+  method?: unknown
+  path?: unknown
+  routeGeneration?: unknown
+}
+
+const currentGenerations = new Map<string, string>()
+
+const GENERATION_GATED_MUTATIONS = new Set([
+  'POST /api/fs/write-text',
+  'POST /api/git/branch/switch',
+  'POST /api/git/review/commit',
+  'POST /api/git/review/create-pr',
+  'POST /api/git/review/push',
+  'POST /api/git/review/revert',
+  'POST /api/git/review/stage',
+  'POST /api/git/review/unstage',
+  'POST /api/git/worktree/add',
+  'POST /api/git/worktree/remove'
+])
+
+function clean(value: unknown): string {
+  return String(value ?? '').trim()
+}
+
+function requestRoute(request: RouteGenerationRequest | null | undefined): string {
+  const method = clean(request?.method || 'GET').toUpperCase()
+  const rawPath = clean(request?.path)
+
+  if (!rawPath) {
+    return `${method} `
+  }
+
+  try {
+    return `${method} ${new URL(rawPath, 'https://hermes.invalid').pathname}`
+  } catch {
+    return `${method} ${rawPath.split(/[?#]/, 1)[0]}`
+  }
+}
+
+export function apiRequestRequiresRouteGeneration(request: RouteGenerationRequest | null | undefined): boolean {
+  return GENERATION_GATED_MUTATIONS.has(requestRoute(request))
+}
+
+export function replaceRegistryRouteGenerations(entries: Iterable<RegistryGenerationEntry>): void {
+  currentGenerations.clear()
+
+  for (const entry of entries) {
+    const id = clean(entry.id)
+    const generation = clean(entry.generation)
+
+    if (id && generation) {
+      currentGenerations.set(id, generation)
+    }
+  }
+}
+
+export function rememberRegistryRouteGeneration(idValue: unknown, generationValue: unknown): void {
+  const id = clean(idValue)
+  const generation = clean(generationValue)
+
+  if (id && generation) {
+    currentGenerations.set(id, generation)
+  }
+}
+
+export function forgetRegistryRouteGeneration(idValue: unknown): void {
+  const id = clean(idValue)
+
+  if (id) {
+    currentGenerations.delete(id)
+  }
+}
+
+export function assertApiRequestRouteGeneration(
+  request: RouteGenerationRequest | null | undefined,
+  connectionIdValue: unknown
+): void {
+  if (!apiRequestRequiresRouteGeneration(request)) {
+    return
+  }
+
+  const connectionId = clean(connectionIdValue)
+
+  if (!connectionId) {
+    throw new Error('Remote filesystem/Git mutation requires an exact registered connection route.')
+  }
+
+  const supplied = clean(request?.routeGeneration)
+  const current = currentGenerations.get(connectionId)
+
+  if (!supplied || !current || supplied !== current) {
+    throw new Error('Remote filesystem/Git mutation route is stale or has been replaced; reactivate the connection.')
+  }
+}
+
+/** @internal Test-only visibility without exposing the mutable map. */
+export function currentRegistryRouteGeneration(connectionIdValue: unknown): null | string {
+  return currentGenerations.get(clean(connectionIdValue)) ?? null
+}

--- a/apps/desktop/src/lib/desktop-fs-route-proof.test.ts
+++ b/apps/desktop/src/lib/desktop-fs-route-proof.test.ts
@@ -1,0 +1,143 @@
+import { atom } from 'nanostores'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesConnection } from '@/global'
+
+const $connection = atom<HermesConnection | null>(null)
+const hermesApi = vi.fn()
+const routeProof = vi.hoisted(() => ({ currentForMutation: vi.fn() }))
+
+vi.mock('@/hermes', () => ({ hermesApi }))
+vi.mock('@/store/gateway-activation', () => ({
+  currentRouteActivationReceiptForMutation: routeProof.currentForMutation
+}))
+vi.mock('@/store/session', () => ({ $connection }))
+
+const { desktopFsCacheKey, readDesktopFileText, writeDesktopFileText } = await import('./desktop-fs')
+
+const localConnection = (over: Partial<HermesConnection> = {}): HermesConnection =>
+  ({ baseUrl: '', mode: 'local', profile: 'default', ...over }) as HermesConnection
+
+const remoteConnection = (over: Partial<HermesConnection> = {}): HermesConnection =>
+  ({
+    baseUrl: 'https://homelab.invalid',
+    connectionId: 'homelab',
+    mode: 'remote',
+    profile: 'research',
+    registryScoped: true,
+    routeGeneration: 'homelab-generation-1',
+    ...over
+  }) as HermesConnection
+
+const api = vi.fn()
+const readFileText = vi.fn()
+const writeTextFile = vi.fn()
+
+beforeEach(() => {
+  api.mockReset()
+  hermesApi.mockReset()
+  readFileText.mockReset()
+  routeProof.currentForMutation.mockReset()
+  writeTextFile.mockReset()
+  vi.stubGlobal('window', {
+    hermesDesktop: {
+      api,
+      readFileText,
+      writeTextFile
+    }
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  $connection.set(null)
+})
+
+describe('Desktop FS proof-carrying route mutation (#90866 / #89916)', () => {
+  it('keeps same-profile caches separate across registry owners', () => {
+    const first = remoteConnection({ connectionId: 'homelab-a' })
+    const second = remoteConnection({ connectionId: 'homelab-b' })
+
+    expect(desktopFsCacheKey(first)).not.toBe(desktopFsCacheKey(second))
+  })
+
+  it('sends a remote write only to the exact owner, profile, and source generation carried by the receipt', async () => {
+    const descriptor = remoteConnection()
+    const receipt = {
+      connection: descriptor,
+      route: { connectionId: 'homelab', profile: 'research' },
+      status: 'ready'
+    }
+
+    $connection.set(descriptor)
+    routeProof.currentForMutation.mockReturnValue(receipt)
+    api.mockResolvedValue({ ok: true, path: '/repo/README.md' })
+
+    await expect(writeDesktopFileText('/repo/README.md', 'proof')).resolves.toEqual({ path: '/repo/README.md' })
+
+    expect(routeProof.currentForMutation).toHaveBeenCalledWith(descriptor)
+    expect(api).toHaveBeenCalledWith({
+      body: { content: 'proof', path: '/repo/README.md' },
+      connectionId: 'homelab',
+      method: 'POST',
+      path: '/api/fs/write-text',
+      profile: 'research',
+      routeGeneration: 'homelab-generation-1'
+    })
+    expect(hermesApi).not.toHaveBeenCalled()
+  })
+
+  it('rejects a remote write when the active route has no current exact mutation proof', async () => {
+    const descriptor = remoteConnection()
+
+    $connection.set(descriptor)
+    routeProof.currentForMutation.mockReturnValue(null)
+
+    await expect(writeDesktopFileText('/repo/README.md', 'unsafe')).rejects.toThrow(
+      'Remote file mutation requires a current exact generated route activation'
+    )
+
+    expect(api).not.toHaveBeenCalled()
+    expect(hermesApi).not.toHaveBeenCalled()
+  })
+
+  it('rejects a nominally ready receipt that carries no source generation', async () => {
+    const descriptor = remoteConnection({ routeGeneration: undefined } as Partial<HermesConnection>)
+    const receipt = {
+      connection: descriptor,
+      route: { connectionId: 'homelab', profile: 'research' },
+      status: 'ready'
+    }
+
+    $connection.set(descriptor)
+    routeProof.currentForMutation.mockReturnValue(receipt)
+
+    await expect(writeDesktopFileText('/repo/README.md', 'unsafe')).rejects.toThrow(
+      'Remote file mutation requires a current exact generated route activation'
+    )
+    expect(api).not.toHaveBeenCalled()
+  })
+
+  it('keeps local writes on hardened local IPC without requiring gateway route proof', async () => {
+    $connection.set(localConnection())
+    writeTextFile.mockResolvedValue({ path: '/tmp/local.txt' })
+
+    await expect(writeDesktopFileText('/tmp/local.txt', 'local')).resolves.toEqual({ path: '/tmp/local.txt' })
+
+    expect(writeTextFile).toHaveBeenCalledWith('/tmp/local.txt', 'local')
+    expect(routeProof.currentForMutation).not.toHaveBeenCalled()
+  })
+
+  it('routes remote reads through the gateway-owned connection context instead of a profile-only bridge call', async () => {
+    $connection.set(remoteConnection())
+    hermesApi.mockResolvedValue({ path: '/repo/README.md', text: 'hello' })
+
+    await readDesktopFileText('/repo/README.md')
+
+    expect(hermesApi).toHaveBeenCalledWith({
+      path: '/api/fs/read-text?path=%2Frepo%2FREADME.md',
+      profile: 'research'
+    })
+    expect(api).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -4,10 +4,16 @@ import type {
   HermesReadFileTextResult,
   HermesSelectPathsOptions
 } from '@/global'
+import { hermesApi } from '@/hermes'
+import { currentRouteActivationReceiptForMutation } from '@/store/gateway-activation'
 import { $connection } from '@/store/session'
 
 export interface DesktopFsRemotePicker {
   selectPaths: (options?: HermesSelectPathsOptions) => Promise<string[]>
+}
+
+type RouteGenerationBoundConnection = HermesConnection & {
+  routeGeneration?: string
 }
 
 let remotePicker: DesktopFsRemotePicker | null = null
@@ -26,7 +32,9 @@ function connectionCacheKey(connection: HermesConnection | null) {
       ? connection.remoteIdentity || connection.remoteHost || ''
       : connection.baseUrl || ''
 
-  return `${connection.mode || 'local'}:${connection.remoteKind || ''}:${connection.profile || ''}:${target}`
+  const owner = connection.connectionId ? `${connection.connectionId}:` : ''
+
+  return `${owner}${connection.mode || 'local'}:${connection.remoteKind || ''}:${connection.profile || ''}:${target}`
 }
 
 export function desktopFsCacheKey(connection: HermesConnection | null = $connection.get()) {
@@ -37,8 +45,8 @@ export function isDesktopFsRemoteMode() {
   return $connection.get()?.mode === 'remote'
 }
 
-// Active profile for FS/git REST calls. Without it the Electron api bridge
-// hits the primary (local) backend even when the user switched to a remote profile.
+// Active logical profile for FS/git REST calls. hermesApi carries the active
+// registry source separately; profile names are not globally unique.
 export function desktopFsProfile(): string | undefined {
   return $connection.get()?.profile || undefined
 }
@@ -58,9 +66,43 @@ function bridge() {
 }
 
 function remoteFsApi<T>(path: string, body?: Record<string, unknown>): Promise<T> {
-  return bridge().api<T>(
+  // Route read-only requests through the same active connection context the
+  // gateway registry maintains. The old direct bridge call carried only a
+  // profile, so a registry agent silently fell back to the primary source
+  // (#89916, the owner-loss form of #90866).
+  return hermesApi<T>(
     body ? { body, method: 'POST', path, profile: desktopFsProfile() } : { path, profile: desktopFsProfile() }
   )
+}
+
+function remoteFsMutationApi<T>(path: string, body: Record<string, unknown>): Promise<T> {
+  const connection = $connection.get()
+  const receipt = currentRouteActivationReceiptForMutation(connection)
+  const connectionId = receipt?.route.connectionId
+  const routeGeneration = String(
+    (receipt?.connection as RouteGenerationBoundConnection | undefined)?.routeGeneration || ''
+  ).trim()
+
+  // A remote write must name an exact registry owner AND the main-owned source
+  // generation that the activation proved. A stable connectionId is UI
+  // identity only: Settings can edit it in place to target a different host.
+  if (!receipt || !connectionId || !routeGeneration) {
+    throw new Error('Remote file mutation requires a current exact generated route activation')
+  }
+
+  // Consume the receipt directly at the side-effect boundary. Main revalidates
+  // routeGeneration before resolving/dialling the registry source, so a stale
+  // renderer receipt cannot authorize a replacement source under the same id.
+  const request = {
+    body,
+    connectionId,
+    method: 'POST' as const,
+    path,
+    profile: receipt.route.profile,
+    routeGeneration
+  }
+
+  return bridge().api<T>(request)
 }
 
 export async function readDesktopDir(path: string): Promise<HermesReadDirResult> {
@@ -80,9 +122,9 @@ export async function readDesktopFileText(path: string): Promise<HermesReadFileT
 }
 
 // Save UTF-8 text back to a file. Local writes go through the hardened Electron
-// IPC; remote writes hit the dashboard's POST /api/fs/write-text (same path
-// hardening, parent-must-exist, size cap) so the editor behaves identically in
-// both modes. Stale-on-disk detection is the caller's job (re-read before save).
+// IPC; remote writes hit the dashboard's POST /api/fs/write-text only after
+// the active route proves its exact registry owner, descriptor realization, and
+// generation. Stale-on-disk detection is the caller's job (re-read before save).
 export async function writeDesktopFileText(path: string, content: string): Promise<{ path: string }> {
   const desktop = bridge()
 
@@ -94,7 +136,7 @@ export async function writeDesktopFileText(path: string, content: string): Promi
     return desktop.writeTextFile(path, content)
   }
 
-  const result = await remoteFsApi<{ ok?: boolean; path?: string }>('/api/fs/write-text', { content, path })
+  const result = await remoteFsMutationApi<{ ok?: boolean; path?: string }>('/api/fs/write-text', { content, path })
 
   return { path: result.path || path }
 }

--- a/apps/desktop/src/lib/desktop-git.test.ts
+++ b/apps/desktop/src/lib/desktop-git.test.ts
@@ -1,12 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { HermesConnection } from '@/global'
+import { setApiRequestConnection } from '@/hermes'
 import { $connection } from '@/store/session'
 
 import { desktopGit } from './desktop-git'
 
+const routeProof = vi.hoisted(() => ({ currentForMutation: vi.fn() }))
+
+vi.mock('@/store/gateway-activation', () => ({
+  currentRouteActivationReceiptForMutation: routeProof.currentForMutation
+}))
+
 const repoStatus = vi.fn(async () => ({ branch: 'main' }))
+const stage = vi.fn(async () => ({ ok: true }))
 const worktreeList = vi.fn(async () => [{ branch: 'main', detached: false, isMain: true, locked: false, path: '/r' }])
-const localGit = { repoStatus, review: { stage: vi.fn() }, worktreeList }
+const localGit = { repoStatus, review: { stage }, worktreeList }
 
 const api = vi.fn(async ({ path }: { path: string }) => {
   if (path.startsWith('/api/git/status')) {
@@ -27,18 +36,54 @@ const api = vi.fn(async ({ path }: { path: string }) => {
     }
   }
 
+  if (path.startsWith('/api/git/review/pr-list')) {
+    return { pullRequests: [] }
+  }
+
   return { ok: true }
+})
+
+type GeneratedHermesConnection = HermesConnection & { routeGeneration: string }
+
+const remoteConnection = (
+  connectionId: string,
+  routeGeneration = `${connectionId}-generation-1`
+): GeneratedHermesConnection => ({
+  baseUrl: `https://${connectionId}.invalid`,
+  connectionId,
+  isFullscreen: false,
+  logs: [],
+  mode: 'remote',
+  nativeOverlayWidth: 0,
+  profile: 'research',
+  registryScoped: true,
+  routeGeneration,
+  token: '',
+  windowButtonPosition: null,
+  wsUrl: `wss://${connectionId}.invalid/api/ws`
+})
+
+const readyReceipt = (connectionId: string) => ({
+  connection: remoteConnection(connectionId),
+  route: { connectionId, profile: 'research' },
+  status: 'ready'
 })
 
 describe('desktop git facade', () => {
   beforeEach(() => {
     vi.stubGlobal('window', { hermesDesktop: { api, git: localGit } })
+    api.mockClear()
+    repoStatus.mockClear()
+    routeProof.currentForMutation.mockReset()
+    stage.mockClear()
+    worktreeList.mockClear()
+    setApiRequestConnection(null)
     $connection.set(null)
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
-    vi.clearAllMocks()
+    setApiRequestConnection(null)
     $connection.set(null)
   })
 
@@ -48,79 +93,152 @@ describe('desktop git facade', () => {
     expect(desktopGit()).toBeUndefined()
   })
 
-  it('uses Electron git locally', async () => {
+  it('keeps local reads and mutations on Electron without requiring route proof', async () => {
     $connection.set({ mode: 'local' } as never)
 
     await expect(desktopGit()?.repoStatus('/work')).resolves.toEqual({ branch: 'main' })
+    await desktopGit()?.review.stage('/work', 'a.txt')
+
     expect(repoStatus).toHaveBeenCalledWith('/work')
+    expect(stage).toHaveBeenCalledWith('/work', 'a.txt')
     expect(api).not.toHaveBeenCalled()
+    expect(routeProof.currentForMutation).not.toHaveBeenCalled()
   })
 
-  it('routes reads through the backend REST mirror on a remote gateway', async () => {
-    $connection.set({ mode: 'remote' } as never)
+  it('keeps same-profile Git reads on their exact registry owners', async () => {
+    $connection.set(remoteConnection('homelab-a'))
+    setApiRequestConnection('homelab-a')
 
     await expect(desktopGit()?.repoStatus('/srv/work')).resolves.toEqual({ branch: 'remote-main' })
-    expect(api).toHaveBeenCalledWith({ path: '/api/git/status?path=%2Fsrv%2Fwork' })
+    expect(api).toHaveBeenLastCalledWith({
+      connectionId: 'homelab-a',
+      path: '/api/git/status?path=%2Fsrv%2Fwork',
+      profile: 'research'
+    })
 
-    // List endpoints unwrap their envelope to the bare array the bridge returns.
+    api.mockClear()
+    $connection.set(remoteConnection('homelab-b'))
+    setApiRequestConnection('homelab-b')
+
+    await desktopGit()?.repoStatus('/srv/work')
+    expect(api).toHaveBeenLastCalledWith({
+      connectionId: 'homelab-b',
+      path: '/api/git/status?path=%2Fsrv%2Fwork',
+      profile: 'research'
+    })
+    expect(routeProof.currentForMutation).not.toHaveBeenCalled()
+  })
+
+  it('preserves read envelopes and read-only POST queries on the active registry owner', async () => {
+    $connection.set(remoteConnection('homelab'))
+    setApiRequestConnection('homelab')
+
     await expect(desktopGit()?.worktreeList('/srv/work')).resolves.toEqual([
       { branch: 'main', detached: false, isMain: true, locked: false, path: '/srv/r' }
     ])
-
-    // review.diff unwraps { diff } to a string.
     await expect(desktopGit()?.review.diff('/srv/work', 'a.txt', 'uncommitted', null, false)).resolves.toBe(
       'remote-diff'
     )
+    await desktopGit()?.review.prList('/srv/work', ['feature'], [123])
 
-    expect(repoStatus).not.toHaveBeenCalled()
+    expect(api).toHaveBeenLastCalledWith({
+      body: { branches: ['feature'], numbers: [123], path: '/srv/work' },
+      connectionId: 'homelab',
+      method: 'POST',
+      path: '/api/git/review/pr-list',
+      profile: 'research'
+    })
+    expect(routeProof.currentForMutation).not.toHaveBeenCalled()
   })
 
-  it('targets the active profile backend so a remote profile never touches the local repo', async () => {
-    $connection.set({ mode: 'remote', profile: 'remote-docker' } as never)
+  it('routes a permitted Git mutation from the receipt rather than ambient profile state', async () => {
+    const descriptor = remoteConnection('homelab-a')
 
-    await desktopGit()?.repoStatus('/srv/work')
+    $connection.set(descriptor)
+    setApiRequestConnection('homelab-b')
+    routeProof.currentForMutation.mockReturnValue(readyReceipt('homelab-a'))
+
     await desktopGit()?.review.stage('/srv/work', 'a.txt')
 
-    expect(api).toHaveBeenCalledWith({ path: '/api/git/status?path=%2Fsrv%2Fwork', profile: 'remote-docker' })
+    expect(routeProof.currentForMutation).toHaveBeenCalledWith(descriptor)
     expect(api).toHaveBeenCalledWith({
       body: { file: 'a.txt', path: '/srv/work' },
+      connectionId: 'homelab-a',
       method: 'POST',
       path: '/api/git/review/stage',
-      profile: 'remote-docker'
+      profile: 'research',
+      routeGeneration: 'homelab-a-generation-1'
     })
   })
 
-  it('sends mutations as POST bodies on a remote gateway', async () => {
-    $connection.set({ mode: 'remote' } as never)
+  it('rejects every remote Git mutation surface without current exact proof', () => {
+    $connection.set(remoteConnection('homelab'))
+    setApiRequestConnection('homelab')
+    routeProof.currentForMutation.mockReturnValue(null)
 
-    await desktopGit()?.review.stage('/srv/work', 'a.txt')
+    const git = desktopGit()
 
-    expect(api).toHaveBeenCalledWith({
-      body: { file: 'a.txt', path: '/srv/work' },
-      method: 'POST',
-      path: '/api/git/review/stage'
-    })
-    expect(localGit.review.stage).not.toHaveBeenCalled()
+    expect(git).toBeDefined()
+
+    if (!git) {
+      throw new Error('remote Git facade unavailable')
+    }
+
+    const mutations = [
+      () => git.worktreeAdd('/srv/work', { existingBranch: 'origin/feature' }),
+      () => git.worktreeRemove('/srv/work', '/srv/worktree', { force: true }),
+      () => git.branchSwitch('/srv/work', 'feature'),
+      () => git.review.stage('/srv/work', 'a.txt'),
+      () => git.review.unstage('/srv/work', 'a.txt'),
+      () => git.review.revert('/srv/work', 'a.txt'),
+      () => git.review.commit('/srv/work', 'message', false),
+      () => git.review.push('/srv/work'),
+      () => git.review.createPr('/srv/work')
+    ]
+
+    for (const mutate of mutations) {
+      expect(mutate).toThrow('Remote Git mutation requires a current exact generated route activation')
+    }
+
+    expect(api).not.toHaveBeenCalled()
+    expect(routeProof.currentForMutation).toHaveBeenCalledTimes(mutations.length)
   })
 
-  // The ⌘⇧B "convert a branch into a worktree" flow (#81724): on a remote
-  // gateway both halves must reach the backend mirror — the picker's branch
-  // list (which now carries remote-tracking refs) and the worktree add that
-  // receives the picked `origin/…` name.
-  it('routes the convert-a-branch worktree flow through the backend on a remote gateway', async () => {
-    $connection.set({ mode: 'remote' } as never)
+  it('rejects a nominally ready Git receipt without a source generation', () => {
+    const descriptor = remoteConnection('homelab', '')
+
+    $connection.set(descriptor)
+    routeProof.currentForMutation.mockReturnValue({
+      connection: descriptor,
+      route: { connectionId: 'homelab', profile: 'research' },
+      status: 'ready'
+    })
+
+    expect(() => desktopGit()?.review.push('/srv/work')).toThrow(
+      'Remote Git mutation requires a current exact generated route activation'
+    )
+    expect(api).not.toHaveBeenCalled()
+  })
+
+  it('keeps the remote branch-to-worktree flow under one exact generated mutation owner', async () => {
+    const descriptor = remoteConnection('homelab')
+
+    $connection.set(descriptor)
+    setApiRequestConnection('homelab')
+    routeProof.currentForMutation.mockReturnValue(readyReceipt('homelab'))
 
     await expect(desktopGit()?.branchList('/srv/work')).resolves.toEqual([
       { checkedOut: false, isDefault: false, isRemote: true, name: 'origin/feature', worktreePath: null }
     ])
-    expect(api).toHaveBeenCalledWith({ path: '/api/git/branches?path=%2Fsrv%2Fwork' })
-
     await desktopGit()?.worktreeAdd('/srv/work', { existingBranch: 'origin/feature' })
 
-    expect(api).toHaveBeenCalledWith({
+    expect(api).toHaveBeenLastCalledWith({
       body: { existingBranch: 'origin/feature', path: '/srv/work' },
+      connectionId: 'homelab',
       method: 'POST',
-      path: '/api/git/worktree/add'
+      path: '/api/git/worktree/add',
+      profile: 'research',
+      routeGeneration: 'homelab-generation-1'
     })
   })
 })

--- a/apps/desktop/src/lib/desktop-git.ts
+++ b/apps/desktop/src/lib/desktop-git.ts
@@ -1,4 +1,5 @@
 import type {
+  HermesConnection,
   HermesGitBaseBranch,
   HermesGitBranch,
   HermesGitWorktree,
@@ -7,6 +8,9 @@ import type {
   HermesReviewList,
   HermesReviewShipInfo
 } from '@/global'
+import { hermesApi } from '@/hermes'
+import { currentRouteActivationReceiptForMutation } from '@/store/gateway-activation'
+import { $connection } from '@/store/session'
 
 import { desktopFsProfile, isDesktopFsRemoteMode } from './desktop-fs'
 
@@ -18,16 +22,54 @@ import { desktopFsProfile, isDesktopFsRemoteMode } from './desktop-fs'
 
 type GitBridge = NonNullable<NonNullable<Window['hermesDesktop']>['git']>
 
-function desktopApi<T>(path: string, body?: Record<string, unknown>): Promise<T> {
+type RouteGenerationBoundConnection = HermesConnection & {
+  routeGeneration?: string
+}
+
+function desktopBridge() {
   const desktop = window.hermesDesktop
 
   if (!desktop) {
     throw new Error('Hermes Desktop bridge is unavailable')
   }
 
-  return desktop.api<T>(
+  return desktop
+}
+
+function desktopReadApi<T>(path: string, body?: Record<string, unknown>): Promise<T> {
+  // hermesApi carries the active registry connection as well as the logical
+  // profile. A profile name alone is not a globally unique Git owner.
+  return hermesApi<T>(
     body ? { body, method: 'POST', path, profile: desktopFsProfile() } : { path, profile: desktopFsProfile() }
   )
+}
+
+function desktopMutationApi<T>(path: string, body: Record<string, unknown>): Promise<T> {
+  const connection = $connection.get()
+  const receipt = currentRouteActivationReceiptForMutation(connection)
+  const connectionId = receipt?.route.connectionId
+  const routeGeneration = String(
+    (receipt?.connection as RouteGenerationBoundConnection | undefined)?.routeGeneration || ''
+  ).trim()
+
+  // Git mutations are filesystem mutations with a larger blast radius. Never
+  // reconstruct their owner from the foreground profile or ambient API route:
+  // consume the exact activation receipt and its main-owned source generation
+  // at the side-effect boundary.
+  if (!receipt || !connectionId || !routeGeneration) {
+    throw new Error('Remote Git mutation requires a current exact generated route activation')
+  }
+
+  const request = {
+    body,
+    connectionId,
+    method: 'POST' as const,
+    path,
+    profile: receipt.route.profile,
+    routeGeneration
+  }
+
+  return desktopBridge().api<T>(request)
 }
 
 function gitGet<T>(route: string, params: Record<string, boolean | null | string | undefined>): Promise<T> {
@@ -39,23 +81,27 @@ function gitGet<T>(route: string, params: Record<string, boolean | null | string
     }
   }
 
-  return desktopApi<T>(`/api/git/${route}?${query.toString()}`)
+  return desktopReadApi<T>(`/api/git/${route}?${query.toString()}`)
 }
 
-function gitPost<T>(route: string, body: Record<string, unknown>): Promise<T> {
-  return desktopApi<T>(`/api/git/${route}`, body)
+function gitMutate<T>(route: string, body: Record<string, unknown>): Promise<T> {
+  return desktopMutationApi<T>(`/api/git/${route}`, body)
+}
+
+function gitPostQuery<T>(route: string, body: Record<string, unknown>): Promise<T> {
+  return desktopReadApi<T>(`/api/git/${route}`, body)
 }
 
 const remoteGit: GitBridge = {
   worktreeList: async repoPath =>
     (await gitGet<{ worktrees: HermesGitWorktree[] }>('worktrees', { path: repoPath })).worktrees,
 
-  worktreeAdd: (repoPath, options) => gitPost('worktree/add', { path: repoPath, ...options }),
+  worktreeAdd: (repoPath, options) => gitMutate('worktree/add', { path: repoPath, ...options }),
 
   worktreeRemove: (repoPath, worktreePath, options) =>
-    gitPost('worktree/remove', { force: options?.force ?? false, path: repoPath, worktreePath }),
+    gitMutate('worktree/remove', { force: options?.force ?? false, path: repoPath, worktreePath }),
 
-  branchSwitch: (repoPath, branch) => gitPost('branch/switch', { branch, path: repoPath }),
+  branchSwitch: (repoPath, branch) => gitMutate('branch/switch', { branch, path: repoPath }),
 
   branchList: async repoPath =>
     (await gitGet<{ branches: HermesGitBranch[] }>('branches', { path: repoPath })).branches,
@@ -76,31 +122,31 @@ const remoteGit: GitBridge = {
       (await gitGet<{ diff: string }>('review/diff', { base: baseRef, file: filePath, path: repoPath, scope, staged }))
         .diff,
 
-    stage: (repoPath, filePath) => gitPost('review/stage', { file: filePath ?? null, path: repoPath }),
+    stage: (repoPath, filePath) => gitMutate('review/stage', { file: filePath ?? null, path: repoPath }),
 
-    unstage: (repoPath, filePath) => gitPost('review/unstage', { file: filePath ?? null, path: repoPath }),
+    unstage: (repoPath, filePath) => gitMutate('review/unstage', { file: filePath ?? null, path: repoPath }),
 
-    revert: (repoPath, filePath) => gitPost('review/revert', { file: filePath ?? null, path: repoPath }),
+    revert: (repoPath, filePath) => gitMutate('review/revert', { file: filePath ?? null, path: repoPath }),
 
     revParse: async (repoPath, ref) =>
       (await gitGet<{ sha: null | string }>('review/rev-parse', { path: repoPath, ref })).sha,
 
-    commit: (repoPath, message, push) => gitPost('review/commit', { message, path: repoPath, push }),
+    commit: (repoPath, message, push) => gitMutate('review/commit', { message, path: repoPath, push }),
 
     commitContext: repoPath => gitGet('review/commit-context', { path: repoPath }),
 
-    push: repoPath => gitPost('review/push', { path: repoPath }),
+    push: repoPath => gitMutate('review/push', { path: repoPath }),
 
     shipInfo: repoPath => gitGet<HermesReviewShipInfo>('review/ship-info', { path: repoPath }),
 
     prList: (repoPath, branches, numbers) =>
-      gitPost<HermesRepoPullRequests>('review/pr-list', { branches, numbers: numbers ?? [], path: repoPath }),
+      gitPostQuery<HermesRepoPullRequests>('review/pr-list', { branches, numbers: numbers ?? [], path: repoPath }),
 
     // Remote gateways have no PR-comment route yet; resolve to null so the
     // paste degrades to a plain URL instead of throwing mid-paste.
     fetchPrComment: async () => null,
 
-    createPr: repoPath => gitPost('review/create-pr', { path: repoPath })
+    createPr: repoPath => gitMutate('review/create-pr', { path: repoPath })
   },
 
   // Repo discovery is a local-disk crawl; on a remote gateway the backend

--- a/apps/desktop/src/plugin-socket-scope.test.ts
+++ b/apps/desktop/src/plugin-socket-scope.test.ts
@@ -54,12 +54,23 @@ let getConnectionFor: ReturnType<typeof vi.fn>
 
 beforeEach(() => {
   getConnection = vi.fn(async (profile?: null | string) => conn({ profile: profile ?? 'default' }))
-  getConnectionFor = vi.fn(async ({ profile }: { connectionId?: null | string; profile?: null | string }) =>
-    conn({ baseUrl: 'https://homelab.invalid', profile: profile ?? 'default' })
+  getConnectionFor = vi.fn(
+    async ({ connectionId, profile }: { connectionId?: null | string; profile?: null | string }) =>
+      conn({
+        baseUrl: 'https://homelab.invalid',
+        connectionId: connectionId ?? undefined,
+        profile: profile ?? 'default',
+        registryScoped: true
+      })
   )
   Object.defineProperty(window, 'hermesDesktop', {
     configurable: true,
     value: {
+      connections: {
+        list: vi.fn(async () => ({
+          connections: [{ generation: 'homelab-generation-1', id: 'homelab' }]
+        }))
+      },
       getConnection,
       getConnectionFor,
       getGatewayWsUrl: vi.fn(async () => 'wss://pool.invalid/api/ws?ticket=fake'),

--- a/apps/desktop/src/store/gateway-activation-generation-order.test.ts
+++ b/apps/desktop/src/store/gateway-activation-generation-order.test.ts
@@ -1,0 +1,94 @@
+import { atom } from 'nanostores'
+import { beforeEach, expect, it, vi } from 'vitest'
+
+import type { HermesConnection } from '@/global'
+
+const state = vi.hoisted(() => ({
+  connectionId: null as null | string,
+  ensureAgent: vi.fn(),
+  epoch: 0,
+  gateway: { connectionState: 'open', id: 'gateway' },
+  profile: 'default'
+}))
+const $gateway = atom<unknown>(state.gateway)
+
+vi.mock('@/store/gateway', () => ({
+  $gateway,
+  activeGatewayConnectionId: () => state.connectionId,
+  activeGatewayProfileKey: () => state.profile,
+  ensureGatewayForAgent: state.ensureAgent,
+  ensureGatewayForProfile: vi.fn(),
+  gatewayActivationEpoch: () => state.epoch,
+  isActivePrimary: () => false
+}))
+
+const { $routeActivationReceipt, activateGatewayAgentWithProof } = await import('./gateway-activation')
+
+beforeEach(() => {
+  state.connectionId = null
+  state.epoch = 0
+  state.profile = 'default'
+  state.ensureAgent.mockReset()
+  state.ensureAgent.mockImplementation((connectionId: string, profile: string) => {
+    state.epoch += 1
+    state.connectionId = connectionId
+    state.profile = profile
+
+    return Promise.resolve(true)
+  })
+  $gateway.set(state.gateway)
+  $routeActivationReceipt.set(null)
+})
+
+it('does not start descriptor or gateway resolution before generation N is observed', async () => {
+  let releaseGeneration!: () => void
+  const generationGate = new Promise<void>(resolve => {
+    releaseGeneration = resolve
+  })
+  let listCalls = 0
+  let descriptorStarted = false
+
+  vi.stubGlobal('window', {
+    hermesDesktop: {
+      connections: {
+        list: vi.fn(async () => {
+          listCalls += 1
+
+          if (listCalls === 1) {
+            await generationGate
+          }
+
+          return { connections: [{ generation: 'generation-1', id: 'homelab' }] }
+        })
+      }
+    }
+  })
+
+  const activation = activateGatewayAgentWithProof('homelab', 'research', async () => {
+    descriptorStarted = true
+
+    return {
+      baseUrl: 'https://homelab.test',
+      connectionId: 'homelab',
+      mode: 'remote',
+      profile: 'research',
+      registryScoped: true
+    } as HermesConnection
+  })
+
+  await Promise.resolve()
+  expect(descriptorStarted).toBe(false)
+  expect(state.ensureAgent).not.toHaveBeenCalled()
+
+  releaseGeneration()
+  const receipt = await activation
+
+  expect(descriptorStarted).toBe(true)
+  expect(state.ensureAgent).toHaveBeenCalledWith('homelab', 'research')
+  expect(receipt).toMatchObject({
+    connection: { routeGeneration: 'generation-1' },
+    status: 'ready'
+  })
+
+  vi.unstubAllGlobals()
+})

--- a/apps/desktop/src/store/gateway-activation-reconnect-generation.test.ts
+++ b/apps/desktop/src/store/gateway-activation-reconnect-generation.test.ts
@@ -1,0 +1,96 @@
+import { atom } from 'nanostores'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+
+import type { HermesConnection } from '@/global'
+
+const state = vi.hoisted(() => ({
+  connectionId: null as null | string,
+  epoch: 0,
+  gateway: { connectionState: 'open', id: 'gateway' },
+  profile: 'default'
+}))
+const $gateway = atom<unknown>(state.gateway)
+
+vi.mock('@/store/gateway', () => ({
+  $gateway,
+  activeGatewayConnectionId: () => state.connectionId,
+  activeGatewayProfileKey: () => state.profile,
+  ensureGatewayForAgent: vi.fn(async (connectionId: string, profile: string) => {
+    state.epoch += 1
+    state.connectionId = connectionId
+    state.profile = profile
+
+    return true
+  }),
+  ensureGatewayForProfile: vi.fn(),
+  gatewayActivationEpoch: () => state.epoch,
+  isActivePrimary: () => false
+}))
+
+const {
+  $routeActivationReceipt,
+  activateGatewayAgentWithProof,
+  currentRouteActivationReceiptForMutation,
+  routeActivationReceiptAllowsMutation
+} = await import('./gateway-activation')
+
+const descriptor = (routeGeneration?: string): HermesConnection =>
+  ({
+    baseUrl: 'https://homelab.test',
+    connectionId: 'homelab',
+    mode: 'remote',
+    profile: 'research',
+    registryScoped: true,
+    ...(routeGeneration ? { routeGeneration } : {})
+  }) as HermesConnection
+
+beforeEach(() => {
+  state.connectionId = null
+  state.epoch = 0
+  state.profile = 'default'
+  $gateway.set(state.gateway)
+  $routeActivationReceipt.set(null)
+  vi.stubGlobal('window', {
+    hermesDesktop: {
+      connections: {
+        list: vi.fn(async () => ({
+          connections: [{ generation: 'generation-1', id: 'homelab' }]
+        }))
+      }
+    }
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+it('retains renderer proof when reconnect refreshes an equivalent descriptor without copying generation', async () => {
+  const receipt = await activateGatewayAgentWithProof('homelab', 'research', async () => descriptor())
+
+  expect(receipt.status).toBe('ready')
+
+  if (receipt.status !== 'ready') {
+    throw new Error('expected ready route')
+  }
+
+  const reconnectDescriptor = descriptor()
+
+  expect(routeActivationReceiptAllowsMutation(receipt, reconnectDescriptor)).toBe(true)
+  expect(currentRouteActivationReceiptForMutation(reconnectDescriptor)).toBe(receipt)
+})
+
+it('still rejects an explicitly different generation before the main-process gate', async () => {
+  const receipt = await activateGatewayAgentWithProof('homelab', 'research', async () => descriptor())
+
+  expect(receipt.status).toBe('ready')
+
+  if (receipt.status !== 'ready') {
+    throw new Error('expected ready route')
+  }
+
+  const replacementDescriptor = descriptor('generation-2')
+
+  expect(routeActivationReceiptAllowsMutation(receipt, replacementDescriptor)).toBe(false)
+  expect(currentRouteActivationReceiptForMutation(replacementDescriptor)).toBe(null)
+})

--- a/apps/desktop/src/store/gateway-activation.test.ts
+++ b/apps/desktop/src/store/gateway-activation.test.ts
@@ -1,0 +1,584 @@
+import { atom } from 'nanostores'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesConnection } from '@/global'
+
+import { deferred } from '../test/deferred'
+
+const gatewayState = vi.hoisted(() => ({
+  connectionId: null as null | string,
+  ensureAgent: vi.fn(),
+  ensureProfile: vi.fn(),
+  epoch: 0,
+  gateway: null as null | { connectionState: string; id: string },
+  primary: true,
+  profile: 'default',
+  registryList: vi.fn(),
+  routeGenerations: new Map<string, string>()
+}))
+const $gateway = atom<unknown>(null)
+
+vi.mock('@/store/gateway', () => ({
+  $gateway,
+  activeGatewayConnectionId: () => gatewayState.connectionId,
+  activeGatewayProfileKey: () => gatewayState.profile,
+  ensureGatewayForAgent: gatewayState.ensureAgent,
+  ensureGatewayForProfile: gatewayState.ensureProfile,
+  gatewayActivationEpoch: () => gatewayState.epoch,
+  isActivePrimary: () => gatewayState.primary
+}))
+
+const {
+  $routeActivationReceipt,
+  activeGatewayRouteMatches,
+  activateGatewayAgentWithProof,
+  activateGatewayProfileWithProof,
+  currentRouteActivationReceiptForMutation,
+  routeActivationReceiptAllowsMutation,
+  routeActivationReceiptIsCurrent
+} = await import('./gateway-activation')
+
+const connection = (over: Partial<HermesConnection> = {}): HermesConnection =>
+  ({ baseUrl: '', mode: 'local', profile: 'default', ...over }) as HermesConnection
+
+function installGateway(id: string, connectionState = 'open'): void {
+  gatewayState.gateway = { connectionState, id }
+  $gateway.set(gatewayState.gateway)
+}
+
+function installRouteGeneration(connectionId: string, generation = `${connectionId}-generation-1`): void {
+  gatewayState.routeGenerations.set(connectionId, generation)
+}
+
+beforeEach(() => {
+  gatewayState.connectionId = null
+  gatewayState.epoch = 0
+  gatewayState.primary = true
+  gatewayState.profile = 'default'
+  installGateway('primary')
+  gatewayState.ensureProfile.mockReset()
+  gatewayState.ensureProfile.mockImplementation((profile: string) => {
+    gatewayState.epoch += 1
+    gatewayState.connectionId = null
+    gatewayState.primary = profile === 'default'
+    gatewayState.profile = profile
+
+    return Promise.resolve()
+  })
+  gatewayState.ensureAgent.mockReset()
+  gatewayState.ensureAgent.mockImplementation((connectionId: string, profile: string) => {
+    gatewayState.epoch += 1
+    gatewayState.connectionId = connectionId
+    gatewayState.primary = false
+    gatewayState.profile = profile
+
+    return Promise.resolve(true)
+  })
+  gatewayState.routeGenerations.clear()
+  for (const id of ['homelab', 'other-source', 'removed-source']) {
+    installRouteGeneration(id)
+  }
+  gatewayState.registryList.mockReset()
+  gatewayState.registryList.mockImplementation(async () => ({
+    connections: [...gatewayState.routeGenerations].map(([id, generation]) => ({ generation, id }))
+  }))
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: {
+      connections: {
+        list: gatewayState.registryList
+      }
+    }
+  })
+  $routeActivationReceipt.set(null)
+})
+
+describe('proof-carrying gateway activation (#90866)', () => {
+  it('returns ready proof for an exact local profile route and permits mutation', async () => {
+    const descriptor = connection({ profile: 'worker' })
+    const result = await activateGatewayProfileWithProof('worker', Promise.resolve(descriptor))
+
+    expect(result).toMatchObject({
+      activationGeneration: 1,
+      epistemic: 'authoritative',
+      physicalRoute: { connectionId: null, profile: 'worker' },
+      proof: { authority: 'gateway-activation', kind: 'local-physical-route' },
+      readiness: { descriptor: 'resolved', gateway: 'open', route: 'exact' },
+      requested: { connectionId: null, profile: 'worker' },
+      route: { connectionId: null, profile: 'worker' },
+      status: 'ready'
+    })
+    expect(routeActivationReceiptIsCurrent(result)).toBe(true)
+    expect(routeActivationReceiptAllowsMutation(result, descriptor)).toBe(true)
+    expect(currentRouteActivationReceiptForMutation(descriptor)).toBe(result)
+    expect(activeGatewayRouteMatches({ connectionId: null, profile: 'worker' })).toBe(true)
+    expect($routeActivationReceipt.get()).toBe(result)
+  })
+
+  it('binds registry-agent proof to the exact connectionId, profile, and source generation', async () => {
+    installGateway('homelab')
+    const descriptor = connection({
+      baseUrl: 'https://homelab.invalid',
+      connectionId: 'homelab',
+      mode: 'remote',
+      profile: 'research',
+      registryScoped: true
+    })
+
+    const result = await activateGatewayAgentWithProof('homelab', 'research', Promise.resolve(descriptor))
+
+    expect(result).toMatchObject({
+      connection: { routeGeneration: 'homelab-generation-1' },
+      epistemic: 'authoritative',
+      physicalRoute: { connectionId: 'homelab', profile: 'research' },
+      proof: { kind: 'registry-scoped-descriptor' },
+      requested: { connectionId: 'homelab', profile: 'research' },
+      route: { connectionId: 'homelab', profile: 'research' },
+      status: 'ready'
+    })
+    expect(result.status === 'ready' && routeActivationReceiptAllowsMutation(result, result.connection)).toBe(true)
+    expect(activeGatewayRouteMatches({ connectionId: 'homelab', profile: 'research' })).toBe(true)
+    expect(gatewayState.registryList).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects a route edited while descriptor activation is in flight', async () => {
+    installGateway('homelab')
+    let reads = 0
+    gatewayState.registryList.mockImplementation(async () => {
+      reads += 1
+
+      return {
+        connections: [{ generation: reads === 1 ? 'generation-1' : 'generation-2', id: 'homelab' }]
+      }
+    })
+
+    const result = await activateGatewayAgentWithProof(
+      'homelab',
+      'research',
+      Promise.resolve(
+        connection({
+          connectionId: 'homelab',
+          mode: 'remote',
+          profile: 'research',
+          registryScoped: true
+        })
+      )
+    )
+
+    expect(result).toMatchObject({
+      reason: 'route-generation-changed',
+      requested: { connectionId: 'homelab', profile: 'research' },
+      status: 'failed'
+    })
+    expect(activeGatewayRouteMatches({ connectionId: 'homelab', profile: 'research' })).toBe(false)
+    expect(currentRouteActivationReceiptForMutation(descriptorFrom(result))).toBe(null)
+  })
+
+  it('rejects a registry route whose generation cannot be proven', async () => {
+    installGateway('homelab')
+    gatewayState.registryList.mockResolvedValue({ connections: [{ id: 'homelab' }] })
+
+    const result = await activateGatewayAgentWithProof(
+      'homelab',
+      'research',
+      Promise.resolve(
+        connection({
+          connectionId: 'homelab',
+          mode: 'remote',
+          profile: 'research',
+          registryScoped: true
+        })
+      )
+    )
+
+    expect(result).toMatchObject({ reason: 'route-generation-unavailable', status: 'failed' })
+    expect(activeGatewayRouteMatches({ connectionId: 'homelab', profile: 'research' })).toBe(false)
+  })
+
+  it('does not promote a legacy inferred remote connectionId to mutation authority', async () => {
+    const descriptor = connection({
+      baseUrl: 'https://remote.invalid',
+      connectionId: 'first-similar-route',
+      mode: 'remote',
+      profile: 'worker'
+    })
+
+    const result = await activateGatewayProfileWithProof('worker', Promise.resolve(descriptor))
+
+    expect(result).toMatchObject({
+      epistemic: 'inferred',
+      proof: { kind: 'legacy-inferred-descriptor' },
+      readiness: { descriptor: 'resolved', gateway: 'open', route: 'inferred' },
+      route: { connectionId: 'first-similar-route', profile: 'worker' },
+      status: 'degraded'
+    })
+    expect(routeActivationReceiptIsCurrent(result)).toBe(true)
+    expect(routeActivationReceiptAllowsMutation(result, descriptor)).toBe(false)
+    expect(currentRouteActivationReceiptForMutation(descriptor)).toBe(null)
+    expect(activeGatewayRouteMatches({ connectionId: null, profile: 'worker' })).toBe(false)
+  })
+
+  it('does not let an activation that never acquired a generation overwrite current proof', async () => {
+    const currentDescriptor = connection({ profile: 'worker' })
+    const current = await activateGatewayProfileWithProof('worker', Promise.resolve(currentDescriptor))
+
+    gatewayState.ensureProfile.mockImplementationOnce((_profile: string) => Promise.resolve())
+
+    const failed = await activateGatewayProfileWithProof(
+      'coder',
+      Promise.resolve(connection({ profile: 'coder' }))
+    )
+
+    expect(failed).toMatchObject({
+      activationGeneration: 1,
+      reason: 'target-unavailable',
+      status: 'failed'
+    })
+    expect($routeActivationReceipt.get()).toBe(current)
+    expect(currentRouteActivationReceiptForMutation(currentDescriptor)).toBe(current)
+  })
+
+  it('rejects the older receipt when another activation advances the generation', async () => {
+    const gate = deferred()
+
+    gatewayState.ensureProfile.mockImplementationOnce((_profile: string) => {
+      gatewayState.epoch += 1
+
+      return gate.promise
+    })
+
+    const older = activateGatewayProfileWithProof(
+      'worker',
+      Promise.resolve(connection({ profile: 'worker' }))
+    )
+
+    // A later route owner wins while the first activation is still pending.
+    const newer = await activateGatewayProfileWithProof(
+      'coder',
+      Promise.resolve(connection({ profile: 'coder' }))
+    )
+
+    gate.resolve()
+
+    const result = await older
+
+    expect(result).toMatchObject({
+      activationGeneration: 1,
+      observedGeneration: 2,
+      observedRoute: { connectionId: null, profile: 'coder' },
+      reason: 'newer-activation',
+      status: 'superseded'
+    })
+    expect(routeActivationReceiptIsCurrent(result)).toBe(false)
+    expect(routeActivationReceiptAllowsMutation(result, null)).toBe(false)
+    // A late stale completion cannot replace the observable proof from the
+    // newer winner.
+    expect($routeActivationReceipt.get()).toBe(newer)
+  })
+
+  it('reacquires ready proof after a route lands before its gateway opens', async () => {
+    const descriptor = connection({ profile: 'worker' })
+    installGateway('worker-connecting', 'connecting')
+
+    const degraded = await activateGatewayProfileWithProof('worker', Promise.resolve(descriptor))
+
+    expect(degraded).toMatchObject({
+      readiness: { descriptor: 'resolved', gateway: 'not-open', route: 'exact' },
+      status: 'degraded'
+    })
+    expect(activeGatewayRouteMatches({ connectionId: null, profile: 'worker' })).toBe(false)
+
+    installGateway('worker-open', 'open')
+    const recovered = await activateGatewayProfileWithProof('worker', Promise.resolve(descriptor))
+
+    expect(recovered).toMatchObject({
+      activationGeneration: 2,
+      readiness: { descriptor: 'resolved', gateway: 'open', route: 'exact' },
+      status: 'ready'
+    })
+    expect(activeGatewayRouteMatches({ connectionId: null, profile: 'worker' })).toBe(true)
+    expect(currentRouteActivationReceiptForMutation(descriptor)).toBe(recovered)
+  })
+
+  it('reacquires ready proof after descriptor publication follows a degraded landing', async () => {
+    const degraded = await activateGatewayProfileWithProof('worker', Promise.resolve(null))
+
+    expect(degraded).toMatchObject({
+      epistemic: 'unavailable',
+      proof: { kind: 'unqualified-descriptor' },
+      readiness: { descriptor: 'unavailable', gateway: 'open', route: 'unqualified' },
+      status: 'degraded'
+    })
+    expect(routeActivationReceiptIsCurrent(degraded)).toBe(true)
+    expect(activeGatewayRouteMatches({ connectionId: null, profile: 'worker' })).toBe(false)
+
+    const descriptor = connection({ profile: 'worker' })
+    const recovered = await activateGatewayProfileWithProof('worker', Promise.resolve(descriptor))
+
+    expect(recovered).toMatchObject({ activationGeneration: 2, status: 'ready' })
+    expect(activeGatewayRouteMatches({ connectionId: null, profile: 'worker' })).toBe(true)
+    expect(currentRouteActivationReceiptForMutation(descriptor)).toBe(recovered)
+  })
+
+  it('reacquires A after a failed B activation leaves A physically selected', async () => {
+    installGateway('homelab')
+    const descriptor = connection({
+      baseUrl: 'https://homelab.invalid',
+      connectionId: 'homelab',
+      mode: 'remote',
+      profile: 'research',
+      registryScoped: true
+    })
+    const readyA = await activateGatewayAgentWithProof('homelab', 'research', Promise.resolve(descriptor))
+
+    expect(readyA.status).toBe('ready')
+
+    gatewayState.ensureAgent.mockImplementationOnce((_connectionId: string, _profile: string) => {
+      gatewayState.epoch += 1
+
+      return Promise.resolve(false)
+    })
+
+    const failedB = await activateGatewayAgentWithProof(
+      'removed-source',
+      'research',
+      Promise.resolve(
+        connection({
+          connectionId: 'removed-source',
+          mode: 'remote',
+          profile: 'research',
+          registryScoped: true
+        })
+      )
+    )
+
+    expect(failedB).toMatchObject({ reason: 'target-unavailable', status: 'failed' })
+    expect(gatewayState.connectionId).toBe('homelab')
+    expect(activeGatewayRouteMatches({ connectionId: 'homelab', profile: 'research' })).toBe(false)
+
+    const recoveredA = await activateGatewayAgentWithProof('homelab', 'research', Promise.resolve(descriptor))
+
+    expect(recoveredA).toMatchObject({ activationGeneration: 3, status: 'ready' })
+    expect(activeGatewayRouteMatches({ connectionId: 'homelab', profile: 'research' })).toBe(true)
+    expect(recoveredA.status === 'ready' && currentRouteActivationReceiptForMutation(recoveredA.connection)).toBe(
+      recoveredA
+    )
+  })
+
+  it('retains shared-primary logical scope for display but reacquires mutation proof on reselection', async () => {
+    gatewayState.ensureProfile.mockImplementationOnce((_profile: string) => {
+      gatewayState.epoch += 1
+      gatewayState.connectionId = null
+      gatewayState.primary = true
+      gatewayState.profile = 'default'
+
+      return Promise.resolve()
+    })
+
+    const descriptor = connection({
+      baseUrl: 'https://primary.invalid',
+      connectionId: 'primary-remote',
+      mode: 'remote',
+      profile: 'worker',
+      sharedPrimary: true
+    })
+    const result = await activateGatewayProfileWithProof('worker', Promise.resolve(descriptor))
+
+    expect(result).toMatchObject({
+      epistemic: 'inferred',
+      physicalRoute: { connectionId: null, profile: 'default' },
+      readiness: { descriptor: 'resolved', gateway: 'open', route: 'inferred' },
+      requested: { connectionId: null, profile: 'worker' },
+      route: { connectionId: 'primary-remote', profile: 'worker' },
+      status: 'degraded'
+    })
+    expect(routeActivationReceiptIsCurrent(result)).toBe(true)
+    expect(activeGatewayRouteMatches({ connectionId: null, profile: 'worker' })).toBe(false)
+    expect(routeActivationReceiptAllowsMutation(result, descriptor)).toBe(false)
+  })
+
+  it('returns failed proof when an exact registry target disappears mid-activation', async () => {
+    gatewayState.ensureAgent.mockImplementationOnce((_connectionId: string, _profile: string) => {
+      gatewayState.epoch += 1
+
+      return Promise.resolve(false)
+    })
+
+    const result = await activateGatewayAgentWithProof(
+      'removed-source',
+      'research',
+      Promise.resolve(
+        connection({
+          connectionId: 'removed-source',
+          mode: 'remote',
+          profile: 'research',
+          registryScoped: true
+        })
+      )
+    )
+
+    expect(result).toMatchObject({
+      reason: 'target-unavailable',
+      requested: { connectionId: 'removed-source', profile: 'research' },
+      status: 'failed'
+    })
+    expect(routeActivationReceiptIsCurrent(result)).toBe(false)
+    expect(activeGatewayRouteMatches({ connectionId: 'removed-source', profile: 'research' })).toBe(false)
+  })
+
+  it('rejects a descriptor whose profile differs from the activated owner', async () => {
+    installGateway('homelab')
+
+    const result = await activateGatewayAgentWithProof(
+      'homelab',
+      'research',
+      Promise.resolve(
+        connection({
+          connectionId: 'homelab',
+          mode: 'remote',
+          profile: 'coder',
+          registryScoped: true
+        })
+      )
+    )
+
+    expect(result).toMatchObject({
+      reason: 'descriptor-owner-mismatch',
+      requested: { connectionId: 'homelab', profile: 'research' },
+      status: 'failed'
+    })
+  })
+
+  it('rejects a registry descriptor that names a different owner than the activated socket', async () => {
+    installGateway('homelab')
+
+    const result = await activateGatewayAgentWithProof(
+      'homelab',
+      'research',
+      Promise.resolve(
+        connection({
+          connectionId: 'other-source',
+          mode: 'remote',
+          profile: 'research',
+          registryScoped: true
+        })
+      )
+    )
+
+    expect(result).toMatchObject({
+      reason: 'descriptor-owner-mismatch',
+      requested: { connectionId: 'homelab', profile: 'research' },
+      status: 'failed'
+    })
+  })
+
+  it('invalidates a landed receipt when the active gateway realization changes', async () => {
+    const descriptor = connection({ profile: 'worker' })
+    const result = await activateGatewayProfileWithProof('worker', Promise.resolve(descriptor))
+
+    expect(routeActivationReceiptIsCurrent(result)).toBe(true)
+
+    gatewayState.epoch += 1
+    gatewayState.profile = 'coder'
+    installGateway('coder')
+
+    expect(routeActivationReceiptIsCurrent(result)).toBe(false)
+    expect(routeActivationReceiptAllowsMutation(result, descriptor)).toBe(false)
+  })
+
+  it('retains mutation authority across descriptor clones that preserve the exact local route proof', async () => {
+    const descriptor = connection({ profile: 'worker' })
+    const result = await activateGatewayProfileWithProof('worker', Promise.resolve(descriptor))
+    const replacement = connection({ isFullscreen: true, profile: 'worker' })
+
+    expect(routeActivationReceiptIsCurrent(result)).toBe(true)
+    expect(routeActivationReceiptAllowsMutation(result, replacement)).toBe(true)
+    expect(currentRouteActivationReceiptForMutation(replacement)).toBe(result)
+  })
+
+  it('retains registry authority across presentation clones with the same source generation', async () => {
+    installGateway('homelab')
+    const result = await activateGatewayAgentWithProof(
+      'homelab',
+      'research',
+      Promise.resolve(
+        connection({
+          connectionId: 'homelab',
+          mode: 'remote',
+          profile: 'research',
+          registryScoped: true
+        })
+      )
+    )
+
+    expect(result.status).toBe('ready')
+
+    if (result.status !== 'ready') {
+      throw new Error('expected ready route')
+    }
+
+    const replacement = { ...result.connection, isFullscreen: true }
+
+    expect(routeActivationReceiptAllowsMutation(result, replacement)).toBe(true)
+  })
+
+  it('withholds registry authority after source generation replacement under the same id', async () => {
+    installGateway('homelab')
+    const result = await activateGatewayAgentWithProof(
+      'homelab',
+      'research',
+      Promise.resolve(
+        connection({
+          connectionId: 'homelab',
+          mode: 'remote',
+          profile: 'research',
+          registryScoped: true
+        })
+      )
+    )
+
+    expect(result.status).toBe('ready')
+
+    if (result.status !== 'ready') {
+      throw new Error('expected ready route')
+    }
+
+    const replacement = { ...result.connection, routeGeneration: 'homelab-generation-2' }
+
+    expect(routeActivationReceiptAllowsMutation(result, replacement)).toBe(false)
+    expect(currentRouteActivationReceiptForMutation(replacement)).toBe(null)
+  })
+
+  it('withholds mutation authority when a replacement descriptor changes the proven profile', async () => {
+    const descriptor = connection({ profile: 'worker' })
+    const result = await activateGatewayProfileWithProof('worker', Promise.resolve(descriptor))
+    const replacement = connection({ profile: 'coder' })
+
+    expect(routeActivationReceiptIsCurrent(result)).toBe(true)
+    expect(routeActivationReceiptAllowsMutation(result, replacement)).toBe(false)
+    expect(currentRouteActivationReceiptForMutation(replacement)).toBe(null)
+  })
+
+  it('does not treat a same-named profile on another source as the local route', async () => {
+    installGateway('homelab')
+    const descriptor = connection({
+      connectionId: 'homelab',
+      mode: 'remote',
+      profile: 'research',
+      registryScoped: true
+    })
+
+    await activateGatewayAgentWithProof('homelab', 'research', Promise.resolve(descriptor))
+
+    expect(activeGatewayRouteMatches({ connectionId: null, profile: 'research' })).toBe(false)
+    expect(activeGatewayRouteMatches({ connectionId: 'homelab', profile: 'research' })).toBe(true)
+  })
+})
+
+function descriptorFrom(receipt: unknown): HermesConnection | null {
+  if (!receipt || typeof receipt !== 'object') {
+    return null
+  }
+
+  return ((receipt as { connection?: HermesConnection | null }).connection ?? null) as HermesConnection | null
+}

--- a/apps/desktop/src/store/gateway-activation.ts
+++ b/apps/desktop/src/store/gateway-activation.ts
@@ -1,0 +1,635 @@
+import { atom } from 'nanostores'
+
+import type { HermesConnection } from '@/global'
+import type { HermesGateway } from '@/hermes'
+import {
+  $gateway,
+  activeGatewayConnectionId,
+  activeGatewayProfileKey,
+  ensureGatewayForAgent,
+  ensureGatewayForProfile,
+  gatewayActivationEpoch,
+  isActivePrimary
+} from '@/store/gateway'
+
+/** Exact owner of one Desktop route. A profile name is not globally unique. */
+export interface RouteOwnerRef {
+  connectionId: null | string
+  profile: string
+}
+
+export type RouteActivationEpistemic = 'authoritative' | 'inferred' | 'unavailable'
+
+export type RouteActivationProofKind =
+  | 'legacy-inferred-descriptor'
+  | 'local-physical-route'
+  | 'registry-scoped-descriptor'
+  | 'unqualified-descriptor'
+
+export type RouteActivationReadiness = {
+  descriptor: 'resolved' | 'unavailable'
+  gateway: 'open' | 'not-open' | 'unavailable'
+  route: 'exact' | 'inferred' | 'unqualified'
+}
+
+type ConnectionResolver =
+  | Promise<HermesConnection | null>
+  | (() => Promise<HermesConnection | null>)
+
+type RouteGenerationBoundConnection = HermesConnection & {
+  routeGeneration?: string
+}
+
+type LandedRouteActivationBase = {
+  activationGeneration: number
+  connection: HermesConnection | null
+  epistemic: RouteActivationEpistemic
+  gateway: HermesGateway | null
+  physicalRoute: RouteOwnerRef
+  proof: {
+    authority: 'gateway-activation'
+    kind: RouteActivationProofKind
+  }
+  requested: RouteOwnerRef
+  route: RouteOwnerRef
+}
+
+export type ReadyRouteActivationReceipt = LandedRouteActivationBase & {
+  connection: HermesConnection
+  epistemic: 'authoritative'
+  readiness: {
+    descriptor: 'resolved'
+    gateway: 'open'
+    route: 'exact'
+  }
+  status: 'ready'
+}
+
+export type DegradedRouteActivationReceipt = LandedRouteActivationBase & {
+  readiness: RouteActivationReadiness
+  status: 'degraded'
+}
+
+export type RejectedRouteActivationReceipt = {
+  activationGeneration: number
+  gateway: HermesGateway | null
+  observedGeneration: number
+  observedRoute: RouteOwnerRef
+  reason:
+    | 'descriptor-owner-mismatch'
+    | 'newer-activation'
+    | 'route-generation-changed'
+    | 'route-generation-unavailable'
+    | 'route-not-activated'
+    | 'target-unavailable'
+  requested: RouteOwnerRef
+  status: 'failed' | 'superseded'
+}
+
+/**
+ * Proof produced by the gateway activation boundary and consumed before the
+ * renderer publishes route-dependent state or performs a route-dependent
+ * mutation. The receipt retains owner, generation, gateway realization,
+ * descriptor provenance, and readiness instead of projecting them to a bare
+ * profile or boolean (#90866).
+ */
+export type RouteActivationReceipt =
+  | DegradedRouteActivationReceipt
+  | ReadyRouteActivationReceipt
+  | RejectedRouteActivationReceipt
+
+/**
+ * Latest activation verdict. Consumers must still revalidate it at the use
+ * site: completion order is not authority order, and a reconnect may replace
+ * the descriptor realization without changing the logical route.
+ */
+export const $routeActivationReceipt = atom<RouteActivationReceipt | null>(null)
+
+const normalizeProfile = (profile: string | null | undefined): string => (profile ?? '').trim() || 'default'
+
+const normalizeConnectionId = (connectionId: string | null | undefined): null | string =>
+  (connectionId ?? '').trim() || null
+
+const normalizeRouteGeneration = (generation: unknown): null | string => String(generation ?? '').trim() || null
+
+function routeOwner(connectionId: string | null | undefined, profile: string | null | undefined): RouteOwnerRef {
+  return {
+    connectionId: normalizeConnectionId(connectionId),
+    profile: normalizeProfile(profile)
+  }
+}
+
+function sameRoute(left: RouteOwnerRef, right: RouteOwnerRef): boolean {
+  return left.connectionId === right.connectionId && left.profile === right.profile
+}
+
+function currentPhysicalRoute(): RouteOwnerRef {
+  return routeOwner(activeGatewayConnectionId(), activeGatewayProfileKey())
+}
+
+function currentGatewayReadiness(gateway: HermesGateway | null): RouteActivationReadiness['gateway'] {
+  if (!gateway) {
+    return 'unavailable'
+  }
+
+  return gateway.connectionState === 'open' ? 'open' : 'not-open'
+}
+
+function publishReceipt(receipt: RouteActivationReceipt): RouteActivationReceipt {
+  const current = $routeActivationReceipt.get()
+
+  // Completion order is not authority order. A slow generation N may finish
+  // after generation N+1; never let that stale completion replace the newer
+  // observable proof. The direct N receipt is still returned to its caller so
+  // that operation can deterministically reject itself.
+  if (!current || receipt.activationGeneration > current.activationGeneration) {
+    $routeActivationReceipt.set(receipt)
+  }
+
+  return receipt
+}
+
+function startConnectionResolution(resolver: ConnectionResolver): Promise<HermesConnection | null> {
+  return typeof resolver === 'function' ? resolver() : resolver
+}
+
+async function registryRouteGeneration(connectionId: string): Promise<null | string> {
+  const list = window.hermesDesktop?.connections?.list
+
+  if (!list) {
+    return null
+  }
+
+  try {
+    const registry = (await list()) as unknown as {
+      connections?: Array<{ generation?: unknown; id?: unknown }>
+    }
+    const entry = Array.isArray(registry?.connections)
+      ? registry.connections.find(candidate => normalizeConnectionId(String(candidate?.id ?? '')) === connectionId)
+      : undefined
+
+    return normalizeRouteGeneration(entry?.generation)
+  } catch {
+    return null
+  }
+}
+
+function routeGeneration(connection: HermesConnection | null): null | string {
+  return normalizeRouteGeneration((connection as RouteGenerationBoundConnection | null)?.routeGeneration)
+}
+
+function bindRouteGeneration(connection: HermesConnection | null, generation: string): HermesConnection | null {
+  return connection ? ({ ...connection, routeGeneration: generation } as RouteGenerationBoundConnection) : null
+}
+
+interface DescriptorRouteProof {
+  epistemic: RouteActivationEpistemic
+  mismatch: boolean
+  proofKind: RouteActivationProofKind
+  route: RouteOwnerRef
+  routeReadiness: RouteActivationReadiness['route']
+}
+
+function descriptorRouteProof(
+  kind: 'agent' | 'profile',
+  requested: RouteOwnerRef,
+  connection: HermesConnection | null,
+  requireGeneration = true
+): DescriptorRouteProof {
+  if (!connection) {
+    return {
+      epistemic: 'unavailable',
+      mismatch: false,
+      proofKind: 'unqualified-descriptor',
+      route: requested,
+      routeReadiness: 'unqualified'
+    }
+  }
+
+  const descriptorConnectionId = normalizeConnectionId(connection.connectionId)
+  const descriptorProfile = normalizeProfile(connection.profile)
+  const descriptorGeneration = routeGeneration(connection)
+  const profileMismatch = descriptorProfile !== requested.profile
+
+  if (kind === 'agent') {
+    const mismatch =
+      profileMismatch ||
+      (descriptorConnectionId !== null && descriptorConnectionId !== requested.connectionId)
+
+    if (
+      connection.registryScoped === true &&
+      descriptorConnectionId === requested.connectionId &&
+      (!requireGeneration || descriptorGeneration !== null) &&
+      !profileMismatch
+    ) {
+      return {
+        epistemic: 'authoritative',
+        mismatch: false,
+        proofKind: 'registry-scoped-descriptor',
+        route: requested,
+        routeReadiness: 'exact'
+      }
+    }
+
+    if (connection.registryScoped === true && descriptorConnectionId === requested.connectionId && !profileMismatch) {
+      return {
+        epistemic: 'unavailable',
+        mismatch: false,
+        proofKind: 'unqualified-descriptor',
+        route: requested,
+        routeReadiness: 'unqualified'
+      }
+    }
+
+    return {
+      epistemic: descriptorConnectionId ? 'inferred' : 'unavailable',
+      mismatch,
+      proofKind: descriptorConnectionId ? 'legacy-inferred-descriptor' : 'unqualified-descriptor',
+      route: routeOwner(descriptorConnectionId ?? requested.connectionId, descriptorProfile),
+      routeReadiness: descriptorConnectionId ? 'inferred' : 'unqualified'
+    }
+  }
+
+  // A local profile-keyed route is physically exact without a registry row:
+  // Electron performs the mutation on this machine and the gateway generation
+  // proves which profile backend owns it. A legacy REMOTE descriptor is
+  // different: `hermes:connection` reconstructs connectionId with
+  // resolvedConnectionId, so it is explicitly inferred (#90048) and cannot
+  // authorize a connection-scoped REST mutation.
+  if (connection.mode === 'local') {
+    return {
+      epistemic: 'authoritative',
+      mismatch: profileMismatch,
+      proofKind: 'local-physical-route',
+      route: routeOwner(null, descriptorProfile),
+      routeReadiness: 'exact'
+    }
+  }
+
+  if (connection.registryScoped === true && descriptorConnectionId) {
+    return {
+      epistemic: 'authoritative',
+      mismatch: profileMismatch,
+      proofKind: 'registry-scoped-descriptor',
+      route: routeOwner(descriptorConnectionId, descriptorProfile),
+      routeReadiness: 'exact'
+    }
+  }
+
+  if (descriptorConnectionId) {
+    return {
+      epistemic: 'inferred',
+      mismatch: profileMismatch,
+      proofKind: 'legacy-inferred-descriptor',
+      route: routeOwner(descriptorConnectionId, descriptorProfile),
+      routeReadiness: 'inferred'
+    }
+  }
+
+  return {
+    epistemic: 'unavailable',
+    mismatch: profileMismatch,
+    proofKind: 'unqualified-descriptor',
+    route: routeOwner(null, descriptorProfile),
+    routeReadiness: 'unqualified'
+  }
+}
+
+function routeLanded(
+  kind: 'agent' | 'profile',
+  requested: RouteOwnerRef,
+  observedRoute: RouteOwnerRef,
+  connection: HermesConnection | null
+): boolean {
+  if (kind === 'agent') {
+    return sameRoute(observedRoute, requested)
+  }
+
+  if (observedRoute.connectionId !== null) {
+    return false
+  }
+
+  if (observedRoute.profile === requested.profile) {
+    return true
+  }
+
+  // Shared-primary routing deliberately keeps the physical gateway on its
+  // launch profile while the descriptor scopes requests to the selected
+  // logical profile. The activation generation binds that logical scope to the
+  // physical gateway realization; without the descriptor this cannot be
+  // reconstructed and the receipt fails closed.
+  return Boolean(connection?.sharedPrimary || connection?.sharedRemote) && isActivePrimary()
+}
+
+function finishActivation({
+  activationGeneration,
+  connection,
+  kind,
+  landed,
+  requested
+}: {
+  activationGeneration: number
+  connection: HermesConnection | null
+  kind: 'agent' | 'profile'
+  landed: boolean
+  requested: RouteOwnerRef
+}): RouteActivationReceipt {
+  const observedGeneration = gatewayActivationEpoch()
+  const observedRoute = currentPhysicalRoute()
+  const gateway = $gateway.get()
+
+  if (observedGeneration !== activationGeneration) {
+    return publishReceipt({
+      activationGeneration,
+      gateway,
+      observedGeneration,
+      observedRoute,
+      reason: 'newer-activation',
+      requested,
+      status: 'superseded'
+    })
+  }
+
+  if (!landed) {
+    return publishReceipt({
+      activationGeneration,
+      gateway,
+      observedGeneration,
+      observedRoute,
+      reason: 'target-unavailable',
+      requested,
+      status: 'failed'
+    })
+  }
+
+  if (!routeLanded(kind, requested, observedRoute, connection)) {
+    return publishReceipt({
+      activationGeneration,
+      gateway,
+      observedGeneration,
+      observedRoute,
+      reason: 'route-not-activated',
+      requested,
+      status: 'failed'
+    })
+  }
+
+  const descriptorProof = descriptorRouteProof(kind, requested, connection)
+
+  if (descriptorProof.mismatch) {
+    return publishReceipt({
+      activationGeneration,
+      gateway,
+      observedGeneration,
+      observedRoute,
+      reason: 'descriptor-owner-mismatch',
+      requested,
+      status: 'failed'
+    })
+  }
+
+  const gatewayReadiness = currentGatewayReadiness(gateway)
+  const base = {
+    activationGeneration,
+    connection,
+    epistemic: descriptorProof.epistemic,
+    gateway,
+    physicalRoute: observedRoute,
+    proof: {
+      authority: 'gateway-activation' as const,
+      kind: descriptorProof.proofKind
+    },
+    requested,
+    route: descriptorProof.route
+  }
+
+  if (
+    connection &&
+    descriptorProof.epistemic === 'authoritative' &&
+    descriptorProof.routeReadiness === 'exact' &&
+    gatewayReadiness === 'open'
+  ) {
+    return publishReceipt({
+      ...base,
+      connection,
+      epistemic: 'authoritative',
+      readiness: {
+        descriptor: 'resolved',
+        gateway: 'open',
+        route: 'exact'
+      },
+      status: 'ready'
+    })
+  }
+
+  return publishReceipt({
+    ...base,
+    readiness: {
+      descriptor: connection ? 'resolved' : 'unavailable',
+      gateway: gatewayReadiness,
+      route: descriptorProof.routeReadiness
+    },
+    status: 'degraded'
+  })
+}
+
+function rejectGeneration(
+  activationGeneration: number,
+  requested: RouteOwnerRef,
+  reason: RejectedRouteActivationReceipt['reason']
+): RouteActivationReceipt {
+  const observedGeneration = gatewayActivationEpoch()
+  const observedRoute = currentPhysicalRoute()
+  const gateway = $gateway.get()
+
+  return publishReceipt({
+    activationGeneration,
+    gateway,
+    observedGeneration,
+    observedRoute,
+    reason,
+    requested,
+    status: observedGeneration === activationGeneration ? 'failed' : 'superseded'
+  })
+}
+
+/**
+ * Activate one local/legacy profile while retaining the descriptor result and
+ * the gateway generation established by the same operation. Both reads start
+ * concurrently, preserving the fail-open/atomic publication shape from #89797.
+ */
+export async function activateGatewayProfileWithProof(
+  profile: string,
+  connectionResolver: ConnectionResolver
+): Promise<RouteActivationReceipt> {
+  const requested = routeOwner(null, profile)
+  const previousGeneration = gatewayActivationEpoch()
+  const connectionPromise = startConnectionResolution(connectionResolver)
+  const gatewayPromise = ensureGatewayForProfile(requested.profile)
+  // The async function increments its epoch synchronously before its first
+  // await. If it returns before doing so (bridge/registry unavailable), this
+  // operation never acquired an activation generation and cannot claim the
+  // pre-existing route as its own.
+  const activationGeneration = gatewayActivationEpoch()
+  const activationStarted = activationGeneration > previousGeneration
+  const [connection] = await Promise.all([connectionPromise, gatewayPromise])
+
+  return finishActivation({
+    activationGeneration,
+    connection,
+    kind: 'profile',
+    landed: activationStarted,
+    requested
+  })
+}
+
+/**
+ * Activate one exact registry source/profile route and bind its receipt to the
+ * source generation that remained stable across descriptor resolution. The
+ * stable connection id alone cannot authorize a replacement route edited in
+ * place under the same id.
+ */
+export async function activateGatewayAgentWithProof(
+  connectionId: string,
+  profile: string,
+  connectionResolver: ConnectionResolver
+): Promise<RouteActivationReceipt> {
+  const requested = routeOwner(connectionId, profile)
+
+  // Generation N must be observed before descriptor or gateway resolution
+  // starts. Accepting an already-started Promise remains a compatibility path
+  // for focused tests, but production callers pass a factory so an edit cannot
+  // land between descriptor start and the first generation observation.
+  const generationBefore = await registryRouteGeneration(requested.connectionId || '')
+  const previousGeneration = gatewayActivationEpoch()
+  const connectionPromise = startConnectionResolution(connectionResolver)
+  const gatewayPromise = ensureGatewayForAgent(requested.connectionId, requested.profile)
+  const activationGeneration = gatewayActivationEpoch()
+  const activationStarted = activationGeneration > previousGeneration
+  const [connection, landed] = await Promise.all([connectionPromise, gatewayPromise])
+
+  if (!activationStarted || !landed) {
+    return finishActivation({
+      activationGeneration,
+      connection,
+      kind: 'agent',
+      landed: false,
+      requested
+    })
+  }
+
+  const generationAfter = await registryRouteGeneration(requested.connectionId || '')
+
+  if (!generationBefore || !generationAfter) {
+    return rejectGeneration(activationGeneration, requested, 'route-generation-unavailable')
+  }
+
+  if (generationBefore !== generationAfter) {
+    return rejectGeneration(activationGeneration, requested, 'route-generation-changed')
+  }
+
+  return finishActivation({
+    activationGeneration,
+    connection: bindRouteGeneration(connection, generationBefore),
+    kind: 'agent',
+    landed: true,
+    requested
+  })
+}
+
+/**
+ * Exact no-op gate for route activation. Display-route equality is not enough:
+ * degraded or rejected receipts must reacquire proof, even when the requested
+ * route is still physically selected. Only a current ready receipt can suppress
+ * the activation operation that mints mutation authority.
+ */
+export function activeGatewayRouteMatches(requested: RouteOwnerRef): boolean {
+  const expected = routeOwner(requested.connectionId, requested.profile)
+  const receipt = $routeActivationReceipt.get()
+
+  return Boolean(
+    receipt &&
+      receipt.status === 'ready' &&
+      routeActivationReceiptIsCurrent(receipt) &&
+      sameRoute(receipt.requested, expected) &&
+      receipt.gateway?.connectionState === 'open'
+  )
+}
+
+/**
+ * Revalidate immediately before publication. JavaScript cannot interleave an
+ * activation between this synchronous check and the following Nanostores
+ * batch, so a stale receipt deterministically becomes a no-op.
+ */
+export function routeActivationReceiptIsCurrent(
+  receipt: RouteActivationReceipt
+): receipt is DegradedRouteActivationReceipt | ReadyRouteActivationReceipt {
+  if (receipt.status !== 'ready' && receipt.status !== 'degraded') {
+    return false
+  }
+
+  return (
+    receipt.activationGeneration === gatewayActivationEpoch() &&
+    receipt.gateway === $gateway.get() &&
+    sameRoute(receipt.physicalRoute, currentPhysicalRoute())
+  )
+}
+
+function connectionRetainsReadyRouteProof(
+  receipt: ReadyRouteActivationReceipt,
+  currentConnection: HermesConnection | null
+): boolean {
+  if (!currentConnection) {
+    return false
+  }
+
+  const kind = receipt.requested.connectionId ? 'agent' : 'profile'
+  const currentProof = descriptorRouteProof(kind, receipt.requested, currentConnection, false)
+  const receiptGeneration = routeGeneration(receipt.connection)
+  const currentGeneration = routeGeneration(currentConnection)
+  const generationCompatible =
+    receipt.requested.connectionId === null ||
+    currentGeneration === null ||
+    (receiptGeneration !== null && currentGeneration === receiptGeneration)
+
+  // Renderer presentation updates clone HermesConnection, and reconnect paths
+  // can reissue an equivalent exact descriptor without copying the renderer's
+  // non-secret generation field. Accept that exact-owner refresh here while
+  // preserving an explicit generation mismatch as an immediate rejection.
+  // The receipt's generation is still carried to Electron, whose main-process
+  // registry map validates it immediately before backend resolution; a source
+  // replaced under the same stable id therefore fails before the side effect.
+  return (
+    generationCompatible &&
+    !currentProof.mismatch &&
+    currentProof.epistemic === 'authoritative' &&
+    currentProof.proofKind === receipt.proof.kind &&
+    currentProof.routeReadiness === 'exact' &&
+    sameRoute(currentProof.route, receipt.route)
+  )
+}
+
+/** Consequential side effects require exact, current, fully ready route proof. */
+export function routeActivationReceiptAllowsMutation(
+  receipt: RouteActivationReceipt,
+  currentConnection: HermesConnection | null
+): receipt is ReadyRouteActivationReceipt {
+  return (
+    receipt.status === 'ready' &&
+    routeActivationReceiptIsCurrent(receipt) &&
+    connectionRetainsReadyRouteProof(receipt, currentConnection) &&
+    receipt.gateway?.connectionState === 'open'
+  )
+}
+
+/**
+ * Resolve the current observable receipt into mutation authority without
+ * reconstructing owner/generation from ambient profile or endpoint state.
+ */
+export function currentRouteActivationReceiptForMutation(
+  currentConnection: HermesConnection | null
+): ReadyRouteActivationReceipt | null {
+  const receipt = $routeActivationReceipt.get()
+
+  return receipt && routeActivationReceiptAllowsMutation(receipt, currentConnection) ? receipt : null
+}

--- a/apps/desktop/src/store/profile-agent-activation.test.ts
+++ b/apps/desktop/src/store/profile-agent-activation.test.ts
@@ -21,12 +21,24 @@ const ensureGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const $gateway = atom<unknown>({ id: 'live-socket' })
 const resetStarmapGraph = vi.fn()
+const activationProof = vi.hoisted(() => ({
+  activeRouteMatches: vi.fn(),
+  activateAgent: vi.fn(),
+  activateProfile: vi.fn(),
+  receiptIsCurrent: vi.fn()
+}))
 
 vi.mock('@/store/gateway', () => ({
   $gateway,
   ensureGatewayForAgent,
   ensureGatewayForProfile,
   openGatewayForProfile
+}))
+vi.mock('@/store/gateway-activation', () => ({
+  activeGatewayRouteMatches: activationProof.activeRouteMatches,
+  activateGatewayAgentWithProof: activationProof.activateAgent,
+  activateGatewayProfileWithProof: activationProof.activateProfile,
+  routeActivationReceiptIsCurrent: activationProof.receiptIsCurrent
 }))
 vi.mock('@/hermes', () => ({
   getProfiles: vi.fn(async () => ({ profiles: [] })),
@@ -49,11 +61,79 @@ const getConnection = vi.fn<(profile?: string | null) => Promise<HermesConnectio
 const getConnectionFor =
   vi.fn<(payload: { connectionId?: null | string; profile?: null | string }) => Promise<HermesConnection>>()
 
+type ConnectionResolver =
+  | Promise<HermesConnection | null>
+  | (() => Promise<HermesConnection | null>)
+
+function startConnectionResolver(resolver: ConnectionResolver): Promise<HermesConnection | null> {
+  return typeof resolver === 'function' ? resolver() : resolver
+}
+
+function landedReceipt(connectionId: null | string, profile: string, connection: HermesConnection | null) {
+  const route = { connectionId, profile }
+
+  return {
+    activationGeneration: 1,
+    connection,
+    gateway: $gateway.get(),
+    physicalRoute: route,
+    readiness: { descriptor: 'resolved', gateway: 'open', route: 'exact' },
+    requested: route,
+    route,
+    status: 'ready' as const
+  }
+}
+
+function failedReceipt(connectionId: null | string, profile: string) {
+  return {
+    activationGeneration: 1,
+    gateway: $gateway.get(),
+    observedGeneration: 1,
+    observedRoute: { connectionId: null, profile: 'default' },
+    reason: 'target-unavailable' as const,
+    requested: { connectionId, profile },
+    status: 'failed' as const
+  }
+}
+
 beforeEach(() => {
   getConnection.mockReset()
   getConnectionFor.mockReset()
-  ensureGatewayForAgent.mockClear()
-  ensureGatewayForProfile.mockClear()
+  ensureGatewayForAgent.mockReset()
+  ensureGatewayForAgent.mockResolvedValue(true)
+  ensureGatewayForProfile.mockReset()
+  ensureGatewayForProfile.mockResolvedValue(undefined)
+  activationProof.activeRouteMatches.mockReset()
+  activationProof.activeRouteMatches.mockImplementation(
+    ({ connectionId, profile }: { connectionId: null | string; profile: string }) =>
+      connectionId === null && profile === $activeGatewayProfile.get() && Boolean($gateway.get())
+  )
+  activationProof.activateProfile.mockReset()
+  activationProof.activateProfile.mockImplementation(
+    async (profile: string, connectionResolver: ConnectionResolver) => {
+      const connectionPromise = startConnectionResolver(connectionResolver)
+      const gatewayPromise = ensureGatewayForProfile(profile)
+      const [connection] = await Promise.all([connectionPromise, gatewayPromise])
+
+      return landedReceipt(null, profile, connection)
+    }
+  )
+  activationProof.activateAgent.mockReset()
+  activationProof.activateAgent.mockImplementation(
+    async (connectionId: string, profile: string, connectionResolver: ConnectionResolver) => {
+      const connectionPromise = startConnectionResolver(connectionResolver)
+      const gatewayPromise = ensureGatewayForAgent(connectionId, profile)
+      const [connection, landed] = await Promise.all([connectionPromise, gatewayPromise])
+
+      return landed
+        ? landedReceipt(connectionId, profile, connection)
+        : failedReceipt(connectionId, profile)
+    }
+  )
+  activationProof.receiptIsCurrent.mockReset()
+  activationProof.receiptIsCurrent.mockImplementation(
+    (value: { status: string }) => value.status === 'ready' || value.status === 'degraded'
+  )
   $gateway.set({ id: 'live-socket' })
   $activeGatewayProfile.set('default')
   $connection.set(localConn())
@@ -97,11 +177,20 @@ describe('ensureGatewayAgent → $connection / $activeGatewayProfile sync', () =
 
     expect($activeGatewayProfile.get()).toBe('default')
     expect($connection.get()?.mode).toBe('local')
-    // The descriptor lookup DOES run: it is issued concurrently with the dial
-    // so nothing awaits between the activation verdict and the publication
-    // frame. The invariant that matters — nothing is PUBLISHED for a dead
-    // target — is asserted above; the lookup itself is a read-only probe.
+    // Once route generation is observed, descriptor lookup and the dial start
+    // together. A dead target can still be read-probed; it cannot publish.
     expect(getConnectionFor).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not publish a descriptor after the exact source/profile receipt is superseded', async () => {
+    getConnectionFor.mockResolvedValue(agentConn())
+    activationProof.receiptIsCurrent.mockReturnValueOnce(false)
+
+    await ensureGatewayAgent('homelab', 'research')
+
+    expect(ensureGatewayForAgent).toHaveBeenCalledWith('homelab', 'research')
+    expect($activeGatewayProfile.get()).toBe('default')
+    expect($connection.get()?.mode).toBe('local')
   })
 
   it('falls through to the profile path for a null connectionId', async () => {

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -6,13 +6,25 @@ import type { ProfileInfo } from '@/types/hermes'
 
 // Keep profile.ts's side-effecting imports inert: the gateway socket layer and
 // the REST query client must not run for real in a unit test.
-const ensureGatewayForProfile = vi.fn(async () => undefined)
-const ensureGatewayForAgent = vi.fn(async () => undefined)
+const ensureGatewayForProfile = vi.fn(async (_profile: string) => undefined)
+const ensureGatewayForAgent = vi.fn(async (_connectionId: null | string, _profile: string) => undefined)
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const $gateway = atom<unknown>({ id: 'live-socket' })
 const resetStarmapGraph = vi.fn()
+const activationProof = vi.hoisted(() => ({
+  activeRouteMatches: vi.fn(),
+  activateAgent: vi.fn(),
+  activateProfile: vi.fn(),
+  receiptIsCurrent: vi.fn()
+}))
 
 vi.mock('@/store/gateway', () => ({ $gateway, ensureGatewayForAgent, ensureGatewayForProfile, openGatewayForProfile }))
+vi.mock('@/store/gateway-activation', () => ({
+  activeGatewayRouteMatches: activationProof.activeRouteMatches,
+  activateGatewayAgentWithProof: activationProof.activateAgent,
+  activateGatewayProfileWithProof: activationProof.activateProfile,
+  routeActivationReceiptIsCurrent: activationProof.receiptIsCurrent
+}))
 vi.mock('@/hermes', () => ({
   getProfiles: vi.fn(async () => ({ profiles: [] })),
   setApiRequestProfile: vi.fn()
@@ -51,10 +63,66 @@ const localConn = (over: Partial<HermesConnection> = {}): HermesConnection =>
 
 const getConnection = vi.fn<(profile?: string | null) => Promise<HermesConnection>>()
 
+type ConnectionResolver =
+  | Promise<HermesConnection | null>
+  | (() => Promise<HermesConnection | null>)
+
+function startConnectionResolver(resolver: ConnectionResolver): Promise<HermesConnection | null> {
+  return typeof resolver === 'function' ? resolver() : resolver
+}
+
+function receipt(connectionId: null | string, profile: string, connection: HermesConnection | null) {
+  const route = { connectionId, profile }
+
+  return {
+    activationGeneration: 1,
+    connection,
+    gateway: $gateway.get(),
+    physicalRoute: route,
+    readiness: { descriptor: 'resolved', gateway: 'open', route: 'exact' },
+    requested: route,
+    route,
+    status: 'ready' as const
+  }
+}
+
 beforeEach(() => {
   getConnection.mockReset()
-  ensureGatewayForProfile.mockClear()
-  openGatewayForProfile.mockClear()
+  ensureGatewayForAgent.mockReset()
+  ensureGatewayForAgent.mockResolvedValue(undefined)
+  ensureGatewayForProfile.mockReset()
+  ensureGatewayForProfile.mockResolvedValue(undefined)
+  openGatewayForProfile.mockReset()
+  openGatewayForProfile.mockResolvedValue(undefined)
+  activationProof.activeRouteMatches.mockReset()
+  activationProof.activeRouteMatches.mockImplementation(
+    ({ connectionId, profile }: { connectionId: null | string; profile: string }) =>
+      connectionId === null && profile === $activeGatewayProfile.get() && Boolean($gateway.get())
+  )
+  activationProof.activateProfile.mockReset()
+  activationProof.activateProfile.mockImplementation(
+    async (profile: string, connectionResolver: ConnectionResolver) => {
+      const connectionPromise = startConnectionResolver(connectionResolver)
+      const gatewayPromise = ensureGatewayForProfile(profile)
+      const [connection] = await Promise.all([connectionPromise, gatewayPromise])
+
+      return receipt(null, profile, connection)
+    }
+  )
+  activationProof.activateAgent.mockReset()
+  activationProof.activateAgent.mockImplementation(
+    async (connectionId: string, profile: string, connectionResolver: ConnectionResolver) => {
+      const connectionPromise = startConnectionResolver(connectionResolver)
+      const gatewayPromise = ensureGatewayForAgent(connectionId, profile)
+      const [connection] = await Promise.all([connectionPromise, gatewayPromise])
+
+      return receipt(connectionId, profile, connection)
+    }
+  )
+  activationProof.receiptIsCurrent.mockReset()
+  activationProof.receiptIsCurrent.mockImplementation(
+    (value: { status: string }) => value.status === 'ready' || value.status === 'degraded'
+  )
   $gateway.set({ id: 'live-socket' })
   $activeGatewayProfile.set('default')
   $connection.set(localConn())
@@ -105,12 +173,25 @@ describe('ensureGatewayProfile → $connection sync (#46651)', () => {
     expect($connection.get()?.mode).toBe('local')
   })
 
-  it('does not churn $connection when the target is already the active profile', async () => {
+  it('does not publish a descriptor from a superseded activation generation', async () => {
+    getConnection.mockResolvedValue(remoteConn())
+    activationProof.receiptIsCurrent.mockReturnValueOnce(false)
+
+    await ensureGatewayProfile('vps-remote')
+
+    expect(ensureGatewayForProfile).toHaveBeenCalledWith('vps-remote')
+    expect(getConnection).toHaveBeenCalledWith('vps-remote')
+    expect($activeGatewayProfile.get()).toBe('default')
+    expect($connection.get()?.mode).toBe('local')
+  })
+
+  it('does not churn $connection when the exact target route is already active', async () => {
     $activeGatewayProfile.set('vps-remote')
     $connection.set(remoteConn())
 
     await ensureGatewayProfile('vps-remote')
 
+    expect(activationProof.activeRouteMatches).toHaveBeenCalledWith({ connectionId: null, profile: 'vps-remote' })
     expect(getConnection).not.toHaveBeenCalled()
     expect(ensureGatewayForProfile).not.toHaveBeenCalled()
     expect($connection.get()?.mode).toBe('remote')

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -13,7 +13,13 @@ import {
   storedStringRecord
 } from '@/lib/storage'
 import { invalidateCronModelImpactScopeState } from '@/store/cron-model-impact-scope'
-import { $gateway, ensureGatewayForAgent, ensureGatewayForProfile, openGatewayForProfile } from '@/store/gateway'
+import { openGatewayForProfile } from '@/store/gateway'
+import {
+  activateGatewayAgentWithProof,
+  activateGatewayProfileWithProof,
+  activeGatewayRouteMatches,
+  routeActivationReceiptIsCurrent
+} from '@/store/gateway-activation'
 import { setConnection } from '@/store/session'
 import { resetStarmapGraph } from '@/store/starmap'
 import type { ProfileInfo } from '@/types/hermes'
@@ -320,8 +326,12 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
   }
 
   const target = normalizeProfileKey(profile)
+  const requested = { connectionId: null, profile: target }
 
-  if (normalizeProfileKey($activeGatewayProfile.get()) === target && $gateway.get()) {
+  // A bare profile atom is not route authority: a registry agent can expose
+  // the same profile name. Skip only when the gateway store proves the exact
+  // local/legacy owner is already active.
+  if (activeGatewayRouteMatches(requested)) {
     return
   }
 
@@ -330,31 +340,38 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
   if (gatewaySwitch) {
     await gatewaySwitch.catch(() => undefined)
 
-    if (normalizeProfileKey($activeGatewayProfile.get()) === target && $gateway.get()) {
+    if (activeGatewayRouteMatches(requested)) {
       return
     }
   }
 
   $gatewaySwapTarget.set(target)
   gatewaySwitch = (async () => {
-    // ensureGatewayForProfile opens (or reuses) the target's socket and points
-    // the active gateway at it — without closing the profile you came from.
-    // The descriptor resolves concurrently so nothing awaits between the
-    // activation and the publication below: the old post-activation
-    // syncConnectionToActiveProfile await left a window where $gateway
-    // already targeted the new backend while $connection still described the
-    // previous one, and remote-aware paths announced the wrong mode (#46651).
-    const [connection] = await Promise.all([resolveConnectionForProfile(target), ensureGatewayForProfile(target)])
+    // The activation helper starts the descriptor lookup and gateway dial in
+    // parallel, captures the gateway's exact activation generation, and
+    // returns a route-qualified readiness verdict. This preserves #89797's
+    // fail-open atomic publication contract without discarding the proof that
+    // says which activation actually landed (#90866).
+    const receipt = await activateGatewayProfileWithProof(target, () => resolveConnectionForProfile(target))
+
+    // A later activation, source removal, or route mismatch makes this a
+    // deterministic no-op. The synchronous recheck and batch are one
+    // JavaScript turn, so no successor generation can interleave between them.
+    if (!routeActivationReceiptIsCurrent(receipt)) {
+      console.warn(`[profile] profile gateway activation for "${target}" did not retain current route proof`)
+
+      return
+    }
 
     // ONE publication frame. batch() defers Nanostores' notifications to the
     // end of the callback, so the profile pointer and the connection
-    // descriptor become visible together; a null descriptor (no bridge, or a
-    // failed best-effort lookup) keeps the previous one — fail open.
+    // descriptor become visible together; a degraded receipt with no
+    // descriptor keeps the previous one — fail open for display/navigation.
     batch(() => {
       $activeGatewayProfile.set(target)
 
-      if (connection) {
-        setConnection(connection)
+      if (receipt.connection) {
+        setConnection(receipt.connection)
       }
     })
   })()
@@ -420,31 +437,32 @@ export async function ensureGatewayAgent(connectionId: null | string, profile: s
 
   $gatewaySwapTarget.set(target)
   gatewaySwitch = (async () => {
-    // Descriptor resolves concurrently with the dial, same as the profile
-    // path, so no await sits between the activation and the publication.
-    const [descriptor, activated] = await Promise.all([
-      resolveConnectionForAgent(connection, target),
-      ensureGatewayForAgent(connection, target)
-    ])
+    // Generation N is observed before this lazy descriptor resolver starts;
+    // descriptor lookup and dial then run concurrently inside the proof
+    // boundary. An edit/remove/recreate under the same id cannot borrow the
+    // successor generation.
+    const receipt = await activateGatewayAgentWithProof(connection, target, () =>
+      resolveConnectionForAgent(connection, target)
+    )
 
-    if (!activated) {
-      // The target stopped existing mid-dial (source edited/removed). Keep
-      // every atom on the previous backend; the caller's surfaces re-check
-      // what's active. Log so a dead agent click is diagnosable (#89622's
-      // silence lesson) — but never fail the whole switch closed here.
-      console.warn(`[profile] agent gateway activation for "${connection}:${target}" did not land`)
+    if (!routeActivationReceiptIsCurrent(receipt)) {
+      // The target stopped existing, another activation superseded this one,
+      // or the route no longer names this exact source/profile. Keep every atom
+      // on the successor backend; the read-only descriptor probe may complete,
+      // but it cannot publish authority for a different route.
+      console.warn(`[profile] agent gateway activation for "${connection}:${target}" did not retain current route proof`)
 
       return
     }
 
-    // ONE publication frame, profile pointer + descriptor together. A null
-    // descriptor keeps the previous one — fail open, resynced by
-    // boot/reconnect later.
+    // ONE publication frame, profile pointer + descriptor together. A degraded
+    // receipt with no descriptor keeps the previous one — fail open for
+    // display/navigation while mutation consumers require a ready receipt.
     batch(() => {
       $activeGatewayProfile.set(target)
 
-      if (descriptor) {
-        setConnection(descriptor)
+      if (receipt.connection) {
+        setConnection(receipt.connection)
       }
     })
   })()


### PR DESCRIPTION
## Summary

- adds a typed `RouteActivationReceipt` that carries exact owner, activation generation, gateway realization, descriptor provenance, epistemic status, and readiness across Desktop activation
- revalidates that receipt immediately before atomic profile/descriptor publication, so late generation N cannot publish after N+1 and same-named profiles on different sources cannot satisfy the no-op gate
- routes read-only Desktop FS/Git facade calls through the gateway-owned connection context and requires a current exact receipt at the remote file-write boundary
- keeps legacy/inferred routes usable for display/read-only paths while rejecting them as mutation authority

## Root cause

The gateway registry already maintains an activation epoch and qualified `(connectionId, profile)` route, but `profile.ts` projected activation to `void | boolean` plus a separately resolved descriptor. Downstream code reconstructed authority from a bare profile, `$connection`, or endpoint-shaped state. `desktop-fs.ts` then dropped `connectionId` entirely before the side effect.

That allowed:

- late/superseded activations to publish renderer state;
- same-profile routes on different sources to appear equivalent;
- legacy inferred source identity to become apparent mutation authority;
- remote FS writes to fall through a profile-only bridge request.

## Guarantees

- activation completion is generation-monotonic; N cannot overwrite N+1
- an operation that never acquired a new activation generation cannot claim an existing route
- profile publication consumes the activation receipt and revalidates generation, gateway object, and physical route in the same JS turn as the Nanostores batch
- mutation authority additionally requires an authoritative exact descriptor proof and an open current gateway
- presentation-only descriptor clones and reconnect-equivalent exact descriptors retain authority; owner/profile changes, inferred descriptors, and unqualified descriptors fail closed
- exact registry writes carry `connectionId + profile` to the bridge
- legacy inferred/unqualified remote routes remain degraded/read-only rather than silently acquiring current/default authority
- local IPC writes and the existing fail-open display/navigation behavior are preserved

## Tests

- exact local and registry-agent activation
- stale generation and late completion
- no-generation activation failure
- source/profile mismatch
- descriptor owner/profile mismatch
- descriptor unavailability and legacy inference
- shared-primary degradation
- gateway realization replacement
- descriptor clone retention vs route-changing replacement
- exact remote file-write routing and mutation rejection
- source-qualified FS cache identity
- profile/agent publication and activation mutex regressions

Local validation:

- strict targeted TypeScript typecheck
- 10-scenario runtime contention/authority harness
- `git diff --check`

## Scope

This is the first complete Desktop source → observable publication → mutation-boundary proof path for #90866. It does not close the repository-wide architecture umbrella; updater, persistence, transport, and packaged-realization paths remain separate migrations.

Refs #90866
Refs #89916
Refs #90048