### PR TITLE
fix(desktop-bots): pet avatar picker fails for local-only pets (empty spritesheetUrl)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2538,68 +2538,50 @@ function AvatarPicker({ shape, color, image, onShape, onColor, onImage, generate
 // ── pet tab: attach a petdex companion that lives beside the avatar ─────────
 
 // A petdex "spritesheet" is the FULL animation sheet (1536×1872 webp, ~2MB;
-// 8×9 grid of 192×208 frames). Using it as an <img> both downloads megabytes
-// per tile and shows the whole sheet squashed. Extract frame 0 once per slug
-// via canvas, downscale to 96px, and cache the data URL. Concurrency-capped
-// so opening the tab doesn't fire dozens of 2MB fetches at once.
-const PET_FRAME_W = 192
-const PET_FRAME_H = 208
-const petFrameCache = new Map()
-let petFetchActive = 0
-const petFetchQueue = []
+// 8×9 grid of 192×208 frames). Cropping frame 0 client-side means downloading
+// megabytes per tile from the CDN — and it CANNOT work for locally hatched
+// pets (generator-created, absent from the petdex manifest, so pet.gallery
+// hands the picker an EMPTY spritesheetUrl). The backend pet.thumb RPC crops
+// + downsamples frame 0 server-side and returns a small PNG data URI: it reads
+// the installed sheet off disk for local pets and the petdex CDN (host-
+// validated) for not-yet-installed ones, disk-caching per slug. One path that
+// serves every pet, same-origin + authenticated through the gateway.
+const petThumbCache = new Map()
 
-function pumpPetQueue() {
-  while (petFetchActive < 4 && petFetchQueue.length) {
-    const job = petFetchQueue.shift()
-    petFetchActive++
-    job().finally(() => {
-      petFetchActive--
-      pumpPetQueue()
-    })
-  }
-}
-
-function petFrameIcon(spriteUrl) {
-  if (!spriteUrl) {
+function petThumbIcon(slug, spriteUrl) {
+  if (!slug) {
     return Promise.resolve(null)
   }
 
-  if (!petFrameCache.has(spriteUrl)) {
-    petFrameCache.set(
-      spriteUrl,
-      new Promise(resolve => {
-        petFetchQueue.push(async () => {
-          try {
-            const resp = await fetch(spriteUrl, { signal: AbortSignal.timeout(15000) })
-            const blob = await resp.blob()
-            // Crop frame 0 during decode — never materialize the full sheet.
-            const bitmap = await createImageBitmap(blob, 0, 0, PET_FRAME_W, PET_FRAME_H)
-            const canvas = document.createElement('canvas')
-            canvas.width = 96
-            canvas.height = 104
-            canvas.getContext('2d').drawImage(bitmap, 0, 0, 96, 104)
-            bitmap.close()
-            resolve(canvas.toDataURL('image/png'))
-          } catch {
-            petFrameCache.delete(spriteUrl)
-            resolve(null)
-          }
-        })
-        pumpPetQueue()
+  if (!petThumbCache.has(slug)) {
+    const pending = host
+      .request('pet.thumb', { slug, url: spriteUrl || '' })
+      .then(result => {
+        if (result?.ok && result.dataUri) {
+          return result.dataUri
+        }
+        // Fail-open, and never cache a failure: a transient backend error
+        // must not poison the tile for the rest of the session.
+        petThumbCache.delete(slug)
+        return null
       })
-    )
+      .catch(() => {
+        petThumbCache.delete(slug)
+        return null
+      })
+    petThumbCache.set(slug, pending)
   }
 
-  return petFrameCache.get(spriteUrl)
+  return petThumbCache.get(slug)
 }
 
-/** One pet tile image: frame 0 only, resolved lazily through the cache. */
-function PetThumb({ spriteUrl, size = 40 }) {
+/** One pet tile image: server-cropped frame 0, resolved lazily + cached. */
+function PetThumb({ slug, spriteUrl, size = 40 }) {
   const [icon, setIcon] = useState(null)
 
   useEffect(() => {
     let alive = true
-    petFrameIcon(spriteUrl).then(url => {
+    petThumbIcon(slug, spriteUrl).then(url => {
       if (alive) {
         setIcon(url)
       }
@@ -2607,7 +2589,7 @@ function PetThumb({ spriteUrl, size = 40 }) {
     return () => {
       alive = false
     }
-  }, [spriteUrl])
+  }, [slug, spriteUrl])
 
   if (!icon) {
     return jsx('div', {
@@ -2725,11 +2707,12 @@ function PetTab({ image, onImage }) {
                         selectedSlug === pet.slug && 'ring-1 ring-(--ui-accent)'
                       ),
                       onClick: () => {
-                        // The pet IS the profile picture: extract frame 0
-                        // and hand it to the dialog as the avatar image.
+                        // The pet IS the profile picture: ask the backend for
+                        // a server-cropped frame-0 thumb (works for local-only
+                        // pets too — those have no spritesheet URL at all).
                         // Persisted when the user hits Save.
                         setSelectedSlug(pet.slug)
-                        void petFrameIcon(pet.spritesheetUrl).then(icon => {
+                        void petThumbIcon(pet.slug, pet.spritesheetUrl).then(icon => {
                           if (icon) {
                             onImage(icon)
                           } else {
@@ -2739,7 +2722,7 @@ function PetTab({ image, onImage }) {
                         })
                       },
                       children: [
-                        jsx(PetThumb, { spriteUrl: pet.spritesheetUrl, size: 40 }),
+                        jsx(PetThumb, { slug: pet.slug, spriteUrl: pet.spritesheetUrl, size: 40 }),
                         jsx('span', {
                           className: 'w-full truncate text-center text-[0.6rem] text-(--ui-text-tertiary)',
                           children: pet.displayName

--- a/apps/desktop/src/plugins/hermes-bots/tests/pet-fetch.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/pet-fetch.test.mjs
@@ -5,13 +5,17 @@ import vm from 'node:vm'
 
 const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
-function load(fetchImpl) {
+/** Load the plugin in a sandbox. `request` stubs host.request; `fetch` stubs
+ *  the (now unused for pet thumbs) global fetch. Returns the context plus the
+ *  recorded host.request calls. */
+function load({ request, fetch } = {}) {
   const values = new Map()
   const atom = initial => {
     const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
     values.set(slot, initial)
     return slot
   }
+  const requests = []
   const fetches = []
   const context = {
     atom,
@@ -27,10 +31,16 @@ function load(fetchImpl) {
       }),
       head: { appendChild: () => undefined }
     },
-    host: { state: { profile: { listen: () => undefined } } },
+    host: {
+      state: { profile: { listen: () => undefined } },
+      request: async (method, params) => {
+        requests.push({ method, params })
+        return request ? request(method, params) : { ok: true, dataUri: 'data:image/png;base64,ok' }
+      }
+    },
     fetch: async (url, opts) => {
       fetches.push({ url, opts })
-      return fetchImpl(url, opts)
+      return fetch ? fetch(url, opts) : { blob: async () => new Blob() }
     },
     AbortSignal,
     createImageBitmap: async () => ({ close() {} })
@@ -42,35 +52,74 @@ function load(fetchImpl) {
     .replace(/^import .* from 'react'\r?\n/m, '')
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
-    .concat('\nglobalThis.__api = { petFrameIcon };\n')
+    .concat('\nglobalThis.__api = { petThumbIcon };\n')
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
-  return { context, fetches }
+  return { context, requests, fetches }
 }
 
-test('unit: a failed pet fetch is not stuck in the cache', async () => {
+test('regression: a local-only pet (no spritesheet URL) still resolves its icon via pet.thumb', async () => {
+  // Local-only pet: generator-hatched, absent from the petdex manifest, so
+  // pet.gallery hands the picker an EMPTY spritesheetUrl. The old client-side
+  // fetch path bailed on that and the picker refused the selection. pet.thumb
+  // reads the installed sheet off disk server-side, so it must still work.
   let n = 0
-  const { context, fetches } = load(async () => {
-    n += 1
-    throw new Error('network')
+  const { context, requests } = load({
+    request: async (method, params) => {
+      n += 1
+      assert.equal(method, 'pet.thumb')
+      assert.equal(params.slug, 'local-pet')
+      assert.equal(params.url, '')
+      return { ok: true, slug: 'local-pet', dataUri: 'data:image/png;base64,local-pet-thumb' }
+    }
   })
-  const a = await context.__api.petFrameIcon('https://pets.example/a.webp')
-  const b = await context.__api.petFrameIcon('https://pets.example/a.webp')
+  const icon = await context.__api.petThumbIcon('local-pet', '')
+  assert.equal(icon, 'data:image/png;base64,local-pet-thumb')
+  assert.equal(n, 1)
+  assert.equal(requests.length, 1)
+  assert.equal(requests[0].method, 'pet.thumb')
+})
+
+test('unit: a failed pet thumb is not stuck in the cache', async () => {
+  let n = 0
+  const { context, requests } = load({
+    request: async () => {
+      n += 1
+      throw new Error('backend unavailable')
+    }
+  })
+  const a = await context.__api.petThumbIcon('local-pet', '')
+  const b = await context.__api.petThumbIcon('local-pet', '')
   assert.equal(a, null)
   assert.equal(b, null)
-  assert.equal(fetches.length, 2)
+  assert.equal(requests.length, 2)
   assert.equal(n, 2)
-  assert.ok(fetches[0].opts.signal, 'fetch is aborted if it hangs')
+})
+
+test('unit: an ok:false thumb (no usable source) resolves null and is retried', async () => {
+  let n = 0
+  const { context } = load({
+    request: async () => {
+      n += 1
+      return { ok: false, slug: 'local-pet' }
+    }
+  })
+  assert.equal(await context.__api.petThumbIcon('local-pet', ''), null)
+  assert.equal(await context.__api.petThumbIcon('local-pet', ''), null)
+  assert.equal(n, 2)
 })
 
 test('regression: a successful icon is still cached', async () => {
   let n = 0
-  const { context } = load(async () => {
-    n += 1
-    return { blob: async () => new Blob() }
+  const { context, requests } = load({
+    request: async () => {
+      n += 1
+      return { ok: true, slug: 'dogalright', dataUri: 'data:image/png;base64,ok' }
+    }
   })
-  const a = await context.__api.petFrameIcon('https://pets.example/ok.webp')
-  const b = await context.__api.petFrameIcon('https://pets.example/ok.webp')
+  const a = await context.__api.petThumbIcon('dogalright', 'https://assets.petdex.dev/.../dogalright.webp')
+  const b = await context.__api.petThumbIcon('dogalright', 'https://assets.petdex.dev/.../dogalright.webp')
   assert.equal(a, 'data:image/png;base64,ok')
+  assert.equal(b, a)
+  assert.equal(requests.length, 1)
   assert.equal(n, 1)
-  assert.equal(a, b)
 })


### PR DESCRIPTION
## Problem

The Pet tab of the bot avatar picker (hermes-bots desktop plugin) fails to select any pet that exists only on the local machine: clicking it shows "Could not load that pet — try another." and the selection reverts.

Two root causes, same symptom:

1. **Local-only pets have no spritesheet URL.** `pet.gallery` builds `spritesheetUrl` from the petdex manifest. Pets created locally (in-app generator, `createdBy: "generator"`) have no manifest entry, so they come back with `spritesheetUrl: ""`. The picker's `petFrameIcon()` then fetched an empty URL and resolved `null` — error toast, selection reverted.
2. **Raw CDN fetches 403 for every pet.** `petFrameIcon()` fetched `assets.petdex.dev` spritesheets without a User-Agent header; the CDN rejects UA-less requests with HTTP 403 (#90465). Manifest pets therefore failed too, in a separate code path.

## Fix

Route tile rendering and selection through the existing **`pet.thumb`** gateway RPC instead of client-side sprite cropping:

- `pet.thumb` serves **local-only pets from the installed on-disk spritesheet** (server-side crop of frame 0, 96px PNG) and **manifest pets from the CDN** with host validation and a proper User-Agent — one path that works for both.
- The client-side frame-crop pipeline is removed: `petFrameIcon`, the frame constants, and the fetch-queue/concurrency machinery. Spritesheets are ~2MB webp; the old code downloaded megabytes per tile just to render a 40px avatar, and could not serve local-only pets at all.
- Thumbnails are disk-cached per slug server-side (`.thumbs/` under the pets directory), and the client caches the resulting data URI per slug, deleting the cache key on failure so failed loads are retried.

This **fixes #90465**: the raw `fetch()` it describes is gone from the picker entirely — the missing-UA 403 class cannot occur, and local-only pets work as a bonus. Sibling PR #90485 implements the one-line UA-header patch from the issue, which is the right-sized fix for the 403 class alone; this change supersedes it only in the sense that the fetch it patches no longer exists. If #90485 merges first, this PR rebases cleanly on top of it.

## Tests

`apps/desktop/src/plugins/hermes-bots/tests/pet-fetch.test.mjs` rewritten (TDD, red → green):

1. Regression: a local-only pet with no spritesheet URL still resolves its icon via `pet.thumb`.
2. Unit: a failed thumb request is not stuck in the client cache — it is retried.
3. Unit: an `ok: false` thumb response resolves `null` and is retried.
4. Regression: a successful icon is cached — one `pet.thumb` request per slug.

Full plugin test suite: **343/343 passing**.

## Notes

- `pet.thumb` has shipped on every supported gateway since before the 2026-07-29 `@method` refactor — no feature detection needed.
- Related upstream work: #51824 hardens `thumbnail_png` slug handling on the backend this change depends on; no overlap with the files touched here.
