### PR TITLE
fix(desktop): deliver timed-out group replies automatically

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -214,6 +214,12 @@ const $groupNeedsYou = atom({})
 // the room renders answer cards from it.
 const $groupClarify = atom({})
 
+// Timed-out group turns keep running in their hidden member sessions. These
+// timers harvest the eventual answer without requiring another user message.
+const groupStrandedTimers = new Map()
+const groupStrandedInFlight = new Set()
+let groupStrandedDisposed = false
+
 // ── group activity feed ─────────────────────────────────────────────────────
 // Runtime-only, bounded per-room record of turn events that feeds the
 // collapsible Activity view. Never persisted — it is presentation state like
@@ -4159,6 +4165,7 @@ async function disbandGroupChat(group, members) {
   // Invalidate any in-flight round-robin FIRST: bump the epoch so a running
   // drive bails at its next member boundary instead of appending to a room
   // the user just discarded.
+  cancelStrandedGroupTimers(group)
   const all = { ...$groupChats.get() }
   const prior = all[group] || {}
 
@@ -4195,6 +4202,7 @@ async function disbandGroupChat(group, members) {
           log: room.log,
           watermarks: room.watermarks,
           sessions: room.sessions || {},
+          stranded: room.stranded || {},
           members: Array.isArray(room.members) ? room.members : [],
           image: room.image || null
         }
@@ -4326,8 +4334,8 @@ async function renameGroupChat(oldName, newName, members) {
   return next
 }
 
-function appendGroupChatEntry(group, from, text, thread, images) {
-  const entry = { at: Date.now(), from, text: String(text).trim(), thread: thread || 'legacy' }
+function appendGroupChatEntry(group, from, text, thread, images, extra = {}) {
+  const entry = { at: Date.now(), from, text: String(text).trim(), thread: thread || 'legacy', ...extra }
 
   if (Array.isArray(images) && images.length) {
     // [{ name, data }] — data URLs. Persisted with the room log so reloads
@@ -4359,6 +4367,7 @@ async function ensureGroupChatSession(group, member) {
   const room = $groupChats.get()[group] || {}
   const key = groupMemberKey(member)
   const known = room.sessions && room.sessions[key]
+  let rotateOversizedSession = false
 
   // Try resuming what we know (stored sid first, then title lookup).
   for (const target of [known, title]) {
@@ -4374,6 +4383,17 @@ async function ensureGroupChatSession(group, member) {
       })
 
       if (res?.session_id) {
+        const messageCount = Number(res.message_count || 0)
+
+        // Hidden group sessions accumulate the complete room transcript plus
+        // tool output. Rotate an idle oversized session before its context
+        // starts degrading tool calls. The previous session remains intact
+        // in Hermes history; only the room's active pointer changes.
+        if (!res.inflight && !res.running && messageCount >= GROUP_SESSION_ROTATE_MESSAGES) {
+          rotateOversizedSession = true
+          break
+        }
+
         return { runtime: res.session_id, stored: res.session_key || known }
       }
     } catch {
@@ -4383,7 +4403,7 @@ async function ensureGroupChatSession(group, member) {
 
   const created = await requestForBot(member, 'session.create', {
     profile: member.name,
-    title,
+    title: rotateOversizedSession ? `${title} · ${Date.now()}` : title,
     // Room member sessions are plumbing — always hidden from the sidebar.
     hidden: true
   })
@@ -4401,12 +4421,118 @@ async function ensureGroupChatSession(group, member) {
 
 const GROUP_TURN_TIMEOUT_MS = 180000
 const GROUP_TURN_POLL_MS = 2000
-// A member turn that is VISIBLY still working (session reports
-// inflight/running) keeps its slot alive up to this hard cap. The base
-// timeout alone silently dropped long real turns: a 7-minute research run
-// timed out at 3 minutes, read as a pass, and its finished result never
-// reached the room (db's Aug 2026 report).
-const GROUP_TURN_HARD_CAP_MS = 20 * 60000
+const GROUP_SESSION_ROTATE_MESSAGES = 300
+const GROUP_LATE_POLL_MS = 10000
+const GROUP_LATE_TTL_MS = 24 * 60 * 60 * 1000
+
+function durableGroupMember(member) {
+  const durable = {
+    name: String(member?.name || '').trim() || 'default',
+    title: String(member?.title || '').trim()
+  }
+
+  for (const key of ['handle', 'connectionId', 'connectionKind', 'connectionLabel']) {
+    if (member?.[key]) {
+      durable[key] = member[key]
+    }
+  }
+
+  if (member?.remoteSource) {
+    durable.remoteSource = true
+    durable.sourceScoped = true
+  }
+
+  return durable
+}
+
+function strandedTimerKey(group, memberKey) {
+  return `${group}\u0000${memberKey}`
+}
+
+function cancelStrandedGroupTimers(group = null) {
+  for (const [key, timer] of groupStrandedTimers.entries()) {
+    if (group === null || key.startsWith(`${group}\u0000`)) {
+      clearTimeout(timer)
+      groupStrandedTimers.delete(key)
+    }
+  }
+}
+
+function scheduleStrandedGroupHarvest(group, memberKey, delay = GROUP_LATE_POLL_MS) {
+  if (groupStrandedDisposed) {
+    return
+  }
+
+  const key = strandedTimerKey(group, memberKey)
+
+  if (groupStrandedTimers.has(key) || groupStrandedInFlight.has(key)) {
+    return
+  }
+
+  const timer = setTimeout(() => {
+    groupStrandedTimers.delete(key)
+    void pollStrandedGroupReply(group, memberKey)
+  }, delay)
+
+  groupStrandedTimers.set(key, timer)
+}
+
+function resumeStrandedGroupTurns() {
+  for (const [group, room] of Object.entries($groupChats.get())) {
+    for (const memberKey of Object.keys(room?.stranded || {})) {
+      scheduleStrandedGroupHarvest(group, memberKey, 0)
+    }
+  }
+}
+
+async function pollStrandedGroupReply(group, memberKey) {
+  const room = $groupChats.get()[group]
+  const marker = room?.stranded?.[memberKey]
+
+  if (marker === undefined || marker === null) {
+    return
+  }
+
+  const expiresAt = typeof marker === 'object' ? marker.expiresAt : null
+
+  if (expiresAt && Date.now() >= expiresAt) {
+    updateGroupChat(group, r => {
+      const next = { ...(r.stranded || {}) }
+      delete next[memberKey]
+      r.stranded = next
+      return r
+    })
+    appendGroupChatEntry(
+      group,
+      { kind: 'system', name: 'Hermes' },
+      `@${marker.member?.name || memberKey}'s background turn did not finish within 24 hours.`,
+      marker.thread || 'legacy'
+    )
+    return
+  }
+
+  const member = marker?.member
+    || (room.members || []).find(candidate => groupMemberKey(candidate) === memberKey)
+
+  if (!member) {
+    scheduleStrandedGroupHarvest(group, memberKey)
+    return
+  }
+
+  const before = room.log.length
+  await harvestStrandedGroupReply(group, member)
+  const current = $groupChats.get()[group]
+
+  if (current?.stranded?.[memberKey]) {
+    scheduleStrandedGroupHarvest(group, memberKey)
+  } else if (current?.log?.length > before) {
+    host.notify?.({
+      kind: 'success',
+      title: `@${member.name} finished`,
+      message: `The reply was posted in “${group}”.`
+    })
+  }
+}
 
 /** Mirror a member's pending prompt — clarify question OR command approval —
  *  from its resume snapshot into the room store, keyed
@@ -4549,11 +4675,9 @@ async function answerGroupClarify(entry, member, answers) {
 
 /** One member turn, gateway-native: submit the room delta as a prompt into
  *  the member's per-group session, then poll the session until a NEW
- *  assistant message lands (or timeout → pass). While the session visibly
- *  reports work in flight the deadline extends (bounded by the hard cap),
- *  so slow models aren't cut off mid-run. A turn that still times out
- *  records a stranded marker so the finished reply can be harvested into
- *  the room at the member's next turn instead of being lost. */
+ *  assistant message lands. At three minutes the room is released while a
+ *  durable background watcher keeps polling the same session and posts the
+ *  eventual answer back into the original thread. */
 async function runGroupChatMemberTurn(group, member, prompt, thread, images) {
   const { runtime, stored } = await ensureGroupChatSession(group, member)
 
@@ -4627,8 +4751,7 @@ async function runGroupChatMemberTurn(group, member, prompt, thread, images) {
 
   await requestForBot(member, 'prompt.submit', { session_id: runtime, text: turnText })
 
-  const started = Date.now()
-  let deadline = started + GROUP_TURN_TIMEOUT_MS
+  const deadline = Date.now() + GROUP_TURN_TIMEOUT_MS
 
   while (Date.now() < deadline) {
     await new Promise(resolve => setTimeout(resolve, GROUP_TURN_POLL_MS))
@@ -4679,12 +4802,6 @@ async function runGroupChatMemberTurn(group, member, prompt, thread, images) {
       return null
     }
 
-    // Still visibly working — or waiting on the user's answer to a clarify:
-    // extend the deadline (never past the hard cap). A pending question must
-    // outlive the base turn timeout or it dies unanswered at 3 minutes.
-    if (busy || awaitingUser) {
-      deadline = Math.min(started + GROUP_TURN_HARD_CAP_MS, Math.max(deadline, Date.now() + GROUP_TURN_TIMEOUT_MS))
-    }
   }
 
   // Timeout — clear any still-mirrored question card (the server-side
@@ -4693,92 +4810,122 @@ async function runGroupChatMemberTurn(group, member, prompt, thread, images) {
   // thread instead of vanishing.
   recordGroupActivity(group, { kind: 'timed-out', member: member.name, thread })
   syncGroupClarify(group, member, null)
+  const memberKey = groupMemberKey(member)
+  const now = Date.now()
+  const lateTurnId = `${memberKey}-${now}-${Math.random().toString(36).slice(2, 9)}`
+
   updateGroupChat(group, r => {
-    r.stranded = { ...(r.stranded || {}), [groupMemberKey(member)]: { before, thread } }
+    r.stranded = {
+      ...(r.stranded || {}),
+      [memberKey]: {
+        id: lateTurnId,
+        before,
+        thread,
+        member: durableGroupMember(member),
+        submittedAt: now,
+        expiresAt: now + GROUP_LATE_TTL_MS
+      }
+    }
     return r
   })
+  scheduleStrandedGroupHarvest(group, memberKey)
 
   return null
 }
 
 /** Post a timed-out member's finished reply into the room, if it landed
- *  after we stopped waiting. Called at the member's next turn boundary and
- *  on user sends, so long-running work is delivered late rather than lost. */
+ *  after we stopped waiting. A background poller calls this until the member
+ *  finishes, so delivery does not depend on another user message. */
 async function harvestStrandedGroupReply(group, member) {
   const memberKey = groupMemberKey(member)
-  const room = $groupChats.get()[group] || {}
-  const marker = room.stranded?.[memberKey]
-  // Markers were a bare number before threads; normalize both shapes.
-  const strandedBefore = typeof marker === 'number' ? marker : marker?.before
-  const strandedThread = (typeof marker === 'object' && marker?.thread) || 'legacy'
+  const harvestKey = strandedTimerKey(group, memberKey)
 
-  if (typeof strandedBefore !== 'number') {
+  if (groupStrandedInFlight.has(harvestKey)) {
     return
   }
 
-  let state = null
+  groupStrandedInFlight.add(harvestKey)
 
   try {
-    const stored = room.sessions?.[memberKey]
-    state = await requestForBot(member, 'session.resume', {
-      session_id: stored || `Group: ${group}`,
-      profile: member.name
-    })
-  } catch {
-    return // source unreachable — leave the marker for the next boundary
-  }
+    const room = $groupChats.get()[group] || {}
+    const marker = room.stranded?.[memberKey]
+    // Markers were a bare number before threads; normalize both shapes.
+    const strandedBefore = typeof marker === 'number' ? marker : marker?.before
+    const strandedThread = (typeof marker === 'object' && marker?.thread) || 'legacy'
 
-  if (state?.inflight || state?.running) {
-    return // still grinding — keep waiting
-  }
-
-  // A stranded member blocked on a clarify is not "grinding" — surface the
-  // question card (#90694) and keep the marker until it resolves.
-  if (syncGroupClarify(group, member, state)) {
-    return
-  }
-
-  // Done (or dead): the marker is consumed either way.
-  updateGroupChat(group, r => {
-    const next = { ...(r.stranded || {}) }
-    delete next[memberKey]
-    r.stranded = next
-    return r
-  })
-
-  const messages = Array.isArray(state?.messages) ? state.messages : []
-
-  if (messages.length <= strandedBefore) {
-    return
-  }
-
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i]
-
-    if (msg?.role === 'assistant') {
-      const text = typeof msg.content === 'string'
-        ? msg.content
-        : Array.isArray(msg.content)
-          ? msg.content.map(p => (typeof p === 'string' ? p : p?.text || '')).join('')
-          : msg?.text || ''
-      const reply = String(text).trim()
-
-      if (reply && !isGroupPassText(reply)) {
-        recordGroupActivity(group, { kind: 'delivered', member: member.name, thread: strandedThread })
-        appendGroupChatEntry(
-          group,
-          { kind: 'member', name: member.name, ...(member.remoteSource ? { source: member.connectionLabel || member.connectionId } : {}) },
-          reply,
-          strandedThread
-        )
-        updateGroupChat(group, r => {
-          r.watermarks[`${strandedThread}::${memberKey}`] = r.log.length
-          return r
-        })
-      }
-
+    if (typeof strandedBefore !== 'number') {
       return
     }
+
+    let state = null
+
+    try {
+      const stored = room.sessions?.[memberKey]
+      state = await requestForBot(member, 'session.resume', {
+        session_id: stored || `Group: ${group}`,
+        profile: member.name
+      })
+    } catch {
+      return // source unreachable — leave the marker for the next poll
+    }
+
+    if (state?.inflight || state?.running) {
+      return // still grinding — keep waiting
+    }
+
+    // A stranded member blocked on a clarify is not "grinding" — surface the
+    // question card (#90694) and keep the marker until it resolves.
+    if (syncGroupClarify(group, member, state)) {
+      return
+    }
+
+    // Done (or dead): the marker is consumed either way.
+    updateGroupChat(group, r => {
+      const next = { ...(r.stranded || {}) }
+      delete next[memberKey]
+      r.stranded = next
+      return r
+    })
+
+    const messages = Array.isArray(state?.messages) ? state.messages : []
+
+    if (messages.length <= strandedBefore) {
+      return
+    }
+
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i]
+
+      if (msg?.role === 'assistant') {
+        const text = typeof msg.content === 'string'
+          ? msg.content
+          : Array.isArray(msg.content)
+            ? msg.content.map(p => (typeof p === 'string' ? p : p?.text || '')).join('')
+            : msg?.text || ''
+        const reply = String(text).trim()
+        const lateTurnId = typeof marker === 'object' ? marker.id : null
+
+        if (reply && !isGroupPassText(reply) && !room.log.some(entry => lateTurnId && entry.lateTurnId === lateTurnId)) {
+          recordGroupActivity(group, { kind: 'delivered', member: member.name, thread: strandedThread })
+          appendGroupChatEntry(
+            group,
+            { kind: 'member', name: member.name, ...(member.remoteSource ? { source: member.connectionLabel || member.connectionId } : {}) },
+            reply,
+            strandedThread,
+            null,
+            { late: true, ...(lateTurnId ? { lateTurnId } : {}) }
+          )
+          updateGroupChat(group, r => {
+            r.watermarks[`${strandedThread}::${memberKey}`] = r.log.length
+            return r
+          })
+        }
+
+        return
+      }
+    }
+  } finally {
+    groupStrandedInFlight.delete(harvestKey)
   }
 }
 
@@ -9144,6 +9291,9 @@ function GroupChatWorkspace({ group, members, onBack }) {
   const rooms = useValue($groupChats)
   const allMeta = useValue($botMeta)
   const room = rooms[group] || { log: [], running: false }
+  const strandedNames = Object.values(room.stranded || {})
+    .map(marker => marker?.member?.name)
+    .filter(Boolean)
   const [draft, setDraft] = useState('')
   const [confirmDisband, setConfirmDisband] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
@@ -9748,10 +9898,12 @@ function GroupChatWorkspace({ group, members, onBack }) {
             ...roomClarifies.map(entry =>
               jsx(GroupClarifyCard, { entry, members }, `clarify:${entry.memberKey}:${entry.requestId}`)
             ),
-            room.running
+            room.running || strandedNames.length
               ? jsx('div', {
                   className: 'px-2 py-1 text-[0.7rem] italic text-(--ui-text-quaternary)',
-                  children: roomClarifies.length
+                  children: strandedNames.length
+                    ? `${strandedNames.map(groupSpeakerLabel).join(', ')} still working — the finished reply will return here automatically.`
+                    : roomClarifies.length
                     ? 'Waiting for your answer…'
                     : room.turn
                       ? `${groupSpeakerLabel(room.turn)} is thinking…`
@@ -10483,6 +10635,7 @@ export default {
   description: 'Bot Mode — a one-chat-per-agent roster with avatars, routines, group chats, and bot-to-bot messaging. Ships with the app; disable here if unwanted.',
   register(ctx) {
     pluginCtx = ctx
+    groupStrandedDisposed = false
     startFaceClock()
     // Disabling the plugin (or a hot reload) must actually stop the clock —
     // before this, the rAF loop + 1Hz document scan ran until app restart.
@@ -10622,6 +10775,7 @@ export default {
             }
 
             $groupChats.set({ ...rooms, ...$groupChats.get() })
+            resumeStrandedGroupTurns()
           }
         })
         .catch(() => undefined)
@@ -10642,6 +10796,8 @@ export default {
 
     if (typeof ctx.onDispose === 'function') {
       ctx.onDispose(() => {
+        groupStrandedDisposed = true
+        cancelStrandedGroupTimers()
         if (typeof unbindProfileListener === 'function') {
           unbindProfileListener()
         }

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -124,7 +124,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, disbandGroupChat, updateGroupChat, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, ensureGroupChatSession, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, disbandGroupChat, updateGroupChat, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -659,6 +659,42 @@ test('stranded harvest: a timed-out turn whose reply landed late posts into the 
   assert.equal(gc.$groupChats.get().Late.stranded.research, undefined, 'marker consumed')
 })
 
+test('stranded harvest: the same completed turn is delivered exactly once', async () => {
+  const gc = load(() => '(pass)')
+  const marker = {
+    id: 'late-turn-1',
+    before: 0,
+    thread: 'thread-1',
+    member: { name: 'research', title: '' }
+  }
+
+  gc.updateGroupChat('Once', r => {
+    r.stranded = { research: marker }
+    r.sessions = { research: 'sid-research' }
+    return r
+  })
+  gc.sessions.set('sid-research', {
+    stored: 'sid-research',
+    runtime: 'rt-research',
+    profile: 'research',
+    title: 'Group: Once',
+    messages: [
+      { role: 'user', content: 'work' },
+      { role: 'assistant', content: 'Finished exactly once.' }
+    ]
+  })
+
+  await gc.harvestStrandedGroupReply('Once', { name: 'research', title: '' })
+  // Recreate a stale persisted marker to simulate a reload/racing poll.
+  gc.updateGroupChat('Once', r => {
+    r.stranded = { research: marker }
+    return r
+  })
+  await gc.harvestStrandedGroupReply('Once', { name: 'research', title: '' })
+
+  assert.equal(roomLog(gc, 'Once').filter(entry => entry.lateTurnId === marker.id).length, 1)
+})
+
 test('stranded + still busy: the round loop never re-submits into a member whose harvest just confirmed they are still running', async () => {
   // research is confirmed busy on exactly its first two session.resume
   // calls — the number of harvest-only touches the FIXED code makes across
@@ -754,9 +790,36 @@ test('stranded markers persist so late replies survive a window reload', async (
   assert.equal(durable.Persist.stranded.research, 3, 'stranded marker rides the durable map')
 })
 
-test('source contract: long visible turns extend the deadline up to a hard cap', () => {
-  assert.match(pluginSource, /const GROUP_TURN_HARD_CAP_MS = /)
-  assert.match(pluginSource, /deadline = Math\.min\(started \+ GROUP_TURN_HARD_CAP_MS/)
+test('source contract: room releases at three minutes and polls late work automatically', () => {
+  assert.match(pluginSource, /const GROUP_TURN_TIMEOUT_MS = 180000/)
+  assert.match(pluginSource, /const deadline = Date\.now\(\) \+ GROUP_TURN_TIMEOUT_MS/)
+  assert.match(pluginSource, /scheduleStrandedGroupHarvest\(group, memberKey\)/)
+  assert.match(pluginSource, /resumeStrandedGroupTurns\(\)/)
+  assert.match(pluginSource, /finished reply will return here automatically/)
+  assert.doesNotMatch(pluginSource, /GROUP_TURN_HARD_CAP_MS/)
+})
+
+test('oversized hidden group session rotates without deleting its history', async () => {
+  const gc = load(() => '(pass)')
+  const messages = Array.from({ length: 300 }, (_, index) => ({ role: 'user', content: `message-${index}` }))
+
+  gc.sessions.set('sid-rory-old', {
+    stored: 'sid-rory-old',
+    runtime: 'rt-rory-old',
+    profile: 'rory',
+    title: 'Group: Marketing Team',
+    messages
+  })
+  gc.updateGroupChat('Marketing Team', r => {
+    r.sessions = { rory: 'sid-rory-old' }
+    return r
+  })
+
+  const active = await gc.ensureGroupChatSession('Marketing Team', { name: 'rory', title: '' })
+
+  assert.notEqual(active.stored, 'sid-rory-old', 'room points at a fresh hidden session')
+  assert.equal(gc.sessions.get('sid-rory-old').messages.length, 300, 'old history remains intact')
+  assert.equal(gc.$groupChats.get()['Marketing Team'].sessions.rory, active.stored)
 })
 
 test('source contract: the working line names the member on turn', () => {
@@ -1027,7 +1090,7 @@ test('source contract: room renders clarify cards and the poll gates on them', (
   assert.match(pluginSource, /function GroupClarifyCard\(/)
   assert.match(pluginSource, /syncGroupClarify\(group, member, state\)/)
   assert.match(pluginSource, /const done = !busy && !awaitingUser/)
-  assert.match(pluginSource, /busy \|\| awaitingUser/)
+  assert.match(pluginSource, /const done = !busy && !awaitingUser/)
   assert.match(pluginSource, /roomClarifies\.map\(entry =>/)
   assert.match(pluginSource, /'clarify\.respond'/)
 })

--- a/tests/tools/test_terminal_none_command_guard.py
+++ b/tests/tools/test_terminal_none_command_guard.py
@@ -17,5 +17,17 @@ def test_terminal_tool_none_command_returns_clean_error():
 
     assert result["exit_code"] == -1
     assert result["status"] == "error"
-    assert "expected string" in result["error"].lower()
+    assert result["error_code"] == "terminal_command_required"
+    assert result["retryable"] is False
+    assert result["repair_hint"]["required_field"] == "command"
+    assert result["repair_hint"]["example"] == {"command": "pwd"}
+    assert "do not repeat" in result["error"].lower()
     assert "nonetype" in result["error"].lower()
+
+
+def test_terminal_tool_empty_command_returns_same_non_retryable_schema_error():
+    result = json.loads(terminal_tool("   "))
+
+    assert result["error_code"] == "terminal_command_required"
+    assert result["retryable"] is False
+    assert "empty string" in result["error"].lower()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2645,16 +2645,30 @@ def terminal_tool(
         # Note: force parameter is internal only, not exposed to model API
     """
     try:
-        if not isinstance(command, str):
+        if not isinstance(command, str) or not command.strip():
+            received = type(command).__name__ if not isinstance(command, str) else "empty string"
             logger.warning(
                 "Rejected invalid terminal command value: %s",
-                type(command).__name__,
+                received,
             )
             return json.dumps({
                 "output": "",
                 "exit_code": -1,
-                "error": f"Invalid command: expected string, got {type(command).__name__}",
+                "error": (
+                    "SCHEMA_ERROR: terminal requires a non-empty string field named "
+                    f"'command'; got {received}. Do not repeat terminal "
+                    "with empty arguments. Retry once with "
+                    "{'command': '<shell command>'} or use a non-terminal tool."
+                ),
                 "status": "error",
+                "error_code": "terminal_command_required",
+                "retryable": False,
+                "repair_hint": {
+                    "required_field": "command",
+                    "required_type": "string",
+                    "example": {"command": "pwd"},
+                    "max_retries": 1,
+                },
             }, ensure_ascii=False)
 
         # Get configuration


### PR DESCRIPTION
## Summary
- release group-chat turns after the existing three-minute foreground budget
- keep polling timed-out hidden sessions and post the finished reply automatically
- persist late-turn identity and deliver exactly once across reloads
- rotate oversized hidden group sessions without deleting history
- return a non-retryable repair hint for empty terminal tool arguments

## Why
Long-running agents currently either block a group room for up to 20 minutes or require another user message before a finished reply is harvested. Local models can also fall into repeated empty terminal calls without an actionable schema response.

## Tests
- TAP version 13
# Subtest: pass detection: (pass), pass, pass., empty are silence; real text is not
ok 1 - pass detection: (pass), pass, pass., empty are silence; real text is not
  ---
  duration_ms: 9.1905
  type: 'test'
  ...
# Subtest: mention routing: only @-mentioned members respond; @everyone or none = all
ok 2 - mention routing: only @-mentioned members respond; @everyone or none = all
  ---
  duration_ms: 23.031667
  type: 'test'
  ...
# Subtest: mention routing: display titles resolve to the member and @user never matches a bot
ok 3 - mention routing: display titles resolve to the member and @user never matches a bot
  ---
  duration_ms: 16.8045
  type: 'test'
  ...
# Subtest: a member @-mentioned by another bot joins the NEXT round
ok 4 - a member @-mentioned by another bot joins the NEXT round
  ---
  duration_ms: 25.614875
  type: 'test'
  ...
# Subtest: settle: everyone passing ends the room turn with only the user message logged
ok 5 - settle: everyone passing ends the room turn with only the user message logged
  ---
  duration_ms: 2.614917
  type: 'test'
  ...
# Subtest: hard caps: chatty members stop at GROUP_CHAT_MAX_MESSAGES total
ok 6 - hard caps: chatty members stop at GROUP_CHAT_MAX_MESSAGES total
  ---
  duration_ms: 6.097708
  type: 'test'
  ...
# Subtest: failed member turn is a pass, not a room error
ok 7 - failed member turn is a pass, not a room error
  ---
  duration_ms: 4.423
  type: 'test'
  ...
# Subtest: delta injection: a second user send only feeds members the NEW messages
ok 8 - delta injection: a second user send only feeds members the NEW messages
  ---
  duration_ms: 77.812125
  type: 'test'
  ...
# Subtest: concurrent groups sharing one member keep sessions, deltas, and context isolated
ok 9 - concurrent groups sharing one member keep sessions, deltas, and context isolated
  ---
  duration_ms: 12.484708
  type: 'test'
  ...
# Subtest: needs-you: a member reply mentioning @user badges the group; user send clears it
ok 10 - needs-you: a member reply mentioning @user badges the group; user send clears it
  ---
  duration_ms: 101.444833
  type: 'test'
  ...
# Subtest: turn transport is gateway-native (session RPCs) and hostile text rides verbatim
ok 11 - turn transport is gateway-native (session RPCs) and hostile text rides verbatim
  ---
  duration_ms: 9.569167
  type: 'test'
  ...
# Subtest: log trimming keeps watermarks consistent
ok 12 - log trimming keeps watermarks consistent
  ---
  duration_ms: 2.508875
  type: 'test'
  ...
# Subtest: source contract: workspace + main-window door + prompt rules are wired
ok 13 - source contract: workspace + main-window door + prompt rules are wired
  ---
  duration_ms: 0.492458
  type: 'test'
  ...
# Subtest: group selection follows main-window open and close
ok 14 - group selection follows main-window open and close
  ---
  duration_ms: 7.403875
  type: 'test'
  ...
# Subtest: older and failed workspace hosts keep the in-pane group fallback
ok 15 - older and failed workspace hosts keep the in-pane group fallback
  ---
  duration_ms: 9.563959
  type: 'test'
  ...
# Subtest: main-tab ownership is recorded before the selection atom paints (\#89788 follow-up)
ok 16 - main-tab ownership is recorded before the selection atom paints (\#89788 follow-up)
  ---
  duration_ms: 4.946791
  type: 'test'
  ...
# Subtest: tab open/close bumps the reactive rev so the pane gate re-evaluates
ok 17 - tab open/close bumps the reactive rev so the pane gate re-evaluates
  ---
  duration_ms: 3.031667
  type: 'test'
  ...
# Subtest: closing an older selected group does not clear the newer selection
ok 18 - closing an older selected group does not clear the newer selection
  ---
  duration_ms: 3.5895
  type: 'test'
  ...
# Subtest: source contract: active group styling suppresses bot styling
ok 19 - source contract: active group styling suppresses bot styling
  ---
  duration_ms: 0.445541
  type: 'test'
  ...
# Subtest: disband: removes only this membership, room log, workspace, and needs-you state
ok 20 - disband: removes only this membership, room log, workspace, and needs-you state
  ---
  duration_ms: 5.650167
  type: 'test'
  ...
# Subtest: disband: skips source-qualified remote members instead of mutating same-named local metadata
ok 21 - disband: skips source-qualified remote members instead of mutating same-named local metadata
  ---
  duration_ms: 3.485542
  type: 'test'
  ...
# Subtest: disband: a running room leaves an epoch-bumped empty tombstone so in-flight turns bail
ok 22 - disband: a running room leaves an epoch-bumped empty tombstone so in-flight turns bail
  ---
  duration_ms: 142.200042
  type: 'test'
  ...
# Subtest: source contract: workspace header offers disband behind a ConfirmDialog
ok 23 - source contract: workspace header offers disband behind a ConfirmDialog
  ---
  duration_ms: 0.316542
  type: 'test'
  ...
# Subtest: default profile speaks as Hermes in room transcripts, not @default
ok 24 - default profile speaks as Hermes in room transcripts, not @default
  ---
  duration_ms: 3.219958
  type: 'test'
  ...
# Subtest: turn prompt addresses the default profile as @hermes
ok 25 - turn prompt addresses the default profile as @hermes
  ---
  duration_ms: 54.24875
  type: 'test'
  ...
# Subtest: mention routing: @hermes resolves to the default member
ok 26 - mention routing: @hermes resolves to the default member
  ---
  duration_ms: 3.510667
  type: 'test'
  ...
# Subtest: source contract: workspace speaker labels use displayName with a click-to-reveal handle
ok 27 - source contract: workspace speaker labels use displayName with a click-to-reveal handle
  ---
  duration_ms: 0.354125
  type: 'test'
  ...
# Subtest: source contract: room messages carry the speaker avatar via the roster appearance pipeline
ok 28 - source contract: room messages carry the speaker avatar via the roster appearance pipeline
  ---
  duration_ms: 0.328375
  type: 'test'
  ...
# Subtest: stranded harvest: a timed-out turn whose reply landed late posts into the room and clears the marker
ok 29 - stranded harvest: a timed-out turn whose reply landed late posts into the room and clears the marker
  ---
  duration_ms: 40.572375
  type: 'test'
  ...
# Subtest: stranded harvest: the same completed turn is delivered exactly once
ok 30 - stranded harvest: the same completed turn is delivered exactly once
  ---
  duration_ms: 20.0635
  type: 'test'
  ...
# Subtest: stranded + still busy: the round loop never re-submits into a member whose harvest just confirmed they are still running
ok 31 - stranded + still busy: the round loop never re-submits into a member whose harvest just confirmed they are still running
  ---
  duration_ms: 16.010625
  type: 'test'
  ...
# Subtest: stranded harvest: a late (pass) or no-new-message consumes the marker without posting
ok 32 - stranded harvest: a late (pass) or no-new-message consumes the marker without posting
  ---
  duration_ms: 32.316667
  type: 'test'
  ...
# Subtest: stranded markers persist so late replies survive a window reload
ok 33 - stranded markers persist so late replies survive a window reload
  ---
  duration_ms: 6.577875
  type: 'test'
  ...
# Subtest: source contract: room releases at three minutes and polls late work automatically
ok 34 - source contract: room releases at three minutes and polls late work automatically
  ---
  duration_ms: 1.163333
  type: 'test'
  ...
# Subtest: oversized hidden group session rotates without deleting its history
ok 35 - oversized hidden group session rotates without deleting its history
  ---
  duration_ms: 33.660625
  type: 'test'
  ...
# Subtest: source contract: the working line names the member on turn
ok 36 - source contract: the working line names the member on turn
  ---
  duration_ms: 18.814541
  type: 'test'
  ...
# Subtest: source contract: creating a group with a taken name mints a fresh room, never reopens the old log
ok 37 - source contract: creating a group with a taken name mints a fresh room, never reopens the old log
  ---
  duration_ms: 0.181042
  type: 'test'
  ...
# Subtest: turn prompt: results are full quality — only chatter is asked to stay short
ok 38 - turn prompt: results are full quality — only chatter is asked to stay short
  ---
  duration_ms: 13.702791
  type: 'test'
  ...
# Subtest: threads: room composer mints a new thread; replies land in it
ok 39 - threads: room composer mints a new thread; replies land in it
  ---
  duration_ms: 20.8755
  type: 'test'
  ...
# Subtest: threads: replying with an explicit thread id continues that thread and scopes the member delta to it
ok 40 - threads: replying with an explicit thread id continues that thread and scopes the member delta to it
  ---
  duration_ms: 34.64025
  type: 'test'
  ...
# Subtest: threads: hydration assigns legacy thread ids — lull splits, follow-ups stay together
ok 41 - threads: hydration assigns legacy thread ids — lull splits, follow-ups stay together
  ---
  duration_ms: 4.543625
  type: 'test'
  ...
# Subtest: source contract: thread UI — folded rows, per-thread reply box, new-thread composer
ok 42 - source contract: thread UI — folded rows, per-thread reply box, new-thread composer
  ---
  duration_ms: 0.550459
  type: 'test'
  ...
# Subtest: source contract: group chat log lines expose CopyButton on the entry body
ok 43 - source contract: group chat log lines expose CopyButton on the entry body
  ---
  duration_ms: 0.369834
  type: 'test'
  ...
# Subtest: source contract: group chat message bodies opt back into selectable text
ok 44 - source contract: group chat message bodies opt back into selectable text
  ---
  duration_ms: 0.180542
  type: 'test'
  ...
# Subtest: group room preview renders the bot HANDLE, not the raw profile name
ok 45 - group room preview renders the bot HANDLE, not the raw profile name
  ---
  duration_ms: 0.1975
  type: 'test'
  ...
# Subtest: a member blocked on clarify surfaces its question and holds the turn open
ok 46 - a member blocked on clarify surfaces its question and holds the turn open
  ---
  duration_ms: 50.101958
  type: 'test'
  ...
# Subtest: syncGroupClarify mirrors, badges needs-you, and is idempotent per request
ok 47 - syncGroupClarify mirrors, badges needs-you, and is idempotent per request
  ---
  duration_ms: 36.667125
  type: 'test'
  ...
# Subtest: older backends without pending_clarify never mirror a question
ok 48 - older backends without pending_clarify never mirror a question
  ---
  duration_ms: 12.067375
  type: 'test'
  ...
# Subtest: answerGroupClarify routes clarify.respond and clears the mirror
ok 49 - answerGroupClarify routes clarify.respond and clears the mirror
  ---
  duration_ms: 26.85725
  type: 'test'
  ...
# Subtest: answerGroupClarify sends one respond per batch question, in order
ok 50 - answerGroupClarify sends one respond per batch question, in order
  ---
  duration_ms: 10.62825
  type: 'test'
  ...
# Subtest: disband clears the room mirrored questions
ok 51 - disband clears the room mirrored questions
  ---
  duration_ms: 22.949166
  type: 'test'
  ...
# Subtest: source contract: room renders clarify cards and the poll gates on them
ok 52 - source contract: room renders clarify cards and the poll gates on them
  ---
  duration_ms: 0.4025
  type: 'test'
  ...
# Subtest: a member blocked on a command approval surfaces an approval card and holds the turn
ok 53 - a member blocked on a command approval surfaces an approval card and holds the turn
  ---
  duration_ms: 9.717041
  type: 'test'
  ...
# Subtest: syncGroupClarify mirrors an approval with kind, command, and server choices
ok 54 - syncGroupClarify mirrors an approval with kind, command, and server choices
  ---
  duration_ms: 35.879
  type: 'test'
  ...
# Subtest: an approval without a server choice set falls back to once/deny
ok 55 - an approval without a server choice set falls back to once/deny
  ---
  duration_ms: 34.54625
  type: 'test'
  ...
# Subtest: answerGroupClarify routes approvals through approval.respond with session + choice
ok 56 - answerGroupClarify routes approvals through approval.respond with session + choice
  ---
  duration_ms: 7.794584
  type: 'test'
  ...
# Subtest: clarify outranks approval when a snapshot carries both
ok 57 - clarify outranks approval when a snapshot carries both
  ---
  duration_ms: 6.004125
  type: 'test'
  ...
# Subtest: source contract: approval card renders the command and routes approval.respond
ok 58 - source contract: approval card renders the command and routes approval.respond
  ---
  duration_ms: 0.255625
  type: 'test'
  ...
1..58
# tests 58
# suites 0
# pass 58
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 1236.986458 (58 passed)
- ...                                                                      [100%]
3 passed in 3.78s (3 passed)
- All checks passed!
- 