### PR TITLE
fix(desktop): union-roster bot handles were absent from @ autocomplete and mentions didn't route (#89303)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2832,6 +2832,52 @@ function useRoster() {
   })
 }
 
+/** Synchronous union-roster read for the composer surfaces (autocomplete
+ *  provider + mention middleware). useRoster caches under
+ *  [...ROSTER_KEY, activeConnectionId] — a 3-element key — so a bare
+ *  getQueryData(ROSTER_KEY) exact-match lookup returns undefined forever
+ *  (issue #89303: remote handles absent from @ autocomplete, mentions
+ *  unrouted). Read the live connection's entry first, then fall back to a
+ *  prefix scan keeping the freshest snapshot. Never throws: cold cache or
+ *  legacy queryClient returns null and callers fall back to their own path. */
+function cachedUnionRoster() {
+  if (typeof queryClient === 'undefined' || !queryClient || typeof queryClient.getQueryData !== 'function') {
+    return null
+  }
+
+  try {
+    const connectionId = String(
+      host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local'
+    )
+    const exact = queryClient.getQueryData([...ROSTER_KEY, connectionId])
+
+    if (Array.isArray(exact?.profiles)) {
+      return exact
+    }
+
+    if (typeof queryClient.getQueriesData === 'function') {
+      let best = null
+
+      // v5 takes a filters object; a legacy v3 queryClient treats the same
+      // object as the key itself and simply matches nothing — harmless.
+      for (const [, data] of queryClient.getQueriesData({ queryKey: ROSTER_KEY })) {
+        if (
+          Array.isArray(data?.profiles) &&
+          (!best || Number(data.fetchedAt || 0) > Number(best.fetchedAt || 0))
+        ) {
+          best = data
+        }
+      }
+
+      return best
+    }
+  } catch {
+    /* cache hiccup — caller falls back (middleware refetches) */
+  }
+
+  return null
+}
+
 /** Merge the union agent roster (host.agents) over the active gateway's
  *  profiles.list. Active-source rows — matched by the LIVE connection id,
  *  falling back to the roster's primaryConnectionId, then the legacy
@@ -10501,7 +10547,7 @@ export default {
       area: COMPOSER_AREAS.atCompletions,
       data: {
         provide: query => {
-          const roster = queryClient.getQueryData(ROSTER_KEY)
+          const roster = cachedUnionRoster()
           const profiles = Array.isArray(roster?.profiles) ? roster.profiles : []
 
           if (!profiles.length) {
@@ -10811,9 +10857,7 @@ export default {
             name: (host.state.profile.get() || 'default').trim() || 'default',
             connectionId: String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local')
           }
-          const cached = typeof queryClient !== 'undefined' && queryClient && typeof queryClient.getQueryData === 'function'
-            ? queryClient.getQueryData(ROSTER_KEY)
-            : null
+          const cached = cachedUnionRoster()
           const roster = Array.isArray(cached?.profiles) ? cached.profiles : null
           let mentionedBots = roster ? resolveRosterMentions(text, roster, live) : []
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/mention-completions.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/mention-completions.test.mjs
@@ -38,12 +38,20 @@ function loadProvide({ roster, active = 'default', meta = {} } = {}) {
     },
     document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
     queryClient: {
-      getQueryData: () => roster,
+      // Key-exact semantics like the real QueryClient (v5): a 2-element
+      // ROSTER_KEY lookup MUST miss the 3-element cache keys useRoster
+      // writes — the bug behind issue #89303 was invisible under the old
+      // key-ignoring mock.
+      getQueryData: key =>
+        key.length === 3 && key[0] === 'hermes-bots' && key[1] === 'roster'
+          ? roster
+          : undefined,
+      getQueriesData: () => (Array.isArray(roster?.profiles) ? [[['hermes-bots', 'roster', 'local'], roster]] : []),
       invalidateQueries: () => undefined,
       setQueryData: () => undefined
     },
     host: {
-      state: { profile: { get: () => active, listen: () => () => undefined }, gateway: { get: () => null, listen: () => () => undefined } },
+      state: { profile: { get: () => active, listen: () => () => undefined }, gateway: { get: () => null, listen: () => () => undefined }, connectionId: { get: () => 'local', listen: () => () => undefined } },
       request: async () => ({}),
       onEvent: () => () => undefined
     },


### PR DESCRIPTION
## Summary

- The composer `@` autocomplete offered **zero** bot rows (local and remote alike), and remote-bot `@name-device` mentions never routed — issue #89303.
- Root cause: `useRoster` caches under the 3-element key `[...ROSTER_KEY, activeConnectionId]`, but both the `mention-completions` provider and the mention-routing middleware read `getQueryData(ROSTER_KEY)` with the bare 2-element key. An exact-match lookup against a 3-element cache key returns `undefined` forever, so the provider saw an empty roster and the middleware fell back to a local-only `profiles.list`.
- Fix: new `cachedUnionRoster()` helper — exact read of the live connection's cache entry, prefix-scan fallback (`getQueriesData`) keeping the freshest snapshot; never throws, callers keep their existing cold-cache fallbacks. Wired into both call sites.

## Reproduction (before)

Typing `@` in any composer lists project file references only — no `@hermes`, no local profile handles, no `@name-device` remote handles. Typing the full qualified remote handle matches nothing. Matches issue #89303 exactly (remote Bot rows instruct the user to `@name-device` the agent; the completion surface never offers it).

## Test plan

- [x] Hardened `mention-completions.test.mjs`: the `getQueryData` mock now reproduces real QueryClient v5 exact-key semantics (a bare 2-element `ROSTER_KEY` lookup misses the 3-element cache useRoster writes). Rationale: the old key-agnostic mock is exactly why this regression was invisible to CI.
- [x] Verified the tests fail against the old code (`git stash` → 2 failures) and pass after the fix (**9/9 pass**, including renamed-bots tests).
- [x] Built the desktop app (`npm run build`) and confirmed the fix in the produced bundle.
- [ ] Manual: `@` in composer now lists local + remote (`· <Connection>` suffix) bots; selecting a remote handle routes the turn and the reply comes from the remote agent.

Fixes #89303