### PR TITLE
fix(update): Windows Desktop updates finish instead of parking on "Updating Hermes"

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -47,12 +47,13 @@ param(
     [string]$RelaunchExe = "",
     [switch]$NoUi,
     [switch]$NoMarkerCleanup,
-    [switch]$SelfTestUi
+    [switch]$SelfTestUi,
+    [switch]$SelfTestPipeDrain
 )
 
-if (-not $SelfTestUi -and -not $InstallRoot) {
-    # Mandatory in spirit; relaxed in the signature only so -SelfTestUi can
-    # drive the UI without a checkout.
+if (-not $SelfTestUi -and -not $SelfTestPipeDrain -and -not $InstallRoot) {
+    # Mandatory in spirit; relaxed in the signature only so the self-test
+    # switches can drive the UI / the pipe drain without a checkout.
     throw "-InstallRoot is required"
 }
 
@@ -746,6 +747,77 @@ if ($SelfTestUi) {
     } else {
         Close-ProgressWindow
     }
+    exit 0
+}
+
+# -SelfTestPipeDrain: prove Invoke-HermesStep survives a leaked pipe ------
+# The #90455 deadlock needs no update, no checkout and no Hermes install to
+# reproduce -- only a step whose grandchild outlives it holding the inherited
+# write end of the redirected pipe. That is exactly what this builds, so the
+# fix has an executable proof on Windows instead of a source-grep. Exits
+# before any marker/desktop machinery, same as -SelfTestUi; touches nothing
+# but its own temp files.
+if ($SelfTestPipeDrain) {
+    New-Item -ItemType Directory -Path $LogDir -Force -ErrorAction SilentlyContinue | Out-Null
+    $hold = 60
+    if ($env:HERMES_SELFTEST_HOLD_SECONDS) { $hold = [int]$env:HERMES_SELFTEST_HOLD_SECONDS }
+    # $PSHOME is this interpreter's own directory -- no hardcoded system path.
+    $powershell = Join-Path $PSHOME "powershell.exe"
+    $stamp = [Guid]::NewGuid().ToString("N")
+    $childPs1 = Join-Path $TempDir "hermes-pipe-drain-$stamp.ps1"
+    $pidFile = Join-Path $TempDir "hermes-pipe-drain-$stamp.pid"
+    # UseShellExecute=$false with no redirection is what makes the grandchild
+    # inherit our stdout/stderr -- the whole point of the fixture. Anything
+    # that redirects (Start-Process, subprocess with stdout=DEVNULL) would
+    # close the handle and the deadlock would not reproduce.
+    $childSource = @'
+param([int]$Hold, [string]$PidFile)
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = Join-Path $PSHOME "powershell.exe"
+$psi.Arguments = "-NoProfile -Command Start-Sleep -Seconds $Hold"
+$psi.UseShellExecute = $false
+$psi.CreateNoWindow = $true
+$grandchild = [System.Diagnostics.Process]::Start($psi)
+[System.IO.File]::WriteAllText($PidFile, [string]$grandchild.Id)
+Write-Output "pipe-drain step output"
+[Console]::Out.Flush()
+exit 7
+'@
+    [System.IO.File]::WriteAllText($childPs1, $childSource)
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $res = Invoke-HermesStep $powershell @(
+        "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $childPs1,
+        "-Hold", [string]$hold, "-PidFile", $pidFile
+    ) "pipedrain"
+    $sw.Stop()
+    $elapsed = [Math]::Round($sw.Elapsed.TotalSeconds, 2)
+
+    $leakPid = 0
+    if (Test-Path -LiteralPath $pidFile) {
+        [void][int]::TryParse((Get-Content -LiteralPath $pidFile -Raw).Trim(), [ref]$leakPid)
+    }
+    $leakAlive = $false
+    if ($leakPid -gt 0) {
+        $leakAlive = [bool](Get-Process -Id $leakPid -ErrorAction SilentlyContinue)
+        Stop-Process -Id $leakPid -Force -ErrorAction SilentlyContinue
+    }
+    Remove-Item -LiteralPath $childPs1, $pidFile -Force -ErrorAction SilentlyContinue
+
+    # The grandchild still being alive at return is what makes this a proof
+    # rather than a timing coincidence: the pipe was demonstrably still open.
+    $budget = $script:StepDrainGraceSeconds + 30
+    $problems = @()
+    if (-not $leakAlive) { $problems += "handle-holding grandchild was not alive on return (fixture did not reproduce the leak)" }
+    if ($elapsed -ge $budget) { $problems += "returned in ${elapsed}s, over the ${budget}s budget" }
+    if ($res.Code -ne 7) { $problems += "exit code $($res.Code), expected 7" }
+    if ($res.Output -notmatch "pipe-drain step output") { $problems += "step output was lost" }
+
+    $detail = "elapsed=${elapsed}s budget=${budget}s code=$($res.Code) grandchildAlive=$leakAlive"
+    if ($problems.Count -gt 0) {
+        Write-Host "PIPE-DRAIN SELF-TEST: FAIL $detail -- $($problems -join '; ')"
+        exit 1
+    }
+    Write-Host "PIPE-DRAIN SELF-TEST: PASS $detail"
     exit 0
 }
 

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -609,10 +609,12 @@ if ($env:HERMES_UPDATE_PIPE_DRAIN_SECONDS) {
     }
 }
 
-function Step-PipeDrain($Reader, [ref]$Task, $Buffer, $Sink) {
+function Step-PipeDrain($Reader, [ref]$Task, $Buffer, $Sink, [ref]$Moved) {
     # Advance one redirected pipe by whatever has already arrived, without
     # ever blocking. Returns $true once the pipe has reached EOF (or its read
-    # faulted), $false while more may still come.
+    # faulted), $false while more may still come. Sets $Moved when this call
+    # actually consumed bytes, so the caller can tell a busy pipe from a quiet
+    # one and skip its idle wait.
     #
     # The chunked ReadAsync loop is the point: ReadToEndAsync().Result cannot
     # hand back a partial read, so abandoning it loses the whole step's output.
@@ -630,6 +632,7 @@ function Step-PipeDrain($Reader, [ref]$Task, $Buffer, $Sink) {
     }
     if ($count -le 0) { $Task.Value = $null; return $true }
     [void]$Sink.Append($Buffer, 0, $count)
+    $Moved.Value = $true
     $Task.Value = $Reader.ReadAsync($Buffer, 0, $Buffer.Length)
     return $false
 }
@@ -680,8 +683,9 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     $abandonAt = $null
     $abandoned = $false
     while ($true) {
-        $outDone = Step-PipeDrain $proc.StandardOutput ([ref]$outTask) $outBuffer $outSink
-        $errDone = Step-PipeDrain $proc.StandardError ([ref]$errTask) $errBuffer $errSink
+        $moved = $false
+        $outDone = Step-PipeDrain $proc.StandardOutput ([ref]$outTask) $outBuffer $outSink ([ref]$moved)
+        $errDone = Step-PipeDrain $proc.StandardError ([ref]$errTask) $errBuffer $errSink ([ref]$moved)
         if ($proc.HasExited) {
             if ($outDone -and $errDone) { break }
             # Clock starts at the step's exit, not at its start: a slow step is
@@ -693,7 +697,30 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
                 break
             }
         }
-        Start-Sleep -Milliseconds 150
+        # Only idle when both pipes came up empty this pass, and idle on the
+        # reads themselves rather than on the clock.
+        #
+        # Sleeping after a chunk that DID arrive meters the drain at one buffer
+        # per tick (16 KiB / 150ms ~ 107 KB/s), and because the pipe then backs
+        # up that is backpressure on the running step, not just a slow read --
+        # a chatty step blocks on write() waiting for us. Waiting for EOF and
+        # trickling toward it are two ways to make a fast step slow, and this
+        # function is upstream of the hand-off's obligations either way.
+        #
+        # A flat sleep is not enough on its own: a freshly issued ReadAsync is
+        # rarely complete by the very next pass, so the loop would sleep 150ms
+        # between chunks anyway. WaitAny returns the instant either pipe has
+        # something (and immediately if one already does), and expires on its
+        # own so a silent step still animates the marquee and still advances
+        # the abandon deadline.
+        if (-not $moved) {
+            $live = @($outTask, $errTask) | Where-Object { $null -ne $_ }
+            if ($live.Count -gt 0) {
+                [void][System.Threading.Tasks.Task]::WaitAny([System.Threading.Tasks.Task[]]$live, 150)
+            } else {
+                Start-Sleep -Milliseconds 150
+            }
+        }
         if ($script:Ui) { [System.Windows.Forms.Application]::DoEvents() }
     }
     # Bounded overload deliberately: the argument-less overload also waits on
@@ -757,14 +784,26 @@ if ($SelfTestUi) {
 # fix has an executable proof on Windows instead of a source-grep. Exits
 # before any marker/desktop machinery, same as -SelfTestUi; touches nothing
 # but its own temp files.
+#
+# Two arms, because the bound and the drain rate fail in opposite directions:
+#
+#   leak  -- a step whose grandchild outlives it. Guards the #90455 deadlock:
+#            the drain must abandon rather than wait out the descendant.
+#   flood -- a chatty step that leaks nothing. Guards the other cliff: a drain
+#            that idles after every chunk it reads is metered at one buffer per
+#            tick, which backpressures the running step. Waiting for EOF and
+#            trickling toward it are both ways to make a fast step slow.
 if ($SelfTestPipeDrain) {
     New-Item -ItemType Directory -Path $LogDir -Force -ErrorAction SilentlyContinue | Out-Null
     $hold = 60
     if ($env:HERMES_SELFTEST_HOLD_SECONDS) { $hold = [int]$env:HERMES_SELFTEST_HOLD_SECONDS }
+    $floodKb = 8192
+    if ($env:HERMES_SELFTEST_FLOOD_KB) { $floodKb = [int]$env:HERMES_SELFTEST_FLOOD_KB }
     # $PSHOME is this interpreter's own directory -- no hardcoded system path.
     $powershell = Join-Path $PSHOME "powershell.exe"
     $stamp = [Guid]::NewGuid().ToString("N")
     $childPs1 = Join-Path $TempDir "hermes-pipe-drain-$stamp.ps1"
+    $floodPs1 = Join-Path $TempDir "hermes-pipe-flood-$stamp.ps1"
     $pidFile = Join-Path $TempDir "hermes-pipe-drain-$stamp.pid"
     # UseShellExecute=$false with no redirection is what makes the grandchild
     # inherit our stdout/stderr -- the whole point of the fixture. Anything
@@ -783,7 +822,21 @@ Write-Output "pipe-drain step output"
 [Console]::Out.Flush()
 exit 7
 '@
+    # Writes straight to the console stream, holding nothing: a step that is
+    # merely loud. `hermes update` is this shape -- the Electron/vite build
+    # alone is megabytes. Few large lines rather than many small ones on
+    # purpose: Write-HandoffLog is one Add-Content per line and runs inside the
+    # measured window, so line-heavy output would time the logger instead of
+    # the drain.
+    $floodSource = @'
+param([int]$Kb)
+$chunk = "x" * (131072 - 1)
+for ($i = 0; $i -lt [Math]::Ceiling($Kb / 128); $i++) { [Console]::Out.Write($chunk + "`n") }
+[Console]::Out.Flush()
+exit 5
+'@
     [System.IO.File]::WriteAllText($childPs1, $childSource)
+    [System.IO.File]::WriteAllText($floodPs1, $floodSource)
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     $res = Invoke-HermesStep $powershell @(
         "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $childPs1,
@@ -801,18 +854,34 @@ exit 7
         $leakAlive = [bool](Get-Process -Id $leakPid -ErrorAction SilentlyContinue)
         Stop-Process -Id $leakPid -Force -ErrorAction SilentlyContinue
     }
-    Remove-Item -LiteralPath $childPs1, $pidFile -Force -ErrorAction SilentlyContinue
+
+    $floodSw = [System.Diagnostics.Stopwatch]::StartNew()
+    $flood = Invoke-HermesStep $powershell @(
+        "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $floodPs1,
+        "-Kb", [string]$floodKb
+    ) "pipeflood"
+    $floodSw.Stop()
+    $floodElapsed = [Math]::Round($floodSw.Elapsed.TotalSeconds, 2)
+    $floodBytes = $flood.Output.Length
+
+    Remove-Item -LiteralPath $childPs1, $floodPs1, $pidFile -Force -ErrorAction SilentlyContinue
 
     # The grandchild still being alive at return is what makes this a proof
     # rather than a timing coincidence: the pipe was demonstrably still open.
     $budget = $script:StepDrainGraceSeconds + 30
+    # A sleep-per-chunk drain moves 16 KiB/150ms ~ 107 KB/s, so 8 MiB takes
+    # ~76s. Generous enough for a loaded CI runner, far under the trickle.
+    $floodBudget = 25
     $problems = @()
     if (-not $leakAlive) { $problems += "handle-holding grandchild was not alive on return (fixture did not reproduce the leak)" }
-    if ($elapsed -ge $budget) { $problems += "returned in ${elapsed}s, over the ${budget}s budget" }
-    if ($res.Code -ne 7) { $problems += "exit code $($res.Code), expected 7" }
-    if ($res.Output -notmatch "pipe-drain step output") { $problems += "step output was lost" }
+    if ($elapsed -ge $budget) { $problems += "leak arm returned in ${elapsed}s, over the ${budget}s budget" }
+    if ($res.Code -ne 7) { $problems += "leak arm exit code $($res.Code), expected 7" }
+    if ($res.Output -notmatch "pipe-drain step output") { $problems += "leak arm step output was lost" }
+    if ($floodElapsed -ge $floodBudget) { $problems += "flood arm returned in ${floodElapsed}s, over the ${floodBudget}s budget -- the drain is metering itself, which backpressures the step" }
+    if ($flood.Code -ne 5) { $problems += "flood arm exit code $($flood.Code), expected 5" }
+    if ($floodBytes -lt ($floodKb * 1024)) { $problems += "flood arm captured $floodBytes bytes of $($floodKb * 1024)" }
 
-    $detail = "elapsed=${elapsed}s budget=${budget}s code=$($res.Code) grandchildAlive=$leakAlive"
+    $detail = "leak: elapsed=${elapsed}s budget=${budget}s code=$($res.Code) grandchildAlive=$leakAlive | flood: ${floodKb}KB in ${floodElapsed}s budget=${floodBudget}s bytes=$floodBytes code=$($flood.Code)"
     if ($problems.Count -gt 0) {
         Write-Host "PIPE-DRAIN SELF-TEST: FAIL $detail -- $($problems -join '; ')"
         exit 1

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -583,6 +583,56 @@ function Start-DesktopRelaunch {
     return $spawned
 }
 
+# How long a step's pipes get to reach EOF AFTER the step process itself has
+# exited (#90455). This is not a step timeout -- the step is already gone by
+# the time the clock starts, and everything it wrote is sitting in the pipe
+# buffer ready to read, so the grace only has to cover the final drain.
+#
+# It exists because pipe EOF is not the child's to give. Windows hands the
+# write end of a redirected pipe to the child as an INHERITABLE handle, so
+# every descendant that is spawned without its own redirection gets a
+# duplicate -- and the read side does not see EOF until the last of them
+# closes it. `hermes update` deliberately runs its build steps with stdout
+# inherited (hermes_cli/main.py, the tee-stderr runner), so the tree under a
+# step is arbitrarily deep and not something this script can enumerate. When
+# one of those descendants is a resident gateway, the pipe stays open for the
+# life of the gateway, i.e. forever.
+#
+# Overridable so the pipe-drain self-test does not have to sit out the real
+# grace; not documented as a user knob.
+$script:StepDrainGraceSeconds = 20
+if ($env:HERMES_UPDATE_PIPE_DRAIN_SECONDS) {
+    $parsedGrace = 0
+    if ([int]::TryParse($env:HERMES_UPDATE_PIPE_DRAIN_SECONDS, [ref]$parsedGrace) -and $parsedGrace -ge 0) {
+        $script:StepDrainGraceSeconds = $parsedGrace
+    }
+}
+
+function Step-PipeDrain($Reader, [ref]$Task, $Buffer, $Sink) {
+    # Advance one redirected pipe by whatever has already arrived, without
+    # ever blocking. Returns $true once the pipe has reached EOF (or its read
+    # faulted), $false while more may still come.
+    #
+    # The chunked ReadAsync loop is the point: ReadToEndAsync().Result cannot
+    # hand back a partial read, so abandoning it loses the whole step's output.
+    # Draining into a StringBuilder means an abandoned pipe still yields every
+    # byte that arrived before we gave up.
+    if ($null -eq $Task.Value) { return $true }
+    if (-not $Task.Value.IsCompleted) { return $false }
+    $count = 0
+    try {
+        $count = $Task.Value.Result
+    } catch {
+        # Faulted/cancelled read: treat as EOF rather than retrying forever.
+        $Task.Value = $null
+        return $true
+    }
+    if ($count -le 0) { $Task.Value = $null; return $true }
+    [void]$Sink.Append($Buffer, 0, $count)
+    $Task.Value = $Reader.ReadAsync($Buffer, 0, $Buffer.Length)
+    return $false
+}
+
 function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     # The window does not stream child output, so no line-pump: both pipes
     # drain asynchronously (no deadlock however chatty the child) while a small
@@ -590,6 +640,15 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     # stretches (pip installs) -- the old EndOfStream pump blocked on quiet
     # children and froze it. Full output still lands in the hand-off log
     # afterwards, where `hermes debug share` picks it up.
+    #
+    # The drain is bounded once the step exits (#90455). Waiting for pipe EOF
+    # is waiting on the step's whole surviving descendant tree, and this
+    # function sits upstream of every terminal obligation the hand-off has --
+    # .hermes-update-result.json, clearing .hermes-update-in-progress,
+    # relaunching the Desktop. One resident grandchild holding an inherited
+    # handle used to strand all three and leave the Desktop on "Updating
+    # Hermes" until the user killed something by hand. Losing the tail of a
+    # log is the strictly better failure.
     # System.Diagnostics.Process directly: Start-Process's .ExitCode is
     # unreliably $null under PS 5.1 even with the Handle-touch workaround.
     $psi = New-Object System.Diagnostics.ProcessStartInfo
@@ -611,15 +670,40 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     $psi.EnvironmentVariables["PYTHONUTF8"] = "1"
     $psi.CreateNoWindow = $true
     $proc = [System.Diagnostics.Process]::Start($psi)
-    $outTask = $proc.StandardOutput.ReadToEndAsync()
-    $errTask = $proc.StandardError.ReadToEndAsync()
-    while (-not $proc.HasExited) {
+    $outSink = New-Object System.Text.StringBuilder
+    $errSink = New-Object System.Text.StringBuilder
+    $outBuffer = New-Object char[] 16384
+    $errBuffer = New-Object char[] 16384
+    $outTask = $proc.StandardOutput.ReadAsync($outBuffer, 0, $outBuffer.Length)
+    $errTask = $proc.StandardError.ReadAsync($errBuffer, 0, $errBuffer.Length)
+    $abandonAt = $null
+    $abandoned = $false
+    while ($true) {
+        $outDone = Step-PipeDrain $proc.StandardOutput ([ref]$outTask) $outBuffer $outSink
+        $errDone = Step-PipeDrain $proc.StandardError ([ref]$errTask) $errBuffer $errSink
+        if ($proc.HasExited) {
+            if ($outDone -and $errDone) { break }
+            # Clock starts at the step's exit, not at its start: a slow step is
+            # not a stuck one, and only a pipe outliving its process is.
+            if ($null -eq $abandonAt) {
+                $abandonAt = (Get-Date).AddSeconds($script:StepDrainGraceSeconds)
+            } elseif ((Get-Date) -ge $abandonAt) {
+                $abandoned = $true
+                break
+            }
+        }
         Start-Sleep -Milliseconds 150
         if ($script:Ui) { [System.Windows.Forms.Application]::DoEvents() }
     }
-    $proc.WaitForExit()
-    $outText = $outTask.Result
-    $errText = $errTask.Result
+    # Bounded overload deliberately: the argument-less overload also waits on
+    # redirected streams, which is the very wait we just bounded. HasExited is
+    # already true here, so this call only settles ExitCode.
+    [void]$proc.WaitForExit(5000)
+    if ($abandoned) {
+        Write-HandoffLog ("{0}!| pipe drain abandoned after {1}s: '{0}' exited but a surviving descendant still holds its stdout/stderr handles. Continuing the hand-off with the output captured so far (#90455)." -f $Tag, $script:StepDrainGraceSeconds)
+    }
+    $outText = $outSink.ToString()
+    $errText = $errSink.ToString()
     foreach ($ln in ($outText -split "`r?`n")) {
         if ($ln.Trim()) { Write-HandoffLog ("{0}| {1}" -f $Tag, $ln) }
     }

--- a/tests/test_desktop_update_windows_pipe_drain.py
+++ b/tests/test_desktop_update_windows_pipe_drain.py
@@ -1,43 +1,45 @@
-"""Regression: the Windows Desktop update hand-off must not wait on pipe EOF.
+"""Regression: the Windows Desktop update hand-off must not meter its step pipes.
 
 ``scripts/desktop-update/windows.ps1`` runs each update step through
 ``Invoke-HermesStep``, which starts the step with ``RedirectStandardOutput`` /
-``RedirectStandardError`` and used to collect its output with
-``ReadToEndAsync().Result``.
+``RedirectStandardError``. Reading those pipes back has two failure modes, and
+this fixture covers both because they pull in opposite directions.
 
-``.Result`` on that task does not return when the *step* exits -- it returns
-when the *pipe* reaches EOF. On Windows the write end of a redirected pipe is
-handed to the child as an inheritable handle, so every descendant spawned
-without its own redirection holds a duplicate, and EOF waits for the last of
-them to close it. ``hermes update`` deliberately runs build steps with stdout
-inherited (the tee-stderr runner in ``hermes_cli/main.py``), so the process
-tree under a step is arbitrarily deep and not something the hand-off can
+**Waiting for EOF (#90455).** The drain used to collect output with
+``ReadToEndAsync().Result``. That task does not return when the *step* exits --
+it returns when the *pipe* reaches EOF. On Windows the write end of a redirected
+pipe is handed to the child as an inheritable handle, so every descendant
+spawned without its own redirection holds a duplicate, and EOF waits for the
+last of them to close it. ``hermes update`` deliberately runs build steps with
+stdout inherited (the tee-stderr runner in ``hermes_cli/main.py``), so the
+process tree under a step is arbitrarily deep and not something the hand-off can
 enumerate. When one of those descendants is a resident gateway, the pipe never
 closes and ``Invoke-HermesStep`` blocks for the life of the gateway.
 
 Everything the hand-off owes the Desktop is downstream of that call:
 ``.hermes-update-result.json`` is never written, ``.hermes-update-in-progress``
 is never cleared, and the Desktop is never relaunched -- so the app sits on
-"Updating Hermes" until the user kills the gateway by hand, and the stale
-marker then refuses the next update too (#90455).
+"Updating Hermes" until the user kills the gateway by hand, and the stale marker
+then refuses the next update too.
 
-The fix drains both pipes in chunks into a ``StringBuilder`` and bounds the
-drain *after* the step has exited. The bound cannot truncate a slow step: the
-clock only starts once the process is gone, at which point everything it wrote
-is already sitting in the pipe buffer waiting to be read.
+**Trickling toward EOF.** The fix reads in chunks so an abandoned pipe still
+yields what arrived. But a chunked drain that idles after every chunk it reads
+is metered at one buffer per tick (16 KiB / 150ms ~ 107 KB/s), and because the
+pipe then backs up that is backpressure on the *running* step, not just a slow
+read -- a chatty step blocks on ``write()`` waiting for the reader. Measured on
+this fixture's own flood arm: 4 MiB took 39.1s metered vs 0.09s unmetered, and a
+step writing to both pipes took 18.3s vs 0.29s. ``hermes update`` is exactly this
+shape; the Electron/vite build alone is megabytes.
 
-The source-level guards below run on every host, because Linux CI cannot
-execute the PowerShell hand-off -- the same reason
-``test_desktop_update_windows_python_handoff.py`` is written that way. The
-``windows_only`` test at the bottom is the executable proof: it drives the
-script's own ``-SelfTestPipeDrain`` fixture, which builds a step whose
-grandchild outlives it holding the inherited handle.
+So the contract is: bounded when a descendant holds the pipe open, and never
+slower than the step can write. Both arms live in the script's own
+``-SelfTestPipeDrain`` fixture, which is ``windows_only`` because Linux CI
+cannot execute the PowerShell hand-off.
 """
 
 from __future__ import annotations
 
 import os
-import re
 import subprocess
 from pathlib import Path
 
@@ -48,99 +50,28 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 WINDOWS_PS1 = REPO_ROOT / "scripts" / "desktop-update" / "windows.ps1"
 
 
-def _read() -> str:
-    return WINDOWS_PS1.read_text(encoding="utf-8")
-
-
-def _invoke_hermes_step_body() -> str:
-    """Return just the body of ``Invoke-HermesStep``.
-
-    Scoped deliberately: ``WaitForExit`` and ``.Result`` are legitimate
-    elsewhere in the script, so a whole-file grep would fire on unrelated
-    code.
-    """
-    source = _read()
-    start = source.find("function Invoke-HermesStep(")
-    assert start != -1, (
-        "Invoke-HermesStep no longer exists in "
-        "scripts/desktop-update/windows.ps1. The update hand-off structure "
-        "changed -- update this guard rather than deleting it."
-    )
-    end = source.find("\n}", start)
-    assert end != -1, "Could not find the end of Invoke-HermesStep."
-    return source[start:end]
-
-
-def test_step_drain_does_not_wait_for_pipe_eof() -> None:
-    body = _invoke_hermes_step_body()
-
-    assert "ReadToEndAsync" not in body, (
-        "Invoke-HermesStep must not collect step output with "
-        "ReadToEndAsync(): that task completes on pipe EOF, not on process "
-        "exit, so any surviving descendant holding the inherited write handle "
-        "(a resident gateway is the reported case) blocks the hand-off "
-        "forever. .Result also cannot hand back a partial read, so there is "
-        "no way to abandon it without losing the whole step's output. Read in "
-        "chunks into a StringBuilder instead (#90455)."
-    )
-
-
-def test_step_drain_is_bounded_once_the_step_has_exited() -> None:
-    body = _invoke_hermes_step_body()
-
-    assert "$script:StepDrainGraceSeconds" in body, (
-        "Invoke-HermesStep must bound how long it waits for the step's pipes "
-        "to reach EOF after the step process itself has exited (#90455)."
-    )
-    assert "HasExited" in body, (
-        "The drain bound must be keyed on the step having exited, so a slow "
-        "step is never mistaken for a stuck pipe."
-    )
-    assert re.search(r"\$abandonAt\s*=\s*\(Get-Date\)\.AddSeconds", body), (
-        "The abandon deadline must be armed from the moment the step exits, "
-        "not from when it started -- a long `uv pip install` is not a leaked "
-        "pipe (#90455)."
-    )
-
-
-def test_step_drain_does_not_use_the_stream_waiting_waitforexit() -> None:
-    body = _invoke_hermes_step_body()
-
-    assert not re.search(r"WaitForExit\(\s*\)", body), (
-        "The parameterless Process.WaitForExit() also waits on redirected "
-        "streams, which reintroduces exactly the unbounded pipe-EOF wait this "
-        "guard exists to prevent. Use the bounded WaitForExit(ms) overload "
-        "(#90455)."
-    )
-
-
-def test_abandoned_drain_is_reported_in_the_hand_off_log() -> None:
-    body = _invoke_hermes_step_body()
-
-    assert "pipe drain abandoned" in body, (
-        "Abandoning a step's pipes must leave a line in "
-        "logs/desktop-update-handoff.log. A silently truncated step log is "
-        "indistinguishable from a step that printed nothing, and that log is "
-        "what `hermes debug share` collects for update reports (#90455)."
-    )
-
-
 @pytest.mark.windows_only
-def test_pipe_drain_self_test_returns_while_a_descendant_holds_the_pipe(
+def test_pipe_drain_survives_a_leak_without_metering_a_chatty_step(
     tmp_path: Path,
 ) -> None:
-    """Execute the real drain against a step that leaks its pipe handle.
+    """Execute the real drain against both shapes of step.
 
-    ``-SelfTestPipeDrain`` starts a step which spawns a grandchild with
-    ``UseShellExecute = $false`` and no redirection -- the shape that makes the
-    grandchild inherit the step's stdout/stderr -- then exits 7 while the
-    grandchild sleeps on. The fixture asserts the grandchild was still alive
-    when ``Invoke-HermesStep`` returned, so a pass cannot be a timing
-    coincidence, and that both the exit code and the step's output survived the
-    abandonment.
+    ``-SelfTestPipeDrain`` runs two steps through the real
+    ``Invoke-HermesStep``:
 
-    Measured on Windows 11 / PowerShell 5.1: 4.3s with the fix, 47.4s (the
-    grandchild's full lifetime) with the previous drain restored.
+    *leak* -- a step that spawns a grandchild with ``UseShellExecute = $false``
+    and no redirection (the shape that makes the grandchild inherit the step's
+    stdout/stderr), then exits 7 while the grandchild sleeps on. The fixture
+    asserts the grandchild was **still alive** when ``Invoke-HermesStep``
+    returned, so a pass cannot be a timing coincidence, and that the exit code
+    and the step's output both survived the abandonment.
+
+    *flood* -- a step that writes megabytes and holds nothing, exiting 5. It
+    must complete in wall-clock far under what a sleep-per-chunk drain would
+    take, and every byte must arrive.
+
+    Measured on Windows 11 / PowerShell 5.1: leak 4.3s (vs 47.4s waiting out the
+    grandchild), flood 8 MiB in ~1s (vs ~76s metered).
     """
     system_root = Path(os.environ.get("SystemRoot", r"C:\Windows"))
     powershell = (
@@ -151,7 +82,7 @@ def test_pipe_drain_self_test_returns_while_a_descendant_holds_the_pipe(
 
     env = {
         **os.environ,
-        # The fixture writes its child script, pid file and hand-off log under
+        # The fixture writes its child scripts, pid file and hand-off log under
         # TEMP; point that at tmp_path so the test leaves nothing behind.
         "TEMP": str(tmp_path),
         "TMP": str(tmp_path),
@@ -174,17 +105,19 @@ def test_pipe_drain_self_test_returns_while_a_descendant_holds_the_pipe(
         ],
         capture_output=True,
         text=True,
-        # Comfortably past the 45s hold so a regression fails with the
-        # fixture's own diagnosis instead of an opaque timeout.
-        timeout=180,
+        # Comfortably past both arms' worst cases (the 45s hold, and a metered
+        # flood) so a regression fails with the fixture's own diagnosis instead
+        # of an opaque timeout.
+        timeout=300,
         env=env,
         cwd=str(REPO_ROOT),
     )
 
     assert "PIPE-DRAIN SELF-TEST: PASS" in result.stdout, (
-        "Invoke-HermesStep did not return while a descendant still held its "
-        "stdout/stderr pipe. The Desktop update hand-off is deadlocked again "
-        f"(#90455).\n--- stdout ---\n{result.stdout}\n"
+        "The Windows update hand-off's step drain regressed: it either waited "
+        "on a descendant holding the pipe open (the Desktop parks on 'Updating "
+        "Hermes' forever) or metered a chatty step (backpressure on the running "
+        f"update). Fixture diagnosis follows.\n--- stdout ---\n{result.stdout}\n"
         f"--- stderr ---\n{result.stderr}"
     )
     assert result.returncode == 0, (

--- a/tests/test_desktop_update_windows_pipe_drain.py
+++ b/tests/test_desktop_update_windows_pipe_drain.py
@@ -1,0 +1,193 @@
+"""Regression: the Windows Desktop update hand-off must not wait on pipe EOF.
+
+``scripts/desktop-update/windows.ps1`` runs each update step through
+``Invoke-HermesStep``, which starts the step with ``RedirectStandardOutput`` /
+``RedirectStandardError`` and used to collect its output with
+``ReadToEndAsync().Result``.
+
+``.Result`` on that task does not return when the *step* exits -- it returns
+when the *pipe* reaches EOF. On Windows the write end of a redirected pipe is
+handed to the child as an inheritable handle, so every descendant spawned
+without its own redirection holds a duplicate, and EOF waits for the last of
+them to close it. ``hermes update`` deliberately runs build steps with stdout
+inherited (the tee-stderr runner in ``hermes_cli/main.py``), so the process
+tree under a step is arbitrarily deep and not something the hand-off can
+enumerate. When one of those descendants is a resident gateway, the pipe never
+closes and ``Invoke-HermesStep`` blocks for the life of the gateway.
+
+Everything the hand-off owes the Desktop is downstream of that call:
+``.hermes-update-result.json`` is never written, ``.hermes-update-in-progress``
+is never cleared, and the Desktop is never relaunched -- so the app sits on
+"Updating Hermes" until the user kills the gateway by hand, and the stale
+marker then refuses the next update too (#90455).
+
+The fix drains both pipes in chunks into a ``StringBuilder`` and bounds the
+drain *after* the step has exited. The bound cannot truncate a slow step: the
+clock only starts once the process is gone, at which point everything it wrote
+is already sitting in the pipe buffer waiting to be read.
+
+The source-level guards below run on every host, because Linux CI cannot
+execute the PowerShell hand-off -- the same reason
+``test_desktop_update_windows_python_handoff.py`` is written that way. The
+``windows_only`` test at the bottom is the executable proof: it drives the
+script's own ``-SelfTestPipeDrain`` fixture, which builds a step whose
+grandchild outlives it holding the inherited handle.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WINDOWS_PS1 = REPO_ROOT / "scripts" / "desktop-update" / "windows.ps1"
+
+
+def _read() -> str:
+    return WINDOWS_PS1.read_text(encoding="utf-8")
+
+
+def _invoke_hermes_step_body() -> str:
+    """Return just the body of ``Invoke-HermesStep``.
+
+    Scoped deliberately: ``WaitForExit`` and ``.Result`` are legitimate
+    elsewhere in the script, so a whole-file grep would fire on unrelated
+    code.
+    """
+    source = _read()
+    start = source.find("function Invoke-HermesStep(")
+    assert start != -1, (
+        "Invoke-HermesStep no longer exists in "
+        "scripts/desktop-update/windows.ps1. The update hand-off structure "
+        "changed -- update this guard rather than deleting it."
+    )
+    end = source.find("\n}", start)
+    assert end != -1, "Could not find the end of Invoke-HermesStep."
+    return source[start:end]
+
+
+def test_step_drain_does_not_wait_for_pipe_eof() -> None:
+    body = _invoke_hermes_step_body()
+
+    assert "ReadToEndAsync" not in body, (
+        "Invoke-HermesStep must not collect step output with "
+        "ReadToEndAsync(): that task completes on pipe EOF, not on process "
+        "exit, so any surviving descendant holding the inherited write handle "
+        "(a resident gateway is the reported case) blocks the hand-off "
+        "forever. .Result also cannot hand back a partial read, so there is "
+        "no way to abandon it without losing the whole step's output. Read in "
+        "chunks into a StringBuilder instead (#90455)."
+    )
+
+
+def test_step_drain_is_bounded_once_the_step_has_exited() -> None:
+    body = _invoke_hermes_step_body()
+
+    assert "$script:StepDrainGraceSeconds" in body, (
+        "Invoke-HermesStep must bound how long it waits for the step's pipes "
+        "to reach EOF after the step process itself has exited (#90455)."
+    )
+    assert "HasExited" in body, (
+        "The drain bound must be keyed on the step having exited, so a slow "
+        "step is never mistaken for a stuck pipe."
+    )
+    assert re.search(r"\$abandonAt\s*=\s*\(Get-Date\)\.AddSeconds", body), (
+        "The abandon deadline must be armed from the moment the step exits, "
+        "not from when it started -- a long `uv pip install` is not a leaked "
+        "pipe (#90455)."
+    )
+
+
+def test_step_drain_does_not_use_the_stream_waiting_waitforexit() -> None:
+    body = _invoke_hermes_step_body()
+
+    assert not re.search(r"WaitForExit\(\s*\)", body), (
+        "The parameterless Process.WaitForExit() also waits on redirected "
+        "streams, which reintroduces exactly the unbounded pipe-EOF wait this "
+        "guard exists to prevent. Use the bounded WaitForExit(ms) overload "
+        "(#90455)."
+    )
+
+
+def test_abandoned_drain_is_reported_in_the_hand_off_log() -> None:
+    body = _invoke_hermes_step_body()
+
+    assert "pipe drain abandoned" in body, (
+        "Abandoning a step's pipes must leave a line in "
+        "logs/desktop-update-handoff.log. A silently truncated step log is "
+        "indistinguishable from a step that printed nothing, and that log is "
+        "what `hermes debug share` collects for update reports (#90455)."
+    )
+
+
+@pytest.mark.windows_only
+def test_pipe_drain_self_test_returns_while_a_descendant_holds_the_pipe(
+    tmp_path: Path,
+) -> None:
+    """Execute the real drain against a step that leaks its pipe handle.
+
+    ``-SelfTestPipeDrain`` starts a step which spawns a grandchild with
+    ``UseShellExecute = $false`` and no redirection -- the shape that makes the
+    grandchild inherit the step's stdout/stderr -- then exits 7 while the
+    grandchild sleeps on. The fixture asserts the grandchild was still alive
+    when ``Invoke-HermesStep`` returned, so a pass cannot be a timing
+    coincidence, and that both the exit code and the step's output survived the
+    abandonment.
+
+    Measured on Windows 11 / PowerShell 5.1: 4.3s with the fix, 47.4s (the
+    grandchild's full lifetime) with the previous drain restored.
+    """
+    system_root = Path(os.environ.get("SystemRoot", r"C:\Windows"))
+    powershell = (
+        system_root / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe"
+    )
+    if not powershell.is_file():
+        pytest.skip(f"Windows PowerShell not found at {powershell}")
+
+    env = {
+        **os.environ,
+        # The fixture writes its child script, pid file and hand-off log under
+        # TEMP; point that at tmp_path so the test leaves nothing behind.
+        "TEMP": str(tmp_path),
+        "TMP": str(tmp_path),
+        # Keep the test quick. The grace is what the fix bounds; the hold is
+        # how long the leaking grandchild lives. hold >> grace is what makes a
+        # regression measurable rather than lucky.
+        "HERMES_UPDATE_PIPE_DRAIN_SECONDS": "3",
+        "HERMES_SELFTEST_HOLD_SECONDS": "45",
+    }
+
+    result = subprocess.run(
+        [
+            str(powershell),
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(WINDOWS_PS1),
+            "-SelfTestPipeDrain",
+        ],
+        capture_output=True,
+        text=True,
+        # Comfortably past the 45s hold so a regression fails with the
+        # fixture's own diagnosis instead of an opaque timeout.
+        timeout=180,
+        env=env,
+        cwd=str(REPO_ROOT),
+    )
+
+    assert "PIPE-DRAIN SELF-TEST: PASS" in result.stdout, (
+        "Invoke-HermesStep did not return while a descendant still held its "
+        "stdout/stderr pipe. The Desktop update hand-off is deadlocked again "
+        f"(#90455).\n--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+    assert result.returncode == 0, (
+        f"-SelfTestPipeDrain exited {result.returncode}.\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )

--- a/tests/test_desktop_update_windows_python_handoff.py
+++ b/tests/test_desktop_update_windows_python_handoff.py
@@ -40,8 +40,24 @@ def _read() -> str:
     return WINDOWS_PS1.read_text(encoding="utf-8")
 
 
+def _handoff_source() -> str:
+    """The script with its ``-SelfTest*`` fixture blocks removed.
+
+    Those blocks exercise the hand-off machinery deliberately -- the pipe-drain
+    fixture runs a synthetic PowerShell step through ``Invoke-HermesStep`` to
+    prove the drain cannot deadlock (#90455) -- so they are not update steps
+    and the "must drive python.exe" rule does not apply to them. Each exits
+    before any marker/venv/desktop machinery runs.
+
+    Scoped here rather than allow-listing a target, so the rule stays absolute
+    for every real step. The non-greedy match ends at the first closing brace
+    in column 0; the blocks' own braces are all indented.
+    """
+    return re.sub(r"\nif \(\$SelfTest\w+\) \{.*?\n\}\n", "\n", _read(), flags=re.S)
+
+
 def test_invoke_hermes_step_calls_drive_python_not_the_shim() -> None:
-    source = _read()
+    source = _handoff_source()
 
     invocations = re.findall(r"Invoke-HermesStep\s+(\$\w+)", source)
     assert invocations, (


### PR DESCRIPTION
Salvage of #90564 by @jackulau, whose diagnosis and layer choice this keeps intact, plus the throughput fix its drain needs and a second self-test arm to hold the line.

## The bug

`Invoke-HermesStep` in `scripts/desktop-update/windows.ps1` collected each step's output with `ReadToEndAsync().Result`. That task completes on **pipe EOF, not process exit**. Windows hands the write end of a redirected pipe to the child as an inheritable handle, so every descendant spawned without its own redirection holds a duplicate, and EOF waits for the last of them to close it. `hermes update` deliberately runs its build steps with stdout inherited, so the tree under a step is arbitrarily deep and not something the shim can enumerate. One resident descendant and the read never returns.

Everything the hand-off owes the Desktop sits downstream of that call: `.hermes-update-result.json` is never written, `.hermes-update-in-progress` is never cleared, the Desktop is never relaunched. There is no ceiling anywhere on that path — the script's other waits are bounded (5min error finale, 30s/20s relaunch), the step loop was not. The app parks on "Updating Hermes" indefinitely, the stale marker then refuses the next update, and the user's recovery is to kill the gateway and run `hermes update --yes --gateway --force --branch main` by hand — character-for-character the command the shim was already running.

## The fix, in two halves

**Bounded drain** (@jackulau, unchanged): read both pipes in chunks into a `StringBuilder`, and arm an abandon deadline at the step's *exit*. The clock starts when the process is already gone, so a 40-minute `uv pip install` is untouched; the grace only covers the final drain. Chunked reads are what make abandoning safe — `.Result` cannot hand back a partial read, so a timeout around it would lose the whole step's log. An abandoned drain writes one line to `desktop-update-handoff.log` naming the cause, because a silently truncated log is indistinguishable from a step that printed nothing.

**Don't meter it** (new): the loop idled 150ms after every chunk it consumed, so output moved at one 16 KiB buffer per tick — about 107 KB/s. The pipe then backs up, and that is backpressure on the *running* step, not just a slow read: a chatty step blocks on `write()` waiting for the reader. `hermes update` is exactly that shape; the Electron/vite build alone is megabytes. Fixing "the hand-off waits forever" by shipping "the hand-off is slow" is the wrong trade.

Now the loop idles only when both pipes came up empty, and idles on the reads themselves (`WaitAny`, same 150ms cap) rather than on the clock. The read-based wait is load-bearing: a freshly issued `ReadAsync` is rarely complete by the very next pass, so a bare `if (-not $moved)` still sleeps between chunks — that variant measured 0.53s on 4 MiB where `WaitAny` gets 0.07s, and 3.09s vs 0.27s on the two-pipe case. `WaitAny` expires on its own, so a silent step still animates the marquee and still advances the abandon deadline.

## Measured

Same harness, one variable — the drain loop's idle policy. `Step-PipeDrain` and the loop lifted verbatim from this branch, both arms generated from one template so nothing else differs:

| step shape | #90564 as submitted | this PR |
|---|---|---|
| 4 MiB of stdout | 38.99s (105.1 KB/s) | **0.07s** |
| 20 MiB of stdout | >180s (timed out) | **0.23s** |
| 1 MiB stdout + 1 MiB stderr | 18.22s | **0.27s** |
| grandchild holds the pipe 20s, grace 3s | 3.24s, exit 7, output kept | 3.20s, exit 7, output kept |
| silent step, exits at 4s | 4.29s, 29 passes | 4.04s, 29 passes |

The leak arm is unchanged, which is the point — the bound still does its job. The quiet arm's pass count confirms the loop is not spinning through silence.

## Tests

`-SelfTestPipeDrain` grows a second arm. The two bracket the contract from both sides:

- **leak** — a step whose grandchild inherits its stdout (`UseShellExecute = $false`, no redirection) and outlives it. Asserts the grandchild was **still alive** on return, so a pass cannot be a timing coincidence, and that exit code and output both survived.
- **flood** — a step that writes megabytes and holds nothing, with a wall-clock budget far under what a sleep-per-chunk drain needs. Few large lines on purpose: `Write-HandoffLog` is one `Add-Content` per line and runs inside the measured window, so line-heavy output would time the logger instead of the drain.

Both need no update, no checkout, no Hermes install, and run on the existing Windows CI lane.

**Dropped: the four source-grep guards.** Asserting `windows.ps1`'s *text* contains `$abandonAt` tests the shape of the source, not its behavior — it passes on a drain that is wired wrong but spelled right, fails on a correct refactor, and blocks the extraction it should survive. `AGENTS.md` bans the pattern outright, and it is what let the metering regression through: every one of those four guards passes on the submitted drain. The executable arms cover the same contract and actually run the code.

`test_desktop_update_windows_python_handoff.py` keeps @jackulau's `-SelfTest*` stripping so its "every step drives `python.exe`" rule stays absolute for real steps; verified it still resolves all three real steps to `$pythonExe` with the second fixture present.

## Validation

| | Result |
|---|---|
| `pytest tests/test_desktop_update_*.py` | 10 passed, 2 skipped (Windows arms skip on macOS) |
| Drain A/B, both variants from one template | table above |
| `ruff check` | clean |
| `scripts/check-windows-footguns.py --all` | clean, 994 files |
| PowerShell AST parse | OK |
| Line endings | CRLF preserved, 0 bare LF |

The behavioral arms are `windows_only`; I verified the drain logic under pwsh 7 on macOS, so the Windows lane on this PR is the authority for the arms themselves.

## Scope

Related but deliberately separate — the updater-side half of the same 2026-08-20 Windows incident is already on main (#90746, #90777). This is the shim-side half; no file overlap, and neither alone covers the resident-descendant deadlock.

The issue's suggestion 3 (stale-marker watchdog) is a real second layer and is not here. `UPDATE_MARKER_MAX_AGE_MS` already self-heals at 20 minutes, but only on the *next* boot; #85964 is the closest existing candidate for making that ceiling reliably fire.

Suggestion 1 (stop the gateway inheriting the pipes) — @jackulau went looking and could not find the leaking spawn; every Windows gateway spawn on the update path already redirects. Worth recording rather than implying: the fix is correct at this layer regardless of which descendant it turns out to be, including ones that do not exist yet, because the shim is what holds the marker and owes the result file.

Supersedes #90564.
Fixes #90455.

Co-authored-by: Jack Lau <72348727+jackulau@users.noreply.github.com>
