### PR TITLE
Stop Desktop from scanning the home directory

### DIFF
--- a/apps/desktop/electron/git-repo-scan.test.ts
+++ b/apps/desktop/electron/git-repo-scan.test.ts
@@ -39,6 +39,13 @@ describe('scanGitRepos', () => {
     expect(read).not.toHaveBeenCalled()
   })
 
+  it('does not fall back to scanning the home directory when roots are empty', async () => {
+    const read = vi.spyOn(fs.promises, 'readdir')
+
+    await expect(scanGitRepos([], { enabled: true })).resolves.toEqual([])
+    expect(read).not.toHaveBeenCalled()
+  })
+
   it('scans only configured roots and excludes complete subtrees', async () => {
     const root = tempDir()
     const included = path.join(root, 'included')

--- a/apps/desktop/electron/git-repo-scan.ts
+++ b/apps/desktop/electron/git-repo-scan.ts
@@ -88,12 +88,13 @@ async function mapLimit<T>(items: T[], limit: number, fn: (item: T) => Promise<v
 }
 
 /**
- * Scan roots for Git repositories. An empty root list preserves the historical
- * home-directory scan. Disabled discovery returns before resolving home or
- * reading the filesystem.
+ * Scan explicitly configured roots for Git repositories. An empty root list is
+ * intentionally a no-op: silently expanding it to the user's home directory
+ * can traverse protected macOS locations during ordinary Desktop startup.
+ * Disabled discovery returns before resolving home or reading the filesystem.
  */
 export async function scanGitRepos(roots: string[], options: RepoScanOptions = {}) {
-  if (options.enabled === false) {
+  if (options.enabled === false || !Array.isArray(roots) || roots.length === 0) {
     return []
   }
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3557,7 +3557,8 @@ DEFAULT_CONFIG = {
     # `hermes desktop`; they do not touch the CLI/gateway.
     "desktop": {
         # Git repository discovery for the Desktop Projects sidebar. Empty
-        # roots preserve the historical bounded scan of the user's home.
+        # roots are a safe no-op; users must explicitly configure roots for
+        # filesystem scanning. Session-derived projects remain available.
         "repo_scan_enabled": True,
         "repo_scan_roots": [],
         "repo_scan_exclude_paths": [],

--- a/tests/hermes_cli/test_desktop_repo_discovery_config.py
+++ b/tests/hermes_cli/test_desktop_repo_discovery_config.py
@@ -2,10 +2,12 @@ from hermes_cli.config import DEFAULT_CONFIG
 from hermes_cli.web_server import CONFIG_SCHEMA
 
 
-def test_desktop_repo_discovery_defaults_preserve_existing_behavior():
+def test_desktop_repo_discovery_defaults_are_opt_in_by_root():
     desktop = DEFAULT_CONFIG["desktop"]
 
     assert desktop["repo_scan_enabled"] is True
+    # Empty roots are deliberately safe: Desktop does not infer a home-wide
+    # search. Users must explicitly configure roots or use session projects.
     assert desktop["repo_scan_roots"] == []
     assert desktop["repo_scan_exclude_paths"] == []
 


### PR DESCRIPTION
## Change
- stop Desktop repo discovery when no roots are explicitly configured
- preserve explicit configured roots and session-derived projects
- add a regression test proving an empty-root scan performs no filesystem reads

## Root cause
`scanGitRepos` converted an empty root list into `[os.homedir()]`, so normal Desktop startup recursively read the user's home directory and could touch protected macOS locations.

## Verification
- `npm exec --workspace apps/desktop -- vitest run electron/git-repo-scan.test.ts --project electron`
- `uv run pytest tests/hermes_cli/test_desktop_repo_discovery_config.py -q`
- `npm exec --workspace apps/desktop -- eslint electron/git-repo-scan.ts electron/git-repo-scan.test.ts`
- `git diff --check`

Rollback: revert commit a420d0134f.