### PR TITLE
Prevent duplicate Kanban cards before creation

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -950,6 +950,87 @@ def test_create_respects_auto_subscribe_on_create_false(monkeypatch, worker_env,
     assert _list_subs_for_task(d["task_id"]) == []
 
 
+def test_create_preflight_reuses_overlapping_project_task(worker_env):
+    """The default create preflight returns an active matching card instead
+    of creating a parallel task on the same project board."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        existing = kb.create_task(
+            conn, title="Add audit log retention",
+            body="Keep the audit log retention policy reviewable.", assignee="peer",
+        )
+        before = len(kb.list_tasks(conn))
+    finally:
+        conn.close()
+
+    out = json.loads(kt._handle_create({
+        "title": "Add audit log retention",
+        "body": "Keep the audit log retention policy reviewable.",
+        "assignee": "another-peer",
+    }))
+
+    assert out == {"ok": True, "task_id": existing, "reused": True,
+                   "preflight": "overlap"}
+    conn = kb.connect()
+    try:
+        assert len(kb.list_tasks(conn)) == before
+    finally:
+        conn.close()
+
+
+def test_create_preflight_is_quiet_and_board_scoped(worker_env):
+    """A clean preflight creates normally and does not inspect another
+    board or a task with a different project."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect(board="other")
+    try:
+        kb.create_task(conn, title="Rotate billing credentials",
+                        body="Rotate the billing credentials safely.",
+                        assignee="peer", project_id="different-project")
+    finally:
+        conn.close()
+
+    out = json.loads(kt._handle_create({
+        "title": "Rotate billing credentials",
+        "body": "Rotate the billing credentials safely.",
+        "assignee": "peer", "project": "this-project",
+    }))
+    assert out["ok"] is True
+    assert out.get("reused") is None
+    assert out.get("preflight") is None
+
+
+def test_create_preflight_ignores_legacy_block_but_matches_real_block(worker_env):
+    """Only typed needs_input/capability blocks count as reusable blockers;
+    legacy untyped blocks remain historical evidence."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        legacy = kb.create_task(conn, title="Repair notifier routing",
+                                body="Repair notifier routing.", assignee="peer")
+        kb.block_task(conn, legacy, reason="old evidence")
+        typed = kb.create_task(conn, title="Repair desktop notifier routing",
+                               body="Repair notifier routing.", assignee="peer")
+        kb.block_task(conn, typed, reason="needs owner", kind="capability")
+    finally:
+        conn.close()
+
+    out = json.loads(kt._handle_create({
+        "title": "Repair desktop notifier routing",
+        "body": "Repair notifier routing.", "assignee": "another-peer",
+    }))
+    assert out["ok"] is True
+    assert out["task_id"] == typed
+    assert out["reused"] is True
+
+
 def test_maybe_auto_subscribe_swallows_add_notify_sub_failure(monkeypatch, worker_env):
     """If add_notify_sub itself raises (e.g. DB locked, schema drift),
     _maybe_auto_subscribe must NOT bubble that up and fail the parent

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from typing import Any, Optional
 
 from agent.redact import redact_sensitive_text
@@ -47,6 +48,54 @@ logger = logging.getLogger(__name__)
 
 KANBAN_LIST_DEFAULT_LIMIT = 50
 KANBAN_LIST_MAX_LIMIT = 200
+
+_PREFLIGHT_STOPWORDS = frozenset({
+    "a", "an", "and", "for", "from", "in", "of", "on", "or", "the",
+    "to", "with", "task", "work", "card", "add", "make", "update",
+})
+_PREFLIGHT_REUSABLE_STATUSES = frozenset({
+    "triage", "todo", "scheduled", "ready", "running", "review",
+})
+
+
+def _preflight_tokens(value: Optional[str]) -> set[str]:
+    """Return stable, low-noise words used by the create deduplication guard."""
+    return {
+        token for token in re.findall(r"[a-z0-9]{3,}", (value or "").casefold())
+        if token not in _PREFLIGHT_STOPWORDS
+    }
+
+
+def _find_preflight_overlap(conn: Any, *, title: str, body: Optional[str],
+                            project_id: Optional[str]) -> Optional[str]:
+    """Find one reusable task on this exact board/project, without writing.
+
+    Untyped legacy blocks are intentionally excluded: they remain evidence for
+    human audit, not proof that a new request is currently blocked.
+    """
+    requested_title = " ".join((title or "").casefold().split())
+    requested_tokens = _preflight_tokens(f"{title}\n{body or ''}")
+    candidates = []
+    for task in conn.execute(
+        "SELECT id, title, body, status, block_kind, project_id, created_at "
+        "FROM tasks WHERE status != 'archived' ORDER BY created_at ASC, id ASC"
+    ).fetchall():
+        if task["project_id"] != project_id:
+            continue
+        if task["status"] not in _PREFLIGHT_REUSABLE_STATUSES and not (
+            task["status"] == "blocked"
+            and task["block_kind"] in {"needs_input", "capability"}
+        ):
+            continue
+        candidate_title = " ".join((task["title"] or "").casefold().split())
+        candidate_tokens = _preflight_tokens(
+            f"{task['title']}\n{task['body'] or ''}"
+        )
+        exact_title = bool(requested_title and requested_title == candidate_title)
+        shared_words = len(requested_tokens & candidate_tokens)
+        if exact_title or shared_words >= 2:
+            candidates.append(task["id"])
+    return candidates[0] if candidates else None
 
 
 def _profile_has_kanban_toolset() -> bool:
@@ -1433,6 +1482,26 @@ def _handle_create(args: dict, **kw) -> str:
                     if _self_task is not None and _self_task.project_id:
                         project_id = _self_task.project_id
                         project_source_task_id = _self_task.id
+            preflight_project_id = project_id
+            if preflight_project_id is None:
+                try:
+                    preflight_project_id = kb.read_board_metadata(
+                        board or kb.get_current_board()
+                    ).get("project_id")
+                except Exception:
+                    preflight_project_id = None
+            overlap_id = _find_preflight_overlap(
+                conn,
+                title=str(title).strip(),
+                body=body,
+                project_id=preflight_project_id,
+            )
+            if overlap_id:
+                return _ok(
+                    task_id=overlap_id,
+                    reused=True,
+                    preflight="overlap",
+                )
             new_tid = kb.create_task(
                 conn,
                 title=str(title).strip(),
@@ -2133,7 +2202,10 @@ KANBAN_CREATE_SCHEMA = {
     "name": "kanban_create",
     "description": (
         "Create a new kanban task, optionally as a child of the current "
-        "one (pass the current task id in ``parents``). Used by "
+        "one (pass the current task id in ``parents``). Before creating, "
+        "the default preflight checks this board for an active, review, or "
+        "typed real-blocked task with overlapping intent and returns that "
+        "task with ``reused=true`` instead of making a duplicate. Used by "
         "orchestrator workers to fan out — decompose work into child "
         "tasks with specific assignees, link them into a pipeline, "
         "then complete your own task. The dispatcher picks up the new "


### PR DESCRIPTION
## Summary
- audit live boards without changing unrelated cards
- retain the Desktop-session notifier capability block and record that no JobLogic cards exist on the default board
- preflight `kanban_create` on the target board/project and reuse an active, review, or typed real-blocked overlap
- add deterministic tests for reuse, clean isolation, and legacy untyped blocks

## Verification
- `pytest -q tests/tools/test_kanban_tools.py` (35 passed)
- `python -m compileall -q tools/kanban_tools.py tests/tools/test_kanban_tools.py`
- `git diff --check`

Rollback: revert commit 853c4aee3f.