### PR TITLE
fix: map framework-generic tool aliases (shell, bash) to terminal

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3375,6 +3375,23 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
     if not tool_name:
         return None
 
+    # Explicit alias map for framework-generic tool names that small local
+    # models (qwen3.8, laguna, etc.) emit for the terminal tool. 'shell' and
+    # friends never reach the fuzzy-match cutoff (0.7) against 'terminal',
+    # so without this map the model loops on "Unknown tool 'shell'".
+    _TOOL_NAME_ALIASES = {
+        "shell": "terminal",
+        "bash": "terminal",
+        "execute_command": "terminal",
+        "exec_command": "terminal",
+        "run_command": "terminal",
+        "execute_shell": "terminal",
+        "run_shell": "terminal",
+    }
+    alias = _TOOL_NAME_ALIASES.get(tool_name.lower())
+    if alias and alias in agent.valid_tool_names:
+        return alias
+
     # VolcEngine api/plan workaround (issue #33007): the endpoint's
     # protocol-translation layer occasionally leaks raw XML attribute
     # fragments into tool_use.name, e.g.


### PR DESCRIPTION
## Problem

Small local models (qwen3.8 UD-Q6_K_XL, laguna-xs-2.1, and similar MoE/agentic models) emit framework-generic tool names for terminal operations: `shell`, `bash`, `execute_command`, etc. Hermes' tool is named `terminal`.

`repair_tool_call()` normalizes casing/separators/`_tool` suffixes and falls back to fuzzy matching with `cutoff=0.7`, but `shell` never scores high enough against `terminal`, so the model loops on:

```
⚠️ Unknown tool 'shell' — sending error to model for agent-correction (1/3)
⚠️ Unknown tool 'shell' — sending error to model for agent-correction (2/3)
⚠️ Unknown tool 'shell' — sending error to model for agent-correction (3/3)
```

Observed repeatedly in production on a gateway running a local qwen3.8-27B model (2026-08-20). The existing repair already covers `terminal<` (XML-fragment leak, #33007) but not framework synonyms.

## Fix

Add an explicit alias map resolved before the fuzzy match:

```python
_TOOL_NAME_ALIASES = {
    "shell": "terminal",
    "bash": "terminal",
    "execute_command": "terminal",
    "exec_command": "terminal",
    "run_command": "terminal",
    "execute_shell": "terminal",
    "run_shell": "terminal",
}
```

Only maps known framework synonyms to their canonical tool; no behavioral change for valid names or any other repair path. Generic enough to benefit all users running small local models.

## Verification

- `repair_tool_call` unit-style check: `shell`, `bash`, `execute_command`, `terminal<` → `terminal`; `write file` → `write_file`; `WRITE_FILE` → `write_file` (existing paths untouched).
- Applied live in the ecosystem; the "Unknown tool 'shell'" loop disappears after gateway restart.