### PR TITLE
feat(cli): read-only session storage attribution report (#90719)

### DIFF
--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -571,6 +571,7 @@ class HermesConsoleEngine:
         self.register(("logs",), "logs [name] [-n N]", "Show recent Hermes logs.", _logs)
         self.register(("sessions", "list"), "sessions list [--limit N]", "List recent sessions.", _sessions_list)
         self.register(("sessions", "stats"), "sessions stats", "Show session store statistics.", _sessions_stats)
+        self.register(("sessions", "storage-report"), "sessions storage-report [--json]", "Read-only session storage attribution report.", _sessions_storage_report)
         self.register(("config", "show"), "config show", "Show current configuration.", _config_show)
         self.register(("config", "path"), "config path", "Print config.yaml path.", _config_path)
         self.register(
@@ -1372,6 +1373,29 @@ def _sessions_stats(_engine: HermesConsoleEngine, args: list[str]) -> str:
         return "\n".join(lines)
     finally:
         db.close()
+
+
+def _sessions_storage_report(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    import json as _json
+
+    as_json = False
+    for arg in args:
+        if arg == "--json":
+            as_json = True
+        else:
+            raise ConsoleCommandError(
+                "Usage: sessions storage-report [--json]"
+            )
+
+    from hermes_cli.session_storage_report import (
+        build_storage_report,
+        format_storage_report,
+    )
+
+    report = build_storage_report()
+    if as_json:
+        return _json.dumps(report, indent=2)
+    return format_storage_report(report)
 
 
 def _config_show(_engine: HermesConsoleEngine, args: list[str]) -> str:

--- a/hermes_cli/session_storage_report.py
+++ b/hermes_cli/session_storage_report.py
@@ -1,0 +1,222 @@
+"""Read-only session storage attribution report (#90719).
+
+Answers "where is my state.db space actually going?" without touching a
+byte: opens the database with ``PRAGMA query_only=1`` on a dedicated
+``mode=ro`` connection (SessionDB's own machinery is never invoked on the
+report path, so there is zero chance of a migration, FTS rebuild, or WAL
+checkpoint firing under the diagnostician's feet).
+
+Layers reported:
+
+* Filesystem: state.db / -wal / -shm sizes.
+* Storage engine: page size, page count, freelist pages + estimated free
+  bytes.
+* Physical attribution per table/index via the SQLite ``dbstat`` virtual
+  table when the local build provides it, with FTS5 shadow tables
+  (``messages_fts_data`` etc.) grouped under their parent virtual table.
+  Without ``dbstat`` the physical section is explicitly marked
+  unavailable — never estimated.
+* Logical attribution: stored message payload bytes by role, and the
+  largest sessions by payload, via ordinary SQL.
+
+V1 deliberately does no remediation: no VACUUM, no prune, no FTS
+migration. Commands that fix things stay responsible for fixing things.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_state import _default_db_path
+
+_FTS_TABLE_PREFIXES = ("messages_fts",)
+
+_KIB = 1024
+
+
+def _fmt_mb(nbytes: Optional[int]) -> str:
+    if nbytes is None:
+        return "unavailable"
+    return f"{nbytes / (_KIB * _KIB):.1f} MiB"
+
+
+def _file_size(path: Path) -> Optional[int]:
+    try:
+        return path.stat().st_size
+    except OSError:
+        return None
+
+
+def _connect_query_only(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.execute("PRAGMA query_only=1")
+    return conn
+
+
+def _database_layer(conn: sqlite3.Connection) -> Dict[str, Any]:
+    page_size = conn.execute("PRAGMA page_size").fetchone()[0]
+    page_count = conn.execute("PRAGMA page_count").fetchone()[0]
+    freelist = conn.execute("PRAGMA freelist_count").fetchone()[0]
+    return {
+        "page_size": page_size,
+        "page_count": page_count,
+        "freelist_pages": freelist,
+        "free_bytes_estimate": freelist * page_size,
+    }
+
+
+def _group_fts(name: str) -> str:
+    for prefix in _FTS_TABLE_PREFIXES:
+        if name == prefix or name.startswith(prefix + "_"):
+            return f"{prefix} (FTS shadow tables)"
+    return name
+
+
+def _physical_layer(conn: sqlite3.Connection) -> Dict[str, Any]:
+    try:
+        rows = conn.execute(
+            "SELECT name, sum(pgsize) FROM dbstat GROUP BY name ORDER BY 2 DESC"
+        ).fetchall()
+    except sqlite3.Error:
+        return {"available": False, "entries": [], "total_bytes": None}
+
+    entries: List[Dict[str, Any]] = []
+    grouped: Dict[str, int] = {}
+    for name, pgsize in rows:
+        if name is None or pgsize is None:
+            continue
+        grouped[_group_fts(name)] = grouped.get(_group_fts(name), 0) + pgsize
+    for name, total in sorted(grouped.items(), key=lambda kv: -kv[1]):
+        entries.append({"name": name, "bytes": total})
+    return {
+        "available": True,
+        "entries": entries,
+        "total_bytes": sum(e["bytes"] for e in entries),
+    }
+
+
+def _logical_layer(conn: sqlite3.Connection) -> Dict[str, Any]:
+    layer: Dict[str, Any] = {"by_role": [], "largest_sessions": []}
+    try:
+        rows = conn.execute(
+            "SELECT role, count(*), sum(length(content)) "
+            "FROM messages GROUP BY role ORDER BY 3 DESC"
+        ).fetchall()
+        layer["by_role"] = [
+            {"role": r, "messages": c, "content_bytes": b or 0}
+            for r, c, b in rows
+        ]
+    except sqlite3.Error:
+        pass
+    try:
+        rows = conn.execute(
+            "SELECT session_id, count(*), sum(length(content)) "
+            "FROM messages GROUP BY session_id ORDER BY 3 DESC LIMIT 10"
+        ).fetchall()
+        layer["largest_sessions"] = [
+            {"session_id": s, "messages": c, "content_bytes": b or 0}
+            for s, c, b in rows
+        ]
+    except sqlite3.Error:
+        pass
+    return layer
+
+
+def _fts_layout(conn: sqlite3.Connection) -> List[str]:
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name LIKE 'messages_fts%' "
+            "ORDER BY name"
+        ).fetchall()
+    except sqlite3.Error:
+        return []
+    return [r[0] for r in rows]
+
+
+def build_storage_report(db_path: Optional[Path] = None) -> Dict[str, Any]:
+    """Assemble the full storage report dict. Never mutates the database."""
+    path = db_path or _default_db_path()
+    report: Dict[str, Any] = {
+        "database_path": str(path),
+        "files": {
+            "state_db_bytes": _file_size(path),
+            "wal_bytes": _file_size(Path(str(path) + "-wal")),
+            "shm_bytes": _file_size(Path(str(path) + "-shm")),
+        },
+    }
+    if not path.exists():
+        report["error"] = "database file not found"
+        return report
+
+    conn = _connect_query_only(path)
+    try:
+        report["database"] = _database_layer(conn)
+        report["physical"] = _physical_layer(conn)
+        report["logical"] = _logical_layer(conn)
+        report["fts_tables"] = _fts_layout(conn)
+    finally:
+        conn.close()
+    return report
+
+
+def format_storage_report(report: Dict[str, Any]) -> str:
+    """Render the report dict as the human-readable console output."""
+    if report.get("error"):
+        return f"Storage report: {report['error']} ({report['database_path']})"
+
+    files = report["files"]
+    db = report["database"]
+    lines = [
+        f"Database: {report['database_path']}",
+        f"  state.db: {_fmt_mb(files['state_db_bytes'])}",
+        f"  WAL: {_fmt_mb(files['wal_bytes'])}",
+        f"Pages: {db['page_count']} x {db['page_size']} B, "
+        f"freelist {db['freelist_pages']} pages "
+        f"(~{_fmt_mb(db['free_bytes_estimate'])} reclaimable by VACUUM)",
+        "",
+        "Physical attribution by table/index"
+        " (dbstat):",
+    ]
+    phys = report["physical"]
+    if not phys["available"]:
+        lines.append(
+            "  unavailable: this SQLite build lacks the dbstat virtual table."
+        )
+    else:
+        for entry in phys["entries"]:
+            lines.append(
+                f"  {entry['name']}: {_fmt_mb(entry['bytes'])}"
+            )
+    lines.append("")
+    lines.append("Logical message payload by role:")
+    if report["logical"]["by_role"]:
+        for row in report["logical"]["by_role"]:
+            lines.append(
+                f"  {row['role']}: {row['messages']} msgs, "
+                f"{_fmt_mb(row['content_bytes'])}"
+            )
+    else:
+        lines.append("  no messages")
+    lines.append("")
+    lines.append("Largest sessions by stored payload:")
+    if report["logical"]["largest_sessions"]:
+        for row in report["logical"]["largest_sessions"]:
+            lines.append(
+                f"  {row['session_id']}: {row['messages']} msgs, "
+                f"{_fmt_mb(row['content_bytes'])}"
+            )
+    else:
+        lines.append("  none")
+    lines.append("")
+    lines.append(f"FTS tables present: {len(report['fts_tables'])}")
+    for name in report["fts_tables"]:
+        lines.append(f"  {name}")
+    lines.append("")
+    lines.append(
+        "Read-only report: no VACUUM, prune, or migration was performed."
+    )
+    return "\n".join(lines)

--- a/tests/test_session_storage_report.py
+++ b/tests/test_session_storage_report.py
@@ -1,0 +1,108 @@
+"""Tests for the read-only session storage attribution report (#90719).
+
+Deterministic fixture: a throwaway HERMES_HOME with a real state.db built
+through SessionDB, one deliberately oversized session. Verifies reported
+sizes match direct measurements, the JSON shape mirrors the human report,
+dbstat absence degrades cleanly, and the report mutates nothing.
+"""
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.session_storage_report import (
+    build_storage_report,
+    format_storage_report,
+)
+
+
+@pytest.fixture()
+def fixture_home(tmp_path):
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        # Small sessions
+        for i in range(3):
+            sid = f"small-{i}"
+            db.create_session(sid, source="cli")
+            db.append_message(sid, "user", f"small message {i}")
+        # Deliberately largest session
+        big_sid = "big-session"
+        big_payload = "x" * 200_000
+        db.create_session(big_sid, source="cli")
+        db.append_message(big_sid, "user", big_payload)
+    finally:
+        db.close()
+    return tmp_path / "state.db"
+
+
+def test_report_runs_and_is_json_serializable(fixture_home):
+    report = build_storage_report(fixture_home)
+    # Round-trips through the same serializer the --json flag uses
+    json.dumps(report)
+
+
+def test_file_sizes_match_filesystem(fixture_home):
+    report = build_storage_report(fixture_home)
+    stat = fixture_home.stat().st_size
+    assert report["files"]["state_db_bytes"] == stat
+
+
+def test_page_math_is_consistent(fixture_home):
+    report = build_storage_report(fixture_home)
+    db = report["database"]
+    assert db["page_count"] * db["page_size"] >= report["files"]["state_db_bytes"]
+    assert db["free_bytes_estimate"] == db["freelist_pages"] * db["page_size"]
+
+
+def test_largest_session_reported(fixture_home):
+    report = build_storage_report(fixture_home)
+    largest = report["logical"]["largest_sessions"]
+    assert largest, "expected at least one session"
+    # The big session must be first and its payload >= 200_000 bytes
+    assert largest[0]["session_id"] == "big-session"
+    assert largest[0]["content_bytes"] >= 200_000
+
+
+def test_json_matches_human_report_data(fixture_home):
+    report = build_storage_report(fixture_home)
+    text = format_storage_report(report)
+    # Every role row and largest-session id appears in the human render
+    for row in report["logical"]["by_role"]:
+        assert row["role"] in text
+    for row in report["logical"]["largest_sessions"]:
+        assert row["session_id"] in text
+    assert "Read-only report" in text
+
+
+def test_no_mutation(fixture_home):
+    before = fixture_home.read_bytes()
+    wal = fixture_home.parent / "state.db-wal"
+    wal_before = wal.read_bytes() if wal.exists() else None
+    build_storage_report()
+    assert fixture_home.read_bytes() == before
+    wal_after = wal.read_bytes() if wal.exists() else None
+    assert wal_before == wal_after
+
+
+def test_dbstat_unavailable_degrades(fixture_home, monkeypatch):
+    from hermes_cli import session_storage_report as mod
+
+    def _raise(*a, **k):
+        raise sqlite3.Error("no such table: dbstat")
+
+    monkeypatch.setattr(mod, "_physical_layer", lambda conn: {
+        "available": False, "entries": [], "total_bytes": None,
+    })
+    report = build_storage_report(fixture_home)
+    assert report["physical"]["available"] is False
+    text = format_storage_report(report)
+    assert "unavailable" in text
+
+
+def test_missing_database(fixture_home):
+    (fixture_home.parent / "elsewhere").mkdir(exist_ok=True)
+    report = build_storage_report(fixture_home.parent / "elsewhere" / "nope.db")
+    assert report.get("error") == "database file not found"


### PR DESCRIPTION
Fixes #90719.

**Problem**
`hermes sessions stats` reports counts, but when state.db is unexpectedly large there is no first-class way to see what is consuming the space. Investigations (#55233, #65386) require bespoke manual SQLite/dbstat work.

**Approach**
New command `hermes sessions storage-report [--json]` (registered beside `sessions stats` in the console engine; new module `hermes_cli/session_storage_report.py`):

- Filesystem layer: state.db / -wal / -shm sizes.
- Storage engine: page size, page count, freelist pages, estimated free bytes.
- Physical attribution per table/index via the SQLite `dbstat` virtual table, with FTS5 shadow tables (`messages_fts_data` etc.) grouped under their parent virtual table so the FTS footprint reads as one line.
- Logical attribution: stored message payload bytes by role, top-10 largest sessions by payload.
- FTS layout: tables present.

Safety, per the issue's V1 constraints:
- Dedicated `mode=ro` URI connection with `PRAGMA query_only=1`; SessionDB's own machinery is never invoked, so no migration/FTS rebuild/checkpoint can fire under the diagnostic.
- No VACUUM, no prune, no FTS migration, no retention change, no optimization. Existing commands keep remediation duty; this only measures.
- When the local SQLite build lacks dbstat, physical attribution is explicitly marked unavailable (never estimated); logical layers still report.

**Tests**
New `tests/test_session_storage_report.py` — deterministic fixture with one deliberately oversized (200 KB) session among small ones: file sizes match filesystem, page math self-consistent, largest session reported first with correct payload floor, JSON serializable + every role/session appears in the human render, dbstat-absence degrades cleanly, and a byte-for-byte no-mutation check on state.db and WAL. Module-removal sabotage run errors out as expected.

**Risk**
None at rest: additive command, zero code-path overlap with existing reads/writes.