### PR TITLE
feat(delegation): forward delegation.request_overrides on direct-endpoint branch

### DIFF
--- a/tests/tools/test_delegate_request_overrides.py
+++ b/tests/tools/test_delegate_request_overrides.py
@@ -1,0 +1,52 @@
+"""Regression tests for delegation.request_overrides on the direct-endpoint branch.
+
+The direct base_url branch of _resolve_delegation_credentials (delegation.base_url
+set, provider=custom) used to drop delegation.request_overrides on the floor —
+the named-provider branch forwards runtime request_overrides (delegate_tool.py
+"request_overrides": dict(runtime.get("request_overrides") or {})), but the
+direct branch returned no key. That made it impossible to give delegation
+children OpenRouter routing hints (extra_body.provider = {"sort": "throughput"})
+when delegating straight to openrouter.ai/api/v1 via base_url+api_key.
+"""
+
+import pytest
+
+from tools.delegate_tool import _resolve_delegation_credentials
+
+
+def _cfg(**overrides):
+    cfg = {
+        "model": "deepseek/deepseek-v4-flash-0731",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key": "test-key-1234567890",
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def test_direct_branch_forwards_request_overrides():
+    """delegation.request_overrides flows through the direct-endpoint branch."""
+    cfg = _cfg(
+        request_overrides={
+            "extra_body": {"provider": {"sort": "throughput"}},
+        }
+    )
+    creds = _resolve_delegation_credentials(cfg, parent_agent=None)
+    assert creds["request_overrides"] == {
+        "extra_body": {"provider": {"sort": "throughput"}},
+    }
+
+
+def test_direct_branch_absent_request_overrides_stays_none():
+    """No delegation.request_overrides → None, preserving the old contract."""
+    creds = _resolve_delegation_credentials(_cfg(), parent_agent=None)
+    assert creds["request_overrides"] is None
+
+
+def test_direct_branch_non_dict_request_overrides_stays_none():
+    """Garbage in config (string/list) must not crash or forward junk."""
+    for bad in ("throughput", ["extra_body"], 42):
+        creds = _resolve_delegation_credentials(
+            _cfg(request_overrides=bad), parent_agent=None
+        )
+        assert creds["request_overrides"] is None

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -4452,6 +4452,24 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     _is_native_sdk_provider = _provider_lower in _NATIVE_SDK_PROVIDERS
 
     if configured_base_url and not _is_native_sdk_provider:
+        # delegation.request_overrides: same semantics as the named-provider
+        # branch below (runtime.get("request_overrides")) — a dict merged into
+        # the child's API kwargs by the transport's profile path. Keys are
+        # top-level kwargs (e.g. service_tier); an "extra_body" sub-dict is
+        # merged into extra_body. This is how a direct-endpoint delegation
+        # (provider=custom) forwards OpenRouter routing hints such as
+        # extra_body.provider = {"sort": "throughput"} to its children —
+        # the child's CustomProfile does not emit provider preferences, and
+        # the parent-inheritance path is deliberately cleared when
+        # delegation.provider/base_url overrides the parent (see the
+        # provider-preference clearing in _build_child_agent).
+        configured_request_overrides = cfg.get("request_overrides")
+        request_overrides = (
+            dict(configured_request_overrides)
+            if isinstance(configured_request_overrides, dict)
+            else None
+        )
+
         # When delegation.api_key is not set, return None so _build_child_agent
         # falls back to the parent agent's API key via the credential inheritance
         # path (effective_api_key = override_api_key or parent_api_key). This
@@ -4495,6 +4513,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "base_url": configured_base_url,
             "api_key": api_key,
             "api_mode": api_mode,
+            "request_overrides": request_overrides,
         }
 
     if not configured_provider:


### PR DESCRIPTION
## What
`_resolve_delegation_credentials` direct-base_url branch (delegation.base_url set, provider=custom) now forwards `delegation.request_overrides` to child agents, matching the named-provider branch's contract.

## Why
- `_build_child_agent` clears inherited provider prefs whenever `delegation.provider` is set (`tools/delegate_tool.py:1880-1889`)
- `CustomProfile.build_extra_body` never emits provider prefs
- so the only clean channel for per-child routing prefs (e.g. OpenRouter `provider.sort: throughput`) on direct-endpoint setups is per-child request overrides — which the direct branch dropped

## Verification
- 3 new hermetic tests (forward / absent→None / garbage→None): 3/3
- Neighbors: async_delegation 23/23, delegate batch/output-schema/cron-sync 38/38
- Live dry-run via real transport classes: config → creds → `ChatCompletionsTransport.build_kwargs` → wire `extra_body.provider = {sort: throughput}` — PASS

Takes effect for sessions started after this change (running sessions keep the old module in memory).