### PR TITLE
fix(desktop): park unowned completion notifications instead of dropping them

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -57,6 +57,19 @@ def _neuter_agent_prewarm_timer(request, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _clear_parked_notifications():
+    """Empty the process-global notification park between tests.
+
+    ``server._parked_notifications`` holds addressed events whose owner was
+    not live. It is module state, so an event parked by one test would be
+    claimed by a later test that happens to use the same ``session_key``.
+    """
+    server._parked_notifications.clear()
+    yield
+    server._parked_notifications.clear()
+
+
+@pytest.fixture(autouse=True)
 def _reap_leaked_notification_pollers():
     """Stop and join notification pollers leaked by each test.
 
@@ -6015,6 +6028,93 @@ def test_notification_poller_live_loop_drops_addressed_orphan(
         process_registry._completion_consumed.discard(event["session_id"])
         while not isolated_queue.empty():
             isolated_queue.get_nowait()
+
+
+def test_notification_poller_parks_orphan_until_its_owner_returns(monkeypatch):
+    """An addressed completion outliving its chat is parked, not destroyed.
+
+    Bot Mode delivers a handoff reply exclusively as this notification (see
+    ``messagingProtocolSection`` in the hermes-bots plugin), so destroying it
+    when the owning session is briefly not live loses the reply for good. The
+    owner must still get it when its poller comes back.
+    """
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    delivered = []
+    emitted = []
+    foreign = _session(session_key="unrelated-live-key")
+    event = {
+        "type": "completion",
+        "session_id": "proc-park-owner",
+        "command": "echo reply",
+        "exit_code": 0,
+        "output": "reply",
+        "session_key": "owner-session-key",
+    }
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_emit", lambda *args, **_kwargs: emitted.append(args))
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda _rid, _sid, _session, text: delivered.append(text),
+    )
+    server._sessions["sid-park-foreign"] = foreign
+    process_registry._completion_consumed.discard(event["session_id"])
+
+    try:
+        # The owner has no live session: a foreign poller may neither inject
+        # the event nor throw it away.
+        server._notification_poller_loop(
+            _StopAfterOneNotificationPoll(), "sid-park-foreign", foreign
+        )
+        assert delivered == []
+        assert emitted == []
+        assert isolated_queue.empty()
+        assert len(server._parked_notifications) == 1
+
+        # The owner comes back and claims it on its next poll.
+        owner = _session(session_key="owner-session-key")
+        server._sessions["sid-park-owner"] = owner
+        server._notification_poller_loop(
+            _StopAfterOneNotificationPoll(), "sid-park-owner", owner
+        )
+        assert server._parked_notifications == []
+        assert len(delivered) == 1
+        assert "proc-park-owner" in delivered[0]
+    finally:
+        server._sessions.pop("sid-park-foreign", None)
+        server._sessions.pop("sid-park-owner", None)
+        process_registry._completion_consumed.discard(event["session_id"])
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
+def test_park_unowned_notification_needs_a_durable_key():
+    """Without a ``session_key`` there is no identity to hand it back to."""
+    assert server._park_unowned_notification({"type": "completion"}) is False
+    assert server._parked_notifications == []
+
+
+def test_parked_notifications_expire_after_the_ttl(monkeypatch):
+    """A parked event whose owner never returns is pruned, not kept forever."""
+    event = {
+        "type": "completion",
+        "session_id": "proc-park-stale",
+        "session_key": "gone-forever",
+    }
+    assert server._park_unowned_notification(event) is True
+    assert len(server._parked_notifications) == 1
+
+    stale = time.time() - server._PARKED_NOTIFICATION_TTL_SECONDS - 1
+    server._parked_notifications[:] = [(stale, event)]
+    session = _session(session_key="someone-else")
+    assert server._claim_parked_notifications("sid-ttl", session) == 0
+    assert server._parked_notifications == []
 
 
 @pytest.mark.parametrize(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9786,6 +9786,74 @@ def _notification_event_requires_owner(evt: dict) -> bool:
     )
 
 
+# An addressed notification whose owner has no live session used to be
+# destroyed on the spot, which silently lost the completion for a background
+# process that outlived its chat (Bot Mode handoff replies are delivered
+# exclusively this way). Park it here instead: the owner's poller claims it
+# when the session comes back, and nothing is re-queued in the meantime, so
+# the "re-queued events spin the poller" hazard does not apply.
+_PARKED_NOTIFICATION_TTL_SECONDS = 24 * 60 * 60
+_parked_notifications: "list[tuple[float, dict]]" = []
+_parked_notifications_lock = threading.Lock()
+
+
+def _prune_parked_notifications_locked(now: float) -> None:
+    """Drop parked events past the TTL. Caller holds the lock."""
+    _parked_notifications[:] = [
+        (ts, evt)
+        for (ts, evt) in _parked_notifications
+        if now - ts < _PARKED_NOTIFICATION_TTL_SECONDS
+    ]
+
+
+def _park_unowned_notification(evt: dict) -> bool:
+    """Hold ``evt`` for a session that is not live yet. True when parked.
+
+    Only events carrying a durable ``session_key`` can be parked: without one
+    there is no identity to hand the event back to later, so the caller keeps
+    the old drop behavior.
+    """
+    if not str(evt.get("session_key") or ""):
+        return False
+    now = time.time()
+    identity = _notification_event_dedup_key(evt)
+    with _parked_notifications_lock:
+        _prune_parked_notifications_locked(now)
+        for _ts, parked in _parked_notifications:
+            if _notification_event_dedup_key(parked) == identity:
+                return True
+        _parked_notifications.append((now, evt))
+    return True
+
+
+def _claim_parked_notifications(sid: str, session: dict) -> int:
+    """Re-queue parked events this session provably owns. Returns the count.
+
+    Called from the poller loop rather than session init because a session's
+    ``session_key`` is populated from a later frame, so init is too early to
+    match reliably.
+    """
+    if not _parked_notifications:
+        return 0
+    now = time.time()
+    claimed: list = []
+    with _parked_notifications_lock:
+        _prune_parked_notifications_locked(now)
+        kept: "list[tuple[float, dict]]" = []
+        for ts, evt in _parked_notifications:
+            if _session_owns_notification_event(sid, session, evt):
+                claimed.append(evt)
+            else:
+                kept.append((ts, evt))
+        _parked_notifications[:] = kept
+    if claimed:
+        from tools.process_registry import process_registry
+
+        for evt in claimed:
+            process_registry.completion_queue.put(evt)
+    return len(claimed)
+
+
 def _notification_event_dedup_key(evt: dict) -> tuple:
     """Return the UI-emission identity for a process notification event.
 
@@ -10109,6 +10177,15 @@ def _notification_poller_loop(
     _last_loop_poll = 0.0
     while not stop_event.is_set() and not session.get("_finalized"):
         _now = time.monotonic()
+        # Re-queue anything parked for this session while it was not live.
+        try:
+            _claim_parked_notifications(sid, session)
+        except Exception as _park_exc:
+            print(
+                f"[tui_gateway] parked notification claim failed: "
+                f"{type(_park_exc).__name__}: {_park_exc}",
+                file=sys.stderr,
+            )
         # ── /loop wakeup driver ──────────────────────────────────────
         # Fire a due /loop tick for THIS session while it's idle. Same
         # claim-under-lock pattern as the kanban dispatch below. Active
@@ -10183,6 +10260,15 @@ def _notification_poller_loop(
         # ownerless ordinary notifications retain legacy global delivery.
         requires_owner = _notification_event_requires_owner(evt)
         if requires_owner and not _session_owns_notification_event(sid, session, evt):
+            if _park_unowned_notification(evt):
+                logger.debug(
+                    "Parking unowned %s notification for its owner "
+                    "(key=%r); session %s does not own it",
+                    evt.get("type", "completion"),
+                    str(evt.get("session_key") or ""),
+                    sid,
+                )
+                continue
             log = (
                 logger.warning
                 if evt.get("type") == "async_delegation"
@@ -10280,6 +10366,13 @@ def _notification_poller_loop(
         if requires_owner and not _session_owns_notification_event(sid, session, evt):
             if evt.get("type") == "async_delegation":
                 deferred.append(evt)
+            elif _park_unowned_notification(evt):
+                logger.debug(
+                    "Parking unowned %s notification during shutdown drain "
+                    "(key=%r)",
+                    evt.get("type", "completion"),
+                    str(evt.get("session_key") or ""),
+                )
             else:
                 logger.debug(
                     "Dropping unowned %s notification during shutdown drain "

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9849,6 +9849,11 @@ def _claim_parked_notifications(sid: str, session: dict) -> int:
     if claimed:
         from tools.process_registry import process_registry
 
+        # Re-queued at the TAIL, so a returning owner sees its parked
+        # completion after any newly-produced events rather than in original
+        # emission order. Harmless for completions, which are independent
+        # terminal events; revisit if a consumer ever needs FIFO across the
+        # park boundary.
         for evt in claimed:
             process_registry.completion_queue.put(evt)
     return len(claimed)


### PR DESCRIPTION
Fixes #90879.

## What

A background process notification addressed to a session that is not currently live is destroyed instead of being kept for its owner. This parks it instead, and the owning session claims it on its next poll.

## Why

`_notification_poller_loop` has three outcomes for an addressed event: owned by another live session means requeue, ownerless means deliver, and addressed but with no live owner means a bare `continue`. That third case is silent data loss. The registry captures the exit code and the full output, so the completion exists, but nobody is ever told it happened.

Bot Mode makes it severe. `messagingProtocolSection` in the hermes-bots plugin gives every agent exactly one reply channel for a handoff:

> Run the send with background=true and notify_on_complete=true on the terminal tool, then finish your turn, the reply arrives later as a background process notification. Never block waiting for it.

So a handoff whose recipient takes longer than the user stays in that chat loses the reply permanently, while the caller sits there having promised to relay it. That is what #90879 documents, with the captured debug line:

```
Dropping unowned completion notification (origin='' key='20260820_065034_4e22d9')
instead of delivering to session 7c762f4f
```

`key` is the rightful owner. `7c762f4f` is an unrelated session whose poller woke first.

## How it works

- Park the event in a module-level list under a lock, keyed by nothing more than its own identity, and return early.
- The poller claims parked events it provably owns at the top of each iteration, reusing the existing fail-closed `_session_owns_notification_event`.
- Parked events expire after 24 hours, so an owner that never comes back cannot leak them.

Notes on the design:

- **No poller spin.** Parked events leave the queue entirely, so this does not reintroduce the busy loop that the existing requeue paths guard against with sleeps.
- **Parking needs a durable `session_key`.** Without one there is no identity to hand the event back to later, so the previous drop behavior is kept for those.
- **The claim lives in the poller loop, not `_start_notification_poller`,** because `session["session_key"]` is populated from a later frame, so init is too early to match reliably.
- **Async delegation behavior is untouched.** Those events already had a deferral path and keep it.
- Parking is in-memory, so a backend restart still loses events. Durable parking, along the lines of `restore_undelivered_completions`, would be the natural follow-up if you want it.

## How to test

Reproduction on a Desktop attached to a remote `hermes serve`:

1. In a bot's canonical "Bot Chat", run `terminal(background=true, notify_on_complete=true)` with `for i in $(seq 1 90); do echo tick $i; sleep 2; done`.
2. End the turn and switch to a different chat so the session's poller is torn down.
3. Before this change the completion never arrives and the debug line above is logged. After it, the notification is delivered when you return to the chat.

Automated:

```
scripts/run_tests.sh tests/test_tui_gateway_server.py
scripts/run_tests.sh tests/tools/test_process_registry.py
scripts/run_tests.sh tests/tools/test_notify_on_complete.py
```

693 passed, 4 skipped across those three files on Python 3.11.16, Linux.

New tests:

- `test_notification_poller_parks_orphan_until_its_owner_returns` covers the whole path: a foreign poller may neither inject nor destroy the event, and the owner receives it when it returns.
- `test_park_unowned_notification_needs_a_durable_key`
- `test_parked_notifications_expire_after_the_ttl`

A behavior-only probe asserting that the owner eventually receives the completion fails on unpatched `f43eabee5f` with `delivered == []` and passes with this change.

The two existing orphan tests still pass. `test_notification_poller_drops_orphaned_events` covers both routings: the `origin_ui_session_id` case has no `session_key` and still drops, and the `session_key` case now parks, with its assertions (nothing delivered, nothing emitted, queue drained) holding either way.

An autouse fixture clears the new module state between tests, for the same reason as the existing poller reaper: it is process global and would otherwise leak across tests that share a `session_key`.

## Platforms

Tested on Linux (Debian, Python 3.11.16). No platform specific APIs are involved: the change is a list, a lock, and `time.time()`.
