### PR TITLE
fix(state): surface archived+hidden sessions in the archived-only listing

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8765,7 +8765,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             where_clauses.append("s.archived = 1")
         elif not include_archived:
             where_clauses.append("s.archived = 0")
-        if not include_hidden:
+        if not include_hidden and not archived_only:
+            # The archived-only view is the recovery surface for sessions
+            # that dropped out of every default list. A row that is both
+            # archived and hidden (Bot Mode marks its sessions hidden) must
+            # still be reachable there, otherwise it is unrecoverable from
+            # any UI — only direct DB access can bring it back (#90946).
             where_clauses.append("s.hidden = 0")
 
         where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""

--- a/tests/hermes_state/test_session_archiving.py
+++ b/tests/hermes_state/test_session_archiving.py
@@ -49,3 +49,18 @@ def test_unarchiving_compression_tip_unarchives_projected_root(db):
     assert db.get_session("root")["archived"] == 0
     assert db.get_session("tip")["archived"] == 0
     assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True)] == ["tip"]
+
+
+def test_archived_only_view_includes_hidden_archived_sessions(db):
+    """The archived-only view is the recovery surface: a session that is both
+    archived and hidden (Bot Mode marks its sessions hidden) must appear
+    there, otherwise it is unreachable from every UI list (#90946)."""
+    db.create_session("plain", source="cli")
+    db.create_session("both", source="cli")
+    assert db.set_session_hidden("both", True) is True
+    assert db.set_session_archived("both", True) is True
+
+    # Default list: hidden rows stay excluded (unchanged behaviour)...
+    assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True)] == ["plain"]
+    # ...and the archived-only view must surface the archived+hidden row.
+    assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True, archived_only=True)] == ["both"]


### PR DESCRIPTION
## What does this PR do?

Fixes the session-recovery dead end where a session that is both `archived=1` and `hidden=1` is unreachable from every UI list. `list_sessions_rich()` applied the `hidden = 0` filter even when `archived_only=True`, so a row with both flags set was excluded from the default list by `archived = 0` AND from the archived-only list by `hidden = 0` — only direct DB/API access could bring it back (#90946). Hidden is not exotic: Bot Mode's `session.set_hidden` sets it on bot sessions, and a user's main session can end up with it after profile cross-talk.

The archived-only view is the recovery surface, so it now includes hidden rows: the `hidden = 0` clause is skipped when `archived_only` is set. Everything else is unchanged — the default list still excludes hidden sessions, and `include_hidden=True` keeps its explicit-override meaning. The two other `archived_only` sites (`session_count`, `session_count_by_source`) have no hidden filter and are unaffected.

## Related Issue

Fixes #90946

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` — `list_sessions_rich()`: the `hidden = 0` WHERE clause is now guarded with `and not archived_only`, with a comment documenting the recovery-surface rationale (#90946)
- `tests/hermes_state/test_session_archiving.py` — regression test: an archived+hidden session stays excluded from the default list but appears in the `archived_only=True` listing

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_state/test_session_archiving.py -q` — should pass (3 passed, including the new `test_archived_only_view_includes_hidden_archived_sessions`)
2. Observed result: with the fix stashed, the new test fails (`archived_only` listing returns `[]` for the archived+hidden row — the #90946 dead end); with the fix it returns the row
3. `.venv/bin/python -m pytest tests/hermes_state/ -q` — should pass; on this dev machine one pre-existing environment-sensitive failure remains (`test_live_db_guard_ancestry` — verified to fail identically on unmodified main via `git stash`对照; it spawns a real child probe against this machine's live state root and is unrelated to listing filters). CI's clean environment is unaffected.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (recovery-surface rationale inline)
- [x] Tests added that prove the fix (default-list exclusion unchanged + archived-only inclusion)
- [x] All new and existing tests pass locally (hermes_state: 151 passed; 1 pre-existing env-sensitive failure present on unmodified main too)
- [x] Platform: macOS (SQL filter change, platform-independent)
