### PR TITLE
fix(bot-mode): persist canonical chat before opening

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3495,6 +3495,21 @@ function createCanonicalChat(name) {
     const sid = res?.stored_session_id
     const runtime = res?.session_id
 
+    // session.create is intentionally lazy: its stored row does not exist until
+    // the first prompt. Mounting `sid` immediately therefore emits a noisy REST
+    // 404 ("Session not found"), and the turn-start auto-titler can win the race
+    // against the deferred `title: 'Bot Chat'`, breaking canonical-chat identity
+    // on the next click. session.title materializes the row now and records a
+    // user-authority title before either the open or kickoff. Older gateways may
+    // not support the eager write; retain the kickoff-and-retry fallback below.
+    if (runtime) {
+      try {
+        await host.request('session.title', { session_id: runtime, title: 'Bot Chat' })
+      } catch {
+        /* compatibility fallback: prompt.submit will persist the lazy row */
+      }
+    }
+
     if (sid) {
       saveBotMeta(name, { chat: sid })
     }

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-creation.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-creation.test.mjs
@@ -25,7 +25,31 @@ function loadCanonicalCreation({ openSession, request }) {
   return { ...context.__canonical, saved }
 }
 
-test('regression: navigation retries after the kickoff persists a new canonical chat', async () => {
+test('regression: creation materializes and titles the lazy row before opening it', async () => {
+  const events = []
+  const runtime = loadCanonicalCreation({
+    openSession: async id => events.push(`open:${id}`),
+    request: async (method, params) => {
+      events.push(method)
+      if (method === 'session.create') return { stored_session_id: 'stored-1', session_id: 'runtime-1' }
+      if (method === 'session.title') {
+        assert.deepEqual(params, { session_id: 'runtime-1', title: 'Bot Chat' })
+      }
+      return {}
+    }
+  })
+
+  assert.equal(await runtime.createCanonicalChat('ops'), 'stored-1')
+  assert.deepEqual(events, [
+    'session.list',
+    'session.create',
+    'session.title',
+    'open:stored-1',
+    'prompt.submit'
+  ])
+})
+
+test('compatibility: navigation retries after kickoff when eager title persistence is unavailable', async () => {
   const events = []
   let attempts = 0
   const runtime = loadCanonicalCreation({
@@ -36,6 +60,7 @@ test('regression: navigation retries after the kickoff persists a new canonical 
     },
     request: async method => {
       if (method === 'session.create') return { stored_session_id: 'stored-1', session_id: 'runtime-1' }
+      if (method === 'session.title') throw new Error('unknown method')
       if (method === 'prompt.submit') events.push('kickoff:persisted')
       return {}
     }


### PR DESCRIPTION
## Bug Description

Creating a Bot Mode agent's first canonical chat can log repeated `404: {"detail":"Session not found"}` errors when the bot row is clicked. The same race can let the kickoff prompt auto-title the session instead of preserving `Bot Chat`, so later clicks no longer recognize it as canonical.

## Root Cause

`session.create` intentionally returns a stored session key before materializing its `state.db` row. Bot Mode immediately tries to open that key, so the REST hydration request races the first prompt and can 404. The deferred `title: 'Bot Chat'` also races turn-start auto-titling.

## Fix

- Call `session.title` with the runtime session ID immediately after `session.create`.
- Materialize the lazy row and persist `Bot Chat` at user-title authority before opening or submitting the kickoff.
- Preserve the existing kickoff-and-retry path when an older gateway does not support eager title persistence.
- Add regression coverage for request ordering and the compatibility fallback.

## How to Verify

1. Create a fresh Bot Mode agent with no existing canonical chat.
2. Click its roster row and confirm no `Session not found` 404 is emitted.
3. Confirm the stored session remains titled `Bot Chat` and subsequent clicks reuse it.

## Test Plan

- [x] Regression test fails when the implementation change is removed and passes when restored.
- [x] `node --test tests/*.test.mjs` — 342 passed.
- [x] `npm run typecheck`.
- [x] `npm run lint` — 0 errors; existing repository warnings only.
- [x] `npm run build`.
- [x] Reproduced the original failure against a live macOS Desktop connected to an SSH-backed Hermes host and verified repaired canonical session metadata.

## Risk Assessment

Low — the change is confined to first-time canonical-chat creation, uses an existing gateway RPC, and retains the previous persistence/retry behavior as a compatibility fallback.
