### PR TITLE
fix(desktop): sidebar rows own their right edge (trailing inset in the shell)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/chrome.tsx
+++ b/apps/desktop/src/app/chat/sidebar/chrome.tsx
@@ -23,9 +23,19 @@ export function SidebarSectionMeta({ children }: { children: React.ReactNode }) 
 // Height lives ONLY on SidebarRowShell (min-h-[1.625rem]). Inset children
 // stretch to fill the cell and center content internally — never items-center
 // on the shell grid, or short clusters (projects) float 1–2px off sessions.
+//
+// `rowPadX` is the BODY's padding: the lead's inset, plus the gap the label
+// keeps from the actions column, both inside the row's click target.
+// `rowPadTrail` is the row's own trailing inset and belongs to the SHELL — the
+// only box containing both the actions column AND the card's in-body cluster,
+// so one class insets every trailing thing a row can render. Owned anywhere
+// else, the age / chips / kebab sit flush on the border box, which is exactly
+// where a working row paints its arc (`.arc-row` has zero standoff) — the ring
+// ran through the text.
 
 const rowMinH = 'min-h-[1.625rem]'
-const rowPadX = 'pl-2 pr-1'
+const rowPadX = 'pl-2 pr-2'
+const rowPadTrail = 'pr-2'
 const rowGap = 'gap-1.5'
 const rowLead = 'grid size-3.5 shrink-0 place-items-center'
 const rowInset = cn(rowPadX, rowGap, 'flex h-full min-w-0 items-center self-stretch py-0.5')
@@ -71,9 +81,11 @@ export function SidebarDateDivider({
   )
 }
 
-/** Outer grid — sole owner of row height. The trailing `actions` slot is
- *  marked `data-row-actions` so a row-wide drag gesture can exclude it with
- *  one selector: it holds real controls, never grab surface. */
+/** Outer grid — sole owner of row height and of the trailing inset. The
+ *  `actions` slot is marked `data-row-actions` so a row-wide drag gesture can
+ *  exclude it with one selector: it holds real controls, never grab surface.
+ *  It stretches so that exclusion covers the column, not just its tallest
+ *  control. */
 export function SidebarRowShell({
   actions,
   actionsClassName,
@@ -82,10 +94,13 @@ export function SidebarRowShell({
   ...props
 }: React.ComponentProps<'div'> & { actions?: React.ReactNode; actionsClassName?: string }) {
   return (
-    <div className={cn(rowMinH, 'grid grid-cols-[minmax(0,1fr)_auto] items-stretch rounded-md', className)} {...props}>
+    <div
+      className={cn(rowMinH, rowPadTrail, 'grid grid-cols-[minmax(0,1fr)_auto] items-stretch rounded-md', className)}
+      {...props}
+    >
       {children}
       {actions ? (
-        <div className={cn('flex shrink-0 items-center self-center', actionsClassName)} data-row-actions>
+        <div className={cn('flex shrink-0 items-center self-stretch', actionsClassName)} data-row-actions>
           {actions}
         </div>
       ) : null}

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -23,6 +23,7 @@ import type { CronJob } from '@/types/hermes'
 import { jobState, jobTitle, STATE_DOT } from '../../cron/job-state'
 import { SidebarPanelLabel } from '../../shell/sidebar-label'
 
+import { SidebarRowBody, SidebarRowLabel, SidebarRowLead, SidebarRowShell } from './chrome'
 import { SidebarLoadMoreRow } from './load-more-row'
 
 const INACTIVE_STATES = new Set(['completed', 'disabled', 'error', 'paused'])
@@ -304,21 +305,57 @@ function CronJobSidebarRow({
 
   return (
     <div>
+      {/* The shared row chrome, not a copy of it: a cron job and a session sit
+          in the same list, so they line up only if one place owns the geometry. */}
       <ActionsContextMenu ariaLabel={c.actionsTitle} contentClassName="w-44" items={items}>
-        <div className="group/cron relative grid min-h-[1.625rem] grid-cols-[minmax(0,1fr)_auto] items-center rounded-md hover:bg-(--chrome-action-hover)">
-          {/* Lead with the dot in the same w-3.5 cell + pl-2 the session rows use
-              so the cron dots line up with the sessions above; the caret sits next
-              to the label (matching the other sidebar disclosures) and the whole
-              label area toggles the run peek. */}
+        <SidebarRowShell
+          actions={
+            /* Trailing cluster: countdown by default, quick actions on hover. */
+            <div className="flex items-center gap-0.5">
+              <span className="text-[0.6875rem] text-(--ui-text-tertiary) tabular-nums group-hover/cron:hidden">
+                {meta}
+              </span>
+              <div className="hidden items-center gap-0.5 group-hover/cron:flex">
+                <Tip label={c.triggerNow}>
+                  <button
+                    aria-label={c.triggerNow}
+                    className="grid size-5 place-items-center rounded-sm text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground disabled:cursor-wait disabled:opacity-60"
+                    disabled={busy}
+                    onClick={onTrigger}
+                    type="button"
+                  >
+                    {busy ? (
+                      <GlyphSpinner ariaLabel={c.triggerNow} className="text-[0.75rem]" />
+                    ) : (
+                      <Codicon name="zap" size="0.75rem" />
+                    )}
+                  </button>
+                </Tip>
+                <Tip label={c.manage}>
+                  <button
+                    aria-label={c.manage}
+                    className="grid size-5 place-items-center rounded-sm text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground"
+                    onClick={onManage}
+                    type="button"
+                  >
+                    <Codicon name="watch" size="0.75rem" />
+                  </button>
+                </Tip>
+              </div>
+            </div>
+          }
+          className="group/cron relative hover:bg-(--chrome-action-hover)"
+        >
+          {/* The caret sits next to the label (matching the other sidebar
+              disclosures) and the whole label area toggles the run peek. */}
           <Tip label={label}>
-            <button
+            <SidebarRowBody
               aria-expanded={expanded}
               aria-label={expanded ? c.hideRuns : c.showRuns}
-              className="flex min-w-0 items-center gap-1.5 bg-transparent py-0.5 pl-2 pr-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+              className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
               onClick={onTogglePeek}
-              type="button"
             >
-              <span className="grid w-3.5 shrink-0 place-items-center">
+              <SidebarRowLead>
                 <span
                   aria-hidden="true"
                   className={cn(
@@ -327,10 +364,8 @@ function CronJobSidebarRow({
                     state === 'running' && 'size-1.5 animate-pulse'
                   )}
                 />
-              </span>
-              <span className="min-w-0 truncate text-[0.8125rem] text-(--ui-text-secondary) group-hover/cron:text-foreground">
-                {label}
-              </span>
+              </SidebarRowLead>
+              <SidebarRowLabel className="group-hover/cron:text-foreground">{label}</SidebarRowLabel>
               <DisclosureCaret
                 className={cn(
                   'shrink-0 text-(--ui-text-tertiary) transition',
@@ -338,42 +373,9 @@ function CronJobSidebarRow({
                 )}
                 open={expanded}
               />
-            </button>
+            </SidebarRowBody>
           </Tip>
-          {/* Trailing cluster: countdown by default, quick actions on hover. */}
-          <div className="flex items-center gap-0.5 justify-self-end pr-1">
-            <span className="text-[0.6875rem] text-(--ui-text-tertiary) tabular-nums group-hover/cron:hidden">
-              {meta}
-            </span>
-            <div className="hidden items-center gap-0.5 group-hover/cron:flex">
-              <Tip label={c.triggerNow}>
-                <button
-                  aria-label={c.triggerNow}
-                  className="grid size-5 place-items-center rounded-sm text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground disabled:cursor-wait disabled:opacity-60"
-                  disabled={busy}
-                  onClick={onTrigger}
-                  type="button"
-                >
-                  {busy ? (
-                    <GlyphSpinner ariaLabel={c.triggerNow} className="text-[0.75rem]" />
-                  ) : (
-                    <Codicon name="zap" size="0.75rem" />
-                  )}
-                </button>
-              </Tip>
-              <Tip label={c.manage}>
-                <button
-                  aria-label={c.manage}
-                  className="grid size-5 place-items-center rounded-sm text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground"
-                  onClick={onManage}
-                  type="button"
-                >
-                  <Codicon name="watch" size="0.75rem" />
-                </button>
-              </Tip>
-            </div>
-          </div>
-        </div>
+        </SidebarRowShell>
       </ActionsContextMenu>
       {expanded && <CronJobSidebarRuns jobId={job.id} onOpenRun={onOpenRun} />}
     </div>

--- a/apps/desktop/src/app/chat/sidebar/load-more-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/load-more-row.tsx
@@ -11,7 +11,9 @@ interface SidebarLoadMoreRowProps {
 
 // Compact "load more" affordance shared by recents, messaging, and cron. Kept
 // intentionally identical to workspace "show more" controls (ellipsis button)
-// so pagination reads as one interaction everywhere.
+// so pagination reads as one interaction everywhere. It hangs off the list
+// instead of sitting in a row, so it repeats the row's trailing inset
+// (SidebarRowShell's `pr-2`) to stay on the edge the rows stop at.
 export function SidebarLoadMoreRow({ step, onClick, loading = false }: SidebarLoadMoreRowProps) {
   const { t } = useI18n()
   const label = loading ? t.sidebar.loading : step > 0 ? t.sidebar.loadCount(step) : t.sidebar.loadMore
@@ -20,7 +22,7 @@ export function SidebarLoadMoreRow({ step, onClick, loading = false }: SidebarLo
     <Tip label={label}>
       <button
         aria-label={label}
-        className="ml-auto grid size-5 place-items-center rounded-sm bg-transparent text-(--ui-text-tertiary) transition-colors hover:bg-(--ui-control-hover-background) hover:text-foreground disabled:cursor-default disabled:opacity-60 disabled:hover:bg-transparent disabled:hover:text-(--ui-text-tertiary)"
+        className="mr-2 ml-auto grid size-5 place-items-center rounded-sm bg-transparent text-(--ui-text-tertiary) transition-colors hover:bg-(--ui-control-hover-background) hover:text-foreground disabled:cursor-default disabled:opacity-60 disabled:hover:bg-transparent disabled:hover:text-(--ui-text-tertiary)"
         disabled={loading}
         onClick={onClick}
         type="button"

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
@@ -48,6 +48,8 @@ export function WorkspaceAddButton({ label, onClick }: { label: string; onClick:
 }
 
 // Reveals the next page of already-loaded rows within a workspace/worktree.
+// Hangs off the lane instead of sitting in a row, so it repeats the row's
+// trailing inset (SidebarRowShell's `pr-2`) to stay on the edge the rows stop at.
 export function WorkspaceShowMoreButton({
   count,
   label,
@@ -64,7 +66,7 @@ export function WorkspaceShowMoreButton({
     <Tip label={text}>
       <button
         aria-label={text}
-        className="ml-auto grid size-5 place-items-center rounded-sm bg-transparent text-(--ui-text-tertiary) transition-colors hover:bg-(--ui-control-hover-background) hover:text-foreground"
+        className="mr-2 ml-auto grid size-5 place-items-center rounded-sm bg-transparent text-(--ui-text-tertiary) transition-colors hover:bg-(--ui-control-hover-background) hover:text-foreground"
         onClick={onClick}
         type="button"
       >

--- a/apps/desktop/src/app/chat/sidebar/right-edge-ownership.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/right-edge-ownership.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Regression test for PR #90920 — "Sidebar rows own their right edge".
+ *
+ * Renders the REAL sidebar chrome components and asserts the geometry
+ * contract at the DOM level: the SHELL owns the trailing (right-edge) inset.
+ *
+ * Post-fix contract:
+ *   - SidebarRowShell:      owns the trailing inset (rowPadTrail = 'pr-2')
+ *   - actions slot:         self-stretch (drag exclusion covers the whole
+ *                           column), inset by the shell's own pr-2
+ *   - SidebarRowBody:       rowPadX = 'pl-2 pr-2' (lead inset + the
+ *                           label-to-actions gap, both inside the click target)
+ *   - load-more ellipsis:   mr-2 (repeats the row's inset — it hangs off the
+ *                           list where no row geometry reaches it)
+ *   - workspace "show more": same mr-2 repeat
+ *
+ * Every trailing thing a row renders — age, chips, kebab, cron countdown,
+ * project totals, ellipses — therefore stops on one right edge (the shell's
+ * pr-2) instead of ending flush on the border box where .arc-row paints its
+ * travelling ring (--arc-standoff: 0rem, styles.css).
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SidebarRowBody, SidebarRowShell } from './chrome'
+import { SidebarLoadMoreRow } from './load-more-row'
+import { WorkspaceShowMoreButton } from './projects/workspace-header'
+
+afterEach(cleanup)
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      sidebar: {
+        loadCount: (n: number) => `Load ${n} more`,
+        loadMore: 'Load more',
+        loading: 'Loading…',
+        projects: {
+          copyPath: 'Copy path',
+          menu: 'Actions',
+          removeWorktree: 'Remove worktree',
+          reveal: 'Reveal in file manager',
+          startWork: 'New worktree'
+        },
+        showMoreIn: (n: number, label: string) => `Show ${n} more in ${label}`
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/projects', () => ({
+  copyPath: vi.fn(),
+  revealPath: vi.fn()
+}))
+
+vi.mock('@/store/coding-status', () => ({
+  openWorktreeDialog: vi.fn()
+}))
+
+const TRAILING = /(?:^|\s)(?:pr|mr)-[\d.]+(?:\s|$)/
+
+describe('right-edge ownership (PR #90920)', () => {
+  it('SidebarRowShell owns the trailing inset: shell pr-2, actions self-stretch, body pl-2 pr-2', () => {
+    const { container } = render(
+      <SidebarRowShell actions={<span>age</span>}>
+        <SidebarRowBody>title</SidebarRowBody>
+      </SidebarRowShell>
+    )
+
+    // The shell is the outer grid and now owns the trailing inset — one class
+    // (rowPadTrail = 'pr-2') insets every trailing thing a row can render.
+    const shell = container.firstElementChild as HTMLElement
+    expect(shell.className).toContain('grid grid-cols-[minmax(0,1fr)_auto]')
+    expect(shell.className).toMatch(/pr-2/)
+
+    // The actions slot stretches so the drag-exclusion selector covers the
+    // whole column, not just its tallest control — and it needs no padding of
+    // its own, because the shell's pr-2 already insets it.
+    const actions = shell.querySelector('[data-row-actions]') as HTMLElement
+    expect(actions).toBeTruthy()
+    expect(actions.className).toMatch(/self-stretch/)
+    expect(actions.className).not.toMatch(/self-center/)
+    expect(actions.className).not.toMatch(TRAILING)
+
+    // The body carries rowPadX = 'pl-2 pr-2': the lead's inset plus the
+    // label-to-actions gap, both inside the row's click target.
+    const body = shell.querySelector('button') as HTMLElement
+    expect(body.className).toMatch(/pl-2/)
+    expect(body.className).toMatch(/pr-2/)
+  })
+
+  it('the one-line session row actions column is inset by the shell, not flush', () => {
+    // session-row.tsx passes its actions cluster to the shell's actions slot,
+    // so the trailing text now stops at the shell's pr-2 instead of the
+    // border box the arc paints on.
+    const { container } = render(
+      <SidebarRowShell actions={<span data-testid="trailing">5m</span>}>
+        <SidebarRowBody>Session title</SidebarRowBody>
+      </SidebarRowShell>
+    )
+
+    const trailing = container.querySelector('[data-row-actions]') as HTMLElement
+    expect(trailing).toBeTruthy()
+    // No per-caller padding: the inset is owned by the shell one level up.
+    expect(trailing.className).not.toMatch(TRAILING)
+
+    const shell = container.firstElementChild as HTMLElement
+    expect(shell.className).toMatch(/pr-2/)
+  })
+
+  it('the load-more ellipsis repeats the row trailing inset with mr-2', () => {
+    render(<SidebarLoadMoreRow onClick={() => {}} step={20} />)
+
+    const button = screen.getByRole('button')
+    expect(button.className).toMatch(/ml-auto/)
+    expect(button.className).toMatch(/mr-2/)
+  })
+
+  it('the workspace "show more" ellipsis repeats the row trailing inset with mr-2', () => {
+    render(<WorkspaceShowMoreButton count={5} label="Test D" onClick={() => {}} />)
+
+    const button = screen.getByRole('button', { name: 'Show 5 more in Test D' })
+    expect(button.className).toMatch(/ml-auto/)
+    expect(button.className).toMatch(/mr-2/)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/section-states.tsx
+++ b/apps/desktop/src/app/chat/sidebar/section-states.tsx
@@ -4,19 +4,22 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
 
+import { SidebarRowCluster, SidebarRowShell, SidebarRowStack } from './chrome'
+
+// Stands in for session rows, so it borrows their chrome instead of copying
+// the grid — a placeholder on a different edge than the rows it resolves into
+// makes the list step sideways on load.
 export function SidebarSessionSkeletons() {
   return (
-    <div aria-hidden="true" className="grid gap-px">
+    <SidebarRowStack aria-hidden="true">
       {['w-32', 'w-40', 'w-28', 'w-36', 'w-24'].map((width, i) => (
-        <div
-          className="grid min-h-[1.625rem] grid-cols-[minmax(0,1fr)_1.375rem] items-center rounded-md pl-2"
-          key={`${width}-${i}`}
-        >
-          <Skeleton className={cn('h-3 rounded-sm', width)} />
-          <Skeleton className="mx-auto size-3.5 rounded-sm opacity-60" />
-        </div>
+        <SidebarRowShell actions={<Skeleton className="size-3.5 rounded-sm opacity-60" />} key={`${width}-${i}`}>
+          <SidebarRowCluster>
+            <Skeleton className={cn('h-3 rounded-sm', width)} />
+          </SidebarRowCluster>
+        </SidebarRowShell>
       ))}
-    </div>
+    </SidebarRowStack>
   )
 }
 

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -8,6 +8,7 @@ import { createClientSessionState } from '@/lib/chat-runtime'
 import type * as ChatRuntime from '@/lib/chat-runtime'
 import type * as Time from '@/lib/time'
 import type * as ComposerStatusStore from '@/store/composer-status'
+import type * as ProjectsStore from '@/store/projects'
 import type * as SessionStore from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
 import type * as SessionStatesStore from '@/store/session-states'
@@ -32,7 +33,8 @@ vi.mock('@/i18n', () => ({
           sessionActions: 'Session actions',
           sessionRunning: 'Running',
           waitingForAnswer: 'Waiting for answer'
-        }
+        },
+        projects: { home: 'Home' }
       },
       assistant: {
         thread: {
@@ -112,6 +114,13 @@ vi.mock('@/store/windows', async importOriginal => {
     canOpenSessionWindow: () => false,
     openSessionInNewWindow: vi.fn()
   }
+})
+
+// The card variant reads the projects store to label its workspace header.
+vi.mock('@/store/projects', async importOriginal => {
+  const actual = await importOriginal<typeof ProjectsStore>()
+
+  return { ...actual, $projects: atom({}) }
 })
 
 // SessionActionsMenu open behavior is covered in session-actions-menu.test.tsx
@@ -386,5 +395,49 @@ describe('SidebarSessionRow', () => {
     const avatar = handoffAvatar(container)
     expect(avatar).toBeTruthy()
     expect(tipTrigger(avatar as HTMLElement)).toBeTruthy()
+  })
+
+  // PR #90920 — the shell owns the trailing inset. The one-line row's body
+  // drops its literal `pr-2` (the gap now lives once in rowPadX = 'pl-2 pr-2'),
+  // and the card opts OUT (`pr-0`) because its cluster is inside the body,
+  // ending at the shell's own trailing inset.
+  describe('right-edge ownership (PR #90920)', () => {
+    it('the one-line row body no longer hardcodes pr-2; the shell owns the trailing inset', () => {
+      const { container } = renderRow(makeSession({ title: 'Edge row' }))
+
+      // The main tap target is the first button whose text is the title.
+      const target = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Edge row'))
+      expect(target).toBeTruthy()
+      // rowPadX supplies the label-to-actions gap: pl-2 pr-2.
+      expect(target?.className).toMatch(/pl-2/)
+      expect(target?.className).toMatch(/pr-2/)
+
+      // The actions column ends inside the shell's own pr-2, not flush.
+      const actions = container.querySelector('[data-row-actions]')
+      expect(actions).toBeTruthy()
+    })
+
+    it('the card body opts out of the trailing gap (pr-0) so the header shares the shell edge', () => {
+      const { container } = render(
+        <SidebarSessionRow
+          card
+          isPinned={false}
+          isSelected={false}
+          onArchive={noop}
+          onDelete={noop}
+          onPin={noop}
+          onResume={noop}
+          onToggleUnread={noop}
+          session={makeSession({ title: 'Card row' })}
+          unread={false}
+        />
+      )
+
+      const target = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('Card row'))
+      expect(target).toBeTruthy()
+      // The card's cluster is INSIDE the body, ending at the shell's trailing
+      // inset — keeping the gap would pull the header in past every line below.
+      expect(target?.className).toMatch(/pr-0/)
+    })
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -405,9 +405,13 @@ function SidebarSessionRowImpl({
         <SidebarRowBody
           // Every trailing figure lives in the actions slot, which the row
           // measures — so the title needs a gap from it and nothing else. Hover
-          // changes what you can see in that slot, never how wide it is.
+          // changes what you can see in that slot, never how wide it is. The
+          // card has no such column to clear (its cluster is INSIDE the body,
+          // ending at the shell's own trailing inset), and keeping the gap
+          // would pull the header in past every line below it.
           className={cn(
-            'z-0 pr-2',
+            'z-0',
+            card && 'pr-0',
             branchStem && 'pl-3.5',
             // The card is a grid with ONE spacing knob: --card-gap. Every row
             // gap is gap-y-(--card-gap); the title/preview group opts out


### PR DESCRIPTION
Implements the sidebar right-edge ownership fix described in #90920.

**Problem:** no single box owns the trailing inset of a sidebar row. `SidebarRowShell` owns height and the body owns the leading inset, but the trailing side is left to each caller — the one-line session row's actions column (age / chips / kebab) sits flush on the border box, which is exactly the pixel a working row's arc (`.arc-row`, `--arc-standoff: 0rem`) paints on, so the animation ran through the text. Four surfaces, four answers (flush / 8px / 4px / flush), one visible right edge.

**Fix:**
- `SidebarRowShell` now owns the trailing inset (`rowPadTrail = 'pr-2'`) — one class insets every trailing thing a row can render.
- `rowPadX` becomes the body's `pl-2 pr-2` (lead inset + label-to-actions gap); the one-line row's body drops its literal `pr-2`, and the card opts out with `pr-0` because its cluster is inside the body, ending at the shell's own inset.
- The actions slot is `self-stretch` so the `data-row-actions` drag-exclusion covers the whole column.
- The cron row composes the shared chrome (`SidebarRowShell` / `SidebarRowBody` / `SidebarRowLead` / `SidebarRowLabel`) instead of a copied grid, so it cannot drift again.
- Both pagination ellipses (load-more row and workspace "show more") repeat the inset explicitly with `mr-2`, since they hang off the list where no row geometry reaches them.
- Session skeletons borrow the shared row chrome too, so placeholders land on the same edge as the rows they become.

**Verification:** sidebar vitest suite 198/198 pass, including new DOM-level regression coverage (`right-edge-ownership.test.tsx`, plus `session-row.test.tsx` additions) that pins the shell-owned trailing inset and the `mr-2` ellipses. Typecheck delta vs base: zero new errors (only the pre-existing `use-session-actions.test.tsx` fixture error, identical at base). ESLint and Prettier clean on all changed files.

Note: this is the same change as upstream PR #90920 by OutThisLife — commits cherry-picked to preserve authorship. If both land, one can be closed.
