### PR TITLE
fix(cron): /blueprint and /suggestions carry the canonical origin shape

### DIFF
--- a/hermes_cli/blueprint_cmd.py
+++ b/hermes_cli/blueprint_cmd.py
@@ -60,17 +60,9 @@ def _resolve_origin(explicit: Optional[Dict[str, Any]]) -> Optional[Dict[str, An
     if explicit is not None:
         return explicit
     try:
-        from gateway.session_context import get_session_env
+        from tools.cronjob_tools import _origin_from_env
 
-        platform = get_session_env("HERMES_SESSION_PLATFORM")
-        chat_id = get_session_env("HERMES_SESSION_CHAT_ID")
-        if platform and chat_id:
-            return {
-                "platform": platform,
-                "chat_id": chat_id,
-                "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME") or None,
-                "thread_id": get_session_env("HERMES_SESSION_THREAD_ID") or None,
-            }
+        return _origin_from_env()
     except Exception:
         pass
     return None

--- a/hermes_cli/suggestions_cmd.py
+++ b/hermes_cli/suggestions_cmd.py
@@ -42,22 +42,18 @@ def _fmt_pending(pending: list) -> str:
 def _resolve_origin() -> Optional[Dict[str, Any]]:
     """Best-effort current-chat origin from session env (CLI and gateway both set it).
 
-    Mirrors cron's ``_origin_from_env`` so an accepted suggestion's job delivers
-    back to the chat where it was accepted. Returns None if unavailable, in
-    which case create_job falls back to a configured home channel.
+    Delegates to cron's canonical ``_origin_from_env`` (scope_id, user_id, the
+    Slack synthetic-per-message-thread guard — see its docstring) so an
+    accepted suggestion's job carries the exact same origin shape a job
+    created any other way does; a hand-rolled subset here previously baked a
+    scope_id-less / user_id-less origin into the job, breaking scoped Slack
+    workspace delivery. Returns None if unavailable, in which case create_job
+    falls back to a configured home channel.
     """
     try:
-        from gateway.session_context import get_session_env
+        from tools.cronjob_tools import _origin_from_env
 
-        platform = get_session_env("HERMES_SESSION_PLATFORM")
-        chat_id = get_session_env("HERMES_SESSION_CHAT_ID")
-        if platform and chat_id:
-            return {
-                "platform": platform,
-                "chat_id": chat_id,
-                "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME") or None,
-                "thread_id": get_session_env("HERMES_SESSION_THREAD_ID") or None,
-            }
+        return _origin_from_env()
     except Exception:
         pass
     return None

--- a/tests/hermes_cli/test_blueprint_cmd_origin.py
+++ b/tests/hermes_cli/test_blueprint_cmd_origin.py
@@ -1,0 +1,62 @@
+"""``/blueprint``'s origin capture must match cron's canonical shape.
+
+``_resolve_origin`` previously hand-rolled a truncated origin dict (platform,
+chat_id, chat_name, thread_id only) instead of delegating to
+``tools.cronjob_tools._origin_from_env`` — the function ``8b6cf434cb`` fixed to
+carry ``scope_id`` (embedded in every scoped Slack session key) and drop the
+Slack synthetic per-message thread stamp. A ``/blueprint`` job created via the
+deterministic ``slot=val`` shortcut baked the truncated shape permanently into
+the job, reproducing the exact "continuation amnesia" bug in a scoped Slack
+workspace that ``8b6cf434cb`` fixed for the main creation path.
+"""
+
+from unittest.mock import patch
+
+from hermes_cli.blueprint_cmd import _resolve_origin
+
+
+def _session_env(env: dict):
+    return patch(
+        "gateway.session_context.get_session_env",
+        side_effect=lambda name, default="": env.get(name, default),
+    )
+
+
+class TestBlueprintResolveOrigin:
+    def test_explicit_origin_passthrough(self):
+        """An explicit origin (dashboard/API caller) is returned untouched."""
+        explicit = {"platform": "slack", "chat_id": "C1"}
+        assert _resolve_origin(explicit) is explicit
+
+    def test_captures_scope_id_and_user_id(self):
+        env = {
+            "HERMES_SESSION_PLATFORM": "slack",
+            "HERMES_SESSION_CHAT_ID": "D0BJTDCSR7C",
+            "HERMES_SESSION_SCOPE_ID": "T0WORKSPACE",
+            "HERMES_SESSION_USER_ID": "U0USER",
+        }
+        with _session_env(env):
+            origin = _resolve_origin(None)
+        assert origin is not None
+        assert origin["platform"] == "slack"
+        assert origin["chat_id"] == "D0BJTDCSR7C"
+        assert origin["scope_id"] == "T0WORKSPACE"
+        assert origin["user_id"] == "U0USER"
+
+    def test_drops_synthetic_slack_per_message_thread(self):
+        """thread_id == message_id on Slack is a session-keying stamp, not a
+        durable thread — must be dropped, same as cron's own creation path."""
+        env = {
+            "HERMES_SESSION_PLATFORM": "slack",
+            "HERMES_SESSION_CHAT_ID": "D0BJTDCSR7C",
+            "HERMES_SESSION_THREAD_ID": "1755043010.123456",
+            "HERMES_SESSION_MESSAGE_ID": "1755043010.123456",
+        }
+        with _session_env(env):
+            origin = _resolve_origin(None)
+        assert origin is not None
+        assert origin["thread_id"] is None
+
+    def test_no_session_env_returns_none(self):
+        with _session_env({}):
+            assert _resolve_origin(None) is None

--- a/tests/hermes_cli/test_suggestions_cmd_origin.py
+++ b/tests/hermes_cli/test_suggestions_cmd_origin.py
@@ -1,0 +1,54 @@
+"""``/suggestions accept``'s origin capture must match cron's canonical shape.
+
+Same bug class as ``tests/hermes_cli/test_blueprint_cmd_origin.py``: the
+module's own docstring claimed to "mirror cron's ``_origin_from_env``" but
+actually mirrored its pre-``8b6cf434cb`` shape (no ``scope_id``/``user_id``,
+no Slack synthetic-thread guard). ``accept_suggestion`` merges this origin
+straight into the persisted job spec (``cron/suggestions.py``), so the gap
+baked a scope_id-less origin into every job created via ``/suggestions
+accept`` in a scoped Slack workspace.
+"""
+
+from unittest.mock import patch
+
+from hermes_cli.suggestions_cmd import _resolve_origin
+
+
+def _session_env(env: dict):
+    return patch(
+        "gateway.session_context.get_session_env",
+        side_effect=lambda name, default="": env.get(name, default),
+    )
+
+
+class TestSuggestionsResolveOrigin:
+    def test_captures_scope_id_and_user_id(self):
+        env = {
+            "HERMES_SESSION_PLATFORM": "slack",
+            "HERMES_SESSION_CHAT_ID": "D0BJTDCSR7C",
+            "HERMES_SESSION_SCOPE_ID": "T0WORKSPACE",
+            "HERMES_SESSION_USER_ID": "U0USER",
+        }
+        with _session_env(env):
+            origin = _resolve_origin()
+        assert origin is not None
+        assert origin["platform"] == "slack"
+        assert origin["chat_id"] == "D0BJTDCSR7C"
+        assert origin["scope_id"] == "T0WORKSPACE"
+        assert origin["user_id"] == "U0USER"
+
+    def test_drops_synthetic_slack_per_message_thread(self):
+        env = {
+            "HERMES_SESSION_PLATFORM": "slack",
+            "HERMES_SESSION_CHAT_ID": "D0BJTDCSR7C",
+            "HERMES_SESSION_THREAD_ID": "1755043010.123456",
+            "HERMES_SESSION_MESSAGE_ID": "1755043010.123456",
+        }
+        with _session_env(env):
+            origin = _resolve_origin()
+        assert origin is not None
+        assert origin["thread_id"] is None
+
+    def test_no_session_env_returns_none(self):
+        with _session_env({}):
+            assert _resolve_origin() is None


### PR DESCRIPTION
## Summary

`hermes_cli/blueprint_cmd.py::_resolve_origin()` and `hermes_cli/suggestions_cmd.py::_resolve_origin()` each hand-rolled a truncated origin dict (`platform`, `chat_id`, `chat_name`, `thread_id`) instead of delegating to cron's canonical `tools.cronjob_tools._origin_from_env()`. That function was extended by `8b6cf434cb` ("carry Slack workspace scope_id into continuable seed keys") to also carry `scope_id` (embedded in every scoped Slack session key) and drop the Slack synthetic per-message thread stamp. `suggestions_cmd.py`'s own docstring even claims to "mirror" `_origin_from_env` — but it mirrors the pre-`8b6cf434cb` shape, not the current one.

`accept_suggestion()` (`cron/suggestions.py`) and `fill_blueprint()` (`cron/blueprint_catalog.py`) merge this origin dict straight into the job spec passed to `create_job()`, which persists it verbatim as `job["origin"]`. `cron/scheduler.py`'s delivery path reads `origin.get("scope_id")` at 6 separate sites (session seeding, route metadata, media metadata). A job created via the deterministic `/blueprint <name> slot=val…` shortcut or `/suggestions accept` in a scoped Slack workspace therefore baked a `scope_id`-less / `user_id`-less origin into the job permanently — reproducing the exact "continuation amnesia" bug `8b6cf434cb` fixed for the main cron creation path (seeded session key `agent:main:slack:dm:<chat>:<thread>` vs. the real scoped reply's `agent:main:slack:dm:<team>:<chat>:<thread>` — a row no reply resolves to), plus missing the Slack synthetic-thread guard for top-level messages.

## Fix

Both functions now delegate to `_origin_from_env()` directly instead of duplicating its logic a third time, so any future change to the canonical origin shape propagates to both automatically — this is the third independent implementation of the same "current chat origin" concept that had drifted from the canonical one, so I picked the fix that removes the duplication rather than mirroring the fields once more.

`blueprint_cmd.py::_resolve_origin(explicit)` keeps its `explicit` override parameter (used by the dashboard/API caller) — only the fallback path changed.

## Verification

- New regression tests: `tests/hermes_cli/test_blueprint_cmd_origin.py`, `tests/hermes_cli/test_suggestions_cmd_origin.py` (scope_id/user_id capture, Slack synthetic-thread drop, explicit-origin passthrough, no-session-env fallback).
- Mutation-verify: stashed the fix, confirmed all 4 new assertions covering `scope_id`/synthetic-thread genuinely fail against the pre-fix code (`KeyError: 'scope_id'`, thread_id not dropped), then restored the fix and confirmed all 7 pass again.
- Broader neighbor suite: `tests/cron/test_suggestions.py tests/cron/test_blueprint_catalog.py tests/cron/test_cron_origin_synthetic_thread.py tests/cron/test_scheduler.py` — 142 passed, no regressions.
- `ruff check` clean on all changed files.

## Test plan

- [x] New unit tests cover both `_resolve_origin()` functions
- [x] Mutation-verify: fix reverted → new tests fail; fix restored → new tests pass
- [x] `tests/cron/` neighbor suite green (142 passed)
- [x] `ruff check` clean