### PR TITLE
fix(agent): classify Kimi K3 reasoning-replay 400 as retryable in-provider

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -70,6 +70,7 @@ class FailoverReason(enum.Enum):
 
     # Provider-specific
     thinking_signature = "thinking_signature"  # Anthropic thinking block sig invalid
+    kimi_reasoning_replay = "kimi_reasoning_replay"  # Kimi K3 replayed encrypted-reasoning signature rejected (intermittent) — retry in-provider
     long_context_tier = "long_context_tier"    # Anthropic "extra usage" tier gate
     oauth_long_context_beta_forbidden = "oauth_long_context_beta_forbidden"  # Anthropic OAuth subscription rejects 1M context beta — disable beta and retry
     llama_cpp_grammar_pattern = "llama_cpp_grammar_pattern"  # llama.cpp json-schema-to-grammar rejects regex escapes in `pattern` / `format` — strip from tools and retry
@@ -1633,6 +1634,26 @@ def _classify_400(
             retryable=True,
             # The request shape was fine — never route this into compression.
             should_compress=False,
+        )
+
+    # Kimi K3 replayed encrypted-reasoning signature rejected (400).  On
+    # multi-turn replay Kimi intermittently rejects the replayed encrypted
+    # reasoning block's signature with a base64 vs base64url validation
+    # asymmetry on some upstream instances (25/27 same-signature calls
+    # succeed; 8/8 replays of the "offending" signature succeed).  The
+    # error carries ``signature`` + ``reasoning`` but NOT the literal token
+    # ``thinking``, so the thinking_signature branch above misses it and it
+    # would otherwise fall through to a non-retryable format_error that
+    # leaks the turn to fallback.  A plain in-provider retry is the correct
+    # recovery.  ``error_msg`` is lowercased upstream — match accordingly.
+    if (
+        "malformed encrypted reasoning content" in error_msg
+        and "invalid base64url" in error_msg
+    ):
+        return result_fn(
+            FailoverReason.kimi_reasoning_replay,
+            retryable=True,
+            should_fallback=False,
         )
 
     # Request-validation errors (unsupported / unknown parameter) MUST be

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1656,6 +1656,18 @@ def _classify_400(
             should_fallback=False,
         )
 
+    # Tripwire: a 400 that still carries both the ``signature`` and
+    # ``reasoning`` fields but fell through the exact-phrase match above means
+    # Moonshot likely rewrote the error wording — the guard is coupled to the
+    # exact phrasing, so this fires before the incident silently degrades back
+    # to a non-retryable format_error and reproduces undiagnosed.
+    if "signature" in error_msg and "reasoning" in error_msg:
+        logger.warning(
+            "Kimi K3 400 carried both 'signature' and 'reasoning' but did not "
+            "match the replay-signature phrase; classification may have "
+            "drifted (check upstream error wording)",
+        )
+
     # Request-validation errors (unsupported / unknown parameter) MUST be
     # checked BEFORE context_overflow.  A GPT-5 model rejecting max_tokens
     # returns:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -67,6 +67,7 @@ class TestFailoverReason:
             "provider_policy_blocked",
             "content_policy_blocked",
             "thinking_signature", "long_context_tier",
+            "kimi_reasoning_replay",
             "oauth_long_context_beta_forbidden",
             "llama_cpp_grammar_pattern",
             "unknown",
@@ -688,6 +689,46 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.invalid_encrypted_content
         assert result.retryable is True
         assert result.should_fallback is False
+
+    # ── Provider-specific: Kimi K3 reasoning-replay ──
+
+    def test_kimi_reasoning_replay_400_is_retryable_in_provider(self):
+        """Kimi K3 intermittently rejects a replayed encrypted-reasoning
+        signature with a 400 (base64 vs base64url validation asymmetry on
+        some upstream instances). Must be classified as a retryable
+        in-provider error (no fallback), NOT a non-retryable format_error
+        that leaks the turn to the fallback chain."""
+        e = MockAPIError(
+            "Error code: 400 - bad request",
+            status_code=400,
+            body={
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": (
+                        "messages.1.content.0.signature: malformed encrypted "
+                        "reasoning content: invalid base64url encoding"
+                    ),
+                }
+            },
+        )
+        result = classify_api_error(e, provider="kimi-coding", model="k3-256k")
+        assert result.reason == FailoverReason.kimi_reasoning_replay
+        assert result.retryable is True
+        assert result.should_fallback is False
+
+    def test_kimi_reasoning_replay_pattern_is_specific(self):
+        """A normal 400 must still classify as format_error, proving the
+        kimi_reasoning_replay pattern is specific to the signature-replay
+        error and does not swallow generic bad requests."""
+        e = MockAPIError(
+            "Error code: 400 - bad request",
+            status_code=400,
+            body={"error": {"type": "invalid_request_error", "message": "Bad request"}},
+        )
+        result = classify_api_error(e, provider="kimi-coding", model="k3-256k")
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_fallback is True
 
     # ── Provider-specific: llama.cpp grammar-parse ──
 


### PR DESCRIPTION
## Summary

Kimi K3 (`k3-256k`, provider `kimi-coding`, base_url `https://api.kimi.com/coding`) intermittently fails on multi-turn conversation replay with HTTP 400 `messages.1.content.0.signature: malformed encrypted reasoning content: invalid base64url encoding`. The turn was not self-healed — it leaked to the fallback chain, so the user perceived it as "the model disconnected".

The error carries `signature` + `reasoning` but **not** the literal token `thinking`, so the existing `thinking_signature` classifier branch (which requires `"thinking" in error_msg`) missed it, and it fell through to a generic non-retryable `format_error` that leaked the turn to fallback.

The issue's own investigation confirmed the error is **intermittent** — a server-side base64 vs base64url validation asymmetry on some Kimi upstream instances (25/27 same-signature calls succeeded; 8/8 replays of the "offending" signature succeeded). A plain in-provider retry is therefore the correct recovery.

## Changes

- `agent/error_classifier.py`:
  - New `FailoverReason.kimi_reasoning_replay` enum value.
  - New branch in `_classify_400` matching `"malformed encrypted reasoning content"` + `"invalid base64url"`, returning `retryable=True, should_fallback=False` — retry in-provider, don't leak to fallback.
  - Deliberately does **not** reuse `thinking_signature` (whose recovery handler strips `reasoning_details`, degrading the preserved-thinking contract K3 relies on) nor `invalid_encrypted_content` (gated on `codex_responses` mode). The new reason has no special recovery handler, so it falls through to the normal in-provider retry path — correct for an intermittent error.
- `tests/agent/test_error_classifier.py`:
  - Updated the enum-completeness test.
  - `test_kimi_reasoning_replay_400_is_retryable_in_provider` — asserts the Kimi error classifies as `kimi_reasoning_replay`, retryable, no fallback.
  - `test_kimi_reasoning_replay_pattern_is_specific` — asserts a generic 400 still classifies as `format_error`, proving the pattern is specific.

## Tests

- `pytest tests/agent/test_error_classifier.py -q` → **99 passed**
- Regression suite (`test_error_classifier.py` + `test_anthropic_kimi_signed_thinking_replay.py` + `test_thinking_sig_recovery_persistence.py`) → **106 passed**
- Revert-to-buggy verified: the new test fails on unpatched code (`AttributeError: kimi_reasoning_replay`) and passes with the fix.

Closes #90886
