### PR TITLE
fix(auth): accept voice-only provider ids in 'hermes auth add'

### DIFF
--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -170,12 +170,26 @@ def _format_exhausted_status(entry) -> str:
 # Kept OUT of ``PROVIDER_REGISTRY`` on purpose so inference-side provider
 # resolution is untouched; overlapping ids (gemini/xai/minimax/deepinfra) are
 # already registry entries and need no listing here.
-VOICE_CREDENTIAL_PROVIDER_IDS = frozenset({
-    "elevenlabs",  # TTS + STT (Scribe)
-    "openai",      # TTS + STT (Whisper) — voice uses the bare id; inference uses openai-api/openai-codex
-    "groq",        # STT (Whisper-compatible endpoint)
-    "mistral",     # TTS + STT (Voxtral)
-})
+# DERIVED from DEFAULT_CONFIG's tts/stt sections (per-provider dict keys) so a
+# voice provider added to the defaults can never be silently rejected by
+# ``auth add`` while the read side accepts it — the split-brain #90956 fixed,
+# in reverse (review finding on #90965).
+def _derive_voice_credential_provider_ids() -> frozenset:
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    ids: set = set()
+    for section in ("tts", "stt"):
+        cfg = DEFAULT_CONFIG.get(section)
+        if isinstance(cfg, dict):
+            ids |= {
+                key
+                for key, val in cfg.items()
+                if key != "provider" and isinstance(val, dict)
+            }
+    return frozenset(ids - set(PROVIDER_REGISTRY))
+
+
+VOICE_CREDENTIAL_PROVIDER_IDS = _derive_voice_credential_provider_ids()
 
 
 def auth_add_command(args) -> None:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -162,9 +162,30 @@ def _format_exhausted_status(entry) -> str:
     return f" {label}{reason_text}{code} ({wait} left)"
 
 
+# Voice-only provider ids (the ``tts.provider`` / ``stt.provider`` id space)
+# that have no inference ``PROVIDER_REGISTRY`` entry but ARE valid
+# credential-pool targets: the voice tools resolve their keys through
+# ``resolve_provider_secret()`` step 3, which reads the pool by exactly these
+# ids (#90956 — #68003 landed the read side, the write side rejected them).
+# Kept OUT of ``PROVIDER_REGISTRY`` on purpose so inference-side provider
+# resolution is untouched; overlapping ids (gemini/xai/minimax/deepinfra) are
+# already registry entries and need no listing here.
+VOICE_CREDENTIAL_PROVIDER_IDS = frozenset({
+    "elevenlabs",  # TTS + STT (Scribe)
+    "openai",      # TTS + STT (Whisper) — voice uses the bare id; inference uses openai-api/openai-codex
+    "groq",        # STT (Whisper-compatible endpoint)
+    "mistral",     # TTS + STT (Voxtral)
+})
+
+
 def auth_add_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", ""))
-    if provider not in PROVIDER_REGISTRY and provider != "openrouter" and not provider.startswith(CUSTOM_POOL_PREFIX):
+    if (
+        provider not in PROVIDER_REGISTRY
+        and provider not in VOICE_CREDENTIAL_PROVIDER_IDS
+        and provider != "openrouter"
+        and not provider.startswith(CUSTOM_POOL_PREFIX)
+    ):
         raise SystemExit(f"Unknown provider: {provider}")
 
     requested_type = str(getattr(args, "auth_type", "") or "").strip().lower()

--- a/tests/hermes_cli/test_auth_add_voice_providers.py
+++ b/tests/hermes_cli/test_auth_add_voice_providers.py
@@ -1,0 +1,73 @@
+"""`hermes auth add` must accept the voice-only provider ids (#90956).
+
+`resolve_provider_secret()` step 3 reads the credential pool by the
+``tts.provider`` / ``stt.provider`` id (elevenlabs, bare "openai", groq,
+mistral), but the auth-add validation only accepted ``PROVIDER_REGISTRY``
+(inference ids), so the pool was unwritable for exactly the providers the
+read side was written for — "Unknown provider: elevenlabs".
+"""
+
+import types
+
+import pytest
+
+from hermes_cli import auth_commands
+from hermes_cli.auth_commands import VOICE_CREDENTIAL_PROVIDER_IDS, auth_add_command
+
+
+def _args(provider: str, api_key: str) -> types.SimpleNamespace:
+    return types.SimpleNamespace(
+        provider=provider, auth_type="api-key", api_key=api_key, label=None
+    )
+
+
+class _FakePool:
+    def __init__(self):
+        self.entries_list = []
+
+    def entries(self):
+        return self.entries_list
+
+    def add_entry(self, entry):
+        self.entries_list.append(entry)
+
+
+@pytest.mark.parametrize("provider", sorted(VOICE_CREDENTIAL_PROVIDER_IDS))
+def test_auth_add_accepts_voice_only_providers(monkeypatch, provider):
+    """Each voice-only id passes validation and lands in the pool under its
+    own id — the exact key `resolve_provider_secret()` step 3 looks up."""
+    fake = _FakePool()
+    monkeypatch.setattr(auth_commands, "load_pool", lambda _p: fake)
+    # Non-interactive path: label falls back to the default (no stdin prompt).
+    monkeypatch.setattr(auth_commands.sys, "stdin", types.SimpleNamespace(isatty=lambda: False))
+
+    auth_add_command(_args(provider, "test-key-placeholder-not-real"))
+
+    assert len(fake.entries_list) == 1
+    assert fake.entries_list[0].provider == provider
+
+
+def test_unknown_provider_still_rejected(monkeypatch):
+    """Fail-closed guard on the carve-out: ids outside both the registry and
+    the voice set keep being rejected."""
+    fake = _FakePool()
+    monkeypatch.setattr(auth_commands, "load_pool", lambda _p: fake)
+
+    with pytest.raises(SystemExit, match="Unknown provider"):
+        auth_add_command(_args("not-a-real-provider", "test-key-placeholder-not-real"))
+    assert fake.entries_list == []
+
+
+def test_voice_ids_are_config_legal_voice_provider_values():
+    """Consistency contract: every id we accept must be a value the voice
+    config actually uses (a key under the tts/stt sections), otherwise the
+    pool key could never be read back by the tools."""
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    tts_ids = set(DEFAULT_CONFIG.get("tts", {}).keys())
+    stt_ids = set(DEFAULT_CONFIG.get("stt", {}).keys())
+    for pid in VOICE_CREDENTIAL_PROVIDER_IDS:
+        assert pid in tts_ids or pid in stt_ids, (
+            f"{pid!r} is not a configured tts/stt provider — the pool entry "
+            f"would be unreadable by resolve_provider_secret()"
+        )


### PR DESCRIPTION
## What does this PR do?

Makes `hermes auth add <voice_provider>` work for the STT/TTS-only providers, unblocking the credential-pool write side that #68003's read side depends on. `resolve_provider_secret()` documents the pool as resolution step 3 and reads it by the `tts.provider` / `stt.provider` id (`elevenlabs`, bare `openai`, `groq`, `mistral`) — but `auth_add_command()` validated only against `PROVIDER_REGISTRY` (inference ids), so every one of those writes died with `Unknown provider: elevenlabs` and step 3 stayed unreachable for four of the eight key-requiring voice providers (#90956, lane `vox/06-credential-pool` of #78207).

The fix adds a `VOICE_CREDENTIAL_PROVIDER_IDS` allowlist to the auth-add validation. The ids are deliberately kept OUT of `PROVIDER_REGISTRY`: inference-side provider resolution is untouched, and overlapping ids (gemini / xai / minimax / deepinfra) are already registry entries. With this, `hermes auth add elevenlabs --type api-key` stores the key in the pool under `provider_id="elevenlabs"` — exactly the key the voice tools already look up — so voice keys get the same rotation/exhaustion machinery as inference keys instead of being forced onto plaintext `~/.hermes/.env`.

## Related Issue

Fixes #90956

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth_commands.py` — new `VOICE_CREDENTIAL_PROVIDER_IDS` frozenset (elevenlabs / openai / groq / mistral, with the read-side and id-space rationale documented inline); `auth_add_command()` validation now also accepts those ids
- `tests/hermes_cli/test_auth_add_voice_providers.py` — parametrized acceptance test per voice id (passes validation, lands in the pool under its own id), a fail-closed guard (unknown ids still rejected), and a consistency contract (every accepted id is a configured tts/stt section key, so the pool entry is readable back by the tools)

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_cli/test_auth_add_voice_providers.py -q` — should pass (6 passed)
2. Observed result: on unmodified main, the acceptance test fails with `SystemExit: Unknown provider: elevenlabs` (validation rejects the voice ids — the #90956 dead end); with this fix the entry lands in the pool under its own provider id
3. Regression checks: `tests/tools/test_voice_credential_pool_resolution.py` (the #68003 read side) — 16 passed; `tests/tools/test_tool_backend_helpers.py` — 27 passed

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (voice id space vs inference registry, why not in PROVIDER_REGISTRY)
- [x] Tests added that prove the fix (per-id acceptance + fail-closed rejection + config-consistency contract)
- [x] All new and existing tests pass locally (6 + 16 + 27 passed)
- [x] Platform: macOS (validation logic, platform-independent)
