### PR TITLE
fix(web): rescue-eligibility for Firecrawl honors self-hosted/gateway mode

### DIFF
--- a/tests/tools/test_web_keyless_rescue.py
+++ b/tests/tools/test_web_keyless_rescue.py
@@ -101,6 +101,63 @@ class TestEligibility:
         )
         assert web_tools._rescue_eligible(_KeyedBoomProvider()) is False
 
+    def test_firecrawl_self_hosted_is_eligible(self, monkeypatch):
+        """Self-hosted Firecrawl (FIRECRAWL_API_URL, no key) is a keyed path,
+        not the keyless ring — its failure must still get a rescue.
+
+        A naive api-key-only eligibility check can't see FIRECRAWL_API_URL and
+        misclassifies this as "already walked the ring", wrongly denying the
+        rescue the whole feature exists to provide (verified against the
+        provider's own dispatch decision, ``_use_keyless_ring()``, not a
+        re-derivation of it).
+        """
+        from plugins.web.firecrawl.provider import (
+            FirecrawlWebSearchProvider,
+            _use_keyless_ring,
+        )
+
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        monkeypatch.setenv("FIRECRAWL_API_URL", "https://firecrawl.internal.example")
+        monkeypatch.setattr(web_tools, "_peek_nous_access_token", lambda: None)
+
+        provider = FirecrawlWebSearchProvider()
+        assert _use_keyless_ring() is False, "sanity: self-hosted must dispatch keyed"
+        assert web_tools._rescue_eligible(provider) is True
+
+    def test_firecrawl_keyless_mode_not_eligible(self, monkeypatch):
+        """No FIRECRAWL_API_URL/API_KEY: the call rode the keyless ring;
+        its failure must not double-walk the ring."""
+        from plugins.web.firecrawl.provider import (
+            FirecrawlWebSearchProvider,
+            _use_keyless_ring,
+        )
+
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        monkeypatch.delenv("FIRECRAWL_API_URL", raising=False)
+        monkeypatch.setattr(web_tools, "_peek_nous_access_token", lambda: None)
+        monkeypatch.setattr(
+            "agent.web_search_registry._keyless_tier_enabled", lambda: True
+        )
+
+        provider = FirecrawlWebSearchProvider()
+        assert _use_keyless_ring() is True, "sanity: no config must dispatch keyless"
+        assert web_tools._rescue_eligible(provider) is False
+
+    def test_firecrawl_keyed_api_key_is_eligible(self, monkeypatch):
+        """A real FIRECRAWL_API_KEY (direct, non-self-hosted) is keyed too."""
+        from plugins.web.firecrawl.provider import (
+            FirecrawlWebSearchProvider,
+            _use_keyless_ring,
+        )
+
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-real-key")
+        monkeypatch.delenv("FIRECRAWL_API_URL", raising=False)
+        monkeypatch.setattr(web_tools, "_peek_nous_access_token", lambda: None)
+
+        provider = FirecrawlWebSearchProvider()
+        assert _use_keyless_ring() is False, "sanity: a real key must dispatch keyed"
+        assert web_tools._rescue_eligible(provider) is True
+
 
 class TestSearchRescue:
     def _dispatch(self, monkeypatch, provider):

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -466,11 +466,20 @@ def _rescue_eligible(provider) -> bool:
 
         name = getattr(provider, "name", "")
         if name in _KEYLESS_RING:
+            if name == "firecrawl":
+                # Firecrawl is the one ring vendor with a self-hosted
+                # (FIRECRAWL_API_URL) / managed-gateway keyed mode that an
+                # API-key-only check can't see — re-deriving eligibility from
+                # just FIRECRAWL_API_KEY misclassifies those as "already
+                # walked the ring" and wrongly denies the rescue. Use the
+                # provider's own dispatch decision instead of guessing it.
+                from plugins.web.firecrawl.provider import _use_keyless_ring
+
+                return not _use_keyless_ring()
             key_var = {
                 "exa": "EXA_API_KEY",
                 "parallel": "PARALLEL_API_KEY",
                 "tavily": "TAVILY_API_KEY",
-                "firecrawl": "FIRECRAWL_API_KEY",
                 "keenable": "KEENABLE_API_KEY",
             }.get(name, "")
             from agent.web_search_provider import get_provider_env


### PR DESCRIPTION
## Summary

`tools/web_tools.py::_rescue_eligible()` (the one-shot keyless-ring rescue feature, `d1eefe6acc`) decides whether a failed call should get the rescue by re-deriving "was this call already keyless?" from a hardcoded `key_var` dict per ring vendor, fed into `use_keyless(name, api_key)`.

For Firecrawl specifically this ignores two things the *real* dispatch decision accounts for:

- `FIRECRAWL_API_URL` (self-hosted Firecrawl)
- managed-gateway mode (Nous tool-gateway routing)

`plugins/web/firecrawl/provider.py::_use_keyless_ring()` is the actual function the search/extract dispatch path calls to decide keyless-vs-keyed, and it checks both of those before falling back to `use_keyless("firecrawl", "")`. `_rescue_eligible()`'s simplified re-derivation only checks `FIRECRAWL_API_KEY`.

**Effect:** a self-hosted (`FIRECRAWL_API_URL` set, no `FIRECRAWL_API_KEY`) or gateway-routed Firecrawl call that fails is misclassified as "already walked the keyless ring" and the one-shot rescue — the entire point of the feature — is silently denied.

Verified empirically:

```
FIRECRAWL_API_URL=https://self-hosted.example, no FIRECRAWL_API_KEY
  _use_keyless_ring()  -> False   (real dispatch: keyed, correct)
  _rescue_eligible()   -> False   (BEFORE fix — wrongly denies rescue)
  _rescue_eligible()   -> True    (AFTER fix — correctly offers rescue)
```

## Fix

Firecrawl is special-cased in `_rescue_eligible()` to call `_use_keyless_ring()` directly instead of re-deriving an approximation of it. The other 4 ring vendors (exa, parallel, tavily, keenable) have no self-hosted/URL-override concept, so their existing api-key-only check is correct and unchanged.

## Verification

- New regression tests in `tests/tools/test_web_keyless_rescue.py::TestEligibility`: self-hosted (eligible), pure-keyless (not eligible — ring already walked), and keyed-API-key (eligible) — each cross-checked against `_use_keyless_ring()`'s own decision as a sanity assertion.
- Mutation-verify: stashed the fix, confirmed the self-hosted and keyed-API-key tests genuinely fail against pre-fix code (`assert False is True`); the pure-keyless test correctly still passes on both (negative control — not everything trivially flips). Restored the fix, all 17 tests in the file pass.
- Broader neighbor suite: `tests/tools/test_web_keyless_rescue.py tests/tools/test_web_tools_config.py tests/tools/test_web_providers.py tests/tools/test_web_keyless_fallback.py tests/tools/test_web_tools_tavily.py` — 132/134 pass; the 2 failures (`TestParallelClientConfig`) are a pre-existing, fix-independent environment gap (`parallel-web` package not installed, lazy installs disabled) confirmed by reproducing the same failures with the fix stashed.
- `ruff check` clean on both changed files.

## Test plan

- [x] New unit tests cover self-hosted, pure-keyless, and keyed-API-key Firecrawl scenarios
- [x] Mutation-verify: fix reverted → new tests fail (except the negative control); fix restored → all pass
- [x] Broader `tests/tools/test_web_*` suite green apart from a pre-existing, unrelated environment gap
- [x] `ruff check` clean