### PR TITLE
fix(sessions): export error paths return non-zero exit codes

### DIFF
--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -423,7 +423,7 @@ def cmd_sessions(args, sessions_parser=None):
                 filters = build_prune_filters(args)
             except ValueError as e:
                 print(f"Error: {e}")
-                return
+                return 1
             # Unlike prune/archive, export includes archived sessions.
             filters["archived"] = None
 
@@ -434,14 +434,22 @@ def cmd_sessions(args, sessions_parser=None):
 
             return redact_session_data(data)
 
+        # Set by _collect_sessions() when its None return means "nothing was
+        # exported because of a genuine error" (not found / bad --dry-run
+        # usage), as opposed to a --dry-run preview that printed and returned
+        # None by design. Callers use it to pick the exit code (SES-04/SES-10).
+        _collect_error = [False]
+
         def _collect_sessions():
             """Resolve --session-id / filters / bare export into a list
-            of redacted session dicts, or None after printing an error."""
+            of redacted session dicts, or None after printing an error or a
+            --dry-run preview (see _collect_error for which one)."""
             if args.session_id:
                 resolved = db.resolve_session_id(args.session_id)
                 data = _redact(db.export_session(resolved)) if resolved else None
                 if not data:
                     print(f"Session '{args.session_id}' not found.")
+                    _collect_error[0] = True
                     return None
                 return [data]
             if filters:
@@ -465,6 +473,7 @@ def cmd_sessions(args, sessions_parser=None):
                 ]
             if args.dry_run:
                 print("--dry-run requires at least one filter.")
+                _collect_error[0] = True
                 return None
             return [_redact(s) for s in db.export_all(source=None)]
 
@@ -474,7 +483,7 @@ def cmd_sessions(args, sessions_parser=None):
         if getattr(args, "only", None):
             if args.format not in ("jsonl", "md"):
                 print("--only user-prompts supports --format jsonl or md.")
-                return
+                return 1
             from hermes_cli.session_export import (
                 export_record_count,
                 render_sessions_export,
@@ -483,7 +492,7 @@ def cmd_sessions(args, sessions_parser=None):
             sessions = _collect_sessions()
             if sessions is None:
                 db.close()
-                return
+                return 1 if _collect_error[0] else None
             rendered = render_sessions_export(
                 sessions,
                 fmt="markdown" if args.format == "md" else "jsonl",
@@ -506,7 +515,7 @@ def cmd_sessions(args, sessions_parser=None):
         if args.format == "html":
             if not args.output or args.output == "-":
                 print("HTML export requires an output file path.")
-                return
+                return 1
             from hermes_cli.session_export_html import (
                 generate_html_export,
                 generate_multi_session_html_export,
@@ -515,7 +524,7 @@ def cmd_sessions(args, sessions_parser=None):
             sessions = _collect_sessions()
             if sessions is None:
                 db.close()
-                return
+                return 1 if _collect_error[0] else None
             if len(sessions) == 1:
                 content = generate_html_export(sessions[0])
             else:
@@ -534,7 +543,7 @@ def cmd_sessions(args, sessions_parser=None):
             if getattr(args, "only", None):
                 print("--only user-prompts supports --format jsonl or md.")
                 db.close()
-                return
+                return 1
             session_id = args.session_id
             if not session_id and not filters:
                 # Match the shell's common intent: "the last thing I did".
@@ -543,11 +552,11 @@ def cmd_sessions(args, sessions_parser=None):
                 if not session_id:
                     print("No session found to export. Pass --session-id.")
                     db.close()
-                    return
+                    return 1
             if session_id and not db.resolve_session_id(session_id):
                 print(f"Session '{session_id}' not found.")
                 db.close()
-                return
+                return 1
 
             from agent.trace_upload import (
                 TraceRedactionError,
@@ -561,7 +570,7 @@ def cmd_sessions(args, sessions_parser=None):
                 if not session_id:
                     print("--upload exports one session: pass --session-id (or drop filters to use the most recent).")
                     db.close()
-                    return
+                    return 1
                 resolved = db.resolve_session_id(session_id)
                 db.close()
                 status = upload_session_trace(
@@ -614,7 +623,7 @@ def cmd_sessions(args, sessions_parser=None):
                     if not jsonl:
                         print(f"No transcript to export for session '{ids[0]}'.")
                         db.close()
-                        return
+                        return 1
                     if not args.output or args.output == "-":
                         sys.stdout.write(jsonl)
                     else:
@@ -640,22 +649,24 @@ def cmd_sessions(args, sessions_parser=None):
                     print(f"Exported {exported} session trace(s) to {out_dir}")
             except TraceRedactionError:
                 print("Redaction failed; refusing to export unredacted trace content.")
+                db.close()
+                return 1
             db.close()
             return
 
         if args.format == "jsonl":
             if not args.output:
                 print("JSONL export requires an output path (use - for stdout).")
-                return
+                return 1
             if args.session_id:
                 resolved_session_id = db.resolve_session_id(args.session_id)
                 if not resolved_session_id:
                     print(f"Session '{args.session_id}' not found.")
-                    return
+                    return 1
                 data = _redact(db.export_session(resolved_session_id))
                 if not data:
                     print(f"Session '{args.session_id}' not found.")
-                    return
+                    return 1
                 line = _json.dumps(data, ensure_ascii=False) + "\n"
                 if args.output == "-":
 
@@ -687,7 +698,7 @@ def cmd_sessions(args, sessions_parser=None):
                 else:
                     if args.dry_run:
                         print("--dry-run requires at least one filter.")
-                        return
+                        return 1
                     sessions = db.export_all(source=None)
                 if args.output == "-":
 
@@ -714,7 +725,7 @@ def cmd_sessions(args, sessions_parser=None):
         if args.output == "-":
             print("Markdown/QMD export writes files; stdout (-) is only supported with --format jsonl.")
             db.close()
-            return
+            return 1
         output_dir = Path(args.output).expanduser() if args.output else get_hermes_home() / "session-exports"
 
         def _export_one(session_id: str, *, include_lineage: bool = False):
@@ -738,11 +749,11 @@ def cmd_sessions(args, sessions_parser=None):
         if args.delete_after_verified and not args.yes:
             print("--delete-after-verified requires --yes.")
             db.close()
-            return
+            return 1
         if args.delete_after_verified and not args.session_id:
             print("--delete-after-verified is only supported with --session-id.")
             db.close()
-            return
+            return 1
 
         lineage_is_logical = getattr(args, "lineage", "single") == "logical"
 
@@ -751,7 +762,7 @@ def cmd_sessions(args, sessions_parser=None):
             if not resolved_session_id:
                 print(f"Session '{args.session_id}' not found.")
                 db.close()
-                return
+                return 1
             delete_target_ids = [resolved_session_id]
             if args.delete_after_verified:
                 delete_target_ids = db.get_session_delete_targets(
@@ -774,14 +785,14 @@ def cmd_sessions(args, sessions_parser=None):
                         "Pass --force to overwrite."
                     )
                     db.close()
-                    return
+                    return 1
                 if not data or not exported_path:
                     print(
                         f"Session '{target_id}' disappeared during export; "
                         "nothing was deleted."
                     )
                     db.close()
-                    return
+                    return 1
                 exported_items.append((data, exported_path))
 
             message_count = sum(
@@ -808,7 +819,7 @@ def cmd_sessions(args, sessions_parser=None):
                             f"session '{data.get('id')}': {reason}"
                         )
                         db.close()
-                        return
+                        return 1
                 sessions_dir = get_hermes_home() / "sessions"
                 if db.delete_session(
                     resolved_session_id,
@@ -840,7 +851,7 @@ def cmd_sessions(args, sessions_parser=None):
                 "at least one filter (e.g. --older-than 90, --source telegram)."
             )
             db.close()
-            return
+            return 1
         candidates = db.list_prune_candidates(**filters)
         if args.dry_run:
             print(

--- a/tests/hermes_cli/test_sessions_export_exit_codes.py
+++ b/tests/hermes_cli/test_sessions_export_exit_codes.py
@@ -1,0 +1,202 @@
+"""Regression tests: `hermes sessions export` error paths return non-zero.
+
+``aca40d1d63`` fixed delete/rename/prune/import so scripting/CI could detect
+a failure (SES-04/SES-10) — every one of those actions' error paths now
+``return 1`` instead of a bare ``return`` (exit 0). The ``export`` action was
+left untouched: every one of its many error paths (session-not-found, a bad
+``build_prune_filters`` argument — the exact same try/except shape fixed for
+prune/archive, ``--only``/format mismatches, a missing ``--output`` for
+HTML/JSONL, a missing/empty trace session, refusing a bulk export without a
+filter, etc.) still printed an error and returned exit 0. A script doing
+``hermes sessions export --session-id bad_id ... || retry`` could not detect
+the failure.
+
+These tests cover a representative sample across every export format
+(jsonl/md/html/trace) plus the one subtlety in the fix: a ``--dry-run``
+*preview* (session list printed, nothing exported, by design) must NOT
+return 1 — only a genuine error should. ``_collect_sessions()``'s internal
+``_collect_error`` flag is what tells the two callers (``--only`` and
+``--format html``) which of the two a ``None`` result means.
+"""
+
+from argparse import Namespace
+
+import hermes_cli.sessions_cmd as sc
+from hermes_state import SessionDB
+
+
+def _export_args(**kw):
+    base = dict(
+        sessions_action="export",
+        output=None,
+        format="jsonl",
+        upload=False,
+        public=False,
+        no_redact=False,
+        only=None,
+        session_id=None,
+        redact=False,
+        lineage="single",
+        delete_after_verified=False,
+        force=False,
+        dry_run=False,
+        yes=False,
+        # Filter args recognized by _any_filters / build_prune_filters.
+        older_than=None, newer_than=None, before=None, after=None,
+        source=None, title=None, end_reason=None, cwd=None,
+        min_messages=None, max_messages=None, model=None, provider=None,
+        user=None, chat_id=None, chat_type=None, branch=None,
+        min_tokens=None, max_tokens=None, min_cost=None, max_cost=None,
+        min_tool_calls=None, max_tool_calls=None,
+    )
+    base.update(kw)
+    return Namespace(**base)
+
+
+def _init_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    SessionDB(tmp_path / "state.db")  # initialize an empty store
+
+
+class TestExportErrorReturns1:
+    def test_bad_filter_returns_1(self, tmp_path, monkeypatch, capsys):
+        """Same try/except shape aca40d1d63 fixed for prune/archive."""
+        _init_store(tmp_path, monkeypatch)
+        rc = sc.cmd_sessions(
+            _export_args(output=str(tmp_path / "out.jsonl"), older_than="not-a-real-duration")
+        )
+        assert rc == 1
+        assert "error" in capsys.readouterr().out.lower()
+
+    def test_jsonl_missing_output_returns_1(self, tmp_path, monkeypatch):
+        _init_store(tmp_path, monkeypatch)
+        rc = sc.cmd_sessions(_export_args(format="jsonl", output=None))
+        assert rc == 1
+
+    def test_jsonl_session_not_found_returns_1(self, tmp_path, monkeypatch, capsys):
+        _init_store(tmp_path, monkeypatch)
+        rc = sc.cmd_sessions(
+            _export_args(format="jsonl", output=str(tmp_path / "out.jsonl"), session_id="nope_xyz")
+        )
+        assert rc == 1
+        assert "not found" in capsys.readouterr().out.lower()
+
+    def test_only_bad_format_returns_1(self, tmp_path, monkeypatch):
+        """--only user-prompts requires --format jsonl or md."""
+        _init_store(tmp_path, monkeypatch)
+        rc = sc.cmd_sessions(_export_args(format="html", only="user-prompts", output=str(tmp_path / "out.html")))
+        assert rc == 1
+
+    def test_html_missing_output_returns_1(self, tmp_path, monkeypatch):
+        _init_store(tmp_path, monkeypatch)
+        rc = sc.cmd_sessions(_export_args(format="html", output=None))
+        assert rc == 1
+
+    def test_html_session_not_found_returns_1(self, tmp_path, monkeypatch, capsys):
+        _init_store(tmp_path, monkeypatch)
+        rc = sc.cmd_sessions(
+            _export_args(format="html", output=str(tmp_path / "out.html"), session_id="nope_xyz")
+        )
+        assert rc == 1
+        assert "not found" in capsys.readouterr().out.lower()
+
+    def test_trace_no_session_found_returns_1(self, tmp_path, monkeypatch, capsys):
+        """No --session-id, no filters, and no sessions exist at all."""
+        _init_store(tmp_path, monkeypatch)
+        rc = sc.cmd_sessions(_export_args(format="trace"))
+        assert rc == 1
+        assert "no session found" in capsys.readouterr().out.lower()
+
+    def test_trace_session_not_found_returns_1(self, tmp_path, monkeypatch, capsys):
+        _init_store(tmp_path, monkeypatch)
+        rc = sc.cmd_sessions(_export_args(format="trace", session_id="nope_xyz"))
+        assert rc == 1
+        assert "not found" in capsys.readouterr().out.lower()
+
+    def test_trace_upload_missing_session_id_returns_1(self, tmp_path, monkeypatch, capsys):
+        """A filter (not a session-id) is set, so the "no session found"
+        auto-resolve-to-most-recent shortcut is skipped and --upload's own
+        "needs exactly one session" check is reached."""
+        _init_store(tmp_path, monkeypatch)
+        rc = sc.cmd_sessions(_export_args(format="trace", upload=True, older_than="1d"))
+        assert rc == 1
+        assert "--upload exports one session" in capsys.readouterr().out
+
+    def test_md_stdout_not_supported_returns_1(self, tmp_path, monkeypatch):
+        _init_store(tmp_path, monkeypatch)
+        rc = sc.cmd_sessions(_export_args(format="md", output="-"))
+        assert rc == 1
+
+    def test_md_bulk_without_filter_returns_1(self, tmp_path, monkeypatch, capsys):
+        """Refusing a bulk export without --session-id or a filter."""
+        _init_store(tmp_path, monkeypatch)
+        rc = sc.cmd_sessions(_export_args(format="md", output=str(tmp_path / "out")))
+        assert rc == 1
+        assert "refusing bulk export" in capsys.readouterr().out.lower()
+
+    def test_md_session_not_found_returns_1(self, tmp_path, monkeypatch, capsys):
+        _init_store(tmp_path, monkeypatch)
+        rc = sc.cmd_sessions(
+            _export_args(format="md", output=str(tmp_path / "out"), session_id="nope_xyz")
+        )
+        assert rc == 1
+        assert "not found" in capsys.readouterr().out.lower()
+
+    def test_delete_after_verified_requires_yes_returns_1(self, tmp_path, monkeypatch):
+        _init_store(tmp_path, monkeypatch)
+        rc = sc.cmd_sessions(
+            _export_args(
+                format="md", output=str(tmp_path / "out"),
+                session_id="whatever", delete_after_verified=True, yes=False,
+            )
+        )
+        assert rc == 1
+
+    def test_delete_after_verified_requires_session_id_returns_1(self, tmp_path, monkeypatch):
+        _init_store(tmp_path, monkeypatch)
+        rc = sc.cmd_sessions(
+            _export_args(
+                format="md", output=str(tmp_path / "out"),
+                delete_after_verified=True, yes=True, older_than="1d",
+            )
+        )
+        assert rc == 1
+
+    def test_jsonl_dry_run_without_filter_returns_1(self, tmp_path, monkeypatch, capsys):
+        """--dry-run with no --session-id and no filter is a usage error,
+        not a preview — must not silently exit 0."""
+        _init_store(tmp_path, monkeypatch)
+        rc = sc.cmd_sessions(_export_args(format="jsonl", output=str(tmp_path / "out.jsonl"), dry_run=True))
+        assert rc == 1
+        assert "requires at least one filter" in capsys.readouterr().out.lower()
+
+
+class TestExportDryRunPreviewIsNotAnError:
+    """A --dry-run preview with a real filter prints and exits 0 — it did
+    exactly what was asked, unlike the usage-error case above. This is the
+    one place _collect_sessions()'s None-but-not-an-error distinction
+    (_collect_error) has to get right."""
+
+    def test_only_dry_run_with_filter_does_not_return_1(self, tmp_path, monkeypatch, capsys):
+        _init_store(tmp_path, monkeypatch)
+        rc = sc.cmd_sessions(
+            _export_args(format="jsonl", only="user-prompts", dry_run=True, older_than="1d")
+        )
+        assert rc != 1
+        assert "would export" in capsys.readouterr().out.lower()
+
+    def test_html_dry_run_with_filter_does_not_return_1(self, tmp_path, monkeypatch, capsys):
+        _init_store(tmp_path, monkeypatch)
+        rc = sc.cmd_sessions(
+            _export_args(format="html", output=str(tmp_path / "out.html"), dry_run=True, older_than="1d")
+        )
+        assert rc != 1
+        assert "would export" in capsys.readouterr().out.lower()
+
+    def test_jsonl_dry_run_with_filter_does_not_return_1(self, tmp_path, monkeypatch, capsys):
+        _init_store(tmp_path, monkeypatch)
+        rc = sc.cmd_sessions(
+            _export_args(format="jsonl", output=str(tmp_path / "out.jsonl"), dry_run=True, older_than="1d")
+        )
+        assert rc != 1
+        assert "would export" in capsys.readouterr().out.lower()


### PR DESCRIPTION
## Summary

`aca40d1d63` ("error paths return non-zero exit codes (delete/rename/prune/import)") converted those four actions' error paths from a bare `return` (exit 0) to `return 1`, so scripts/CI can detect a failure (SES-04/SES-10 — e.g. a script pinning a bad id fails loudly via `pin`, but deleting a bad id "succeeded" silently). The `export` action was left untouched.

Every error path across all five export formats still prints an error and silently returns exit 0:

- the same `build_prune_filters` `ValueError` shape already fixed for prune/archive
- session-not-found (jsonl/md/html/trace, single-session and `--session-id` paths)
- `--only`/format mismatches
- a missing `--output` for html/jsonl
- a missing/empty trace session, and `--upload` without a resolvable session-id
- `--delete-after-verified` misuse (`--yes` missing, `--session-id` missing)
- refusing a bulk export without a filter
- export-already-exists (`FileExistsError`) and export-verification-failed during `--delete-after-verified`
- misuse of `--dry-run` with no filter and no `--session-id`

A script doing `hermes sessions export --session-id bad_id ... || retry` could not detect the failure.

## Fix

Converted every genuine error `return` in the export action to `return 1`, mirroring `aca40d1d63`'s pattern exactly.

One subtlety: `_collect_sessions()` (shared by the `--only` and `--format html` paths) returns `None` for three different reasons — session not found (error), a `--dry-run` preview with a real filter (**not** an error — it printed exactly what was asked and intentionally did nothing else), and `--dry-run` with no filter at all (error: bad usage). A new `_collect_error` flag, set only in the two genuine-error branches, lets both callers pick the correct exit code without conflating a dry-run preview with an actual failure.

## Verification

- New regression tests in `tests/hermes_cli/test_sessions_export_exit_codes.py`: 15 cases covering a representative error path in every export format (jsonl/md/html/trace, plus `--delete-after-verified` misuse and the bad-filter/dry-run-misuse paths), plus 3 negative-control cases proving a `--dry-run` preview with a real filter does **not** return 1.
- Mutation-verify: stashed the fix, confirmed all 15 error-path assertions genuinely fail against pre-fix code (`assert None == 1`) while the 3 dry-run-preview negative controls correctly still pass unchanged (proving the test suite discriminates real errors from informational previews, not just "any change flips something"). Restored the fix, all 18 pass.
- Broader neighbor suite: `tests/hermes_cli/test_sessions_error_exit_codes.py` + `tests/hermes_cli/ -k session` — 254 passed (plus the new 18); 5 failures in `test_dashboard_param_clamps.py` are a pre-existing test-order-pollution artifact, confirmed unrelated by reproducing the identical 5 failures with this fix stashed out.
- `ruff check` clean on both changed files.

## Note on concurrent activity in this file

`hermes_cli/sessions_cmd.py`'s export action is under active, concurrent development — open PRs #81498 (output-path/directory consistency across formats), #89856 / #89226 (include open sessions in export candidates), and #87982 (trace export `cwd`/`gitBranch` attribution) all touch overlapping line ranges in the same function (`_collect_sessions` / `_render_trace` / `_export_one`). None of them touch exit codes or overlap semantically with this change — it's purely `return` → `return 1` at existing error sites — but a rebase may need light conflict resolution depending on merge order.

## Test plan

- [x] New unit tests cover a representative error path in every export format
- [x] Mutation-verify: fix reverted → error-path tests fail; dry-run-preview negative controls unaffected; fix restored → all pass
- [x] Broader `tests/hermes_cli/ -k session` suite green apart from a pre-existing, unrelated test-order-pollution artifact
- [x] `ruff check` clean