### PR TITLE
fix(session_search): recall the current session own early context (#90939)

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -17,6 +17,7 @@ import pytest
 from hermes_state import SessionDB
 from tools.session_search_tool import (
     SESSION_SEARCH_SCHEMA,
+    _LIVE_CONTEXT_WINDOW_MESSAGES,
     _format_timestamp,
     _is_compacted_message,
     _is_compression_ended,
@@ -1144,3 +1145,116 @@ class TestNewResetLineageBrowse:
         sids = [r["session_id"] for r in result["results"]]
         assert "s_legacy_child" in sids
 
+
+
+# =========================================================================
+# Current-session early context in long live sessions (#90939)
+#
+# In a long live session the early turns fall out of the live context window
+# WITHOUT any archival mark (active=1, compacted=0 — the prune path never
+# flips the compaction flag). The same-session skip assumed "active ⇒ in live
+# context" and hid the whole session, so terms unique to the current
+# session's own early content returned `count: 0, sessions_searched: 0` and
+# the agent had to fall back to raw SQL. The live window is bounded (newest
+# _LIVE_CONTEXT_WINDOW_MESSAGES active rows), so hits below that floor are
+# provably out of context and must surface — while hits inside the window,
+# compacted archives, rewind rows, and foreign-session dedup all stay as
+# before.
+# =========================================================================
+
+class TestCurrentSessionEarlyContext:
+    """Long live session: early content outside the live window is recallable."""
+
+    def _seed_long_current_session(self, db, sid="s_long", needle="gamelandia"):
+        db.create_session(sid, source="telegram")
+        db.append_message(sid, role="user",
+                          content=f"{needle} and battle academy are the storefronts to review")
+        db.append_message(sid, role="assistant",
+                          content=f"Noted: checking {needle} first.")
+        # Grow the session far past the live-window ceiling; the needle stays
+        # only in the earliest messages (no compaction ever runs, so the rows
+        # remain active=1, compacted=0 — exactly the #90939 storage shape).
+        for i in range(_LIVE_CONTEXT_WINDOW_MESSAGES + 40):
+            db.append_message(sid, role="user", content=f"follow-up step {i}")
+            db.append_message(sid, role="assistant", content=f"step {i} done")
+        db._conn.commit()
+
+    def test_early_current_session_hits_surface_after_window_growth(self, db):
+        """The core regression: a term that exists ONLY in the current
+        session's early messages must surface once the session outgrew the
+        live window — no compaction archive involved."""
+        self._seed_long_current_session(db)
+
+        result = json.loads(session_search(
+            query="gamelandia", db=db, current_session_id="s_long",
+        ))
+        assert result["success"] is True
+        assert result["count"] >= 1
+        sids = [r["session_id"] for r in result["results"]]
+        assert "s_long" in sids
+        hit = result["results"][sids.index("s_long")]
+        # The surfaced anchor is one of the two early needle rows (id 1 or 2),
+        # far below the live-context floor.
+        assert hit["match_message_id"] in (1, 2)
+        assert "gamelandia" in (hit["snippet"] or "")
+
+    def test_foreign_session_hits_still_dedupe_by_lineage(self, db):
+        """A foreign-session hit must still surface AND dedupe by lineage —
+        the long-session escape must not disturb foreign-session handling."""
+        self._seed_long_current_session(db)
+        # Foreign session with the needle in TWO messages → one lineage entry.
+        db.create_session("s_foreign", source="telegram")
+        db.append_message("s_foreign", role="user", content="gamelandia stock report")
+        db.append_message("s_foreign", role="assistant", content="gamelandia restocked today")
+        db._conn.commit()
+
+        result = json.loads(session_search(
+            query="gamelandia", db=db, current_session_id="s_long",
+        ))
+        assert result["success"] is True
+        sids = [r["session_id"] for r in result["results"]]
+        assert "s_long" in sids
+        assert "s_foreign" in sids
+        # Both lineages surface exactly once: the two foreign hits dedupe into
+        # a single s_foreign result, the early current-session hits into one
+        # s_long result.
+        assert result["count"] == 2
+        assert result["sessions_searched"] == 2
+
+    def test_recent_tail_hits_still_filtered_on_current_session(self, db):
+        """The escape must not widen to the whole session: a hit inside the
+        newest window rows is still in live context and stays filtered."""
+        db.create_session("s_long", source="telegram")
+        db.append_message("s_long", role="user", content="first mention of verdant hollow")
+        for i in range(_LIVE_CONTEXT_WINDOW_MESSAGES + 40):
+            db.append_message("s_long", role="user", content=f"bulk {i}")
+            db.append_message("s_long", role="assistant", content=f"bulk reply {i}")
+        # The needle lives only in the two most recent rows (inside the live
+        # tail → still in context → filtered).
+        db.append_message("s_long", role="user", content="lucerne valley final check")
+        db.append_message("s_long", role="assistant", content="lucerne valley confirmed")
+        db._conn.commit()
+
+        result = json.loads(session_search(
+            query="lucerne valley", db=db, current_session_id="s_long",
+        ))
+        assert result["count"] == 0
+
+    def test_scroll_accepts_below_floor_anchor_on_current_session(self, db):
+        """Discovery may hand back a below-floor current-session anchor; the
+        follow-up scroll must not reject it as 'already in your active
+        context'."""
+        self._seed_long_current_session(db)
+
+        result = json.loads(session_search(
+            query="gamelandia", db=db, current_session_id="s_long",
+        ))
+        hit = next(r for r in result["results"] if r["session_id"] == "s_long")
+
+        scroll = json.loads(session_search(
+            session_id="s_long", around_message_id=hit["match_message_id"],
+            db=db, current_session_id="s_long",
+        ))
+        assert scroll["success"] is True
+        assert scroll["mode"] == "scroll"
+        assert scroll["around_message_id"] == hit["match_message_id"]

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -73,6 +73,20 @@ _DISCOVER_SEARCH_FIELDS = (
     "session_started",
 )
 
+# Message-count ceiling for the live context window of the CURRENT session.
+# The live window is token-bounded, so this is a conservative upper bound on
+# how many of the session's most recent active rows can still be inside it.
+# In a long live session the early turns fall out of the window WITHOUT any
+# archival mark (active=1, compacted=0 — the prune path never flips the
+# compaction flag), so "active" alone cannot tell in-context from
+# out-of-context. Discovery surfaces same-session hits older than this bound
+# (#90939); hits within the newest rows are assumed in-context and skipped,
+# preserving the original "the current session IS the current context"
+# behavior for short sessions. Well above the compressor's protected tail
+# (protect_last_n=20) and typical small-window tails, so normal sessions
+# never hit the escape hatch.
+_LIVE_CONTEXT_WINDOW_MESSAGES = 200
+
 # Prefixes that identify generated context-compaction handoff summaries.
 # These are inserted by agent/context_compressor.py as normal user/assistant
 # messages but contain machine-generated summary metadata — not user content.
@@ -254,6 +268,54 @@ def _is_compacted_message(db, message_id) -> bool:
     """
     state = _get_message_storage_state(db, message_id)
     return state is not None and state["active"] == 0 and state["compacted"] == 1
+
+
+def _live_context_floor_id(db, session_id: str) -> Optional[int]:
+    """Return the oldest message id that can still be inside the live window.
+
+    The live context window is built from the newest rows of the session, so
+    only the most recent ``_LIVE_CONTEXT_WINDOW_MESSAGES`` active messages can
+    possibly still be in live context. This helper returns the id of the
+    oldest row within that bound (the "floor"): any hit with a smaller id is
+    provably outside the live window, even though its row is still
+    ``active=1`` — long live sessions drop early turns out of context WITHOUT
+    any archival mark, so ``active`` alone cannot tell in-context from
+    out-of-context (#90939).
+
+    Returns ``None`` when the session has fewer active messages than the
+    window bound (everything could still be in context) or on any error — the
+    caller then falls back to the safe default (skip same-session hits).
+    """
+    if not session_id:
+        return None
+    try:
+        with db._lock:
+            cursor = db._conn.execute(
+                "SELECT id FROM messages "
+                "WHERE session_id = ? AND active = 1 "
+                "ORDER BY id DESC "
+                "LIMIT 1 OFFSET ?",
+                (session_id, _LIVE_CONTEXT_WINDOW_MESSAGES - 1),
+            )
+            row = cursor.fetchone()
+    except Exception:
+        logging.debug(
+            "live-context floor lookup failed for %s", session_id, exc_info=True
+        )
+        return None
+    return int(row["id"]) if row is not None else None
+
+
+def _is_below_live_context_floor(db, session_id: str, message_id) -> bool:
+    """True when *message_id* is older than the current session's live window.
+
+    See :func:`_live_context_floor_id`. Returns False on any error so callers
+    fall back to the safe default (treat the message as still in context).
+    """
+    if not message_id:
+        return False
+    floor = _live_context_floor_id(db, session_id)
+    return floor is not None and int(message_id) < floor
 
 
 def _annotate_rebuild_status(db, payload: Dict[str, Any]) -> None:
@@ -571,9 +633,11 @@ def _scroll(
 
     # Locate the anchor before applying the current-lineage guard. Discovery
     # intentionally surfaces same-lineage history that is no longer in live
-    # context: in-place compacted rows, compression-ended parents, and
-    # /new-reset predecessors. Scroll must preserve that distinction instead
-    # of rejecting the discovery result it just returned.
+    # context: in-place compacted rows, compression-ended parents, /new-reset
+    # predecessors, and — for long live sessions — the current session's own
+    # early turns that fell out of the live window (#90939). Scroll must
+    # preserve that distinction instead of rejecting the discovery result it
+    # just returned.
     anchor_state = _get_message_storage_state(db, around_message_id)
     owning_session_id = (
         anchor_state.get("session_id") if anchor_state is not None else None
@@ -598,7 +662,12 @@ def _scroll(
                 not is_inactive_non_compacted_anchor
                 and _session_left_live_context(db, anchor_session_id)
             )
-            if not (is_compacted_anchor or is_out_of_context_history):
+            is_below_live_floor = (
+                not is_inactive_non_compacted_anchor
+                and anchor_session_id == current_session_id
+                and _is_below_live_context_floor(db, current_session_id, around_message_id)
+            )
+            if not (is_compacted_anchor or is_out_of_context_history or is_below_live_floor):
                 return tool_error(
                     "scroll rejected: anchor lives in the current session lineage (already in your active context)",
                     success=False,
@@ -789,6 +858,14 @@ def _discover(
     # within each class.
     raw_results = _order_for_recall(raw_results)
 
+    # Live-context floor of the current session, computed once per discovery.
+    # None when the session is short enough that every active row could still
+    # be inside the live window.
+    current_live_floor = (
+        _live_context_floor_id(db, current_session_id)
+        if current_session_id else None
+    )
+
     if not raw_results and not title_result:
         _empty_payload = {
             "success": True,
@@ -837,16 +914,27 @@ def _discover(
         # current session, but the matched message row is an archived
         # (active=0, compacted=1) row. The live-context load filters active=1,
         # so that content is no longer in context — let it through.
+        #
+        # Long live sessions: the current session's OWN early turns leave the
+        # live window without any archival mark (active=1, compacted=0 — the
+        # prune path never flips the compaction flag). Blanket-skipping them
+        # hid the whole session, so terms unique to its early content returned
+        # 0 results (#90939). Active hits older than the live-context floor
+        # are provably outside the window — let them through too.
         is_compacted_hit = _is_compacted_message(db, r.get("id"))
         is_ended_session = _session_left_live_context(db, raw_sid)
-        if current_lineage_root and resolved_sid == current_lineage_root:
+        is_current_session_hit = bool(current_session_id and raw_sid == current_session_id)
+        if is_current_session_hit:
             if not (is_ended_session or is_compacted_hit):
-                continue
-        if current_session_id and raw_sid == current_session_id:
-            # Same-session hit: only skip if the matched message is still live
-            # (active=1). Archived/compacted rows are pre-compaction content
-            # that's been summarised away — let them through.
-            if not is_compacted_hit:
+                # Active row on the current session: skip only while it can
+                # still be inside the live window (no floor = short session,
+                # everything in context).
+                if current_live_floor is None or (r.get("id") or 0) >= current_live_floor:
+                    continue
+        elif current_lineage_root and resolved_sid == current_lineage_root:
+            # Other same-lineage sessions (compression parents, /new-reset
+            # predecessors, delegation children): unchanged lineage escape.
+            if not (is_ended_session or is_compacted_hit):
                 continue
         if resolved_sid not in seen_sessions:
             row = dict(r)


### PR DESCRIPTION
## Summary

`session_search` could not recall the **current session's own early context** in long live sessions. For a session that had outgrown the live context window, discovery returned `count: 0, sessions_searched: 0` for terms that existed verbatim in the current session's message store (FTS index complete, all rows `active=1`), forcing the agent to fall back to raw SQL against `state.db`.

This PR makes current-session hits that have fallen out of the live window discoverable again, while keeping the existing behavior for short sessions, compaction archives, rewind rows, and foreign-session lineage dedup untouched.

## Root Cause

In `tools/session_search_tool.py`, `_discover` skips FTS hits whose `session_id` is the current session, on the assumption that "the current session IS the current context". The only escape hatch was `_is_compacted_message` — rows archived by in-place compaction (`active=0, compacted=1`):

```python
if current_session_id and raw_sid == current_session_id:
    if not is_compacted_hit:
        continue
```

That assumption breaks in a long live session: early turns leave the live window **without any archival mark** (`active=1, compacted=0` — the prune path never flips the compaction flag, and no compaction archive is produced). The heuristic then classified every same-session hit as "in context" and filtered the whole session out of discovery — including content that is provably no longer in the live window. The issue documents this exactly: 353-message session, 23–24 FTS hits for "gamelandia", `session_search` → `count: 0, sessions_searched: 0`.

There is no persisted "live-context floor": the live window is token-bounded and nothing in the DB records where it starts, so `active=1` alone cannot distinguish in-context from out-of-context content.

## Change

- **`_LIVE_CONTEXT_WINDOW_MESSAGES = 200`** — a conservative message-count ceiling for the live context window of the current session (the window is token-bounded; this is a safe upper bound on how many of the newest rows can still be inside it).
- **`_live_context_floor_id(db, session_id)`** — returns the id of the oldest row that can still be in the live window (the newest `_LIVE_CONTEXT_WINDOW_MESSAGES` active rows), or `None` when the session is short enough that everything could still be in context. Fail-safe: any error returns `None`, preserving the old skip behavior.
- **`_is_below_live_context_floor(db, session_id, message_id)`** — predicate used by the scroll gate.
- **`_discover`**: same-session hits now surface when they are provably below the live-context floor. Hits inside the newest window rows (or short sessions with no floor) are still skipped as in-context; compaction-archived rows and compression-ended sessions keep surfacing as before; all other same-lineage and foreign-session logic is unchanged.
- **`_scroll`**: the current-lineage guard now accepts anchors below the live-context floor, so a scroll on a discovery result that just surfaced a current-session early hit is not rejected as "already in your active context".

Trade-off direction: when in doubt, the tool now leans toward surfacing (a redundant in-context hit costs a few tokens) rather than hiding (which caused total recall blindness for the current session's own history).

## Verification

- New regression tests in `tests/tools/test_session_search.py` (`TestCurrentSessionEarlyContext`):
  - early current-session hits surface after the session outgrows the window (the #90939 repro shape — needle only in the first messages, all rows `active=1, compacted=0`);
  - a foreign-session hit still surfaces **and** dedupes by lineage (two foreign hits → one result; `count == 2`, `sessions_searched == 2`);
  - hits inside the newest window rows stay filtered (the escape does not widen to the whole session);
  - scroll accepts a below-floor current-session anchor returned by discovery.
- Verified the 3 core regression tests **fail without the fix** (exactly the issue's `count: 0` behavior) and pass with it.
- `tests/tools/test_session_search.py`: **57 passed** (was 53); `tests/run_agent/test_token_persistence_non_cli.py`: 3 passed. Full suite not run, per focused-change policy.

## Related

Fixes the distinct trigger reported in #90939 (long live session, no archival mark). Existing compaction (#38763), `/new`-reset (#85756), and delegation-exclusion semantics are preserved and covered by the pre-existing tests.

Closes #90939
