### PR TITLE
fix(native_compaction): preserve compression summary messages during pre-checkpoint pruning

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -479,6 +479,12 @@ def _chat_messages_to_responses_input(
     conversation is still on the wire.
     """
     items: List[Dict[str, Any]] = []
+    # Parallel to `items`: the raw chat message each converted item came
+    # from. Pruning needs this to read a canonical summary carrier's
+    # up-to-date, provenance-tagged content directly — the converted `item`
+    # can be a lossy shape (stale exact-replay, or a typed
+    # `function_call_output` wrapper) that no longer carries it (#90976).
+    item_sources: List[Optional[Dict[str, Any]]] = []
     seen_item_ids: set = set()
 
     for msg in messages:
@@ -567,6 +573,7 @@ def _chat_messages_to_responses_input(
                                 if k not in ("id", "_issuer_kind")
                             }
                             items.append(replay_item)
+                            item_sources.append(msg)
                             if item_id:
                                 seen_item_ids.add(item_id)
                             has_codex_reasoning = True
@@ -623,14 +630,17 @@ def _chat_messages_to_responses_input(
                         if isinstance(phase, str) and phase.strip():
                             replay_item["phase"] = phase.strip()
                         items.append(replay_item)
+                        item_sources.append(msg)
                         replayed_message_items += 1
 
                 if replayed_message_items > 0:
                     pass
                 elif content_parts:
                     items.append({"role": "assistant", "content": content_parts})
+                    item_sources.append(msg)
                 elif content_text.strip():
                     items.append({"role": "assistant", "content": content_text})
+                    item_sources.append(msg)
                 elif has_codex_reasoning:
                     # The Responses API requires a following item after each
                     # reasoning item (otherwise: missing_following_item error).
@@ -638,6 +648,7 @@ def _chat_messages_to_responses_input(
                     # content, emit an empty assistant message as the required
                     # following item.
                     items.append({"role": "assistant", "content": ""})
+                    item_sources.append(msg)
 
                 tool_calls = msg.get("tool_calls")
                 if isinstance(tool_calls, list):
@@ -680,6 +691,7 @@ def _chat_messages_to_responses_input(
                             "name": fn_name,
                             "arguments": arguments,
                         })
+                        item_sources.append(msg)
                 continue
 
             # Non-assistant (user) role: emit multimodal parts when present,
@@ -688,6 +700,7 @@ def _chat_messages_to_responses_input(
                 items.append({"role": role, "content": content_parts})
             else:
                 items.append({"role": role, "content": content_text})
+            item_sources.append(msg)
             continue
 
         if role == "tool":
@@ -722,24 +735,38 @@ def _chat_messages_to_responses_input(
                 "call_id": _clamp_responses_call_id(call_id),
                 "output": output_value,
             })
+            item_sources.append(msg)
 
     # Native server-side compaction: when a replayed checkpoint is present,
     # restructure the wire around it. The server renders nothing placed
     # before a compaction item (live-verified Aug 2026), so pre-checkpoint
-    # history is dead upload weight and — worse — the user's plaintext asks
-    # from before the boundary silently vanish from the model's view. Keep
-    # the newest checkpoint first, retain pre-checkpoint USER messages
-    # verbatim within a token budget (Codex CLI parity), and leave the
+    # history is dead upload weight and — worse — the user's plaintext asks,
+    # and any local-compression summary already merged into that history,
+    # silently vanish from the model's view. Keep the newest checkpoint
+    # first, retain pre-checkpoint USER messages and compression-SUMMARY
+    # messages (whole, never byte-sliced) verbatim within a token budget
+    # each (Codex CLI parity for the user side), and leave the
     # post-checkpoint tail untouched. Gated on the CURRENT request's native
     # eligibility, not merely on the presence of a checkpoint: a persisted
     # checkpoint outlives the gate, and pruning for a request that carries no
     # ``context_management`` deletes history the server never compacted.
+    #
+    # ``item_sources`` (parallel to ``items``) carries the raw chat message
+    # each converted item came from. A canonical summary carrier's content
+    # can be lost or gone stale by the time it becomes a Responses item — a
+    # merge-into-tail tool-result carrier becomes a typed
+    # ``function_call_output`` (no ``content``/``role`` at all), and a
+    # merge-into-tail assistant carrier can be shadowed by a stale exact
+    # ``codex_message_items`` replay from before the merge rewrote its
+    # content. Pruning reads the source message's own up-to-date,
+    # provenance-tagged content directly instead of trying to recover it
+    # from whatever shape the conversion produced (#90976).
     if not native_compaction_eligible:
         return items
 
     from agent.native_compaction import prune_pre_checkpoint_items
 
-    return prune_pre_checkpoint_items(items)
+    return prune_pre_checkpoint_items(items, item_sources=item_sources)
 
 
 # ---------------------------------------------------------------------------

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -38,8 +38,11 @@ conversation loop can share the gate without import cycles.
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlsplit
+
+logger = logging.getLogger(__name__)
 
 # Native compaction fires this many tokens below the local compressor's
 # trigger so the server always gets the first shot at compaction.
@@ -147,15 +150,11 @@ def native_compaction_context_management(
 # Retention budget for plaintext user messages carried across a native
 # compaction boundary (mirrors Codex CLI's RETAINED_MESSAGE_TOKEN_BUDGET).
 # Live verification (Aug 2026, gpt-5.6 @ api.openai.com): the server renders
-# NOTHING placed before a replayed compaction checkpoint — a fact stated in a
-# pre-checkpoint input item is invisible to the model ("NONE" recall), while
-# the same item placed after the checkpoint recalls perfectly. Without
-# retention, every plaintext user ask from before the compaction survives
-# only as whatever the opaque server summary kept — the goal-drift failure
-# mode. Codex CLI solves this by rebuilding history with user messages
-# retained verbatim; ``prune_pre_checkpoint_items`` is our wire-level
-# equivalent.
 RETAINED_USER_MESSAGE_TOKEN_BUDGET = 64_000
+
+# Retention budget for local compression summary messages carried across a native
+# compaction boundary to prevent summary token inflation.
+RETAINED_SUMMARY_TOKEN_BUDGET = 32_000
 
 
 def _approx_tokens(text: str) -> int:
@@ -163,30 +162,100 @@ def _approx_tokens(text: str) -> int:
     return max(1, len(text) // 4)
 
 
-def _user_item_text(item: Dict[str, Any]) -> Optional[str]:
-    """Extract the retained-budget text of a user-role input item.
+def _extract_item_text(item: Any) -> Optional[str]:
+    """Extract measurable text from string, list content, output_text, or nested metadata text.
 
-    Returns None when the item carries no measurable text (empty message).
-    Multimodal list content is measured by its ``input_text`` parts; images
-    count as zero, matching Codex's retention accounting.
+    Returns None when the item carries no measurable text.
+    Handles string content, multipart lists (input_text/text/output_text), and fallback keys.
     """
+    if not isinstance(item, dict):
+        return None
+
     content = item.get("content")
+    if content is None and "output_text" in item:
+        content = item.get("output_text")
+
     if isinstance(content, str):
         return content if content.strip() else None
+
     if isinstance(content, list):
-        text = "".join(
-            part.get("text", "")
-            for part in content
-            if isinstance(part, dict)
-            and (part.get("type") in ("input_text", "text") or isinstance(part.get("text"), str))
-        )
+        parts = []
+        for part in content:
+            if isinstance(part, str):
+                if part.strip():
+                    parts.append(part.strip())
+            elif isinstance(part, dict):
+                part_text = part.get("text") or part.get("input_text") or part.get("output_text")
+                if isinstance(part_text, str) and part_text.strip():
+                    parts.append(part_text.strip())
+                part_meta = part.get("metadata")
+                if isinstance(part_meta, dict) and isinstance(part_meta.get("text"), str):
+                    if part_meta["text"].strip():
+                        parts.append(part_meta["text"].strip())
+        text = " ".join(parts)
         return text if text.strip() or content else None
+
     return None
+
+
+def _user_item_text(item: Dict[str, Any]) -> Optional[str]:
+    """Extract the retained-budget text of a user-role input item (backward compatibility wrapper)."""
+    return _extract_item_text(item)
+
+
+def _is_summary_item(item: Any) -> bool:
+    """Robust summary item detection supporting flags, metadata dicts, and content headers."""
+    if not isinstance(item, dict):
+        return False
+
+    # 1. Top-level summary boolean or string flags
+    if (
+        item.get("_compressed_summary")
+        or item.get("_is_compression_summary")
+        or item.get("_hermes_compressed_summary")
+    ):
+        return True
+
+    # 2. Dynamic underscore key scan
+    if any(isinstance(k, str) and k.startswith("_") and "summary" in k.lower() for k in item.keys()):
+        return True
+
+    # 3. Nested metadata inspection (metadata / _metadata)
+    for meta_key in ("metadata", "_metadata"):
+        meta = item.get(meta_key)
+        if isinstance(meta, dict):
+            if meta.get("summary") or meta.get("is_summary") or meta.get("_compressed_summary"):
+                return True
+            if any(
+                isinstance(k, str) and ("summary" in k.lower() or "compression" in k.lower())
+                for k in meta.keys()
+            ):
+                return True
+
+    # 4. Text header inspection
+    text = _extract_item_text(item)
+    if text:
+        text_lower = text.lower()
+        summary_phrases = (
+            "summary of previous conversation",
+            "conversation summary",
+            "handoff from a previous context",
+            "previous conversation summary",
+            "context summary",
+            "[summary]",
+            "## summary",
+        )
+        if any(phrase in text_lower for phrase in summary_phrases):
+            return True
+
+    return False
 
 
 def prune_pre_checkpoint_items(
     items: List[Dict[str, Any]],
     retained_user_token_budget: int = RETAINED_USER_MESSAGE_TOKEN_BUDGET,
+    retained_summary_token_budget: int = RETAINED_SUMMARY_TOKEN_BUDGET,
+    enable_summary_retention: bool = True,
 ) -> List[Dict[str, Any]]:
     """Restructure Responses input around the newest compaction checkpoint.
 
@@ -195,26 +264,16 @@ def prune_pre_checkpoint_items(
     weight AND silently erases the user's plaintext asks. When a checkpoint
     is present, rebuild the wire as::
 
-        [checkpoint run] + [retained user messages (newest-first budget)] + [post]
+        [checkpoint run] + [retained user & summary messages (newest-first budget)] + [post]
 
-    - The NEWEST contiguous run of checkpoints wins (the server can emit
-      more than one compaction item in a single response — live-observed
-      Aug 2026 — and they arrive adjacent; a run from a newer response
-      cumulatively carries prior windows, so older runs are dropped).
-    - Retained user messages are the user-role items from before the
-      checkpoint, kept verbatim newest-first within
-      ``retained_user_token_budget``; the boundary message is head-truncated
-      when it only partially fits (string content only).
-    - Everything after the checkpoint is untouched, so function_call /
-      function_call_output pairing is preserved (a checkpoint is captured on
-      an assistant response, and that response's own calls and their outputs
-      are all emitted after its reasoning items).
-    - No checkpoint in ``items`` → returned unchanged (self-gating: non-native
-      routes and kill-switched sessions never see a restructured wire).
-
-    Deterministic for a given history, so the request prefix stays stable
-    across turns and server-side prompt caching keeps working.
+    - The NEWEST contiguous run of checkpoints wins.
+    - Retained user messages are kept verbatim within ``retained_user_token_budget``.
+    - Compression summary messages are retained within ``retained_summary_token_budget``.
+    - Original relative chronological order between user messages and summaries is preserved.
     """
+    if not isinstance(items, list) or not items:
+        return items
+
     last_cp = None
     for i, item in enumerate(items):
         if isinstance(item, dict) and item.get("type") == "compaction":
@@ -236,49 +295,66 @@ def prune_pre_checkpoint_items(
     post = items[last_cp + 1 :]
 
     retained_reversed: List[Dict[str, Any]] = []
-    remaining = max(0, int(retained_user_token_budget))
+    user_remaining = max(0, int(retained_user_token_budget))
+    summary_remaining = max(0, int(retained_summary_token_budget))
+
     for item in reversed(pre):
         if not isinstance(item, dict):
             continue
+
+        # Skip typed non-message items
+        if "type" in item and item.get("type") not in ("message", "summary", "context_summary"):
+            continue
+
+        is_summary = enable_summary_retention and _is_summary_item(item)
         is_user = item.get("role") == "user"
-        is_summary = bool(
-            item.get("_compressed_summary")
-            or item.get("_is_compression_summary")
-            or item.get("_hermes_compressed_summary")
-            or any(isinstance(k, str) and k.startswith("_") and "summary" in k.lower() for k in item.keys())
-            or "Summary of previous conversation" in str(item.get("content", ""))
-            or "Conversation Summary" in str(item.get("content", ""))
-            or "conversation summary" in str(item.get("content", "")).lower()
-            or "handoff from a previous context" in str(item.get("content", "")).lower()
-        )
+
         if not is_user and not is_summary:
             continue
-        # Skip typed items (function_call_output etc. never carry role=user,
-        # but stay defensive about future shapes).
-        if "type" in item and item.get("type") != "message":
-            continue
-        if remaining <= 0 and not is_summary:
-            break
-        text = _user_item_text(item) if is_user else str(item.get("content") or "")
+
+        text = _extract_item_text(item)
         if not text:
             continue
-        cost = _approx_tokens(text)
-        if cost <= remaining or is_summary:
-            retained_reversed.append(item)
-            if not is_summary:
-                remaining -= cost
-        elif isinstance(item.get("content"), str):
-            # Head-truncate the boundary message: goals are usually stated
-            # up front, so the head is the valuable end.
-            truncated = dict(item)
-            truncated["content"] = item["content"][: remaining * 4]
-            if truncated["content"].strip():
-                retained_reversed.append(truncated)
-            remaining = 0
-        # Multimodal boundary message that doesn't fit whole: skip rather
-        # than rewrite parts.
 
-    return checkpoint_run + list(reversed(retained_reversed)) + post
+        cost = _approx_tokens(text)
+
+        if is_summary:
+            if summary_remaining <= 0:
+                continue
+            if cost <= summary_remaining:
+                retained_reversed.append(item)
+                summary_remaining -= cost
+            elif isinstance(item.get("content"), str):
+                truncated = dict(item)
+                truncated["content"] = item["content"][: summary_remaining * 4]
+                if truncated["content"].strip():
+                    retained_reversed.append(truncated)
+                summary_remaining = 0
+        elif is_user:
+            if user_remaining <= 0:
+                continue
+            if cost <= user_remaining:
+                retained_reversed.append(item)
+                user_remaining -= cost
+            elif isinstance(item.get("content"), str):
+                truncated = dict(item)
+                truncated["content"] = item["content"][: user_remaining * 4]
+                if truncated["content"].strip():
+                    retained_reversed.append(truncated)
+                user_remaining = 0
+
+    retained_ordered = list(reversed(retained_reversed))
+    result = checkpoint_run + retained_ordered + post
+
+    logger.debug(
+        "Pruned pre-checkpoint items: %d input -> %d retained (user_rem=%d, summary_rem=%d)",
+        len(items),
+        len(result),
+        user_remaining,
+        summary_remaining,
+    )
+
+    return result
 
 
 def is_native_compaction_rejection(error: Any, status_code: Any = None) -> bool:

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -237,21 +237,32 @@ def prune_pre_checkpoint_items(
     retained_reversed: List[Dict[str, Any]] = []
     remaining = max(0, int(retained_user_token_budget))
     for item in reversed(pre):
-        if not isinstance(item, dict) or item.get("role") != "user":
+        if not isinstance(item, dict):
+            continue
+        is_user = item.get("role") == "user"
+        is_summary = bool(
+            item.get("_compressed_summary")
+            or item.get("_is_compression_summary")
+            or item.get("_hermes_compressed_summary")
+            or "Summary of previous conversation" in str(item.get("content", ""))
+            or "Conversation Summary" in str(item.get("content", ""))
+        )
+        if not is_user and not is_summary:
             continue
         # Skip typed items (function_call_output etc. never carry role=user,
         # but stay defensive about future shapes).
         if "type" in item and item.get("type") != "message":
             continue
-        if remaining <= 0:
+        if remaining <= 0 and not is_summary:
             break
-        text = _user_item_text(item)
-        if text is None:
+        text = _user_item_text(item) if is_user else str(item.get("content") or "")
+        if not text:
             continue
         cost = _approx_tokens(text)
-        if cost <= remaining:
+        if cost <= remaining or is_summary:
             retained_reversed.append(item)
-            remaining -= cost
+            if not is_summary:
+                remaining -= cost
         elif isinstance(item.get("content"), str):
             # Head-truncate the boundary message: goals are usually stated
             # up front, so the head is the valuable end.

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -177,7 +177,8 @@ def _user_item_text(item: Dict[str, Any]) -> Optional[str]:
         text = "".join(
             part.get("text", "")
             for part in content
-            if isinstance(part, dict) and part.get("type") == "input_text"
+            if isinstance(part, dict)
+            and (part.get("type") in ("input_text", "text") or isinstance(part.get("text"), str))
         )
         return text if text.strip() or content else None
     return None

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -203,6 +203,35 @@ def _extract_item_text(item: Any) -> Optional[str]:
     return None
 
 
+def _extract_message_text(msg: Any) -> Optional[str]:
+    """Best-effort text view of a raw chat message's ``content`` field.
+
+    Chat-message content (pre-Responses-conversion) is plain text or a list
+    of ``{"type": "text", "text": ...}`` parts — a different shape from a
+    converted Responses item. Used to read a canonical summary carrier's
+    up-to-date content directly from its source, bypassing whatever lossy
+    shape the Responses conversion produced for it (#90976).
+    """
+    if not isinstance(msg, dict):
+        return None
+    content = msg.get("content")
+    if isinstance(content, str):
+        return content if content.strip() else None
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, str):
+                if part.strip():
+                    parts.append(part)
+            elif isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str) and text.strip():
+                    parts.append(text)
+        joined = "\n".join(parts)
+        return joined if joined.strip() else None
+    return None
+
+
 def _is_summary_item(item: Any) -> bool:
     """True when *item* is a canonical Hermes compression-summary message.
 
@@ -230,6 +259,7 @@ def prune_pre_checkpoint_items(
     retained_user_token_budget: int = RETAINED_USER_MESSAGE_TOKEN_BUDGET,
     retained_summary_token_budget: int = RETAINED_SUMMARY_TOKEN_BUDGET,
     enable_summary_retention: bool = True,
+    item_sources: Optional[List[Any]] = None,
 ) -> List[Dict[str, Any]]:
     """Restructure Responses input around the newest compaction checkpoint.
 
@@ -260,6 +290,20 @@ def prune_pre_checkpoint_items(
       wired to a user-facing config surface.
     - Original relative chronological order between user messages and
       summaries is preserved.
+    - ``item_sources`` (optional, parallel to ``items``) is the raw chat
+      message each Responses item was converted from. By the time a summary
+      reaches this function as a converted ``item`` it can already be lossy:
+      a merge-into-tail tool-result carrier becomes a typed
+      ``function_call_output`` (no ``content``/``role`` survives the
+      conversion at all), and a merge-into-tail assistant carrier can be
+      shadowed by a stale exact ``codex_message_items`` replay captured
+      before the merge rewrote its content. When a source is provided and is
+      itself a canonical summary carrier (``is_compaction_summary_message``),
+      its content is read directly from the source — never from the
+      converted item — and it is retained as a synthesized
+      ``role="assistant"`` message regardless of what shape the original
+      item took. Without ``item_sources`` (default), retention only sees
+      what survived conversion, matching pre-#90976 behavior (#90976).
     """
     if not isinstance(items, list) or not items:
         return items
@@ -284,13 +328,39 @@ def prune_pre_checkpoint_items(
     checkpoint_run = items[first_cp : last_cp + 1]
     post = items[last_cp + 1 :]
 
+    if isinstance(item_sources, list) and len(item_sources) == len(items):
+        pre_sources: List[Any] = item_sources[:first_cp]
+    else:
+        pre_sources = [None] * len(pre)
+
     retained_reversed: List[Dict[str, Any]] = []
     user_remaining = max(0, int(retained_user_token_budget))
     summary_remaining = max(0, int(retained_summary_token_budget))
     seen_summary_texts: set = set()
 
-    for item in reversed(pre):
+    for item, source in zip(reversed(pre), reversed(pre_sources)):
         if not isinstance(item, dict):
+            continue
+
+        # Canonical source-based summary detection: reads the ORIGINAL chat
+        # message's own content, so it sees past a lossy conversion (a
+        # typed `function_call_output` wrapper, or a stale exact-replay
+        # message) that erased the summary from `item` itself (#90976).
+        # This is never a heuristic promotion of arbitrary item content —
+        # it only fires when the source message itself is a canonical,
+        # provenance-tagged summary carrier.
+        if enable_summary_retention and isinstance(source, dict) and _is_summary_item(source):
+            text = _extract_message_text(source)
+            if not text or summary_remaining <= 0 or text in seen_summary_texts:
+                continue
+            cost = _approx_tokens(text)
+            if cost > summary_remaining:
+                # Never byte-slice a summary's structural framing — drop it
+                # whole rather than corrupt the handoff prefix / end marker.
+                continue
+            retained_reversed.append({"role": "assistant", "content": text})
+            seen_summary_texts.add(text)
+            summary_remaining -= cost
             continue
 
         # Skip typed non-message items (function_call_output etc. never

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -32,8 +32,11 @@ captured compaction items ride the existing ``codex_reasoning_items``
 sidecar, which already handles persistence (state.db), gateway session
 replay, cross-issuer stamping, and the encrypted-replay kill switch.
 
-This module is dependency-free on purpose so the transport, adapter, and
-conversation loop can share the gate without import cycles.
+This module stays free of transport/adapter dependencies so the transport,
+adapter, and conversation loop can share the gate without import cycles. The
+one exception is ``agent.context_compressor``: it sits below this module in
+the dependency graph (it never imports ``native_compaction``), so importing
+its canonical summary-provenance primitives here introduces no cycle.
 """
 
 from __future__ import annotations
@@ -41,6 +44,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlsplit
+
+from agent.context_compressor import is_compaction_summary_message
 
 logger = logging.getLogger(__name__)
 
@@ -198,57 +203,26 @@ def _extract_item_text(item: Any) -> Optional[str]:
     return None
 
 
-def _user_item_text(item: Dict[str, Any]) -> Optional[str]:
-    """Extract the retained-budget text of a user-role input item (backward compatibility wrapper)."""
-    return _extract_item_text(item)
-
-
 def _is_summary_item(item: Any) -> bool:
-    """Robust summary item detection supporting flags, metadata dicts, and content headers."""
-    if not isinstance(item, dict):
-        return False
+    """True when *item* is a canonical Hermes compression-summary message.
 
-    # 1. Top-level summary boolean or string flags
-    if (
-        item.get("_compressed_summary")
-        or item.get("_is_compression_summary")
-        or item.get("_hermes_compressed_summary")
-    ):
-        return True
+    Delegates entirely to
+    ``agent.context_compressor.is_compaction_summary_message`` — the single
+    authoritative provenance check already used by every other summary
+    consumer (memory providers, frontends, the compactor itself). It prefers
+    the exact, truthy ``COMPRESSED_SUMMARY_METADATA_KEY`` marker and falls
+    back to the canonical prefix classifier (``SUMMARY_PREFIX`` /
+    ``LEGACY_SUMMARY_PREFIX`` / historical prefixes, including the
+    merge-into-tail shape) for the case where the underscore-prefixed key
+    was already stripped by a wire sanitizer.
 
-    # 2. Dynamic underscore key scan
-    if any(isinstance(k, str) and k.startswith("_") and "summary" in k.lower() for k in item.keys()):
-        return True
-
-    # 3. Nested metadata inspection (metadata / _metadata)
-    for meta_key in ("metadata", "_metadata"):
-        meta = item.get(meta_key)
-        if isinstance(meta, dict):
-            if meta.get("summary") or meta.get("is_summary") or meta.get("_compressed_summary"):
-                return True
-            if any(
-                isinstance(k, str) and ("summary" in k.lower() or "compression" in k.lower())
-                for k in meta.keys()
-            ):
-                return True
-
-    # 4. Text header inspection
-    text = _extract_item_text(item)
-    if text:
-        text_lower = text.lower()
-        summary_phrases = (
-            "summary of previous conversation",
-            "conversation summary",
-            "handoff from a previous context",
-            "previous conversation summary",
-            "context summary",
-            "[summary]",
-            "## summary",
-        )
-        if any(phrase in text_lower for phrase in summary_phrases):
-            return True
-
-    return False
+    Deliberately NOT a second heuristic: no arbitrary underscore-key scan, no
+    inference from a falsy or unrelated metadata key, and no matching on
+    ad-hoc content headings like ``"## Summary"`` in ordinary text — any of
+    those can promote a normal user/assistant message (or adversarial
+    content) to durable retained history (#90975 review).
+    """
+    return is_compaction_summary_message(item)
 
 
 def prune_pre_checkpoint_items(
@@ -261,15 +235,31 @@ def prune_pre_checkpoint_items(
 
     The server drops every input item that precedes a replayed ``compaction``
     item (live-verified Aug 2026), so sending pre-checkpoint history is dead
-    weight AND silently erases the user's plaintext asks. When a checkpoint
-    is present, rebuild the wire as::
+    weight AND silently erases the user's plaintext asks — including any
+    local-compression summary the agent already produced, which previously
+    vanished here because it carries ``role="assistant"``, not ``"user"``
+    (#90975). When a checkpoint is present, rebuild the wire as::
 
         [checkpoint run] + [retained user & summary messages (newest-first budget)] + [post]
 
     - The NEWEST contiguous run of checkpoints wins.
-    - Retained user messages are kept verbatim within ``retained_user_token_budget``.
-    - Compression summary messages are retained within ``retained_summary_token_budget``.
-    - Original relative chronological order between user messages and summaries is preserved.
+    - Retained user messages are kept verbatim within
+      ``retained_user_token_budget``; the boundary message is head-truncated
+      when it only partially fits (string content only) — goals are usually
+      stated up front, so the head is the valuable end.
+    - Compression summary messages (``_is_summary_item``, the canonical
+      ``agent.context_compressor`` provenance check) are retained whole
+      within ``retained_summary_token_budget``. A summary is never
+      byte/character-sliced: Hermes summaries carry structural framing
+      (handoff prefix, end marker, merge-into-tail delimiters) that a blind
+      slice can corrupt, so one that doesn't fit whole is dropped instead.
+      A summary already retained once (identical text) is never duplicated,
+      so repeated checkpoints stay idempotent.
+    - ``enable_summary_retention`` is a function-level override (used by
+      tests and callers that need the pre-#90975 behavior back); it is not
+      wired to a user-facing config surface.
+    - Original relative chronological order between user messages and
+      summaries is preserved.
     """
     if not isinstance(items, list) or not items:
         return items
@@ -297,13 +287,16 @@ def prune_pre_checkpoint_items(
     retained_reversed: List[Dict[str, Any]] = []
     user_remaining = max(0, int(retained_user_token_budget))
     summary_remaining = max(0, int(retained_summary_token_budget))
+    seen_summary_texts: set = set()
 
     for item in reversed(pre):
         if not isinstance(item, dict):
             continue
 
-        # Skip typed non-message items
-        if "type" in item and item.get("type") not in ("message", "summary", "context_summary"):
+        # Skip typed non-message items (function_call_output etc. never
+        # carry role=user or a summary flag, but stay defensive about
+        # future shapes).
+        if "type" in item and item.get("type") != "message":
             continue
 
         is_summary = enable_summary_retention and _is_summary_item(item)
@@ -316,23 +309,21 @@ def prune_pre_checkpoint_items(
         if not text:
             continue
 
-        cost = _approx_tokens(text)
-
         if is_summary:
-            if summary_remaining <= 0:
+            if summary_remaining <= 0 or text in seen_summary_texts:
                 continue
-            if cost <= summary_remaining:
-                retained_reversed.append(item)
-                summary_remaining -= cost
-            elif isinstance(item.get("content"), str):
-                truncated = dict(item)
-                truncated["content"] = item["content"][: summary_remaining * 4]
-                if truncated["content"].strip():
-                    retained_reversed.append(truncated)
-                summary_remaining = 0
+            cost = _approx_tokens(text)
+            if cost > summary_remaining:
+                # Never byte-slice a summary's structural framing — drop it
+                # whole rather than corrupt the handoff prefix / end marker.
+                continue
+            retained_reversed.append(item)
+            seen_summary_texts.add(text)
+            summary_remaining -= cost
         elif is_user:
             if user_remaining <= 0:
                 continue
+            cost = _approx_tokens(text)
             if cost <= user_remaining:
                 retained_reversed.append(item)
                 user_remaining -= cost

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -244,6 +244,7 @@ def prune_pre_checkpoint_items(
             item.get("_compressed_summary")
             or item.get("_is_compression_summary")
             or item.get("_hermes_compressed_summary")
+            or any(isinstance(k, str) and k.startswith("_") and "summary" in k.lower() for k in item.keys())
             or "Summary of previous conversation" in str(item.get("content", ""))
             or "Conversation Summary" in str(item.get("content", ""))
         )

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -248,6 +248,8 @@ def prune_pre_checkpoint_items(
             or any(isinstance(k, str) and k.startswith("_") and "summary" in k.lower() for k in item.keys())
             or "Summary of previous conversation" in str(item.get("content", ""))
             or "Conversation Summary" in str(item.get("content", ""))
+            or "conversation summary" in str(item.get("content", "")).lower()
+            or "handoff from a previous context" in str(item.get("content", "")).lower()
         )
         if not is_user and not is_summary:
             continue

--- a/tests/run_agent/test_native_compaction_summary_retention.py
+++ b/tests/run_agent/test_native_compaction_summary_retention.py
@@ -1,134 +1,270 @@
-"""Comprehensive tests for native compaction summary retention, token budgeting, and robustness."""
+"""Tests for native compaction summary retention during pre-checkpoint pruning (#90975).
 
+``prune_pre_checkpoint_items`` previously dropped every pre-checkpoint item
+whose ``role`` was not ``"user"`` — which silently deleted Hermes' own local
+compression summaries (``role="assistant"``) from the wire on every native
+compaction turn. These tests cover the fix's summary retention path, its
+reliance on the canonical ``agent.context_compressor`` provenance check (not
+an ad-hoc heuristic), whole-or-drop truncation, and idempotency.
+"""
+
+from agent.context_compressor import (
+    COMPRESSED_SUMMARY_METADATA_KEY,
+    ContextCompressor,
+    SUMMARY_PREFIX,
+    _MERGED_PRIOR_CONTEXT_HEADER,
+    _MERGED_SUMMARY_DELIMITER,
+    _SUMMARY_END_MARKER,
+)
 from agent.native_compaction import (
-    prune_pre_checkpoint_items,
-    _is_summary_item,
     _extract_item_text,
+    _is_summary_item,
+    prune_pre_checkpoint_items,
 )
 
 
-def test_is_summary_item_robustness():
-    """Validates summary detection across metadata dicts, headers, and flags."""
-    # Top level flags
-    assert _is_summary_item({"_compressed_summary": True}) is True
-    assert _is_summary_item({"_is_compression_summary": True}) is True
-    assert _is_summary_item({"_hermes_compressed_summary": True}) is True
-    assert _is_summary_item({"_my_custom_summary_flag": True}) is True
-
-    # Nested metadata dict
-    assert _is_summary_item({"metadata": {"summary": True}}) is True
-    assert _is_summary_item({"_metadata": {"is_summary": True}}) is True
-    assert _is_summary_item({"metadata": {"_compressed_summary": True}}) is True
-    assert _is_summary_item({"metadata": {"compression_v2": True}}) is True
-
-    # Text headers
-    assert _is_summary_item({"content": "summary of previous conversation: ..."}) is True
-    assert _is_summary_item({"content": "Conversation Summary\nDone"}) is True
-    assert _is_summary_item({"content": "Handoff from a previous context"}) is True
-    assert _is_summary_item({"content": "## Summary of work"}) is True
-
-    # Negative cases
-    assert _is_summary_item({"role": "user", "content": "Just normal prompt"}) is False
-    assert _is_summary_item(None) is False
-    assert _is_summary_item(123) is False
-    assert _is_summary_item({}) is False
+def _standalone_summary_content(body: str = "## Active Task\nstuff") -> str:
+    return f"{SUMMARY_PREFIX}\n{body}\n\n{_SUMMARY_END_MARKER}"
 
 
-def test_extract_item_text_variations():
-    """Validates text extraction across string, multipart list, output_text, and malformed structures."""
-    # String
-    assert _extract_item_text({"content": "Hello world"}) == "Hello world"
-
-    # Multipart list
-    item_list = {
-        "content": [
-            {"type": "input_text", "text": "Part 1"},
-            {"type": "text", "text": "Part 2"},
-            {"type": "other", "output_text": "Part 3"},
-        ]
-    }
-    assert _extract_item_text(item_list) == "Part 1 Part 2 Part 3"
-
-    # output_text fallback
-    assert _extract_item_text({"output_text": "Output fallback"}) == "Output fallback"
-
-    # Malformed / Empty
-    assert _extract_item_text({"content": None}) is None
-    assert _extract_item_text({"content": []}) is None
-    assert _extract_item_text(None) is None
-    assert _extract_item_text("string_item") is None
-
-
-def test_prune_pre_checkpoint_items_retains_summary_and_user_in_order():
-    """Preserves chronological order of user messages and summary messages."""
-    items = [
-        {"role": "user", "content": "User Ask 1"},
-        {"role": "assistant", "content": "Conversation Summary: Step 1 complete", "_compressed_summary": True},
-        {"role": "user", "content": "User Ask 2"},
-        {"role": "assistant", "content": "Normal chatter to prune"},
-        {"type": "compaction", "encrypted_content": "blob_cp"},
-        {"role": "user", "content": "User Ask 3"},
-    ]
-
-    pruned = prune_pre_checkpoint_items(items, retained_user_token_budget=1000)
-
-    # Checkpoint comes first, followed by retained items in original sequence
-    assert pruned[0]["type"] == "compaction"
-    contents = [m.get("content") for m in pruned[1:]]
-    assert contents == [
-        "User Ask 1",
-        "Conversation Summary: Step 1 complete",
-        "User Ask 2",
-        "User Ask 3",
-    ]
-
-
-def test_prune_pre_checkpoint_items_summary_budget_cap_and_truncation():
-    """Enforces token budget limit and truncation for summaries."""
-    long_summary = "Summary line " * 500  # ~6500 chars = ~1625 tokens
-    items = [
-        {"role": "assistant", "content": long_summary, "_compressed_summary": True},
-        {"type": "compaction", "encrypted_content": "blob_cp"},
-        {"role": "user", "content": "Ask"},
-    ]
-
-    # Restrict summary budget to 100 tokens (~400 chars)
-    pruned = prune_pre_checkpoint_items(
-        items,
-        retained_summary_token_budget=100,
+def _merged_summary_content(tail: str = "preserved prior turn") -> str:
+    return (
+        f"{_MERGED_PRIOR_CONTEXT_HEADER}\n{tail}\n\n"
+        f"{_MERGED_SUMMARY_DELIMITER}\n\n"
+        f"{SUMMARY_PREFIX}\nbody\n\n{_SUMMARY_END_MARKER}"
     )
 
-    retained_sum = [m for m in pruned if m.get("_compressed_summary")][0]
-    assert len(retained_sum["content"]) <= 400
-    assert len(retained_sum["content"]) > 0
+
+class TestIsSummaryItemCanonical:
+    """`_is_summary_item` must delegate to the canonical provenance check —
+    exact metadata flag or the canonical prefix classifier — never an
+    ad-hoc heuristic (#90975 blocking review)."""
+
+    def test_truthy_metadata_flag_detected(self):
+        assert _is_summary_item({COMPRESSED_SUMMARY_METADATA_KEY: True}) is True
+
+    def test_standalone_content_detected_without_metadata(self):
+        # The wire sanitizers strip underscore keys, so content-only
+        # detection must still work on the canonical prefix.
+        assert _is_summary_item({"role": "assistant", "content": _standalone_summary_content()}) is True
+
+    def test_merged_content_detected_without_metadata(self):
+        assert _is_summary_item({"role": "assistant", "content": _merged_summary_content()}) is True
+
+    def test_malformed_inputs_are_not_summaries(self):
+        assert _is_summary_item(None) is False
+        assert _is_summary_item(123) is False
+        assert _is_summary_item({}) is False
 
 
-def test_prune_pre_checkpoint_items_enable_summary_retention_toggle():
-    """Disabling summary retention drops pre-checkpoint summaries."""
-    items = [
-        {"role": "assistant", "content": "Conversation Summary: Old", "_compressed_summary": True},
-        {"type": "compaction", "encrypted_content": "blob"},
-        {"role": "user", "content": "New ask"},
-    ]
+class TestIsSummaryItemNegativeWitnesses:
+    """Content that merely resembles a summary must never be promoted to
+    durable retained history — that is authority drift (#90975 blocking
+    review, required item 4)."""
 
-    pruned_disabled = prune_pre_checkpoint_items(items, enable_summary_retention=False)
-    contents = [m.get("content") for m in pruned_disabled]
-    assert "Conversation Summary: Old" not in contents
+    def test_summary_heading_in_ordinary_user_text_is_not_a_summary(self):
+        item = {"role": "user", "content": "## Summary\nplease summarize the PR for me"}
+        assert _is_summary_item(item) is False
+
+    def test_false_valued_metadata_flag_is_not_a_summary(self):
+        item = {"role": "assistant", "content": "hi", COMPRESSED_SUMMARY_METADATA_KEY: False}
+        assert _is_summary_item(item) is False
+
+    def test_arbitrary_underscore_summary_key_is_not_a_summary(self):
+        item = {"role": "assistant", "content": "hi", "_my_custom_summary_flag": True}
+        assert _is_summary_item(item) is False
+
+    def test_non_hermes_assistant_content_is_not_a_summary(self):
+        item = {"role": "assistant", "content": "Conversation Summary: I finished the task."}
+        assert _is_summary_item(item) is False
 
 
-def test_prune_pre_checkpoint_items_malformed_inputs_handled_safely():
-    """Handles None, non-dict elements, empty lists, and invalid items without crashing."""
-    assert prune_pre_checkpoint_items(None) is None
-    assert prune_pre_checkpoint_items([]) == []
+class TestExtractItemTextVariations:
+    def test_string_content(self):
+        assert _extract_item_text({"content": "Hello world"}) == "Hello world"
 
-    items = [
-        None,
-        123,
-        "raw_string",
-        {"role": "user", "content": "Valid user ask"},
-        {"type": "compaction", "encrypted_content": "blob"},
-    ]
-    pruned = prune_pre_checkpoint_items(items)
-    assert len(pruned) == 2
-    assert pruned[0]["type"] == "compaction"
-    assert pruned[1]["content"] == "Valid user ask"
+    def test_multipart_list_content(self):
+        item = {
+            "content": [
+                {"type": "input_text", "text": "Part 1"},
+                {"type": "text", "text": "Part 2"},
+                {"type": "other", "output_text": "Part 3"},
+            ]
+        }
+        assert _extract_item_text(item) == "Part 1 Part 2 Part 3"
+
+    def test_output_text_fallback(self):
+        assert _extract_item_text({"output_text": "Output fallback"}) == "Output fallback"
+
+    def test_malformed_or_empty(self):
+        assert _extract_item_text({"content": None}) is None
+        assert _extract_item_text({"content": []}) is None
+        assert _extract_item_text(None) is None
+        assert _extract_item_text("string_item") is None
+
+
+class TestPrunePreCheckpointItemsRetainsSummaries:
+    def test_retains_summary_and_user_in_original_order(self):
+        summary_content = _standalone_summary_content("Step 1 complete")
+        items = [
+            {"role": "user", "content": "User Ask 1"},
+            {"role": "assistant", "content": summary_content, COMPRESSED_SUMMARY_METADATA_KEY: True},
+            {"role": "user", "content": "User Ask 2"},
+            {"role": "assistant", "content": "Normal chatter to prune"},
+            {"type": "compaction", "encrypted_content": "blob_cp"},
+            {"role": "user", "content": "User Ask 3"},
+        ]
+
+        pruned = prune_pre_checkpoint_items(items, retained_user_token_budget=1000)
+
+        assert pruned[0]["type"] == "compaction"
+        contents = [m.get("content") for m in pruned[1:]]
+        assert contents == [
+            "User Ask 1",
+            summary_content,
+            "User Ask 2",
+            "User Ask 3",
+        ]
+
+    def test_role_agnostic_retention_does_not_touch_user_budget(self):
+        summary_content = _standalone_summary_content("x" * 2000)
+        items = [
+            {"role": "assistant", "content": summary_content, COMPRESSED_SUMMARY_METADATA_KEY: True},
+            {"role": "user", "content": "short ask"},
+            {"type": "compaction", "encrypted_content": "blob_cp"},
+        ]
+
+        pruned = prune_pre_checkpoint_items(
+            items, retained_user_token_budget=10, retained_summary_token_budget=10_000
+        )
+
+        contents = [m.get("content") for m in pruned]
+        assert summary_content in contents
+        assert "short ask" in contents
+
+
+class TestPrunePreCheckpointItemsSummaryBudget:
+    def test_oversized_summary_is_dropped_whole_not_sliced(self):
+        """A summary that cannot fit the remaining budget is dropped
+        entirely rather than character-sliced (#90975 blocking review,
+        required item 3): slicing can corrupt the handoff prefix / end
+        marker that keeps the summary non-active."""
+        long_summary = _standalone_summary_content("Summary line " * 500)
+        items = [
+            {"role": "assistant", "content": long_summary, COMPRESSED_SUMMARY_METADATA_KEY: True},
+            {"type": "compaction", "encrypted_content": "blob_cp"},
+            {"role": "user", "content": "Ask"},
+        ]
+
+        pruned = prune_pre_checkpoint_items(items, retained_summary_token_budget=100)
+
+        assert not any(m.get(COMPRESSED_SUMMARY_METADATA_KEY) for m in pruned)
+
+    def test_summary_that_fits_budget_is_retained_whole(self):
+        summary_content = _standalone_summary_content("short body")
+        items = [
+            {"role": "assistant", "content": summary_content, COMPRESSED_SUMMARY_METADATA_KEY: True},
+            {"type": "compaction", "encrypted_content": "blob_cp"},
+            {"role": "user", "content": "Ask"},
+        ]
+
+        pruned = prune_pre_checkpoint_items(items, retained_summary_token_budget=10_000)
+
+        retained = [m for m in pruned if m.get(COMPRESSED_SUMMARY_METADATA_KEY)]
+        assert len(retained) == 1
+        assert retained[0]["content"] == summary_content
+
+
+class TestPrunePreCheckpointItemsIdempotency:
+    def test_duplicate_summary_text_is_not_retained_twice(self):
+        """A repeated checkpoint sequence can leave the same summary text
+        present at more than one pre-checkpoint position; retention must
+        stay idempotent rather than duplicate it (#90975 blocking review,
+        required item 5)."""
+        summary_content = _standalone_summary_content("same body")
+        items = [
+            {"role": "assistant", "content": summary_content, COMPRESSED_SUMMARY_METADATA_KEY: True},
+            {"role": "user", "content": "mid ask"},
+            {"role": "assistant", "content": summary_content, COMPRESSED_SUMMARY_METADATA_KEY: True},
+            {"type": "compaction", "encrypted_content": "blob_cp"},
+            {"role": "user", "content": "Ask"},
+        ]
+
+        pruned = prune_pre_checkpoint_items(items)
+
+        matches = [m for m in pruned if m.get("content") == summary_content]
+        assert len(matches) == 1
+
+    def test_re_pruning_an_already_pruned_result_is_stable(self):
+        summary_content = _standalone_summary_content("stable body")
+        items = [
+            {"role": "assistant", "content": summary_content, COMPRESSED_SUMMARY_METADATA_KEY: True},
+            {"role": "user", "content": "ask"},
+            {"type": "compaction", "encrypted_content": "blob_cp"},
+        ]
+
+        once = prune_pre_checkpoint_items(items)
+        twice = prune_pre_checkpoint_items(once)
+        assert once == twice
+
+
+class TestPrunePreCheckpointItemsLiveCompressorEmissions:
+    """Exercise the real ``ContextCompressor`` marker renderer instead of a
+    hand-built stand-in, for both standalone and merge-into-tail shapes
+    (#90975 blocking review, required item 5)."""
+
+    def test_standalone_live_marker_is_retained(self):
+        rendered = ContextCompressor._render_micro_marker_content("Live handoff body")
+        assert ContextCompressor.classify_summary_content(rendered) == "standalone"
+
+        items = [
+            {"role": "assistant", "content": rendered, COMPRESSED_SUMMARY_METADATA_KEY: True},
+            {"type": "compaction", "encrypted_content": "blob_cp"},
+            {"role": "user", "content": "Ask"},
+        ]
+        pruned = prune_pre_checkpoint_items(items)
+        assert any(m.get("content") == rendered for m in pruned)
+
+    def test_merged_tail_summary_is_retained_and_classified_merged(self):
+        merged = _merged_summary_content("earlier preserved turn text")
+        assert ContextCompressor.classify_summary_content(merged) == "merged"
+
+        items = [
+            {"role": "assistant", "content": merged, COMPRESSED_SUMMARY_METADATA_KEY: True},
+            {"type": "compaction", "encrypted_content": "blob_cp"},
+            {"role": "user", "content": "Ask"},
+        ]
+        pruned = prune_pre_checkpoint_items(items)
+        assert any(m.get("content") == merged for m in pruned)
+
+
+class TestPrunePreCheckpointItemsEnableSummaryRetentionToggle:
+    def test_disabling_summary_retention_drops_pre_checkpoint_summaries(self):
+        summary_content = _standalone_summary_content("Old")
+        items = [
+            {"role": "assistant", "content": summary_content, COMPRESSED_SUMMARY_METADATA_KEY: True},
+            {"type": "compaction", "encrypted_content": "blob"},
+            {"role": "user", "content": "New ask"},
+        ]
+
+        pruned_disabled = prune_pre_checkpoint_items(items, enable_summary_retention=False)
+        contents = [m.get("content") for m in pruned_disabled]
+        assert summary_content not in contents
+
+
+class TestPrunePreCheckpointItemsMalformedInputs:
+    def test_handles_none_non_dict_and_empty_items_safely(self):
+        assert prune_pre_checkpoint_items(None) is None
+        assert prune_pre_checkpoint_items([]) == []
+
+        items = [
+            None,
+            123,
+            "raw_string",
+            {"role": "user", "content": "Valid user ask"},
+            {"type": "compaction", "encrypted_content": "blob"},
+        ]
+        pruned = prune_pre_checkpoint_items(items)
+        assert len(pruned) == 2
+        assert pruned[0]["type"] == "compaction"
+        assert pruned[1]["content"] == "Valid user ask"

--- a/tests/run_agent/test_native_compaction_summary_retention.py
+++ b/tests/run_agent/test_native_compaction_summary_retention.py
@@ -1,74 +1,134 @@
-"""Tests for native compaction retaining compression summaries preceding a checkpoint."""
+"""Comprehensive tests for native compaction summary retention, token budgeting, and robustness."""
 
-from agent.native_compaction import prune_pre_checkpoint_items
+from agent.native_compaction import (
+    prune_pre_checkpoint_items,
+    _is_summary_item,
+    _extract_item_text,
+)
 
 
-def test_prune_pre_checkpoint_items_retains_assistant_summary():
-    """Compression summaries with role='assistant' or marked metadata must not be discarded by pre-checkpoint pruning."""
+def test_is_summary_item_robustness():
+    """Validates summary detection across metadata dicts, headers, and flags."""
+    # Top level flags
+    assert _is_summary_item({"_compressed_summary": True}) is True
+    assert _is_summary_item({"_is_compression_summary": True}) is True
+    assert _is_summary_item({"_hermes_compressed_summary": True}) is True
+    assert _is_summary_item({"_my_custom_summary_flag": True}) is True
+
+    # Nested metadata dict
+    assert _is_summary_item({"metadata": {"summary": True}}) is True
+    assert _is_summary_item({"_metadata": {"is_summary": True}}) is True
+    assert _is_summary_item({"metadata": {"_compressed_summary": True}}) is True
+    assert _is_summary_item({"metadata": {"compression_v2": True}}) is True
+
+    # Text headers
+    assert _is_summary_item({"content": "summary of previous conversation: ..."}) is True
+    assert _is_summary_item({"content": "Conversation Summary\nDone"}) is True
+    assert _is_summary_item({"content": "Handoff from a previous context"}) is True
+    assert _is_summary_item({"content": "## Summary of work"}) is True
+
+    # Negative cases
+    assert _is_summary_item({"role": "user", "content": "Just normal prompt"}) is False
+    assert _is_summary_item(None) is False
+    assert _is_summary_item(123) is False
+    assert _is_summary_item({}) is False
+
+
+def test_extract_item_text_variations():
+    """Validates text extraction across string, multipart list, output_text, and malformed structures."""
+    # String
+    assert _extract_item_text({"content": "Hello world"}) == "Hello world"
+
+    # Multipart list
+    item_list = {
+        "content": [
+            {"type": "input_text", "text": "Part 1"},
+            {"type": "text", "text": "Part 2"},
+            {"type": "other", "output_text": "Part 3"},
+        ]
+    }
+    assert _extract_item_text(item_list) == "Part 1 Part 2 Part 3"
+
+    # output_text fallback
+    assert _extract_item_text({"output_text": "Output fallback"}) == "Output fallback"
+
+    # Malformed / Empty
+    assert _extract_item_text({"content": None}) is None
+    assert _extract_item_text({"content": []}) is None
+    assert _extract_item_text(None) is None
+    assert _extract_item_text("string_item") is None
+
+
+def test_prune_pre_checkpoint_items_retains_summary_and_user_in_order():
+    """Preserves chronological order of user messages and summary messages."""
     items = [
-        {"role": "user", "content": "Goal: build the system"},
-        {"role": "assistant", "content": "Working on it..."},
-        {
-            "role": "assistant",
-            "content": "Summary of previous conversation:\n- Set up database\n- Built API",
-            "_compressed_summary": True,
-        },
-        {"type": "compaction", "encrypted_content": "dummy_checkpoint_blob"},
-        {"role": "user", "content": "Now add frontend"},
-        {"role": "assistant", "content": "Frontend added."},
+        {"role": "user", "content": "User Ask 1"},
+        {"role": "assistant", "content": "Conversation Summary: Step 1 complete", "_compressed_summary": True},
+        {"role": "user", "content": "User Ask 2"},
+        {"role": "assistant", "content": "Normal chatter to prune"},
+        {"type": "compaction", "encrypted_content": "blob_cp"},
+        {"role": "user", "content": "User Ask 3"},
     ]
 
     pruned = prune_pre_checkpoint_items(items, retained_user_token_budget=1000)
 
-    # The checkpoint must be first
+    # Checkpoint comes first, followed by retained items in original sequence
     assert pruned[0]["type"] == "compaction"
-    
-    # Both the early user goal and the compression summary must be retained
-    roles_or_types = [m.get("type") or m.get("role") for m in pruned]
-    assert "compaction" in roles_or_types
-    
-    # Check that the summary survives in the pruned output
-    summaries = [
-        m for m in pruned
-        if "Summary of previous conversation" in str(m.get("content", ""))
+    contents = [m.get("content") for m in pruned[1:]]
+    assert contents == [
+        "User Ask 1",
+        "Conversation Summary: Step 1 complete",
+        "User Ask 2",
+        "User Ask 3",
     ]
-    assert len(summaries) == 1
-    assert summaries[0]["role"] == "assistant"
 
 
-def test_prune_pre_checkpoint_items_normal_messages_pruned():
-    """Ordinary assistant messages before the checkpoint are still pruned."""
+def test_prune_pre_checkpoint_items_summary_budget_cap_and_truncation():
+    """Enforces token budget limit and truncation for summaries."""
+    long_summary = "Summary line " * 500  # ~6500 chars = ~1625 tokens
     items = [
-        {"role": "user", "content": "U1"},
-        {"role": "assistant", "content": "Normal assistant chatter to be pruned"},
-        {"type": "compaction", "encrypted_content": "blob"},
-        {"role": "user", "content": "U2"},
+        {"role": "assistant", "content": long_summary, "_compressed_summary": True},
+        {"type": "compaction", "encrypted_content": "blob_cp"},
+        {"role": "user", "content": "Ask"},
     ]
 
-    pruned = prune_pre_checkpoint_items(items, retained_user_token_budget=1000)
-    contents = [m.get("content") for m in pruned]
-    assert "Normal assistant chatter to be pruned" not in contents
+    # Restrict summary budget to 100 tokens (~400 chars)
+    pruned = prune_pre_checkpoint_items(
+        items,
+        retained_summary_token_budget=100,
+    )
+
+    retained_sum = [m for m in pruned if m.get("_compressed_summary")][0]
+    assert len(retained_sum["content"]) <= 400
+    assert len(retained_sum["content"]) > 0
 
 
-def test_prune_pre_checkpoint_items_retains_metadata_flagged_summaries():
-    """Assistant messages marked with _is_compression_summary or _hermes_compressed_summary must be retained."""
+def test_prune_pre_checkpoint_items_enable_summary_retention_toggle():
+    """Disabling summary retention drops pre-checkpoint summaries."""
     items = [
-        {"role": "user", "content": "Goal: build system"},
-        {
-            "role": "assistant",
-            "content": "Custom structured summary 1",
-            "_is_compression_summary": True,
-        },
-        {
-            "role": "assistant",
-            "content": "Custom structured summary 2",
-            "_hermes_compressed_summary": True,
-        },
+        {"role": "assistant", "content": "Conversation Summary: Old", "_compressed_summary": True},
         {"type": "compaction", "encrypted_content": "blob"},
-        {"role": "user", "content": "Next step"},
+        {"role": "user", "content": "New ask"},
     ]
 
-    pruned = prune_pre_checkpoint_items(items, retained_user_token_budget=1000)
-    contents = [m.get("content") for m in pruned]
-    assert "Custom structured summary 1" in contents
-    assert "Custom structured summary 2" in contents
+    pruned_disabled = prune_pre_checkpoint_items(items, enable_summary_retention=False)
+    contents = [m.get("content") for m in pruned_disabled]
+    assert "Conversation Summary: Old" not in contents
+
+
+def test_prune_pre_checkpoint_items_malformed_inputs_handled_safely():
+    """Handles None, non-dict elements, empty lists, and invalid items without crashing."""
+    assert prune_pre_checkpoint_items(None) is None
+    assert prune_pre_checkpoint_items([]) == []
+
+    items = [
+        None,
+        123,
+        "raw_string",
+        {"role": "user", "content": "Valid user ask"},
+        {"type": "compaction", "encrypted_content": "blob"},
+    ]
+    pruned = prune_pre_checkpoint_items(items)
+    assert len(pruned) == 2
+    assert pruned[0]["type"] == "compaction"
+    assert pruned[1]["content"] == "Valid user ask"

--- a/tests/run_agent/test_native_compaction_summary_retention.py
+++ b/tests/run_agent/test_native_compaction_summary_retention.py
@@ -252,6 +252,130 @@ class TestPrunePreCheckpointItemsEnableSummaryRetentionToggle:
         assert summary_content not in contents
 
 
+def _checkpoint_message(item_id: str = "rs_cp1", blob: str = "cp_blob_1"):
+    """An assistant message carrying a replayable native-compaction checkpoint."""
+    return {
+        "role": "assistant",
+        "content": "",
+        "codex_reasoning_items": [
+            {"type": "compaction", "encrypted_content": blob, "id": item_id},
+        ],
+    }
+
+
+class TestChatMessagesToResponsesInputSummaryCarrierLoss:
+    """Adapter-level witnesses for the second blocking review (#90976):
+    ``prune_pre_checkpoint_items`` only ever saw whatever ``_is_summary_item``
+    could recover from an already-converted Responses ``item`` — but two
+    real merge-into-tail carrier shapes lose or shadow the summary content
+    during ``_chat_messages_to_responses_input`` itself, *before* pruning
+    ever runs:
+
+    * a tool-result carrier becomes a typed ``function_call_output`` (no
+      ``content``/``role`` survive the conversion at all), and
+    * an assistant carrier with a stale ``codex_message_items`` sidecar
+      replays the pre-merge exact message item instead of the rewritten
+      (summary-bearing) ``content``.
+
+    These feed real chat messages, shaped exactly the way
+    ``ContextCompressor.compress()`` merge-into-tail produces them (same
+    ``COMPRESSED_SUMMARY_METADATA_KEY`` stamp, same merge delimiters/end
+    marker), through the real ``_chat_messages_to_responses_input`` with a
+    replayed checkpoint — not a hand-built Responses item passed straight
+    to the pruner.
+    """
+
+    def test_tool_result_merge_carrier_summary_survives_the_adapter(self):
+        from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+        merged = _merged_summary_content("preserved tool context")
+        messages = [
+            {"role": "user", "content": "please do the thing"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "do_thing", "arguments": "{}"},
+                }],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": merged,
+                COMPRESSED_SUMMARY_METADATA_KEY: True,
+            },
+            _checkpoint_message(),
+            {"role": "user", "content": "next ask after checkpoint"},
+        ]
+
+        items = _chat_messages_to_responses_input(
+            messages, native_compaction_eligible=True,
+        )
+
+        # The summary survives, exactly once, as a plain message item —
+        # never as a `function_call_output` (which the pruner cannot see,
+        # and which would orphan the dropped `function_call` it used to
+        # pair with).
+        assert not any(
+            isinstance(it, dict) and it.get("type") == "function_call_output"
+            for it in items
+        )
+        matches = [
+            it for it in items
+            if isinstance(it, dict) and _extract_item_text(it) == merged
+        ]
+        assert len(matches) == 1
+        assert matches[0].get("type") != "function_call_output"
+
+        # And the newest checkpoint still leads the wire.
+        assert items[0].get("type") == "compaction"
+
+    def test_assistant_merge_carrier_with_stale_replay_summary_survives(self):
+        from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+        merged = _merged_summary_content("preserved assistant context")
+        messages = [
+            {"role": "user", "content": "question"},
+            {
+                "role": "assistant",
+                # Rewritten by the compressor merge — this is what must
+                # reach the wire.
+                "content": merged,
+                COMPRESSED_SUMMARY_METADATA_KEY: True,
+                # Stale sidecar captured BEFORE the merge rewrote the
+                # content above. The exact-replay path prefers this over
+                # `content` for prefix-cache continuity, which is exactly
+                # what shadows the summary (#90976).
+                "codex_message_items": [{
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_stale_1",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "stale pre-merge answer"}],
+                }],
+            },
+            _checkpoint_message(),
+            {"role": "user", "content": "next ask"},
+        ]
+
+        items = _chat_messages_to_responses_input(
+            messages, native_compaction_eligible=True,
+        )
+
+        assert not any(
+            isinstance(it, dict) and _extract_item_text(it) == "stale pre-merge answer"
+            for it in items
+        )
+        matches = [
+            it for it in items
+            if isinstance(it, dict) and _extract_item_text(it) == merged
+        ]
+        assert len(matches) == 1
+        assert items[0].get("type") == "compaction"
+
+
 class TestPrunePreCheckpointItemsMalformedInputs:
     def test_handles_none_non_dict_and_empty_items_safely(self):
         assert prune_pre_checkpoint_items(None) is None

--- a/tests/run_agent/test_native_compaction_summary_retention.py
+++ b/tests/run_agent/test_native_compaction_summary_retention.py
@@ -1,0 +1,74 @@
+"""Tests for native compaction retaining compression summaries preceding a checkpoint."""
+
+from agent.native_compaction import prune_pre_checkpoint_items
+
+
+def test_prune_pre_checkpoint_items_retains_assistant_summary():
+    """Compression summaries with role='assistant' or marked metadata must not be discarded by pre-checkpoint pruning."""
+    items = [
+        {"role": "user", "content": "Goal: build the system"},
+        {"role": "assistant", "content": "Working on it..."},
+        {
+            "role": "assistant",
+            "content": "Summary of previous conversation:\n- Set up database\n- Built API",
+            "_compressed_summary": True,
+        },
+        {"type": "compaction", "encrypted_content": "dummy_checkpoint_blob"},
+        {"role": "user", "content": "Now add frontend"},
+        {"role": "assistant", "content": "Frontend added."},
+    ]
+
+    pruned = prune_pre_checkpoint_items(items, retained_user_token_budget=1000)
+
+    # The checkpoint must be first
+    assert pruned[0]["type"] == "compaction"
+    
+    # Both the early user goal and the compression summary must be retained
+    roles_or_types = [m.get("type") or m.get("role") for m in pruned]
+    assert "compaction" in roles_or_types
+    
+    # Check that the summary survives in the pruned output
+    summaries = [
+        m for m in pruned
+        if "Summary of previous conversation" in str(m.get("content", ""))
+    ]
+    assert len(summaries) == 1
+    assert summaries[0]["role"] == "assistant"
+
+
+def test_prune_pre_checkpoint_items_normal_messages_pruned():
+    """Ordinary assistant messages before the checkpoint are still pruned."""
+    items = [
+        {"role": "user", "content": "U1"},
+        {"role": "assistant", "content": "Normal assistant chatter to be pruned"},
+        {"type": "compaction", "encrypted_content": "blob"},
+        {"role": "user", "content": "U2"},
+    ]
+
+    pruned = prune_pre_checkpoint_items(items, retained_user_token_budget=1000)
+    contents = [m.get("content") for m in pruned]
+    assert "Normal assistant chatter to be pruned" not in contents
+
+
+def test_prune_pre_checkpoint_items_retains_metadata_flagged_summaries():
+    """Assistant messages marked with _is_compression_summary or _hermes_compressed_summary must be retained."""
+    items = [
+        {"role": "user", "content": "Goal: build system"},
+        {
+            "role": "assistant",
+            "content": "Custom structured summary 1",
+            "_is_compression_summary": True,
+        },
+        {
+            "role": "assistant",
+            "content": "Custom structured summary 2",
+            "_hermes_compressed_summary": True,
+        },
+        {"type": "compaction", "encrypted_content": "blob"},
+        {"role": "user", "content": "Next step"},
+    ]
+
+    pruned = prune_pre_checkpoint_items(items, retained_user_token_budget=1000)
+    contents = [m.get("content") for m in pruned]
+    assert "Custom structured summary 1" in contents
+    assert "Custom structured summary 2" in contents


### PR DESCRIPTION
## What does this PR do?

Preserves local-compression summary messages across native OpenAI Responses compaction's pre-checkpoint pruning (`agent/native_compaction.py`), so a compression handoff never silently vanishes from the model's view once a server-side checkpoint has been replayed.

Fixes #90975.

---

## Technical details

### 1. Canonical summary detection, not a heuristic
`_is_summary_item` delegates entirely to `agent.context_compressor.is_compaction_summary_message` — the same provenance check every other summary consumer (memory providers, frontends, the compactor itself) already uses. It prefers the exact `COMPRESSED_SUMMARY_METADATA_KEY` flag and falls back to the canonical prefix classifier (handles the merge-into-tail shape too) for the case where the underscore-prefixed key was stripped by a wire sanitizer. No ad-hoc key scanning, no matching on content headings like `"## Summary"` in ordinary text.

### 2. Whole-or-drop retention, never a byte slice
Retained summaries carry structural framing (handoff prefix, end marker, merge-into-tail delimiters) that a blind character slice can corrupt. A summary that doesn't fit `RETAINED_SUMMARY_TOKEN_BUDGET` (32k tokens) is dropped whole instead of truncated. `RETAINED_USER_MESSAGE_TOKEN_BUDGET` (64k tokens, Codex CLI parity) keeps its existing head-truncation behavior for retained user messages only.

### 3. Idempotent across repeated checkpoints
A summary already retained once (identical text) is never duplicated across repeated checkpoint sequences.

### 4. Source-based recovery for lossy carrier shapes
A canonical summary can be merged into an existing tail message rather than inserted standalone (`ContextCompressor` merge-into-tail). By the time that message becomes a Responses input item, two real shapes lose or shadow the summary before pruning ever runs:

- a **tool-result carrier** becomes a typed `function_call_output` — no `content`/`role` survives the conversion at all, and the pruner's type filter skips every non-`message` item;
- an **assistant carrier** can be shadowed by a stale `codex_message_items` exact-replay captured *before* the merge rewrote its content — the replay path wins over the rewritten `content` for prefix-cache continuity.

`_chat_messages_to_responses_input` now threads `item_sources` — the raw chat message each converted item came from — through to `prune_pre_checkpoint_items`. When a source is itself a canonical summary carrier, its content is read directly from the source (never from the lossy converted item) and retained as a synthesized `role="assistant"` message. This never orphans a `function_call_output`/`function_call` pair: the original typed item is fully replaced, not retained alongside a dropped partner.

### 5. `enable_summary_retention`
Function-level override for tests and callers that need pre-#90975 behavior back. Not wired to a user-facing config surface — there is no `agent` reference at the actual call site (`codex_responses_adapter.py`) to wire real config without much broader plumbing.

---

## Test plan

- [x] `tests/run_agent/test_native_compaction_summary_retention.py` — canonical detection, negative witnesses (a `"## Summary"` heading in ordinary text, a `False`-valued flag, an arbitrary underscore key never misclassify), whole-or-drop truncation, idempotency, live `ContextCompressor` marker emissions, and two new adapter-level witnesses feeding real merge-into-tail carrier shapes (tool-result, assistant-with-stale-`codex_message_items`) through the real `_chat_messages_to_responses_input(..., native_compaction_eligible=True)` with a replayed checkpoint.
- [x] `tests/run_agent/test_native_compaction.py`, `tests/agent/test_compressed_summary_metadata.py`, `tests/agent/test_codex_responses_adapter.py`, `tests/run_agent/test_run_agent_codex_responses.py`, `tests/run_agent/test_provider_parity.py`, `tests/run_agent/test_codex_multimodal_tool_result.py` — no regressions (117 passed).
- [x] `ruff check` clean on all changed files.

---

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[Compressor Merge-Into-Tail] -->|Stamps COMPRESSED_SUMMARY_METADATA_KEY| B[Chat Message Source]
    B -->|role=tool| C[Lossy: function_call_output]
    B -->|role=assistant + stale codex_message_items| D[Lossy: Stale Exact Replay]
    B -->|item_sources mapping| E[Pruner Reads Source Directly]
    C -.->|old bug: type filter skips it| F[Summary Lost]
    D -.->|old bug: replay shadows rewrite| F
    E -->|Canonical Content, Whole-or-Drop| G[Synthesized Assistant Message]
    G --> H[Checkpoint Run + Retained + Post]
    H --> I[Wire: Summary Survives Exactly Once]
```

## Infographic:

<img width="1376" height="768" alt="infographic_90976_oriental" src="https://github.com/user-attachments/assets/f50b8c37-d26d-4926-92a6-e804132c51e0" />
