### PR TITLE
test(s6): put the supervise-skeleton setgid assertion on the Linux lane

### DIFF
--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -193,7 +193,7 @@ def fake_subprocess_run(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
-    """Verifies the dirs + FIFO + modes the helper lays down."""
+    """Verifies the dirs + FIFO the helper lays down."""
     import stat
 
     from hermes_cli.service_manager import _seed_supervise_skeleton
@@ -206,9 +206,6 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     # Top-level event/ — s6-svlisten1 event subscription dir.
     event = svc_dir / "event"
     assert event.is_dir(), "missing top-level event/"
-    assert stat.S_IMODE(event.stat().st_mode) == 0o3730, (
-        f"event/ mode = {oct(event.stat().st_mode)}, want 03730"
-    )
 
     # supervise/ dir.
     supervise = svc_dir / "supervise"
@@ -218,7 +215,6 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     # supervise/event/.
     supervise_event = supervise / "event"
     assert supervise_event.is_dir(), "missing supervise/event/"
-    assert stat.S_IMODE(supervise_event.stat().st_mode) == 0o3730
 
     # supervise/control FIFO.
     control = supervise / "control"
@@ -227,6 +223,31 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
         "supervise/control must be a FIFO"
     )
     assert stat.S_IMODE(control.stat().st_mode) == 0o660
+
+
+@pytest.mark.linux_only
+def test_seed_supervise_skeleton_sets_setgid_on_event_dirs(tmp_path) -> None:
+    """The event dirs carry setgid so s6-supervise's EEXIST path leaves them alone.
+
+    Linux-only because the assertion is about what ``chmod`` does, and that
+    differs by kernel: BSD (macOS) silently drops ``S_ISGID`` from a directory
+    unless the caller is root or a member of the directory's group, so the same
+    correct helper produces 01730 there. s6 only ever runs on Linux — inside
+    s6-overlay's stage2 as root with umask 0 — so Linux is the host whose
+    answer matters.
+    """
+    import stat
+
+    from hermes_cli.service_manager import _seed_supervise_skeleton
+
+    svc_dir = tmp_path / "gateway-foo"
+    svc_dir.mkdir()
+
+    _seed_supervise_skeleton(svc_dir)
+
+    for rel in ("event", "supervise/event"):
+        mode = stat.S_IMODE((svc_dir / rel).stat().st_mode)
+        assert mode == 0o3730, f"{rel}/ mode = {oct(mode)}, want 0o3730"
 
 
 


### PR DESCRIPTION
`test_seed_supervise_skeleton_creates_expected_layout` fails on every macOS checkout, so `scripts/run_tests.sh tests/hermes_cli/` is red for anyone developing on a Mac:

```
AssertionError: event/ mode = 0o41730, want 03730
```

The helper is not at fault. It chmods explicitly after `mkdir`, so this isn't the usual umask story:

```python
path.mkdir(parents=False, exist_ok=False)
path.chmod(mode)
```

It's a kernel difference. BSD drops `S_ISGID` from a directory `chmod` unless the caller is root or a member of the directory's group, so the sticky bit survives and setgid doesn't — `0o3730` becomes `0o1730`. Linux keeps it. s6 only ever runs on Linux, inside s6-overlay's stage2 as root with umask 0, so Linux is the host whose answer matters and the assertion belongs on that lane.

Split rather than marking the whole test. The layout it also covers — the dirs exist, `supervise/` is 0755, `supervise/control` is a 0660 FIFO — is host-independent and worth keeping on the machines developers actually run. Only the two setgid mode assertions move into a `linux_only` test.

Uses the registered marker, not a bare `skipif`, so `scripts/ci/list_os_marked_tests.py` and the lane's `-m` filter both see it.

## Test plan

- [x] `scripts/run_tests.sh tests/hermes_cli/test_service_manager.py` on macOS: 8 passed, 1 skipped. Was 7 passed, 1 failed.
- [ ] Linux lane runs the new `linux_only` case and asserts 0o3730 for real — that's this PR's CI, which is where the premise gets confirmed rather than assumed. I could not verify locally (no Linux host, Docker daemon down) and did not want to claim otherwise.