### PR TITLE
fix(mcp): stop add from reporting unpersisted servers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12339,7 +12339,7 @@ def cmd_plugins(args):
 def cmd_mcp(args):
     from hermes_cli.mcp_config import mcp_command
 
-    mcp_command(args)
+    return mcp_command(args)
 
 
 def cmd_claw(args):

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -841,7 +841,7 @@ def install_entry(entry: CatalogEntry, *, enable: bool = True) -> None:
 
     if not _save_mcp_server(entry.name, server_cfg):
         raise CatalogError(
-            f"catalog entry '{entry.name}' rejected: suspicious command/args configuration"
+            f"catalog entry '{entry.name}' could not be saved; see diagnostics above"
         )
 
     # ── Probe + tool selection ──────────────────────────────────────────

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -583,23 +583,23 @@ def cmd_mcp_add(args):
         tools = _probe_single_server(name, server_config)
     except Exception as exc:
         _error(f"Failed to connect: {exc}")
-        if _confirm("Save config anyway (you can test later)?", default=False):
-            server_config["enabled"] = False
-            if _save_mcp_server(name, server_config):
-                _success(f"Saved '{name}' to config (disabled)")
-                _info("Fix the issue, then: hermes mcp test " + name)
-            else:
-                return 1
-        return
+        if not _confirm("Save config anyway (you can test later)?", default=False):
+            return 1
+        server_config["enabled"] = False
+        if _save_mcp_server(name, server_config):
+            _success(f"Saved '{name}' to config (disabled)")
+            _info("Fix the issue, then: hermes mcp test " + name)
+            return 0
+        return 1
 
     if not tools:
         _warning("Server connected but reported no tools.")
-        if _confirm("Save config anyway?", default=True):
-            if _save_mcp_server(name, server_config):
-                _success(f"Saved '{name}' to config")
-            else:
-                return 1
-        return
+        if not _confirm("Save config anyway?", default=True):
+            return 1
+        if _save_mcp_server(name, server_config):
+            _success(f"Saved '{name}' to config")
+            return 0
+        return 1
 
     # ── Tool selection ────────────────────────────────────────────────
 

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -91,8 +91,9 @@ def _save_mcp_server(name: str, server_config: dict) -> bool:
     """Add or update a server entry in config.yaml.
 
     Returns False when a high-signal exfiltration-shaped stdio command is
-    rejected. MCP stdio servers are user-chosen local commands, so this blocks
-    shell+egress payloads rather than whitelisting command families.
+    rejected or when the exact entry cannot be verified after saving. MCP stdio
+    servers are user-chosen local commands, so validation blocks shell+egress
+    payloads rather than whitelisting command families.
     """
     issues = validate_mcp_server_entry(name, server_config)
     if issues:

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -12,12 +12,14 @@ import asyncio
 import logging
 import os
 import re
+import sys
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_cli.config import (
     cfg_get,
     load_config,
+    read_user_config_raw,
     save_config,
     get_env_value,
     save_env_value,
@@ -98,9 +100,24 @@ def _save_mcp_server(name: str, server_config: dict) -> bool:
             _warning(issue)
         _warning(f"Server '{name}' was NOT saved due to suspicious configuration.")
         return False
-    config = load_config()
+    # This is a read-modify-write of the user's document, so do not start from
+    # load_config(): that includes defaults, managed overlays, and expanded env
+    # references that do not belong in config.yaml.
+    config = read_user_config_raw()
     config.setdefault("mcp_servers", {})[name] = server_config
     save_config(config)
+
+    # save_config() intentionally has no return value and may refuse a write
+    # (for example in package-manager-managed mode). Never turn that into a
+    # false success: verify the exact entry from an uncached disk read before
+    # the caller prints "Saved".
+    persisted = read_user_config_raw().get("mcp_servers")
+    if not isinstance(persisted, dict) or persisted.get(name) != server_config:
+        print(
+            f"Server '{name}' was not persisted to {display_hermes_home()}/config.yaml.",
+            file=sys.stderr,
+        )
+        return False
     return True
 
 
@@ -571,6 +588,8 @@ def cmd_mcp_add(args):
             if _save_mcp_server(name, server_config):
                 _success(f"Saved '{name}' to config (disabled)")
                 _info("Fix the issue, then: hermes mcp test " + name)
+            else:
+                return 1
         return
 
     if not tools:
@@ -578,6 +597,8 @@ def cmd_mcp_add(args):
         if _confirm("Save config anyway?", default=True):
             if _save_mcp_server(name, server_config):
                 _success(f"Saved '{name}' to config")
+            else:
+                return 1
         return
 
     # ── Tool selection ────────────────────────────────────────────────
@@ -638,6 +659,8 @@ def cmd_mcp_add(args):
         print()
         _success(f"Saved '{name}' to {display_hermes_home()}/config.yaml ({tool_count}/{total} tools enabled)")
         _info("Start a new session to use these tools.")
+        return 0
+    return 1
 
 
 # ─── hermes mcp remove ───────────────────────────────────────────────────────
@@ -1135,7 +1158,7 @@ def mcp_command(args):
 
     handler = handlers.get(action)
     if handler:
-        handler(args)
+        return handler(args)
     else:
         # No subcommand — drop the user into the catalog picker. This is the
         # "try enabling and it flows you into setup" UX matching `hermes plugin`.

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -103,7 +103,7 @@ async def add_mcp_server(body: MCPServerCreate, profile: Optional[str] = None):
                 if not _save_mcp_server(name, server_config):
                     raise HTTPException(
                         status_code=400,
-                        detail=f"Server '{name}' rejected: suspicious command/args configuration",
+                        detail=f"Server '{name}' could not be saved; see server diagnostics",
                     )
 
     try:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13447,7 +13447,10 @@ def _run_dashboard_mcp_oauth(flow, cfg: dict) -> None:
                             "The server responded, but no OAuth token was obtained — "
                             "this provider may require a manually-registered OAuth client."
                         )
-                    _save_mcp_server(flow.server_name, cfg)
+                    if not _save_mcp_server(flow.server_name, cfg):
+                        raise RuntimeError(
+                            f"Server '{flow.server_name}' could not be persisted after OAuth approval."
+                        )
                     flow.tools = [{"name": t, "description": d} for t, d in tools]
                     flow.mark_approved()
                     if flow.reconnect_live:

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -248,6 +248,19 @@ class TestInstall:
         assert servers["demo"]["args"] == ["-y", "demo-mcp"]
         assert servers["demo"]["enabled"] is True
 
+    def test_install_reports_generic_save_failure(self, catalog_dir, monkeypatch):
+        _write_manifest(catalog_dir, "demo", _basic_manifest())
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._save_mcp_server", lambda name, config: False
+        )
+
+        from hermes_cli.mcp_catalog import CatalogError, install_entry
+
+        with pytest.raises(CatalogError, match="could not be saved") as exc_info:
+            install_entry(_entry("demo"), enable=True)
+
+        assert "suspicious" not in str(exc_info.value)
+
 
 
     def test_install_with_api_key_prompts_and_saves(self, catalog_dir, monkeypatch):

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -715,6 +715,14 @@ class TestConfigHelpers:
 # ---------------------------------------------------------------------------
 
 class TestDispatcher:
+    def test_top_level_wrapper_preserves_dispatcher_status(self, monkeypatch):
+        from hermes_cli import mcp_config
+        from hermes_cli.main import cmd_mcp
+
+        monkeypatch.setattr(mcp_config, "mcp_command", lambda args: 1)
+
+        assert cmd_mcp(_make_args()) == 1
+
     def test_no_action_shows_list(self, tmp_path, capsys):
         from hermes_cli.mcp_config import mcp_command
 

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -305,6 +305,32 @@ class TestMcpAdd:
         assert "Saved 'github'" not in captured.out
         assert "was not persisted" in captured.err.lower()
 
+    @pytest.mark.parametrize("probe_result", [[], RuntimeError("unreachable")])
+    def test_add_returns_failure_when_user_declines_fallback_save(
+        self, tmp_path, monkeypatch, probe_result
+    ):
+        def probe(name, config):
+            if isinstance(probe_result, Exception):
+                raise probe_result
+            return probe_result
+
+        monkeypatch.setattr("hermes_cli.mcp_config._probe_single_server", probe)
+        monkeypatch.setattr("builtins.input", lambda _: "n")
+
+        from hermes_cli.mcp_config import mcp_command
+
+        rc = mcp_command(
+            _make_args(
+                name="github",
+                mcp_action="add",
+                mcp_command="npx",
+                args=["@mcp/github"],
+            )
+        )
+
+        assert rc == 1
+        assert not (tmp_path / "config.yaml").exists()
+
 
 # ---------------------------------------------------------------------------
 # Tests: cmd_mcp_test

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -277,6 +277,34 @@ class TestMcpAdd:
         assert srv["args"] == ["-y", "test-mcp-server"]
         assert "env" not in srv
 
+    def test_add_returns_failure_when_discovered_server_is_not_persisted(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        for subdir in ("cron", "sessions", "logs", "memories"):
+            (tmp_path / subdir).mkdir()
+        (tmp_path / ".managed").write_text("nixos", encoding="utf-8")
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, config: [("search", "Search")],
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "")
+
+        from hermes_cli.mcp_config import mcp_command
+
+        rc = mcp_command(
+            _make_args(
+                name="github",
+                mcp_action="add",
+                mcp_command="npx",
+                args=["@mcp/github"],
+            )
+        )
+
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "Saved 'github'" not in captured.out
+        assert "was not persisted" in captured.err.lower()
+
 
 # ---------------------------------------------------------------------------
 # Tests: cmd_mcp_test
@@ -653,6 +681,24 @@ class TestConfigHelpers:
         servers = _get_mcp_servers()
         assert "mysvr" in servers
         assert servers["mysvr"]["url"] == "https://example.com/mcp"
+
+    def test_save_reports_failure_when_config_write_is_refused(
+        self, tmp_path, capsys
+    ):
+        """A refused write must not be reported as a persisted MCP server."""
+        for subdir in ("cron", "sessions", "logs", "memories"):
+            (tmp_path / subdir).mkdir()
+        (tmp_path / ".managed").write_text("nixos", encoding="utf-8")
+
+        from hermes_cli.mcp_config import _save_mcp_server
+
+        saved = _save_mcp_server(
+            "mysvr", {"url": "https://example.com/mcp", "enabled": True}
+        )
+
+        assert saved is False
+        assert not (tmp_path / "config.yaml").exists()
+        assert "was not persisted" in capsys.readouterr().err.lower()
 
 
     def test_env_key_for_server(self):

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -174,7 +174,10 @@ def _worker(session_id: str, hermes_home: str, server_name: str, cfg: dict, reco
                             "The server responded, but no OAuth token was obtained — "
                             "this provider may require a manually-registered OAuth client."
                         )
-                    _save_mcp_server(server_name, cfg)
+                    if not _save_mcp_server(server_name, cfg):
+                        raise RuntimeError(
+                            f"Server '{server_name}' could not be persisted after OAuth approval."
+                        )
                     if flow is not None:
                         flow.tools = [{"name": t, "description": d} for t, d in tools]
                         flow.mark_approved()

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -2071,7 +2071,7 @@ def _(rid, params: dict) -> dict:
             return _err(
                 rid,
                 4001,
-                f"server '{name}' rejected: suspicious command/args configuration",
+                f"server '{name}' could not be saved; see server diagnostics",
             )
         saved = _get_mcp_servers().get(name, server_config)
         return _ok(rid, {"ok": True, "name": name, "server": _mcp_summarize_server(name, saved)})


### PR DESCRIPTION
## What does this PR do?

`hermes mcp add` could connect to a server, discover its tools, print a successful save message, and exit 0 even when `config.yaml` was unchanged. This fix verifies the exact server entry from a fresh disk read before reporting success and propagates persistence failures to the process exit code, so users no longer lose MCP registrations silently.

### Symptom

After successful MCP connection and tool discovery, the command reports that the server was saved, but `hermes mcp list` does not show it and the server is unavailable after restart.

### Impact

Affected users receive a false success result from the primary MCP registration path. Their server configuration is not persisted, and the missing registration is only discovered in a later command or session.

### Bug Cause

**Trigger:** `hermes_cli/mcp_config.py:_save_mcp_server` when `save_config()` refuses or otherwise does not produce the requested `mcp_servers` entry.

**Causal chain:**
1. `hermes mcp add` validates the server and calls `_save_mcp_server`.
2. `_save_mcp_server` previously mutated the merged effective config, called the void `save_config()`, and returned `True` without checking disk state.
3. The add handler printed `Saved`, while the top-level `cmd_mcp` wrapper discarded handler status, leaving the process exit code at 0.

**Why it is wrong:** A valid no-write path in `save_config()`, such as package-manager-managed mode, was converted into success because neither persistence nor the final return status was checked.

**Working sibling / contrast:** `hermes config set` writes raw user configuration through its dedicated persistence path and reports that operation directly. MCP add now also starts from raw user configuration and verifies its own exact persisted entry.

**Ruled out:** MCP startup-only discovery is not involved. The failure occurs before restart because the target `config.yaml` lacks the server entry and `hermes mcp list` cannot read it.

### Fix

- Build the MCP upsert from `read_user_config_raw()` instead of the merged effective configuration.
- Re-read the user configuration after `save_config()` and fail explicitly when the exact server entry is absent or differs.
- Propagate failure through `cmd_mcp_add`, `mcp_command`, and the top-level `cmd_mcp` wrapper so the CLI exits nonzero.
- Cover both the real managed-mode no-write path and successful persistence with temporary `HERMES_HOME` tests.

## Related Issue

Fixes #90947

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/mcp_config.py` - persist raw MCP user config, verify the disk result, and return explicit add status.
- `hermes_cli/main.py` - preserve MCP dispatcher status at the CLI boundary.
- `tests/hermes_cli/test_mcp_config.py` - add regression coverage for refused writes and top-level status propagation.

## How to Test

1. Run the focused MCP CLI and config tests:

```bash
scripts/run_tests.sh -j 1 tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_add_command_dest.py tests/hermes_cli/test_subcommands_followup.py -q
```

2. Confirm all 53 tests pass, including the temporary managed `HERMES_HOME` case where no `config.yaml` write is allowed.
3. Confirm that case returns 1, omits the `Saved` message, and reports that the server was not persisted.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the focused tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior now matches the documented command
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model tool schema changed

## Screenshots / Logs

Focused verification result: 53 passed, 0 failed.
