### PR TITLE
fix(rollback): gateway and TUI bare /rollback fall back to all-directories

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3353,7 +3353,20 @@ class GatewaySlashCommandsMixin:
         arg = " ".join(arg_parts)
 
         if not arg:
+            # List checkpoints — fall back to the cross-project view when the
+            # current directory has none (#10505, reapply of PR #10633 by
+            # @nightq, ported here from hermes_cli.cli_commands_mixin's
+            # identical fix). Without this, a checkpoint written under a
+            # different cwd than TERMINAL_CWD's project reports "No
+            # checkpoints found" despite fresh checkpoints existing.
             checkpoints = mgr.list_checkpoints(cwd)
+            if not checkpoints:
+                all_checkpoints = mgr.list_all_checkpoints()
+                if all_checkpoints:
+                    return (
+                        f"No checkpoints for {cwd} — showing all directories.\n"
+                        + format_checkpoint_list(all_checkpoints, "all directories")
+                    )
             return format_checkpoint_list(checkpoints, cwd)
 
         # Restore by number or hash

--- a/tests/gateway/test_rollback_command.py
+++ b/tests/gateway/test_rollback_command.py
@@ -1,0 +1,106 @@
+"""End-to-end tests for the gateway ``/rollback`` command.
+
+Bare ``/rollback`` (no args) previously reported "no checkpoints found" for
+the current directory even when checkpoints existed under a DIFFERENT
+directory (a stale ``TERMINAL_CWD``, or a checkpoint written from a
+different session cwd). ``hermes_cli.cli_commands_mixin``'s CLI ``/rollback``
+already fell back to a cross-project "all directories" view in this case
+(#10505, reapply of PR #10633 by @nightq) — the gateway's own independent
+``_handle_rollback_command`` implementation (used by Discord/Slack/Telegram/
+etc, and by TUI via ``GatewaySlashCommandsMixin``) never got the same fix.
+"""
+
+import pytest
+
+import gateway.run as gateway_run
+import tools.checkpoint_manager as cpm
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.session_store = None
+    runner.config = None
+    return runner
+
+
+def _event(text: str) -> MessageEvent:
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="user-1",
+        chat_id="chat-1",
+        user_name="tester",
+        chat_type="dm",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _enable_checkpoints(tmp_path, monkeypatch, enabled=True):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        f"checkpoints:\n  enabled: {str(enabled).lower()}\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", home, raising=False)
+    monkeypatch.setattr(cpm, "CHECKPOINT_BASE", tmp_path / "checkpoints")
+
+
+@pytest.mark.asyncio
+async def test_bare_rollback_falls_back_to_all_directories(tmp_path, monkeypatch):
+    _enable_checkpoints(tmp_path, monkeypatch)
+
+    other_project = tmp_path / "other-project"
+    other_project.mkdir()
+    (other_project / "main.py").write_text("print('hi')\n", encoding="utf-8")
+    mgr = cpm.CheckpointManager(enabled=True, max_snapshots=50)
+    assert mgr.ensure_checkpoint(str(other_project), "baseline") is True
+
+    # The session's own cwd has zero checkpoints.
+    empty_project = tmp_path / "empty-project"
+    empty_project.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(empty_project))
+
+    result = await _runner()._handle_rollback_command(_event("/rollback"))
+
+    assert f"No checkpoints for {empty_project}" in result
+    assert "showing all directories" in result
+    assert "baseline" in result
+
+
+@pytest.mark.asyncio
+async def test_bare_rollback_no_checkpoints_anywhere(tmp_path, monkeypatch):
+    """No fallback claim when there is truly nothing to show anywhere."""
+    _enable_checkpoints(tmp_path, monkeypatch)
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(project))
+
+    result = await _runner()._handle_rollback_command(_event("/rollback"))
+
+    assert "showing all directories" not in result
+    assert "no checkpoints" in result.lower() or "0" in result
+
+
+@pytest.mark.asyncio
+async def test_bare_rollback_uses_own_directory_when_present(tmp_path, monkeypatch):
+    """The fallback must not fire when the session's own cwd already has
+    checkpoints — same-directory checkpoints always take priority."""
+    _enable_checkpoints(tmp_path, monkeypatch)
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "main.py").write_text("print('own')\n", encoding="utf-8")
+    monkeypatch.setenv("TERMINAL_CWD", str(project))
+    mgr = cpm.CheckpointManager(enabled=True, max_snapshots=50)
+    assert mgr.ensure_checkpoint(str(project), "own baseline") is True
+
+    other_project = tmp_path / "other-project"
+    other_project.mkdir()
+    (other_project / "main.py").write_text("print('other')\n", encoding="utf-8")
+    assert mgr.ensure_checkpoint(str(other_project), "other baseline") is True
+
+    result = await _runner()._handle_rollback_command(_event("/rollback"))
+
+    assert "showing all directories" not in result
+    assert "own baseline" in result

--- a/tests/tui_gateway/test_rollback_list_rpc.py
+++ b/tests/tui_gateway/test_rollback_list_rpc.py
@@ -1,0 +1,95 @@
+"""``rollback.list`` RPC: fall back to the cross-project view (#10505).
+
+Bare ``/rollback`` in the classic CLI already fell back to a cross-project
+"all directories" view when the current directory has zero checkpoints
+(hermes_cli.cli_commands_mixin, reapply of PR #10633 by @nightq). The TUI's
+own ``rollback.list`` RPC — used by the Ink TUI's ``/rollback`` (and, per
+#90029, planned for Desktop) — never got the same fix and just returned an
+empty list, offering no information.
+
+``rollback.list``'s handler bodies live in tui_gateway/methods_tools.py but
+are rebound onto tui_gateway.server's globals at import time (see
+method_ctx.py) — the installed handler in ``server._methods`` is what's
+under test, invoked exactly as the JSON-RPC dispatcher would.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import tools.checkpoint_manager as cpm
+import tui_gateway.server as server
+
+
+def _call(method, params=None):
+    handler = server._methods[method]
+    return handler(1, params or {})
+
+
+@pytest.fixture()
+def checkpoint_store(tmp_path, monkeypatch):
+    monkeypatch.setattr(cpm, "CHECKPOINT_BASE", tmp_path / "checkpoints")
+    return cpm.CheckpointManager(enabled=True, max_snapshots=50)
+
+
+def _fake_session(monkeypatch, *, cwd: str, mgr: cpm.CheckpointManager):
+    session = {"cwd": cwd, "agent": SimpleNamespace(_checkpoint_mgr=mgr)}
+    monkeypatch.setattr(server, "_sess", lambda params, rid: (session, None))
+
+
+def test_rollback_list_falls_back_to_all_directories(tmp_path, monkeypatch, checkpoint_store):
+    mgr = checkpoint_store
+    other_project = tmp_path / "other-project"
+    other_project.mkdir()
+    (other_project / "main.py").write_text("print('hi')\n", encoding="utf-8")
+    assert mgr.ensure_checkpoint(str(other_project), "baseline") is True
+
+    empty_project = tmp_path / "empty-project"
+    empty_project.mkdir()
+    _fake_session(monkeypatch, cwd=str(empty_project), mgr=mgr)
+
+    resp = _call("rollback.list", {"session_id": "s1"})
+
+    assert "error" not in resp
+    result = resp["result"]
+    assert result["enabled"] is True
+    assert result["all_directories"] is True
+    assert len(result["checkpoints"]) == 1
+    assert result["checkpoints"][0]["hash"]
+
+
+def test_rollback_list_no_checkpoints_anywhere(tmp_path, monkeypatch, checkpoint_store):
+    mgr = checkpoint_store
+    project = tmp_path / "project"
+    project.mkdir()
+    _fake_session(monkeypatch, cwd=str(project), mgr=mgr)
+
+    resp = _call("rollback.list", {"session_id": "s1"})
+
+    result = resp["result"]
+    assert result["enabled"] is True
+    assert result["all_directories"] is False
+    assert result["checkpoints"] == []
+
+
+def test_rollback_list_uses_own_directory_when_present(tmp_path, monkeypatch, checkpoint_store):
+    """The fallback must not fire when the session's own cwd already has
+    checkpoints — same-directory checkpoints always take priority."""
+    mgr = checkpoint_store
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "main.py").write_text("print('own')\n", encoding="utf-8")
+    assert mgr.ensure_checkpoint(str(project), "own baseline") is True
+
+    other_project = tmp_path / "other-project"
+    other_project.mkdir()
+    (other_project / "main.py").write_text("print('other')\n", encoding="utf-8")
+    assert mgr.ensure_checkpoint(str(other_project), "other baseline") is True
+
+    _fake_session(monkeypatch, cwd=str(project), mgr=mgr)
+
+    resp = _call("rollback.list", {"session_id": "s1"})
+
+    result = resp["result"]
+    assert result["all_directories"] is False
+    assert len(result["checkpoints"]) == 1

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1306,17 +1306,31 @@ def _(rid, params: dict) -> dict:
         def go(mgr, cwd):
             if not mgr.enabled:
                 return _ok(rid, {"enabled": False, "checkpoints": []})
+            checkpoints = mgr.list_checkpoints(cwd)
+            all_directories = False
+            # Fall back to the cross-project view when the current directory
+            # has none (#10505, reapply of PR #10633 by @nightq, mirroring
+            # hermes_cli.cli_commands_mixin's identical CLI fix). Without
+            # this, a checkpoint written under a different cwd than the
+            # session's reports zero checkpoints despite fresh ones existing
+            # elsewhere.
+            if not checkpoints:
+                all_checkpoints = mgr.list_all_checkpoints()
+                if all_checkpoints:
+                    checkpoints = all_checkpoints
+                    all_directories = True
             return _ok(
                 rid,
                 {
                     "enabled": True,
+                    "all_directories": all_directories,
                     "checkpoints": [
                         {
                             "hash": c.get("hash", ""),
                             "timestamp": c.get("timestamp", ""),
                             "message": c.get("message", ""),
                         }
-                        for c in mgr.list_checkpoints(cwd)
+                        for c in checkpoints
                     ],
                 },
             )


### PR DESCRIPTION
## Summary

`fa89d87ea6` (#10505, reapply of PR #10633 by @nightq) fixed the classic CLI's bare `/rollback`: when the current directory has zero checkpoints, it now falls back to a cross-project "all directories" view instead of reporting "No checkpoints found" despite fresh checkpoints existing under a different cwd (the fix's own commit message: writes landed checkpoints under the session cwd `/tmp/qa-repo` while bare `/rollback` searched only `TERMINAL_CWD`'s project).

Two other independent implementations of the exact same bare-`/rollback`-listing logic never got the fix:

- **`gateway/slash_commands.py::_handle_rollback_command`** — the handler behind every chat-platform `/rollback` (Discord, Slack, Telegram, etc.)
- **`tui_gateway/methods_tools.py`'s `rollback.list` RPC** — used by the Ink TUI's `/rollback` (`ui-tui/src/app/slash/commands/ops.ts`), and planned for Desktop per open PR #90029 ("route /rollback through the native rollback RPCs instead of the slash worker")

Both still just call `mgr.list_checkpoints(cwd)` and return whatever comes back — empty if empty, with no fallback and no hint that checkpoints exist elsewhere.

## Fix

Both now call `CheckpointManager.list_all_checkpoints()` (the method the CLI's own fix introduced) with the exact same fallback condition: only when the session's own cwd has zero checkpoints AND at least one other directory has some.

- The gateway handler mirrors the CLI's text output exactly (`"No checkpoints for {cwd} — showing all directories."` + the labeled list).
- The RPC additionally returns a new `all_directories: bool` field so a future UI update can label the fallback list the way the CLI does; today's TUI client already renders the (larger) checkpoint list correctly without reading that field — nothing breaks by its absence being ignored.

## Verification

- New regression tests: `tests/gateway/test_rollback_command.py` (end-to-end against a real `CheckpointManager` + real git checkpoint store, mirroring `tests/gateway/test_diff_command.py`'s established pattern) and `tests/tui_gateway/test_rollback_list_rpc.py` (invokes the installed `rollback.list` handler via `server._methods["rollback.list"]`, same pattern as `tests/tui_gateway/test_projects_rpc.py`). Both cover: falls back when own-cwd is empty, no fallback claim when nothing exists anywhere, and own-cwd checkpoints always take priority over the fallback.
- Mutation-verify: stashed both fixes, confirmed 4/6 new assertions genuinely fail against pre-fix code (`KeyError: 'all_directories'`, missing fallback text) while the 2 "no fallback needed" negative controls correctly still pass unchanged. Restored the fixes, all 6 pass.
- Broader neighbor suite: `tests/gateway/test_rollback_command.py tests/gateway/test_diff_command.py tests/tui_gateway/test_rollback_list_rpc.py tests/tools/test_checkpoint_manager.py tests/tools/test_rollback_all_directories.py` — 60 passed, no regressions.
- `ruff check` clean on all changed files.

## Notes

- Restore-by-number (`/rollback <N>`) is intentionally left untouched, matching the CLI's own established scope: the fallback view is informational only (it shows what exists elsewhere so the user knows to `cd` there), not a promise that `<N>` against the shown listing is directly restorable — the CLI's own fix has this same limitation.
- While writing the RPC test I found `rollback.list`'s response reads a checkpoint's `message` field via `c.get("message", "")`, but `CheckpointManager.list_checkpoints()` actually names that field `reason` — every checkpoint's `message` has always come back empty. This is a separate, pre-existing bug unrelated to the all-directories fallback and is left out of scope here.
- Checked for competing PRs: none touch the bare-arg listing branch of `_handle_rollback_command` or the `rollback.list` RPC. #78603 (open, "`/rollback` now undoes the conversation turn it reverts") touches a different branch of the same function (the successful-restore path, `if result["success"]:`) — no overlap.

## Test plan

- [x] New end-to-end tests cover the gateway handler and the TUI RPC
- [x] Mutation-verify: fixes reverted → fallback assertions fail; negative controls unaffected; fixes restored → all pass
- [x] Broader `tests/gateway/` + `tests/tui_gateway/` + `tests/tools/` checkpoint/rollback suite green
- [x] `ruff check` clean