### PR TITLE
fix(cli): let 'profile alias --remove' clear orphaned wrappers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10626,6 +10626,10 @@ def cmd_profile(args):
                 print(f"✓ Removed alias '{alias_name}'")
             else:
                 print(f"No alias '{alias_name}' found to remove.")
+                print(
+                    "  Tip: run `hermes doctor` — its \"Orphan alias\" section "
+                    "lists wrapper/profile mismatches like this one (#90983)."
+                )
         else:
             collision = check_alias_collision(alias_name)
             if collision:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10602,7 +10602,14 @@ def cmd_profile(args):
 
         from hermes_cli.profiles import profile_exists, validate_alias_name
 
-        if not profile_exists(name):
+        if not remove and not profile_exists(name):
+            # Removal must stay reachable for orphaned wrappers — the target
+            # profile may be gone (manual dir removal, interrupted delete,
+            # typo'd alias), which is exactly when the CLI is the only
+            # supported cleanup path (`hermes doctor` reports these as
+            # "Orphan alias"). remove_wrapper_script() already refuses
+            # traversal-shaped names and only unlinks files whose content
+            # carries the `hermes -p` marker (#90983).
             print(f"Error: Profile '{name}' does not exist.")
             sys.exit(1)
 

--- a/tests/hermes_cli/test_profile_alias_orphan_remove.py
+++ b/tests/hermes_cli/test_profile_alias_orphan_remove.py
@@ -1,0 +1,87 @@
+"""`hermes profile alias <name> --remove` must work for orphaned wrappers (#90983).
+
+The action validated `profile_exists(name)` before the `--remove` branch, so
+the remove path was unreachable exactly when a wrapper is orphaned (its target
+profile no longer exists) — the state `hermes doctor` reports as "Orphan
+alias". Removal now skips the profile check; `remove_wrapper_script()` itself
+only unlinks files inside the wrapper dir whose content carries the
+`hermes -p` marker, so the fail-closed properties hold without it.
+"""
+
+import types
+from pathlib import Path
+
+import pytest
+
+import hermes_cli.main as main_mod
+from hermes_cli.profiles import remove_wrapper_script
+
+
+def _args(action: str, name: str, remove: bool = False, alias_name=None):
+    return types.SimpleNamespace(
+        profile_name=name, profile_action=action, remove=remove, alias_name=alias_name
+    )
+
+
+@pytest.fixture
+def wrapper_dir(tmp_path, monkeypatch):
+    import hermes_cli.profiles as profiles_mod
+
+    d = tmp_path / "bin"
+    d.mkdir()
+    monkeypatch.setattr(profiles_mod, "_get_wrapper_dir", lambda: d)
+    return d
+
+
+def test_remove_clears_orphaned_wrapper_without_profile(wrapper_dir, monkeypatch, capsys):
+    """The #90983 shape: wrapper exists (marker intact), profile is gone —
+    removal must succeed instead of exiting with 'Profile does not exist'."""
+    import hermes_cli.profiles as profiles_mod
+
+    (wrapper_dir / "demo").write_text("#!/bin/sh\nhermes -p demo \"$@\"\n")
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda _n: False)
+    monkeypatch.setattr(
+        main_mod, "profile_exists", lambda _n: False, raising=False
+    )
+
+    main_mod.cmd_profile(_args("alias", "demo", remove=True))
+
+    assert not (wrapper_dir / "demo").exists()
+    out = capsys.readouterr().out
+    assert "Removed alias 'demo'" in out
+
+
+def test_remove_refuses_non_wrapper_file_in_wrapper_dir(wrapper_dir, monkeypatch, capsys):
+    """Fail-closed: a same-named file without the `hermes -p` marker is NOT
+    unlinked — skipping the profile check must not turn --remove into an
+    arbitrary-file-delete primitive."""
+    import hermes_cli.profiles as profiles_mod
+
+    innocent = wrapper_dir / "demo"
+    innocent.write_text("#!/bin/sh\necho not-a-hermes-wrapper\n")
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda _n: False)
+    monkeypatch.setattr(
+        main_mod, "profile_exists", lambda _n: False, raising=False
+    )
+
+    main_mod.cmd_profile(_args("alias", "demo", remove=True))
+
+    assert innocent.exists()
+    out = capsys.readouterr().out
+    assert "No alias 'demo' found to remove." in out
+
+
+def test_add_still_requires_existing_profile(wrapper_dir, monkeypatch, capsys):
+    """The create path keeps its precondition — the orphan carve-out is
+    removal-only."""
+    import hermes_cli.profiles as profiles_mod
+
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda _n: False)
+    monkeypatch.setattr(
+        main_mod, "profile_exists", lambda _n: False, raising=False
+    )
+
+    with pytest.raises(SystemExit):
+        main_mod.cmd_profile(_args("alias", "ghost", remove=False))
+    out = capsys.readouterr().out
+    assert "does not exist" in out

--- a/tests/hermes_cli/test_profile_alias_orphan_remove.py
+++ b/tests/hermes_cli/test_profile_alias_orphan_remove.py
@@ -69,6 +69,8 @@ def test_remove_refuses_non_wrapper_file_in_wrapper_dir(wrapper_dir, monkeypatch
     assert innocent.exists()
     out = capsys.readouterr().out
     assert "No alias 'demo' found to remove." in out
+    # The dead-end message points at the tool that surfaces these states.
+    assert "hermes doctor" in out
 
 
 def test_add_still_requires_existing_profile(wrapper_dir, monkeypatch, capsys):


### PR DESCRIPTION
## What does this PR do?

Makes `hermes profile alias <name> --remove` work for **orphaned** wrappers — ones whose target profile no longer exists. The action validated `profile_exists(name)` unconditionally before dispatching, so the remove path was unreachable in exactly the state where it is needed: `hermes doctor` reports these as "Orphan alias" but there was no supported CLI cleanup (#90983).

Removal now skips the profile-existence check (create keeps it — a new alias still requires a real target). The fail-closed properties do not depend on that check: `remove_wrapper_script()` already refuses traversal-shaped alias names, only ever unlinks inside the wrapper dir, and verifies the file's content carries the `hermes -p` marker before deleting — so a same-named non-wrapper file is never touched.

## Related Issue

Fixes #90983

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` — the alias action's `profile_exists` guard becomes `if not remove and not profile_exists(name)`, with a comment documenting the orphan-cleanup rationale and the marker/traversal safety already inside `remove_wrapper_script()`
- `tests/hermes_cli/test_profile_alias_orphan_remove.py` — three behavior tests: orphaned wrapper (marker intact) is removed with the profile gone; a same-named file WITHOUT the marker is refused (fail-closed guard on the carve-out); the create path still requires an existing profile

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_cli/test_profile_alias_orphan_remove.py -q` — should pass (3 passed)
2. Observed result: on unmodified main, the first test fails with `SystemExit: Error: Profile 'demo' does not exist.` (the #90983 dead end); with this fix the wrapper is unlinked and the marker-less file test still proves refusal
3. Regression: `tests/hermes_cli/test_profiles.py` + `tests/hermes_cli/test_subcommands_profile_gateway.py` — 56 passed, 2 skipped

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (why removal skips the check + where the safety lives)
- [x] Tests added that prove the fix works (orphan removal + marker refusal + create precondition unchanged)
- [x] All new and existing tests pass locally (3 + 56 passed)
- [x] Platform: macOS (wrapper logic has Windows .bat handling in `remove_wrapper_script`, untouched)
