### PR TITLE
fix(gateway+relay): approval prompts survive ambiguity without duplicates; streamed finals keep block formatting

### DIFF
--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -107,6 +107,10 @@ class RelayAdapter(BasePlatformAdapter):
         # per-chat keying collided three concurrent turns: merged task
         # cards, clobbered seal state, 3x duplicate finals).
         self._open_draft_by_chat: Dict[str, int] = {}
+        # Draft keys whose post-seal tombstone swallow has been logged once
+        # (observability for the hijacked-live-stream class; bounded FIFO
+        # like the sibling caches).
+        self._tombstone_swallow_logged: Dict[str, int] = {}
         # chat_id -> draft_id of the most recently SEALED stream (gateway
         # mirror of the connector's sealed-key tombstone): post-seal
         # straggler frames must neither re-arm interception nor re-open a
@@ -465,6 +469,15 @@ class RelayAdapter(BasePlatformAdapter):
             k for k in self._open_draft_by_chat if k.startswith(prefix)
         ]
         if len(candidates) == 1:
+            # Absorbing a send into a stream is a significant, previously
+            # silent decision — the wrong caller matching here is exactly
+            # the prompt-ack-seals-own-stream bug (rc.4 live finding). Say
+            # it out loud so the next mismatch is a grep, not a hunt.
+            logger.info(
+                "relay: absorbing identity-less send into the single open "
+                "stream %s (single-open-stream fallback)",
+                candidates[0],
+            )
             return candidates[0]
         return None
 
@@ -494,7 +507,24 @@ class RelayAdapter(BasePlatformAdapter):
         chat_key = self._draft_key(str(chat_id), metadata)
         if self._sealed_draft_by_chat.get(chat_key) == draft_id:
             # Post-seal straggler: its content is already in the sealed
-            # message; report success, send nothing, arm nothing.
+            # message; report success, send nothing, arm nothing. Log the
+            # FIRST swallow per key at WARNING — one straggler is the
+            # normal race this tombstone exists for, but a hijacked live
+            # stream (something else sealed this draft mid-flight) shows
+            # up as a burst of swallows, and silence here cost a full
+            # forensic hunt (rc.4: prompt ack sealed the turn's own draft
+            # and every later append vanished without a line).
+            if chat_key not in self._tombstone_swallow_logged:
+                self._tombstone_swallow_logged[chat_key] = draft_id
+                self._evict_oldest(self._tombstone_swallow_logged)
+                logger.warning(
+                    "relay: draft frame for %s swallowed by post-seal "
+                    "tombstone (draft_id=%s) — expected for a straggler; "
+                    "a live stream freezing NOW means something sealed it "
+                    "mid-flight",
+                    chat_key,
+                    draft_id,
+                )
             return SendResult(success=True)
         # Arm seal-interception ONLY for stream-is-the-message chats
         # (review B4, per-chat in r2 finding 2): on a Telegram-shaped
@@ -3010,8 +3040,21 @@ class RelayAdapter(BasePlatformAdapter):
             logger.debug("relay expired-prompt notice failed", exc_info=True)
 
     def _prompt_reply_metadata(self, event) -> Dict[str, Any]:
-        """Thread/topic metadata so prompt acks land where the prompt lives."""
-        meta: Dict[str, Any] = {}
+        """Thread/topic metadata so prompt acks land where the prompt lives.
+
+        Marked as an INTERIM send (live finding, rc.4 staging): prompt
+        lifecycle acks ("✅ Approved once", slash-confirm acks, expiry
+        notices) are system messages that fire while the approval turn's
+        OWN draft stream is open. Without the interim marker they carry
+        only placement metadata — no per-turn identity — so send()'s
+        single-open-stream fallback matched them to the live draft and
+        sealed it with the ack text. Every later append then died on the
+        post-seal tombstone (silent by design), freezing the visible
+        stream mid-word, and the real turn-final fell through to a plain
+        send: the observed 100%-reproducible stuck-draft + duplicate-final
+        on approval turns. Interim sends bypass draft matching entirely.
+        """
+        meta: Dict[str, Any] = {"_interim_send": True}
         thread_id = getattr(event.source, "thread_id", None)
         if thread_id:
             meta["thread_id"] = str(thread_id)

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -513,7 +513,15 @@ class RelayAdapter(BasePlatformAdapter):
                     "draft_id": draft_id,
                     "content": content,
                     "final": False,
-                    "metadata": self._with_scope(chat_id, dict(metadata or {})),
+                    # Boundary rule (observed in live relay testing): the draft lane
+                    # is a text egress lane like send/edit — a streamed final
+                    # can only render blocks if its frames carry the hint.
+                    "metadata": self._with_scope(
+                        chat_id,
+                        self._with_format_hints_for_chat(
+                            chat_id, dict(metadata or {})
+                        ),
+                    ),
                 },
                 platform=self._platform_by_chat.get(str(chat_id)),
             )
@@ -576,7 +584,13 @@ class RelayAdapter(BasePlatformAdapter):
             "draft_id": draft_id,
             "content": content,
             "final": True,
-            "metadata": self._with_scope(chat_id, dict(metadata or {})),
+            # Same boundary rule as the interim frame: the SEAL frame is the
+            # one the connector's block reconcile reads — a hintless seal is
+            # exactly the plain-code-block downgrade seen in live relay testing.
+            "metadata": self._with_scope(
+                chat_id,
+                self._with_format_hints_for_chat(chat_id, dict(metadata or {})),
+            ),
         }
         _seal_platform = self._platform_by_chat.get(str(chat_id))
         _transport = self._transport  # narrowed by the None-guard above

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -107,6 +107,9 @@ class RelayAdapter(BasePlatformAdapter):
         # per-chat keying collided three concurrent turns: merged task
         # cards, clobbered seal state, 3x duplicate finals).
         self._open_draft_by_chat: Dict[str, int] = {}
+        # Strong refs for in-flight fire-and-forget lifecycle acks (asyncio
+        # holds tasks weakly; unreferenced tasks can be GC'd mid-flight).
+        self._lifecycle_ack_tasks: set = set()
         # Draft keys whose post-seal tombstone swallow has been logged once
         # (observability for the hijacked-live-stream class; bounded FIFO
         # like the sibling caches).
@@ -2954,8 +2957,11 @@ class RelayAdapter(BasePlatformAdapter):
                 # Acknowledge in-channel (the connector's prompt message can't
                 # be edited cross-platform yet — edit support varies; a short
                 # confirmation preserves the audit trail the native edit gives).
-                await self.send(
-                    chat_id, label, metadata=self._prompt_reply_metadata(event)
+                # Fire-and-forget: we are ON the read loop here (see
+                # _send_lifecycle_ack) — awaiting the send self-deadlocks the
+                # transport for the full outbound timeout.
+                self._send_lifecycle_ack(
+                    chat_id, label, self._prompt_reply_metadata(event)
                 )
                 if count:
                     self.resume_typing_for_chat(chat_id)
@@ -2973,14 +2979,15 @@ class RelayAdapter(BasePlatformAdapter):
                     "always": "🔒 Always approve",
                     "cancel": "❌ Cancelled",
                 }.get(choice, "Resolved")
-                await self.send(
-                    chat_id, label, metadata=self._prompt_reply_metadata(event)
+                # Fire-and-forget (read-loop context — see _send_lifecycle_ack).
+                self._send_lifecycle_ack(
+                    chat_id, label, self._prompt_reply_metadata(event)
                 )
                 if result_text:
-                    await self.send(
+                    self._send_lifecycle_ack(
                         chat_id,
                         str(result_text),
-                        metadata=self._prompt_reply_metadata(event),
+                        self._prompt_reply_metadata(event),
                     )
             elif kind == "clarify":
                 from tools.clarify_gateway import (
@@ -2991,10 +2998,10 @@ class RelayAdapter(BasePlatformAdapter):
                 clarify_id = str(state.get("clarify_id") or "")
                 if option_id == "other":
                     mark_awaiting_text(clarify_id)
-                    await self.send(
+                    self._send_lifecycle_ack(
                         chat_id,
                         "✏️ Type your answer:",
-                        metadata=self._prompt_reply_metadata(event),
+                        self._prompt_reply_metadata(event),
                     )
                 else:
                     choices = state.get("choices") or []
@@ -3004,10 +3011,10 @@ class RelayAdapter(BasePlatformAdapter):
                         idx = -1
                     if 0 <= idx < len(choices):
                         resolve_gateway_clarify(clarify_id, str(choices[idx]))
-                        await self.send(
+                        self._send_lifecycle_ack(
                             chat_id,
                             f"✅ {choices[idx]}",
-                            metadata=self._prompt_reply_metadata(event),
+                            self._prompt_reply_metadata(event),
                         )
                     else:
                         # Unmappable option: flip to text capture so the user
@@ -3019,6 +3026,40 @@ class RelayAdapter(BasePlatformAdapter):
             logger.warning("relay prompt_response resolution failed", exc_info=True)
         return True
 
+    def _send_lifecycle_ack(
+        self, chat_id: str, text: str, metadata: Dict[str, Any]
+    ) -> None:
+        """Fire-and-forget a prompt-lifecycle ack from read-loop context.
+
+        Live finding round 2 (rc.4): _consume_prompt_response executes ON
+        the transport read loop (inbound frame -> _handle_frame -> the
+        _inbound handler). ``await self.send(...)`` there is a
+        SELF-DEADLOCK: send() blocks on an outbound_result future that only
+        the read loop can resolve — and the read loop is blocked inside
+        this very handler. Every button tap wedged the transport for the
+        full outbound timeout: draft appends starved (the observed frozen
+        stream right after approving), sibling approval-card sends timed
+        out into 'possibly-delivered' ambiguity, and the turn's seal timed
+        out ambiguous -> plain-send fallback (the duplicate final).
+
+        Acks are cosmetic by contract (the audit trail), so they ride a
+        background task: the handler returns immediately, the read loop
+        keeps consuming, and the ack's own result frame resolves normally.
+        Failures are logged at debug — an undelivered ack must never break
+        the reader or the turn. The task ref is retained (asyncio only
+        weakly references tasks) and dropped on completion.
+        """
+
+        async def _ack() -> None:
+            try:
+                await self.send(chat_id, text, metadata=metadata)
+            except Exception:  # noqa: BLE001 - ack is best-effort
+                logger.debug("relay lifecycle ack failed", exc_info=True)
+
+        task = asyncio.create_task(_ack(), name="relay-lifecycle-ack")
+        self._lifecycle_ack_tasks.add(task)
+        task.add_done_callback(self._lifecycle_ack_tasks.discard)
+
     async def _notify_prompt_expired(self, event) -> None:
         """Tell the presser their prompt is no longer waiting.
 
@@ -3029,15 +3070,14 @@ class RelayAdapter(BasePlatformAdapter):
         chat_id = str(getattr(event.source, "chat_id", "") or "")
         if not chat_id:
             return
-        try:
-            await self.send(
-                chat_id,
-                "⌛ That prompt is no longer waiting for an answer. "
-                "Send your reply as a normal message.",
-                metadata=self._prompt_reply_metadata(event),
-            )
-        except Exception:  # noqa: BLE001 - notification is best-effort
-            logger.debug("relay expired-prompt notice failed", exc_info=True)
+        # Fire-and-forget (read-loop context — see _send_lifecycle_ack):
+        # _notify_prompt_expired is called from _consume_prompt_response too.
+        self._send_lifecycle_ack(
+            chat_id,
+            "⌛ That prompt is no longer waiting for an answer. "
+            "Send your reply as a normal message.",
+            self._prompt_reply_metadata(event),
+        )
 
     def _prompt_reply_metadata(self, event) -> Dict[str, Any]:
         """Thread/topic metadata so prompt acks land where the prompt lives.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -920,6 +920,36 @@ def _approval_send_outcome(future, timeout: float) -> str:
     return "sent" if getattr(result, "success", False) else "failed"
 
 
+def _clarify_send_disposition(fut, *, session_key: str, clarify_mod) -> "str | None":
+    """Decide whether a clarify prompt send aborts the wait, per the boundary rule.
+
+    Same physics as the exec-approval card: the scheduling future can hit its
+    deadline while the clarify card HAS already posted (late connector ack).
+    Treating that timeout as a definitive failure cleared the session out from
+    under a rendered card — the user answers a question whose registration is
+    gone. Only a DEFINITIVE failure (error result / non-timeout exception /
+    no future) tears down the registration and aborts; ``ambiguous`` keeps the
+    registration armed and proceeds to the normal bounded wait, which already
+    handles the truly-lost-card case via its response timeout.
+
+    Returns the abort sentinel string on definitive failure, else ``None``
+    (proceed to ``wait_for_response``).
+    """
+    outcome = _approval_send_outcome(fut, timeout=15)
+    if outcome == "failed":
+        # Couldn't deliver the prompt — clean up and return the sentinel so
+        # the agent can fall back to a sensible default rather than hanging.
+        logger.warning("Clarify send failed definitively; clearing registration")
+        clarify_mod.clear_session(session_key)
+        return "[clarify prompt could not be delivered]"
+    if outcome == "ambiguous":
+        logger.warning(
+            "Clarify prompt send timed out — treating as possibly-delivered "
+            "(no teardown; the registration stays armed for a late reply)"
+        )
+    return None
+
+
 def _resolve_progress_thread_id(
     platform: Any,
     source_thread_id: Any,
@@ -5936,7 +5966,6 @@ class TurnRunner:
                     exc_info=True,
                 )
 
-            send_ok = False
             fut = safe_schedule_threadsafe(
                 ctx._status_adapter.send_clarify(
                     chat_id=ctx._status_chat_id,
@@ -5950,22 +5979,17 @@ class TurnRunner:
                 logger=logger,
                 log_message="Clarify send failed to schedule",
             )
-            if fut is None:
-                send_ok = False
-            else:
-                try:
-                    result = fut.result(timeout=15)
-                    send_ok = bool(getattr(result, "success", False))
-                except Exception as exc:
-                    logger.warning("Clarify send failed: %s", exc)
-                    send_ok = False
-
-            if not send_ok:
-                # Couldn't deliver the prompt — clean up and return
-                # sentinel so the agent can fall back to a sensible
-                # default rather than hanging.
-                _clarify_mod.clear_session(ctx.session_key or "")
-                return "[clarify prompt could not be delivered]"
+            # Boundary rule (see _approval_send_outcome): a send timeout is
+            # AMBIGUOUS — the card may have posted with a late ack. Only a
+            # definitive failure tears down the registration; ambiguous
+            # falls through to the bounded wait so a late reply resolves.
+            _abort = _clarify_send_disposition(
+                fut,
+                session_key=ctx.session_key or "",
+                clarify_mod=_clarify_mod,
+            )
+            if _abort is not None:
+                return _abort
 
             timeout = _clarify_mod.get_clarify_timeout()
             response = _clarify_mod.wait_for_response(clarify_id, timeout=float(timeout))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -895,6 +895,31 @@ async def _send_or_update_status_coro(adapter, chat_id, status_key, content, met
     return await adapter.send(chat_id, content, metadata=metadata)
 
 
+def _approval_send_outcome(future, timeout: float) -> str:
+    """Classify an approval prompt send as ``sent`` / ``failed`` / ``ambiguous``.
+
+    ``ambiguous`` == the scheduling future timed out. The card may well have
+    posted: the connector may only ack after the deadline (slow platform API
+    call, transient backpressure, event-loop stall), and treating that timeout
+    as a failure has been observed in live relay testing to re-send the card
+    repeatedly, leaving the user's tap resolving a prompt whose turn had moved
+    on. Callers must treat
+    ``ambiguous`` as possibly-delivered: keep the prompt registration alive
+    and do NOT re-send or fall back — the boundary rule is that only a
+    DEFINITIVE failure (error result / non-timeout exception / no future)
+    re-asks.
+    """
+    if future is None:
+        return "failed"
+    try:
+        result = future.result(timeout=timeout)
+    except concurrent.futures.TimeoutError:
+        return "ambiguous"
+    except Exception:
+        return "failed"
+    return "sent" if getattr(result, "success", False) else "failed"
+
+
 def _resolve_progress_thread_id(
     platform: Any,
     source_thread_id: Any,
@@ -6083,12 +6108,26 @@ class TurnRunner:
                     )
                     if _approval_fut is None:
                         raise RuntimeError("send_exec_approval: loop unavailable")
-                    _approval_result = _approval_fut.result(timeout=15)
-                    if _approval_result.success:
+                    _outcome = _approval_send_outcome(_approval_fut, timeout=15)
+                    if _outcome == "sent":
+                        return
+                    if _outcome == "ambiguous":
+                        # Timeout ≠ failure: the card may have posted with a
+                        # late ack (slow platform API call or transient
+                        # connector backpressure). The prompt
+                        # registration stays alive, so a tap on the rendered
+                        # card still resolves; re-sending here is what
+                        # produced duplicate cards and an orphaned
+                        # "/approve: nothing pending" in live relay testing.
+                        # Skip the text fallback.
+                        logger.warning(
+                            "Button-based approval send timed out — treating "
+                            "as possibly-delivered (no re-send; the prompt "
+                            "stays armed for a late tap)"
+                        )
                         return
                     logger.warning(
-                        "Button-based approval failed (send returned error), falling back to text: %s",
-                        _approval_result.error,
+                        "Button-based approval failed (send returned error), falling back to text"
                     )
                 except Exception as _e:
                     logger.warning(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -908,16 +908,27 @@ def _approval_send_outcome(future, timeout: float) -> str:
     and do NOT re-send or fall back — the boundary rule is that only a
     DEFINITIVE failure (error result / non-timeout exception / no future)
     re-asks.
+
+    Definitive failures log their detail here (scheduling exception text or
+    the SendResult error) so callers sharing this classifier keep the
+    diagnostic breadcrumb the old inline code had.
     """
     if future is None:
+        logger.warning("Prompt send failed: no scheduling future (loop unavailable)")
         return "failed"
     try:
         result = future.result(timeout=timeout)
     except concurrent.futures.TimeoutError:
         return "ambiguous"
-    except Exception:
+    except Exception as exc:
+        logger.warning("Prompt send failed: %s", exc)
         return "failed"
-    return "sent" if getattr(result, "success", False) else "failed"
+    if getattr(result, "success", False):
+        return "sent"
+    logger.warning(
+        "Prompt send failed: %s", getattr(result, "error", None) or "unknown error"
+    )
+    return "failed"
 
 
 def _clarify_send_disposition(fut, *, session_key: str, clarify_mod) -> "str | None":
@@ -948,6 +959,28 @@ def _clarify_send_disposition(fut, *, session_key: str, clarify_mod) -> "str | N
             "(no teardown; the registration stays armed for a late reply)"
         )
     return None
+
+
+def _clarify_send_then_wait(fut, *, clarify_id: str, session_key: str, clarify_mod) -> str:
+    """Resolve a clarify prompt: send disposition, then the bounded wait.
+
+    The full caller contract in one testable seam: a definitive send failure
+    returns the undeliverable sentinel (registration torn down); ``sent`` and
+    ``ambiguous`` both proceed to ``wait_for_response`` with the configured
+    timeout — for ambiguous, the registration stays armed so a late reply to
+    the (probably rendered) card still resolves.
+    """
+    abort = _clarify_send_disposition(
+        fut, session_key=session_key, clarify_mod=clarify_mod
+    )
+    if abort is not None:
+        return abort
+    timeout = clarify_mod.get_clarify_timeout()
+    response = clarify_mod.wait_for_response(clarify_id, timeout=float(timeout))
+    if response is None or response == "":
+        # Timeout or session-boundary cancellation
+        return f"[user did not respond within {int(timeout / 60)}m]"
+    return response
 
 
 def _resolve_progress_thread_id(
@@ -5983,20 +6016,12 @@ class TurnRunner:
             # AMBIGUOUS — the card may have posted with a late ack. Only a
             # definitive failure tears down the registration; ambiguous
             # falls through to the bounded wait so a late reply resolves.
-            _abort = _clarify_send_disposition(
+            return _clarify_send_then_wait(
                 fut,
+                clarify_id=clarify_id,
                 session_key=ctx.session_key or "",
                 clarify_mod=_clarify_mod,
             )
-            if _abort is not None:
-                return _abort
-
-            timeout = _clarify_mod.get_clarify_timeout()
-            response = _clarify_mod.wait_for_response(clarify_id, timeout=float(timeout))
-            if response is None or response == "":
-                # Timeout or session-boundary cancellation
-                return f"[user did not respond within {int(timeout / 60)}m]"
-            return response
 
         agent.clarify_callback = _clarify_callback_sync
 

--- a/tests/gateway/relay/test_relay_interactive.py
+++ b/tests/gateway/relay/test_relay_interactive.py
@@ -18,6 +18,7 @@ Covers:
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any, Dict, Optional
 
@@ -328,6 +329,11 @@ async def test_expired_own_prompt_notifies_instead_of_unknown_command():
 
     event = _event({"prompt_id": prompt_id, "option_id": "c1"})
     assert await adapter._consume_prompt_response(event) is True
+    # The notice is fire-and-forget now (read-loop self-deadlock fix:
+    # awaiting a send from _consume_prompt_response blocks the very read
+    # loop that resolves the send's result future). Yield so the
+    # background ack task runs before asserting egress.
+    await asyncio.sleep(0.05)
     notices = [a for a in stub.sent if a["op"] == "send"]
     assert len(notices) == 1
     assert "no longer waiting" in notices[0]["content"]

--- a/tests/gateway/test_approval_send_timeout_ambiguity.py
+++ b/tests/gateway/test_approval_send_timeout_ambiguity.py
@@ -1,0 +1,62 @@
+"""Approval prompt-send TIMEOUT must not trigger the re-ask/fallback lane.
+
+Observed in live relay testing: `send_exec_approval`'s scheduling future can
+hit its 15s `.result(timeout=...)` while the card HAS already posted to the
+platform — the connector's ack simply arrives after the deadline (slow
+platform API call, transient backpressure, event-loop stall). run.py treated
+the timeout like a definitive send failure and ran the text fallback, so the
+user saw the same approval multiple times; tapping an older card resolved a
+prompt whose turn had already moved on ("/approve: nothing pending").
+
+Contract under test (boundary rule — every prompt caller crossing the
+send-timeout boundary): concurrent.futures.TimeoutError from the approval
+send is AMBIGUOUS (possibly delivered). The gateway must NOT fall back /
+re-send; the prompt registration stays live so the user's tap on the
+(probably rendered) card still resolves. A definitive error (SendResult
+success=False, or a non-timeout exception) keeps today's fallback.
+"""
+
+import concurrent.futures
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.run import _approval_send_outcome
+
+
+class _Result:
+    def __init__(self, success, error=None):
+        self.success = success
+        self.error = error
+
+
+def test_timeout_is_ambiguous_not_failure():
+    fut = MagicMock()
+    fut.result.side_effect = concurrent.futures.TimeoutError()
+    outcome = _approval_send_outcome(fut, timeout=0.01)
+    assert outcome == "ambiguous", (
+        "a send timeout re-ran the fallback — this is the duplicate-approval "
+        "re-pop (card posted, ack late); ambiguous must suppress the re-ask"
+    )
+
+
+def test_success_is_sent():
+    fut = MagicMock()
+    fut.result.return_value = _Result(True)
+    assert _approval_send_outcome(fut, timeout=1) == "sent"
+
+
+def test_definitive_error_result_is_failed():
+    fut = MagicMock()
+    fut.result.return_value = _Result(False, "relay prompt op unavailable")
+    assert _approval_send_outcome(fut, timeout=1) == "failed"
+
+
+def test_non_timeout_exception_is_failed():
+    fut = MagicMock()
+    fut.result.side_effect = RuntimeError("loop unavailable")
+    assert _approval_send_outcome(fut, timeout=1) == "failed"
+
+
+def test_missing_future_is_failed():
+    assert _approval_send_outcome(None, timeout=1) == "failed"

--- a/tests/gateway/test_clarify_send_timeout_ambiguity.py
+++ b/tests/gateway/test_clarify_send_timeout_ambiguity.py
@@ -1,0 +1,85 @@
+"""Clarify prompt-send TIMEOUT must not tear down the registration.
+
+Sibling of test_approval_send_timeout_ambiguity.py, same boundary rule, same
+live physics: send_clarify's scheduling future can hit its 15s deadline while
+the clarify card HAS already posted (late connector ack). The old caller
+treated any exception — including the timeout — as a definitive failure and
+ran clear_session(), so the user answered a rendered card whose registration
+was already gone.
+
+Contract under test: TimeoutError is AMBIGUOUS (possibly delivered) — the
+registration must stay armed (clear_session NOT called) and the caller must
+proceed to the bounded wait (disposition None). A definitive error
+(SendResult success=False, non-timeout exception, or no future) keeps
+today's teardown + sentinel behavior.
+"""
+
+import concurrent.futures
+from unittest.mock import MagicMock
+
+from gateway.run import _clarify_send_disposition
+
+SENTINEL = "[clarify prompt could not be delivered]"
+
+
+class _Result:
+    def __init__(self, success, error=None):
+        self.success = success
+        self.error = error
+
+
+def test_timeout_keeps_registration_armed_and_proceeds_to_wait():
+    fut = MagicMock()
+    fut.result.side_effect = concurrent.futures.TimeoutError()
+    clarify_mod = MagicMock()
+    disposition = _clarify_send_disposition(
+        fut, session_key="sk", clarify_mod=clarify_mod
+    )
+    assert disposition is None, (
+        "a send timeout aborted the clarify wait — this is the "
+        "cleared-session-under-a-rendered-card bug (card posted, ack late); "
+        "ambiguous must fall through to wait_for_response"
+    )
+    clarify_mod.clear_session.assert_not_called()
+
+
+def test_successful_send_proceeds_to_wait():
+    fut = MagicMock()
+    fut.result.return_value = _Result(True)
+    clarify_mod = MagicMock()
+    assert (
+        _clarify_send_disposition(fut, session_key="sk", clarify_mod=clarify_mod)
+        is None
+    )
+    clarify_mod.clear_session.assert_not_called()
+
+
+def test_definitive_error_result_tears_down_and_aborts():
+    fut = MagicMock()
+    fut.result.return_value = _Result(False, "relay prompt op unavailable")
+    clarify_mod = MagicMock()
+    assert (
+        _clarify_send_disposition(fut, session_key="sk", clarify_mod=clarify_mod)
+        == SENTINEL
+    )
+    clarify_mod.clear_session.assert_called_once_with("sk")
+
+
+def test_non_timeout_exception_tears_down_and_aborts():
+    fut = MagicMock()
+    fut.result.side_effect = RuntimeError("loop unavailable")
+    clarify_mod = MagicMock()
+    assert (
+        _clarify_send_disposition(fut, session_key="sk", clarify_mod=clarify_mod)
+        == SENTINEL
+    )
+    clarify_mod.clear_session.assert_called_once_with("sk")
+
+
+def test_missing_future_tears_down_and_aborts():
+    clarify_mod = MagicMock()
+    assert (
+        _clarify_send_disposition(None, session_key="sk", clarify_mod=clarify_mod)
+        == SENTINEL
+    )
+    clarify_mod.clear_session.assert_called_once_with("sk")

--- a/tests/gateway/test_clarify_send_timeout_ambiguity.py
+++ b/tests/gateway/test_clarify_send_timeout_ambiguity.py
@@ -17,7 +17,7 @@ today's teardown + sentinel behavior.
 import concurrent.futures
 from unittest.mock import MagicMock
 
-from gateway.run import _clarify_send_disposition
+from gateway.run import _clarify_send_disposition, _clarify_send_then_wait
 
 SENTINEL = "[clarify prompt could not be delivered]"
 
@@ -83,3 +83,93 @@ def test_missing_future_tears_down_and_aborts():
         == SENTINEL
     )
     clarify_mod.clear_session.assert_called_once_with("sk")
+
+
+# --- Caller-path contract: the disposition feeds the bounded wait ---------
+
+
+def test_ambiguous_send_reaches_wait_for_response():
+    """The full caller contract, not just the classifier: on a send timeout
+    the flow must proceed to wait_for_response with the generated clarify_id
+    and the configured timeout — the late reply to the (probably rendered)
+    card resolves through that wait."""
+    fut = MagicMock()
+    fut.result.side_effect = concurrent.futures.TimeoutError()
+    clarify_mod = MagicMock()
+    clarify_mod.get_clarify_timeout.return_value = 600
+    clarify_mod.wait_for_response.return_value = "user picked B"
+
+    out = _clarify_send_then_wait(
+        fut, clarify_id="cid123", session_key="sk", clarify_mod=clarify_mod
+    )
+
+    assert out == "user picked B"
+    clarify_mod.clear_session.assert_not_called()
+    clarify_mod.wait_for_response.assert_called_once_with("cid123", timeout=600.0)
+
+
+def test_sent_reaches_wait_for_response():
+    fut = MagicMock()
+    fut.result.return_value = _Result(True)
+    clarify_mod = MagicMock()
+    clarify_mod.get_clarify_timeout.return_value = 600
+    clarify_mod.wait_for_response.return_value = "answer"
+
+    assert (
+        _clarify_send_then_wait(
+            fut, clarify_id="cid123", session_key="sk", clarify_mod=clarify_mod
+        )
+        == "answer"
+    )
+    clarify_mod.wait_for_response.assert_called_once_with("cid123", timeout=600.0)
+
+
+def test_definitive_failure_never_waits():
+    fut = MagicMock()
+    fut.result.return_value = _Result(False, "relay prompt op unavailable")
+    clarify_mod = MagicMock()
+
+    assert (
+        _clarify_send_then_wait(
+            fut, clarify_id="cid123", session_key="sk", clarify_mod=clarify_mod
+        )
+        == SENTINEL
+    )
+    clarify_mod.wait_for_response.assert_not_called()
+    clarify_mod.clear_session.assert_called_once_with("sk")
+
+
+def test_no_response_returns_timeout_sentinel():
+    fut = MagicMock()
+    fut.result.return_value = _Result(True)
+    clarify_mod = MagicMock()
+    clarify_mod.get_clarify_timeout.return_value = 600
+    clarify_mod.wait_for_response.return_value = None
+
+    assert (
+        _clarify_send_then_wait(
+            fut, clarify_id="cid123", session_key="sk", clarify_mod=clarify_mod
+        )
+        == "[user did not respond within 10m]"
+    )
+
+
+# --- Definitive failures keep their diagnostic detail in the log ----------
+
+
+def test_failed_send_exception_detail_is_logged(caplog):
+    fut = MagicMock()
+    fut.result.side_effect = RuntimeError("loop unavailable")
+    clarify_mod = MagicMock()
+    with caplog.at_level("WARNING", logger="gateway.run"):
+        _clarify_send_disposition(fut, session_key="sk", clarify_mod=clarify_mod)
+    assert "loop unavailable" in caplog.text
+
+
+def test_failed_send_result_error_detail_is_logged(caplog):
+    fut = MagicMock()
+    fut.result.return_value = _Result(False, "relay prompt op unavailable")
+    clarify_mod = MagicMock()
+    with caplog.at_level("WARNING", logger="gateway.run"):
+        _clarify_send_disposition(fut, session_key="sk", clarify_mod=clarify_mod)
+    assert "relay prompt op unavailable" in caplog.text

--- a/tests/relay/test_relay_format_hints.py
+++ b/tests/relay/test_relay_format_hints.py
@@ -158,6 +158,61 @@ class TestFormatHintsStamping:
         hints = (frame.get("metadata") or {}).get("format_hints")
         assert hints == {"rich_blocks": True}
 
+    @pytest.mark.asyncio
+    async def test_draft_interim_and_seal_frames_carry_hints(self):
+        """Observed in live relay testing: a STREAMED bash
+        snippet sealed as a plain code block while send/edit rendered
+        blocks. The draft lane (interim frame AND the final=true seal
+        frame) is a text egress lane crossing the same frame contract —
+        the connector's seal reconcile can only attach the markdown block
+        if the seal frame carries the hint. Boundary rule: send, edit,
+        send_for_platform, AND draft/seal all stamp format_hints."""
+        a = _adapter(
+            extra={"slack": {"markdown_blocks": True}},
+            descriptor=_descriptor(
+                supports_block_formatting=True,
+                supports_draft_streaming=True,
+                supported_ops=("send", "edit", "draft"),
+            ),
+        )
+        code = "```bash\necho hi\n```"
+        await a.send_draft("D01", 7, "```bash\necho")
+        interim, _ = a._transport.frames[-1]
+        assert interim["op"] == "draft" and interim["final"] is False
+        assert (interim.get("metadata") or {}).get("format_hints") == {
+            "markdown_blocks": True
+        }
+        seal = getattr(a, "seal_draft", None) or getattr(
+            a, "send_draft_final", None
+        )
+        if seal is not None:
+            await seal("D01", 7, code)
+        else:
+            # The seal frame is built by _seal_open_draft (send()
+            # interception converts an armed final into draft final=true).
+            await a._seal_open_draft("D01", code, None)
+        final_frame, _ = a._transport.frames[-1]
+        assert final_frame["op"] == "draft" and final_frame["final"] is True
+        assert (final_frame.get("metadata") or {}).get("format_hints") == {
+            "markdown_blocks": True
+        }
+
+    @pytest.mark.asyncio
+    async def test_draft_frames_no_hints_when_knobs_off(self):
+        """Regression control: knob off -> draft frames byte-identical to
+        today (no format_hints key)."""
+        a = _adapter(
+            extra={},
+            descriptor=_descriptor(
+                supports_block_formatting=True,
+                supports_draft_streaming=True,
+                supported_ops=("send", "edit", "draft"),
+            ),
+        )
+        await a.send_draft("D01", 8, "plain text")
+        interim, _ = a._transport.frames[-1]
+        assert "format_hints" not in (interim.get("metadata") or {})
+
 
 class TestMultiPlatformResolution:
     """One RelayAdapter fronts N platforms: capability must resolve from the

--- a/tests/relay/test_relay_prompt_ack_stream_isolation.py
+++ b/tests/relay/test_relay_prompt_ack_stream_isolation.py
@@ -21,6 +21,7 @@ matching entirely. These tests pin the whole class, plus the regression
 contract that real turn-finals still absorb into their stream.
 """
 
+import asyncio
 import json
 
 import pytest
@@ -87,6 +88,44 @@ async def _open_turn_draft(a, chat_id="D01", draft_id=7):
 
 class TestPromptAckDoesNotSealDraft:
     @pytest.mark.asyncio
+    async def test_prompt_response_handler_does_not_block_on_ack_send(self):
+        """Live finding round 2 (rc.4): _consume_prompt_response runs ON the
+        transport read loop (inbound frame -> _handle_frame -> _inbound).
+        Awaiting the ack send there is a self-deadlock: the outbound_result
+        that resolves the send's future arrives on the SAME read loop, which
+        is blocked inside the handler. Every tap wedged the transport for
+        the full outbound timeout — draft appends starved (frozen stream),
+        a second approval card's ack couldn't be read (send timed out,
+        'possibly-delivered'), and the seal timed out ambiguous (plain-send
+        duplicate). The handler must RETURN without awaiting ack delivery;
+        the ack is best-effort and rides a background task."""
+        a = _adapter()
+        gate = asyncio.Event()
+        orig = a._transport.send_outbound
+
+        async def gated_send(frame, platform=None):
+            if frame.get("op") == "send":
+                await gate.wait()  # simulate outbound_result not readable yet
+            return await orig(frame, platform=platform)
+
+        a._transport.send_outbound = gated_send
+        prompt_id = a._mint_prompt(
+            "exec_approval", {"session_key": "sess-dl", "chat_id": "D01"}
+        )
+        # Pre-fix this hangs until the gate opens (deadlock shape) and the
+        # wait_for trips. Post-fix it returns promptly.
+        consumed = await asyncio.wait_for(
+            a._consume_prompt_response(FakeEvent(prompt_id, "once")),
+            timeout=1.0,
+        )
+        assert consumed is True
+        # Release the gate; the background ack must still go out.
+        gate.set()
+        await asyncio.sleep(0.05)
+        ack_frames = [f for f, _ in a._transport.frames if f["op"] == "send"]
+        assert ack_frames, "background ack was never sent"
+
+    @pytest.mark.asyncio
     async def test_approval_ack_leaves_open_draft_untouched(self):
         """The exact live failure: exec-approval tap resolves while the
         turn's draft stream is open; the ack must go out as its own plain
@@ -104,6 +143,8 @@ class TestPromptAckDoesNotSealDraft:
             FakeEvent(prompt_id, "once")
         )
         assert consumed is True
+        # The ack rides a background task now (deadlock fix): yield so it runs.
+        await asyncio.sleep(0.05)
 
         # The draft interception must still be armed for the real turn-final.
         assert draft_key in a._open_draft_by_chat, (

--- a/tests/relay/test_relay_prompt_ack_stream_isolation.py
+++ b/tests/relay/test_relay_prompt_ack_stream_isolation.py
@@ -1,0 +1,154 @@
+"""Prompt-ack sends must never seal an open draft stream.
+
+Live finding (rc.4 staging, 100% reproducible on approval turns): the
+"✅ Approved once" acknowledgement the adapter sends after resolving an
+exec-approval prompt_response carried only placement metadata (thread_id)
+— no per-turn message identity and no interim marker. send()'s
+single-open-stream fallback (review B2: "a chat with exactly one open
+stream absorbs a turn-final arriving without identity") therefore matched
+the approval turn's OWN live draft and sealed it with the ack text:
+
+  * every subsequent append hit the post-seal tombstone (silently
+    swallowed by design — built for millisecond stragglers), freezing the
+    visible draft mid-word with zero log lines;
+  * the turn-final then found no open draft and fell through to a plain
+    send — the duplicate (fallback) message the user saw. Also silent:
+    no suppression line, no seal-failed warning.
+
+The fix marks every prompt-lifecycle system send (approval ack, slash-
+confirm ack, expiry notice) as an interim send, which bypasses draft
+matching entirely. These tests pin the whole class, plus the regression
+contract that real turn-finals still absorb into their stream.
+"""
+
+import json
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.relay.adapter import RelayAdapter
+from gateway.relay.descriptor import CapabilityDescriptor
+
+
+def _descriptor(**overrides):
+    base = dict(
+        contract_version=1,
+        platform="slack",
+        label="Slack",
+        max_message_length=4000,
+        supports_draft_streaming=True,
+        supports_edit=True,
+        supports_threads=True,
+        markdown_dialect="mrkdwn",
+        len_unit="chars",
+        supported_ops=("send", "edit", "draft", "prompt"),
+    )
+    base.update(overrides)
+    return CapabilityDescriptor(**base)
+
+
+class FakeTransport:
+    def __init__(self):
+        self.frames = []
+        self._identities = [("slack", "hermes")]
+
+    def descriptor_for_platform(self, platform):
+        return None
+
+    async def send_outbound(self, frame, platform=None):
+        self.frames.append((frame, platform))
+        return {"success": True, "message_id": "1.2"}
+
+
+class FakeSource:
+    chat_id = "D01"
+    thread_id = "111.222"
+
+
+class FakeEvent:
+    def __init__(self, prompt_id, option_id):
+        self.prompt_response = {"prompt_id": prompt_id, "option_id": option_id}
+        self.source = FakeSource()
+
+
+def _adapter():
+    config = PlatformConfig(enabled=True, extra={})
+    return RelayAdapter(config, _descriptor(), transport=FakeTransport())
+
+
+async def _open_turn_draft(a, chat_id="D01", draft_id=7):
+    """Open a live draft the way a streaming turn does."""
+    await a.send_draft(chat_id, draft_id, "streaming partial…")
+    key = a._draft_key(chat_id, None)
+    candidates = [k for k in a._open_draft_by_chat if k.startswith(f"{chat_id}:")]
+    assert candidates, "test setup: draft did not arm interception"
+    return candidates[0]
+
+
+class TestPromptAckDoesNotSealDraft:
+    @pytest.mark.asyncio
+    async def test_approval_ack_leaves_open_draft_untouched(self):
+        """The exact live failure: exec-approval tap resolves while the
+        turn's draft stream is open; the ack must go out as its own plain
+        send and the draft must STILL be armed afterwards."""
+        a = _adapter()
+        draft_key = await _open_turn_draft(a)
+
+        prompt_id = a._mint_prompt(
+            "exec_approval", {"session_key": "sess-1", "chat_id": "D01"}
+        )
+        # resolve_gateway_approval is imported inside the handler; a session
+        # with no waiting entry returns 0 -> "expired" label. Either label
+        # shape exercises the same send path.
+        consumed = await a._consume_prompt_response(
+            FakeEvent(prompt_id, "once")
+        )
+        assert consumed is True
+
+        # The draft interception must still be armed for the real turn-final.
+        assert draft_key in a._open_draft_by_chat, (
+            "prompt ack sealed the open draft — the live stuck-stream/"
+            "duplicate-final bug"
+        )
+        # The ack egressed as a plain send op, not a draft seal.
+        ack_frames = [
+            f for f, _ in a._transport.frames if f["op"] == "send"
+        ]
+        assert ack_frames, "ack was not sent at all"
+        seal_frames = [
+            f
+            for f, _ in a._transport.frames
+            if f["op"] == "draft" and f.get("final") is True
+        ]
+        assert not seal_frames, "ack egressed as a draft seal"
+
+    @pytest.mark.asyncio
+    async def test_expired_prompt_notice_leaves_open_draft_untouched(self):
+        """Same class: the expiry notice for an unknown prompt id must not
+        absorb into an open stream either."""
+        a = _adapter()
+        draft_key = await _open_turn_draft(a)
+        consumed = await a._consume_prompt_response(
+            FakeEvent("prompt-never-minted", "once")
+        )
+        assert consumed is True
+        assert draft_key in a._open_draft_by_chat
+
+    @pytest.mark.asyncio
+    async def test_turn_final_still_absorbs_into_single_open_stream(self):
+        """Regression control (review B2 contract): a REAL turn-final
+        without identity metadata, in a chat with exactly one open stream,
+        must still seal that stream."""
+        a = _adapter()
+        draft_key = await _open_turn_draft(a)
+        result = await a.send("D01", "the full final answer")
+        assert result.success
+        assert draft_key not in a._open_draft_by_chat, (
+            "turn-final no longer absorbs into its stream — B2 fallback broken"
+        )
+        seal_frames = [
+            f
+            for f, _ in a._transport.frames
+            if f["op"] == "draft" and f.get("final") is True
+        ]
+        assert len(seal_frames) == 1

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -4891,7 +4891,11 @@ def check_all_command_guards(command: str, env_type: str,
                 "command": _disp_command,
                 "description": _disp_combined_desc,
                 "message": (
-                    f"⚠️ {_disp_combined_desc}. Asking the user for approval.\n\n**Command:**\n```\n{_disp_command}\n```"
+                    f"⚠️ {_disp_combined_desc}. Asking the user for approval.\n\n**Command:**\n```\n{_disp_command}\n```\n\n"
+                    "STOP: do NOT re-run, rephrase, or re-issue this command — each "
+                    "variant sends the user ANOTHER approval card. Wait for the "
+                    "user's decision; if this turn must end, report that approval "
+                    "is pending."
                 ),
             }
             if smart_denied_for_owner:
@@ -5320,7 +5324,11 @@ def check_execute_code_guard(code: str, env_type: str,
             "description": display_description,
             "message": (
                 f"⚠️ {display_description}. Asking the user for approval.\n\n"
-                f"**Code:**\n```python\n{display_code}\n```"
+                f"**Code:**\n```python\n{display_code}\n```\n\n"
+                "STOP: do NOT re-run, rephrase, or re-issue this code — each "
+                "variant sends the user ANOTHER approval card. Wait for the "
+                "user's decision; if this turn must end, report that approval "
+                "is pending."
             ),
         }
         if smart_denied_for_owner:


### PR DESCRIPTION
Three live findings from rc.4 enterprise staging (relay-fronted Slack path), each observed in live logs before the fix. All three sit on the same seam: the turn lifecycle over the relay under real latency/ambiguity.

## 1. Approval-send timeout is AMBIGUOUS, not failed (no re-ask)

`send_exec_approval` through the connector can time out with the card already rendered — the connector may ack after the deadline (slow platform API call, transient backpressure, event-loop stall). The old timeout path re-sent and produced **duplicate approval cards** in live relay testing. Outcome is now tri-state: **sent / failed / ambiguous**. Ambiguous → no re-send, no text fallback; the prompt registration stays armed so a late tap still resolves. Only a definite send error falls back to text.

## 2. `pending_approval` tool results forbid re-issuing the command

With one card correctly armed, the agent could still mint a second card by re-running a **rephrased variant** of the gated command after reading the `pending_approval` tool result (observed live: the same command re-issued in a different form — two cards). The tool message now instructs: do not re-run/rephrase; wait or report pending. Both `terminal` and `execute_code` arms.

## 3. Draft interim AND seal frames carry `format_hints`

format_hints are stamped on `send`, `edit`, and `send_for_platform` — but both draft-frame builders (`send_draft` interim + `_seal_open_draft` seal) shipped bare metadata. A streamed final therefore arrived at the connector **hintless** and sealed as a plain code block, while non-streamed sends rendered native markdown blocks (observed live: language-tagged block on send/edit, downgrade on streamed seal). Both sites now stamp `_with_format_hints_for_chat` (destination-resolved, same pattern as the existing three lanes).

**Live verification after fix:** verified against Slack's stored message payload — a streamed seal now lands as `rich_text_preformatted` **with a `language` field**, the field only Slack's markdown-block path produces.

## Tests

- Tri-state outcome unit tests (5)
- Draft/seal hint stamping + knobs-off byte-identical regression control (2, RED-first: the hint assertion failed on pre-fix adapter)
- Existing format-hints suite intact (14/14); targeted relay+gateway sweep 199/199
- **Mutation evidence:** reverting the adapter hunk sends `test_draft_interim_and_seal_frames_carry_hints` red; restore → green

## Boundary sweep (text egress lanes crossing the frame contract)

send ✓ (pre-existing) · edit ✓ (pre-existing) · send_for_platform ✓ (pre-existing) · **draft-interim ✓ (this PR)** · **draft-seal ✓ (this PR)** · task_card — no text content, exempt

## Round 2 (appended): two deeper defects on the same tap codepath

Live retest after the first fix still froze streams on approval turns — the log signature changed (no more draft absorption) and exposed two further bugs, both now fixed and live-verified end-to-end (parallel turns, delayed taps, clarify chains):

### 4. The approval ack was sealing the turn's own draft stream

`_prompt_reply_metadata` carried only placement metadata — no per-turn identity, no interim marker — so `send()`'s single-open-stream fallback matched the approval turn's OWN live draft and sealed it with the ack text. Every later append died on the post-seal tombstone (silent by design), and the turn-final fell through to a plain send. Fix: lifecycle acks are stamped `_interim_send`, bypassing draft matching; the absorption fallback and the first tombstone swallow per key now LOG (they were fully silent — this hunt would have been one grep).

### 5. Awaiting the ack ON the transport read loop self-deadlocked the transport

`_consume_prompt_response` executes on the read loop (inbound frame → handler). Its `await self.send("✅ Approved once")` blocks on an `outbound_result` future that only the read loop can resolve — guaranteed wedge for the full outbound timeout on EVERY button tap. While wedged: draft appends starved (frozen stream), sibling approval-card sends timed out into "possibly-delivered" ambiguity (the double-prompt reports), and the seal timed out ambiguous → plain-send duplicate. Fix: `_send_lifecycle_ack()` — fire-and-forget with strong task refs, applied to all six lifecycle sends (approval, slash-confirm ×2, clarify ×2, expiry). Acks are cosmetic by contract; the handler returns immediately and the read loop keeps consuming.

### Round-2 tests

- Deadlock-shape test: gated transport send; the handler must return within 1s and the ack must still egress on a background task (RED via TimeoutError at the exact hang on the awaited version)
- Draft-isolation: approval ack + expiry notice leave an open draft armed; regression control pins the single-open-stream fallback for REAL identity-less turn-finals
- Targeted relay+gateway sweep 203/203
