### PR TITLE
fix(cli): render startup config warnings through prompt_toolkit (#87919)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2202,6 +2202,53 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
     return issues
 
 
+def _emit_startup_warning(lines: List[str]) -> None:
+    """Emit an ANSI-colored startup warning without letting the TUI garble it.
+
+    These warnings fire from two very different places.  The gateway prints
+    them at module-import time with nothing else attached to the terminal, so
+    a plain ``sys.stderr.write`` is exactly right.  The interactive CLI reaches
+    the same code *while a prompt_toolkit ``Application`` is running* — the
+    gateway module is imported lazily during ``_init_agent`` — and there
+    ``patch_stdout``'s ``StdoutProxy`` owns stderr.  Every proxied write lands
+    in ``Vt100_Output.write()``, whose body is literally
+    ``data.replace("\\x1b", "?")``, so the escapes surface as garbled
+    ``?[33m⚠ …?[0m`` text instead of color (#87919; same class as #2262,
+    which #2448 fixed for the status printouts but not for these two).
+
+    Note the ``isatty()`` trap: ``StdoutProxy.isatty()`` delegates to the real
+    terminal, so it answers True inside the TUI.  Gating the escapes on
+    ``isatty`` / ``NO_COLOR`` therefore leaves this case garbled exactly as
+    before — the text has to reach prompt_toolkit's renderer, not merely be
+    withheld from a dumb pipe.
+
+    When the TUI is live, hand the text to ``cli._cprint`` instead: it renders
+    through ``print_formatted_text(ANSI(...))``, which parses the escapes into
+    real style, and it records the line in the resize-replay history so the
+    warning survives a terminal resize like every other CLI line.
+
+    ``cli`` is read out of ``sys.modules`` rather than imported.  A running
+    Application implies ``cli`` is already loaded, and this keeps a headless
+    gateway from ever pulling the ~1MB CLI module in as an import side effect.
+    Any failure falls through to the plain path — a startup warning must never
+    be the thing that breaks startup.
+    """
+    body = "\n".join(lines)
+    try:
+        from prompt_toolkit.application.current import get_app_or_none
+
+        if get_app_or_none() is not None:
+            cprint = getattr(sys.modules.get("cli"), "_cprint", None)
+            if cprint is not None:
+                # _cprint appends the line break; the extra "\n" preserves the
+                # blank spacer line the plain path writes below.
+                cprint(body + "\n")
+                return
+    except Exception:
+        pass
+    sys.stderr.write(body + "\n\n")
+
+
 def print_config_warnings(config: Optional[Dict[str, Any]] = None) -> None:
     """Print config structure warnings to stderr at startup.
 
@@ -2221,7 +2268,7 @@ def print_config_warnings(config: Optional[Dict[str, Any]] = None) -> None:
         marker = "\033[31m✗\033[0m" if ci.severity == "error" else "\033[33m⚠\033[0m"
         lines.append(f"  {marker} {ci.message}")
     lines.append("  \033[2mRun 'hermes doctor' for fix suggestions.\033[0m")
-    sys.stderr.write("\n".join(lines) + "\n\n")
+    _emit_startup_warning(lines)
 
 
 def warn_deprecated_cwd_env_vars() -> None:
@@ -2256,14 +2303,17 @@ def warn_deprecated_cwd_env_vars() -> None:
 
         hint_path = display_hermes_home()
         lines.insert(0, "\033[33m⚠ Deprecated .env settings detected:\033[0m")
-        lines.append(
-            "  \033[2mMove to config.yaml instead:  "
-            "terminal:\\n    cwd: /your/project/path\033[0m"
-        )
+        # The YAML hint is meant to be copy-pasted, so it has to be laid out as
+        # real lines.  Emitting it as one string containing a literal "\n"
+        # escape printed the two characters backslash-n and produced a snippet
+        # that is invalid YAML the moment anyone pastes it.
+        lines.append("  \033[2mMove to config.yaml instead:\033[0m")
+        lines.append("    \033[2mterminal:\033[0m")
+        lines.append("      \033[2mcwd: /your/project/path\033[0m")
         lines.append(
             f"  \033[2mThen remove the old entries from {hint_path}/.env\033[0m"
         )
-        sys.stderr.write("\n".join(lines) + "\n\n")
+        _emit_startup_warning(lines)
 
 
 def _persist_migration(config: Dict[str, Any]) -> None:

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -1,5 +1,7 @@
 """Tests for warn_deprecated_cwd_env_vars() migration warning."""
 
+import types
+
 
 def _write_env(monkeypatch, tmp_path, content):
     hermes_home = tmp_path / ".hermes"
@@ -89,3 +91,137 @@ class TestDeprecatedCwdWarning:
         config_module.warn_deprecated_cwd_env_vars()
 
         assert capsys.readouterr().err == ""
+
+    def test_migration_hint_uses_real_newlines_not_literal_backslash_n(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        """The YAML hint must be readable, not a one-liner with a literal \\n.
+
+        The hint is a copy-paste snippet; emitting the two-character sequence
+        backslash-n inside it makes the suggested YAML invalid if pasted.
+        """
+        _write_env(monkeypatch, tmp_path, "MESSAGING_CWD=/msg/path\n")
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+
+        warn_deprecated_cwd_env_vars()
+
+        err = capsys.readouterr().err
+        assert "\\n" not in err
+        # terminal: and cwd: land on separate real lines.
+        lines = [ln.strip() for ln in err.splitlines()]
+        assert "\033[2mterminal:\033[0m" in lines or any(
+            ln.endswith("terminal:\033[0m") for ln in lines
+        )
+        assert any("cwd: /your/project/path" in ln for ln in lines)
+
+
+class TestStartupWarningAnsiRouting:
+    """ANSI escapes must survive prompt_toolkit's patch_stdout StdoutProxy.
+
+    prompt_toolkit's ``Vt100_Output.write()`` does ``data.replace("\\x1b", "?")``,
+    so a raw ``sys.stderr.write`` of colored text inside the live TUI surfaces
+    as garbled ``?[33m…?[0m``.  When an Application is running the warning must
+    be routed through ``cli._cprint`` instead (#2262).
+    """
+
+    def _fake_tui(self, monkeypatch, recorded):
+        """Pretend a prompt_toolkit Application is running with cli imported."""
+        import sys
+        import types
+
+        import prompt_toolkit.application.current as pt_current
+
+        monkeypatch.setattr(pt_current, "get_app_or_none", lambda: object())
+
+        fake_cli = types.ModuleType("cli")
+        fake_cli._cprint = recorded.append
+        monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    def test_deprecation_warning_routes_through_cprint_in_tui(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        _write_env(monkeypatch, tmp_path, "MESSAGING_CWD=/msg/path\n")
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
+
+        recorded: list = []
+        self._fake_tui(monkeypatch, recorded)
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+
+        warn_deprecated_cwd_env_vars()
+
+        assert recorded, "warning was not routed through _cprint"
+        payload = "".join(recorded)
+        assert "\033[33m" in payload, "real ESC must reach prompt_toolkit"
+        assert "MESSAGING_CWD=/msg/path" in payload
+        # Nothing may bypass the renderer and hit stderr raw.
+        assert capsys.readouterr().err == ""
+
+    def test_config_warnings_route_through_cprint_in_tui(
+        self, monkeypatch, capsys
+    ):
+        import hermes_cli.config as config_module
+
+        recorded: list = []
+        self._fake_tui(monkeypatch, recorded)
+
+        issue = types.SimpleNamespace(
+            severity="error", message="providers.bogus is not a mapping"
+        )
+        monkeypatch.setattr(
+            config_module, "validate_config_structure", lambda cfg=None: [issue]
+        )
+
+        config_module.print_config_warnings()
+
+        assert recorded, "config warning was not routed through _cprint"
+        payload = "".join(recorded)
+        assert "\033[31m" in payload
+        assert "providers.bogus is not a mapping" in payload
+        assert capsys.readouterr().err == ""
+
+    def test_headless_still_writes_plain_stderr(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        """No Application running -> keep the plain stderr path (gateway boot)."""
+        import sys
+
+        _write_env(monkeypatch, tmp_path, "MESSAGING_CWD=/msg/path\n")
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
+        monkeypatch.delitem(sys.modules, "cli", raising=False)
+
+        import prompt_toolkit.application.current as pt_current
+
+        monkeypatch.setattr(pt_current, "get_app_or_none", lambda: None)
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+
+        warn_deprecated_cwd_env_vars()
+
+        assert "MESSAGING_CWD=/msg/path" in capsys.readouterr().err
+
+    def test_tui_detection_never_imports_cli(self, monkeypatch, tmp_path, capsys):
+        """A headless gateway must not drag the 1MB cli module into memory."""
+        import builtins
+        import sys
+
+        _write_env(monkeypatch, tmp_path, "MESSAGING_CWD=/msg/path\n")
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
+        monkeypatch.delitem(sys.modules, "cli", raising=False)
+
+        real_import = builtins.__import__
+
+        def guard(name, *args, **kwargs):
+            if name == "cli" or name.startswith("cli."):
+                raise AssertionError(f"headless path imported {name!r}")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", guard)
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+
+        warn_deprecated_cwd_env_vars()
+
+        assert "MESSAGING_CWD=/msg/path" in capsys.readouterr().err


### PR DESCRIPTION
Fixes #87919.

## What

`print_config_warnings()` and `warn_deprecated_cwd_env_vars()` render as garbled `?[33m…?[0m` text in the interactive CLI. This routes both through prompt_toolkit's renderer, and fixes a literal `\n` in the migration hint.

Real output before, from a user launching `hermes`:

```
?[33m⚠ Deprecated .env settings detected:?[0m
  ?[33m⚠?[0m MESSAGING_CWD=/Users/…/clawd found in .env — this is deprecated.
  ?[2mMove to config.yaml instead:  terminal:\n    cwd: /your/project/path?[0m
```

Note both defects on that third line: the garbled escapes, and the literal two-character `\n` inside what is meant to be a copy-pasteable YAML snippet.

## Why

Both functions write raw ANSI escapes with `sys.stderr.write()`. The gateway module is imported lazily from `_init_agent`, so in the interactive CLI that write happens **while `patch_stdout` owns stderr**. Every proxied write reaches `Vt100_Output.write()`, whose body is:

```python
def write(self, data: str) -> None:
    self._buffer.append(data.replace("\x1b", "?"))
```

That single `replace` is the whole bug — `\x1b[33m` becomes `?[33m`.

### On the `isatty()` approach

Worth flagging, since #87613 also touches `warn_deprecated_cwd_env_vars`: gating the escapes on `isatty()` / `NO_COLOR` does **not** fix this case. `StdoutProxy.isatty()` delegates to the real terminal:

```python
def isatty(self) -> bool:
    stdout = self._output.stdout
    if stdout is None:
        return False
    return stdout.isatty()
```

So inside the TUI it answers `True`, the gate opens, and the escapes are emitted and mangled exactly as before. I measured all three approaches through the real `StdoutProxy` in a TTY-backed app session:

| approach | `stderr.isatty()` in TUI | garbled `?[` sequences |
|---|---|---|
| current `main` | True | 4 |
| `isatty`/`NO_COLOR` gate | True | 4 (byte-identical to `main`) |
| this PR | True | 0 |

The text has to reach prompt_toolkit's renderer, not merely be withheld from a dumb pipe. #87613's **banner** half (routing `cli.py` through the TUI-safe console) is a genuine fix for a different call site and doesn't conflict with this.

## How

A small `_emit_startup_warning()` helper:

- When a prompt_toolkit `Application` is live → hand the text to `cli._cprint`, which renders via `print_formatted_text(ANSI(...))` and records the line in the resize-replay history, so the warning behaves like every other CLI line.
- Otherwise (gateway boot, scripts, tests) → the existing plain `sys.stderr.write`, unchanged.
- `cli` is read out of `sys.modules` rather than imported: a live `Application` implies `cli` is already loaded, so a headless gateway never pulls the ~1MB CLI module in as an import side effect.
- Any failure falls through to the plain write — a startup warning must never be the thing that breaks startup.

This is the fix proposed in #87919 itself, and mirrors the existing `_cprint` pattern already used at `cli_agent_setup_mixin.py:557` and `cli_commands_mixin.py:740`.

The migration hint is now emitted as real lines instead of one string containing a literal `\n`:

```
  Move to config.yaml instead:
    terminal:
      cwd: /your/project/path
```

## How to test

Reproduce: put `MESSAGING_CWD=/some/path` in `~/.hermes/.env` (or a `custom_providers` entry with no `base_url` in `config.yaml`), launch `hermes`, and send a message — agent init imports the gateway, which emits the warning inside the live TUI.

Automated — 5 new tests in `tests/hermes_cli/test_deprecated_cwd_warning.py`:

```bash
scripts/run_tests.sh tests/hermes_cli/test_deprecated_cwd_warning.py tests/hermes_cli/test_config_validation.py
```

They cover: escapes routed through `_cprint` when an app is live (both functions), the plain stderr path preserved when headless, `cli` never imported on the headless path, and no literal `\n` in the hint.

Red-green verified — reverting `hermes_cli/config.py` while keeping the tests gives 3 failures; restoring gives 10 passes.

## Verification

- `scripts/run_tests.sh` on the affected files: **21 tests passed, 0 failed** (hermetic runner, matches CI).
- All config-related suites (`tests/hermes_cli/*config*.py` + this file): **410 passed**.
- End-to-end through the real `StdoutProxy` in a TTY-backed app session: current `main` reproduces the reported garbling byte-for-byte; this branch emits real ESC bytes with 0 garbled sequences and no literal `\n`.
- `hermes` launches clean with the patch applied.

One gap, stated plainly: I verified the live-TUI path through the real prompt_toolkit machinery (`StdoutProxy` → `Vt100_Output`) and unit tests, but did not drive a full message turn through the TUI against a live provider, so that last mile rests on the harness rather than a manual session.

## Platforms

Tested on macOS 26 (Darwin 25.6.0, arm64), Python 3.11, prompt_toolkit 3.0.52. No platform-specific APIs are used; the changed code is a `sys.modules` lookup and a function call.
