### PR TITLE
fix(acp): complete session/prompt on terminal session/update (#90952)

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -59,6 +59,43 @@ def _is_gh_copilot_deprecation_message(stderr_text: str) -> bool:
     return any(marker in lower for marker in _DEPRECATION_MARKERS)
 
 
+# Terminal session/update states: once the server emits one of these for a
+# prompt turn, the turn is complete and the accumulated text/thought parts
+# are the full outcome — even if the id-matched JSON-RPC result never
+# arrives (opencode ACP v1.18+ can wedge the event subscription and hang
+# session/prompt; #90952). Matched case-insensitively against the
+# ``sessionUpdate`` field value.
+_TERMINAL_SESSION_UPDATE_STATES = {
+    "turn_complete",
+    "turn_finished",
+    "complete",
+    "finished",
+    "done",
+}
+
+
+def _is_terminal_session_update(msg: dict[str, Any]) -> bool:
+    """True when ``msg`` is a session/update carrying a TERMINAL turn state.
+
+    A terminal state means the turn's content is final: the caller should
+    stop waiting for an id-matched result and use the accumulated parts.
+    Non-terminal states (agent_message_chunk, agent_thought_chunk,
+    heartbeat, ...) return False.
+    """
+    if not isinstance(msg, dict):
+        return False
+    if str(msg.get("method") or "") != "session/update":
+        return False
+    params = msg.get("params") or {}
+    if not isinstance(params, dict):
+        return False
+    update = params.get("update") or {}
+    if not isinstance(update, dict):
+        return False
+    kind = str(update.get("sessionUpdate") or "").strip()
+    return kind.casefold() in _TERMINAL_SESSION_UPDATE_STATES
+
+
 def _resolve_command() -> str:
     return (
         os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
@@ -662,6 +699,26 @@ class CopilotACPClient:
                     text_parts=text_parts,
                     reasoning_parts=reasoning_parts,
                 ):
+                    # A server-initiated event (e.g. session/update) was
+                    # consumed. For session/prompt specifically, the protocol
+                    # also delivers a terminal session/update
+                    # (sessionUpdate == "turn_complete" / finished state)
+                    # BEFORE the id-matched JSON-RPC result in some transports
+                    # (opencode ACP v1.18+ when the event subscription wedges
+                    # — #90952). If we have accumulated text and the turn is
+                    # terminally complete, do not keep waiting for the
+                    # id-matched result that may never arrive: return the
+                    # accumulated parts as the prompt outcome.
+                    if (
+                        method == "session/prompt"
+                        and text_parts
+                        and _is_terminal_session_update(msg)
+                    ):
+                        return {
+                            "sessionId": params.get("sessionId", ""),
+                            "content": [],
+                            "completed": True,
+                        }
                     continue
 
                 if msg.get("id") != request_id:

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -317,3 +317,92 @@ def test_probe_skipped_for_custom_args_without_acp():
     with _patch("agent.copilot_acp_client.subprocess.run") as run_mock:
         assert _acp_supported("mycli", ["--custom-transport"]) is True
     run_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# #90952: terminal session/update must complete session/prompt without waiting
+# for the id-matched JSON-RPC result (opencode ACP v1.18+ can wedge the event
+# subscription and never deliver the prompt result in gateway async runs).
+# ---------------------------------------------------------------------------
+
+class _WedgePopen:
+    """Fake Popen: emits initialize/session/new results and a prompt turn that
+    ENDS with a terminal session/update (turn_complete) but NEVER sends the
+    id-matched session/prompt result — reproducing the #90952 hang."""
+
+    def __init__(self, cmd, **kwargs):
+        self.stdin = _FakeStdin()
+        lines = [
+            {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": 1}},
+            {"jsonrpc": "2.0", "id": 2, "result": {"sessionId": "sess-1"}},
+            {"jsonrpc": "2.0", "method": "session/update", "params": {
+                "sessionId": "sess-1",
+                "update": {"sessionUpdate": "agent_message_chunk",
+                           "content": {"type": "text", "text": "Hello from the worker"}},
+            }},
+            {"jsonrpc": "2.0", "method": "session/update", "params": {
+                "sessionId": "sess-1",
+                "update": {"sessionUpdate": "turn_complete", "content": {}},
+            }},
+            # NOTE: no id=3 session/prompt result — the wedged transport.
+        ]
+        self._lines = lines
+        self.stdout = iter([json.dumps(l) + "\n" for l in lines])
+        self.stderr = iter([])
+        self.returncode = None
+        self.pid = 4242
+
+    def poll(self):
+        return None  # never exits
+
+    def kill(self):
+        self.returncode = -9
+
+
+class _FakeStdin:
+    def __init__(self):
+        self.buf = []
+
+    def write(self, s):
+        self.buf.append(s)
+
+    def flush(self):
+        pass
+
+
+def test_run_prompt_completes_on_terminal_session_update_without_result(tmp_path):
+    """#90952 regression: when the ACP server delivers text chunks + a
+    terminal turn_complete session/update but NEVER sends the id-matched
+    session/prompt JSON-RPC result, _run_prompt must still complete with the
+    accumulated text instead of hanging until the timeout."""
+    client = _make_home_client(tmp_path)
+    with _patch("agent.copilot_acp_client.subprocess.run",
+                side_effect=FileNotFoundError) as _probe:
+        with _patch("agent.copilot_acp_client.subprocess.Popen",
+                    side_effect=_WedgePopen) as _popen:
+            text, reasoning = client._run_prompt("do the thing", timeout_seconds=5)
+    assert "Hello from the worker" in text, (
+        "accumulated agent_message_chunk text must be returned"
+    )
+    assert reasoning == ""
+
+
+def test_run_prompt_still_waits_for_result_when_no_terminal_update(tmp_path):
+    """Control: without a terminal session/update, _run_prompt must still wait
+    for the id-matched result (the fallback must not fire on plain chunks)."""
+    client = _make_home_client(tmp_path)
+
+    class _NoTerminalPopen(_WedgePopen):
+        def __init__(self, cmd, **kwargs):
+            super().__init__(cmd, **kwargs)
+            # Drop the turn_complete line; keep only the chunk.
+            self._lines = [l for l in self._lines
+                           if "turn_complete" not in json.dumps(l)]
+            self.stdout = iter([json.dumps(l) + "\n" for l in self._lines])
+
+    with _patch("agent.copilot_acp_client.subprocess.run",
+                side_effect=FileNotFoundError) as _probe:
+        with _patch("agent.copilot_acp_client.subprocess.Popen",
+                    side_effect=_NoTerminalPopen) as _popen:
+            with pytest.raises(TimeoutError, match="session/prompt"):
+                client._run_prompt("do the thing", timeout_seconds=1)


### PR DESCRIPTION
## Summary

Fixes #90952 — `delegate_task(background=true)` from a gateway session spawning a `copilot-acp` subagent (harness `opencode acp` v1.18.18) hangs: the child never receives a response to its `session/prompt` request, the batch stays `state=running` until the 20-minute timeout, and the parent only gets a streamed ack.

## Root Cause

Investigation (acp sources + Hermes shim): `session/prompt` only returns after `runUntilIdle` receives a `session.status == idle` event, which requires the SDK global-event subscription to connect to the ephemeral local HTTP server. In the detached gateway async path (child runs on the module-level `DaemonThreadPoolExecutor` with a stripped/profile-home env), that subscription can wedge — `initialize` / `session/new` still answer (they don't depend on the event connection), but `session/prompt` never resolves. Hermes' `_request()` then waits its full 900s budget and raises `TimeoutError("Timed out waiting for Copilot ACP response to session/prompt")` — the exact text in the batch's error summary.

## Change

`agent/copilot_acp_client.py`:
- New `_is_terminal_session_update(msg)`: recognizes a `session/update` whose `sessionUpdate` is a TERMINAL turn state (`turn_complete` / `turn_finished` / `complete` / `finished` / `done`, case-insensitive).
- `_request()` for `session/prompt`: when text/thought parts have accumulated AND a terminal `session/update` arrives, the turn is complete — return the accumulated parts instead of continuing to wait for the wedged id-matched JSON-RPC result. Plain `agent_message_chunk` / `agent_thought_chunk` updates still do NOT complete the request; the id-matched result remains authoritative when it does arrive.

## Verification

- `test_run_prompt_completes_on_terminal_session_update_without_result`: fake Popen emits initialize → session/new → `agent_message_chunk` ("Hello from the worker") → `turn_complete`, and NEVER the id=3 prompt result. `_run_prompt` returns the accumulated text. **RED without the fix** (`TimeoutError`), GREEN with it.
- `test_run_prompt_still_waits_for_result_when_no_terminal_update` (control): without a terminal update the request still waits for the id-matched result and times out — the fallback does not fire on plain chunks.
- Focused suite: 5 passed (`tests/agent/test_copilot_acp_client.py`).

Closes #90952
