### PR TITLE
fix(auth): persist fallback pools to owner store

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -9,6 +9,7 @@ import threading
 import time
 import uuid
 import re
+from contextlib import contextmanager
 from dataclasses import dataclass, fields, replace
 from datetime import datetime, timezone
 from pathlib import Path
@@ -32,6 +33,7 @@ from hermes_cli.auth import (
     _load_auth_store,
     _load_provider_state,
     _load_provider_state_with_source,
+    _read_credential_pool_with_source,
     _resolve_kimi_base_url,
     _resolve_zai_base_url,
     _same_path,
@@ -648,9 +650,20 @@ def _write_through_provider_state_to_global_root(
 
 
 class CredentialPool:
-    def __init__(self, provider: str, entries: List[PooledCredential]):
+    def __init__(
+        self,
+        provider: str,
+        entries: List[PooledCredential],
+        *,
+        source_path: Optional[Path] = None,
+        source_entry_ids: Optional[Set[str]] = None,
+    ):
         self.provider = provider
         self._entries = sorted(entries, key=lambda entry: entry.priority)
+        self._source_path = source_path or auth_mod._auth_file_path()
+        self._source_entry_ids = (
+            set(source_entry_ids) if source_entry_ids is not None else None
+        )
         self._current_id: Optional[str] = None
         self._strategy = get_pool_strategy(provider)
         # RLock: the mutation primitives below (_replace_entry/_persist)
@@ -778,11 +791,84 @@ class CredentialPool:
         # Self-locking (RLock): snapshotting self._entries must not race a
         # concurrent rotation when called from the deferred refresh path.
         with self._lock:
+            current_ids = {entry.id for entry in self._entries if entry.id}
             write_credential_pool(
                 self.provider,
                 [entry.to_dict() for entry in self._entries],
                 removed_ids=removed_ids,
+                required_ids=self._source_entry_ids,
+                target_path=self._source_path,
             )
+            self._source_entry_ids = current_ids
+
+    def _sync_entry_from_pool_store(
+        self, entry: PooledCredential
+    ) -> PooledCredential:
+        """Adopt the latest tracked rows from the exact store this pool owns.
+
+        A pool write persists the whole in-memory provider slice. Refreshing
+        only ``entry`` is therefore insufficient: another process may have
+        rotated a different row while this instance was waiting for the owner
+        lock, and writing our stale sibling row would roll that single-use
+        token chain back. Rebase every row this instance originally loaded;
+        entries added later remain protected by ``write_credential_pool``'s
+        merge.
+        """
+        auth_store = _load_auth_store(self._source_path)
+        pool = auth_store.get("credential_pool")
+        persisted_entries = pool.get(self.provider) if isinstance(pool, dict) else None
+        if not isinstance(persisted_entries, list):
+            if self._source_entry_ids is not None:
+                raise RuntimeError(
+                    "Credential pool source changed while it was in use"
+                )
+            return entry
+        persisted_by_id = {
+            payload.get("id"): payload
+            for payload in persisted_entries
+            if isinstance(payload, dict) and payload.get("id")
+        }
+        if self._source_entry_ids is not None:
+            missing_ids = self._source_entry_ids - set(persisted_by_id)
+            if missing_ids:
+                raise RuntimeError(
+                    "Credential pool entry disappeared while it was in use"
+                )
+
+        target = entry
+        with self._lock:
+            for index, current in enumerate(self._entries):
+                persisted = persisted_by_id.get(current.id)
+                if not isinstance(persisted, dict):
+                    continue
+                stored = PooledCredential.from_dict(self.provider, persisted)
+                if (
+                    stored.access_token != current.access_token
+                    or stored.refresh_token != current.refresh_token
+                ):
+                    logger.debug(
+                        "Pool entry %s: adopting tokens rotated in owner store",
+                        current.id,
+                    )
+                self._entries[index] = stored
+                if current.id == entry.id:
+                    target = stored
+        return target
+
+    @contextmanager
+    def _single_use_refresh_store_lock(self):
+        """Lock active profile then the pool owner in deterministic order."""
+        timeout = self._single_use_refresh_lock_timeout()
+        active_path = auth_mod._auth_file_path()
+        with _auth_store_lock(timeout_seconds=timeout):
+            if _same_path(active_path, self._source_path):
+                yield
+                return
+            with _auth_store_lock(
+                timeout_seconds=timeout,
+                target_path=self._source_path,
+            ):
+                yield
 
     def _is_terminal_auth_failure(
         self,
@@ -921,7 +1007,7 @@ class CredentialPool:
         device_code-sourced entries; env/API-key-sourced entries have no
         auth.json shadow to sync from.
         """
-        if self.provider != "openai-codex" or entry.source not in ("device_code", "manual:device_code"):
+        if self.provider != "openai-codex" or entry.source != "device_code":
             return entry
         try:
             with _auth_store_lock():
@@ -1048,45 +1134,6 @@ class CredentialPool:
                 return updated
         except Exception as exc:
             logger.debug("Failed to sync xAI OAuth entry from auth.json: %s", exc)
-        return entry
-
-    def _sync_xai_oauth_entry_from_pool_store(
-        self, entry: PooledCredential
-    ) -> PooledCredential:
-        """Adopt a token pair rotated by another pool instance.
-
-        Direct xAI integrations load a fresh ``CredentialPool`` for each
-        request. Their in-memory locks therefore cannot protect xAI's
-        single-use refresh token across concurrent requests or processes.
-        This helper is called while the shared auth-store lock is held and
-        re-reads the exact persisted row before a refresh POST is attempted.
-        """
-        if self.provider != "xai-oauth":
-            return entry
-        try:
-            persisted = next(
-                (
-                    payload
-                    for payload in read_credential_pool(self.provider)
-                    if isinstance(payload, dict) and payload.get("id") == entry.id
-                ),
-                None,
-            )
-            if not isinstance(persisted, dict):
-                return entry
-            stored = PooledCredential.from_dict(self.provider, persisted)
-            if (
-                stored.access_token != entry.access_token
-                or stored.refresh_token != entry.refresh_token
-            ):
-                logger.debug(
-                    "Pool entry %s: adopting xAI OAuth tokens rotated by another pool instance",
-                    entry.id,
-                )
-                self._replace_entry(entry, stored)
-                return stored
-        except Exception as exc:
-            logger.debug("Failed to sync xAI OAuth entry from credential pool: %s", exc)
         return entry
 
     def _sync_nous_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
@@ -1320,27 +1367,22 @@ class CredentialPool:
         # the lock, the in-lock re-sync below picks up the rotated token the
         # winner persisted and skips the POST.
         if self.provider in ("openai-codex", "xai-oauth"):
-            sync_entry = (
-                self._sync_codex_entry_from_auth_store
-                if self.provider == "openai-codex"
-                else self._sync_xai_oauth_entry_from_pool_store
-            )
-            with _auth_store_lock(
-                timeout_seconds=self._single_use_refresh_lock_timeout()
-            ):
-                synced = sync_entry(entry)
-                if self.provider == "openai-codex":
-                    if synced is not entry:
-                        entry = synced
-                        if not force and not self._entry_needs_refresh(entry):
-                            return entry
-                    return self._refresh_entry_impl(entry, force=force)
+            with self._single_use_refresh_store_lock():
+                owner_synced = self._sync_entry_from_pool_store(entry)
                 if (
-                    synced.access_token != entry.access_token
-                    or synced.refresh_token != entry.refresh_token
+                    owner_synced.access_token != entry.access_token
+                    or owner_synced.refresh_token != entry.refresh_token
                 ):
-                    return synced
-                return self._refresh_entry_impl(synced, force=force)
+                    return owner_synced
+                if self.provider == "openai-codex":
+                    synced = self._sync_codex_entry_from_auth_store(owner_synced)
+                    if (
+                        synced.access_token != owner_synced.access_token
+                        or synced.refresh_token != owner_synced.refresh_token
+                    ):
+                        return synced
+                    return self._refresh_entry_impl(owner_synced, force=force)
+                return self._refresh_entry_impl(owner_synced, force=force)
         return self._refresh_entry_impl(entry, force=force)
 
     def _single_use_refresh_lock_timeout(self) -> float:
@@ -1962,7 +2004,7 @@ class CredentialPool:
                     sync_fn = (
                         self._sync_codex_entry_from_auth_store
                         if self.provider == "openai-codex"
-                        else self._sync_xai_oauth_entry_from_pool_store
+                        else self._sync_entry_from_pool_store
                     )
                     pending_refresh.append((entry, sync_fn))
                     continue
@@ -2366,7 +2408,12 @@ class CredentialPool:
                 self.provider,
                 [entry.to_dict() for entry in self._entries],
                 removed_ids=[removed.id],
+                required_ids=self._source_entry_ids,
+                target_path=self._source_path,
             )
+            self._source_entry_ids = {
+                entry.id for entry in self._entries if entry.id
+            }
             if self._current_id == removed.id:
                 self._current_id = None
             return removed
@@ -2399,6 +2446,11 @@ class CredentialPool:
 
     def add_entry(self, entry: PooledCredential) -> PooledCredential:
         with self._lock:
+            # ``hermes auth add`` inside a profile is an explicit local
+            # override. Preserve the documented shadowing contract even when
+            # this pool was initially populated through global fallback.
+            self._source_path = auth_mod._auth_file_path()
+            self._source_entry_ids = None
             entry = replace(entry, priority=_next_priority(self._entries))
             self._entries.append(entry)
             self._persist()
@@ -3131,7 +3183,7 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
 
 def load_pool(provider: str) -> CredentialPool:
     provider = (provider or "").strip().lower()
-    raw_entries = read_credential_pool(provider)
+    raw_entries, source_path = _read_credential_pool_with_source(provider)
     disk_ids = {
         entry.get("id")
         for entry in raw_entries
@@ -3192,4 +3244,11 @@ def load_pool(provider: str) -> CredentialPool:
             [entry.to_dict() for entry in sorted(entries, key=lambda item: item.priority)],
             removed_ids=disk_ids - new_ids,
         )
-    return CredentialPool(provider, entries)
+        source_path = auth_mod._auth_file_path()
+        disk_ids = {entry.id for entry in entries if entry.id}
+    return CredentialPool(
+        provider,
+        entries,
+        source_path=source_path,
+        source_entry_ids=disk_ids,
+    )

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1611,7 +1611,10 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     ``hermes auth add <provider>`` inside the profile, profile entries
     fully shadow global for that provider on the next read.
 
-    Writes always go to the profile (``write_credential_pool`` is unchanged).
+    Direct writes still go to the profile. Runtime ``CredentialPool`` objects
+    additionally retain the source path returned by
+    ``_read_credential_pool_with_source`` so refresh/status mutations of a
+    fallback pool update its global owner without creating a profile shadow.
     See issue #18594 follow-up.
     """
     auth_store = _load_auth_store()
@@ -1637,12 +1640,46 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
             merged[gp_key] = list(gp_entries)
         return merged
 
-    provider_entries = pool.get(provider_id)
-    if isinstance(provider_entries, list) and provider_entries:
-        return list(provider_entries)
-    # Profile has no entries for this provider — fall back to global.
-    global_entries = global_pool.get(provider_id)
-    return list(global_entries) if isinstance(global_entries, list) else []
+    entries, _source_path = _read_credential_pool_with_source(
+        provider_id,
+        auth_store=auth_store,
+        global_store=global_store,
+    )
+    return entries
+
+
+def _read_credential_pool_with_source(
+    provider_id: str,
+    *,
+    auth_store: Optional[Dict[str, Any]] = None,
+    global_store: Optional[Dict[str, Any]] = None,
+) -> tuple[List[Dict[str, Any]], Path]:
+    """Return one provider slice and the auth store that owns those rows.
+
+    An empty or missing local slice does not own the global fallback. If no
+    usable slice exists in either store, the active profile path is returned
+    so a later explicit add keeps the established profile-local write scope.
+    """
+    active_path = _auth_file_path()
+    if auth_store is None:
+        auth_store = _load_auth_store()
+    pool = auth_store.get("credential_pool")
+    if isinstance(pool, dict):
+        provider_entries = pool.get(provider_id)
+        if isinstance(provider_entries, list) and provider_entries:
+            return list(provider_entries), active_path
+
+    global_path = _global_auth_file_path()
+    if global_path is None:
+        return [], active_path
+    if global_store is None:
+        global_store = _load_global_auth_store()
+    global_pool = global_store.get("credential_pool") if global_store else None
+    if isinstance(global_pool, dict):
+        global_entries = global_pool.get(provider_id)
+        if isinstance(global_entries, list) and global_entries:
+            return list(global_entries), global_path
+    return [], active_path
 
 
 _POOL_STATUS_FIELDS = (
@@ -1717,6 +1754,8 @@ def write_credential_pool(
     entries: List[Dict[str, Any]],
     *,
     removed_ids: Optional[Iterable[str]] = None,
+    required_ids: Optional[Iterable[str]] = None,
+    target_path: Optional[Path] = None,
 ) -> Path:
     """Persist one provider's credential pool under auth.json.
 
@@ -1734,11 +1773,17 @@ def write_credential_pool(
     snapshot cannot erase a cooldown/quarantine another process just wrote.
 
     Pass ``removed_ids`` for entries the caller intentionally removed, so the
-    merge does not resurrect them from the on-disk copy.
+    merge does not resurrect them from the on-disk copy. Direct callers omit
+    ``target_path`` and retain the profile-local write contract. A runtime
+    pool loaded through global fallback passes its recorded owner path so
+    rotating tokens and status metadata do not fork into a profile shadow.
+    ``required_ids`` seals that owner snapshot: a missing row fails closed
+    instead of being silently recreated from stale in-memory credentials.
     """
     removed = {rid for rid in (removed_ids or ()) if rid}
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
+    required = {rid for rid in (required_ids or ()) if rid}
+    with _auth_store_lock(target_path=target_path):
+        auth_store = _load_auth_store(target_path)
         pool = auth_store.get("credential_pool")
         if not isinstance(pool, dict):
             pool = {}
@@ -1755,6 +1800,12 @@ def write_credential_pool(
             for entry in existing_list
             if isinstance(entry, dict) and entry.get("id")
         }
+        missing_required = required - set(existing_by_id)
+        if missing_required:
+            raise RuntimeError(
+                "Credential pool source changed while it was in use; "
+                "refusing to recreate missing entries"
+            )
         new_ids = {
             entry.get("id")
             for entry in sanitized_entries
@@ -1776,7 +1827,7 @@ def write_credential_pool(
                 continue
             merged.append(sanitize_borrowed_credential_payload(disk_entry, provider_id))
         pool[provider_id] = merged
-        return _save_auth_store(auth_store)
+        return _save_auth_store(auth_store, target_path=target_path)
 
 
 def suppress_credential_source(provider_id: str, source: str) -> None:
@@ -1813,7 +1864,25 @@ def is_source_suppressed(provider_id: str, source: str) -> bool:
     try:
         auth_store = _load_auth_store()
         suppressed = auth_store.get("suppressed_sources", {})
-        return source in suppressed.get(provider_id, [])
+        if isinstance(suppressed, dict) and provider_id in suppressed:
+            provider_sources = suppressed.get(provider_id, [])
+            if isinstance(provider_sources, dict):
+                provider_sources = list(provider_sources)
+            return source in provider_sources
+
+        # A profile borrowing a global provider/pool must also inherit the
+        # root suppression that defines that source set. Otherwise every
+        # profile re-seeds a globally suppressed singleton and immediately
+        # creates a local pool shadow. An explicit profile provider key stays
+        # authoritative, matching per-provider pool shadowing.
+        global_store = _load_global_auth_store()
+        global_suppressed = global_store.get("suppressed_sources", {})
+        if not isinstance(global_suppressed, dict):
+            return False
+        provider_sources = global_suppressed.get(provider_id, [])
+        if isinstance(provider_sources, dict):
+            provider_sources = list(provider_sources)
+        return source in provider_sources
     except Exception:
         return False
 

--- a/tests/agent/test_credential_pool_profile_source.py
+++ b/tests/agent/test_credential_pool_profile_source.py
@@ -1,0 +1,577 @@
+"""Profile fallback pools persist mutations to the store that owns them."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs
+
+import pytest
+
+from agent.credential_pool import PooledCredential, STATUS_EXHAUSTED, load_pool
+from hermes_cli import auth as auth_mod
+
+
+PROVIDER = "openai-codex"
+
+
+class _TokenHandler(BaseHTTPRequestHandler):
+    calls = 0
+    calls_lock = threading.Lock()
+
+    def do_POST(self):
+        content_length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(content_length).decode("utf-8")
+        refresh_token = parse_qs(body).get("refresh_token", [""])[0]
+        with type(self).calls_lock:
+            type(self).calls += 1
+        if refresh_token == "refresh-old":
+            access_token = "access-process-rotated"
+            rotated_refresh_token = "refresh-process-rotated"
+        else:
+            access_token = f"access-{refresh_token}-rotated"
+            rotated_refresh_token = f"{refresh_token}-rotated"
+        payload = json.dumps({
+            "access_token": access_token,
+            "refresh_token": rotated_refresh_token,
+        }).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, _format, *_args):
+        return
+
+
+def _refresh_in_process(
+    profile_auth: str,
+    root_auth: str,
+    token_url: str,
+    credential_id: str,
+    ready_queue,
+    start_event,
+    result_queue,
+) -> None:
+    from pathlib import Path
+
+    from agent import credential_pool as pool_mod
+    from hermes_cli import auth as process_auth
+
+    profile_path = Path(profile_auth)
+    root_path = Path(root_auth)
+    process_auth._auth_file_path = lambda: profile_path
+    process_auth._global_auth_file_path = lambda: root_path
+    pool_mod._global_auth_file_path = lambda: root_path
+    process_auth.CODEX_OAUTH_TOKEN_URL = token_url
+    pool = pool_mod.load_pool(PROVIDER)
+    entry = next(item for item in pool.entries() if item.id == credential_id)
+    ready_queue.put("ready")
+    if not start_event.wait(timeout=10):
+        result_queue.put(("error", "start timeout"))
+        return
+    try:
+        refreshed = pool._refresh_entry(entry, force=True)
+        result_queue.put(("ok", refreshed.refresh_token if refreshed else None))
+    except Exception as exc:
+        result_queue.put(("error", f"{type(exc).__name__}: {exc}"))
+
+
+def _entry(
+    credential_id: str = "global-codex",
+    *,
+    access_token: str = "access-old",
+    refresh_token: str = "refresh-old",
+) -> dict:
+    return {
+        "id": credential_id,
+        "label": credential_id,
+        "auth_type": "oauth",
+        "priority": 0,
+        "source": "manual:device_code",
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+    }
+
+
+def _write_store(
+    path: Path,
+    entries: list[dict],
+    *,
+    providers: dict | None = None,
+    suppressed_sources: dict | None = None,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({
+            "version": 1,
+            "providers": providers or {},
+            "credential_pool": {PROVIDER: entries},
+            "suppressed_sources": suppressed_sources or {},
+        }),
+        encoding="utf-8",
+    )
+
+
+def _read_store(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture()
+def profile_pool_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "worker"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    root_auth = root / "auth.json"
+    profile_auth = profile / "auth.json"
+    _write_store(root_auth, [_entry()])
+    return root_auth, profile_auth
+
+
+def test_fallback_pool_status_persists_to_global_owner_without_profile_shadow(
+    profile_pool_env,
+):
+    root_auth, profile_auth = profile_pool_env
+    pool = load_pool(PROVIDER)
+    entry = pool.entries()[0]
+
+    pool._mark_exhausted(entry, 429)
+
+    root_entry = _read_store(root_auth)["credential_pool"][PROVIDER][0]
+    assert root_entry["last_status"] == STATUS_EXHAUSTED
+    assert not profile_auth.exists()
+
+
+def test_fallback_pool_remove_targets_global_owner(profile_pool_env):
+    root_auth, profile_auth = profile_pool_env
+    pool = load_pool(PROVIDER)
+
+    removed = pool.remove_index(1)
+
+    assert removed is not None
+    assert _read_store(root_auth)["credential_pool"][PROVIDER] == []
+    assert not profile_auth.exists()
+
+
+def test_profile_owned_pool_still_shadows_and_writes_only_profile(
+    profile_pool_env,
+):
+    root_auth, profile_auth = profile_pool_env
+    _write_store(profile_auth, [_entry("profile-codex")])
+    pool = load_pool(PROVIDER)
+
+    pool._mark_exhausted(pool.entries()[0], 429)
+
+    root_entry = _read_store(root_auth)["credential_pool"][PROVIDER][0]
+    profile_entry = _read_store(profile_auth)["credential_pool"][PROVIDER][0]
+    assert root_entry.get("last_status") is None
+    assert profile_entry["id"] == "profile-codex"
+    assert profile_entry["last_status"] == STATUS_EXHAUSTED
+
+
+def test_explicit_profile_add_still_creates_local_shadow(profile_pool_env):
+    root_auth, profile_auth = profile_pool_env
+    pool = load_pool(PROVIDER)
+
+    pool.add_entry(
+        PooledCredential.from_dict(
+            PROVIDER,
+            _entry(
+                "profile-personal",
+                access_token="profile-access",
+                refresh_token="profile-refresh",
+            ),
+        )
+    )
+
+    assert [
+        entry["id"] for entry in _read_store(root_auth)["credential_pool"][PROVIDER]
+    ] == ["global-codex"]
+    assert [
+        entry["id"] for entry in _read_store(profile_auth)["credential_pool"][PROVIDER]
+    ] == ["global-codex", "profile-personal"]
+
+
+def test_stale_fallback_pool_instances_refresh_single_use_token_once(
+    profile_pool_env,
+    monkeypatch,
+):
+    root_auth, profile_auth = profile_pool_env
+    first_pool = load_pool(PROVIDER)
+    second_pool = load_pool(PROVIDER)
+    refresh_calls: list[str] = []
+
+    def fake_refresh(access_token, refresh_token, **_kwargs):
+        refresh_calls.append(refresh_token)
+        return {
+            "access_token": "access-rotated",
+            "refresh_token": "refresh-rotated",
+            "last_refresh": "2026-08-20T17:00:00Z",
+        }
+
+    monkeypatch.setattr(auth_mod, "refresh_codex_oauth_pure", fake_refresh)
+
+    first = first_pool._refresh_entry(first_pool.entries()[0], force=True)
+    second = second_pool._refresh_entry(second_pool.entries()[0], force=True)
+
+    assert first is not None
+    assert second is not None
+    assert refresh_calls == ["refresh-old"]
+    assert second.refresh_token == "refresh-rotated"
+    root_entry = _read_store(root_auth)["credential_pool"][PROVIDER][0]
+    assert root_entry["access_token"] == "access-rotated"
+    assert root_entry["refresh_token"] == "refresh-rotated"
+    assert not profile_auth.exists()
+
+
+def test_manual_pool_refresh_keeps_identity_separate_from_singleton(
+    profile_pool_env,
+    monkeypatch,
+):
+    root_auth, profile_auth = profile_pool_env
+    providers = {
+        PROVIDER: {
+            "tokens": {
+                "access_token": "singleton-access",
+                "refresh_token": "singleton-refresh",
+            }
+        }
+    }
+    entries = [
+        _entry("work", access_token="work-access", refresh_token="work-refresh"),
+        _entry(
+            "personal",
+            access_token="personal-access",
+            refresh_token="personal-refresh",
+        ),
+    ]
+    _write_store(
+        root_auth,
+        entries,
+        providers=providers,
+        suppressed_sources={PROVIDER: ["device_code"]},
+    )
+    pool = load_pool(PROVIDER)
+    personal = next(entry for entry in pool.entries() if entry.id == "personal")
+    refresh_calls: list[str] = []
+
+    def fake_refresh(access_token, refresh_token, **_kwargs):
+        refresh_calls.append(refresh_token)
+        return {
+            "access_token": "personal-access-rotated",
+            "refresh_token": "personal-refresh-rotated",
+            "last_refresh": "2026-08-20T17:00:00Z",
+        }
+
+    monkeypatch.setattr(auth_mod, "refresh_codex_oauth_pure", fake_refresh)
+
+    refreshed = pool._refresh_entry(personal, force=True)
+
+    assert refreshed is not None
+    assert refresh_calls == ["personal-refresh"]
+    persisted = {
+        entry["id"]: entry
+        for entry in _read_store(root_auth)["credential_pool"][PROVIDER]
+    }
+    assert persisted["work"]["refresh_token"] == "work-refresh"
+    assert persisted["personal"]["refresh_token"] == "personal-refresh-rotated"
+    assert not profile_auth.exists()
+
+
+def test_global_suppression_prevents_profile_singleton_reseed(
+    profile_pool_env,
+):
+    root_auth, profile_auth = profile_pool_env
+    entries = [
+        _entry("work", access_token="work-access", refresh_token="work-refresh"),
+        _entry(
+            "personal",
+            access_token="personal-access",
+            refresh_token="personal-refresh",
+        ),
+    ]
+    _write_store(
+        root_auth,
+        entries,
+        providers={
+            PROVIDER: {
+                "tokens": {
+                    "access_token": "singleton-access",
+                    "refresh_token": "singleton-refresh",
+                }
+            }
+        },
+        suppressed_sources={PROVIDER: ["device_code"]},
+    )
+
+    pool = load_pool(PROVIDER)
+
+    assert [entry.id for entry in pool.entries()] == ["work", "personal"]
+    assert not profile_auth.exists()
+
+
+def test_two_profile_processes_share_one_single_use_refresh_post(
+    profile_pool_env,
+):
+    root_auth, profile_auth = profile_pool_env
+    _TokenHandler.calls = 0
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _TokenHandler)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    token_url = f"http://127.0.0.1:{server.server_port}/oauth/token"
+    context = multiprocessing.get_context("spawn")
+    ready_queue = context.Queue()
+    start_event = context.Event()
+    result_queue = context.Queue()
+    processes = [
+        context.Process(
+            target=_refresh_in_process,
+            args=(
+                str(profile_auth),
+                str(root_auth),
+                token_url,
+                "global-codex",
+                ready_queue,
+                start_event,
+                result_queue,
+            ),
+        )
+        for _ in range(2)
+    ]
+    try:
+        for process in processes:
+            process.start()
+        assert [ready_queue.get(timeout=15) for _ in processes] == [
+            "ready",
+            "ready",
+        ]
+        start_event.set()
+        results = [result_queue.get(timeout=20) for _ in processes]
+        for process in processes:
+            process.join(timeout=20)
+            assert process.exitcode == 0
+    finally:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=5)
+
+    assert results == [
+        ("ok", "refresh-process-rotated"),
+        ("ok", "refresh-process-rotated"),
+    ]
+    assert _TokenHandler.calls == 1
+    root_entry = _read_store(root_auth)["credential_pool"][PROVIDER][0]
+    assert root_entry["refresh_token"] == "refresh-process-rotated"
+    assert not profile_auth.exists()
+
+
+def test_two_profiles_refreshing_different_entries_preserve_both_rotations(
+    profile_pool_env,
+):
+    root_auth, profile_auth = profile_pool_env
+    _write_store(
+        root_auth,
+        [
+            _entry(
+                "work",
+                access_token="access-work-old",
+                refresh_token="refresh-work-old",
+            ),
+            _entry(
+                "personal",
+                access_token="access-personal-old",
+                refresh_token="refresh-personal-old",
+            ),
+        ],
+        suppressed_sources={PROVIDER: ["device_code"]},
+    )
+    _TokenHandler.calls = 0
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _TokenHandler)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    token_url = f"http://127.0.0.1:{server.server_port}/oauth/token"
+    context = multiprocessing.get_context("spawn")
+    ready_queue = context.Queue()
+    start_event = context.Event()
+    result_queue = context.Queue()
+    processes = [
+        context.Process(
+            target=_refresh_in_process,
+            args=(
+                str(profile_auth),
+                str(root_auth),
+                token_url,
+                credential_id,
+                ready_queue,
+                start_event,
+                result_queue,
+            ),
+        )
+        for credential_id in ("work", "personal")
+    ]
+    try:
+        for process in processes:
+            process.start()
+        assert [ready_queue.get(timeout=15) for _ in processes] == [
+            "ready",
+            "ready",
+        ]
+        start_event.set()
+        results = [result_queue.get(timeout=20) for _ in processes]
+        for process in processes:
+            process.join(timeout=20)
+            assert process.exitcode == 0
+    finally:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=5)
+
+    assert sorted(results) == [
+        ("ok", "refresh-personal-old-rotated"),
+        ("ok", "refresh-work-old-rotated"),
+    ]
+    assert _TokenHandler.calls == 2
+    persisted = {
+        entry["id"]: entry
+        for entry in _read_store(root_auth)["credential_pool"][PROVIDER]
+    }
+    assert persisted["work"]["refresh_token"] == "refresh-work-old-rotated"
+    assert persisted["personal"]["refresh_token"] == "refresh-personal-old-rotated"
+    assert not profile_auth.exists()
+
+
+def test_concurrent_add_status_and_remove_preserve_unrelated_owner_row(
+    profile_pool_env,
+):
+    root_auth, profile_auth = profile_pool_env
+    pool = load_pool(PROVIDER)
+    original = pool.entries()[0]
+    auth_mod.write_credential_pool(
+        PROVIDER,
+        [
+            _entry(),
+            _entry(
+                "concurrent-add",
+                access_token="access-added",
+                refresh_token="refresh-added",
+            ),
+        ],
+        target_path=root_auth,
+    )
+
+    pool._mark_exhausted(original, 429)
+    after_status = {
+        entry["id"]: entry
+        for entry in _read_store(root_auth)["credential_pool"][PROVIDER]
+    }
+    assert set(after_status) == {"global-codex", "concurrent-add"}
+    assert after_status["global-codex"]["last_status"] == STATUS_EXHAUSTED
+
+    removed = pool.remove_index(1)
+
+    assert removed is not None
+    remaining = _read_store(root_auth)["credential_pool"][PROVIDER]
+    assert [entry["id"] for entry in remaining] == ["concurrent-add"]
+    assert not profile_auth.exists()
+
+
+def test_missing_owner_entry_fails_closed_before_refresh_post(
+    profile_pool_env,
+    monkeypatch,
+):
+    root_auth, profile_auth = profile_pool_env
+    pool = load_pool(PROVIDER)
+    entry = pool.entries()[0]
+    _write_store(root_auth, [])
+    refresh_calls: list[str] = []
+
+    def fake_refresh(access_token, refresh_token, **_kwargs):
+        refresh_calls.append(refresh_token)
+        return {
+            "access_token": "must-not-write",
+            "refresh_token": "must-not-write",
+        }
+
+    monkeypatch.setattr(auth_mod, "refresh_codex_oauth_pure", fake_refresh)
+
+    with pytest.raises(RuntimeError, match="disappeared"):
+        pool._refresh_entry(entry, force=True)
+
+    assert refresh_calls == []
+    assert _read_store(root_auth)["credential_pool"][PROVIDER] == []
+    assert not profile_auth.exists()
+
+
+def test_malformed_owner_fails_closed_before_refresh_post(
+    profile_pool_env,
+    monkeypatch,
+):
+    root_auth, profile_auth = profile_pool_env
+    pool = load_pool(PROVIDER)
+    entry = pool.entries()[0]
+    root_auth.write_text("{malformed", encoding="utf-8")
+    refresh_calls: list[str] = []
+
+    def fake_refresh(access_token, refresh_token, **_kwargs):
+        refresh_calls.append(refresh_token)
+        return {
+            "access_token": "must-not-write",
+            "refresh_token": "must-not-write",
+        }
+
+    monkeypatch.setattr(auth_mod, "refresh_codex_oauth_pure", fake_refresh)
+
+    with pytest.raises(RuntimeError, match="source changed"):
+        pool._refresh_entry(entry, force=True)
+
+    assert refresh_calls == []
+    assert root_auth.read_text(encoding="utf-8") == "{malformed"
+    assert not profile_auth.exists()
+
+
+def test_owner_lock_timeout_fails_closed_before_refresh_post(
+    profile_pool_env,
+    monkeypatch,
+):
+    from agent import credential_pool as pool_mod
+
+    _root_auth, profile_auth = profile_pool_env
+    pool = load_pool(PROVIDER)
+    entry = pool.entries()[0]
+    refresh_calls: list[str] = []
+
+    def fake_refresh(access_token, refresh_token, **_kwargs):
+        refresh_calls.append(refresh_token)
+        return {
+            "access_token": "must-not-write",
+            "refresh_token": "must-not-write",
+        }
+
+    @contextmanager
+    def fail_lock(*_args, **_kwargs):
+        raise TimeoutError("synthetic owner lock timeout")
+        yield
+
+    monkeypatch.setattr(auth_mod, "refresh_codex_oauth_pure", fake_refresh)
+    monkeypatch.setattr(pool_mod, "_auth_store_lock", fail_lock)
+
+    with pytest.raises(TimeoutError, match="owner lock timeout"):
+        pool._refresh_entry(entry, force=True)
+
+    assert refresh_calls == []
+    assert not profile_auth.exists()


### PR DESCRIPTION
## What does this PR do?

Fixes credential-pool persistence when a named profile reads a provider pool through the existing global fallback.

Previously, the read came from the global auth store but runtime mutations (OAuth refresh, status updates, and removal) were written to the active profile. The first mutation therefore created a profile-local shadow, and concurrent processes could refresh the same single-use token twice or roll a sibling credential back to a stale token chain.

This change keeps direct CLI writes profile-local, while a runtime `CredentialPool` records the exact store that supplied its rows and writes mutations back to that owner. It locks the active profile and owner stores in deterministic order, fails closed if tracked rows disappear, and rebases every tracked owner row before persistence.

Related to #34143 and complements #34141, but addresses a different write-ownership and concurrency path.

## Related Issue

Related: #34143, #34141

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth.py`: return credential-pool rows with their owner path; allow runtime writes to target that exact store while preserving profile-local direct writes; inherit global source suppression only when the profile has no explicit provider override.
- `agent/credential_pool.py`: retain source ownership, lock active/owner stores deterministically for single-use refresh, rebase all tracked rows, fail closed on owner drift, and keep manually added Codex identities independent from the singleton device-code record.
- `tests/agent/test_credential_pool_profile_source.py`: add 13 regressions, including real spawn-based multi-process refresh tests for same-entry and different-entry races, owner deletion/malformed-store/lock-timeout fail-closed cases, and add/status/remove concurrency.

## How to Test

1. Run `HERMES_PYTHON=/path/to/python scripts/run_tests.sh tests/agent/test_credential_pool*.py tests/hermes_cli/test_*auth*.py -q`.
2. Confirm 514 tests pass (2 platform skips on macOS).
3. Run `python scripts/check-windows-footguns.py agent/credential_pool.py hermes_cli/auth.py tests/agent/test_credential_pool_profile_source.py` and `python -m ruff check agent/credential_pool.py hermes_cli/auth.py tests/agent/test_credential_pool_profile_source.py`.

Repository-wide disclosure: the complete macOS suite was run on this exact snapshot. All changed and related auth/pool tests passed, but the repository-wide run is not green in this local environment: 18 unrelated platform/optional-extra test files fail (for example Linux-only systemd sockets, GNU `timeout`, `/tmp` canonicalization, and disabled lazy extras such as `fal`, `daytona`, `modal`, `hindsight`, and `parallel-web`). A focused rerun reproduced the same 18-file baseline: 659 passed, 76 failed, 29 skipped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (full-suite exceptions disclosed above; 514 related tests pass)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS arm64, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings updated; user docs N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows footgun checker passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable. This is a storage-ownership and concurrency fix covered by deterministic unit and spawned-process regression tests.
