### PR TITLE
fix(updater): preserve the holder's age across update-marker handoffs

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -133,17 +133,13 @@ struct MarkerOwner {
     age_secs: u64,
 }
 
-/// Read the marker and report a live *foreign* owner, if any. `None` for every
-/// "no live update" case — absent, unreadable, malformed, dead pid, past the
-/// ceiling, or a marker whose pid is **this** process — matching
-/// `readLiveUpdateMarker` in the Electron gate. Never panics.
+/// Read the marker and report a live owner, if any. `None` for every "no live
+/// update" case — absent, unreadable, malformed, dead pid, or past the ceiling
+/// — matching `readLiveUpdateMarker` in the Electron gate. Never panics.
 ///
-/// Self-PID is treated as non-ownership on purpose (#74761): since #50238 the
-/// desktop pre-writes this marker with the spawned updater's pid before the
-/// updater reaches `acquire`. Without the exclusion, `acquire` sees a live
-/// owner that is itself and aborts ("Another Hermes update is already
-/// running"), then the desktop relaunches and retries forever. A foreign live
-/// pid (e.g. a dashboard-spawned `hermes update`) still blocks.
+/// Self-PID is returned so `acquire` can adopt the desktop's pre-written claim
+/// without refreshing its acquisition time (#74761). A foreign live pid (e.g.
+/// a dashboard-spawned `hermes update`) still blocks.
 fn live_marker_owner(path: &Path) -> Option<MarkerOwner> {
     let raw = std::fs::read_to_string(path).ok()?;
     let mut lines = raw.lines();
@@ -155,11 +151,6 @@ fn live_marker_owner(path: &Path) -> Option<MarkerOwner> {
         .unwrap_or(0);
     let age_secs = now.saturating_sub(started_at);
     if age_secs > UPDATE_MARKER_MAX_AGE_SECS || !pid_is_alive(pid) {
-        return None;
-    }
-    // Desktop `writeUpdateMarker(hermesHome, child.pid)` races ahead of us;
-    // adopt that pre-claim rather than refusing our own marker.
-    if pid == std::process::id() {
         return None;
     }
     Some(MarkerOwner { pid, age_secs })
@@ -207,10 +198,16 @@ impl UpdateMarkerGuard {
     /// behavior), so we log and carry on with a guard that still attempts
     /// cleanup of whatever may exist at the path.
     fn acquire(path: PathBuf) -> Result<Self, MarkerOwner> {
+        let pid = std::process::id();
         if let Some(owner) = live_marker_owner(&path) {
+            if owner.pid == pid {
+                // The desktop races ahead and pre-writes our pid. Adopt that
+                // claim verbatim: rewriting started_at here lets retries reset
+                // a wedged updater's age before the stale ceiling can clear it.
+                return Ok(Self { path, owned: true });
+            }
             return Err(owner);
         }
-        let pid = std::process::id();
         let started_at = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())
@@ -1321,8 +1318,8 @@ mod tests {
 
     /// Spawn a short-lived sibling process whose pid stands in for a foreign
     /// updater. Same-process double-acquire no longer models contention: since
-    /// #74761 `live_marker_owner` treats our own pid as adoptable (desktop
-    /// pre-writes it), so a second acquire in *this* process would succeed.
+    /// #74761 `acquire` treats our own pid as adoptable (desktop pre-writes it),
+    /// so a second acquire in *this* process would succeed.
     fn spawn_foreign_holder() -> std::process::Child {
         #[cfg(windows)]
         {
@@ -1379,7 +1376,8 @@ mod tests {
     fn acquire_adopts_a_marker_prewritten_with_our_own_pid() {
         // #74761: desktop writeUpdateMarker(hermesHome, child.pid) races ahead
         // of UpdateMarkerGuard::acquire. The marker names US; refusing it made
-        // every in-app desktop update loop forever. Adopt and rewrite.
+        // every in-app desktop update loop forever. Adopt it without resetting
+        // the holder age, so a wedged updater still reaches the stale ceiling.
         let dir = unique_tmp_dir("marker-own-pid");
         std::fs::create_dir_all(&dir).unwrap();
         let marker = dir.join(".hermes-update-in-progress");
@@ -1402,7 +1400,12 @@ mod tests {
         assert_eq!(
             body.lines().next().unwrap().trim().parse::<u32>().unwrap(),
             std::process::id(),
-            "acquire rewrites the marker with our pid + fresh started_at"
+            "acquire keeps the adopted marker owner"
+        );
+        assert_eq!(
+            body.lines().nth(1).unwrap().trim().parse::<u64>().unwrap(),
+            started_at,
+            "adopting an own-pid marker must preserve its original holder age"
         );
         drop(guard);
         assert!(

--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -201,6 +201,8 @@ impl UpdateMarkerGuard {
         let pid = std::process::id();
         if let Some(owner) = live_marker_owner(&path) {
             if owner.pid == pid {
+                // Repeated acquisition in this process is intentionally
+                // re-entrant because the desktop may have pre-written our pid.
                 // The desktop races ahead and pre-writes our pid. Adopt that
                 // claim verbatim: rewriting started_at here lets retries reset
                 // a wedged updater's age before the stale ceiling can clear it.

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3640,6 +3640,7 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
     let child
 
     if (scriptHandoff) {
+      const updateStartedAt = Math.floor(Date.now() / 1000)
       // A bare detached+hidden powershell spawn silently dies before -File
       // processing (console-subsystem init failure — see
       // wrapHandoffForDetachedConsole). Route through `cmd start` so the
@@ -3663,6 +3664,7 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
         env: {
           ...process.env,
           HERMES_HOME,
+          HERMES_UPDATE_STARTED_AT: String(updateStartedAt),
           PATH: pathWithHermesManagedNode(venvBin)
         },
         detached: true,
@@ -3677,7 +3679,7 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
       // The `hermes update` child adopts the SCRIPT's claim via
       // update_lock.py's process-ancestry rule; no mtime heuristics needed.
       if (Number.isInteger(child.pid)) {
-        writeUpdateMarker(HERMES_HOME, child.pid)
+        writeUpdateMarker(HERMES_HOME, child.pid, { startedAt: updateStartedAt })
       }
 
       rememberLog(
@@ -4020,6 +4022,7 @@ async function applyUpdatesPosixHandoff(opts: any) {
   }
 
   const args = [...handoff.args, '--install-root', updateRoot, '--branch', branch, '--desktop-pid', String(process.pid)]
+  const updateStartedAt = Math.floor(Date.now() / 1000)
 
   // Relaunch target: the running .app bundle on mac (script swaps the
   // rebuilt bundle over it), the running binary elsewhere. The script's gate
@@ -4052,6 +4055,7 @@ async function applyUpdatesPosixHandoff(opts: any) {
     env: {
       ...process.env,
       HERMES_HOME,
+      HERMES_UPDATE_STARTED_AT: String(updateStartedAt),
       PATH: pathWithHermesManagedNode(path.join(updateRoot, 'venv', 'bin'))
     },
     detached: true,
@@ -4062,7 +4066,7 @@ async function applyUpdatesPosixHandoff(opts: any) {
   // until the script claims the marker with its own pid as step 0. If the
   // script never starts, the dead pid reads as stale and self-deletes.
   if (Number.isInteger(child.pid)) {
-    writeUpdateMarker(HERMES_HOME, child.pid)
+    writeUpdateMarker(HERMES_HOME, child.pid, { startedAt: updateStartedAt })
   }
 
   rememberLog(`[updates] launched posix hand-off: ${handoff.scriptPath} (branch ${branch}); quitting to hand off`)

--- a/apps/desktop/electron/update-handoff-marker.test.ts
+++ b/apps/desktop/electron/update-handoff-marker.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..')
+const POSIX_SCRIPT = path.join(REPO_ROOT, 'scripts', 'desktop-update', 'posix.sh')
+const WINDOWS_SCRIPT = path.join(REPO_ROOT, 'scripts', 'desktop-update', 'windows.ps1')
+
+function sandbox(tag: string) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), `hermes-handoff-marker-${tag}-`))
+  const installRoot = path.join(home, 'hermes-agent')
+  fs.mkdirSync(installRoot)
+
+  return { home, installRoot }
+}
+
+function markerStartedAt(home: string): number {
+  const [, startedAt] = fs.readFileSync(path.join(home, '.hermes-update-in-progress'), 'utf8').split('\n')
+
+  return Number.parseInt(startedAt, 10)
+}
+
+function runPosix(installRoot: string, startedAt?: string) {
+  const env = { ...process.env }
+  if (startedAt === undefined) delete env.HERMES_UPDATE_STARTED_AT
+  else env.HERMES_UPDATE_STARTED_AT = startedAt
+
+  return spawnSync('/bin/bash', [POSIX_SCRIPT, '--install-root', installRoot, '--self-test-marker'], {
+    env,
+    encoding: 'utf8'
+  })
+}
+
+function runWindows(installRoot: string, startedAt?: string) {
+  const env = { ...process.env }
+  if (startedAt === undefined) delete env.HERMES_UPDATE_STARTED_AT
+  else env.HERMES_UPDATE_STARTED_AT = startedAt
+
+  return spawnSync(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      WINDOWS_SCRIPT,
+      '-InstallRoot',
+      installRoot,
+      '-NoUi',
+      '-NoMarkerCleanup',
+      '-SelfTestMarker'
+    ],
+    { env, encoding: 'utf8' }
+  )
+}
+
+function assertScriptHandoff(run: (installRoot: string, startedAt?: string) => ReturnType<typeof spawnSync>) {
+  const preserved = sandbox('preserved')
+  const acquiredAt = Math.floor(Date.now() / 1000) - 300
+  const preservedResult = run(preserved.installRoot, String(acquiredAt))
+
+  assert.equal(preservedResult.status, 0, preservedResult.stderr || preservedResult.stdout)
+  assert.equal(markerStartedAt(preserved.home), acquiredAt, 'the script must preserve the Desktop acquisition time')
+
+  const refreshed = sandbox('refreshed')
+  fs.writeFileSync(path.join(refreshed.home, '.hermes-update-in-progress'), '999999\n1\n')
+  const before = Math.floor(Date.now() / 1000)
+  const refreshedResult = run(refreshed.installRoot, 'malformed')
+  const after = Math.floor(Date.now() / 1000)
+
+  assert.equal(refreshedResult.status, 0, refreshedResult.stderr || refreshedResult.stdout)
+  assert.ok(
+    markerStartedAt(refreshed.home) >= before && markerStartedAt(refreshed.home) <= after,
+    'an invalid hand-off timestamp must start a fresh claim'
+  )
+}
+
+test.skipIf(process.platform === 'win32')('POSIX hand-off preserves the Desktop marker acquisition time', () => {
+  assertScriptHandoff(runPosix)
+})
+
+test.skipIf(process.platform !== 'win32')('PowerShell hand-off preserves the Desktop marker acquisition time', () => {
+  assertScriptHandoff(runWindows)
+})

--- a/apps/desktop/electron/update-handoff-marker.test.ts
+++ b/apps/desktop/electron/update-handoff-marker.test.ts
@@ -63,7 +63,7 @@ function assertScriptHandoff(run: (installRoot: string, startedAt?: string) => R
   const acquiredAt = Math.floor(Date.now() / 1000) - 300
   const preservedResult = run(preserved.installRoot, String(acquiredAt))
 
-  assert.equal(preservedResult.status, 0, preservedResult.stderr || preservedResult.stdout)
+  assert.equal(preservedResult.status, 0, String(preservedResult.stderr || preservedResult.stdout))
   assert.equal(markerStartedAt(preserved.home), acquiredAt, 'the script must preserve the Desktop acquisition time')
 
   const refreshed = sandbox('refreshed')
@@ -72,7 +72,7 @@ function assertScriptHandoff(run: (installRoot: string, startedAt?: string) => R
   const refreshedResult = run(refreshed.installRoot, 'malformed')
   const after = Math.floor(Date.now() / 1000)
 
-  assert.equal(refreshedResult.status, 0, refreshedResult.stderr || refreshedResult.stdout)
+  assert.equal(refreshedResult.status, 0, String(refreshedResult.stderr || refreshedResult.stdout))
   assert.ok(
     markerStartedAt(refreshed.home) >= before && markerStartedAt(refreshed.home) <= after,
     'an invalid hand-off timestamp must start a fresh claim'

--- a/apps/desktop/electron/update-handoff-marker.test.ts
+++ b/apps/desktop/electron/update-handoff-marker.test.ts
@@ -32,10 +32,11 @@ function runPosix(installRoot: string, startedAt?: string) {
     env.HERMES_UPDATE_STARTED_AT = startedAt
   }
 
-  return spawnSync('/bin/bash', [POSIX_SCRIPT, '--install-root', installRoot, '--self-test-marker'], {
-    env,
-    encoding: 'utf8'
-  })
+  return spawnSync(
+    '/bin/bash',
+    [POSIX_SCRIPT, '--daemonized', '--install-root', installRoot, '--self-test-marker'],
+    { env, encoding: 'utf8' }
+  )
 }
 
 function runWindows(installRoot: string, startedAt?: string) {
@@ -82,6 +83,17 @@ function assertScriptHandoff(run: (installRoot: string, startedAt?: string) => R
   assert.ok(
     markerStartedAt(refreshed.home) >= before && markerStartedAt(refreshed.home) <= after,
     'an invalid hand-off timestamp must start a fresh claim'
+  )
+
+  const oversized = sandbox('oversized')
+  const oversizedBefore = Math.floor(Date.now() / 1000)
+  const oversizedResult = run(oversized.installRoot, '99999999999999999999')
+  const oversizedAfter = Math.floor(Date.now() / 1000)
+
+  assert.equal(oversizedResult.status, 0, String(oversizedResult.stderr || oversizedResult.stdout))
+  assert.ok(
+    markerStartedAt(oversized.home) >= oversizedBefore && markerStartedAt(oversized.home) <= oversizedAfter,
+    'an oversized hand-off timestamp must start a fresh claim'
   )
 }
 

--- a/apps/desktop/electron/update-handoff-marker.test.ts
+++ b/apps/desktop/electron/update-handoff-marker.test.ts
@@ -26,8 +26,11 @@ function markerStartedAt(home: string): number {
 
 function runPosix(installRoot: string, startedAt?: string) {
   const env = { ...process.env }
-  if (startedAt === undefined) delete env.HERMES_UPDATE_STARTED_AT
-  else env.HERMES_UPDATE_STARTED_AT = startedAt
+  if (startedAt === undefined) {
+    delete env.HERMES_UPDATE_STARTED_AT
+  } else {
+    env.HERMES_UPDATE_STARTED_AT = startedAt
+  }
 
   return spawnSync('/bin/bash', [POSIX_SCRIPT, '--install-root', installRoot, '--self-test-marker'], {
     env,
@@ -37,8 +40,11 @@ function runPosix(installRoot: string, startedAt?: string) {
 
 function runWindows(installRoot: string, startedAt?: string) {
   const env = { ...process.env }
-  if (startedAt === undefined) delete env.HERMES_UPDATE_STARTED_AT
-  else env.HERMES_UPDATE_STARTED_AT = startedAt
+  if (startedAt === undefined) {
+    delete env.HERMES_UPDATE_STARTED_AT
+  } else {
+    env.HERMES_UPDATE_STARTED_AT = startedAt
+  }
 
   return spawnSync(
     'powershell.exe',

--- a/apps/desktop/electron/update-marker.test.ts
+++ b/apps/desktop/electron/update-marker.test.ts
@@ -128,6 +128,17 @@ test('writeUpdateMarker preserves a live holder age across pid hand-off', () => 
   assert.equal(Number.parseInt(startedLine, 10), startedAt, 'the holder age must not restart during hand-off')
 })
 
+test('writeUpdateMarker uses the acquisition time passed to a detached script', () => {
+  const home = tmpHome('write-script-acquired-at')
+  const now = 1_000_000_000_000
+  const startedAt = Math.floor(now / 1000) - 300
+
+  writeUpdateMarker(home, 2020, { now: () => now, startedAt })
+
+  const [, startedLine] = fs.readFileSync(markerPath(home), 'utf8').split('\n')
+  assert.equal(Number.parseInt(startedLine, 10), startedAt)
+})
+
 test('writeUpdateMarker is best-effort (no throw on bad path)', () => {
   // A non-existent directory should not throw.
   const badHome = path.join(os.tmpdir(), 'hermes-marker-nonexistent-' + Date.now())

--- a/apps/desktop/electron/update-marker.test.ts
+++ b/apps/desktop/electron/update-marker.test.ts
@@ -115,6 +115,19 @@ test('writeUpdateMarker writes a marker that readLiveUpdateMarker accepts', () =
   assert.ok(fs.existsSync(markerPath(home)), 'marker file should exist after write')
 })
 
+test('writeUpdateMarker preserves a live holder age across pid hand-off', () => {
+  const home = tmpHome('write-handoff-age')
+  const now = 1_000_000_000_000
+  const startedAt = Math.floor(now / 1000) - 300
+
+  writeMarker(home, 1010, startedAt)
+  writeUpdateMarker(home, 2020, { kill: ALIVE, now: () => now })
+
+  const [pidLine, startedLine] = fs.readFileSync(markerPath(home), 'utf8').split('\n')
+  assert.equal(Number.parseInt(pidLine, 10), 2020, 'the hand-off records the new owner')
+  assert.equal(Number.parseInt(startedLine, 10), startedAt, 'the holder age must not restart during hand-off')
+})
+
 test('writeUpdateMarker is best-effort (no throw on bad path)', () => {
   // A non-existent directory should not throw.
   const badHome = path.join(os.tmpdir(), 'hermes-marker-nonexistent-' + Date.now())

--- a/apps/desktop/electron/update-marker.ts
+++ b/apps/desktop/electron/update-marker.ts
@@ -119,15 +119,30 @@ export function readLiveUpdateMarker(
  *
  * Fix: the desktop writes the marker itself, using the spawned updater's
  * PID, immediately after `spawn()`. The updater's `UpdateMarkerGuard` will
- * later overwrite it with its own PID — that's fine, the marker body is
- * the same format and `readLiveUpdateMarker` only cares that *some* live
- * pid owns it. When the updater finishes it deletes the marker as before.
+ * later adopt it or another hand-off stage may replace the PID. A live
+ * holder's original timestamp is preserved across those transfers so retries
+ * cannot keep resetting the 20-minute stale ceiling. When the updater finishes
+ * it deletes the marker as before.
  * If the updater never starts (spawn failure) the marker still contains a
  * real PID, so `readLiveUpdateMarker` will self-heal once that PID exits.
  */
-export function writeUpdateMarker(hermesHome, pid, { now = Date.now } = {}) {
+export function writeUpdateMarker(
+  hermesHome,
+  pid,
+  {
+    kill,
+    now = Date.now,
+    maxAgeMs = UPDATE_MARKER_MAX_AGE_MS
+  }: {
+    now?: () => number
+    maxAgeMs?: number
+    kill?: typeof process.kill
+  } = {}
+) {
   const file = markerPath(hermesHome)
-  const startedAt = Math.floor(now() / 1000)
+  const nowMs = now()
+  const owner = readLiveUpdateMarker(hermesHome, { kill, maxAgeMs, now: () => nowMs })
+  const startedAt = owner ? Math.floor((nowMs - owner.ageMs) / 1000) : Math.floor(nowMs / 1000)
 
   try {
     fs.writeFileSync(file, `${pid}\n${startedAt}\n`, 'utf8')

--- a/apps/desktop/electron/update-marker.ts
+++ b/apps/desktop/electron/update-marker.ts
@@ -132,20 +132,26 @@ export function writeUpdateMarker(
   {
     kill,
     now = Date.now,
-    maxAgeMs = UPDATE_MARKER_MAX_AGE_MS
+    maxAgeMs = UPDATE_MARKER_MAX_AGE_MS,
+    startedAt
   }: {
     now?: () => number
     maxAgeMs?: number
     kill?: typeof process.kill
+    startedAt?: number
   } = {}
 ) {
   const file = markerPath(hermesHome)
   const nowMs = now()
   const owner = readLiveUpdateMarker(hermesHome, { kill, maxAgeMs, now: () => nowMs })
-  const startedAt = owner ? Math.floor((nowMs - owner.ageMs) / 1000) : Math.floor(nowMs / 1000)
+  const acquiredAt = typeof startedAt === 'number' && Number.isInteger(startedAt)
+    ? startedAt
+    : owner
+      ? Math.floor((nowMs - owner.ageMs) / 1000)
+      : Math.floor(nowMs / 1000)
 
   try {
-    fs.writeFileSync(file, `${pid}\n${startedAt}\n`, 'utf8')
+    fs.writeFileSync(file, `${pid}\n${acquiredAt}\n`, 'utf8')
   } catch {
     // Best-effort: if we can't write the marker, proceed anyway. The
     // updater will write its own when it reaches run_update.

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -19,6 +19,7 @@
 #     [--sandbox-fallback]     linux: the caller vouches for a sandbox opt-out
 #                              (ELECTRON_DISABLE_SANDBOX / --no-sandbox launch)
 #     [--no-ui] [--no-marker-cleanup] [--self-test-ui] [--self-test-gate]
+#     [--self-test-marker]
 #     [-- <args...>]           linux: filtered launch args to replay
 #
 # The shim (ui.html in a chromeless browser app window) is decoration: it
@@ -37,7 +38,8 @@ set -u
 ORIGINAL_ARGS=("$@")
 INSTALL_ROOT="" BRANCH="main" DESKTOP_PID=0 RELAUNCH_TARGET=""
 RELAUNCH_CWD="" SANDBOX_FALLBACK=0 RELAUNCH_ARGS=()
-NO_UI=0 NO_MARKER_CLEANUP=0 SELF_TEST_UI=0 SELF_TEST_GATE=0 HANDOFF_DAEMONIZED=0
+NO_UI=0 NO_MARKER_CLEANUP=0 SELF_TEST_UI=0 SELF_TEST_GATE=0 SELF_TEST_MARKER=0
+HANDOFF_DAEMONIZED=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --install-root) INSTALL_ROOT="$2"; shift 2 ;;
@@ -51,6 +53,7 @@ while [ $# -gt 0 ]; do
     --self-test-ui) SELF_TEST_UI=1; shift ;;
     --self-test-gate) SELF_TEST_GATE=1; shift ;;
     --daemonized) HANDOFF_DAEMONIZED=1; shift ;;
+    --self-test-marker) SELF_TEST_MARKER=1; NO_UI=1; NO_MARKER_CLEANUP=1; shift ;;
     --) shift; RELAUNCH_ARGS=("$@"); shift $# ;;
     *) echo "unknown arg: $1" >&2; exit 64 ;;
   esac
@@ -466,7 +469,23 @@ rm -f "$RESULT" 2>/dev/null || true
 
 # Marker claim: same cross-process lock contract as windows.ps1 /
 # update_lock.py (the `hermes update` child adopts it via process ancestry).
-printf '%s\n%s\n' "$$" "$(date +%s)" > "$MARKER" 2>/dev/null || log "WARNING: could not write update marker"
+# The Desktop supplies one acquisition time for the whole ownership chain.
+NOW="$(date +%s)"
+STARTED_AT="${HERMES_UPDATE_STARTED_AT:-$NOW}"
+case "$STARTED_AT" in ''|*[!0-9]*) STARTED_AT="$NOW" ;; esac
+MIN_STARTED_AT=$((NOW - 1200))
+# Compare the validated decimal strings before doing arithmetic. Shell integer
+# expansion can wrap on an attacker-controlled value wider than signed 64-bit.
+if [ "${#STARTED_AT}" -ne "${#NOW}" ] \
+    || [[ "$STARTED_AT" > "$NOW" || "$STARTED_AT" < "$MIN_STARTED_AT" ]]; then
+  STARTED_AT="$NOW"
+fi
+printf '%s\n%s\n' "$$" "$STARTED_AT" > "$MARKER" 2>/dev/null || log "WARNING: could not write update marker"
+
+if [ "$SELF_TEST_MARKER" -eq 1 ]; then
+  trap - EXIT
+  exit 0
+fi
 
 # Wait out the Desktop (FAIL CLOSED: updating under live backends bricks).
 if [ "$DESKTOP_PID" -gt 0 ] 2>/dev/null; then

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -35,7 +35,8 @@
 #
 # Marker: we claim HERMES_HOME\.hermes-update-in-progress with OUR pid as
 # step 0 (the wrapper cmd.exe pid the Desktop saw is useless -- it exits
-# immediately). hermes_cli/update_lock.py's ancestry rule lets our
+# immediately), retaining HERMES_UPDATE_STARTED_AT from the Desktop hand-off.
+# hermes_cli/update_lock.py's ancestry rule lets our
 # `hermes update` child adopt the claim; electron/update-marker.ts parks a
 # relaunched Desktop on it. Cleanup only removes the marker while WE still
 # own it (a handoff partner that rewrote it keeps its claim).
@@ -48,7 +49,8 @@ param(
     [switch]$NoUi,
     [switch]$NoMarkerCleanup,
     [switch]$SelfTestUi,
-    [switch]$SelfTestPipeDrain
+    [switch]$SelfTestPipeDrain,
+    [switch]$SelfTestMarker
 )
 
 if (-not $SelfTestUi -and -not $SelfTestPipeDrain -and -not $InstallRoot) {
@@ -899,12 +901,23 @@ try {
     # -- 0. Claim the update marker with OUR pid ---------------------------
     try {
         $epoch = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+        $startedAt = 0L
+        $hasStartedAt = [int64]::TryParse($env:HERMES_UPDATE_STARTED_AT, [ref]$startedAt)
+        if (-not $hasStartedAt -or $startedAt -gt $epoch -or ($epoch - $startedAt) -gt 1200) {
+            $startedAt = $epoch
+        }
         # WriteAllText for byte-exact LF framing: Set-Content emits CRLF and
         # the marker contract (Rust/TS/Python readers) is "<pid>\n<ts>\n".
-        [System.IO.File]::WriteAllText($MarkerPath, "$PID`n$epoch`n")
+        [System.IO.File]::WriteAllText($MarkerPath, "$PID`n$startedAt`n")
         Write-HandoffLog "claimed update marker (pid $PID)"
     } catch {
         Write-HandoffLog "WARNING: could not write update marker: $($_.Exception.Message)"
+    }
+
+    if ($SelfTestMarker) {
+        $finalCode = 0
+        $finalMsg = "marker self-test complete"
+        exit 0
     }
 
     # -- 1. Wait for the Desktop to exit (FAIL CLOSED) ----------------------


### PR DESCRIPTION
Rebase-merge of [#85964](https://github.com/NousResearch/hermes-agent/pull/85964) by @fangliquanflq onto current `main`. All five commits cherry-picked, authorship intact.

## The bug

The update marker carries `<pid>\n<started_at>\n`, and every reader — Electron, Python, Rust — releases it once the holder is dead or older than 20 minutes. That ceiling never fired, because ownership legitimately moves between cooperating processes (Desktop pre-writes the marker for the process it's about to spawn, the handoff script re-claims it with its own PID, the Rust updater adopts it), and every one of those transfers rewrote `started_at` to now.

Age belongs to the update *attempt*, not to whoever currently holds the marker. Refreshing it on transfer turns a bounded stale lock into an indefinitely renewable one. The reported symptom is a Desktop update that refuses every retry because it thinks the current attempt started seconds ago; one user sat wedged for about 13 hours.

## The fix

One acquisition timestamp is created once and carried through the handoff chain. `writeUpdateMarker` inherits a live holder's existing age instead of resetting it, both handoff scripts (`posix.sh`, `windows.ps1`) retain an inherited `HERMES_UPDATE_STARTED_AT` when it's valid, non-future and inside the ceiling, and the Rust `UpdateMarkerGuard` adopts its own pre-written marker without rewriting it. Invalid, future or already-expired values are refreshed, so a corrupt marker can't pin the lock open either.

## Why now, and why it matters less than it did

This is defense-in-depth behind the three updater fixes that just landed. [#90937](https://github.com/NousResearch/hermes-agent/pull/90937) and [#90941](https://github.com/NousResearch/hermes-agent/pull/90941) removed the pipe-EOF hang that produced these long-lived wedges in the first place, so the marker should now rarely be held by a process that isn't making progress. This closes the case where it happens anyway — for a cause we haven't found yet — by making the ceiling actually reachable.

## Rebase notes

Conflicted with [#90937](https://github.com/NousResearch/hermes-agent/pull/90937) in `scripts/desktop-update/windows.ps1`: both sides added a self-test switch to the same `param()` block. Resolved by keeping both, `-SelfTestPipeDrain` and `-SelfTestMarker`. `apps/bootstrap-installer/src-tauri/src/update.rs` auto-merged against the `pump_child` change from [#90941](https://github.com/NousResearch/hermes-agent/pull/90941) — the two touch different regions.

Verified both fixes still coexist after the rebase rather than assuming it: `Step-PipeDrain` is still wired in `windows.ps1` and `update.rs` still calls `pump_child`.

## Test plan

- [x] `npx vitest run electron/update-marker.test.ts electron/update-handoff-marker.test.ts` — 18 passed, 1 skipped
- [x] `cargo test --lib` in `apps/bootstrap-installer/src-tauri` — 59 passed (58 before this PR; it adds one)
- [x] `scripts/run_tests.sh tests/test_desktop_update_windows_pipe_drain.py tests/test_desktop_update_windows_python_handoff.py` — 4 passed, 1 skipped, confirming the `windows.ps1` conflict resolution didn't disturb the drain
- [ ] Windows lane exercises `-SelfTestMarker` and `-SelfTestPipeDrain` against a real PowerShell host

Closes #85894. Supersedes #85964.