### PR TITLE
refactor(webhook): establish canonical intake authority

### DIFF
--- a/gateway/platforms/webhook_contract.py
+++ b/gateway/platforms/webhook_contract.py
@@ -1,0 +1,469 @@
+"""Canonical webhook route, provider, identity, and intake-envelope authority.
+
+This module deliberately has no HTTP-server, secret-storage, session, delivery,
+or callback dependencies. It owns the domain facts those layers consume:
+which provider a route is bound to, which provider-native identifier is stable
+enough for retry deduplication, which event header belongs to that provider, and
+the immutable envelope handed across the HTTP/domain boundary.
+
+Legacy request-header inference exists only as an explicit compatibility bridge
+for routes that have not declared a provider/signature mode yet. Once a route
+is bound, downstream code never re-selects provider authority from headers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping, Optional
+
+
+class WebhookContractError(ValueError):
+    """Webhook configuration cannot be normalized without ambiguity."""
+
+
+@dataclass(frozen=True)
+class WebhookProviderSpec:
+    """Wire facts owned by one webhook provider namespace."""
+
+    name: str
+    aliases: tuple[str, ...] = ()
+    delivery_id_headers: tuple[str, ...] = ()
+    event_headers: tuple[str, ...] = ()
+    legacy_detection_headers: tuple[str, ...] = ()
+    payload_delivery_id_keys: tuple[str, ...] = ()
+    signature_modes: tuple[str, ...] = ()
+    default_signature_mode: Optional[str] = None
+
+
+_PROVIDER_SPECS = (
+    WebhookProviderSpec(
+        name="svix",
+        aliases=("agentmail",),
+        delivery_id_headers=("svix-id",),
+        legacy_detection_headers=("svix-id", "svix-signature", "svix-timestamp"),
+        signature_modes=("svix",),
+        default_signature_mode="svix",
+    ),
+    WebhookProviderSpec(
+        name="github",
+        aliases=("github_hmac_sha256",),
+        delivery_id_headers=("X-GitHub-Delivery",),
+        event_headers=("X-GitHub-Event",),
+        legacy_detection_headers=("X-Hub-Signature-256", "X-GitHub-Delivery"),
+        signature_modes=("github", "github_hmac_sha256"),
+        default_signature_mode="github",
+    ),
+    WebhookProviderSpec(
+        name="gitlab",
+        aliases=("gitlab_token",),
+        delivery_id_headers=(
+            "X-Gitlab-Event-UUID",
+            "X-Gitlab-Webhook-UUID",
+            "X-Gitlab-Idempotency-Key",
+            "Idempotency-Key",
+        ),
+        event_headers=("X-GitLab-Event",),
+        legacy_detection_headers=(
+            "X-Gitlab-Token",
+            "X-Gitlab-Event-UUID",
+            "X-Gitlab-Webhook-UUID",
+            "X-Gitlab-Idempotency-Key",
+        ),
+        signature_modes=("gitlab", "gitlab_token"),
+        default_signature_mode="gitlab",
+    ),
+    WebhookProviderSpec(
+        name="standard_webhooks",
+        aliases=("gitlab_standard",),
+        delivery_id_headers=("webhook-id", "Idempotency-Key"),
+        legacy_detection_headers=("webhook-id", "webhook-signature"),
+        signature_modes=("standard_webhooks", "gitlab_standard"),
+        default_signature_mode="standard_webhooks",
+    ),
+    WebhookProviderSpec(
+        name="chatwoot",
+        delivery_id_headers=("X-Chatwoot-Delivery",),
+        legacy_detection_headers=("X-Chatwoot-Delivery",),
+        payload_delivery_id_keys=("id",),
+        signature_modes=("chatwoot", "generic_v1", "generic_v2"),
+        default_signature_mode="generic_v1",
+    ),
+    WebhookProviderSpec(
+        name="linear",
+        legacy_detection_headers=("linear-signature",),
+        signature_modes=("linear",),
+        default_signature_mode="linear",
+    ),
+    WebhookProviderSpec(
+        name="hindsight",
+        aliases=("hindsight_hmac_sha256",),
+        legacy_detection_headers=("X-Hindsight-Signature",),
+        signature_modes=("hindsight", "hindsight_hmac_sha256"),
+        default_signature_mode="hindsight",
+    ),
+    WebhookProviderSpec(
+        name="stripe",
+        payload_delivery_id_keys=("id",),
+        signature_modes=("stripe", "generic_v1", "generic_v2"),
+        default_signature_mode="generic_v1",
+    ),
+    WebhookProviderSpec(
+        name="generic",
+        aliases=("generic_v1", "generic_v2"),
+        delivery_id_headers=("X-Request-ID",),
+        legacy_detection_headers=(
+            "X-Webhook-Signature-V2",
+            "X-Webhook-Signature",
+            "X-Request-ID",
+        ),
+        signature_modes=("generic", "generic_v1", "generic_v2"),
+        default_signature_mode="generic_v2",
+    ),
+)
+
+PROVIDER_REGISTRY: Mapping[str, WebhookProviderSpec] = MappingProxyType(
+    {spec.name: spec for spec in _PROVIDER_SPECS}
+)
+_PROVIDER_ALIASES = MappingProxyType(
+    {
+        alias: spec.name
+        for spec in _PROVIDER_SPECS
+        for alias in (spec.name, *spec.aliases)
+    }
+)
+_SIGNATURE_MODE_TO_PROVIDER = MappingProxyType(
+    {
+        mode: spec.name
+        for spec in _PROVIDER_SPECS
+        for mode in spec.signature_modes
+        if mode not in {"generic_v1", "generic_v2"}
+    }
+    | {"generic_v1": "generic", "generic_v2": "generic"}
+)
+
+# Compatibility inference order intentionally checks provider-specific families
+# before generic HMAC. It is used only when a route has no declared provider or
+# signature mode; it is never a downstream authorization mechanism.
+_LEGACY_PROVIDER_ORDER = (
+    "svix",
+    "github",
+    "gitlab",
+    "standard_webhooks",
+    "chatwoot",
+    "linear",
+    "hindsight",
+    "generic",
+)
+
+
+def _normalize_token(value: str) -> str:
+    return str(value or "").strip().lower().replace("-", "_")
+
+
+def _nonempty_scalar(value: Any) -> Optional[str]:
+    if isinstance(value, bool) or value is None:
+        return None
+    if not isinstance(value, (str, int)):
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _header(headers: Mapping[str, Any], name: str) -> str:
+    """Read a case-insensitive HTTP header from real or test mappings."""
+
+    direct = headers.get(name)
+    if direct not in (None, ""):
+        return str(direct)
+    target = name.lower()
+    for key, value in headers.items():
+        if str(key).lower() == target and value not in (None, ""):
+            return str(value)
+    return ""
+
+
+def canonical_provider(value: str) -> str:
+    """Return the canonical provider namespace or fail closed."""
+
+    normalized = _normalize_token(value)
+    if not normalized:
+        raise WebhookContractError("webhook provider must be non-empty")
+    provider = _PROVIDER_ALIASES.get(normalized)
+    if provider is None:
+        raise WebhookContractError(f"unsupported webhook provider {value!r}")
+    return provider
+
+
+def canonical_signature_mode(value: str) -> str:
+    """Return one registered verifier mode or fail closed."""
+
+    normalized = _normalize_token(value)
+    if not normalized:
+        raise WebhookContractError("webhook signature mode must be non-empty")
+    if normalized not in _SIGNATURE_MODE_TO_PROVIDER:
+        raise WebhookContractError(f"unsupported webhook signature mode {value!r}")
+    return normalized
+
+
+def infer_legacy_provider(headers: Mapping[str, Any]) -> str:
+    """Compatibility-only provider inference for undeclared legacy routes."""
+
+    for name in _LEGACY_PROVIDER_ORDER:
+        spec = PROVIDER_REGISTRY[name]
+        if any(
+            _header(headers, header).strip()
+            for header in spec.legacy_detection_headers
+        ):
+            return name
+    return "generic"
+
+
+@dataclass(frozen=True)
+class WebhookRouteConfig:
+    """Normalized route identity/security binding consumed by intake."""
+
+    name: str
+    profile: str
+    provider: str
+    provider_declared: bool
+    signature_mode: str
+    enabled: bool
+    events: tuple[str, ...]
+
+    @classmethod
+    def bind(
+        cls,
+        name: str,
+        route: Mapping[str, Any],
+        *,
+        headers: Mapping[str, Any],
+        request_profile: Optional[str] = None,
+    ) -> "WebhookRouteConfig":
+        route_name = str(name or "").strip()
+        if not route_name:
+            raise WebhookContractError("webhook route name must be non-empty")
+
+        if "profile" in route:
+            profile_value = route.get("profile")
+            if not isinstance(profile_value, str) or not profile_value.strip():
+                raise WebhookContractError(
+                    f"route {route_name!r} has malformed profile binding"
+                )
+            configured_profile = profile_value.strip()
+        else:
+            configured_profile = "default"
+
+        effective_profile = str(request_profile or "default").strip() or "default"
+        if configured_profile != effective_profile:
+            raise WebhookContractError(
+                f"route {route_name!r} is not bound to profile {effective_profile!r}"
+            )
+
+        provider_raw = route.get("provider")
+        if provider_raw is not None and (
+            not isinstance(provider_raw, str) or not provider_raw.strip()
+        ):
+            raise WebhookContractError(
+                f"route {route_name!r} has malformed provider"
+            )
+        signature_raw = route.get("signature_mode")
+        if signature_raw is not None and (
+            not isinstance(signature_raw, str) or not signature_raw.strip()
+        ):
+            raise WebhookContractError(
+                f"route {route_name!r} has malformed signature_mode"
+            )
+
+        provider_declared = bool(provider_raw or signature_raw)
+        if provider_raw:
+            provider = canonical_provider(provider_raw)
+        elif signature_raw:
+            mode = canonical_signature_mode(signature_raw)
+            provider = _SIGNATURE_MODE_TO_PROVIDER[mode]
+        else:
+            provider = infer_legacy_provider(headers)
+
+        spec = PROVIDER_REGISTRY[provider]
+        if signature_raw:
+            signature_mode = canonical_signature_mode(signature_raw)
+            if signature_mode not in spec.signature_modes:
+                raise WebhookContractError(
+                    f"route {route_name!r} provider {provider!r} does not allow "
+                    f"signature mode {signature_mode!r}"
+                )
+        else:
+            signature_mode = spec.default_signature_mode or provider
+
+        events_raw = route.get("events", ())
+        if events_raw in (None, ""):
+            events: tuple[str, ...] = ()
+        elif isinstance(events_raw, (list, tuple, set, frozenset)):
+            events = tuple(
+                value
+                for value in (str(item).strip() for item in events_raw)
+                if value
+            )
+        else:
+            raise WebhookContractError(
+                f"route {route_name!r} events must be a sequence"
+            )
+
+        return cls(
+            name=route_name,
+            profile=configured_profile,
+            provider=provider,
+            provider_declared=provider_declared,
+            signature_mode=signature_mode,
+            enabled=route.get("enabled", True) is not False,
+            events=events,
+        )
+
+    @property
+    def provider_spec(self) -> WebhookProviderSpec:
+        return PROVIDER_REGISTRY[self.provider]
+
+
+@dataclass(frozen=True)
+class WebhookDeliveryIdentity:
+    provider: str
+    value: str
+
+    @property
+    def namespaced(self) -> str:
+        return f"{self.provider}:{self.value}"
+
+
+def resolve_delivery_identity(
+    route: WebhookRouteConfig,
+    headers: Mapping[str, Any],
+    payload: Mapping[str, Any],
+) -> Optional[WebhookDeliveryIdentity]:
+    """Return one provider-native retry identity, never a synthetic timestamp.
+
+    Payload IDs are accepted only for explicitly declared providers. This
+    prevents a generic/legacy route from becoming Stripe or Chatwoot merely
+    because an attacker supplied an ``id`` field with a convenient shape.
+    """
+
+    spec = route.provider_spec
+    for header_name in spec.delivery_id_headers:
+        candidate = _nonempty_scalar(_header(headers, header_name))
+        if candidate is not None:
+            return WebhookDeliveryIdentity(route.provider, candidate)
+
+    if route.provider_declared:
+        for key in spec.payload_delivery_id_keys:
+            candidate = _nonempty_scalar(payload.get(key))
+            if candidate is not None:
+                return WebhookDeliveryIdentity(route.provider, candidate)
+    return None
+
+
+def resolve_event_type(
+    route: WebhookRouteConfig,
+    headers: Mapping[str, Any],
+    payload: Mapping[str, Any],
+) -> str:
+    """Resolve event type from the already-bound provider namespace."""
+
+    for header_name in route.provider_spec.event_headers:
+        value = _nonempty_scalar(_header(headers, header_name))
+        if value is not None:
+            return value
+    for key in ("event_type", "type"):
+        value = _nonempty_scalar(payload.get(key))
+        if value is not None:
+            return value
+    return "unknown"
+
+
+def _freeze_json(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {str(key): _freeze_json(item) for key, item in value.items()}
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_json(item) for item in value)
+    return value
+
+
+@dataclass(frozen=True)
+class WebhookAuthProvenance:
+    provider: str
+    signature_mode: str
+    provider_declared: bool
+
+    @property
+    def compatibility_inferred(self) -> bool:
+        return not self.provider_declared
+
+
+@dataclass(frozen=True)
+class WebhookEnvelope:
+    """Immutable domain object handed across the HTTP intake boundary."""
+
+    route: WebhookRouteConfig
+    auth: WebhookAuthProvenance
+    event_type: str
+    delivery_identity: Optional[WebhookDeliveryIdentity]
+    trace_id: str
+    body_sha256: str
+    payload: Mapping[str, Any]
+
+    @classmethod
+    def build(
+        cls,
+        route: WebhookRouteConfig,
+        *,
+        headers: Mapping[str, Any],
+        payload: Mapping[str, Any],
+        raw_body: bytes,
+        trace_id: Optional[str] = None,
+    ) -> "WebhookEnvelope":
+        if not isinstance(raw_body, (bytes, bytearray)):
+            raise WebhookContractError("raw_body must be bytes")
+        if not isinstance(payload, Mapping):
+            raise WebhookContractError("webhook payload must be an object")
+
+        delivery_identity = resolve_delivery_identity(route, headers, payload)
+        event_type = resolve_event_type(route, headers, payload)
+        trace = _nonempty_scalar(trace_id) or str(uuid.uuid4())
+        return cls(
+            route=route,
+            auth=WebhookAuthProvenance(
+                provider=route.provider,
+                signature_mode=route.signature_mode,
+                provider_declared=route.provider_declared,
+            ),
+            event_type=event_type,
+            delivery_identity=delivery_identity,
+            trace_id=trace,
+            body_sha256=hashlib.sha256(bytes(raw_body)).hexdigest(),
+            payload=_freeze_json(payload),
+        )
+
+    @property
+    def session_identity(self) -> str:
+        """Stable provider ID when available, otherwise this request's trace."""
+
+        if self.delivery_identity is not None:
+            return self.delivery_identity.value
+        return self.trace_id
+
+    @property
+    def idempotency_key(self) -> Optional[str]:
+        """Profile/route/provider-scoped key, or None when dedupe is unsafe."""
+
+        if self.delivery_identity is None:
+            return None
+        return ":".join(
+            (
+                self.route.profile,
+                self.route.name,
+                self.delivery_identity.provider,
+                self.delivery_identity.value,
+            )
+        )

--- a/tests/gateway/test_webhook_contract.py
+++ b/tests/gateway/test_webhook_contract.py
@@ -1,0 +1,294 @@
+"""Contract tests for canonical webhook provider/identity/envelope authority."""
+
+import hashlib
+from types import MappingProxyType
+
+import pytest
+
+from gateway.platforms.webhook_contract import (
+    PROVIDER_REGISTRY,
+    WebhookContractError,
+    WebhookEnvelope,
+    WebhookRouteConfig,
+    canonical_provider,
+    canonical_signature_mode,
+    infer_legacy_provider,
+    resolve_delivery_identity,
+    resolve_event_type,
+)
+
+
+def bind(route=None, headers=None, *, profile=None):
+    return WebhookRouteConfig.bind(
+        "events",
+        route or {},
+        headers=headers or {},
+        request_profile=profile,
+    )
+
+
+def test_registry_is_read_only_and_has_expected_namespaces():
+    assert isinstance(PROVIDER_REGISTRY, MappingProxyType)
+    assert {
+        "github",
+        "gitlab",
+        "svix",
+        "standard_webhooks",
+        "chatwoot",
+        "linear",
+        "hindsight",
+        "stripe",
+        "generic",
+    } <= set(PROVIDER_REGISTRY)
+    with pytest.raises(TypeError):
+        PROVIDER_REGISTRY["evil"] = PROVIDER_REGISTRY["generic"]  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("agentmail", "svix"),
+        ("github-hmac-sha256", "github"),
+        ("gitlab_token", "gitlab"),
+        ("gitlab-standard", "standard_webhooks"),
+        ("generic_v1", "generic"),
+        ("generic-v2", "generic"),
+        ("hindsight_hmac_sha256", "hindsight"),
+    ],
+)
+def test_provider_aliases_canonicalize(configured, expected):
+    assert canonical_provider(configured) == expected
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("github", "github"),
+        ("gitlab-token", "gitlab_token"),
+        ("generic-v2", "generic_v2"),
+        ("gitlab_standard", "gitlab_standard"),
+    ],
+)
+def test_signature_modes_canonicalize(configured, expected):
+    assert canonical_signature_mode(configured) == expected
+
+
+def test_unknown_explicit_provider_fails_closed():
+    with pytest.raises(WebhookContractError, match="unsupported webhook provider"):
+        bind({"provider": "made-up"})
+
+
+def test_unknown_explicit_signature_mode_fails_closed():
+    with pytest.raises(WebhookContractError, match="unsupported webhook signature mode"):
+        bind({"signature_mode": "made-up"})
+
+
+def test_provider_and_verifier_mode_cannot_disagree():
+    with pytest.raises(WebhookContractError, match="does not allow signature mode"):
+        bind({"provider": "github", "signature_mode": "svix"})
+
+
+def test_provider_can_use_registered_generic_verifier_when_contract_allows_it():
+    route = bind({"provider": "chatwoot", "signature_mode": "generic_v2"})
+    assert route.provider == "chatwoot"
+    assert route.signature_mode == "generic_v2"
+
+
+def test_explicit_provider_cannot_be_reselected_by_attacker_headers():
+    route = bind(
+        {"provider": "github"},
+        {
+            "svix-id": "msg_attacker",
+            "svix-signature": "v1,attacker",
+            "X-GitHub-Delivery": "gh_123",
+        },
+    )
+    assert route.provider == "github"
+    assert route.provider_declared is True
+    identity = resolve_delivery_identity(
+        route,
+        {
+            "svix-id": "msg_attacker",
+            "X-GitHub-Delivery": "gh_123",
+        },
+        {},
+    )
+    assert identity is not None
+    assert identity.provider == "github"
+    assert identity.value == "gh_123"
+
+
+def test_explicit_generic_route_ignores_github_event_header():
+    route = bind({"provider": "generic"})
+    assert (
+        resolve_event_type(
+            route,
+            {"X-GitHub-Event": "push"},
+            {"event_type": "generic.tick"},
+        )
+        == "generic.tick"
+    )
+
+
+def test_legacy_inference_happens_once_with_specific_provider_precedence():
+    headers = {
+        "svix-id": "msg_1",
+        "X-Hub-Signature-256": "sha256=also-present",
+        "X-Request-ID": "generic-id",
+    }
+    assert infer_legacy_provider(headers) == "svix"
+    route = bind({}, headers)
+    assert route.provider == "svix"
+    assert route.provider_declared is False
+    identity = resolve_delivery_identity(
+        route,
+        {"X-GitHub-Delivery": "gh_2", "svix-id": "msg_1"},
+        {},
+    )
+    assert identity is not None
+    assert identity.provider == "svix"
+    assert identity.value == "msg_1"
+
+
+def test_signature_mode_can_bind_provider_namespace():
+    route = bind({"signature_mode": "generic_v2"})
+    assert route.provider == "generic"
+    assert route.signature_mode == "generic_v2"
+    assert route.provider_declared is True
+
+
+def test_gitlab_uses_provider_native_identity_order():
+    route = bind({"provider": "gitlab"})
+    identity = resolve_delivery_identity(
+        route,
+        {
+            "Idempotency-Key": "fallback",
+            "X-Gitlab-Webhook-UUID": "webhook-uuid",
+            "X-Gitlab-Event-UUID": "event-uuid",
+        },
+        {},
+    )
+    assert identity is not None
+    assert identity.value == "event-uuid"
+
+
+def test_no_stable_provider_id_means_no_idempotency_authority():
+    route = bind({"provider": "generic"})
+    envelope = WebhookEnvelope.build(
+        route,
+        headers={"X-Webhook-Signature-V2": "sig"},
+        payload={"type": "tick"},
+        raw_body=b'{"type":"tick"}',
+        trace_id="trace-1",
+    )
+    assert envelope.delivery_identity is None
+    assert envelope.idempotency_key is None
+    assert envelope.session_identity == "trace-1"
+
+
+def test_timestamp_headers_are_never_delivery_identity():
+    route = bind({"provider": "svix"})
+    envelope = WebhookEnvelope.build(
+        route,
+        headers={"svix-timestamp": "1787248000"},
+        payload={},
+        raw_body=b"{}",
+        trace_id="trace-2",
+    )
+    assert envelope.delivery_identity is None
+    assert envelope.idempotency_key is None
+    assert envelope.session_identity == "trace-2"
+
+
+@pytest.mark.parametrize("provider", ["stripe", "chatwoot"])
+def test_payload_id_is_accepted_only_for_explicit_provider(provider):
+    explicit = bind({"provider": provider})
+    identity = resolve_delivery_identity(explicit, {}, {"id": "evt_123"})
+    assert identity is not None
+    assert identity.provider == provider
+    assert identity.value == "evt_123"
+
+    legacy = bind({}, {})
+    assert legacy.provider_declared is False
+    assert resolve_delivery_identity(legacy, {}, {"id": "evt_123"}) is None
+
+
+def test_idempotency_key_is_profile_route_provider_scoped():
+    route = WebhookRouteConfig.bind(
+        "deploy",
+        {"profile": "ops", "provider": "github"},
+        headers={},
+        request_profile="ops",
+    )
+    envelope = WebhookEnvelope.build(
+        route,
+        headers={"X-GitHub-Delivery": "abc"},
+        payload={},
+        raw_body=b"{}",
+        trace_id="trace-3",
+    )
+    assert envelope.idempotency_key == "ops:deploy:github:abc"
+
+
+def test_route_profile_mismatch_fails_closed():
+    with pytest.raises(WebhookContractError, match="not bound to profile"):
+        WebhookRouteConfig.bind(
+            "deploy",
+            {"profile": "ops", "provider": "github"},
+            headers={},
+            request_profile="default",
+        )
+
+
+def test_envelope_captures_body_hash_and_auth_provenance():
+    raw_body = b'{"action":"opened"}'
+    route = bind({"provider": "github", "signature_mode": "github"})
+    envelope = WebhookEnvelope.build(
+        route,
+        headers={
+            "X-GitHub-Delivery": "delivery-1",
+            "X-GitHub-Event": "pull_request",
+        },
+        payload={"action": "opened"},
+        raw_body=raw_body,
+        trace_id="trace-4",
+    )
+    assert envelope.event_type == "pull_request"
+    assert envelope.auth.provider == "github"
+    assert envelope.auth.signature_mode == "github"
+    assert envelope.auth.compatibility_inferred is False
+    assert envelope.body_sha256 == hashlib.sha256(raw_body).hexdigest()
+
+
+def test_envelope_payload_is_recursively_immutable():
+    payload = {"outer": {"items": [1, {"x": 2}]}}
+    envelope = WebhookEnvelope.build(
+        bind({"provider": "generic"}),
+        headers={},
+        payload=payload,
+        raw_body=b"{}",
+        trace_id="trace-5",
+    )
+    with pytest.raises(TypeError):
+        envelope.payload["new"] = 1  # type: ignore[index]
+    with pytest.raises(TypeError):
+        envelope.payload["outer"]["new"] = 1  # type: ignore[index]
+    assert envelope.payload["outer"]["items"][1]["x"] == 2
+
+
+def test_mutating_source_payload_after_build_does_not_mutate_envelope():
+    payload = {"nested": {"value": "original"}}
+    envelope = WebhookEnvelope.build(
+        bind({"provider": "generic"}),
+        headers={},
+        payload=payload,
+        raw_body=b"{}",
+        trace_id="trace-6",
+    )
+    payload["nested"]["value"] = "changed"
+    assert envelope.payload["nested"]["value"] == "original"
+
+
+def test_malformed_route_events_are_rejected():
+    with pytest.raises(WebhookContractError, match="events must be a sequence"):
+        bind({"provider": "github", "events": "push"})


### PR DESCRIPTION
Refs #90989.

## Purpose

This is the first implementation slice of the webhook surface-convergence issue. It creates the domain authority that the existing webhook campaign lanes can compose onto instead of continuing to derive provider, delivery identity, event identity, and intake provenance independently.

## Exact topology

- base: `5e32e3aecd2070e8245d9ae2c9ee257f547fcb71`
- head: `a9af5efcfeb6d81ae7be04421c7fcc8e872440fa`
- tree: `f174a69ead1a509be956207581eaccf927fe6665`
- one commit
- two files
- no campaign receipts, contributor churn, UI/router spillover, or `webhook.py` god-file rewrite

The branch was rebuilt after `main` advanced during PR creation. The current head overlays only the two webhook-authority blobs onto the exact new main tree; no intervening upstream files are dropped.

## What this establishes

### Canonical provider registry

`gateway/platforms/webhook_contract.py` owns provider namespaces and the wire facts required by intake: aliases, provider-native delivery-ID headers, event headers, compatibility-detection headers, payload identity keys, allowed verifier modes, and default verifier mode.

Provider identity and cryptographic verifier identity are related but deliberately not conflated. For example, an explicitly declared Chatwoot route can remain in the `chatwoot` provider namespace while using a registered generic HMAC verifier. Impossible provider/verifier combinations fail closed.

### One route/provider binding decision

`WebhookRouteConfig.bind()` normalizes profile, provider, signature mode, enabled state, and event allowlist once. Explicit route authority cannot subsequently be replaced by attacker-controlled request headers.

Undeclared historical routes retain one explicit compatibility bridge (`infer_legacy_provider`) so migration can be staged without silently breaking existing installs. The compatibility result is recorded as provenance and is not a downstream authorization mechanism.

### Provider-native retry identity

`resolve_delivery_identity()` consumes only the already-bound provider namespace:

- GitHub: `X-GitHub-Delivery`
- Svix: `svix-id`
- GitLab: event/webhook/idempotency UUID headers
- Standard Webhooks: `webhook-id` / `Idempotency-Key`
- Chatwoot: declared delivery header, then declared payload ID
- Stripe: declared payload ID
- generic: `X-Request-ID`

There is **no timestamp fallback**. If no stable provider identity exists, deduplication authority is absent and the envelope receives a unique trace/session identity instead.

Payload `id` is accepted only for explicitly declared providers, so an attacker cannot turn an undeclared/generic route into Stripe or Chatwoot by shaping the JSON body.

### Immutable intake envelope

`WebhookEnvelope` carries the facts that downstream execution should consume exactly once:

- normalized route/profile
- provider + verifier/auth provenance
- provider-scoped event type
- stable delivery identity when one exists
- unique trace identity
- SHA-256 of the exact raw body
- recursively immutable payload
- profile/route/provider-scoped idempotency key

This creates the intended HTTP/domain boundary: later composition can move from `aiohttp.Request` to `WebhookEnvelope` without re-deriving security or identity facts.

## Focused verification surface

`tests/gateway/test_webhook_contract.py` covers immutable registry behavior, alias normalization, unknown provider/verifier rejection, provider/verifier disagreement, valid provider + generic-verifier composition, attacker-header resistance, provider-scoped event extraction, bounded legacy inference, provider-native identity precedence, absence of dedupe authority without a stable ID, timestamp non-identity, explicit-only payload IDs, scoped idempotency keys, profile mismatch, raw-body provenance, and recursive envelope immutability.

Fresh hosted CI/Docker/Nix is required on `a9af5efc...`; no sibling or historical green is inherited.

## Composition boundary

This PR intentionally does **not** rewrite the current `WebhookAdapter` handler yet. Doing that before the current Task 10/auth/session candidates converge would recreate the same multi-owner conflict #90989 is intended to eliminate.

- #90236 remains the canonical executable Task 10 intake/idempotency/raw-body owner.
- #85318 remains the exact-head-green explicit signature-verifier authority.
- #90304 owns session/interaction policy.
- #85640 remains the sole terminal integration owner.

The next convergence slice should wire current intake/auth onto this contract, preserving #90236's body-hash/idempotency semantics and consuming #85318's verifier rather than copying either implementation again.