### PR TITLE
fix(telegram): warn when base_file_url falls back to base_url

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -20,7 +20,7 @@ import threading
 import time
 from contextvars import ContextVar
 from datetime import datetime, timezone
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
+from typing import Any, Awaitable, Callable, Dict, List, Mapping, Optional, Set
 
 logger = logging.getLogger(__name__)
 
@@ -461,6 +461,48 @@ def check_telegram_requirements() -> bool:
     TypeHandler = _TH
     TELEGRAM_AVAILABLE = True
     return True
+
+
+def _resolve_telegram_file_url(extra: Mapping[str, Any]) -> tuple:
+    """Resolve the PTB ``base_file_url`` from platform ``extra`` config.
+
+    python-telegram-bot builds media download URLs as
+    ``<base_file_url><token>/<file_path>``. When a custom ``base_url`` is
+    configured (reverse proxy in front of api.telegram.org, local
+    telegram-bot-api server, ...) and ``base_file_url`` is not set, the
+    adapter falls back to ``base_url`` — which ends in ``/bot`` and is the
+    *API method* endpoint, not the *file* endpoint. Every media download
+    (voice note, audio, photo, document) then hits a bogus API method and
+    fails with HTTP 404, which PTB surfaces as
+    ``telegram.error.InvalidToken`` (the gateway logs
+    ``Failed to cache voice: Not Found``).
+
+    Returns ``(resolved_url, warning)`` where ``warning`` is a human-readable
+    hint (or ``None`` when the resolved URL looks correct).
+    """
+    custom_base_url = extra.get("base_url")
+    base_file_url = extra.get("base_file_url", custom_base_url)
+    if not custom_base_url:
+        # PTB defaults (https://api.telegram.org/bot + /file/bot) apply.
+        return base_file_url or "", None
+    if base_file_url == custom_base_url:
+        suggested = str(custom_base_url).removesuffix("/bot") + "/file/bot"
+        warning = (
+            "base_file_url resolves to base_url "
+            f"({base_file_url!r}); media downloads will fail with "
+            "'InvalidToken: Not Found' because file URLs are built as "
+            "<base_file_url><token>/<path>. Set telegram.extra.base_file_url "
+            f"to the file endpoint, e.g. {suggested!r}."
+        )
+        return base_file_url, warning
+    if "/file/" not in base_file_url:
+        warning = (
+            "base_file_url "
+            f"({base_file_url!r}) does not look like a file endpoint "
+            "(no '/file/' segment); media downloads may fail."
+        )
+        return base_file_url, warning
+    return base_file_url, None
 
 
 # Matches every character that MarkdownV2 requires to be backslash-escaped
@@ -4297,9 +4339,13 @@ class TelegramAdapter(BasePlatformAdapter):
             custom_base_url = self.config.extra.get("base_url")
             if custom_base_url:
                 builder = builder.base_url(custom_base_url)
-                builder = builder.base_file_url(
-                    self.config.extra.get("base_file_url", custom_base_url)
+                base_file_url, file_url_warning = _resolve_telegram_file_url(
+                    self.config.extra
                 )
+                if base_file_url:
+                    builder = builder.base_file_url(base_file_url)
+                if file_url_warning:
+                    logger.warning("[%s] %s", self.name, file_url_warning)
                 logger.info(
                     "[%s] Using custom Telegram base_url: %s",
                     self.name, custom_base_url,

--- a/tests/gateway/platforms/test_telegram_base_file_url.py
+++ b/tests/gateway/platforms/test_telegram_base_file_url.py
@@ -1,0 +1,76 @@
+"""Tests for ``_resolve_telegram_file_url`` in the Telegram platform adapter.
+
+python-telegram-bot builds media download URLs as
+``<base_file_url><token>/<file_path>``. When a custom ``base_url`` is set
+(reverse proxy in front of api.telegram.org, local telegram-bot-api server)
+but ``base_file_url`` is missing — or was explicitly copied from ``base_url``
+— the resolved URL ends in ``/bot`` and is the *API method* endpoint, not the
+*file* endpoint. Every media download (voice note, audio, photo, document)
+then hits a bogus API method, gets HTTP 404, and PTB raises
+``telegram.error.InvalidToken`` ("Failed to cache voice: Not Found").
+
+These tests pin the resolution + warning behavior for both broken
+situations, the correct /file/ configuration, and the PTB-defaults path.
+"""
+
+import pytest
+
+from plugins.platforms.telegram.adapter import _resolve_telegram_file_url
+
+
+@pytest.mark.parametrize(
+    ("extra", "expected_url", "expect_warning"),
+    [
+        # No custom base_url → PTB defaults apply, no warning.
+        ({}, "", False),
+        # Only base_url set → falls back to base_url (/bot), must warn.
+        ({"base_url": "https://tg.example.com/bot"}, "https://tg.example.com/bot", True),
+        # base_file_url explicitly copied from base_url → same broken URL, warn.
+        (
+            {
+                "base_url": "https://tg.example.com/bot",
+                "base_file_url": "https://tg.example.com/bot",
+            },
+            "https://tg.example.com/bot",
+            True,
+        ),
+        # Correct file endpoint → no warning.
+        (
+            {
+                "base_url": "https://tg.example.com/bot",
+                "base_file_url": "https://tg.example.com/file/bot",
+            },
+            "https://tg.example.com/file/bot",
+            False,
+        ),
+        # Local telegram-bot-api server (docs example) → no warning.
+        (
+            {
+                "base_url": "http://127.0.0.1:8081/bot",
+                "base_file_url": "http://127.0.0.1:8081/file/bot",
+            },
+            "http://127.0.0.1:8081/file/bot",
+            False,
+        ),
+        # Suspicious suffix without a /file/ segment → soft warning.
+        (
+            {
+                "base_url": "https://tg.example.com/bot",
+                "base_file_url": "https://cdn.example.com/downloads",
+            },
+            "https://cdn.example.com/downloads",
+            True,
+        ),
+    ],
+)
+def test_resolve_telegram_file_url(extra, expected_url, expect_warning):
+    url, warning = _resolve_telegram_file_url(extra)
+    assert url == expected_url
+    assert (warning is not None) is expect_warning
+
+
+def test_warning_suggests_file_endpoint():
+    """The warning must point at the correct /file/bot URL for a /bot base_url."""
+    _, warning = _resolve_telegram_file_url({"base_url": "https://tg2.rmg7.com/bot"})
+    assert warning is not None
+    assert "https://tg2.rmg7.com/file/bot" in warning

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -325,6 +325,20 @@ The proxy applies to both the main Telegram connection and the fallback IP trans
 
 If the fallback IP discovery path is unhealthy on your host, set `HERMES_TELEGRAM_DISABLE_FALLBACK_IPS=true` to keep cold connect on the plain `api.telegram.org` path. You can also bound DNS-over-HTTPS fallback discovery with `HERMES_TELEGRAM_FALLBACK_DISCOVERY_TIMEOUT` in seconds; the default is `5`.
 
+## Custom API Endpoint (Reverse Proxy)
+
+If you front the Telegram Bot API with your own reverse proxy (to bypass an API block, add auth, or pin a local `telegram-bot-api` daemon), point Hermes at it with `base_url` and **also** set `base_file_url` to the proxy's *file* endpoint:
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      base_url: "https://tg.example.com/bot"
+      base_file_url: "https://tg.example.com/file/bot"
+```
+
+The two endpoints are different: API methods live under `/bot<TOKEN>/<METHOD>`, file downloads under `/file/bot<TOKEN>/<path>`. If `base_file_url` is omitted — or copied from `base_url` — Hermes reuses the `/bot` URL for downloads, every media download (voice notes, audio, photos, documents) then fails with `telegram.error.InvalidToken: Not Found`, and the gateway logs `Failed to cache voice: Not Found`. Point `base_file_url` at the `/file/` endpoint; the gateway logs a startup warning when the resolved value looks wrong.
+
 ## Home Channel
 
 Use the `/sethome` command in any Telegram chat (DM or group) to designate it as the **home channel**. Scheduled tasks (cron jobs) deliver their results to this channel.


### PR DESCRIPTION
## Problem

When a custom Telegram Bot API endpoint is configured via `telegram.extra.base_url` (a reverse proxy in front of `api.telegram.org`, or a local `telegram-bot-api` server) and `base_file_url` is **not** set, the adapter silently reuses `base_url` for media downloads:

```python
builder = builder.base_file_url(
    self.config.extra.get("base_file_url", custom_base_url)
)
```

python-telegram-bot builds file download URLs as `<base_file_url><token>/<file_path>`. Since `base_url` ends with `/bot` (the *API method* endpoint), every download becomes `https://host/bot<TOKEN>/voice/file_1.ogg` — the proxy forwards it as a non-existent API method, api.telegram.org answers HTTP 404, and PTB raises `telegram.error.InvalidToken: Not Found`. The gateway logs `[Telegram] Failed to cache voice: Not Found` and the user's voice note/audio/photo/document silently becomes an empty turn.

Both of these situations produce the same broken URL:
- `base_file_url` missing → fallback to `base_url`
- `base_file_url` explicitly copied from `base_url` (e.g. `https://customtg.mydomain.com/bot`)

The correct value is the `/file/` endpoint: `https://host/file/bot`.

## Changes

- **adapter.py**: resolve the file URL through a new `_resolve_telegram_file_url()` helper and log a **startup warning** when the resolved value falls back to `base_url` (or lacks a `/file/` segment), suggesting the correct `/file/bot` endpoint. Warning only — existing correct configs (e.g. the documented local `telegram-bot-api` setup with `base_file_url: http://127.0.0.1:8081/file/bot`) are untouched.
- **tests/gateway/platforms/test_telegram_base_file_url.py**: parametrized coverage of the PTB-defaults path, the missing-key fallback, the explicit-copy case, the correct `/file/bot` endpoint, the local `telegram-bot-api` docs example, and a suspicious URL without a `/file/` segment.
- **website/docs/user-guide/messaging/telegram.md**: new "Custom API Endpoint (Reverse Proxy)" section documenting `base_url` + `base_file_url` and the `/bot` vs `/file/bot` distinction.

## Verification

- `pytest tests/gateway/platforms/test_telegram_base_file_url.py` → 7 passed
- `ruff check plugins/platforms/telegram/adapter.py tests/gateway/platforms/test_telegram_base_file_url.py` → all checks passed

Related: #55698 (same `InvalidToken: method not found` failure mode for media caching).
