### PR TITLE
fix(slack): generate agent manifests for new apps by default

### DIFF
--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -42,18 +42,18 @@ def _build_full_manifest(
     for a Hermes deployment — users can tweak them in the Slack UI after
     pasting.
 
-    By default, this keeps Hermes on Slack's older Assistant messaging
-    experience (``assistant_view``) for backward compatibility. Pass
-    ``messaging_experience="agent"`` (``--agent-view``) to emit Slack's Agent
-    messaging experience (``agent_view`` + ``app_home_opened``). Pass
-    ``include_assistant=False`` or ``messaging_experience="none"``
+    By default, this emits Slack's Agent messaging experience (``agent_view``).
+    Pass ``messaging_experience="assistant"`` (``--assistant-view``) only when
+    updating an existing app that still uses the older Assistant messaging
+    experience. Pass ``include_assistant=False`` or
+    ``messaging_experience="none"``
     (``--no-assistant``) to omit Slack AI messaging features and get a flat DM
     surface where ``/help``, ``/new``, etc. work inline.
     """
     from hermes_cli.commands import slack_app_manifest
 
     if messaging_experience is None:
-        messaging_experience = "assistant" if include_assistant else "none"
+        messaging_experience = "agent" if include_assistant else "none"
     messaging_experience = str(messaging_experience).strip().lower()
     if messaging_experience not in {"assistant", "agent", "none"}:
         raise ValueError(
@@ -118,13 +118,17 @@ def _build_full_manifest(
         )
     elif messaging_experience == "agent":
         features["agent_view"] = {
-            "agent_description": "Chat with Hermes in Slack Messages.",
+            "agent_description": (
+                bot_description or "Your Hermes agent on Slack"
+            )[:300],
         }
         bot_scopes.append("assistant:write")
         # Slack includes current viewing context in Agent DM events only after
         # this subscription is enabled; the adapter consumes that context to
         # preserve the referred channel across the agent turn.
-        bot_events.extend(["app_context_changed", "app_home_opened"])
+        bot_events.extend(
+            ["agent_session_stopped", "app_context_changed", "app_home_opened"]
+        )
 
     bot_scopes.sort()
     bot_events.sort()
@@ -179,9 +183,11 @@ def slack_manifest_command(args) -> int:
                       assistant:write scope, assistant_thread_* events) so
                       DMs render as a flat chat where bare slash commands
                       work inline instead of the Assistant thread pane.
-      --agent-view    Use Slack's Agent messaging experience (agent_view,
-                      app_home_opened + message.im) instead of the legacy
-                      Assistant messaging experience.
+      --agent-view    Explicitly use the default Agent messaging experience.
+      --assistant-view
+                      Keep an existing app on the legacy Assistant messaging
+                      experience while preparing for its February 2027
+                      deprecation.
     """
     name = getattr(args, "name", None) or "Hermes"
     description = getattr(args, "description", None) or "Your Hermes agent on Slack"
@@ -231,12 +237,12 @@ def slack_manifest_command(args) -> int:
             file=sys.stderr,
         )
         return 2
-    if getattr(args, "agent_view", False):
-        messaging_experience = "agent"
+    if getattr(args, "assistant_view", False):
+        messaging_experience = "assistant"
     elif getattr(args, "no_assistant", False):
         messaging_experience = "none"
     else:
-        messaging_experience = "assistant"
+        messaging_experience = "agent"
 
     if getattr(args, "slashes_only", False):
         from hermes_cli.commands import slack_app_manifest
@@ -249,6 +255,14 @@ def slack_manifest_command(args) -> int:
             messaging_experience=messaging_experience,
             long_description=long_description,
         )
+        if messaging_experience == "assistant":
+            print(
+                "Note: --assistant-view is only for existing assistant_view "
+                "apps. Slack plans to deprecate the Assistant messaging "
+                "experience in February 2027; new apps should use the default "
+                "agent_view.",
+                file=sys.stderr,
+            )
 
     payload = json.dumps(manifest, indent=2, ensure_ascii=False) + "\n"
 

--- a/hermes_cli/subcommands/slack.py
+++ b/hermes_cli/subcommands/slack.py
@@ -85,9 +85,14 @@ def build_slack_parser(subparsers, *, cmd_slack: Callable) -> None:
     slack_messaging.add_argument(
         "--agent-view",
         action="store_true",
-        help="Emit Slack's Agent messaging experience (agent_view, "
-        "app_home_opened + message.im) instead of the legacy assistant_view "
-        "experience. This changes Slack's app messaging surface and cannot "
-        "be reversed in Slack after applying the manifest.",
+        help="Explicitly emit Slack's default Agent messaging experience "
+        "(agent_view, app_home_opened + message.im).",
+    )
+    slack_messaging.add_argument(
+        "--assistant-view",
+        action="store_true",
+        help="Emit the legacy Assistant messaging experience for an existing "
+        "assistant_view app. Slack plans to deprecate it in February 2027; "
+        "new apps should use the default Agent experience.",
     )
     slack_parser.set_defaults(func=cmd_slack)

--- a/tests/hermes_cli/test_slack_cli.py
+++ b/tests/hermes_cli/test_slack_cli.py
@@ -75,6 +75,18 @@ class TestSlackManifestConsoleExitStatus:
 class TestSlackManifestArgparse:
     """Slack manifest messaging-experience flags wire through argparse."""
 
+    def test_assistant_view_is_an_explicit_compatibility_mode(self, capsys):
+        args = _parse_slack_args(["slack", "manifest", "--assistant-view"])
+
+        assert slack_manifest_command(args) == 0
+
+        captured = capsys.readouterr()
+        manifest = json.loads(captured.out)
+        assert "assistant_view" in manifest["features"]
+        assert "agent_view" not in manifest["features"]
+        assert "February 2027" in captured.err
+        assert "existing assistant_view apps" in captured.err
+
 
 
 
@@ -121,14 +133,24 @@ class TestSlackFullManifest:
 
 
 
-    def test_assistant_features_remain_enabled(self):
-        manifest = _build_full_manifest("Hermes", "Your Hermes agent on Slack")
+    def test_agent_features_are_enabled_by_default(self):
+        manifest = _build_full_manifest("Hermes", "A workspace-specific agent")
 
-        assert "assistant_view" in manifest["features"]
-        assert "agent_view" not in manifest["features"]
+        assert "agent_view" in manifest["features"]
+        assert "assistant_view" not in manifest["features"]
+        assert (
+            manifest["features"]["agent_view"]["agent_description"]
+            == "A workspace-specific agent"
+        )
         assert "assistant:write" in manifest["oauth_config"]["scopes"]["bot"]
         bot_events = manifest["settings"]["event_subscriptions"]["bot_events"]
-        assert "assistant_thread_started" in bot_events
+        for event in ("app_context_changed", "app_home_opened", "agent_session_stopped"):
+            assert event in bot_events
+
+    def test_agent_description_respects_slack_limit(self):
+        manifest = _build_full_manifest("Hermes", "x" * 301)
+
+        assert manifest["features"]["agent_view"]["agent_description"] == "x" * 300
 
 
 


### PR DESCRIPTION
## What does this PR do?

`hermes slack manifest` now generates Slack's Agent messaging experience by default, so manifests for new Slack apps use `agent_view` instead of the legacy `assistant_view` that Slack no longer accepts for new apps. Existing Assistant apps can still opt into their current surface explicitly while they prepare for Slack's February 2027 deprecation.

### Symptom

Running `hermes slack manifest` without messaging flags emitted `features.assistant_view` and Assistant thread events. A user creating a new Slack app therefore received a manifest built around a messaging experience that Slack no longer permits for new apps.

### Impact

New Hermes Slack app setup could not use the generated default manifest as intended. Existing apps also need an explicit compatibility path so updating their manifests does not silently switch messaging experiences.

### Bug Cause

**Trigger:** `hermes_cli/slack_cli.py` in `_build_full_manifest()` and `slack_manifest_command()` when no messaging-experience flag is supplied.

**Causal chain:**
1. A user runs `hermes slack manifest` with the default options.
2. Both default-selection paths resolve the unspecified experience to `assistant`.
3. The generator emits `assistant_view` and legacy Assistant events, which are unsuitable for a newly created Slack app.

**Why it is wrong:** The CLI default retained Slack's legacy Assistant surface after Slack moved new apps to Agent messaging.

**Working sibling / contrast:** The existing explicit Agent branch already emitted `agent_view`, and the Slack adapter already consumes Agent context and app-home events. The failure was limited to selection and manifest composition.

**Ruled out:** This is not a missing Agent runtime route. The existing adapter already handles `app_home_opened` and `app_context_changed`; changing runtime dispatch is outside this fix.

### Fix

The manifest helper and real CLI now select Agent messaging by default. Agent manifests derive `agent_description` from the configured description within Slack's 300-character limit and subscribe to `agent_session_stopped`, `app_context_changed`, and `app_home_opened`. A new mutually exclusive `--assistant-view` flag preserves legacy manifests for existing apps and prints a deprecation notice; `--agent-view` and `--no-assistant` remain supported.

## Related Issue

Closes #90979

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/slack_cli.py` - default to Agent messaging, complete Agent manifest fields, and preserve explicit Assistant compatibility with a deprecation notice.
- `hermes_cli/subcommands/slack.py` - expose the mutually exclusive `--assistant-view` compatibility flag and describe Agent messaging as the default.
- `tests/hermes_cli/test_slack_cli.py` - cover default Agent output, description limits, Agent events, and explicit Assistant compatibility.

## How to Test

1. Run `hermes slack manifest` and confirm `features.agent_view` is present while `features.assistant_view` is absent.
2. Run `hermes slack manifest --assistant-view` and confirm the legacy feature remains available and the February 2027 notice is written to stderr.
3. Run the focused automated tests (already run locally, 9 passed):

```bash
scripts/run_tests.sh tests/hermes_cli/test_slack_cli.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant test file and all 9 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; CLI help and inline command documentation were updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - the change is platform-independent manifest formatting
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model tool changed
