### PR TITLE
tests: assert the fixture secret source is registered, not that it is alone

### DIFF
--- a/tests/hermes_cli/test_secret_source_bootstrap.py
+++ b/tests/hermes_cli/test_secret_source_bootstrap.py
@@ -247,8 +247,8 @@ def test_real_plugin_source_discovery_applies_dotenv(monkeypatch, tmp_path):
         PluginManager().discover_and_load()
 
         assert os.environ["HERMES_TEST_PLUGIN_BOOTSTRAP"] == "from-plugin"
-        assert [source.name for source in reg.list_plugin_sources()] == [
-            "fixturevault"
+        assert "fixturevault" in [
+            source.name for source in reg.list_plugin_sources()
         ]
     finally:
         os.environ.pop("HERMES_TEST_PLUGIN_BOOTSTRAP", None)


### PR DESCRIPTION
`tests/hermes_cli/test_secret_source_bootstrap.py::test_real_plugin_source_discovery_applies_dotenv` asserts the plugin secret-source registry equals `["fixturevault"]` exactly:

```python
assert [source.name for source in reg.list_plugin_sources()] == ["fixturevault"]
```

That holds only as long as no bundled plugin registers a secret source of its own.

`PluginManager._discover_and_load_inner` loads any manifest with `source == "bundled"` and `kind == "backend"` unconditionally, before the `plugins.enabled` gate — bundled backends "ship with hermes and must just work". The test runs a real `discover_and_load()` against a temp `HERMES_HOME`, so bundled plugins are in scope. The moment a build ships a bundled backend whose `register()` calls `ctx.register_secret_source()`, this test fails on the extra name:

```
E  AssertionError: assert ['somesource', 'fixturevault'] == ['fixturevault']
```

Nothing under test broke: the fixture plugin was discovered, its source registered, and `HERMES_TEST_PLUGIN_BOOTSTRAP` applied to the environment. The failure is the exact-list shape of one assertion.

This changes that assertion to membership. The other two assertions in the test are untouched, and they are the ones that pin the behaviour the test is named for. No production code changes.

Reported from a downstream distribution that ships a bundled backend, but the defect is not specific to it — any bundled plugin registering a secret source hits it.
