### PR TITLE
fix(agent): apply CustomProfile to named local Ollama providers

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1821,6 +1821,38 @@ def interruptible_api_call(agent, api_kwargs: dict):
     return result["response"]
 
 
+def _resolve_chat_provider_profile(agent):
+    """Return the registered profile, or CustomProfile for unnamed local Ollama.
+
+    Named local endpoints (``ollama-launch``, user-defined keys) are not in
+    the provider registry, so they otherwise skip CustomProfile's max_tokens
+    floor, reasoning_effort, num_ctx, and Qwen 3.8 user-query injection.
+    """
+    from providers import get_provider_profile
+
+    provider = getattr(agent, "provider", None)
+    profile = get_provider_profile(provider)
+    if profile is not None:
+        return profile
+
+    base_url = (getattr(agent, "base_url", None) or "").strip()
+    if not base_url or not is_local_endpoint(base_url):
+        return None
+
+    try:
+        from agent.model_metadata import detect_local_server_type
+
+        server_type = detect_local_server_type(
+            base_url,
+            api_key=getattr(agent, "api_key", "") or "",
+        )
+    except Exception:
+        return None
+
+    if server_type in ("ollama", "vllm", "llamacpp"):
+        return get_provider_profile("custom")
+    return None
+
 
 def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = None) -> dict:
     """Build the keyword arguments dict for the active API mode."""
@@ -2023,9 +2055,10 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     # ── Provider profile path (registered providers) ───────────────────
     # Profiles handle per-provider quirks via hooks. When a profile is
     # found, delegate fully; otherwise fall through to the legacy flag path.
+    # Named local Ollama endpoints (e.g. ollama-launch) are not registered,
+    # so resolve them onto CustomProfile when the base_url is local Ollama.
     try:
-        from providers import get_provider_profile
-        _profile = get_provider_profile(agent.provider)
+        _profile = _resolve_chat_provider_profile(agent)
     except Exception:
         _profile = None
 
@@ -3020,9 +3053,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             provider_preferences = _provider_preferences_for_agent(agent)
             profile_extra_body = {}
             try:
-                from providers import get_provider_profile
-
-                provider_profile = get_provider_profile(agent.provider)
+                provider_profile = _resolve_chat_provider_profile(agent)
                 if provider_profile is not None:
                     profile_extra_body = provider_profile.build_extra_body(
                         session_id=getattr(agent, "session_id", None),

--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -126,6 +126,23 @@ META_AI_EFFORTS: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
 #: Upstage Solar Pro/Open: low/medium/high.
 SOLAR_EFFORTS: tuple[str, ...] = ("low", "medium", "high")
 
+#: Local Ollama qwen3.8 renderer template levels (low / medium / xhigh).
+#: ``high`` is not in the template, so clamp_effort maps it to medium
+#: (nearest weaker). ``max`` / ``ultra`` map down to ``xhigh``.
+QWEN38_LOCAL_EFFORTS: tuple[str, ...] = ("low", "medium", "xhigh")
+
+
+def custom_endpoint_efforts(model: Optional[str]) -> tuple[str, ...]:
+    """Supported effort set for provider=custom and unnamed local Ollama.
+
+    Named local keys (``ollama-launch``) reuse CustomProfile. Stock
+    qwen3.8 rejects ``high`` / ``max``; other custom OpenAI-compat
+    endpoints keep the wide wire vocabulary.
+    """
+    if "qwen3.8" in (model or "").lower():
+        return QWEN38_LOCAL_EFFORTS
+    return OPENAI_COMPAT_WIRE_EFFORTS
+
 
 def kimi_supported_efforts(model: Optional[str]) -> tuple[str, ...]:
     """Supported effort set for a Moonshot/Kimi model slug.

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -10,6 +10,8 @@ Volcengine ARK, vLLM, llama.cpp). Key quirks:
   - reasoning_config enabled + effort → top-level reasoning_effort
     (the native OpenAI-compatible format GLM/ARK expect; unset omits it
     so the endpoint's server default applies)
+  - tool-loop payloads with no plain user query get a synthetic user
+    turn (Ollama qwen3.8 renderer 500s otherwise — ollama#17778)
 """
 
 from typing import Any
@@ -17,9 +19,79 @@ from typing import Any
 from providers import register_provider
 from providers.base import ProviderProfile
 
+# Ollama's qwen3.8 renderer validateMessages() requires at least one
+# user-role message that is not a <tool_response> wrapper. Hermes tool
+# loops and compaction can legally send [system, assistant(tool_calls),
+# tool] — inject a continuation user turn for the wire only.
+_OLLAMA_USER_QUERY_PLACEHOLDER = (
+    "Continue with the current task using the latest tool results."
+)
+
+
+def _message_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(parts)
+    return ""
+
+
+def _has_plain_user_query(messages: list[dict[str, Any]]) -> bool:
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            continue
+        text = _message_text(msg.get("content")).strip()
+        if text and "<tool_response>" not in text:
+            return True
+    return False
+
+
+def _looks_like_tool_loop(messages: list[dict[str, Any]]) -> bool:
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") == "tool" or msg.get("tool_calls"):
+            return True
+        if msg.get("role") == "user" and "<tool_response>" in _message_text(
+            msg.get("content")
+        ):
+            return True
+    return False
+
 
 class CustomProfile(ProviderProfile):
     """Custom/Ollama local provider — think=false and num_ctx support."""
+
+    def prepare_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Keep a plain user query on the wire for local Ollama tool loops.
+
+        Does not mutate the caller's list. The placeholder is request-only.
+        """
+        if not messages or _has_plain_user_query(messages):
+            return messages
+        if not _looks_like_tool_loop(messages):
+            return messages
+
+        prepared = list(messages)
+        insert_at = 0
+        while insert_at < len(prepared):
+            msg = prepared[insert_at]
+            if not isinstance(msg, dict) or msg.get("role") != "system":
+                break
+            insert_at += 1
+        prepared.insert(
+            insert_at,
+            {"role": "user", "content": _OLLAMA_USER_QUERY_PLACEHOLDER},
+        )
+        return prepared
 
     def build_api_kwargs_extras(
         self,
@@ -64,17 +136,18 @@ class CustomProfile(ProviderProfile):
                 top_level["reasoning_effort"] = "none"
                 extra_body["think"] = False
             elif _effort:
-                # Clamp the internal ladder onto the widest OpenAI-compatible
-                # wire vocabulary (shared policy in agent.reasoning_effort) —
-                # GLM/ARK, vLLM and SGLang all top out at "max"; forwarding
-                # "ultra" verbatim is a guaranteed 400 (#89503).
+                # Clamp the internal ladder onto the endpoint's wire
+                # vocabulary (shared policy in agent.reasoning_effort).
+                # qwen3.8 is a narrower local-Ollama set; other custom
+                # OpenAI-compat endpoints keep the wide vocabulary.
+                # Forwarding "ultra" verbatim is a guaranteed 400 (#89503).
                 from agent.reasoning_effort import (
-                    OPENAI_COMPAT_WIRE_EFFORTS,
                     clamp_effort,
+                    custom_endpoint_efforts,
                 )
 
                 top_level["reasoning_effort"] = clamp_effort(
-                    _effort, OPENAI_COMPAT_WIRE_EFFORTS
+                    _effort, custom_endpoint_efforts(ctx.get("model"))
                 )
 
         return extra_body, top_level

--- a/tests/agent/test_reasoning_effort_module.py
+++ b/tests/agent/test_reasoning_effort_module.py
@@ -24,7 +24,9 @@ from agent.reasoning_effort import (
     KIMI_K3_EFFORTS,
     KIMI_K3_OVERRIDES,
     OPENAI_COMPAT_WIRE_EFFORTS,
+    QWEN38_LOCAL_EFFORTS,
     clamp_effort,
+    custom_endpoint_efforts,
     kimi_supported_efforts,
     requested_effort,
 )
@@ -159,6 +161,17 @@ class TestCodexVocabulary:
         assert clamp_effort("max", CODEX_LEGACY_EFFORTS) == "xhigh"
         assert clamp_effort("ultra", CODEX_LEGACY_EFFORTS) == "xhigh"
         assert clamp_effort("minimal", CODEX_LEGACY_EFFORTS) == "low"
+
+
+class TestCustomEndpointVocabulary:
+    def test_qwen38_uses_template_levels(self):
+        assert custom_endpoint_efforts("qwen3.8:latest") is QWEN38_LOCAL_EFFORTS
+        assert clamp_effort("high", QWEN38_LOCAL_EFFORTS) == "medium"
+        assert clamp_effort("max", QWEN38_LOCAL_EFFORTS) == "xhigh"
+
+    def test_other_custom_models_keep_wide_wire(self):
+        assert custom_endpoint_efforts("qwen3:8b") is OPENAI_COMPAT_WIRE_EFFORTS
+        assert custom_endpoint_efforts("glm-5.2") is OPENAI_COMPAT_WIRE_EFFORTS
 
 
 class TestRequestedEffort:

--- a/tests/agent/test_resolve_chat_provider_profile.py
+++ b/tests/agent/test_resolve_chat_provider_profile.py
@@ -1,0 +1,50 @@
+"""Named local Ollama endpoints must still get CustomProfile.
+
+``providers.ollama-launch`` is a user-defined key, not a registered
+profile name. Without the local-server fallback, Qwen 3.8 skips the
+max_tokens floor, reasoning_effort, and user-query injection.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.chat_completion_helpers import _resolve_chat_provider_profile
+
+
+def test_named_local_ollama_uses_custom_profile():
+    import model_tools  # noqa: F401
+    import providers
+
+    agent = SimpleNamespace(
+        provider="ollama-launch",
+        base_url="http://127.0.0.1:11434/v1",
+        api_key="",
+    )
+    with patch(
+        "agent.model_metadata.detect_local_server_type",
+        return_value="ollama",
+    ):
+        profile = _resolve_chat_provider_profile(agent)
+    assert profile is providers.get_provider_profile("custom")
+
+
+def test_registered_provider_is_unchanged():
+    import model_tools  # noqa: F401
+    import providers
+
+    agent = SimpleNamespace(
+        provider="ollama-cloud",
+        base_url="https://ollama.com/v1",
+        api_key="sk-test",
+    )
+    profile = _resolve_chat_provider_profile(agent)
+    assert profile is providers.get_provider_profile("ollama-cloud")
+
+
+def test_unknown_remote_provider_stays_unresolved():
+    agent = SimpleNamespace(
+        provider="mystery-lab",
+        base_url="https://api.example.com/v1",
+        api_key="sk-test",
+    )
+    assert _resolve_chat_provider_profile(agent) is None

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -107,3 +107,114 @@ class TestCustomReasoningWithNumCtx:
         assert eb == {"options": {"num_ctx": 8192}}
         assert tl == {}
 
+
+class TestQwen38EffortMapping:
+    """qwen3.8's renderer accepts low/medium/xhigh; clamp never escalates."""
+
+    def test_high_clamps_to_medium_for_qwen38(self, custom_profile):
+        _, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="qwen3.8:latest",
+        )
+        assert tl == {"reasoning_effort": "medium"}
+
+    def test_max_clamps_to_xhigh_for_qwen38(self, custom_profile):
+        _, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "max"},
+            model="qwen3.8",
+        )
+        assert tl == {"reasoning_effort": "xhigh"}
+
+    def test_keeps_medium_for_qwen38(self, custom_profile):
+        _, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"},
+            model="qwen3.8",
+        )
+        assert tl == {"reasoning_effort": "medium"}
+
+    def test_does_not_remap_qwen3_colon_8b(self, custom_profile):
+        _, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="qwen3:8b",
+        )
+        assert tl == {"reasoning_effort": "high"}
+
+
+class TestOllamaUserQueryInjection:
+    """Ollama qwen3.8 500s when the payload has no plain user query (#17778)."""
+
+    def test_injects_user_after_system_in_tool_loop(self, custom_profile):
+        original = [
+            {"role": "system", "content": "You are Hermes."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "web_search", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "results"},
+        ]
+        prepared = custom_profile.prepare_messages(original)
+        assert original[1]["role"] == "assistant"
+        assert prepared[0] == original[0]
+        assert prepared[1] == {
+            "role": "user",
+            "content": "Continue with the current task using the latest tool results.",
+        }
+        assert prepared[2:] == original[1:]
+
+    def test_leaves_real_user_message_alone(self, custom_profile):
+        original = [
+            {"role": "system", "content": "You are Hermes."},
+            {"role": "user", "content": "Search for local qwen3.8"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "web_search", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "results"},
+        ]
+        prepared = custom_profile.prepare_messages(original)
+        assert prepared is original
+
+    def test_treats_tool_response_wrapper_as_not_a_query(self, custom_profile):
+        original = [
+            {"role": "system", "content": "You are Hermes."},
+            {
+                "role": "user",
+                "content": "<tool_response>compressed tool output</tool_response>",
+            },
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "web_search", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "results"},
+        ]
+        prepared = custom_profile.prepare_messages(original)
+        assert prepared[1]["role"] == "user"
+        assert prepared[1]["content"].startswith("Continue with the current task")
+        assert prepared[2]["content"] == original[1]["content"]
+
+    def test_does_not_inject_without_a_tool_loop(self, custom_profile):
+        original = [{"role": "system", "content": "You are Hermes."}]
+        prepared = custom_profile.prepare_messages(original)
+        assert prepared is original
+


### PR DESCRIPTION
## What does this PR do?

Named custom providers such as `ollama-launch` are config keys, not registered profile names. `get_provider_profile("ollama-launch")` returns None, so Hermes skips CustomProfile on the chat-completions path.

That drops the local Ollama `default_max_tokens=65536` floor (Ollama then uses `num_predict=128`) and drops `reasoning_effort`. On local `qwen3.8` this produced truncated replies after four length-continuations. Tool loops can also legally send `[system, assistant(tool_calls), tool]` with no plain user turn; Ollama's qwen3.8 renderer then returns HTTP 500 `no user query found in messages` ([ollama/ollama#17778](https://github.com/ollama/ollama/issues/17778)).

This PR:

- Resolves unnamed **local** Ollama/vLLM/llama.cpp endpoints onto CustomProfile by `base_url`, not by hardcoding `ollama-launch`.
- Injects a request-only continuation user turn for tool-loop payloads that have no plain user query.
- Clamps `qwen3.8` onto its template levels (`low` / `medium` / `xhigh`) via the existing `clamp_effort` policy (`high` -> `medium`, `max`/`ultra` -> `xhigh`).

Registered providers (including `ollama-cloud`) are unchanged.

## Related Issue

Related to #22317 (named custom providers skipped by registry lookup). The Ollama 500 is [ollama/ollama#17778](https://github.com/ollama/ollama/issues/17778). Truncation without max_tokens is #39281.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` — `_resolve_chat_provider_profile` used from `build_api_kwargs` and the summary extra_body merge.
- `plugins/model-providers/custom/__init__.py` — `prepare_messages` user-query injection; qwen3.8 effort via `custom_endpoint_efforts`.
- `agent/reasoning_effort.py` — `QWEN38_LOCAL_EFFORTS` + `custom_endpoint_efforts`.
- Tests for resolver, injection, and qwen3.8 clamp.

## How to Test

1. `pytest tests/plugins/model_providers/test_custom_profile.py tests/agent/test_resolve_chat_provider_profile.py tests/agent/test_reasoning_effort_module.py -q`
2. Point Hermes at a named local provider (`providers.ollama-launch` -> `http://127.0.0.1:11434/v1`) with `qwen3.8`.
3. Start a **new** session and run a multi-tool prompt. Old transcripts that already lack a user turn can still 500.
4. Confirm a registered provider such as `ollama-cloud` still uses its own profile.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (native Hermes Desktop v0.20.4 against Ollama 0.32.14). Focused tests above: 53 passed.

### Documentation & Housekeeping

- [x] Documentation — N/A (behavior fix; existing CustomProfile docs still apply)
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md / AGENTS.md — N/A
- [x] Cross-platform impact considered (URL detection, no Windows-only APIs)
- [x] Tool descriptions/schemas — N/A