### PR TITLE
fix(anthropic): GLM-5 family uses adaptive thinking on Z.AI's Messages endpoint

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import platform
+import re
 import secrets
 import stat
 import subprocess
@@ -272,8 +273,15 @@ def _supports_adaptive_thinking(model: str) -> bool:
     Kimi / Moonshot models are the exception: their Anthropic-compatible
     endpoints implement the adaptive contract (``thinking.type="adaptive"``
     + ``output_config.effort``, including ``xhigh`` and ``display``).
+
+    Z.AI's GLM-5 family is the same shape of exception: api.z.ai's
+    Anthropic-compatible endpoint accepts the adaptive contract, while the
+    manual ``budget_tokens`` field is accepted but ignored — see
+    :func:`_model_name_is_glm_5_family`.
     """
     if _model_name_is_kimi_family(model):
+        return True
+    if _model_name_is_glm_5_family(model):
         return True
     if not _is_claude_model(model):
         return False
@@ -513,6 +521,30 @@ def _model_name_is_kimi_family(model: str | None) -> bool:
     if m in _KIMI_FAMILY_EXACT_SLUGS:
         return True
     return m.startswith(_KIMI_FAMILY_MODEL_PREFIXES)
+
+
+def _model_name_is_glm_5_family(model: str | None) -> bool:
+    """True for GLM-5.x models (``glm-5.3``, ``glm-5.2``, ``glm-5-turbo``).
+
+    Z.AI's Anthropic-compatible endpoint (api.z.ai/api/anthropic) implements
+    the adaptive-thinking contract for the GLM-5 family —
+    ``thinking.type="adaptive"`` + ``output_config.effort`` — the same shape
+    as Kimi/Moonshot. Verified live: a clean dose-response across
+    low/medium/high effort, while the manual ``budget_tokens`` field is
+    accepted but ignored (a 1024-token budget produced 8K+ thinking chars),
+    so the manual path silently loses effort control for GLM-5.
+    """
+    if not isinstance(model, str):
+        return False
+    m = model.strip().lower()
+    if not m:
+        return False
+    # Strip vendor prefix (e.g. ``z-ai/glm-5.3`` → ``glm-5.3``)
+    if "/" in m:
+        m = m.rsplit("/", 1)[-1]
+    # glm-5, glm-5.3, glm-5-2, glm-5p2 (relay spelling), glm-5-turbo —
+    # but NOT glm-4.6 / glm-4-9b / glm50.
+    return bool(re.match(r"^glm-5(?:[.\-p]|$)", m))
 
 
 def _is_kimi_family_endpoint(base_url: str | None, model: str | None = None) -> bool:

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1031,8 +1031,10 @@ class TestBuildAnthropicKwargs:
 
     def test_non_claude_anthropic_models_use_manual_path(self):
         """Non-Claude Anthropic-Messages models (minimax, qwen3, glm) must not
-        be misclassified as adaptive by the default-to-modern rule. Kimi is
-        the deliberate exception — see test_kimi_family_uses_adaptive_path."""
+        be misclassified as adaptive by the default-to-modern rule. Kimi and
+        the GLM-5 family are the deliberate exceptions — see
+        test_kimi_family_uses_adaptive_path and
+        test_glm_5_family_uses_adaptive_path."""
         from agent.anthropic_adapter import (
             _supports_adaptive_thinking,
             _supports_xhigh_effort,
@@ -1042,6 +1044,59 @@ class TestBuildAnthropicKwargs:
             assert _supports_adaptive_thinking(m) is False, m
             assert _supports_xhigh_effort(m) is False, m
             assert _forbids_sampling_params(m) is False, m
+
+    def test_glm_5_family_uses_adaptive_path(self):
+        """Z.AI's GLM-5 family on the Anthropic-compatible endpoint
+        (api.z.ai/api/anthropic) honors the adaptive contract
+        (``thinking.type="adaptive"`` + ``output_config.effort``) with a
+        clean dose-response across low/medium/high, while the manual
+        ``budget_tokens`` field is accepted but ignored — so GLM-5 must take
+        the adaptive path like Kimi, or reasoning-effort control is silently
+        lost. Verified live against glm-5.3 (2026-08-20): effort low ≈1K
+        thinking chars, medium ≈3K, high ≈8.4K; budget_tokens=1024 still
+        produced 8K+ thinking chars."""
+        from agent.anthropic_adapter import (
+            _model_name_is_glm_5_family,
+            _supports_adaptive_thinking,
+            _supports_xhigh_effort,
+        )
+        for m in ("glm-5.3", "glm-5.2", "glm-5", "glm-5-turbo", "z-ai/glm-5.3", "GLM-5.3"):
+            assert _model_name_is_glm_5_family(m) is True, m
+            assert _supports_adaptive_thinking(m) is True, m
+        # glm-5.2 documents high/max only, but the endpoint accepts xhigh
+        # (mapped per ADAPTIVE_EFFORT_MAP at build time) — keep it allowed.
+        assert _supports_xhigh_effort("glm-5.3") is True
+        # Older GLM generations stay on the manual budget path.
+        for m in ("glm-4.6", "glm-4-9b", "glm50", "glm-3-turbo"):
+            assert _model_name_is_glm_5_family(m) is False, m
+            assert _supports_adaptive_thinking(m) is False, m
+
+    def test_glm_5_builds_adaptive_effort_kwargs(self):
+        """build_anthropic_kwargs must emit the adaptive contract for GLM-5
+        (never the manual budget_tokens path, which Z.AI ignores)."""
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kw = build_anthropic_kwargs(
+            model="glm-5.3",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=1024,
+            reasoning_config={"enabled": True, "effort": "high"},
+            base_url="https://api.z.ai/api/anthropic",
+        )
+        assert kw["thinking"] == {"type": "adaptive", "display": "summarized"}
+        assert kw["output_config"] == {"effort": "high"}
+        assert "budget_tokens" not in kw["thinking"]
+        # A weaker ask maps to a weaker wire level — no silent cost floor.
+        kw_low = build_anthropic_kwargs(
+            model="glm-5.3",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=1024,
+            reasoning_config={"enabled": True, "effort": "low"},
+            base_url="https://api.z.ai/api/anthropic",
+        )
+        assert kw_low["output_config"] == {"effort": "low"}
 
 
     def test_bare_k3_coding_plan_slug_is_kimi_family(self):


### PR DESCRIPTION
## Summary

GLM-5 models (`glm-5.3`, `glm-5.2`, `glm-5-turbo`) served over Z.AI's Anthropic-compatible endpoint (`api.z.ai/api/anthropic`, e.g. the GLM Coding Plan) implement the **adaptive-thinking contract** — `thinking.type="adaptive"` + `output_config.effort` — the same shape as Kimi/Moonshot.

Hermes classified them via the generic non-Claude rule (manual `budget_tokens` path). On that path Z.AI **accepts `budget_tokens` but ignores it** — so every explicit reasoning-effort setting silently no-op'd and the server default (max effort on glm-5.3) always applied. With Coding-Plan output points billed at the top multiplier, a low-effort ask billed like a max-effort one.

## Change

Follows the existing Kimi family precedent exactly:
- new `_model_name_is_glm_5_family()` (matches glm-5, glm-5.3, glm-5-2/glm-5p2 relay spellings, vendor-prefixed forms; **not** glm-4.6/glm-4-9b/glm50)
- `_supports_adaptive_thinking()` returns True for the GLM-5 family
- glm-4.6 and older generations keep the manual budget path unchanged

## Live verification (glm-5.3, 2026-08-20, Coding Plan key)

Adaptive contract, harder-reasoning prompt, n=1 per level:

| request | thinking chars | output tokens |
|---|---|---|
| adaptive effort=low | ≈1.0K | 687 |
| adaptive effort=medium | ≈3.0K | 1403 |
| adaptive effort=high | ≈8.4K | 2500 (cap) |
| manual budget_tokens=1024 | 8.0K+ | 2500 (cap) — **budget ignored** |
| no reasoning params | ≈0.5K | 528 |

Endpoint accepts medium/xhigh too; documented native levels for 5.3 are low/high/max. `reasoning_effort` as a top-level field is also accepted (that's the chat-completions knob #86947 wires up — complementary; this PR covers the `anthropic_messages` transport, which is what the Coding Plan's Anthropic endpoint serves).

## Tests

- `tests/agent/test_anthropic_adapter.py`: +2 tests (family classification incl. negative cases; kwargs builder emits adaptive + effort, never budget_tokens for GLM-5). Full file: **97 passed**.
- Related suites green: `tests/agent/test_minimax_provider.py`, `tests/test_ctx_halving_fix.py` (35 passed), `tests/run_agent/test_run_agent.py -k 'anthropic or glm or reasoning'` (28 passed).

Closes nothing standalone; complements #86947 (chat-completions plugin path) and the glm-5.3 catalog/context-window PRs (#86221, #89842, #90530).

## Duplicate check

Searched open+merged PRs for glm-5.3 / zai / adaptive: #86947 covers the `chat_completions` plugin path only; no existing PR touches the anthropic_messages transport classification for GLM-5.