### PR TITLE
fix(vertex): route Gemini thought deltas to the reasoning stream, not visible content

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4143,6 +4143,33 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 _fire_first_delta()
                 agent._fire_reasoning_delta(reasoning_text)
 
+            # Vertex/Gemini OpenAI-compat streams thought summaries as plain
+            # content deltas flagged ``extra_content.google.thought: true``
+            # (no <think> tags on the streaming wire), so the think scrubber
+            # never sees them. Route flagged deltas into the reasoning stream
+            # instead of visible content.
+            _delta_extra = getattr(delta, "extra_content", None)
+            if _delta_extra is None and hasattr(delta, "model_extra"):
+                _me = getattr(delta, "model_extra", None)
+                if isinstance(_me, dict):
+                    _delta_extra = _me.get("extra_content")
+            if (
+                isinstance(_delta_extra, dict)
+                and isinstance(_delta_extra.get("google"), dict)
+                and _delta_extra["google"].get("thought")
+                and not getattr(delta, "tool_calls", None)
+            ):
+                _thought_text = getattr(delta, "content", None)
+                if _thought_text:
+                    _thought_text = separate_glued_reasoning_blocks(
+                        reasoning_parts[-1] if reasoning_parts else "",
+                        _thought_text,
+                    )
+                    reasoning_parts.append(_thought_text)
+                    _fire_first_delta()
+                    agent._fire_reasoning_delta(_thought_text)
+                continue
+
             # Accumulate text content — fire callback only when no tool calls
             delta_content = getattr(delta, "content", None)
             if delta_content:

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -605,6 +605,96 @@ class TestReasoningStreaming:
         assert response.choices[0].message.content == "The answer is 42"
 
 
+class TestGeminiThoughtDeltaRouting:
+    """Vertex/Gemini OpenAI-compat thought deltas stay out of visible content.
+
+    The Vertex OpenAI-compat surface streams Gemini thought summaries as
+    ordinary ``delta.content`` chunks flagged only by
+    ``delta.extra_content = {"google": {"thought": True}}`` — no <think>
+    tags on the streaming wire — so tag-based scrubbing never fires and the
+    summaries leaked into the visible reply. Flagged deltas must be routed
+    to the reasoning stream instead.
+    """
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_thought_deltas_route_to_reasoning(self, mock_close, mock_create):
+        from run_agent import AIAgent
+
+        def _thought_chunk(text):
+            chunk = _make_stream_chunk(content=text)
+            chunk.choices[0].delta.extra_content = {"google": {"thought": True}}
+            return chunk
+
+        chunks = [
+            _thought_chunk("**Analyzing The Question**\n\nWorking it through.\n\n"),
+            _thought_chunk("**Refining The Answer**\n\nDouble-checking.\n\n"),
+            _make_stream_chunk(content="The answer is 42"),
+            _make_stream_chunk(finish_reason="stop"),
+        ]
+
+        reasoning_deltas = []
+        text_deltas = []
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="google/gemini-3-flash-preview",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            stream_delta_callback=lambda t: text_deltas.append(t),
+            reasoning_callback=lambda t: reasoning_deltas.append(t),
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        # Thought text never reaches visible content or text deltas.
+        assert text_deltas == ["The answer is 42"]
+        assert response.choices[0].message.content == "The answer is 42"
+        # It lands in the reasoning stream instead.
+        assert "Analyzing The Question" in "".join(reasoning_deltas)
+        reasoning_content = response.choices[0].message.reasoning_content or ""
+        assert "Analyzing The Question" in reasoning_content
+        assert "Refining The Answer" in reasoning_content
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_unflagged_extra_content_stays_visible(self, mock_close, mock_create):
+        """A non-thought extra_content payload doesn't hijack normal content."""
+        from run_agent import AIAgent
+
+        chunk = _make_stream_chunk(content="Visible text")
+        chunk.choices[0].delta.extra_content = {"google": {"thought_signature": "abc"}}
+        chunks = [chunk, _make_stream_chunk(finish_reason="stop")]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="google/gemini-3-flash-preview",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.choices[0].message.content == "Visible text"
+        assert response.choices[0].message.reasoning_content is None
+
+
 # ── Test: _has_stream_consumers ──────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

When using Gemini thinking models through the **Vertex AI** provider (`vertex`, OpenAI-compat endpoint) with streaming enabled, thought summaries leak verbatim into the visible reply — every answer starts with blocks like:

```
**Analyzing The Question**

I'm currently examining how ...
```

## Root cause

The Vertex OpenAI-compat surface encodes thoughts differently per mode:

- **non-streaming**: thoughts arrive inside `message.content` wrapped in `<think>…</think>` → already handled by `strip_think_blocks`;
- **streaming**: thoughts arrive as ordinary `delta.content` chunks with **no tags**, flagged only by `delta.extra_content = {"google": {"thought": true}}`:

```json
{"choices":[{"delta":{"content":"**Exploring Irrationality**\n\nI'm currently...","extra_content":{"google":{"thought":true}},"role":"assistant"}}]}
```

`interruptible_streaming_api_call` only inspects `extra_content` on tool-call deltas (thought_signature replay), so flagged text deltas fall through to content accumulation and `StreamingThinkScrubber` never fires (nothing to scrub — no tags on the wire).

## Fix

In the streaming loop, route content deltas flagged `extra_content.google.thought` into the existing reasoning accumulation (`reasoning_parts` + `_fire_reasoning_delta`), so they surface through the reasoning display exactly like `reasoning_content`-style providers. Deltas whose `extra_content` carries only a `thought_signature` (no `thought` flag) are untouched.

## Testing

- New `TestGeminiThoughtDeltaRouting` in `tests/run_agent/test_streaming.py`: flagged deltas end up in `reasoning_content`/reasoning callback and never in `message.content` or text deltas; a `thought_signature`-only `extra_content` payload still streams as visible content.
- `pytest tests/run_agent/test_streaming.py`: 35 passed, 4 skipped, 3 pre-existing failures (`TestAnthropicStreamCallbacks` — fail identically on clean `main` in my environment).
- Reproduced and verified live against `google/gemini-3.7-flash` on Vertex (`include_thoughts: true`, `thinking_level: high`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes #64035 (streaming path: the flagged-delta leak). The effort/visibility coupling in `_build_gemini_thinking_config` that issue also describes is untouched here — with this fix, enabled thoughts flow to the reasoning display where `show_reasoning` policy applies, instead of into the reply text.
