### PR TITLE
fix(daytona): preserve self-hosted disk requests above 10 GiB

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2158,6 +2158,18 @@ def run_doctor(args):
     
     # Daytona (if using daytona backend)
     if terminal_env == "daytona":
+        from tools.environments.daytona import (
+            is_daytona_cloud_endpoint,
+            resolve_daytona_api_url,
+        )
+
+        daytona_api_url = resolve_daytona_api_url()
+        endpoint_kind = (
+            "Daytona Cloud"
+            if is_daytona_cloud_endpoint(daytona_api_url)
+            else "self-hosted"
+        )
+        check_ok("Daytona endpoint", f"({daytona_api_url}; {endpoint_kind})")
         daytona_key = os.getenv("DAYTONA_API_KEY")
         if daytona_key:
             check_ok("Daytona API key", "(configured)")

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -278,6 +278,28 @@ def test_doctor_reports_vercel_backend_diagnostics(monkeypatch, tmp_path):
     assert "snapshot filesystem only" in out
 
 
+def test_doctor_reports_resolved_self_hosted_daytona_endpoint(monkeypatch, tmp_path):
+    monkeypatch.setenv("TERMINAL_ENV", "daytona")
+    monkeypatch.setenv("DAYTONA_API_KEY", "super-secret-value")
+    monkeypatch.setenv("DAYTONA_API_URL", "https://daytona.internal.example/api")
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert "Daytona endpoint" in out
+    assert "https://daytona.internal.example/api" in out
+    assert "self-hosted" in out
+    assert "super-secret-value" not in out
+
+
 # ── Memory provider section (doctor should only check the *active* provider) ──
 
 

--- a/tests/tools/test_daytona_environment.py
+++ b/tests/tools/test_daytona_environment.py
@@ -61,6 +61,7 @@ def make_env(daytona_sdk, monkeypatch):
     """Factory that creates a DaytonaEnvironment with a mocked SDK."""
     monkeypatch.setattr("tools.lazy_deps.ensure", lambda *args, **kwargs: None)
     monkeypatch.delenv("DAYTONA_API_URL", raising=False)
+    monkeypatch.delenv("DAYTONA_SERVER_URL", raising=False)
     # Prevent is_interrupted from interfering — patch where it's used (base.py)
     monkeypatch.setattr("tools.environments.base.is_interrupted", lambda: False)
     # Prevent skills/credential sync from consuming mock exec calls
@@ -233,6 +234,17 @@ class TestResourceConversion:
 
         assert self._get_resources_kwargs(daytona_sdk)["disk"] == 50
         daytona_sdk.Daytona.assert_called_once_with()
+
+    def test_legacy_self_hosted_endpoint_preserves_disk_above_cloud_limit(
+        self, make_env, daytona_sdk, monkeypatch
+    ):
+        monkeypatch.setenv(
+            "DAYTONA_SERVER_URL", "https://daytona.internal.example/api"
+        )
+
+        make_env(disk=51200)
+
+        assert self._get_resources_kwargs(daytona_sdk)["disk"] == 50
 
     def test_default_cloud_endpoint_caps_disk_at_cloud_limit(
         self, make_env, daytona_sdk

--- a/tests/tools/test_daytona_environment.py
+++ b/tests/tools/test_daytona_environment.py
@@ -59,6 +59,8 @@ def daytona_sdk(monkeypatch):
 @pytest.fixture()
 def make_env(daytona_sdk, monkeypatch):
     """Factory that creates a DaytonaEnvironment with a mocked SDK."""
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda *args, **kwargs: None)
+    monkeypatch.delenv("DAYTONA_API_URL", raising=False)
     # Prevent is_interrupted from interfering — patch where it's used (base.py)
     monkeypatch.setattr("tools.environments.base.is_interrupted", lambda: False)
     # Prevent skills/credential sync from consuming mock exec calls
@@ -221,6 +223,32 @@ class TestResourceConversion:
         kw = self._get_resources_kwargs(daytona_sdk)
         assert kw["memory"] == 1
         assert kw["disk"] == 1
+
+    def test_self_hosted_endpoint_preserves_disk_above_cloud_limit(
+        self, make_env, daytona_sdk, monkeypatch
+    ):
+        monkeypatch.setenv("DAYTONA_API_URL", "https://daytona.internal.example/api")
+
+        make_env(disk=51200)
+
+        assert self._get_resources_kwargs(daytona_sdk)["disk"] == 50
+        daytona_sdk.Daytona.assert_called_once_with()
+
+    def test_default_cloud_endpoint_caps_disk_at_cloud_limit(
+        self, make_env, daytona_sdk
+    ):
+        make_env(disk=51200)
+
+        assert self._get_resources_kwargs(daytona_sdk)["disk"] == 10
+
+    def test_explicit_cloud_endpoint_caps_disk_at_cloud_limit(
+        self, make_env, daytona_sdk, monkeypatch
+    ):
+        monkeypatch.setenv("DAYTONA_API_URL", "https://app.daytona.io/api/")
+
+        make_env(disk=51200)
+
+        assert self._get_resources_kwargs(daytona_sdk)["disk"] == 10
 
 
 # ---------------------------------------------------------------------------

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -1,6 +1,6 @@
-"""Daytona cloud execution environment.
+"""Daytona Cloud and self-hosted execution environment.
 
-Uses the Daytona Python SDK to run commands in cloud sandboxes.
+Uses the Daytona Python SDK to run commands in remote sandboxes.
 Supports persistent sandboxes: when enabled, sandboxes are stopped on cleanup
 and resumed on next creation, preserving the filesystem across sessions.
 """
@@ -26,9 +26,20 @@ from tools.environments.file_sync import (
 
 logger = logging.getLogger(__name__)
 
+DAYTONA_CLOUD_API_URL = "https://app.daytona.io/api"
+
+
+def resolve_daytona_api_url() -> str:
+    """Return the endpoint the Daytona SDK resolves from the environment."""
+    return os.getenv("DAYTONA_API_URL", "").strip() or DAYTONA_CLOUD_API_URL
+
+
+def is_daytona_cloud_endpoint(api_url: str) -> bool:
+    return api_url.rstrip("/").lower() == DAYTONA_CLOUD_API_URL
+
 
 class DaytonaEnvironment(BaseEnvironment):
-    """Daytona cloud sandbox execution backend.
+    """Daytona remote sandbox execution backend.
 
     Spawn-per-call via _ThreadedProcessHandle wrapping blocking SDK calls.
     cancel_fn wired to sandbox.stop() for interrupt support.
@@ -75,9 +86,9 @@ class DaytonaEnvironment(BaseEnvironment):
 
         memory_gib = max(1, math.ceil(memory / 1024))
         disk_gib = max(1, math.ceil(disk / 1024))
-        if disk_gib > 10:
+        if disk_gib > 10 and is_daytona_cloud_endpoint(resolve_daytona_api_url()):
             logger.warning(
-                "Daytona: requested disk (%dGB) exceeds platform limit (10GB). "
+                "Daytona: requested disk (%dGB) exceeds Daytona Cloud limit (10GB). "
                 "Capping to 10GB.", disk_gib,
             )
             disk_gib = 10

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -31,7 +31,11 @@ DAYTONA_CLOUD_API_URL = "https://app.daytona.io/api"
 
 def resolve_daytona_api_url() -> str:
     """Return the endpoint the Daytona SDK resolves from the environment."""
-    return os.getenv("DAYTONA_API_URL", "").strip() or DAYTONA_CLOUD_API_URL
+    return (
+        os.getenv("DAYTONA_API_URL", "").strip()
+        or os.getenv("DAYTONA_SERVER_URL", "").strip()
+        or DAYTONA_CLOUD_API_URL
+    )
 
 
 def is_daytona_cloud_endpoint(api_url: str) -> bool:

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -184,7 +184,9 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `OPENVIKING_ENDPOINT` | OpenViking server URL (default: `http://127.0.0.1:1933`) |
 | `BRV_API_KEY` | ByteRover API key (optional, for cloud sync — local-first by default) ([app.byterover.dev](https://app.byterover.dev)) |
 | `SUPERMEMORY_API_KEY` | Semantic long-term memory with profile recall and session ingest ([supermemory.ai](https://supermemory.ai)) |
-| `DAYTONA_API_KEY` | Daytona cloud sandboxes ([daytona.io](https://daytona.io/)) |
+| `DAYTONA_API_KEY` | API key for Daytona Cloud or a self-hosted Daytona deployment ([daytona.io](https://daytona.io/)) |
+| `DAYTONA_API_URL` | Daytona API endpoint (default: `https://app.daytona.io/api`); set this for a self-hosted deployment |
+| `DAYTONA_TARGET` | Optional Daytona runner target; the organization's default region is used when unset |
 | `VERCEL_TOKEN` | Vercel Sandbox access token ([vercel.com](https://vercel.com/)) |
 | `VERCEL_PROJECT_ID` | Vercel project ID (required with `VERCEL_TOKEN`) |
 | `VERCEL_TEAM_ID` | Vercel team ID (required with `VERCEL_TOKEN`) |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -162,7 +162,7 @@ For cloud sandboxes such as Modal, Daytona, and Vercel Sandbox, `container_persi
 | **docker** | Single persistent Docker container (shared across session, `/new`, subagents) | Full (namespaces, cap-drop) | Safe sandboxing, CI/CD |
 | **ssh** | Remote server via SSH | Network boundary | Remote dev, powerful hardware |
 | **modal** | Modal cloud sandbox | Full (cloud VM) | Ephemeral cloud compute, evals |
-| **daytona** | Daytona workspace | Full (cloud container) | Managed cloud dev environments |
+| **daytona** | Daytona Cloud or a self-hosted Daytona workspace | Full (container) | Persistent managed or self-hosted dev environments |
 | **vercel_sandbox** | Vercel Sandbox | Full (cloud microVM) | Cloud execution with snapshot-backed filesystem persistence |
 | **singularity** | Singularity/Apptainer container | Namespaces (--containall) | HPC clusters, shared machines |
 
@@ -386,22 +386,29 @@ terminal:
 
 ### Daytona Backend
 
-Runs commands in a [Daytona](https://daytona.io) managed workspace. Supports stop/resume for persistence.
+Runs commands in a [Daytona](https://daytona.io) Cloud or self-hosted workspace. Supports stop/resume for persistence.
 
 ```yaml
 terminal:
   backend: daytona
   container_cpu: 1                 # CPU cores
   container_memory: 5120           # MB → converted to GiB
-  container_disk: 10240            # MB → converted to GiB (max 10 GiB)
+  container_disk: 10240            # MB → converted to GiB
   container_persistent: true       # Stop/resume instead of delete
 ```
 
-**Required:** `DAYTONA_API_KEY` environment variable.
+The Daytona SDK reads `DAYTONA_API_KEY`, `DAYTONA_API_URL`, and `DAYTONA_TARGET` from the environment. `DAYTONA_API_KEY` is required. When `DAYTONA_API_URL` is unset, the SDK connects to Daytona Cloud at `https://app.daytona.io/api`. `DAYTONA_TARGET` optionally selects a runner target; otherwise Daytona uses the organization's default region.
+
+To connect to a self-hosted Daytona deployment, add the endpoint and API key to `~/.hermes/.env`:
+
+```bash
+DAYTONA_API_KEY=***
+DAYTONA_API_URL=https://daytona.internal.example.com/api
+```
 
 **Persistence:** When enabled, sandboxes are stopped (not deleted) on cleanup and resumed on next session. Sandbox names follow the pattern `hermes-{task_id}`.
 
-**Disk limit:** Daytona enforces a 10 GiB maximum. Requests above this are capped with a warning.
+**Disk limit:** Daytona Cloud enforces a 10 GiB maximum, so Hermes caps larger Cloud requests with a warning. Self-hosted endpoints receive the configured disk request unchanged.
 
 ### Vercel Sandbox Backend
 


### PR DESCRIPTION
## What does this PR do?

Self-hosted Daytona users can now request disks larger than the Daytona Cloud 10 GiB quota without Hermes silently reducing them. Hermes distinguishes the resolved Cloud endpoint from custom and legacy self-hosted endpoints, reports that endpoint in `hermes doctor` without exposing the API key, and documents the SDK environment configuration.

### Symptom

A self-hosted Daytona deployment configured with `DAYTONA_API_URL` or the pinned SDK's legacy `DAYTONA_SERVER_URL` received a 10 GiB disk request even when `terminal.container_disk` requested more capacity. The warning incorrectly described the Cloud quota as a universal platform limit.

### Impact

Operators running Daytona on their own infrastructure could not provision the configured sandbox disk capacity through Hermes. A 50 GiB request, for example, was silently reduced to 10 GiB even though the self-hosted server was not subject to the Cloud quota.

### Bug Cause

**Trigger:** `tools/environments/daytona.py` resource conversion when the requested disk exceeds 10 GiB.

**Causal chain:**
1. Hermes converts `terminal.container_disk` from MiB to GiB before constructing the SDK `Resources` object.
2. The conversion path applied a 10 GiB clamp without checking the SDK-resolved Daytona endpoint.
3. Custom self-hosted endpoints therefore received the Cloud-limited value instead of the configured value.

**Why it is wrong:** the 10 GiB maximum is a Daytona Cloud quota, not a limit of self-hosted Daytona deployments.

**Working sibling / contrast:** requests to the default or explicitly configured `https://app.daytona.io/api` endpoint still require and retain the 10 GiB guard.

**Ruled out:** the SDK constructor did not need explicit endpoint configuration. The pinned SDK already resolves `DAYTONA_API_URL` and its legacy `DAYTONA_SERVER_URL` fallback from the environment.

### Fix

Resolve the effective Daytona endpoint using the pinned SDK's environment precedence, apply the disk cap only to the Daytona Cloud endpoint, and preserve larger requests for self-hosted endpoints. Doctor now prints the resolved endpoint and its Cloud/self-hosted classification, while the documentation covers `DAYTONA_API_KEY`, `DAYTONA_API_URL`, and `DAYTONA_TARGET`.

## Related Issue

Closes #90969

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/daytona.py` - classify the resolved endpoint and scope the 10 GiB cap to Daytona Cloud.
- `hermes_cli/doctor.py` - report the resolved Daytona endpoint without printing credentials.
- `website/docs/` - document self-hosted Daytona configuration and Cloud-only disk limits.
- `tests/tools/test_daytona_environment.py` - cover default Cloud, explicit Cloud, current self-hosted, and legacy self-hosted endpoint behavior.
- `tests/hermes_cli/test_doctor.py` - verify endpoint observability and API-key redaction.

## How to Test

1. Configure a custom `DAYTONA_API_URL` and request a disk larger than 10 GiB; verify the SDK `Resources.disk` keeps the requested GiB value.
2. Leave the endpoint unset or set it to `https://app.daytona.io/api`; verify the request remains capped at 10 GiB.
3. Run the focused automated coverage:

```bash
scripts/run_tests.sh tests/tools/test_daytona_environment.py -k ResourceConversion -q
scripts/run_tests.sh tests/hermes_cli/test_doctor.py -q
```

Verified locally: 6 resource-conversion tests and 57 doctor tests passed. Ruff on the changed Python files and `git diff --check` also passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] `cli-config.yaml.example` is N/A because no Hermes config key changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; endpoint classification and resource conversion are platform-independent
- [x] Tool descriptions and schemas are N/A because no model tool schema changed

## Screenshots / Logs

N/A - focused automated tests cover resource conversion and doctor output.
