### PR TITLE
fix(docker): let the hermes user reach /.fly/api so scale-to-zero can…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -354,6 +354,11 @@ RUN mkdir -p /etc/cont-init.d && \
         > /etc/cont-init.d/01-hermes-setup && \
     chmod +x /etc/cont-init.d/01-hermes-setup
 COPY --chmod=0755 docker/cont-init.d/015-supervise-perms /etc/cont-init.d/015-supervise-perms
+# 016-flaps-socket-perms lets the unprivileged hermes user connect(2) to
+# /.fly/api, without which scale-to-zero's self-suspend gets EACCES and the
+# machine never sleeps. Ordered after 015 (both are root-time permission
+# fixups) and before 02, though it depends on neither.
+COPY --chmod=0755 docker/cont-init.d/016-flaps-socket-perms /etc/cont-init.d/016-flaps-socket-perms
 COPY --chmod=0755 docker/cont-init.d/02-reconcile-profiles /etc/cont-init.d/02-reconcile-profiles
 
 # ---------- Runtime ----------

--- a/docker/cont-init.d/016-flaps-socket-perms
+++ b/docker/cont-init.d/016-flaps-socket-perms
@@ -1,0 +1,51 @@
+#!/command/with-contenv sh
+# shellcheck shell=sh
+# Let the unprivileged hermes user reach Fly's in-machine Machines API socket.
+#
+# Scale-to-zero self-suspend (gateway/scale_to_zero.py::suspend_self) POSTs
+# /v1/apps/$FLY_APP_NAME/machines/$FLY_MACHINE_ID/suspend over /.fly/api. Fly
+# creates that socket root:root 0755, and connect(2) on a unix socket requires
+# WRITE permission — so the gateway, which runs under ``s6-setuidgid hermes``
+# like every other Hermes runtime path, gets EACCES. The watcher then logs
+# "self-suspend not accepted (fail-awake)" and retries every idle window
+# forever, so the machine NEVER sleeps.
+#
+# The de-privileging (PR #30136, s6-overlay as PID 1) predates the self-suspend
+# by three months, so the two never met in review; the flaps call was written
+# against a runtime that had already stopped being root.
+#
+# Sibling of 015-supervise-perms: same shape, same reason — a root-time
+# permission fixup so the unprivileged runtime can use a facility that s6 or
+# Fly created owned by root.
+#
+# SCOPE OF WHAT THIS GRANTS — measured against live flaps, not assumed:
+#   permitted : suspend/stop THIS machine; POST /v1/tokens/oidc
+#   refused   : exec on this machine (403); update this machine's config (403);
+#               any operation targeting another app's machines (403)
+# The socket is self-scoped: this does NOT confer the Machines API at large and
+# does NOT make the agent root. The single capability reaching beyond this
+# machine is the OIDC token (iss https://oidc.fly.io/<org>), which is inert
+# unless some cloud role trusts that issuer — confirm that before relying on
+# this, and prefer a narrow root helper if such a trust ever exists.
+#
+# Off-Fly (local dev, CI, non-Fly hosts) the socket is absent and this no-ops.
+
+set -eu
+
+SOCKET=/.fly/api
+
+if [ ! -S "$SOCKET" ]; then
+    echo "[flaps-perms] $SOCKET not present; skipping (not a Fly machine)"
+    exit 0
+fi
+
+# root:hermes 0660 — the hermes group gains connect(2). This also drops the
+# world r-x bits Fly leaves on the socket, which nothing in this image uses.
+# Non-fatal on failure: a machine that can't self-suspend still runs fine (it
+# just stays awake), so this must never take the container down with it.
+chown root:hermes "$SOCKET" 2>/dev/null ||
+    echo "[flaps-perms] could not chown $SOCKET"
+chmod 0660 "$SOCKET" 2>/dev/null ||
+    echo "[flaps-perms] could not chmod $SOCKET"
+
+echo "[flaps-perms] $(ls -l "$SOCKET")"


### PR DESCRIPTION
## What does this PR do?

Auto-suspend for cloud instances stopped working on the latest changes. Until then machines were suspended by Fly autostop, which worked. #84295 replaced that with gateway-owned self-suspend, and that indtroduced an error.

`gateway/scale_to_zero.py::suspend_self()` POSTs to Fly's Machines API over the `/.fly/api` unix socket. Fly creates that socket `root:root 0755`, and `connect(2)` on a unix socket requires the write bit. The gateway runs under `s6-setuidgid hermes` (uid 10000), so every attempt fails with `[Errno 13] Permission denied`.

The failure is fail-awake, so nothing surfaces. The watcher logs a warning and retries every idle window forever, and the machine never sleeps.

The runtime was de-privileged to `hermes` in May (`feat(docker)!: replace tini with s6-overlay as PID 1`). The flaps call landed three months later, written against a runtime that had stopped being root. The two never met in review.

The socket cannot be fixed at build time, since Fly creates it at machine boot, and the gateway cannot fix it itself, since it is not root. A root-time hook is the only option. This mirrors `015-supervise-perms`, which exists for the same reason.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`docker/cont-init.d/016-flaps-socket-perms`** (new): root-time `chown root:hermes` plus `chmod 0660` on `/.fly/api`. Guarded on the socket existing so it no-ops off-Fly, and non-fatal on failure.
- **`Dockerfile`**: one `COPY --chmod=0755` line.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Fly machine, current image

### Documentation & Housekeeping

- [x] I've updated relevant documentation: N/A, the rationale lives in the script header
- [x] I've updated `cli-config.yaml.example`: N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] I've considered cross-platform impact: Fly-only, no-ops elsewhere
- [x] I've updated tool descriptions/schemas: N/A
