### PR TITLE
fix(shell-hooks): resolve chat cwd via file-tool workspace ladder

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -739,20 +739,46 @@ def _evaluate_result(
     return parsed
 
 
+def _resolve_hook_cwd(task_id: Any) -> str:
+    """Resolve the hook payload ``cwd`` using the same ladder file tools use.
+
+    Order (mirrors ``tools.file_tools._resolve_base_dir``):
+
+      1. this chat's recorded session cwd (``terminal_tool.get_session_cwd``);
+      2. a registered task/session workspace override;
+      3. an absolute, sentinel-free ``$TERMINAL_CWD`` (never the literal
+         ``"."`` a stale config can leave behind);
+      4. the process cwd as a last resort.
+
+    Reusing ``_resolve_base_dir`` guarantees the hook and the file tools pick
+    the *same* directory — the property a house write-guard (P0b) depends on
+    to join relative paths against the chat folder rather than the
+    program-start folder.
+    """
+    try:
+        from tools.file_tools import _resolve_base_dir
+
+        return str(_resolve_base_dir(str(task_id or "default")))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug(
+            "shell hook cwd ladder unavailable (%s) — using process cwd", exc,
+        )
+    try:
+        return str(Path.cwd())
+    except OSError:
+        return ""
+
+
 def _serialize_payload(event: str, kwargs: Dict[str, Any]) -> str:
     """Render the stdin JSON payload.  Unserialisable values are
     stringified via ``default=str`` rather than dropped."""
     extras = {k: v for k, v in kwargs.items() if k not in _TOP_LEVEL_PAYLOAD_KEYS}
-    try:
-        cwd = str(Path.cwd())
-    except OSError:
-        cwd = ""
     payload = {
         "hook_event_name": event,
         "tool_name": kwargs.get("tool_name"),
         "tool_input": kwargs.get("args") if isinstance(kwargs.get("args"), dict) else None,
         "session_id": kwargs.get("session_id") or kwargs.get("parent_session_id") or "",
-        "cwd": cwd,
+        "cwd": _resolve_hook_cwd(extras.get("task_id")),
         "extra": extras,
     }
     return json.dumps(payload, ensure_ascii=False, default=str)

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -9,6 +9,7 @@ covered in ``test_shell_hooks_consent.py``.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -102,6 +103,63 @@ class TestSerializePayload:
         assert payload["tool_input"] is None
 
 
+# ── cwd ladder (P0a) ─────────────────────────────────────────────────────
+
+
+class TestHookCwdLadder:
+    """payload cwd follows the same ladder file tools use:
+
+    recorded session cwd → registered workspace override → absolute
+    TERMINAL_CWD → process cwd.  A task that recorded a cwd must win over
+    the process cwd; sentinel/relative TERMINAL_CWD must never be honored.
+    """
+
+    def _cwd_for_task(self, task_id: str) -> str:
+        return json.loads(
+            shell_hooks._serialize_payload(
+                "post_tool_call",
+                {"task_id": task_id, "session_id": "sess-1"},
+            ),
+        )["cwd"]
+
+    def test_process_cwd_no_task_falls_back(self, tmp_path, monkeypatch):
+        """No session record, no workspace, no configured cwd → process cwd."""
+        monkeypatch.setenv("TERMINAL_CWD", ".")
+        monkeypatch.chdir(tmp_path)
+        assert self._cwd_for_task("") == os.path.realpath(str(tmp_path))
+
+    def test_task_cwd_wins_over_process_cwd(self, tmp_path, monkeypatch):
+        """Process cwd ~/.hermes + task cwd ~/Projects/foo → task cwd."""
+        from tools import terminal_tool
+
+        process_cwd = tmp_path / "process"
+        process_cwd.mkdir()
+        task_dir = tmp_path / "Projects" / "foo"
+        task_dir.mkdir(parents=True)
+        monkeypatch.chdir(process_cwd)
+        terminal_tool.record_session_cwd("t-99", str(task_dir))
+        try:
+            assert self._cwd_for_task("t-99") == os.path.realpath(str(task_dir))
+        finally:
+            terminal_tool.clear_session_cwd("t-99")
+
+    def test_absolute_terminal_cwd_used_when_no_record(
+        self, tmp_path, monkeypatch,
+    ):
+        """No record/override → sentinel-free absolute TERMINAL_CWD."""
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(ws))
+        monkeypatch.chdir(tmp_path)
+        assert self._cwd_for_task("t-x") == os.path.realpath(str(ws))
+
+    def test_sentinel_terminal_cwd_rejected(
+        self, tmp_path, monkeypatch,
+    ):
+        """Literal ``\".\"`` from a stale config is not a real anchor."""
+        monkeypatch.setenv("TERMINAL_CWD", ".")
+        monkeypatch.chdir(tmp_path)
+        assert self._cwd_for_task("") == os.path.realpath(str(tmp_path))
 
 
 # ── Matcher behaviour ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

In `_serialize_payload`, the shell-hook payload `cwd` is always the
program-start folder (`Path.cwd()`). Each chat may actually live in a
project; file saves already use the chat folder. A house write-guard that
joins relative paths against the hook `cwd` would therefore treat a good
project save as a dump into `~/.hermes/` — you cannot turn the guard on
until this lie is fixed.

## Change

Set payload `cwd` using the **same ladder file tools use**, given
`extra.task_id` (already passed into the hook, previously ignored for
`cwd`):

1. this chat's recorded session cwd (`terminal_tool.get_session_cwd`)
2. a registered task/session workspace override
3. an absolute, sentinel-free `$TERMINAL_CWD` (never the literal `"."`)
4. the process cwd only as a last resort

Implemented by delegating to `tools.file_tools._resolve_base_dir`, so the
hook and the file tools are guaranteed to pick the **same** target.

## Tests

Targeted unit tests in `tests/agent/test_shell_hooks.py::TestHookCwdLadder`:
process-cwd fallback, task-cwd-wins-over-process-cwd, absolute TERMINAL_CWD,
and sentinel `"."` rejection. `51 passed` (full shell_hooks module).

Does **not** add the house write-guard (that's a follow-up ticket) and does
not change Home as a product bucket.