### PR TITLE
fix(compression): show when configured thresholds are raised

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2897,6 +2897,10 @@ def init_agent(
             if _cap and _cap > 0:
                 _cap_note = f" (capped at {_cap:,} tokens)"
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (compress at {int(_active_threshold_pct*100)}% = {agent.context_compressor.threshold_tokens:,}{_cap_note})")
+            from agent.context_compressor import compression_threshold_floor_notice
+            _floor_notice = compression_threshold_floor_notice(agent.context_compressor)
+            if _floor_notice:
+                print(f"  {_floor_notice}")
         else:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (auto-compression disabled)")
         # Notice with the exact opt-back-out command. Printed inline at startup

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1091,6 +1091,18 @@ _SMALL_CTX_WINDOW_LIMIT = 512_000
 _SMALL_CTX_THRESHOLD_PERCENT = 0.75
 
 
+def compression_threshold_floor_notice(compressor: Any) -> str:
+    """Describe a small-window threshold raise for session-aware surfaces."""
+    if not getattr(compressor, "threshold_floor_applied", False):
+        return ""
+    requested = float(getattr(compressor, "requested_threshold_percent", 0) or 0)
+    effective = float(getattr(compressor, "threshold_percent", 0) or 0)
+    return (
+        f"Requested threshold: {requested * 100:.0f}%; raised to "
+        f"{effective * 100:.0f}% by the sub-512K context safety floor."
+    )
+
+
 _PATH_MENTION_RE = re.compile(r"(?:/|~/?|[A-Za-z]:\\)[^\s`'\")\]}<>]+")
 
 # MEDIA delivery directives must not reach the summarizer — if one leaks into
@@ -2763,6 +2775,20 @@ class ContextCompressor(ContextEngine):
         if context_length and context_length < _SMALL_CTX_WINDOW_LIMIT:
             return max(threshold_percent, _SMALL_CTX_THRESHOLD_PERCENT)
         return threshold_percent
+
+    @property
+    def requested_threshold_percent(self) -> float:
+        """Return the active model's threshold before the small-window floor."""
+        return getattr(self, "_base_threshold_percent", self.threshold_percent)
+
+    @property
+    def threshold_floor_applied(self) -> bool:
+        """Whether the small-window safeguard raised the requested threshold."""
+        requested = self.requested_threshold_percent
+        return (
+            self.context_length < _SMALL_CTX_WINDOW_LIMIT
+            and self.threshold_percent > requested + 1e-9
+        )
 
     @staticmethod
     def _compute_threshold_tokens(

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -916,6 +916,10 @@ class GatewaySlashCommandsMixin:
                                 to_go=f"{threshold - used:,}",
                             )
                         )
+                    from agent.context_compressor import compression_threshold_floor_notice
+                    floor_notice = compression_threshold_floor_notice(ctx)
+                    if floor_notice:
+                        lines.append(floor_notice)
                 compressions = getattr(ctx, "compression_count", 0) or 0
                 lines.append(t("gateway.context.compressions", count=compressions))
                 if compressions:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -3151,6 +3151,32 @@ class TestContextLengthSetterCoherence:
         # ...and budgets recompute from the same window+percent.
         assert c.threshold_tokens == 150_000
 
+    def test_small_window_exposes_requested_threshold_and_floor(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=262_144):
+            c = ContextCompressor(
+                model="test",
+                threshold_percent=0.60,
+                quiet_mode=True,
+            )
+            _ = c.context_length
+
+        assert c.requested_threshold_percent == 0.60
+        assert c.threshold_percent == 0.75
+        assert c.threshold_floor_applied is True
+
+    def test_unchanged_threshold_does_not_report_floor(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=1_000_000):
+            c = ContextCompressor(
+                model="test",
+                threshold_percent=0.60,
+                quiet_mode=True,
+            )
+            _ = c.context_length
+
+        assert c.requested_threshold_percent == 0.60
+        assert c.threshold_percent == 0.60
+        assert c.threshold_floor_applied is False
+
 
 
 class TestPreLlmFeasibilityCheck:

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -541,6 +541,49 @@ def _stub_agent(**overrides) -> SimpleNamespace:
 
 
 @pytest.mark.asyncio
+async def test_context_command_explains_small_window_threshold_floor():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-threshold-floor",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    compressor = SimpleNamespace(
+        last_prompt_tokens=105_352,
+        context_length=262_144,
+        threshold_tokens=196_608,
+        threshold_percent=0.75,
+        requested_threshold_percent=0.60,
+        threshold_floor_applied=True,
+        compression_count=0,
+        _last_compression_savings_pct=None,
+    )
+    runner._running_agents[session_entry.session_key] = _stub_agent(
+        context_compressor=compressor,
+    )
+
+    with patch(
+        "agent.context_breakdown.compute_session_context_breakdown",
+        return_value={
+            "categories": [],
+            "context_max": 262_144,
+            "context_percent": 40,
+            "context_used": 105_352,
+            "estimated_total": 0,
+            "model": "openai/gpt-test",
+        },
+    ):
+        result = await runner._handle_context_command(_make_event("/context"))
+
+    assert "Auto-compresses at: 196,608 (75%)" in result
+    assert "Requested threshold: 60%; raised to 75%" in result
+    assert "sub-512K context safety floor" in result
+
+
+@pytest.mark.asyncio
 async def test_context_all_appends_expanded_listings():
     """/context all appends per-toolset and per-skill cost listings."""
     session_entry = SessionEntry(


### PR DESCRIPTION
## What does this PR do?

Users who configure `compression.threshold` below 75% for a sub-512K model currently see only the silently raised effective threshold at session startup and in `/context`, while `hermes config get` correctly returns the persisted request. This change preserves the anti-thrashing 75% safety floor but makes the requested and effective values explicit on both session-aware surfaces, preventing operators from mistaking the configured value for the runtime trigger.

### Symptom

With `compression.threshold: 0.6` and a 262,144-token context window, `/context` reports `Auto-compresses at: 196,608 (75%)` without explaining why the configured 60% threshold is not active. CLI startup has the same visibility gap.

### Impact

Operators using sub-512K models cannot tell from existing session output that Hermes raised their requested compression threshold. This can delay compression relative to their configured value, especially on local endpoints where later compaction increases wall-clock latency.

### Bug Cause

**Trigger:** `agent/context_compressor.py` / `ContextCompressor._effective_threshold_percent()` when `context_length < 512_000` and the requested threshold is below 75%.

**Causal chain:**
1. A user configures a threshold such as 60% for a sub-512K model.
2. `ContextCompressor` intentionally raises the active threshold to 75% to avoid repeated low-headroom compactions, while retaining the original request only in internal base state.
3. CLI startup and gateway `/context` render only the effective threshold, so the user cannot see that the safety floor changed the request.

**Why it is wrong:** The safety behavior is intentional, but the session-aware status surfaces omit the relationship between persisted configuration and runtime behavior.

**Working sibling / contrast:** Models at or above 512K, and requested thresholds already at or above 75%, are not changed by the floor and therefore need no additional notice.

**Ruled out:** `hermes config get` is not computing the wrong value. It reports persisted configuration and has no resolved session provider, model, or context window from which to derive an effective threshold.

### Fix

Expose the active model's requested threshold and whether the small-window floor changed it. Reuse one formatter to add a notice to CLI startup and gateway `/context` only when the floor applies, while leaving unchanged thresholds and the persisted configuration contract untouched.

## Related Issue

Closes #91007

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py` - expose requested-versus-effective threshold state and format the safety-floor notice.
- `agent/agent_init.py` - print the notice beside the effective CLI startup threshold.
- `gateway/slash_commands.py` - include the notice in the live `/context` response.
- `tests/agent/test_context_compressor.py` - cover applied and unchanged threshold states.
- `tests/gateway/test_status_command.py` - verify the user-visible `/context` explanation.

## How to Test

1. Configure `compression.threshold` to `0.6` for a model with a 262,144-token context window.
2. Start a CLI session or run `/context` through a gateway and verify the effective 75% trigger is accompanied by `Requested threshold: 60%; raised to 75% by the sub-512K context safety floor.`
3. Use a context window at or above 512K and verify no floor notice is shown.
4. Run the focused automated tests:

```bash
scripts/run_tests.sh tests/agent/test_context_compressor.py -k 'small_window_exposes_requested_threshold_and_floor or unchanged_threshold_does_not_report_floor'
scripts/run_tests.sh tests/gateway/test_status_command.py -k threshold_floor
scripts/run_tests.sh tests/run_agent/test_per_model_threshold_init_ordering.py tests/run_agent/test_plugin_context_engine_init.py
```

The focused suite passed 12 tests. A live in-process model-switch and external-context-engine probe also passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; the behavior is self-describing at runtime
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - the change is platform-independent Python formatting
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model tool behavior changed

## Screenshots / Logs

N/A - focused behavioral tests cover the compressor state and gateway output.