### PR TITLE
fix(goals): honor auxiliary.goal_judge.timeout instead of a hardcoded 30s cap

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -995,6 +995,34 @@ def _goal_judge_max_tokens() -> int:
     return DEFAULT_JUDGE_MAX_TOKENS
 
 
+def _goal_judge_timeout() -> float:
+    """Resolve auxiliary.goal_judge.timeout, falling back to the default.
+
+    Mirrors :func:`_goal_judge_max_tokens`. The key is declared in
+    ``DEFAULT_CONFIG`` and surfaces in the auxiliary config UI, but the
+    judge path used to hardcode ``DEFAULT_JUDGE_TIMEOUT`` and never read
+    it — so a user raising the timeout for a slow-but-healthy reasoning
+    endpoint got no effect, and the loop auto-paused on misleading
+    transport failures pointing at provider/key (#91022). A non-positive
+    or non-numeric value falls back rather than crashing the goal loop.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        value = (
+            (cfg.get("auxiliary") or {})
+            .get("goal_judge", {})
+            .get("timeout", DEFAULT_JUDGE_TIMEOUT)
+        )
+        value = float(value)
+        if value > 0:
+            return value
+    except Exception:
+        pass
+    return DEFAULT_JUDGE_TIMEOUT
+
+
 def _parse_judge_response(raw: str) -> Tuple[str, str, bool, Optional[Dict[str, Any]]]:
     """Parse the judge's reply. Fail-open on unusable output.
 
@@ -1142,7 +1170,7 @@ def judge_goal(
     goal: str,
     last_response: str,
     *,
-    timeout: float = DEFAULT_JUDGE_TIMEOUT,
+    timeout: Optional[float] = None,
     subgoals: Optional[List[str]] = None,
     background_processes: Optional[List[Dict[str, Any]]] = None,
     contract: Optional[GoalContract] = None,
@@ -1189,6 +1217,10 @@ def judge_goal(
     if not last_response.strip():
         # No substantive reply this turn — almost certainly not done yet.
         return "continue", "empty response (nothing to evaluate)", False, None, False
+    if timeout is None:
+        # The declared default for this path is the config key, not the
+        # module constant — see _goal_judge_timeout (#91022).
+        timeout = _goal_judge_timeout()
 
     try:
         from agent.auxiliary_client import call_llm
@@ -1290,7 +1322,7 @@ def gather_background_processes(task_id: Optional[str] = None) -> List[Dict[str,
     return [s for s in sessions if isinstance(s, dict) and s.get("status") != "exited"]
 
 
-def draft_contract(objective: str, *, timeout: float = DEFAULT_JUDGE_TIMEOUT) -> Optional[GoalContract]:
+def draft_contract(objective: str, *, timeout: Optional[float] = None) -> Optional[GoalContract]:
     """Expand a plain-language objective into a structured completion contract.
 
     Uses the ``goal_judge`` auxiliary task (main-model-first, cache-safe — it
@@ -1303,6 +1335,9 @@ def draft_contract(objective: str, *, timeout: float = DEFAULT_JUDGE_TIMEOUT) ->
     objective = (objective or "").strip()
     if not objective:
         return None
+    if timeout is None:
+        # Same config-backed default as judge_goal (#91022).
+        timeout = _goal_judge_timeout()
 
     try:
         from agent.auxiliary_client import call_llm

--- a/tests/hermes_cli/test_goal_judge_timeout_config.py
+++ b/tests/hermes_cli/test_goal_judge_timeout_config.py
@@ -1,0 +1,80 @@
+"""`auxiliary.goal_judge.timeout` must actually reach the judge (#91022).
+
+The key is declared in DEFAULT_CONFIG (60s) and surfaces in the auxiliary
+config UI, but the judge path hardcoded `DEFAULT_JUDGE_TIMEOUT = 30.0` and
+never read it — a user raising the timeout for a slow-but-healthy reasoning
+endpoint got no effect, and the loop auto-paused on misleading transport
+failures pointing at provider/key. The reader mirrors `_goal_judge_max_tokens`
+(max_tokens is wired, timeout was not).
+"""
+
+import pytest
+
+import hermes_cli.goals as goals
+from hermes_cli.goals import DEFAULT_JUDGE_TIMEOUT, _goal_judge_timeout
+
+
+def _patch_config(monkeypatch, cfg):
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(config_mod, "load_config", lambda: cfg)
+
+
+def test_reader_returns_configured_timeout(monkeypatch):
+    _patch_config(monkeypatch, {"auxiliary": {"goal_judge": {"timeout": 120}}})
+    assert _goal_judge_timeout() == 120.0
+
+
+def test_reader_falls_back_when_key_absent(monkeypatch):
+    _patch_config(monkeypatch, {"auxiliary": {"goal_judge": {"max_tokens": 512}}})
+    assert _goal_judge_timeout() == DEFAULT_JUDGE_TIMEOUT
+
+
+def test_reader_falls_back_on_non_positive_or_garbage(monkeypatch):
+    for bad in (0, -5, "fast", None):
+        _patch_config(monkeypatch, {"auxiliary": {"goal_judge": {"timeout": bad}}})
+        assert _goal_judge_timeout() == DEFAULT_JUDGE_TIMEOUT
+
+
+def test_judge_goal_resolves_timeout_from_config(monkeypatch):
+    """The wiring that matters: a caller that passes no timeout (all four
+    production call sites) must have the configured value reach call_llm."""
+    captured = {}
+
+    class _FakeAux:
+        @staticmethod
+        def call_llm(*args, **kwargs):
+            captured.update(kwargs)
+            raise TimeoutError("simulated transport timeout")
+
+    import sys
+
+    monkeypatch.setitem(sys.modules, "agent.auxiliary_client", _FakeAux)
+    _patch_config(monkeypatch, {"auxiliary": {"goal_judge": {"timeout": 120}}})
+
+    verdict, _, _, _, transport_failed = goals.judge_goal(
+        "do the thing", "here is a substantive response to evaluate"
+    )
+
+    assert captured.get("timeout") == 120.0
+    # Fail-open contract preserved: a timeout is still a transport failure.
+    assert verdict == "continue"
+    assert transport_failed is True
+
+
+def test_judge_goal_explicit_timeout_wins(monkeypatch):
+    captured = {}
+
+    class _FakeAux:
+        @staticmethod
+        def call_llm(*args, **kwargs):
+            captured.update(kwargs)
+            raise TimeoutError("simulated transport timeout")
+
+    import sys
+
+    monkeypatch.setitem(sys.modules, "agent.auxiliary_client", _FakeAux)
+    _patch_config(monkeypatch, {"auxiliary": {"goal_judge": {"timeout": 120}}})
+
+    goals.judge_goal("g", "r", timeout=7.5)
+    assert captured.get("timeout") == 7.5


### PR DESCRIPTION
## What does this PR do?

Wires `auxiliary.goal_judge.timeout` into the goal judge path. The key is declared in `DEFAULT_CONFIG` (60s) and surfaces in the auxiliary config UI, but the code hardcoded `DEFAULT_JUDGE_TIMEOUT = 30.0` and never read it — so a user who correctly diagnosed "the judge times out on my slow-but-healthy reasoning endpoint" and raised the timeout to 120 got the same 30s cap, and after 5 consecutive transport failures the loop auto-paused advising them to check `auxiliary.goal_judge provider/key` — the wrong cause (#91022).

The fix mirrors the existing sibling `_goal_judge_max_tokens()` reader (max_tokens from the same config section was already wired; timeout was not): a new `_goal_judge_timeout()` resolves the key with fail-safe fallback, and `judge_goal()` / `draft_contract()` now default `timeout=None` and resolve from config at call time. All four production call sites pass no timeout, so they pick up the configured value with zero changes; an explicit `timeout=` argument still wins.

## Related Issue

Fixes #91022

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/goals.py` — new `_goal_judge_timeout()` (mirrors `_goal_judge_max_tokens`, non-positive/garbage falls back to `DEFAULT_JUDGE_TIMEOUT`); `judge_goal()` and `draft_contract()` default `timeout=None` and resolve the config-backed default at call time, so every existing call site honors `auxiliary.goal_judge.timeout`
- `tests/hermes_cli/test_goal_judge_timeout_config.py` — reader tests (configured value returned / absent-key fallback / garbage fallback) plus the wiring tests that matter: a no-timeout `judge_goal()` call has the configured value reach `call_llm` (fail-open transport contract preserved), and an explicit `timeout=` still wins

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_cli/test_goal_judge_timeout_config.py -q` — should pass (5 passed)
2. Observed result: on unmodified main, `test_judge_goal_resolves_timeout_from_config` fails — `call_llm` receives the hardcoded 30.0 instead of the configured 120 (the #91022 dead end); with this fix it receives 120
3. Regression: `tests/hermes_cli/test_goals.py` + `test_goal_gates.py` + `test_goals_db_bootstrap_off_loop.py` — 54 passed; 4 pre-existing failures verified identical on unmodified main via `git stash`对照 (local live-system guard intercepts real-process signals on this dev machine; unrelated to timeouts, CI's clean environment unaffected)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (config-backed default rationale, #91022 reference)
- [x] Tests added that prove the fix (reader fallbacks + call-site wiring + explicit-override precedence)
- [x] All new and existing tests pass locally (5 new passed; goals suites 54 passed with 4 pre-existing env-sensitive failures present on unmodified main)
- [x] Platform: macOS (config resolution, platform-independent)
