### PR TITLE
feat(cron): wall-clock run budget for agent fires (cron.run_budget_seconds)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1289,6 +1289,53 @@ def _cron_inactivity_seconds() -> float:
         return 600.0
 
 
+def _normalize_cron_run_budget(value) -> Optional[float]:
+    """Normalize a cron wall-clock run-budget value (seconds).
+
+    None / empty / invalid / non-positive all mean "off" (returns None),
+    matching the agent-side ``agent.run_budget_seconds`` semantics — a broken
+    config must leave the feature dormant, never crash a fire.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        logger.warning("Invalid cron run_budget_seconds=%r (bool); ignoring", value)
+        return None
+    try:
+        parsed = float(value)
+    except (ValueError, TypeError):
+        logger.warning("Invalid cron run_budget_seconds=%r; ignoring", value)
+        return None
+    if parsed <= 0:
+        logger.warning(
+            "Invalid cron run_budget_seconds=%r (non-positive); ignoring", value
+        )
+        return None
+    return parsed
+
+
+def _cron_run_budget_seconds(job: Any, cfg: Any) -> Optional[float]:
+    """Wall-clock budget for one cron agent run, in seconds.
+
+    Resolution: per-job ``run_budget_seconds`` (jobs.json) wins over the
+    ``cron.run_budget_seconds`` config default; both absent = off. The
+    inactivity watchdog (``_cron_inactivity_seconds``) only catches fully
+    silent stalls — a trickling stream updates activity on every chunk, so a
+    slow-but-alive provider call can consume an entire fire window. The wall
+    budget closes that gap: the agent-side budget machinery (80% wrap-up
+    notice + per-call stale-timeout capping) plus ``run_job``'s hard
+    interrupt at 100% (see the poll loop below).
+    """
+    raw = None
+    if isinstance(job, dict):
+        raw = job.get("run_budget_seconds")
+    if raw is None and isinstance(cfg, dict):
+        cron_cfg = cfg.get("cron")
+        if isinstance(cron_cfg, dict):
+            raw = cron_cfg.get("run_budget_seconds")
+    return _normalize_cron_run_budget(raw)
+
+
 def _cwd_lock_timeout_seconds() -> float:
     """Bound for the TERMINAL_CWD lock wait: inactivity limit + margin."""
     inactivity = _cron_inactivity_seconds()
@@ -5549,6 +5596,12 @@ def run_job(
                 job_id, _mcp_exc,
             )
 
+        # Wall-clock run budget for this fire (seconds; None = off). Resolved
+        # BEFORE the AIAgent is built so the agent-side budget machinery (80%
+        # wrap-up notice + per-call stale-timeout capping) is active for the
+        # whole run; the poll loop below hard-interrupts at 100%.
+        _cron_budget = _cron_run_budget_seconds(job, _cfg)
+
         agent = AIAgent(
             model=model,
             api_key=runtime.get("api_key"),
@@ -5559,6 +5612,7 @@ def run_job(
             acp_command=runtime.get("command"),
             acp_args=runtime.get("args"),
             max_iterations=max_iterations,
+            run_budget_seconds=_cron_budget,
             reasoning_config=reasoning_config,
             prefill_messages=prefill_messages,
             fallback_model=fallback_model,
@@ -5646,11 +5700,19 @@ def run_job(
         _audit_t_start = time.monotonic()
         _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
         _inactivity_timeout = False
+        _wall_budget_exhausted = False
+
+        def _wall_budget_exceeded() -> bool:
+            """True once the fire has run past its wall-clock budget (if any)."""
+            if _cron_budget is None:
+                return False
+            return (time.monotonic() - _audit_t_start) >= float(_cron_budget)
+
         try:
             if _cron_inactivity_limit is None:
-                # Unlimited — no inactivity watchdog, but a one-shot still
-                # needs its run_claim heartbeat, so poll instead of blocking.
-                if _is_oneshot or cancel_event is not None:
+                # Unlimited inactivity — but a wall-clock budget still needs
+                # polling to enforce, as does a one-shot claim heartbeat.
+                if _is_oneshot or cancel_event is not None or _cron_budget is not None:
                     result = None
                     while True:
                         done, _ = concurrent.futures.wait(
@@ -5662,6 +5724,9 @@ def run_job(
                             break
                         _abort_if_fire_claim_lost()
                         _heartbeat_run_claim_if_due()
+                        if _wall_budget_exceeded():
+                            _wall_budget_exhausted = True
+                            break
                 else:
                     result = _cron_future.result()
             else:
@@ -5676,6 +5741,12 @@ def run_job(
                         break
                     _abort_if_fire_claim_lost()
                     _heartbeat_run_claim_if_due()
+                    # Agent still running — check the wall-clock budget first:
+                    # a trickling stream keeps activity fresh, so inactivity
+                    # alone cannot bound a fire window.
+                    if _wall_budget_exceeded():
+                        _wall_budget_exhausted = True
+                        break
                     # Agent still running — check inactivity.
                     _idle_secs = 0.0
                     if hasattr(agent, "get_activity_summary"):
@@ -5693,7 +5764,7 @@ def run_job(
         finally:
             _cron_pool.shutdown(wait=False, cancel_futures=True)
 
-        if _inactivity_timeout:
+        if _inactivity_timeout or _wall_budget_exhausted:
             # Build diagnostic summary from the agent's activity tracker.
             _activity = {}
             if hasattr(agent, "get_activity_summary"):
@@ -5706,6 +5777,28 @@ def run_job(
             _cur_tool = _activity.get("current_tool")
             _iter_n = _activity.get("api_call_count", 0)
             _iter_max = _activity.get("max_iterations", 0)
+
+            if _wall_budget_exhausted:
+                # _wall_budget_exceeded() only returns True with a non-None
+                # budget; bind a narrowed local for the diagnostics below.
+                _budget_secs = float(_cron_budget) if _cron_budget is not None else 0.0
+                _elapsed = time.monotonic() - _audit_t_start
+                logger.error(
+                    "Job '%s' exceeded its wall-clock budget (%.0fs elapsed, "
+                    "limit %.0fs) | last_activity=%s | iteration=%s/%s | tool=%s",
+                    job_name, _elapsed, _budget_secs,
+                    _last_desc, _iter_n, _iter_max,
+                    _cur_tool or "none",
+                )
+                request_hard_interrupt(
+                    agent,
+                    f"Cron job exceeded wall-clock budget ({int(_budget_secs)}s)",
+                )
+                raise TimeoutError(
+                    f"Cron job '{job_name}' exceeded its wall-clock budget of "
+                    f"{int(_budget_secs)}s (elapsed {int(_elapsed)}s) "
+                    f"— last activity: {_last_desc}"
+                )
 
             logger.error(
                 "Job '%s' idle for %.0fs (inactivity limit %.0fs) "

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2550,6 +2550,17 @@ DEFAULT_CONFIG = {
         # overridable via HERMES_CRON_MEDIA_SEND_TIMEOUT env var. Keep in
         # sync with cron.scheduler._DEFAULT_MEDIA_SEND_TIMEOUT.
         "media_send_timeout_seconds": 300,
+        # Wall-clock budget (seconds) for cron AGENT runs. None = off. When
+        # set (or a job carries its own run_budget_seconds in jobs.json), the
+        # run gets the agent-side wall-clock budget: an 80% wrap-up notice is
+        # injected, per-call stale timeouts are capped at half the remaining
+        # budget (so one hung-but-active provider stream cannot eat the whole
+        # fire window — the inactivity watchdog only catches fully silent
+        # stalls), and the scheduler hard-interrupts at 100%. Jobs that need
+        # to run indefinitely leave this unset. Interaction: choose a value
+        # comfortably below the job's cadence so a fire never overlaps the
+        # next one.
+        "run_budget_seconds": None,
     },
 
     # Kanban multi-agent coordination — controls the dispatcher loop that

--- a/tests/cron/test_cron_wall_budget.py
+++ b/tests/cron/test_cron_wall_budget.py
@@ -1,0 +1,277 @@
+"""Tests for the cron wall-clock run budget (cron.run_budget_seconds / per-job).
+
+Covers:
+
+1. Budget resolution in ``cron.scheduler._cron_run_budget_seconds``:
+   - per-job ``run_budget_seconds`` (jobs.json) wins over the
+     ``cron.run_budget_seconds`` config default;
+   - config fallback when the job carries no budget;
+   - invalid values (bool, non-numeric, non-positive) resolve to None and
+     leave the feature dormant — a broken config must never crash a fire.
+
+2. The hard ceiling in ``run_job``: when a fire exceeds its budget, the poll
+   loop hard-interrupts the agent and raises TimeoutError with a diagnostic
+   naming the budget and the last activity — the gap the inactivity watchdog
+   cannot close, because a trickling provider stream marks activity on every
+   chunk while a single hung call consumes the whole fire window.
+
+3. Backward-compat guards: with no budget the run is untouched (including
+   the unlimited-inactivity path), and the inactivity abort still fires when
+   no budget is set.
+"""
+
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Ensure project root is importable (house style in tests/cron).
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cron.scheduler import _cron_run_budget_seconds, _normalize_cron_run_budget, run_job
+
+
+# ── unit: resolution + normalization ───────────────────────────────────────
+
+
+class TestBudgetResolution:
+    def test_job_field_wins_over_config(self):
+        job = {"id": "j", "run_budget_seconds": 900}
+        cfg = {"cron": {"run_budget_seconds": 3600}}
+        assert _cron_run_budget_seconds(job, cfg) == 900.0
+
+    def test_config_fallback(self):
+        assert _cron_run_budget_seconds(
+            {"id": "j"}, {"cron": {"run_budget_seconds": 3600}}
+        ) == 3600.0
+
+    def test_both_absent_means_off(self):
+        assert _cron_run_budget_seconds({"id": "j"}, {}) is None
+        assert _cron_run_budget_seconds(None, None) is None
+
+    def test_invalid_values_are_dormant(self):
+        for bad in (True, False, "abc", -5, 0, [], {}):
+            assert _normalize_cron_run_budget(bad) is None
+
+    def test_valid_values_normalize(self):
+        assert _normalize_cron_run_budget(900) == 900.0
+        assert _normalize_cron_run_budget("600") == 600.0
+        assert _normalize_cron_run_budget(0.5) == 0.5
+        assert _normalize_cron_run_budget(None) is None
+
+
+# ── integration: hard ceiling inside run_job ──────────────────────────────
+
+
+_RUNTIME = {
+    "api_key": "test-key",
+    "base_url": "https://example.invalid/v1",
+    "provider": "openrouter",
+    "api_mode": "chat_completions",
+}
+
+
+class FakeSessionDB:
+    def get_compression_tip(self, _session_id):
+        return None
+
+    def end_session(self, *_args, **_kwargs):
+        return None
+
+    def close(self):
+        return None
+
+
+class BlockingAgent:
+    """Agent whose run never returns until released; records interrupts.
+
+    Reports itself permanently ACTIVE (seconds_since_activity=0) — the exact
+    trickling-stream shape the inactivity watchdog cannot catch.
+    """
+
+    def __init__(self, release: threading.Event):
+        self.release = release
+        self.interrupted = False
+        self.interrupt_reason = None
+        self.max_iterations = 90
+
+    def get_activity_summary(self):
+        return {
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "receiving stream response",
+            "seconds_since_activity": 0.0,
+            "current_tool": None,
+            "api_call_count": 41,
+            "max_iterations": self.max_iterations,
+        }
+
+    def interrupt(self, msg):
+        self.interrupted = True
+        self.interrupt_reason = msg
+
+    def close(self):
+        return None
+
+    def run_conversation(self, prompt):
+        self.release.wait(10)
+        return {"final_response": "done", "messages": []}
+
+
+class QuickAgent(BlockingAgent):
+    def run_conversation(self, prompt):
+        return {"final_response": "done", "messages": []}
+
+
+class Stepper:
+    """Fake monotonic clock advancing 60s per read.
+
+    The run_job poll loop waits 5 real seconds per iteration but every clock
+    read jumps 60s, so the budget deadline is crossed on the FIRST wait and
+    the test costs ~0s of wall time.
+    """
+
+    def __init__(self):
+        self._t = 0.0
+
+    def __call__(self):
+        self._t += 60.0
+        return self._t
+
+
+def _drive_run_job(job, agent, release, hermes_home):
+    """Run the REAL ``run_job`` against fakes (harness shape from
+    test_cleanup_timeout.py)."""
+    from unittest.mock import MagicMock
+
+    agent_cls = MagicMock()
+    agent_cls.return_value = agent
+    patchers = [
+        patch("cron.scheduler._hermes_home", hermes_home),
+        patch("cron.scheduler._resolve_origin", return_value=None),
+        patch("hermes_cli.env_loader.load_hermes_dotenv"),
+        patch("hermes_cli.env_loader.reset_secret_source_cache"),
+        patch("hermes_state.SessionDB", return_value=FakeSessionDB()),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=_RUNTIME,
+        ),
+        patch("cron.scheduler._cron_cleanup_timeout_seconds", return_value=0.02),
+        patch("run_agent.AIAgent", agent_cls),
+    ]
+    for p in patchers:
+        p.start()
+    try:
+        return run_job(job)
+    finally:
+        for p in patchers:
+            p.stop()
+
+
+def test_fire_exceeding_budget_hard_interrupts_and_fails(monkeypatch, tmp_path):
+    """A fire past its wall-clock budget is hard-interrupted and fails with a
+    TimeoutError naming the budget — even while the agent looks fully active
+    (the inactivity watchdog can never catch this shape)."""
+    release = threading.Event()
+    agent = BlockingAgent(release)
+    monkeypatch.setattr("cron.scheduler.time.monotonic", Stepper())
+
+    job = {
+        "id": "budget-overrun",
+        "name": "budget-overrun",
+        "prompt": "work",
+        "schedule": {"kind": "interval", "minutes": 120, "display": "every 120m"},
+        "run_budget_seconds": 30,
+        "enabled": True,
+        "deliver": "local",
+    }
+
+    try:
+        success, output, _final_response, error = _drive_run_job(job, agent, release, tmp_path)
+        assert success is False
+        assert "wall-clock budget" in (error or "")
+        assert "budget-overrun" in (error or "")
+        assert agent.interrupted is True
+        assert "wall-clock budget (30s)" in agent.interrupt_reason
+    finally:
+        release.set()
+
+
+def test_no_budget_leaves_unlimited_run_untouched(monkeypatch, tmp_path):
+    """Budget unset + HERMES_CRON_TIMEOUT=0: the run proceeds to completion
+    exactly as before the feature existed."""
+    monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0")
+    release = threading.Event()
+    agent = QuickAgent(release)
+
+    job = {
+        "id": "no-budget",
+        "name": "no-budget",
+        "prompt": "work",
+        "schedule": {"kind": "interval", "minutes": 120, "display": "every 120m"},
+        "enabled": True,
+        "deliver": "local",
+    }
+    success, _output, final_response, error = _drive_run_job(job, agent, release, tmp_path)
+
+    assert success is True
+    assert final_response == "done"
+    assert error is None
+    assert agent.interrupted is False
+
+
+def test_inactivity_timeout_still_fires_without_budget(monkeypatch, tmp_path):
+    """No budget set: the pre-existing inactivity abort is unchanged."""
+    monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0.001")  # < poll interval
+    release = threading.Event()
+    # Idle from the very first read: activity summary reports huge idle.
+    agent = BlockingAgent(release)
+    agent.get_activity_summary = lambda: {
+        "last_activity_ts": time.time() - 999,
+        "last_activity_desc": "api_call_streaming",
+        "seconds_since_activity": 999.0,
+        "current_tool": None,
+        "api_call_count": 41,
+        "max_iterations": 90,
+    }
+
+    job = {
+        "id": "idle-job",
+        "name": "idle-job",
+        "prompt": "work",
+        "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+        "enabled": True,
+        "deliver": "local",
+    }
+
+    try:
+        success, output, _final_response, error = _drive_run_job(job, agent, release, tmp_path)
+        assert success is False
+        assert "idle for" in (error or "")
+        assert agent.interrupted is True
+    finally:
+        release.set()
+
+
+def test_per_job_budget_reaches_the_agent(monkeypatch, tmp_path):
+    """run_budget_seconds from jobs.json is forwarded into the AIAgent
+    constructor so the agent-side budget machinery is active for the run."""
+    release = threading.Event()
+    agent = QuickAgent(release)
+
+    job = {
+        "id": "agent-budget",
+        "name": "agent-budget",
+        "prompt": "work",
+        "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+        "run_budget_seconds": 900,
+        "enabled": True,
+        "deliver": "local",
+    }
+
+    success, _output, final_response, _error = _drive_run_job(job, agent, release, tmp_path)
+    assert success is True
+    assert final_response == "done"

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1053,6 +1053,17 @@ When a budget is set, two things happen:
 
 The budget is per `run_conversation` turn (it resets on each user message) and the feature is completely dormant when unset — no clock reads, no injection, no timeout changes.
 
+### Cron jobs
+
+Cron agent runs can opt in to the same wall-clock budget. Set it fleet-wide under `cron:`, or per job with a `run_budget_seconds` field in `jobs.json` (the per-job value wins):
+
+```yaml
+cron:
+  run_budget_seconds: null    # Optional; null/unset = off (default)
+```
+
+A budgeted cron run gets the two agent-side behaviors above **plus a hard ceiling at 100%**: `run_job`'s poll loop hard-interrupts the agent at budget expiry and fails the fire (the run is recorded as failed, not `ok`, with a diagnostic including the last activity). This closes a real gap — the cron inactivity watchdog only catches *fully silent* stalls, because a slow provider stream marks activity on every chunk, so a hung-but-trickling call could otherwise consume an entire fire window and overlap the next scheduled fire. Choose a value comfortably below the job's cadence.
+
 ## Verify-on-Stop (coding verification)
 
 When enabled, Hermes refuses to accept a final answer on a turn where the agent edited code in a workspace but produced no fresh verification evidence (a passing test run, build, lint, etc.) — it injects a synthetic follow-up asking the agent to verify or explain why it can't. Doc/markdown/skill-only edits never trigger it, and the loop is bounded so it can never trap the agent.


### PR DESCRIPTION
## Problem

A cron agent fire can outlive its entire scheduled window. The inactivity
watchdog (`HERMES_CRON_TIMEOUT`, default 600s) only catches **fully silent**
stalls: the agent's activity tracker marks progress on every tool call, API
call, **and stream chunk** (`_touch_activity("receiving stream response")`).
A hung-but-trickling provider stream therefore keeps a fire alive
indefinitely — observed in the field as a 45-minute cron run containing a
30-minute dead gap (a 17-minute stream drop, then another ~16-minute one),
which then leaked into/overlapped the next scheduled fire. There was no
wall-clock cap anywhere in the cron run path.

### What this does

Wires the existing agent-side wall-clock budget (merged in commit
`803397ecc3`, `agent.run_budget_seconds` / `--run-budget`) into cron runs
and adds the missing hard ceiling:

1. **Resolution** — per-job `run_budget_seconds` (jobs.json) >
   `cron.run_budget_seconds` (config) > off (`None`). Non-numeric /
   non-positive / bool values are dormant with a warning, matching
   agent-side semantics: a broken config never crashes a fire.
2. **Agent wiring** — the budget is passed into `AIAgent` so the existing
   machinery activates for the whole run: one-time 80% wrap-up notice
   (cache-safe, appended to the newest tool result) and deadline-scaled
   stale-timeout capping (`max(60, remaining × 0.5)`) so a single hung
   call cannot eat the remaining budget.
3. **Hard ceiling** — `run_job`'s poll loop trips on budget expiry,
   `request_hard_interrupt`s the agent with a reason naming the budget,
   and fails the fire through the *same abort path as the inactivity
   timeout*: `last_status` never `ok`, failure output written, next
   scheduled tick resumes normally. The wall check runs **before** the
   inactivity check and also in the unlimited-inactivity poll loop, so it
   works even with `HERMES_CRON_TIMEOUT=0`.

**Off by default**: no budget set ⇒ behavior byte-for-byte unchanged.

### Why not just lower the inactivity timeout?

Inactivity counts stream deltas, so the failing shape (slow-but-alive
provider) is invisible to it; lowering it would only false-positive on
legit long generations. A wall-clock budget is the only bound that can
guarantee a fire ends by a deadline.

### Tests

New `tests/cron/test_cron_wall_budget.py` (9 tests, all passing):

- budget resolution precedence + invalid-value dormancy;
- **real `run_job`** with a permanently-"active" agent: budget expiry →
  hard interrupt + failed fire with `wall-clock budget` in the error
  (the exact trickling-stream shape the inactivity watchdog cannot catch);
- no budget + `HERMES_CRON_TIMEOUT=0` → unchanged successful completion;
- no budget + idle agent → inactivity abort still fires;
- per-job budget reaches the `AIAgent` constructor.

Local run: `pytest tests/cron/ tests/agent/test_run_budget.py` →
**837 passed, 1 skipped**; the 5 failures in `test_monitor_kind.py`
reproduce identically on pristine `origin/main` (model-drift guard
#44585 test-fixture mismatch, unrelated). `ruff check` clean on all
changed files.

### Docs

`website/docs/user-guide/configuration.md` — new "Cron jobs" subsection
under Wall-Clock Run Budget documenting the config key, per-job override,
precedence, and the hard-ceiling behavior.

### Notes for reviewers

- The per-job field round-trips through `jobs.json` naturally
  (`update_job` does not whitelist fields); CLI surface is deliberately
  out of scope to keep the diff minimal.
- The 5s `_POLL_INTERVAL` means a budget is enforced within ≤5s of expiry —
  acceptable and consistent with the existing inactivity poll.