### PR TITLE
fix(approval): prevent Docker authorization bypass of deny policy

### DIFF
--- a/hermes_cli/approvals_test.py
+++ b/hermes_cli/approvals_test.py
@@ -5,10 +5,10 @@ running it, prompting anyone, or persisting anything. It composes the REAL
 runtime evaluators from ``tools.approval`` in the same order the runtime
 guard (``check_all_command_guards``) applies them:
 
-    1. container-skip gate (isolated backends bypass all guards),
-    2. hardline blocklist (never bypassable, fires before yolo/off),
-    3. sudo-stdin guard (unconditional),
-    4. user ``approvals.deny`` rules (fire before yolo/off),
+    1. hardline blocklist for host-reaching backends,
+    2. sudo-stdin guard for host-reaching backends,
+    3. user ``approvals.deny`` rules (never bypassed by containers or yolo/off),
+    4. container-skip gate for ordinary command guards,
     5. yolo / ``approvals.mode: off`` bypass,
     6. permanent ``command_allowlist``,
     7. dangerous-pattern detection → would ask for approval.
@@ -77,13 +77,22 @@ def evaluate_command(command: str, env_type: str = "local") -> dict:
             "normalized_variants": variants,
         }
 
-    # 1. Isolated container backends skip every guard (runtime parity:
-    #    this fires BEFORE the hardline floor in check_all_command_guards).
+    # Isolated container backends skip host-oriented guards, but the runtime
+    # evaluates the operator's explicit deny policy before that fast path.
     if approval._should_skip_container_guards(env_type):
+        deny_pattern = approval._match_user_deny_rule(command)
+        if deny_pattern is not None:
+            return result(
+                "user-deny", rule=deny_pattern,
+                detail="matches a user-defined approvals.deny rule in "
+                       "config.yaml (blocked even in an isolated container, "
+                       "under --yolo, or with mode=off)",
+            )
         return result(
             "allow",
             detail=(f"env_type '{env_type}' is an isolated container backend; "
-                    "the runtime skips all command guards for it"),
+                    "the runtime skips ordinary command guards after "
+                    "approvals.deny evaluation"),
         )
 
     # 2. Hardline blocklist — never bypassable, even under yolo.

--- a/tests/hermes_cli/test_approvals_test.py
+++ b/tests/hermes_cli/test_approvals_test.py
@@ -89,6 +89,27 @@ class TestVerdicts:
         assert "allow" in out
         assert "container" in out or "isolated" in out
 
+    def test_container_env_type_cannot_skip_user_deny(
+            self, isolated_approvals, capsys, monkeypatch):
+        monkeypatch.setattr(
+            A,
+            "_get_approval_config",
+            lambda: {"mode": "off", "deny": ["*chmod*"]},
+        )
+        monkeypatch.setattr(A, "_YOLO_MODE_FROZEN", True)
+
+        rc = at.approvals_test_command(
+            _args(
+                ["chmod", "600", "/tmp/hermes-approval-deny-test"],
+                env_type="docker",
+            )
+        )
+        out = capsys.readouterr().out
+
+        assert rc == 3
+        assert "user-deny" in out
+        assert "*chmod*" in out
+
     def test_mode_off_bypasses_dangerous_but_not_hardline(self, isolated_approvals,
                                                           capsys, monkeypatch):
         monkeypatch.setattr(A, "_get_approval_config", lambda: {"mode": "off"})

--- a/tests/tools/test_approval_deny_rules.py
+++ b/tests/tools/test_approval_deny_rules.py
@@ -113,11 +113,38 @@ class TestDenyOrdering:
         assert result["approved"] is False
         assert result.get("user_deny") is True
 
-    def test_container_backend_skips_deny(self, deny_config, clean_env):
-        """Isolated container backends bypass the whole guard stack (existing
-        contract) — deny rules protect the host, containers can't touch it."""
-        deny_config(["git push --force*"])
-        result = mod.check_dangerous_command("git push --force origin main", "docker")
+    @pytest.mark.parametrize(
+        "guard",
+        [mod.check_dangerous_command, mod.check_all_command_guards],
+    )
+    @pytest.mark.parametrize(
+        "env_type",
+        ["docker", "singularity", "modal", "daytona", "vercel_sandbox"],
+    )
+    def test_container_backend_cannot_skip_deny(
+            self, guard, env_type, deny_config, clean_env, monkeypatch):
+        deny_config(["*chmod*"], mode="off")
+        monkeypatch.setattr(mod, "_YOLO_MODE_FROZEN", True)
+
+        result = guard("chmod 600 /tmp/hermes-approval-deny-test", env_type)
+
+        assert result["approved"] is False
+        assert result.get("user_deny") is True
+
+    @pytest.mark.parametrize(
+        "guard",
+        [mod.check_dangerous_command, mod.check_all_command_guards],
+    )
+    @pytest.mark.parametrize(
+        "env_type",
+        ["docker", "singularity", "modal", "daytona", "vercel_sandbox"],
+    )
+    def test_container_backend_still_skips_non_denied_command(
+            self, guard, env_type, deny_config, clean_env):
+        deny_config(["*chmod*"])
+
+        result = guard("rm -rf build/", env_type)
+
         assert result["approved"] is True
 
     def test_benign_command_unaffected(self, deny_config, clean_env):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3733,6 +3733,11 @@ def check_dangerous_command(command: str, env_type: str,
         {"approved": True/False, "message": str or None, ...}
     """
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
+        deny_pattern = _match_user_deny_rule(command)
+        if deny_pattern is not None:
+            logger.warning("User deny rule %r blocked command: %s",
+                           deny_pattern, command[:200])
+            return _user_deny_block_result(deny_pattern)
         return {"approved": True, "message": None}
 
     # Hardline floor: commands with no recovery path (rm -rf /, mkfs, dd
@@ -4353,9 +4358,14 @@ def check_all_command_guards(command: str, env_type: str,
     such a session is no longer isolated, so it goes through the normal flow
     instead of the container fast-path.
     """
-    # Skip isolated container backends for both checks. Docker stops skipping
-    # once host paths are bind-mounted into the sandbox.
+    # Skip ordinary guards for isolated containers, but never an operator's
+    # explicit approvals.deny policy.
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
+        deny_pattern = _match_user_deny_rule(command)
+        if deny_pattern is not None:
+            logger.warning("User deny rule %r blocked command: %s",
+                           deny_pattern, command[:200])
+            return _user_deny_block_result(deny_pattern)
         return {"approved": True, "message": None}
 
     # Hardline floor: unconditional block for catastrophic commands


### PR DESCRIPTION
## What does this PR do?

Isolated Docker backends no longer bypass operator-defined `approvals.deny` policy. Matching commands are blocked before the container fast path in both public shell guard APIs, preventing an authorization policy bypass while preserving the fast path for non-matching commands.

### Symptom

With Docker configured without host bind mounts, a command matching `approvals.deny` was approved and could reach the container shell. The same policy correctly blocked the command on local and host-bound backends.

### Impact

Operators could not rely on `approvals.deny` as a non-bypassable policy for isolated Docker commands. The bypass also applied under `--yolo` and `approvals.mode: off`, even though explicit deny rules are intended to take precedence over those modes.

### Bug Cause

**Trigger:** `tools/approval.py` / `check_dangerous_command` and `check_all_command_guards` / isolated container fast path

**Causal chain:**
1. Docker without host mounts selects the isolated-container path.
2. Both shell guard entry points returned approval before evaluating `_match_user_deny_rule`.
3. A command matching an explicit deny rule reached the container shell.

**Why it is wrong:** The isolation shortcut bypassed operator policy instead of only bypassing ordinary host-oriented command guards.

**Working sibling / contrast:** Local and host-bound Docker backends already continued through deny evaluation. This change applies the same deny floor to both public shell guard APIs and the dry-run CLI evaluator.

**Ruled out:** Deny glob matching and command normalization are not involved; the existing matcher works when reached. The defect was the early return ordering.

### Fix

Evaluate `approvals.deny` inside the isolated-container branch before returning approval. Keep the ordinary container bypass unchanged for commands that do not match a deny rule, and update `hermes approvals test` to report the runtime ordering accurately.

## Related Issue

Closes #91002

## Type of Change

- [x] Security fix

## Changes Made

- `tools/approval.py` - enforce explicit deny rules before isolated-container approval in both shell guard APIs.
- `hermes_cli/approvals_test.py` - keep dry-run verdict ordering and explanations aligned with runtime behavior.
- `tests/tools/test_approval_deny_rules.py` - cover both public guards, yolo/off modes, and non-matching container bypasses.
- `tests/hermes_cli/test_approvals_test.py` - cover isolated-container deny verdict parity.

## How to Test

1. Configure `approvals.deny` with `*chmod*` and evaluate a matching command with `env_type="docker"` and no host access.
2. Confirm both public shell guards return a user-deny result, including under yolo and `mode=off`.
3. Confirm a non-matching command still uses the isolated-container fast path.
4. Run the focused approval suite:

```bash
scripts/run_tests.sh tests/tools/test_approval_deny_rules.py tests/hermes_cli/test_approvals_test.py tests/tools/test_hardline_blocklist.py tests/tools/test_command_guards.py tests/tools/test_force_dangerous_override.py -q
```

Result: 269 passed.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the repository test entry on the relevant tests and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation - N/A; no user-facing documentation changes are required
- [x] `cli-config.yaml.example` - N/A; no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` - N/A; no architecture or workflow changed
- [x] I have considered cross-platform impact per the compatibility guide
- [x] Tool descriptions/schemas - N/A; the approval result contract is unchanged

## Screenshots / Logs

Focused automated verification: 269 tests passed. Independent base/current probes reproduced the bypass on the base commit and confirmed both public shell guards block the same command at this tip.