### PR TITLE
feat(desktop): connector UI primitives — one identity chip, a real favicon, and a card with no connector logic in it

### DIFF
--- a/apps/desktop/electron/favicon.test.ts
+++ b/apps/desktop/electron/favicon.test.ts
@@ -1,0 +1,284 @@
+import assert from 'node:assert/strict'
+
+import { describe, test } from 'vitest'
+
+import {
+  fallbackIconCandidates,
+  type FaviconIo,
+  iconCandidatesFromHtml,
+  iconCandidatesFromManifest,
+  imageMime,
+  isPublicHttpUrl,
+  largestDeclaredSize,
+  manifestUrlFromHtml,
+  rankCandidates,
+  resolveFavicon,
+  sniffImageMime
+} from './favicon'
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, ...new Array(60).fill(0)])
+const HTML_BYTES = new Uint8Array([...Buffer.from('<!doctype html><html>nope</html>'), ...new Array(40).fill(0x20)])
+
+/** An IO that serves fixed text per URL and images only for listed URLs,
+ *  recording what was asked for and in what order. */
+function fakeIo(options: {
+  images?: Record<string, { bytes: Uint8Array; mime: string }>
+  text?: Record<string, string>
+}): { asked: string[]; io: FaviconIo } {
+  const asked: string[] = []
+
+  return {
+    asked,
+    io: {
+      fetchImage: async url => {
+        asked.push(url)
+
+        return options.images?.[url] ?? null
+      },
+      fetchText: async url => options.text?.[url] ?? ''
+    }
+  }
+}
+
+describe('which hosts we will ask at all', () => {
+  test('a public https host is fair game', () => {
+    assert.equal(isPublicHttpUrl('https://linear.app'), true)
+  })
+
+  test.each([
+    ['loopback by name', 'http://localhost:8000/mcp'],
+    ['loopback by address', 'http://127.0.0.1:3000'],
+    ['RFC1918 class A', 'http://10.1.2.3'],
+    ['RFC1918 class B', 'http://172.16.0.9'],
+    ['RFC1918 class C', 'http://192.168.1.5'],
+    ['link-local', 'http://169.254.1.1'],
+    ['mDNS', 'http://nas.local'],
+    ['a bare hostname', 'http://buildbox'],
+    ['a non-http scheme', 'file:///etc/passwd']
+  ])('%s is refused', (_label, url) => {
+    // A private endpoint has no logo out there to find, and asking would
+    // announce an internal hostname.
+    assert.equal(isPublicHttpUrl(url), false)
+  })
+})
+
+describe('reading a page for the marks it declares', () => {
+  test('declared icons come back absolute against the page', () => {
+    const found = iconCandidatesFromHtml('<link rel="icon" href="/assets/mark.png">', 'https://acme.test/docs/start')
+
+    assert.deepEqual(
+      found.map(candidate => candidate.url),
+      ['https://acme.test/assets/mark.png']
+    )
+  })
+
+  test('a <base href> wins over the page URL, as a browser would resolve it', () => {
+    const found = iconCandidatesFromHtml(
+      '<base href="https://cdn.acme.test/"><link rel="icon" href="mark.png">',
+      'https://acme.test/docs/'
+    )
+
+    assert.deepEqual(
+      found.map(candidate => candidate.url),
+      ['https://cdn.acme.test/mark.png']
+    )
+  })
+
+  test('single-quoted and unquoted attributes parse too', () => {
+    const found = iconCandidatesFromHtml(
+      `<link rel='icon' href='/a.png'><link rel=icon href=/b.png>`,
+      'https://acme.test'
+    )
+
+    assert.deepEqual(found.map(candidate => candidate.url).sort(), [
+      'https://acme.test/a.png',
+      'https://acme.test/b.png'
+    ])
+  })
+
+  test('non-icon links are left alone', () => {
+    const found = iconCandidatesFromHtml(
+      '<link rel="stylesheet" href="/app.css"><link rel="canonical" href="/">',
+      'https://acme.test'
+    )
+
+    assert.deepEqual(found, [])
+  })
+
+  test('a linked manifest is found', () => {
+    assert.equal(
+      manifestUrlFromHtml('<link rel="manifest" href="/site.webmanifest">', 'https://acme.test/x'),
+      'https://acme.test/site.webmanifest'
+    )
+  })
+
+  test('a page with no manifest says so rather than guessing one', () => {
+    assert.equal(manifestUrlFromHtml('<link rel="icon" href="/a.png">', 'https://acme.test'), '')
+  })
+})
+
+describe('ranking, so the best mark is fetched first', () => {
+  test('the largest declared square wins', () => {
+    assert.equal(largestDeclaredSize('32x32 180x180 16x16'), 180)
+  })
+
+  test('scalable outranks every raster size', () => {
+    const [best] = rankCandidates(
+      iconCandidatesFromHtml(
+        '<link rel="icon" sizes="256x256" href="/big.png"><link rel="icon" type="image/svg+xml" href="/mark.svg">',
+        'https://acme.test'
+      )
+    )
+
+    assert.equal(best.url, 'https://acme.test/mark.svg')
+  })
+
+  test('an apple-touch link with no sizes still beats a guessed path', () => {
+    const declared = iconCandidatesFromHtml('<link rel="apple-touch-icon" href="/touch.png">', 'https://acme.test')
+    const ranked = rankCandidates([...fallbackIconCandidates('https://acme.test'), ...declared])
+
+    assert.equal(ranked[0].url, 'https://acme.test/touch.png')
+  })
+
+  test('a manifest icon is ranked on its declared size', () => {
+    const found = iconCandidatesFromManifest(
+      JSON.stringify({
+        icons: [
+          { sizes: '512x512', src: '/pwa-512.png' },
+          { sizes: '48x48', src: '/pwa-48.png' }
+        ]
+      }),
+      'https://acme.test/site.webmanifest'
+    )
+
+    assert.equal(rankCandidates(found)[0].url, 'https://acme.test/pwa-512.png')
+  })
+
+  test('unparseable manifest JSON is not an error, just no candidates', () => {
+    assert.deepEqual(iconCandidatesFromManifest('<!doctype html>', 'https://acme.test/m.json'), [])
+  })
+
+  test('the same URL declared twice is fetched once, at its best score', () => {
+    const ranked = rankCandidates([
+      { score: 32, url: 'https://acme.test/a.png' },
+      { score: 180, url: 'https://acme.test/a.png' }
+    ])
+
+    assert.deepEqual(ranked, [{ score: 180, url: 'https://acme.test/a.png' }])
+  })
+
+  test('a page declaring many icons cannot turn one card into many requests', () => {
+    const many = Array.from({ length: 40 }, (_unused, index) => ({
+      score: index,
+      url: `https://acme.test/${index}.png`
+    }))
+
+    assert.equal(rankCandidates(many).length, 6)
+  })
+
+  test('the apex is tried as well as the subdomain', () => {
+    // Vendors routinely serve icons from example.com and nothing from
+    // api.example.com.
+    const urls = fallbackIconCandidates('https://mcp.acme.test/sse').map(candidate => candidate.url)
+
+    assert.ok(urls.includes('https://mcp.acme.test/favicon.ico'))
+    assert.ok(urls.includes('https://acme.test/favicon.ico'))
+  })
+})
+
+describe('deciding whether bytes are actually an image', () => {
+  test.each([
+    ['png', [0x89, 0x50, 0x4e, 0x47], 'image/png'],
+    ['jpeg', [0xff, 0xd8, 0xff], 'image/jpeg'],
+    ['gif', [0x47, 0x49, 0x46, 0x38], 'image/gif'],
+    ['ico', [0x00, 0x00, 0x01, 0x00], 'image/x-icon']
+  ])('%s is recognised from its magic bytes', (_label, signature, expected) => {
+    assert.equal(sniffImageMime(new Uint8Array([...signature, ...new Array(60).fill(0)])), expected)
+  })
+
+  test('webp needs both its RIFF header and its WEBP tag', () => {
+    const riff = [0x52, 0x49, 0x46, 0x46]
+    const webp = [0x57, 0x45, 0x42, 0x50]
+
+    assert.equal(sniffImageMime(new Uint8Array([...riff, 0, 0, 0, 0, ...webp, ...new Array(48).fill(0)])), 'image/webp')
+    assert.equal(sniffImageMime(new Uint8Array([...riff, ...new Array(60).fill(0)])), '')
+  })
+
+  test('the bytes overrule the server', () => {
+    // A blocked request answers 200 with an HTML challenge page under
+    // content-type: image/png often enough that believing the header is how
+    // you end up rendering a broken-image box.
+    assert.equal(imageMime('image/png', HTML_BYTES), '')
+  })
+
+  test('an SVG whose opening tag is past the sniff window is trusted on its header', () => {
+    const padded = new Uint8Array([...Buffer.from(`<!--${'x'.repeat(2000)}--><svg/>`)])
+
+    assert.equal(imageMime('image/svg+xml', padded), 'image/svg+xml')
+  })
+
+  test('a response too short to be an image is refused', () => {
+    assert.equal(imageMime('image/png', new Uint8Array([0x89, 0x50])), '')
+  })
+})
+
+describe('walking the ladder', () => {
+  test('a private host is never fetched at all', async () => {
+    const { asked, io } = fakeIo({})
+
+    assert.equal(await resolveFavicon('http://127.0.0.1:8000/mcp', io), '')
+    assert.deepEqual(asked, [])
+  })
+
+  test('a declared icon is preferred over the well-known path', async () => {
+    const { io } = fakeIo({
+      images: {
+        'https://acme.test/declared.png': { bytes: PNG, mime: 'image/png' },
+        'https://acme.test/favicon.ico': { bytes: PNG, mime: 'image/x-icon' }
+      },
+      text: { 'https://acme.test': '<link rel="icon" sizes="180x180" href="/declared.png">' }
+    })
+
+    const icon = await resolveFavicon('https://acme.test', io)
+
+    assert.ok(icon.startsWith('data:image/png;base64,'))
+  })
+
+  test('a site that declares nothing still gets its guessed favicon', async () => {
+    const { io } = fakeIo({ images: { 'https://acme.test/favicon.ico': { bytes: PNG, mime: '' } } })
+
+    assert.ok((await resolveFavicon('https://acme.test', io)).startsWith('data:image/png;base64,'))
+  })
+
+  test('a candidate that answers with a challenge page is skipped for the next one', async () => {
+    const { io } = fakeIo({
+      images: {
+        'https://acme.test/apple-touch-icon.png': { bytes: HTML_BYTES, mime: 'image/png' },
+        'https://acme.test/favicon.ico': { bytes: PNG, mime: 'image/x-icon' }
+      }
+    })
+
+    assert.ok((await resolveFavicon('https://acme.test', io)).startsWith('data:image/png;base64,'))
+  })
+
+  test('a site nobody can read keeps its monogram rather than asking a third party', async () => {
+    const { asked, io } = fakeIo({})
+
+    assert.equal(await resolveFavicon('https://walled.test', io), '')
+    // Every attempt was against the site itself. No icon service, because
+    // asking one means telling it which connector someone is wiring up.
+    assert.ok(asked.length > 0)
+    assert.ok(asked.every(url => url.includes('walled.test')))
+  })
+
+  test('a page that throws on read falls through to the guessed paths', async () => {
+    const io: FaviconIo = {
+      fetchImage: async url => (url.endsWith('/favicon.ico') ? { bytes: PNG, mime: '' } : null),
+      fetchText: async () => {
+        throw new Error('ECONNRESET')
+      }
+    }
+
+    assert.ok((await resolveFavicon('https://acme.test', io)).startsWith('data:image/png;base64,'))
+  })
+})

--- a/apps/desktop/electron/favicon.ts
+++ b/apps/desktop/electron/favicon.ts
@@ -1,0 +1,347 @@
+/**
+ * Favicon resolution, the thorough way.
+ *
+ * `<origin>/favicon.ico` answers for maybe half the web. Everyone else
+ * declares their marks in the page head (`<link rel="icon">`, apple-touch,
+ * SVG mask icons) or in a web app manifest, at paths that are frequently
+ * hashed build artifacts on a CDN — unguessable. So: read the page, collect
+ * every declared icon, rank them, and only then fall back to the well-known
+ * paths.
+ *
+ * Only ever the site's own marks. A public icon service would answer for the
+ * hosts that hide behind a bot wall, but asking one means telling a third
+ * party which connector a user is wiring up — so a site we can't read keeps
+ * its monogram instead.
+ *
+ * This lives in the main process because none of it is possible from the
+ * renderer: cross-origin HTML is unreadable under CORS, and the whole point
+ * is reading someone else's markup.
+ *
+ * Everything here is pure — URL math, parsing, ranking. The I/O is injected
+ * so the ladder can be tested without a network.
+ */
+
+export interface IconCandidate {
+  url: string
+  /** Rough pixel edge, or a synthetic rank for scalable/unsized marks. */
+  score: number
+}
+
+export interface FaviconIo {
+  /** Page/manifest text, or '' when it can't be read. */
+  fetchText: (url: string) => Promise<string>
+  /** Image bytes plus the server's content type, or null on any refusal. */
+  fetchImage: (url: string) => Promise<null | { bytes: Uint8Array; mime: string }>
+}
+
+/** Scalable beats every raster size; below it, bigger wins up to a point. */
+const SCORE_SVG = 1024
+/** `sizes="any"` — usually an SVG or a multi-res ICO. */
+const SCORE_ANY = 512
+/** Apple's spec size, which is what unsized apple-touch links almost always are. */
+const SCORE_APPLE_TOUCH = 180
+/** A declared icon with no size at all still beats a guessed path. */
+const SCORE_UNSIZED = 96
+/** Guessed well-known paths, tried only after everything declared. */
+const SCORE_GUESS = 48
+
+/** Past this the file is a download, not an icon. */
+const SCORE_CEILING = 512
+
+/**
+ * A host worth asking for an icon.
+ *
+ * Loopback and RFC1918 addresses serve MCP endpoints, not brands, and an
+ * icon service can't see them anyway. Refusing them here is also what keeps
+ * a private hostname from being handed to that service.
+ */
+export function isPublicHttpUrl(raw: string): boolean {
+  let url: URL
+
+  try {
+    url = new URL(raw)
+  } catch {
+    return false
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return false
+  }
+
+  const host = url.hostname.toLowerCase()
+
+  return !(
+    host === 'localhost' ||
+    host === '::1' ||
+    host.endsWith('.local') ||
+    host.endsWith('.internal') ||
+    !host.includes('.') ||
+    /^127\./.test(host) ||
+    /^10\./.test(host) ||
+    /^192\.168\./.test(host) ||
+    /^169\.254\./.test(host) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(host)
+  )
+}
+
+const absolute = (href: string, base: string): string => {
+  try {
+    const url = new URL(href.trim(), base)
+
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : ''
+  } catch {
+    return ''
+  }
+}
+
+/** "180x180 32x32" → 180. Takes the largest declared square edge. */
+export function largestDeclaredSize(sizes: string): number {
+  let best = 0
+
+  for (const token of sizes.toLowerCase().split(/\s+/)) {
+    if (token === 'any') {
+      best = Math.max(best, SCORE_ANY)
+
+      continue
+    }
+
+    const edge = Number(token.split('x')[0])
+
+    if (Number.isFinite(edge)) {
+      best = Math.max(best, edge)
+    }
+  }
+
+  return best
+}
+
+const attr = (tag: string, name: string): string =>
+  tag
+    .match(new RegExp(`\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s"'>]+))`, 'i'))
+    ?.slice(2)
+    .find(Boolean) ?? ''
+
+const scoreFor = (rel: string, type: string, sizes: string): number => {
+  if (type.includes('svg') || rel.includes('mask-icon')) {
+    return SCORE_SVG
+  }
+
+  const declared = largestDeclaredSize(sizes)
+
+  if (declared > 0) {
+    return Math.min(declared, SCORE_CEILING)
+  }
+
+  return rel.includes('apple-touch-icon') ? SCORE_APPLE_TOUCH : SCORE_UNSIZED
+}
+
+/** Every icon the page declares, absolute and ranked. */
+export function iconCandidatesFromHtml(html: string, pageUrl: string): IconCandidate[] {
+  const base = absolute(attr(html.match(/<base\b[^>]*>/i)?.[0] ?? '', 'href'), pageUrl) || pageUrl
+  const candidates: IconCandidate[] = []
+
+  for (const tag of html.match(/<link\b[^>]*>/gi) ?? []) {
+    const rel = attr(tag, 'rel').toLowerCase()
+
+    if (!/\b(icon|shortcut icon|apple-touch-icon|apple-touch-icon-precomposed|fluid-icon|mask-icon)\b/.test(rel)) {
+      continue
+    }
+
+    const url = absolute(attr(tag, 'href'), base)
+
+    if (url) {
+      candidates.push({ score: scoreFor(rel, attr(tag, 'type').toLowerCase(), attr(tag, 'sizes')), url })
+    }
+  }
+
+  return candidates
+}
+
+/** The page's web app manifest, if it links one. */
+export function manifestUrlFromHtml(html: string, pageUrl: string): string {
+  for (const tag of html.match(/<link\b[^>]*>/gi) ?? []) {
+    if (/\bmanifest\b/i.test(attr(tag, 'rel'))) {
+      return absolute(attr(tag, 'href'), pageUrl)
+    }
+  }
+
+  return ''
+}
+
+/** PWA manifests carry the best assets a site has — 192px and 512px marks
+ *  designed to stand alone on a home screen, which is exactly our use. */
+export function iconCandidatesFromManifest(raw: string, manifestUrl: string): IconCandidate[] {
+  let parsed: unknown
+
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+
+  const icons = (parsed as { icons?: unknown })?.icons
+
+  if (!Array.isArray(icons)) {
+    return []
+  }
+
+  const candidates: IconCandidate[] = []
+
+  for (const icon of icons) {
+    const src = typeof icon?.src === 'string' ? absolute(icon.src, manifestUrl) : ''
+
+    if (!src) {
+      continue
+    }
+
+    const type = typeof icon?.type === 'string' ? icon.type.toLowerCase() : ''
+    const sizes = typeof icon?.sizes === 'string' ? icon.sizes : ''
+
+    candidates.push({ score: scoreFor('', type, sizes), url: src })
+  }
+
+  return candidates
+}
+
+/** The well-known paths, on the origin and on its apex — vendors routinely
+ *  serve icons from `example.com` and nothing from `api.example.com`. */
+export function fallbackIconCandidates(pageUrl: string): IconCandidate[] {
+  let url: URL
+
+  try {
+    url = new URL(pageUrl)
+  } catch {
+    return []
+  }
+
+  const labels = url.hostname.split('.')
+  const apex = labels.length > 2 ? `${url.protocol}//${labels.slice(-2).join('.')}` : url.origin
+  const origins = [...new Set([url.origin, apex])]
+
+  return origins.flatMap(origin => [
+    { score: SCORE_GUESS + 2, url: `${origin}/apple-touch-icon.png` },
+    { score: SCORE_GUESS + 1, url: `${origin}/apple-touch-icon-precomposed.png` },
+    { score: SCORE_GUESS, url: `${origin}/favicon.ico` },
+    { score: SCORE_GUESS - 1, url: `${origin}/favicon.png` }
+  ])
+}
+
+/** Highest-ranked first, one entry per URL, capped so a page declaring
+ *  twenty icons can't turn one card into twenty requests. */
+export function rankCandidates(candidates: IconCandidate[], limit = 6): IconCandidate[] {
+  const best = new Map<string, number>()
+
+  for (const candidate of candidates) {
+    best.set(candidate.url, Math.max(best.get(candidate.url) ?? 0, candidate.score))
+  }
+
+  return [...best.entries()]
+    .map(([url, score]) => ({ score, url }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+}
+
+/** Magic bytes, because plenty of servers hand back an icon as
+ *  `application/octet-stream` — and an HTML error page as `image/png`. */
+export function sniffImageMime(bytes: Uint8Array): string {
+  const at = (offset: number, ...signature: number[]) =>
+    signature.every((byte, index) => bytes[offset + index] === byte)
+
+  if (at(0, 0x89, 0x50, 0x4e, 0x47)) {
+    return 'image/png'
+  }
+
+  if (at(0, 0xff, 0xd8, 0xff)) {
+    return 'image/jpeg'
+  }
+
+  if (at(0, 0x47, 0x49, 0x46, 0x38)) {
+    return 'image/gif'
+  }
+
+  if (at(0, 0x00, 0x00, 0x01, 0x00)) {
+    return 'image/x-icon'
+  }
+
+  if (at(0, 0x52, 0x49, 0x46, 0x46) && at(8, 0x57, 0x45, 0x42, 0x50)) {
+    return 'image/webp'
+  }
+
+  const head = new TextDecoder().decode(bytes.subarray(0, 1024)).toLowerCase()
+
+  return head.includes('<svg') ? 'image/svg+xml' : ''
+}
+
+/**
+ * The mime to trust for these bytes, or '' if they aren't an image.
+ *
+ * The bytes decide, never the header. A blocked request answers 200 with an
+ * HTML challenge page under `content-type: image/png` often enough that
+ * believing the server is how you end up rendering a broken-image box.
+ */
+export function imageMime(declared: string, bytes: Uint8Array): string {
+  if (bytes.length < 48) {
+    return ''
+  }
+
+  const sniffed = sniffImageMime(bytes)
+
+  // An SVG that opens with a license comment long enough to push `<svg` past
+  // the sniff window is still an SVG if the server said so.
+  return sniffed || (declared.toLowerCase().includes('svg') ? 'image/svg+xml' : '')
+}
+
+export const toDataUrl = (mime: string, bytes: Uint8Array): string =>
+  `data:${mime};base64,${Buffer.from(bytes).toString('base64')}`
+
+/**
+ * Walk the ladder and return the first real image, as a data URL.
+ *
+ * Data URL rather than a link so the renderer paints without a second
+ * network trip, the icon survives a site going down, and one cached string
+ * covers every surface showing that connector.
+ */
+export async function resolveFavicon(pageUrl: string, io: FaviconIo): Promise<string> {
+  if (!isPublicHttpUrl(pageUrl)) {
+    return ''
+  }
+
+  const candidates: IconCandidate[] = []
+  const html = await io.fetchText(pageUrl).catch(() => '')
+
+  if (html) {
+    candidates.push(...iconCandidatesFromHtml(html, pageUrl))
+
+    const manifestUrl = manifestUrlFromHtml(html, pageUrl)
+
+    if (manifestUrl) {
+      const manifest = await io.fetchText(manifestUrl).catch(() => '')
+
+      if (manifest) {
+        candidates.push(...iconCandidatesFromManifest(manifest, manifestUrl))
+      }
+    }
+  }
+
+  candidates.push(...fallbackIconCandidates(pageUrl))
+
+  // Only the site's own marks. A third-party icon service would answer for
+  // the hosts that serve nothing readable, but asking it means naming a
+  // connector's host to someone else — so a site that won't show us its icon
+  // simply keeps its monogram.
+  for (const candidate of rankCandidates(candidates)) {
+    const image = await io.fetchImage(candidate.url).catch(() => null)
+
+    if (!image) {
+      continue
+    }
+
+    const mime = imageMime(image.mime, image.bytes)
+
+    if (mime) {
+      return toDataUrl(mime, image.bytes)
+    }
+  }
+
+  return ''
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -141,6 +141,7 @@ import {
   terminalScriptExtension,
   tuiResumeArgs
 } from './external-terminal'
+import { type FaviconIo, resolveFavicon } from './favicon'
 import { findGitBash as _findGitBash } from './find-git-bash'
 import {
   installFindShortcut,
@@ -5369,6 +5370,159 @@ function fetchLinkTitle(rawUrl) {
     })
 
   titleInflight.set(key, pending)
+
+  return pending
+}
+
+// ─── Favicon resolution ──────────────────────────────────────────────────────
+// The ladder itself is electron/favicon.ts; this is its I/O, its cache, and
+// the one rule that belongs to the app rather than the algorithm: one icon
+// per host. A connector's mark doesn't vary by path, and hosting the cache on
+// the host key means Linear's docs page and Linear's MCP endpoint cost one
+// lookup between them.
+
+const FAVICON_CACHE_PATH = path.join(app.getPath('userData'), 'favicon-cache.json')
+const FAVICON_CACHE_LIMIT = 400
+const FAVICON_TTL_MS = 30 * 24 * 60 * 60 * 1000
+// A miss is cheap to re-check and expensive to be wrong about (a site that
+// was behind a captcha yesterday has a logo today), so it expires fast.
+const FAVICON_MISS_TTL_MS = 12 * 60 * 60 * 1000
+const FAVICON_TIMEOUT_MS = 6000
+const FAVICON_MAX_BYTES = 256 * 1024
+const FAVICON_WRITE_DEBOUNCE_MS = 3000
+
+let faviconCache: Map<string, { at: number; icon: string }> | null = null
+let faviconWriteTimer: null | ReturnType<typeof setTimeout> = null
+const faviconInflight = new Map<string, Promise<string>>()
+
+function faviconCacheKey(rawUrl: string): string {
+  try {
+    return new URL(rawUrl).hostname.replace(/^www\./i, '').toLowerCase()
+  } catch {
+    return ''
+  }
+}
+
+function loadFaviconCache(): Map<string, { at: number; icon: string }> {
+  if (faviconCache) {
+    return faviconCache
+  }
+
+  faviconCache = new Map()
+
+  try {
+    const raw = JSON.parse(fs.readFileSync(FAVICON_CACHE_PATH, 'utf8'))
+
+    for (const [host, entry] of Object.entries(raw?.icons ?? {})) {
+      const at = Number((entry as { at?: number })?.at)
+      const icon = String((entry as { icon?: string })?.icon ?? '')
+
+      if (Number.isFinite(at) && Date.now() - at < (icon ? FAVICON_TTL_MS : FAVICON_MISS_TTL_MS)) {
+        faviconCache.set(host, { at, icon })
+      }
+    }
+  } catch {
+    // No cache yet, or it's unreadable — resolving again is the whole cost.
+  }
+
+  return faviconCache
+}
+
+function saveFaviconCacheSoon() {
+  if (faviconWriteTimer) {
+    return
+  }
+
+  faviconWriteTimer = setTimeout(() => {
+    faviconWriteTimer = null
+
+    try {
+      const icons = Object.fromEntries(loadFaviconCache())
+
+      fs.writeFileSync(FAVICON_CACHE_PATH, JSON.stringify({ icons }), 'utf8')
+    } catch {
+      // Cache is an optimization; failing to persist it costs one refetch.
+    }
+  }, FAVICON_WRITE_DEBOUNCE_MS)
+
+  faviconWriteTimer.unref?.()
+}
+
+async function faviconFetch(url: string, accept: string) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), FAVICON_TIMEOUT_MS)
+
+  try {
+    return await electronNet.fetch(url, {
+      // Same browser-shaped identity the title fetcher uses: a plain Electron
+      // UA gets a challenge page from anything behind a bot wall.
+      headers: { Accept: accept, 'Accept-Language': 'en-US,en;q=0.7', 'User-Agent': TITLE_USER_AGENT },
+      redirect: 'follow',
+      signal: controller.signal
+    })
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+const faviconIo: FaviconIo = {
+  fetchImage: async url => {
+    const response = await faviconFetch(url, 'image/avif,image/webp,image/svg+xml,image/*;q=0.8,*/*;q=0.5')
+
+    if (!response.ok) {
+      return null
+    }
+
+    const buffer = await response.arrayBuffer()
+
+    if (buffer.byteLength === 0 || buffer.byteLength > FAVICON_MAX_BYTES) {
+      return null
+    }
+
+    return { bytes: new Uint8Array(buffer), mime: response.headers.get('content-type') ?? '' }
+  },
+  fetchText: async url => {
+    const response = await faviconFetch(url, 'text/html,application/xhtml+xml,application/json;q=0.9,*/*;q=0.5')
+
+    return response.ok ? (await response.text()).slice(0, TITLE_BYTE_BUDGET * 2) : ''
+  }
+}
+
+function resolveFaviconCached(rawUrl: string): Promise<string> {
+  const key = faviconCacheKey(String(rawUrl || '').trim())
+
+  if (!key) {
+    return Promise.resolve('')
+  }
+
+  const cache = loadFaviconCache()
+  const hit = cache.get(key)
+
+  if (hit && Date.now() - hit.at < (hit.icon ? FAVICON_TTL_MS : FAVICON_MISS_TTL_MS)) {
+    return Promise.resolve(hit.icon)
+  }
+
+  const inflight = faviconInflight.get(key)
+
+  if (inflight) {
+    return inflight
+  }
+
+  const pending = resolveFavicon(rawUrl, faviconIo)
+    .catch(() => '')
+    .then(icon => {
+      if (cache.size >= FAVICON_CACHE_LIMIT) {
+        cache.delete(cache.keys().next().value)
+      }
+
+      cache.set(key, { at: Date.now(), icon })
+      saveFaviconCacheSoon()
+      faviconInflight.delete(key)
+
+      return icon
+    })
+
+  faviconInflight.set(key, pending)
 
   return pending
 }
@@ -14287,6 +14441,8 @@ ipcMain.handle('hermes:setting:defaultProjectDir:pick', async () => {
 })
 
 ipcMain.handle('hermes:fetchLinkTitle', (_event, url) => fetchLinkTitle(url))
+
+ipcMain.handle('hermes:resolveFavicon', (_event, url) => resolveFaviconCached(url))
 
 ipcMain.handle('hermes:logs:reveal', async () => {
   try {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -236,6 +236,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   openPreviewInBrowser: url => ipcRenderer.invoke('hermes:openPreviewInBrowser', url),
   reachPreviewUrl: url => ipcRenderer.invoke('hermes:preview:reach', url),
   fetchLinkTitle: url => ipcRenderer.invoke('hermes:fetchLinkTitle', url),
+  resolveFavicon: url => ipcRenderer.invoke('hermes:resolveFavicon', url),
   sanitizeWorkspaceCwd: cwd => ipcRenderer.invoke('hermes:workspace:sanitize', cwd),
   settings: {
     getDefaultProjectDir: () => ipcRenderer.invoke('hermes:setting:defaultProjectDir:get'),

--- a/apps/desktop/src/app/messaging/platform-icon.tsx
+++ b/apps/desktop/src/app/messaging/platform-icon.tsx
@@ -15,8 +15,8 @@ import {
 import type { ComponentPropsWithoutRef, ComponentType, SVGProps } from 'react'
 import { forwardRef, memo } from 'react'
 
+import { AvatarChip } from '@/components/ui/avatar-chip'
 import { Globe, Link as LinkIcon, MessageSquareText } from '@/lib/icons'
-import { cn } from '@/lib/utils'
 
 // ---------------------------------------------------------------------------
 // Photon brand icon — three diagonal rounded bars (the Photon logo mark).
@@ -84,48 +84,18 @@ interface PlatformAvatarProps extends Omit<ComponentPropsWithoutRef<'span'>, 'ch
 // silently — the tooltip renders but never opens (#67500).
 export const PlatformAvatar = memo(
   forwardRef<HTMLSpanElement, PlatformAvatarProps>(function PlatformAvatar(
-    { className, platformId, platformName, style, ...rest },
+    { className, platformId, platformName, ...rest },
     ref
   ) {
-    const spec = PLATFORM_ICONS[platformId]
-
-    const baseClass = cn(
-      'inline-grid size-6 shrink-0 place-items-center rounded-md text-[length:var(--conversation-caption-font-size)] font-medium',
-      className
-    )
-
-    if (!spec) {
-      return (
-        <span
-          aria-hidden="true"
-          className={cn(baseClass, 'bg-(--ui-bg-tertiary) text-(--ui-text-tertiary)')}
-          ref={ref}
-          style={style}
-          {...rest}
-        >
-          {platformName.charAt(0).toUpperCase()}
-        </span>
-      )
-    }
-
-    const { Icon, color } = spec
-
     return (
-      <span
+      <AvatarChip
         aria-hidden="true"
-        className={baseClass}
+        brand={PLATFORM_ICONS[platformId]}
+        className={className}
+        name={platformName}
         ref={ref}
-        style={{
-          // 16% tint of the brand color so the glyph reads against any surface
-          // without the avatar dominating the row.
-          backgroundColor: `color-mix(in srgb, ${color} 16%, transparent)`,
-          color,
-          ...style
-        }}
         {...rest}
-      >
-        {Icon ? <Icon className="size-3.5" /> : spec.monogram || platformName.charAt(0).toUpperCase()}
-      </span>
+      />
     )
   })
 )

--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -6,6 +6,7 @@ import { type CodeEditorApi } from '@/components/chat/code-editor'
 import { JsonDocumentEditor } from '@/components/chat/json-document-editor'
 import { LogTail } from '@/components/chat/log-tail'
 import { PageLoader } from '@/components/page-loader'
+import { AvatarChip } from '@/components/ui/avatar-chip'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { ErrorBanner } from '@/components/ui/error-state'
@@ -33,7 +34,7 @@ import {
 } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
 import { compactNumber } from '@/lib/format'
-import { brandFor, brandGlyphStyle } from '@/lib/mcp-brands'
+import { brandFor } from '@/lib/mcp-brands'
 import { estimateServerTokens, serverUsageCount } from '@/lib/mcp-cost'
 import { completeMcpDesktopOAuth } from '@/lib/mcp-dashboard-oauth'
 import { type McpImportEntry, parseMcpImport } from '@/lib/mcp-import'
@@ -1757,41 +1758,28 @@ function McpLogs({
 // Avatars + list rows
 // ---------------------------------------------------------------------------
 
-// Brand glyphs for well-known MCP providers, exactly the Messaging avatar
-// treatment (simpleicons on a 16% brand tint) — shared with the composer
-// suggestion pills and inline setup card via lib/mcp-brands. Unknown servers
-// fall back to the same letter monogram Messaging uses.
-
-// PlatformAvatar (messaging), copied 1:1 — same size, radius, type scale, and
-// brand-tint treatment — plus a status dot overlay. Identity ladder: curated
-// brand glyph → letter monogram. We deliberately do NOT fetch remote favicons:
-// a configured MCP URL can be a private/internal host, and hitting Google's
-// favicon service for it would leak that hostname off-box.
+// The shared identity chip (`ui/avatar-chip`) plus a status dot. Identity
+// ladder: curated brand glyph (lib/mcp-brands, shared with the composer
+// suggestion pills and the inline setup card) → letter monogram. Nothing here
+// reaches the network for a mark: a configured MCP URL can be a private host,
+// and the connector card's favicon rung only ever reads a public site's own
+// markup, never a third-party icon service.
 function McpAvatar({ className, name, status }: { className?: string; name: string; status: ServerStatus }) {
-  const brand = brandFor(name)
-
   return (
-    <span
-      className={cn(
-        'relative inline-grid size-6 shrink-0 place-items-center rounded-md text-[length:var(--conversation-caption-font-size)] font-medium',
-        !brand && 'bg-(--ui-bg-tertiary) text-(--ui-text-tertiary)',
-        className
-      )}
-      style={brand ? { backgroundColor: `color-mix(in srgb, ${brand.color} 16%, transparent)` } : undefined}
-    >
-      {brand ? (
-        <brand.Icon aria-hidden className="size-3.5" style={brandGlyphStyle(brand)} />
-      ) : (
-        name.charAt(0).toUpperCase()
-      )}
-      <span
-        aria-hidden
-        className={cn(
-          'absolute -bottom-0.5 -right-0.5 size-2 rounded-full ring-2 ring-(--ui-chat-surface-background)',
-          STATUS_DOT[status]
-        )}
-      />
-    </span>
+    <AvatarChip
+      brand={brandFor(name)}
+      className={className}
+      name={name}
+      overlay={
+        <span
+          aria-hidden
+          className={cn(
+            'absolute -bottom-0.5 -right-0.5 size-2 rounded-full ring-2 ring-(--ui-chat-surface-background)',
+            STATUS_DOT[status]
+          )}
+        />
+      }
+    />
   )
 }
 

--- a/apps/desktop/src/components/ui/avatar-chip.test.tsx
+++ b/apps/desktop/src/components/ui/avatar-chip.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { AvatarChip, monogramFor } from './avatar-chip'
+
+afterEach(cleanup)
+
+const Glyph = () => <svg data-testid="glyph" />
+
+describe('the identity ladder', () => {
+  it('paints a brand glyph on a tint of its own color', () => {
+    render(<AvatarChip brand={{ Icon: Glyph, color: '#5E6AD2' }} data-testid="chip" name="Linear" />)
+
+    const background = screen.getByTestId('chip').style.backgroundColor
+
+    expect(screen.getByTestId('glyph')).toBeTruthy()
+    // jsdom normalises the hex, so assert the tint rather than the literal.
+    expect(background).toContain('rgb(94, 106, 210)')
+    expect(background).toContain('16%')
+  })
+
+  it('falls back to a letter when we have no mark for the name', () => {
+    render(<AvatarChip name="Zulip" />)
+
+    expect(screen.getByText('Z')).toBeTruthy()
+  })
+
+  it('prefers a brand-supplied monogram over the first letter', () => {
+    render(<AvatarChip brand={{ color: '#000', monogram: 'n8' }} name="n8n" />)
+
+    expect(screen.getByText('n8')).toBeTruthy()
+  })
+
+  it('lets a caller replace the mark entirely, which is how a resolved favicon gets in', () => {
+    render(
+      <AvatarChip brand={{ Icon: Glyph, color: '#000' }} name="Acme">
+        <img alt="" data-testid="favicon" src="data:image/png;base64,iVBOR" />
+      </AvatarChip>
+    )
+
+    expect(screen.getByTestId('favicon')).toBeTruthy()
+    expect(screen.queryByTestId('glyph')).toBeNull()
+  })
+
+  it('leaves a monochrome mark to follow the surrounding text color rather than vanish into the theme', () => {
+    render(<AvatarChip brand={{ Icon: Glyph, color: '#0E1128', monochrome: true }} data-testid="chip" name="Unreal" />)
+
+    expect(screen.getByTestId('chip').style.color).toBe('')
+  })
+
+  it('carries an overlay for a status dot', () => {
+    render(<AvatarChip name="Acme" overlay={<span data-testid="dot" />} />)
+
+    expect(screen.getByTestId('dot')).toBeTruthy()
+  })
+})
+
+describe('the monogram', () => {
+  it.each([
+    ['linear', 'L'],
+    ['  spaced', 'S'],
+    ['', '']
+  ])('%s → %s', (name, expected) => {
+    expect(monogramFor(name)).toBe(expected)
+  })
+})

--- a/apps/desktop/src/components/ui/avatar-chip.tsx
+++ b/apps/desktop/src/components/ui/avatar-chip.tsx
@@ -1,0 +1,73 @@
+import type { ComponentPropsWithoutRef, ComponentType, ReactNode, SVGProps } from 'react'
+import { forwardRef } from 'react'
+
+import { cn } from '@/lib/utils'
+
+/**
+ * The square identity chip: a brand glyph on a 16% tint of its own color, or
+ * a letter monogram when we have no mark for the thing.
+ *
+ * One treatment, three surfaces — messaging platforms, the MCP servers tab,
+ * connector cards — which is one more than it took for the copies to drift.
+ * They had already diverged on radius, on glyph size, and on what an unknown
+ * name looks like. Size and radius are the caller's call (`className`);
+ * everything else is fixed here so a Slack row and a Linear card wear the
+ * same chip.
+ */
+export interface AvatarChipBrand {
+  Icon?: ComponentType<SVGProps<SVGSVGElement>>
+  color: string
+  /** Marks that are black or white by design (GitHub, Notion, Unreal) follow
+   *  the surrounding text color instead of vanishing into the theme. */
+  monochrome?: boolean
+  monogram?: string
+}
+
+interface AvatarChipProps extends Omit<ComponentPropsWithoutRef<'span'>, 'children'> {
+  brand?: AvatarChipBrand | null
+  /** Replaces the mark entirely — a resolved favicon, a spinner. */
+  children?: ReactNode
+  /** The monogram's source, and what a screen reader gets. */
+  name: string
+  /** Painted over the mark: a status dot, a badge. */
+  overlay?: ReactNode
+}
+
+/** Proportional to the chip so one glyph size serves every size the chip is
+ *  used at — 14px inside the 24px row chip, matching what it replaced. */
+const GLYPH_CLASS = 'size-[58%]'
+
+export const AvatarChip = forwardRef<HTMLSpanElement, AvatarChipProps>(function AvatarChip(
+  { brand, children, className, name, overlay, style, ...rest },
+  ref
+) {
+  const Icon = brand?.Icon
+
+  return (
+    <span
+      className={cn(
+        // Not `overflow-hidden`: an overlay dot sits proud of the corner. A
+        // caller painting a raster mark clips at its own layer.
+        'relative inline-grid size-6 shrink-0 place-items-center rounded-md text-[length:var(--conversation-caption-font-size)] font-medium',
+        !brand && 'bg-(--ui-bg-tertiary) text-(--ui-text-tertiary)',
+        className
+      )}
+      ref={ref}
+      style={
+        brand
+          ? {
+              backgroundColor: `color-mix(in srgb, ${brand.color} 16%, transparent)`,
+              color: brand.monochrome ? undefined : brand.color,
+              ...style
+            }
+          : style
+      }
+      {...rest}
+    >
+      {children ?? (Icon ? <Icon aria-hidden className={GLYPH_CLASS} /> : (brand?.monogram ?? monogramFor(name)))}
+      {overlay}
+    </span>
+  )
+})
+
+export const monogramFor = (name: string): string => name.trim().charAt(0).toUpperCase()

--- a/apps/desktop/src/components/ui/connector-card.test.tsx
+++ b/apps/desktop/src/components/ui/connector-card.test.tsx
@@ -1,0 +1,258 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  ConnectorCard,
+  type ConnectorCardCopy,
+  type ConnectorCardProps,
+  type ConnectorCardSubject
+} from './connector-card'
+import { connectorLogoSource } from './connector-logo'
+
+afterEach(cleanup)
+
+const COPY: ConnectorCardCopy = {
+  connectAction: 'Connect',
+  decline: 'Not now',
+  envRequired: 'Fill in the required credentials first',
+  grantAction: 'Grant access',
+  retryAction: 'Retry',
+  stateConnected: 'Connected',
+  stateDeclined: 'Skipped',
+  stateDisabled: 'currently off',
+  stateFailed: 'Failed',
+  stateNeedsAuth: 'signed out',
+  toolCount: count => (count === 1 ? '1 tool' : `${count} tools`),
+  trustCommunity: 'unreviewed',
+  trustCommunityTip: host => `Nobody has verified who runs ${host}`,
+  trustVerified: publisher => `verified · ${publisher}`,
+  trustVerifiedTip: publisher => `The publisher proved it owns ${publisher}`
+}
+
+const LINEAR: ConnectorCardSubject = {
+  description: 'Issues and projects.',
+  homepage: 'https://linear.app',
+  name: 'linear',
+  title: 'Linear',
+  trust: 'catalog'
+}
+
+function renderCard(overrides: Partial<ConnectorCardProps> = {}) {
+  const onConnect = vi.fn()
+  const onDismiss = vi.fn()
+
+  render(
+    <ConnectorCard
+      connector={LINEAR}
+      copy={COPY}
+      onConnect={onConnect}
+      onDismiss={onDismiss}
+      state="not_configured"
+      {...overrides}
+    />
+  )
+
+  return { onConnect, onDismiss }
+}
+
+describe('the resting offer', () => {
+  it('leads with what the thing is, not with a question about it', () => {
+    renderCard()
+
+    // Scoped to a span: the brand glyph is an <svg> carrying its own
+    // <title>Linear</title>, which is the mark's accessible name rather than
+    // the card's copy.
+    expect(screen.getByText('Linear', { selector: 'span' })).toBeTruthy()
+    expect(screen.getByText('Issues and projects.')).toBeTruthy()
+  })
+
+  it('offers a connect and a way out', () => {
+    const { onConnect, onDismiss } = renderCard()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
+    expect(onConnect).toHaveBeenCalledOnce()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Not now' }))
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
+
+  it('says how a configured connector currently stands', () => {
+    renderCard({ state: 'needs_auth' })
+
+    expect(screen.getByText('signed out')).toBeTruthy()
+  })
+})
+
+describe('while it is working', () => {
+  it('shows the phase instead of the resting state, because the browser tab that just took focus is otherwise unexplained', () => {
+    renderCard({ phase: 'Signing in…', state: 'needs_auth' })
+
+    expect(screen.getByText('Signing in…')).toBeTruthy()
+    expect(screen.queryByText('signed out')).toBeNull()
+  })
+
+  it('holds its own action but never the way out', () => {
+    // While a connect is in flight, decline is the escape from a stuck
+    // sign-in tab or a hung install.
+    renderCard({ phase: 'Installing…' })
+
+    expect(screen.getByRole('button', { name: 'Not now' }).hasAttribute('disabled')).toBe(false)
+  })
+
+  it('holds its action while a sibling is mid-flight, so two sign-in tabs never race for focus', () => {
+    renderCard({ otherBusy: true })
+
+    expect(screen.getByRole('button', { name: 'Connect' }).hasAttribute('disabled')).toBe(true)
+    expect(screen.getByRole('button', { name: 'Not now' }).hasAttribute('disabled')).toBe(false)
+  })
+})
+
+describe('once it is answered', () => {
+  it('collapses to a single line reporting what came of it', () => {
+    renderCard({ outcome: { status: 'connected', tools: ['a', 'b', 'c'] } })
+
+    expect(screen.getByText('Connected · 3 tools')).toBeTruthy()
+    // The offer is spent; the space belongs to whatever is still asking.
+    expect(screen.queryByRole('button', { name: 'Connect' })).toBeNull()
+  })
+
+  it('collapses the same way when waved off, still naming the thing', () => {
+    renderCard({ dismissed: true })
+
+    expect(screen.getByText('Linear', { selector: 'span' })).toBeTruthy()
+    expect(screen.getByText('Skipped')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Not now' })).toBeNull()
+  })
+
+  it('does not claim a tool count it does not have', () => {
+    renderCard({ outcome: { status: 'connected' } })
+
+    expect(screen.getByText('Connected')).toBeTruthy()
+  })
+})
+
+describe('after a failure', () => {
+  it('stays live with the reason and a retry', () => {
+    renderCard({ outcome: { detail: 'Connection refused', status: 'error' } })
+
+    expect(screen.getByText('Connection refused')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy()
+  })
+
+  it('asks for access rather than a retry when the credential was refused', () => {
+    // Repeating a refused grant just gets refused again; the fix is to ask.
+    renderCard({ outcome: { detail: 'insufficient scope', needsAuth: true, status: 'error' } })
+
+    expect(screen.getByRole('button', { name: 'Grant access' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull()
+  })
+
+  it('brings the setup steps back, because the failure was usually caused by one of them', () => {
+    const withSetup: ConnectorCardSubject = { ...LINEAR, setup: ['Enable the API'] }
+
+    renderCard({ connector: withSetup, outcome: { status: 'error' }, state: 'connected' })
+
+    expect(screen.getByText('Enable the API')).toBeTruthy()
+  })
+})
+
+describe('the work only the user can do', () => {
+  it('numbers the steps, because their order matters', () => {
+    renderCard({ connector: { ...LINEAR, setup: ['Create a project', 'Enable the API'] } })
+
+    expect(screen.getByText('1.')).toBeTruthy()
+    expect(screen.getByText('2.')).toBeTruthy()
+  })
+
+  it('turns a markdown link into a real link, because the whole cost of a step is finding the page', () => {
+    renderCard({ connector: { ...LINEAR, setup: ['Create a token at [Settings](https://linear.app/settings/api)'] } })
+
+    const link = screen.getByRole('link', { name: 'Settings' })
+
+    expect(link.getAttribute('href')).toBe('https://linear.app/settings/api')
+  })
+
+  it('does not repeat console instructions at a connector that already works', () => {
+    renderCard({ connector: { ...LINEAR, setup: ['Enable the API'] }, state: 'disabled' })
+
+    expect(screen.queryByText('Enable the API')).toBeNull()
+  })
+})
+
+describe('credentials', () => {
+  const withEnv: ConnectorCardSubject = {
+    ...LINEAR,
+    requiredEnv: [{ name: 'LINEAR_API_KEY', prompt: 'API key', required: true }]
+  }
+
+  it('stays out of the way until the card asks for it', () => {
+    renderCard({ connector: withEnv })
+
+    expect(screen.queryByText('API key *')).toBeNull()
+  })
+
+  it('reports each keystroke so the caller owns the draft', () => {
+    const onEnvChange = vi.fn()
+
+    renderCard({ connector: withEnv, envOpen: true, onEnvChange })
+
+    fireEvent.change(screen.getByLabelText('API key *'), { target: { value: 'lin_abc' } })
+    expect(onEnvChange).toHaveBeenCalledWith('LINEAR_API_KEY', 'lin_abc')
+  })
+
+  it('masks the value, since these are secrets', () => {
+    renderCard({ connector: withEnv, envOpen: true })
+
+    expect(screen.getByLabelText('API key *').getAttribute('type')).toBe('password')
+  })
+})
+
+describe('how much the source vouches for it', () => {
+  it('says nothing for a reviewed source, so the badge that matters is not trained away', () => {
+    renderCard()
+
+    expect(screen.queryByText('unreviewed')).toBeNull()
+    expect(screen.queryByText(/verified/)).toBeNull()
+  })
+
+  it('names the domain a publisher proved it owns, rather than claiming trust', () => {
+    renderCard({ connector: { ...LINEAR, publisher: 'notion.com', trust: 'verified' } })
+
+    expect(screen.getByText('verified · notion.com')).toBeTruthy()
+  })
+
+  it('flags a publisher nobody has vouched for', () => {
+    renderCard({ connector: { ...LINEAR, trust: 'community', url: 'https://random.test/mcp' } })
+
+    expect(screen.getByText('unreviewed')).toBeTruthy()
+  })
+})
+
+describe('where a mark is read from', () => {
+  it('prefers the product site over the endpoint it talks to', () => {
+    expect(
+      connectorLogoSource({ homepage: 'https://linear.app', name: 'linear', url: 'https://mcp.linear.app/sse' })
+    ).toBe('https://linear.app')
+  })
+
+  it('falls back to the endpoint, then to the docs', () => {
+    expect(connectorLogoSource({ name: 'linear', url: 'https://mcp.linear.app/sse' })).toBe('https://mcp.linear.app')
+    expect(connectorLogoSource({ docs: 'https://docs.stripe.com/x', name: 'stripe' })).toBe('https://docs.stripe.com')
+  })
+
+  it('reads the origin, never the path, so an endpoint is not fetched just to draw a logo', () => {
+    expect(connectorLogoSource({ name: 'acme', url: 'https://acme.test/deep/mcp?token=1' })).toBe('https://acme.test')
+  })
+
+  it('refuses a code host, because a bridge published on GitHub is not GitHub', () => {
+    expect(connectorLogoSource({ name: 'n8n-bridge', url: 'https://github.com/someone/n8n-mcp' })).toBe('')
+  })
+
+  it('refuses a private host, which has no logo to find and should not be named aloud', () => {
+    expect(connectorLogoSource({ name: 'unreal-engine', url: 'http://127.0.0.1:8000/mcp' })).toBe('')
+  })
+
+  it('shrugs at something that is not a URL at all', () => {
+    expect(connectorLogoSource({ docs: 'see the README', name: 'local' })).toBe('')
+  })
+})

--- a/apps/desktop/src/components/ui/connector-card.tsx
+++ b/apps/desktop/src/components/ui/connector-card.tsx
@@ -1,0 +1,348 @@
+import { SCAFFOLD_META_CLASS, ScaffoldRow } from '@/components/chat/scaffold-row'
+import { WIDGET_SHELL_CLASS } from '@/components/chat/widget-shell'
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { ConnectorLogo, type ConnectorLogoSubject } from '@/components/ui/connector-logo'
+import { Input } from '@/components/ui/input'
+import { Tip } from '@/components/ui/tooltip'
+import { MarkdownLinkText } from '@/lib/external-link'
+import { Loader2 } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+
+/**
+ * The consent card for connecting a thing to Hermes, as pure presentation.
+ *
+ * Deliberately knows nothing about MCP. It renders a subject, a state, and an
+ * outcome, and it calls back — what a connector IS, how one connects, and
+ * where the strings come from all belong to the caller. That boundary is the
+ * point: the transcript's inline setup card and any other surface that has to
+ * ask "connect this?" should look identical without sharing a data layer.
+ *
+ * Consent vocabulary follows the tool approval bar: primary-tinted action,
+ * quiet ghost decline, the same `mt-2` stand-off.
+ */
+
+/** Where the subject stands before anything is attempted. */
+export type ConnectorCardState = 'connected' | 'disabled' | 'needs_auth' | 'not_configured'
+
+/** How much the source vouches for the subject. */
+export type ConnectorCardTrust = 'catalog' | 'community' | 'verified'
+
+/** One credential the subject declares it needs. */
+export interface ConnectorCardField {
+  name: string
+  prompt?: string
+  required?: boolean
+}
+
+/** What the card renders. Structural, so a caller's richer type satisfies it
+ *  without this file importing that type. */
+export interface ConnectorCardSubject extends ConnectorLogoSubject {
+  description?: string
+  /** Named by the publisher and checked against the serving domain. */
+  publisher?: string
+  requiredEnv?: ConnectorCardField[]
+  /** Ordered work only the user can do, elsewhere, before this can connect. */
+  setup?: string[]
+  title: string
+  trust?: ConnectorCardTrust
+}
+
+/** How an attempt ended. */
+export interface ConnectorCardOutcome {
+  detail?: string
+  /** The failure was a refusal, not a fault: wrong key, expired grant, or a
+   *  grant that never covered the tools. Asking again is the fix, so the card
+   *  offers access rather than a retry. */
+  needsAuth?: boolean
+  status: 'connected' | 'declined' | 'error'
+  tools?: unknown[]
+}
+
+/** Every string the card shows. Passed in rather than read from i18n so the
+ *  card stays a leaf that anything can render, tests included. */
+export interface ConnectorCardCopy {
+  connectAction: string
+  decline: string
+  envRequired: string
+  grantAction: string
+  retryAction: string
+  stateConnected: string
+  stateDeclined: string
+  stateDisabled: string
+  stateFailed: string
+  stateNeedsAuth: string
+  toolCount: (count: number) => string
+  trustCommunity: string
+  trustCommunityTip: (host: string) => string
+  trustVerified: (publisher: string) => string
+  trustVerifiedTip: (publisher: string) => string
+}
+
+const SHELL_CLASS = `${WIDGET_SHELL_CLASS} text-[length:var(--conversation-text-font-size)] text-(--ui-text-primary)`
+
+const hostOf = (url: null | string | undefined): string => {
+  if (!url) {
+    return ''
+  }
+
+  try {
+    return new URL(url).hostname
+  } catch {
+    return url
+  }
+}
+
+/** What trails a settled subject's name: how it ended, and the useful number
+ *  or reason behind that. */
+export function outcomeMeta(outcome: ConnectorCardOutcome, copy: ConnectorCardCopy): string {
+  if (outcome.status === 'connected') {
+    const toolCount = Array.isArray(outcome.tools) ? outcome.tools.length : 0
+
+    return toolCount > 0 ? `${copy.stateConnected} · ${copy.toolCount(toolCount)}` : copy.stateConnected
+  }
+
+  if (outcome.status === 'error') {
+    return outcome.detail || copy.stateFailed
+  }
+
+  return copy.stateDeclined
+}
+
+/**
+ * A subject that no longer needs anything: connected, skipped, failed.
+ *
+ * Not a card. An answered offer is transcript scaffolding — the same kind of
+ * line as a settled tool run — so it renders through `ScaffoldRow` and reads
+ * like everything else already done. The name keeps full contrast because
+ * that's the content; the verdict trails it as meta.
+ */
+export function ConnectorSummary({
+  connector,
+  meta,
+  tone
+}: {
+  connector: ConnectorLogoSubject
+  meta?: string
+  tone?: 'error'
+}) {
+  // The scaffold mark goes on the row, never on a container holding several:
+  // opacity opens a stacking context and would pin every sibling to one level.
+  return (
+    <div data-conversation-scaffold="" data-slot="connector-card">
+      <ScaffoldRow>
+        <ConnectorLogo className="size-4 rounded-[0.25rem]" connector={connector} />
+        <span className="truncate text-[length:var(--conversation-tool-font-size)] text-(--ui-text-primary)">
+          {connector.title || connector.name}
+        </span>
+        {meta ? <span className={cn(SCAFFOLD_META_CLASS, tone === 'error' && 'text-destructive')}>{meta}</span> : null}
+      </ScaffoldRow>
+    </div>
+  )
+}
+
+/**
+ * How much the source vouches for this subject.
+ *
+ * Only the exceptions get a badge. Something we shipped in a reviewed catalog
+ * is the ordinary case — badging it "reviewed" spends a word on every card to
+ * say "normal", and a label whose meaning nobody can guess teaches the user to
+ * ignore the one that matters.
+ *
+ * So: nothing for vetted sources. A publisher that proved it owns the serving
+ * domain says "verified · notion.com" — checkable identity, not an
+ * endorsement, which is why it names the domain instead of claiming trust.
+ * Everything else gets the amber "unreviewed" with the host in its tooltip:
+ * the card doesn't spend a line on an endpoint nobody reads, but for a
+ * publisher nobody has vouched for, the host is the whole question.
+ */
+function TrustBadge({ connector, copy }: { connector: ConnectorCardSubject; copy: ConnectorCardCopy }) {
+  if (!connector.trust || connector.trust === 'catalog') {
+    return null
+  }
+
+  if (connector.trust === 'verified') {
+    // No publisher domain means a curated directory of vendor remotes, which
+    // is the ordinary case again — nothing to say.
+    if (!connector.publisher) {
+      return null
+    }
+
+    return (
+      <Tip label={copy.trustVerifiedTip(connector.publisher)}>
+        <span className="text-[0.6875rem] text-(--ui-text-tertiary)">{copy.trustVerified(connector.publisher)}</span>
+      </Tip>
+    )
+  }
+
+  return (
+    <Tip label={copy.trustCommunityTip(hostOf(connector.url))}>
+      <span className="inline-flex items-center gap-1 text-[0.6875rem] text-amber-500">
+        <Codicon name="warning" size="0.6875rem" />
+        {copy.trustCommunity}
+      </span>
+    </Tip>
+  )
+}
+
+export interface ConnectorCardProps {
+  connector: ConnectorCardSubject
+  copy: ConnectorCardCopy
+  /** Waved off by the user. Collapses to the same settled line as success. */
+  dismissed?: boolean
+  envDraft?: Record<string, string>
+  /** Whether the credential fields are revealed. The caller owns this because
+   *  a refused credential should reveal them without a second click. */
+  envOpen?: boolean
+  onConnect: () => void
+  onDismiss: () => void
+  onEnvChange?: (key: string, value: string) => void
+  /** A sibling card is mid-flight. Two sign-in tabs racing for focus is
+   *  hostile, so the action waits — but the decline never does. */
+  otherBusy?: boolean
+  outcome?: ConnectorCardOutcome
+  /** Present only while working; replaces the resting state label. */
+  phase?: string
+  state: ConnectorCardState
+}
+
+/**
+ * One subject's consent card.
+ *
+ * Owns everything about that subject and nothing about its siblings: its own
+ * trust badge, credential fields, failure reason, and its own action. A
+ * connected card collapses to a single confirmed line, because its offer is
+ * spent and the space belongs to the ones still asking.
+ */
+export function ConnectorCard({
+  connector,
+  copy,
+  dismissed = false,
+  envDraft = {},
+  envOpen = false,
+  onConnect,
+  onDismiss,
+  onEnvChange,
+  otherBusy = false,
+  outcome,
+  phase,
+  state
+}: ConnectorCardProps) {
+  const working = phase !== undefined
+  const connected = outcome?.status === 'connected'
+  const failed = outcome?.status === 'error'
+
+  // Answered: the offer is spent, so the card collapses to a scaffold line and
+  // gives the space back to whatever is still asking.
+  if (connected || dismissed) {
+    return <ConnectorSummary connector={connector} meta={outcomeMeta(outcome ?? { status: 'declined' }, copy)} />
+  }
+
+  const stateLabel = state === 'disabled' ? copy.stateDisabled : state === 'needs_auth' ? copy.stateNeedsAuth : null
+
+  // Before the first connect, and again after a failed one. Something that
+  // connected doesn't need its console instructions repeated — but a failure
+  // usually happened BECAUSE of that console: an API left un-enabled, the
+  // wrong client type, a secret copied one character short. Withdrawing the
+  // steps and the fields at the moment they're finally needed is backwards,
+  // and it leaves a wrong credential with nowhere to be corrected.
+  const fixable = state === 'not_configured' || failed
+  const envFields = fixable ? (connector.requiredEnv ?? []) : []
+  const steps = fixable ? (connector.setup ?? []) : []
+
+  // Logo owns the left rail; everything the card says and every control it
+  // offers shares the one text column, so the buttons sit on the copy's grid
+  // line instead of hanging off the card's edge under the mark.
+  return (
+    <div className={cn(SHELL_CLASS, 'flex items-start gap-3')} data-slot="connector-card">
+      <ConnectorLogo connector={connector} />
+
+      <div className="grid min-w-0 flex-1 gap-0.5">
+        <div className="flex flex-wrap items-baseline gap-x-1.5">
+          <span className="font-medium">{connector.title}</span>
+          {/* While the card is working its phase replaces the resting state —
+              "Signing in…" is the one the user needs, because the browser tab
+              that just took focus is otherwise unexplained. */}
+          {working ? (
+            <span className="text-[0.6875rem] text-(--ui-text-tertiary)">{phase}</span>
+          ) : (
+            stateLabel && <span className="text-[0.6875rem] text-(--ui-text-tertiary)">{stateLabel}</span>
+          )}
+          <TrustBadge connector={connector} copy={copy} />
+        </div>
+
+        {connector.description ? <p className="text-(--ui-text-secondary)">{connector.description}</p> : null}
+
+        {failed && outcome.detail ? <p className="text-[0.6875rem] text-destructive">{outcome.detail}</p> : null}
+
+        {/* The part we cannot do. Numbered because order matters, linked
+            because the whole cost of these steps is finding the page. */}
+        {steps.length > 0 && (
+          <ol className="mt-1.5 grid gap-1" data-slot="connector-card-steps">
+            {steps.map((step, index) => (
+              <li className="flex gap-1.5 text-[0.6875rem] text-(--ui-text-secondary)" key={step}>
+                <span className="tabular-nums text-(--ui-text-tertiary)">{index + 1}.</span>
+                <MarkdownLinkText text={step} />
+              </li>
+            ))}
+          </ol>
+        )}
+
+        {envOpen && envFields.length > 0 && (
+          <div className="mt-1 grid gap-2" data-slot="connector-card-env">
+            <p className="text-[0.6875rem] text-(--ui-text-tertiary)">{copy.envRequired}</p>
+            {envFields.map(env => (
+              <label className="grid gap-1" key={env.name}>
+                <span className="text-[0.6875rem] text-(--ui-text-secondary)">
+                  {env.prompt || env.name}
+                  {env.required ? ' *' : ''}
+                </span>
+                <Input
+                  className="h-7 text-xs"
+                  onChange={event => onEnvChange?.(env.name, event.currentTarget.value)}
+                  type="password"
+                  value={envDraft[env.name] ?? ''}
+                />
+              </label>
+            ))}
+          </div>
+        )}
+
+        {/* Same strip as the tool approval bar (tool/approval.tsx), down to its
+            `mt-2` stand-off: a bordered primary-tinted action plus a quiet
+            ghost decline. One consent vocabulary across the transcript. */}
+        <div className="mt-2 flex items-center gap-2.5">
+          <div className="inline-flex h-6 items-stretch overflow-hidden rounded-md border border-primary/25 bg-primary/10 text-primary">
+            <Button
+              className="h-full gap-1 rounded-none px-2 text-xs font-medium text-primary hover:bg-primary/15 hover:text-primary"
+              disabled={working || otherBusy}
+              onClick={onConnect}
+              size="xs"
+              variant="ghost"
+            >
+              {working ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : outcome?.needsAuth ? (
+                copy.grantAction
+              ) : failed ? (
+                copy.retryAction
+              ) : (
+                copy.connectAction
+              )}
+            </Button>
+          </div>
+          {/* Never disabled: while a connect is in flight this is the way out
+              of a stuck sign-in tab or a hung install. */}
+          <Button
+            className="h-6 gap-1.5 rounded-md px-1.5 text-xs font-normal text-(--ui-text-tertiary) hover:text-foreground"
+            onClick={onDismiss}
+            size="xs"
+            variant="ghost"
+          >
+            {copy.decline}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/components/ui/connector-logo.tsx
+++ b/apps/desktop/src/components/ui/connector-logo.tsx
@@ -1,40 +1,77 @@
 import { brandFor } from '@/lib/mcp-brands'
-import { type Connector, connectorLogoSource } from '@/lib/mcp-connectors'
 import { cn } from '@/lib/utils'
 
 import { AvatarChip, monogramFor } from './avatar-chip'
 import { Favicon } from './favicon'
+
+/** The least a mark needs: something to name it, and somewhere a logo might
+ *  live. Structural on purpose — a caller's richer connector type satisfies
+ *  this without the visual layer knowing that type exists. */
+export interface ConnectorLogoSubject {
+  docs?: string
+  homepage?: string
+  name: string
+  title?: string
+  url?: null | string
+}
+
+/** Hosts whose favicon would name the wrong thing: a bridge published on
+ *  GitHub is not GitHub, and a package page is not the product. */
+const NOT_A_LOGO =
+  /(^|\.)(github\.com|githubusercontent\.com|gitlab\.com|bitbucket\.org|npmjs\.com|pypi\.org|readthedocs\.io)$/
+
+const isLoopback = (host: string) =>
+  host === 'localhost' || host === '::1' || /^127\./.test(host) || /^(10|192\.168)\./.test(host)
+
+/**
+ * Where to read this subject's mark from.
+ *
+ * The product's own site first (the only source that is certainly the right
+ * logo), then the endpoint it talks to — `mcp.linear.app` is Linear — then
+ * vendor docs, which for most entries is `docs.stripe.com` and friends.
+ * Nothing for a private or loopback host: there is no logo out there to find,
+ * and asking would announce an internal hostname.
+ */
+export function connectorLogoSource(subject: ConnectorLogoSubject): string {
+  for (const candidate of [subject.homepage, subject.url, subject.docs]) {
+    if (!candidate) {
+      continue
+    }
+
+    try {
+      const { hostname, origin } = new URL(candidate)
+
+      if (!NOT_A_LOGO.test(hostname) && !isLoopback(hostname)) {
+        // The origin, never the path: the icon lives on the site, and this
+        // way a not-yet-connected endpoint is never fetched just to draw a
+        // logo.
+        return origin
+      }
+    } catch {
+      // Not a URL (a bare repo path, a note) — nothing to read a mark from.
+    }
+  }
+
+  return ''
+}
 
 /**
  * A connector's mark, resolved as far as it goes.
  *
  * Curated brand glyph → the product's own favicon → the monogram every other
  * unknown name in the app falls back to. The middle rung is what keeps the
- * long tail from all looking alike: the catalog is a couple dozen names and
- * the registry is thousands, so a connector we ship no icon for still arrives
- * wearing its own logo. Which site to read that favicon from is
- * `connectorLogoSource`'s call, not this component's.
+ * long tail from all looking alike: a curated icon set is a couple dozen names
+ * and a public registry is thousands, so something we ship no icon for still
+ * arrives wearing its own logo.
  */
-export function ConnectorLogo({
-  className,
-  connector
-}: {
-  className?: string
-  // Name and title are the identity; the URLs are what a favicon lookup needs
-  // and a settled transcript row no longer has.
-  connector: Partial<Pick<Connector, 'docs' | 'homepage' | 'url'>> & Pick<Connector, 'name' | 'title'>
-}) {
+export function ConnectorLogo({ className, connector }: { className?: string; connector: ConnectorLogoSubject }) {
+  const label = connector.title || connector.name
   const brand = brandFor(connector.name)
   const site = brand ? '' : connectorLogoSource(connector)
 
   return (
-    <AvatarChip
-      brand={brand}
-      className={cn(site && 'overflow-hidden', className)}
-      name={connector.title || connector.name}
-      title={connector.title}
-    >
-      {site ? <Favicon fallback={monogramFor(connector.title || connector.name)} url={site} /> : undefined}
+    <AvatarChip brand={brand} className={cn(site && 'overflow-hidden', className)} name={label} title={connector.title}>
+      {site ? <Favicon fallback={monogramFor(label)} url={site} /> : undefined}
     </AvatarChip>
   )
 }

--- a/apps/desktop/src/components/ui/connector-logo.tsx
+++ b/apps/desktop/src/components/ui/connector-logo.tsx
@@ -1,0 +1,40 @@
+import { brandFor } from '@/lib/mcp-brands'
+import { type Connector, connectorLogoSource } from '@/lib/mcp-connectors'
+import { cn } from '@/lib/utils'
+
+import { AvatarChip, monogramFor } from './avatar-chip'
+import { Favicon } from './favicon'
+
+/**
+ * A connector's mark, resolved as far as it goes.
+ *
+ * Curated brand glyph → the product's own favicon → the monogram every other
+ * unknown name in the app falls back to. The middle rung is what keeps the
+ * long tail from all looking alike: the catalog is a couple dozen names and
+ * the registry is thousands, so a connector we ship no icon for still arrives
+ * wearing its own logo. Which site to read that favicon from is
+ * `connectorLogoSource`'s call, not this component's.
+ */
+export function ConnectorLogo({
+  className,
+  connector
+}: {
+  className?: string
+  // Name and title are the identity; the URLs are what a favicon lookup needs
+  // and a settled transcript row no longer has.
+  connector: Partial<Pick<Connector, 'docs' | 'homepage' | 'url'>> & Pick<Connector, 'name' | 'title'>
+}) {
+  const brand = brandFor(connector.name)
+  const site = brand ? '' : connectorLogoSource(connector)
+
+  return (
+    <AvatarChip
+      brand={brand}
+      className={cn(site && 'overflow-hidden', className)}
+      name={connector.title || connector.name}
+      title={connector.title}
+    >
+      {site ? <Favicon fallback={monogramFor(connector.title || connector.name)} url={site} /> : undefined}
+    </AvatarChip>
+  )
+}

--- a/apps/desktop/src/components/ui/favicon.tsx
+++ b/apps/desktop/src/components/ui/favicon.tsx
@@ -1,0 +1,89 @@
+import { type ReactNode, useEffect, useState } from 'react'
+
+import { Loader2 } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+
+/**
+ * A site's icon, resolved the thorough way.
+ *
+ * The work happens in the main process (`electron/favicon.ts`): read the
+ * page, collect every declared `<link rel="icon">` and web-app-manifest
+ * icon, rank them, then fall back to the well-known paths. None of that is
+ * reachable from here — cross-origin HTML is unreadable under CORS — so this
+ * component is just the request, the wait, and the placeholder.
+ *
+ * `fallback` holds the box before and after: a spinner marks the lookup, and
+ * a site with no readable icon keeps the caller's own glyph rather than
+ * flashing a broken image.
+ */
+
+/** url → data URL, or '' for a site we've already failed to read. The main
+ *  process caches across restarts; this keeps a remount from crossing the
+ *  IPC boundary at all. */
+const resolved = new Map<string, string>()
+
+export function Favicon({
+  className,
+  fallback,
+  title,
+  url
+}: {
+  className?: string
+  fallback: ReactNode
+  title?: string
+  url: null | string | undefined
+}) {
+  const [icon, setIcon] = useState(() => (url ? (resolved.get(url) ?? '') : ''))
+  const [pending, setPending] = useState(false)
+
+  useEffect(() => {
+    const resolveFavicon = window.hermesDesktop?.resolveFavicon
+
+    if (!url || !resolveFavicon) {
+      setIcon('')
+      setPending(false)
+
+      return
+    }
+
+    const cached = resolved.get(url)
+
+    if (cached !== undefined) {
+      setIcon(cached)
+      setPending(false)
+
+      return
+    }
+
+    let live = true
+
+    setPending(true)
+
+    void resolveFavicon(url)
+      .catch(() => '')
+      .then(found => {
+        resolved.set(url, found)
+
+        if (live) {
+          setIcon(found)
+          setPending(false)
+        }
+      })
+
+    return () => {
+      live = false
+    }
+  }, [url])
+
+  return (
+    <span className={cn('inline-grid size-full place-items-center', className)} title={title}>
+      {icon ? (
+        <img alt="" aria-hidden className="size-full object-contain" src={icon} />
+      ) : pending ? (
+        <Loader2 aria-hidden className="h-1/2 w-1/2 animate-spin opacity-60" />
+      ) : (
+        fallback
+      )}
+    </span>
+  )
+}

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -262,6 +262,9 @@ declare global {
       openExternal: (url: string) => Promise<void>
       openPreviewInBrowser?: (url: string) => Promise<void>
       fetchLinkTitle: (url: string) => Promise<string>
+      /** A site's icon as a data URL, or '' when it has none we can read.
+       *  Resolved and cached in the main process (electron/favicon.ts). */
+      resolveFavicon?: (url: string) => Promise<string>
       sanitizeWorkspaceCwd: (cwd?: null | string) => Promise<{ cwd: string; sanitized: boolean }>
       settings: {
         getDefaultProjectDir: () => Promise<{ defaultLabel: string; dir: null | string; resolvedCwd: string }>

--- a/apps/desktop/src/lib/external-link.test.tsx
+++ b/apps/desktop/src/lib/external-link.test.tsx
@@ -11,6 +11,7 @@ import {
   hostPathLabel,
   isTitleFetchable,
   LinkifiedText,
+  MarkdownLinkText,
   PrettyLink,
   urlSlugTitleLabel
 } from './external-link'
@@ -131,6 +132,21 @@ describe('external link helpers', () => {
     fireEvent.click(screen.getByRole('link', { name: 'Example link' }), IS_MAC ? { metaKey: true } : { ctrlKey: true })
 
     expect(openExternal).toHaveBeenCalledWith('https://example.com/path/to/resource')
+    expect($previewTabs.get()).toHaveLength(0)
+  })
+
+  // A setup step sends you to a console you are signed into in your own
+  // browser, to fill in a form and copy a secret back. The in-app pane has
+  // none of that session and is the wrong destination even for web URLs.
+  it('sends a setup-step link straight to the OS browser', () => {
+    const openExternal = vi.fn().mockResolvedValue(undefined)
+    installDesktopBridge({ openExternal: openExternal as unknown as Window['hermesDesktop']['openExternal'] })
+
+    render(<MarkdownLinkText text="Enable the [Docs API](https://console.cloud.google.com/apis/library) first." />)
+
+    fireEvent.click(screen.getByRole('link', { name: 'Docs API' }))
+
+    expect(openExternal).toHaveBeenCalledWith('https://console.cloud.google.com/apis/library')
     expect($previewTabs.get()).toHaveLength(0)
   })
 

--- a/apps/desktop/src/lib/external-link.tsx
+++ b/apps/desktop/src/lib/external-link.tsx
@@ -247,6 +247,9 @@ export function openLink(href: string, options: { native?: boolean } = {}): void
 interface ExternalLinkProps extends Omit<ComponentProps<'a'>, 'href' | 'target'> {
   href: string
   children?: ReactNode
+  /** Skip the in-app pane. For links whose whole point is the session you are
+   *  signed into over there — a cloud console, an account page. */
+  native?: boolean
   showExternalIcon?: boolean
 }
 
@@ -274,6 +277,7 @@ export function ExternalLink({
   children,
   className,
   href,
+  native = false,
   onClick,
   showExternalIcon = false,
   ...rest
@@ -307,7 +311,7 @@ export function ExternalLink({
         }
 
         event.preventDefault()
-        openLink(target, { native: wantsNativeBrowser(event.nativeEvent) })
+        openLink(target, { native: native || wantsNativeBrowser(event.nativeEvent) })
       }}
       rel="noopener noreferrer"
       target="_blank"
@@ -369,6 +373,49 @@ export function LinkifiedText({ className, explicitOnly = false, pretty = true, 
           {raw}
         </ExternalLink>
       )
+    )
+
+    cursor = index + raw.length
+  }
+
+  if (cursor < text.length) {
+    nodes.push(text.slice(cursor))
+  }
+
+  return <span className={className}>{nodes.length ? nodes : text}</span>
+}
+
+const MD_LINK_RE = /\[([^\]]+)]\((https?:\/\/[^\s)]+)\)/g
+
+/**
+ * Inline `[label](url)` and nothing else.
+ *
+ * For short authored strings — a catalog entry's setup steps — where the
+ * label carries the meaning ("enable the Docs API") and the URL is a console
+ * page whose own title is useless or, behind a login wall, actively wrong.
+ * `LinkifiedText` can't serve this: it finds bare URLs and guesses a label.
+ * Full markdown is the other extreme, a block renderer inside a card row.
+ *
+ * These open in the real browser. The destination is a console the user is
+ * already signed into there, and the work is a form to fill in and a secret to
+ * copy back — none of which the in-app pane is for.
+ */
+export function MarkdownLinkText({ className, text }: { className?: string; text: string }) {
+  const nodes: ReactNode[] = []
+  let cursor = 0
+
+  for (const match of text.matchAll(MD_LINK_RE)) {
+    const [raw, label, href] = match
+    const index = match.index ?? 0
+
+    if (index > cursor) {
+      nodes.push(text.slice(cursor, index))
+    }
+
+    nodes.push(
+      <ExternalLink href={href} key={`${href}-${index}`} native title={href}>
+        {label}
+      </ExternalLink>
     )
 
     cursor = index + raw.length

--- a/apps/desktop/src/lib/mcp-brands.tsx
+++ b/apps/desktop/src/lib/mcp-brands.tsx
@@ -1,10 +1,13 @@
 /**
  * Curated brand glyphs for MCP server names — extracted from the mcp-tab's
  * avatar (its `MCP_BRAND_ICONS`) the moment a second surface (the composer
- * suggestion pills / inline setup card) needed the same identity ladder:
- * curated brand glyph → letter monogram. We deliberately do NOT fetch remote
- * favicons: a configured MCP URL can be a private/internal host, and hitting
- * a favicon service for it would leak that hostname off-box.
+ * suggestion pills / inline setup card) needed the same identity ladder.
+ *
+ * This is the first rung only. Everything below it — the endpoint's own
+ * favicon, then the initial — lives in `components/ui/connector-logo`, which
+ * is what a surface should render when it wants a mark rather than a glyph.
+ * Either way we never ask a third-party favicon service: an MCP URL can be a
+ * private host, and that lookup would leak the hostname off-box.
  */
 import {
   SiAirtable,
@@ -17,6 +20,7 @@ import {
   SiHuggingface,
   SiIntercom,
   SiLinear,
+  SiN8n,
   SiNetlify,
   SiNotion,
   SiPaypal,
@@ -25,6 +29,7 @@ import {
   SiSquare,
   SiStripe,
   SiSupabase,
+  SiUnrealengine,
   SiVercel,
   SiWebflow,
   SiZapier
@@ -52,6 +57,7 @@ export const MCP_BRAND_ICONS: Record<string, McpBrand> = {
   huggingface: { Icon: SiHuggingface, color: '#FFD21E' },
   intercom: { Icon: SiIntercom, color: '#6AFDEF' },
   linear: { Icon: SiLinear, color: '#5E6AD2' },
+  n8n: { Icon: SiN8n, color: '#EA4B71' },
   netlify: { Icon: SiNetlify, color: '#00C7B7' },
   notion: { Icon: SiNotion, color: '#000000', monochrome: true },
   paypal: { Icon: SiPaypal, color: '#003087' },
@@ -61,6 +67,7 @@ export const MCP_BRAND_ICONS: Record<string, McpBrand> = {
   square: { Icon: SiSquare, color: '#3E4348', monochrome: true },
   stripe: { Icon: SiStripe, color: '#635BFF' },
   supabase: { Icon: SiSupabase, color: '#3FCF8E' },
+  'unreal-engine': { Icon: SiUnrealengine, color: '#0E1128', monochrome: true },
   vercel: { Icon: SiVercel, color: '#000000', monochrome: true },
   webflow: { Icon: SiWebflow, color: '#146EF5' },
   zapier: { Icon: SiZapier, color: '#FF4A00' }
@@ -71,8 +78,23 @@ export const MCP_BRAND_ICONS: Record<string, McpBrand> = {
 export const brandGlyphStyle = (brand: McpBrand): { color: string } | undefined =>
   brand.monochrome ? undefined : { color: brand.color }
 
-export const brandFor = (name: string): McpBrand | null => {
-  const lower = name.toLowerCase()
+/** The same brand under every spelling a connector arrives with: catalog slug
+ *  (`unreal-engine`), registry id (`unreal_engine`), display name (`Unreal
+ *  Engine`). Compare on letters and digits alone so none of them miss. */
+const squash = (value: string): string => value.toLowerCase().replace(/[^a-z0-9]/g, '')
 
-  return MCP_BRAND_ICONS[lower] ?? Object.entries(MCP_BRAND_ICONS).find(([key]) => lower.includes(key))?.[1] ?? null
+export const brandFor = (name: string): McpBrand | null => {
+  const target = squash(name)
+
+  if (!target) {
+    return null
+  }
+
+  const entries = Object.entries(MCP_BRAND_ICONS)
+
+  return (
+    entries.find(([key]) => squash(key) === target)?.[1] ??
+    entries.find(([key]) => target.includes(squash(key)))?.[1] ??
+    null
+  )
 }


### PR DESCRIPTION
The visual layer for asking someone to connect something, with no MCP in it.

Three surfaces — messaging platforms, the MCP servers tab, and the connector
card — were each drawing their own square brand chip, and the copies had
already drifted on radius, glyph size, and what an unknown name falls back to.
They now share one `AvatarChip`.

Underneath it, a name with no bundled brand glyph had nothing to render at all,
and the renderer could not go find one because CORS makes another origin's
markup unreadable. Favicon resolution therefore moves to the main process: read
the page, collect every icon declared in its head and web manifest, rank them,
sniff the bytes, cache per host on disk. Only ever the site's own marks — a
public icon service would answer for the hosts behind a bot wall, but asking
one means telling a third party which tools someone is wiring up, so an
unreadable site keeps its monogram.

On top sits `ConnectorCard`: the card, the settled scaffold line it collapses
to, the trust badge, and the numbered setup steps. It renders a subject, a
state, and an outcome, and calls back.

## The boundary

Nothing here imports a connector engine, a store, or i18n — the prop types are
structural and the strings are passed in, so a caller's richer type satisfies
them without this layer knowing that type exists. `lib/mcp-connectors` does not
exist in this branch at all, which is the proof: it typechecks without it.

That is the point of splitting it out. Any surface that has to ask "connect
this?" should look identical without sharing a data layer.

## Consumers

`AvatarChip` lands with its three, `McpAvatar` and `PlatformAvatar` refactored
onto it here. `ConnectorCard` and `ConnectorLogo` are consumed by the connector
work in [#90660](https://github.com/NousResearch/hermes-agent/pull/90660),
which is written and rebases onto this — one conflict, verified by replaying it.

## Tests

74 new: the resolver's ranking, sniffing and host rules against an injected IO
(no network), the chip's identity ladder, and the card's states — resting,
working, settled, failed, credential-refused, and the trust badge.

Behaviour only; nothing reads source text or freezes a snapshot.