### PR TITLE
feat: add GLM-5.3 model + 1M context window (Z.AI coding plan)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -508,6 +508,11 @@ DEFAULT_CONTEXT_LENGTHS = {
     # ensures "glm-5.2" resolves to 1M while older variants still hit the
     # generic 202K fallback.
     "glm-5.2": 1_048_576,
+    # GLM-5.3 ships a 1M context window, same as 5.2 (models.dev:
+    # zai-coding-plan glm-5.3 context=1M, output=128K; verified 2026-08).
+    # Without this entry "glm-5.3" falls through to the generic "glm" 202K
+    # fallback and context gets compressed ~5x too early.
+    "glm-5.3": 1_048_576,
     "glm": 202752,
     # xAI Grok — xAI /v1/models does not return context_length metadata,
     # so these hardcoded fallbacks prevent Hermes from probing-down to

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -366,6 +366,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-3.1-flash-lite-preview",
     ],
     "zai": [
+        "glm-5.3",
         "glm-5.2",
         "glm-5.1",
         "glm-5",


### PR DESCRIPTION
## Summary
- Add `glm-5.3` to `DEFAULT_CONTEXT_LENGTHS` (1,048,576) — without it, the model falls through to the generic `glm` 202,752 fallback and context gets compressed ~5x too early
- Add `glm-5.3` to the curated `zai` catalog in `_PROVIDER_MODELS` — prevents 'Model was not found in this provider's model listing' when the live /v1/models fetch is unavailable

## Context
GLM-5.3 is live on `api.z.ai/api/coding/paas/v4` and served via `/v1/models`, but the z.ai live listing returns no context_length metadata (verified 2026-08), so the static table is the only correct source. Per models.dev (zai-coding-plan), GLM-5.3 ships a 1M context window (output 128K), same as 5.2.

## Verification
- Live endpoint probe: glm-5.3 served, HTTP 200
- `get_model_context_length('glm-5.3', base_url='https://api.z.ai/api/coding/paas/v4')` → 1,048,576 with this patch vs 202,752 without
- Models list: z.ai live listing includes glm-5.3 (curated entry is the fallback for stale-cache cases)