### PR TITLE
fix(desktop): keep command approval readable on transparent themes

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -87,7 +87,7 @@ export const PendingApprovalFallback: FC = () => {
       data-slot="tool-approval-fallback"
       style={{ bottom: 'calc(var(--composer-measured-height) + 0.875rem)' }}
     >
-      <div className="pointer-events-auto rounded-xl border border-primary/30 bg-(--ui-chat-surface-background) px-3 py-2 shadow-lg backdrop-blur-xl [-webkit-backdrop-filter:blur(1rem)]">
+      <div className="pointer-events-auto rounded-xl border border-primary/30 bg-popover/95 px-3 py-2 shadow-lg backdrop-blur-xl [-webkit-backdrop-filter:blur(1rem)]">
         <div className="flex min-w-0 items-center gap-2 text-sm text-primary">
           <AlertCircle className="size-4 shrink-0" />
           <span className="shrink-0 font-medium">{t.assistant.approval.jumpToApproval}</span>


### PR DESCRIPTION
## What does this PR do?

Keeps the floating command-approval surface readable when the desktop transparent aesthetic is enabled. The fallback card previously used `--ui-chat-surface-background`, which intentionally becomes translucent with that aesthetic, so window content could compete with a security-sensitive approve/deny decision.

The card now uses the existing elevated popover surface at 95% opacity while retaining its backdrop blur, border, and shadow. Inline approvals inside tool rows are unchanged.

Fixes #91026

## Evidence

- Exact base: `9ef9b2d2d01eb4bcf9420973c5ef6c98f2176455`
- Exact head: `bce8a8418a61ec59f58cf1a8a732db49424e1b33`
- Scope: one production line, one surface token replacement
- `git diff --check` passes
- Exact diff is 1 insertion / 1 deletion in `apps/desktop/src/components/assistant-ui/tool/approval.tsx`
- Existing adjacent foreground convention: notifications use the same high-opacity popover surface plus backdrop blur

## Validation boundary

The local checkout does not have the desktop Vitest dependency installed (`vitest: command not found`), so I am not claiming a local component-test run. The change is a Tailwind class-token substitution with no control-flow, event, or approval-protocol changes; hosted CI is the public validation path.

## Type of Change

- [x] Bug fix (non-breaking change)

## Checklist

- [x] Searched issue number, title/symptom terms, owner component, and both surface tokens for competing open PRs
- [x] Diff is limited to the reported transparent-aesthetic readability bug
- [x] `git diff --check` passes
- [x] Cross-platform behavior considered: the opacity applies at the renderer surface and is not OS-specific