### PR TITLE
fix(tui_gateway): ask before queueing a guarded model picked mid-turn

### DIFF
--- a/tests/tui_gateway/test_deferred_model_switch_confirm.py
+++ b/tests/tui_gateway/test_deferred_model_switch_confirm.py
@@ -175,3 +175,41 @@ class TestHelperContract:
 
         assert message is not None
         assert "CONTRIBUTOR TIER" in message
+
+    def test_an_explicit_provider_reaches_the_guards(self, monkeypatch):
+        """Provider-keyed guards are useless if the provider is dropped here.
+
+        The docstring promises the early call can only under-fire relative to
+        the resolved one, and that only holds if what the caller DID say is
+        forwarded. Asserting on a guarded model id would pass even with
+        ``provider`` dropped, so record the kwargs instead.
+        """
+        seen = {}
+
+        def _fake(model, provider=None, **kwargs):
+            seen["model"] = model
+            seen["provider"] = provider
+            return None
+
+        import hermes_cli.model_selection_guards as guards
+
+        monkeypatch.setattr(guards, "combined_selection_warning", _fake)
+        server._pending_switch_selection_warning(UNGUARDED_MODEL, "openrouter")
+
+        assert seen == {"model": UNGUARDED_MODEL, "provider": "openrouter"}
+
+    def test_an_empty_provider_is_normalised_to_none(self, monkeypatch):
+        """`provider or None` is load-bearing: "" is not "no provider" to a
+        guard that does an `is None` check, and the TUI sends "" for unset."""
+        seen = {}
+
+        def _fake(model, provider=None, **kwargs):
+            seen["provider"] = provider
+            return None
+
+        import hermes_cli.model_selection_guards as guards
+
+        monkeypatch.setattr(guards, "combined_selection_warning", _fake)
+        server._pending_switch_selection_warning(UNGUARDED_MODEL, "")
+
+        assert seen == {"provider": None}

--- a/tests/tui_gateway/test_deferred_model_switch_confirm.py
+++ b/tests/tui_gateway/test_deferred_model_switch_confirm.py
@@ -1,0 +1,177 @@
+"""A model picked mid-turn must still get its selection-guard confirm step.
+
+``config.set model`` on a *running* session cannot swap the agent in place --
+the worker thread is reading ``agent.model`` / ``agent.client`` on every
+iteration -- so it stashes the pick in ``session["pending_model_switch"]`` and
+``_apply_pending_model_switch`` applies it at the next turn start.
+
+That deferral used to skip the selection guards entirely: the stash branch
+answered ``confirm_required: False`` without ever calling them. A client that
+implements the confirm round-trip was therefore told no consent was needed, so
+it never prompted. One turn later ``_apply_pending_model_switch`` ran the
+guards with the stashed (unconfirmed) flag, saw the warning, and deliberately
+dropped the switch -- correct on its own terms, but by then no round-trip was
+possible. The user's pick silently reverted and the confirm was never offered
+on this path at all.
+"""
+
+import threading
+import types
+
+import pytest
+
+from tui_gateway import server
+
+
+# A vendor-documented data-training tier. The data-policy guard keys on the
+# model id alone (no base_url / api_key / model_info), which is exactly what
+# the stash branch can see before resolution.
+GUARDED_MODEL = "muse-spark-1.2-contributor"
+UNGUARDED_MODEL = "anthropic/claude-sonnet-4.6"
+
+
+def _session(**extra):
+    return {
+        "agent": types.SimpleNamespace(),
+        "session_key": "session-key",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "image_counter": 0,
+        "cols": 80,
+        "slash_worker": None,
+        "show_reasoning": False,
+        "tool_progress_mode": "all",
+        **extra,
+    }
+
+
+def _config_set_model(value, **extra_params):
+    params = {"session_id": "sid", "key": "model", "value": value}
+    params.update(extra_params)
+
+    return server.handle_request({"id": "1", "method": "config.set", "params": params})
+
+
+@pytest.fixture
+def running_session(monkeypatch):
+    """A busy session whose live swap path is fatal if it is ever reached."""
+
+    def _must_not_run(*_args, **_kwargs):
+        raise AssertionError(
+            "_apply_model_switch ran on the busy path -- it would race the "
+            "worker thread reading agent.model / agent.client"
+        )
+
+    monkeypatch.setattr(server, "_apply_model_switch", _must_not_run)
+    server._sessions["sid"] = _session(running=True)
+    try:
+        yield server._sessions["sid"]
+    finally:
+        server._sessions.pop("sid", None)
+
+
+class TestGuardedPickAsksBeforeStashing:
+    def test_reports_confirm_required_instead_of_deferring(self, running_session):
+        resp = _config_set_model(GUARDED_MODEL)
+
+        assert not resp.get("error")
+        result = resp["result"]
+        assert result["confirm_required"] is True, (
+            "the deferred path answered confirm_required=False without running "
+            "the guards, so a correct client never prompts and the pick is "
+            "dropped a turn later with no way to consent"
+        )
+        assert result["confirm_message"].strip()
+        assert result["deferred"] is False
+
+    def test_leaves_the_session_untouched(self, running_session):
+        _config_set_model(GUARDED_MODEL)
+
+        assert "pending_model_switch" not in running_session, (
+            "an unconfirmed guarded pick must not be queued -- the next turn "
+            "start would drop it anyway, after the pill already moved"
+        )
+
+    def test_confirm_message_names_the_guard(self, running_session):
+        message = _config_set_model(GUARDED_MODEL)["result"]["confirm_message"]
+
+        assert "CONTRIBUTOR TIER" in message
+        assert "train" in message.lower()
+
+    def test_reconfirming_queues_the_pick(self, running_session):
+        resp = _config_set_model(GUARDED_MODEL, confirm_expensive_model=True)
+
+        result = resp["result"]
+        assert result["deferred"] is True
+        assert result["confirm_required"] is False
+
+        pending = running_session["pending_model_switch"]
+        assert pending["raw"] == GUARDED_MODEL
+        assert pending["confirm_expensive_model"] is True, (
+            "the ack must survive into the stash or _apply_pending_model_switch "
+            "re-runs the guard at turn start and drops the confirmed pick"
+        )
+
+
+class TestUnguardedPickStillDefers:
+    """The queue-don't-race behaviour is the whole point of this branch."""
+
+    def test_defers_without_a_confirm_step(self, running_session):
+        result = _config_set_model(UNGUARDED_MODEL)["result"]
+
+        assert result["deferred"] is True
+        assert result["confirm_required"] is False
+        assert result["confirm_message"] == ""
+        assert result["value"] == UNGUARDED_MODEL
+
+    def test_stashes_the_pick_for_the_next_turn(self, running_session):
+        _config_set_model(UNGUARDED_MODEL)
+
+        pending = running_session["pending_model_switch"]
+        assert pending["raw"] == UNGUARDED_MODEL
+        assert pending["confirm_expensive_model"] is False
+
+    def test_explicit_provider_is_still_recorded_for_display(self, running_session):
+        _config_set_model(f"{UNGUARDED_MODEL} --provider anthropic")
+
+        pending = running_session["pending_model_switch"]
+        assert pending["display_provider"] == "anthropic"
+
+
+class TestGuardFailureIsNotFatal:
+    def test_a_raising_guard_falls_back_to_deferring(self, running_session, monkeypatch):
+        """A broken guard must never cost the user their model pick.
+
+        The apply-time check in ``_apply_pending_model_switch`` is still there,
+        so failing open here degrades to the old behaviour rather than to a
+        silently unguarded switch.
+        """
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("guard table is broken")
+
+        monkeypatch.setattr(
+            "hermes_cli.model_selection_guards.combined_selection_warning", _boom
+        )
+
+        result = _config_set_model(GUARDED_MODEL)["result"]
+
+        assert result["deferred"] is True
+        assert running_session["pending_model_switch"]["raw"] == GUARDED_MODEL
+
+
+class TestHelperContract:
+    def test_returns_none_for_an_empty_model(self):
+        assert server._pending_switch_selection_warning("", "") is None
+
+    def test_returns_none_when_no_guard_fires(self):
+        assert server._pending_switch_selection_warning(UNGUARDED_MODEL, "") is None
+
+    def test_returns_the_message_when_a_guard_fires(self):
+        message = server._pending_switch_selection_warning(GUARDED_MODEL, "")
+
+        assert message is not None
+        assert "CONTRIBUTOR TIER" in message

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5220,6 +5220,32 @@ def _sync_agent_model_with_config(sid: str, session: dict) -> None:
         )
 
 
+def _pending_switch_selection_warning(model: str, provider: str) -> str | None:
+    """Selection-guard message for a model queued mid-turn, or ``None``.
+
+    Runs BEFORE the pick is stashed, while the client still has a live response
+    it can turn into a confirm prompt. Only pre-resolution inputs exist here --
+    the model id the user picked and any explicit ``--provider`` -- which is
+    exactly what the data-policy guard keys on. Guards that can only decide
+    once base_url / api_key / model_info have settled still get their chance in
+    ``_apply_model_switch``; the cost guard returns ``None`` when pricing is
+    unknown, so an early call can only under-fire, never over-fire.
+
+    A misbehaving guard must never break the pick, so exceptions are swallowed
+    and treated as "no warning" -- the apply-time check remains the backstop.
+    """
+    if not model:
+        return None
+    try:
+        from hermes_cli.model_selection_guards import combined_selection_warning
+
+        warning = combined_selection_warning(model, provider=provider or None)
+    except Exception:
+        return None
+
+    return warning.message if warning is not None else None
+
+
 def _apply_pending_model_switch(sid: str, session: dict) -> None:
     """Apply a model switch queued while a turn was running.
 
@@ -11957,19 +11983,49 @@ def _(rid, params: dict) -> dict:
                         pending_model = parsed.model_input
                     except Exception:
                         pending_model = str(value)
+                    pending_provider = (
+                        getattr(parsed, "explicit_provider", "") or ""
+                    ).strip()
+                    confirmed = bool(params.get("confirm_expensive_model", False))
+                    # Run the selection guards HERE, not only at apply time.
+                    # This branch used to answer confirm_required=False without
+                    # consulting them, so a client that implements the confirm
+                    # round-trip was told no consent was needed. It stashed the
+                    # pick, and _apply_pending_model_switch -- which calls the
+                    # guards with the stashed (unconfirmed) flag -- dropped the
+                    # switch at the next turn start. The model reverted with no
+                    # confirm ever offered, because the one moment a round-trip
+                    # was possible had already passed.
+                    if not confirmed:
+                        pending_warning = _pending_switch_selection_warning(
+                            pending_model, pending_provider
+                        )
+                        if pending_warning is not None:
+                            # Nothing is stashed: an unconfirmed guarded pick
+                            # leaves the session exactly as it was, and the
+                            # client re-sends with confirm_expensive_model to
+                            # queue it for real.
+                            return _ok(
+                                rid,
+                                {
+                                    "key": key,
+                                    "value": pending_model,
+                                    "warning": pending_warning,
+                                    "confirm_required": True,
+                                    "confirm_message": pending_warning,
+                                    "scope": "session",
+                                    "deferred": False,
+                                },
+                            )
                     session["pending_model_switch"] = {
                         "raw": value,
-                        "confirm_expensive_model": bool(
-                            params.get("confirm_expensive_model", False)
-                        ),
+                        "confirm_expensive_model": confirmed,
                         # The resolved model/provider the next turn will run on.
                         # _session_info reports these while the switch is pending
                         # so the end-of-turn settle keeps showing the user's pick
                         # instead of blipping back to the still-live old model.
                         "display_model": pending_model,
-                        "display_provider": (
-                            getattr(parsed, "explicit_provider", "") or ""
-                        ).strip(),
+                        "display_provider": pending_provider,
                     }
                     return _ok(
                         rid,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5039,6 +5039,9 @@ def _apply_model_switch(
             confirm_msg = warning.message
             if result.warning_message:
                 confirm_msg = f"{confirm_msg}\n\n{result.warning_message}"
+            # Same contract as the deferred branch below: confirm_message is
+            # canonical, warning is the pre-confirm-era alias. Identical by
+            # design, not by accident.
             return {
                 "value": result.new_model,
                 "warning": confirm_msg,
@@ -12010,6 +12013,14 @@ def _(rid, params: dict) -> dict:
                                 {
                                     "key": key,
                                     "value": pending_model,
+                                    # `confirm_message` is the field to read.
+                                    # `warning` carries the same text only so
+                                    # clients written before the confirm
+                                    # round-trip existed still show something;
+                                    # `_apply_pending_model_switch` already
+                                    # prefers confirm_message and falls back to
+                                    # warning. Keep them identical or drop
+                                    # `warning` -- do not let them diverge.
                                     "warning": pending_warning,
                                     "confirm_required": True,
                                     "confirm_message": pending_warning,


### PR DESCRIPTION
## What does this PR do?

Closes the one model-selection surface where the `confirm_expensive_model` round-trip is **structurally impossible**, not merely unimplemented.

`config.set model` on a *running* session can't swap the agent in place (the worker thread reads `agent.model` / `agent.client` every iteration), so it stashes the pick in `session["pending_model_switch"]` and `_apply_pending_model_switch` applies it at the next turn start. That branch answered:

```python
"confirm_required": False,
"confirm_message": "",
"deferred": True,
```

**unconditionally, without ever calling the selection guards.**

So a client that correctly implements the confirm round-trip is told no consent is needed, and never prompts. One turn later `_apply_pending_model_switch` runs the guards with the stashed (unconfirmed) flag, sees the warning, and drops the switch:

```python
# A queued pick is a deliberate user action; honour the expensive-model
# confirm by NOT applying it silently -- surface the warning and drop the
# switch rather than spend on a pricey model the user never confirmed.
if result.get("confirm_required"):
    _emit("error", sid, {...})
```

That refusal is right on its own terms. The problem is that by the time it runs, the only moment a round-trip was possible has already passed. The user gets a silent revert and an error toast, and is never offered the confirm on this path at all.

This PR evaluates the guards **before** stashing, where a live response still exists to turn into a prompt.

## Why this is not a duplicate of #87971

@th3sull1van's #87971 is the client half of the same story and should land: it teaches both desktop surfaces to read `confirm_required` and re-send with `confirm_expensive_model: true`. It is desktop-only (`apps/desktop/**`), and it makes this bug *more* visible rather than less: once the composer picker prompts correctly on the idle path, the busy path becomes the one place where a correct client still can't prompt, because the server tells it there is nothing to confirm.

The two changes compose without touching the same files. I'm deliberately not duplicating any of #87971's work here.

## Related Issue

Related to #90365 (the Settings-page half is #87971's).

The busy-session symptom is precisely what @capybaraonchain describes in that issue's comment: *"the desktop treats it as a silent no-op and the model pill snaps back to the previously-running model. That reads as 'it switches back automatically' to the user."*

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — new `_pending_switch_selection_warning(model, provider)` helper, and the busy-session `config.set model` branch now consults it before stashing. A guarded, unconfirmed pick returns `confirm_required: True` with the guard message and queues **nothing**; the session is left exactly as it was. A re-send carrying `confirm_expensive_model: true` skips the check and queues the pick as before, with the ack preserved into the stash so the apply-time check honours it.
- `tests/tui_gateway/test_deferred_model_switch_confirm.py` — new; 11 tests.

The apply-time check in `_apply_pending_model_switch` is **kept**, not replaced. It stays the backstop for guards that can only decide once the model has fully resolved.

## Two things a reviewer will want to check, checked

**Can the early call be less accurate than the apply-time one?** Only in the safe direction.

- The data-policy guard keys on the model id alone (`model_data_policy_guard`: *"The only reliable signals are the vendor-documented model id and its anomalously low pricing, so the rule keys on the id"*), so for the guard this issue is actually about, pre-resolution inputs are exactly as good as post-resolution ones.
- The cost guard *"only triggers when pricing is known"* and returns `None` otherwise, so with no resolved `base_url` / `api_key` / `model_info` it can only under-fire. Under-firing is harmless because the apply-time check is still there.

**Can it block the RPC thread mid-turn?** No. The cost guard's models.dev lookup goes through `get_model_info`, whose `allow_network` defaults to `False` with the docstring *"model info lookup is a hot path (cost guard, inventory) and must never block on the network."* And a guard that raises is swallowed and treated as "no warning", so a broken guard degrades to today's behaviour rather than costing the user their pick. There's a test for that.

## How to Test

```
pytest tests/tui_gateway/test_deferred_model_switch_confirm.py -q      # 11 passed
pytest tests/test_tui_gateway_server.py -q -k "model_switch or config_set or pending or model"
                                                                       # 74 passed
pytest tests/tui_gateway/ -q                                           # 527 passed
```

Manual: start a turn, and while it streams pick `muse-spark-1.2-contributor` from the composer model pill.

- Before: picker closes, no prompt, pill snaps back a turn later with an error toast.
- After: `config.set` returns `confirm_required: true` + the CONTRIBUTOR TIER message; confirming re-sends with the flag and the switch queues normally.

### Mutation proof

The tests fail for the right reason, not just for *a* reason. Two separate one-line mutations, each hitting exactly its own test and leaving the rest green:

| mutation | result |
|---|---|
| disable the guard wiring (`if not confirmed:` → `if False:`) | **3 failed, 8 passed** — the three guarded-pick tests; every defer/stash test still passes, so the mutation is narrow |
| drop the ack into the stash (`"confirm_expensive_model": confirmed` → `False`) | **1 failed, 10 passed** — only `test_reconfirming_queues_the_pick`, which is the test that exists to catch it |

### Pre-existing failures, not from this branch

`pytest tests/tui_gateway/` reports 3 failures on this branch. The identical 3 fail on a clean checkout of `9ef9b2d2d0` (the base commit) in a separate worktree, and none is in a model-switch path:

| | base `9ef9b2d2d0` | this branch |
|---|---|---|
| | 3 failed, 516 passed, 1 skipped | 3 failed, **527** passed, 1 skipped |

The +11 is exactly this PR's new tests. The three:

- `test_entry_import_off_main_thread` — `AttributeError: module 'signal' has no attribute 'SIGPIPE'`, a POSIX-only assumption failing on Windows.
- `test_compute_host_line_json_seed_turn_interrupt`
- `TestDesktopUiToolset::test_holds_exactly_the_gui_affordances`

One further note in the interest of not overstating: my *first* run on this branch also showed `test_append_log_record_single_write_lines` red, which is not in the base list. It did not reproduce on a second run, and it is a 32-thread concurrent-append race over `append_log_record` in `tui_gateway/host_supervisor.py` — a module this diff does not touch and cannot reach from `config.set`. I'm calling it a load-sensitive flake rather than quietly dropping it from the count.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tui_gateway): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — the closest are #87971 (desktop client half, complementary, addressed above), #79510 (transports `pending_model_switch` across the compute-host boundary; touches the same block, no guard logic), #75730 (administrator-managed key refusal), #82853 (OpenCode Zen free-only policy). None evaluates the selection guards on the deferred path.
- [x] My PR contains **only** changes related to this fix (one commit, two files)
- [x] I've run the relevant suites and all pass (see How to Test; the 4 `tests/tui_gateway/` failures are proven pre-existing at the base commit)
- [x] I've added tests for my changes — 11 new, with two mutation proofs
- [x] I've tested on my platform: Windows 11, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the new helper and the changed branch explain why the guard runs here rather than only at apply time) — no user-facing docs change, the protocol shape is unchanged
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — pure Python control flow, no paths, no signals, no subprocesses; nothing platform-dependent
