### PR TITLE
fix(memory): prevent dimension mismatches with Qdrant host configs

### DIFF
--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -214,10 +214,18 @@ class OSSBackend(Mem0Backend):
                 from qdrant_client import QdrantClient
                 path = vs_config.get("path")
                 url = vs_config.get("url")
+                host = vs_config.get("host")
+                port = vs_config.get("port")
                 if path:
                     client = QdrantClient(path=path)
                 elif url:
                     client = QdrantClient(url=url, api_key=vs_config.get("api_key"))
+                elif host and port:
+                    client = QdrantClient(
+                        host=host,
+                        port=port,
+                        api_key=vs_config.get("api_key"),
+                    )
                 else:
                     return
                 try:

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -1,6 +1,9 @@
 """Tests for Mem0Backend abstraction — PlatformBackend, OSSBackend, SelfHostedBackend."""
 
 import copy
+import sys
+import types
+
 import pytest
 
 from plugins.memory.mem0._backend import (
@@ -112,11 +115,59 @@ class TestOSSBackend:
         backend._memory = memory
         return backend, memory
 
+    def test_dimension_guard_supports_qdrant_host_and_port(self, monkeypatch):
+        calls = []
+
+        class QdrantClient:
+            def __init__(self, **kwargs):
+                calls.append(("init", kwargs))
+
+            def collection_exists(self, collection_name):
+                calls.append(("exists", collection_name))
+                return True
+
+            def get_collection(self, collection_name):
+                calls.append(("get", collection_name))
+                vectors = types.SimpleNamespace(size=768)
+                params = types.SimpleNamespace(vectors=vectors)
+                return types.SimpleNamespace(
+                    config=types.SimpleNamespace(params=params)
+                )
+
+            def delete_collection(self, collection_name):
+                calls.append(("delete", collection_name))
+
+            def close(self):
+                calls.append(("close",))
+
+        stub_qdrant = types.ModuleType("qdrant_client")
+        stub_qdrant.QdrantClient = QdrantClient  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "qdrant_client", stub_qdrant)
+
+        OSSBackend._recreate_collection_if_dims_changed(
+            "qdrant",
+            {
+                "collection_name": "hermes_mem0",
+                "host": "127.0.0.1",
+                "port": 6333,
+                "api_key": "secret",
+            },
+            expected_dims=1536,
+        )
+
+        assert calls == [
+            (
+                "init",
+                {"host": "127.0.0.1", "port": 6333, "api_key": "secret"},
+            ),
+            ("exists", "hermes_mem0"),
+            ("get", "hermes_mem0"),
+            ("delete", "hermes_mem0"),
+            ("close",),
+        ]
+
 
     def test_legacy_api_base_aliases_are_normalized_before_mem0_init(self, monkeypatch):
-        import sys
-        import types
-
         captured = {}
 
         class Memory:


### PR DESCRIPTION
## What does this PR do?

Qdrant server users who configure mem0 OSS with `host` and `port` can retain a collection built for an old embedding dimension after changing embedders. Subsequent searches and upserts then fail with dimension mismatches instead of allowing Hermes to recreate the stale collection. This change sends the accepted `host` and `port` connection shape through the existing dimension guard.

### Symptom

After changing to an embedder with a different output dimension, a Qdrant collection configured through `host` and `port` is not deleted. The next search or upsert can fail because the stored collection dimension no longer matches the embedder.

### Impact

This affects mem0 OSS users who connect to a Qdrant server through `host` and `port`. Their automatic dimension-change protection is silently skipped, leaving the memory backend unusable until the stale collection is removed or the configuration is rewritten to use `url`.

### Bug Cause

**Trigger:** `plugins/memory/mem0/_backend.py` / `OSSBackend._recreate_collection_if_dims_changed()` / a Qdrant config containing `host` and `port` but no `path` or `url`

**Causal chain:**
1. `OSSBackend` detects the configured embedder dimension and invokes the collection dimension guard.
2. The Qdrant branch only constructs a client for `path` or `url`, so a valid `host` and `port` config returns before inspecting the collection.
3. The stale collection survives and later vector operations encounter a dimension mismatch.

**Why it is wrong:** mem0 accepts `host` and `port` as a Qdrant server connection shape, but Hermes omitted that shape from the guard's client construction branch.

**Working sibling / contrast:** Qdrant `path` and `url` configurations already construct a client and run the same collection inspection and deletion logic.

**Ruled out:** the dimension comparison and deletion logic are not the failure point. The regression test demonstrates that the old branch makes no client calls for `host` and `port`, while the fixed branch reaches the existing comparison and deletes the stale collection.

### Fix

Construct `QdrantClient` with `host`, `port`, and the optional `api_key` when that server connection shape is configured. The regression test verifies constructor forwarding, stale-dimension deletion, and client closure.

## Related Issue

Closes #91034

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/mem0/_backend.py` - support Qdrant `host` and `port` when running the collection dimension guard.
- `tests/plugins/memory/test_mem0_backend.py` - cover connection forwarding, stale collection deletion, and client cleanup for this configuration path.

## How to Test

1. Configure the dimension guard with a Qdrant collection using `host` and `port`.
2. Return a collection dimension that differs from the expected embedder dimension.
3. Run the related backend tests and verify that the stale collection is deleted and the client is closed:

```bash
scripts/run_tests.sh tests/plugins/memory/test_mem0_backend.py -q
```

Result: 8 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - N/A, the change forwards provider configuration without OS-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no tool schema changed

## Screenshots / Logs

N/A - the automated regression test exercises the affected constructor and collection lifecycle behavior directly.
