### PR TITLE
fix(picker): show LM Studio in Telegram /model picker for keyless local endpoints

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2492,9 +2492,7 @@ def list_authenticated_providers(
     # (when current provider is lmstudio) > 127.0.0.1 default.
     # On auth rejection or unreachable server, fall back to the caller-supplied
     # current model so the picker still shows something when offline / mis-keyed.
-    if "lmstudio" not in curated and (
-        os.environ.get("LM_API_KEY") or os.environ.get("LM_BASE_URL") or current_provider.strip().lower() == "lmstudio"
-    ):
+    if "lmstudio" not in curated:
         from hermes_cli.models import fetch_lmstudio_models
         from hermes_cli.auth import AuthError
         is_current_lmstudio = current_provider.strip().lower() == "lmstudio"
@@ -2505,7 +2503,7 @@ def list_authenticated_providers(
         )
         try:
             live = fetch_lmstudio_models(
-                api_key=os.environ.get("LM_API_KEY", ""),
+                api_key=os.environ.get("LM_API_KEY", "") or os.environ.get("LMSTUDIO_API_KEY", ""),
                 base_url=lm_base,
                 timeout=1.5, # Smaller timeout for picker
             )
@@ -2611,6 +2609,12 @@ def list_authenticated_providers(
 
         # Check if any env var is set
         has_creds = any(os.environ.get(ev) for ev in env_vars)
+        # LM Studio is a local keyless endpoint — treat as authenticated if
+        # the native probe succeeded (curated has models) even without API key.
+        # This fixes Telegram /model picker hiding LM Studio when not current.
+        if not has_creds and hermes_id == "lmstudio":
+            if curated.get("lmstudio"):
+                has_creds = True
         if not has_creds:
             try:
                 from hermes_cli.auth import _load_auth_store


### PR DESCRIPTION
Telegram /model picker hid LM Studio when current provider was not lmstudio.

- list_authenticated_providers gated curated population on LM_API_KEY or current_provider==lmstudio and then required an API key env var for has_creds, so a default local install on 127.0.0.1:1234 with no auth showed 0 models and was dropped from the picker, while hermes model CLI worked via live probe.

- Fix: always probe 127.0.0.1:1234/v1 for lmstudio (no gate), handle LMSTUDIO_API_KEY alias, and treat LM Studio as authenticated when the native /api/v0/models probe succeeds even without env var. This makes picker show LM Studio (8) alongside OpenCode Go and Copilot regardless of current provider.

Tested: list_authenticated_providers() now returns [('opencode-go',27),('copilot',17),('lmstudio',8)] with no env var and current_provider='opencode-go', and Telegram picker shows LM Studio. Previously returned 0 for lmstudio when not current.

Fixes the case reported where openai/gpt-oss-20b Provider: LM Studio is current but /model only listed Mixture of Agents / OpenCode Go / Copilot.