### PR TITLE
fix(telegram): preserve rich finals after DM drafts

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1212,18 +1212,27 @@ class GatewayStreamConsumer:
                             and (
                                 not self._adapter_requires_finalize
                                 or self._last_edit_overflowed
+                                or self._use_draft_streaming
                             )
                         ):
-                            # Mid-stream edit above already delivered the
-                            # final accumulated content.  Skip the redundant
-                            # final edit for adapters that don't need an
-                            # explicit finalize signal, and for any adapter
-                            # when that edit split-and-delivered across
-                            # continuations: the split edit carried
-                            # finalize=True itself, and re-finalizing with
-                            # the full text would overflow-split again into
-                            # the adopted continuation, duplicating chunks
-                            # on screen.
+                            # The update above already delivered the final
+                            # accumulated content.  Native drafts have no
+                            # message id, so their got_done update is a fresh,
+                            # persistent send with finalize=True; running the
+                            # adapter's explicit finalize hook immediately
+                            # afterward would edit that already-final message
+                            # a second time.  This is especially harmful for
+                            # Telegram, where a successful sendRichMessage was
+                            # being followed by editMessageText and could fall
+                            # back to the legacy table-to-bullets formatter.
+                            #
+                            # Also skip the redundant final edit for adapters
+                            # that don't need an explicit finalize signal, and
+                            # for any adapter when the update split-and-
+                            # delivered across continuations: that update
+                            # carried finalize=True itself, and re-finalizing
+                            # with the full text would overflow-split again into
+                            # the adopted continuation, duplicating chunks.
                             #
                             # Delivery is recorded via the shared helper so
                             # the recorded payload is the last ACKED edit,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5955,21 +5955,15 @@ class TelegramAdapter(BasePlatformAdapter):
         (added to python-telegram-bot in 22.6); older PTB installs gracefully
         fall back to the edit path even on DMs.
 
-        When ``rich_messages`` is enabled but ``rich_drafts`` is not, decline
-        drafts even on DMs.  Final delivery then uses ``sendRichMessage`` /
-        rich ``editMessageText``, while the default draft path still renders
-        MarkdownV2 (tables → bullet lists).  That mismatch makes the streaming
-        preview look unformatted/"crooked" and the finalized reply a second
-        beautiful wiki-style bubble.  Prefer edit-in-place streaming so the
-        same message upgrades via rich finalize.  Operators who want animated
-        rich drafts opt in with ``rich_drafts: true``.
+        ``rich_drafts`` controls the draft *format*, not whether native draft
+        streaming is available.  When final rich delivery is enabled but rich
+        drafts are not, keep the preview ephemeral and persist the completed
+        response through ``sendRichMessage``.  A plain message edited in place
+        cannot be relied on to upgrade through ``editMessageText``'s
+        ``rich_message`` parameter; when that edit is rejected, the fallback
+        formatter permanently turns tables into bullet lists.
         """
         if not self._bot or not hasattr(self._bot, "send_message_draft"):
-            return False
-        if (
-            getattr(self, "_rich_messages_enabled", False)
-            and not getattr(self, "_rich_drafts_enabled", False)
-        ):
             return False
         return (chat_type or "").lower() in {"dm", "private"}
 
@@ -6023,7 +6017,19 @@ class TelegramAdapter(BasePlatformAdapter):
         # malformed escape would be rejected — mirroring the (True, False)
         # retry the streaming send loop uses — so a single bad token never
         # kills draft streaming for the whole response.
-        for use_markdown in (True, False):
+        # When the persistent response will use a Rich Message but rich draft
+        # rendering is intentionally disabled, do not run rich-only constructs
+        # through the legacy formatter in the ephemeral preview.  In particular,
+        # that formatter rewrites pipe tables into bullet groups.  A raw draft
+        # preserves the table source until ``sendRichMessage`` replaces it with
+        # the native persistent rendering at finalization.
+        plain_rich_preview = bool(
+            getattr(self, "_rich_messages_enabled", False)
+            and not getattr(self, "_rich_drafts_enabled", False)
+            and self._needs_rich_rendering(text)
+        )
+        draft_modes = (False,) if plain_rich_preview else (True, False)
+        for use_markdown in draft_modes:
             kwargs: Dict[str, Any] = {
                 "chat_id": normalize_telegram_chat_id(chat_id),
                 "draft_id": int(draft_id),

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -10,6 +10,7 @@ The ``telegram`` package is mocked by ``tests/gateway/conftest.py``
 ``TelegramAdapter`` and wire a mock bot.
 """
 
+import asyncio
 import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -387,12 +388,9 @@ def test_prefers_fresh_final_streaming_stays_disabled_when_rich_enabled():
 
 @pytest.mark.asyncio
 async def test_legacy_draft_stream_finalizes_with_persistent_rich_message():
-    """A MarkdownV2 draft must not force the persistent final to MarkdownV2."""
+    """A plain draft must not force the persistent final to MarkdownV2."""
     adapter = _make_adapter()  # rich messages on, rich drafts off
-    # With the gate in supports_draft_streaming, draft streaming is declined
-    # when rich_drafts is off.  The test force-enables it to verify that even
-    # a legacy MDV2 draft still finalizes as a rich message.
-    assert adapter.supports_draft_streaming(chat_type="dm") is False
+    assert adapter.supports_draft_streaming(chat_type="dm") is True
 
     consumer = GatewayStreamConsumer(
         adapter,
@@ -412,16 +410,64 @@ async def test_legacy_draft_stream_finalizes_with_persistent_rich_message():
 
 
 # ----------------------------------------------------------------------
-# supports_draft_streaming: rich_messages without rich_drafts must NOT use
-# MDV2 sendMessageDraft previews that later snap to sendRichMessage (wiki)
-# finals — that is the "first bubble crooked, second bubble beautiful" bug.
+# supports_draft_streaming: rich_drafts controls draft rendering, not whether
+# Telegram's ephemeral DM draft transport is available.  Keeping that transport
+# lets the persistent final use sendRichMessage instead of relying on an
+# edit-in-place conversion from a plain message.
 # ----------------------------------------------------------------------
 
 
-def test_supports_draft_streaming_disabled_when_rich_without_rich_drafts():
+def test_supports_plain_draft_streaming_when_rich_without_rich_drafts():
     adapter = _make_adapter()  # rich_messages True, rich_drafts default False
-    assert adapter.supports_draft_streaming(chat_type="dm") is False
-    assert adapter.supports_draft_streaming(chat_type="private") is False
+    assert adapter.supports_draft_streaming(chat_type="dm") is True
+    assert adapter.supports_draft_streaming(chat_type="private") is True
+
+
+@pytest.mark.asyncio
+async def test_rich_table_uses_raw_plain_draft_before_persistent_rich_final():
+    adapter = _make_adapter()  # rich messages on, rich drafts off
+
+    result = await adapter.send_draft("12345", draft_id=7, content=RICH_CONTENT)
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_not_called()
+    adapter._bot.send_message_draft.assert_awaited_once_with(
+        chat_id=12345,
+        draft_id=7,
+        text=RICH_CONTENT,
+    )
+
+
+@pytest.mark.asyncio
+async def test_dm_table_stream_persists_through_send_rich_message():
+    """Exercise the reporter's transport: ephemeral DM draft, then rich final."""
+    adapter = _make_adapter()  # rich messages on, rich drafts off
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "12345",
+        StreamConsumerConfig(
+            transport="auto",
+            chat_type="dm",
+            edit_interval=0.01,
+            buffer_threshold=1,
+            cursor="",
+        ),
+    )
+
+    task = asyncio.create_task(consumer.run())
+    consumer.on_delta(RICH_CONTENT)
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    adapter._bot.send_message_draft.assert_awaited()
+    draft_kwargs = adapter._bot.send_message_draft.call_args.kwargs
+    assert draft_kwargs["text"] == RICH_CONTENT
+    assert "parse_mode" not in draft_kwargs
+    rich_endpoints = [call.args[0] for call in adapter._bot.do_api_request.await_args_list]
+    assert rich_endpoints == ["sendRichMessage"]
+    adapter._bot.edit_message_text.assert_not_called()
+    adapter._bot.send_message.assert_not_called()
 
 
 def test_supports_draft_streaming_enabled_when_rich_drafts_opt_in():
@@ -604,5 +650,3 @@ async def test_rich_reply_records_and_recovers_text(monkeypatch, tmp_path):
     )
     assert event.reply_to_message_id == "678"
     assert event.reply_to_text == "Your morning briefing: CI is green."
-
-


### PR DESCRIPTION
## What does this PR do?

Preserves Telegram Rich Message finals for streamed DMs when `rich_messages: true` and `rich_drafts: false`.

The current transport disables Telegram native drafts in that configuration and streams through an ordinary editable message instead. Finalization then depends on upgrading that plain preview with `editMessageText.rich_message`; when Telegram rejects the upgrade, Hermes falls back to MarkdownV2 and permanently converts pipe tables into bullet groups.

This restores the native ephemeral-draft lifecycle without enabling rich draft rendering. Rich-only constructs use a raw plain draft preview, and the completed response is persisted once through `sendRichMessage`. The stream consumer also recognizes that this got-done send was already finalized and no longer follows it with a redundant `editMessageText` call.

## Related Issue

Discord support thread: https://discord.com/channels/1053877538025386074/1540026433072668672

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/telegram/adapter.py`: keep native DM draft transport available when only rich draft rendering is disabled; preserve rich-only Markdown as raw text in the ephemeral preview.
- `gateway/stream_consumer.py`: do not run a second explicit finalize edit after a native draft's fresh persistent final send already completed with `finalize=True`.
- `tests/gateway/test_telegram_rich_messages.py`: cover the reporter's full draft-to-rich-final sequence and assert there is one `sendRichMessage` and no trailing `editMessageText` downgrade.

## How to Test

1. Enable `gateway.platforms.telegram.extra.rich_messages` and leave `rich_drafts` disabled.
2. In a Telegram DM, request a Markdown pipe table while gateway streaming is enabled.
3. Verify the preview remains ephemeral and the persistent response is delivered through `sendRichMessage` as a native table, without a second edit or legacy bullet conversion.

Focused verification:

`uv run --extra dev python -m pytest tests/gateway/test_telegram_rich_newlines.py tests/gateway/test_stream_consumer.py tests/gateway/test_stream_consumer_draft.py tests/gateway/test_telegram_rich_messages.py -q`

Result: `113 passed, 1 skipped`

`uv run --extra dev ruff check gateway/stream_consumer.py plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_rich_messages.py`

Result: `All checks passed!`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, repository-managed Python 3.11 environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

The diagnostic bundle recorded the affected turn as streamed and final-delivery-confirmed. The new behavioral regression test reproduces the transport sequence directly and fails on current main because the final `sendRichMessage` is followed by `editMessageText`; the fix leaves exactly one persistent rich send.