### PR TITLE
fix(mcp-oauth): recover stranded auth-flow locks

### DIFF
--- a/tests/tools/test_mcp_oauth_bidirectional.py
+++ b/tests/tools/test_mcp_oauth_bidirectional.py
@@ -206,6 +206,87 @@ async def test_hermes_provider_forwards_401_triggers_refresh(tmp_path, monkeypat
     await flow.aclose()
 
 
+@pytest.mark.asyncio
+async def test_httpx_timeout_closes_inner_flow_and_releases_lock(
+    tmp_path, monkeypatch
+):
+    """A transport timeout must leave the cached provider reusable."""
+    import anyio
+
+    from tools.mcp_tool import sdk_httpx
+
+    httpx = sdk_httpx()
+    from mcp.shared.auth import (
+        OAuthClientInformationFull,
+        OAuthClientMetadata,
+        OAuthToken,
+    )
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="fixture-access",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="fixture-refresh",
+        )
+    )
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="fixture-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:43119/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+    )
+
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=OAuthClientMetadata(
+            redirect_uris=[AnyUrl("http://127.0.0.1:43119/callback")],
+            client_name="Hermes Agent",
+        ),
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+    attempts = 0
+
+    async def handler(request):
+        nonlocal attempts
+        attempts += 1
+        assert provider.context.lock.locked()
+        if attempts == 1:
+            raise httpx.ReadTimeout("forced OAuth transport timeout", request=request)
+        return httpx.Response(200, request=request)
+
+    async with httpx.AsyncClient(
+        auth=provider,
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        with pytest.raises(httpx.ReadTimeout, match="forced OAuth transport timeout"):
+            with anyio.fail_after(3):
+                await client.post("https://example.com/mcp")
+
+        assert not provider.context.lock.locked()
+        with anyio.fail_after(3):
+            response = await client.post("https://example.com/mcp")
+
+    assert response.status_code == 200
+    assert attempts == 2
+    assert not provider.context.lock.locked()
+
+
 async def _noop_redirect(_url: str) -> None:
     """Redirect handler that does nothing (won't be invoked in these tests)."""
     return None

--- a/tests/tools/test_mcp_oauth_generator_cleanup.py
+++ b/tests/tools/test_mcp_oauth_generator_cleanup.py
@@ -1,0 +1,91 @@
+"""Focused safety tests for stranded MCP OAuth lock recovery."""
+
+from __future__ import annotations
+
+import asyncio
+
+import anyio
+import pytest
+
+from tools.mcp_oauth_manager import _reclaim_stranded_auth_lock
+
+
+@pytest.mark.asyncio
+async def test_reclaim_frees_lock_owned_by_abandoned_flow():
+    lock = anyio.Lock()
+    owner_ready = asyncio.Event()
+    owner_done = asyncio.Event()
+
+    async def abandoned_owner() -> None:
+        await lock.acquire()
+        owner_ready.set()
+        await owner_done.wait()
+
+    owner_task = asyncio.create_task(abandoned_owner())
+    with anyio.fail_after(3):
+        await owner_ready.wait()
+    prior_owner = getattr(lock, "_owner_task", None)
+
+    assert prior_owner is owner_task
+    assert _reclaim_stranded_auth_lock(lock, prior_owner, server_name="fixture")
+    assert not lock.locked()
+
+    owner_done.set()
+    with anyio.fail_after(3):
+        await owner_task
+
+
+@pytest.mark.asyncio
+async def test_reclaim_ignores_lock_owned_by_different_flow():
+    lock = anyio.Lock()
+    await lock.acquire()
+
+    assert not _reclaim_stranded_auth_lock(lock, object(), server_name="fixture")
+    assert lock.locked()
+    lock.release()
+
+
+@pytest.mark.asyncio
+async def test_reclaim_is_noop_without_recorded_owner():
+    lock = anyio.Lock()
+
+    assert not _reclaim_stranded_auth_lock(lock, None, server_name="fixture")
+    assert not lock.locked()
+
+
+@pytest.mark.asyncio
+async def test_reclaim_hands_lock_to_waiting_flow():
+    lock = anyio.Lock()
+    owner_ready = asyncio.Event()
+    owner_done = asyncio.Event()
+    waiter_acquired = asyncio.Event()
+
+    async def abandoned_owner() -> None:
+        await lock.acquire()
+        owner_ready.set()
+        await owner_done.wait()
+
+    async def waiter() -> None:
+        await lock.acquire()
+        waiter_acquired.set()
+        lock.release()
+
+    owner_task = asyncio.create_task(abandoned_owner())
+    with anyio.fail_after(3):
+        await owner_ready.wait()
+    prior_owner = getattr(lock, "_owner_task", None)
+    waiter_task = asyncio.create_task(waiter())
+
+    with anyio.fail_after(3):
+        while not getattr(lock, "_waiters", ()):
+            await anyio.lowlevel.checkpoint()
+
+    assert _reclaim_stranded_auth_lock(lock, prior_owner, server_name="fixture")
+    with anyio.fail_after(3):
+        await waiter_acquired.wait()
+        await waiter_task
+    assert not lock.locked()
+
+    owner_done.set()
+    with anyio.fail_after(3):
+        await owner_task

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -65,6 +65,51 @@ def _same_endpoint(a: str, b: str) -> bool:
     )
 
 
+def _reclaim_stranded_auth_lock(
+    lock: Any,
+    prior_owner: Any,
+    *,
+    server_name: str = "",
+) -> bool:
+    """Release an OAuth lock stranded by cleanup from a different task.
+
+    AnyIO's asyncio lock is task-owned. Reclaim only when the lock is still
+    owned by the exact task recorded for the abandoned flow; a clean release
+    or handoff changes that owner and makes this a no-op.
+    """
+    if lock is None or prior_owner is None:
+        return False
+    try:
+        if not lock.locked():
+            return False
+        if getattr(lock, "_owner_task", None) is not prior_owner:
+            return False
+
+        # AnyIO exposes no public cross-task recovery operation. Its asyncio
+        # backend records the owning asyncio.Task in this private field. Keep
+        # this identity-checked and behavior-tested so an AnyIO change fails
+        # closed instead of releasing a lock owned by another live flow.
+        lock._owner_task = asyncio.current_task()  # noqa: SLF001
+        try:
+            lock.release()
+        except Exception:
+            lock._owner_task = prior_owner  # noqa: SLF001
+            raise
+    except Exception as exc:  # pragma: no cover - defensive, must not throw
+        logger.debug(
+            "MCP OAuth '%s': could not reclaim stranded auth lock: %s",
+            server_name,
+            exc,
+        )
+        return False
+
+    logger.warning(
+        "MCP OAuth '%s': reclaimed OAuth lock stranded by cross-task cleanup",
+        server_name,
+    )
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Per-server entry
 # ---------------------------------------------------------------------------
@@ -531,8 +576,14 @@ def _make_hermes_provider_class() -> Optional[type]:
             # contract. Regression from PR #11383 caught by
             # tests/tools/test_mcp_oauth_bidirectional.py.
             inner = super().async_auth_flow(request)
+            lock = getattr(self.context, "lock", None)
+            prior_lock_owner: Any = None
             try:
                 outgoing = await inner.__anext__()
+                # The SDK acquires context.lock before its first yielded
+                # request. Capture that exact owner so exceptional cross-task
+                # cleanup cannot steal a lock handed to a different flow.
+                prior_lock_owner = getattr(lock, "_owner_task", None)
                 while True:
                     incoming = yield outgoing
                     # Sniff the response for a dead-client-registration signal
@@ -544,6 +595,44 @@ def _make_hermes_provider_class() -> Optional[type]:
                 # 401 branch so a subsequent cold-load skips discovery.
                 self._persist_oauth_metadata_if_changed()
                 return
+            finally:
+                await self._close_inner_auth_flow(
+                    inner,
+                    lock,
+                    prior_lock_owner,
+                )
+
+        async def _close_inner_auth_flow(
+            self,
+            inner: Any,
+            lock: Any,
+            prior_lock_owner: Any,
+        ) -> None:
+            """Close the delegated SDK flow and recover only its stranded lock."""
+            try:
+                try:
+                    await inner.aclose()
+                except RuntimeError as exc:
+                    # The outer wrapper itself can be GC-finalized from a
+                    # different task. AnyIO then rejects the SDK lock release;
+                    # the identity-checked recovery below handles that case.
+                    logger.debug(
+                        "MCP OAuth '%s': auth-flow cleanup raised (non-fatal): %s",
+                        self._hermes_server_name,
+                        exc,
+                    )
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.debug(
+                        "MCP OAuth '%s': auth-flow cleanup failed (non-fatal): %s",
+                        self._hermes_server_name,
+                        exc,
+                    )
+            finally:
+                _reclaim_stranded_auth_lock(
+                    lock,
+                    prior_lock_owner,
+                    server_name=self._hermes_server_name,
+                )
 
     return HermesMCPOAuthProvider
 


### PR DESCRIPTION
## What does this PR do?

Closes the delegated MCP SDK OAuth generator deterministically and adds a narrowly fenced fallback for the cross-task finalizer case that AnyIO otherwise rejects with `RuntimeError: The current task is not holding this lock`.

The fallback reclaims only a still-locked AnyIO lock whose private owner is the exact task captured for the abandoned flow. A clean release, waiter handoff, different owner, or changed AnyIO internals makes recovery a no-op.

The HTTP transport regression uses Hermes's `sdk_httpx()` selector. Current MCP SDK 2.0 resolves that transport to `httpx2`, so the test exercises the same auth base class used by the runtime instead of importing legacy `httpx` directly.

This consolidates and preserves credit for the work in #38198, #63495, and #76526. The commit includes their authors as co-authors.

## Related Issue

Fixes #38193

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `finally` cleanup around the manually delegated SDK auth generator.
- Recover a cross-task-stranded AnyIO lock only after exact owner identity verification.
- Prove ordinary HTTPX timeout teardown releases the lock and allows provider reuse.
- Cover exact-owner recovery, wrong-owner refusal, missing-owner no-op, and queued-waiter handoff.

## How to Test

1. Run the focused OAuth and reconnect surface:
   `scripts/run_tests.sh tests/tools/test_mcp_oauth_generator_cleanup.py tests/tools/test_mcp_oauth_bidirectional.py tests/tools/test_mcp_oauth_metadata.py tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_cold_load_expiry.py tests/tools/test_mcp_oauth_integration.py tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth_user_agent.py tests/tools/test_mcp_tool_401_handling.py tests/tools/test_mcp_reconnect_signal.py -q`
2. Run Ruff and Python compilation on the three changed files.
3. Drive `HermesMCPOAuthProvider` through an SDK-selected mock transport timeout and confirm its lock is released and the same provider completes a second request.

Local result: 10 files, 111 tests passed, 0 failed. Behavioral probe: `oauth_generator_cleanup=PASS`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing issues and PRs and linked the overlapping work above.
- [x] My PR contains only changes related to this fix.
- [ ] I've run the entire `pytest tests/ -q` suite. The focused 111-test OAuth/reconnect surface passes; local all-extras setup is blocked by the declared `python-olm==3.2.16` CMake policy floor on this host, so CI should provide the full matrix.
- [x] I've added tests for the change.
- [x] Tested on macOS 27.0 arm64, Python 3.11.14, MCP 2.0.0, AnyIO 4.12.1, HTTPX2 2.7.0.

### Documentation & Housekeeping

- [x] Documentation update: N/A; behavior is internal recovery and documented in code/tests.
- [x] `cli-config.yaml.example`: N/A; no configuration changes.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no workflow changes.
- [x] Cross-platform impact considered: the fallback is specific to AnyIO's asyncio backend and fails closed if its owner representation changes.
- [x] Tool descriptions/schemas: N/A.

## Screenshots / Logs

```text
=== Summary: 10 files, 111 tests passed, 0 failed ===
All checks passed!
oauth_generator_cleanup=PASS
```
