### PR TITLE
fix(account-usage): label Codex windows by duration

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -507,6 +507,30 @@ def _resolve_codex_usage_credentials(
     return entry.runtime_api_key, str(entry.runtime_base_url or base_url or "").strip(), None
 
 
+def _codex_window_label(window_key: str, window_seconds: Any) -> str:
+    if window_seconds == 18000:
+        return "Session"
+    if window_seconds == 604800:
+        return "Weekly"
+    seconds: Optional[int] = None
+    if isinstance(window_seconds, int) and not isinstance(window_seconds, bool):
+        seconds = window_seconds
+    elif isinstance(window_seconds, float) and window_seconds.is_integer():
+        seconds = int(window_seconds)
+    if seconds is not None and seconds > 0:
+        if seconds <= 86400 and seconds % 3600 == 0:
+            hours = seconds // 3600
+            return f"{hours}-hour window"
+        if seconds % 86400 == 0:
+            days = seconds // 86400
+            return f"{days}-day window"
+        if seconds % 60 == 0:
+            minutes = seconds // 60
+            return f"{minutes}-minute window"
+        return f"{seconds}-second window"
+    return "Session" if window_key == "primary_window" else "Weekly"
+
+
 def _fetch_codex_account_usage(
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
@@ -525,11 +549,13 @@ def _fetch_codex_account_usage(
     payload = response.json() or {}
     rate_limit = payload.get("rate_limit") or {}
     windows: list[AccountUsageWindow] = []
-    for key, label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
+    for key in ("primary_window", "secondary_window"):
         window = rate_limit.get(key) or {}
         used = window.get("used_percent")
         if used is None:
             continue
+        window_seconds = window.get("limit_window_seconds")
+        label = _codex_window_label(key, window_seconds)
         windows.append(
             AccountUsageWindow(
                 label=label,

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -49,7 +49,7 @@ class _RoutingClient:
         return _Response(self._payloads[url])
 
 
-def test_fetch_account_usage_codex(monkeypatch):
+def _stub_codex_usage(monkeypatch, payload):
     monkeypatch.setattr(
         "agent.account_usage.resolve_codex_runtime_credentials",
         lambda refresh_if_expiring=True: {
@@ -64,24 +64,29 @@ def test_fetch_account_usage_codex(monkeypatch):
     )
     monkeypatch.setattr(
         "agent.account_usage.httpx.Client",
-        lambda timeout=15.0: _Client(
-            {
-                "plan_type": "pro",
-                "rate_limit": {
-                    "primary_window": {
-                        "used_percent": 15,
-                        "reset_at": 1_900_000_000,
-                        "limit_window_seconds": 18000,
-                    },
-                    "secondary_window": {
-                        "used_percent": 40,
-                        "reset_at": 1_900_500_000,
-                        "limit_window_seconds": 604800,
-                    },
+        lambda timeout=15.0: _Client(payload),
+    )
+
+
+def test_fetch_account_usage_codex(monkeypatch):
+    _stub_codex_usage(
+        monkeypatch,
+        {
+            "plan_type": "pro",
+            "rate_limit": {
+                "primary_window": {
+                    "used_percent": 15,
+                    "reset_at": 1_900_000_000,
+                    "limit_window_seconds": 18000,
                 },
-                "credits": {"has_credits": True, "balance": 12.5},
-            }
-        ),
+                "secondary_window": {
+                    "used_percent": 40,
+                    "reset_at": 1_900_500_000,
+                    "limit_window_seconds": 604800,
+                },
+            },
+            "credits": {"has_credits": True, "balance": 12.5},
+        },
     )
 
     snapshot = fetch_account_usage("openai-codex")
@@ -93,6 +98,55 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert snapshot.windows[0].used_percent == 15.0
     assert snapshot.windows[0].reset_at == datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
     assert "Credits balance: $12.50" in snapshot.details
+
+
+def test_fetch_account_usage_codex_labels_primary_seven_day_window_as_weekly(monkeypatch):
+    _stub_codex_usage(
+        monkeypatch,
+        {
+            "plan_type": "prolite",
+            "rate_limit": {
+                "primary_window": {
+                    "used_percent": 3,
+                    "reset_at": 1_900_000_000,
+                    "limit_window_seconds": 604800,
+                },
+                "secondary_window": None,
+            },
+            "credits": {"has_credits": False},
+        },
+    )
+
+    snapshot = fetch_account_usage("openai-codex")
+
+    assert snapshot is not None
+    assert len(snapshot.windows) == 1
+    assert snapshot.windows[0].label == "Weekly"
+    assert snapshot.windows[0].used_percent == 3.0
+    assert snapshot.windows[0].reset_at == datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
+
+
+def test_fetch_account_usage_codex_labels_unknown_duration_neutrally(monkeypatch):
+    _stub_codex_usage(
+        monkeypatch,
+        {
+            "plan_type": "pro",
+            "rate_limit": {
+                "primary_window": {
+                    "used_percent": 9,
+                    "reset_at": 1_900_000_000,
+                    "limit_window_seconds": 86400,
+                }
+            },
+            "credits": {"has_credits": False},
+        },
+    )
+
+    snapshot = fetch_account_usage("openai-codex")
+
+    assert snapshot is not None
+    assert len(snapshot.windows) == 1
+    assert snapshot.windows[0].label == "24-hour window"
 
 
 def test_render_account_usage_lines_includes_reset_and_provider():


### PR DESCRIPTION
## Bug Description

Codex `/usage` responses include `limit_window_seconds`, but Hermes labels windows only by their payload position: `primary_window` is always shown as **Session** and `secondary_window` as **Weekly**. When an account exposes a seven-day allowance as the primary window—or another duration—the UI reports the wrong period.

## Root Cause

`_fetch_codex_account_usage()` hardcodes labels by window key and ignores the duration metadata already returned by the API.

## Fix

- Derive Codex usage labels from `limit_window_seconds`.
- Preserve the familiar names for exact known durations:
  - 18,000 seconds → `Session`
  - 604,800 seconds → `Weekly`
- Render other positive integral durations neutrally in hours, days, minutes, or seconds.
- Fall back to the existing primary/secondary labels for missing, malformed, fractional, boolean, or nonpositive duration values.
- Add coverage for a primary seven-day window and an unknown 24-hour duration.

## How to Verify

```bash
scripts/run_tests.sh tests/test_account_usage.py
scripts/run_tests.sh tests/agent/test_account_usage.py
```

Exercise `/usage` with a payload where `primary_window.limit_window_seconds` is `604800`; the displayed label should be `Weekly`, not `Session`.

## Test Plan

- [x] Added regression for a primary seven-day window
- [x] Added regression for a neutral unknown duration
- [x] Canonical affected suites pass: 10/10
- [x] Independent exact-tree review passes with no security or logic findings
- [x] Independent adversarial duration matrix passes: 28/28
- [x] Added-line security scan and `git diff --check` pass
- [x] Repository-wide baseline comparison introduced no new failures; existing failures were in unrelated optional-dependency surfaces
- [ ] Upstream CI

## Risk Assessment

**Low** — the change affects display labels only. Credential resolution, API requests, percentages, reset timestamps, credits, and account selection remain unchanged. Invalid or unavailable duration metadata preserves the old positional labels.
