### PR TITLE
feat(desktop): follow the focused bot in the profile-grouped sidebar

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -26,7 +26,6 @@ import { useContributions } from '@/contrib/react/use-contributions'
 import { searchSessions, type SessionInfo, type SessionSearchResult } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { comboTokens } from '@/lib/keybinds/combo'
-import { resolveProfileColor } from '@/lib/profile-color'
 import { sessionMatchesSearch } from '@/lib/session-search'
 import { normalizeSessionSource, sessionSourceLabel } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
@@ -68,6 +67,7 @@ import {
   setSidebarSessionOrderManual,
   setSidebarWorkspaceOrderIds,
   setSidebarWorkspaceParentOrderIds,
+  setWorkspaceNodeOpen,
   SIDEBAR_SESSIONS_PAGE_SIZE,
   toggleSidebarMessagingOpen,
   unpinSession
@@ -127,7 +127,7 @@ import {
 } from '@/store/session'
 import { $sessionDotStateById, sessionStatusBucket } from '@/store/session-dot-state'
 import { $unconfirmedPinWrites } from '@/store/session-pin-sync'
-import { $focusedStoredSessionId, $workingSessionIds, type SplitDir } from '@/store/session-states'
+import { $focusedSessionProfile, $focusedStoredSessionId, $workingSessionIds, type SplitDir } from '@/store/session-states'
 import { ackAllSessionsRead } from '@/store/session-unread'
 import { markSessionUnread } from '@/store/session-unread-remote'
 import { $archivedSessions, loadArchivedSessions } from '@/store/sidebar-archive'
@@ -148,6 +148,7 @@ import { SidebarCronJobsSection } from './cron-jobs-section'
 import { SidebarFilterMenu } from './filter-menu'
 import { SidebarLoadMoreRow } from './load-more-row'
 import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
+import { buildProfileGroups } from './profile-groups'
 import { filterSessionsByProfileScope } from './profile-scope'
 import { ProfileRail } from './profile-switcher'
 import { ProjectDialog } from './project-dialog'
@@ -389,6 +390,7 @@ export function ChatSidebar({
   const unreadCount = useStore($unreadFinishedSessionIds).length
   const profiles = useStore($profiles)
   const profileColors = useStore($profileColors)
+  const focusedSessionProfile = useStore($focusedSessionProfile)
   const profileScope = useStore($profileScope)
   const activeConnectionId = useStore($activeConnectionId)
 
@@ -1243,40 +1245,25 @@ export function ChatSidebar({
   }, [visibleMessagingSessions, messagingPlatformTotals, messagingTruncated, isPinnedSession, messagingProfile])
 
   // Grouping by profile: one collapsible group per profile, color on the header
-  // (not on every row). Default profile floats to the top, the rest alpha.
-  // Only reachable while the sidebar is showing every profile — scoped to one,
-  // it would draw a single group around the whole list.
+  // (not on every row). The focused chat's profile heads the list, then
+  // default, then the rest alpha (see buildProfileGroups). Only reachable
+  // while the sidebar is showing every profile — scoped to one, it would draw
+  // a single group around the whole list.
   const profileGrouped = showAllProfiles && grouping === 'profile'
 
-  const profileGroups = useMemo<SidebarSessionGroup[] | undefined>(() => {
-    if (!profileGrouped) {
-      return undefined
+  const profileGroups = useMemo<SidebarSessionGroup[] | undefined>(
+    () => (profileGrouped ? buildProfileGroups(agentSessions, profileColors, focusedSessionProfile) : undefined),
+    [profileGrouped, agentSessions, profileColors, focusedSessionProfile]
+  )
+
+  // Follow the focused bot: whichever chat holds focus, its group is revealed —
+  // re-opened even if it was collapsed earlier — so switching bots always
+  // shows that bot's sessions without hunting for its section (#89347).
+  useEffect(() => {
+    if (profileGrouped && focusedSessionProfile) {
+      setWorkspaceNodeOpen(focusedSessionProfile, true)
     }
-
-    const groups = new Map<string, SidebarSessionGroup>()
-
-    for (const session of agentSessions) {
-      const key = normalizeProfileKey(session.profile)
-
-      const group = groups.get(key) ?? {
-        color: resolveProfileColor(key, profileColors),
-        id: key,
-        label: key,
-        mode: 'profile',
-        path: null,
-        sessions: []
-      }
-
-      group.sessions.push(session)
-
-      groups.set(key, group)
-    }
-
-    // default (root) first, then the rest alphabetically.
-    return [...groups.values()].sort((a, b) =>
-      a.id === 'default' ? -1 : b.id === 'default' ? 1 : a.label.localeCompare(b.label)
-    )
-  }, [profileGrouped, agentSessions, profileColors])
+  }, [profileGrouped, focusedSessionProfile])
 
   // The flat Sessions list always shows ALL recent sessions; Projects is a
   // parallel grouped view, not a filter on this one — nothing is hidden here.

--- a/apps/desktop/src/app/chat/sidebar/profile-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/profile-groups.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+import { buildProfileGroups } from './profile-groups'
+
+/** Build the smallest session row the profile grouper needs. */
+const row = (id: string, profile?: string): SessionInfo =>
+  ({ id, message_count: 1, profile, source: 'desktop', started_at: 0, title: id }) as SessionInfo
+
+describe('buildProfileGroups', () => {
+  it('groups sessions under their normalized profile and keeps default first without a focus', () => {
+    const groups = buildProfileGroups(
+      [row('r1', 'research'), row('d1', 'default'), row('a1', 'analyst'), row('r2', 'research')],
+      {},
+      null
+    )
+
+    expect(groups.map(group => group.id)).toEqual(['default', 'analyst', 'research'])
+    expect(groups[2].sessions.map(session => session.id)).toEqual(['r1', 'r2'])
+  })
+
+  it('treats legacy rows without a profile as default', () => {
+    const groups = buildProfileGroups([row('legacy'), row('a1', 'analyst')], {}, null)
+
+    expect(groups.map(group => group.id)).toEqual(['default', 'analyst'])
+    expect(groups[0].sessions.map(session => session.id)).toEqual(['legacy'])
+  })
+
+  it('floats the focused profile above default and the alphabetical rest', () => {
+    const groups = buildProfileGroups(
+      [row('d1', 'default'), row('a1', 'analyst'), row('r1', 'research')],
+      {},
+      'research'
+    )
+
+    expect(groups.map(group => group.id)).toEqual(['research', 'default', 'analyst'])
+  })
+
+  it('keeps default first when it is itself the focused profile', () => {
+    const groups = buildProfileGroups([row('d1', 'default'), row('a1', 'analyst')], {}, 'default')
+
+    expect(groups.map(group => group.id)).toEqual(['default', 'analyst'])
+  })
+
+  it('normalizes the focused profile before ranking', () => {
+    const groups = buildProfileGroups([row('a1', 'analyst'), row('r1', 'research')], {}, '  research ')
+
+    expect(groups.map(group => group.id)).toEqual(['research', 'analyst'])
+  })
+
+  it('ignores a focused profile that has no sessions', () => {
+    const groups = buildProfileGroups([row('d1', 'default'), row('a1', 'analyst')], {}, 'ghost')
+
+    expect(groups.map(group => group.id)).toEqual(['default', 'analyst'])
+  })
+
+  it('stamps profile colors on the headers and none on default', () => {
+    const groups = buildProfileGroups([row('d1', 'default'), row('a1', 'analyst')], { analyst: '#123456' }, null)
+
+    expect(groups.find(group => group.id === 'analyst')?.color).toBe('#123456')
+    expect(groups.find(group => group.id === 'default')?.color).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/profile-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/profile-groups.ts
@@ -1,0 +1,47 @@
+import { resolveProfileColor } from '@/lib/profile-color'
+import { normalizeProfileKey } from '@/store/profile'
+import type { SessionInfo } from '@/types/hermes'
+
+import type { SidebarSessionGroup } from './projects/workspace-groups'
+
+/**
+ * Build the ALL-profiles sidebar groups: one collapsible group per profile,
+ * color on the header (not on every row).
+ *
+ * Ordering answers "what is THIS bot doing?" passively (#89347): the focused
+ * chat's profile floats to the top, so switching bots re-ranks the list and
+ * the bot you are looking at heads it. `default` keeps its historical spot
+ * right after (first when nothing else is focused), and the rest sort
+ * alphabetically. A focused profile with no sessions simply has no group —
+ * ranking never invents empty groups.
+ */
+export function buildProfileGroups(
+  sessions: readonly SessionInfo[],
+  profileColors: Record<string, string>,
+  focusedProfile: null | string
+): SidebarSessionGroup[] {
+  const groups = new Map<string, SidebarSessionGroup>()
+
+  for (const session of sessions) {
+    const key = normalizeProfileKey(session.profile)
+
+    const group = groups.get(key) ?? {
+      color: resolveProfileColor(key, profileColors),
+      id: key,
+      label: key,
+      mode: 'profile',
+      path: null,
+      sessions: []
+    }
+
+    group.sessions.push(session)
+
+    groups.set(key, group)
+  }
+
+  const focused = focusedProfile ? normalizeProfileKey(focusedProfile) : null
+
+  const rank = (group: SidebarSessionGroup) => (group.id === focused ? 0 : group.id === 'default' ? 1 : 2)
+
+  return [...groups.values()].sort((a, b) => rank(a) - rank(b) || a.label.localeCompare(b.label))
+}

--- a/apps/desktop/src/app/chat/sidebar/profile-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/profile-groups.ts
@@ -25,18 +25,22 @@ export function buildProfileGroups(
   for (const session of sessions) {
     const key = normalizeProfileKey(session.profile)
 
-    const group = groups.get(key) ?? {
-      color: resolveProfileColor(key, profileColors),
-      id: key,
-      label: key,
-      mode: 'profile',
-      path: null,
-      sessions: []
+    let group = groups.get(key)
+
+    if (!group) {
+      group = {
+        color: resolveProfileColor(key, profileColors),
+        id: key,
+        label: key,
+        mode: 'profile',
+        path: null,
+        sessions: []
+      }
+
+      groups.set(key, group)
     }
 
     group.sessions.push(session)
-
-    groups.set(key, group)
   }
 
   const focused = focusedProfile ? normalizeProfileKey(focusedProfile) : null

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
@@ -122,13 +122,20 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
           // project labels it alternates with (`Home`, and whatever the user
           // named theirs) — profile keys are stored lowercase.
           label={
-            <SidebarRowLink
-              aria-label={t.profiles.switchToProfile(group.label)}
-              labelClassName="capitalize hover:text-foreground hover:underline"
-              onClick={() => selectProfile(group.id)}
-            >
-              {group.label}
-            </SidebarRowLink>
+            <>
+              <SidebarRowLink
+                aria-label={t.profiles.switchToProfile(group.label)}
+                labelClassName="capitalize hover:text-foreground hover:underline"
+                onClick={() => selectProfile(group.id)}
+              >
+                {group.label}
+              </SidebarRowLink>
+              {/* Session count, so the header answers "how busy is this bot?"
+                  at a glance even while the group is collapsed (#89347). */}
+              <span className="shrink-0 text-[0.625rem] leading-none text-(--ui-text-quaternary)">
+                {group.sessions.length}
+              </span>
+            </>
           }
           lead={
             <SidebarRowLead>

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -77,20 +77,19 @@ import {
   $gatewayState,
   $messages,
   $selectedStoredSessionId,
-  $sessions,
-  getSessionOwnerHints,
-  rememberedSessionProfile,
   requestSessionResume,
-  sessionMatchesStoredId,
   setResumeExhaustedSessionId,
   setSessionOwnerHint
 } from '@/store/session'
 import {
   $focusedRuntimeId,
+  $focusedSessionOwner,
+  $focusedSessionProfile,
   $focusedSessionState,
   $focusedStoredSessionId,
   $sessionStates,
-  $sessionTiles
+  $sessionTiles,
+  type FocusedSessionOwner
 } from '@/store/session-states'
 import { runGatewayRestart } from '@/store/system-actions'
 import type { PaginatedSessions, UsageStats } from '@/types/hermes'
@@ -125,69 +124,10 @@ const $focusedAwaitingResponse = focusedTurnFlag(
   PRIMARY_SESSION_VIEW.$awaitingResponse
 )
 
-export interface PluginFocusedSessionOwner {
-  connectionId: string
-  profile: string
-}
-
-/**
- * Connection-qualified owner of the FOCUSED chat. The gateway-routing atom
- * (`$activeGatewayProfile`) answers "which backend is the live socket homed
- * on" — but tab/tile focus moves without swapping the socket, and a cold
- * start can restore a route into a session the booting gateway doesn't own.
- * Any per-bot readout must follow the chat the user is LOOKING AT, so this
- * resolves the focused stored session to a unique immutable owner hint or a
- * unique connection-qualified aggregated row. Ambiguous or unresolved focused
- * ids fail closed with null; only a draft/no focused id uses the active gateway
- * owner. `focusedSessionProfile` remains the profile-only compatibility ladder.
- */
-const $focusedSessionOwner = computed(
-  [$focusedStoredSessionId, $sessions, $activeGatewayProfile, $connection],
-  (focused, sessions, activeProfile, connection): PluginFocusedSessionOwner | null => {
-    const activeConnectionId = String(connection?.connectionId || (connection?.mode === 'local' ? 'local' : '')).trim()
-
-    const fallback = {
-      connectionId: activeConnectionId,
-      profile: normalizeProfileKey(activeProfile)
-    }
-
-    if (!focused) {
-      return fallback
-    }
-
-    const hints = getSessionOwnerHints(focused)
-
-    if (hints.length === 1) {
-      return {
-        connectionId: hints[0].connectionId,
-        profile: normalizeProfileKey(hints[0].profile)
-      }
-    }
-
-    if (hints.length > 1) {
-      return null
-    }
-
-    const owners = new Map<string, PluginFocusedSessionOwner>()
-
-    for (const row of sessions.filter(session => sessionMatchesStoredId(session, focused))) {
-      const connectionId = String(row.connection_id || '').trim()
-      const profile = normalizeProfileKey(row.profile)
-
-      if (connectionId) {
-        owners.set(`${connectionId}::${profile}`, { connectionId, profile })
-      }
-    }
-
-    return owners.size === 1 ? [...owners.values()][0] : null
-  }
-)
-
-const $focusedSessionProfile = computed(
-  [$focusedSessionOwner, $focusedStoredSessionId, $sessions, $activeGatewayProfile],
-  (owner, focused, sessions, activeProfile) =>
-    owner?.profile || rememberedSessionProfile(sessions, focused, activeProfile)
-)
+// Owner resolution of the FOCUSED chat — lives in the session-states store
+// (the profile-grouped sidebar follows the same atoms) and is re-exposed on
+// host.state.
+export type PluginFocusedSessionOwner = FocusedSessionOwner
 
 export interface PluginProfileRoute {
   connectionId: string

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -41,6 +41,8 @@ vi.mock('@/store/session-states', async () => {
 
   return {
     $focusedRuntimeId: atom(null),
+    $focusedSessionOwner: atom(null),
+    $focusedSessionProfile: atom('default'),
     $focusedSessionState: atom(null),
     $focusedStoredSessionId: atom(null),
     $sessionTiles: atom([]),

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -44,10 +44,12 @@ import {
   $sessions,
   clearReadBaseline,
   getSessionOwnerHint,
+  getSessionOwnerHints,
   knownSessionOwner,
   lineageAliases,
   markSessionRead,
   ownerLookupSessionRows,
+  rememberedSessionProfile,
   sessionMatchesStoredId,
   setActiveSessionStoredIdRotation,
   setAwaitingResponse,
@@ -1596,6 +1598,76 @@ export const $focusedStoredSessionId = computed(
 
     return active?.startsWith(TILE_PANE_PREFIX) ? active.slice(TILE_PANE_PREFIX.length) : selected
   }
+)
+
+export interface FocusedSessionOwner {
+  connectionId: string
+  profile: string
+}
+
+/**
+ * Connection-qualified owner of the FOCUSED chat. The gateway-routing atom
+ * (`$activeGatewayProfile`) answers "which backend is the live socket homed
+ * on" — but tab/tile focus moves without swapping the socket, and a cold
+ * start can restore a route into a session the booting gateway doesn't own.
+ * Any per-bot readout (the roster highlight, the profile-grouped sidebar, the
+ * plugin SDK's `focusedSessionOwner`) must follow the chat the user is
+ * LOOKING AT, so this resolves the focused stored session to a unique
+ * immutable owner hint or a unique connection-qualified aggregated row.
+ * Ambiguous or unresolved focused ids fail closed with null; only a draft/no
+ * focused id uses the active gateway owner. `$focusedSessionProfile` remains
+ * the profile-only compatibility ladder.
+ */
+export const $focusedSessionOwner = computed(
+  [$focusedStoredSessionId, $sessions, $activeGatewayProfile, $connection],
+  (focused, sessions, activeProfile, connection): FocusedSessionOwner | null => {
+    const activeConnectionId = String(connection?.connectionId || (connection?.mode === 'local' ? 'local' : '')).trim()
+
+    const fallback = {
+      connectionId: activeConnectionId,
+      profile: normalizeProfileKey(activeProfile)
+    }
+
+    if (!focused) {
+      return fallback
+    }
+
+    const hints = getSessionOwnerHints(focused)
+
+    if (hints.length === 1) {
+      return {
+        connectionId: hints[0].connectionId,
+        profile: normalizeProfileKey(hints[0].profile)
+      }
+    }
+
+    if (hints.length > 1) {
+      return null
+    }
+
+    const owners = new Map<string, FocusedSessionOwner>()
+
+    for (const row of sessions.filter(session => sessionMatchesStoredId(session, focused))) {
+      const connectionId = String(row.connection_id || '').trim()
+      const profile = normalizeProfileKey(row.profile)
+
+      if (connectionId) {
+        owners.set(`${connectionId}::${profile}`, { connectionId, profile })
+      }
+    }
+
+    return owners.size === 1 ? [...owners.values()][0] : null
+  }
+)
+
+/** Profile-only ladder over the focused owner — an ambiguous owner falls back
+ *  to the remembered-navigation resolution, so per-profile consumers (the
+ *  profile-grouped sidebar, host.state's `focusedSessionProfile`) always get
+ *  a usable key. */
+export const $focusedSessionProfile = computed(
+  [$focusedSessionOwner, $focusedStoredSessionId, $sessions, $activeGatewayProfile],
+  (owner, focused, sessions, activeProfile) =>
+    owner?.profile || rememberedSessionProfile(sessions, focused, activeProfile)
 )
 
 /** Every session currently OPEN as a surface: the primary's selection plus


### PR DESCRIPTION
## What

With **Grouping → Profile** in the all-profiles scope, the sidebar now answers *"what is THIS bot doing?"* passively:

- **Follow the focused bot** — the focused chat's profile group floats to the top of the list and is re-opened if it had been collapsed, so switching bots (roster click, tile focus) always reveals that bot's sessions without hunting for its section. `default` keeps its historical first spot when nothing else is focused; the rest stay alphabetical. A focused profile with no sessions changes nothing.
- **Session count on group headers** — each profile group shows its session count next to the label, readable while collapsed (`analyst · 3`-style, in the quaternary text tone so it stays out of the way of the cost/token totals).

Closes #89347

## How

- `$focusedSessionProfile` moves from the plugin SDK (`src/sdk/index.ts`) into the **session-states store**, so the sidebar and `host.state.focusedSessionProfile` share one resolver — same focused-row → owner-profile ladder, behavior unchanged for SDK consumers.
- Profile-group construction is extracted from the `index.tsx` memo into a pure **`buildProfileGroups()`** (`sidebar/profile-groups.ts`) with colocated unit tests covering ranking (focused > default > alpha), normalization, legacy rows without a profile, and color stamping.
- A small effect calls `setWorkspaceNodeOpen(focusedProfile, true)` when focus moves while profile-grouped, reusing the existing collapse-state store.

## Testing

- `vitest run --project ui src/app/chat/sidebar src/sdk src/store` — **1285 passed** (includes 7 new tests in `profile-groups.test.ts`; `profile-routing.test.ts` mock updated for the moved atom).
- `tsc -p . --noEmit` clean; `eslint` clean on all touched files.

## Notes

- The `PROJECT_PREVIEW_COUNT` cap on profile groups (only a handful of rows per group, click the label to scope) is untouched — happy to follow up there if there's appetite, since "few visible rows" was also raised in the issue discussion.
- For reference, the interaction model was first prototyped as a desktop plugin: NousResearch/hermes-example-plugins#12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)