### PR TITLE
fix(auth): stop repeated auxiliary Nous 401 refreshes

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -10476,6 +10476,7 @@ async def _async_call_llm_impl(
                 base_url=resolved_base_url,
                 api_key=resolved_api_key,
                 api_mode=resolved_api_mode,
+                main_runtime=main_runtime,
                 is_vision=(task == "vision"),
             )
             if refreshed_client is not None:
@@ -10512,6 +10513,7 @@ async def _async_call_llm_impl(
                 base_url=resolved_base_url,
                 api_key=resolved_api_key,
                 api_mode=resolved_api_mode,
+                main_runtime=main_runtime,
                 is_vision=(task == "vision"),
             )
             if refreshed_client is not None:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7584,13 +7584,14 @@ def _refresh_nous_auxiliary_client(
     cache_provider: str,
     model: Optional[str],
     async_mode: bool,
+    task: Optional[str] = None,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
     api_mode: Optional[str] = None,
     main_runtime: Optional[Dict[str, Any]] = None,
     is_vision: bool = False,
 ) -> Tuple[Optional[Any], Optional[str]]:
-    """Refresh Nous runtime creds, rebuild the client, and replace the cache entry."""
+    """Refresh Nous creds and replace the originating task's cache entry."""
     runtime = _resolve_nous_runtime_api(force_refresh=True)
     if runtime is None:
         return None, model
@@ -7618,6 +7619,7 @@ def _refresh_nous_auxiliary_client(
         api_mode=api_mode,
         main_runtime=main_runtime,
         is_vision=is_vision,
+        task=task,
         model=final_model,
     )
     _store_cached_client(cache_key, client, final_model, bound_loop=current_loop)
@@ -9723,6 +9725,7 @@ def _call_llm_impl(
                 cache_provider=resolved_provider or "nous",
                 model=final_model,
                 async_mode=False,
+                task=task,
                 base_url=resolved_base_url,
                 api_key=resolved_api_key,
                 api_mode=resolved_api_mode,
@@ -9759,6 +9762,7 @@ def _call_llm_impl(
                 cache_provider=resolved_provider or "nous",
                 model=final_model,
                 async_mode=False,
+                task=task,
                 base_url=resolved_base_url,
                 api_key=resolved_api_key,
                 api_mode=resolved_api_mode,
@@ -10468,6 +10472,7 @@ async def _async_call_llm_impl(
                 cache_provider=resolved_provider or "nous",
                 model=final_model,
                 async_mode=True,
+                task=task,
                 base_url=resolved_base_url,
                 api_key=resolved_api_key,
                 api_mode=resolved_api_mode,
@@ -10503,6 +10508,7 @@ async def _async_call_llm_impl(
                 cache_provider=resolved_provider or "nous",
                 model=final_model,
                 async_mode=True,
+                task=task,
                 base_url=resolved_base_url,
                 api_key=resolved_api_key,
                 api_mode=resolved_api_mode,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7583,6 +7583,7 @@ def _refresh_nous_auxiliary_client(
     *,
     cache_provider: str,
     model: Optional[str],
+    cache_model: Optional[str],
     async_mode: bool,
     task: Optional[str] = None,
     base_url: Optional[str] = None,
@@ -7620,7 +7621,7 @@ def _refresh_nous_auxiliary_client(
         main_runtime=main_runtime,
         is_vision=is_vision,
         task=task,
-        model=final_model,
+        model=cache_model,
     )
     _store_cached_client(cache_key, client, final_model, bound_loop=current_loop)
     return client, final_model
@@ -9724,6 +9725,7 @@ def _call_llm_impl(
             refreshed_client, refreshed_model = _refresh_nous_auxiliary_client(
                 cache_provider=resolved_provider or "nous",
                 model=final_model,
+                cache_model=resolved_model,
                 async_mode=False,
                 task=task,
                 base_url=resolved_base_url,
@@ -9761,6 +9763,7 @@ def _call_llm_impl(
             refreshed_client, refreshed_model = _refresh_nous_auxiliary_client(
                 cache_provider=resolved_provider or "nous",
                 model=final_model,
+                cache_model=resolved_model,
                 async_mode=False,
                 task=task,
                 base_url=resolved_base_url,
@@ -10471,6 +10474,7 @@ async def _async_call_llm_impl(
             refreshed_client, refreshed_model = _refresh_nous_auxiliary_client(
                 cache_provider=resolved_provider or "nous",
                 model=final_model,
+                cache_model=resolved_model,
                 async_mode=True,
                 task=task,
                 base_url=resolved_base_url,
@@ -10508,6 +10512,7 @@ async def _async_call_llm_impl(
             refreshed_client, refreshed_model = _refresh_nous_auxiliary_client(
                 cache_provider=resolved_provider or "nous",
                 model=final_model,
+                cache_model=resolved_model,
                 async_mode=True,
                 task=task,
                 base_url=resolved_base_url,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1283,7 +1283,7 @@ class TestAuxiliaryPoolAwareness:
             with (
                 patch(
                     "agent.auxiliary_client._resolve_task_provider_model",
-                    return_value=("auto", "nous-model", None, None, None),
+                    return_value=("auto", None, None, None, None),
                 ),
                 patch(
                     "agent.auxiliary_client.resolve_provider_client",
@@ -1307,10 +1307,12 @@ class TestAuxiliaryPoolAwareness:
             ):
                 first = call_llm(
                     task="goal_judge",
+                    main_runtime={"provider": "nous", "model": "main-model"},
                     messages=[{"role": "user", "content": "first"}],
                 )
                 second = call_llm(
                     task="goal_judge",
+                    main_runtime={"provider": "nous", "model": "main-model"},
                     messages=[{"role": "user", "content": "second"}],
                 )
         finally:
@@ -1337,7 +1339,7 @@ class TestAuxiliaryPoolAwareness:
         fresh_client.base_url = "https://inference-api.nousresearch.com/v1"
         fresh_client.chat.completions.create = AsyncMock(return_value={"ok": True})
 
-        main_runtime = {"provider": "nous", "model": "nous-model"}
+        main_runtime = {"provider": "nous", "model": "main-model"}
 
         import agent.auxiliary_client as aux
 
@@ -1346,7 +1348,7 @@ class TestAuxiliaryPoolAwareness:
             with (
                 patch(
                     "agent.auxiliary_client._resolve_task_provider_model",
-                    return_value=("auto", "nous-model", None, None, None),
+                    return_value=("auto", None, None, None, None),
                 ),
                 patch(
                     "agent.auxiliary_client.resolve_provider_client",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1264,6 +1264,64 @@ class TestAuxiliaryPoolAwareness:
         assert stale_client.chat.completions.create.call_count == 1
         assert fresh_client.chat.completions.create.call_count == 1
 
+    def test_call_llm_reuses_refreshed_nous_client_for_same_auto_task(self):
+        class _Auth401(Exception):
+            status_code = 401
+
+        stale_client = MagicMock()
+        stale_client.base_url = "https://inference-api.nousresearch.com/v1"
+        stale_client.chat.completions.create.side_effect = _Auth401("stale nous key")
+
+        fresh_client = MagicMock()
+        fresh_client.base_url = "https://inference-api.nousresearch.com/v1"
+        fresh_client.chat.completions.create.return_value = {"ok": True}
+
+        import agent.auxiliary_client as aux
+
+        aux.shutdown_cached_clients()
+        try:
+            with (
+                patch(
+                    "agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("auto", "nous-model", None, None, None),
+                ),
+                patch(
+                    "agent.auxiliary_client.resolve_provider_client",
+                    return_value=(stale_client, "nous-model"),
+                ) as mock_resolve,
+                patch(
+                    "agent.auxiliary_client._create_openai_client",
+                    return_value=fresh_client,
+                ),
+                patch(
+                    "agent.auxiliary_client._resolve_nous_runtime_api",
+                    return_value=(
+                        "fresh-agent-key",
+                        "https://inference-api.nousresearch.com/v1",
+                    ),
+                ),
+                patch(
+                    "agent.auxiliary_client._validate_llm_response",
+                    side_effect=lambda resp, _task, **_kw: resp,
+                ),
+            ):
+                first = call_llm(
+                    task="goal_judge",
+                    messages=[{"role": "user", "content": "first"}],
+                )
+                second = call_llm(
+                    task="goal_judge",
+                    messages=[{"role": "user", "content": "second"}],
+                )
+        finally:
+            aux.shutdown_cached_clients()
+
+        assert first == {"ok": True}
+        assert second == {"ok": True}
+        assert stale_client.chat.completions.create.call_count == 1
+        assert fresh_client.chat.completions.create.call_count == 2
+        assert mock_resolve.call_count == 1
+
 
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1322,6 +1322,72 @@ class TestAuxiliaryPoolAwareness:
         assert fresh_client.chat.completions.create.call_count == 2
         assert mock_resolve.call_count == 1
 
+    @pytest.mark.asyncio
+    async def test_async_call_llm_reuses_refreshed_nous_client_for_same_auto_runtime(self):
+        class _Auth401(Exception):
+            status_code = 401
+
+        stale_client = MagicMock()
+        stale_client.base_url = "https://inference-api.nousresearch.com/v1"
+        stale_client.chat.completions.create = AsyncMock(
+            side_effect=_Auth401("stale nous key")
+        )
+
+        fresh_client = MagicMock()
+        fresh_client.base_url = "https://inference-api.nousresearch.com/v1"
+        fresh_client.chat.completions.create = AsyncMock(return_value={"ok": True})
+
+        main_runtime = {"provider": "nous", "model": "nous-model"}
+
+        import agent.auxiliary_client as aux
+
+        aux.shutdown_cached_clients()
+        try:
+            with (
+                patch(
+                    "agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("auto", "nous-model", None, None, None),
+                ),
+                patch(
+                    "agent.auxiliary_client.resolve_provider_client",
+                    return_value=(stale_client, "nous-model"),
+                ) as mock_resolve,
+                patch("agent.auxiliary_client._create_openai_client"),
+                patch(
+                    "agent.auxiliary_client._to_async_client",
+                    return_value=(fresh_client, "nous-model"),
+                ),
+                patch(
+                    "agent.auxiliary_client._resolve_nous_runtime_api",
+                    return_value=(
+                        "fresh-agent-key",
+                        "https://inference-api.nousresearch.com/v1",
+                    ),
+                ),
+                patch(
+                    "agent.auxiliary_client._validate_llm_response",
+                    side_effect=lambda resp, _task, **_kw: resp,
+                ),
+            ):
+                first = await async_call_llm(
+                    task="goal_judge",
+                    main_runtime=main_runtime,
+                    messages=[{"role": "user", "content": "first"}],
+                )
+                second = await async_call_llm(
+                    task="goal_judge",
+                    main_runtime=main_runtime,
+                    messages=[{"role": "user", "content": "second"}],
+                )
+        finally:
+            aux.shutdown_cached_clients()
+
+        assert first == {"ok": True}
+        assert second == {"ok": True}
+        assert stale_client.chat.completions.create.await_count == 1
+        assert fresh_client.chat.completions.create.await_count == 2
+        assert mock_resolve.call_count == 1
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Long-lived auxiliary tasks using Nous credentials no longer incur a 401 and credential refresh on the first attempt of every call. Refreshed sync and async clients now replace the exact cache entry that produced the authentication failure, so subsequent calls reuse the valid client instead of retrying stale credentials.

### Symptom

In a long-lived gateway process, repeated auxiliary tasks such as goal judging or approval can each log a Nous runtime credential 401, refresh successfully, and then succeed only on retry. The main agent can continue using the same Portal OAuth account without the repeated failure.

### Impact

Affected gateway operators pay for an avoidable failed request and credential refresh on every invocation of the same auxiliary task. This adds latency and repeated authentication noise to otherwise successful auxiliary work.

### Bug Cause

**Trigger:** `agent/auxiliary_client.py` / `_refresh_nous_auxiliary_client()` after a Nous 401 from an auto-routed auxiliary task.

**Causal chain:**
1. An auto-routed task caches its auxiliary client under a key that includes the task discriminator and the pre-resolution model.
2. A 401 refresh rebuilds a valid client but previously stored it under a different key that omitted the task and used the resolved final model; async refresh also omitted the originating main runtime.
3. The next call reads the unchanged stale entry under the original key and repeats the 401 and refresh cycle.

**Why it is wrong:** The refresh path must replace the cache entry that supplied the failed client. Recomputing that key from post-resolution values creates a parallel entry that the originating task never reads.

**Working sibling / contrast:** Concrete-provider paths do not include an auto-routing task discriminator, which masks the mismatch. This change covers both sync and async refresh paths and preserves async main-runtime routing.

**Ruled out:** Token expiry and failed credential persistence do not explain the behavior because the forced refresh succeeds and the retried request uses the rebuilt client successfully; the failure is that later calls retrieve a different stale cache entry.

### Fix

Pass the originating task, pre-resolution model, and async main runtime through the Nous refresh helper when rebuilding the cache key. Add sync and async two-call regressions that prove the first call refreshes once and the second call reuses the refreshed client without resolving or refreshing again.

## Related Issue

Closes #91023

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` - preserve the originating cache-key inputs across sync and async Nous credential refreshes.
- `tests/agent/test_auxiliary_client.py` - cover long-lived reuse of refreshed sync and async clients for auto-routed tasks.

## How to Test

1. Run the related auxiliary client, cache-key, and resolution regression suites.
2. Confirm all 194 tests pass.

```bash
scripts/run_tests.sh tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_runtime_cache_key.py tests/agent/test_auxiliary_client_resolve_dedup.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant auxiliary test suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation is N/A because this fixes internal cache replacement behavior without changing user-facing configuration or APIs
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] Cross-platform impact was considered; the cache-key logic is platform-independent
- [x] Tool descriptions and schemas are N/A because no tool behavior changed

## Screenshots / Logs

N/A - the automated regressions exercise the repeated-call failure and verify refreshed-client reuse directly.
