### PR TITLE
fix(gateway): preserve startup resume provenance

### DIFF
--- a/gateway/platforms/event.py
+++ b/gateway/platforms/event.py
@@ -81,8 +81,11 @@ class MessageEvent:
     metadata: Dict[str, Any] = field(default_factory=dict)
     timestamp: datetime = field(default_factory=datetime.now)
     # May this event resolve gateway commands / control prompts? Proactive plugin events set False
-    # so untrusted payload text stays conversational. Kept last for positional compat.
+    # so untrusted payload text stays conversational.
     allow_gateway_control: bool = True
+    # Exact provenance for the synthetic startup recovery turn. Kept last to
+    # preserve positional construction compatibility for existing fields.
+    startup_resume: bool = False
 
     # Process-local admission receipt, never routing metadata or execution acknowledgement.
     _gateway_accepted: bool = field(default=False, init=False, repr=False, compare=False)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1019,7 +1019,9 @@ def _is_fresh_gateway_interruption(
 
 
 def build_resume_recovery_note(
-    reason: Optional[str], message: str = "", *, interactive: bool = True) -> str:
+    reason: Optional[str], message: str = "", *, interactive: bool = True,
+    startup_resume: bool = False,
+) -> str:
     """Build the resume-pending recovery system note for an interrupted turn (empty ``message`` = auto-resume).
 
     Interactive platforms report the restore and ask what next; non-interactive ones finish the work.
@@ -1031,7 +1033,7 @@ def build_resume_recovery_note(
     reason_phrase = (
         "a gateway restart" if reason == "restart_timeout"
         else "a gateway shutdown" if reason == "shutdown_timeout" else "a gateway interruption")
-    if message:
+    if not startup_resume:
         resume_guidance = (
             "Address the user's NEW message below FIRST and focus on what the user is asking now.")
         tail_guidance = (
@@ -1062,7 +1064,9 @@ def build_resume_recovery_note(
 
 
 def _prepare_resume_pending_message(
-    reason: Optional[str], message: Optional[str], *, interactive: bool = True) -> tuple[str, str]:
+    reason: Optional[str], message: Optional[str], *, interactive: bool = True,
+    startup_resume: bool = False,
+) -> tuple[str, Optional[str]]:
     """Return the recovery message and the user text to persist.
 
     Empty original: persist the note (a "" user row trips the pre-call sanitizer). Real text: persist clean.
@@ -1074,8 +1078,12 @@ def _prepare_resume_pending_message(
     words: the transcript stays scaffold-free (the model still receives the wrapped note), and a non-empty
     row never trips the sanitizer.
     """
-    recovery_message = build_resume_recovery_note(reason, message or "", interactive=interactive)
-    persist_message = message if isinstance(message, str) and message.strip() else recovery_message
+    recovery_message = build_resume_recovery_note(
+        reason, message or "", interactive=interactive, startup_resume=startup_resume,
+    )
+    # A real captionless media event may have no string to persist; only the synthetic
+    # startup wake persists the recovery scaffold itself.
+    persist_message = recovery_message if startup_resume else (message or None)
     return recovery_message, persist_message
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1083,7 +1083,15 @@ def _prepare_resume_pending_message(
     )
     # A real captionless media event may have no string to persist; only the synthetic
     # startup wake persists the recovery scaffold itself.
-    persist_message = recovery_message if startup_resume else (message or None)
+    persist_message = (
+        recovery_message
+        if startup_resume
+        else (
+            message
+            if isinstance(message, str) and message.strip()
+            else None
+        )
+    )
     return recovery_message, persist_message
 
 

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -547,7 +547,10 @@ class GatewayStartupMixin:
             _resume_state.turn.started_ts = time.time()
             self._persist_active_agents()
             # Empty-text internal event: the _is_resume_pending branch prepends the reason-aware note.
-            event = MessageEvent(text="", message_type=MessageType.TEXT, source=source, internal=True)
+            event = MessageEvent(
+                text="", message_type=MessageType.TEXT, source=source,
+                internal=True, startup_resume=True,
+            )
             task = self._retain_background_task(
                 asyncio.create_task(self._run_startup_resume_event(adapter, event, entry.session_key))
             )

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1980,6 +1980,7 @@ class GatewayTurnMixin:
                 persist_user_display_kind=prepared.persist_user_display_kind,
                 persist_user_display_metadata={"gateway_input_owner": prepared.persistence_owner},
                 message_type=event.message_type,
+                startup_resume=bool(getattr(event, "startup_resume", False)),
             )
             _turn_seconds = time.monotonic() - _turn_started_monotonic
 
@@ -3820,6 +3821,7 @@ class GatewayTurnMixin:
         persist_user_message: Optional[Any] = None, persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None, message_type: Optional[str] = None,
         persist_user_display_metadata: Optional[dict] = None,
+        startup_resume: bool = False,
     ) -> Dict[str, Any]:
         """Run the agent; returns the full run_conversation result dict.
 
@@ -3844,6 +3846,7 @@ class GatewayTurnMixin:
             persist_user_timestamp=persist_user_timestamp,
             persist_user_display_kind=persist_user_display_kind,
             persist_user_display_metadata=persist_user_display_metadata,
+            startup_resume=startup_resume,
         )
         _status_thread_metadata = self._run_agent_bind_turn_wiring(
             turn_ctx, turn_runner, source, event_message_id, disp._native_slack_task_cards,

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1432,8 +1432,10 @@ class TurnRunner:
     def _prepare_turn_message(self, agent_history):
         """Prepend recovery/notice guidance to ``ctx.message``.
 
-        Returns (persist_user_message_override, persist_user_timestamp_override): real user text is
-        kept separate from API-only recovery guidance so stale guidance never replays as user text.
+        Returns (persist_user_message_override, persist_user_timestamp_override,
+        native_persist_user_text): real user text is kept separate from API-only recovery guidance
+        so stale guidance never replays as user text, including native multimodal turns whose
+        persisted override must mirror the API content-list shape.
         """
         from gateway.run import (
             _auto_continue_freshness_window, _is_fresh_gateway_interruption,
@@ -1441,6 +1443,13 @@ class TurnRunner:
         )
         ctx = self._ctx
         persist_override: Optional[Any] = ctx.persist_user_message
+        native_persist_user_text = (
+            persist_override
+            if isinstance(persist_override, str)
+            else ctx.message
+            if persist_override is None and isinstance(ctx.message, str)
+            else None
+        )
         self._prepend_pending_note("_pending_model_notes")
         # Auto-continue: history ending with a tool result means the previous turn was cut off
         # (restart, crash, SIGTERM). Session-level resume_pending (drain-timeout shutdown) uses
@@ -1493,29 +1502,44 @@ class TurnRunner:
                 interactive=self._resume_note_interactive(),
                 startup_resume=True,
             )
-        return persist_override, ctx.persist_user_timestamp
+        return persist_override, ctx.persist_user_timestamp, native_persist_user_text
 
-    def _native_image_run_message(self):
+    def _native_image_run_message(self, persist_user_text: Optional[str] = None):
         """Wrap the user turn as an OpenAI-style multimodal content list when
         _prepare_inbound_message_text buffered image paths; consume-and-clear so later turns on the
-        same runner never re-attach stale images. Falls back to plain text when nothing is readable."""
+        same runner never re-attach stale images. Return ``(api_message, clean_persist_parts)``;
+        the latter is populated when API-only guidance changed the visible text. Falls back to
+        plain text when nothing is readable."""
         ctx = self._ctx
         native_imgs = self._runner._consume_pending_native_image_paths(ctx.session_key)
         if not native_imgs:
-            return ctx.message
+            return ctx.message, None
         try:
             from agent.image_routing import build_native_content_parts
             parts, skipped = build_native_content_parts(ctx.message, native_imgs)
             if skipped:
                 logger.warning("Native image attachment: skipped %d unreadable path(s): %s", len(skipped), skipped)
             if any(p.get("type") == "image_url" for p in parts):
-                return parts
+                persist_parts = None
+                if persist_user_text is not None and persist_user_text != ctx.message:
+                    # Reuse the exact attached image parts instead of reading the files twice. The
+                    # builder's documented first part is ``<caption>\n\n<attachment hints>``.
+                    api_prefix = (ctx.message or "").strip() or "What do you see in this image?"
+                    clean_prefix = persist_user_text.strip() or "What do you see in this image?"
+                    combined_text = parts[0].get("text", "")
+                    if combined_text.startswith(api_prefix):
+                        persist_parts = [
+                            {**parts[0], "text": clean_prefix + combined_text[len(api_prefix):]},
+                            *parts[1:],
+                        ]
+                return parts, persist_parts
         except Exception as exc:
             logger.warning("Native image attachment failed, falling back to text: %s", exc)
-        return ctx.message
+        return ctx.message, None
 
     def _run_conversation_with_approval(self, agent, agent_history, observed_group_context,
-                                        persist_user_message_override, persist_user_timestamp_override):
+                                        persist_user_message_override, persist_user_timestamp_override,
+                                        native_persist_user_text):
         """Run the turn with the per-session gateway approval callback registered: dangerous-command
         approval blocks the agent thread (mirrors CLI input()); the callback bridges sync→async."""
         from gateway.run import _wrap_current_message_with_observed_context
@@ -1526,13 +1550,18 @@ class TurnRunner:
         token = set_current_session_key(session_key)
         register_gateway_notify(session_key, self._approval_notify_sync)
         try:
-            api_message = _wrap_current_message_with_observed_context(self._native_image_run_message(), observed_group_context)
+            native_message, native_persist_override = self._native_image_run_message(
+                native_persist_user_text
+            )
+            api_message = _wrap_current_message_with_observed_context(native_message, observed_group_context)
             kwargs = {"conversation_history": agent_history, "task_id": ctx.session_id}
             if _accepts_keyword(agent.run_conversation, "turn_author"):
                 # Sent on every transport: a provider gating durable writes needs the bot flag in a DM too.
                 kwargs["turn_author"] = {"id": ctx.source.user_id or None, "name": ctx.source.user_name or None,
                                          "is_bot": bool(getattr(ctx.source, "is_bot", False))}
-            if persist_user_message_override is not None:
+            if native_persist_override is not None:
+                kwargs["persist_user_message"] = native_persist_override
+            elif persist_user_message_override is not None:
                 kwargs["persist_user_message"] = persist_user_message_override
             elif observed_group_context:
                 kwargs["persist_user_message"] = ctx.message
@@ -1755,8 +1784,11 @@ class TurnRunner:
         )
         self._wire_turn_agent_callbacks(agent, turn_route, reasoning_config, stream_delta_cb, interim_cb, want_interim)
         agent_history, observed_group_context, history_media_paths = self._load_turn_history(agent, reused_cached_agent)
-        persist_msg, persist_ts = self._prepare_turn_message(agent_history)
-        result = self._run_conversation_with_approval(agent, agent_history, observed_group_context, persist_msg, persist_ts)
+        persist_msg, persist_ts, native_persist_text = self._prepare_turn_message(agent_history)
+        result = self._run_conversation_with_approval(
+            agent, agent_history, observed_group_context, persist_msg, persist_ts,
+            native_persist_text,
+        )
         self._finish_stream_consumer(result, agent_history, stream_consumer)
         # The streaming-TTS consumer's finish() runs on the outer loop thread after the executor
         # returns, so early run_sync returns are also finalised.

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1463,7 +1463,10 @@ class TurnRunner:
         if resume_pending and (interruption_is_fresh or mark_is_fresh):
             # Empty message = the startup auto-resume turn; there is no NEW user message.
             ctx.message, persist_override = _prepare_resume_pending_message(
-                resume_reason, ctx.message, interactive=self._resume_note_interactive(),
+                resume_reason,
+                ctx.message,
+                interactive=self._resume_note_interactive(),
+                startup_resume=ctx.startup_resume,
             )
         elif agent_history and agent_history[-1].get("role") == "tool" and interruption_is_fresh:
             persist_override = ctx.message
@@ -1478,8 +1481,18 @@ class TurnRunner:
         # Safety net: a startup auto-resume event carries empty text; if the resume_pending branch
         # did not fire (freshness signals disagreed, marker cleared) we must NOT hand the model a blank
         # user turn. Restricted to resume_pending sessions so caption-less image turns are untouched.
-        if isinstance(ctx.message, str) and not ctx.message.strip() and resume_pending:
-            ctx.message = build_resume_recovery_note(resume_reason, "", interactive=self._resume_note_interactive())
+        if (
+            ctx.startup_resume
+            and isinstance(ctx.message, str)
+            and not ctx.message.strip()
+            and resume_pending
+        ):
+            ctx.message = build_resume_recovery_note(
+                resume_reason,
+                "",
+                interactive=self._resume_note_interactive(),
+                startup_resume=True,
+            )
         return persist_override, ctx.persist_user_timestamp
 
     def _native_image_run_message(self):

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -93,3 +93,7 @@ class TurnContext:
     _native_slack_task_cards: bool = False
     native_tool_start_callback: Optional[Callable] = None
     native_tool_complete_callback: Optional[Callable] = None
+
+    # Exact provenance for the synthetic startup recovery turn. Kept last to
+    # preserve positional construction compatibility for existing fields.
+    startup_resume: bool = False

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -366,6 +366,15 @@ class TestResumePendingSystemNote:
         # Keep native multimodal persistence in control of captionless media.
         assert persisted is None
 
+    def test_whitespace_real_event_defers_to_native_persistence(self):
+        """Blank-ish real input must not recreate sanitizer-healed rows."""
+        message, persisted = _prepare_resume_pending_message(
+            "restart_timeout", "   ", interactive=True, startup_resume=False
+        )
+
+        assert "Address the user's NEW message" in message
+        assert persisted is None
+
 
     def test_resume_pending_fires_without_tool_tail(self):
         """Key improvement over PR #9934: the restart-resume note fires

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -28,6 +28,7 @@ PRs #9850, #9934, #7536):
 import asyncio
 import time
 from datetime import datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -45,7 +46,9 @@ from gateway.run import (
     _should_clear_resume_pending_after_turn,
     build_resume_recovery_note,
 )
+from gateway.run_turn_runner import TurnRunner
 from gateway.session import SessionEntry, SessionSource, SessionStore
+from gateway.turn_context import TurnContext
 from tests.gateway.restart_test_helpers import (
     make_restart_runner,
     make_restart_source,
@@ -374,6 +377,75 @@ class TestResumePendingSystemNote:
 
         assert "Address the user's NEW message" in message
         assert persisted is None
+
+    def test_captionless_native_media_persists_clean_multimodal_content(self, tmp_path):
+        """The model receives recovery guidance, but the durable native-image row does not."""
+        from agent.session_persistence import durable_user_row_content
+
+        image = tmp_path / "recovery.png"
+        image.write_bytes(bytes.fromhex(
+            "89504e470d0a1a0a0000000d494844520000000100000001080600000"
+            "01f15c4890000000a49444154789c6360000002000100ffff0300000600"
+            "0557bfabd40000000049454e44ae426082"
+        ))
+        entry = SimpleNamespace(
+            resume_pending=True,
+            resume_reason="restart_timeout",
+            last_resume_marked_at=datetime.now(),
+        )
+
+        class Runner:
+            session_store = SimpleNamespace(_entries={"session-key": entry})
+
+            @staticmethod
+            def _adapter_for_source(source):
+                return SimpleNamespace(interactive_resume=True)
+
+            @staticmethod
+            def _consume_pending_native_image_paths(session_key):
+                assert session_key == "session-key"
+                return [str(image)]
+
+        ctx = TurnContext(
+            source=_make_source(),
+            session_key="session-key",
+            session_id="session-id",
+            message="",
+            history=[{"role": "assistant", "content": "working", "timestamp": time.time()}],
+        )
+        turn = TurnRunner(Runner(), ctx)  # type: ignore[arg-type]
+        persist_msg, persist_ts, native_persist_text = turn._prepare_turn_message([])
+        assert isinstance(ctx.message, str)
+        assert "[System note:" in ctx.message
+        assert persist_msg is None
+        assert persist_ts is None
+        assert native_persist_text == ""
+
+        captured = {}
+
+        class Agent:
+            def run_conversation(self, message, **kwargs):
+                captured["api_message"] = message
+                captured["persist_message"] = kwargs.get("persist_user_message")
+                captured["turn_author"] = kwargs.get("turn_author")
+                self._persist_user_message_override = captured["persist_message"]
+                captured["durable_message"], _ = durable_user_row_content(
+                    self, {"role": "user"}, message, None
+                )
+                return {"final_response": "ok", "messages": []}
+
+        turn._run_conversation_with_approval(
+            Agent(), [], None, persist_msg, persist_ts, native_persist_text
+        )
+
+        api_message = captured["api_message"]
+        persist_message = captured["persist_message"]
+        assert captured["turn_author"] == {"id": "u1", "name": None, "is_bot": False}
+        assert "[System note:" in api_message[0]["text"]
+        assert "[System note:" not in persist_message[0]["text"]
+        assert "What do you see in this image?" in persist_message[0]["text"]
+        assert api_message[1:] == persist_message[1:]
+        assert captured["durable_message"] == persist_message
 
 
     def test_resume_pending_fires_without_tool_tail(self):

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -176,7 +176,9 @@ def _simulate_note_injection(
         and getattr(resume_entry, "resume_pending", False)
     ):
         sn_reason = getattr(resume_entry, "resume_reason", None) or "restart_timeout"
-        message = build_resume_recovery_note(sn_reason, "")
+        message = build_resume_recovery_note(
+            sn_reason, "", startup_resume=True
+        )
     return message
 
 
@@ -306,7 +308,9 @@ class TestResumePendingSystemNote:
         """Non-interactive platforms (webhook, API server): nobody can answer
         'what next?', so the resumed turn must complete the interrupted work
         instead of acknowledging (#57056)."""
-        note = build_resume_recovery_note("restart_timeout", "", interactive=False)
+        note = build_resume_recovery_note(
+            "restart_timeout", "", interactive=False, startup_resume=True
+        )
         assert "CONTINUE the interrupted task" in note
         assert "session was restored" not in note
         assert "ask what they would like to do next" not in note
@@ -319,7 +323,7 @@ class TestResumePendingSystemNote:
     def test_resume_note_is_persisted_instead_of_original_empty_message(self):
         """The auto-resume note must not leave an empty row in state.db."""
         message, persisted = _prepare_resume_pending_message(
-            "restart_timeout", "", interactive=False
+            "restart_timeout", "", interactive=False, startup_resume=True
         )
 
         assert message
@@ -331,7 +335,7 @@ class TestResumePendingSystemNote:
         """A whitespace-only startup event is as blank as an empty one —
         persisting it verbatim would recreate the sanitizer loop (#86580)."""
         message, persisted = _prepare_resume_pending_message(
-            "shutdown_timeout", "   ", interactive=True
+            "shutdown_timeout", "   ", interactive=True, startup_resume=True
         )
 
         assert persisted == message
@@ -350,6 +354,17 @@ class TestResumePendingSystemNote:
         assert message != persisted
         assert "what were we doing?" in message
         assert "[System note:" in message
+
+    def test_captionless_media_is_still_new_user_input(self):
+        """An empty real event must not inherit synthetic startup semantics."""
+        message, persisted = _prepare_resume_pending_message(
+            "restart_timeout", "", interactive=True, startup_resume=False
+        )
+
+        assert "Address the user's NEW message" in message
+        assert "ask what they would like to do next" not in message
+        # Keep native multimodal persistence in control of captionless media.
+        assert persisted is None
 
 
     def test_resume_pending_fires_without_tool_tail(self):
@@ -703,6 +718,8 @@ async def test_reconnect_reschedule_is_platform_scoped():
     adapter.handle_message.assert_awaited_once()
     event = adapter.handle_message.await_args.args[0]
     assert event.source == tg_source
+    assert event.internal is True
+    assert event.startup_resume is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- mark only the gateway-generated startup recovery event with explicit `startup_resume` provenance
- carry that provenance through the agent turn instead of inferring it from empty text or the broad `internal` flag
- keep captionless media and other empty real events on the new-user-message path while preserving native multimodal persistence

## Problem
The resume-pending path treated an empty message as the synthetic startup wake. Real inbound events can also have empty text, notably media without a caption. `internal` is not a safe substitute because it also covers plugin injections, handoffs, and background completions.

## Testing
- `HERMES_PYTHON=/opt/hermes-agent/venv/bin/python scripts/run_tests.sh tests/gateway/test_restart_resume_pending.py tests/gateway/test_run_progress_interrupt.py tests/gateway/test_matrix_message_event_metadata.py -q`
- 43 passed
- `python -m py_compile` on all changed Python files

## Scope
This keeps the existing interactive/non-interactive recovery policy. It only gives that policy exact event provenance and adds regression coverage for captionless input.