### PR TITLE
fix(tools): preserve client certificates with custom CAs

### DIFF
--- a/tests/tools/test_mcp_client_cert.py
+++ b/tests/tools/test_mcp_client_cert.py
@@ -5,19 +5,133 @@ Covers:
 1. ``_resolve_client_cert`` helper — string, tuple, encrypted-key, validation
    errors, missing-file errors.
 
-2. HTTP (new SDK ``streamable_http_client``) path forwards ``cert=`` into the
-   user-owned ``httpx.AsyncClient``.
+2. HTTP (new and legacy SDK paths) forward one normalized SSL context into
+   their user-owned ``httpx.AsyncClient`` without the deprecated ``cert=``.
 
-3. SSE path forwards ``cert`` and ``ssl_verify`` via an ``httpx_client_factory``
-   without breaking the OAuth/headers/timeout passthrough.
+3. SSE path forwards that context via an ``httpx_client_factory`` without
+   breaking the OAuth/headers/timeout passthrough.
 """
 
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
+import http.server
+import ipaddress
+import ssl
+import threading
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+
+@pytest.fixture
+def mtls_material(tmp_path):
+    """Create a CA plus server/client identities for a real local mTLS probe."""
+    now = dt.datetime.now(dt.timezone.utc)
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Hermes test CA")])
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(ca_name)
+        .issuer_name(ca_name)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - dt.timedelta(minutes=1))
+        .not_valid_after(now + dt.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    def issue(name, *, server=False):
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, name)]))
+            .issuer_name(ca_name)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - dt.timedelta(minutes=1))
+            .not_valid_after(now + dt.timedelta(days=1))
+            .add_extension(
+                x509.ExtendedKeyUsage([
+                    ExtendedKeyUsageOID.SERVER_AUTH if server
+                    else ExtendedKeyUsageOID.CLIENT_AUTH
+                ]),
+                critical=False,
+            )
+        )
+        if server:
+            builder = builder.add_extension(
+                x509.SubjectAlternativeName([x509.IPAddress(ipaddress.ip_address("127.0.0.1"))]),
+                critical=False,
+            )
+        return key, builder.sign(ca_key, hashes.SHA256())
+
+    server_key, server_cert = issue("127.0.0.1", server=True)
+    client_key, client_cert = issue("Hermes client")
+
+    def write_cert(name, cert):
+        path = tmp_path / name
+        path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+        return path
+
+    def write_key(name, key, encryption=serialization.NoEncryption()):
+        path = tmp_path / name
+        path.write_bytes(key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption,
+        ))
+        return path
+
+    return {
+        "ca": write_cert("ca.pem", ca_cert),
+        "server_cert": write_cert("server.pem", server_cert),
+        "server_key": write_key("server.key", server_key),
+        "client_cert": write_cert("client.pem", client_cert),
+        "client_key": write_key("client.key", client_key),
+        "encrypted_client_key": write_key(
+            "client-encrypted.key",
+            client_key,
+            serialization.BestAvailableEncryption(b"test-passphrase"),
+        ),
+    }
+
+
+@contextmanager
+def _serve_mtls(material):
+    seen_requests = []
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_HEAD(self):
+            seen_requests.append(self.command)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+
+        def log_message(self, *_args):
+            pass
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(material["server_cert"], material["server_key"])
+    context.load_verify_locations(cafile=material["ca"])
+    context.verify_mode = ssl.CERT_REQUIRED
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"https://127.0.0.1:{server.server_port}/mcp", seen_requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
 
 
 def _patch_sdk_async_client(dummy):
@@ -84,19 +198,101 @@ class TestResolveClientCert:
             })
 
 
+class TestBuildHttpxSSLContext:
+    def test_default_https_keeps_certificate_verification_enabled(self):
+        from tools.mcp_tool import _build_httpx_ssl_context
+
+        context = _build_httpx_ssl_context("srv", True, None)
+
+        assert isinstance(context, ssl.SSLContext)
+        assert context.verify_mode == ssl.CERT_REQUIRED
+        assert context.check_hostname is True
+
+    def test_false_preserves_disabled_verification(self):
+        from tools.mcp_tool import _build_httpx_ssl_context
+
+        context = _build_httpx_ssl_context("srv", False, None)
+
+        assert context.verify_mode == ssl.CERT_NONE
+        assert context.check_hostname is False
+
+    def test_accepts_existing_ssl_context(self):
+        from tools.mcp_tool import _build_httpx_ssl_context
+
+        existing = ssl.create_default_context()
+        assert _build_httpx_ssl_context("srv", existing, None) is existing
+
+    def test_accepts_custom_ca_directory(self, tmp_path):
+        from tools.mcp_tool import _build_httpx_ssl_context
+
+        context = _build_httpx_ssl_context("srv", str(tmp_path), None)
+
+        assert context.verify_mode == ssl.CERT_REQUIRED
+
+    def test_loads_combined_client_pem(self, mtls_material, tmp_path):
+        from tools.mcp_tool import _build_httpx_ssl_context
+
+        combined = tmp_path / "combined.pem"
+        combined.write_bytes(
+            mtls_material["client_cert"].read_bytes()
+            + mtls_material["client_key"].read_bytes()
+        )
+
+        context = _build_httpx_ssl_context(
+            "srv", str(mtls_material["ca"]), str(combined)
+        )
+
+        assert context.verify_mode == ssl.CERT_REQUIRED
+
+    def test_invalid_client_key_error_is_server_scoped_and_sanitized(self, tmp_path):
+        from tools.mcp_tool import _build_httpx_ssl_context
+
+        cert = tmp_path / "client.pem"
+        key = tmp_path / "secret-client.key"
+        cert.write_text("not a certificate")
+        key.write_text("SUPER-SECRET-KEY-CONTENT")
+
+        with pytest.raises(ValueError) as exc_info:
+            _build_httpx_ssl_context("private-server", True, (str(cert), str(key)))
+
+        message = str(exc_info.value)
+        assert "private-server" in message
+        assert "SUPER-SECRET" not in message
+
+    def test_custom_ca_and_encrypted_client_key_complete_real_mtls_handshake(
+        self, mtls_material,
+    ):
+        from tools.mcp_tool import MCPServerTask, _resolve_client_cert
+
+        task = MCPServerTask.__new__(MCPServerTask)
+        task.name = "real-mtls"
+        client_cert = _resolve_client_cert("real-mtls", {
+            "client_cert": [
+                str(mtls_material["client_cert"]),
+                str(mtls_material["encrypted_client_key"]),
+                "test-passphrase",
+            ],
+        })
+
+        with _serve_mtls(mtls_material) as (url, seen_requests):
+            asyncio.run(task._preflight_content_type(
+                url,
+                ssl_verify=str(mtls_material["ca"]),
+                client_cert=client_cert,
+                timeout=5,
+            ))
+        assert seen_requests == ["HEAD"]
+
+
 # ---------------------------------------------------------------------------
 # HTTP transport — cert forwarded into httpx.AsyncClient
 # ---------------------------------------------------------------------------
 
 
 class TestHTTPClientCert:
-    def test_cert_forwarded_to_async_client(self, tmp_path):
-        """When client_cert is set, the new-SDK HTTP path passes ``cert=``
-        into ``httpx.AsyncClient``."""
+    def test_tls_context_forwarded_to_async_client(self, mtls_material):
+        """The new-SDK HTTP path passes one normalized TLS context."""
         from tools.mcp_tool import MCPServerTask
-
-        cert = tmp_path / "client.pem"
-        cert.write_text("dummy")
 
         server = MCPServerTask("remote")
         captured: dict = {}
@@ -144,11 +340,14 @@ class TestHTTPClientCert:
                  patch.object(MCPServerTask, "_discover_tools", _discover_tools):
                 await server._run_http({
                     "url": "https://example.com/mcp",
-                    "client_cert": str(cert),
+                    "ssl_verify": str(mtls_material["ca"]),
+                    "client_cert": str(mtls_material["client_cert"]),
+                    "client_key": str(mtls_material["client_key"]),
                 })
 
         asyncio.run(_drive())
-        assert captured.get("cert") == str(cert)
+        assert isinstance(captured["verify"], ssl.SSLContext)
+        assert "cert" not in captured
 
 
     def test_missing_cert_file_surfaces_clear_error(self, tmp_path):
@@ -167,6 +366,82 @@ class TestHTTPClientCert:
 
         with pytest.raises(FileNotFoundError, match=r"remote.*client_cert.*not found"):
             asyncio.run(_drive())
+
+
+class TestLegacyHTTPClientCert:
+    def test_legacy_transport_receives_tls_context_factory(self, mtls_material):
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("legacy-remote")
+        captured: dict = {}
+
+        class DummyTransportCtx:
+            async def __aenter__(self):
+                return MagicMock(), MagicMock(), (lambda: None)
+
+            async def __aexit__(self, *args):
+                return False
+
+        def fake_transport(url, **kwargs):
+            captured["url"] = url
+            captured.update(kwargs)
+            return DummyTransportCtx()
+
+        class DummySession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def initialize(self):
+                return None
+
+        async def discover_and_stop(self):
+            self._shutdown_event.set()
+
+        async def drive():
+            with patch("tools.mcp_tool._MCP_HTTP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._MCP_NEW_HTTP", False), \
+                 patch("tools.mcp_tool.streamablehttp_client", fake_transport, create=True), \
+                 patch("tools.mcp_tool.ClientSession", DummySession), \
+                 patch.object(MCPServerTask, "_discover_tools", discover_and_stop):
+                await server._run_http({
+                    "url": "https://example.com/mcp",
+                    "headers": {"X-Test": "preserved"},
+                    "connect_timeout": 17,
+                    "ssl_verify": str(mtls_material["ca"]),
+                    "client_cert": str(mtls_material["client_cert"]),
+                    "client_key": str(mtls_material["client_key"]),
+                })
+
+        asyncio.run(drive())
+        assert captured["headers"]["X-Test"] == "preserved"
+        assert captured["timeout"] == 17.0
+        assert "verify" not in captured
+        assert "cert" not in captured
+
+        client_kwargs = {}
+
+        class DummyAsyncClient:
+            def __init__(self, **kwargs):
+                client_kwargs.update(kwargs)
+
+        from tools.mcp_tool import sdk_httpx
+
+        with _patch_sdk_async_client(DummyAsyncClient):
+            captured["httpx_client_factory"](
+                headers={"X-Factory": "preserved"},
+                timeout=sdk_httpx().Timeout(17),
+                auth=None,
+            )
+
+        assert isinstance(client_kwargs["verify"], ssl.SSLContext)
+        assert "cert" not in client_kwargs
+        assert client_kwargs["headers"] == {"X-Factory": "preserved"}
 
 
 # ---------------------------------------------------------------------------
@@ -217,9 +492,8 @@ def patch_sse_client():
 
 
 class TestSSEClientCert:
-    def test_no_factory_when_defaults(self, patch_sse_client):
-        """With no cert and ssl_verify=True (default), the SDK's own factory is
-        used — we don't inject one."""
+    def test_default_https_uses_normalized_context_factory(self, patch_sse_client):
+        """Default SSE HTTPS also flows through the centralized TLS context."""
         from tools.mcp_tool import MCPServerTask
 
         server = MCPServerTask("sse-test")
@@ -230,28 +504,22 @@ class TestSSEClientCert:
             with patch.object(MCPServerTask, "_wait_for_lifecycle_event",
                               new=AsyncMock(return_value="shutdown")), \
                  patch.object(MCPServerTask, "_discover_tools", new=AsyncMock()):
-                try:
-                    await asyncio.wait_for(
-                        server._run_http({
-                            "url": "https://example.com/mcp/sse",
-                            "transport": "sse",
-                        }),
-                        timeout=2.0,
-                    )
-                except (asyncio.TimeoutError, StopAsyncIteration, Exception):
-                    pass
+                await asyncio.wait_for(
+                    server._run_http({
+                        "url": "https://example.com/mcp/sse",
+                        "transport": "sse",
+                    }),
+                    timeout=2.0,
+                )
 
         asyncio.run(drive())
-        assert "httpx_client_factory" not in patch_sse_client
+        assert "httpx_client_factory" in patch_sse_client
 
-    def test_factory_injected_when_cert_set(self, patch_sse_client, tmp_path):
+    def test_factory_injected_when_cert_set(self, patch_sse_client, mtls_material):
         """With client_cert set, an httpx_client_factory is injected that
         applies the cert (and follow_redirects=True to match the SDK)."""
         from tools.mcp_tool import MCPServerTask
 
-        cert = tmp_path / "client.pem"
-        cert.write_text("dummy")
-
         server = MCPServerTask("sse-test")
         server._auth_type = ""
         server._sampling = None
@@ -260,17 +528,15 @@ class TestSSEClientCert:
             with patch.object(MCPServerTask, "_wait_for_lifecycle_event",
                               new=AsyncMock(return_value="shutdown")), \
                  patch.object(MCPServerTask, "_discover_tools", new=AsyncMock()):
-                try:
-                    await asyncio.wait_for(
-                        server._run_http({
-                            "url": "https://example.com/mcp/sse",
-                            "transport": "sse",
-                            "client_cert": str(cert),
-                        }),
-                        timeout=2.0,
-                    )
-                except (asyncio.TimeoutError, StopAsyncIteration, Exception):
-                    pass
+                await asyncio.wait_for(
+                    server._run_http({
+                        "url": "https://example.com/mcp/sse",
+                        "transport": "sse",
+                        "client_cert": str(mtls_material["client_cert"]),
+                        "client_key": str(mtls_material["client_key"]),
+                    }),
+                    timeout=2.0,
+                )
 
         asyncio.run(drive())
 
@@ -289,17 +555,14 @@ class TestSSEClientCert:
         with _patch_sdk_async_client(DummyAsyncClient):
             factory(headers={"x": "y"}, timeout=sdk_httpx().Timeout(30.0), auth=None)
 
-        assert captured_client_kwargs["cert"] == str(cert)
-        assert captured_client_kwargs["verify"] is True
+        assert isinstance(captured_client_kwargs["verify"], ssl.SSLContext)
+        assert "cert" not in captured_client_kwargs
         assert captured_client_kwargs["follow_redirects"] is True
         assert captured_client_kwargs["headers"] == {"x": "y"}
 
-    def test_factory_forwards_custom_ca_bundle(self, patch_sse_client, tmp_path):
-        """ssl_verify as a path is forwarded to the factory's httpx client."""
+    def test_factory_forwards_custom_ca_context(self, patch_sse_client, mtls_material):
+        """A custom CA path is normalized before reaching the SSE client."""
         from tools.mcp_tool import MCPServerTask
-
-        ca_bundle = tmp_path / "ca.pem"
-        ca_bundle.write_text("dummy")
 
         server = MCPServerTask("sse-test")
         server._auth_type = ""
@@ -309,17 +572,14 @@ class TestSSEClientCert:
             with patch.object(MCPServerTask, "_wait_for_lifecycle_event",
                               new=AsyncMock(return_value="shutdown")), \
                  patch.object(MCPServerTask, "_discover_tools", new=AsyncMock()):
-                try:
-                    await asyncio.wait_for(
-                        server._run_http({
-                            "url": "https://example.com/mcp/sse",
-                            "transport": "sse",
-                            "ssl_verify": str(ca_bundle),
-                        }),
-                        timeout=2.0,
-                    )
-                except (asyncio.TimeoutError, StopAsyncIteration, Exception):
-                    pass
+                await asyncio.wait_for(
+                    server._run_http({
+                        "url": "https://example.com/mcp/sse",
+                        "transport": "sse",
+                        "ssl_verify": str(mtls_material["ca"]),
+                    }),
+                    timeout=2.0,
+                )
 
         asyncio.run(drive())
 
@@ -335,5 +595,5 @@ class TestSSEClientCert:
         with _patch_sdk_async_client(DummyAsyncClient):
             factory(headers=None, timeout=None, auth=None)
 
-        assert captured_client_kwargs["verify"] == str(ca_bundle)
+        assert isinstance(captured_client_kwargs["verify"], ssl.SSLContext)
         assert "cert" not in captured_client_kwargs

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -107,6 +107,7 @@ import os
 import random
 import re
 import shutil
+import ssl
 import sys
 import threading
 import time
@@ -1485,8 +1486,9 @@ def _validate_remote_mcp_url(server_name: str, url: Any) -> str:
 def _resolve_client_cert(server_name: str, config: dict):
     """Resolve the ``client_cert`` / ``client_key`` config for mTLS.
 
-    Returns whatever ``httpx``'s ``cert=`` parameter accepts, or ``None`` when
-    no client certificate is configured:
+    Returns the certificate-chain description consumed by
+    :func:`_build_httpx_ssl_context`, or ``None`` when no client certificate
+    is configured:
 
       - ``None`` if neither ``client_cert`` nor ``client_key`` is set.
       - A single absolute path string if ``client_cert`` is a string and
@@ -1553,6 +1555,84 @@ def _resolve_client_cert(server_name: str, config: dict):
         return (cert_path, key_path)
     # Single combined PEM file (cert + key in one file).
     return cert_path
+
+
+def _build_httpx_ssl_context(
+    server_name: str,
+    ssl_verify: Any = True,
+    client_cert: Any = None,
+) -> ssl.SSLContext:
+    """Build the single TLS context used by every remote MCP transport.
+
+    HTTPX 0.28.x does not reliably combine ``verify=<custom CA path>`` with
+    its deprecated ``cert=`` argument: constructing the verification context
+    from the path can bypass loading the client identity.  Normalize both
+    settings here and load the client chain directly into the verification
+    context so preflight, SSE, and both Streamable HTTP implementations share
+    identical mTLS behavior.
+    """
+    try:
+        if isinstance(ssl_verify, ssl.SSLContext):
+            context = ssl_verify
+        elif ssl_verify is True:
+            context = ssl.create_default_context()
+        elif ssl_verify is False:
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_NONE
+        elif isinstance(ssl_verify, (str, os.PathLike)):
+            ca_path = os.path.expanduser(os.fspath(ssl_verify).strip())
+            if os.path.isfile(ca_path):
+                context = ssl.create_default_context(cafile=ca_path)
+            elif os.path.isdir(ca_path):
+                context = ssl.create_default_context(capath=ca_path)
+            else:
+                raise FileNotFoundError(
+                    f"MCP server '{server_name}': ssl_verify CA path not found"
+                )
+        else:
+            raise ValueError(
+                f"MCP server '{server_name}': ssl_verify must be true, false, "
+                "a CA file/directory path, or an SSLContext"
+            )
+    except (FileNotFoundError, ValueError):
+        raise
+    except (OSError, ssl.SSLError) as exc:
+        raise ValueError(
+            f"MCP server '{server_name}': could not load ssl_verify CA material"
+        ) from exc
+
+    if client_cert is None:
+        return context
+
+    try:
+        if isinstance(client_cert, str):
+            context.load_cert_chain(client_cert)
+        elif isinstance(client_cert, tuple) and len(client_cert) == 2:
+            context.load_cert_chain(client_cert[0], client_cert[1])
+        elif isinstance(client_cert, tuple) and len(client_cert) == 3:
+            context.load_cert_chain(
+                client_cert[0], client_cert[1], password=client_cert[2]
+            )
+        else:
+            raise ValueError(
+                f"MCP server '{server_name}': invalid resolved client certificate"
+            )
+    except ValueError as exc:
+        # Preserve our own setup error, but replace OpenSSL parse/password
+        # details so no key material or passphrase can reach logs.
+        if str(exc).startswith(f"MCP server '{server_name}':"):
+            raise
+        raise ValueError(
+            f"MCP server '{server_name}': could not load client certificate "
+            "or key; check the configured files and passphrase"
+        ) from exc
+    except (OSError, ssl.SSLError) as exc:
+        raise ValueError(
+            f"MCP server '{server_name}': could not load client certificate "
+            "or key; check the configured files and passphrase"
+        ) from exc
+    return context
 
 
 def _resolve_identity_header(server_name: str, config: dict):
@@ -3215,7 +3295,7 @@ class MCPServerTask:
         url: str,
         *,
         headers: Optional[dict] = None,
-        ssl_verify: bool = True,
+        ssl_verify: Any = True,
         client_cert=None,
         timeout: float = 5.0,
     ) -> None:
@@ -3253,12 +3333,12 @@ class MCPServerTask:
             return  # No httpx → skip probe; SDK import would have failed first.
 
         client_kwargs: dict = {
-            "verify": ssl_verify,
+            "verify": _build_httpx_ssl_context(
+                self.name, ssl_verify, client_cert
+            ),
             "follow_redirects": True,
             "timeout": _httpx.Timeout(timeout),
         }
-        if client_cert is not None:
-            client_kwargs["cert"] = client_cert
 
         probe_headers = dict(headers) if headers else {}
         try:
@@ -3415,6 +3495,9 @@ class MCPServerTask:
         connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
         ssl_verify = config.get("ssl_verify", True)
         client_cert = _resolve_client_cert(self.name, config)
+        ssl_context = _build_httpx_ssl_context(
+            self.name, ssl_verify, client_cert
+        )
 
         # OAuth 2.1 PKCE: route through the central MCPOAuthManager so the
         # same provider instance is reused across reconnects, pre-flow
@@ -3440,6 +3523,21 @@ class MCPServerTask:
             sampling_kwargs["message_handler"] = self._make_message_handler()
         if _MCP_LOGGING_CALLBACK_SUPPORTED:
             sampling_kwargs["logging_callback"] = self._make_logging_callback()
+
+        _httpx_mod = sdk_httpx()
+
+        def _mcp_http_client_factory(headers=None, timeout=None, auth=None):
+            """Mirror the MCP SDK factory while applying normalized TLS."""
+            kwargs: dict = {
+                "follow_redirects": True,
+                "verify": ssl_context,
+                "timeout": timeout or _httpx_mod.Timeout(30.0, read=300.0),
+            }
+            if headers is not None:
+                kwargs["headers"] = headers
+            if auth is not None:
+                kwargs["auth"] = auth
+            return _httpx_mod.AsyncClient(**kwargs)
 
         # SSE transport (for MCP servers that implement the SSE transport protocol
         # rather than Streamable HTTP). Configure with ``transport: sse`` in the
@@ -3478,39 +3576,9 @@ class MCPServerTask:
                 # behind OAuth 2.1 PKCE work. Previously built but never
                 # forwarded — SSE OAuth would silently fail with 401s.
                 _sse_kwargs["auth"] = _oauth_auth
-            if client_cert is not None or ssl_verify is not True:
-                # SSE transport doesn't expose verify/cert as kwargs, so route
-                # them through an httpx_client_factory that wraps the SDK's
-                # defaults (follow_redirects=True) and adds our TLS settings.
-                # The SDK calls the factory with (headers, auth, timeout); we
-                # forward all of those and layer verify/cert on top.
-                # The client MUST come from the SDK's own httpx module
-                # (httpx2 on mcp >= 2.0) — see sdk_httpx().
-                _httpx_mod = sdk_httpx()
-
-                _cert_for_factory = client_cert
-                _verify_for_factory = ssl_verify
-
-                def _mcp_http_client_factory(
-                    headers=None, timeout=None, auth=None,
-                ):
-                    kwargs: dict = {
-                        "follow_redirects": True,
-                        "verify": _verify_for_factory,
-                    }
-                    if timeout is not None:
-                        kwargs["timeout"] = timeout
-                    else:
-                        kwargs["timeout"] = _httpx_mod.Timeout(30.0, read=300.0)
-                    if headers is not None:
-                        kwargs["headers"] = headers
-                    if auth is not None:
-                        kwargs["auth"] = auth
-                    if _cert_for_factory is not None:
-                        kwargs["cert"] = _cert_for_factory
-                    return _httpx_mod.AsyncClient(**kwargs)
-
-                _sse_kwargs["httpx_client_factory"] = _mcp_http_client_factory
+            # SSE doesn't expose ``verify`` directly. Route the normalized
+            # context through the SDK factory while preserving its arguments.
+            _sse_kwargs["httpx_client_factory"] = _mcp_http_client_factory
             try:
                 async with sse_client(**_sse_kwargs) as (read_stream, write_stream):
                     async with ClientSession(
@@ -3563,15 +3631,13 @@ class MCPServerTask:
             client_kwargs: dict = {
                 "follow_redirects": True,
                 "timeout": httpx.Timeout(float(connect_timeout), read=300.0),
-                "verify": ssl_verify,
+                "verify": ssl_context,
                 "event_hooks": {"response": [_strip_auth_on_cross_origin_redirect]},
             }
             if headers:
                 client_kwargs["headers"] = headers
             if _oauth_auth is not None:
                 client_kwargs["auth"] = _oauth_auth
-            if client_cert is not None:
-                client_kwargs["cert"] = client_cert
 
             # Caller owns the client lifecycle — the SDK skips cleanup when
             # http_client is provided, so we wrap in async-with.
@@ -3622,7 +3688,7 @@ class MCPServerTask:
             _http_kwargs: dict = {
                 "headers": headers,
                 "timeout": float(connect_timeout),
-                "verify": ssl_verify,
+                "httpx_client_factory": _mcp_http_client_factory,
             }
             if _oauth_auth is not None:
                 _http_kwargs["auth"] = _oauth_auth


### PR DESCRIPTION
## What does this PR do?

Fixes remote MCP mTLS connections when Hermes is configured with both a custom CA and a client certificate.

HTTPX 0.28 ignores the separate client certificate tuple when `verify` is supplied as a CA path string. This change normalizes TLS configuration into an explicit `ssl.SSLContext`, loads the client identity into that context, and reuses it across preflight, SSE, modern Streamable HTTP, and legacy Streamable HTTP clients.

## Related Issue

No existing issue or PR matched this defect after searching mTLS, client-certificate, CA-bundle, and certificate-required symptoms.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add centralized SSLContext construction in `tools/mcp_tool.py`.
- Preserve secure verification defaults, custom CA files/directories, caller-provided contexts, combined PEM identities, separate certificate/key pairs, and encrypted keys.
- Route the normalized context through preflight and all remote MCP HTTP transports.
- Add real local mTLS handshake coverage and transport-factory regression tests in `tests/tools/test_mcp_client_cert.py`.
- Preserve MCP 2.0 `httpx2` compatibility via the SDK-selected HTTP client module.

## How to Test

1. `uv sync --frozen --extra dev`
2. `./.venv/bin/python -m pytest tests/tools/test_mcp_client_cert.py -q` — 17 passed.
3. `./.venv/bin/python -m pytest tests/tools/test_mcp*.py -q` — 586 passed.
4. `./.venv/bin/python -m ruff check tools/mcp_tool.py tests/tools/test_mcp_client_cert.py`
5. `git diff --check origin/main`

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing issues and PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass.
- [x] I've added tests for my changes.
- [x] I've tested on Linux with Python 3.11.

### Documentation & Housekeeping

- [x] Documentation update: N/A; behavior and compatibility rationale are documented in code and tests.
- [x] `cli-config.yaml.example`: N/A; no configuration keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no workflow or architecture policy changed.
- [x] Cross-platform impact considered: uses Python's standard `ssl.SSLContext` and HTTPX-supported APIs.
- [x] Tool descriptions/schemas: N/A; no tool schema changed.

## Review Scope

This PR changes 532 lines across the implementation and its regression tests. The maintainer explicitly authorized a single-PR size exception because splitting the production fix from the executable TLS coverage would create an incomplete review unit.

Native four-lens review completed with zero findings. Final candidate verification passed 17 focused tests, 586 MCP tests, Ruff lint, and diff checks.
