### PR TITLE
fix(desktop): make the chat window snap-eligible when glass translucency is off

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -998,7 +998,18 @@ function chatWindowSurfaceOptions() {
     // (electron#49443). Chat windows on glass-capable Windows are born
     // transparent so a live Clear→Glass toggle doesn't need a recreate; the
     // opaque themed backgroundColor covers it while glass is off.
-    ...(IS_WINDOWS && GLASS_SUPPORTED ? { transparent: true } : {}),
+    //
+    // However, a `transparent: true` window drops the WS_THICKFRAME style,
+    // which is what Windows requires for snap / snap-assist (Win+Arrow,
+    // edge-drag) — see electron#37888. The window only needs to be
+    // transparent while glass is actually rendering; when translucency is
+    // 0% / `clear` nothing is painted, so the transparency is pure downside
+    // (it strips the frame that makes the window snappable). Gate the flag
+    // on `glassActive` so the window stays opaque and snap-eligible when
+    // glass is off, and transparent only when glass is on.
+    ...(IS_WINDOWS && GLASS_SUPPORTED && glassActive(translucencyState)
+      ? { transparent: true }
+      : {}),
     backgroundMaterial: IS_WINDOWS && GLASS_SUPPORTED ? backgroundMaterialFor(translucencyState) : undefined,
     opacity: windowOpacity(),
     ...windowBackingOptions(translucencyState, getWindowBackgroundColor())


### PR DESCRIPTION
## What does this PR do?

Makes the Windows desktop chat window snap-eligible (Win+Left / Win+Right /
Win+Up, edge-drag) whenever glass translucency is **off**, which is the default
look most people run.

On glass-capable Windows 11 (build >= 22621), `chatWindowSurfaceOptions()`
created the chat window `transparent: true` unconditionally. A transparent
Electron window on Windows drops the `WS_THICKFRAME` style — the one Windows
requires for snap (electron#37888) — so the window looked normal but refused
every snap gesture. A reinstall could never fix it because the flag is set at
creation, not per-install.

The window is only *supposed* to be transparent while glass is actually
rendering (the Win11 DWM material must reach a transparent client area,
electron#49443). When translucency is 0%, nothing is painted, so the
transparency was pure downside: it stripped the frame that makes the window
snappable while buying nothing. This PR gates the flag on `glassActive`, so the
window is opaque (snappable) when glass is off and transparent only when it's
on.

## Related Issue

Fixes #91060  <!-- the bug report drafted alongside this PR -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.ts` — `chatWindowSurfaceOptions()` now sets
  `transparent: true` only when `IS_WINDOWS && GLASS_SUPPORTED &&
  glassActive(translucencyState)`, instead of whenever `GLASS_SUPPORTED`.
  `glassActive` is already imported in this file.

```diff
-    ...(IS_WINDOWS && GLASS_SUPPORTED ? { transparent: true } : {}),
+    ...(IS_WINDOWS && GLASS_SUPPORTED && glassActive(translucencyState)
+      ? { transparent: true }
+      : {}),
```

## How to Test

1. Windows 11 build >= 22621 (tested on 26200).
2. Set translucency to 0% / `clear` (Settings → Appearance).
3. Relaunch Hermes desktop.
4. Select the chat window; press Win+Left / Win+Right — it snaps to half
   width. Win+Up maximizes; edge-drag works.
5. Set translucency back to a glass value; the window renders glass as before
   (it will be unsnappable while glass is on — that is the unavoidable
   transparent-window tradeoff, see note below).

**Caveats (disclosed, not hidden):**
- Runtime glass ON → OFF works immediately (window stays opaque/snappable).
  OFF → ON at runtime does not make a window born-opaque transparent until a
  relaunch — the codebase already documents that runtime backing swaps are
  unreliable (`translucency.ts`), so this does not regress anything that used
  to work.
- Fresh installs default to `mode: 'glass'` (intensity > 0), so a brand-new
  user still starts with a transparent, unsnappable window. A follow-up could
  default Windows intensity to 0; out of scope for this fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) — `fix(desktop): make the chat window snap-eligible when glass translucency is off`
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (searched open + merged for `transparent`, `snap`, `WS_THICKFRAME`, `thickFrame` — none address the chat window's snap eligibility; the only in-tree `electron#37888` references concern HUD `setPosition` drift, a different symptom)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant checks and all pass: `npm run typecheck` and `npm run lint` in `apps/desktop/` both exit 0; the Python `pytest tests/ -q` suite doesn't cover this change (the fix is in the Electron main process, TypeScript) so it's not a meaningful gate here
- [x] I've added tests for my changes — N/A (Electron window-option creation path; no existing unit harness for `chatWindowSurfaceOptions`; verified empirically on Windows 11)
- [x] I've tested on my platform: Windows 11 build 26200

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys touched)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (guard is `IS_WINDOWS && GLASS_SUPPORTED`; macOS/Linux and sub-22621 Windows are byte-identical to before)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Verified on Windows 11 build 26200: before the change, Win+Left / Win+Right did
nothing to the chat window at translucency 0%; after, the window snaps to half
width and Win+Up maximizes. (Screenshot/log of the snap available on request.)

## Disclosure

This change was prepared with the assistance of an AI assistant (Hermes Agent).
I reviewed the diff line-by-line, traced the root cause to the exact line in
`main.ts`, confirmed the Electron limitation against the upstream issue
(electron#37888), and reproduced the bug and the fix on my own machine before
opening this PR.
