### PR TITLE
fix(bot-mode): canonical bot DMs always follow the profile's current config

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3490,7 +3490,12 @@ function createCanonicalChat(name) {
       // plugin-owned. Core applies this via the generic `hidden` flag
       // (deferred as pending_hidden until the row exists); older gateways
       // ignore the unknown param and it stays visible.
-      hidden: true
+      hidden: true,
+      // Explicit contract: this session's runtime always follows the member
+      // profile's CURRENT config. Resume must NOT restore the stored
+      // model/provider pin from an old row (that left bot DMs stuck on a
+      // stale provider — e.g. "out of Nous credits" — after a profile switch).
+      follow_profile_config: true
     })
     const sid = res?.stored_session_id
     const runtime = res?.session_id
@@ -4385,7 +4390,11 @@ async function ensureGroupChatSession(group, member) {
     profile: member.name,
     title,
     // Room member sessions are plumbing — always hidden from the sidebar.
-    hidden: true
+    hidden: true,
+    // Same follow-profile-config contract as the canonical Bot Chat: a room
+    // member's runtime always follows the member profile's CURRENT config,
+    // never a stale stored model/provider pin from an old row.
+    follow_profile_config: true
   })
   const stored = created?.stored_session_id || null
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -355,6 +355,19 @@ test('turn transport is gateway-native (session RPCs) and hostile text rides ver
   assert.match(pluginSource, /const title = `Group: \$\{group\}`/)
 })
 
+test('bot sessions carry the follow-profile-config contract (canonical DM + room)', () => {
+  // Canonical Bot Chat: the ONE forever DM per bot must always follow the
+  // member profile's CURRENT config — never a stale stored model/provider pin
+  // (the "out of Nous credits" DM bug after a profile switch).
+  assert.match(pluginSource, /follow_profile_config: true/)
+  // The contract is sent on session.create for BOTH the canonical chat and
+  // room plumbing sessions, so resume rebuilds from current config.
+  const canonical = pluginSource.slice(pluginSource.indexOf('function createCanonicalChat'))
+  assert.match(canonical, /follow_profile_config: true/)
+  const room = pluginSource.slice(pluginSource.indexOf('async function ensureGroupChatSession'))
+  assert.match(room, /follow_profile_config: true/)
+})
+
 test('log trimming keeps watermarks consistent', () => {
   const gc = load(() => '(pass)')
   const log = Array.from({ length: 200 }, (_, i) => ({ from: { kind: 'user', name: 'You' }, text: `m${i}`, at: i }))

--- a/tests/tui_gateway/test_custom_provider_session_persistence.py
+++ b/tests/tui_gateway/test_custom_provider_session_persistence.py
@@ -343,3 +343,112 @@ class TestModelNameRecoversEntryIdentity:
         )
 
 
+# --- Regression: bot DM stuck on a stale provider pin (GH #89497 class) ------
+#
+# Bot-Mode canonical chats (the ONE forever DM per bot) and room plumbing
+# sessions are plugin-owned scratch conversations. They are created with the
+# explicit ``follow_profile_config`` contract so resume ALWAYS rebuilds from
+# the member profile's CURRENT config — restoring the stored model/provider
+# pin from an old row is what left bot DMs stuck on a stale provider (e.g.
+# "out of Nous credits" after the profile was switched to ollama-cloud) while
+# the same bot worked fine in rooms. Normal 1:1 user chats keep the
+# stored-runtime restore (opening an older chat must show the model it
+# actually used).
+
+
+class TestFollowProfileConfigRuntimeOverrides:
+    def test_marked_row_returns_no_overrides(self):
+        """A row carrying the follow_profile_config marker never restores a
+        stored provider pin — resume falls back to the profile's CURRENT
+        config."""
+        from tui_gateway.server import _stored_session_runtime_overrides
+
+        row = {
+            "model": "openai/gpt-5.6-luna-pro",
+            "billing_provider": "nous",
+            "model_config": json.dumps(
+                {
+                    "model": "openai/gpt-5.6-luna-pro",
+                    "provider": "nous",
+                    "follow_profile_config": True,
+                }
+            ),
+        }
+        assert _stored_session_runtime_overrides(row) == {}
+
+    def test_marked_row_dict_model_config_returns_no_overrides(self):
+        """Same contract when model_config is already a dict (not JSON)."""
+        from tui_gateway.server import _stored_session_runtime_overrides
+
+        row = {
+            "model": "openai/gpt-5.6-luna-pro",
+            "model_config": {
+                "model": "openai/gpt-5.6-luna-pro",
+                "provider": "nous",
+                "follow_profile_config": True,
+            },
+        }
+        assert _stored_session_runtime_overrides(row) == {}
+
+    def test_unmarked_row_still_restores_stored_runtime(self):
+        """Normal 1:1 user chats keep the stored-runtime restore — the
+        contract must not leak into ordinary sessions."""
+        from tui_gateway.server import _stored_session_runtime_overrides
+
+        row = {
+            "model": "openai/gpt-5.6-luna-pro",
+            "billing_provider": "nous",
+            "model_config": json.dumps(
+                {"model": "openai/gpt-5.6-luna-pro", "provider": "nous"}
+            ),
+        }
+        overrides = _stored_session_runtime_overrides(row)
+        assert overrides["model_override"]["model"] == "openai/gpt-5.6-luna-pro"
+        assert overrides["model_override"]["provider"] == "nous"
+
+    def test_ensure_db_row_persists_contract_marker(self, monkeypatch):
+        """_ensure_session_db_row stamps follow_profile_config into the row's
+        model_config when the session carries the contract."""
+        import tui_gateway.server as server
+
+        captured = {}
+
+        class FakeDB:
+            def create_session(self, *args, **kwargs):
+                captured["model_config"] = kwargs.get("model_config")
+                return None
+
+        monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+        monkeypatch.setattr(server, "_resolve_model", lambda: "glm-5.1")
+
+        session = {
+            "session_key": "key-1",
+            "model_override": {"model": "glm-5.1", "provider": "ollama-cloud"},
+            "follow_profile_config": True,
+        }
+        server._ensure_session_db_row(session)
+        assert captured["model_config"].get("follow_profile_config") is True
+
+    def test_ensure_db_row_omits_marker_without_contract(self, monkeypatch):
+        """Sessions without the contract do NOT get the marker — normal chats
+        keep the stored-runtime restore."""
+        import tui_gateway.server as server
+
+        captured = {}
+
+        class FakeDB:
+            def create_session(self, *args, **kwargs):
+                captured["model_config"] = kwargs.get("model_config")
+                return None
+
+        monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+        monkeypatch.setattr(server, "_resolve_model", lambda: "glm-5.1")
+
+        session = {
+            "session_key": "key-2",
+            "model_override": {"model": "glm-5.1", "provider": "ollama-cloud"},
+        }
+        server._ensure_session_db_row(session)
+        assert captured["model_config"].get("follow_profile_config") is None
+
+

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -99,6 +99,7 @@ def _(rid, params: dict) -> dict:
             "parent_session_id": parent_session_id,
             "pending_title": title or None,
             "pending_hidden": is_truthy_value(params.get("hidden", False)),
+            "follow_profile_config": is_truthy_value(params.get("follow_profile_config", False)),
             "profile_home": str(profile_home) if profile_home is not None else None,
             "running": False,
             "session_key": key,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3008,6 +3008,15 @@ def _ensure_session_db_row(session: dict) -> None:
     parent_session_id = session.get("parent_session_id") or None
     if parent_session_id:
         model_config["_branched_from"] = parent_session_id
+    # Bot-Mode canonical chats (the ONE forever DM per bot) and room plumbing
+    # sessions are plugin-owned scratch conversations: their runtime must ALWAYS
+    # follow the member profile's CURRENT config, never the model/provider that
+    # was pinned when the row was first written. Persist that contract explicitly
+    # so resume can distinguish them from a normal user chat (whose stored
+    # model/provider must be restored verbatim). See
+    # _stored_session_runtime_overrides.
+    if session.get("follow_profile_config"):
+        model_config["follow_profile_config"] = True
     try:
         db.create_session(
             key,
@@ -4132,6 +4141,31 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
     ``billing_provider``, and richer runtime knobs in JSON ``model_config``.
     """
     if not row:
+        return {}
+
+    # Bot-Mode canonical chats (the ONE forever DM per bot) and room plumbing
+    # sessions are plugin-owned scratch conversations. They must always rebuild
+    # from the member profile's CURRENT config: restoring the stored
+    # model/provider pin from an old row is what left bot DMs stuck on a stale
+    # provider (e.g. "out of Nous credits" after the profile was switched to
+    # ollama-cloud) while the same bot worked fine in rooms. 1:1 user chats
+    # keep the stored-runtime restore (opening an older chat must show the
+    # model it actually used); only the plugin-owned bot sessions are exempt.
+    #
+    # The primary signal is the EXPLICIT ``follow_profile_config`` contract
+    # persisted by session.create consumers (desktop Bot Mode) — a deliberate
+    # marker, not a presentation heuristic.
+    raw_follow = row.get("model_config")
+    if isinstance(raw_follow, dict):
+        _follow_marker = raw_follow.get("follow_profile_config")
+    elif isinstance(raw_follow, str) and raw_follow.strip():
+        try:
+            _follow_marker = json.loads(raw_follow).get("follow_profile_config")
+        except Exception:
+            _follow_marker = None
+    else:
+        _follow_marker = None
+    if _follow_marker:
         return {}
 
     raw_config = row.get("model_config")


### PR DESCRIPTION
Fixes the mirror image of #89497: bot DMs stuck on a stale provider pin.

## Summary

Bot-Mode canonical chats (the ONE forever DM per bot) and room plumbing sessions are plugin-owned scratch conversations. They are now created with an explicit `follow_profile_config` contract, persisted in the session row's `model_config`, so `session.resume` rebuilds from the member profile's **CURRENT** config instead of restoring the stored model/provider pin from an old row.

That stale pin is what left bot DMs stuck on a dead provider (e.g. "out of Nous credits" after the profile was switched to ollama-cloud) while the same bot worked fine in rooms — the mirror image of the room-plumbing bug (#89497 class). Normal 1:1 user chats keep the stored-runtime restore: opening an older chat must show the model it actually used.

## How to Test

1. Configure a bot profile with model A (e.g. a paid Nous model), open its Bot Chat DM, send a message.
2. Switch the profile to model B (e.g. ollama-cloud/glm-5.1).
3. Reopen the DM. Before this fix: resume restores the stored model A pin → "out of Nous credits" / HTTP 404. After: resume uses the profile's current model B.

## Verification

- Backend: `_stored_session_runtime_overrides` returns `{}` for rows carrying the marker (dict and JSON `model_config` shapes); unmarked rows still restore stored runtime; `_ensure_session_db_row` persists the marker only when the contract is set.
- Desktop: `createCanonicalChat` and `ensureGroupChatSession` both send `follow_profile_config: true` on `session.create`.
- Tests: 16/16 `test_custom_provider_session_persistence.py`, 24/24 with `test_session_resume_db_ownership.py`, 57/57 desktop group-chat tests.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally
