### PR TITLE
fix(desktop): recover corrupt Windows native deps in isolation

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -28,7 +28,7 @@
     "profile:main:cpu": "tsc --build tsconfig.electron.json && wait-on http://127.0.0.1:5174 && node scripts/bundle-electron-main.mjs --dev && cross-env XCURSOR_SIZE=24 NODE_OPTIONS=--cpu-prof HERMES_DESKTOP_DEV_SERVER=http://127.0.0.1:5174 electron .",
     "start": "npm run build && electron .",
     "prebuild": "npm run clean",
-    "build": "node scripts/assert-root-install.mjs && node scripts/write-build-stamp.mjs && vite build && node scripts/bundle-electron-main.mjs && node scripts/stage-native-deps.mjs",
+    "build": "node scripts/assert-root-install.mjs && node scripts/write-build-stamp.mjs && vite build && node scripts/bundle-electron-main.mjs && node scripts/stage-native-deps-recovery.mjs",
     "postbuild": "node scripts/assert-dist-built.mjs",
     "prebuilder": "node scripts/patch-electron-builder-mac-binary.mjs",
     "builder": "cross-env NODE_OPTIONS=--max-old-space-size=16384 node scripts/run-electron-builder.mjs",
@@ -71,7 +71,7 @@
     "check:test:ui:shard-1of3": "node scripts/run-ui-shard.mjs",
     "check:test:ui:shard-2of3": "node scripts/run-ui-shard.mjs",
     "check:test:ui:shard-3of3": "node scripts/run-ui-shard.mjs",
-    "check:test:desktop:all": "npm run test:desktop:all",
+    "check:test:desktop:all": "node --test scripts/stage-native-deps-recovery.test.mjs && npm run test:desktop:all",
     "check:lint": "npm run typecheck && npm run lint",
     "check": "npm run check:lint && npm run test:ui && npm run test:desktop:platforms && npm run test:desktop:all",
     "test:e2e": "npm run build && playwright test e2e/",
@@ -208,7 +208,7 @@
       "package.json"
     ],
     "beforeBuild": "scripts/before-build.mjs",
-    "beforePack": "scripts/before-pack.mjs",
+    "beforePack": "scripts/before-pack-recovery.mjs",
     "afterPack": "scripts/after-pack.mjs",
     "extraResources": [
       {

--- a/apps/desktop/scripts/before-pack-recovery.mjs
+++ b/apps/desktop/scripts/before-pack-recovery.mjs
@@ -1,0 +1,45 @@
+// Recovery wrapper around the canonical electron-builder beforePack hook.
+// The base hook remains the owner of stale-app cleanup, rollback preservation,
+// and native staging. This wrapper handles only one residual: a corrupt or
+// unresolvable get-windows package root on a supported native build host.
+
+import { Arch } from 'electron-builder'
+
+import beforePack from './before-pack.mjs'
+import {
+  isMissingGetWindowsPackageError,
+  stageGetWindowsWithRecovery
+} from './stage-native-deps-recovery.mjs'
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export default async function beforePackWithRecovery(context) {
+  try {
+    return await beforePack(context)
+  } catch (error) {
+    if (!isMissingGetWindowsPackageError(error)) {
+      throw error
+    }
+
+    const platform = context && context.electronPlatformName
+    const arch = context && typeof context.arch === 'number' ? Arch[context.arch] : undefined
+    if (!platform || !arch) {
+      throw error
+    }
+
+    console.warn(
+      `[before-pack] canonical native staging found a corrupt get-windows package root; ` +
+        `retrying ${platform}-${arch} from an isolated dependency realization`
+    )
+    try {
+      stageGetWindowsWithRecovery({ platform, arch })
+      console.log(`[before-pack] recovered and staged get-windows for target ${platform}-${arch}`)
+    } catch (recoveryError) {
+      throw new Error(
+        `[before-pack] isolated get-windows recovery failed for ${platform}-${arch}: ${errorMessage(recoveryError)}`
+      )
+    }
+  }
+}

--- a/apps/desktop/scripts/stage-native-deps-recovery.mjs
+++ b/apps/desktop/scripts/stage-native-deps-recovery.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+// Isolated dependency-realization wrapper for stage-native-deps.mjs.
+//
+// The normal Desktop build stages get-windows from the repository's installed
+// dependency tree. On Windows, an interrupted/in-place npm extraction can leave
+// node_modules/get-windows present but unresolvable (for example, package.json
+// is missing). Reusing that tree makes every later Desktop rebuild fail at the
+// same stage. This wrapper preserves the fail-closed native staging contract,
+// but realizes the exact package in a fresh temporary npm prefix and stages
+// from that verified root instead of mutating or trusting active node_modules.
+
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { stageGetWindows, stageNodePty } from './stage-native-deps.mjs'
+import { isMain } from './utils.mjs'
+
+const require = createRequire(import.meta.url)
+
+export const GET_WINDOWS_RECOVERY_VERSION = '9.3.0'
+export const GET_WINDOWS_MISSING_ROOT_MARKER =
+  '[stage-native-deps] get-windows is not installed; cannot stage its '
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export function isMissingGetWindowsPackageError(error) {
+  return errorMessage(error).includes(GET_WINDOWS_MISSING_ROOT_MARKER)
+}
+
+export function canRecoverGetWindowsPackage({
+  platform,
+  arch,
+  hostPlatform = process.platform,
+  hostArch = process.arch
+}) {
+  if (platform !== hostPlatform) {
+    return false
+  }
+
+  if (platform === 'darwin') {
+    // get-windows' macOS helper is universal.
+    return true
+  }
+
+  if (platform === 'win32') {
+    // The package's node-pre-gyp lifecycle realizes a host-architecture
+    // binding. Only consume it when the requested package architecture is the
+    // same one the active Node process can actually verify and execute.
+    return arch === hostArch && (arch === 'x64' || arch === 'ia32')
+  }
+
+  return false
+}
+
+function cleanupRecoveryRoot(recoveryRoot) {
+  try {
+    rmSync(recoveryRoot, {
+      force: true,
+      maxRetries: 5,
+      recursive: true,
+      retryDelay: 100
+    })
+    return true
+  } catch (error) {
+    console.warn(
+      `[stage-native-deps] could not remove isolated get-windows recovery root ${recoveryRoot}: ${errorMessage(error)}`
+    )
+    return false
+  }
+}
+
+export function recoverGetWindowsPackage({
+  platform = process.platform,
+  arch = process.arch,
+  npmExecPath = process.env.npm_execpath,
+  run = spawnSync,
+  tempParent = tmpdir()
+} = {}) {
+  if (!npmExecPath) {
+    throw new Error(
+      '[stage-native-deps] cannot recover get-windows: npm_execpath is unavailable; run the Desktop build through npm'
+    )
+  }
+
+  const recoveryRoot = mkdtempSync(join(tempParent, 'hermes-get-windows-'))
+  let completed = false
+
+  try {
+    const recoveryManifest = {
+      name: 'hermes-get-windows-recovery',
+      private: true,
+      version: '0.0.0',
+      dependencies: {
+        'get-windows': GET_WINDOWS_RECOVERY_VERSION
+      },
+      allowScripts: {
+        [`get-windows@${GET_WINDOWS_RECOVERY_VERSION}`]: true
+      }
+    }
+    writeFileSync(
+      join(recoveryRoot, 'package.json'),
+      `${JSON.stringify(recoveryManifest, null, 2)}\n`,
+      'utf8'
+    )
+
+    const result = run(
+      process.execPath,
+      [
+        npmExecPath,
+        'install',
+        '--workspaces=false',
+        '--include=optional',
+        '--ignore-scripts=false',
+        '--no-audit',
+        '--no-fund',
+        '--package-lock=false',
+        '--prefer-online'
+      ],
+      {
+        cwd: recoveryRoot,
+        env: {
+          ...process.env,
+          npm_config_arch: arch,
+          npm_config_platform: platform,
+          npm_config_target_arch: arch
+        },
+        stdio: 'inherit'
+      }
+    )
+
+    if (result.error) {
+      throw new Error(
+        `[stage-native-deps] isolated get-windows recovery could not start npm: ${result.error.message}`
+      )
+    }
+    if (result.status !== 0) {
+      throw new Error(
+        `[stage-native-deps] isolated get-windows recovery install exited with ${result.status}`
+      )
+    }
+
+    let packageRoot
+    try {
+      // get-windows does not export package.json; resolve its root entry and
+      // validate the manifest beside it.
+      packageRoot = dirname(
+        require.resolve('get-windows', {
+          paths: [recoveryRoot]
+        })
+      )
+    } catch (error) {
+      throw new Error(
+        `[stage-native-deps] isolated get-windows recovery completed without an importable package: ${errorMessage(error)}`
+      )
+    }
+
+    const installedVersion = JSON.parse(
+      readFileSync(join(packageRoot, 'package.json'), 'utf8')
+    ).version
+    if (installedVersion !== GET_WINDOWS_RECOVERY_VERSION) {
+      throw new Error(
+        `[stage-native-deps] isolated get-windows recovery resolved ${installedVersion}; expected ${GET_WINDOWS_RECOVERY_VERSION}`
+      )
+    }
+
+    completed = true
+    let cleaned = false
+    return {
+      packageRoot,
+      recoveryRoot,
+      cleanup() {
+        if (cleaned) {
+          return true
+        }
+        cleaned = cleanupRecoveryRoot(recoveryRoot)
+        return cleaned
+      }
+    }
+  } finally {
+    if (!completed) {
+      cleanupRecoveryRoot(recoveryRoot)
+    }
+  }
+}
+
+export function stageGetWindowsWithRecovery({
+  platform = process.platform,
+  arch = process.arch,
+  hostPlatform = process.platform,
+  hostArch = process.arch,
+  recover = recoverGetWindowsPackage,
+  stage = stageGetWindows
+} = {}) {
+  try {
+    return stage({ platform, arch })
+  } catch (error) {
+    if (
+      !isMissingGetWindowsPackageError(error) ||
+      !canRecoverGetWindowsPackage({ platform, arch, hostPlatform, hostArch })
+    ) {
+      throw error
+    }
+
+    console.warn(
+      `[stage-native-deps] get-windows package root is missing or corrupt for ${platform}-${arch}; ` +
+        `recovering exact ${GET_WINDOWS_RECOVERY_VERSION} in an isolated npm prefix`
+    )
+    const recovery = recover({ platform, arch })
+
+    try {
+      return stage({
+        platform,
+        arch,
+        resolveRoot: () => recovery.packageRoot
+      })
+    } finally {
+      recovery.cleanup()
+    }
+  }
+}
+
+export function stageNativeDeps({ platform = process.platform, arch = process.arch } = {}) {
+  const nodePty = stageNodePty({ platform, arch })
+  const getWindows = stageGetWindowsWithRecovery({ platform, arch })
+  return { getWindows, nodePty }
+}
+
+if (isMain(import.meta.url)) {
+  const [platform, arch] = process.argv.slice(2)
+  stageNativeDeps({ platform, arch })
+}

--- a/apps/desktop/scripts/stage-native-deps-recovery.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps-recovery.test.mjs
@@ -2,7 +2,8 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { test } from 'vitest'
+
+const { test } = process.env.VITEST ? await import('vitest') : await import('node:test')
 
 import {
   GET_WINDOWS_MISSING_ROOT_MARKER,

--- a/apps/desktop/scripts/stage-native-deps-recovery.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps-recovery.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import test from 'node:test'
+import { test } from 'vitest'
 
 import {
   GET_WINDOWS_MISSING_ROOT_MARKER,
@@ -12,76 +12,81 @@ import {
   stageGetWindowsWithRecovery
 } from './stage-native-deps-recovery.mjs'
 
-function tempParent(t) {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-get-windows-recovery-test-'))
-  t.after(() => fs.rmSync(root, { force: true, recursive: true }))
-  return root
+function tempParent() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-get-windows-recovery-test-'))
 }
 
-test('isolated recovery installs the exact get-windows package outside active node_modules', (t) => {
-  const parent = tempParent(t)
-  let invocation
+test('isolated recovery installs the exact get-windows package outside active node_modules', () => {
+  const parent = tempParent()
+  try {
+    let invocation
 
-  const recovery = recoverGetWindowsPackage({
-    arch: 'x64',
-    npmExecPath: '/fake/npm-cli.js',
-    platform: 'win32',
-    tempParent: parent,
-    run(command, args, options) {
-      invocation = { args, command, options }
-      const packageRoot = path.join(options.cwd, 'node_modules', 'get-windows')
-      fs.mkdirSync(path.join(packageRoot, 'lib'), { recursive: true })
-      fs.writeFileSync(
-        path.join(packageRoot, 'package.json'),
-        JSON.stringify({ name: 'get-windows', version: GET_WINDOWS_RECOVERY_VERSION })
-      )
-      fs.writeFileSync(path.join(packageRoot, 'index.js'), 'export default {}\n')
-      return { status: 0 }
-    }
-  })
+    const recovery = recoverGetWindowsPackage({
+      arch: 'x64',
+      npmExecPath: '/fake/npm-cli.js',
+      platform: 'win32',
+      tempParent: parent,
+      run(command, args, options) {
+        invocation = { args, command, options }
+        const packageRoot = path.join(options.cwd, 'node_modules', 'get-windows')
+        fs.mkdirSync(path.join(packageRoot, 'lib'), { recursive: true })
+        fs.writeFileSync(
+          path.join(packageRoot, 'package.json'),
+          JSON.stringify({ name: 'get-windows', version: GET_WINDOWS_RECOVERY_VERSION })
+        )
+        fs.writeFileSync(path.join(packageRoot, 'index.js'), 'export default {}\n')
+        return { status: 0 }
+      }
+    })
 
-  assert.equal(invocation.command, process.execPath)
-  assert.equal(invocation.args[0], '/fake/npm-cli.js')
-  assert.equal(invocation.args[1], 'install')
-  assert.ok(invocation.args.includes('--workspaces=false'))
-  assert.ok(invocation.args.includes('--include=optional'))
-  assert.equal(invocation.options.cwd, recovery.recoveryRoot)
-  assert.equal(invocation.options.env.npm_config_platform, 'win32')
-  assert.equal(invocation.options.env.npm_config_arch, 'x64')
+    assert.equal(invocation.command, process.execPath)
+    assert.equal(invocation.args[0], '/fake/npm-cli.js')
+    assert.equal(invocation.args[1], 'install')
+    assert.ok(invocation.args.includes('--workspaces=false'))
+    assert.ok(invocation.args.includes('--include=optional'))
+    assert.equal(invocation.options.cwd, recovery.recoveryRoot)
+    assert.equal(invocation.options.env.npm_config_platform, 'win32')
+    assert.equal(invocation.options.env.npm_config_arch, 'x64')
 
-  const manifest = JSON.parse(
-    fs.readFileSync(path.join(recovery.recoveryRoot, 'package.json'), 'utf8')
-  )
-  assert.deepEqual(manifest.dependencies, {
-    'get-windows': GET_WINDOWS_RECOVERY_VERSION
-  })
-  assert.deepEqual(manifest.allowScripts, {
-    [`get-windows@${GET_WINDOWS_RECOVERY_VERSION}`]: true
-  })
-  assert.equal(
-    recovery.packageRoot,
-    path.join(recovery.recoveryRoot, 'node_modules', 'get-windows')
-  )
-  assert.ok(fs.existsSync(recovery.recoveryRoot))
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(recovery.recoveryRoot, 'package.json'), 'utf8')
+    )
+    assert.deepEqual(manifest.dependencies, {
+      'get-windows': GET_WINDOWS_RECOVERY_VERSION
+    })
+    assert.deepEqual(manifest.allowScripts, {
+      [`get-windows@${GET_WINDOWS_RECOVERY_VERSION}`]: true
+    })
+    assert.equal(
+      recovery.packageRoot,
+      path.join(recovery.recoveryRoot, 'node_modules', 'get-windows')
+    )
+    assert.ok(fs.existsSync(recovery.recoveryRoot))
 
-  assert.equal(recovery.cleanup(), true)
-  assert.equal(recovery.cleanup(), true)
-  assert.equal(fs.existsSync(recovery.recoveryRoot), false)
+    assert.equal(recovery.cleanup(), true)
+    assert.equal(recovery.cleanup(), true)
+    assert.equal(fs.existsSync(recovery.recoveryRoot), false)
+  } finally {
+    fs.rmSync(parent, { force: true, recursive: true })
+  }
 })
 
-test('failed isolated install is removed and cannot poison a later update', (t) => {
-  const parent = tempParent(t)
-
-  assert.throws(
-    () =>
-      recoverGetWindowsPackage({
-        npmExecPath: '/fake/npm-cli.js',
-        run: () => ({ status: 1 }),
-        tempParent: parent
-      }),
-    /isolated get-windows recovery install exited with 1/
-  )
-  assert.deepEqual(fs.readdirSync(parent), [])
+test('failed isolated install is removed and cannot poison a later update', () => {
+  const parent = tempParent()
+  try {
+    assert.throws(
+      () =>
+        recoverGetWindowsPackage({
+          npmExecPath: '/fake/npm-cli.js',
+          run: () => ({ status: 1 }),
+          tempParent: parent
+        }),
+      /isolated get-windows recovery install exited with 1/
+    )
+    assert.deepEqual(fs.readdirSync(parent), [])
+  } finally {
+    fs.rmSync(parent, { force: true, recursive: true })
+  }
 })
 
 test('supported native Windows staging retries with the recovered package root', () => {

--- a/apps/desktop/scripts/stage-native-deps-recovery.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps-recovery.test.mjs
@@ -2,8 +2,7 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-
-const { test } = process.env.VITEST ? await import('vitest') : await import('node:test')
+import { test } from 'node:test'
 
 import {
   GET_WINDOWS_MISSING_ROOT_MARKER,

--- a/apps/desktop/scripts/stage-native-deps-recovery.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps-recovery.test.mjs
@@ -1,0 +1,210 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  GET_WINDOWS_MISSING_ROOT_MARKER,
+  GET_WINDOWS_RECOVERY_VERSION,
+  canRecoverGetWindowsPackage,
+  recoverGetWindowsPackage,
+  stageGetWindowsWithRecovery
+} from './stage-native-deps-recovery.mjs'
+
+function tempParent(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-get-windows-recovery-test-'))
+  t.after(() => fs.rmSync(root, { force: true, recursive: true }))
+  return root
+}
+
+test('isolated recovery installs the exact get-windows package outside active node_modules', (t) => {
+  const parent = tempParent(t)
+  let invocation
+
+  const recovery = recoverGetWindowsPackage({
+    arch: 'x64',
+    npmExecPath: '/fake/npm-cli.js',
+    platform: 'win32',
+    tempParent: parent,
+    run(command, args, options) {
+      invocation = { args, command, options }
+      const packageRoot = path.join(options.cwd, 'node_modules', 'get-windows')
+      fs.mkdirSync(path.join(packageRoot, 'lib'), { recursive: true })
+      fs.writeFileSync(
+        path.join(packageRoot, 'package.json'),
+        JSON.stringify({ name: 'get-windows', version: GET_WINDOWS_RECOVERY_VERSION })
+      )
+      fs.writeFileSync(path.join(packageRoot, 'index.js'), 'export default {}\n')
+      return { status: 0 }
+    }
+  })
+
+  assert.equal(invocation.command, process.execPath)
+  assert.equal(invocation.args[0], '/fake/npm-cli.js')
+  assert.equal(invocation.args[1], 'install')
+  assert.ok(invocation.args.includes('--workspaces=false'))
+  assert.ok(invocation.args.includes('--include=optional'))
+  assert.equal(invocation.options.cwd, recovery.recoveryRoot)
+  assert.equal(invocation.options.env.npm_config_platform, 'win32')
+  assert.equal(invocation.options.env.npm_config_arch, 'x64')
+
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(recovery.recoveryRoot, 'package.json'), 'utf8')
+  )
+  assert.deepEqual(manifest.dependencies, {
+    'get-windows': GET_WINDOWS_RECOVERY_VERSION
+  })
+  assert.deepEqual(manifest.allowScripts, {
+    [`get-windows@${GET_WINDOWS_RECOVERY_VERSION}`]: true
+  })
+  assert.equal(
+    recovery.packageRoot,
+    path.join(recovery.recoveryRoot, 'node_modules', 'get-windows')
+  )
+  assert.ok(fs.existsSync(recovery.recoveryRoot))
+
+  assert.equal(recovery.cleanup(), true)
+  assert.equal(recovery.cleanup(), true)
+  assert.equal(fs.existsSync(recovery.recoveryRoot), false)
+})
+
+test('failed isolated install is removed and cannot poison a later update', (t) => {
+  const parent = tempParent(t)
+
+  assert.throws(
+    () =>
+      recoverGetWindowsPackage({
+        npmExecPath: '/fake/npm-cli.js',
+        run: () => ({ status: 1 }),
+        tempParent: parent
+      }),
+    /isolated get-windows recovery install exited with 1/
+  )
+  assert.deepEqual(fs.readdirSync(parent), [])
+})
+
+test('supported native Windows staging retries with the recovered package root', () => {
+  const calls = []
+  let cleaned = false
+
+  const result = stageGetWindowsWithRecovery({
+    arch: 'x64',
+    hostArch: 'x64',
+    hostPlatform: 'win32',
+    platform: 'win32',
+    recover: () => ({
+      cleanup() {
+        cleaned = true
+      },
+      packageRoot: 'C:\\Temp\\isolated\\node_modules\\get-windows'
+    }),
+    stage(options) {
+      calls.push(options)
+      if (calls.length === 1) {
+        throw new Error(`${GET_WINDOWS_MISSING_ROOT_MARKER}win32-x64 native payload`)
+      }
+      assert.equal(
+        options.resolveRoot(),
+        'C:\\Temp\\isolated\\node_modules\\get-windows'
+      )
+      return 'staged'
+    }
+  })
+
+  assert.equal(result, 'staged')
+  assert.equal(calls.length, 2)
+  assert.equal(cleaned, true)
+})
+
+test('recovered temporary dependency is removed when the second staging attempt fails', () => {
+  let calls = 0
+  let cleaned = false
+
+  assert.throws(
+    () =>
+      stageGetWindowsWithRecovery({
+        arch: 'x64',
+        hostArch: 'x64',
+        hostPlatform: 'win32',
+        platform: 'win32',
+        recover: () => ({
+          cleanup() {
+            cleaned = true
+          },
+          packageRoot: 'C:\\Temp\\isolated\\node_modules\\get-windows'
+        }),
+        stage() {
+          calls += 1
+          if (calls === 1) {
+            throw new Error(`${GET_WINDOWS_MISSING_ROOT_MARKER}win32-x64 native payload`)
+          }
+          throw new Error('recovered package has no binding')
+        }
+      }),
+    /recovered package has no binding/
+  )
+  assert.equal(cleaned, true)
+})
+
+test('unrelated staging failures are never converted into dependency recovery', () => {
+  let recovered = false
+
+  assert.throws(
+    () =>
+      stageGetWindowsWithRecovery({
+        recover() {
+          recovered = true
+          throw new Error('should not run')
+        },
+        stage() {
+          throw new Error('native binary platform mismatch')
+        }
+      }),
+    /native binary platform mismatch/
+  )
+  assert.equal(recovered, false)
+})
+
+test('cross-platform and unsupported Windows architecture requests remain fail-closed', () => {
+  assert.equal(
+    canRecoverGetWindowsPackage({
+      arch: 'x64',
+      hostArch: 'x64',
+      hostPlatform: 'linux',
+      platform: 'win32'
+    }),
+    false
+  )
+  assert.equal(
+    canRecoverGetWindowsPackage({
+      arch: 'arm64',
+      hostArch: 'arm64',
+      hostPlatform: 'win32',
+      platform: 'win32'
+    }),
+    false
+  )
+  assert.equal(
+    canRecoverGetWindowsPackage({
+      arch: 'x64',
+      hostArch: 'x64',
+      hostPlatform: 'win32',
+      platform: 'win32'
+    }),
+    true
+  )
+})
+
+test('Desktop build and electron-builder hook both consume the recovery owner', () => {
+  const manifest = JSON.parse(
+    fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8')
+  )
+
+  assert.match(manifest.scripts.build, /stage-native-deps-recovery\.mjs$/)
+  assert.match(
+    manifest.scripts['check:test:desktop:all'],
+    /stage-native-deps-recovery\.test\.mjs/
+  )
+  assert.equal(manifest.build.beforePack, 'scripts/before-pack-recovery.mjs')
+})

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -21,7 +21,13 @@ const electronNative: TestProjectConfiguration = {
     name: 'electron',
     environment: 'node',
     include: ['electron/**/*.test.ts', 'scripts/**.test.{ts,mjs}'],
-    exclude: ['scripts/run-short-session-hang-repro.test.mjs']
+    exclude: [
+      'scripts/run-short-session-hang-repro.test.mjs',
+      // This suite is wired explicitly through `node --test` in
+      // check:test:desktop:all. Let one runner own it instead of making Node
+      // and Vitest reject each other's registration APIs.
+      'scripts/stage-native-deps-recovery.test.mjs'
+    ]
   }
 }
 


### PR DESCRIPTION
## Summary

Closes the repeat-update failure in #90829 where an interrupted or in-place Windows npm extraction leaves `node_modules/get-windows` present but unresolvable, and every later Desktop rebuild fails at the same fail-closed native staging gate.

The repair keeps supported Windows native staging fail-closed. It does **not** pretend `read_window_below` is optional on win32-x64, delete the active dependency tree, or retry another install into the same potentially locked/corrupt `node_modules`.

Instead, the Desktop build now:

1. lets the canonical staging owner inspect the active package tree;
2. recognizes only its exact missing/unresolvable-package verdict;
3. realizes exact `get-windows@9.3.0` in a fresh temporary npm prefix outside active `node_modules`;
4. enables only the pinned package's lifecycle script in that isolated manifest;
5. verifies the recovered package is importable and exactly version 9.3.0;
6. stages through the existing `stageGetWindows()` / `stageGetWindowsInto()` authority, including binding and binary-classification gates;
7. removes the temporary realization on success or failure.

Both ordinary `npm run build` staging and electron-builder's per-target `beforePack` path consume the same recovery owner.

## Root cause

#88233 by @helix4u correctly repaired the case where a valid `get-windows` package root exists but its Windows binding is missing: Hermes invokes that package's own `node-pre-gyp` installer and verifies the requested binding.

#90829 is the residual one boundary earlier. The reported Windows tree contains a partial `node_modules/get-windows` directory with no importable package root. The existing binding repair cannot run because staging never acquires a valid package object. Reusing the same active tree makes the failure persistent across every update.

## Guarantees

- Supported native targets remain fail-closed.
- A foreign-platform request cannot trigger host-native recovery.
- win32-arm64 retains the existing explicit degraded contract because 9.3.0 publishes no supported ARM64 binding.
- win32-x64/ia32 recovery is accepted only on the matching native host architecture.
- Unrelated native-platform, version, and binding failures are never laundered into recovery.
- The active repository `node_modules` is never deleted, rewritten, or used as the recovery destination.
- Failed recovery leaves no state that can poison the next update attempt.
- The existing rollback-preserving `beforePack` owner remains intact; the wrapper handles only the corrupt package-root residual.

## Files

- [`stage-native-deps-recovery.mjs`](https://github.com/andrexibiza/hermes-agent/blob/f88bbe7547e790c40da6586ce6948f936b356a8d/apps/desktop/scripts/stage-native-deps-recovery.mjs)
  - isolated exact-package realization and one bounded retry through canonical staging;
- [`before-pack-recovery.mjs`](https://github.com/andrexibiza/hermes-agent/blob/f88bbe7547e790c40da6586ce6948f936b356a8d/apps/desktop/scripts/before-pack-recovery.mjs)
  - preserves the existing beforePack transaction and handles only its missing-package verdict;
- [`stage-native-deps-recovery.test.mjs`](https://github.com/andrexibiza/hermes-agent/blob/f88bbe7547e790c40da6586ce6948f936b356a8d/apps/desktop/scripts/stage-native-deps-recovery.test.mjs)
  - exact package pin, isolated cwd, failure cleanup, exact retry, cleanup-after-stage-failure, unrelated-error preservation, architecture refusal, and production wiring;
- [`apps/desktop/package.json`](https://github.com/andrexibiza/hermes-agent/blob/f88bbe7547e790c40da6586ce6948f936b356a8d/apps/desktop/package.json)
  - routes normal build and per-target beforePack through the recovery owner and invokes the focused suite explicitly with `node --test`;
- [`apps/desktop/vitest.config.ts`](https://github.com/andrexibiza/hermes-agent/blob/f88bbe7547e790c40da6586ce6948f936b356a8d/apps/desktop/vitest.config.ts)
  - excludes that Node-owned suite from the broad Vitest collector so one runner owns one test file.

## CI runner correction

The first hosted run exposed a real wiring defect rather than a product failure: the focused `.test.mjs` file was both invoked explicitly by `node --test` and auto-collected by Vitest. A test module cannot statically register through both runner APIs.

The final arrangement is explicit:

- `stage-native-deps-recovery.test.mjs` imports `node:test`;
- `check:test:desktop:all` runs it directly;
- `vitest.config.ts` excludes it from the broad Electron-project glob;
- the rest of the Desktop platform suite remains under Vitest unchanged.

## Exact source-of-truth receipts

Current head: [`f88bbe7547e790c40da6586ce6948f936b356a8d`](https://github.com/andrexibiza/hermes-agent/commit/f88bbe7547e790c40da6586ce6948f936b356a8d)

Implementation chronology:

- [`9c6b47c66d197e88f0cdd1a1e06084a25edff589`](https://github.com/andrexibiza/hermes-agent/commit/9c6b47c66d197e88f0cdd1a1e06084a25edff589) — isolated exact dependency recovery;
- [`f67f4bd1bba730b89b2bf1c14c7ce6e6194a5fee`](https://github.com/andrexibiza/hermes-agent/commit/f67f4bd1bba730b89b2bf1c14c7ce6e6194a5fee) — expose the focused suite to hosted CI;
- [`4194a90b30fdc84e3f8b1d87634cc86d716bf47c`](https://github.com/andrexibiza/hermes-agent/commit/4194a90b30fdc84e3f8b1d87634cc86d716bf47c) — restore explicit Node-runner ownership;
- [`f88bbe7547e790c40da6586ce6948f936b356a8d`](https://github.com/andrexibiza/hermes-agent/commit/f88bbe7547e790c40da6586ce6948f936b356a8d) — remove the duplicate Vitest collection path.

Fresh exact-head workflows are attached directly to `f88bbe75...`:

- [CI run 32424226187](https://github.com/NousResearch/hermes-agent/actions/runs/32424226187)
- [Docker run 32424225554](https://github.com/NousResearch/hermes-agent/actions/runs/32424225554)
- [Nix run 32424225540](https://github.com/NousResearch/hermes-agent/actions/runs/32424225540)

No green status is inherited from a former head, parent, or adjacent PR.

## Topology and contributor credit

- Builds directly on merged #88233 by @helix4u; that PR remains the binding-level repair and provenance owner.
- #76088 by @RelaxJonh and #38170 / #34327 by @liuhao1024 remain complementary updater-wide npm-tree work.
- Interlocks #88683's transactional deployment architecture, #91079's package-generation settlement owner, and the stale/destructive Desktop update class represented by #88251 and #86443.

This is deliberately a narrow current-main repair: acquire a clean exact dependency realization before staging, verify it at the existing native boundary, and never let one corrupted active tree permanently brick future Windows updates.