### PR TITLE
feat(dashboard): add scoped Kanban read auth

### DIFF
--- a/hermes_cli/dashboard_auth/secret_strength.py
+++ b/hermes_cli/dashboard_auth/secret_strength.py
@@ -1,0 +1,50 @@
+"""Shared fail-closed strength checks for dashboard service secrets."""
+from __future__ import annotations
+
+import math
+from collections import Counter
+from typing import Optional
+
+
+# Default entropy bar: 43 url-safe-base64 chars ~= 256 bits. token_urlsafe(32)
+# produces 43 chars, so a correctly-provisioned secret clears this exactly.
+_DEFAULT_MIN_SECRET_CHARS = 43
+_MIN_DISTINCT_CHARS = 16
+_MIN_SHANNON_BITS = 128.0
+
+
+def _shannon_bits(value: str) -> float:
+    """Return the total Shannon entropy (bits) of ``value``."""
+    if not value:
+        return 0.0
+    counts = Counter(value)
+    n = len(value)
+    per_char = -sum((count / n) * math.log2(count / n) for count in counts.values())
+    return per_char * n
+
+
+def assess_secret_strength(
+    secret: str, *, min_chars: int = _DEFAULT_MIN_SECRET_CHARS
+) -> Optional[str]:
+    """Return a rejection reason for a weak secret, else ``None``."""
+    if not secret:
+        return "secret is empty"
+    if len(secret) < min_chars:
+        return (
+            f"secret too short: {len(secret)} chars (need >= {min_chars}; "
+            "use a >=256-bit value, e.g. `python -c \"import secrets; "
+            "print(secrets.token_urlsafe(32))\"`)"
+        )
+    distinct = len(set(secret))
+    if distinct < _MIN_DISTINCT_CHARS:
+        return (
+            f"secret has only {distinct} distinct characters (need >= "
+            f"{_MIN_DISTINCT_CHARS}); looks structured/low-entropy"
+        )
+    bits = _shannon_bits(secret)
+    if bits < _MIN_SHANNON_BITS:
+        return (
+            f"secret entropy too low: {bits:.0f} bits (need >= "
+            f"{_MIN_SHANNON_BITS:.0f}); looks structured/repeated"
+        )
+    return None

--- a/hermes_cli/dashboard_auth/token_auth.py
+++ b/hermes_cli/dashboard_auth/token_auth.py
@@ -15,7 +15,9 @@ How it fits the existing auth framework:
   * A route opts in by registering its exact path via
     :func:`register_token_route`. Only registered paths are token-authable;
     everything else is untouched, so this can never accidentally widen the
-    auth surface of an existing route.
+    auth surface of an existing route. A route may explicitly allow requests
+    without a bearer, or the exact legacy dashboard session bearer, to fall
+    through to the existing gate.
 
   * :func:`token_auth_middleware` runs OUTERMOST (installed last in
     ``web_server.py``). For a token route it fully owns the auth decision:
@@ -38,8 +40,11 @@ seam remembers and surfaces as 503 only if NO provider accepts the token.
 """
 from __future__ import annotations
 
+import hmac
+import ipaddress
 import logging
 import threading
+from dataclasses import dataclass
 from typing import Awaitable, Callable, Optional, Tuple
 
 from fastapi import Request
@@ -52,26 +57,137 @@ from hermes_cli.dashboard_auth.base import ProviderError, TokenPrincipal
 _log = logging.getLogger(__name__)
 
 # Exact paths that accept non-interactive bearer-token auth. A route registers
-# itself here at import/startup; the seam only acts on registered paths.
-_token_routes: set[str] = set()
+# itself here at import/startup; the seam only acts on registered paths. The
+# rule is deliberately exact-path only: there is no prefix or template match.
+@dataclass(frozen=True)
+class _TokenRouteRule:
+    methods: frozenset[str] | None = None
+    required_scope: str | None = None
+    loopback_only: bool = False
+    allow_session_fallback: bool = False
+
+
+_token_routes: dict[str, _TokenRouteRule] = {}
 _lock = threading.Lock()
 
 
-def register_token_route(path: str) -> None:
+def _normalise_methods(methods) -> frozenset[str] | None:
+    if methods is None:
+        return None
+    if isinstance(methods, str):
+        methods = (methods,)
+    normalised = []
+    for method in methods:
+        if not isinstance(method, str) or not method.strip():
+            raise ValueError("token route methods must be non-empty strings")
+        normalised.append(method.strip().upper())
+    if not normalised:
+        raise ValueError("token route methods must not be empty")
+    return frozenset(normalised)
+
+
+def register_token_route(
+    path: str,
+    *,
+    methods=None,
+    required_scope: str | None = None,
+    loopback_only: bool = False,
+    allow_session_fallback: bool = False,
+) -> None:
     """Mark ``path`` (exact match) as token-authable.
 
-    Idempotent. Call at module import / app setup so the seam knows which
-    routes to guard. Registering a route does NOT make it public — it makes
-    it authenticate by token instead of by session cookie.
+    ``methods=None``, ``required_scope=None``, ``loopback_only=False``, and
+    ``allow_session_fallback=False`` preserve the original route-agnostic
+    behaviour. Configured methods are normalised to uppercase. Duplicate
+    identical registrations are idempotent; a conflicting registration fails
+    rather than silently weakening a rule.
+
+    Call at module import / app setup so the seam knows which routes to guard.
+    Registering a route does NOT make it public — it makes it authenticate by
+    token instead of by session cookie.
     """
+    rule = _TokenRouteRule(
+        methods=_normalise_methods(methods),
+        required_scope=(
+            required_scope.strip() if required_scope is not None else None
+        ),
+        loopback_only=bool(loopback_only),
+        allow_session_fallback=bool(allow_session_fallback),
+    )
+    if rule.required_scope == "":
+        raise ValueError("token route required_scope must be non-empty")
     with _lock:
-        _token_routes.add(path)
+        previous = _token_routes.get(path)
+        if previous is None:
+            _token_routes[path] = rule
+            return
+        if previous == rule:
+            return
+        raise ValueError(
+            f"conflicting token route registration for exact path {path!r}: "
+            f"existing={previous!r}, requested={rule!r}"
+        )
 
 
-def is_token_route(path: str) -> bool:
-    """True if ``path`` was registered as token-authable (exact match)."""
+def is_token_route(path: str, method: str | None = None) -> bool:
+    """True if ``path`` (and optional ``method``) is token-authable."""
     with _lock:
-        return path in _token_routes
+        rule = _token_routes.get(path)
+    if rule is None:
+        return False
+    if method is None or rule.methods is None:
+        return True
+    return method.strip().upper() in rule.methods
+
+
+def _route_for_request(request: Request) -> Optional[_TokenRouteRule]:
+    """Return the applicable rule, or ``None`` to fall through to normal auth."""
+    path = request.url.path
+    with _lock:
+        rule = _token_routes.get(path)
+    if rule is None:
+        return None
+
+    method = getattr(request, "method", "GET")
+    if rule.methods is not None and method.upper() not in rule.methods:
+        return None
+
+    if rule.loopback_only:
+        app_state = getattr(getattr(request, "app", None), "state", None)
+        bound_host = getattr(app_state, "bound_host", None)
+        peer = getattr(getattr(request, "client", None), "host", None)
+        if not _is_loopback_bind(bound_host) or not _is_loopback_peer(peer):
+            return None
+    return rule
+
+
+def _is_loopback_bind(value: object) -> bool:
+    """Return True only for a known loopback bind value.
+
+    ``localhost`` is a deliberate, existing dashboard bind alias. Other
+    hostnames are not resolved here: DNS is not a trustworthy auth boundary.
+    Literal IPv4/IPv6 addresses use the standard library's loopback semantics,
+    including the complete IPv4 loopback range and IPv6 loopback forms.
+    """
+    if not isinstance(value, str):
+        return False
+    host = value.strip().lower()
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _is_loopback_peer(value: object) -> bool:
+    """Return True only for a literal, identifiable loopback request peer."""
+    if not isinstance(value, str) or not value.strip():
+        return False
+    try:
+        return ipaddress.ip_address(value.strip()).is_loopback
+    except ValueError:
+        return False
 
 
 def clear_token_routes() -> None:
@@ -101,14 +217,39 @@ def extract_bearer_token(request: Request) -> str:
     return ""
 
 
+def _has_valid_legacy_session_bearer(request: Request) -> bool:
+    """Return True only for the exact native dashboard session bearer.
+
+    This compatibility path is deliberately kept behind a route rule's
+    ``allow_session_fallback`` opt-in. It does not accept arbitrary bearer
+    headers and it reuses the dashboard's existing process-local session token
+    without logging or exposing the secret.
+    """
+    token = extract_bearer_token(request)
+    if not token:
+        return False
+    from hermes_cli import web_server
+
+    return hmac.compare_digest(
+        token.encode("utf-8"), web_server._SESSION_TOKEN.encode("utf-8")
+    )
+
+
 def authenticate_token(
     request: Request,
+    *,
+    required_scope: str | None = None,
 ) -> Tuple[Optional[TokenPrincipal], Optional[str]]:
     """Try every token provider against the request's bearer token.
 
     Returns ``(principal, unreachable_provider_name)``:
-      * ``(TokenPrincipal, None)`` — a provider recognised and accepted the token.
+      * ``(TokenPrincipal, None)`` — a provider recognised and accepted the
+        token. With ``required_scope``, providers lacking that scope are
+        skipped until a matching principal is found.
       * ``(None, None)`` — no token, or no provider recognised it (reject 401).
+      * ``(TokenPrincipal, None)`` lacking ``required_scope`` — one or more
+        providers recognised the token, but none had the required scope
+        (reject 403).
       * ``(None, name)`` — no provider accepted it AND at least one provider's
         backing store was unreachable (the caller surfaces 503, not 401, so a
         transient outage doesn't read as "bad credentials").
@@ -119,6 +260,7 @@ def authenticate_token(
     if not token:
         return None, None
     unreachable: Optional[str] = None
+    missing_scope: Optional[TokenPrincipal] = None
     for provider in list_token_providers():
         try:
             principal = provider.verify_token(token=token)
@@ -137,7 +279,12 @@ def authenticate_token(
             )
             continue
         if principal is not None:
-            return principal, None
+            if required_scope is None or required_scope in principal.scopes:
+                return principal, None
+            if missing_scope is None:
+                missing_scope = principal
+    if missing_scope is not None:
+        return missing_scope, None
     return None, unreachable
 
 
@@ -148,10 +295,13 @@ async def token_auth_middleware(
     """Outermost auth seam for token-authable routes.
 
     No-op pass-through for any path not registered via
-    :func:`register_token_route`. For a registered path, token auth is the
-    only accepted scheme:
+    :func:`register_token_route`. For an applicable exact route rule, token
+    auth is the only accepted scheme:
 
       * valid token  → attach principal + ``token_authenticated`` flag, pass through.
+      * valid token without the route's scope  → 403, without token auth.
+      * configured session fallback with no bearer, or the exact legacy
+        dashboard session bearer → downstream cookie/session/local auth decides.
       * unreachable  → 503 (provider backing store down; not "bad credentials").
       * otherwise    → 401 unauthenticated.
 
@@ -160,11 +310,37 @@ async def token_auth_middleware(
     enforcement, so a token-authed request is never redirected to ``/login``.
     """
     path = request.url.path
-    if not is_token_route(path):
+    rule = _route_for_request(request)
+    if rule is None:
         return await call_next(request)
 
-    principal, unreachable = authenticate_token(request)
+    if rule.allow_session_fallback:
+        if not request.headers.get("authorization", "").strip():
+            return await call_next(request)
+        if _has_valid_legacy_session_bearer(request):
+            return await call_next(request)
+
+    principal, unreachable = authenticate_token(
+        request, required_scope=rule.required_scope
+    )
     if principal is not None:
+        if rule.required_scope is not None and rule.required_scope not in principal.scopes:
+            # Do not let a principal that authenticated but lacks this route's
+            # capability bypass the downstream dashboard/session gate.
+            request.state.token_authenticated = False
+            audit_log(
+                AuditEvent.TOKEN_AUTH_FAILURE,
+                provider=principal.provider,
+                principal=principal.principal,
+                reason="missing_scope",
+                required_scope=rule.required_scope,
+                path=path,
+                ip=_client_ip(request),
+            )
+            return JSONResponse(
+                {"error": "forbidden", "detail": "Forbidden"},
+                status_code=403,
+            )
         request.state.token_principal = principal
         request.state.token_authenticated = True
         return await call_next(request)

--- a/plugins/dashboard_auth/drain/__init__.py
+++ b/plugins/dashboard_auth/drain/__init__.py
@@ -55,9 +55,7 @@ from __future__ import annotations
 
 import hmac
 import logging
-import math
 import os
-from collections import Counter
 from typing import Optional
 
 from hermes_cli.dashboard_auth import (
@@ -66,18 +64,15 @@ from hermes_cli.dashboard_auth import (
     Session,
     TokenPrincipal,
 )
+from hermes_cli.dashboard_auth.secret_strength import (
+    _DEFAULT_MIN_SECRET_CHARS,
+    _MIN_DISTINCT_CHARS,
+    _MIN_SHANNON_BITS,
+    _shannon_bits,
+    assess_secret_strength,
+)
 
 logger = logging.getLogger(__name__)
-
-# Default entropy bar: 43 url-safe-base64 chars ~= 256 bits. token_urlsafe(32)
-# produces 43 chars, so a correctly-provisioned secret clears this exactly.
-_DEFAULT_MIN_SECRET_CHARS = 43
-# A secret must contain at least this many DISTINCT characters — rejects
-# degenerate values like "aaaa..." that are long but trivially low-entropy.
-_MIN_DISTINCT_CHARS = 16
-# Shannon entropy floor (bits) over the secret's characters — a second,
-# distribution-aware guard on top of the length + distinct-count checks.
-_MIN_SHANNON_BITS = 128.0
 
 # The path the begin/cancel-drain endpoint lives on. Registered as a
 # token-authable route by ``register()`` so the generic seam guards it. Kept
@@ -85,56 +80,6 @@ _MIN_SHANNON_BITS = 128.0
 DRAIN_ROUTE_PATH = "/api/gateway/drain"
 
 LAST_SKIP_REASON: str = ""
-
-
-def _shannon_bits(value: str) -> float:
-    """Total Shannon entropy (bits) of ``value`` over its character distribution.
-
-    H = len * sum(-p_i * log2(p_i)). A long string drawn from a wide alphabet
-    scores high; a long run of one character scores ~0.
-    """
-    if not value:
-        return 0.0
-    counts = Counter(value)
-    n = len(value)
-    per_char = -sum((c / n) * math.log2(c / n) for c in counts.values())
-    return per_char * n
-
-
-def assess_secret_strength(
-    secret: str, *, min_chars: int = _DEFAULT_MIN_SECRET_CHARS
-) -> Optional[str]:
-    """Return a rejection reason if ``secret`` is too weak, else ``None``.
-
-    Fail-closed entropy gate (decisions.md Q-A). Checks, in order:
-      * length >= ``min_chars`` (default 43 url-safe-b64 chars ~= 256 bits),
-      * at least ``_MIN_DISTINCT_CHARS`` distinct characters,
-      * Shannon entropy >= ``_MIN_SHANNON_BITS`` bits.
-
-    A ``None`` return means the secret passes. Any string return is a
-    human-readable reason the caller logs + records as the skip reason.
-    """
-    if not secret:
-        return "secret is empty"
-    if len(secret) < min_chars:
-        return (
-            f"secret too short: {len(secret)} chars (need >= {min_chars}; "
-            "use a >=256-bit value, e.g. `python -c \"import secrets; "
-            "print(secrets.token_urlsafe(32))\"`)"
-        )
-    distinct = len(set(secret))
-    if distinct < _MIN_DISTINCT_CHARS:
-        return (
-            f"secret has only {distinct} distinct characters (need >= "
-            f"{_MIN_DISTINCT_CHARS}); looks structured/low-entropy"
-        )
-    bits = _shannon_bits(secret)
-    if bits < _MIN_SHANNON_BITS:
-        return (
-            f"secret entropy too low: {bits:.0f} bits (need >= "
-            f"{_MIN_SHANNON_BITS:.0f}); looks structured/repeated"
-        )
-    return None
 
 
 class DrainSecretProvider(DashboardAuthProvider):
@@ -270,19 +215,27 @@ def register(ctx) -> None:
         logger.warning("dashboard-auth-drain: %s", LAST_SKIP_REASON)
         return
 
-    ctx.register_dashboard_auth_provider(provider)
-
     # Opt the begin/cancel-drain endpoint into the generic token-auth seam so
     # the dashboard's interactive cookie gate doesn't bounce NAS's bearer call.
     try:
         from hermes_cli.dashboard_auth.token_auth import register_token_route
 
-        register_token_route(DRAIN_ROUTE_PATH)
-    except Exception as exc:  # noqa: BLE001 — seam import must not crash plugin load
-        logger.warning(
-            "dashboard-auth-drain: could not register token route %s: %s",
-            DRAIN_ROUTE_PATH, exc,
+        register_token_route(
+            DRAIN_ROUTE_PATH,
+            methods=("POST",),
+            required_scope=scope,
         )
+    except (ImportError, TypeError, ValueError) as exc:
+        LAST_SKIP_REASON = (
+            f"Drain token-route registration failed: {exc}; provider remains "
+            "disabled."
+        )
+        logger.warning(
+            "dashboard-auth-drain: %s", LAST_SKIP_REASON,
+        )
+        return
+
+    ctx.register_dashboard_auth_provider(provider)
 
     logger.info(
         "dashboard-auth-drain: registered drain service-credential provider "

--- a/plugins/dashboard_auth/kanban_read/__init__.py
+++ b/plugins/dashboard_auth/kanban_read/__init__.py
@@ -1,0 +1,128 @@
+"""KanbanReadSecretProvider — loopback-only read access to the board projection.
+
+This provider exposes one fixed capability: ``kanban.read``. Its bearer
+credential can authenticate only the exact ``GET /api/plugins/kanban/board``
+route, and only when both the dashboard bind and request peer are loopback.
+Browser requests without a service bearer continue through the native session
+gate; the native Kanban handler remains the sole source of the response
+envelope.
+"""
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+from typing import Optional
+
+from hermes_cli.dashboard_auth import (
+    DashboardAuthProvider,
+    LoginStart,
+    Session,
+    TokenPrincipal,
+)
+from hermes_cli.dashboard_auth.secret_strength import assess_secret_strength
+
+logger = logging.getLogger(__name__)
+
+KANBAN_BOARD_ROUTE_PATH = "/api/plugins/kanban/board"
+KANBAN_READ_SCOPE = "kanban.read"
+LAST_SKIP_REASON: str = ""
+
+
+class KanbanReadSecretProvider(DashboardAuthProvider):
+    """Non-interactive provider for the loopback Kanban board projection."""
+
+    name = "kanban-read-secret"
+    display_name = "Kanban Board Reader (service credential)"
+    supports_token = True
+    supports_session = False
+
+    def __init__(self, *, secret: str) -> None:
+        reason = assess_secret_strength(secret)
+        if reason is not None:
+            raise ValueError(f"kanban read secret rejected: {reason}")
+        self._secret = secret
+
+    def verify_token(self, *, token: str) -> Optional[TokenPrincipal]:
+        """Return the fixed board-reader principal on a constant-time match."""
+        if not token:
+            return None
+        if hmac.compare_digest(token.encode("utf-8"), self._secret.encode("utf-8")):
+            return TokenPrincipal(
+                principal="kanban-board-reader",
+                provider=self.name,
+                scopes=(KANBAN_READ_SCOPE,),
+            )
+        return None
+
+    def start_login(self, *, redirect_uri: str) -> LoginStart:
+        raise NotImplementedError(
+            "KanbanReadSecretProvider is a non-interactive service credential; "
+            "there is no login flow."
+        )
+
+    def complete_login(
+        self, *, code: str, state: str, code_verifier: str, redirect_uri: str
+    ) -> Session:
+        raise NotImplementedError(
+            "KanbanReadSecretProvider is a non-interactive service credential."
+        )
+
+    def verify_session(self, *, access_token: str) -> Optional[Session]:
+        return None
+
+    def refresh_session(self, *, refresh_token: str) -> Session:
+        raise NotImplementedError(
+            "KanbanReadSecretProvider is a non-interactive service credential."
+        )
+
+    def revoke_session(self, *, refresh_token: str) -> None:
+        return None
+
+
+def register(ctx) -> None:
+    """Register the provider only when its strong env credential is present."""
+    global LAST_SKIP_REASON
+    LAST_SKIP_REASON = ""
+
+    secret = os.environ.get("HERMES_DASHBOARD_KANBAN_READ_SECRET", "").strip()
+    if not secret:
+        LAST_SKIP_REASON = (
+            "HERMES_DASHBOARD_KANBAN_READ_SECRET is not set; the Kanban "
+            "read service credential remains disabled."
+        )
+        logger.debug("dashboard-auth-kanban-read: %s", LAST_SKIP_REASON)
+        return
+
+    reason = assess_secret_strength(secret)
+    if reason is not None:
+        LAST_SKIP_REASON = (
+            f"HERMES_DASHBOARD_KANBAN_READ_SECRET rejected — {reason}. "
+            "The Kanban read route stays disabled (fail-closed)."
+        )
+        logger.warning("dashboard-auth-kanban-read: %s", LAST_SKIP_REASON)
+        return
+
+    try:
+        provider = KanbanReadSecretProvider(secret=secret)
+        from hermes_cli.dashboard_auth.token_auth import register_token_route
+
+        register_token_route(
+            KANBAN_BOARD_ROUTE_PATH,
+            methods=("GET",),
+            required_scope=KANBAN_READ_SCOPE,
+            loopback_only=True,
+            allow_session_fallback=True,
+        )
+    except (ValueError, TypeError) as exc:
+        LAST_SKIP_REASON = f"Kanban read registration failed: {exc}"
+        logger.warning("dashboard-auth-kanban-read: %s", LAST_SKIP_REASON)
+        return
+
+    ctx.register_dashboard_auth_provider(provider)
+    logger.info(
+        "dashboard-auth-kanban-read: registered board-reader provider "
+        "(scope=%s, route=%s, method=GET, loopback-only)",
+        KANBAN_READ_SCOPE,
+        KANBAN_BOARD_ROUTE_PATH,
+    )

--- a/plugins/dashboard_auth/kanban_read/plugin.yaml
+++ b/plugins/dashboard_auth/kanban_read/plugin.yaml
@@ -1,0 +1,7 @@
+name: kanban-read-secret
+version: 1.0.0
+description: "Dashboard auth provider for exact loopback-only GET access to the native Kanban board projection. Uses HERMES_DASHBOARD_KANBAN_READ_SECRET, exposes the fixed kanban.read capability, and fails closed on weak or missing credentials."
+author: NousResearch
+kind: backend
+requires_env:
+  - HERMES_DASHBOARD_KANBAN_READ_SECRET

--- a/tests/hermes_cli/test_dashboard_token_auth.py
+++ b/tests/hermes_cli/test_dashboard_token_auth.py
@@ -62,7 +62,14 @@ class _TokenProvider(_OAuthOnly):
     display_name = "Token Provider"
     supports_token = True
 
-    def __init__(self, *, secret: str = "good-secret", scopes=("drain",)):
+    def __init__(
+        self,
+        *,
+        secret: str = "good-secret",
+        scopes=("drain",),
+        name: str = "tok",
+    ):
+        self.name = name
         self._secret = secret
         self._scopes = tuple(scopes)
 
@@ -112,21 +119,38 @@ class _FakeURL:
 
 
 class _FakeClient:
-    host = "1.2.3.4"
+    def __init__(self, host="1.2.3.4"):
+        self.host = host
 
 
 class _FakeRequest:
     """Minimal Request stand-in for the seam (no real Starlette needed)."""
 
-    def __init__(self, path="/api/gateway/drain", headers=None):
+    def __init__(
+        self,
+        path="/api/gateway/drain",
+        headers=None,
+        *,
+        method="GET",
+        bound_host=None,
+        client_host="1.2.3.4",
+    ):
         self.url = _FakeURL(path)
         self.headers = headers or {}
-        self.client = _FakeClient()
+        self.method = method
+        self.client = _FakeClient(client_host)
 
         class _State:
             pass
 
         self.state = _State()
+
+        class _AppState:
+            pass
+
+        self.app = type("_App", (), {})()
+        self.app.state = _AppState()
+        self.app.state.bound_host = bound_host
 
 
 def _run(coro):
@@ -210,6 +234,24 @@ def test_authenticate_token_buggy_provider_does_not_crash():
     assert principal is not None and principal.provider == "tok"
 
 
+def test_scoped_auth_continues_after_same_secret_principal_without_scope():
+    register_provider(
+        _TokenProvider(secret="same", scopes=("drain",), name="first")
+    )
+    register_provider(
+        _TokenProvider(secret="same", scopes=("kanban.read",), name="second")
+    )
+    token_auth.register_token_route(
+        "/read", required_scope="kanban.read"
+    )
+    req = _FakeRequest(path="/read", headers={"authorization": "Bearer same"})
+
+    resp = _run(token_auth.token_auth_middleware(req, _call_next_ok))
+
+    assert resp.status_code == 200
+    assert req.state.token_principal.provider == "second"
+
+
 # --------------------------------------------------------------------------
 # Middleware seam (route-agnostic)
 # --------------------------------------------------------------------------
@@ -235,3 +277,166 @@ def test_seam_rejects_wrong_token_401():
     assert resp.status_code == 401
 
 
+def test_legacy_route_registration_remains_method_agnostic_and_unscoped():
+    register_provider(_TokenProvider(secret="good", scopes=("anything",)))
+    token_auth.register_token_route("/legacy")
+    assert token_auth.is_token_route("/legacy")
+    assert token_auth.is_token_route("/legacy", "GET")
+    assert token_auth.is_token_route("/legacy", "POST")
+
+    req = _FakeRequest(
+        path="/legacy", method="PATCH", headers={"authorization": "Bearer good"}
+    )
+    resp = _run(token_auth.token_auth_middleware(req, _call_next_ok))
+    assert resp.status_code == 200
+    assert req.state.token_authenticated is True
+
+
+def test_route_method_matching_falls_through_for_other_methods():
+    register_provider(_TokenProvider(secret="good"))
+    token_auth.register_token_route("/read", methods=("get",))
+    assert token_auth.is_token_route("/read", "GET")
+    assert not token_auth.is_token_route("/read", "POST")
+
+    req = _FakeRequest(
+        path="/read", method="POST", headers={"authorization": "Bearer good"}
+    )
+    resp = _run(token_auth.token_auth_middleware(req, _call_next_ok))
+    assert resp.status_code == 200
+    assert not hasattr(req.state, "token_authenticated")
+
+
+def test_required_scope_allows_matching_principal():
+    register_provider(_TokenProvider(secret="good", scopes=("kanban.read",)))
+    token_auth.register_token_route(
+        "/read", methods=("GET",), required_scope="kanban.read"
+    )
+    req = _FakeRequest(
+        path="/read", headers={"authorization": "Bearer good"}, bound_host="127.0.0.1"
+    )
+    resp = _run(token_auth.token_auth_middleware(req, _call_next_ok))
+    assert resp.status_code == 200
+    assert req.state.token_authenticated is True
+
+
+def test_missing_required_scope_returns_403_without_token_authentication(monkeypatch):
+    register_provider(_TokenProvider(secret="good", scopes=("drain",)))
+    token_auth.register_token_route(
+        "/read", methods=("GET",), required_scope="kanban.read"
+    )
+    events = []
+    monkeypatch.setattr(
+        token_auth,
+        "audit_log",
+        lambda event, **fields: events.append((event, fields)),
+    )
+    req = _FakeRequest(
+        path="/read", headers={"authorization": "Bearer good"}, bound_host="127.0.0.1"
+    )
+    resp = _run(token_auth.token_auth_middleware(req, _call_next_ok))
+    assert resp.status_code == 403
+    assert getattr(req.state, "token_authenticated", False) is False
+    assert events[0][0].value == "token_auth_failure"
+    assert events[0][1]["reason"] == "missing_scope"
+
+
+def test_loopback_only_route_requires_known_loopback_bind():
+    register_provider(_TokenProvider(secret="good", scopes=("kanban.read",)))
+    token_auth.register_token_route(
+        "/read", methods=("GET",), required_scope="kanban.read", loopback_only=True
+    )
+    for bound_host in (None, "10.0.0.7"):
+        req = _FakeRequest(
+            path="/read",
+            headers={"authorization": "Bearer good"},
+            bound_host=bound_host,
+            client_host="127.0.0.1",
+        )
+        resp = _run(token_auth.token_auth_middleware(req, _call_next_ok))
+        assert resp.status_code == 200
+        assert not hasattr(req.state, "token_authenticated")
+
+    req = _FakeRequest(
+        path="/read",
+        headers={"authorization": "Bearer good"},
+        bound_host="localhost",
+        client_host="::1",
+    )
+    resp = _run(token_auth.token_auth_middleware(req, _call_next_ok))
+    assert resp.status_code == 200
+    assert req.state.token_authenticated is True
+
+
+@pytest.mark.parametrize("client_host", [None, "10.0.0.7", "not-an-ip"])
+def test_loopback_only_route_requires_known_loopback_peer_and_ignores_forwarded_for(
+    client_host,
+):
+    register_provider(_TokenProvider(secret="good", scopes=("kanban.read",)))
+    token_auth.register_token_route(
+        "/read", required_scope="kanban.read", loopback_only=True
+    )
+    req = _FakeRequest(
+        path="/read",
+        headers={
+            "authorization": "Bearer good",
+            "x-forwarded-for": "127.0.0.1",
+        },
+        bound_host="127.0.0.1",
+        client_host=client_host,
+    )
+
+    resp = _run(token_auth.token_auth_middleware(req, _call_next_ok))
+
+    assert resp.status_code == 200
+    assert not hasattr(req.state, "token_authenticated")
+
+
+def test_token_route_can_fall_through_to_native_session_gate_without_bearer():
+    register_provider(_TokenProvider(secret="good", scopes=("kanban.read",)))
+    token_auth.register_token_route(
+        "/read",
+        required_scope="kanban.read",
+        allow_session_fallback=True,
+    )
+    req = _FakeRequest(path="/read", headers={})
+
+    resp = _run(token_auth.token_auth_middleware(req, _call_next_ok))
+
+    assert resp.status_code == 200
+    assert not hasattr(req.state, "token_authenticated")
+
+
+def test_token_route_session_fallback_does_not_accept_invalid_bearer():
+    register_provider(_TokenProvider(secret="good", scopes=("kanban.read",)))
+    token_auth.register_token_route(
+        "/read",
+        required_scope="kanban.read",
+        allow_session_fallback=True,
+    )
+    req = _FakeRequest(
+        path="/read", headers={"authorization": "Bearer wrong"}
+    )
+
+    resp = _run(token_auth.token_auth_middleware(req, _call_next_ok))
+
+    assert resp.status_code == 401
+
+
+def test_duplicate_identical_route_is_idempotent_but_conflict_fails_closed():
+    token_auth.register_token_route(
+        "/read", methods=("get",), required_scope="kanban.read", loopback_only=True
+    )
+    token_auth.register_token_route(
+        "/read", methods=("GET",), required_scope="kanban.read", loopback_only=True
+    )
+    with pytest.raises(ValueError, match="conflicting token route registration"):
+        token_auth.register_token_route(
+            "/read", methods=("POST",), required_scope="kanban.read", loopback_only=True
+        )
+
+
+def test_route_clearing_removes_method_rules():
+    token_auth.register_token_route("/read", methods=("GET",))
+    assert token_auth.is_token_route("/read")
+    token_auth.clear_token_routes()
+    assert not token_auth.is_token_route("/read")

--- a/tests/plugins/dashboard_auth/test_drain_provider.py
+++ b/tests/plugins/dashboard_auth/test_drain_provider.py
@@ -147,6 +147,8 @@ class TestRegister:
         assert drain.LAST_SKIP_REASON == ""
         # The drain endpoint is now token-authable.
         assert token_auth.is_token_route(drain.DRAIN_ROUTE_PATH)
+        assert token_auth.is_token_route(drain.DRAIN_ROUTE_PATH, "POST")
+        assert not token_auth.is_token_route(drain.DRAIN_ROUTE_PATH, "GET")
 
     def test_config_scope_applied(self, drain, monkeypatch):
         s = _strong_secret()
@@ -158,6 +160,29 @@ class TestRegister:
         drain.register(ctx)
         provider = ctx.register_dashboard_auth_provider.call_args.args[0]
         assert provider.verify_token(token=s).scopes == ("lifecycle",)
+        assert token_auth.is_token_route(drain.DRAIN_ROUTE_PATH, "POST")
+        assert not token_auth.is_token_route(drain.DRAIN_ROUTE_PATH, "GET")
+
+    def test_route_registration_failure_does_not_register_provider(
+        self, drain, monkeypatch
+    ):
+        secret = _strong_secret()
+        monkeypatch.setenv("HERMES_DASHBOARD_DRAIN_SECRET", secret)
+        monkeypatch.setattr(drain, "_load_config_drain_auth_section", lambda: {})
+
+        def fail_route_registration(*args, **kwargs):
+            raise ValueError("route conflict")
+
+        monkeypatch.setattr(
+            token_auth, "register_token_route", fail_route_registration
+        )
+        ctx = MagicMock()
+
+        drain.register(ctx)
+
+        ctx.register_dashboard_auth_provider.assert_not_called()
+        assert "route conflict" in drain.LAST_SKIP_REASON
+        assert not token_auth.is_token_route(drain.DRAIN_ROUTE_PATH)
 
     def test_config_min_secret_chars_can_reject_otherwise_ok_secret(
         self, drain, monkeypatch

--- a/tests/plugins/dashboard_auth/test_kanban_read_provider.py
+++ b/tests/plugins/dashboard_auth/test_kanban_read_provider.py
@@ -1,0 +1,296 @@
+"""Tests for the loopback-only Kanban board read credential."""
+from __future__ import annotations
+
+import secrets
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hermes_cli import kanban_db
+from hermes_cli.dashboard_auth import (
+    TokenPrincipal,
+    assert_protocol_compliance,
+    clear_providers,
+    register_provider,
+)
+from hermes_cli.dashboard_auth import token_auth
+from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+import plugins.dashboard_auth.drain as drain_plugin
+import plugins.dashboard_auth.kanban_read as kanban_read
+
+
+def _strong_secret() -> str:
+    return secrets.token_urlsafe(32)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env_and_routes(monkeypatch):
+    monkeypatch.delenv("HERMES_DASHBOARD_KANBAN_READ_SECRET", raising=False)
+    monkeypatch.delenv("HERMES_DASHBOARD_DRAIN_SECRET", raising=False)
+    token_auth.clear_token_routes()
+    clear_providers()
+    yield
+    clear_providers()
+    token_auth.clear_token_routes()
+
+
+def test_protocol_and_capability_flags():
+    assert_protocol_compliance(kanban_read.KanbanReadSecretProvider)
+    provider = kanban_read.KanbanReadSecretProvider(secret=_strong_secret())
+    assert provider.supports_token is True
+    assert provider.supports_session is False
+
+
+def test_verify_token_returns_fixed_principal_and_scope():
+    secret = _strong_secret()
+    provider = kanban_read.KanbanReadSecretProvider(secret=secret)
+
+    principal = provider.verify_token(token=secret)
+    assert isinstance(principal, TokenPrincipal)
+    assert principal.principal == "kanban-board-reader"
+    assert principal.provider == "kanban-read-secret"
+    assert principal.scopes == ("kanban.read",)
+    assert provider.verify_token(token="wrong") is None
+    assert provider.verify_token(token="") is None
+
+
+def test_verify_token_uses_constant_time_credential_comparison(monkeypatch):
+    secret = _strong_secret()
+    provider = kanban_read.KanbanReadSecretProvider(secret=secret)
+    calls = []
+
+    def compare_digest(left, right):
+        calls.append((left, right))
+        return left == right
+
+    monkeypatch.setattr(kanban_read.hmac, "compare_digest", compare_digest)
+    assert provider.verify_token(token=secret) is not None
+    assert provider.verify_token(token="wrong") is None
+    assert len(calls) == 2
+    assert all(
+        isinstance(left, bytes) and isinstance(right, bytes)
+        for left, right in calls
+    )
+
+
+def test_constructor_rejects_weak_secret():
+    with pytest.raises(ValueError, match="kanban read secret rejected"):
+        kanban_read.KanbanReadSecretProvider(secret="weak")
+
+
+def test_interactive_methods_remain_unsupported():
+    provider = kanban_read.KanbanReadSecretProvider(secret=_strong_secret())
+    with pytest.raises(NotImplementedError):
+        provider.start_login(redirect_uri="https://example.test/callback")
+    with pytest.raises(NotImplementedError):
+        provider.complete_login(
+            code="c",
+            state="s",
+            code_verifier="v",
+            redirect_uri="https://example.test/callback",
+        )
+    with pytest.raises(NotImplementedError):
+        provider.refresh_session(refresh_token="r")
+
+
+class TestRegister:
+    def test_noop_when_secret_missing(self):
+        ctx = MagicMock()
+        kanban_read.register(ctx)
+        ctx.register_dashboard_auth_provider.assert_not_called()
+        assert "HERMES_DASHBOARD_KANBAN_READ_SECRET" in kanban_read.LAST_SKIP_REASON
+        assert not token_auth.is_token_route(kanban_read.KANBAN_BOARD_ROUTE_PATH)
+
+    def test_weak_secret_fails_closed(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DASHBOARD_KANBAN_READ_SECRET", "too-weak")
+        ctx = MagicMock()
+        kanban_read.register(ctx)
+        ctx.register_dashboard_auth_provider.assert_not_called()
+        assert "rejected" in kanban_read.LAST_SKIP_REASON
+        assert not token_auth.is_token_route(kanban_read.KANBAN_BOARD_ROUTE_PATH)
+
+    def test_strong_env_secret_registers_exact_get_and_fixed_scope(self, monkeypatch):
+        secret = _strong_secret()
+        monkeypatch.setenv("HERMES_DASHBOARD_KANBAN_READ_SECRET", f"  {secret}  ")
+        ctx = MagicMock()
+        kanban_read.register(ctx)
+
+        ctx.register_dashboard_auth_provider.assert_called_once()
+        provider = ctx.register_dashboard_auth_provider.call_args.args[0]
+        assert isinstance(provider, kanban_read.KanbanReadSecretProvider)
+        assert provider.verify_token(token=secret).scopes == ("kanban.read",)
+        assert kanban_read.LAST_SKIP_REASON == ""
+        assert token_auth.is_token_route(kanban_read.KANBAN_BOARD_ROUTE_PATH, "GET")
+        assert not token_auth.is_token_route(kanban_read.KANBAN_BOARD_ROUTE_PATH, "POST")
+
+    def test_route_registration_conflict_skips_provider(self, monkeypatch):
+        secret = _strong_secret()
+        monkeypatch.setenv("HERMES_DASHBOARD_KANBAN_READ_SECRET", secret)
+
+        def fail_route_registration(*args, **kwargs):
+            raise ValueError("route conflict")
+
+        monkeypatch.setattr(
+            token_auth, "register_token_route", fail_route_registration
+        )
+        ctx = MagicMock()
+
+        kanban_read.register(ctx)
+
+        ctx.register_dashboard_auth_provider.assert_not_called()
+        assert "route conflict" in kanban_read.LAST_SKIP_REASON
+        assert not token_auth.is_token_route(kanban_read.KANBAN_BOARD_ROUTE_PATH)
+
+
+@pytest.fixture
+def mounted_dashboard(tmp_path, monkeypatch):
+    from hermes_cli import web_server
+
+    home = tmp_path / "hermes-home"
+    kanban_home = tmp_path / "kanban-home"
+    home.mkdir()
+    kanban_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(kanban_home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kanban_db.init_db()
+
+    kanban_secret = _strong_secret()
+    drain_secret = _strong_secret()
+    monkeypatch.setenv("HERMES_DASHBOARD_KANBAN_READ_SECRET", kanban_secret)
+    monkeypatch.setenv("HERMES_DASHBOARD_DRAIN_SECRET", drain_secret)
+    monkeypatch.setattr(drain_plugin, "_load_config_drain_auth_section", lambda: {})
+
+    kanban_ctx = MagicMock()
+    kanban_read.register(kanban_ctx)
+    drain_ctx = MagicMock()
+    drain_plugin.register(drain_ctx)
+    register_provider(kanban_ctx.register_dashboard_auth_provider.call_args.args[0])
+    register_provider(drain_ctx.register_dashboard_auth_provider.call_args.args[0])
+    register_provider(StubAuthProvider())
+
+    previous = {
+        "bound_host": getattr(web_server.app.state, "bound_host", None),
+        "bound_port": getattr(web_server.app.state, "bound_port", None),
+        "auth_required": getattr(web_server.app.state, "auth_required", None),
+    }
+    web_server.app.state.bound_host = "127.0.0.1"
+    web_server.app.state.bound_port = 8765
+    web_server.app.state.auth_required = False
+    client = TestClient(
+        web_server.app,
+        base_url="http://127.0.0.1:8765",
+        client=("127.0.0.1", 50000),
+    )
+
+    yield client, web_server.app, kanban_secret, drain_secret
+
+    clear_providers()
+    token_auth.clear_token_routes()
+    for key, value in previous.items():
+        setattr(web_server.app.state, key, value)
+
+
+def _count_tasks() -> int:
+    conn = kanban_db.connect()
+    try:
+        return len(kanban_db.list_tasks(conn))
+    finally:
+        conn.close()
+
+
+def test_mounted_loopback_routes_are_read_only_and_scope_bound(mounted_dashboard):
+    client, app, kanban_secret, drain_secret = mounted_dashboard
+    from hermes_cli import web_server
+
+    board_path = kanban_read.KANBAN_BOARD_ROUTE_PATH
+    kanban_headers = {"Authorization": f"Bearer {kanban_secret}"}
+    browser_headers = {
+        web_server._SESSION_HEADER_NAME: web_server._SESSION_TOKEN,
+    }
+
+    board = client.get(board_path, headers=kanban_headers)
+    assert board.status_code == 200, board.text
+    assert {"columns", "tenants", "assignees", "latest_event_id", "now"}.issubset(
+        board.json()
+    )
+
+    browser_board = client.get(board_path, headers=browser_headers)
+    assert browser_board.status_code == 200, browser_board.text
+    assert {"columns", "latest_event_id"}.issubset(browser_board.json())
+    assert client.get(board_path).status_code == 401
+    assert client.get(board_path, headers={"Authorization": "Bearer wrong"}).status_code == 401
+    assert client.get(
+        board_path, headers={"Authorization": f"Bearer {drain_secret}"}
+    ).status_code == 403
+    assert client.post(
+        "/api/gateway/drain", headers=kanban_headers, json={"action": "drain"}
+    ).status_code == 403
+
+    before = _count_tasks()
+    task_response = client.post(
+        "/api/plugins/kanban/tasks",
+        headers=kanban_headers,
+        json={"title": "must not exist"},
+    )
+    assert not 200 <= task_response.status_code < 300
+    assert _count_tasks() == before
+
+
+def test_mounted_kanban_board_accepts_legacy_dashboard_bearer_session(
+    mounted_dashboard,
+):
+    client, _app, _kanban_secret, _drain_secret = mounted_dashboard
+    from hermes_cli import web_server
+
+    response = client.get(
+        kanban_read.KANBAN_BOARD_ROUTE_PATH,
+        headers={"Authorization": f"Bearer {web_server._SESSION_TOKEN}"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert {"columns", "latest_event_id"}.issubset(response.json())
+
+
+def test_mounted_non_loopback_and_unknown_bind_fall_back_to_dashboard_session(
+    mounted_dashboard,
+):
+    _loopback_client, app, kanban_secret, _drain_secret = mounted_dashboard
+
+    app.state.bound_host = "10.0.0.7"
+    app.state.auth_required = True
+    remote = TestClient(
+        app,
+        base_url="https://10.0.0.7:8765",
+        client=("10.0.0.7", 50001),
+    )
+    service_response = remote.get(
+        kanban_read.KANBAN_BOARD_ROUTE_PATH,
+        headers={"Authorization": f"Bearer {kanban_secret}"},
+    )
+    assert service_response.status_code == 401
+
+    login = remote.get("/auth/login?provider=stub", follow_redirects=False)
+    assert login.status_code == 302
+    state = login.headers["location"].split("state=", 1)[1]
+    callback = remote.get(
+        f"/auth/callback?code=stub_code&state={state}", follow_redirects=False
+    )
+    assert callback.status_code == 302
+    assert remote.get(kanban_read.KANBAN_BOARD_ROUTE_PATH).status_code == 200
+    assert remote.get("/api/auth/me").status_code == 200
+
+    app.state.bound_host = None
+    unknown_bind = TestClient(
+        app,
+        base_url="http://127.0.0.1:8765",
+        client=("127.0.0.1", 50002),
+    )
+    unknown_response = unknown_bind.get(
+        kanban_read.KANBAN_BOARD_ROUTE_PATH,
+        headers={"Authorization": f"Bearer {kanban_secret}"},
+    )
+    assert unknown_response.status_code == 401


### PR DESCRIPTION
## Summary

- extend the existing dashboard token route registry with exact HTTP methods, required scopes, and an optional loopback-only peer check
- add a bundled `kanban.read` service credential for only `GET /api/plugins/kanban/board`
- keep browser/session access compatible, including the existing dashboard bearer-session token on routes that explicitly allow session fallback
- share the existing fail-closed service-secret strength checks with the drain provider

## Security boundaries

- missing, malformed, weak, or wrong service credentials fail closed
- the `kanban.read` credential is accepted only on a loopback-bound dashboard from a loopback peer
- exact path + exact method + exact scope are checked before the Kanban handler runs
- Kanban POST/PATCH/PUT/DELETE routes and sibling GET routes remain outside this credential's authority
- token comparison is constant-time; credentials are not returned or logged

## Compatibility

The native Kanban handler remains the response authority. Existing browser cookie/session access is unchanged. Providers that use the older path-only registration continue to work with the existing defaults.

This is intentionally narrower than #61982, which proposes a broader Kanban API/RBAC surface. This PR only supplies a scoped service-auth seam for the existing board projection route.

## Verification

After rebasing onto current `main` (`4a5b6dd4512a10c3c18da3e5b9e5c7fb681cbfbb`):

- `tests/hermes_cli/test_dashboard_token_auth.py`: 20 passed
- `tests/plugins/dashboard_auth/test_drain_provider.py`: 18 passed
- `tests/plugins/dashboard_auth/test_kanban_read_provider.py`: 12 passed
- targeted total: 50 passed, 0 failed
- changed Python files compile successfully
- `git diff --check` passes

No installed Hermes runtime, service, database, or production configuration was changed.
