### PR TITLE
fix(desktop): sidebar search rows show the session title, not the matched snippet

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -267,7 +267,13 @@ export function stripFtsMarkers(snippet: string): string {
   return snippet.replaceAll('>>>', '').replaceAll('<<<', '')
 }
 
-function searchResultToSession(result: SessionSearchResult): SessionInfo {
+// The backend already ships the real session title on every search hit
+// (web_routers/sessions.py add_lineage_result enriches via
+// get_session_rich_row). Map it onto the synthesized row so the sidebar
+// paints the actual name; the snippet stays as the preview. Sessions with
+// no title keep today's snippet fallback via sessionTitle().
+// Exported for tests.
+export function searchResultToSession(result: SessionSearchResult): SessionInfo {
   const ts = result.session_started ?? Date.now() / 1000
 
   return {
@@ -285,7 +291,7 @@ function searchResultToSession(result: SessionSearchResult): SessionInfo {
     preview: stripFtsMarkers(result.snippet ?? '').trim() || null,
     source: result.source ?? null,
     started_at: ts,
-    title: null,
+    title: result.title?.trim() || null,
     tool_call_count: 0
   }
 }

--- a/apps/desktop/src/app/chat/sidebar/search-result-to-session.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/search-result-to-session.test.ts
@@ -1,0 +1,57 @@
+// Regression: the backend's /api/sessions/search payload already carries the
+// real session title on every hit (web_routers/sessions.py add_lineage_result
+// enriches via get_session_rich_row), but the sidebar search mapper dropped it
+// (title: null). sessionTitle() then fell back to the preview — the FTS
+// snippet of the matched message — painting rows with raw message content
+// (tool JSON, shell commands) as the session name until the row loaded
+// (Aug 2026).
+import { describe, expect, it } from 'vitest'
+
+import { searchResultToSession } from './index'
+
+describe('searchResultToSession', () => {
+  it('uses the backend-provided title for the synthesized row', () => {
+    const s = searchResultToSession({
+      lineage_root: 'root-1',
+      model: 'deepseek-v4-flash',
+      role: 'tool',
+      session_id: '20260725_132',
+      session_started: 1753450000,
+      snippet: '{"bytes_written": 1879, "dirs_created": true}',
+      source: 'agent',
+      title: '  Fact-checking PR review comments  '
+    })
+
+    expect(s.title).toBe('Fact-checking PR review comments')
+    expect(s.id).toBe('20260725_132')
+  })
+
+  it('keeps the FTS snippet as the preview with markers stripped', () => {
+    const s = searchResultToSession({
+      session_id: 'cron_f7da0e4',
+      session_started: null,
+      snippet: '...Report "PR #>>>67834<<< still in draft..."',
+      role: 'user',
+      model: null,
+      source: 'cron',
+      title: 'PR #67834 CI followup'
+    })
+
+    expect(s.title).toBe('PR #67834 CI followup')
+    expect(s.preview).toBe('...Report "PR #67834 still in draft..."')
+  })
+
+  it('leaves title null when the backend sends none (untitled session)', () => {
+    const s = searchResultToSession({
+      session_id: '20260720_233',
+      session_started: null,
+      snippet: '[{"id": "call_d632e8dc7bf740048f242bfe", "c...',
+      role: 'assistant',
+      model: null,
+      source: null
+    })
+
+    expect(s.title).toBeNull()
+    expect(s.preview).toBe('[{"id": "call_d632e8dc7bf740048f242bfe", "c...')
+  })
+})

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1177,6 +1177,11 @@ export interface SessionSearchResult {
   session_started: number | null
   snippet: string
   source: string | null
+  /** Real session title from the sessions table (absent for untitled
+   *  sessions). The backend enriches every result with it; the sidebar maps
+   *  it onto the synthesized row so search hits show the actual name, not
+   *  the matched-message snippet. */
+  title?: string | null
 }
 
 export interface SessionSearchResponse {


### PR DESCRIPTION
## What

Desktop sidebar session search results painted the **matched message content** (tool JSON, shell commands, report text) as the session name instead of the session's actual title. Clicking a row loaded the session and the name corrected itself. This PR makes search rows show the real session title immediately; the FTS snippet stays as the secondary preview.

## Root cause

The backend already sends the real title on every search hit — `hermes_cli/web_routers/sessions.py` `add_lineage_result()` enriches each result via `get_session_rich_row()` (which selects `s.*` including `title`). The renderer dropped it:

- `apps/desktop/src/types/hermes.ts` — `SessionSearchResult` never declared the `title` field the backend sends.
- `apps/desktop/src/app/chat/sidebar/index.tsx` — `searchResultToSession()` synthesized the pre-load row with `title: null` hardcoded and `preview` = the stripped FTS snippet.
- `apps/desktop/src/lib/chat-runtime.ts` — `sessionTitle()` is `title?.trim() || preview?.trim() || 'Untitled session'`, so the row label fell through to the matched-message snippet.

Rows already loaded in the sidebar were unaffected (`loaded ?? searchResultToSession(match)`); only server-synthesized rows showed garbage names — exactly the reported behavior.

## Change

1. `SessionSearchResult` gains `title?: string | null` (matches `SessionInfo.title: null | string`).
2. `searchResultToSession()` maps `result.title?.trim() || null` onto the synthesized row (exported for tests, mirroring `stripFtsMarkers`).
3. New regression test `search-result-to-session.test.ts`: titled rows use the backend title, the snippet stays as preview with FTS markers stripped, and genuinely untitled sessions keep the snippet fallback.

No backend change — the payload already carried the data.

## Verification

- Live probe against a real profile DB calling the actual endpoint handler: 7 of 8 results carried a real `title`; the UI showed the snippet instead (symptom reproduced 1:1 from the report).
- `vitest run --environment jsdom src/app/chat/sidebar/search-result-to-session.test.ts` — **3/3 pass**; with the fix reverted, **2 fail** (`expected null to be 'Fact-checking PR review comments'`) — the test guards the regression, not a tautology.
- `tsc --noEmit -p apps/desktop/tsconfig.json` — clean.
- ESLint on changed files — clean.

Closes #91068
