### PR TITLE
fix(cron): route multiplex cron delivery through each profile's adapters

### DIFF
--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -511,6 +511,7 @@ class InProcessCronScheduler(CronScheduler):
         interval=60,
         can_dispatch=None,
         profile_homes=None,
+        profile_adapters=None,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
@@ -538,6 +539,7 @@ class InProcessCronScheduler(CronScheduler):
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
+                profile_adapters=profile_adapters,
             )
             return
 
@@ -609,6 +611,7 @@ class InProcessCronScheduler(CronScheduler):
         loop=None,
         interval=60,
         can_dispatch=None,
+        profile_adapters=None,
     ):
         """Tick every served profile's cron store when multiplex_profiles is on.
 
@@ -662,12 +665,33 @@ class InProcessCronScheduler(CronScheduler):
                 else:
                     for entry in profile_homes:
                         home = entry[1] if isinstance(entry, tuple) else entry
+                        profile_name = entry[0] if isinstance(entry, tuple) else None
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
+                                # Route delivery through the OWNING profile's
+                                # live adapters. Platforms that scope user ids
+                                # per app (QQ/WeCom openids) reject a recipient
+                                # that belongs to a different bot, so a
+                                # secondary profile must never be delivered
+                                # through the default profile's adapters.
+                                #
+                                # Fail closed when a secondary profile has no
+                                # registry entry (its adapter failed to connect
+                                # or has not registered yet): deliver with no
+                                # adapters rather than over the wrong bot,
+                                # matching the inbound path's fail-closed
+                                # resolution for unregistered secondary
+                                # profiles.
+                                tick_adapters = adapters
+                                if profile_adapters is not None and profile_name:
+                                    if profile_name in profile_adapters:
+                                        tick_adapters = profile_adapters[profile_name]
+                                    elif profile_name != "default":
+                                        tick_adapters = {}
                                 cron_tick(
                                     verbose=False,
-                                    adapters=adapters,
+                                    adapters=tick_adapters,
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30671,6 +30671,14 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             profile_homes = _multiplex_profile_homes(runner.config)
             if profile_homes:
                 cron_start_kwargs["profile_homes"] = profile_homes
+                # Secondary-profile cron jobs must deliver through THAT
+                # profile's live adapters, not the default profile's — on
+                # platforms that scope user ids per app (QQ/WeCom openids)
+                # sending with the wrong bot's token fails outright. Pass the
+                # per-profile adapter map so the ticker can route delivery.
+                cron_start_kwargs["profile_adapters"] = getattr(
+                    runner, "_profile_adapters", {}
+                ) or {}
                 logger.info(
                     "Cron scheduler will tick %d profile(s) under multiplex: %s",
                     len(profile_homes),

--- a/tests/cron/test_multiplex_cron_delivery_adapter.py
+++ b/tests/cron/test_multiplex_cron_delivery_adapter.py
@@ -1,0 +1,198 @@
+"""Multiplex cron delivery must use each profile's own live adapters.
+
+Regression coverage for a multiplex-only delivery bug: when
+``gateway.multiplex_profiles`` is on, a secondary profile's cron job was
+delivered through the DEFAULT profile's adapter map instead of that
+profile's own adapters.
+
+Why that breaks in the real world: per-app messaging platforms scope their
+user identifiers to the bot/app that received them (QQ and WeCom openids,
+for example). Delivering a secondary profile's job through the default
+profile's adapter sends the message with the wrong bot's token, so the
+platform rejects the recipient id outright — the job runs, is recorded as
+successful, and the user silently never receives the output.
+
+``GatewayRunner._profile_adapters`` (``Dict[str, Dict[Platform, adapter]]``,
+populated by ``_start_secondary_profile_adapters``) already holds the
+per-profile adapter maps for the inbound path. These tests pin the contract
+that the multiplex cron ticker routes delivery through the same map, that an
+unregistered secondary profile fails closed instead of borrowing the default
+profile's adapters, and that callers which pass no registry keep the previous
+behaviour.
+"""
+
+import threading
+
+import pytest
+
+
+def _drive_one_multiplex_tick(monkeypatch, *, profile_homes, adapters, profile_adapters):
+    """Run ``_start_multiplex`` for a single tick and return the captured
+    ``adapters=`` kwarg that ``cron.scheduler.tick`` was called with, keyed by
+    the HERMES_HOME override active at call time.
+
+    The ticker loop is stopped after the first full pass so the assertions run
+    against exactly one tick per profile.
+    """
+    from cron import scheduler_provider as sp
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    seen = []
+    stop = threading.Event()
+
+    def fake_tick(*args, **kwargs):
+        # Record which home is scoped so each call can be attributed to the
+        # profile whose store is being ticked.
+        from hermes_constants import get_hermes_home
+
+        seen.append((str(get_hermes_home()), kwargs.get("adapters")))
+        if len(seen) >= len(profile_homes):
+            stop.set()
+        return 0
+
+    monkeypatch.setattr("cron.scheduler.tick", fake_tick)
+
+    # Neutralise the per-profile bookkeeping so the test exercises delivery
+    # routing only; these are covered by their own suites.
+    monkeypatch.setattr(sp.InProcessCronScheduler, "recover_interrupted", lambda self: 0)
+    monkeypatch.setattr("cron.jobs.record_ticker_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr("cron.jobs.clear_ticker_error", lambda *a, **k: None)
+    monkeypatch.setattr("cron.jobs.record_ticker_error", lambda *a, **k: None)
+
+    scheduler = InProcessCronScheduler()
+    scheduler._start_multiplex(
+        stop,
+        profile_homes=profile_homes,
+        adapters=adapters,
+        loop=None,
+        interval=0,
+        profile_adapters=profile_adapters,
+    )
+    return seen
+
+
+@pytest.fixture
+def profile_homes(tmp_path):
+    """Two served profiles, mirroring a default + secondary multiplex setup."""
+    default_home = tmp_path / "default"
+    secondary_home = tmp_path / "secondary"
+    for home in (default_home, secondary_home):
+        (home / "cron").mkdir(parents=True, exist_ok=True)
+    return [("default", default_home), ("secondary", secondary_home)]
+
+
+def test_secondary_profile_ticks_with_its_own_adapters(monkeypatch, profile_homes):
+    """Each profile's tick receives that profile's own adapter map.
+
+    This is the bug: the secondary profile used to be ticked with the shared
+    (default) adapters, so its delivery went out over the wrong bot.
+    """
+    shared_adapters = {"qq": "default-bot-adapter"}
+    profile_adapters = {
+        "default": {"qq": "default-bot-adapter"},
+        "secondary": {"qq": "secondary-bot-adapter"},
+    }
+
+    seen = _drive_one_multiplex_tick(
+        monkeypatch,
+        profile_homes=profile_homes,
+        adapters=shared_adapters,
+        profile_adapters=profile_adapters,
+    )
+
+    by_home = {home: used for home, used in seen}
+    default_home = str(profile_homes[0][1])
+    secondary_home = str(profile_homes[1][1])
+
+    assert by_home[default_home] == profile_adapters["default"]
+    assert by_home[secondary_home] == profile_adapters["secondary"], (
+        "secondary profile was ticked with the wrong adapter map — its cron "
+        "delivery would go out over the default profile's bot token"
+    )
+
+
+def test_unregistered_secondary_profile_does_not_fall_back_to_default(
+    monkeypatch, profile_homes
+):
+    """A secondary profile missing from the registry must NOT use the shared map.
+
+    Secondary adapters connect asynchronously and can fail to connect at all,
+    so a tick can land while a profile has no registry entry. Falling back to
+    the shared (default) adapters would re-introduce exactly the bug this fix
+    closes: the message goes out over the default bot's token and a per-app
+    platform rejects the recipient id.
+
+    This mirrors the inbound path's fail-closed adapter resolution for
+    unregistered secondary profiles.
+    """
+    shared_adapters = {"qq": "default-bot-adapter"}
+    # Only the default profile is registered; 'secondary' is absent.
+    profile_adapters = {"default": {"qq": "default-bot-adapter"}}
+
+    seen = _drive_one_multiplex_tick(
+        monkeypatch,
+        profile_homes=profile_homes,
+        adapters=shared_adapters,
+        profile_adapters=profile_adapters,
+    )
+
+    by_home = {home: used for home, used in seen}
+    default_home = str(profile_homes[0][1])
+    secondary_home = str(profile_homes[1][1])
+
+    # The default profile still uses its own (== shared) adapters.
+    assert by_home[default_home] == profile_adapters["default"]
+    # The unregistered secondary profile must not inherit them.
+    assert by_home[secondary_home] != shared_adapters, (
+        "unregistered secondary profile fell back to the default profile's "
+        "adapters — delivery would go out over the wrong bot's token"
+    )
+    assert not by_home[secondary_home]
+
+
+def test_no_registry_preserves_single_profile_behaviour(monkeypatch, profile_homes):
+    """Without ``profile_adapters`` every profile ticks with the shared map.
+
+    Back-compat contract: callers that never pass the registry (and the
+    non-multiplex path) must behave exactly as before this fix.
+    """
+    shared_adapters = {"qq": "default-bot-adapter"}
+
+    seen = _drive_one_multiplex_tick(
+        monkeypatch,
+        profile_homes=profile_homes,
+        adapters=shared_adapters,
+        profile_adapters=None,
+    )
+
+    assert seen, "ticker never called tick()"
+    for home, used in seen:
+        assert used == shared_adapters, f"profile at {home} lost the shared adapters"
+
+
+def test_empty_registry_still_fails_closed_for_secondary(monkeypatch, profile_homes):
+    """An empty registry is a "nothing registered yet" state, not "no multiplex".
+
+    ``gateway/run.py`` passes the registry only on the multiplex path, where it
+    is empty until secondary adapters finish connecting. During that window the
+    default profile keeps the shared adapters (they are its own), while a
+    secondary profile must still fail closed rather than borrow them.
+    """
+    shared_adapters = {"qq": "default-bot-adapter"}
+
+    seen = _drive_one_multiplex_tick(
+        monkeypatch,
+        profile_homes=profile_homes,
+        adapters=shared_adapters,
+        profile_adapters={},
+    )
+
+    by_home = {home: used for home, used in seen}
+    default_home = str(profile_homes[0][1])
+    secondary_home = str(profile_homes[1][1])
+
+    assert by_home[default_home] == shared_adapters
+    assert not by_home[secondary_home], (
+        "secondary profile borrowed the default profile's adapters while the "
+        "registry was still empty"
+    )


### PR DESCRIPTION
### Problem

Reported in #83182, which has two root causes — this PR fixes the **adapter-map routing** half only.

When `gateway.multiplex_profiles` is on, `InProcessCronScheduler._start_multiplex` scopes every profile's tick correctly (`set_hermes_home_override` + `use_cron_store`) but passes the same shared adapter map to each `cron_tick()` call. A secondary profile's job is therefore delivered through the **default** profile's adapters.

Platforms that scope user identifiers per app reject a recipient id that belongs to a different bot — QQ and WeCom openids, and the Telegram thread ownership in the original report (`Thread 9539 not found ... retrying without message_thread_id`). The job runs, records success, and the output silently never reaches the user, which is the worst failure mode for a scheduled alert.

### Fix

Route multiplex cron delivery through the owning profile's live adapter registry. `GatewayRunner._profile_adapters` (`Dict[str, Dict[Platform, adapter]]`, populated by `_start_secondary_profile_adapters`) already holds those maps for the inbound multiplex path, so this reuses the existing registry rather than adding new state.

An unregistered secondary profile **fails closed** instead of falling back to the default profile's adapters:

```python
tick_adapters = adapters
if profile_adapters is not None and profile_name:
    if profile_name in profile_adapters:
        tick_adapters = profile_adapters[profile_name]
    elif profile_name != "default":
        tick_adapters = {}
```

Secondary adapters connect asynchronously and can fail to connect entirely, so a tick can land while a profile has no registry entry. Borrowing the shared map in that window would re-introduce the very bug this closes. This matches the inbound path's fail-closed resolution for unregistered secondary profiles (ab70551b3) and #83182's expected behaviour, where the shared map is the fallback for the *default* profile only.

The registry is passed inside the existing `isinstance(cron_provider, InProcessCronScheduler)` guard in `gateway/run.py`, so the `CronScheduler` ABC and external providers keep their current signature — `profile_adapters` never reaches a third-party provider's `start()`.

### Not covered here

The secret-scope half of #83182 — `cron/scheduler.py::run_one_job` resets the owning profile's secret scope before `_deliver_result`, so delivery-time `_getenv` misses that profile's `.env` — is untouched and needs a separate change. This PR does not close the issue.

### Tests

`tests/cron/test_multiplex_cron_delivery_adapter.py`, 4 cases:

- each profile ticks with its own adapter map
- an unregistered secondary profile does not fall back to the default adapters
- `profile_adapters=None` preserves the previous behaviour for callers that pass no registry
- an empty registry still fails closed for a secondary profile while the default keeps the shared map

Verified in both directions:

- reverting the whole change → all 4 fail (`TypeError: unexpected keyword argument 'profile_adapters'`)
- keeping the routing but restoring a `.get(profile_name, adapters) or adapters` fallback → the two fail-closed cases fail
- `tests/cron/` regression on this branch → **823 passed, 1 skipped**
