### PR TITLE
fix(state): collapse stacked/adjacent FTS5 boolean operators instead of a silent empty search

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1250,9 +1250,38 @@ class SessionSearchMixin:
         sanitized = re.sub(r"(^|\s)\*", r"\1", sanitized)
 
         # Step 4: Remove dangling boolean operators at start/end that would
-        # cause syntax errors (e.g. "hello AND" or "OR world")
-        sanitized = re.sub(r"(?i)^(AND|OR|NOT)\b\s*", "", sanitized.strip())
-        sanitized = re.sub(r"(?i)\s+(AND|OR|NOT)\s*$", "", sanitized.strip())
+        # cause syntax errors (e.g. "hello AND" or "OR world"). Loop to a
+        # fixpoint so stacked operators are fully stripped — a single pass
+        # leaves the next operator dangling ("AND NOT docker" -> "NOT docker",
+        # still invalid) (#56871).
+        while True:
+            stripped = re.sub(r"(?i)^(AND|OR|NOT)\b\s*", "", sanitized.strip())
+            stripped = re.sub(r"(?i)\s+(AND|OR|NOT)\s*$", "", stripped.strip())
+            if stripped == sanitized:
+                break
+            sanitized = stripped
+
+        # Step 4b: Collapse adjacent mid-query operator runs ("docker AND OR
+        # kubernetes", "docker AND AND kubernetes"). Every adjacent pair is an
+        # FTS5 syntax error, which the execute site swallows into a silent
+        # zero-result return even though matching content exists (#56871).
+        # "x AND NOT y" collapses to "x NOT y" — FTS5's NOT is binary, so that
+        # keeps the user's exclusion intent — all other pairs collapse to
+        # their first operator. Loop to a fixpoint so three-plus runs
+        # ("a AND NOT AND b") settle too.
+        def _collapse_op_pair(m):
+            first, second = m.group(1).upper(), m.group(2).upper()
+            if (first, second) == ("AND", "NOT"):
+                return "NOT"
+            return m.group(1)
+
+        while True:
+            collapsed = re.sub(
+                r"(?i)\b(AND|OR|NOT)\s+(AND|OR|NOT)\b", _collapse_op_pair, sanitized
+            )
+            if collapsed == sanitized:
+                break
+            sanitized = collapsed
 
         # Step 5: Wrap unquoted dotted and/or hyphenated terms in double
         # quotes.  FTS5's tokenizer splits on dots and hyphens, turning

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2865,6 +2865,56 @@ class TestAutoMaintenance:
 # FTS5 indexing of tool_calls / tool_name (#16751)
 # =========================================================================
 
+class TestFTS5BooleanOperatorSanitization:
+    """Regression tests: stacked/adjacent boolean operators must not silently
+    return zero results (#56871).
+
+    ``_sanitize_fts5_query``'s dangling-operator pass ran only once, so
+    stacked leading operators ("AND NOT docker") left the second operator
+    dangling, and adjacent mid-query runs ("docker AND OR kubernetes",
+    "docker AND AND kubernetes") passed through untouched. Every one of
+    those is an FTS5 syntax error, which the execute site swallows into a
+    silent empty return even though matching content exists — the same
+    silent-empty failure class previously fixed for the ``:`` column-filter
+    operator.
+    """
+
+    def _seed(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(
+            "s1", role="user", content="docker and kubernetes deployment notes"
+        )
+        db.append_message("s1", role="user", content="docker only notes")
+
+    def test_adjacent_operators_still_find_content(self, db):
+        self._seed(db)
+        assert len(db.search_messages("docker AND kubernetes")) == 1  # control
+        assert len(db.search_messages("docker AND OR kubernetes")) == 1
+        assert len(db.search_messages("docker AND AND kubernetes")) == 1
+
+    def test_stacked_leading_operators_are_fully_stripped(self, db):
+        self._seed(db)
+        # Single-pass stripping left a dangling "NOT"; the fixpoint pass must
+        # remove the whole run.
+        results = db.search_messages("AND NOT docker")
+        assert len(results) == 2
+
+    def test_trailing_operator_still_stripped(self, db):
+        self._seed(db)
+        assert len(db.search_messages("docker kubernetes OR")) == 1
+
+    def test_and_not_collapses_to_binary_not_keeping_exclusion(self, db):
+        self._seed(db)
+        # FTS5's NOT is binary: "x AND NOT y" collapses to "x NOT y" so the
+        # user's exclusion intent survives instead of flipping to AND.
+        results = db.search_messages("docker AND NOT kubernetes")
+        assert [r for r in results] and len(results) == 1
+
+    def test_triple_operator_run_settles(self, db):
+        self._seed(db)
+        assert len(db.search_messages("docker AND NOT AND kubernetes")) == 1
+
+
 class TestFTS5ToolCallIndexing:
     """Regression tests: search_messages must see tool_name and tool_calls.
 


### PR DESCRIPTION
## What does this PR do?

Stops `session_search` from silently returning zero results for queries containing stacked or adjacent FTS5 boolean operators. `_sanitize_fts5_query`'s dangling-operator pass ran only once, so a stacked leading run (`AND NOT docker`) left the second operator dangling, and adjacent mid-query runs (`docker AND OR kubernetes`, `docker AND AND kubernetes`) passed through untouched. Every one of those shapes is an FTS5 syntax error, which `search_messages` swallows at the execute site into a silent empty return even though matching content exists (#56871) — the same silent-empty failure class previously fixed for the `:` column-filter operator.

Two changes, both verified against a real FTS5 table before coding:

1. **Step 4 loops to a fixpoint** — dangling start/end operators are stripped until the string is stable, so `AND NOT docker` fully reduces to `docker` instead of stopping at the still-invalid `NOT docker`.
2. **New Step 4b collapses adjacent operator runs** — every adjacent pair is illegal in FTS5 (measured: `AND OR`, `AND AND`, `AND NOT` mid-query all raise `fts5: syntax error`), so runs collapse to a single operator. `x AND NOT y` collapses to `x NOT y` rather than `x AND y` — FTS5's NOT is binary, so that preserves the user's exclusion intent instead of flipping it. The fixpoint loop also settles three-plus runs (`a AND NOT AND b` → `a NOT b`).

## Related Issue

Fixes #56871

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_search.py` — `_sanitize_fts5_query` Step 4 now loops to a fixpoint (stacked dangling operators fully stripped); new Step 4b collapses adjacent mid-query operator runs with the `AND NOT` → `NOT` exclusion-preserving rule, documented inline with the #56871 rationale
- `tests/test_hermes_state.py` — new `TestFTS5BooleanOperatorSanitization` class: adjacent/doubled operators still find content (vs the silent zero), stacked leading operators fully stripped, trailing single operator regression, `AND NOT` collapses to binary NOT keeping exclusion semantics (returns the docker-only row, not both), triple-operator run settles

## How to Test

1. `.venv/bin/python -m pytest tests/test_hermes_state.py::TestFTS5BooleanOperatorSanitization -q` — should pass (5 passed)
2. Observed result: on unmodified main, the adjacent/doubled/stacked tests return 0 rows (the #56871 silent-empty dead end — the sanitize pass leaves the invalid operators in place and the execute site swallows the `fts5: syntax error`); with this fix all shapes return the matching rows
3. Regression: `tests/test_hermes_state.py -k "search or fts or FTS"` — 64 passed (quoted-phrase, colon-filter, CJK, tool-call indexing behaviors unchanged)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (fixpoint rationale + the AND-NOT-to-NOT exclusion rule and why every adjacent pair is illegal)
- [x] Tests added that prove the fix (all three report shapes + exclusion-intent preservation + single-operator regressions)
- [x] All new and existing tests pass locally (5 + 64 passed)
- [x] Platform: macOS (pure query-string sanitization, platform-independent)
