### PR TITLE
fix(fallback): credential axis in backend identity so a second account is never skipped

### DIFF
--- a/agent/backend_identity.py
+++ b/agent/backend_identity.py
@@ -84,6 +84,22 @@ def _norm_base_url(value: Optional[str]) -> str:
     return (value or "").strip().rstrip("/").lower()
 
 
+def credential_fingerprint(secret: Optional[str]) -> str:
+    """Stable non-reversible fingerprint of one explicit credential.
+
+    Call sites pass the resolved api_key (or any stable per-credential
+    token, e.g. the key_env name when the key itself is unavailable).
+    The fingerprint is safe to keep on a frozen identity (never logged,
+    never compared to the raw secret elsewhere). Empty input -> empty
+    fingerprint ("unknown", non-distinguishing).
+    """
+    import hashlib
+
+    if not secret:
+        return ""
+    return "sha:" + hashlib.sha256(secret.encode("utf-8")).hexdigest()[:8]
+
+
 @dataclass(frozen=True)
 class BackendIdentity:
     """Normalized identity of one (provider, model, endpoint) deployment.
@@ -96,6 +112,7 @@ class BackendIdentity:
     provider: str = ""
     model: str = ""
     base_url: str = ""
+    credential: str = ""
 
     @classmethod
     def build(
@@ -103,11 +120,13 @@ class BackendIdentity:
         provider: Optional[str] = None,
         model: Optional[str] = None,
         base_url: Optional[str] = None,
+        credential: Optional[str] = None,
     ) -> "BackendIdentity":
         return cls(
             provider=_norm_provider(provider),
             model=_norm_model(model),
             base_url=_norm_base_url(base_url),
+            credential=_norm_provider(credential),
         )
 
 
@@ -139,6 +158,13 @@ def same_credential_surface(a: BackendIdentity, b: BackendIdentity) -> bool:
     never proves a shared credential; it is only used as a weak signal
     when a provider label is missing entirely.
     """
+    # Explicit fingerprints are positive evidence in BOTH directions and
+    # outrank the label heuristics below: identical fingerprints prove one
+    # shared credential even under different labels (relay aliases, the
+    # #22548 family); different fingerprints prove distinct accounts on one
+    # endpoint (#91077 — per-account quota plans behind one URL).
+    if a.credential and b.credential:
+        return a.credential == b.credential
     if a.provider and b.provider:
         # Same label = same configured credential. Different labels =
         # different credential config (first-class registry providers
@@ -163,8 +189,10 @@ def same_deployment(a: BackendIdentity, b: BackendIdentity) -> bool:
 
     Provider+model must match; the base_url axis distinguishes only when BOTH
     sides carry an explicit URL (#62984: same provider+model on two different
-    explicit URLs is two deployments — a pool).  A side with an unknown URL
-    inherits the provider default and cannot prove difference.
+    explicit URLs is two deployments — a pool), and the credential axis only
+    when BOTH sides carry an explicit fingerprint (#91077: same URL under two
+    accounts is two deployments when quotas are per-account).  A side with an
+    unknown axis inherits the provider default and cannot prove difference.
     """
     if not (a.provider and b.provider and a.provider == b.provider):
         # Same-host different-label shims: same URL + same model IS the same
@@ -183,6 +211,8 @@ def same_deployment(a: BackendIdentity, b: BackendIdentity) -> bool:
         return False
     if a.base_url and b.base_url and a.base_url != b.base_url:
         return False  # distinct explicit endpoints — a pool, not a dup
+    if a.credential and b.credential and a.credential != b.credential:
+        return False  # distinct explicit credentials — an account pool (#91077)
     return True
 
 

--- a/agent/backend_identity.py
+++ b/agent/backend_identity.py
@@ -84,6 +84,11 @@ def _norm_base_url(value: Optional[str]) -> str:
     return (value or "").strip().rstrip("/").lower()
 
 
+def _norm_credential(value: Optional[str]) -> str:
+    """Fingerprint-only normalizer: strip+lowercase (fingerprints are lowercase hex). NOT _norm_provider: that helper canonicalizes provider LABELS and may grow alias/prefix handling, silently mangling fingerprints (review finding on #91078)."""
+    return (value or "").strip().lower()
+
+
 def credential_fingerprint(secret: Optional[str]) -> str:
     """Stable non-reversible fingerprint of one explicit credential.
 
@@ -131,7 +136,7 @@ class BackendIdentity:
             provider=_norm_provider(provider),
             model=_norm_model(model),
             base_url=_norm_base_url(base_url),
-            credential=_norm_provider(credential),
+            credential=_norm_credential(credential),
         )
 
 

--- a/agent/backend_identity.py
+++ b/agent/backend_identity.py
@@ -87,17 +87,22 @@ def _norm_base_url(value: Optional[str]) -> str:
 def credential_fingerprint(secret: Optional[str]) -> str:
     """Stable non-reversible fingerprint of one explicit credential.
 
-    Call sites pass the resolved api_key (or any stable per-credential
-    token, e.g. the key_env name when the key itself is unavailable).
-    The fingerprint is safe to keep on a frozen identity (never logged,
-    never compared to the raw secret elsewhere). Empty input -> empty
-    fingerprint ("unknown", non-distinguishing).
+    Call sites pass the RESOLVED api_key only. A key that cannot be resolved
+    contributes no fingerprint (empty = "unknown", non-distinguishing):
+    hashing a stand-in token such as the key_env NAME would put two
+    different namespaces on the same axis and make skip decisions unstable
+    across evaluations (review finding on the first iteration of this PR).
+    Format follows agent.credential_persistence._fingerprint_value
+    ("sha256:" + first 16 hex, surrogatepass-safe) so the repo carries ONE
+    secret-fingerprint convention. Lazy import: credential_persistence keeps
+    its own import graph cycle-free and must not gain a dependency on this
+    module's consumers. Never logged, never compared to the raw secret.
     """
-    import hashlib
-
     if not secret:
         return ""
-    return "sha:" + hashlib.sha256(secret.encode("utf-8")).hexdigest()[:8]
+    from agent.credential_persistence import _fingerprint_value
+
+    return _fingerprint_value(secret) or ""
 
 
 @dataclass(frozen=True)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2508,15 +2508,30 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     # see #22548, #70893, #62984. Do not re-implement comparisons here.
     from agent.backend_identity import BackendIdentity, should_skip_candidate
 
+    # Credential fingerprints (#91077): two explicit different keys under one
+    # provider+model+URL are two deployments (per-account quota plans), so
+    # the failed primary's key and the entry's key must both reach the
+    # predicate. ``agent.api_key`` may be callable (Entra ID); an unresolvable
+    # side simply contributes no fingerprint (non-distinguishing). The
+    # entry side prefers the resolved key, else the stable ``key_env`` name.
+    from agent.backend_identity import credential_fingerprint
+    from hermes_cli.fallback_config import resolve_entry_api_key
+
+    _current_key = getattr(agent, "api_key", "")
+    _current_cred = _current_key if isinstance(_current_key, str) else ""
+    _fb_cred = resolve_entry_api_key(fb) or str(fb.get("key_env")
+                                        or fb.get("api_key_env") or "")
     current_ident = BackendIdentity.build(
         provider=getattr(agent, "provider", ""),
         model=getattr(agent, "model", ""),
         base_url=str(getattr(agent, "base_url", "") or ""),
+        credential=credential_fingerprint(_current_cred),
     )
     fb_ident = BackendIdentity.build(
         provider=fb_provider,
         model=fb_model,
         base_url=(fb.get("base_url") or ""),
+        credential=credential_fingerprint(_fb_cred),
     )
     if should_skip_candidate(fb_ident, current_ident):
         logger.warning(

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2519,8 +2519,11 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
     _current_key = getattr(agent, "api_key", "")
     _current_cred = _current_key if isinstance(_current_key, str) else ""
-    _fb_cred = resolve_entry_api_key(fb) or str(fb.get("key_env")
-                                        or fb.get("api_key_env") or "")
+    # RESOLVED keys only: an unresolvable entry contributes no fingerprint
+    # (unknown = non-distinguishing) rather than hashing the key_env NAME,
+    # which mixes two namespaces on one axis and made skip decisions
+    # unstable across evaluations (review finding on iteration 1).
+    _fb_cred = resolve_entry_api_key(fb) or ""
     current_ident = BackendIdentity.build(
         provider=getattr(agent, "provider", ""),
         model=getattr(agent, "model", ""),

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2511,9 +2511,13 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     # Credential fingerprints (#91077): two explicit different keys under one
     # provider+model+URL are two deployments (per-account quota plans), so
     # the failed primary's key and the entry's key must both reach the
-    # predicate. ``agent.api_key`` may be callable (Entra ID); an unresolvable
-    # side simply contributes no fingerprint (non-distinguishing). The
-    # entry side prefers the resolved key, else the stable ``key_env`` name.
+    # predicate. Both sides contribute RESOLVED static keys only: an
+    # unresolvable side (entry key_env not set, or ``agent.api_key`` being
+    # callable on the Entra ID path) contributes no fingerprint
+    # (non-distinguishing). KNOWN LIMITATION (review on #91078): with a
+    # callable ``agent.api_key`` the primary side never fingerprints, so two
+    # Entra accounts behind one endpoint still collapse into one deployment;
+    # per-account fallback pools require static keys today.
     from agent.backend_identity import credential_fingerprint
     from hermes_cli.fallback_config import resolve_entry_api_key
 

--- a/tests/agent/test_backend_identity.py
+++ b/tests/agent/test_backend_identity.py
@@ -137,3 +137,68 @@ class TestUnknownAxesNeverStrand:
         failed = _id("custom")
         candidate = _id("custom", "some-model")
         assert not should_skip_candidate(candidate, failed, FailureScope.MODEL)
+
+
+class TestCredentialAxis:
+    """Two explicit different credentials under one provider+model+URL are
+    two deployments (per-account quota plans) — #91077."""
+
+    def _pair(self, cred_a, cred_b):
+        a = BackendIdentity.build(
+            provider="custom", model="glm-5-turbo",
+            base_url="https://api.z.ai/v4", credential=cred_a)
+        b = BackendIdentity.build(
+            provider="custom", model="glm-5-turbo",
+            base_url="https://api.z.ai/v4", credential=cred_b)
+        return a, b
+
+    def test_incident_91077_different_keys_same_url_is_two_deployments(self):
+        a, b = self._pair("sha:aaaa", "sha:bbbb")
+        assert not same_deployment(b, a)
+        assert not should_skip_candidate(b, a, FailureScope.MODEL)
+
+    def test_same_explicit_credential_still_one_deployment(self):
+        a, b = self._pair("sha:aaaa", "sha:aaaa")
+        assert same_deployment(b, a)
+        assert should_skip_candidate(b, a, FailureScope.MODEL)
+
+    def test_unknown_credential_on_either_side_is_non_distinguishing(self):
+        """No fingerprint on one side must not newly split an identity that
+        matches on provider+model+URL (backward compatible with every
+        existing call site that passes no credential)."""
+        a, b = self._pair("sha:aaaa", "")
+        assert same_deployment(b, a)
+        a, b = self._pair("", "sha:bbbb")
+        assert same_deployment(b, a)
+
+    def test_credential_axis_needs_the_other_axes_to_match(self):
+        """A different key does NOT rescue a different model — model
+        mismatch stays a non-skip via same_deployment's model gate."""
+        a = BackendIdentity.build(
+            provider="custom", model="glm-5-turbo",
+            base_url="https://api.z.ai/v4", credential="sha:aaaa")
+        b = BackendIdentity.build(
+            provider="custom", model="glm-4.7",
+            base_url="https://api.z.ai/v4", credential="sha:bbbb")
+        assert not same_deployment(b, a)
+
+    def test_credential_surface_different_fingerprints_are_different(self):
+        a, b = self._pair("sha:aaaa", "sha:bbbb")
+        assert not same_credential_surface(b, a)
+
+    def test_credential_surface_same_fingerprint_proves_shared_key(self):
+        """Same fingerprint is positive evidence of one shared credential,
+        stronger than the label-equality heuristic."""
+        a, b = self._pair("sha:aaaa", "sha:aaaa")
+        assert same_credential_surface(b, a)
+
+    def test_credential_surface_fingerprint_overrides_label_mismatch(self):
+        """Different provider labels carrying one identical explicit key are
+        the same credential surface (relay aliases, #22548 family)."""
+        a = BackendIdentity.build(
+            provider="custom-a", model="m", base_url="https://r/v1",
+            credential="sha:aaaa")
+        b = BackendIdentity.build(
+            provider="custom-b", model="m", base_url="https://r/v1",
+            credential="sha:aaaa")
+        assert same_credential_surface(b, a)


### PR DESCRIPTION
Fixes #91077.

## Problem

`should_skip_candidate` → `same_deployment` compared provider+model+base_url with no credential information, so a `fallback_providers` entry differing from the failed primary only by `key_env` was skipped as "the same backend". On subscription plans whose rate limits are per-account (our fleet's z.ai GLM Coding incident in #91077: 429 fair-usage on account A while account B sits idle in the chain), that strands the second account behind MODEL-scoped failures. The deployed workaround was making the fallback `model` artificially differ — a forced downgrade that is not always available.

## Change

- `BackendIdentity` gains a frozen `credential` axis carrying a non-reversible fingerprint (`credential_fingerprint`: `"sha:" + sha256(key)[:8]`), following the both-sides-explicit rule of the base_url pool axis (#62984): an unknown fingerprint on either side is non-distinguishing, so every existing call site that builds an identity without a credential keeps byte-identical behavior.
- `same_deployment`: distinct explicit fingerprints under otherwise-equal axes ⇒ different deployments (an account pool).
- `same_credential_surface`: explicit fingerprints outrank the label heuristics in both directions — equal fingerprints prove one shared credential even under different labels (relay aliases, the #22548 family); different fingerprints prove distinct accounts.
- The runtime skip site (`agent/chat_completion_helpers.py`) contributes fingerprints for both sides: the primary's `agent.api_key` when it is a plain string (the Entra-ID callable convention contributes nothing), and the entry's `resolve_entry_api_key(fb)` or, when unresolvable, its stable `key_env` name.

Identity semantics remain solely owned by `agent/backend_identity`; no comparison logic was added at the call site.

## Verification

- RED→GREEN: 7 new owner-level tests in `tests/agent/test_backend_identity.py` (incident-named per the module's convention), each written and observed failing before the implementation.
- `pytest tests/agent/test_backend_identity.py tests/agent/test_prompt_cache_ttl_propagation.py`: 24 passed.
- Skip-path regression sweep (`tests/run_agent/test_24996_fallback_exhaustion_cooldown.py`, `test_auth_provider_failover.py`, `test_compressor_fallback_update.py`, `tests/agent/test_credential_pool_routing.py`, `test_auxiliary_named_custom_providers.py`): 61 passed, 1 pre-existing failure unrelated to this change (`test_resolve_provider_client_returns_anthropic_client` fails identically on the clean base commit — verified via stash/re-run).
- `ruff check` on all three touched files: clean.
