### PR TITLE
fix(desktop): route bot mentions by focused profile

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -195,6 +195,13 @@ const $selectedBot = atom('default')
  *  the socket happened to be homed on. */
 const $focusedBotProfile = host.state.focusedSessionProfile || host.state.profile
 
+/** Profile that owns the chat currently on screen. Bot Mode opens another
+ *  profile's session without moving the gateway socket, so mention filtering
+ *  and sender identity must follow focus rather than host.state.profile. */
+function focusedMentionProfile() {
+  return String($focusedBotProfile.get?.() || '').trim() || 'default'
+}
+
 /** Optional secondary navigation inside the Bots pane (group-chat rooms). */
 
 /** Group-chat rooms: { [group]: { log: [{from:{kind,name},text,at}], watermarks:{[member]:idx}, epoch, running } }.
@@ -10554,7 +10561,7 @@ export default {
             return []
           }
 
-          const active = (host.state.profile.get() || 'default').trim() || 'default'
+          const active = focusedMentionProfile()
           const q = (query || '').toLowerCase()
           const items = []
           const live = {
@@ -10854,7 +10861,7 @@ export default {
           }
 
           const live = {
-            name: (host.state.profile.get() || 'default').trim() || 'default',
+            name: focusedMentionProfile(),
             connectionId: String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local')
           }
           const cached = cachedUnionRoster()

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2832,6 +2832,52 @@ function useRoster() {
   })
 }
 
+/** Synchronous union-roster read for the composer surfaces (autocomplete
+ *  provider + mention middleware). useRoster caches under
+ *  [...ROSTER_KEY, activeConnectionId] — a 3-element key — so a bare
+ *  getQueryData(ROSTER_KEY) exact-match lookup returns undefined forever
+ *  (issue #89303: remote handles absent from @ autocomplete, mentions
+ *  unrouted). Read the live connection's entry first, then fall back to a
+ *  prefix scan keeping the freshest snapshot. Never throws: cold cache or
+ *  legacy queryClient returns null and callers fall back to their own path. */
+function cachedUnionRoster() {
+  if (typeof queryClient === 'undefined' || !queryClient || typeof queryClient.getQueryData !== 'function') {
+    return null
+  }
+
+  try {
+    const connectionId = String(
+      host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local'
+    )
+    const exact = queryClient.getQueryData([...ROSTER_KEY, connectionId])
+
+    if (Array.isArray(exact?.profiles)) {
+      return exact
+    }
+
+    if (typeof queryClient.getQueriesData === 'function') {
+      let best = null
+
+      // v5 takes a filters object; a legacy v3 queryClient treats the same
+      // object as the key itself and simply matches nothing — harmless.
+      for (const [, data] of queryClient.getQueriesData({ queryKey: ROSTER_KEY })) {
+        if (
+          Array.isArray(data?.profiles) &&
+          (!best || Number(data.fetchedAt || 0) > Number(best.fetchedAt || 0))
+        ) {
+          best = data
+        }
+      }
+
+      return best
+    }
+  } catch {
+    /* cache hiccup — caller falls back (middleware refetches) */
+  }
+
+  return null
+}
+
 /** Merge the union agent roster (host.agents) over the active gateway's
  *  profiles.list. Active-source rows — matched by the LIVE connection id,
  *  falling back to the roster's primaryConnectionId, then the legacy
@@ -10501,7 +10547,7 @@ export default {
       area: COMPOSER_AREAS.atCompletions,
       data: {
         provide: query => {
-          const roster = queryClient.getQueryData(ROSTER_KEY)
+          const roster = cachedUnionRoster()
           const profiles = Array.isArray(roster?.profiles) ? roster.profiles : []
 
           if (!profiles.length) {
@@ -10811,9 +10857,7 @@ export default {
             name: (host.state.profile.get() || 'default').trim() || 'default',
             connectionId: String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local')
           }
-          const cached = typeof queryClient !== 'undefined' && queryClient && typeof queryClient.getQueryData === 'function'
-            ? queryClient.getQueryData(ROSTER_KEY)
-            : null
+          const cached = cachedUnionRoster()
           const roster = Array.isArray(cached?.profiles) ? cached.profiles : null
           let mentionedBots = roster ? resolveRosterMentions(text, roster, live) : []
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/mention-completions.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/mention-completions.test.mjs
@@ -9,7 +9,7 @@ import vm from 'node:vm'
 
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
-function loadProvide({ roster, active = 'default', meta = {} } = {}) {
+function loadProvide({ roster, active = 'default', focused = active, meta = {} } = {}) {
   const registrations = []
   const atom = value => {
     let current = value
@@ -51,7 +51,12 @@ function loadProvide({ roster, active = 'default', meta = {} } = {}) {
       setQueryData: () => undefined
     },
     host: {
-      state: { profile: { get: () => active, listen: () => () => undefined }, gateway: { get: () => null, listen: () => () => undefined }, connectionId: { get: () => 'local', listen: () => () => undefined } },
+      state: {
+        profile: { get: () => active, listen: () => () => undefined },
+        focusedSessionProfile: { get: () => focused, listen: () => () => undefined },
+        gateway: { get: () => null, listen: () => () => undefined },
+        connectionId: { get: () => 'local', listen: () => () => undefined }
+      },
       request: async () => ({}),
       onEvent: () => () => undefined
     },
@@ -109,6 +114,29 @@ test('prefix-filters against the handle', () => {
 
   assert.deepStrictEqual([...provide('wri').map(i => i.insert)], ['@writer-homelab'])
   assert.strictEqual(provide('zzz').length, 0)
+})
+
+test('filters self by the focused Bot Chat owner, not the gateway socket profile', () => {
+  const provide = loadProvide({
+    active: 'default',
+    focused: 'renametest',
+    roster: {
+      profiles: [
+        { name: 'default', display_name: 'Lucy' },
+        { name: 'renametest' }
+      ]
+    }
+  })
+
+  const inserts = provide('').map(item => item.insert)
+  assert.ok(
+    inserts.includes('@lucy'),
+    'renamed default profile remains mentionable from the focused bot chat'
+  )
+  assert.ok(
+    !inserts.includes('@renametest'),
+    'focused bot excludes itself even when the socket stays on default'
+  )
 })
 
 test('empty roster cache yields no rows (never throws)', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/mention-completions.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/mention-completions.test.mjs
@@ -38,12 +38,20 @@ function loadProvide({ roster, active = 'default', meta = {} } = {}) {
     },
     document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
     queryClient: {
-      getQueryData: () => roster,
+      // Key-exact semantics like the real QueryClient (v5): a 2-element
+      // ROSTER_KEY lookup MUST miss the 3-element cache keys useRoster
+      // writes — the bug behind issue #89303 was invisible under the old
+      // key-ignoring mock.
+      getQueryData: key =>
+        key.length === 3 && key[0] === 'hermes-bots' && key[1] === 'roster'
+          ? roster
+          : undefined,
+      getQueriesData: () => (Array.isArray(roster?.profiles) ? [[['hermes-bots', 'roster', 'local'], roster]] : []),
       invalidateQueries: () => undefined,
       setQueryData: () => undefined
     },
     host: {
-      state: { profile: { get: () => active, listen: () => () => undefined }, gateway: { get: () => null, listen: () => () => undefined } },
+      state: { profile: { get: () => active, listen: () => () => undefined }, gateway: { get: () => null, listen: () => () => undefined }, connectionId: { get: () => 'local', listen: () => () => undefined } },
       request: async () => ({}),
       onEvent: () => () => undefined
     },

--- a/apps/desktop/src/plugins/hermes-bots/tests/mention-handoff-quoting.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/mention-handoff-quoting.test.mjs
@@ -15,7 +15,12 @@ import vm from 'node:vm'
 
 const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
-function load({ activeProfile = 'research', profiles = ['research', 'ops'], title = null } = {}) {
+function load({
+  activeProfile = 'research',
+  focusedProfile = activeProfile,
+  profiles = ['research', 'ops'],
+  title = null
+} = {}) {
   const values = new Map()
   const atom = initial => {
     const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
@@ -30,11 +35,19 @@ function load({ activeProfile = 'research', profiles = ['research', 'ops'], titl
     host: {
       request: async method => {
         if (method === 'profiles.list') {
-          return { profiles: profiles.map(name => ({ name })) }
+          return {
+            profiles: profiles.map(profile =>
+              typeof profile === 'string' ? { name: profile } : profile
+            )
+          }
         }
         return {}
       },
-      state: { profile: { get: () => activeProfile, listen: () => undefined }, gateway: { listen: () => undefined } }
+      state: {
+        profile: { get: () => activeProfile, listen: () => undefined },
+        focusedSessionProfile: { get: () => focusedProfile, listen: () => undefined },
+        gateway: { listen: () => undefined }
+      }
     }
   }
   const source = pluginSource
@@ -109,6 +122,22 @@ test('regression: the handoff command quotes the recipient argument', async () =
   const { handler } = load()
   const result = await handler({ text: 'ping @ops please' })
   assert.match(result.text, /`hermes -p 'ops' chat --in ~/)
+})
+
+test('behavior: a renamed default profile routes from another focused Bot Chat', async () => {
+  const { handler } = load({
+    activeProfile: 'default',
+    focusedProfile: 'renametest',
+    profiles: [
+      { name: 'default', display_name: 'Lucy' },
+      { name: 'renametest' }
+    ]
+  })
+
+  const result = await handler({ text: 'ask @lucy for a status update' })
+
+  assert.match(result.text, /`hermes -p 'default' chat --in ~/)
+  assert.match(result.text, /Message from 🤖 Renametest \(@renametest\)/)
 })
 
 test('behavior: @dixie on a Connections bot stays in this chat and does not hermes -p', async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes the Bot Mode mention path when the chat on screen belongs to a different profile than the gateway socket.

A user can open a secondary bot's canonical chat while the Desktop gateway remains homed on `default`. The mention autocomplete and submit middleware were both using `host.state.profile` to decide which bot was speaking, so they still treated the default profile as self. A renamed default profile such as `Lucy` was therefore filtered out of autocomplete and a manually typed `@lucy` did not route, even though the secondary bot was visibly focused.

There was a second prerequisite bug: `useRoster()` writes under the connection-scoped key `[...ROSTER_KEY, connectionId]`, while both mention readers used the shorter exact key and missed the roster. This PR preserves ArthurFranckPat's #90936 commit verbatim with its original authorship, then adds the focused-session owner fix on top. The combined change is required for the reported path: correcting only the cache makes Bot rows available, but `host.state.profile` still filters the wrong bot.

The generic backend profile rows explain the misleading partial behavior: renaming a secondary profile changes its canonical id, so `@renametest` appeared to work through `complete.path`; renaming `default` only changes `display_name`, leaving the backend fallback as `@default` / `@hermes`.

## Related Issue

- Discord report: https://discord.com/channels/1053877538025386074/1540069696701730911
- Builds on merged rename support in #90592.
- Consolidates the roster-cache correction from #90936 while preserving its contributor commit and authorship.
- #89710 independently overlaps the same roster-cache seam but does not cover focused-session ownership.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js`
  - Read the connection-scoped union roster for autocomplete and submit middleware.
  - Resolve the speaking bot from `host.state.focusedSessionProfile` through the plugin's existing `$focusedBotProfile` compatibility ladder.
  - Use that same focused owner for autocomplete self-filtering, mention resolution, sender display name, and sender handle.
- `apps/desktop/src/plugins/hermes-bots/tests/mention-completions.test.mjs`
  - Model real QueryClient v5 exact-key behavior.
  - Regress gateway=`default`, focused=`renametest`, renamed default=`Lucy`: offer `@lucy` and exclude the actual focused bot.
- `apps/desktop/src/plugins/hermes-bots/tests/mention-handoff-quoting.test.mjs`
  - Regress the same split through submission: `@lucy` routes to canonical profile `default` with Renametest as the sender.

## How to Test

1. Run `node --test "src/plugins/hermes-bots/tests/*.test.mjs"` from `apps/desktop`.
2. Open Bot Mode with the gateway socket homed on `default`, rename default to `Lucy`, and open another profile's Bot Chat.
3. Type `@`: `@lucy` should appear as a Bot completion, the focused bot should not offer itself, and submitting `@lucy ...` should route to profile `default`.

Validation performed:

- Focused mention/rename tests: 15/15 passed.
- Full bundled Bot Mode suite: 343/343 passed.
- Mutation proof: removing only the focused-session production change made exactly the new autocomplete and handoff regressions fail; restoring it returned both to green.
- `git diff --check`: passed.
- ESLint was not available in the isolated worktree because Desktop dependencies were not installed there (`globals` missing). GitHub CI remains authoritative for lint/build/typecheck.
- No Python tests were run because this is a Desktop JavaScript-only change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Node behavioral tests in an isolated clean worktree

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: behavior repair only; inline ownership comment updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only state/cache selection; no platform APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The Discord report includes the before-state screenshot: the visibly focused Renametest chat showed only generic `@default`, `@renametest`, and `@hermes` `agent profile` rows, with no `Bot · Lucy` completion.