### PR TITLE
fix: recreating a same-name Bot Mode group gets fresh member sessions (#90005, salvage #90028)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3817,12 +3817,25 @@ function groupChatNames(metaByName, rooms) {
   const names = new Set(knownGroups(metaByName))
 
   for (const [name, room] of Object.entries(rooms || {})) {
+    if (room?.tombstone) {
+      continue
+    }
+
     if ((Array.isArray(room?.members) && room.members.length) || (Array.isArray(room?.log) && room.log.length)) {
       names.add(name)
     }
   }
 
   return [...names]
+}
+
+/** Names of REAL rooms in the atom — disband tombstones excluded. Feeds the
+ *  create/rename collision sets so a just-disbanded name is immediately
+ *  reusable even while an in-flight drive's tombstone still holds its key. */
+function liveGroupChatNames() {
+  return Object.entries($groupChats.get())
+    .filter(([, room]) => !room?.tombstone)
+    .map(([name]) => name)
 }
 
 /** Millisecond timestamp of a room's newest log entry (0 for a silent room) —
@@ -4126,6 +4139,14 @@ function updateGroupChat(group, mutate) {
     const durable = {}
 
     for (const [name, room] of Object.entries(all)) {
+      // Disband tombstones are runtime-only coordination state (they hold the
+      // epoch bump for an in-flight drive). Persisting one would resurrect
+      // the room as an empty record on the next load AND keep its name
+      // "taken" for same-name recreates.
+      if (room.tombstone) {
+        continue
+      }
+
       durable[name] = {
         log: room.log,
         watermarks: room.watermarks,
@@ -4166,9 +4187,12 @@ async function disbandGroupChat(group, members) {
 
   delete all[group]
   // Keep a runtime-only tombstone while a drive may still be mid-turn; it
-  // carries no log and is never persisted, so it can't rehydrate.
+  // carries no log and is flagged so persistence and name-dedup skip it —
+  // updateGroupChat writes the WHOLE atom map, so an unflagged tombstone
+  // would be persisted by the next unrelated room write and its name would
+  // count as taken, suffixing a same-name recreate to "<name> 2" forever.
   if (prior.running) {
-    all[group] = { log: [], watermarks: {}, sessions: {}, epoch: (prior.epoch || 0) + 1, running: false }
+    all[group] = { log: [], watermarks: {}, sessions: {}, epoch: (prior.epoch || 0) + 1, running: false, tombstone: true }
   }
 
   $groupChats.set(all)
@@ -4254,8 +4278,9 @@ async function renameGroupChat(oldName, newName, members) {
   }
 
   // Renames are explicit user intent: reject a collision honestly instead of
-  // silently suffixing like creation does.
-  const taken = new Set(Object.keys($groupChats.get()))
+  // silently suffixing like creation does. Disband tombstones don't hold
+  // their name — the room is gone, only its epoch survives briefly.
+  const taken = new Set(liveGroupChatNames())
 
   for (const meta of Object.values($botMeta.get() || {})) {
     for (const existing of botGroups(meta)) {
@@ -8626,7 +8651,7 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
     // roomId: member sessions are titled by that roomId, so a
     // disbanded-and-recreated group with the SAME display name still gets
     // new sessions instead of resuming the old room's by title.
-    const taken = new Set(Object.keys($groupChats.get()))
+    const taken = new Set(liveGroupChatNames())
 
     for (const meta of Object.values($botMeta.get() || {})) {
       for (const existing of botGroups(meta)) {

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4137,6 +4137,8 @@ function updateGroupChat(group, mutate) {
         // Source-qualified member descriptors keep the room whole when the
         // active connection changes and today's local members become remote.
         members: Array.isArray(room.members) ? room.members : [],
+        // Immutable room identity: the member-session title for new rooms.
+        roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
         // Room picture (small data URL, same normalization as bot avatars).
         image: room.image || null
       }
@@ -4154,7 +4156,7 @@ function updateGroupChat(group, mutate) {
  *  membership list (the metadata syncs cross-machine via ui_meta), drop the
  *  room log from the atom + plugin storage, and close the room view if it's
  *  open. Other group memberships and the members' per-group gateway sessions
- *  ("Group: <name>") are intentionally KEPT. */
+ *  ("Group: <roomId>", or legacy "Group: <name>") are intentionally KEPT. */
 async function disbandGroupChat(group, members) {
   // Invalidate any in-flight round-robin FIRST: bump the epoch so a running
   // drive bails at its next member boundary instead of appending to a room
@@ -4196,6 +4198,7 @@ async function disbandGroupChat(group, members) {
           watermarks: room.watermarks,
           sessions: room.sessions || {},
           members: Array.isArray(room.members) ? room.members : [],
+          roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
           image: room.image || null
         }
       }
@@ -4238,9 +4241,11 @@ function setGroupChatImage(group, image) {
 /** Rename a group chat. The group's NAME is its identity everywhere — the
  *  room-map key, each local member's ui_meta membership list, and derived
  *  state — so a rename re-keys all of them. Member gateway sessions are kept
- *  as-is: stored sids keep resuming, so no history is lost (only a member
- *  whose sid is later lost falls back to a fresh "Group: <new name>" title
- *  lookup). Returns the new name, or null when the target name is taken. */
+ *  as-is: stored sids keep resuming, so no history is lost. The room's
+ *  immutable roomId (the member-session title) is preserved across the
+ *  rename, so even a member whose sid is later lost falls back to the same
+ *  "Group: <roomId>" title lookup instead of a fresh "Group: <new name>".
+ *  Returns the new name, or null when the target name is taken. */
 async function renameGroupChat(oldName, newName, members) {
   const next = String(newName || '').trim().slice(0, 64)
 
@@ -4348,6 +4353,33 @@ function appendGroupChatEntry(group, from, text, thread, images) {
   return entry
 }
 
+/** Fresh room identity for a group. Independent of the editable display
+ *  name: a disbanded-and-recreated group mints a new roomId even when the
+ *  display name is identical, so member sessions never resume by title. */
+function mintGroupRoomId() {
+  return `r${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`
+}
+
+/** Unique display name for a NEW group. Collisions get a " 2", " 3", …
+ *  suffix; the BASE is truncated (never the joined string), so a 64-char
+ *  base keeps its suffix instead of colliding with the original. */
+function uniqueGroupChatName(base, taken) {
+  if (!taken.has(base)) {
+    return base
+  }
+
+  for (let n = 2; n < 100; n++) {
+    const suffix = ` ${n}`
+    const candidate = base.slice(0, 64 - suffix.length) + suffix
+
+    if (!taken.has(candidate)) {
+      return candidate
+    }
+  }
+
+  throw new Error('No free name for the group.')
+}
+
 /** Ensure the member's per-group session exists and return a LIVE runtime
  *  session id for it. Gateway-native: session.create mints the session
  *  (lazy until its first message), session.resume by stored id — or by
@@ -4355,8 +4387,11 @@ function appendGroupChatEntry(group, from, text, thread, images) {
  *  it after restarts. Cross-connection members route to their OWN source
  *  via requestForBot; the window's gateway never switches. */
 async function ensureGroupChatSession(group, member) {
-  const title = `Group: ${group}`
   const room = $groupChats.get()[group] || {}
+  // New rooms title member sessions by their immutable roomId so a
+  // same-name recreate never resumes the old room's sessions by title;
+  // legacy rooms without a roomId fall back to the display name.
+  const title = `Group: ${room.roomId || group}`
   const key = groupMemberKey(member)
   const known = room.sessions && room.sessions[key]
 
@@ -4721,7 +4756,7 @@ async function harvestStrandedGroupReply(group, member) {
   try {
     const stored = room.sessions?.[memberKey]
     state = await requestForBot(member, 'session.resume', {
-      session_id: stored || `Group: ${group}`,
+      session_id: stored || `Group: ${room.roomId || group}`,
       profile: member.name
     })
   } catch {
@@ -8577,9 +8612,9 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
   const canCreate = selected.length >= 2 && Boolean(name.trim() || selected.length)
 
   const create = () => {
-    let groupName = (name.trim() || placeholder).slice(0, 64)
+    const base = (name.trim() || placeholder).slice(0, 64)
 
-    if (selected.length < 2 || !groupName) {
+    if (selected.length < 2 || !base) {
       return
     }
 
@@ -8587,7 +8622,10 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
     // group under an existing name (easy — the default name is just the
     // member names) silently reopens the old room with its full log, which
     // reads as "not a fresh group" (db's Aug 2026 report). Uniquify against
-    // both live rooms and any bot's current grouping.
+    // both live rooms and any bot's current grouping, then mint a fresh
+    // roomId: member sessions are titled by that roomId, so a
+    // disbanded-and-recreated group with the SAME display name still gets
+    // new sessions instead of resuming the old room's by title.
     const taken = new Set(Object.keys($groupChats.get()))
 
     for (const meta of Object.values($botMeta.get() || {})) {
@@ -8596,15 +8634,8 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
       }
     }
 
-    if (taken.has(groupName)) {
-      let n = 2
-
-      while (taken.has(`${groupName} ${n}`)) {
-        n += 1
-      }
-
-      groupName = `${groupName} ${n}`.slice(0, 64)
-    }
+    const groupName = uniqueGroupChatName(base, taken)
+    const roomId = mintGroupRoomId()
 
     for (const bot of selected) {
       if (!bot.remoteSource) {
@@ -8619,6 +8650,7 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
 
     updateGroupChat(groupName, room => {
       room.members = roomMembers
+      room.roomId = roomId
 
       if (image) {
         room.image = image
@@ -10614,6 +10646,7 @@ export default {
                   sessions: room.sessions && typeof room.sessions === 'object' ? room.sessions : {},
                   stranded: room.stranded && typeof room.stranded === 'object' ? room.stranded : {},
                   members: Array.isArray(room.members) ? room.members : [],
+                  roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
                   image: typeof room.image === 'string' && room.image ? room.image : null,
                   epoch: 0,
                   running: false

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -9841,9 +9841,9 @@ function GroupChatWorkspace({ group, members, onBack }) {
             jsx('span', { className: 'font-medium text-foreground', children: group }),
             ' grouping from its ',
             String(members.length),
-            ' bots and clears the shared room log. The bots themselves and their “Group: ',
-            group,
-            '” sessions are kept.'
+            // New rooms title member sessions by roomId, legacy rooms by name —
+            // so the copy names the concept, not a literal session title.
+            ' bots and clears the shared room log. The bots themselves and their per-group sessions are kept.'
           ]
         }),
         destructive: true,

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -124,7 +124,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, disbandGroupChat, updateGroupChat, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, disbandGroupChat, updateGroupChat, ensureGroupChatSession, uniqueGroupChatName, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -324,6 +324,88 @@ test('concurrent groups sharing one member keep sessions, deltas, and context is
   assert.equal(betaSession.messages.some(message => String(message.content).includes('ALPHA_ONLY')), false)
 })
 
+test('recreating a same-name group after disband mints fresh member sessions', async () => {
+  const gc = load(() => '(pass)')
+  const member = { name: 'research', title: '' }
+
+  // First incarnation of the room.
+  gc.updateGroupChat('Alpha', r => {
+    r.roomId = 'r-one'
+    return r
+  })
+  const first = await gc.ensureGroupChatSession('Alpha', member)
+
+  // Disband: the room record is gone; the member's gateway session survives.
+  const rooms = { ...gc.$groupChats.get() }
+  delete rooms.Alpha
+  gc.$groupChats.set(rooms)
+
+  // Recreate under the same display name with a freshly minted roomId.
+  gc.updateGroupChat('Alpha', r => {
+    r.roomId = 'r-two'
+    return r
+  })
+  const second = await gc.ensureGroupChatSession('Alpha', member)
+
+  assert.notEqual(first.stored, second.stored, 'the recreated room must not resume the old member session')
+  assert.equal(gc.sessions.get(first.stored).title, 'Group: r-one')
+  assert.equal(gc.sessions.get(second.stored).title, 'Group: r-two')
+})
+
+test('group session titles are pinned to the roomId, with a legacy fallback to the display name', async () => {
+  const gc = load(() => '(pass)')
+
+  // Rooms persisted before roomIds keep name-based titles so their existing
+  // "Group: <name>" sessions keep resolving after an upgrade.
+  gc.updateGroupChat('Legacy', r => r)
+  const legacy = await gc.ensureGroupChatSession('Legacy', { name: 'research', title: '' })
+  assert.equal(gc.sessions.get(legacy.stored).title, 'Group: Legacy')
+
+  // New rooms pin the title to the immutable roomId, never the display name.
+  gc.updateGroupChat('New', r => {
+    r.roomId = 'r-abc'
+    return r
+  })
+  const fresh = await gc.ensureGroupChatSession('New', { name: 'research', title: '' })
+  assert.equal(gc.sessions.get(fresh.stored).title, 'Group: r-abc')
+})
+
+test('same-name group dedup reserves suffix length at the 64-char cap', () => {
+  const gc = load(() => '(pass)')
+
+  assert.equal(gc.uniqueGroupChatName('Team', new Set(['Other'])), 'Team')
+
+  // Slicing the joined string would chop the " 2"/" 3" suffix off a
+  // max-length base and collide with the original forever.
+  const base = 'x'.repeat(64)
+  const taken = new Set([base, `${base.slice(0, 62)} 2`])
+
+  const next = gc.uniqueGroupChatName(base, taken)
+
+  assert.notEqual(next, base)
+  assert.equal(next.length, 64)
+  assert.equal(next, `${base.slice(0, 62)} 3`)
+})
+
+test('roomId persists with the room record and survives disband of other rooms', async () => {
+  const gc = load(() => '(pass)')
+
+  gc.updateGroupChat('Keep', r => {
+    r.roomId = 'r-keep'
+    return r
+  })
+  gc.updateGroupChat('Gone', r => {
+    r.roomId = 'r-gone'
+    return r
+  })
+
+  await gc.disbandGroupChat('Gone', [{ name: 'builder' }])
+
+  const durable = gc.storageWrites.get('group-chats')
+  assert.equal(durable.Keep.roomId, 'r-keep', 'roomId survives disband of another room')
+  assert.ok(!('Gone' in durable), 'disbanded room not persisted')
+})
+
 test('needs-you: a member reply mentioning @user badges the group; user send clears it', async () => {
   const gc = load(profile => (profile === 'research' ? 'Blocked on billing access — @user which account?' : '(pass)'))
 
@@ -352,7 +434,7 @@ test('turn transport is gateway-native (session RPCs) and hostile text rides ver
   assert.equal(call.prompt.includes('hello "there" `whoami` $(id)'), true)
   // The per-group session is created with the room title.
   assert.match(pluginSource, /title,\n/)
-  assert.match(pluginSource, /const title = `Group: \$\{group\}`/)
+  assert.match(pluginSource, /const title = `Group: \$\{room\.roomId \|\| group\}`/)
 })
 
 test('log trimming keeps watermarks consistent', () => {
@@ -767,7 +849,9 @@ test('source contract: the working line names the member on turn', () => {
 
 test('source contract: creating a group with a taken name mints a fresh room, never reopens the old log', () => {
   assert.match(pluginSource, /const taken = new Set\(Object\.keys\(\$groupChats\.get\(\)\)\)/)
-  assert.match(pluginSource, /while \(taken\.has\(`\$\{groupName\} \$\{n\}`\)\)/)
+  assert.match(pluginSource, /const groupName = uniqueGroupChatName\(base, taken\)/)
+  assert.match(pluginSource, /const roomId = mintGroupRoomId\(\)/)
+  assert.match(pluginSource, /room\.roomId = roomId/)
 })
 
 test('turn prompt: results are full quality — only chatter is asked to stay short', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -124,7 +124,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, disbandGroupChat, updateGroupChat, ensureGroupChatSession, uniqueGroupChatName, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, disbandGroupChat, updateGroupChat, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -635,8 +635,23 @@ test('disband: a running room leaves an epoch-bumped empty tombstone so in-fligh
   assert.equal(tomb.log.length, 0)
   assert.equal(tomb.running, false)
   assert.equal(tomb.epoch, 4, 'epoch bumped so the loop bails at its member boundary')
+  assert.equal(tomb.tombstone, true, 'flagged so persistence and name-dedup skip it')
   const durable = gc.storageWrites.get('group-chats')
   assert.ok(!durable || !('Live' in (durable || {})), 'tombstone is never persisted')
+
+  // Regression (#90028 live E2E): updateGroupChat persists the WHOLE atom
+  // map — an unrelated room write while the tombstone lingers must not
+  // smuggle the tombstone into durable storage, and the disbanded name must
+  // be immediately reusable (uniqueGroupChatName would suffix it otherwise).
+  gc.updateGroupChat('Other', room => {
+    room.log.push({ at: Date.now(), from: { kind: 'user' }, text: 'x', thread: 't' })
+    return room
+  })
+  const durable2 = gc.storageWrites.get('group-chats')
+  assert.ok(durable2 && 'Other' in durable2, 'real room persists')
+  assert.ok(!('Live' in durable2), 'tombstone excluded from later whole-map writes')
+  assert.equal(gc.uniqueGroupChatName('Live', new Set(gc.liveGroupChatNames())), 'Live',
+    'disbanded name is immediately reusable — tombstone does not hold it')
 })
 
 test('source contract: workspace header offers disband behind a ConfirmDialog', () => {
@@ -848,7 +863,7 @@ test('source contract: the working line names the member on turn', () => {
 })
 
 test('source contract: creating a group with a taken name mints a fresh room, never reopens the old log', () => {
-  assert.match(pluginSource, /const taken = new Set\(Object\.keys\(\$groupChats\.get\(\)\)\)/)
+  assert.match(pluginSource, /const taken = new Set\(liveGroupChatNames\(\)\)/)
   assert.match(pluginSource, /const groupName = uniqueGroupChatName\(base, taken\)/)
   assert.match(pluginSource, /const roomId = mintGroupRoomId\(\)/)
   assert.match(pluginSource, /room\.roomId = roomId/)

--- a/contributors/emails/yuyigeng97@gmail.com
+++ b/contributors/emails/yuyigeng97@gmail.com
@@ -1,0 +1,1 @@
+YuYigeng


### PR DESCRIPTION
## Summary
Recreating a Bot Mode group under the same display name now gets a genuinely fresh room — member sessions no longer resume the old room's conversation and system prompt (fixes #90005). Salvage of #90028 by @YuYigeng onto current main.

Root cause was twofold: member-session titles derived from the editable display name (`Group: <name>`), so a same-name recreate resumed the old sessions by title lookup; and creation dedup sliced the joined name to 64 chars, chopping the ` 2` suffix off max-length names so the "unique" candidate collided forever.

## Changes
- `plugin.js`: every new room mints an immutable `roomId` persisted with the room record; member sessions are titled `Group: <roomId>` (legacy rooms without one keep name-based titles so existing sessions keep resolving); rename preserves `roomId`; `uniqueGroupChatName` truncates the base, never the suffix.
- Follow-ups found in live E2E (ours, on top of the salvage):
  - disband tombstones are now flagged and excluded from durable persistence, create/rename collision sets (`liveGroupChatNames()`), and roster rows — an unflagged tombstone was persisted by the next whole-map write and held its name "taken", silently suffixing a same-name recreate to `<name> 2`;
  - disband confirm copy no longer quotes the legacy `Group: <name>` session title.
- Tests: contributor's roomId/dedup/rename coverage + tombstone persistence/name-reuse regression added to the existing tombstone test.

## Validation
| Check | Result |
|---|---|
| Plugin suite (`node --test tests/*.test.mjs`) | 345/345 pass |
| Live desktop E2E (built renderer, real gateway) | create "Squad" → roomId `rmt1z5hkx…` persisted → roster-row delete → recreate "Squad" → **same name reusable (no " 2"), fresh roomId `rmt1z623k…`, empty log**, zero page errors |
| Legacy path | rooms without `roomId` fall back to name-based titles (compat test) |

Credit: @YuYigeng (first submitter, #90028) — commit cherry-picked with authorship preserved.

## Infographic

![Fresh rooms every time — immutable roomId decouples sessions from display names](https://v3b.fal.media/files/b/0aa723b4/8QG7uI_x-AIKGN5-ZKm-E_9RsgWa0l.png)
