### PR TITLE
fix: Bot Mode group chats can be deleted from their roster row (salvage #90270)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -9999,7 +9999,7 @@ function openGroupChat(group) {
  *  (markdown flattened), relative time of the last activity, and the
  *  needs-you badge on the row itself. Sorts into the same recency ordering
  *  as bot rows; clicking opens the room in the main chat window. */
-function GroupRow({ active, group, members, needsYou, onOpen }) {
+function GroupRow({ active, group, members, needsYou, onOpen, onDisband }) {
   const rooms = useValue($groupChats)
   const allMeta = useValue($botMeta)
   const room = rooms[group] || { log: [] }
@@ -10015,7 +10015,7 @@ function GroupRow({ active, group, members, needsYou, onOpen }) {
     : 'No messages yet — say hi to the room'
   const faces = members.slice(0, 3)
 
-  return jsxs('button', {
+  const row = jsxs('button', {
     type: 'button',
     onClick: () => {
       haptic('tap')
@@ -10104,6 +10104,26 @@ function GroupRow({ active, group, members, needsYou, onOpen }) {
       })
     ]
   })
+
+  return jsxs(ContextMenu, {
+    children: [
+      jsx(ContextMenuTrigger, { asChild: true, children: row }),
+      jsxs(ContextMenuContent, {
+        children: [
+          jsx(ContextMenuItem, {
+            onSelect: () => onOpen(group),
+            children: 'Open Group Chat'
+          }),
+          jsx(ContextMenuSeparator, {}),
+          jsx(ContextMenuItem, {
+            className: 'text-destructive focus:text-destructive',
+            onSelect: () => onDisband({ name: group, members }),
+            children: 'Delete Group'
+          })
+        ]
+      })
+    ]
+  })
 }
 
 function BotsPane() {
@@ -10115,6 +10135,7 @@ function BotsPane() {
   const [groupCreateOpen, setGroupCreateOpen] = useState(false)
   const [editing, setEditing] = useState(null)
   const [deleting, setDeleting] = useState(null)
+  const [deletingGroup, setDeletingGroup] = useState(null)
   const [grouping, setGrouping] = useState(null)
   const [query, setQuery] = useState('')
   const activityToasts = useValue($activityToasts)
@@ -10452,7 +10473,8 @@ function BotsPane() {
                               group: row.name,
                               members: row.members,
                               needsYou: Boolean(groupNeedsYou[row.name]),
-                              onOpen: openGroupChat
+                              onOpen: openGroupChat,
+                              onDisband: setDeletingGroup
                             },
                             `group:${row.name}`
                           )
@@ -10526,6 +10548,23 @@ function BotsPane() {
           await deleteBot(deleting)
           await refetch()
           host.notify({ kind: 'success', message: `Deleted profile ${name}` })
+        }
+      }),
+      jsx(ConfirmDialog, {
+        open: Boolean(deletingGroup),
+        title: 'Delete group chat?',
+        description: deletingGroup
+          ? `This removes “${deletingGroup.name}” from its bots and clears the shared room log. The bots and their individual chats are kept.`
+          : null,
+        destructive: true,
+        confirmLabel: 'Delete Group',
+        busyLabel: 'Deleting…',
+        doneLabel: 'Deleted',
+        onClose: () => setDeletingGroup(null),
+        onConfirm: async () => {
+          if (!deletingGroup) return
+          await disbandGroupChat(deletingGroup.name, deletingGroup.members)
+          host.notify({ kind: 'success', message: `Deleted group “${deletingGroup.name}”` })
         }
       })
     ]

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -553,6 +553,13 @@ test('source contract: active group styling suppresses bot styling', () => {
   assert.match(pluginSource, /active: groupChatName === row\.name/)
 })
 
+test('source contract: group roster rows expose a confirmed Delete Group action', () => {
+  assert.match(pluginSource, /function GroupRow\(\{ active, group, members, needsYou, onOpen, onDisband \}\)/)
+  assert.match(pluginSource, /children: 'Delete Group'/)
+  assert.match(pluginSource, /title: 'Delete group chat\?'/)
+  assert.match(pluginSource, /await disbandGroupChat\(deletingGroup\.name, deletingGroup\.members\)/)
+})
+
 test('disband: removes only this membership, room log, workspace, and needs-you state', async () => {
   const gc = load(() => '(pass)')
 

--- a/contributors/emails/bkashjee@gmail.com
+++ b/contributors/emails/bkashjee@gmail.com
@@ -1,0 +1,1 @@
+BkashJEE


### PR DESCRIPTION
## Summary
Group chats can now be deleted from where users look for it — right-click the group's roster row → Delete Group (confirm-gated). Salvage of #90270 by @BkashJEE onto current main.

Previously the only disband affordance was inside the open room's header; users who right-clicked the roster row where they created the group concluded groups couldn't be deleted.

## Changes
- `plugin.js` (`GroupRow`): wraps the row in the existing ContextMenu primitives with **Open Group Chat** and destructive **Delete Group**; delete routes through a `ConfirmDialog` into the existing `disbandGroupChat()` — same soft-delete semantics (membership + room log go, bots and their chats are kept).
- `tests/group-chat.test.mjs`: contributor's source-shape contract for the new entries.

## Validation
| Check | Result |
|---|---|
| Plugin suite | 342/342 pass |
| Live desktop E2E | right-click "Squad" row → menu shows Open Group Chat / Delete Group → confirm → room record + both members' `groups` cleared in storage, row gone and stayed gone across roster polls (write-fence from #90809 holding) |

Credit: @BkashJEE (#90270) — commit cherry-picked with authorship preserved.

## Infographic

![Delete where you created — roster-row context menu gains a confirm-gated Delete Group](https://v3b.fal.media/files/b/0aa723ba/_5Pa9NhJNV9wSnqZlLx-2_xoIHetTB.png)
