### PR TITLE
fix: group-room UX — Shift+Enter newlines, open-at-latest incl. retained-pane reopen, late replies harvested (refresh #90526)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -62,7 +62,7 @@ import {
   useQuery,
   useValue
 } from '@hermes/plugin-sdk'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { jsx, jsxs } from 'react/jsx-runtime'
 
 const { McpTab, ToolsetConfigPanel } = sdk
@@ -9268,7 +9268,7 @@ function GroupClarifyCard({ entry, members }) {
   })
 }
 
-function GroupChatWorkspace({ group, members, onBack }) {
+function GroupChatWorkspace({ group, members, onBack, visible = true }) {
   const rooms = useValue($groupChats)
   const allMeta = useValue($botMeta)
   const room = rooms[group] || { log: [], running: false }
@@ -9324,6 +9324,22 @@ function GroupChatWorkspace({ group, members, onBack }) {
       bottomSentinelRef.current?.scrollIntoView({ block: 'end' })
     }
   }, [room.log.length, room.running])
+
+  // Retained-pane reopen (#89835 follow-up): a hot-mounted room pane stays
+  // mounted while another workspace tab is active, so returning to it never
+  // remounts and the mount-time anchor doesn't rerun. Re-anchor on the
+  // hidden → visible edge — an explicit reopen, so it overrides a stale
+  // read-position and mirrors what a fresh open does.
+  const wasVisibleRef = useRef(visible)
+
+  useEffect(() => {
+    if (visible && !wasVisibleRef.current) {
+      stickToBottomRef.current = true
+      bottomSentinelRef.current?.scrollIntoView({ block: 'end' })
+    }
+
+    wasVisibleRef.current = visible
+  }, [visible])
 
   const imagesFor = thread => pendingImages[thread ?? 'main'] || []
 
@@ -10049,15 +10065,25 @@ function closeGroupChatMainTab(group) {
 
 /** Main-window wrapper: seats the member roster reactively (live roster +
  *  bot meta + the room's stored cross-connection descriptors) so the room
- *  keeps working as members change while the tab is open. */
+ *  keeps working as members change while the tab is open. Also subscribes to
+ *  this pane's visibility (feature-detected host.paneVisibility): retained
+ *  panes stay mounted while hidden, so the workspace needs the hidden →
+ *  visible edge to re-anchor its log to the bottom (#89835 follow-up). */
 function GroupChatMainView({ group }) {
   const allMeta = useValue($botMeta)
   // Subscribe: membership changes ride bot meta AND the room record.
   useValue($groupChats)
   const roster = useValue($lastRoster)
   const members = groupChatMemberBots(group, roster, allMeta)
+  // Older SDKs have no paneVisibility: fall back to an always-visible atom so
+  // the hook order stays stable and behavior matches the previous build.
+  const $visible = useMemo(
+    () => (typeof host.paneVisibility === 'function' ? host.paneVisibility(`plugin-workspace:${ID}:group:${slugify(group)}`) : atom(true)),
+    [group]
+  )
+  const visible = useValue($visible)
 
-  return jsx(GroupChatWorkspace, { group, members, onBack: () => closeGroupChatMainTab(group) })
+  return jsx(GroupChatWorkspace, { group, members, visible, onBack: () => closeGroupChatMainTab(group) })
 }
 
 /** Open a group chat the Discord way: a tab taking over the MAIN chat window

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4969,8 +4969,56 @@ async function runGroupChatRounds(group, members, thread) {
         r.turn = null
         return r
       })
+
+      // #89545: the loop's harvest pass only ran at the top of each round of
+      // an ACTIVE loop — a member whose turn timed out after the final round
+      // stayed stranded until the user's NEXT send. Poll for the late reply
+      // in the background (bounded) so long work is late, never lost.
+      // (window feature-detect: the engine also runs under node in tests.)
+      const strandedLeft = Object.keys(($groupChats.get()[group] || {}).stranded || {})
+
+      if (strandedLeft.length && typeof window !== 'undefined') {
+        void harvestStrandedUntilSettled(group, members, thread)
+      }
     }
   }
+}
+
+/** Bounded background harvest for members whose replies outlived the turn
+ *  loop. Polls every 5s for up to 5 minutes; stops early when nothing is
+ *  stranded, a new loop takes the room over (it harvests on its own), or the
+ *  room record disappears (disband). */
+async function harvestStrandedUntilSettled(group, members, thread) {
+  const HARVEST_INTERVAL_MS = 5000
+  const HARVEST_MAX_TRIES = 60
+
+  for (let attempt = 0; attempt < HARVEST_MAX_TRIES; attempt++) {
+    await new Promise(resolve => window.setTimeout(resolve, HARVEST_INTERVAL_MS))
+
+    const room = $groupChats.get()[group]
+
+    if (!room || room.running) {
+      return
+    }
+
+    const stranded = room.stranded || {}
+
+    if (!Object.keys(stranded).length) {
+      return
+    }
+
+    for (const member of members) {
+      if (Object.prototype.hasOwnProperty.call(stranded, groupMemberKey(member))) {
+        try {
+          await harvestStrandedGroupReply(group, member)
+        } catch {
+          // Best-effort: the next tick retries; the bound stops runaways.
+        }
+      }
+    }
+  }
+
+  recordGroupActivity(group, { kind: 'failed', member: null, thread })
 }
 
 /** User send into a group room. `thread` continues that thread (its reply
@@ -8892,7 +8940,7 @@ function mentionTokenAt(text, caret) {
  *  the strings parseGroupChatMentions resolves. Keyboard: Up/Down navigate,
  *  Enter/Tab insert (Enter falls through to submit when the popover is
  *  closed), Escape dismisses. */
-function GroupMentionInput({ members, onChange, value, ...inputProps }) {
+function GroupMentionInput({ members, onChange, onSubmitDraft, value, ...inputProps }) {
   const allMeta = useValue($botMeta)
   const inputRef = useRef(null)
   const [token, setToken] = useState(null)
@@ -8995,32 +9043,55 @@ function GroupMentionInput({ members, onChange, value, ...inputProps }) {
             )
           })
         : null,
-      jsx(Input, {
+      jsx(Textarea, {
         ...inputProps,
         ref: inputRef,
         value,
+        rows: 1,
+        // Multi-line room prompts (#89884): the composer was a single-line
+        // Input whose form submitted on every Enter — newlines were
+        // impossible. Enter (no Shift) still submits via onSubmitDraft;
+        // Shift+Enter falls through to the textarea's native newline.
+        className: cn('max-h-40 min-h-9 resize-none', inputProps.className),
         onChange: event => {
           onChange(event.target.value)
           refreshToken(event.target)
         },
         onClick: event => refreshToken(event.target),
         onKeyDown: event => {
-          if (!open) {
-            return
+          if (open) {
+            if (event.key === 'ArrowDown') {
+              event.preventDefault()
+              setSelected((active + 1) % options.length)
+
+              return
+            }
+
+            if (event.key === 'ArrowUp') {
+              event.preventDefault()
+              setSelected((active - 1 + options.length) % options.length)
+
+              return
+            }
+
+            if (event.key === 'Enter' || event.key === 'Tab') {
+              event.preventDefault()
+              insert(options[active].handle)
+
+              return
+            }
+
+            if (event.key === 'Escape') {
+              event.preventDefault()
+              setToken(null)
+
+              return
+            }
           }
 
-          if (event.key === 'ArrowDown') {
+          if (event.key === 'Enter' && !event.shiftKey) {
             event.preventDefault()
-            setSelected((active + 1) % options.length)
-          } else if (event.key === 'ArrowUp') {
-            event.preventDefault()
-            setSelected((active - 1 + options.length) % options.length)
-          } else if (event.key === 'Enter' || event.key === 'Tab') {
-            event.preventDefault()
-            insert(options[active].handle)
-          } else if (event.key === 'Escape') {
-            event.preventDefault()
-            setToken(null)
+            onSubmitDraft?.()
           }
         },
         onBlur: () => setToken(null)
@@ -9220,6 +9291,39 @@ function GroupChatWorkspace({ group, members, onBack }) {
   // composer, otherwise the reply box of that thread. Data URLs, already
   // downscaled — they ride the send into every responding member's session.
   const [pendingImages, setPendingImages] = useState({})
+
+  // Scroll anchoring (#89835): rooms used to open at scroll position 0 and
+  // stay there while replies streamed in. Scroll the bottom sentinel into
+  // view on mount and whenever the log grows — but only when the user is
+  // already near the bottom, so reading history is never yanked away.
+  const bottomSentinelRef = useRef(null)
+  const stickToBottomRef = useRef(true)
+
+  useEffect(() => {
+    const sentinel = bottomSentinelRef.current
+
+    if (!sentinel) {
+      return
+    }
+
+    const viewport = sentinel.closest('[data-slot="scroll-area-viewport"]')
+
+    if (viewport) {
+      const onScroll = () => {
+        stickToBottomRef.current = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight < 80
+      }
+
+      viewport.addEventListener('scroll', onScroll, { passive: true })
+
+      return () => viewport.removeEventListener('scroll', onScroll)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (stickToBottomRef.current) {
+      bottomSentinelRef.current?.scrollIntoView({ block: 'end' })
+    }
+  }, [room.log.length, room.running])
 
   const imagesFor = thread => pendingImages[thread ?? 'main'] || []
 
@@ -9733,6 +9837,7 @@ function GroupChatWorkspace({ group, members, onBack }) {
                     members,
                     value: replyDrafts[id] || '',
                     onChange: text => setReplyDrafts(prev => ({ ...prev, [id]: text })),
+                    onSubmitDraft: () => submitReply(id),
                     onPaste: event => pasteImages(id, event)
                   }),
                   attachButton(id),
@@ -9814,7 +9919,11 @@ function GroupChatWorkspace({ group, members, onBack }) {
                       ? `${groupSpeakerLabel(room.turn)} is thinking…`
                       : 'The room is working…'
                 }, 'working')
-              : null
+              : null,
+            // Scroll anchor (#89835): rooms opened at scroll position 0, mid-
+            // history. The effect below scrolls this sentinel into view on
+            // mount and on log growth — unless the user has scrolled up.
+            jsx('div', { ref: bottomSentinelRef, 'aria-hidden': true }, 'bottom-sentinel')
           ]
         })
       }),
@@ -9837,6 +9946,7 @@ function GroupChatWorkspace({ group, members, onBack }) {
                   members,
                   value: draft,
                   onChange: setDraft,
+                  onSubmitDraft: submit,
                   onPaste: event => pasteImages(null, event)
                 }),
                 attachButton(null),

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-mention-composer.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-mention-composer.test.mjs
@@ -21,8 +21,9 @@ test('group room composers mount GroupMentionInput, not bare Input', () => {
   assert.ok(!/jsx\(Input, \{\s*'aria-label': `Message \$\{group\}`/.test(source))
   assert.ok(!/jsx\(Input, \{\s*'aria-label': 'Reply in thread'/.test(source))
 
-  // Both receive the seated members for the popover scope.
-  assert.ok(/GroupMentionInput\(\{ members, onChange, value/.test(source))
+  // Both receive the seated members for the popover scope (onSubmitDraft
+  // rides along so Enter submits from the multi-line textarea, #89884).
+  assert.ok(/GroupMentionInput\(\{ members, onChange, onSubmitDraft, value/.test(source))
 })
 
 test('popover offers @everyone/@all and inserts parser-compatible strings', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-room-ux.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-room-ux.test.mjs
@@ -15,10 +15,11 @@ const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 //            until the user's NEXT send (harvest only ran inside the loop).
 
 test('room composer is a textarea with Enter=submit, Shift+Enter=newline (#89884)', () => {
-  const component = source.slice(
-    source.indexOf('function GroupMentionInput'),
-    source.indexOf('function GroupChatWorkspace')
-  )
+  // Slice ONLY GroupMentionInput — functions merged between it and
+  // GroupChatWorkspace (e.g. GroupClarifyCard) legitimately use Input.
+  const start = source.indexOf('function GroupMentionInput')
+  const nextFn = source.indexOf('\nfunction ', start + 1)
+  const component = source.slice(start, nextFn)
 
   // The control is the SDK Textarea, not the single-line Input.
   assert.match(component, /jsx\(Textarea, \{/)
@@ -42,6 +43,21 @@ test('room log anchors to the bottom with a user-scroll guard (#89835)', () => {
   // Effect keys on log growth; the guard keeps history reading stable.
   assert.match(workspace, /\[room\.log\.length, room\.running\]/)
   assert.match(workspace, /scrollIntoView/)
+})
+
+test('retained-pane reopen re-anchors to the bottom (#89835 follow-up)', () => {
+  // A hot-mounted room pane never remounts when the user tabs back to it, so
+  // the workspace re-anchors on the hidden → visible edge, fed by the
+  // feature-detected host.paneVisibility authority (always-visible fallback
+  // keeps older SDKs on the previous behavior).
+  const workspace = source.slice(source.indexOf('function GroupChatWorkspace'))
+  assert.match(workspace, /visible = true/)
+  assert.match(workspace, /wasVisibleRef/)
+  assert.match(workspace, /\[visible\]/)
+  const mainView = source.slice(source.indexOf('function GroupChatMainView'), source.indexOf('function openGroupChat'))
+  assert.match(mainView, /typeof host\.paneVisibility === 'function'/)
+  assert.match(mainView, /plugin-workspace:\$\{ID\}:group:\$\{slugify\(group\)\}/)
+  assert.match(mainView, /atom\(true\)/)
 })
 
 test('stranded replies get a bounded background harvest after the loop settles (#89545)', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-room-ux.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-room-ux.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+// Room UX cluster (Aug 2026 desktop audit): three confirmed defects in the
+// group-chat surface, fixed together.
+//
+//   #89884 — the composer was a single-line Input; Enter always submitted and
+//            multi-line prompts were impossible.
+//   #89835 — rooms opened at scroll position 0 with no anchoring; new replies
+//            streamed in below the fold.
+//   #89545 — a member whose reply outlived the turn loop stayed stranded
+//            until the user's NEXT send (harvest only ran inside the loop).
+
+test('room composer is a textarea with Enter=submit, Shift+Enter=newline (#89884)', () => {
+  const component = source.slice(
+    source.indexOf('function GroupMentionInput'),
+    source.indexOf('function GroupChatWorkspace')
+  )
+
+  // The control is the SDK Textarea, not the single-line Input.
+  assert.match(component, /jsx\(Textarea, \{/)
+  assert.doesNotMatch(component, /jsx\(Input, \{/)
+  // Enter (no Shift) submits through the injected handler...
+  assert.match(component, /event\.key === 'Enter' && !event\.shiftKey/)
+  assert.match(component, /onSubmitDraft\?\.\(\)/)
+  // ...and the popover branch still owns Enter while it is open.
+  assert.match(component, /insert\(options\[active\]\.handle\)/)
+})
+
+test('both room composers wire onSubmitDraft (#89884)', () => {
+  assert.match(source, /onSubmitDraft: submit,/)
+  assert.match(source, /onSubmitDraft: \(\) => submitReply\(id\),/)
+})
+
+test('room log anchors to the bottom with a user-scroll guard (#89835)', () => {
+  const workspace = source.slice(source.indexOf('function GroupChatWorkspace'))
+  assert.match(workspace, /bottomSentinelRef/)
+  assert.match(workspace, /stickToBottomRef/)
+  // Effect keys on log growth; the guard keeps history reading stable.
+  assert.match(workspace, /\[room\.log\.length, room\.running\]/)
+  assert.match(workspace, /scrollIntoView/)
+})
+
+test('stranded replies get a bounded background harvest after the loop settles (#89545)', () => {
+  assert.match(source, /function harvestStrandedUntilSettled\(/)
+  // The loop's finally block kicks it off only when members remain stranded.
+  assert.match(source, /strandedLeft\.length/)
+  // Bounded: interval + max tries, and it yields to a live loop.
+  const harvester = source.slice(source.indexOf('async function harvestStrandedUntilSettled'))
+  assert.match(harvester.slice(0, 1600), /HARVEST_MAX_TRIES/)
+  assert.match(harvester.slice(0, 1600), /room\.running/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/legacy-sdk-compat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/legacy-sdk-compat.test.mjs
@@ -69,7 +69,7 @@ function writeReactStubs(root) {
       2
     )}\n`
   )
-  writeFileSync(join(packageRoot, 'index.js'), proxyModule(['useEffect', 'useRef', 'useState']))
+  writeFileSync(join(packageRoot, 'index.js'), proxyModule(['useEffect', 'useMemo', 'useRef', 'useState']))
   writeFileSync(join(packageRoot, 'jsx-runtime.js'), proxyModule(['jsx', 'jsxs']))
 }
 


### PR DESCRIPTION
## Summary
Three group-room UX defects fixed together (refresh of #90526 onto current main), plus the retained-pane scroll gap found in that PR's live review.

## Changes
- **Multi-line prompts (#89884):** `GroupMentionInput` renders the SDK `Textarea` — Enter submits via injected `onSubmitDraft`, Shift+Enter inserts a newline, the @mention popover keeps priority while open.
- **Open at latest (#89835):** bottom sentinel + effect anchors the log on mount and log growth, with an 80px near-bottom guard so reading history is never yanked.
- **Retained-pane reopen (new, from the review repro on #90526):** keep-alive workspace panes stay mounted while hidden, so returning to an open room never re-ran the mount anchor. `GroupChatMainView` now subscribes to feature-detected `host.paneVisibility` (always-visible atom fallback for older SDKs) and the workspace re-anchors on the hidden→visible edge.
- **Late replies harvested (#89545):** bounded background poll (5s × 60) after the turn loop settles picks up members whose replies outlived their turn.
- Test upkeep: composer shape test slices only `GroupMentionInput` (GroupClarifyCard, merged since the branch was cut, legitimately uses `Input`); legacy-SDK react proxy learns `useMemo`; new reopen source-shape regression.

## Validation
| Check | Result |
|---|---|
| Plugin suite | 346/346 pass |
| Live desktop E2E — composer | textarea confirmed; Shift+Enter produced `line1\nline2`; Enter submitted and drained the draft into the room log |
| Live desktop E2E — reviewer's exact repro | seeded 60-message RoomA (scroll max 3428px) at bottom → scrolled to top → opened RoomB → returned to RoomA's retained tab → **re-anchored to bottom (top 3421/3428)** |
| Older SDKs | no `paneVisibility` → always-visible fallback, previous behavior unchanged |

## Infographic

![Group room UX blueprint — Shift+Enter newlines, open-at-latest with reopen re-anchor, bounded late-reply harvest](https://v3b.fal.media/files/b/0aa723c1/MnvC9qxhAoXsFI3zYpA_f_jzddqy2R.png)
