### PR TITLE
fix: normalize WhatsApp JIDs before admin check in slash_access

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1101,6 +1101,17 @@ class GatewaySlashCommandsMixin:
             from gateway.slash_access import policy_for_source
             policy = policy_for_source(self.config, source)
             uid = getattr(source, "user_id", None)
+            if not uid:
+                return False
+            # WhatsApp user_ids arrive as raw JIDs (e.g. "556884063903:47@s.whatsapp.net"
+            # or "202945895362793@lid") but admin config uses bare numeric IDs.
+            # Normalize before comparison so "556884063903" matches any JID variant.
+            if getattr(source, "platform", None) and getattr(source.platform, "value", "") == "whatsapp":
+                try:
+                    from gateway.whatsapp_identity import normalize_whatsapp_identifier
+                    uid = normalize_whatsapp_identifier(uid)
+                except Exception:
+                    pass
             return bool(policy.enabled and uid and policy.is_admin(uid))
         except Exception:
             return False


### PR DESCRIPTION
WhatsApp adapter delivers user_id as raw JIDs (e.g. `556884063903:47@s.whatsapp.net` or `202945895362793@lid`) but admin config uses bare numeric IDs. The `_resume_caller_is_admin` method compared the raw JID directly against the admin list, causing the check to silently fail for WhatsApp users.

Apply `normalize_whatsapp_identifier()` before the comparison so any JID variant maps to the same bare numeric ID the operator configured.

This unblocks `/sessions all` and `/resume --all` for WhatsApp users who configure admin access via `platforms.whatsapp.extra.allow_admin_from`.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

