### PR TITLE
fix(mcp): keep tool errors out of transport breaker

### DIFF
--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -96,9 +96,80 @@ def _cleanup(mcp_tool_module, name: str) -> None:
         mcp_tool_module._server_breaker_opened_at.pop(name, None)
 
 
+def _tool_error_result(text: str):
+    """Return an MCP result whose RPC succeeded but whose tool rejected the call."""
+    result = MagicMock()
+    result.is_error = True
+    block = MagicMock()
+    block.text = text
+    block.type = "text"
+    result.content = [block]
+    result.structured_content = None
+    result.meta = None
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+def test_tool_errors_do_not_trip_transport_breaker(monkeypatch, tmp_path):
+    """A completed RPC returning isError proves the transport is healthy."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    calls = {"count": 0}
+
+    async def _call_tool_error(*_args, **_kwargs):
+        calls["count"] += 1
+        return _tool_error_result(f"bad parameter {calls['count']}")
+
+    _install_stub_server(mcp_tool, "srv", _call_tool_error)
+    mcp_tool._ensure_mcp_loop()
+    try:
+        handler = _make_tool_handler("srv", "tool1", 10.0)
+        for expected in range(1, 5):
+            parsed = json.loads(handler({}))
+            assert f"bad parameter {expected}" in parsed["error"]
+
+        assert calls["count"] == 4, "the fourth call must reach the healthy transport"
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0
+        assert mcp_tool._server_breaker_opened_at.get("srv") is None
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
+def test_tool_error_resets_prior_transport_strikes(monkeypatch, tmp_path):
+    """Any completed round-trip closes a breaker that has not opened yet."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    behavior = {"transport_down": True}
+
+    async def _call_tool(*_args, **_kwargs):
+        if behavior["transport_down"]:
+            raise RuntimeError("transport down")
+        return _tool_error_result("tool denied")
+
+    _install_stub_server(mcp_tool, "srv", _call_tool)
+    mcp_tool._ensure_mcp_loop()
+    try:
+        handler = _make_tool_handler("srv", "tool1", 10.0)
+        handler({})
+        handler({})
+        assert mcp_tool._server_error_counts.get("srv") == 2
+
+        behavior["transport_down"] = False
+        assert "tool denied" in json.loads(handler({}))["error"]
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0
+        assert mcp_tool._server_breaker_opened_at.get("srv") is None
+    finally:
+        _cleanup(mcp_tool, "srv")
 
 
 def test_circuit_breaker_half_opens_after_cooldown(monkeypatch, tmp_path):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5818,6 +5818,11 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     )
                 return tool_error(f"MCP server '{server_name}' is not connected")
 
+        # Set by _call() when the MCP tool itself returns isError. The RPC
+        # round-trip completed in that case, so the transport is healthy and
+        # the result must not count against the transport circuit breaker.
+        tool_error_encountered = False
+
         async def _call():
             _mark_server_call_started(server)
             async with server._rpc_lock:
@@ -5839,6 +5844,8 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             # MCP CallToolResult has .content (list of content blocks) and
             # .is_error (.isError before mcp 2.0)
             if mcp_field(result, "is_error", "isError", False):
+                nonlocal tool_error_encountered
+                tool_error_encountered = True
                 error_text = ""
                 for block in (result.content or []):
                     if getattr(block, "text", None):
@@ -5969,7 +5976,10 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             try:
                 parsed = json.loads(result)
                 if "error" in parsed:
-                    _bump_server_error(server_name)
+                    if tool_error_encountered:
+                        _reset_server_error(server_name)
+                    else:
+                        _bump_server_error(server_name)
                 else:
                     _reset_server_error(server_name)  # success — reset
             except (json.JSONDecodeError, TypeError):


### PR DESCRIPTION
## Summary

Keep MCP tool-level `isError` results out of the per-server transport circuit breaker.

An `isError` result arrives only after a completed RPC round-trip, so it proves the transport is healthy. The current outer handler serializes that result to `{"error": ...}`, sees the generic `error` key, and increments `_server_error_counts`. Three ordinary validation/domain errors can therefore make a healthy server report "unreachable" for the cooldown period.

The handler now records when the error came from the MCP tool itself and resets the transport breaker for that completed round-trip. Transport exceptions continue to increment and open the breaker.

## Tests

- four consecutive tool errors all reach the server and leave the breaker closed
- a tool error resets two prior transport strikes
- existing half-open, reconnect, and transport-failure behavior remains covered
- 134 targeted MCP tests pass
- Ruff passes
