### PR TITLE
fix(agent): cap runaway delegation and fail closed on Codex stop

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import math
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional
@@ -44,6 +45,34 @@ class AccountUsageSnapshot:
     @property
     def available(self) -> bool:
         return bool(self.windows or self.details) and not self.unavailable_reason
+
+
+def codex_weekly_used_percent(snapshot: Optional[AccountUsageSnapshot]) -> Optional[float]:
+    """Return the Codex weekly window used_percent, if present."""
+    if snapshot is None:
+        return None
+    for window in snapshot.windows:
+        if str(window.label or "").strip().lower() == "weekly":
+            if window.used_percent is None:
+                return None
+            return float(window.used_percent)
+    return None
+
+
+def should_trip_codex_weekly_breaker(
+    snapshot: Optional[AccountUsageSnapshot],
+    threshold_percent: float,
+) -> bool:
+    """Trip when the weekly window is at or above the configured percent.
+
+    ``threshold_percent <= 0`` disables the breaker. Missing snapshots fail open.
+    """
+    if threshold_percent is None or float(threshold_percent) <= 0:
+        return False
+    used = codex_weekly_used_percent(snapshot)
+    if used is None:
+        return False
+    return used >= float(threshold_percent)
 
 
 def _title_case_slug(value: Optional[str]) -> Optional[str]:
@@ -900,3 +929,26 @@ def fetch_account_usage(
     except Exception:
         return None
     return None
+
+
+def cached_codex_usage_snapshot(agent: Any, *, ttl_seconds: float = 60.0) -> Optional[AccountUsageSnapshot]:
+    """Return the last Codex usage snapshot, refreshing at most once per TTL."""
+    now = time.time()
+    cache = getattr(agent, "_codex_usage_snapshot_cache", None)
+    if isinstance(cache, tuple) and len(cache) == 2:
+        ts, snap = cache
+        try:
+            if now - float(ts) < float(ttl_seconds):
+                return snap
+        except (TypeError, ValueError):
+            pass
+    snap = fetch_account_usage(
+        "openai-codex",
+        base_url=getattr(agent, "base_url", None),
+        api_key=getattr(agent, "api_key", None),
+    )
+    try:
+        agent._codex_usage_snapshot_cache = (now, snap)
+    except Exception:
+        pass
+    return snap

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1401,6 +1401,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
 
         intercepted_events = []
         writer_token = {"value": None}
+        superseded = {"value": False}
 
         def _open_codex_stream(next_api_kwargs: dict[str, Any]):
             stream_kwargs = _sanitize_consumer_codex_request(
@@ -1422,9 +1423,11 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
             logger.warning(
                 "Codex streaming attempt superseded by a newer stream; "
                 "stopping consumption to preserve the single-writer "
-                "invariant (model=%s).",
+                "invariant (model=%s). Not retrying this turn.",
                 api_kwargs.get("model", "unknown"),
             )
+            superseded["value"] = True
+            agent._interrupt_requested = True
             return False
 
         def _finalize_codex_stream() -> Any:
@@ -1493,7 +1496,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
             raise
 
         def _interrupt_or_superseded() -> bool:
-            return bool(agent._interrupt_requested)
+            return bool(agent._interrupt_requested) or bool(superseded["value"])
 
         try:
             try:
@@ -1515,6 +1518,10 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                     interrupt_check=_interrupt_or_superseded,
                 )
             except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
+                if superseded["value"]:
+                    raise InterruptedError(
+                        "Codex streaming attempt superseded; not retrying"
+                    ) from exc
                 if attempt < max_stream_retries:
                     logger.debug(
                         "Codex Responses stream transport failed mid-iteration "
@@ -1530,6 +1537,10 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 )
                 raise
             except RuntimeError:
+                if superseded["value"]:
+                    raise InterruptedError(
+                        "Codex streaming attempt superseded; not retrying"
+                    )
                 if event_stream.final_response is not None:
                     return event_stream.final_response
                 raise
@@ -1540,6 +1551,11 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                     stream_opened=writer_token["value"] is not None,
                 )
                 raise
+
+            if superseded["value"]:
+                raise InterruptedError(
+                    "Codex streaming attempt superseded; not retrying"
+                )
 
             # A terminal response has already been assembled at this point
             # (``final`` is built), so a transport error while draining the

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1998,6 +1998,20 @@ def run_conversation(
             if not agent.quiet_mode:
                 agent._safe_print("\n⚡ Breaking out of tool loop due to interrupt...")
             break
+
+        if getattr(agent, "_delegate_depth", 0) > 0:
+            try:
+                from agent.tool_guardrails import child_session_budget_exhausted
+                _child_cap = child_session_budget_exhausted(agent)
+                if _child_cap is not None:
+                    interrupted = True
+                    _turn_exit_reason = "child_session_budget"
+                    agent._interrupt_requested = True
+                    if not agent.quiet_mode:
+                        agent._safe_print(f"\n{_child_cap.message}")
+                    break
+            except Exception:
+                pass
         
         api_call_count += 1
         agent._api_call_count = api_call_count
@@ -2883,6 +2897,65 @@ def run_conversation(
                     pass
                 except Exception:
                     pass  # Never let rate guard break the agent loop
+
+            # Codex weekly allowance circuit breaker (#91040). Fail-open on
+            # fetch errors; 0 disables. Prefer fallback over burning the cap.
+            if str(getattr(agent, "provider", "") or "") == "openai-codex":
+                try:
+                    _caps = getattr(
+                        getattr(agent, "_tool_guardrails", None), "config", None
+                    )
+                    _loop_caps = getattr(_caps, "loop_caps", None)
+                    _weekly_pct = int(
+                        getattr(_loop_caps, "codex_weekly_break_percent", 90) or 0
+                    )
+                    if _weekly_pct > 0:
+                        from agent.account_usage import (
+                            cached_codex_usage_snapshot,
+                            codex_weekly_used_percent,
+                            should_trip_codex_weekly_breaker,
+                        )
+                        _snap = cached_codex_usage_snapshot(agent)
+                        if should_trip_codex_weekly_breaker(_snap, _weekly_pct):
+                            _used = codex_weekly_used_percent(_snap)
+                            _codex_msg = (
+                                f"Codex weekly usage is at {_used:.0f}% "
+                                f"(circuit breaker {_weekly_pct}%). Stopping "
+                                "further API calls this turn."
+                            )
+                            agent._buffer_vprint(f"⏳ {_codex_msg} Trying fallback...")
+                            agent._buffer_status(f"⏳ {_codex_msg}")
+                            try:
+                                from agent.interrupt_compat import request_hard_interrupt
+                                request_hard_interrupt(agent, _codex_msg)
+                            except Exception:
+                                agent._interrupt_requested = True
+                            if agent._try_activate_fallback():
+                                active_system_prompt = _sync_failover_system_message(
+                                    agent, api_messages, active_system_prompt)
+                                retry_count = 0
+                                compression_attempts = 0
+                                _retry.primary_recovery_attempted = False
+                                _retry.restart_with_rebuilt_messages = True
+                                break
+                            agent._flush_status_buffer()
+                            agent._persist_session(messages, conversation_history)
+                            return {
+                                "final_response": (
+                                    f"⏳ {_codex_msg}\n\n"
+                                    "No fallback provider available. "
+                                    "Wait for the weekly reset, redeem a "
+                                    "Codex reset credit, or add a fallback "
+                                    "provider in config.yaml."
+                                ),
+                                "messages": messages,
+                                "api_calls": api_call_count,
+                                "completed": False,
+                                "failed": True,
+                                "error": _codex_msg,
+                            }
+                except Exception:
+                    pass
 
             try:
                 agent._reset_stream_delivery_tracking()
@@ -4193,6 +4266,17 @@ def run_conversation(
                     agent.session_cache_read_tokens += canonical_usage.cache_read_tokens
                     agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
                     agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
+
+                    if getattr(agent, "_delegate_depth", 0) > 0:
+                        try:
+                            from agent.tool_guardrails import record_child_session_usage
+                            record_child_session_usage(
+                                agent,
+                                api_calls=1,
+                                tokens=int(total_tokens or 0),
+                            )
+                        except Exception:
+                            pass
 
                     # Log API call details for debugging/observability
                     _cache_pct = ""

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -31,6 +31,46 @@ from agent.usage_pricing import (
     format_duration_compact,
     has_known_pricing,
 )
+from hermes_state_common import _ephemeral_child_sql
+
+
+def _session_token_total(session: Dict[str, Any]) -> int:
+    return (
+        int(session.get("input_tokens") or 0)
+        + int(session.get("output_tokens") or 0)
+        + int(session.get("cache_read_tokens") or 0)
+        + int(session.get("cache_write_tokens") or 0)
+    )
+
+
+def fold_parent_child_session_usage(sessions: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Drop child rows only when the parent token fields already cover them.
+
+    If the parent is smaller than its ephemeral children, keep both (no
+    token rollup). If the parent is at least as large, treat the parent as
+    already including child activity and omit the children so insights
+    does not double-count.
+    """
+    by_id = {s.get("id"): s for s in sessions if s.get("id")}
+    children_by_parent: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    drop_ids: set[str] = set()
+    for session in sessions:
+        if int(session.get("is_ephemeral") or 0) != 1:
+            continue
+        parent_id = session.get("parent_session_id")
+        if not parent_id:
+            continue
+        children_by_parent[str(parent_id)].append(session)
+    for parent_id, kids in children_by_parent.items():
+        parent = by_id.get(parent_id)
+        if parent is None:
+            continue
+        child_total = sum(_session_token_total(kid) for kid in kids)
+        if _session_token_total(parent) >= child_total:
+            drop_ids.update(str(kid["id"]) for kid in kids if kid.get("id"))
+    if not drop_ids:
+        return sessions
+    return [session for session in sessions if session.get("id") not in drop_ids]
 
 
 def _fmt_est_cost(est_cost: float) -> str:
@@ -158,7 +198,7 @@ class InsightsEngine:
             flush()
 
         # Gather raw data
-        sessions = self._get_sessions(cutoff, source)
+        sessions = fold_parent_child_session_usage(self._get_sessions(cutoff, source))
         tool_usage = self._get_tool_usage(cutoff, source)
         skill_usage = self._get_skill_usage(cutoff, source)
         message_stats = self._get_message_stats(cutoff, source)
@@ -232,19 +272,23 @@ class InsightsEngine:
                      "message_count, tool_call_count, input_tokens, output_tokens, "
                      "cache_read_tokens, cache_write_tokens, billing_provider, "
                      "billing_base_url, billing_mode, estimated_cost_usd, "
-                     "actual_cost_usd, cost_status, cost_source, api_call_count")
+                     "actual_cost_usd, cost_status, cost_source, api_call_count, "
+                     "parent_session_id")
 
     # Pre-computed query strings — f-string evaluated once at class definition,
     # not at runtime, so no user-controlled value can alter the query structure.
+    _EPHEMERAL_FLAG = (
+        f", CASE WHEN {_ephemeral_child_sql('s')} THEN 1 ELSE 0 END AS is_ephemeral"
+    )
     _GET_SESSIONS_WITH_SOURCE = (
-        f"SELECT {_SESSION_COLS} FROM sessions"
-        " WHERE started_at >= ? AND source = ?"
-        " ORDER BY started_at DESC"
+        f"SELECT {_SESSION_COLS}{_EPHEMERAL_FLAG} FROM sessions s"
+        " WHERE s.started_at >= ? AND s.source = ?"
+        " ORDER BY s.started_at DESC"
     )
     _GET_SESSIONS_ALL = (
-        f"SELECT {_SESSION_COLS} FROM sessions"
-        " WHERE started_at >= ?"
-        " ORDER BY started_at DESC"
+        f"SELECT {_SESSION_COLS}{_EPHEMERAL_FLAG} FROM sessions s"
+        " WHERE s.started_at >= ?"
+        " ORDER BY s.started_at DESC"
     )
 
     # Assistant ``tool_calls`` scan for tool/skill usage.  ``INDEXED BY`` pins
@@ -670,6 +714,8 @@ class InsightsEngine:
             return display_model
 
         usage_rows = self._get_model_usage(cutoff, source)
+        allowed_ids = {s.get("id") for s in sessions if s.get("id")}
+        usage_rows = [r for r in usage_rows if r.get("session_id") in allowed_ids]
         usage_totals = defaultdict(lambda: {
             "input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0,
             "cache_write_tokens": 0, "reasoning_tokens": 0,

--- a/agent/interrupt_compat.py
+++ b/agent/interrupt_compat.py
@@ -33,3 +33,50 @@ def request_hard_interrupt(agent: Any, message: str | None = None) -> bool:
     else:
         interrupt(message)
     return True
+
+
+INTERRUPT_JOIN_MAX_TICKS = 50  # 50 * 0.2s = 10s, same bound as before this incident
+
+
+def interrupt_join_should_stop(
+    *,
+    ticks_elapsed: int,
+    agent_thread_alive: bool,
+    should_exit: bool,
+    max_ticks: int = INTERRUPT_JOIN_MAX_TICKS,
+) -> bool:
+    """Bounded interrupt wait: stop on death, force-exit, or timeout.
+
+    An unbounded wait freezes the CLI when a child ignores interrupt.
+    """
+    if not agent_thread_alive or should_exit:
+        return True
+    return ticks_elapsed >= max_ticks
+
+
+def interrupt_followup_disposition(
+    *,
+    agent_thread_alive: bool,
+    should_exit: bool = False,
+) -> str:
+    """What to do with the user's post-interrupt message.
+
+    enqueue: thread is dead; starting a new turn is safe.
+    park: thread still alive after the bounded wait; hold the text.
+    drop: process is exiting (second Ctrl+C).
+    """
+    if should_exit:
+        return "drop"
+    if agent_thread_alive:
+        return "park"
+    return "enqueue"
+
+
+def should_enqueue_interrupt_followup(*, agent_thread_alive: bool) -> bool:
+    """Whether CLI may start a new user turn after /stop or interrupt.
+
+    A still-running agent thread shares the Codex stream writer with the next
+    turn. Enqueueing follow-up while it is alive is what produces
+    ``Codex streaming attempt superseded`` plus post-stop tool/API calls.
+    """
+    return interrupt_followup_disposition(agent_thread_alive=agent_thread_alive) == "enqueue"

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
+import threading
 from dataclasses import dataclass, field
 from typing import Any, Mapping
 
@@ -178,8 +180,21 @@ class ToolCallGuardrailConfig:
 # single turn" rather than cumulative over the whole session. A single loop
 # issuing dozens of web searches or spawning dozens of subagents is already
 # pathological, so the defaults are deliberately low.
+#
+# Session-lifetime delegation caps do NOT reset between turns. Sequential
+# review batches across an 8-hour CLI task are one session; a per-turn cap
+# of 50 cannot stop 17 batches of reviewers. 0 disables a given cap.
 _DEFAULT_MAX_WEB_SEARCHES_PER_TURN = 50
 _DEFAULT_MAX_SUBAGENTS_PER_TURN = 50
+_DEFAULT_MAX_SUBAGENTS_PER_SESSION = 16
+_DEFAULT_MAX_DELEGATE_BATCHES_PER_SESSION = 4
+_DEFAULT_MAX_CHILD_API_CALLS_PER_SESSION = 80
+_DEFAULT_MAX_CHILD_TOKENS_PER_SESSION = 8_000_000
+_DEFAULT_CODEX_WEEKLY_BREAK_PERCENT = 90
+_REVIEW_DELEGATE_RE = re.compile(
+    r"\b(code\s*review|reviewer|review|nitpick|lgtm)\b",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -202,6 +217,12 @@ class LoopCapConfig:
 
     max_web_searches: int = _DEFAULT_MAX_WEB_SEARCHES_PER_TURN
     max_subagents: int = _DEFAULT_MAX_SUBAGENTS_PER_TURN
+    max_subagents_per_session: int = _DEFAULT_MAX_SUBAGENTS_PER_SESSION
+    max_delegate_batches_per_session: int = _DEFAULT_MAX_DELEGATE_BATCHES_PER_SESSION
+    max_child_api_calls_per_session: int = _DEFAULT_MAX_CHILD_API_CALLS_PER_SESSION
+    max_child_tokens_per_session: int = _DEFAULT_MAX_CHILD_TOKENS_PER_SESSION
+    require_delegate_batch_checkpoint: bool = True
+    codex_weekly_break_percent: int = _DEFAULT_CODEX_WEEKLY_BREAK_PERCENT
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any] | None) -> "LoopCapConfig":
@@ -215,6 +236,30 @@ class LoopCapConfig:
             ),
             max_subagents=_non_negative_int(
                 data.get("max_subagents"), defaults.max_subagents
+            ),
+            max_subagents_per_session=_non_negative_int(
+                data.get("max_subagents_per_session"),
+                defaults.max_subagents_per_session,
+            ),
+            max_delegate_batches_per_session=_non_negative_int(
+                data.get("max_delegate_batches_per_session"),
+                defaults.max_delegate_batches_per_session,
+            ),
+            max_child_api_calls_per_session=_non_negative_int(
+                data.get("max_child_api_calls_per_session"),
+                defaults.max_child_api_calls_per_session,
+            ),
+            max_child_tokens_per_session=_non_negative_int(
+                data.get("max_child_tokens_per_session"),
+                defaults.max_child_tokens_per_session,
+            ),
+            require_delegate_batch_checkpoint=_as_bool(
+                data.get("require_delegate_batch_checkpoint"),
+                defaults.require_delegate_batch_checkpoint,
+            ),
+            codex_weekly_break_percent=_non_negative_int(
+                data.get("codex_weekly_break_percent"),
+                defaults.codex_weekly_break_percent,
             ),
         )
 
@@ -336,6 +381,15 @@ class ToolCallGuardrailController:
 
     def __init__(self, config: ToolCallGuardrailConfig | None = None):
         self.config = config or ToolCallGuardrailConfig()
+        # Session-lifetime counters survive reset_for_turn(). The controller is
+        # constructed once per AIAgent, so these bound one parent task.
+        self._session_subagent_count = 0
+        self._session_delegate_batches = 0
+        self._session_child_api_calls = 0
+        self._session_child_tokens = 0
+        self._session_checkpoint_granted = False
+        self._session_awaiting_delegate_checkpoint = False
+        self._session_lock = threading.Lock()
         self.reset_for_turn()
 
     def reset_for_turn(self) -> None:
@@ -368,6 +422,10 @@ class ToolCallGuardrailController:
         # single agent loop rather than accumulating across the session.
         self._turn_web_search_count = 0
         self._turn_subagent_count = 0
+        # A new user turn after a blocked follow-up batch is the checkpoint.
+        if self._session_delegate_batches > 0 and self._session_awaiting_delegate_checkpoint:
+            self._session_checkpoint_granted = True
+            self._session_awaiting_delegate_checkpoint = False
 
     @property
     def halt_decision(self) -> ToolGuardrailDecision | None:
@@ -694,16 +752,87 @@ class ToolCallGuardrailController:
             return None
 
         if tool_name == "delegate_task":
-            cap = caps.max_subagents
-            if not cap:
-                return None
             spawn_count = _subagent_spawn_count(args)
             if spawn_count == 0:
                 # Control action (list/steer/stop) — spawns nothing. Never
                 # block: once the spawn cap is hit, steering/stopping the
                 # existing children is exactly what should still work.
                 return None
-            if self._turn_subagent_count >= cap:
+
+            usage_block = self._child_usage_block(tool_name, signature)
+            if usage_block is not None:
+                return usage_block
+
+            if (
+                caps.require_delegate_batch_checkpoint
+                and self._session_delegate_batches >= 1
+                and not self._session_checkpoint_granted
+            ):
+                kind = (
+                    "review"
+                    if looks_like_review_delegate(args)
+                    else "delegation"
+                )
+                decision = ToolGuardrailDecision(
+                    action="block",
+                    code="loop_delegate_batch_checkpoint",
+                    message=(
+                        f"Blocked delegate_task: this session already ran a "
+                        f"{kind} batch. A second review/delegation batch "
+                        "needs an explicit user checkpoint (a new user "
+                        "message after this halt). Summarize progress and wait."
+                    ),
+                    tool_name=tool_name,
+                    count=self._session_delegate_batches,
+                    signature=signature,
+                )
+                self._halt_decision = decision
+                self._session_awaiting_delegate_checkpoint = True
+                return decision
+
+            session_cap = caps.max_subagents_per_session
+            if session_cap and (
+                self._session_subagent_count >= session_cap
+                or self._session_subagent_count + spawn_count > session_cap
+            ):
+                decision = ToolGuardrailDecision(
+                    action="block",
+                    code="loop_subagent_session_cap",
+                    message=(
+                        f"Blocked delegate_task: this session has already spawned "
+                        f"{self._session_subagent_count} subagents "
+                        f"(session limit {session_cap}). Do not start another "
+                        "review or rework batch. Finish with the results you "
+                        "have, or ask the user before delegating more."
+                    ),
+                    tool_name=tool_name,
+                    count=self._session_subagent_count,
+                    signature=signature,
+                )
+                self._halt_decision = decision
+                return decision
+
+            batch_cap = caps.max_delegate_batches_per_session
+            if batch_cap and self._session_delegate_batches >= batch_cap:
+                decision = ToolGuardrailDecision(
+                    action="block",
+                    code="loop_delegate_batch_session_cap",
+                    message=(
+                        f"Blocked delegate_task: this session has already run "
+                        f"{self._session_delegate_batches} delegation batches "
+                        f"(session limit {batch_cap}). Repeated review → patch → "
+                        "review loops require a user checkpoint. Summarize "
+                        "progress and wait for the user."
+                    ),
+                    tool_name=tool_name,
+                    count=self._session_delegate_batches,
+                    signature=signature,
+                )
+                self._halt_decision = decision
+                return decision
+
+            cap = caps.max_subagents
+            if cap and self._turn_subagent_count >= cap:
                 decision = ToolGuardrailDecision(
                     action="block",
                     code="loop_subagent_cap",
@@ -720,9 +849,71 @@ class ToolCallGuardrailController:
                 self._halt_decision = decision
                 return decision
             self._turn_subagent_count += spawn_count
+            self._session_subagent_count += spawn_count
+            self._session_delegate_batches += 1
+            if self._session_checkpoint_granted:
+                self._session_checkpoint_granted = False
+            self._session_awaiting_delegate_checkpoint = True
             return None
 
         return None
+
+    def _child_usage_block(
+        self,
+        tool_name: str,
+        signature: ToolCallSignature,
+    ) -> ToolGuardrailDecision | None:
+        caps = self.config.loop_caps
+        api_cap = caps.max_child_api_calls_per_session
+        token_cap = caps.max_child_tokens_per_session
+        with self._session_lock:
+            api_used = self._session_child_api_calls
+            token_used = self._session_child_tokens
+        if api_cap and api_used >= api_cap:
+            decision = ToolGuardrailDecision(
+                action="block",
+                code="loop_child_api_session_cap",
+                message=(
+                    f"Blocked delegate_task: child agents in this session have "
+                    f"already made {api_used} API calls (session limit {api_cap}). "
+                    "Stop delegating and finish with the results you have."
+                ),
+                tool_name=tool_name,
+                count=api_used,
+                signature=signature,
+            )
+            self._halt_decision = decision
+            return decision
+        if token_cap and token_used >= token_cap:
+            decision = ToolGuardrailDecision(
+                action="block",
+                code="loop_child_token_session_cap",
+                message=(
+                    f"Blocked delegate_task: child agents in this session have "
+                    f"already used {token_used} tokens (session limit {token_cap}). "
+                    "Stop delegating and finish with the results you have."
+                ),
+                tool_name=tool_name,
+                count=token_used,
+                signature=signature,
+            )
+            self._halt_decision = decision
+            return decision
+        return None
+
+    def record_child_usage(self, *, api_calls: int = 0, tokens: int = 0) -> None:
+        """Accumulate live child spend. Session-lifetime; does not reset per turn."""
+        if api_calls <= 0 and tokens <= 0:
+            return
+        with self._session_lock:
+            if api_calls > 0:
+                self._session_child_api_calls += int(api_calls)
+            if tokens > 0:
+                self._session_child_tokens += int(tokens)
+
+    def child_budget_exhausted(self) -> ToolGuardrailDecision | None:
+        """True when live child spend already hit a session cap (stop in-flight children)."""
+        return self._child_usage_block("delegate_task", ToolCallSignature.from_call("delegate_task", {}))
 
 
 def toolguard_synthetic_result(decision: ToolGuardrailDecision) -> str:
@@ -845,6 +1036,59 @@ def _subagent_spawn_count(args: Mapping[str, Any]) -> int:
     if isinstance(tasks, list) and tasks:
         return len(tasks)
     return 1
+
+
+def looks_like_review_delegate(args: Mapping[str, Any] | None) -> bool:
+    """Heuristic for review→patch→review fan-out (issue #91040)."""
+    if not isinstance(args, Mapping):
+        return False
+    blobs: list[str] = []
+    goal = args.get("goal")
+    if isinstance(goal, str):
+        blobs.append(goal)
+    tasks = args.get("tasks")
+    if isinstance(tasks, list):
+        for item in tasks:
+            if isinstance(item, Mapping):
+                item_goal = item.get("goal")
+                if isinstance(item_goal, str):
+                    blobs.append(item_goal)
+            elif isinstance(item, str):
+                blobs.append(item)
+    text = " ".join(blobs)
+    return bool(text and _REVIEW_DELEGATE_RE.search(text))
+
+
+def session_root_guardrails(agent: Any) -> ToolCallGuardrailController | None:
+    """Walk ``_delegate_parent_ref`` to the parent task's guardrail controller."""
+    cur = agent
+    seen: set[int] = set()
+    while cur is not None:
+        ident = id(cur)
+        if ident in seen:
+            break
+        seen.add(ident)
+        ref = getattr(cur, "_delegate_parent_ref", None)
+        parent = ref() if callable(ref) else None
+        if parent is None:
+            break
+        cur = parent
+    controller = getattr(cur, "_tool_guardrails", None)
+    return controller if isinstance(controller, ToolCallGuardrailController) else None
+
+
+def record_child_session_usage(agent: Any, *, api_calls: int = 0, tokens: int = 0) -> None:
+    controller = session_root_guardrails(agent)
+    if controller is None:
+        return
+    controller.record_child_usage(api_calls=api_calls, tokens=tokens)
+
+
+def child_session_budget_exhausted(agent: Any) -> ToolGuardrailDecision | None:
+    controller = session_root_guardrails(agent)
+    if controller is None:
+        return None
+    return controller.child_budget_exhausted()
 
 
 def _sha256(value: str) -> str:

--- a/cli.py
+++ b/cli.py
@@ -54,7 +54,12 @@ from hermes_cli.fallback_config import get_fallback_chain
 from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
 from hermes_cli.cli_commands_mixin import CLICommandsMixin
 from hermes_cli.cli_billing_mixin import CLIBillingMixin
-from agent.interrupt_compat import request_hard_interrupt
+from agent.interrupt_compat import (
+    request_hard_interrupt,
+    INTERRUPT_JOIN_MAX_TICKS,
+    interrupt_followup_disposition,
+    interrupt_join_should_stop,
+)
 
 # prompt_toolkit for fixed input area TUI
 from prompt_toolkit.history import FileHistory
@@ -5449,6 +5454,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._agent_running = False
         self._pending_input = queue.Queue()
         self._interrupt_queue = queue.Queue()
+        self._deferred_followups: list = []
         # Tracks whether the turn that just finished was interrupted via
         # Ctrl+C. Consumed by _maybe_continue_goal_after_turn so /goal loops
         # don't auto-queue another continuation on top of a user-cancelled
@@ -12836,6 +12842,31 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         except Exception:
             pass  # Non-fatal — never break the main loop
 
+    def _park_interrupt_followup(self, text: str) -> None:
+        """Hold a follow-up until the interrupted agent thread has exited."""
+        if not text:
+            return
+        held = getattr(self, "_deferred_followups", None)
+        if held is None:
+            self._deferred_followups = []
+            held = self._deferred_followups
+        held.append(text)
+
+    def _flush_deferred_followups(self) -> None:
+        """Move parked interrupt follow-ups onto the idle input queue."""
+        held = getattr(self, "_deferred_followups", None)
+        if not held or not hasattr(self, "_pending_input"):
+            return
+        if getattr(self, "_agent_running", False):
+            return
+        thread = getattr(self, "_last_agent_thread", None)
+        if thread is not None and thread.is_alive():
+            return
+        self._deferred_followups = []
+        for text in held:
+            if text:
+                self._pending_input.put(text)
+
     def _maybe_continue_goal_after_turn(self) -> None:
         """Hook run after every CLI turn. Judges + maybe re-queues.
 
@@ -16479,6 +16510,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._prompt_start_time = time.time()
             self._prompt_duration = 0.0
             agent_thread = threading.Thread(target=run_agent, daemon=True)
+            self._last_agent_thread = agent_thread
             agent_thread.start()
 
             # Ambient "thinking" sound: calm bubble blips while the agent
@@ -16566,21 +16598,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # stays responsive — if the user sent another interrupt or the
             # agent gets stuck, we can break out instead of freezing forever.
             if interrupt_msg is not None:
-                # Interrupt path: poll briefly, then move on.  The agent
-                # thread is daemon — it dies on process exit regardless.
-                for _wait_tick in range(50):  # 50 * 0.2s = 10s max
+                # Bounded wait (10s). Do not freeze forever if a child ignores
+                # interrupt; do not start a new Codex turn on the same agent
+                # while the thread is still alive — park the follow-up instead.
+                for _wait_tick in range(INTERRUPT_JOIN_MAX_TICKS):
                     agent_thread.join(timeout=0.2)
-                    if not agent_thread.is_alive():
-                        break
-                    # Check if user fired ANOTHER interrupt (Ctrl+C sets
-                    # _should_exit which process_loop checks on next pass).
-                    if getattr(self, '_should_exit', False):
+                    if interrupt_join_should_stop(
+                        ticks_elapsed=_wait_tick + 1,
+                        agent_thread_alive=agent_thread.is_alive(),
+                        should_exit=bool(getattr(self, '_should_exit', False)),
+                    ):
                         break
                 if agent_thread.is_alive():
                     logger.warning(
                         "Agent thread still alive after interrupt "
-                        "(thread %s). Daemon thread will be cleaned up "
-                        "on exit.",
+                        "(thread %s); parking follow-up until it exits.",
                         agent_thread.ident,
                     )
             else:
@@ -16873,19 +16905,45 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 combined = "\n".join(all_parts)
                 n = len(all_parts)
                 preview = combined[:50] + ("..." if len(combined) > 50 else "")
-                if n > 1:
-                    print(f"\n⚡ Sending {n} messages after interrupt: '{preview}'")
-                else:
-                    print(f"\n⚡ Sending after interrupt: '{preview}'")
-                self._pending_input.put(combined)
+                disposition = interrupt_followup_disposition(
+                    agent_thread_alive=agent_thread.is_alive(),
+                    should_exit=bool(getattr(self, "_should_exit", False)),
+                )
+                if disposition == "enqueue":
+                    if n > 1:
+                        print(f"\n⚡ Sending {n} messages after interrupt: '{preview}'")
+                    else:
+                        print(f"\n⚡ Sending after interrupt: '{preview}'")
+                    self._pending_input.put(combined)
+                elif disposition == "park":
+                    logger.warning(
+                        "Parking interrupt follow-up; agent thread %s is still alive",
+                        agent_thread.ident,
+                    )
+                    print(
+                        "\n⚡ Stop is still draining parent/child work; "
+                        "holding your message until that thread exits."
+                    )
+                    self._park_interrupt_followup(combined)
 
             # If a /steer was left over (agent finished before another tool
             # batch could absorb it), deliver it as the next user turn.
             _leftover_steer = result.get("pending_steer") if result else None
             if _leftover_steer and hasattr(self, '_pending_input'):
                 preview = _leftover_steer[:60] + ("..." if len(_leftover_steer) > 60 else "")
-                print(f"\n⏩ Delivering leftover /steer as next turn: '{preview}'")
-                self._pending_input.put(_leftover_steer)
+                disposition = interrupt_followup_disposition(
+                    agent_thread_alive=agent_thread.is_alive(),
+                    should_exit=bool(getattr(self, "_should_exit", False)),
+                )
+                if disposition == "enqueue":
+                    print(f"\n⏩ Delivering leftover /steer as next turn: '{preview}'")
+                    self._pending_input.put(_leftover_steer)
+                elif disposition == "park":
+                    print(
+                        f"\n⏩ Holding leftover /steer until the interrupted "
+                        f"agent thread exits: '{preview}'"
+                    )
+                    self._park_interrupt_followup(_leftover_steer)
 
             return response
             
@@ -20139,6 +20197,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 try:
                     # Check for pending input with timeout
                     try:
+                        if not self._agent_running:
+                            self._flush_deferred_followups()
                         user_input = self._pending_input.get(timeout=0.1)
                     except queue.Empty:
                         # Periodic config watcher — auto-reload MCP on mcp_servers change

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -471,12 +471,14 @@ class CLICommandsMixin:
         print(f"  Use it: hermes -p {imported}")
 
     def _handle_stop_command(self):
-        """Handle /stop — kill all running background processes and
-        background (async) delegations.
+        """Handle /stop — halt the current parent/child turn plus background work.
 
         Inspired by OpenAI Codex's separation of interrupt (stop current turn)
         from /stop (clean up background processes). See openai/codex#14602.
+        The incident in #91040 showed /stop leaving the parent thread and
+        delegated children running; foreground hard-interrupt is required.
         """
+        from agent.interrupt_compat import request_hard_interrupt
         from tools.process_registry import process_registry
 
         processes = process_registry.list_sessions()
@@ -491,7 +493,12 @@ class CLICommandsMixin:
             n_async = 0
             interrupt_all = None
 
-        if not running and not n_async:
+        foreground = bool(getattr(self, "_agent_running", False) and getattr(self, "agent", None))
+        if foreground:
+            request_hard_interrupt(self.agent, "/stop")
+            print("  Interrupted the running agent and any child delegates.")
+
+        if not running and not n_async and not foreground:
             print("  No running background processes.")
             return
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -716,6 +716,16 @@ DEFAULT_CONFIG = {
         "loop_caps": {
             "max_web_searches": 50,   # max web_search calls per turn (0 = unlimited)
             "max_subagents": 50,      # max subagents spawned per turn (0 = unlimited)
+            # Session-lifetime caps (do not reset between turns). Sequential
+            # review batches in one CLI/gateway task share one session; the
+            # per-turn cap alone cannot stop a multi-hour review→patch→review
+            # fan-out. 0 = unlimited.
+            "max_subagents_per_session": 16,
+            "max_delegate_batches_per_session": 4,
+            "max_child_api_calls_per_session": 80,
+            "max_child_tokens_per_session": 8000000,
+            "require_delegate_batch_checkpoint": True,
+            "codex_weekly_break_percent": 90,
         },
     },
 

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -227,3 +227,22 @@ def test_redeem_missing_credentials_reports_unavailable(monkeypatch):
 
     assert result.status == "unavailable"
     assert "hermes auth" in result.message
+
+
+def test_codex_weekly_breaker_trips_at_threshold():
+    from datetime import datetime, timezone
+
+    snap = account_usage.AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(
+            account_usage.AccountUsageWindow(label="Session", used_percent=10),
+            account_usage.AccountUsageWindow(label="Weekly", used_percent=90),
+        ),
+    )
+    assert account_usage.codex_weekly_used_percent(snap) == 90
+    assert account_usage.should_trip_codex_weekly_breaker(snap, 90) is True
+    assert account_usage.should_trip_codex_weekly_breaker(snap, 91) is False
+    assert account_usage.should_trip_codex_weekly_breaker(snap, 0) is False
+    assert account_usage.should_trip_codex_weekly_breaker(None, 90) is False

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -9,6 +9,7 @@ from agent.insights import (
     InsightsEngine,
     _estimate_cost,
     _bar_chart,
+    fold_parent_child_session_usage,
 )
 from agent.usage_pricing import (
     format_duration_compact as _format_duration,
@@ -772,5 +773,80 @@ class TestEdgeCases:
         # The session has no cost data, so it falls in the "unknown" bucket.
         assert "💰 Cost" in text
         assert "Unknown" in text
+
+
+class TestDelegateChildAccounting:
+    def test_insights_do_not_double_count_delegate_child_token_rows(self, db):
+        """Parent token fields can already include child activity; child session
+        rows must not be summed on top (incident #91040 ~2x insights totals).
+        """
+        now = time.time()
+        db.create_session("parent", source="cli", model="gpt-5.6-sol")
+        db.create_session(
+            "child-a",
+            source="cli",
+            model="gpt-5.6-sol",
+            parent_session_id="parent",
+        )
+        db.create_session(
+            "child-b",
+            source="cli",
+            model="gpt-5.6-sol",
+            parent_session_id="parent",
+        )
+        db.update_token_counts("parent", input_tokens=148_700_000, output_tokens=1)
+        db.update_token_counts("child-a", input_tokens=80_000_000, output_tokens=1)
+        db.update_token_counts("child-b", input_tokens=64_700_000, output_tokens=1)
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id IN ('parent','child-a','child-b')",
+            (now,),
+        )
+        db._conn.commit()
+
+        report = InsightsEngine(db).generate(days=1)
+        assert report["overview"]["total_tokens"] == 148_700_001
+
+    def test_insights_keep_disjoint_parent_and_child_token_rows(self, db):
+        now = time.time()
+        db.create_session("parent", source="cli", model="gpt-5.6-sol")
+        db.create_session(
+            "child-a",
+            source="cli",
+            model="gpt-5.6-sol",
+            parent_session_id="parent",
+        )
+        db.update_token_counts("parent", input_tokens=4_000_000, output_tokens=1)
+        db.update_token_counts("child-a", input_tokens=80_000_000, output_tokens=1)
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id IN ('parent','child-a')",
+            (now,),
+        )
+        db._conn.commit()
+
+        report = InsightsEngine(db).generate(days=1)
+        assert report["overview"]["total_tokens"] == 84_000_002
+
+    def test_fold_parent_child_session_usage_is_pure(self):
+        sessions = [
+            {
+                "id": "p",
+                "is_ephemeral": 0,
+                "input_tokens": 10,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+            },
+            {
+                "id": "c",
+                "parent_session_id": "p",
+                "is_ephemeral": 1,
+                "input_tokens": 10,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+            },
+        ]
+        folded = fold_parent_child_session_usage(sessions)
+        assert [s["id"] for s in folded] == ["p"]
 
 

--- a/tests/agent/test_interrupt_compat.py
+++ b/tests/agent/test_interrupt_compat.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import threading
 from unittest.mock import MagicMock
 
-from agent.interrupt_compat import request_hard_interrupt
+from agent.interrupt_compat import (
+    request_hard_interrupt,
+    should_enqueue_interrupt_followup,
+    interrupt_followup_disposition,
+    interrupt_join_should_stop,
+)
 
 
 class _ModernAgent:
@@ -101,3 +106,19 @@ def test_tui_subagent_interrupt_is_an_explicit_hard_stop() -> None:
             delegate_tool._active_subagents.pop(subagent_id, None)
 
     assert agent.calls == [("hard", f"Interrupted via TUI ({subagent_id})")]
+
+
+def test_interrupt_followup_is_not_enqueued_while_agent_thread_alive() -> None:
+    assert should_enqueue_interrupt_followup(agent_thread_alive=False) is True
+    assert should_enqueue_interrupt_followup(agent_thread_alive=True) is False
+    assert interrupt_followup_disposition(agent_thread_alive=True) == "park"
+    assert interrupt_followup_disposition(
+        agent_thread_alive=True, should_exit=True
+    ) == "drop"
+    assert interrupt_followup_disposition(agent_thread_alive=False) == "enqueue"
+    assert interrupt_join_should_stop(
+        ticks_elapsed=50, agent_thread_alive=True, should_exit=False
+    ) is True
+    assert interrupt_join_should_stop(
+        ticks_elapsed=1, agent_thread_alive=True, should_exit=False
+    ) is False

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -149,6 +149,10 @@ def test_loop_cap_zero_disables_and_junk_falls_back():
     assert LoopCapConfig.from_mapping({"max_web_searches": 0}).max_web_searches == 0
     assert LoopCapConfig.from_mapping({"max_web_searches": -5}).max_web_searches == 50
     assert LoopCapConfig.from_mapping({"max_subagents": "nope"}).max_subagents == 50
+    assert LoopCapConfig.from_mapping({"max_subagents_per_session": 0}).max_subagents_per_session == 0
+    assert LoopCapConfig.from_mapping(
+        {"max_delegate_batches_per_session": "nope"}
+    ).max_delegate_batches_per_session == 4
 
 
 def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
@@ -167,6 +171,116 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     assert decision.action == "block"
     assert decision.code == "loop_web_search_cap"
     assert decision.should_halt is True
+
+
+def test_session_subagent_cap_survives_reset_for_turn():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=False,
+            loop_caps=LoopCapConfig(
+                max_subagents=50,
+                max_subagents_per_session=4,
+                max_delegate_batches_per_session=0,
+            ),
+        )
+    )
+    for turn in range(2):
+        controller.reset_for_turn()
+        decision = controller.before_call(
+            "delegate_task",
+            {"tasks": [{"goal": "review-a"}, {"goal": "review-b"}]},
+        )
+        assert decision.action == "allow"
+    controller.reset_for_turn()
+    blocked = controller.before_call("delegate_task", {"goal": "one-more-review"})
+    assert blocked.action == "block"
+    assert blocked.code == "loop_subagent_session_cap"
+    # Control actions must still work after the spawn cap.
+    assert controller.before_call("delegate_task", {"action": "stop"}).action == "allow"
+
+
+def test_session_delegate_batch_cap_stops_review_rework_loop():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=False,
+            loop_caps=LoopCapConfig(
+                max_subagents=50,
+                max_subagents_per_session=0,
+                max_delegate_batches_per_session=4,
+            ),
+        )
+    )
+    for turn in range(4):
+        controller.reset_for_turn()
+        decision = controller.before_call(
+            "delegate_task",
+            {"tasks": [{"goal": "review"}, {"goal": "review"}]},
+        )
+        assert decision.action == "allow"
+    controller.reset_for_turn()
+    blocked = controller.before_call(
+        "delegate_task",
+        {"tasks": [{"goal": "review"}, {"goal": "review"}]},
+    )
+    assert blocked.action == "block"
+    assert blocked.code == "loop_delegate_batch_session_cap"
+
+
+def test_second_delegate_batch_same_turn_requires_checkpoint():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=False,
+            loop_caps=LoopCapConfig(
+                max_subagents=50,
+                max_subagents_per_session=0,
+                max_delegate_batches_per_session=0,
+            ),
+        )
+    )
+    assert controller.before_call("delegate_task", {"goal": "review A"}).action == "allow"
+    blocked = controller.before_call("delegate_task", {"goal": "review B"})
+    assert blocked.action == "block"
+    assert blocked.code == "loop_delegate_batch_checkpoint"
+    controller.reset_for_turn()
+    assert controller.before_call("delegate_task", {"goal": "review C"}).action == "allow"
+
+
+def test_child_api_and_token_session_caps():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=False,
+            loop_caps=LoopCapConfig(
+                max_subagents_per_session=0,
+                max_delegate_batches_per_session=0,
+                require_delegate_batch_checkpoint=False,
+                max_child_api_calls_per_session=2,
+                max_child_tokens_per_session=100,
+            ),
+        )
+    )
+    assert controller.before_call("delegate_task", {"goal": "one"}).action == "allow"
+    controller.record_child_usage(api_calls=2, tokens=10)
+    blocked = controller.before_call("delegate_task", {"goal": "two"})
+    assert blocked.action == "block"
+    assert blocked.code == "loop_child_api_session_cap"
+
+    controller2 = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=False,
+            loop_caps=LoopCapConfig(
+                max_subagents_per_session=0,
+                max_delegate_batches_per_session=0,
+                require_delegate_batch_checkpoint=False,
+                max_child_api_calls_per_session=0,
+                max_child_tokens_per_session=50,
+            ),
+        )
+    )
+    assert controller2.before_call("delegate_task", {"goal": "one"}).action == "allow"
+    controller2.record_child_usage(api_calls=1, tokens=50)
+    blocked2 = controller2.before_call("delegate_task", {"goal": "two"})
+    assert blocked2.action == "block"
+    assert blocked2.code == "loop_child_token_session_cap"
 
 
 

--- a/tests/hermes_cli/test_stop_command.py
+++ b/tests/hermes_cli/test_stop_command.py
@@ -1,0 +1,44 @@
+"""CLI /stop must hard-interrupt the running parent (and thus children)."""
+
+from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+
+class _Agent:
+    def __init__(self):
+        self.messages = []
+
+    def hard_interrupt(self, message=None):
+        self.messages.append(message)
+
+
+class _Stub(CLICommandsMixin):
+    def __init__(self, agent=None, running=False):
+        self.agent = agent
+        self._agent_running = running
+
+
+def test_stop_interrupts_foreground_agent(monkeypatch, capsys):
+    from tools import process_registry as pr
+
+    monkeypatch.setattr(pr.process_registry, "list_sessions", lambda: [])
+    monkeypatch.setattr(
+        "tools.async_delegation.active_count",
+        lambda: 0,
+        raising=False,
+    )
+    agent = _Agent()
+    stub = _Stub(agent=agent, running=True)
+    stub._handle_stop_command()
+    assert agent.messages == ["/stop"]
+    out = capsys.readouterr().out
+    assert "Interrupted the running agent" in out
+
+
+def test_stop_with_nothing_running_is_quiet(monkeypatch, capsys):
+    from tools import process_registry as pr
+
+    monkeypatch.setattr(pr.process_registry, "list_sessions", lambda: [])
+    stub = _Stub(agent=None, running=False)
+    stub._handle_stop_command()
+    out = capsys.readouterr().out
+    assert "No running background processes." in out

--- a/tests/run_agent/test_stream_single_writer_65991.py
+++ b/tests/run_agent/test_stream_single_writer_65991.py
@@ -188,7 +188,8 @@ class TestCodexSingleWriter:
         mock_client = MagicMock()
         mock_client.responses.create.return_value = event_gen()
 
-        run_codex_stream(agent, {"model": "gpt-5.3-codex"}, client=mock_client)
+        with pytest.raises(InterruptedError, match="superseded"):
+            run_codex_stream(agent, {"model": "gpt-5.3-codex"}, client=mock_client)
 
         assert "".join(delivered) == "first"
         assert "-stale-tail" not in "".join(delivered)


### PR DESCRIPTION
## What does this PR do?

Stops an uncontrolled CLI review/delegation loop from burning a session (and a Codex weekly allowance) without a user checkpoint, and makes stop/supersede fail closed.

The per-turn `max_subagents: 50` cap resets every turn, so 17 sequential review batches were legal. This adds session-lifetime caps, a required user checkpoint before a second delegation batch, live child API/token budgets, a Codex weekly usage circuit breaker, `/stop` that hard-interrupts the running parent and children, no retry after a superseded Codex stream, and insights folding so parent+ephemeral-child rows are not double-counted.

Defaults (`max_subagents_per_session: 16`, `max_delegate_batches_per_session: 4`, `max_child_api_calls_per_session: 80`, `max_child_tokens_per_session: 8_000_000`, `codex_weekly_break_percent: 90`) are conservative; the issue is labeled `needs-decision` so maintainers can retune. Set any of those to `0` to disable.

## Related Issue

Related to #91040 (does not claim the issue is fully closed; remaining product calls are the numeric defaults).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/tool_guardrails.py` — session child/batch/API/token caps; checkpoint before a second `delegate_task` spawn; live `record_child_usage`
- `hermes_cli/config_defaults.py` — new `loop_caps` keys
- `agent/conversation_loop.py` — child budget abort; Codex weekly breaker before further API calls
- `agent/account_usage.py` — weekly window trip helper + cached Codex usage snapshot
- `hermes_cli/cli_commands_mixin.py` — `/stop` hard-interrupts the running agent
- `agent/codex_runtime.py` / `cli.py` / `agent/interrupt_compat.py` — superseded stream raises `InterruptedError` (no retry); bounded interrupt wait; park follow-up while the thread is alive
- `agent/insights.py` — fold ephemeral child usage when the parent already includes it

## How to Test

1. `scripts/run_tests.sh tests/agent/test_tool_guardrails.py tests/agent/test_account_usage.py tests/agent/test_insights.py tests/agent/test_interrupt_compat.py tests/hermes_cli/test_stop_command.py tests/run_agent/test_stream_single_writer_65991.py tests/tools/test_delegate_control_actions.py -q`
2. Confirm a second `delegate_task` in the same turn is blocked with `loop_delegate_batch_checkpoint`, and a new user turn grants one more batch.
3. Confirm `/stop` while an agent is running calls `hard_interrupt` even with no background processes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the targeted pytest files above
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


Made with [Cursor](https://cursor.com)