### PR TITLE
feat(cli): add /sessions all|full|search to the classic CLI slash command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9562,8 +9562,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         print(f"  Config File: {config_path} {config_status}")
         print()
     
-    def _list_recent_sessions(self, limit: int = 10) -> list[dict[str, Any]]:
-        """Return recent CLI sessions for in-chat browsing/resume affordances."""
+    def _list_recent_sessions(
+        self, limit: int = 10, *, include_all_sources: bool = False,
+        include_unnamed: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Return recent sessions for in-chat browsing/resume affordances.
+
+        By default this is scoped to ``source="cli"`` — the classic
+        ``/sessions`` behaviour, meant to resume a previous CLI chat. When
+        ``include_all_sources`` is True (``/sessions all``), it widens to
+        every surface (CLI, TUI, desktop/web) so sessions started elsewhere
+        but sharing this one state.db become visible and resumable. ``tool``
+        and ``kanban`` sub-sessions stay excluded in both modes as noise.
+        """
         if not self._session_db:
             return []
         try:
@@ -9571,22 +9582,31 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
             return query_session_listing(
                 self._session_db,
-                source="cli",
+                source=None if include_all_sources else "cli",
                 current_session_id=self.session_id,
-                include_all_sources=False,
-                include_unnamed=True,
+                include_all_sources=include_all_sources,
+                include_unnamed=include_unnamed,
                 limit=limit,
                 exclude_sources=["kanban", "tool"],
             )
         except Exception:
             return []
 
-    def _show_recent_sessions(self, *, reason: str = "history", limit: int = 10) -> bool:
+    def _show_recent_sessions(
+        self, *, reason: str = "history", limit: int = 10,
+        include_all_sources: bool = False, include_unnamed: bool = True,
+    ) -> bool:
         """Render recent sessions inline from the active chat TUI.
 
         Returns True when something was shown, False if no session list was available.
+
+        When ``include_all_sources`` is True the list spans every surface and a
+        ``Src`` column is shown so CLI/TUI/desktop sessions are distinguishable.
         """
-        sessions = self._list_recent_sessions(limit=limit)
+        sessions = self._list_recent_sessions(
+            limit=limit, include_all_sources=include_all_sources,
+            include_unnamed=include_unnamed,
+        )
         if not sessions:
             return False
 
@@ -9595,16 +9615,28 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         _cli_visible_print()
         if reason == "history":
             _cli_visible_print("(._.) No messages in the current chat yet — here are recent sessions you can resume:")
+        elif include_all_sources:
+            _cli_visible_print("  Recent sessions (all surfaces):")
         else:
             _cli_visible_print("  Recent sessions:")
         _cli_visible_print()
-        _cli_visible_print(f"  {'#':<3} {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
-        _cli_visible_print(f"  {'─' * 3} {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
-        for idx, session in enumerate(sessions, start=1):
-            title = session.get("title") or "—"
-            preview = (session.get("preview") or "")[:38]
-            last_active = _relative_time(session.get("last_active"))
-            _cli_visible_print(f"  {idx:<3} {title:<32} {preview:<40} {last_active:<13} {session['id']}")
+        if include_all_sources:
+            _cli_visible_print(f"  {'#':<3} {'Title':<30} {'Preview':<34} {'Src':<6} {'Last Active':<13} {'ID'}")
+            _cli_visible_print(f"  {'─' * 3} {'─' * 30} {'─' * 34} {'─' * 6} {'─' * 13} {'─' * 24}")
+            for idx, session in enumerate(sessions, start=1):
+                title = (session.get("title") or "—")[:28]
+                preview = (session.get("preview") or "")[:32]
+                src = (session.get("source") or "-")[:6]
+                last_active = _relative_time(session.get("last_active"))
+                _cli_visible_print(f"  {idx:<3} {title:<30} {preview:<34} {src:<6} {last_active:<13} {session['id']}")
+        else:
+            _cli_visible_print(f"  {'#':<3} {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
+            _cli_visible_print(f"  {'─' * 3} {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
+            for idx, session in enumerate(sessions, start=1):
+                title = session.get("title") or "—"
+                preview = (session.get("preview") or "")[:38]
+                last_active = _relative_time(session.get("last_active"))
+                _cli_visible_print(f"  {idx:<3} {title:<32} {preview:<40} {last_active:<13} {session['id']}")
         _cli_visible_print()
         _cli_visible_print("  Use /resume <number>, /resume <session id>, or /resume <session title> to continue.")
         _cli_visible_print("  Example: /resume 2")
@@ -10037,7 +10069,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             _cprint("  Use /resume with no arguments to see available sessions.")
             return True
 
-        self._handle_resume_command(f"/resume {index}")
+        # Resolve by the ID captured in the exact list that was shown, not by
+        # re-passing the index: /resume <n> recomputes a cli-only list, which
+        # would mis-resolve a number picked from an all-sources /sessions list.
+        selected = pending[index - 1]
+        sel_id = selected.get("id") if isinstance(selected, dict) else None
+        if sel_id:
+            self._handle_resume_command(f"/resume {sel_id}")
+        else:
+            self._handle_resume_command(f"/resume {index}")
         return True
 
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1201,22 +1201,82 @@ class CLICommandsMixin:
         registered in the central COMMAND_REGISTRY.
         """
         from cli import _cprint
+        from hermes_cli.session_listing import parse_session_listing_args
         parts = cmd_original.split(None, 1)
-        arg = parts[1].strip() if len(parts) > 1 else ""
-        sub = arg.lower()
+        raw_args = parts[1].strip() if len(parts) > 1 else ""
 
-        # Bare /sessions or /sessions list — show recent sessions inline.
-        if not arg or sub in {"list", "ls", "browse"}:
+        # Delegate arg parsing to the shared helper so the classic CLI honours
+        # the same grammar as the gateway/TUI slash surface:
+        #   /sessions            → recent CLI sessions (default)
+        #   /sessions all        → every surface (cli/tui/desktop), Src column
+        #   /sessions full       → include unnamed sessions
+        #   /sessions search <q> → title/id search across sessions
+        #   /sessions <id|title> → delegate to /resume
+        include_all, include_unnamed, target, search_query = (
+            parse_session_listing_args(raw_args)
+        )
+
+        # A search request or any list-style invocation (no positional target)
+        # renders inline; a positional target resumes.
+        if not target:
             if not self._session_db:
                 from hermes_state import format_session_db_unavailable
                 _cprint(f"  {format_session_db_unavailable()}")
                 return
-            if not self._show_recent_sessions(reason="sessions"):
+            if search_query is not None:
+                # /sessions search — reuse the shared query path directly so
+                # id/title matching and ordering match the gateway. Search
+                # spans ALL surfaces by default (a name lookup rarely cares
+                # which surface it ran on); `/sessions search all <q>` is
+                # therefore redundant but harmless.
+                from hermes_cli.main import _relative_time
+                from hermes_cli.session_listing import query_session_listing
+                rows = query_session_listing(
+                    self._session_db,
+                    source=None,
+                    current_session_id=self.session_id,
+                    include_all_sources=True,
+                    include_unnamed=True,
+                    search_query=search_query,
+                    limit=10,
+                    exclude_sources=["kanban", "tool"],
+                )
+                if not rows:
+                    _cprint(f"  (._.) No sessions match '{search_query}'.")
+                    return
+                _cprint("")
+                _cprint(f"  Sessions matching '{search_query}':")
+                _cprint("")
+                _cprint(f"  {'#':<3} {'Title':<30} {'Src':<6} {'Last Active':<13} {'ID'}")
+                _cprint(f"  {'─' * 3} {'─' * 30} {'─' * 6} {'─' * 13} {'─' * 24}")
+                for idx, s in enumerate(rows, start=1):
+                    title = (s.get("title") or "—")[:28]
+                    src = (s.get("source") or "-")[:6]
+                    la = _relative_time(s.get("last_active"))
+                    _cprint(f"  {idx:<3} {title:<30} {src:<6} {la:<13} {s['id']}")
+                _cprint("")
+                _cprint("  Use /resume <session id> to continue.")
+                _cprint("")
+                self._pending_resume_sessions = rows
+                return
+            if not self._show_recent_sessions(
+                reason="sessions",
+                include_all_sources=include_all,
+                include_unnamed=include_unnamed,
+            ):
                 _cprint("  (._.) No previous sessions yet.")
+                return
+            # Arm a one-shot pending-resume selection so a bare number on the
+            # next line resolves against the EXACT list just shown (matters for
+            # `all`, whose ordering differs from the default CLI-only list).
+            self._pending_resume_sessions = self._list_recent_sessions(
+                limit=10, include_all_sources=include_all,
+                include_unnamed=include_unnamed,
+            )
             return
 
         # /sessions <id_or_title> behaves the same as /resume <id_or_title>.
-        self._handle_resume_command(f"/resume {arg}")
+        self._handle_resume_command(f"/resume {target}")
 
     def _handle_worktree_command(self, cmd_original: str) -> None:
         """Handle /worktree — inspect, create, or reclaim isolated git worktrees.


### PR DESCRIPTION
## What

Add `/sessions all | full | search` to the **classic CLI** slash command so it
matches the grammar the gateway/TUI surface already exposes.

The interactive `/sessions` handler was hard-coded to `source="cli"`
(`cli.py:_list_recent_sessions`), so sessions started in the TUI, desktop, or
web dashboard were invisible from a CLI session even though they share the same
`state.db`. A CLI user could never see or resume their TUI/web work.

This routes the CLI handler through the existing shared
`parse_session_listing_args` / `query_session_listing` helpers so the classic
CLI honours:

| command | behaviour |
| --- | --- |
| `/sessions` | recent CLI sessions |
| `/sessions all` | every surface (cli/tui/desktop) + a `Src` column |
| `/sessions full` | include unnamed sessions |
| `/sessions search <q>` | title/id search across sessions |
| `/sessions <id\|title>` | delegate to `/resume` (unchanged) |

Also fixes a latent index-resolution bug: a bare number typed after the
recent-sessions list was resolved by re-indexing a freshly recomputed cli-only
list (`_consume_pending_resume_selection` → `/resume <n>`). Once the shown list
can span surfaces, that double lookup could resume the wrong session — now
resolved by the session **id** captured in the exact list shown.

## Why no admin gate on CLI `/sessions all`

The gateway gates `/sessions all` behind `_resume_caller_is_admin` to prevent
cross-origin session enumeration (the enumeration half of the `/resume` IDOR).
The CLI is a local, single-user process with direct filesystem access to
`state.db`; "all surfaces" there just means the same local user's cli/tui/
desktop sessions, so no gate is needed. Calling this out explicitly since the
asymmetry is intentional.

## Status: DRAFT — do not merge yet

Opened as a draft for review. Known follow-ups we are addressing before marking
ready:

- [ ] **Default-visibility change**: bare `/sessions` now hides unnamed
  sessions (`include_unnamed=False`, aligning with the gateway "Named Sessions"
  default), whereas the old CLI default showed them. Decide: keep the
  gateway-aligned default (and reword the commit) or preserve the old
  include-unnamed behaviour.
- [ ] `/sessions search` with an empty query shows `Sessions matching ''` and
  lists everything; the gateway returns a `Usage:` hint. Align the CLI.
- [ ] The bare-list path queries the DB twice (once in `_show_recent_sessions`,
  again to arm `_pending_resume_sessions`), which can desync the shown vs.
  armed list. Return the shown list instead of re-querying.
- [ ] Three near-identical table renderers now exist; extract one.
- [ ] Contributor attribution mapping for the commit author email.

## Verification

Verified E2E against a temp `state.db` with mixed cli/tui sessions: `all` spans
surfaces with a `Src` column, a bare number after `all` resumes the correct id,
`full` includes unnamed, `search` matches across surfaces, and `/sessions <id>`
still delegates to `/resume`.
