### PR TITLE
fix(session): new tile honors configured provider (#91089)

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -40,6 +40,7 @@ import { $previewTarget } from '@/store/preview'
 import {
   $activeGatewayProfile,
   $freshSessionRequest,
+  $newChatProfile,
   $profileScope,
   ALL_PROFILES,
   ensureGatewayProfile,

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -832,8 +832,9 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // it — Cursor-style. Every click opens a fresh "New session" tab (multiple
   // empty tabs are fine since none touch the session list).
   const openNewSessionTab = useCallback(() => {
+    $newChatProfile.set(null)
     void openNewSessionTile('center', { listed: false })
-  }, [openNewSessionTile])
+  }, [openNewSessionTile, $newChatProfile])
 
   // Archive the selected session (rebindable `session.archive` hotkey).
   const archiveSelectedSession = useCallback(() => {


### PR DESCRIPTION
This fix ensures that the sidebar '+' button uses the same configured provider as Ctrl+N by resetting the $newChatProfile to null before creating a new session tile, matching the behavior of the Ctrl+N keybind.