### PR TITLE
fix(gateway): supervise Windows watchdog exits

### DIFF
--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -185,6 +185,23 @@ def start_loop_liveness_watchdog(
                 logger.debug("Loop liveness faulthandler dump failed", exc_info=True)
             if stop_event.is_set():
                 return
+            try:
+                _write_watchdog_dump(
+                    get_shutdown_watchdog_dump_path(),
+                    delay_s=timeout * strikes,
+                    snapshot={
+                        "strikes": strikes,
+                        "probe_interval_s": interval,
+                        "probe_timeout_s": timeout,
+                        "exit_code": exit_code,
+                    },
+                    event="loop_liveness_watchdog_fired",
+                    emit_stderr=False,
+                )
+            except Exception:
+                logger.debug("Loop liveness durable dump failed", exc_info=True)
+            if stop_event.is_set():
+                return
             # Record the watchdog exit in the lifecycle sentinel so the next
             # boot reports "watchdog hard-exit" instead of misclassifying
             # this as an unclean SIGKILL/OOM death (NS-608).
@@ -293,6 +310,8 @@ def _write_watchdog_dump(
     *,
     delay_s: float,
     snapshot: Optional[Dict[str, Any]],
+    event: str = "shutdown_watchdog_fired",
+    emit_stderr: bool = True,
 ) -> None:
     """Best-effort faulthandler + metadata dump before hard-exit."""
     try:
@@ -301,7 +320,7 @@ def _write_watchdog_dump(
         return
 
     header = {
-        "event": "shutdown_watchdog_fired",
+        "event": event,
         "pid": os.getpid(),
         "delay_s": delay_s,
         "fired_at": datetime.now(timezone.utc).isoformat(),
@@ -323,15 +342,16 @@ def _write_watchdog_dump(
 
     # Also dump to stderr so journald/launchd capture it even if the file
     # write failed (wedged disk was one of the #66892 hypotheses).
-    try:
-        sys.stderr.write(
-            f"Gateway shutdown watchdog fired after {delay_s:.0f}s "
-            f"(pid={os.getpid()}); dumping all thread stacks.\n"
-        )
-        sys.stderr.flush()
-        faulthandler.dump_traceback(all_threads=True)
-    except Exception:
-        pass
+    if emit_stderr:
+        try:
+            sys.stderr.write(
+                f"Gateway shutdown watchdog fired after {delay_s:.0f}s "
+                f"(pid={os.getpid()}); dumping all thread stacks.\n"
+            )
+            sys.stderr.flush()
+            faulthandler.dump_traceback(all_threads=True)
+        except Exception:
+            pass
 
 
 def arm_shutdown_watchdog(

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -468,12 +468,15 @@ def _build_gateway_vbs_script(
 
     ``wscript.exe`` is a GUI-subsystem executable with no console, so this
     launcher receives no console control events. It ``Run``s the console
-    ``python.exe`` with window style 0 (hidden): the gateway owns a single
-    hidden console — never shown, never CTRL_CLOSE'd at logon, and inherited
-    by every console-subsystem descendant (git, gh, node, …) so none of them
-    allocate a visible flashing conhost (#54220/#56747; the previous
-    console-less pythonw.exe gateway forced exactly that per-descendant
-    flash). No cmd.exe anywhere in the chain. Mirrors
+    ``python.exe`` with window style 0 (hidden) and waits for it: the gateway
+    owns a single hidden console — never shown, never CTRL_CLOSE'd at logon,
+    and inherited by every console-subsystem descendant (git, gh, node, …) so
+    none of them allocate a visible flashing conhost (#54220/#56747; the
+    previous console-less pythonw.exe gateway forced exactly that
+    per-descendant flash). Waiting is required because Task Scheduler's
+    ``RestartOnFailure`` policy can only observe the VBS process; propagating
+    the Python exit code lets a watchdog exit 75 trigger the configured
+    restart. No cmd.exe anywhere in the chain. Mirrors
     ``_build_gateway_cmd_script`` (same env + argv via
     ``_resolve_detached_python``).
     """
@@ -494,7 +497,7 @@ def _build_gateway_vbs_script(
     lines = [
         f"' {_TASK_DESCRIPTION}",
         "Option Explicit",
-        "Dim sh, env, existing_pp",
+        "Dim sh, env, existing_pp, exitCode",
         'Set sh = CreateObject("WScript.Shell")',
         'Set env = sh.Environment("PROCESS")',
         f"env.Item({_quote_vbs_string('HERMES_HOME')}) = {_quote_vbs_string(hermes_home)}",
@@ -510,10 +513,11 @@ def _build_gateway_vbs_script(
         f"  env.Item({_quote_vbs_string('PYTHONPATH')}) = {_quote_vbs_string(static_pythonpath)}",
         "End If",
         f"sh.CurrentDirectory = {_quote_vbs_string(working_dir)}",
-        # Window style 0 = hidden; bWaitOnReturn False = detached/async. The
-        # console python's one console is created hidden and inherited by all
-        # descendants, so nothing ever flashes.
-        f"sh.Run {_quote_vbs_string(command_line)}, 0, False",
+        # Window style 0 = hidden; bWaitOnReturn True keeps Task Scheduler
+        # attached to this VBS supervisor. Propagate Python's exit code so the
+        # task's RestartOnFailure policy can restart watchdog exit 75.
+        f"exitCode = sh.Run({_quote_vbs_string(command_line)}, 0, True)",
+        "WScript.Quit exitCode",
     ]
     return "\r\n".join(lines) + "\r\n"
 

--- a/tests/gateway/test_loop_liveness_watchdog.py
+++ b/tests/gateway/test_loop_liveness_watchdog.py
@@ -53,6 +53,32 @@ def test_loop_liveness_watchdog_stop_during_dump_disarms_hard_exit():
     assert exit_codes == []
 
 
+def test_loop_liveness_watchdog_persists_thread_dump(tmp_path, monkeypatch):
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    exit_codes = []
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with patch("gateway.shutdown_watchdog.os._exit", side_effect=exit_codes.append):
+        handle = start_loop_liveness_watchdog(
+            loop,
+            probe_interval=0.01,
+            probe_timeout=0.01,
+            max_strikes=1,
+            exit_code=75,
+        )
+        assert handle is not None
+        handle.join(timeout=2.0)
+
+    assert not handle.is_alive()
+    assert exit_codes == [75]
+    dump = tmp_path / "logs" / "gateway-shutdown-watchdog.log"
+    assert dump.is_file()
+    text = dump.read_text(encoding="utf-8")
+    assert "loop_liveness_watchdog_fired" in text
+    assert "faulthandler dump" in text
+    assert "Current thread" in text
+
+
 def test_loop_liveness_watchdog_stop_during_final_miss_disarms_hard_exit():
     loop = MagicMock(spec=asyncio.AbstractEventLoop)
     probe_scheduled = threading.Event()

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -314,13 +314,17 @@ def test_install_scheduled_task_recreates_instead_of_change(monkeypatch, tmp_pat
     assert "cmd.exe" not in xml_seen["text"]
 
 
-def test_gateway_vbs_script_is_console_less(monkeypatch):
-    """The .vbs launcher must avoid cmd.exe entirely and Run pythonw hidden
-    (issue #45599 fix A: no console -> no logon CTRL_CLOSE_EVENT / 0xC000013A)."""
+def test_gateway_vbs_script_is_console_less_and_propagates_child_exit(monkeypatch):
+    """The Scheduled Task launcher stays hidden while supervising Python.
+
+    Task Scheduler's RestartOnFailure policy only sees the VBS exit status. The
+    launcher must therefore wait for the gateway child and quit with that same
+    status instead of detaching and reporting success immediately.
+    """
     monkeypatch.setattr(
         gateway_windows,
         "_resolve_detached_python",
-        lambda exe: (r"C:\venv\Scripts\pythonw.exe", Path(r"C:\venv"), []),
+        lambda exe: (r"C:\venv\Scripts\python.exe", Path(r"C:\venv"), []),
     )
     content = gateway_windows._build_gateway_vbs_script(
         r"C:\venv\Scripts\python.exe",
@@ -330,10 +334,14 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
     )
     assert "cmd.exe" not in content.lower()
     assert 'CreateObject("WScript.Shell")' in content
-    assert "pythonw.exe" in content
+    assert "python.exe" in content
+    assert "pythonw.exe" not in content
     assert "hermes_cli.main" in content
     assert "gateway run" in content
-    assert ", 0, False" in content  # hidden window, detached/async
+    assert "exitCode = sh.Run" in content
+    assert ", 0, True" in content  # hidden window, wait for supervised child
+    assert "WScript.Quit exitCode" in content
+    assert ", 0, False" not in content
     for var in ("HERMES_HOME", "PYTHONIOENCODING", "HERMES_GATEWAY_DETACHED", "VIRTUAL_ENV", "PYTHONPATH"):
         assert var in content
     assert "--profile" in content and "work" in content


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows gateway reliability gap where Task Scheduler’s configured `RestartOnFailure` policy could not observe the actual gateway process.

The Scheduled Task runs a hidden VBS launcher through `wscript.exe`. That VBS previously called `WScript.Shell.Run(..., 0, False)`, detached from Python, and exited successfully immediately. If the gateway’s loop-liveness watchdog later terminated Python with exit code 75, Task Scheduler still saw only the already-successful VBS launcher and left the task `Ready` with no gateway process.

This change keeps the no-console `wscript.exe` design, but makes the VBS wait for Python and quit with Python’s exit code. The existing Task Scheduler `RestartOnFailure` policy can then observe code 75 and restart the task.

It also persists loop-liveness thread dumps to the existing watchdog log before hard exit. Previously those dumps were written only to uncaptured stderr under the hidden VBS launch, so the blocking frame was lost.

## Related Issue

Fixes #91097

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/gateway_windows.py`
  - Keep the VBS launch hidden.
  - Wait for the Python gateway child.
  - Propagate the child exit code through `WScript.Quit`.
- `gateway/shutdown_watchdog.py`
  - Reuse the durable watchdog writer for loop-liveness exits.
  - Label liveness dumps separately and avoid duplicating the stderr dump.
- `tests/hermes_cli/test_gateway_windows.py`
  - Require hidden, supervised VBS behavior and exit-code propagation.
- `tests/gateway/test_loop_liveness_watchdog.py`
  - Require a durable liveness dump containing actual traceback content.

## How to Test

1. Run the focused tests:

   ```bash
   uv run --with pytest --with pyyaml python -m pytest \
     tests/hermes_cli/test_gateway_windows.py \
     tests/gateway/test_shutdown_watchdog.py \
     tests/gateway/test_loop_liveness_watchdog.py -q
   ```

2. Run focused lint:

   ```bash
   uv run --with ruff ruff check \
     hermes_cli/gateway_windows.py \
     gateway/shutdown_watchdog.py \
     tests/hermes_cli/test_gateway_windows.py \
     tests/gateway/test_loop_liveness_watchdog.py
   ```

3. On Windows, install/start the gateway task and confirm:
   - Task remains `Running` while healthy.
   - Gateway PID is live and heartbeat advances.
   - A child exit 75 is propagated by the VBS and eligible for Task Scheduler restart.
   - A future loop watchdog exit writes `loop_liveness_watchdog_fired` plus thread stacks to `gateway-shutdown-watchdog.log`.

## Checklist

### Code

- [x] Commit message follows Conventional Commits.
- [x] Searched open issues/PRs for this exact defect.
- [x] PR contains only changes related to this fix.
- [ ] Full `pytest tests/ -q` suite run (focused affected suites run instead: 17 passed).
- [x] Added regression tests for both bug classes.
- [x] Tested on Windows 10.

### Documentation & Housekeeping

- [x] Relevant behavior documented in code comments/docstrings; external docs N/A.
- [x] `cli-config.yaml.example` N/A — no config key changes.
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A.
- [x] Cross-platform impact considered: change is confined to the Windows launcher; watchdog dump helper defaults preserve existing shutdown behavior.
- [x] Tool descriptions/schemas N/A.

## Verification Evidence

- Both regression tests were observed failing before implementation and passing after.
- Focused suite: **17 passed**.
- Ruff: **passed**.
- Independent review: no security or logic errors.
- A harmless real `cscript` probe confirmed the wait/quit VBS pattern returns child exit code 75.
- Live Windows task remained `Running`, owned the gateway process, heartbeat advanced, Telegram connected, cron reported fireable, and a controlled Telegram text-only round trip completed once.
