### PR TITLE
fix(acp): set_model resolves active provider (#91090)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2589,6 +2589,7 @@ class HermesACPAgent(acp.Agent):
                 requested_provider=requested_provider,
                 base_url=current_base_url,
                 api_mode=current_api_mode,
+                existing_agent=state.agent,
             )
             self.session_manager.save_session(session_id)
             logger.info(

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -88,44 +88,26 @@ def _format_updated_at(value: Any) -> str | None:
         return value
     try:
         return datetime.fromtimestamp(float(value), tz=timezone.utc).isoformat()
-        except Exception as e:
-            logger.error(
-                "ACP session failed to resolve runtime provider: %s", e, exc_info=True
-            )
-            if existing_agent is not None:
-                # Fall back to the existing agent's provider configuration
-                logger.info("ACP session falling back to existing agent's provider")
-                kwargs.update(
-                    {
-                        "provider": getattr(existing_agent, "provider", None),
-                        "api_mode": api_mode or getattr(existing_agent, "api_mode", None),
-                        "base_url": base_url or getattr(existing_agent, "base_url", None),
-                        "api_key": getattr(existing_agent, "api_key", None),
-                        "command": getattr(existing_agent, "command", None),
-                        "args": list(getattr(existing_agent, "args", []) or []),
-                    }
-                )
-            else:
-                # Re-raise the exception if no fallback agent is available
-                raise
-                "ACP session failed to resolve runtime provider: %s", e, exc_info=True
-            )
-            if existing_agent is not None:
-                # Fall back to the existing agent's provider configuration
-                logger.info("ACP session falling back to existing agent's provider")
-                kwargs.update(
-                    {
-                        "provider": getattr(existing_agent, "provider", None),
-                        "api_mode": api_mode or getattr(existing_agent, "api_mode", None),
-                        "base_url": base_url or getattr(existing_agent, "base_url", None),
-                        "api_key": getattr(existing_agent, "api_key", None),
-                        "command": getattr(existing_agent, "command", None),
-                        "args": list(getattr(existing_agent, "args", []) or []),
-                    }
-                )
-            else:
-                # Re-raise the exception if no fallback agent is available
-                raise
+    except Exception:
+        return None
+
+
+def _updated_at_sort_key(value: Any) -> float:
+    if value is None:
+        return float("-inf")
+    if isinstance(value, (int, float)):
+        return float(value)
+    raw = str(value).strip()
+    if not raw:
+        return float("-inf")
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
+    except Exception:
+        try:
+            return float(raw)
+        except Exception:
+            return float("-inf")
+
 
 def _acp_stderr_print(*args, **kwargs) -> None:
     """Best-effort human-readable output sink for ACP stdio sessions.

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -88,26 +88,44 @@ def _format_updated_at(value: Any) -> str | None:
         return value
     try:
         return datetime.fromtimestamp(float(value), tz=timezone.utc).isoformat()
-    except Exception:
-        return None
-
-
-def _updated_at_sort_key(value: Any) -> float:
-    if value is None:
-        return float("-inf")
-    if isinstance(value, (int, float)):
-        return float(value)
-    raw = str(value).strip()
-    if not raw:
-        return float("-inf")
-    try:
-        return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
-    except Exception:
-        try:
-            return float(raw)
-        except Exception:
-            return float("-inf")
-
+        except Exception as e:
+            logger.error(
+                "ACP session failed to resolve runtime provider: %s", e, exc_info=True
+            )
+            if existing_agent is not None:
+                # Fall back to the existing agent's provider configuration
+                logger.info("ACP session falling back to existing agent's provider")
+                kwargs.update(
+                    {
+                        "provider": getattr(existing_agent, "provider", None),
+                        "api_mode": api_mode or getattr(existing_agent, "api_mode", None),
+                        "base_url": base_url or getattr(existing_agent, "base_url", None),
+                        "api_key": getattr(existing_agent, "api_key", None),
+                        "command": getattr(existing_agent, "command", None),
+                        "args": list(getattr(existing_agent, "args", []) or []),
+                    }
+                )
+            else:
+                # Re-raise the exception if no fallback agent is available
+                raise
+                "ACP session failed to resolve runtime provider: %s", e, exc_info=True
+            )
+            if existing_agent is not None:
+                # Fall back to the existing agent's provider configuration
+                logger.info("ACP session falling back to existing agent's provider")
+                kwargs.update(
+                    {
+                        "provider": getattr(existing_agent, "provider", None),
+                        "api_mode": api_mode or getattr(existing_agent, "api_mode", None),
+                        "base_url": base_url or getattr(existing_agent, "base_url", None),
+                        "api_key": getattr(existing_agent, "api_key", None),
+                        "command": getattr(existing_agent, "command", None),
+                        "args": list(getattr(existing_agent, "args", []) or []),
+                    }
+                )
+            else:
+                # Re-raise the exception if no fallback agent is available
+                raise
 
 def _acp_stderr_print(*args, **kwargs) -> None:
     """Best-effort human-readable output sink for ACP stdio sessions.
@@ -608,6 +626,7 @@ class SessionManager:
         requested_provider: str | None = None,
         base_url: str | None = None,
         api_mode: str | None = None,
+        existing_agent: Any = None,
     ):
         if self._agent_factory is not None:
             return self._agent_factory()
@@ -656,8 +675,26 @@ class SessionManager:
                     "args": list(runtime.get("args") or []),
                 }
             )
-        except Exception:
-            logger.debug("ACP session falling back to default provider resolution", exc_info=True)
+        except Exception as e:
+            logger.error(
+                "ACP session failed to resolve runtime provider: %s", e, exc_info=True
+            )
+            if existing_agent is not None:
+                # Fall back to the existing agent's provider configuration
+                logger.info("ACP session falling back to existing agent's provider")
+                kwargs.update(
+                    {
+                        "provider": getattr(existing_agent, "provider", None),
+                        "api_mode": api_mode or getattr(existing_agent, "api_mode", None),
+                        "base_url": base_url or getattr(existing_agent, "base_url", None),
+                        "api_key": getattr(existing_agent, "api_key", None),
+                        "command": getattr(existing_agent, "command", None),
+                        "args": list(getattr(existing_agent, "args", []) or []),
+                    }
+                )
+            else:
+                # Re-raise the exception if no fallback agent is available
+                raise
 
         _register_task_cwd(session_id, cwd)
 


### PR DESCRIPTION
Closes #91090 — ACP session/set_model failed with 'No LLM provider configured' even when configured. Root cause: provider resolution exceptions were swallowed during agent rebuild; now logged and falls back to the existing agent's provider config. Committed by subagent (6baeb23e66); PR created by parent.