### PR TITLE
fix(provider): accept emoji in gemini message content (#91031)

### DIFF
--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -181,16 +181,16 @@ def build_keepalive_http_client(
         )
         # Generous read=None for SSE streaming endpoints.
         timeout = httpx.Timeout(connect=15.0, read=None, write=15.0, pool=10.0)
-        def fix_json_encoding(request):
+        def _maybe_fix_json_body(request):
             # Only apply to JSON requests
             if request.method != "POST":
-                return request
+                return None
             content_type = request.headers.get("Content-Type", "")
             if not content_type.startswith("application/json"):
-                return request
+                return None
             body = request.content
             if not body:
-                return request
+                return None
             try:
                 # Decode body to string (assuming UTF-8)
                 import json
@@ -199,13 +199,30 @@ def build_keepalive_http_client(
                 data = json.loads(body_str)
                 # Re-serialize with ensure_ascii=False to get raw UTF-8
                 new_body_str = json.dumps(data, ensure_ascii=False)
-                new_body = new_body_str.encode("utf-8")
-                # Update request content and headers
-                request.stream = httpx.ByteStream(new_body)
-                request.headers["Content-Length"] = str(len(new_body))
+                return new_body_str.encode("utf-8")
             except (json.JSONDecodeError, UnicodeDecodeError):
                 # If not JSON or not UTF-8, leave as is
-                pass
+                return None
+
+        def fix_json_encoding(request):
+            new_body = _maybe_fix_json_body(request)
+            if new_body is not None:
+                request.stream = httpx.ByteStream(new_body)
+                request.headers["Content-Length"] = str(len(new_body))
+            return request
+
+        async def fix_json_encoding_async(request):
+            new_body = _maybe_fix_json_body(request)
+            if new_body is not None:
+                class _BodyStream(httpx.AsyncByteStream):
+                    def __init__(self, data: bytes):
+                        self._data = data
+                    async def __aiter__(self):
+                        yield self._data
+                    async def aclose(self) -> None:
+                        pass
+                request.stream = _BodyStream(new_body)
+                request.headers["Content-Length"] = str(len(new_body))
             return request
 
 
@@ -217,13 +234,14 @@ def build_keepalive_http_client(
                 "http://": transport_cls(verify=verify),
                 "https://": transport_cls(verify=verify),
             }
+        request_hook = fix_json_encoding_async if async_mode else fix_json_encoding
         return client_cls(
             limits=limits,
             timeout=timeout,
             proxy=proxy,
             mounts=mounts or None,
             verify=verify,
-            event_hooks={'request': [fix_json_encoding]},
+            event_hooks={'request': [request_hook]},
         )
     except Exception:
         return None

--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -181,6 +181,33 @@ def build_keepalive_http_client(
         )
         # Generous read=None for SSE streaming endpoints.
         timeout = httpx.Timeout(connect=15.0, read=None, write=15.0, pool=10.0)
+        def fix_json_encoding(request):
+            # Only apply to JSON requests
+            if request.method != "POST":
+                return request
+            content_type = request.headers.get("Content-Type", "")
+            if not content_type.startswith("application/json"):
+                return request
+            body = request.content
+            if not body:
+                return request
+            try:
+                # Decode body to string (assuming UTF-8)
+                import json
+                body_str = body.decode("utf-8")
+                # Parse JSON
+                data = json.loads(body_str)
+                # Re-serialize with ensure_ascii=False to get raw UTF-8
+                new_body_str = json.dumps(data, ensure_ascii=False)
+                new_body = new_body_str.encode("utf-8")
+                # Update request content and headers
+                request.content = new_body
+                request.headers["Content-Length"] = str(len(new_body))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                # If not JSON or not UTF-8, leave as is
+                pass
+            return request
+
 
         transport_cls = httpx.AsyncHTTPTransport if async_mode else httpx.HTTPTransport
         client_cls = httpx.AsyncClient if async_mode else httpx.Client
@@ -196,6 +223,7 @@ def build_keepalive_http_client(
             proxy=proxy,
             mounts=mounts or None,
             verify=verify,
+            event_hooks={'request': [fix_json_encoding]},
         )
     except Exception:
         return None

--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -201,7 +201,7 @@ def build_keepalive_http_client(
                 new_body_str = json.dumps(data, ensure_ascii=False)
                 new_body = new_body_str.encode("utf-8")
                 # Update request content and headers
-                request.content = new_body
+                request.stream = httpx.ByteStream(new_body)
                 request.headers["Content-Length"] = str(len(new_body))
             except (json.JSONDecodeError, UnicodeDecodeError):
                 # If not JSON or not UTF-8, leave as is


### PR DESCRIPTION
Closes #91031 — emoji in message content caused HTTP 400 on gemini via Nous proxy. Root cause: httpx serialized JSON with ensure_ascii=True (surrogate-pair escapes) rejected by backend. Fix: event_hook re-serializes JSON bodies with ensure_ascii=False (raw UTF-8). Committed by subagent (cca033d2fb); PR created by parent.