### PR TITLE
fix(mcp): discovery probe honors managed-scope mcp_servers (#91073)

### DIFF
--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -14,9 +14,10 @@ _mcp_discovery_thread: Optional[threading.Thread] = None
 def _has_configured_mcp_servers() -> bool:
     """Cheap config probe so non-MCP users avoid importing the MCP stack."""
     try:
+        from hermes_cli import managed_scope
         from hermes_cli.config import read_raw_config
 
-        raw_config = read_raw_config() or {}
+        raw_config = managed_scope.apply_managed_overlay(read_raw_config() or {})
         mcp_servers = raw_config.get("mcp_servers")
         if isinstance(mcp_servers, dict) and len(mcp_servers) > 0:
             return True


### PR DESCRIPTION
Closes #91073 — the MCP discovery probe (_has_configured_mcp_servers) read only the raw user config, missing mcp_servers declared in Managed Scope. Now applies managed_scope.apply_managed_overlay() before reading — the same source the runtime uses. tui_gateway/entry.py delegates to this shared function, so both paths are covered. Implemented by subagent (diff extracted from contaminated worktree); commit/push/PR by parent.