### PR TITLE
fix(agent): replay plaintext Responses reasoning for relays without encrypted continuation blobs

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -696,9 +696,11 @@ def _chat_messages_to_responses_input(
                     # reasoning item (otherwise: missing_following_item error).
                     # When the assistant produced only reasoning with no visible
                     # content or function call, emit an empty assistant message
-                    # as the required following item. Plaintext reasoning must
-                    # remain directly adjacent to its function_call so a relay
-                    # attaches the thought to that assistant action turn.
+                    # as the required following item. Never inject one into a
+                    # turn that has a function_call: a relay attaches plaintext
+                    # reasoning to the contiguous assistant run that follows it
+                    # (message and/or function_calls — one model turn), and a
+                    # synthetic empty message would split that run.
                     items.append({"role": "assistant", "content": ""})
                     item_sources.append(msg)
 

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -413,6 +413,7 @@ def _chat_messages_to_responses_input(
     is_xai_responses: bool = False,
     is_github_responses: bool = False,
     replay_encrypted_reasoning: bool = True,
+    replay_plaintext_reasoning: bool = False,
     current_issuer_kind: Optional[str] = None,
     native_compaction_eligible: bool = False,
 ) -> List[Dict[str, Any]]:
@@ -436,6 +437,13 @@ def _chat_messages_to_responses_input(
     ``AIAgent._disable_codex_reasoning_replay`` which both strips cached
     items from the conversation history and threads ``replay_enabled=False``
     through this converter so subsequent turns send no reasoning items.
+
+    ``replay_plaintext_reasoning`` is an explicit compatibility capability
+    for Responses relays such as Actual Computer. Those relays expose model
+    thinking as plaintext ``reasoning.content`` instead of OpenAI's opaque
+    ``encrypted_content`` continuation blob. Hermes stores that text on the
+    assistant message as ``reasoning`` / ``reasoning_content``; when enabled,
+    replay it immediately before the assistant output item it belongs to.
 
     ``is_github_responses`` drops the ``id`` field from replayed
     ``codex_message_items`` regardless of length. The Copilot backend
@@ -518,6 +526,7 @@ def _chat_messages_to_responses_input(
                     else None
                 )
                 has_codex_reasoning = False
+                has_plaintext_reasoning = False
                 if isinstance(codex_reasoning, list):
                     for ri in codex_reasoning:
                         if isinstance(ri, dict) and ri.get("encrypted_content"):
@@ -578,6 +587,33 @@ def _chat_messages_to_responses_input(
                                 seen_item_ids.add(item_id)
                             has_codex_reasoning = True
 
+                # Some Responses relays cannot mint OpenAI's opaque encrypted
+                # continuation blob. They instead accept the plaintext
+                # reasoning item returned on the prior turn. Prefer encrypted
+                # reasoning when present so the same thought is not replayed
+                # twice.
+                if replay_plaintext_reasoning and not has_codex_reasoning:
+                    plaintext_reasoning = msg.get("reasoning_content")
+                    if not (
+                        isinstance(plaintext_reasoning, str)
+                        and plaintext_reasoning.strip()
+                    ):
+                        plaintext_reasoning = msg.get("reasoning")
+                    if (
+                        isinstance(plaintext_reasoning, str)
+                        and plaintext_reasoning.strip()
+                    ):
+                        items.append({
+                            "type": "reasoning",
+                            "content": [{
+                                "type": "reasoning_text",
+                                "text": plaintext_reasoning,
+                            }],
+                            "summary": [],
+                        })
+                        item_sources.append(msg)
+                        has_plaintext_reasoning = True
+
                 # Replay exact assistant message items (with id/phase) from
                 # previous turns so the API can maintain prefix-cache hits.
                 # OpenAI docs: "preserve and resend phase on all assistant
@@ -633,6 +669,18 @@ def _chat_messages_to_responses_input(
                         item_sources.append(msg)
                         replayed_message_items += 1
 
+                tool_calls = msg.get("tool_calls")
+                has_replayable_tool_call = (
+                    isinstance(tool_calls, list)
+                    and any(
+                        isinstance(tc, dict)
+                        and isinstance(tc.get("function"), dict)
+                        and isinstance(tc["function"].get("name"), str)
+                        and bool(tc["function"]["name"].strip())
+                        for tc in tool_calls
+                    )
+                )
+
                 if replayed_message_items > 0:
                     pass
                 elif content_parts:
@@ -641,16 +689,19 @@ def _chat_messages_to_responses_input(
                 elif content_text.strip():
                     items.append({"role": "assistant", "content": content_text})
                     item_sources.append(msg)
-                elif has_codex_reasoning:
+                elif has_codex_reasoning or (
+                    has_plaintext_reasoning and not has_replayable_tool_call
+                ):
                     # The Responses API requires a following item after each
                     # reasoning item (otherwise: missing_following_item error).
                     # When the assistant produced only reasoning with no visible
-                    # content, emit an empty assistant message as the required
-                    # following item.
+                    # content or function call, emit an empty assistant message
+                    # as the required following item. Plaintext reasoning must
+                    # remain directly adjacent to its function_call so a relay
+                    # attaches the thought to that assistant action turn.
                     items.append({"role": "assistant", "content": ""})
                     item_sources.append(msg)
 
-                tool_calls = msg.get("tool_calls")
                 if isinstance(tool_calls, list):
                     for tc in tool_calls:
                         if not isinstance(tc, dict):
@@ -778,6 +829,7 @@ def _preflight_codex_input_items(
     *,
     is_github_responses: bool = False,
     sanitize_harmony_tokens: bool = False,
+    allow_plaintext_reasoning: bool = False,
 ) -> List[Dict[str, Any]]:
     if not isinstance(raw_items, list):
         raise ValueError("Codex Responses input must be a list of input items.")
@@ -896,6 +948,27 @@ def _preflight_codex_input_items(
                 else:
                     reasoning_item["summary"] = []
                 normalized.append(reasoning_item)
+            elif allow_plaintext_reasoning:
+                content = item.get("content")
+                plaintext_parts: List[Dict[str, str]] = []
+                if isinstance(content, list):
+                    for part in content:
+                        if not isinstance(part, dict):
+                            continue
+                        if part.get("type") not in {"reasoning_text", "text"}:
+                            continue
+                        text = part.get("text")
+                        if isinstance(text, str) and text.strip():
+                            plaintext_parts.append({
+                                "type": "reasoning_text",
+                                "text": sanitize_text(text),
+                            })
+                if plaintext_parts:
+                    normalized.append({
+                        "type": "reasoning",
+                        "content": plaintext_parts,
+                        "summary": [],
+                    })
             continue
 
         if item_type == "compaction":
@@ -1023,6 +1096,7 @@ def _preflight_codex_api_kwargs(
     allow_stream: bool = False,
     is_github_responses: bool = False,
     sanitize_harmony_tokens: bool = False,
+    allow_plaintext_reasoning: bool = False,
 ) -> Dict[str, Any]:
     if not isinstance(api_kwargs, dict):
         raise ValueError("Codex Responses request must be a dict.")
@@ -1050,6 +1124,7 @@ def _preflight_codex_api_kwargs(
         api_kwargs.get("input"),
         is_github_responses=is_github_responses,
         sanitize_harmony_tokens=sanitize_harmony_tokens,
+        allow_plaintext_reasoning=allow_plaintext_reasoning,
     )
 
     tools = api_kwargs.get("tools")
@@ -1262,16 +1337,25 @@ def _extract_responses_message_text(item: Any) -> str:
 
 def _extract_responses_reasoning_text(item: Any) -> str:
     """Extract a compact reasoning text from a Responses reasoning item."""
-    summary = getattr(item, "summary", None)
-    if isinstance(summary, list):
+    def field(obj: Any, name: str) -> Any:
+        if isinstance(obj, dict):
+            return obj.get(name)
+        return getattr(obj, name, None)
+
+    # Plaintext relays return full reasoning in ``content``; OpenAI returns a
+    # human-readable summary alongside encrypted_content.
+    for part_field in ("content", "summary"):
+        parts = field(item, part_field)
+        if not isinstance(parts, list):
+            continue
         chunks: List[str] = []
-        for part in summary:
-            text = getattr(part, "text", None)
+        for part in parts:
+            text = field(part, "text")
             if isinstance(text, str) and text:
                 chunks.append(text)
         if chunks:
             return "\n".join(chunks).strip()
-    text = getattr(item, "text", None)
+    text = field(item, "text")
     if isinstance(text, str) and text:
         return text.strip()
     return ""

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -256,6 +256,17 @@ def _is_azure_foundry_responses(params: Dict[str, Any]) -> bool:
     )
 
 
+def _supports_actual_plaintext_reasoning(params: Dict[str, Any]) -> bool:
+    """Return True for Actual's plaintext Responses reasoning extension."""
+    from utils import base_url_hostname
+
+    provider = str(params.get("provider") or "").strip().lower()
+    return (
+        provider == "actual"
+        or base_url_hostname(str(params.get("base_url") or "")) == "api.actual.inc"
+    )
+
+
 def _is_post_tool_replay(messages: Optional[List[Dict[str, Any]]]) -> bool:
     """Return True when ``messages`` end on a tool result awaiting a follow-up.
 
@@ -353,6 +364,7 @@ class ResponsesApiTransport(ProviderTransport):
     # response are stamped with the endpoint that minted them. Plain class
     # attribute default; mutated on the instance, not the class.
     _last_issuer_kind: Optional[str] = None
+    _last_allow_plaintext_reasoning: bool = False
 
     @property
     def api_mode(self) -> str:
@@ -373,6 +385,8 @@ class ResponsesApiTransport(ProviderTransport):
         from agent.codex_responses_adapter import _chat_messages_to_responses_input
         issuer = self._resolve_issuer_kind(kwargs)
         self._last_issuer_kind = issuer
+        allow_plaintext_reasoning = _supports_actual_plaintext_reasoning(kwargs)
+        self._last_allow_plaintext_reasoning = allow_plaintext_reasoning
         return _chat_messages_to_responses_input(
             messages,
             is_xai_responses=kwargs.get("is_xai_responses") is True,
@@ -380,6 +394,7 @@ class ResponsesApiTransport(ProviderTransport):
             replay_encrypted_reasoning=bool(
                 kwargs.get("replay_encrypted_reasoning", True)
             ),
+            replay_plaintext_reasoning=allow_plaintext_reasoning,
             current_issuer_kind=issuer,
             native_compaction_eligible=_native_compaction_active(
                 kwargs.get("context_management")
@@ -478,6 +493,8 @@ class ResponsesApiTransport(ProviderTransport):
         # dropped before the API rejects them.
         issuer_kind = self._resolve_issuer_kind(params)
         self._last_issuer_kind = issuer_kind
+        allow_plaintext_reasoning = _supports_actual_plaintext_reasoning(params)
+        self._last_allow_plaintext_reasoning = allow_plaintext_reasoning
 
         # Resolve reasoning effort
         reasoning_effort = "medium"
@@ -584,6 +601,7 @@ class ResponsesApiTransport(ProviderTransport):
                 is_xai_responses=is_xai_responses,
                 is_github_responses=is_github_responses,
                 replay_encrypted_reasoning=replay_encrypted_reasoning,
+                replay_plaintext_reasoning=allow_plaintext_reasoning,
                 current_issuer_kind=issuer_kind,
                 native_compaction_eligible=native_compaction_active,
             ),
@@ -861,20 +879,27 @@ class ResponsesApiTransport(ProviderTransport):
         allow_stream: bool = False,
         is_github_responses: bool = False,
         sanitize_harmony_tokens: bool = False,
+        allow_plaintext_reasoning: Optional[bool] = None,
     ) -> dict:
         """Validate and sanitize Codex API kwargs before the call.
 
         Normalizes input items, strips unsupported fields, validates structure.
         ``sanitize_harmony_tokens`` is enabled only for the ChatGPT Codex
         backend, which rejects literal reserved Harmony wire tokens in text.
+        ``allow_plaintext_reasoning`` defaults to the capability resolved by
+        the matching build_kwargs call, and is True only for Actual.
         """
         from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+
+        if allow_plaintext_reasoning is None:
+            allow_plaintext_reasoning = self._last_allow_plaintext_reasoning
 
         normalized = _preflight_codex_api_kwargs(
             api_kwargs,
             allow_stream=allow_stream,
             is_github_responses=is_github_responses,
             sanitize_harmony_tokens=sanitize_harmony_tokens,
+            allow_plaintext_reasoning=bool(allow_plaintext_reasoning),
         )
         if "prompt_cache_key" in normalized:
             bounded = _bounded_prompt_cache_key(normalized["prompt_cache_key"])

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -335,6 +335,118 @@ def test_chat_messages_to_responses_input_keeps_short_call_id():
 
 
 
+def test_actual_plaintext_reasoning_replays_adjacent_to_function_call():
+    """Actual must receive Kimi's thought on the same assistant action turn."""
+    messages = [
+        {"role": "user", "content": "Inspect the repository"},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "I should inspect the repository before answering.",
+            "reasoning_content": "I should inspect the repository before answering.",
+            "tool_calls": [
+                {
+                    "id": "call_status",
+                    "type": "function",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": '{"command":"git status"}',
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_status", "content": "clean"},
+    ]
+
+    items = _chat_messages_to_responses_input(
+        messages,
+        replay_plaintext_reasoning=True,
+        current_issuer_kind="other:https://api.actual.inc/v1",
+    )
+
+    reasoning_index = next(
+        i for i, item in enumerate(items) if item.get("type") == "reasoning"
+    )
+    call_index = next(
+        i for i, item in enumerate(items) if item.get("type") == "function_call"
+    )
+    output_index = next(
+        i for i, item in enumerate(items)
+        if item.get("type") == "function_call_output"
+    )
+    assert call_index == reasoning_index + 1
+    assert output_index == call_index + 1
+    assert items[reasoning_index] == {
+        "type": "reasoning",
+        "content": [{
+            "type": "reasoning_text",
+            "text": "I should inspect the repository before answering.",
+        }],
+        "summary": [],
+    }
+
+
+def test_plaintext_reasoning_replay_is_opt_in():
+    messages = [{
+        "role": "assistant",
+        "content": "done",
+        "reasoning_content": "private provider thought",
+    }]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    assert not any(item.get("type") == "reasoning" for item in items)
+
+
+def test_preflight_plaintext_reasoning_is_capability_gated():
+    raw = [{
+        "type": "reasoning",
+        "content": [{"type": "reasoning_text", "text": "replay me"}],
+        "summary": [],
+    }]
+
+    assert _preflight_codex_input_items(raw) == []
+    assert _preflight_codex_input_items(
+        raw, allow_plaintext_reasoning=True
+    ) == raw
+
+
+def test_normalize_actual_reasoning_content_extracts_plaintext():
+    response = SimpleNamespace(
+        status="completed",
+        output=[
+            SimpleNamespace(
+                type="reasoning",
+                id="rs_actual_1",
+                status="completed",
+                encrypted_content=None,
+                content=[SimpleNamespace(
+                    type="reasoning_text",
+                    text="I need a repository inspection first.",
+                )],
+                summary=[],
+            ),
+            SimpleNamespace(
+                type="function_call",
+                id="fc_actual_1",
+                call_id="call_actual_1",
+                status="completed",
+                name="terminal",
+                arguments='{"command":"git status"}',
+            ),
+        ],
+    )
+
+    assistant, finish_reason = _normalize_codex_response(
+        response,
+        issuer_kind="other:https://api.actual.inc/v1",
+    )
+
+    assert finish_reason == "tool_calls"
+    assert assistant.reasoning == "I need a repository inspection first."
+    assert assistant.codex_reasoning_items is None
+
+
 def test_preflight_codex_input_items_drops_short_id_for_github_responses():
     items = _preflight_codex_input_items(
         [

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -386,6 +386,75 @@ def test_actual_plaintext_reasoning_replays_adjacent_to_function_call():
     }
 
 
+def test_actual_plaintext_reasoning_heads_mixed_content_action_turn():
+    """A turn with visible text AND a tool call stays one contiguous run.
+
+    Wire order is OpenAI's canonical output order — reasoning, then the
+    assistant message, then the function_call(s) — with nothing interleaved
+    and nothing dropped. The relay attaches reasoning to the contiguous
+    assistant run that follows it (the whole model turn), so the contract is
+    turn-level adjacency, not reasoning-touches-function_call.
+    """
+    messages = [
+        {"role": "user", "content": "Inspect the repository"},
+        {
+            "role": "assistant",
+            "content": "Checking the working tree and the branch.",
+            "reasoning_content": (
+                "Two probes: status for drift, branch for identity."
+            ),
+            "tool_calls": [
+                {
+                    "id": "call_status",
+                    "type": "function",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": '{"command":"git status"}',
+                    },
+                },
+                {
+                    "id": "call_branch",
+                    "type": "function",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": '{"command":"git branch --show-current"}',
+                    },
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_status", "content": "clean"},
+        {"role": "tool", "tool_call_id": "call_branch", "content": "main"},
+    ]
+
+    items = _chat_messages_to_responses_input(
+        messages,
+        replay_plaintext_reasoning=True,
+        current_issuer_kind="other:https://api.actual.inc/v1",
+    )
+
+    reasoning_index = next(
+        i for i, item in enumerate(items) if item.get("type") == "reasoning"
+    )
+    message_index = next(
+        i
+        for i, item in enumerate(items)
+        if i > reasoning_index and item.get("role") == "assistant"
+    )
+    call_indexes = [
+        i for i, item in enumerate(items) if item.get("type") == "function_call"
+    ]
+    assert message_index == reasoning_index + 1
+    assert call_indexes == [message_index + 1, message_index + 2]
+    assert items[reasoning_index]["content"][0]["text"] == (
+        "Two probes: status for drift, branch for identity."
+    )
+    # The missing_following_item guard must not inject an empty assistant
+    # message into a turn that already has visible content.
+    assert items[message_index]["content"] == (
+        "Checking the working tree and the branch."
+    )
+
+
 def test_plaintext_reasoning_replay_is_opt_in():
     messages = [{
         "role": "assistant",

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -321,6 +321,112 @@ class TestCodexBuildKwargs:
         assert "function_call_output" in item_types
         assert kw.get("include") == ["reasoning.encrypted_content"]
 
+    @staticmethod
+    def _actual_plaintext_post_tool_messages():
+        return [
+            {"role": "user", "content": "Inspect the repository"},
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning": "I should inspect the repository before answering.",
+                "reasoning_content": "I should inspect the repository before answering.",
+                "tool_calls": [
+                    {
+                        "id": "call_status",
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": '{"command":"git status"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_status", "content": "clean"},
+        ]
+
+    @pytest.mark.parametrize(
+        "route",
+        [
+            {"provider": "actual", "base_url": "https://relay.example/v1"},
+            {"base_url": "https://api.actual.inc/v1"},
+        ],
+    )
+    def test_actual_replays_plaintext_reasoning_through_double_preflight(
+        self, transport, route
+    ):
+        """Pin the full Hermes wire path, including its two preflight passes."""
+        kwargs = transport.build_kwargs(
+            model="moonshotai/Kimi-K3",
+            messages=self._actual_plaintext_post_tool_messages(),
+            tools=[],
+            **route,
+        )
+
+        first = transport.preflight_kwargs(kwargs)
+        wire = transport.preflight_kwargs(first)
+        relevant = [
+            item for item in wire["input"]
+            if item.get("type") in {
+                "reasoning", "function_call", "function_call_output"
+            }
+        ]
+
+        assert [item["type"] for item in relevant] == [
+            "reasoning", "function_call", "function_call_output"
+        ]
+        assert relevant[0]["content"] == [{
+            "type": "reasoning_text",
+            "text": "I should inspect the repository before answering.",
+        }]
+
+    @pytest.mark.parametrize(
+        "route",
+        [
+            {"provider": "openai", "base_url": "https://api.openai.com/v1"},
+            {"provider": "custom", "base_url": "https://relay.example/api.actual.inc/v1"},
+            {"provider": "custom", "base_url": "https://api.actual.inc.evil.example/v1"},
+        ],
+    )
+    def test_non_actual_routes_never_receive_plaintext_reasoning(
+        self, transport, route
+    ):
+        kwargs = transport.build_kwargs(
+            model="moonshotai/Kimi-K3",
+            messages=self._actual_plaintext_post_tool_messages(),
+            tools=[],
+            **route,
+        )
+        wire = transport.preflight_kwargs(kwargs)
+
+        assert not any(item.get("type") == "reasoning" for item in wire["input"])
+
+    def test_actual_plaintext_capability_does_not_stick_after_provider_switch(
+        self, transport
+    ):
+        actual_kwargs = transport.build_kwargs(
+            model="moonshotai/Kimi-K3",
+            messages=self._actual_plaintext_post_tool_messages(),
+            tools=[],
+            provider="actual",
+            base_url="https://api.actual.inc/v1",
+        )
+        assert any(
+            item.get("type") == "reasoning"
+            for item in transport.preflight_kwargs(actual_kwargs)["input"]
+        )
+
+        openai_kwargs = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=self._actual_plaintext_post_tool_messages(),
+            tools=[],
+            provider="openai",
+            base_url="https://api.openai.com/v1",
+        )
+        assert not any(
+            item.get("type") == "reasoning"
+            for item in transport.preflight_kwargs(openai_kwargs)["input"]
+        )
+
     def test_azure_foundry_post_tool_replay_suppresses_reasoning_items(self, transport):
         """The rejected payload shape drops reasoning, keeps tool continuity."""
         kw = transport.build_kwargs(


### PR DESCRIPTION
## What does this PR do?

Fixes a silent reasoning-history loss that degenerates agents into tool-call loops when Hermes runs in Responses mode against a relay that returns **plaintext** reasoning instead of OpenAI's `encrypted_content` continuation blob.

The failure chain:

1. A Responses relay (e.g. Actual Computer's `api.actual.inc`, serving Kimi-K3 via vLLM) cannot mint OpenAI's opaque encrypted reasoning blob, so it returns model thinking as plaintext `reasoning` content.
2. Hermes's Responses adapter *displays* that reasoning but only *replays* reasoning items carrying `encrypted_content`. Plaintext reasoning is silently dropped from the next request.
3. The backend then renders historical assistant turns as an empty think block plus the tool call (`<think></think>` + action). Models whose chat templates attach thinking to the action turn (Kimi-K3) see malformed action-only history and collapse into repeated tool calls / infinitely growing greps.

The fix: when the route targets a plaintext-reasoning relay, capture the plaintext reasoning from the response and replay it as a `reasoning` item **at the head of the assistant turn it belongs to**, in OpenAI's canonical output order (`reasoning` → assistant message, if any → `function_call`(s)), surviving both preflight passes. The adjacency contract is turn-level: the relay attaches the reasoning to the contiguous assistant run that follows it (the whole model turn), so mixed text+tool-call turns and parallel tool calls replay losslessly too — pinned by regression tests, including the mixed-content shape raised in review.

Safety properties (all pinned by tests):

- Encrypted reasoning always takes precedence; the same thought is never replayed twice.
- The capability is gated to `provider=actual` or the exact `api.actual.inc` hostname (same idiom as the existing Azure Foundry hostname gate). Lookalike hosts (`api.actual.inc.evil.example`, path-embedded) do not qualify.
- Native OpenAI routes are byte-for-byte unaffected; the capability resets on provider switch within a session.
- Reasoning items keep a following item, so `missing_following_item` cannot trigger — and the empty-assistant-message guard never injects a synthetic message into a turn that has a `function_call`, which would split the run.

## Related Issue

No existing issue; searched open/closed PRs and issues for duplicates and found none. Happy to file one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/codex_responses_adapter.py`: `_chat_messages_to_responses_input` gains `replay_plaintext_reasoning`; emits the plaintext reasoning item at the head of the matching assistant turn. `_preflight_codex_input_items` / `_preflight_codex_api_kwargs` gain `allow_plaintext_reasoning` so the replayed items survive preflight. `_extract_responses_reasoning_text` now reads full `content` parts (plaintext relays) before falling back to `summary` (OpenAI), and handles dict-shaped items.
- `agent/transports/codex.py`: new `_supports_actual_plaintext_reasoning` gate; `build_kwargs`/`preflight_kwargs` thread the capability through (mirroring the `_last_issuer_kind` pattern).
- `tests/agent/test_codex_responses_adapter.py`, `tests/agent/transports/test_codex_transport.py`: regression coverage — turn-head placement for reasoning-only-plus-call turns, mixed visible-content + parallel tool-call turns staying one contiguous run, opt-in default, preflight gating, response extraction, double-preflight wire path, non-Actual routes never receive plaintext reasoning, capability does not stick across provider switch.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_codex_responses_adapter.py tests/agent/transports/test_codex_transport.py tests/run_agent/test_run_agent_codex_responses.py -q` — 179 tests pass.
2. Repro before/after: run Hermes in Responses mode against a relay serving Kimi-K3 that returns plaintext reasoning; before this patch multi-turn tool sessions degrade into repeated identical tool calls once history contains action-only assistant turns; after, the model receives its prior thinking and sessions stay coherent.
3. Confirm OpenAI routes unchanged: `test_non_actual_routes_never_receive_plaintext_reasoning`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` — the suites covering the changed code pass in full (179 tests across the three files in How to Test), and a full local run matches the clean-`main` baseline exactly (the only failures are pre-existing local-env ones in unrelated `tests/tools/` mcp/vision/video suites, identical with and without this change). `ruff check` clean.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.6, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — behavior documented inline; no user-facing config change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python, path-free change; `scripts/check-windows-footguns.py` clean

---

Note for maintainers: if you'd rather not gate on a specific provider/hostname, this generalizes naturally to a provider-profile capability flag (e.g. `replay_plaintext_reasoning: true`); happy to rework it that way.
