### PR TITLE
fix(agent): classify Anthropic monthly-spend-limit 429 as billing, not rate_limit

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -133,6 +133,7 @@ _BILLING_PATTERNS = [
     "account is deactivated",
     "plan does not include",
     "out of extra usage",  # Anthropic OAuth Pro/Max overage bucket depleted (HTTP 400)
+    "monthly spend limit",  # Anthropic subscription monthly cap arrives as HTTP 429 (#91091)
     "out of funds",
     "run out of funds",
     "balance_depleted",
@@ -1268,6 +1269,19 @@ def _classify_by_status(
             return result_fn(
                 FailoverReason.overloaded,
                 retryable=True,
+            )
+        # A 429 whose body proves non-transient billing exhaustion must rotate
+        # now: Anthropic surfaces the subscription monthly spend cap as HTTP
+        # 429, and the default rate_limit policy honors the server's
+        # Retry-After (capped at 600s) for api_max_retries attempts before the
+        # fallback chain is consulted — a ~40-50 minute stall at defaults for
+        # a cap that cannot clear inside that window (#91091).
+        if any(p in error_msg for p in _BILLING_PATTERNS):
+            return result_fn(
+                FailoverReason.billing,
+                retryable=False,
+                should_rotate_credential=True,
+                should_fallback=True,
             )
         # Distinguish an OpenRouter-aggregator upstream 429 (an upstream model
         # like DeepSeek rate-limited OpenRouter's aggregate traffic) from an

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1275,8 +1275,11 @@ def _classify_by_status(
         # 429, and the default rate_limit policy honors the server's
         # Retry-After (capped at 600s) for api_max_retries attempts before the
         # fallback chain is consulted — a ~40-50 minute stall at defaults for
-        # a cap that cannot clear inside that window (#91091).
-        if any(p in error_msg for p in _BILLING_PATTERNS):
+        # a cap that cannot clear inside that window (#91091). Patterns are
+        # lowercase; match against the lowered message so real SDK bodies
+        # with title-cased wording ("Monthly Spend Limit") classify too
+        # (review on #91091).
+        if any(p in error_msg.lower() for p in _BILLING_PATTERNS):
             return result_fn(
                 FailoverReason.billing,
                 retryable=False,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -364,6 +364,36 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.rate_limit
         assert result.should_rotate_credential is True
 
+    def test_429_monthly_spend_limit_is_billing_not_rate_limit(self):
+        """Anthropic surfaces the subscription monthly spend cap as HTTP 429.
+        The default rate_limit policy honors Retry-After (capped at 600s) for
+        api_max_retries attempts before fallback — a ~40-50 minute stall for a
+        cap that cannot clear in that window. The body proves non-transient
+        billing exhaustion, so it must rotate now. (#91091)"""
+        e = MockAPIError(
+            "HTTP 429: This request would exceed your account's monthly spend "
+            "limit. Please try again later.",
+            status_code=429,
+        )
+        result = classify_api_error(e, provider="anthropic")
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
+    def test_429_spend_limit_takes_priority_over_upstream_disambiguation(self):
+        """A billing-proven 429 must resolve before the OpenRouter upstream
+        disambiguation: the account state is deterministic regardless of any
+        aggregator wrapping in the body. (#91091)"""
+        e = MockAPIError(
+            "Provider returned error: This request would exceed your "
+            "account's monthly spend limit.",
+            status_code=429,
+        )
+        result = classify_api_error(e, provider="openrouter")
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
     # ── 5xx that are actually request-validation errors ──
     # Some OpenAI-compatible gateways (e.g. codex.nekos.me) return
     # request-validation failures with a 5xx status. These are

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -381,6 +381,20 @@ class TestClassifyApiError:
         assert result.should_rotate_credential is True
         assert result.should_fallback is True
 
+    def test_429_monthly_spend_limit_mixed_case_still_billing(self):
+        """Real SDK bodies may title-case the wording ("Monthly Spend Limit")
+        while _BILLING_PATTERNS are lowercase — the 429 branch matches against
+        the lowered message so the classification cannot go dead in
+        production (review on #91091)."""
+        e = MockAPIError(
+            "HTTP 429: This request would exceed your account's Monthly Spend "
+            "Limit.",
+            status_code=429,
+        )
+        result = classify_api_error(e, provider="anthropic")
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
     def test_429_spend_limit_takes_priority_over_upstream_disambiguation(self):
         """A billing-proven 429 must resolve before the OpenRouter upstream
         disambiguation: the account state is deterministic regardless of any


### PR DESCRIPTION
## What does this PR do?

Classifies an Anthropic monthly-spend-limit 429 as billing instead of rate_limit. Anthropic surfaces the subscription monthly cap as `HTTP 429 {"type": "rate_limit_error", "message": "This request would exceed your account's monthly spend limit. ..."}`, and the default `rate_limit` policy honors the server's `Retry-After` (capped at 600s) for `api_max_retries` attempts before the fallback chain is ever consulted — a ~40–50 minute hard stall at defaults for a cap that cannot clear inside that window, even with a healthy fallback provider configured (#91091).

Two changes in `agent/error_classifier.py`:

1. `_BILLING_PATTERNS` gains `"monthly spend limit"` (the 403/404 branches that already consult the list benefit automatically).
2. The 429 branch now checks `_BILLING_PATTERNS` after the overload disambiguation and **before** the OpenRouter upstream disambiguation — a body that proves non-transient billing exhaustion is deterministic regardless of any aggregator wrapping, so it must resolve to rotate-now (`retryable=False, should_rotate_credential=True, should_fallback=True`) rather than backoff-then-rotate.

## Related Issue

Fixes #91091

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py` — `"monthly spend limit"` added to `_BILLING_PATTERNS` with the #91091 arrival-status note; the 429 branch gains the billing-pattern check (placed after overloaded, before upstream-429) with the stall rationale documented inline
- `tests/agent/test_error_classifier.py` — two regressions: the exact Anthropic spend-limit body classifies as billing/rotate-now/non-retryable, and a billing-proven 429 takes priority over the OpenRouter upstream disambiguation

## How to Test

1. `.venv/bin/python -m pytest tests/agent/test_error_classifier.py -q` — should pass (99 passed, including the two new)
2. Observed result: on unmodified main, both new tests fail — the spend-limit body classifies as `rate_limit` (the #91091 40–50 min stall shape); with this fix it classifies as `billing` with `retryable=False`
3. Guards preserved: `test_429_with_overloaded_body_is_overloaded_not_rate_limit` and `test_429_normal_rate_limit_still_rotates` still pass (overload bodies and plain rate limits keep their existing paths)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (why a billing-proven 429 rotates now, and why it precedes upstream disambiguation)
- [x] Tests added that prove the fix (exact body + priority ordering)
- [x] All new and existing tests pass locally (99 passed)
- [x] Platform: macOS (pure classification logic, platform-independent)
