### PR TITLE
fix(error-classifier): fail fast on key_cmd credential errors

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -709,6 +709,25 @@ _SSL_TRANSIENT_PATTERNS = [
 
 # ── Classification pipeline ─────────────────────────────────────────────
 
+def _has_command_token_error(error: BaseException) -> bool:
+    """True when *error* or anything in its cause chain is a key_cmd failure.
+
+    ``CommandTokenError`` is raised while the SDK is inside its own request
+    path, so the provider SDK re-raises it as a generic connection error and
+    only ``__cause__`` / ``__context__`` still carries the real reason.
+    """
+    from agent.command_token_source import CommandTokenError
+
+    seen: set[int] = set()
+    current: Optional[BaseException] = error
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, CommandTokenError):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
 def classify_api_error(
     error: Exception,
     *,
@@ -726,6 +745,7 @@ def classify_api_error(
       2. HTTP status code + message-aware refinement
       3. Error code classification (from body)
       4. Message pattern matching (billing vs rate_limit vs context vs auth)
+      4b. key_cmd credential failures → fail fast (non-retryable)
       5. SSL/TLS transient alert patterns → retry as timeout
       6. Server disconnect + large session → context overflow
       7. Transport error heuristics
@@ -1037,6 +1057,21 @@ def classify_api_error(
     )
     if classified is not None:
         return classified
+
+    # ── 4b. key_cmd credential failures → fail fast ─────────────────
+    # A key_cmd helper raises CommandTokenError from inside the HTTP
+    # send stack, so the SDK wraps it as APIConnectionError with the
+    # generic text "Connection error." — the transport-error heuristics
+    # below then classify it as transient.  An expired OAuth session
+    # fails identically on every retry, so the retry budget is spent
+    # before the user sees the one message that names the fix.  Inspect
+    # the exception chain, which is where the real cause survives.
+    if _has_command_token_error(error):
+        return _result(
+            FailoverReason.auth_permanent,
+            retryable=False,
+            should_fallback=True,
+        )
 
     # ── 5. SSL certificate verification failures → fail fast ────────
     # A broken certificate chain (TLS-inspecting proxy, missing custom CA,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -988,6 +988,83 @@ class TestSSLCertVerificationFailFast:
         assert result.retryable is True
 
 
+# ── Test: key_cmd credential failures (fail fast) ──────────────────────
+
+class TestCommandTokenErrorFailFast:
+    """A ``key_cmd`` helper with an expired OAuth session fails identically on
+    every retry, so it must not consume the retry budget.
+
+    ``CommandTokenError`` is raised while the provider SDK is inside its own
+    request path, so the SDK re-raises it as ``APIConnectionError("Connection
+    error.")``. The generic message defeats pattern matching and the type name
+    matches the transport-error heuristics, so the real cause survives only in
+    the exception chain.
+    """
+
+    @staticmethod
+    def _sdk_wrapped(inner):
+        """Build the shape ``raise APIConnectionError(...) from inner`` makes."""
+        class APIConnectionError(Exception):
+            pass
+
+        exc = APIConnectionError("Connection error.")
+        exc.__cause__ = inner
+        return exc
+
+    def test_wrapped_command_token_error_is_non_retryable(self):
+        from agent.command_token_source import CommandTokenError
+
+        e = self._sdk_wrapped(
+            CommandTokenError("key_cmd for provider 'gateway' exited 1.")
+        )
+        result = classify_api_error(e, provider="custom", model="some-model")
+        assert result.reason == FailoverReason.auth_permanent
+        assert result.retryable is False
+
+    def test_bare_command_token_error_is_non_retryable(self):
+        from agent.command_token_source import CommandTokenError
+
+        e = CommandTokenError("key_cmd for provider 'gateway' produced no output")
+        result = classify_api_error(e, provider="custom", model="some-model")
+        assert result.reason == FailoverReason.auth_permanent
+        assert result.retryable is False
+
+    def test_context_chain_is_inspected(self):
+        """An implicitly chained cause (bare ``raise``) is also detected."""
+        from agent.command_token_source import CommandTokenError
+
+        class APIConnectionError(Exception):
+            pass
+
+        exc = APIConnectionError("Connection error.")
+        exc.__context__ = CommandTokenError("key_cmd for provider 'g' exited 1.")
+        result = classify_api_error(exc, provider="custom", model="some-model")
+        assert result.reason == FailoverReason.auth_permanent
+        assert result.retryable is False
+
+    def test_genuine_connection_error_still_retries(self):
+        """Regression guard: a real transport failure keeps retrying."""
+        class APIConnectionError(Exception):
+            pass
+
+        result = classify_api_error(
+            APIConnectionError("Connection error."),
+            provider="custom", model="some-model",
+        )
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
+
+    def test_cyclic_cause_chain_terminates(self):
+        """A self-referential chain must not spin forever."""
+        class APIConnectionError(Exception):
+            pass
+
+        exc = APIConnectionError("Connection error.")
+        exc.__cause__ = exc
+        result = classify_api_error(exc, provider="custom", model="some-model")
+        assert result.retryable is True
+
+
 # ── Test: RateLimitError without status_code (Copilot/GitHub Models) ──────────
 
 class TestRateLimitErrorWithoutStatusCode:


### PR DESCRIPTION
Fixes #91108

### What this changes

`classify_api_error` now inspects the exception chain for `CommandTokenError` and classifies it as the existing `FailoverReason.auth_permanent` (`retryable=False`).

A `key_cmd` helper mints tokens per request, so `CommandTokenError` is raised inside httpx's send stack. The provider SDK re-raises it as `APIConnectionError("Connection error.")` — the generic message defeats the auth patterns in `_classify_by_message`, and `APIConnectionError` is in `_TRANSPORT_ERROR_TYPES` (`agent/error_classifier.py:632`), so a dead credential classified as transient and burned 3 retries plus a client rebuild before surfacing. The real message survives only in `__cause__`.

The check sits at step 4b, next to the SSL certificate fail-fast at `agent/error_classifier.py:1049`, which handles the same class of deterministic failure for the same reason.

`should_fallback=True` so a configured `fallback_providers` entry still takes over — one dead credential does not end the turn when another provider can serve it.

### Scope

Two files, +111/-0. No deletions, no new enum member (`auth_permanent` already existed), no config surface, no new env var, no changes to any other classification path.

### Notes

`isinstance` against the imported class rather than a type-name string, so an unrelated exception that happens to share the name cannot match. The import is function-local: `command_token_source` imports only stdlib, so there is no cycle, and this keeps the module's import graph unchanged.

The walk follows `__cause__` then `__context__`, tracking visited ids, so a self-referential chain terminates. There is a test for that.

### Tests

`tests/agent/test_error_classifier.py::TestCommandTokenErrorFailFast` — 5 cases: SDK-wrapped error, bare error, implicitly chained (`__context__`), a genuine `APIConnectionError` that must still retry, and the cyclic chain.

```
tests/agent/test_error_classifier.py ....................... 102 passed
tests/agent/test_error_classifier.py
tests/agent/test_command_token_source.py
tests/agent/test_tool_result_classification.py ............. 133 passed
```

Verified failing before the change and passing after, on `603d565`.
