### PR TITLE
fix(fallback): retry with different credential on same provider+model (#91077)

### DIFF
--- a/agent/backend_identity.py
+++ b/agent/backend_identity.py
@@ -83,6 +83,9 @@ def _norm_model(value: Optional[str]) -> str:
 def _norm_base_url(value: Optional[str]) -> str:
     return (value or "").strip().rstrip("/").lower()
 
+def _norm_credential(value: Optional[str]) -> str:
+    return (value or "").strip()
+
 
 @dataclass(frozen=True)
 class BackendIdentity:
@@ -96,6 +99,7 @@ class BackendIdentity:
     provider: str = ""
     model: str = ""
     base_url: str = ""
+    credential: str = ""
 
     @classmethod
     def build(
@@ -103,11 +107,13 @@ class BackendIdentity:
         provider: Optional[str] = None,
         model: Optional[str] = None,
         base_url: Optional[str] = None,
+        credential: Optional[str] = None,
     ) -> "BackendIdentity":
         return cls(
             provider=_norm_provider(provider),
             model=_norm_model(model),
             base_url=_norm_base_url(base_url),
+            credential=_norm_credential(credential),
         )
 
 
@@ -139,6 +145,8 @@ def same_credential_surface(a: BackendIdentity, b: BackendIdentity) -> bool:
     never proves a shared credential; it is only used as a weak signal
     when a provider label is missing entirely.
     """
+    if a.credential and b.credential:
+        return a.credential == b.credential
     if a.provider and b.provider:
         # Same label = same configured credential. Different labels =
         # different credential config (first-class registry providers
@@ -166,6 +174,8 @@ def same_deployment(a: BackendIdentity, b: BackendIdentity) -> bool:
     explicit URLs is two deployments — a pool).  A side with an unknown URL
     inherits the provider default and cannot prove difference.
     """
+    if a.credential and b.credential and a.credential != b.credential:
+        return False
     if not (a.provider and b.provider and a.provider == b.provider):
         # Same-host different-label shims: same URL + same model IS the same
         # deployment even when the alias labels differ (#22548) — unless both

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2502,21 +2502,26 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         return agent._try_activate_fallback(reason)
 
     # Skip entries that resolve to the same backend that just failed —
-    # falling back to it loops the failure. Identity semantics (which axes
-    # distinguish two backends, shim aliases, first-class credential
-    # surfaces, multi-endpoint pools) are owned by agent.backend_identity —
-    # see #22548, #70893, #62984. Do not re-implement comparisons here.
+# falling back to it loops the failure. Identity semantics (which axes
+# distinguish two backends, shim aliases, first-class credential
+# surfaces, multi-endpoint pools) are owned by agent.backend_identity —
+# see #22548, #70893, #62984. Do not re-implement comparisons here.
     from agent.backend_identity import BackendIdentity, should_skip_candidate
+    from hermes_cli.fallback_config import resolve_entry_api_key
+
+    fb_api_key_hint = resolve_entry_api_key(fb)
 
     current_ident = BackendIdentity.build(
         provider=getattr(agent, "provider", ""),
         model=getattr(agent, "model", ""),
         base_url=str(getattr(agent, "base_url", "") or ""),
+        credential=getattr(agent, "api_key", ""),
     )
     fb_ident = BackendIdentity.build(
         provider=fb_provider,
         model=fb_model,
         base_url=(fb.get("base_url") or ""),
+        credential=fb_api_key_hint,
     )
     if should_skip_candidate(fb_ident, current_ident):
         logger.warning(

--- a/tests/agent/test_backend_identity.py
+++ b/tests/agent/test_backend_identity.py
@@ -79,6 +79,13 @@ class TestSameDeployment:
             assert not should_skip_candidate(a, b, FailureScope.MODEL)
 
 
+    def test_different_credential_same_provider_model_base_url_is_different_deployment(self):
+        """Different credentials on same provider/model/base_url -> different deployment."""
+        failed = BackendIdentity.build(provider="custom", model="m", base_url="http://host/v1", credential="key1")
+        candidate = BackendIdentity.build(provider="custom", model="m", base_url="http://host/v1", credential="key2")
+        assert not same_deployment(candidate, failed)
+        assert not should_skip_candidate(candidate, failed, FailureScope.MODEL)
+
 class TestSameCredentialSurface:
     def test_same_provider_label_shares_credential(self):
         """Auth/payment failure on a provider kills every model on it —
@@ -104,6 +111,13 @@ class TestSameCredentialSurface:
         assert not same_credential_surface(a, b)
 
 
+
+    def test_different_credential_same_provider_model_base_url_different_credential_surface(self):
+        """Different credentials -> different credential surface."""
+        a = BackendIdentity.build(provider="custom", model="m", base_url="http://host/v1", credential="key1")
+        b = BackendIdentity.build(provider="custom", model="m", base_url="http://host/v1", credential="key2")
+        assert not same_credential_surface(a, b)
+        assert not should_skip_candidate(a, b, FailureScope.CREDENTIAL)
 
 class TestSameEndpoint:
     def test_same_explicit_url_is_same_endpoint(self):


### PR DESCRIPTION
Closes #91077