### PR TITLE
fix(cron): fail closed on toolset resolution errors

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -422,7 +422,11 @@ def _merge_mcp_into_per_job_toolsets(per_job: list[str], cfg: dict) -> list[str]
     return result
 
 
-def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
+class CronToolsetResolutionError(RuntimeError):
+    """Raised when an unattended job's effective toolsets cannot be resolved."""
+
+
+def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str]:
     """Resolve the toolset list for a cron job.
 
     Precedence:
@@ -433,26 +437,29 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     2. Per-platform ``hermes tools`` config for the ``cron`` platform.
        Mirrors gateway behavior (``_get_platform_tools(cfg, platform_key)``)
        so users can gate cron toolsets globally without recreating every job.
-    3. ``None`` on any lookup failure — AIAgent loads the full default set
-       (legacy behavior before this change, preserved as the safety net).
+    3. Fail closed on lookup errors. Returning ``None`` would make AIAgent load
+       the full default set, silently widening an unattended job's authority.
 
     _DEFAULT_OFF_TOOLSETS ({moa, homeassistant, rl}) are removed by
     ``_get_platform_tools`` for unconfigured platforms, so fresh installs
     get cron WITHOUT ``moa`` by default (issue reported by Norbert —
     surprise $4.63 run).
     """
-    per_job = job.get("enabled_toolsets")
-    if per_job:
-        return _merge_mcp_into_per_job_toolsets(list(per_job), cfg or {})
     try:
+        per_job = job.get("enabled_toolsets")
+        if per_job:
+            return _merge_mcp_into_per_job_toolsets(list(per_job), cfg or {})
         from hermes_cli.tools_config import _get_platform_tools  # lazy: avoid heavy import at cron module load
         return sorted(_get_platform_tools(cfg or {}, "cron"))
     except Exception as exc:
-        logger.warning(
-            "Cron toolset resolution failed, falling back to full default toolset: %s",
+        logger.error(
+            "Cron toolset resolution failed; refusing to widen to the full "
+            "default toolset: %s",
             exc,
         )
-        return None
+        raise CronToolsetResolutionError(
+            f"cron toolset resolution failed: {exc}"
+        ) from exc
 
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.
@@ -4612,7 +4619,20 @@ def _preflight_check_skills(job: dict) -> Optional[str]:
     return None
 
 
-def _preflight_job_config(job: dict, cfg: dict) -> Optional[str]:
+def _preflight_check_toolsets(job: dict, cfg: dict) -> Optional[str]:
+    try:
+        _resolve_cron_enabled_toolsets(job, cfg)
+    except CronToolsetResolutionError as exc:
+        return str(exc)
+    return None
+
+
+def _preflight_job_config(
+    job: dict,
+    cfg: dict,
+    *,
+    toolsets_resolved: bool = False,
+) -> Optional[str]:
     """Pre-dispatch configuration validation (T1-26).
 
     Returns a human-readable reason when the job's configuration cannot
@@ -4628,11 +4648,14 @@ def _preflight_job_config(job: dict, cfg: dict) -> Optional[str]:
     fail-loud-on-hidden-tools direction in #27948; alert dedup follows the
     alert-once pattern from the dead-pin auto-pause (#73506).
     """
-    for name, check in (
+    checks = [
         ("provider_key", lambda: _preflight_check_provider_key(job, cfg)),
         ("skills", lambda: _preflight_check_skills(job)),
         ("delivery", lambda: _preflight_check_delivery(job)),
-    ):
+    ]
+    if not toolsets_resolved:
+        checks.append(("toolsets", lambda: _preflight_check_toolsets(job, cfg)))
+    for name, check in checks:
         try:
             reason = check()
         except Exception:
@@ -5452,18 +5475,19 @@ def run_job(
         # Runs after the wake-gate/prompt build so silent script ticks stay
         # silent. Opt-out: `cron.preflight: false` in config.yaml.
         # ---------------------------------------------------------------
-        _pf_reason = None
+        _resolved_cron_toolsets = None
         try:
-            if _cron_preflight_enabled(_cfg):
-                _pf_reason = _preflight_job_config(job, _cfg)
-                if not _pf_reason and job.get("preflight_alerted"):
-                    # Configuration validates again — clear the alert-once
-                    # marker so a FUTURE config break re-alerts.
-                    try:
-                        from cron.jobs import clear_preflight_alerted
-                        clear_preflight_alerted(job_id)
-                    except Exception:
-                        pass
+            _resolved_cron_toolsets = _resolve_cron_enabled_toolsets(job, _cfg)
+            _toolset_resolution_reason = None
+        except CronToolsetResolutionError as exc:
+            _toolset_resolution_reason = str(exc)
+
+        _pf_reason = _toolset_resolution_reason
+        try:
+            if not _pf_reason and _cron_preflight_enabled(_cfg):
+                _pf_reason = _preflight_job_config(
+                    job, _cfg, toolsets_resolved=True
+                )
         except Exception:
             # The validator must never take down a runnable job — fail open.
             logger.debug(
@@ -5471,6 +5495,15 @@ def run_job(
                 job_id, exc_info=True,
             )
             _pf_reason = None
+
+        if not _pf_reason and job.get("preflight_alerted"):
+            # Mandatory toolset resolution and any enabled preflight checks are
+            # healthy again — clear alert-once state so a future outage alerts.
+            try:
+                from cron.jobs import clear_preflight_alerted
+                clear_preflight_alerted(job_id)
+            except Exception:
+                pass
 
         if _pf_reason:
             logger.warning(
@@ -5761,7 +5794,7 @@ def run_job(
             providers_order=pr.get("order"),
             provider_sort=pr.get("sort"),
             openrouter_min_coding_score=(_cfg.get("openrouter") or {}).get("min_coding_score"),
-            enabled_toolsets=_resolve_cron_enabled_toolsets(job, _cfg),
+            enabled_toolsets=_resolved_cron_toolsets,
             disabled_toolsets=_resolve_cron_disabled_toolsets(_cfg),
             quiet_mode=True,
             # Cron jobs should always inherit the user's SOUL.md identity from

--- a/tests/cron/test_preflight_config.py
+++ b/tests/cron/test_preflight_config.py
@@ -223,6 +223,64 @@ class TestHealthyJobUnaffected:
             assert not stored.get("preflight_alerted")
 
 
+class TestToolsetResolutionBlocks:
+    def test_resolution_failure_is_blocked_before_agent_construction(self, tmp_path):
+        job = _job()
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            with patch(
+                "hermes_cli.tools_config._get_platform_tools",
+                side_effect=RuntimeError("broken tool config"),
+            ):
+                success, output, _response, error, agent_constructed = _run_job_patched(
+                    job, tmp_path
+                )
+
+        assert agent_constructed is False
+        assert success is False
+        assert error is not None and "[blocked_config]" in error
+        assert "toolset resolution failed" in f"{error} {output}"
+
+    def test_resolution_failure_stays_blocked_when_preflight_opted_out(self, tmp_path):
+        (tmp_path / "config.yaml").write_text(
+            "cron:\n  preflight: false\n", encoding="utf-8"
+        )
+        job = _job()
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            with patch(
+                "hermes_cli.tools_config._get_platform_tools",
+                side_effect=RuntimeError("broken tool config"),
+            ):
+                success, output, _response, error, agent_constructed = _run_job_patched(
+                    job, tmp_path
+                )
+
+            assert agent_constructed is False
+            assert success is False
+            assert error is not None and "[blocked_config]" in error
+            assert "toolset resolution failed" in f"{error} {output}"
+
+            stored = [j for j in cron_jobs.load_jobs() if j["id"] == job["id"]][0]
+            assert stored.get("preflight_alerted")
+
+            success, *_rest, agent_constructed = _run_job_patched(stored, tmp_path)
+            assert success is True
+            assert agent_constructed is True
+            recovered = [j for j in cron_jobs.load_jobs() if j["id"] == job["id"]][0]
+            assert not recovered.get("preflight_alerted")
+
+            with patch(
+                "hermes_cli.tools_config._get_platform_tools",
+                side_effect=RuntimeError("broken tool config again"),
+            ):
+                _success, _output, _response, second_error, _constructed = _run_job_patched(
+                    recovered, tmp_path
+                )
+            assert second_error is not None and "[blocked_config]" in second_error
+            assert "[blocked_config:silent]" not in second_error
+
+
 class TestOptOut:
     def test_preflight_false_restores_old_behavior(self, tmp_path):
         """cron.preflight: false → job proceeds to resolution and fails the

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -14,6 +14,7 @@ from cron.scheduler import (
     _build_job_prompt,
     _deliver_result,
     _merge_mcp_into_per_job_toolsets,
+    _preflight_job_config,
     _resolve_cron_enabled_toolsets,
     _resolve_delivery_target,
     _resolve_origin,
@@ -117,6 +118,45 @@ class TestPerJobToolsetMcpMerge:
         # _get_platform_tools args: (cfg, "cron")
         assert m_platform.call_args[0][1] == "cron"
         assert set(result) == set(sentinel)
+
+    def test_resolver_failure_raises_typed_error_instead_of_loading_defaults(self):
+        import cron.scheduler as scheduler
+
+        job = {"enabled_toolsets": None}
+        with patch(
+            "hermes_cli.tools_config._get_platform_tools",
+            side_effect=RuntimeError("broken tool config"),
+        ):
+            with pytest.raises(scheduler.CronToolsetResolutionError, match="broken tool config"):
+                _resolve_cron_enabled_toolsets(job, self.CFG)
+
+    def test_per_job_mcp_resolution_failure_raises_typed_error(self):
+        import cron.scheduler as scheduler
+
+        job = {"enabled_toolsets": ["web"]}
+        with patch(
+            "hermes_cli.tools_config.enabled_mcp_server_names",
+            side_effect=RuntimeError("broken MCP config"),
+        ):
+            with pytest.raises(scheduler.CronToolsetResolutionError, match="broken MCP config"):
+                _resolve_cron_enabled_toolsets(job, self.CFG)
+
+    def test_preflight_turns_toolset_resolution_error_into_block_reason(self):
+        job = {"enabled_toolsets": None}
+        with (
+            patch("cron.scheduler._preflight_check_provider_key", return_value=None),
+            patch("cron.scheduler._preflight_check_skills", return_value=None),
+            patch("cron.scheduler._preflight_check_delivery", return_value=None),
+            patch(
+                "hermes_cli.tools_config._get_platform_tools",
+                side_effect=RuntimeError("broken tool config"),
+            ),
+        ):
+            reason = _preflight_job_config(job, self.CFG)
+
+        assert reason is not None
+        assert "toolset resolution failed" in reason
+        assert "broken tool config" in reason
 
 
 class TestResolveOrigin:


### PR DESCRIPTION
## Summary

- fail closed when an unattended cron job's effective toolsets cannot be resolved
- resolve the effective toolset once before agent construction and pass that exact list to `AIAgent`
- return `blocked_config` rather than widening to the default toolset
- rearm alert deduplication after recovery, including when optional preflight checks are disabled

## Why

`AIAgent(enabled_toolsets=None)` loads the default toolset. A cron resolution error could therefore silently grant an unattended job more tools than its configuration intended. This change blocks the job before provider or tool execution instead.

## Verification

- `scripts/run_tests.sh tests/cron/test_scheduler.py tests/cron/test_preflight_config.py`
- included in a combined affected-area run: 471 passed, 0 failed
- tests cover resolution failures, exact-once resolution, exact list propagation, recovery, and re-alerting
- Python compilation passed
- `git diff --check` passed

## Scope

This does not add per-job secret allowlists or change successful toolset precedence. Optional preflight remains fail-open for its existing checks; mandatory toolset resolution fails closed.
