### PR TITLE
feat(cli): guard fixed prompt and tool schema budgets

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -426,6 +426,7 @@ if _try_ultrafast_version():
     raise SystemExit(0)
 
 import argparse
+import atexit
 import hashlib
 import json
 import re
@@ -433,6 +434,7 @@ import shlex
 import shutil
 import stat
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Optional
 
@@ -692,6 +694,47 @@ def _apply_profile_override() -> None:
 
 
 _apply_profile_override()
+
+
+def _early_subcommand(argv: list[str]) -> str:
+    """Find the root subcommand without constructing the full argparse tree."""
+    value_options = {
+        "-z", "--oneshot", "--usage-file", "-m", "--model", "--provider",
+        "--reasoning", "-t", "--toolsets", "--resume", "-r", "--in",
+        "--skills", "-s",
+    }
+    optional_value_options = {"--continue", "-c"}
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg in value_options:
+            i += 2
+            continue
+        if arg in optional_value_options:
+            i += 2 if i + 1 < len(argv) and not argv[i + 1].startswith("-") else 1
+            continue
+        if arg.startswith("-"):
+            i += 1
+            continue
+        return arg
+    return ""
+
+
+# ``prompt-size`` is a read-only diagnostic. Redirect startup-time writes
+# (SOUL bootstrap, logs, caches, state.db) before dotenv/logging initialization,
+# while retaining the resolved profile as the source to inspect.
+if _early_subcommand(sys.argv[1:]) == "prompt-size":
+    from hermes_constants import get_hermes_home as _prompt_size_source_home
+    from hermes_cli.prompt_size import prepare_prompt_inspection_home
+
+    _prompt_size_source = _prompt_size_source_home().resolve()
+    _prompt_size_temp = Path(
+        tempfile.mkdtemp(prefix="hermes-prompt-size-cli-")
+    ).resolve()
+    prepare_prompt_inspection_home(_prompt_size_source, _prompt_size_temp)
+    os.environ["HERMES_PROMPT_SIZE_SOURCE_HOME"] = str(_prompt_size_source)
+    os.environ["HERMES_HOME"] = str(_prompt_size_temp)
+    atexit.register(shutil.rmtree, _prompt_size_temp, ignore_errors=True)
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.

--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -13,8 +13,13 @@ calls ``build_system_prompt_parts`` / inspects ``agent.tools`` offline.
 
 from __future__ import annotations
 
+import atexit
 import json
+import os
 import re
+import shutil
+import tempfile
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -31,6 +36,58 @@ _NAMES_ONLY_LINE_RE = re.compile(r"^  .+ \[names only\]: (?P<names>.+)$")
 
 # Cap the human-readable "Skills by size" table; ``--json`` always has them all.
 _SKILLS_TABLE_LIMIT = 20
+
+
+def prepare_prompt_inspection_home(source: Path, target: Path) -> None:
+    """Copy/link read inputs needed for prompt inspection into *target*."""
+    source = source.resolve()
+    target = target.resolve()
+    target.mkdir(parents=True, exist_ok=True)
+    for filename in ("config.yaml", "SOUL.md", ".env", ".skills_prompt_snapshot.json"):
+        src = source / filename
+        if src.is_file():
+            shutil.copy2(src, target / filename)
+    for dirname in ("memories", "plugins"):
+        src = source / dirname
+        if src.is_dir():
+            shutil.copytree(src, target / dirname, dirs_exist_ok=True)
+    skills = source / "skills"
+    if skills.is_dir():
+        try:
+            (target / "skills").symlink_to(skills, target_is_directory=True)
+        except OSError:
+            shutil.copytree(skills, target / "skills", dirs_exist_ok=True)
+
+
+@contextmanager
+def _isolated_inspection_home():
+    """Redirect all inspection-time writes to a disposable profile clone."""
+    from hermes_constants import (
+        get_hermes_home,
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    preisolated_source = os.environ.get("HERMES_PROMPT_SIZE_SOURCE_HOME")
+    if preisolated_source:
+        yield get_hermes_home().resolve(), Path(preisolated_source).resolve()
+        return
+
+    source = get_hermes_home().resolve()
+    raw_temp = tempfile.mkdtemp(prefix="hermes-prompt-size-")
+    atexit.register(shutil.rmtree, raw_temp, ignore_errors=True)
+    target = Path(raw_temp).resolve()
+    try:
+        prepare_prompt_inspection_home(source, target)
+
+        token = set_hermes_home_override(str(target))
+        try:
+            yield target, source
+        finally:
+            reset_hermes_home_override(token)
+    except Exception:
+        shutil.rmtree(target, ignore_errors=True)
+        raise
 
 
 def _bytes(s: str) -> int:
@@ -72,9 +129,11 @@ def _build_inspection_agent(platform: str) -> Any:
     return AIAgent(
         model=model,
         api_key="inspect-only",
-        base_url="https://openrouter.ai/api/v1",
+        base_url="http://127.0.0.1:1/v1",
+        provider="custom",
         quiet_mode=True,
         save_trajectories=False,
+        skip_background_review=True,
         platform=platform,
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
@@ -232,6 +291,28 @@ def _compute_toolsets_breakdown(tools: List[Any]) -> List[Dict[str, Any]]:
     return out
 
 
+def _compute_tools_breakdown(tools: List[Any]) -> List[Dict[str, Any]]:
+    """Return per-tool schema and description sizes, largest description first."""
+    rows: List[Dict[str, Any]] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        fn = tool.get("function")
+        if isinstance(fn, dict):
+            description = str(fn.get("description") or "")
+        else:
+            description = str(tool.get("description") or "")
+        rows.append(
+            {
+                "name": _tool_name(tool),
+                "description_chars": len(description),
+                "json_bytes": _bytes(json.dumps(tool, ensure_ascii=False)),
+            }
+        )
+    rows.sort(key=lambda row: (-row["description_chars"], row["name"]))
+    return rows
+
+
 def compute_prompt_breakdown(platform: str = "cli") -> Dict[str, Any]:
     """Return a dict of prompt-size measurements for a fresh session.
 
@@ -239,63 +320,83 @@ def compute_prompt_breakdown(platform: str = "cli") -> Dict[str, Any]:
     ``user_profile``, ``tools`` (count + json bytes), ``sections`` (a list of
     (label, chars, bytes) for the three prompt tiers), ``skills_breakdown``
     (per-skill index-line + on-disk SKILL.md bytes, largest-first), and
-    ``toolsets_breakdown`` (per-toolset tool count + schema json bytes,
-    largest-first). The last two answer "what should I disable to cut tokens?".
+    ``toolsets_breakdown`` (per-toolset tool count + schema json bytes), and
+    ``tools_breakdown`` (per-tool description/schema size, largest-first).
+    These answer "what should I disable or shorten to cut tokens?".
     """
     from agent.system_prompt import build_system_prompt, build_system_prompt_parts
 
-    agent = _build_inspection_agent(platform)
+    with _isolated_inspection_home() as (inspection_home, source_home):
+        agent = _build_inspection_agent(platform)
+        try:
+            parts = build_system_prompt_parts(agent)
+            full = build_system_prompt(agent)
 
-    parts = build_system_prompt_parts(agent)
-    full = build_system_prompt(agent)
-
-    stable = parts.get("stable", "")
-    context = parts.get("context", "")
-    volatile = parts.get("volatile", "")
+            stable = parts.get("stable", "")
+            context = parts.get("context", "")
+            volatile = parts.get("volatile", "")
 
     # Skills index — the <available_skills> block (the largest single block
     # when many skills are installed). Lives in the volatile tier (moved from
     # stable so skill edits don't invalidate the cached identity prefix).
-    skills_match = _SKILLS_BLOCK_RE.search(volatile) or _SKILLS_BLOCK_RE.search(stable)
-    skills_index = skills_match.group(0) if skills_match else ""
+            skills_match = _SKILLS_BLOCK_RE.search(volatile) or _SKILLS_BLOCK_RE.search(stable)
+            skills_index = skills_match.group(0) if skills_match else ""
 
     # Memory + user profile live in the volatile tier. We re-derive their
     # blocks directly from the memory store so the numbers are attributable
     # even though they're joined into ``volatile``.
-    memory_block = ""
-    user_block = ""
-    store = getattr(agent, "_memory_store", None)
-    if store is not None:
-        try:
-            if getattr(agent, "_memory_enabled", True):
-                memory_block = store.format_for_system_prompt("memory") or ""
-            if getattr(agent, "_user_profile_enabled", True):
-                user_block = store.format_for_system_prompt("user") or ""
-        except Exception:
-            pass
+            memory_block = ""
+            user_block = ""
+            store = getattr(agent, "_memory_store", None)
+            if store is not None:
+                try:
+                    if getattr(agent, "_memory_enabled", True):
+                        memory_block = store.format_for_system_prompt("memory") or ""
+                    if getattr(agent, "_user_profile_enabled", True):
+                        user_block = store.format_for_system_prompt("user") or ""
+                except Exception:
+                    pass
 
     # Tool-schema JSON — the other half of the fixed per-call payload.
-    tools = getattr(agent, "tools", None) or []
-    tools_json = json.dumps(tools, ensure_ascii=False)
+            tools = getattr(agent, "tools", None) or []
+            tools_json = json.dumps(tools, ensure_ascii=False)
 
-    sections: List[Tuple[str, int, int]] = [
-        ("stable (identity/guidance/skills)", len(stable), _bytes(stable)),
-        ("context (AGENTS.md/cwd files)", len(context), _bytes(context)),
-        ("volatile (memory/profile/timestamp)", len(volatile), _bytes(volatile)),
-    ]
+            sections: List[Tuple[str, int, int]] = [
+                ("stable (identity/guidance/skills)", len(stable), _bytes(stable)),
+                ("context (AGENTS.md/cwd files)", len(context), _bytes(context)),
+                ("volatile (memory/profile/timestamp)", len(volatile), _bytes(volatile)),
+            ]
 
-    return {
-        "platform": platform,
-        "model": getattr(agent, "model", "") or "",
-        "system_prompt": {"chars": len(full), "bytes": _bytes(full)},
-        "skills_index": {"chars": len(skills_index), "bytes": _bytes(skills_index)},
-        "memory": {"chars": len(memory_block), "bytes": _bytes(memory_block)},
-        "user_profile": {"chars": len(user_block), "bytes": _bytes(user_block)},
-        "tools": {"count": len(tools), "json_bytes": _bytes(tools_json)},
-        "sections": sections,
-        "skills_breakdown": _compute_skills_breakdown(skills_index),
-        "toolsets_breakdown": _compute_toolsets_breakdown(tools),
-    }
+            skills_breakdown = _compute_skills_breakdown(skills_index)
+            for row in skills_breakdown:
+                raw_path = row.get("path")
+                if not raw_path:
+                    continue
+                try:
+                    relative = Path(raw_path).relative_to(inspection_home / "skills")
+                except ValueError:
+                    continue
+                source_path = source_home / "skills" / relative
+                if source_path.exists():
+                    row["path"] = str(source_path)
+
+            return {
+                "platform": platform,
+                "model": getattr(agent, "model", "") or "",
+                "system_prompt": {"chars": len(full), "bytes": _bytes(full)},
+                "skills_index": {"chars": len(skills_index), "bytes": _bytes(skills_index)},
+                "memory": {"chars": len(memory_block), "bytes": _bytes(memory_block)},
+                "user_profile": {"chars": len(user_block), "bytes": _bytes(user_block)},
+                "tools": {"count": len(tools), "json_bytes": _bytes(tools_json)},
+                "sections": sections,
+                "skills_breakdown": skills_breakdown,
+                "toolsets_breakdown": _compute_toolsets_breakdown(tools),
+                "tools_breakdown": _compute_tools_breakdown(tools),
+            }
+        finally:
+            close = getattr(agent, "close", None)
+            if callable(close):
+                close()
 
 
 def _fmt_kb(n: int) -> str:
@@ -324,6 +425,20 @@ def render_breakdown(data: Dict[str, Any]) -> str:
     lines.append("")
     tools = data["tools"]
     lines.append(f"  Tool schemas         : {tools['json_bytes']:>8,} B  ({_fmt_kb(tools['json_bytes'])}, {tools['count']} tools)")
+
+    tool_rows = data.get("tools_breakdown") or []
+    if tool_rows:
+        lines.append("")
+        lines.append("  Tool descriptions by size (largest first):")
+        lines.append(f"    {'tool':<28} {'description':>12}  {'schema':>10}")
+        for row in tool_rows[:10]:
+            name = row["name"]
+            if len(name) > 28:
+                name = name[:27] + "…"
+            lines.append(
+                f"    {name:<28} {row['description_chars']:>10,} ch  "
+                f"{row['json_bytes']:>8,} B"
+            )
 
     # Per-toolset schema cost — which toolset's tools cost the most to ship.
     toolsets = data.get("toolsets_breakdown") or []

--- a/tests/agent/test_prompt_budget.py
+++ b/tests/agent/test_prompt_budget.py
@@ -1,0 +1,101 @@
+"""Coarse regression guards for the fixed model-visible prompt surface."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from hermes_cli.prompt_size import _compute_tools_breakdown, compute_prompt_breakdown
+
+# Measured against a fresh default CLI profile on 2026-08-20. The fixed prompt
+# was 83,180 bytes and the largest tool description was 4,333 characters.
+# These ceilings leave roughly 50% headroom so ordinary edits do not create a
+# threshold ratchet; they catch the return of an entire block/tool surface.
+MAX_FIXED_PREFIX_BYTES = 125_000
+MAX_TOOL_DESCRIPTION_CHARS = 7_000
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.chdir(tmp_path)
+    for name in list(os.environ):
+        upper = name.upper()
+        if any(marker in upper for marker in ("API_KEY", "TOKEN", "SECRET", "PASSWORD")):
+            monkeypatch.delenv(name, raising=False)
+        elif upper.startswith(("XAI_", "HASS_", "HOMEASSISTANT_")):
+            monkeypatch.delenv(name, raising=False)
+    return hermes_home
+
+
+def test_default_cli_fixed_prefix_stays_within_coarse_budget(isolated_home):
+    data = compute_prompt_breakdown("cli")
+    fixed_bytes = data["system_prompt"]["bytes"] + data["tools"]["json_bytes"]
+
+    assert fixed_bytes <= MAX_FIXED_PREFIX_BYTES, {
+        "fixed_bytes": fixed_bytes,
+        "system_prompt_bytes": data["system_prompt"]["bytes"],
+        "tool_schema_bytes": data["tools"]["json_bytes"],
+        "largest_toolsets": data["toolsets_breakdown"][:5],
+    }
+
+
+def test_no_default_tool_description_is_an_essay(isolated_home):
+    data = compute_prompt_breakdown("cli")
+    over = [
+        row
+        for row in data["tools_breakdown"]
+        if row["description_chars"] > MAX_TOOL_DESCRIPTION_CHARS
+    ]
+
+    assert not over, over
+
+
+def test_tool_breakdown_exposes_oversized_description_for_diagnosis():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "small",
+                "description": "short",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "oversized",
+                "description": "x" * (MAX_TOOL_DESCRIPTION_CHARS + 1),
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "schema-heavy",
+                "description": "small description",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "choice": {"type": "string", "enum": ["x" * 8_000]},
+                    },
+                },
+            },
+        },
+    ]
+
+    rows = _compute_tools_breakdown(tools)
+
+    assert rows[0]["name"] == "oversized"
+    assert rows[0]["description_chars"] == MAX_TOOL_DESCRIPTION_CHARS + 1
+    by_name = {row["name"]: row for row in rows}
+    for tool in tools:
+        name = tool["function"]["name"]
+        assert by_name[name]["json_bytes"] == len(
+            json.dumps(tool, ensure_ascii=False).encode("utf-8")
+        )
+    assert by_name["schema-heavy"]["json_bytes"] > by_name["oversized"]["json_bytes"]

--- a/tests/hermes_cli/test_prompt_size.py
+++ b/tests/hermes_cli/test_prompt_size.py
@@ -1,6 +1,9 @@
 """Tests for the ``hermes prompt-size`` diagnostic (issue #34667)."""
 
 import json
+import os
+import socket
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -12,6 +15,7 @@ from hermes_cli.prompt_size import (
     _build_inspection_agent,
     _compute_skills_breakdown,
     compute_prompt_breakdown,
+    prepare_prompt_inspection_home,
     render_breakdown,
 )
 
@@ -50,8 +54,84 @@ def test_runs_offline_without_credentials(isolated_home, monkeypatch):
     for var in ("OPENROUTER_API_KEY", "OPENAI_API_KEY", "NOUS_API_KEY",
                 "ANTHROPIC_API_KEY"):
         monkeypatch.delenv(var, raising=False)
+    before = sorted(
+        str(path.relative_to(isolated_home))
+        for path in isolated_home.rglob("*")
+    )
+
+    def deny_network(self, address):
+        raise AssertionError(f"network attempted: {address}")
+
+    monkeypatch.setattr(socket.socket, "connect", deny_network)
     data = compute_prompt_breakdown("cli")
     assert data["system_prompt"]["bytes"] > 0
+    after = sorted(
+        str(path.relative_to(isolated_home))
+        for path in isolated_home.rglob("*")
+    )
+    assert after == before
+
+
+def test_cli_prompt_size_leaves_source_home_unchanged(isolated_home):
+    (isolated_home / ".env").write_text(
+        "XAI_API_KEY=synthetic-test-key\n", encoding="utf-8"
+    )
+    before = {
+        str(path.relative_to(isolated_home)): (
+            path.stat().st_size,
+            path.stat().st_mtime_ns,
+        )
+        for path in isolated_home.rglob("*")
+    }
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": os.environ.get("HOME", ""),
+        "LANG": "C.UTF-8",
+        "HERMES_HOME": str(isolated_home),
+        "NO_COLOR": "1",
+    }
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "--reasoning",
+            "high",
+            "prompt-size",
+            "--json",
+        ],
+        cwd=isolated_home.parent,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    json.loads(result.stdout)
+    after = {
+        str(path.relative_to(isolated_home)): (
+            path.stat().st_size,
+            path.stat().st_mtime_ns,
+        )
+        for path in isolated_home.rglob("*")
+    }
+    assert after == before
+
+
+def test_prepare_inspection_home_copies_profile_env(tmp_path):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    (source / ".env").write_text(
+        "XAI_API_KEY=synthetic-test-key\n", encoding="utf-8"
+    )
+
+    prepare_prompt_inspection_home(source, target)
+
+    assert (target / ".env").read_bytes() == (source / ".env").read_bytes()
 
 
 


### PR DESCRIPTION
## Summary

- extend `prompt-size` to measure the assembled fixed prompt and tool schemas
- report per-tool description and schema sizes
- add coarse guards for gross fixed-prefix or individual-description growth
- run inspection in a disposable profile clone before normal startup writes
- preserve source profile inputs while avoiding provider and external-secret network access

## Why

Prompt and tool-schema growth is paid on every model call, but the existing diagnostic did not expose individual tool costs or provide a coarse regression guard. This adds behavior-oriented budget checks with substantial headroom rather than snapshotting current values.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_prompt_size.py tests/agent/test_prompt_budget.py`
- included in a combined affected-area run: 471 passed, 0 failed
- tests cover source-profile immutability, global CLI flags, offline inspection, source-path reporting, schema accounting, and an oversized-description mutation
- Python compilation passed
- `git diff --check` passed

## Scope and limits

The thresholds detect gross payload growth; they do not claim that prompt size alone establishes a behavioral regression. No new model tool or user-facing environment variable is added.
