### PR TITLE
fix(sessions): rebuild FTS indexes before VACUUM after prune

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13490,7 +13490,7 @@ def main():
 
     sessions_subparsers.add_parser(
         "optimize",
-        help="Reclaim disk space: merge FTS5 segments + VACUUM (no data change)",
+        help="Reclaim disk space: rebuild FTS5 indexes + VACUUM (no data change)",
     )
 
     sessions_clean_markers = sessions_subparsers.add_parser(

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -1241,10 +1241,10 @@ def cmd_sessions(args, sessions_parser=None):
             if db_path.exists()
             else 0.0
         )
-        print("Optimizing session store (FTS merge + VACUUM)…")
+        print("Optimizing session store (FTS rebuild + VACUUM)…")
         try:
-            # vacuum() merges FTS5 segments (optimize_fts) then VACUUMs,
-            # and returns the number of indexes it merged.
+            # vacuum() rebuilds FTS5 indexes then VACUUMs, and returns
+            # the number of indexes it rebuilt.
             n = db.vacuum()
         except Exception as e:
             print(f"Error: optimization failed: {e}")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -12811,20 +12811,31 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         active. Safe to call at startup before the gateway/CLI starts
         serving traffic.
 
-        FTS5 segments are merged first via :meth:`optimize_fts` so the
-        subsequent VACUUM reclaims the pages freed by the merge. This is a
-        layout-only optimization — search results are unchanged.
+        FTS5 indexes are rebuilt first via :meth:`rebuild_fts` so the
+        subsequent VACUUM reclaims tombstone pages left by bulk deletes.
+        ``optimize_fts`` (segment merge) is not enough after a large prune:
+        deleted FTS rows stay in ``*_data`` shadow tables until the index is
+        discarded and recreated. Measured on a 1.7 GB gateway ``state.db``
+        after pruning 4,715 sessions: VACUUM alone left 1.0 GB (656 MB of
+        it ``messages_fts_trigram_data``); rebuild then VACUUM dropped the
+        file to 86 MB. Search results are unchanged.
 
-        Returns the number of FTS indexes that were optimized (0 if the
-        merge step failed or no FTS tables exist).
+        This is not the live write-path FTS rebuild (``_try_runtime_fts_rebuild``),
+        which must not run while another process holds WAL sidecars. It
+        shares VACUUM's exclusive-lock window and is the same class of
+        operator/startup maintenance VACUUM already is.
+
+        Returns the number of FTS indexes that were rebuilt (0 if the
+        rebuild step failed or no FTS tables exist).
         """
-        # Merge FTS5 segments before VACUUM so the freed pages are returned
-        # to the OS in the same pass. optimize_fts() manages its own lock.
-        optimized = 0
+        # Rebuild FTS5 indexes before VACUUM so tombstone pages from bulk
+        # deletes are actually returned to the OS. rebuild_fts() manages
+        # its own lock.
+        rebuilt = 0
         try:
-            optimized = self.optimize_fts()
+            rebuilt = self.rebuild_fts()
         except Exception as exc:
-            logger.warning("FTS optimize before VACUUM failed: %s", exc)
+            logger.warning("FTS rebuild before VACUUM failed: %s", exc)
         # VACUUM cannot be executed inside a transaction.
         with self._lock:
             # Best-effort WAL checkpoint first, then VACUUM. PASSIVE, not
@@ -12848,7 +12859,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
             except Exception as exc:
                 logger.debug("WAL checkpoint (TRUNCATE) after VACUUM failed: %s", exc)
-        return optimized
+        return rebuilt
 
     def maybe_auto_prune_and_vacuum(
         self,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2600,6 +2600,60 @@ class TestVacuum:
         # Should not raise, even though there's nothing significant to reclaim.
         db.vacuum()
 
+    def test_vacuum_rebuilds_fts_before_sqlite_vacuum(self, db):
+        """Bulk deletes leave FTS tombstones; vacuum() must rebuild, not only merge.
+
+        ``optimize_fts`` (INSERT 'optimize') merges segments but does not
+        drop deleted FTS rows from ``*_data`` shadow tables. After a large
+        prune that is the bulk of the file. rebuild_fts recreates the
+        index from canonical messages so the subsequent VACUUM actually
+        returns those pages to the OS.
+        """
+        db.create_session(session_id="keep", source="cli")
+        db.append_message(session_id="keep", role="user", content="keep-me")
+        db.create_session(session_id="drop", source="cli")
+        db.append_message(
+            session_id="drop",
+            role="user",
+            content=("tombstone-payload " * 200),
+        )
+        db.end_session("drop", end_reason="done")
+        past = time.time() - 86400
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = ?",
+            (past, past, "drop"),
+        )
+        db._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE session_id = ?",
+            (past, "drop"),
+        )
+        db.prune_sessions(older_than_days=1)
+
+        statements = []
+        db._conn.set_trace_callback(statements.append)
+        rebuild_calls = []
+        real_rebuild = db.rebuild_fts
+
+        def _spy_rebuild():
+            rebuild_calls.append(True)
+            return real_rebuild()
+
+        db.rebuild_fts = _spy_rebuild
+        try:
+            n = db.vacuum()
+        finally:
+            db.rebuild_fts = real_rebuild
+            db._conn.set_trace_callback(None)
+
+        assert rebuild_calls == [True]
+        assert n >= 1
+        rebuild_sql = [sql for sql in statements if "'rebuild'" in sql]
+        optimize_sql = [sql for sql in statements if "'optimize'" in sql]
+        assert rebuild_sql, "vacuum() must issue FTS5 rebuild before VACUUM"
+        assert not optimize_sql
+        assert db.search_messages("keep-me")
+        assert not db.search_messages("tombstone-payload")
+
     def test_auto_maintenance_records_successful_vacuum(self, db, monkeypatch):
         monkeypatch.setattr(db, "prune_sessions", lambda **_kwargs: 3)
         vacuum_calls = []

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -61,7 +61,7 @@ into chat.
 Use `/compress` when a session gets long, `/new` for a fresh thread, and
 `hermes sessions prune` only when you want to delete old ended sessions from
 storage. If `state.db` has simply grown large, start with the non-destructive
-option first: `hermes sessions optimize` merges FTS5 index segments and
+option first: `hermes sessions optimize` rebuilds FTS5 indexes and
 VACUUMs the database without touching any session data. Compression reduces the active context; it is not a privacy delete.
 Pass a name to `/new` (e.g. `/new payments-refactor`) to set the new session's
 initial title up front — useful for finding it later with `/resume <name>` or


### PR DESCRIPTION
## What does this PR do?

After a bulk session prune, `SessionDB.vacuum()` merged FTS5 segments (`optimize_fts`) and then `VACUUM`ed. That does not drop deleted FTS rows from `*_data` shadow tables, so the file stays bloated. This switches the pre-VACUUM step to `rebuild_fts()`, which recreates the index from canonical `messages` rows. Search results are unchanged.

### Symptom

A production gateway `state.db` (1.7 GB, ~5k sessions / 159k messages) was pruned down to 255 sessions / 6.8k messages. `VACUUM` left a **1.0 GB** file — 656 MB of it `messages_fts_trigram_data`. `hermes sessions optimize-storage` reported "already on the compact layout" and did nothing. Rebuilding the FTS indexes and vacuuming again dropped the file to **86 MB**.

### Impact

Heavy gateway/cron users who enable `sessions.auto_prune` + `vacuum_after_prune` (or run `hermes sessions optimize` after a prune) do not get the disk back. The remaining file is almost entirely FTS tombstones, which also keeps `MATCH` queries scanning dead segments.

### Bug Cause

**Trigger:** `SessionDB.vacuum()` (`hermes_state.py`) calling `optimize_fts()` before `VACUUM`.

**Causal chain:**
1. `prune_sessions` deletes ended rows; FTS5 delete triggers insert tombstones into incremental segments.
2. `optimize_fts` issues `INSERT INTO <fts>(<fts>) VALUES('optimize')`, which merges segments but does not discard those tombstones after a large delete.
3. `VACUUM` rewrites the still-bloated shadow tables to disk.

**Why it is wrong:** `rebuild_fts()` already exists for this recovery class (issue #50502) and is the documented FTS5 command that recreates the index from content. `vacuum()` is the exclusive-lock maintenance path that is supposed to return space after prune; it was using the weaker merge.

**Working sibling / contrast:** This is **not** the live write-path rebuild (`_try_runtime_fts_rebuild` / `_recover_stale_fts`) that must not run while another process holds WAL sidecars (see #90871, #89073, #90806). It shares the exclusive-lock window `VACUUM` already requires and is documented as startup/operator maintenance.

### Fix

Call `rebuild_fts()` instead of `optimize_fts()` at the start of `vacuum()`. If rebuild fails, still VACUUM (same fail-open as the previous merge step). Update the CLI copy for `hermes sessions optimize` to say rebuild, not merge.

## Type of Change

- Bug fix (non-breaking change that fixes a bug)

## Changes Made

- `hermes_state.py` — `vacuum()` rebuilds FTS indexes before `VACUUM`.
- `hermes_cli/sessions_cmd.py`, `hermes_cli/main.py` — operator-facing copy.
- `website/docs/user-guide/sessions.md` — same.
- `tests/test_hermes_state.py` — assert `vacuum()` issues FTS5 `'rebuild'` (not `'optimize'`) and that remaining rows stay searchable.

## How to Test

```bash
scripts/run_tests.sh tests/test_hermes_state.py::TestVacuum tests/test_wal_checkpoint_strategy.py::TestVacuumUsesPassive -q
```

Verified locally: 8 passed, 2 skipped (WAL-only cases on this host).

Manual: prune a large `state.db`, run `hermes sessions optimize`, confirm `PRAGMA page_count` drops and `session_search` still matches remaining transcripts.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(sessions): …`)
- [x] I searched existing PRs/issues (FTS rebuild PRs on main are about **live** rebuild corruption under concurrent WAL holders, not prune/VACUUM space reclaim)
- [x] This PR contains only changes related to this fix
- [x] Focused tests pass via `scripts/run_tests.sh`
- [x] Tests added for the new vacuum behavior
- [x] Tested on macOS (unit tests)

### Documentation & Housekeeping

- [x] `website/docs/user-guide/sessions.md` and CLI help updated
- [x] No new config keys
- [x] Cross-platform: stdlib SQLite FTS5 commands only; no process/path changes