### PR TITLE
fix(config): make dotted custom model overrides take effect

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1017,6 +1017,35 @@ def get_missing_env_vars(required_only: bool = False) -> List[Dict[str, Any]]:
     return missing
 
 
+_CUSTOM_PROVIDER_MODEL_OVERRIDE_FIELDS = frozenset({
+    "context_length",
+    "prompt_caching",
+})
+
+
+def _set_path_parts(dotted_key: str) -> List[str]:
+    """Split a config-set path while preserving schema-defined opaque keys."""
+    parts = dotted_key.split(".")
+    if (
+        len(parts) >= 5
+        and parts[0] == "custom_providers"
+        and parts[1].isdigit()
+        and parts[2] == "models"
+    ):
+        model_path = parts[3:]
+        field = model_path[-1]
+        if field in _CUSTOM_PROVIDER_MODEL_OVERRIDE_FIELDS:
+            model_id = ".".join(model_path[:-1])
+            return parts[:3] + [model_id, field]
+        if len(model_path) > 2:
+            raise ValueError(
+                "dotted custom-provider model IDs can only address supported "
+                "model override fields: "
+                + ", ".join(sorted(_CUSTOM_PROVIDER_MODEL_OVERRIDE_FIELDS))
+            )
+    return parts
+
+
 def _set_nested(config, dotted_key: str, value):
     """Set a value at an arbitrarily nested dotted key path.
 
@@ -1039,7 +1068,7 @@ def _set_nested(config, dotted_key: str, value):
     destroying list-typed config like ``custom_providers`` whenever a
     caller used an indexed path.
     """
-    parts = dotted_key.split(".")
+    parts = _set_path_parts(dotted_key)
     current = config
     for part in parts[:-1]:
         if isinstance(current, list):
@@ -5597,7 +5626,11 @@ def set_config_value(key: str, value: str, force: bool = False):
                     file=sys.stderr,
                 )
                 sys.exit(1)
-    _set_nested(user_config, key, value)
+    try:
+        _set_nested(user_config, key, value)
+    except (IndexError, TypeError, ValueError) as exc:
+        print(f"✗ Cannot set {key!r}: {exc}", file=sys.stderr)
+        sys.exit(1)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),
     # so a fresh `hermes config set model.api_base ...` lands on the canonical
     # key the runtime resolver actually reads, instead of being silently

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1037,10 +1037,10 @@ def _set_path_parts(dotted_key: str) -> List[str]:
         if field in _CUSTOM_PROVIDER_MODEL_OVERRIDE_FIELDS:
             model_id = ".".join(model_path[:-1])
             return parts[:3] + [model_id, field]
-        if len(model_path) > 2:
+        if len(model_path) > 1:
             raise ValueError(
-                "dotted custom-provider model IDs can only address supported "
-                "model override fields: "
+                "ambiguous custom-provider model paths can only address "
+                "supported model override fields: "
                 + ", ".join(sorted(_CUSTOM_PROVIDER_MODEL_OVERRIDE_FIELDS))
             )
     return parts

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -347,18 +347,30 @@ class TestDottedCustomProviderModelIds:
             "qwen3.5:4b": {"context_length": 65_536}
         }
 
-    def test_rejects_ambiguous_dotted_model_metadata_path(
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            (
+                "custom_providers.0.models.vendor.model.unsupported_flag",
+                "true",
+            ),
+            (
+                "custom_providers.0.models.qwen3.5:4b",
+                "{context_length: 65536}",
+            ),
+        ],
+    )
+    def test_rejects_ambiguous_dotted_model_path(
         self,
         _isolated_hermes_home,
+        key,
+        value,
     ):
         self._write_config(_isolated_hermes_home, {})
         before = _read_config(_isolated_hermes_home)
 
         with pytest.raises(SystemExit) as exc:
-            set_config_value(
-                "custom_providers.0.models.vendor.model.unsupported_flag",
-                "true",
-            )
+            set_config_value(key, value)
 
         assert exc.value.code == 1
         assert _read_config(_isolated_hermes_home) == before

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -294,6 +294,77 @@ class TestListNavigation:
 
 
 # ---------------------------------------------------------------------------
+# Dotted custom-provider model IDs — regression tests for #91095
+# ---------------------------------------------------------------------------
+
+class TestDottedCustomProviderModelIds:
+    def _write_config(self, home, models):
+        import yaml
+
+        (home / "config.yaml").write_text(
+            yaml.safe_dump({
+                "custom_providers": [{
+                    "name": "Local Ollama",
+                    "base_url": "http://localhost:11434/v1",
+                    "models": models,
+                }]
+            })
+        )
+
+    def _read_models(self, home):
+        import yaml
+
+        saved = yaml.safe_load(_read_config(home))
+        return saved["custom_providers"][0]["models"]
+
+    def test_updates_existing_dotted_model_id(self, _isolated_hermes_home):
+        self._write_config(
+            _isolated_hermes_home,
+            {"qwen3.5:4b": {"context_length": 16_384}},
+        )
+
+        set_config_value(
+            "custom_providers.0.models.qwen3.5:4b.context_length",
+            "65536",
+        )
+
+        assert self._read_models(_isolated_hermes_home) == {
+            "qwen3.5:4b": {"context_length": 65_536}
+        }
+
+    def test_creates_first_override_for_dotted_model_id(
+        self,
+        _isolated_hermes_home,
+    ):
+        self._write_config(_isolated_hermes_home, {})
+
+        set_config_value(
+            "custom_providers.0.models.qwen3.5:4b.context_length",
+            "65536",
+        )
+
+        assert self._read_models(_isolated_hermes_home) == {
+            "qwen3.5:4b": {"context_length": 65_536}
+        }
+
+    def test_rejects_ambiguous_dotted_model_metadata_path(
+        self,
+        _isolated_hermes_home,
+    ):
+        self._write_config(_isolated_hermes_home, {})
+        before = _read_config(_isolated_hermes_home)
+
+        with pytest.raises(SystemExit) as exc:
+            set_config_value(
+                "custom_providers.0.models.vendor.model.unsupported_flag",
+                "true",
+            )
+
+        assert exc.value.code == 1
+        assert _read_config(_isolated_hermes_home) == before
+
+
+# ---------------------------------------------------------------------------
 # Cron drift guard warning — regression tests for #59031
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

`hermes config set` now preserves dotted model IDs when setting supported custom-provider model overrides. Previously, setting `custom_providers.0.models.qwen3.5:4b.context_length` exited successfully but persisted an unreadable nested mapping, so the runtime continued using the stale context length. Ambiguous dotted model paths now fail before the config file is changed instead of reporting false success.

### Symptom

Setting a model override for a custom-provider model such as `qwen3.5:4b` creates `models["qwen3"]["5:4b"]` rather than updating `models["qwen3.5:4b"]`.

### Impact

Users cannot reliably correct context-length or prompt-caching metadata for custom-provider models whose IDs contain dots. The command reports success while exact runtime lookup ignores the newly written value, leaving stale model limits in effect.

### Bug Cause

**Trigger:** `hermes_cli/config.py` / `_set_nested()` when a `custom_providers.<index>.models.<model-id>.<field>` path contains a dotted model ID.

**Causal chain:**
1. A user passes a dotted config path for a custom-provider model override.
2. The generic path parser splits every dot and treats part of the model ID as another mapping level.
3. The config write succeeds under the wrong key, while runtime lookup continues reading the exact model ID and never sees the override.

**Why it is wrong:** Model IDs are opaque keys within `custom_providers[].models`; their dots are data, not config-path separators.

**Working sibling / contrast:** Numeric custom-provider list navigation already works, and model IDs without dots are parsed into the expected mapping key.

**Ruled out:** List navigation is not the cause; focused tests confirm the custom-provider index and surrounding provider fields remain intact.

### Fix

Parse schema-defined custom-provider model override paths separately, joining model-ID segments before setting `context_length` or `prompt_caching`. Reject other ambiguous dotted model paths before persistence, and cover existing-key updates, first-time creation, and refusal without mutation.

## Related Issue

Closes #91095

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` - preserve opaque dotted model IDs for supported custom-provider overrides and report invalid ambiguous paths.
- `tests/hermes_cli/test_set_config_value.py` - verify update, creation, and fail-without-mutation behavior.

## How to Test

1. Configure a custom provider whose `models` mapping contains `qwen3.5:4b`.
2. Run `hermes config set custom_providers.0.models.qwen3.5:4b.context_length 65536` and confirm the exact model key is updated.
3. Run the focused automated suite (122 passed on the reviewed tip):

```bash
scripts/run_tests.sh tests/hermes_cli/test_set_config_value.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation is unchanged because this fixes existing config behavior
- [x] `cli-config.yaml.example` is unchanged because no config key was added or changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are unchanged because architecture and workflows are unchanged
- [x] Cross-platform impact was considered; the parser and YAML persistence path are platform-independent
- [x] Tool descriptions and schemas are unchanged because no model tool behavior changed

## Screenshots / Logs

Focused test result: 122 passed.
