### PR TITLE
fix(skills): load only directly triggered guidance

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2167,17 +2167,18 @@ def _build_skills_system_prompt_inner(
                     index_lines.append(f"    - {name}")
 
         result = (
-            "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
-            "than to miss critical steps, pitfalls, or established workflows. "
-            "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
-            "and proven workflows that outperform general-purpose approaches. Load the skill "
-            "even if you think you could handle the task with basic tools like web_search or terminal. "
-            "Skills also encode the user's preferred approach, conventions, and quality standards "
-            "for tasks like code review, planning, and testing — load them even for tasks you "
-            "already know how to do, because the skill defines how it should be done here.\n"
+            "## Skills (selective)\n"
+            "Before acting, scan the skill descriptions below and load the smallest directly "
+            "triggered set with skill_view(name). A skill is triggered only when the task matches "
+            "the concrete scope in its description; topical overlap or possible usefulness is not "
+            "enough. Start with one primary skill. Load another only when it contributes distinct "
+            "procedure required for the task. When an umbrella router and specialized skills could "
+            "apply, load the router first, then only the child skills it directs you to. Do not "
+            "preload adjacent skills as background context. Do not call skill_view again for a "
+            "skill whose full content is already present in the current conversation unless its "
+            "content was marked unavailable or stale, or a linked file is needed. If no description "
+            "directly matches, proceed without loading a skill. Skills contain specialized "
+            "procedures, tool guidance, and user conventions; follow the skills you do load.\n"
             "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
             "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
             "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
@@ -2190,9 +2191,7 @@ def _build_skills_system_prompt_inner(
             "\n"
             "<available_skills>\n"
             + "\n".join(index_lines) + "\n"
-            "</available_skills>\n"
-            "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
+            "</available_skills>"
             + hidden_note
         )
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -281,7 +281,29 @@ class TestBuildSkillsSystemPrompt:
         yield
         clear_skills_system_prompt_cache(clear_snapshot=True)
 
+    def test_guidance_loads_only_directly_triggered_skills_once(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill = tmp_path / "skills" / "coding" / "router"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            "---\nname: router\ndescription: Route explicit coding-agent tasks\n---\n"
+        )
 
+        result = build_skills_system_prompt()
+
+        assert "## Skills (selective)" in result
+        assert "smallest directly triggered set" in result
+        assert "Start with one primary skill" in result
+        assert "contributes distinct procedure" in result
+        assert "router first" in result
+        assert "Do not call skill_view again" in result
+        assert "topical overlap" in result
+        assert "proceed without loading a skill" in result
+        assert "load the `hermes-agent` skill first" in result
+        assert "even partially relevant" not in result
+        assert "Err on the side of loading" not in result
 
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## Summary

- replace the blanket "load even partially relevant skills" instruction with selective, description-triggered routing
- start with one primary skill, add another only for distinct required procedure, and route through umbrella skills before children
- tell the model not to repeat `skill_view` when the full skill is already in conversation context, while preserving reloads for unavailable/stale content and linked files
- add regression coverage for the selection and no-reload guidance

## Why

The current system prompt explicitly tells the model to err on the side of loading any skill that is even partially relevant. That makes adjacent topical matches look mandatory and encourages redundant skill calls. The skill catalog should still be scanned, but the trigger should be the concrete scope in each description rather than possible usefulness.

Current `main` already has task-scoped duplicate-call protection from #58971. This change addresses the remaining model guidance: select fewer skills up front and avoid asking for content that is already present in the conversation.

## Scope

This is intentionally prompt-only. It does not change skill discovery, indexing, availability, tool permissions, or caching behavior.

## Verification

- `113 passed, 1 skipped` across prompt-builder and skill-tool tests
- Ruff checks passed for the changed Python files
- `git diff --check` passed

Refs #29300 and #72737.

This is a focused current-main extraction of the skill-selection guidance from #62727, which also includes unrelated cron, delegation, and toolset changes and is currently conflicting. John Lussier's authorship is credited in the commit. If maintainers prefer to revive #62727 instead, this PR can close in favor of it.
