### PR TITLE
fix: model-aware extra_headers selection for shared-base_url custom providers

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1467,11 +1467,17 @@ def init_agent(
             # Per-provider extra HTTP headers (providers.<name>.extra_headers /
             # custom_providers[].extra_headers) — proxies, gateways, custom
             # auth. Applied last so the most specific config level wins.
+            # Pass agent.model so a base_url shared by several named custom
+            # providers resolves headers from the entry that actually owns
+            # the requested model, instead of always the first one declared
+            # (see hermes-webui#7176 / PR #7177 for the matching WebUI-side
+            # provider-selection fix this mirrors).
             # SECURITY: values may carry credentials — never log them.
             apply_custom_provider_extra_headers_to_client_kwargs(
                 client_kwargs,
                 _cp_base_url,
                 _cp_entries,
+                model_id=agent.model,
             )
         except Exception:
             logger.debug("custom-provider TLS resolution skipped", exc_info=True)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1744,12 +1744,30 @@ def get_custom_provider_extra_headers(
     base_url: str,
     custom_providers: Optional[List[Dict[str, Any]]] = None,
     config: Optional[Dict[str, Any]] = None,
+    *,
+    model_id: Optional[str] = None,
 ) -> Dict[str, str]:
     """Return ``extra_headers`` from a matching ``providers`` / ``custom_providers`` entry.
 
     Matches the entry whose normalized route identity equals *base_url*,
     mirroring :func:`get_custom_provider_tls_settings`, and returns its
     ``extra_headers`` dict, or ``{}`` when no entry matches or declares none.
+
+    Multiple named entries commonly share ONE physical ``base_url`` (an
+    internal gateway fronting several APIs/api_modes on one host). When
+    ``model_id`` is supplied, prefer the entry that actually owns that model
+    (via its ``model`` field or ``models`` allowlist) over plain base_url
+    declaration order — this mirrors the model-aware provider selection
+    ``hermes-webui`` already performs (see NousResearch/hermes-agent#7176 /
+    hermes-webui PR #7177) so the headers actually sent match the entry that
+    was selected for the request, not just whichever shares the endpoint and
+    happens to be declared first. Without this, entry B can be correctly
+    selected for mode/key/endpoint while its sibling A's ``extra_headers``
+    (e.g. distinct ``CF-Access-Client-Id``/``Secret`` per route) are applied
+    instead, reproducing the same opaque upstream auth failure the model-aware
+    fix was meant to eliminate. Falls back to the first base_url match when no
+    entry claims the model, or when ``model_id`` is not supplied, preserving
+    prior behavior for existing callers.
 
     SECURITY: header values routinely carry credentials (Cloudflare Access
     service tokens, proxy auth, custom bearer schemes). Callers must never
@@ -1764,12 +1782,47 @@ def get_custom_provider_extra_headers(
         return {}
 
     target_url = normalize_route_base_url(base_url)
+    matches: List[Dict[str, Any]] = []
     for entry in custom_providers:
         if not isinstance(entry, dict):
             continue
         entry_url = normalize_route_base_url(entry.get("base_url"))
         if not entry_url or entry_url != target_url:
             continue
+        matches.append(entry)
+    if not matches:
+        return {}
+
+    wanted_model = str(model_id or "").strip()
+    if wanted_model:
+        for entry in matches:
+            entry_model = str(entry.get("model") or "").strip()
+            owned_ids: set = set()
+            models = entry.get("models")
+            if isinstance(models, dict):
+                owned_ids.update(k for k in models if isinstance(k, str))
+            elif isinstance(models, list):
+                for item in models:
+                    if isinstance(item, dict):
+                        candidate = item.get("id") or item.get("model") or item.get("name")
+                    else:
+                        candidate = item
+                    candidate = str(candidate or "").strip()
+                    if candidate:
+                        owned_ids.add(candidate)
+            if entry_model:
+                owned_ids.add(entry_model)
+            if wanted_model in owned_ids:
+                # The owning entry may declare no headers of its own — that
+                # is meaningful and must not fall through to a
+                # differently-scoped sibling's headers.
+                return normalize_extra_headers(entry.get("extra_headers"))
+
+    # No model_id, or no shared-base_url entry claims the model: fall back
+    # to base_url-only matching. Bug #74465: an earlier entry matching the
+    # same URL but without extra_headers (or with an explicit but empty
+    # dict) must not shadow a later entry that DOES declare real headers.
+    for entry in matches:
         headers = normalize_extra_headers(entry.get("extra_headers"))
         if headers:
             return headers
@@ -1781,6 +1834,8 @@ def apply_custom_provider_extra_headers_to_client_kwargs(
     base_url: str,
     custom_providers: Optional[List[Dict[str, Any]]] = None,
     config: Optional[Dict[str, Any]] = None,
+    *,
+    model_id: Optional[str] = None,
 ) -> None:
     """Merge per-provider ``extra_headers`` onto OpenAI client ``default_headers``.
 
@@ -1789,9 +1844,16 @@ def apply_custom_provider_extra_headers_to_client_kwargs(
     when the base_url matches no ``providers`` / ``custom_providers`` entry or
     the entry declares no headers.
 
+    ``model_id``, when supplied, is forwarded to
+    ``get_custom_provider_extra_headers`` so a ``base_url`` shared by several
+    named custom providers resolves headers from the entry that actually owns
+    the requested model, instead of always the first one declared.
+
     SECURITY: values may carry credentials — never log them.
     """
-    extra_headers = get_custom_provider_extra_headers(base_url, custom_providers, config)
+    extra_headers = get_custom_provider_extra_headers(
+        base_url, custom_providers, config, model_id=model_id
+    )
     if not extra_headers:
         return
     merged = dict(client_kwargs.get("default_headers") or {})

--- a/run_agent.py
+++ b/run_agent.py
@@ -6361,6 +6361,11 @@ class AIAgent:
         # Per-provider extra HTTP headers (providers.<name>.extra_headers /
         # custom_providers[].extra_headers) — applied last so the most
         # specific config level survives credential swaps and rebuilds too.
+        # Pass self.model so a base_url shared by several named custom
+        # providers resolves headers from the entry that actually owns the
+        # current model, instead of always the first one declared (mirrors
+        # the model-aware provider selection hermes-webui performs — see
+        # hermes-webui#7176 / PR #7177).
         # SECURITY: values may carry credentials — never log them.
         if self.api_mode not in ("anthropic_messages", "bedrock_converse"):
             try:
@@ -6370,6 +6375,7 @@ class AIAgent:
 
                 apply_custom_provider_extra_headers_to_client_kwargs(
                     self._client_kwargs, base_url,
+                    model_id=getattr(self, "model", None),
                 )
             except Exception:
                 logger.debug("custom-provider extra_headers skipped", exc_info=True)

--- a/tests/hermes_cli/test_custom_provider_extra_headers.py
+++ b/tests/hermes_cli/test_custom_provider_extra_headers.py
@@ -244,3 +244,135 @@ def test_fetch_api_models_sends_extra_headers_to_models_probe(monkeypatch):
     assert captured["headers"]["authorization"] == "Bearer proxy-key"
     assert captured["headers"]["sleeve-harness"] == "hermes"
     assert captured["headers"]["sleeve-base-url"] == "http://localhost:8081/v1"
+
+
+# ---------------------------------------------------------------------------
+# Model-aware header selection for a base_url shared by several named
+# custom_providers[] entries (mirrors hermes-webui#7176 / PR #7177's
+# provider-selection fix — see that PR's review for the header-drop defect
+# this closes: a shared endpoint's resolved entry B could have its
+# extra_headers silently replaced by sibling entry A's headers because
+# get_custom_provider_extra_headers() only matched by base_url).
+# ---------------------------------------------------------------------------
+
+
+SHARED_URL = "https://gateway.example/v1"
+
+_SHARED_ENTRIES = [
+    {
+        "name": "Gateway OpenAI Chat",
+        "base_url": SHARED_URL,
+        "extra_headers": {"CF-Access-Client-Id": "openai-chat-id"},
+        "models": {"gpt-5": {}, "gpt-5-mini": {}},
+    },
+    {
+        "name": "Gateway Claude",
+        "base_url": SHARED_URL,
+        "extra_headers": {"CF-Access-Client-Id": "claude-id"},
+        "models": {"claude-sonnet-5@default": {}, "claude-opus-5@default": {}},
+    },
+]
+
+
+def test_get_custom_provider_extra_headers_prefers_owning_entry_with_model_id():
+    """When two entries share one base_url, model_id must select the
+    entry's headers that actually owns the requested model, not just the
+    first declared entry."""
+    headers = get_custom_provider_extra_headers(
+        SHARED_URL, custom_providers=_SHARED_ENTRIES, model_id="claude-sonnet-5@default"
+    )
+    assert headers == {"CF-Access-Client-Id": "claude-id"}
+
+    headers_openai = get_custom_provider_extra_headers(
+        SHARED_URL, custom_providers=_SHARED_ENTRIES, model_id="gpt-5"
+    )
+    assert headers_openai == {"CF-Access-Client-Id": "openai-chat-id"}
+
+
+def test_get_custom_provider_extra_headers_falls_back_without_model_id():
+    """Existing callers that don't pass model_id keep the prior
+    first-declared-entry behavior — no behavior change for them."""
+    headers = get_custom_provider_extra_headers(
+        SHARED_URL, custom_providers=_SHARED_ENTRIES,
+    )
+    assert headers == {"CF-Access-Client-Id": "openai-chat-id"}
+
+
+def test_get_custom_provider_extra_headers_unclaimed_model_falls_back_to_first():
+    """A model_id that no shared entry claims falls back to the first
+    base_url match, preserving prior behavior rather than failing closed."""
+    headers = get_custom_provider_extra_headers(
+        SHARED_URL, custom_providers=_SHARED_ENTRIES, model_id="totally-unknown-model",
+    )
+    assert headers == {"CF-Access-Client-Id": "openai-chat-id"}
+
+
+def test_get_custom_provider_extra_headers_owning_entry_without_headers_returns_empty():
+    """If the entry that owns the requested model declares NO extra_headers
+    of its own, its sibling's headers must NOT leak in — the absence of
+    headers on the owning entry is itself meaningful and must not silently
+    fall back to a differently-scoped entry's headers."""
+    entries = [
+        {
+            "name": "Gateway OpenAI Chat",
+            "base_url": SHARED_URL,
+            "extra_headers": {"CF-Access-Client-Id": "openai-chat-id"},
+            "models": {"gpt-5": {}},
+        },
+        {
+            "name": "Gateway Claude",
+            "base_url": SHARED_URL,
+            # No extra_headers on the Claude entry.
+            "models": {"claude-sonnet-5@default": {}},
+        },
+    ]
+    headers = get_custom_provider_extra_headers(
+        SHARED_URL, custom_providers=entries, model_id="claude-sonnet-5@default",
+    )
+    assert headers == {}
+
+
+def test_get_custom_provider_extra_headers_singular_model_field_owns_headers():
+    """Ownership via the singular ``model`` field (not just ``models``
+    allowlist) also selects the correct entry's headers."""
+    entries = [
+        {
+            "name": "A",
+            "base_url": SHARED_URL,
+            "model": "model-a",
+            "extra_headers": {"X-Which": "a"},
+        },
+        {
+            "name": "B",
+            "base_url": SHARED_URL,
+            "model": "model-b",
+            "extra_headers": {"X-Which": "b"},
+        },
+    ]
+    assert get_custom_provider_extra_headers(
+        SHARED_URL, custom_providers=entries, model_id="model-b",
+    ) == {"X-Which": "b"}
+    assert get_custom_provider_extra_headers(
+        SHARED_URL, custom_providers=entries, model_id="model-a",
+    ) == {"X-Which": "a"}
+
+
+def test_apply_extra_headers_model_id_selects_owning_entry_headers():
+    """End-to-end: apply_custom_provider_extra_headers_to_client_kwargs with
+    model_id merges the OWNING entry's headers, not the first declared."""
+    client_kwargs = {"api_key": "x", "base_url": SHARED_URL}
+    apply_custom_provider_extra_headers_to_client_kwargs(
+        client_kwargs, SHARED_URL, custom_providers=_SHARED_ENTRIES,
+        model_id="claude-sonnet-5@default",
+    )
+    assert client_kwargs["default_headers"] == {"CF-Access-Client-Id": "claude-id"}
+
+
+def test_apply_extra_headers_without_model_id_keeps_prior_behavior():
+    """apply_custom_provider_extra_headers_to_client_kwargs without model_id
+    is unchanged: first declared entry sharing the base_url wins."""
+    client_kwargs = {"api_key": "x", "base_url": SHARED_URL}
+    apply_custom_provider_extra_headers_to_client_kwargs(
+        client_kwargs, SHARED_URL, custom_providers=_SHARED_ENTRIES,
+    )
+    assert client_kwargs["default_headers"] == {"CF-Access-Client-Id": "openai-chat-id"}


### PR DESCRIPTION
## Summary

Companion fix to hermes-webui PR [#7177](https://github.com/nesquena/hermes-webui/pull/7177) (issue #7176).

`hermes-webui` already resolves the model-owning `custom_providers[]` entry when several named entries share one `base_url` (an internal gateway fronting multiple `api_mode`s on one host — e.g. one OpenAI-chat route and one Anthropic-messages route on the same host). But during that PR's review, it was flagged that the **Agent-side header selector** still picked `extra_headers` by `base_url` alone, with no awareness of which entry was actually selected:

> The current Agent resolver in `hermes_cli/config.py:1698-1749` selects custom `extra_headers` from the endpoint alone; its call does not receive the selected provider/model identity. With A and B sharing the endpoint, B can therefore still be sent with A's headers. That can reproduce the same opaque 401 even after every `api/config.py` fix in [the WebUI] branch.

So even when WebUI (or CLI, or gateway) correctly selects entry B (right `api_mode`, key, endpoint) for a shared-`base_url` request, the `extra_headers` actually attached to the outgoing request could still be entry A's — e.g. a mismatched `CF-Access-Client-Id`/`Secret` pair per route — reproducing the exact opaque upstream 401/400 the model-aware provider-selection fix was meant to eliminate.

## Root cause

`get_custom_provider_extra_headers()` in `hermes_cli/config.py` does a plain first-match-by-`base_url` scan over `custom_providers[]`, with no `model_id` parameter, unlike the model-aware selection algorithm `hermes-webui` already implemented for provider/slug resolution.

## Fix

- `get_custom_provider_extra_headers()` and `apply_custom_provider_extra_headers_to_client_kwargs()` now accept an optional keyword-only `model_id`. When supplied, the entry that actually owns that model (via its `model` field or `models` allowlist) is preferred over the first `base_url` match — mirroring the ownership algorithm `hermes-webui`'s `_named_custom_provider_slug_for_base_url()` uses. Falls back to first-match when no entry claims the model or `model_id` isn't supplied, so every existing caller is unaffected.
  - If the model-owning entry declares **no** `extra_headers` of its own, that's meaningful and must not fall through to a differently-scoped sibling's headers — covered by a dedicated regression test.
- `agent/agent_init.py`: the init-time call now passes `model_id=agent.model`.
- `run_agent.py::_apply_client_headers_for_base_url()`: the credential-swap / `/model`-switch / client-rebuild call now passes `model_id=getattr(self, "model", None)`, so headers stay correct across model switches and credential rotation too, not just at startup.

## Testing

7 new regression tests in `tests/hermes_cli/test_custom_provider_extra_headers.py` covering: owning-entry selection, the no-`model_id` fallback (unchanged behavior), an unclaimed-`model_id` fallback, the owning-entry-with-no-headers case, and singular `model` field ownership. Full file: 18/18 pass.

Also ran the header/model-switch/credential-rotation adjacent suite (`test_switch_model_reapplies_headers.py`, `test_provider_attribution_headers.py`, `test_credential_rotation_route_settings.py`, `test_restore_primary_pool_reselect.py`, `test_codex_cloudflare_headers.py`): 61/61 pass — no regressions versus the same suite on unmodified `main` (which also passes in full; this PR only adds tests, doesn't change existing test expectations).

## Scope

Diff limited to the two `extra_headers`-resolution functions in `hermes_cli/config.py`, their two real call sites (`agent_init.py`, `run_agent.py`), and the new test file additions — no unrelated refactors.
