### PR TITLE
feat(image_gen): let openai-codex images authenticate via a named provider (key_cmd follow-up to #86891)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1432,6 +1432,10 @@ stt:
 #   deepinfra:
 #     # Leave `model` blank for the first live `image-gen`-tagged result.
 #     model: ""
+#   # The Codex image backend normally uses Hermes-managed Codex OAuth. To
+#   # reuse a named provider credential instead (including key_cmd), set:
+#   # openai-codex:
+#   #   auth_provider: "my-codex-gateway"
 
 # =============================================================================
 # Response Pacing (Messaging Platforms)

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -297,7 +297,7 @@ def _resolve_named_provider_auth(provider_name: str) -> _CodexImageAuth:
         base_url = str(runtime.get("base_url") or base_url).strip().rstrip("/")
         runtime_headers = normalize_extra_headers(runtime.get("extra_headers"))
         if runtime_headers:
-            extra_headers = runtime_headers
+            extra_headers = _merge_request_headers(extra_headers, runtime_headers)
 
     # "no-key-required" is the resolver's sentinel for an open endpoint. The
     # Codex Responses route is never open, so treat it as "no credential".

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -24,8 +24,9 @@ import base64
 import json
 import logging
 import os
+from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple
 
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
@@ -179,6 +180,132 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
     return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
 
 
+class _CodexImageAuth(NamedTuple):
+    """Resolved credential and route for one Codex image request."""
+
+    token: str
+    base_url: str
+    extra_headers: Dict[str, str]
+
+
+def _configured_auth_provider() -> str:
+    """Return the optional named provider used for Codex image auth."""
+    cfg = _load_image_gen_config()
+    sub = cfg.get("openai-codex")
+    if not isinstance(sub, dict):
+        return ""
+    value = sub.get("auth_provider")
+    return value.strip() if isinstance(value, str) else ""
+
+
+@lru_cache(maxsize=16)
+def _cached_command_token_source(
+    key_cmd: str,
+    provider_label: str,
+) -> Callable[[], str]:
+    """Reuse ``key_cmd`` expiry caching across image-generation calls."""
+    from agent.command_token_source import build_command_token_provider
+
+    source = build_command_token_provider(key_cmd, provider_label)
+    if source is None:  # Defensive: callers only pass non-empty commands.
+        raise RuntimeError(
+            f"Image auth provider {provider_label!r} has an empty key_cmd"
+        )
+    return source
+
+
+class _NamedProviderRoute(NamedTuple):
+    """A named provider's identity and route, resolved without minting."""
+
+    requested: str
+    entry: Dict[str, Any]
+    label: str
+    base_url: str
+    extra_headers: Dict[str, str]
+
+
+def _lookup_named_provider(provider_name: str) -> _NamedProviderRoute:
+    """Find the ``providers.<name>`` entry backing Codex image auth.
+
+    Lookup only — this deliberately does NOT run ``key_cmd``, so availability
+    probes can validate configuration without the side effect of invoking the
+    user's auth helper. Raises when the entry is missing, disabled, or has no
+    route, so a typo can never silently fall through to a different provider.
+    """
+    from hermes_cli.config import normalize_extra_headers
+    from hermes_cli.runtime_provider import _get_named_custom_provider
+
+    requested = provider_name.strip()
+    if not requested.lower().startswith("custom:"):
+        requested = f"custom:{requested}"
+
+    # Returns None for entries that are absent OR carry ``enabled: false``,
+    # so a disabled provider fails closed rather than resolving anyway.
+    entry = _get_named_custom_provider(requested)
+    if not isinstance(entry, dict):
+        raise RuntimeError(
+            f"Named image auth provider {provider_name!r} was not found or is disabled"
+        )
+
+    label = str(entry.get("name") or provider_name).strip() or provider_name
+    base_url = str(entry.get("base_url") or "").strip().rstrip("/")
+    if not base_url:
+        raise RuntimeError(f"Image auth provider {label!r} has no base URL")
+    return _NamedProviderRoute(
+        requested,
+        entry,
+        label,
+        base_url,
+        normalize_extra_headers(entry.get("extra_headers")),
+    )
+
+
+def _resolve_named_provider_auth(provider_name: str) -> _CodexImageAuth:
+    """Resolve a named custom provider for the Codex image backend.
+
+    ``providers.<name>.key_cmd`` is deliberately handled through the shared
+    command-token source so its expiry cache and no-secret error contract stay
+    identical to normal inference. Static named-provider credentials continue
+    through the canonical runtime resolver.
+    """
+    from hermes_cli.config import normalize_extra_headers
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    route = _lookup_named_provider(provider_name)
+    label = route.label
+    base_url = route.base_url
+    extra_headers = route.extra_headers
+
+    key_cmd = str(route.entry.get("key_cmd") or "").strip()
+    if key_cmd:
+        token = _cached_command_token_source(key_cmd, label)()
+    else:
+        runtime = resolve_runtime_provider(requested=route.requested)
+        # resolve_runtime_provider() walks a fallback chain and will happily
+        # return a BUILT-IN provider (codex, openai, openrouter, …) when a name
+        # doesn't land on a custom entry. Adopting that would silently send the
+        # image request to an unrelated endpoint with an unrelated key, so
+        # require it to have resolved to the custom entry we just looked up.
+        if str(runtime.get("provider") or "").strip().lower() != "custom":
+            raise RuntimeError(
+                f"Image auth provider {label!r} resolved to built-in provider "
+                f"{str(runtime.get('provider') or 'unknown')!r}; refusing to "
+                "route image generation through an unrelated provider"
+            )
+        api_key = runtime.get("api_key")
+        token = api_key() if callable(api_key) else str(api_key or "").strip()
+        base_url = str(runtime.get("base_url") or base_url).strip().rstrip("/")
+        runtime_headers = normalize_extra_headers(runtime.get("extra_headers"))
+        if runtime_headers:
+            extra_headers = runtime_headers
+
+    # "no-key-required" is the resolver's sentinel for an open endpoint. The
+    # Codex Responses route is never open, so treat it as "no credential".
+    if not token or token == "no-key-required":
+        raise RuntimeError(f"Image auth provider {label!r} produced no credential")
+    return _CodexImageAuth(token, base_url, extra_headers)
+
+
 def _read_codex_access_token() -> Optional[str]:
     """Return a usable Codex OAuth token, or None.
 
@@ -195,6 +322,37 @@ def _read_codex_access_token() -> Optional[str]:
     except Exception as exc:
         logger.debug("Could not resolve Codex access token: %s", exc)
         return None
+
+
+def _resolve_codex_image_auth() -> Optional[_CodexImageAuth]:
+    """Resolve named-provider auth, then fall back to Hermes Codex OAuth."""
+    auth_provider = _configured_auth_provider()
+    if auth_provider:
+        return _resolve_named_provider_auth(auth_provider)
+    token = _read_codex_access_token()
+    if not token:
+        return None
+    return _CodexImageAuth(token, _CODEX_BASE_URL, {})
+
+
+def _codex_image_auth_available() -> bool:
+    """Cheap availability probe for :meth:`OpenAICodexImageGenProvider.is_available`.
+
+    ``is_available()`` is a fast, side-effect-free hot-path check: the image
+    registry calls it while resolving the active backend and the pet/tool paths
+    call it repeatedly. So a ``key_cmd`` provider is reported available on
+    CONFIGURATION alone — minting here would run the user's auth helper as a
+    side effect of a liveness question, once per probe. A helper that is broken
+    or expired still surfaces a precise error from ``generate()``.
+    """
+    auth_provider = _configured_auth_provider()
+    if not auth_provider:
+        return bool(_read_codex_access_token())
+    route = _lookup_named_provider(auth_provider)
+    if str(route.entry.get("key_cmd") or "").strip():
+        return True
+    # Static credential: resolving it is a config/env read, not a subprocess.
+    return bool(_resolve_named_provider_auth(auth_provider).token)
 
 
 def _sniff_image_mime(raw: bytes) -> Optional[str]:
@@ -452,6 +610,50 @@ def _iter_sse_json(response: Any):
         yield payload
 
 
+# Headers this request owns outright. A named provider's ``extra_headers`` may
+# legitimately carry route/account metadata (ChatGPT-Account-ID, Cloudflare
+# Access service tokens), but it must never reach the wire as a competing
+# Authorization header.
+_RESERVED_REQUEST_HEADERS = frozenset({"accept", "authorization", "content-type"})
+
+
+def _merge_request_headers(
+    base: Dict[str, str],
+    extra: Optional[Dict[str, str]],
+) -> Dict[str, str]:
+    """Overlay config *extra* headers on *base*, case-insensitively.
+
+    Two rules, both of which a plain ``dict.update()`` gets wrong:
+
+    1. Reserved headers are dropped. HTTP header names are case-insensitive but
+       ``dict`` keys are not, and httpx does NOT de-duplicate — a config entry
+       spelled ``authorization`` survives alongside the ``Authorization`` the
+       caller sets, and BOTH are sent, with the config-supplied one first. Most
+       upstreams honour the first, so config could otherwise override the
+       freshly minted bearer. Only the name is logged; values carry secrets.
+    2. Non-reserved overrides replace the existing key in place rather than
+       adding a case-variant twin, so ``chatgpt-account-id`` overrides
+       ``ChatGPT-Account-ID`` instead of being sent next to it.
+    """
+    merged = dict(base)
+    by_lower = {key.lower(): key for key in merged}
+    for raw_key, value in (extra or {}).items():
+        name = str(raw_key).strip()
+        if not name:
+            continue
+        lowered = name.lower()
+        if lowered in _RESERVED_REQUEST_HEADERS:
+            logger.debug(
+                "Ignoring reserved header %r from image auth provider config; "
+                "the resolved credential and content type are authoritative",
+                name,
+            )
+            continue
+        merged[by_lower.get(lowered, name)] = str(value)
+        by_lower.setdefault(lowered, name)
+    return merged
+
+
 def _collect_image_b64(
     token: str,
     *,
@@ -459,6 +661,8 @@ def _collect_image_b64(
     size: str,
     quality: str,
     input_images: Optional[List[Dict[str, str]]] = None,
+    base_url: str = _CODEX_BASE_URL,
+    extra_headers: Optional[Dict[str, str]] = None,
 ) -> Optional[Dict[str, str]]:
     """Stream a Codex Responses image_generation call.
 
@@ -471,7 +675,10 @@ def _collect_image_b64(
     import httpx
     from agent.auxiliary_client import _codex_cloudflare_headers
 
-    headers = _codex_cloudflare_headers(token)
+    # Named-provider headers supply route/account metadata. Authentication and
+    # content-negotiation headers stay authoritative so config cannot replace
+    # the freshly resolved bearer token.
+    headers = _merge_request_headers(_codex_cloudflare_headers(token), extra_headers)
     headers.update({
         "Accept": "text/event-stream",
         "Authorization": f"Bearer {token}",
@@ -488,7 +695,9 @@ def _collect_image_b64(
     final_b64: Optional[str] = None
     partial_b64: Optional[str] = None
     with httpx.Client(timeout=timeout, headers=headers) as http:
-        with http.stream("POST", f"{_CODEX_BASE_URL}/responses", json=payload) as response:
+        with http.stream(
+            "POST", f"{base_url.rstrip('/')}/responses", json=payload
+        ) as response:
             try:
                 response.raise_for_status()
             except httpx.HTTPStatusError as exc:
@@ -528,7 +737,11 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
         return "OpenAI (Codex auth)"
 
     def is_available(self) -> bool:
-        if not _read_codex_access_token():
+        try:
+            if not _codex_image_auth_available():
+                return False
+        except Exception as exc:
+            logger.debug("Could not resolve Codex image auth: %s", exc)
             return False
         try:
             import httpx  # noqa: F401
@@ -590,7 +803,16 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        if not _read_codex_access_token():
+        try:
+            auth = _resolve_codex_image_auth()
+        except Exception as exc:
+            return error_response(
+                error=f"Could not resolve configured Codex image authentication: {exc}",
+                error_type="auth_required",
+                provider="openai-codex",
+                aspect_ratio=aspect,
+            )
+        if auth is None:
             return error_response(
                 error=(
                     "No Codex/ChatGPT OAuth credentials available. Run "
@@ -614,20 +836,6 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
         tier_id, meta = _resolve_model()
         size = _SIZES.get(aspect, _SIZES["square"])
 
-        token = _read_codex_access_token()
-        if not token:
-            return error_response(
-                error=(
-                    "No Codex/ChatGPT OAuth credentials available. Run "
-                    "`hermes auth codex` (or `hermes setup` → Codex) to sign in."
-                ),
-                error_type="auth_required",
-                provider="openai-codex",
-                model=tier_id,
-                prompt=prompt,
-                aspect_ratio=aspect,
-            )
-
         try:
             input_images = _normalize_input_images(image_url, reference_image_urls)
         except Exception as exc:
@@ -644,11 +852,13 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             collected: Optional[Dict[str, str]] = None
             for attempt in range(_NONFINAL_RETRIES + 1):
                 collected = _collect_image_b64(
-                    token,
+                    auth.token,
                     prompt=prompt,
                     size=size,
                     quality=meta["quality"],
                     input_images=input_images or None,
+                    base_url=auth.base_url,
+                    extra_headers=auth.extra_headers,
                 )
                 if collected and collected.get("source") == "final" and collected.get("b64"):
                     break

--- a/plugins/image_gen/openai-codex/plugin.yaml
+++ b/plugins/image_gen/openai-codex/plugin.yaml
@@ -1,5 +1,5 @@
 name: openai-codex
 version: 1.0.0
-description: "OpenAI image generation backed by ChatGPT/Codex OAuth (gpt-image-2 via the Responses image_generation tool). Saves generated images to $HERMES_HOME/cache/images/."
+description: "OpenAI image generation backed by ChatGPT/Codex OAuth or a named credential provider (gpt-image-2 via the Responses image_generation tool). Saves generated images to $HERMES_HOME/cache/images/."
 author: NousResearch
 kind: backend

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import importlib
 import json
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -36,7 +37,9 @@ def _b64_png() -> str:
 @pytest.fixture(autouse=True)
 def _tmp_hermes_home(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    codex_plugin._cached_command_token_source.cache_clear()
     yield tmp_path
+    codex_plugin._cached_command_token_source.cache_clear()
 
 
 @pytest.fixture
@@ -127,7 +130,16 @@ class TestGenerate:
 
         captured = {}
 
-        def _collect(token, *, prompt, size, quality, input_images=None):
+        def _collect(
+            token,
+            *,
+            prompt,
+            size,
+            quality,
+            input_images=None,
+            base_url=None,
+            extra_headers=None,
+        ):
             captured.update(codex_plugin._build_responses_payload(
                 prompt=prompt,
                 size=size,
@@ -161,6 +173,39 @@ class TestGenerate:
         # Progressive previews disabled: partial frames were being saved as
         # finals and presented as smeared/unfinished images.
         assert tool["partial_images"] == 0
+
+    def test_generate_routes_through_named_auth_provider(
+        self, provider, monkeypatch
+    ):
+        monkeypatch.setattr(
+            codex_plugin,
+            "_load_image_gen_config",
+            lambda: {"openai-codex": {"auth_provider": "codex-passive"}},
+        )
+        monkeypatch.setattr(
+            codex_plugin,
+            "_resolve_named_provider_auth",
+            lambda name: codex_plugin._CodexImageAuth(
+                "passive-token",
+                "https://chatgpt.example/backend-api/codex",
+                {"ChatGPT-Account-ID": "acct-test"},
+            ),
+        )
+        captured = {}
+
+        def _collect(token, **kwargs):
+            captured["token"] = token
+            captured.update(kwargs)
+            return {"b64": _b64_png(), "source": "final"}
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
+
+        result = provider.generate("a cat")
+
+        assert result["success"] is True
+        assert captured["token"] == "passive-token"
+        assert captured["base_url"] == "https://chatgpt.example/backend-api/codex"
+        assert captured["extra_headers"] == {"ChatGPT-Account-ID": "acct-test"}
 
     def test_capabilities_advertise_image_inputs(self, provider):
         caps = provider.capabilities()
@@ -400,6 +445,252 @@ class TestGenerate:
 
 
 class TestRequestShape:
+    def test_named_provider_key_cmd_source_is_reused(self, monkeypatch):
+        entry = {
+            "name": "codex-passive",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "key_cmd": "token-helper print",
+            "extra_headers": {"ChatGPT-Account-ID": "acct-test"},
+        }
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda requested: entry,
+        )
+        token_source = Mock(return_value="passive-token")
+        builder = Mock(return_value=token_source)
+        monkeypatch.setattr(
+            "agent.command_token_source.build_command_token_provider", builder
+        )
+
+        first = codex_plugin._resolve_named_provider_auth("codex-passive")
+        second = codex_plugin._resolve_named_provider_auth("codex-passive")
+
+        assert first == second == codex_plugin._CodexImageAuth(
+            "passive-token",
+            "https://chatgpt.com/backend-api/codex",
+            {"ChatGPT-Account-ID": "acct-test"},
+        )
+        builder.assert_called_once_with("token-helper print", "codex-passive")
+        assert token_source.call_count == 2
+
+    def test_is_available_does_not_execute_key_cmd(self, monkeypatch):
+        """Availability is a hot-path probe; it must not run the auth helper."""
+        monkeypatch.setattr(
+            codex_plugin,
+            "_load_image_gen_config",
+            lambda: {"openai-codex": {"auth_provider": "codex-passive"}},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda requested: {
+                "name": "codex-passive",
+                "base_url": "https://gw.example/codex",
+                "key_cmd": "token-helper print",
+            },
+        )
+        builder = Mock(side_effect=AssertionError("key_cmd ran during is_available()"))
+        monkeypatch.setattr(
+            "agent.command_token_source.build_command_token_provider", builder
+        )
+
+        assert codex_plugin.OpenAICodexImageGenProvider().is_available() is True
+        builder.assert_not_called()
+
+    def test_missing_named_provider_never_falls_back_to_codex_oauth(
+        self, provider, monkeypatch
+    ):
+        """A typo'd/disabled auth_provider fails closed, it does not downgrade."""
+        monkeypatch.setattr(
+            codex_plugin,
+            "_load_image_gen_config",
+            lambda: {"openai-codex": {"auth_provider": "typo"}},
+        )
+        # _get_named_custom_provider returns None for absent AND disabled entries.
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda requested: None,
+        )
+        # Legacy OAuth IS present — so a pass here would prove silent fallback.
+        monkeypatch.setattr(
+            codex_plugin, "_read_codex_access_token", lambda: "codex-token"
+        )
+
+        assert provider.is_available() is False
+        result = provider.generate("a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "auth_required"
+
+    def test_named_provider_refuses_builtin_provider_fallback(self, monkeypatch):
+        """resolve_runtime_provider() must not reroute us to a built-in."""
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda requested: {
+                "name": "codex-passive",
+                "base_url": "https://gw.example/codex",
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda **kwargs: {
+                "provider": "codex",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "unrelated-builtin-key",
+            },
+        )
+
+        with pytest.raises(RuntimeError, match="refusing to route"):
+            codex_plugin._resolve_named_provider_auth("codex-passive")
+
+    def test_static_named_provider_uses_runtime_credential(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda requested: {
+                "name": "codex-passive",
+                "base_url": "https://gw.example/codex",
+                "extra_headers": {"ChatGPT-Account-ID": "from-entry"},
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda **kwargs: {
+                "provider": "custom",
+                "base_url": "https://gw.example/codex/",
+                "api_key": "static-key",
+                "extra_headers": {"ChatGPT-Account-ID": "from-runtime"},
+            },
+        )
+
+        assert codex_plugin._resolve_named_provider_auth(
+            "codex-passive"
+        ) == codex_plugin._CodexImageAuth(
+            "static-key",
+            "https://gw.example/codex",
+            {"ChatGPT-Account-ID": "from-runtime"},
+        )
+
+    def test_open_endpoint_sentinel_is_not_treated_as_a_credential(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda requested: {
+                "name": "codex-passive",
+                "base_url": "https://gw.example/codex",
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda **kwargs: {
+                "provider": "custom",
+                "base_url": "https://gw.example/codex",
+                "api_key": "no-key-required",
+            },
+        )
+
+        with pytest.raises(RuntimeError, match="produced no credential"):
+            codex_plugin._resolve_named_provider_auth("codex-passive")
+
+    def test_omitted_auth_provider_leaves_codex_oauth_path_untouched(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(codex_plugin, "_load_image_gen_config", lambda: {})
+        lookup = Mock(side_effect=AssertionError("named-provider lookup ran"))
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider", lookup
+        )
+        monkeypatch.setattr(
+            codex_plugin, "_read_codex_access_token", lambda: "codex-token"
+        )
+
+        assert codex_plugin._resolve_codex_image_auth() == codex_plugin._CodexImageAuth(
+            "codex-token", codex_plugin._CODEX_BASE_URL, {}
+        )
+        lookup.assert_not_called()
+
+    def test_named_provider_headers_and_route_reach_http_boundary(self, monkeypatch):
+        import httpx
+
+        seen = {}
+
+        def _handler(request):
+            seen["request"] = request
+            body = (
+                'event: response.output_item.done\n'
+                "data: "
+                + json.dumps({
+                    "item": {
+                        "type": "image_generation_call",
+                        "result": _b64_png(),
+                    }
+                })
+                + "\n\n"
+            )
+            return httpx.Response(200, text=body, request=request)
+
+        real_client = httpx.Client
+        monkeypatch.setattr(
+            httpx,
+            "Client",
+            lambda *args, **kwargs: real_client(
+                transport=httpx.MockTransport(_handler),
+                headers=kwargs.get("headers"),
+                timeout=kwargs.get("timeout"),
+            ),
+        )
+
+        result = codex_plugin._collect_image_b64(
+            "passive-token",
+            prompt="a cat",
+            size="1024x1024",
+            quality="low",
+            base_url="https://chatgpt.example/backend-api/codex",
+            extra_headers={
+                "ChatGPT-Account-ID": "acct-test",
+                "Authorization": "Bearer stale-token",
+                # Header names are case-insensitive on the wire but dict keys
+                # are not, and httpx does not de-duplicate: an unfiltered
+                # lowercase spelling would be sent ALONGSIDE the real bearer
+                # and win at upstreams that honour the first Authorization.
+                "authorization": "Bearer stale-token-lowercase",
+                "ACCEPT": "application/json",
+                "content-type": "text/plain",
+            },
+        )
+
+        assert result == {"b64": _b64_png(), "source": "final"}
+        request = seen["request"]
+        assert str(request.url) == "https://chatgpt.example/backend-api/codex/responses"
+        assert request.headers["ChatGPT-Account-ID"] == "acct-test"
+        # get_list() exposes every value sent under the name, so a smuggled
+        # duplicate cannot hide behind a single-value lookup.
+        assert request.headers.get_list("authorization") == ["Bearer passive-token"]
+        assert request.headers.get_list("accept") == ["text/event-stream"]
+        assert request.headers.get_list("content-type") == ["application/json"]
+
+    def test_config_headers_cannot_smuggle_a_second_authorization(self):
+        """Reserved headers are dropped regardless of the casing config uses."""
+        merged = codex_plugin._merge_request_headers(
+            {"User-Agent": "codex_cli_rs/0.0.0", "ChatGPT-Account-ID": "from-jwt"},
+            {
+                "Authorization": "Bearer a",
+                "authorization": "Bearer b",
+                "AUTHORIZATION": "Bearer c",
+                "Accept": "application/json",
+                "Content-Type": "text/plain",
+            },
+        )
+        assert not [k for k in merged if k.lower() in {"authorization", "accept", "content-type"}]
+        assert merged["User-Agent"] == "codex_cli_rs/0.0.0"
+
+    def test_config_headers_override_route_metadata_in_place(self):
+        """A case-variant override replaces the key instead of duplicating it."""
+        merged = codex_plugin._merge_request_headers(
+            {"User-Agent": "codex_cli_rs/0.0.0", "ChatGPT-Account-ID": "from-jwt"},
+            {"chatgpt-account-id": "from-config", "  ": "dropped"},
+        )
+        account_keys = [k for k in merged if k.lower() == "chatgpt-account-id"]
+        assert account_keys == ["ChatGPT-Account-ID"]
+        assert merged["ChatGPT-Account-ID"] == "from-config"
+        assert "  " not in merged
+
     def test_payload_omits_tool_choice(self):
         """Codex rejects every tool_choice shape for hosted image_generation."""
         payload = codex_plugin._build_responses_payload(

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -547,7 +547,10 @@ class TestRequestShape:
             lambda requested: {
                 "name": "codex-passive",
                 "base_url": "https://gw.example/codex",
-                "extra_headers": {"ChatGPT-Account-ID": "from-entry"},
+                "extra_headers": {
+                    "ChatGPT-Account-ID": "from-entry",
+                    "X-Entry-Route": "preserved",
+                },
             },
         )
         monkeypatch.setattr(
@@ -565,7 +568,10 @@ class TestRequestShape:
         ) == codex_plugin._CodexImageAuth(
             "static-key",
             "https://gw.example/codex",
-            {"ChatGPT-Account-ID": "from-runtime"},
+            {
+                "X-Entry-Route": "preserved",
+                "ChatGPT-Account-ID": "from-runtime",
+            },
         )
 
     def test_open_endpoint_sentinel_is_not_treated_as_a_credential(self, monkeypatch):

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -73,6 +73,42 @@ image_gen:
 to the global tool-worker limit, so image providers receive bounded parallel
 requests without allowing an image batch to bypass the agent's concurrency cap.
 
+### Codex images with a named credential provider
+
+The `openai-codex` image backend normally reads Hermes-managed ChatGPT/Codex
+OAuth credentials. It can instead reuse an existing named provider, including
+one backed by [`key_cmd`](/integrations/providers#command-minted-credentials-key_cmd):
+
+```yaml
+providers:
+  codex-passive:
+    api: https://chatgpt.com/backend-api/codex
+    transport: codex_responses
+    key_cmd: "my-auth-helper print-token"
+    extra_headers:
+      ChatGPT-Account-ID: "your-account-id"
+
+image_gen:
+  provider: openai-codex
+  openai-codex:
+    auth_provider: codex-passive
+```
+
+The image request uses that provider's base URL, bearer credential, and extra
+headers. Command-minted tokens retain the same expiry-aware cache and
+secret-safe error handling as normal inference. If `auth_provider` is omitted,
+the existing `hermes auth add openai-codex` flow is unchanged.
+
+Two guardrails are worth knowing about:
+
+- `extra_headers` is for route and account metadata. `Authorization`, `Accept`,
+  and `Content-Type` are owned by the request and are ignored (in any casing)
+  if the provider declares them, so config can never shadow the freshly
+  resolved bearer token.
+- A named provider that is missing, disabled (`enabled: false`), or has no
+  credential is an error — Hermes does **not** quietly fall back to
+  Hermes-managed Codex OAuth or to any other provider.
+
 ### OpenRouter: the full Image API catalog
 
 With `image_gen.provider: openrouter`, the model picker lists OpenRouter's


### PR DESCRIPTION
## What does this PR do?

Follow-up to **#86891** (`feat(auth): add key_cmd credential source for custom providers`, merged 2026-08-15), which taught inference to mint provider credentials from a command. Image generation was left behind: the bundled `openai-codex` backend could only read Hermes-managed ChatGPT/Codex OAuth, so anyone reaching Codex through a gateway that issues short-lived bearers had one surface their credential could not serve.

This adds `image_gen.openai-codex.auth_provider`. Point it at a named `providers:` entry and the image request takes that entry's bearer, base URL, and extra headers:

```yaml
providers:
  codex-passive:
    api: https://chatgpt.com/backend-api/codex
    transport: codex_responses
    key_cmd: "my-auth-helper print-token"
    extra_headers:
      ChatGPT-Account-ID: "your-account-id"

image_gen:
  provider: openai-codex
  openai-codex:
    auth_provider: codex-passive
```

`key_cmd` deliberately routes through the shared `agent.command_token_source` rather than re-implementing minting, so the expiry-aware cache and the "never echo stdout/stderr or the command string" error contract from #86891 apply unchanged. The token source is memoized per `(key_cmd, label)`, so the expiry cache survives across image calls instead of re-minting on each one.

**When `auth_provider` is omitted, nothing changes** — the existing `hermes auth codex` OAuth path is untouched, and there is a test asserting the named-provider lookup never runs in that case.

### Why this approach

The alternative was to teach the image plugin to read `providers:` itself. That would have duplicated key_env/api_key precedence, `enabled: false` handling, and legacy `custom_providers:` list support — four things the runtime resolver already owns and that would drift. Instead the plugin looks the entry up through `_get_named_custom_provider`, then delegates: `key_cmd` to the shared command-token source, static credentials to `resolve_runtime_provider`.

### Fail-closed behavior

Delegating to a resolver that has a fallback chain needs guardrails, so each of these is asserted by a test:

- **Config cannot shadow the bearer.** HTTP header names are case-insensitive but `dict` keys are not, and httpx does not de-duplicate — an `extra_headers` key spelled `authorization` would otherwise be sent *alongside* the freshly resolved `Authorization` and win at any upstream that honours the first. `Authorization`, `Accept`, and `Content-Type` are now dropped from `extra_headers` in any casing, and non-reserved overrides replace the existing key in place rather than adding a case-variant twin.
- **No silent reroute to a built-in.** `resolve_runtime_provider()` walks a fallback chain and will return a built-in (`codex`, `openai`, `openrouter`, ...) for a name that doesn't land on a custom entry. Adopting that would send the image request to an unrelated endpoint with an unrelated key, so the result is now required to have resolved to the custom entry we looked up.
- **Missing / disabled / credential-less providers raise** rather than quietly downgrading to Codex OAuth. A typo'd `auth_provider` is an error, not a fallback. `enabled: false` fails closed.
- **`is_available()` stays side-effect free.** It is a documented fast hot-path check — the image registry calls it during backend resolution and the pet/tool paths call it repeatedly. It now validates *configuration* and does not run `key_cmd`; a broken helper still surfaces a precise error from `generate()`.

No credential, token, or `key_cmd` string is logged anywhere — only header *names* appear in debug output.

## Related Issue

No tracking issue. This is the image-generation follow-up to the merged #86891; opening as a draft for maintainer feedback on whether `image_gen.<backend>.auth_provider` is the shape you want before it is generalized to the other image backends.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/image_gen/openai-codex/__init__.py` — `auth_provider` resolution (`_lookup_named_provider`, `_resolve_named_provider_auth`, `_resolve_codex_image_auth`, `_codex_image_auth_available`), reserved-header filtering (`_merge_request_headers`), and `base_url` / `extra_headers` plumbed through `_collect_image_b64`.
- `tests/plugins/image_gen/test_openai_codex_provider.py` — 8 new tests (31 to 39).
- `cli-config.yaml.example` — documents the new `image_gen.openai-codex.auth_provider` key.
- `website/docs/user-guide/features/image-generation.md` — usage example plus the two guardrails users can observe.
- `plugins/image_gen/openai-codex/plugin.yaml` — description mentions the named-credential path.

## How to Test

1. Add a `providers:` entry with `key_cmd` and set `image_gen.openai-codex.auth_provider` to its name (example above).
2. Run an image generation. The request goes to that provider's base URL with a freshly minted bearer; the helper runs about once per token lifetime, not once per image.
3. Set `auth_provider` to a name that doesn't exist. Generation fails with `auth_required` and does **not** fall back to Codex OAuth.
4. Add `authorization: Bearer whatever` to that provider's `extra_headers`. It is ignored; the minted bearer is still what's sent.
5. Remove `auth_provider`. The Codex OAuth path behaves exactly as before.

Automated:

```
scripts/run_tests.sh tests/plugins/image_gen/test_openai_codex_provider.py -q
```

## Test Results

Exact results from this machine. **The full suite was not run** — only the suites below.

| Command | Result |
|---|---|
| `scripts/run_tests.sh tests/plugins/image_gen/test_openai_codex_provider.py -q` | **39 passed, 0 failed** (31 before this PR) |
| `scripts/run_tests.sh` over `test_openai_codex_provider.py`, `tests/hermes_cli/test_runtime_provider_resolution.py`, `tests/agent/test_image_gen_registry.py`, `tests/hermes_cli/test_image_gen_picker.py`, `tests/tools/test_image_generation_plugin_dispatch.py` | **112 passed, 0 failed** |
| `ruff check` on both touched Python files (repo config, and again with `--isolated --select F,E9`) | **All checks passed** |
| `git diff --check` | clean |
| `python scripts/check-windows-footguns.py --all` | **No Windows footguns found (994 files scanned)** |

### Pre-existing failures on this platform (not caused by this PR)

10 tests fail on Windows both **with and without** this change — verified by stashing the diff and re-running against the base commit `28f7c4e68a`, which produced the identical failure list:

- `tests/agent/test_command_token_source.py` — 5 failures
- `tests/plugins/image_gen/test_openrouter_compat_provider.py` — 3 failures
- `tests/plugins/image_gen/test_krea_provider.py` — 1 failure
- `tests/plugins/image_gen/test_openai_provider.py` — 1 failure

Cause for the `test_command_token_source.py` group: those tests drive `key_cmd` with POSIX-only commands (`date +%s%N`, `printf minted-token`), and `subprocess.run(shell=True)` uses `cmd.exe` on Windows. Unrelated to this change and left alone rather than widened into this PR. The new tests here mock `build_command_token_provider`, so they are platform-independent.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run**; see Test Results for exactly which suites were run
- [x] I've added tests for my changes
- [x] I've tested on my platform: **Windows 11 Pro 10.0.26200**

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` for the new config key
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] I've considered cross-platform impact — no new file I/O, process management, or terminal handling; `key_cmd` execution is unchanged and still owned by `agent/command_token_source.py`
- [x] I've updated tool descriptions/schemas — `plugin.yaml` description updated; the `image_generate` tool schema is unchanged

## Platform Caveat

Developed and verified on **Windows 11 Pro 10.0.26200** only. Not exercised on Linux or macOS. The change is pure Python with no platform-specific primitives, so no divergence is expected, but CI is the authority here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
