### PR TITLE
fix(key_cmd): re-mint once on an auth failure

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -939,6 +939,52 @@ def sync_credential_pool_entry_id(agent) -> None:
         agent._credential_pool_entry_id = None
 
 
+def _remint_command_token(
+    agent,
+    status_code: Optional[int],
+    classified_reason: Optional[FailoverReason],
+) -> bool:
+    """Force one key_cmd re-mint after an auth failure. True when re-minted.
+
+    ``agent.api_key`` is the token source itself when the provider uses
+    ``key_cmd``, so the invalidation happens on the object the request path
+    already calls. Providers without a ``key_cmd`` credential are untouched.
+    """
+    is_auth = classified_reason in {FailoverReason.auth, FailoverReason.auth_permanent} or (
+        classified_reason is None and status_code in {401, 403}
+    )
+    if not is_auth:
+        return False
+
+    source = getattr(agent, "api_key", None)
+    invalidate = getattr(source, "invalidate", None)
+    if not callable(invalidate):
+        return False
+
+    # One re-mint per provider: a revoked credential returns the same dead
+    # token every time, and retrying it forever would replace the old
+    # never-recovers bug with a spin.
+    attempted = getattr(agent, "_command_token_reminted", None)
+    if attempted is None:
+        attempted = set()
+        agent._command_token_reminted = attempted
+    key = getattr(agent, "provider", "") or ""
+    if key in attempted:
+        return False
+    attempted.add(key)
+
+    try:
+        invalidate()
+    except Exception:
+        return False
+    _ra().logger.info(
+        "Auth failure on key_cmd provider %s — invalidated cached token, "
+        "re-minting for one retry",
+        key or "?",
+    )
+    return True
+
+
 def recover_with_credential_pool(
     agent,
     *,
@@ -970,6 +1016,13 @@ def recover_with_credential_pool(
     """
     pool = agent._credential_pool
     if pool is None:
+        # No pool, but a key_cmd provider still has a recoverable credential:
+        # its token source caches a bearer whose advertised TTL can outlive
+        # the credential. Invalidate on an auth failure so the next attempt
+        # re-runs the helper. Bounded to one re-mint per provider so a
+        # genuinely dead credential cannot spin.
+        if _remint_command_token(agent, status_code, classified_reason):
+            return True, has_retried_429
         return False, has_retried_429
 
     # Defensive guard: if a fallback provider is active and its provider name

--- a/agent/command_token_source.py
+++ b/agent/command_token_source.py
@@ -178,6 +178,19 @@ class CommandTokenSource:
             )
             return token
 
+    def invalidate(self) -> None:
+        """Drop the cached token so the next call re-runs the helper.
+
+        The advertised TTL can outlive the credential: a helper answering from
+        its own cache may reprint a stale lifetime, and a broker can revoke a
+        token early. A rejected token is therefore the only authoritative
+        signal that the cache is stale, so the request path calls this on an
+        auth failure to force exactly one re-mint.
+        """
+        with self._lock:
+            self._token = ""
+            self._expires_at = 0.0
+
 
 def build_command_token_provider(
     key_cmd: str,

--- a/tests/agent/test_command_token_source.py
+++ b/tests/agent/test_command_token_source.py
@@ -347,3 +347,45 @@ class TestAuxiliaryResolverHonoursKeyCmd:
         assert self._resolve(
             monkeypatch, {**self.BASE, "key_cmd": "   "}
         ) == "no-key-required"
+
+
+# ── invalidate(): one re-mint after an auth failure ────────────────────
+
+class TestInvalidate:
+    """A rejected token is the only authoritative staleness signal.
+
+    The advertised TTL can outlive the credential (a helper answering from its
+    own cache reprints a stale lifetime; a broker can revoke early), so the
+    request path must be able to force a re-mint on an auth failure.
+    """
+
+    def test_invalidate_forces_the_next_call_to_re_mint(self, tmp_path):
+        counter = tmp_path / "n"
+        counter.write_text("0")
+        cmd = (
+            f"python3 -c \"import pathlib;p=pathlib.Path(r'{counter}');"
+            "n=int(p.read_text());p.write_text(str(n+1));"
+            "print('tok-%d' % n)\""
+        )
+        src = build_command_token_provider(cmd, "demo")
+
+        assert src() == "tok-0"
+        assert src() == "tok-0", "cached until expiry"
+        assert counter.read_text() == "1", "helper ran once"
+
+        src.invalidate()
+
+        assert src() == "tok-1", "re-minted after invalidate"
+        assert counter.read_text() == "2"
+
+    def test_invalidate_is_idempotent(self):
+        src = build_command_token_provider("printf tok", "demo")
+        assert src() == "tok"
+        src.invalidate()
+        src.invalidate()
+        assert src() == "tok"
+
+    def test_invalidate_before_first_mint_is_safe(self):
+        src = build_command_token_provider("printf tok", "demo")
+        src.invalidate()
+        assert src() == "tok"

--- a/tests/agent/test_keycmd_auth_remint.py
+++ b/tests/agent/test_keycmd_auth_remint.py
@@ -1,0 +1,139 @@
+"""``key_cmd`` providers re-mint once on an auth failure.
+
+A ``key_cmd`` provider has no credential-pool entry, so
+``recover_with_credential_pool`` used to return at ``pool is None`` and no
+recovery path existed: the cached bearer was returned until its advertised TTL
+expired, even after the gateway rejected it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.agent_runtime_helpers import recover_with_credential_pool
+from agent.command_token_source import build_command_token_provider
+from agent.error_classifier import FailoverReason
+
+
+def _counting_source(tmp_path, label="demo"):
+    counter = tmp_path / "n"
+    counter.write_text("0")
+    cmd = (
+        f"python3 -c \"import pathlib;p=pathlib.Path(r'{counter}');"
+        "n=int(p.read_text());p.write_text(str(n+1));"
+        "print('tok-%d' % n)\""
+    )
+    return build_command_token_provider(cmd, label), counter
+
+
+def _agent(api_key, provider="custom"):
+    class _A:
+        pass
+
+    a = _A()
+    a._credential_pool = None
+    a.provider = provider
+    a.base_url = "https://gateway.invalid/v1"
+    a.api_key = api_key
+    a.log_prefix = ""
+    return a
+
+
+class TestKeyCmdAuthRemint:
+    def test_auth_failure_invalidates_the_cached_token(self, tmp_path):
+        src, counter = _counting_source(tmp_path)
+        agent = _agent(src)
+        assert agent.api_key() == "tok-0"
+
+        recovered, _ = recover_with_credential_pool(
+            agent, status_code=401, has_retried_429=False,
+            classified_reason=FailoverReason.auth,
+        )
+
+        assert recovered is True
+        assert agent.api_key() == "tok-1", "retry sends a freshly minted token"
+        assert counter.read_text() == "2"
+
+    def test_auth_permanent_also_recovers(self, tmp_path):
+        """The classifier reports a failed key_cmd as auth_permanent."""
+        src, _ = _counting_source(tmp_path)
+        agent = _agent(src)
+        agent.api_key()
+        recovered, _ = recover_with_credential_pool(
+            agent, status_code=None, has_retried_429=False,
+            classified_reason=FailoverReason.auth_permanent,
+        )
+        assert recovered is True
+
+    def test_bare_401_without_a_classification_recovers(self, tmp_path):
+        src, _ = _counting_source(tmp_path)
+        agent = _agent(src)
+        agent.api_key()
+        recovered, _ = recover_with_credential_pool(
+            agent, status_code=401, has_retried_429=False,
+        )
+        assert recovered is True
+
+    def test_only_one_remint_per_provider(self, tmp_path):
+        """A revoked credential must not spin: the second attempt refuses."""
+        src, counter = _counting_source(tmp_path)
+        agent = _agent(src)
+        agent.api_key()
+
+        first, _ = recover_with_credential_pool(
+            agent, status_code=401, has_retried_429=False,
+            classified_reason=FailoverReason.auth,
+        )
+        agent.api_key()
+        second, _ = recover_with_credential_pool(
+            agent, status_code=401, has_retried_429=False,
+            classified_reason=FailoverReason.auth,
+        )
+
+        assert (first, second) == (True, False)
+        assert counter.read_text() == "2", "helper ran twice, not three times"
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            FailoverReason.rate_limit,
+            FailoverReason.timeout,
+            FailoverReason.server_error,
+            FailoverReason.context_overflow,
+        ],
+    )
+    def test_non_auth_reasons_do_not_remint(self, tmp_path, reason):
+        src, counter = _counting_source(tmp_path)
+        agent = _agent(src)
+        agent.api_key()
+        recovered, _ = recover_with_credential_pool(
+            agent, status_code=429, has_retried_429=False,
+            classified_reason=reason,
+        )
+        assert recovered is False
+        assert counter.read_text() == "1", "helper not re-run"
+
+    @pytest.mark.parametrize("api_key", ["static-key", None, 123])
+    def test_providers_without_a_key_cmd_are_untouched(self, api_key):
+        """No invalidate() attribute means nothing to re-mint."""
+        agent = _agent(api_key)
+        recovered, _ = recover_with_credential_pool(
+            agent, status_code=401, has_retried_429=False,
+            classified_reason=FailoverReason.auth,
+        )
+        assert recovered is False
+
+    def test_a_raising_invalidate_does_not_break_recovery(self, tmp_path):
+        class Exploding:
+            def __call__(self):
+                return "tok"
+
+            def invalidate(self):
+                raise RuntimeError("boom")
+
+        agent = _agent(Exploding())
+        recovered, _ = recover_with_credential_pool(
+            agent, status_code=401, has_retried_429=False,
+            classified_reason=FailoverReason.auth,
+        )
+        assert recovered is False


### PR DESCRIPTION
Fixes #91119

### What this changes

`CommandTokenSource` gains `invalidate()`, and `recover_with_credential_pool` calls it on an auth failure when the provider has no credential pool.

A `key_cmd` provider had no 401 recovery path. `recover_with_credential_pool` returns at `pool is None` (`agent/agent_runtime_helpers.py:971`) before any auth handling, and `key_cmd` providers have no pool entry, so the OAuth refresh branch below it was unreachable for them. The token source also exposed no way to be told its value was stale, so the cached bearer was returned until its advertised TTL expired even after the gateway rejected it. The session recovered only on restart.

The advertised TTL is not a sufficient signal. A helper answering from its own credential cache reprints a stale `expires_in`, and a broker can revoke a token before its stated expiry. A rejected token is the only authoritative indication that the cache is stale.

The module already noted the gap at `agent/command_token_source.py:53-56`: *"nothing in the request path re-mints on 401"*.

### Scope

Two production files, +66 lines, no deletions and no changes to existing behaviour. The new call sits inside the existing `pool is None` early-return, so pool users reach the same code they did before. Providers whose `api_key` is not a `key_cmd` token source have no `invalidate` attribute and are untouched.

### Bounded to one re-mint

One re-mint per provider, tracked on the agent. A revoked credential returns the same dead token every time, so an unbounded retry would replace a never-recovers bug with a spin. `invalidate()` is lazy — it clears the cache and the helper re-runs on the next call, which is the retry.

### Tests

`tests/agent/test_keycmd_auth_remint.py` (new, 11 cases) and `TestInvalidate` in `tests/agent/test_command_token_source.py` (3 cases): re-mint on `auth`, on `auth_permanent`, on a bare 401 with no classification; the once-per-provider bound; four non-auth reasons that must not re-mint; three non-`key_cmd` credential shapes that must be ignored; a raising `invalidate()`; and idempotency.

Full `tests/agent/` suite on `7ab2e417f`, same command both trees:

| | failed | passed |
|---|---|---|
| `origin/main` | 161 | 4898 |
| this branch | 161 | 4913 |

The 161 failures are pre-existing and identical in both runs (failing-id sets diffed, empty delta). An earlier run of this branch showed one extra failure in `test_title_generator.py`; it passes standalone and did not recur, so it is order-dependent flakiness in the shared suite rather than a regression here.
