### PR TITLE
fix(cli): handle dotted model IDs in custom_providers config paths

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1017,6 +1017,88 @@ def get_missing_env_vars(required_only: bool = False) -> List[Dict[str, Any]]:
     return missing
 
 
+def _parse_quoted_dotted_key(key: str) -> list[str]:
+    """Parse a dotted path that may contain double/single quotes or backslashes."""
+    parts = []
+    current = []
+    in_quote = None
+    escape = False
+    for ch in key:
+        if escape:
+            current.append(ch)
+            escape = False
+        elif ch == "\\":
+            escape = True
+        elif ch in ('"', "'"):
+            if in_quote == ch:
+                in_quote = None
+            elif in_quote is None:
+                in_quote = ch
+            else:
+                current.append(ch)
+        elif ch == "." and in_quote is None:
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+    if escape:
+        current.append("\\")
+    if current or not parts:
+        parts.append("".join(current))
+    return parts
+
+
+def _split_config_key_path(dotted_key: str, root_config: Any = None) -> list[str]:
+    """Split a dotted configuration key into navigation segments.
+
+    Handles:
+      1. Explicit quotes or escapes: ``a."b.c".d`` or ``a.b\\.c.d``
+      2. Dotted model IDs under ``custom_providers.<idx>.models.<model_id>.<field>``:
+         e.g. ``custom_providers.0.models.qwen3.5:4b.context_length``
+         -> ``['custom_providers', '0', 'models', 'qwen3.5:4b', 'context_length']``
+      3. Standard dot-separated segments.
+    """
+    if '"' in dotted_key or "'" in dotted_key or "\\" in dotted_key:
+        return _parse_quoted_dotted_key(dotted_key)
+
+    # Check for custom_providers.<idx>.models.<model_id> pattern
+    cp_match = re.match(r"^custom_providers\.(\d+)\.models\.(.+)$", dotted_key)
+    if cp_match:
+        idx_str = cp_match.group(1)
+        rest = cp_match.group(2)
+        prefix = ["custom_providers", idx_str, "models"]
+
+        # Check existing models in root_config if available
+        if isinstance(root_config, dict):
+            cp_list = root_config.get("custom_providers")
+            if isinstance(cp_list, list) and int(idx_str) < len(cp_list):
+                entry = cp_list[int(idx_str)]
+                if isinstance(entry, dict):
+                    models = entry.get("models")
+                    if isinstance(models, dict):
+                        if rest in models:
+                            return prefix + [rest]
+                        for m_name in sorted(models.keys(), key=len, reverse=True):
+                            if rest.startswith(m_name + "."):
+                                sub_path = rest[len(m_name) + 1 :]
+                                # If sub_path contains ':', m_name was only a prefix match of a longer model ID
+                                # (e.g. existing 'qwen3' matching prefix of 'qwen3.5:4b.context_length')
+                                if ":" in sub_path:
+                                    continue
+                                return prefix + [m_name] + sub_path.split(".")
+
+        # If creating when absent or not matched against existing keys:
+        if "." in rest:
+            model_id, leaf = rest.rsplit(".", 1)
+            # If leaf contains ':', it is part of the model tag (e.g. '5:4b'), not a property attribute
+            if ":" in leaf:
+                return prefix + [rest]
+            return prefix + [model_id, leaf]
+        return prefix + [rest]
+
+    return dotted_key.split(".")
+
+
 def _set_nested(config, dotted_key: str, value):
     """Set a value at an arbitrarily nested dotted key path.
 
@@ -1039,7 +1121,7 @@ def _set_nested(config, dotted_key: str, value):
     destroying list-typed config like ``custom_providers`` whenever a
     caller used an indexed path.
     """
-    parts = dotted_key.split(".")
+    parts = _split_config_key_path(dotted_key, config)
     current = config
     for part in parts[:-1]:
         if isinstance(current, list):
@@ -1101,7 +1183,7 @@ _MISSING = object()
 def _get_nested(config, dotted_key: str):
     """Return a dotted-path value from nested dict/list config data."""
     current = config
-    for part in dotted_key.split("."):
+    for part in _split_config_key_path(dotted_key, config):
         if isinstance(current, list):
             try:
                 current = current[int(part)]
@@ -1118,7 +1200,7 @@ def _get_nested(config, dotted_key: str):
 
 def _unset_nested(config, dotted_key: str) -> bool:
     """Remove a dotted-path value from nested dict/list config data."""
-    parts = dotted_key.split(".")
+    parts = _split_config_key_path(dotted_key, config)
     if not parts:
         return False
 

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -760,3 +760,166 @@ class TestMalformedYAMLConfigPreservation:
         assert "Cannot parse" in captured.out or "Cannot parse" in captured.err
         raw = _read_config(_isolated_hermes_home)
         assert raw == self.BROKEN_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# Custom provider model IDs with dots — regression tests for #91095
+# ---------------------------------------------------------------------------
+
+class TestCustomProviderDottedModelKeys:
+    """#91095: hermes config set on custom_providers.<idx>.models.<model_id>.<leaf>
+    must handle model IDs containing dots (e.g. qwen3.5:4b, llama3.3:70b).
+    """
+
+    def _write_config(self, tmp_path, body):
+        (tmp_path / "config.yaml").write_text(body)
+
+    def test_update_existing_dotted_model_override(self, _isolated_hermes_home):
+        """Updating an existing qwen3.5:4b override must update the exact model entry."""
+        self._write_config(_isolated_hermes_home, (
+            "custom_providers:\n"
+            "- name: Local Ollama\n"
+            "  base_url: http://localhost:11434/v1\n"
+            "  models:\n"
+            "    qwen3.5:4b:\n"
+            "      context_length: 16384\n"
+        ))
+
+        set_config_value("custom_providers.0.models.qwen3.5:4b.context_length", "65536")
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        models = reloaded["custom_providers"][0]["models"]
+        assert "qwen3.5:4b" in models
+        assert models["qwen3.5:4b"]["context_length"] == 65536
+        assert "qwen3" not in models
+
+    def test_create_new_dotted_model_override_when_absent(self, _isolated_hermes_home):
+        """Creating an override for qwen3.5:4b when absent must not create nested sub-dicts."""
+        self._write_config(_isolated_hermes_home, (
+            "custom_providers:\n"
+            "- name: Local Ollama\n"
+            "  base_url: http://localhost:11434/v1\n"
+            "  models: {}\n"
+        ))
+
+        set_config_value("custom_providers.0.models.qwen3.5:4b.context_length", "65536")
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        models = reloaded["custom_providers"][0]["models"]
+        assert "qwen3.5:4b" in models
+        assert models["qwen3.5:4b"]["context_length"] == 65536
+        assert "qwen3" not in models
+
+    def test_quoted_and_escaped_model_key_syntax(self, _isolated_hermes_home):
+        """Explicit quotes or backslashes work identically."""
+        self._write_config(_isolated_hermes_home, (
+            "custom_providers:\n"
+            "- name: Local Ollama\n"
+            "  base_url: http://localhost:11434/v1\n"
+            "  models: {}\n"
+        ))
+
+        set_config_value('custom_providers.0.models."deepseek-r1:1.5b".context_length', "32768")
+        set_config_value('custom_providers.0.models.llama3\\.3:70b.context_length', "131072")
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        models = reloaded["custom_providers"][0]["models"]
+        assert models["deepseek-r1:1.5b"]["context_length"] == 32768
+        assert models["llama3.3:70b"]["context_length"] == 131072
+
+    def test_config_get_and_unset_dotted_model_keys(self, _isolated_hermes_home, capsys):
+        """config get and unset handle dotted model names seamlessly."""
+        self._write_config(_isolated_hermes_home, (
+            "custom_providers:\n"
+            "- name: Local Ollama\n"
+            "  base_url: http://localhost:11434/v1\n"
+            "  models:\n"
+            "    qwen3.5:4b:\n"
+            "      context_length: 65536\n"
+        ))
+
+        from hermes_cli.config import config_command
+        args_get = argparse.Namespace(config_command="get", key="custom_providers.0.models.qwen3.5:4b.context_length", json=False)
+        config_command(args_get)
+        assert capsys.readouterr().out.strip() == "65536"
+
+        args_unset = argparse.Namespace(config_command="unset", key="custom_providers.0.models.qwen3.5:4b.context_length")
+        config_command(args_unset)
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert "context_length" not in reloaded["custom_providers"][0].get("models", {}).get("qwen3.5:4b", {})
+
+    def test_end_to_end_custom_provider_context_length_resolved(self, _isolated_hermes_home):
+        """Verify get_custom_provider_context_length finds the override created by config set."""
+        from hermes_cli.config import get_custom_provider_context_length, load_config
+        self._write_config(_isolated_hermes_home, (
+            "custom_providers:\n"
+            "- name: Local Ollama\n"
+            "  base_url: http://localhost:11434/v1\n"
+            "  models: {}\n"
+        ))
+
+        set_config_value("custom_providers.0.models.qwen3.5:4b.context_length", "65536")
+
+        cfg = load_config()
+        resolved_ctx = get_custom_provider_context_length(
+            model="qwen3.5:4b",
+            base_url="http://localhost:11434/v1",
+            config=cfg,
+        )
+        assert resolved_ctx == 65536
+
+    def test_prefix_collision_with_shorter_existing_model_name(self, _isolated_hermes_home):
+        """Setting qwen3.5:4b when qwen3 already exists in models must not corrupt into qwen3.5:4b."""
+        self._write_config(_isolated_hermes_home, (
+            "custom_providers:\n"
+            "- name: Local Ollama\n"
+            "  base_url: http://localhost:11434/v1\n"
+            "  models:\n"
+            "    qwen3:\n"
+            "      context_length: 8192\n"
+        ))
+
+        set_config_value("custom_providers.0.models.qwen3.5:4b.context_length", "65536")
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        models = reloaded["custom_providers"][0]["models"]
+        assert models["qwen3"]["context_length"] == 8192
+        assert models["qwen3.5:4b"]["context_length"] == 65536
+        assert "5:4b" not in models.get("qwen3", {})
+
+    def test_setting_whole_model_dict_without_leaf(self, _isolated_hermes_home):
+        """Setting custom_providers.0.models.qwen3.5:4b directly assigns the entire model mapping."""
+        self._write_config(_isolated_hermes_home, (
+            "custom_providers:\n"
+            "- name: Local Ollama\n"
+            "  base_url: http://localhost:11434/v1\n"
+            "  models: {}\n"
+        ))
+
+        set_config_value("custom_providers.0.models.qwen3.5:4b", '{"context_length": 65536}')
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        models = reloaded["custom_providers"][0]["models"]
+        assert "qwen3.5:4b" in models
+        assert models["qwen3.5:4b"]["context_length"] == 65536
+
+    def test_model_catalog_standard_nesting_preserved(self, _isolated_hermes_home):
+        """Standard dotted nesting in model_catalog (e.g. providers.openrouter.url) is preserved."""
+        self._write_config(_isolated_hermes_home, "model_catalog: {}\n")
+
+        set_config_value("model_catalog.providers.openrouter.url", "https://example.com/custom.json")
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["model_catalog"]["providers"]["openrouter"]["url"] == "https://example.com/custom.json"
+
+
+
+


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where `hermes config set` could not create or update `custom_providers` model overrides for model identifiers containing dots (e.g. `qwen3.5:4b`, `llama3.3:70b`, `deepseek-r1:1.5b`).

Previously, `_set_nested`, `_get_nested`, and `_unset_nested` in `hermes_cli/config.py` used `dotted_key.split(".")` for path navigation. When configuring `custom_providers.<idx>.models.<model_id>.<leaf>`, the dot inside the model ID caused the path to split into nested dictionaries (e.g. `{"qwen3": {"5:4b": {"context_length": 65536}}}`), preventing `get_custom_provider_context_length` from resolving the override at runtime.

This PR introduces:
- `_split_config_key_path`: parses `custom_providers.<idx>.models.<model_id>.<leaf>` paths preserving opaque model IDs both when updating existing entries and when creating new ones.
- Prefix-collision protection: avoids partial prefix matches when a shorter model ID exists (e.g. existing `qwen3` vs new `qwen3.5:4b`).
- Whole-model assignment support: correctly handles setting `custom_providers.0.models.qwen3.5:4b` directly with a mapping value.
- `_parse_quoted_dotted_key`: adds support for explicit double/single quotes (`"..."`, `'...'`) or backslash escapes (`\.`).
- Symmetric integration: uses `_split_config_key_path` across `_set_nested`, `_get_nested`, and `_unset_nested` for consistent set/get/unset symmetry.

## Related Issue

Fixes #91095

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py`: Added `_split_config_key_path` and `_parse_quoted_dotted_key`; updated `_set_nested`, `_get_nested`, and `_unset_nested` to use path-aware splitting.
- `tests/hermes_cli/test_set_config_value.py`: Added `TestCustomProviderDottedModelKeys` regression suite covering updating existing model overrides, creating new overrides when absent, prefix collision safety, whole-model mapping assignment, quoted/escaped syntax, `config get` / `config unset`, and runtime resolution via `get_custom_provider_context_length`.

## How to Test

1. Run regression suite:
   ```bash
   pytest tests/hermes_cli/test_set_config_value.py -k TestCustomProviderDottedModelKeys -v
   ```
2. Verify setting override:
   ```bash
   hermes config set custom_providers.0.models.qwen3.5:4b.context_length 65536
   hermes config get custom_providers.0.models.qwen3.5:4b.context_length
   ```
   Output: `65536`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
