### PR TITLE
fix(desktop): scale drive_preview click coords by page devicePixelRatio

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-act.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-act.test.ts
@@ -108,14 +108,15 @@ describe('actOnActivePreview (drive_preview tool)', () => {
 
   /** A pane that answers the locate trip with a fixed on-screen point, and the
    *  read-back trip with an empty inventory. Returns the input spy. */
-  const withDrivenPane = () => {
+  const withDrivenPane = (locate: { devicePixelRatio?: number; point?: { x: number; y: number } } = {}) => {
+    const { devicePixelRatio, point = { x: 120, y: 80 } } = locate
     const tabId = openBrowserTab()
     const send = vi.fn()
 
     cleanups.push(
       registerPreviewScriptRunner(tabId, async code =>
         code.includes('"kind":"locate"')
-          ? JSON.stringify({ acted: 'looking at button "Save"', point: { x: 120, y: 80 }, success: true })
+          ? JSON.stringify({ acted: 'looking at button "Save"', devicePixelRatio, point, success: true })
           : // `hit` is the page's witness that the real pointerdown arrived.
             JSON.stringify({ elements: [], hit: { tag: 'BUTTON', trusted: true }, success: true })
       )
@@ -143,6 +144,30 @@ describe('actOnActivePreview (drive_preview tool)', () => {
       y: 80
     })
     expect(result.acted).toBe('clicked button "Save"')
+  })
+
+  it('scales the click point by the page devicePixelRatio (fractional-DPR fix)', async () => {
+    const send = withDrivenPane({ devicePixelRatio: 1.256, point: { x: 120, y: 80 } })
+
+    await actOnActivePreview({ kind: 'click', ref: '@e1' })
+
+    // sendInputEvent expects device-pixel coords; the raw CSS point would land
+    // ~1/DPR short. The aim point must be multiplied by the reported DPR.
+    expect(send.mock.calls.map(([event]) => event).find(event => event.type === 'mouseDown')).toMatchObject({
+      x: Math.round(120 * 1.256),
+      y: Math.round(80 * 1.256)
+    })
+  })
+
+  it('does not scale when devicePixelRatio is absent (defaults to 1)', async () => {
+    const send = withDrivenPane({ point: { x: 120, y: 80 } })
+
+    await actOnActivePreview({ kind: 'click', ref: '@e1' })
+
+    expect(send.mock.calls.map(([event]) => event).find(event => event.type === 'mouseDown')).toMatchObject({
+      x: 120,
+      y: 80
+    })
   })
 
   it('types by pressing keys, after selecting whatever the field held', async () => {

--- a/apps/desktop/src/app/chat/right-rail/preview-act.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-act.ts
@@ -358,7 +358,15 @@ async function driveAction(
     return { error: 'Could not work out where that element is on screen.', success: false }
   }
 
-  await glideTo(input, found.point)
+  // `sendInputEvent` expects coordinates in device-pixel space, but the engine
+  // reports the target's centre in CSS pixels. On a fractional-DPR display the
+  // two diverge: sending the raw CSS point lands the click ~1/DPR short of the
+  // target and it misses. Scale by the page's DPR (1 on ordinary displays, so
+  // this is a no-op there). electron/electron#53050 is the underlying bug.
+  const dpr = found.devicePixelRatio ?? 1
+  const aimPoint = dpr > 0 && dpr !== 1 ? { x: Math.round(found.point.x * dpr), y: Math.round(found.point.y * dpr) } : found.point
+
+  await glideTo(input, aimPoint)
 
   if (action.kind === 'click') {
     await clickAt(input)

--- a/apps/desktop/src/lib/preview-act/act-in-page.ts
+++ b/apps/desktop/src/lib/preview-act/act-in-page.ts
@@ -492,6 +492,11 @@ export function actInPageCore(
 
     return answer({
       acted: 'looking at ' + describe(el),
+      // The page's device-pixel ratio, so the caller can translate this CSS-px
+      // point into the coordinate space `sendInputEvent` expects. On a fractional
+      // DPR display (e.g. 4K under Wayland where DPR lands on ~1.25), un-scaled
+      // coords land ~1/DPR short of the target and clicks miss entirely.
+      devicePixelRatio: win ? win.devicePixelRatio : 1,
       point: { x: spot.clientX, y: spot.clientY },
       success: true,
       // Real typing starts with a triple-click to clear the field. On anything

--- a/apps/desktop/src/lib/preview-act/types.ts
+++ b/apps/desktop/src/lib/preview-act/types.ts
@@ -93,6 +93,10 @@ export interface PreviewActResult {
   elements?: PreviewElement[]
   error?: string
   note?: string
+  /** The page's device-pixel ratio, reported alongside `point` so the caller can
+   *  translate a CSS-px target into the coordinate space `sendInputEvent` expects
+   *  (see preview-act.ts). Absent on synthetic/fallback paths — treat as 1. */
+  devicePixelRatio?: number
   /** Viewport centre of a located target, for aiming real pointer input at it. */
   point?: { x: number; y: number }
   success: boolean


### PR DESCRIPTION
## Summary

Fixes `drive_preview` clicks missing their target on displays where the page's
`devicePixelRatio` is fractional (e.g. 4K under Wayland where DPR lands on
~1.25), which made preview-pane clicks silently do nothing — no navigation even
on a bare `<a>` link.

Reported in #91130; underlying Electron bug is electron/electron#53050.

## Problem

`drive_preview` sends real input via Electron's `webContents.sendInputEvent`.
The click target's coordinates are computed in the page in CSS pixels
(`getBoundingClientRect()` → element centre), but `sendInputEvent` expects
coordinates in device-pixel space. On a display where the page's
`devicePixelRatio` is 1.0 these two spaces coincide, so it always worked. On a
fractional-DPR display the page is scaled (e.g. DPR 1.256), and sending the raw
CSS point lands the click at `~coords/DPR` — ~20% short of the target. The click
misses, the page ignores it, and the tool reports success because the input
*was* genuinely delivered (just in the wrong place).

This reproduces in a standalone Electron app with no Hermes involved
(electron/electron#53050), and on every real page — Google's dialog buttons,
MDN's nav links, and a bare `<a>` on `example.com` all failed identically.

## Fix

The in-page engine already reports the located target's `point`; it now also
reports the page's `devicePixelRatio` alongside it. `driveAction` scales the aim
point by that DPR before gliding to it and sending input:

```
aimPoint = point × devicePixelRatio   (no-op when DPR is 1 or absent)
```

This is the correct coordinate-space translation regardless of the Electron bug,
and it's a no-op on ordinary (DPR 1) displays, so there's no behavior change
for existing setups. It applies to `click`, `type`, and `hover` — all of which
aim real input at a measured point.

## Test plan

- `actOnActivePreview` click with the page reporting `devicePixelRatio: 1.256`
  aims the mouseDown at `point × 1.256`.
- `actOnActivePreview` click with no DPR reported (the synthetic/fallback path)
  leaves the point unscaled — confirms no regression on normal displays.
- Existing `preview-act.test.ts` suite still passes.
