### PR TITLE
feat(image_gen): let openai-codex images authenticate via a named provider

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1432,6 +1432,10 @@ stt:
 #   deepinfra:
 #     # Leave `model` blank for the first live `image-gen`-tagged result.
 #     model: ""
+#   # The Codex image backend normally uses Hermes-managed Codex OAuth. To
+#   # reuse a named provider credential instead (including key_cmd), set:
+#   # openai-codex:
+#   #   auth_provider: "my-codex-gateway"
 
 # =============================================================================
 # Response Pacing (Messaging Platforms)

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -24,8 +24,9 @@ import base64
 import json
 import logging
 import os
+from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple
 
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
@@ -179,6 +180,132 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
     return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
 
 
+class _CodexImageAuth(NamedTuple):
+    """Resolved credential and route for one Codex image request."""
+
+    token: str
+    base_url: str
+    extra_headers: Dict[str, str]
+
+
+def _configured_auth_provider() -> str:
+    """Return the optional named provider used for Codex image auth."""
+    cfg = _load_image_gen_config()
+    sub = cfg.get("openai-codex")
+    if not isinstance(sub, dict):
+        return ""
+    value = sub.get("auth_provider")
+    return value.strip() if isinstance(value, str) else ""
+
+
+@lru_cache(maxsize=16)
+def _cached_command_token_source(
+    key_cmd: str,
+    provider_label: str,
+) -> Callable[[], str]:
+    """Reuse ``key_cmd`` expiry caching across image-generation calls."""
+    from agent.command_token_source import build_command_token_provider
+
+    source = build_command_token_provider(key_cmd, provider_label)
+    if source is None:  # Defensive: callers only pass non-empty commands.
+        raise RuntimeError(
+            f"Image auth provider {provider_label!r} has an empty key_cmd"
+        )
+    return source
+
+
+class _NamedProviderRoute(NamedTuple):
+    """A named provider's identity and route, resolved without minting."""
+
+    requested: str
+    entry: Dict[str, Any]
+    label: str
+    base_url: str
+    extra_headers: Dict[str, str]
+
+
+def _lookup_named_provider(provider_name: str) -> _NamedProviderRoute:
+    """Find the ``providers.<name>`` entry backing Codex image auth.
+
+    Lookup only — this deliberately does NOT run ``key_cmd``, so availability
+    probes can validate configuration without the side effect of invoking the
+    user's auth helper. Raises when the entry is missing, disabled, or has no
+    route, so a typo can never silently fall through to a different provider.
+    """
+    from hermes_cli.config import normalize_extra_headers
+    from hermes_cli.runtime_provider import _get_named_custom_provider
+
+    requested = provider_name.strip()
+    if not requested.lower().startswith("custom:"):
+        requested = f"custom:{requested}"
+
+    # Returns None for entries that are absent OR carry ``enabled: false``,
+    # so a disabled provider fails closed rather than resolving anyway.
+    entry = _get_named_custom_provider(requested)
+    if not isinstance(entry, dict):
+        raise RuntimeError(
+            f"Named image auth provider {provider_name!r} was not found or is disabled"
+        )
+
+    label = str(entry.get("name") or provider_name).strip() or provider_name
+    base_url = str(entry.get("base_url") or "").strip().rstrip("/")
+    if not base_url:
+        raise RuntimeError(f"Image auth provider {label!r} has no base URL")
+    return _NamedProviderRoute(
+        requested,
+        entry,
+        label,
+        base_url,
+        normalize_extra_headers(entry.get("extra_headers")),
+    )
+
+
+def _resolve_named_provider_auth(provider_name: str) -> _CodexImageAuth:
+    """Resolve a named custom provider for the Codex image backend.
+
+    ``providers.<name>.key_cmd`` is deliberately handled through the shared
+    command-token source so its expiry cache and no-secret error contract stay
+    identical to normal inference. Static named-provider credentials continue
+    through the canonical runtime resolver.
+    """
+    from hermes_cli.config import normalize_extra_headers
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    route = _lookup_named_provider(provider_name)
+    label = route.label
+    base_url = route.base_url
+    extra_headers = route.extra_headers
+
+    key_cmd = str(route.entry.get("key_cmd") or "").strip()
+    if key_cmd:
+        token = _cached_command_token_source(key_cmd, label)()
+    else:
+        runtime = resolve_runtime_provider(requested=route.requested)
+        # resolve_runtime_provider() walks a fallback chain and will happily
+        # return a BUILT-IN provider (codex, openai, openrouter, …) when a name
+        # doesn't land on a custom entry. Adopting that would silently send the
+        # image request to an unrelated endpoint with an unrelated key, so
+        # require it to have resolved to the custom entry we just looked up.
+        if str(runtime.get("provider") or "").strip().lower() != "custom":
+            raise RuntimeError(
+                f"Image auth provider {label!r} resolved to built-in provider "
+                f"{str(runtime.get('provider') or 'unknown')!r}; refusing to "
+                "route image generation through an unrelated provider"
+            )
+        api_key = runtime.get("api_key")
+        token = api_key() if callable(api_key) else str(api_key or "").strip()
+        base_url = str(runtime.get("base_url") or base_url).strip().rstrip("/")
+        runtime_headers = normalize_extra_headers(runtime.get("extra_headers"))
+        if runtime_headers:
+            extra_headers = runtime_headers
+
+    # "no-key-required" is the resolver's sentinel for an open endpoint. The
+    # Codex Responses route is never open, so treat it as "no credential".
+    if not token or token == "no-key-required":
+        raise RuntimeError(f"Image auth provider {label!r} produced no credential")
+    return _CodexImageAuth(token, base_url, extra_headers)
+
+
 def _read_codex_access_token() -> Optional[str]:
     """Return a usable Codex OAuth token, or None.
 
@@ -195,6 +322,37 @@ def _read_codex_access_token() -> Optional[str]:
     except Exception as exc:
         logger.debug("Could not resolve Codex access token: %s", exc)
         return None
+
+
+def _resolve_codex_image_auth() -> Optional[_CodexImageAuth]:
+    """Resolve named-provider auth, then fall back to Hermes Codex OAuth."""
+    auth_provider = _configured_auth_provider()
+    if auth_provider:
+        return _resolve_named_provider_auth(auth_provider)
+    token = _read_codex_access_token()
+    if not token:
+        return None
+    return _CodexImageAuth(token, _CODEX_BASE_URL, {})
+
+
+def _codex_image_auth_available() -> bool:
+    """Cheap availability probe for :meth:`OpenAICodexImageGenProvider.is_available`.
+
+    ``is_available()`` is a fast, side-effect-free hot-path check: the image
+    registry calls it while resolving the active backend and the pet/tool paths
+    call it repeatedly. So a ``key_cmd`` provider is reported available on
+    CONFIGURATION alone — minting here would run the user's auth helper as a
+    side effect of a liveness question, once per probe. A helper that is broken
+    or expired still surfaces a precise error from ``generate()``.
+    """
+    auth_provider = _configured_auth_provider()
+    if not auth_provider:
+        return bool(_read_codex_access_token())
+    route = _lookup_named_provider(auth_provider)
+    if str(route.entry.get("key_cmd") or "").strip():
+        return True
+    # Static credential: resolving it is a config/env read, not a subprocess.
+    return bool(_resolve_named_provider_auth(auth_provider).token)
 
 
 def _sniff_image_mime(raw: bytes) -> Optional[str]:
@@ -452,6 +610,50 @@ def _iter_sse_json(response: Any):
         yield payload
 
 
+# Headers this request owns outright. A named provider's ``extra_headers`` may
+# legitimately carry route/account metadata (ChatGPT-Account-ID, Cloudflare
+# Access service tokens), but it must never reach the wire as a competing
+# Authorization header.
+_RESERVED_REQUEST_HEADERS = frozenset({"accept", "authorization", "content-type"})
+
+
+def _merge_request_headers(
+    base: Dict[str, str],
+    extra: Optional[Dict[str, str]],
+) -> Dict[str, str]:
+    """Overlay config *extra* headers on *base*, case-insensitively.
+
+    Two rules, both of which a plain ``dict.update()`` gets wrong:
+
+    1. Reserved headers are dropped. HTTP header names are case-insensitive but
+       ``dict`` keys are not, and httpx does NOT de-duplicate — a config entry
+       spelled ``authorization`` survives alongside the ``Authorization`` the
+       caller sets, and BOTH are sent, with the config-supplied one first. Most
+       upstreams honour the first, so config could otherwise override the
+       freshly minted bearer. Only the name is logged; values carry secrets.
+    2. Non-reserved overrides replace the existing key in place rather than
+       adding a case-variant twin, so ``chatgpt-account-id`` overrides
+       ``ChatGPT-Account-ID`` instead of being sent next to it.
+    """
+    merged = dict(base)
+    by_lower = {key.lower(): key for key in merged}
+    for raw_key, value in (extra or {}).items():
+        name = str(raw_key).strip()
+        if not name:
+            continue
+        lowered = name.lower()
+        if lowered in _RESERVED_REQUEST_HEADERS:
+            logger.debug(
+                "Ignoring reserved header %r from image auth provider config; "
+                "the resolved credential and content type are authoritative",
+                name,
+            )
+            continue
+        merged[by_lower.get(lowered, name)] = str(value)
+        by_lower.setdefault(lowered, name)
+    return merged
+
+
 def _collect_image_b64(
     token: str,
     *,
@@ -459,6 +661,8 @@ def _collect_image_b64(
     size: str,
     quality: str,
     input_images: Optional[List[Dict[str, str]]] = None,
+    base_url: str = _CODEX_BASE_URL,
+    extra_headers: Optional[Dict[str, str]] = None,
 ) -> Optional[Dict[str, str]]:
     """Stream a Codex Responses image_generation call.
 
@@ -471,7 +675,10 @@ def _collect_image_b64(
     import httpx
     from agent.auxiliary_client import _codex_cloudflare_headers
 
-    headers = _codex_cloudflare_headers(token)
+    # Named-provider headers supply route/account metadata. Authentication and
+    # content-negotiation headers stay authoritative so config cannot replace
+    # the freshly resolved bearer token.
+    headers = _merge_request_headers(_codex_cloudflare_headers(token), extra_headers)
     headers.update({
         "Accept": "text/event-stream",
         "Authorization": f"Bearer {token}",
@@ -488,7 +695,9 @@ def _collect_image_b64(
     final_b64: Optional[str] = None
     partial_b64: Optional[str] = None
     with httpx.Client(timeout=timeout, headers=headers) as http:
-        with http.stream("POST", f"{_CODEX_BASE_URL}/responses", json=payload) as response:
+        with http.stream(
+            "POST", f"{base_url.rstrip('/')}/responses", json=payload
+        ) as response:
             try:
                 response.raise_for_status()
             except httpx.HTTPStatusError as exc:
@@ -528,7 +737,11 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
         return "OpenAI (Codex auth)"
 
     def is_available(self) -> bool:
-        if not _read_codex_access_token():
+        try:
+            if not _codex_image_auth_available():
+                return False
+        except Exception as exc:
+            logger.debug("Could not resolve Codex image auth: %s", exc)
             return False
         try:
             import httpx  # noqa: F401
@@ -590,7 +803,16 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        if not _read_codex_access_token():
+        try:
+            auth = _resolve_codex_image_auth()
+        except Exception as exc:
+            return error_response(
+                error=f"Could not resolve configured Codex image authentication: {exc}",
+                error_type="auth_required",
+                provider="openai-codex",
+                aspect_ratio=aspect,
+            )
+        if auth is None:
             return error_response(
                 error=(
                     "No Codex/ChatGPT OAuth credentials available. Run "
@@ -614,20 +836,6 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
         tier_id, meta = _resolve_model()
         size = _SIZES.get(aspect, _SIZES["square"])
 
-        token = _read_codex_access_token()
-        if not token:
-            return error_response(
-                error=(
-                    "No Codex/ChatGPT OAuth credentials available. Run "
-                    "`hermes auth codex` (or `hermes setup` → Codex) to sign in."
-                ),
-                error_type="auth_required",
-                provider="openai-codex",
-                model=tier_id,
-                prompt=prompt,
-                aspect_ratio=aspect,
-            )
-
         try:
             input_images = _normalize_input_images(image_url, reference_image_urls)
         except Exception as exc:
@@ -644,11 +852,13 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             collected: Optional[Dict[str, str]] = None
             for attempt in range(_NONFINAL_RETRIES + 1):
                 collected = _collect_image_b64(
-                    token,
+                    auth.token,
                     prompt=prompt,
                     size=size,
                     quality=meta["quality"],
                     input_images=input_images or None,
+                    base_url=auth.base_url,
+                    extra_headers=auth.extra_headers,
                 )
                 if collected and collected.get("source") == "final" and collected.get("b64"):
                     break

--- a/plugins/image_gen/openai-codex/plugin.yaml
+++ b/plugins/image_gen/openai-codex/plugin.yaml
@@ -1,5 +1,5 @@
 name: openai-codex
 version: 1.0.0
-description: "OpenAI image generation backed by ChatGPT/Codex OAuth (gpt-image-2 via the Responses image_generation tool). Saves generated images to $HERMES_HOME/cache/images/."
+description: "OpenAI image generation backed by ChatGPT/Codex OAuth or a named credential provider (gpt-image-2 via the Responses image_generation tool). Saves generated images to $HERMES_HOME/cache/images/."
 author: NousResearch
 kind: backend

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import importlib
 import json
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -36,7 +37,9 @@ def _b64_png() -> str:
 @pytest.fixture(autouse=True)
 def _tmp_hermes_home(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    codex_plugin._cached_command_token_source.cache_clear()
     yield tmp_path
+    codex_plugin._cached_command_token_source.cache_clear()
 
 
 @pytest.fixture
@@ -127,7 +130,16 @@ class TestGenerate:
 
         captured = {}
 
-        def _collect(token, *, prompt, size, quality, input_images=None):
+        def _collect(
+            token,
+            *,
+            prompt,
+            size,
+            quality,
+            input_images=None,
+            base_url=None,
+            extra_headers=None,
+        ):
             captured.update(codex_plugin._build_responses_payload(
                 prompt=prompt,
                 size=size,
@@ -161,6 +173,39 @@ class TestGenerate:
         # Progressive previews disabled: partial frames were being saved as
         # finals and presented as smeared/unfinished images.
         assert tool["partial_images"] == 0
+
+    def test_generate_routes_through_named_auth_provider(
+        self, provider, monkeypatch
+    ):
+        monkeypatch.setattr(
+            codex_plugin,
+            "_load_image_gen_config",
+            lambda: {"openai-codex": {"auth_provider": "codex-passive"}},
+        )
+        monkeypatch.setattr(
+            codex_plugin,
+            "_resolve_named_provider_auth",
+            lambda name: codex_plugin._CodexImageAuth(
+                "passive-token",
+                "https://chatgpt.example/backend-api/codex",
+                {"ChatGPT-Account-ID": "acct-test"},
+            ),
+        )
+        captured = {}
+
+        def _collect(token, **kwargs):
+            captured["token"] = token
+            captured.update(kwargs)
+            return {"b64": _b64_png(), "source": "final"}
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
+
+        result = provider.generate("a cat")
+
+        assert result["success"] is True
+        assert captured["token"] == "passive-token"
+        assert captured["base_url"] == "https://chatgpt.example/backend-api/codex"
+        assert captured["extra_headers"] == {"ChatGPT-Account-ID": "acct-test"}
 
     def test_capabilities_advertise_image_inputs(self, provider):
         caps = provider.capabilities()
@@ -400,6 +445,252 @@ class TestGenerate:
 
 
 class TestRequestShape:
+    def test_named_provider_key_cmd_source_is_reused(self, monkeypatch):
+        entry = {
+            "name": "codex-passive",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "key_cmd": "token-helper print",
+            "extra_headers": {"ChatGPT-Account-ID": "acct-test"},
+        }
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda requested: entry,
+        )
+        token_source = Mock(return_value="passive-token")
+        builder = Mock(return_value=token_source)
+        monkeypatch.setattr(
+            "agent.command_token_source.build_command_token_provider", builder
+        )
+
+        first = codex_plugin._resolve_named_provider_auth("codex-passive")
+        second = codex_plugin._resolve_named_provider_auth("codex-passive")
+
+        assert first == second == codex_plugin._CodexImageAuth(
+            "passive-token",
+            "https://chatgpt.com/backend-api/codex",
+            {"ChatGPT-Account-ID": "acct-test"},
+        )
+        builder.assert_called_once_with("token-helper print", "codex-passive")
+        assert token_source.call_count == 2
+
+    def test_is_available_does_not_execute_key_cmd(self, monkeypatch):
+        """Availability is a hot-path probe; it must not run the auth helper."""
+        monkeypatch.setattr(
+            codex_plugin,
+            "_load_image_gen_config",
+            lambda: {"openai-codex": {"auth_provider": "codex-passive"}},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda requested: {
+                "name": "codex-passive",
+                "base_url": "https://gw.example/codex",
+                "key_cmd": "token-helper print",
+            },
+        )
+        builder = Mock(side_effect=AssertionError("key_cmd ran during is_available()"))
+        monkeypatch.setattr(
+            "agent.command_token_source.build_command_token_provider", builder
+        )
+
+        assert codex_plugin.OpenAICodexImageGenProvider().is_available() is True
+        builder.assert_not_called()
+
+    def test_missing_named_provider_never_falls_back_to_codex_oauth(
+        self, provider, monkeypatch
+    ):
+        """A typo'd/disabled auth_provider fails closed, it does not downgrade."""
+        monkeypatch.setattr(
+            codex_plugin,
+            "_load_image_gen_config",
+            lambda: {"openai-codex": {"auth_provider": "typo"}},
+        )
+        # _get_named_custom_provider returns None for absent AND disabled entries.
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda requested: None,
+        )
+        # Legacy OAuth IS present — so a pass here would prove silent fallback.
+        monkeypatch.setattr(
+            codex_plugin, "_read_codex_access_token", lambda: "codex-token"
+        )
+
+        assert provider.is_available() is False
+        result = provider.generate("a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "auth_required"
+
+    def test_named_provider_refuses_builtin_provider_fallback(self, monkeypatch):
+        """resolve_runtime_provider() must not reroute us to a built-in."""
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda requested: {
+                "name": "codex-passive",
+                "base_url": "https://gw.example/codex",
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda **kwargs: {
+                "provider": "codex",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "unrelated-builtin-key",
+            },
+        )
+
+        with pytest.raises(RuntimeError, match="refusing to route"):
+            codex_plugin._resolve_named_provider_auth("codex-passive")
+
+    def test_static_named_provider_uses_runtime_credential(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda requested: {
+                "name": "codex-passive",
+                "base_url": "https://gw.example/codex",
+                "extra_headers": {"ChatGPT-Account-ID": "from-entry"},
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda **kwargs: {
+                "provider": "custom",
+                "base_url": "https://gw.example/codex/",
+                "api_key": "static-key",
+                "extra_headers": {"ChatGPT-Account-ID": "from-runtime"},
+            },
+        )
+
+        assert codex_plugin._resolve_named_provider_auth(
+            "codex-passive"
+        ) == codex_plugin._CodexImageAuth(
+            "static-key",
+            "https://gw.example/codex",
+            {"ChatGPT-Account-ID": "from-runtime"},
+        )
+
+    def test_open_endpoint_sentinel_is_not_treated_as_a_credential(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda requested: {
+                "name": "codex-passive",
+                "base_url": "https://gw.example/codex",
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda **kwargs: {
+                "provider": "custom",
+                "base_url": "https://gw.example/codex",
+                "api_key": "no-key-required",
+            },
+        )
+
+        with pytest.raises(RuntimeError, match="produced no credential"):
+            codex_plugin._resolve_named_provider_auth("codex-passive")
+
+    def test_omitted_auth_provider_leaves_codex_oauth_path_untouched(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(codex_plugin, "_load_image_gen_config", lambda: {})
+        lookup = Mock(side_effect=AssertionError("named-provider lookup ran"))
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider", lookup
+        )
+        monkeypatch.setattr(
+            codex_plugin, "_read_codex_access_token", lambda: "codex-token"
+        )
+
+        assert codex_plugin._resolve_codex_image_auth() == codex_plugin._CodexImageAuth(
+            "codex-token", codex_plugin._CODEX_BASE_URL, {}
+        )
+        lookup.assert_not_called()
+
+    def test_named_provider_headers_and_route_reach_http_boundary(self, monkeypatch):
+        import httpx
+
+        seen = {}
+
+        def _handler(request):
+            seen["request"] = request
+            body = (
+                'event: response.output_item.done\n'
+                "data: "
+                + json.dumps({
+                    "item": {
+                        "type": "image_generation_call",
+                        "result": _b64_png(),
+                    }
+                })
+                + "\n\n"
+            )
+            return httpx.Response(200, text=body, request=request)
+
+        real_client = httpx.Client
+        monkeypatch.setattr(
+            httpx,
+            "Client",
+            lambda *args, **kwargs: real_client(
+                transport=httpx.MockTransport(_handler),
+                headers=kwargs.get("headers"),
+                timeout=kwargs.get("timeout"),
+            ),
+        )
+
+        result = codex_plugin._collect_image_b64(
+            "passive-token",
+            prompt="a cat",
+            size="1024x1024",
+            quality="low",
+            base_url="https://chatgpt.example/backend-api/codex",
+            extra_headers={
+                "ChatGPT-Account-ID": "acct-test",
+                "Authorization": "Bearer stale-token",
+                # Header names are case-insensitive on the wire but dict keys
+                # are not, and httpx does not de-duplicate: an unfiltered
+                # lowercase spelling would be sent ALONGSIDE the real bearer
+                # and win at upstreams that honour the first Authorization.
+                "authorization": "Bearer stale-token-lowercase",
+                "ACCEPT": "application/json",
+                "content-type": "text/plain",
+            },
+        )
+
+        assert result == {"b64": _b64_png(), "source": "final"}
+        request = seen["request"]
+        assert str(request.url) == "https://chatgpt.example/backend-api/codex/responses"
+        assert request.headers["ChatGPT-Account-ID"] == "acct-test"
+        # get_list() exposes every value sent under the name, so a smuggled
+        # duplicate cannot hide behind a single-value lookup.
+        assert request.headers.get_list("authorization") == ["Bearer passive-token"]
+        assert request.headers.get_list("accept") == ["text/event-stream"]
+        assert request.headers.get_list("content-type") == ["application/json"]
+
+    def test_config_headers_cannot_smuggle_a_second_authorization(self):
+        """Reserved headers are dropped regardless of the casing config uses."""
+        merged = codex_plugin._merge_request_headers(
+            {"User-Agent": "codex_cli_rs/0.0.0", "ChatGPT-Account-ID": "from-jwt"},
+            {
+                "Authorization": "Bearer a",
+                "authorization": "Bearer b",
+                "AUTHORIZATION": "Bearer c",
+                "Accept": "application/json",
+                "Content-Type": "text/plain",
+            },
+        )
+        assert not [k for k in merged if k.lower() in {"authorization", "accept", "content-type"}]
+        assert merged["User-Agent"] == "codex_cli_rs/0.0.0"
+
+    def test_config_headers_override_route_metadata_in_place(self):
+        """A case-variant override replaces the key instead of duplicating it."""
+        merged = codex_plugin._merge_request_headers(
+            {"User-Agent": "codex_cli_rs/0.0.0", "ChatGPT-Account-ID": "from-jwt"},
+            {"chatgpt-account-id": "from-config", "  ": "dropped"},
+        )
+        account_keys = [k for k in merged if k.lower() == "chatgpt-account-id"]
+        assert account_keys == ["ChatGPT-Account-ID"]
+        assert merged["ChatGPT-Account-ID"] == "from-config"
+        assert "  " not in merged
+
     def test_payload_omits_tool_choice(self):
         """Codex rejects every tool_choice shape for hosted image_generation."""
         payload = codex_plugin._build_responses_payload(

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -742,6 +742,173 @@ class TestRequestShape:
         assert len(message) < len(body)
 
 
+# ── Real key_cmd path ───────────────────────────────────────────────────────
+
+
+class TestKeyCmdRealPath:
+    """Drive the REAL command-token source (subprocess) through the plugin.
+
+    The upstream/mocked tests prove the plugin asks for the right builder and
+    reuses it; these prove the command actually runs, environment expansion
+    works, and the minted token is what lands in the auth record and on the
+    wire.
+    """
+
+    def test_key_cmd_real_subprocess_mints_and_env_expands(self, monkeypatch, tmp_path):
+        counter = tmp_path / "counter"
+        monkeypatch.setenv("CODEX_IMG_TEST_TOKEN", "minted-secret-token-123")
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda requested: {
+                "name": "codex-passive",
+                "base_url": "https://gw.example/codex",
+                # Real subprocess: appends a marker, then prints the
+                # env-expanded token. If env expansion regressed, the token
+                # would come back as the literal variable name.
+                "key_cmd": (
+                    f"printf 'x' >> {counter} && "
+                    "printf '%s' \"$CODEX_IMG_TEST_TOKEN\""
+                ),
+            },
+        )
+
+        first = codex_plugin._resolve_named_provider_auth("codex-passive")
+        second = codex_plugin._resolve_named_provider_auth("codex-passive")
+
+        assert first == second == codex_plugin._CodexImageAuth(
+            "minted-secret-token-123",
+            "https://gw.example/codex",
+            {},
+        )
+        # The no-TTL bearer is cached for a bounded window: the helper ran
+        # exactly once across both resolutions.
+        assert counter.read_text() == "x"
+
+    def test_generate_uses_real_key_cmd_token(self, provider, monkeypatch):
+        """generate() mints via the actual subprocess and sends that token."""
+        monkeypatch.setenv("CODEX_IMG_TEST_TOKEN", "minted-secret-token-123")
+        monkeypatch.setattr(
+            codex_plugin,
+            "_load_image_gen_config",
+            lambda: {"openai-codex": {"auth_provider": "codex-passive"}},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda requested: {
+                "name": "codex-passive",
+                "base_url": "https://gw.example/codex",
+                "key_cmd": "printf '%s' \"$CODEX_IMG_TEST_TOKEN\"",
+            },
+        )
+        captured = {}
+
+        def _collect(token, **kwargs):
+            captured["token"] = token
+            return {"b64": _b64_png(), "source": "final"}
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
+
+        result = provider.generate("a cat")
+
+        assert result["success"] is True
+        assert captured["token"] == "minted-secret-token-123"
+
+
+# ── No secret leakage ───────────────────────────────────────────────────────
+
+
+class TestNoSecretLeak:
+    def test_minted_token_and_key_cmd_never_reach_logs(
+        self, monkeypatch, caplog, tmp_path
+    ):
+        """DEBUG logs may name the provider, never the credential material."""
+        import logging
+
+        caplog.set_level(logging.DEBUG)
+        monkeypatch.setenv("CODEX_IMG_TEST_TOKEN", "minted-secret-token-123")
+        secret_cmd = (
+            f"printf 'x' >> {tmp_path / 'codex-leak-ctr'} && "
+            "printf '%s' \"$CODEX_IMG_TEST_TOKEN\""
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda requested: {
+                "name": "codex-passive",
+                "base_url": "https://gw.example/codex",
+                "key_cmd": secret_cmd,
+                "extra_headers": {
+                    "Authorization": "Bearer should-never-reach-wire",
+                },
+            },
+        )
+
+        codex_plugin._resolve_named_provider_auth("codex-passive")
+
+        blob = caplog.text
+        assert "minted-secret-token-123" not in blob
+        assert "should-never-reach-wire" not in blob
+        # key_cmd can legitimately embed a secret (--client-secret=…), so the
+        # command string itself must never be echoed back into a log record.
+        assert secret_cmd not in blob
+
+    def test_static_secret_never_reaches_logs(self, monkeypatch, caplog):
+        import logging
+
+        caplog.set_level(logging.DEBUG)
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda requested: {
+                "name": "codex-passive",
+                "base_url": "https://gw.example/codex",
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda **kwargs: {
+                "provider": "custom",
+                "api_key": "static-secret-456",
+                "base_url": "https://gw.example/codex",
+            },
+        )
+
+        auth = codex_plugin._resolve_named_provider_auth("codex-passive")
+
+        assert auth.token == "static-secret-456"
+        assert "static-secret-456" not in caplog.text
+
+    def test_failed_key_cmd_error_does_not_leak_command_or_output(
+        self, provider, monkeypatch, caplog
+    ):
+        """A broken auth helper must not leak its output or command string."""
+        import logging
+
+        caplog.set_level(logging.DEBUG)
+        secret_cmd = (
+            "printf 'stdout-SENTINEL'; printf 'stderr-SENTINEL' >&2; exit 1"
+        )
+        monkeypatch.setattr(
+            codex_plugin,
+            "_load_image_gen_config",
+            lambda: {"openai-codex": {"auth_provider": "codex-passive"}},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda requested: {
+                "name": "codex-passive",
+                "base_url": "https://gw.example/codex",
+                "key_cmd": secret_cmd,
+            },
+        )
+
+        result = provider.generate("a cat")
+
+        assert result["success"] is False
+        assert result["error_type"] == "auth_required"
+        assert "SENTINEL" not in result["error"]
+        assert secret_cmd not in result["error"]
+        assert "SENTINEL" not in caplog.text
+
+
 # ── Plugin entry point ──────────────────────────────────────────────────────
 
 

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -126,7 +126,7 @@ Scoped to the Feishu document-comment handler. Drives comment read/write operati
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
-| `image_generate` | Generate images from text prompts (text-to-image) or edit/transform an existing image (image-to-image) via the user-configured backend (FAL.ai, OpenAI, OpenAI Codex auth, xAI, Krea). Pass `image_url` to edit an image and `reference_image_urls` for style references; omit both for text-to-image. The model is user-configured and not selectable by the agent. Returns a single image URL or local path. | FAL_KEY / OPENAI_API_KEY / Codex OAuth / xAI OAuth / KREA_API_KEY |
+| `image_generate` | Generate images from text prompts (text-to-image) or edit/transform an existing image (image-to-image) via the user-configured backend (FAL.ai, OpenAI, OpenAI Codex auth, xAI, Krea). Pass `image_url` to edit an image and `reference_image_urls` for style references; omit both for text-to-image. The model is user-configured and not selectable by the agent. Returns a single image URL or local path. | FAL_KEY / OPENAI_API_KEY / Codex OAuth or named provider / xAI OAuth / KREA_API_KEY |
 
 ## `kanban` toolset
 

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -62,7 +62,7 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | `spotify` | backend (7 tools) | Native Spotify playback, queue, search, playlists, albums, library |
 | `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
 | `image_gen/openai` | image backend | OpenAI `gpt-image-2` image generation backend (alternative to FAL) |
-| `image_gen/openai-codex` | image backend | OpenAI image generation via Codex OAuth |
+| `image_gen/openai-codex` | image backend | OpenAI image generation via Codex OAuth or a named credential provider |
 | `image_gen/xai` | image backend | xAI `grok-2-image` backend |
 | `hermes-achievements` | dashboard tab | Steam-style collectible badges generated from your real Hermes session history |
 | `kanban/dashboard` | dashboard tab | Kanban board UI for the multi-agent dispatcher — tasks, comments, fan-out, board switching. See [Kanban Multi-Agent](./kanban.md). |

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -73,6 +73,54 @@ image_gen:
 to the global tool-worker limit, so image providers receive bounded parallel
 requests without allowing an image batch to bypass the agent's concurrency cap.
 
+### Codex images with a named credential provider
+
+The `openai-codex` image backend normally reads Hermes-managed ChatGPT/Codex
+OAuth credentials (`~/.hermes/auth.json`, provisioned with
+`hermes auth add openai-codex`). It can instead reuse an existing named
+provider, including one backed by
+[`key_cmd`](/integrations/providers#command-minted-credentials-key_cmd):
+
+```yaml
+providers:
+  codex-passive:
+    api: https://chatgpt.com/backend-api/codex
+    transport: codex_responses
+    key_cmd: "my-auth-helper print-token"
+    extra_headers:
+      ChatGPT-Account-ID: "your-account-id"
+
+image_gen:
+  provider: openai-codex
+  openai-codex:
+    auth_provider: codex-passive
+```
+
+Setting `image_gen.openai-codex.auth_provider` points image generation at that
+named `providers:` entry. The image request uses the entry's base URL and
+extra headers, and authenticates with the entry's credential: a
+command-minted token from `key_cmd`, or a static `api_key` inline in config /
+`key_env` naming an environment variable. Command-minted tokens run through
+the same expiry-aware cache and secret-safe error handling as normal
+inference, so a gateway token is minted once and reused until shortly before
+it expires. When `auth_provider` is omitted, the existing
+`hermes auth add openai-codex` flow is unchanged.
+
+Precedence: `auth_provider` wins over Hermes-managed Codex OAuth whenever it
+is set — the two paths never mix. Within the named provider entry,
+`key_cmd` beats a static `api_key` / `key_env` on the same entry, exactly as
+documented for inference providers.
+
+Two guardrails are worth knowing about:
+
+- `extra_headers` is for route and account metadata. `Authorization`, `Accept`,
+  and `Content-Type` are owned by the request and are ignored (in any casing)
+  if the provider declares them, so config can never shadow the freshly
+  resolved bearer token.
+- A named provider that is missing, disabled (`enabled: false`), or has no
+  credential is an error — Hermes does **not** quietly fall back to
+  Hermes-managed Codex OAuth or to any other provider.
+
 ### OpenRouter: the full Image API catalog
 
 With `image_gen.provider: openrouter`, the model picker lists OpenRouter's

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -304,7 +304,7 @@ Debug logs go to `./logs/image_tools_debug_<session_id>.json` with per-call deta
 
 ## Limitations
 
-- **Requires credentials** for the active backend (FAL `FAL_KEY` / Nous Subscription, `OPENAI_API_KEY`, xAI OAuth, `KREA_API_KEY`)
+- **Requires credentials** for the active backend (FAL `FAL_KEY` / Nous Subscription, `OPENAI_API_KEY`, Codex OAuth or named provider, xAI OAuth, `KREA_API_KEY`)
 - **Editing is model-dependent** — image-to-image works only on edit-capable models (see the table above); text-to-image-only models reject image inputs with a clear error
 - **Temporary URLs** — backends return hosted URLs that expire after hours/days; Hermes materializes them to the local cache so delivery still works after expiry
 - **Per-model constraints** — some models don't support `seed`, `num_inference_steps`, etc. The `supports` / `edit_supports` filter silently drops unsupported params; this is expected behavior


### PR DESCRIPTION
feat(image_gen): let openai-codex images authenticate via a named provider

Implements the design described in draft PR #91131 (azilko) — the image-gen
counterpart to #86891's `key_cmd` credential source. The bundled
`openai-codex` image backend previously could only use Hermes-managed
ChatGPT/Codex OAuth; users who reach Codex through a gateway that issues
short-lived bearers (`providers.<name>.key_cmd`) had no way to point image
generation at it.

## What

Adds `image_gen.openai-codex.auth_provider`. When set, the image request
resolves its bearer, base URL, and extra headers from that named
`providers:` entry:

- `key_cmd` routes through the shared `agent.command_token_source`
  (`_cached_command_token_source`, an `lru_cache` over
  `build_command_token_provider`), so its expiry-aware cache and
  secret-safe error contract are identical to normal inference.
- Static named-provider credentials resolve through the canonical
  `resolve_runtime_provider`, pinned to `provider == "custom"` — a name
  that resolves to a built-in provider (codex/openai/openrouter) is
  refused, not silently adopted.
- `is_available()` stays side-effect free: a `key_cmd` provider is
  reported available on configuration alone; the helper is never run by
  liveness probes. A broken helper surfaces a precise error from
  `generate()`.

When `auth_provider` is omitted, the existing Codex OAuth path is
byte-for-byte unchanged (same token reader, same `chatgpt.com` base URL,
same headers).

Fails closed by design:

- `extra_headers` cannot shadow `Authorization`/`Accept`/`Content-Type`
  in any casing (`_merge_request_headers` drops reserved names; httpx does
  not de-duplicate, so a config key spelled `authorization` would
  otherwise be sent alongside the real bearer and win at upstreams that
  honour the first one).
- Missing, disabled (`enabled: false`), or credential-less providers
  raise (`auth_required`) instead of quietly downgrading to Codex OAuth.
- No credential, token, or `key_cmd` string is ever logged — only header
  names in debug output.

## Files

- `plugins/image_gen/openai-codex/__init__.py` (+230/-20)
- `plugins/image_gen/openai-codex/plugin.yaml` (description updated)

Change is byte-identical to draft PR #91131's plugin portion (author Adam
Zilko, authorship preserved via `git commit --author`).

## Verification

- Existing suite `tests/plugins/image_gen/test_openai_codex_provider.py`:
  baseline 28/28 green before the change.
- With draft #91131's test updates applied temporarily: 39/39 pass on
  this change (the PR's own claims confirmed locally).
- 42-check E2E run against a temp `HERMES_HOME` exercising the REAL path
  (real config.yaml, real `providers:` lookup, real `key_cmd` subprocess):
  named-provider selection, key_cmd minting + expiry cache reuse,
  side-effect-free `is_available()`, reserved-header dropping, fail-closed
  missing/disabled/base-less/credential-less providers, OAuth fallback
  unchanged, and zero secret leakage into logs.
- `ruff check` clean (repo-pinned 0.15.10).

## Pipeline note

This is one card in a kanban pipeline for #91131: tests
(`tests/plugins/image_gen/test_openai_codex_provider.py` updates) and
documentation (`cli-config.yaml.example`, website
image-generation.md) land as follow-up commits to this same fork branch
from sibling tasks, then a reviewer approves the final state. Upstream
draft #91131 is the reference design; if it merges first, this PR can be
closed as redundant (same disposition as #90958 vs #90920).
