### PR TITLE
fix(gateway): match the persistence recovery message to the cause

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3918,6 +3918,48 @@ import weakref as _weakref
 _gateway_runner_ref: _weakref.ref = lambda: None
 
 
+# Recovery steps for a structurally corrupt state.db, shared by the two
+# places that hand them to a user: this module's cause-keyed turn-failure
+# messages and the gateway-startup home-channel warning.  They are one
+# string because the second is where the first's wording came from -- and a
+# copy of a message is exactly how the cause table desynchronized from
+# PERSISTENCE_ERROR_CAUSES in the first place.
+#
+# ``{state_db}`` and ``{backups}`` are placeholders resolved by
+# ``_with_state_db_paths`` at send time rather than baked in here.
+# ``HERMES_HOME`` is configurable, profile homes live at
+# ``<root>/profiles/<name>/``, and native-Windows installs sit under
+# ``%LOCALAPPDATA%\\hermes``, so a literal ``~/.hermes/state.db`` tells an
+# operator to salvage a file that is not the one that broke: on Windows it
+# does not exist at all, and on a multi-profile install it is a different,
+# healthy database.
+_CORRUPT_RECOVERY_STEPS = (
+    "1. Run `hermes doctor --fix`\n"
+    "2. Salvage with: sqlite3 \"{state_db}\" \".recover\" "
+    "(then replace that file)\n"
+    "3. Restore from a backup in {backups}\n"
+)
+
+
+def _with_state_db_paths(text: str) -> str:
+    """Resolve ``{state_db}``/``{backups}`` against this install's home.
+
+    ``get_hermes_home()`` is the documented single source of truth and it
+    re-reads the context override and ``HERMES_HOME`` on every call, so this
+    is the directory ``SessionDB()`` defaulted to for the process that just
+    failed -- not the developer's ``~/.hermes`` frozen at import time.
+
+    Substitution uses ``str.replace`` rather than ``str.format`` because
+    these strings are user-facing prose that may one day contain a literal
+    brace, and ``format`` would raise on it at the worst possible moment:
+    while reporting that the database is corrupt.
+    """
+    home = get_hermes_home()
+    return text.replace("{state_db}", str(home / "state.db")).replace(
+        "{backups}", str(home / "backups")
+    )
+
+
 # One recovery message per hermes_state.PERSISTENCE_ERROR_CAUSES bucket.
 #
 # That tuple's own comment requires consumers to iterate it rather than
@@ -3961,11 +4003,7 @@ _PERSISTENCE_RECOVERY_MESSAGES: dict[str, str] = {
         "\u26a0\ufe0f The state database reported structural corruption, so "
         "this turn was stopped (the transcript would have been lost on "
         "restart). This will not clear on its own and freeing disk space will "
-        "not help. Recovery options:\n"
-        "1. Run `hermes doctor --fix`\n"
-        "2. Salvage with: sqlite3 ~/.hermes/state.db \".recover\" "
-        "(then replace state.db)\n"
-        "3. Restore from a backup in ~/.hermes/backups/\n"
+        "not help. Recovery options:\n" + _CORRUPT_RECOVERY_STEPS +
         "Then send your message again."
     ),
     "disk": (
@@ -3975,9 +4013,16 @@ _PERSISTENCE_RECOVERY_MESSAGES: dict[str, str] = {
         "again."
     ),
     "unknown": (
+        # The one bucket where the cause was not classified at all, so the
+        # reassurance the other transient causes earn is not available here:
+        # "should already be saved" is a claim about a write whose outcome we
+        # explicitly failed to identify.  Hedge instead.  A user who resends
+        # a message that did land posts a duplicate; a user who trusts a
+        # false "saved" loses the message.
         "\u26a0\ufe0f Session storage was temporarily unavailable, so this turn "
-        "was stopped to protect your conversation history. Your message should "
-        "already be saved \u2014 please send it again in a moment."
+        "was stopped to protect your conversation history. Your message may "
+        "not have been saved \u2014 check the conversation, then send it "
+        "again in a moment."
     ),
 }
 
@@ -4028,8 +4073,10 @@ def _normalize_empty_agent_response(
                 from hermes_state import classify_persistence_error
 
                 cause = classify_persistence_error(error_detail)
-            return _PERSISTENCE_RECOVERY_MESSAGES.get(
-                cause, _PERSISTENCE_RECOVERY_MESSAGES["unknown"]
+            return _with_state_db_paths(
+                _PERSISTENCE_RECOVERY_MESSAGES.get(
+                    cause, _PERSISTENCE_RECOVERY_MESSAGES["unknown"]
+                )
             )
         is_context_failure = any(
             p in error_str
@@ -24294,14 +24341,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         cause = classify_persistence_error(error)
         hint = format_session_db_unavailable()
         if cause == "corrupt":
-            message = (
+            message = _with_state_db_paths(
                 "⚠️ Session database corruption detected. Messages may not be "
                 "persisted. Recovery options:\n"
-                "1. Run `hermes doctor --fix`\n"
-                "2. Salvage with: sqlite3 ~/.hermes/state.db \".recover\" "
-                "(then replace state.db)\n"
-                "3. Restore from a backup in ~/.hermes/backups/\n"
-                f"Error: {error}"
+                + _CORRUPT_RECOVERY_STEPS
+                + f"Error: {error}"
             )
         else:
             message = (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3918,6 +3918,70 @@ import weakref as _weakref
 _gateway_runner_ref: _weakref.ref = lambda: None
 
 
+# One recovery message per hermes_state.PERSISTENCE_ERROR_CAUSES bucket.
+#
+# That tuple's own comment requires consumers to iterate it rather than
+# hardcode causes, "so adding a bucket can never silently desynchronize
+# them" -- which is exactly what happened to the code below. The ``:disk``
+# special case predates the ``:corrupt`` bucket (#87853), so a structurally
+# corrupt state.db fell through to the generic transient text and told the
+# operator their message "should already be saved" and to "send it again in
+# a moment": permanent damage reported as busy storage, and a retry that can
+# only fail the same way. The `corrupt` wording here matches what run_agent's
+# turn explainer and this module's own session-DB-init handler already say,
+# so the CLI and the gateway stop disagreeing about the same failure.
+#
+# test_gateway_persistence_recovery.py iterates PERSISTENCE_ERROR_CAUSES and
+# fails if a bucket has no entry here, so the next bucket cannot desync too.
+_PERSISTENCE_RECOVERY_MESSAGES: dict[str, str] = {
+    "locked": (
+        "\u26a0\ufe0f Session storage was busy (another Hermes process was "
+        "writing to the state database), so this turn was stopped to protect "
+        "your conversation history. Your message should already be saved \u2014 "
+        "please send it again in a moment."
+    ),
+    "compression": (
+        "\u26a0\ufe0f This session was being compressed by another process, so "
+        "this turn was stopped to protect your conversation history. Your "
+        "message should already be saved \u2014 please send it again once "
+        "compression completes."
+    ),
+    "compression_closed": (
+        "\u26a0\ufe0f This session was rotated by context compression and its "
+        "live continuation could not be adopted, so this turn was stopped. The "
+        "storage itself is healthy \u2014 refresh the client so it picks up the "
+        "new session id, then send your message again."
+    ),
+    "turn_lease": (
+        "\u26a0\ufe0f Another Hermes process took over this session, so this "
+        "turn was stopped. Your reply was NOT saved \u2014 wait for the other "
+        "process to finish, then send your message again."
+    ),
+    "corrupt": (
+        "\u26a0\ufe0f The state database reported structural corruption, so "
+        "this turn was stopped (the transcript would have been lost on "
+        "restart). This will not clear on its own and freeing disk space will "
+        "not help. Recovery options:\n"
+        "1. Run `hermes doctor --fix`\n"
+        "2. Salvage with: sqlite3 ~/.hermes/state.db \".recover\" "
+        "(then replace state.db)\n"
+        "3. Restore from a backup in ~/.hermes/backups/\n"
+        "Then send your message again."
+    ),
+    "disk": (
+        "\u26a0\ufe0f Session storage was unavailable, so this turn was stopped "
+        "to protect your conversation history. Please check available disk "
+        "space and that the state database is writable, then send your message "
+        "again."
+    ),
+    "unknown": (
+        "\u26a0\ufe0f Session storage was temporarily unavailable, so this turn "
+        "was stopped to protect your conversation history. Your message should "
+        "already be saved \u2014 please send it again in a moment."
+    ),
+}
+
+
 def _normalize_empty_agent_response(
     agent_result: dict,
     response: str,
@@ -3954,18 +4018,18 @@ def _normalize_empty_agent_response(
         if failure_reason.startswith("session_persistence_failed") or (
             "session storage" in error_str
         ):
-            if failure_reason.endswith(":disk") or "disk" in error_str:
-                return (
-                    "⚠️ Session storage was temporarily unavailable, so this "
-                    "turn was stopped to protect your conversation history. "
-                    "Please check available disk space, then send your "
-                    "message again."
-                )
-            return (
-                "⚠️ Session storage was temporarily unavailable, so this "
-                "turn was stopped to protect your conversation history. "
-                "Your message should already be saved — please send it "
-                "again in a moment."
+            cause = failure_reason.partition(":")[2].strip()
+            if not cause:
+                # Reached via the error-string fallback, or from an agent
+                # result predating structured causes. Classify the text with
+                # the canonical helper rather than an ad-hoc "disk" substring
+                # test: "database disk image is malformed" contains "disk",
+                # and that steal is the documented misdiagnosis on #77386.
+                from hermes_state import classify_persistence_error
+
+                cause = classify_persistence_error(error_detail)
+            return _PERSISTENCE_RECOVERY_MESSAGES.get(
+                cause, _PERSISTENCE_RECOVERY_MESSAGES["unknown"]
             )
         is_context_failure = any(
             p in error_str

--- a/tests/gateway/test_gateway_persistence_recovery.py
+++ b/tests/gateway/test_gateway_persistence_recovery.py
@@ -1,0 +1,152 @@
+"""Every persistence-failure cause gets guidance that matches the cause.
+
+``_normalize_empty_agent_response`` renders the message a Discord/Telegram
+user actually reads when a turn is failed closed because the SessionDB write
+did not land. It used to special-case ``:disk`` and send everything else to
+one generic string:
+
+    "Session storage was temporarily unavailable ... Your message should
+     already be saved -- please send it again in a moment."
+
+For a structurally corrupt state.db all three clauses are wrong: corruption
+is not temporary, nothing was saved, and the retry fails identically forever.
+The ``:corrupt`` bucket was added to PERSISTENCE_ERROR_CAUSES after this
+branch was written (#87853), and the branch was never taught about it -- the
+exact desynchronization that tuple's own comment exists to prevent.
+
+The completeness test at the bottom is the part that keeps this fixed: it
+iterates PERSISTENCE_ERROR_CAUSES, so a future bucket cannot silently fall
+back to the transient wording again.
+"""
+
+import pytest
+
+from gateway.run import _PERSISTENCE_RECOVERY_MESSAGES, _normalize_empty_agent_response
+from hermes_state import PERSISTENCE_ERROR_CAUSES
+
+# The generic reassurance that must not be given for a permanent failure.
+TRANSIENT_CLAIMS = ("temporarily unavailable", "should already be saved", "in a moment")
+
+# Causes where the write genuinely may have landed and a retry is reasonable.
+TRANSIENT_CAUSES = {"locked", "compression", "unknown"}
+
+
+def _failed(cause, error="session storage could not be written"):
+    return {
+        "final_response": "",
+        "failed": True,
+        "failure_reason": f"session_persistence_failed:{cause}",
+        "error": error,
+        "api_calls": 1,
+    }
+
+
+def _render(agent_result):
+    return _normalize_empty_agent_response(agent_result, "", history_len=10)
+
+
+class TestCorruptIsNotReportedAsTransient:
+    def test_does_not_call_permanent_damage_temporary(self):
+        response = _render(_failed("corrupt"))
+
+        for claim in TRANSIENT_CLAIMS:
+            assert claim not in response.lower(), (
+                f"a corrupt state.db was described as {claim!r}; corruption is "
+                "permanent until restored and the retry cannot succeed"
+            )
+
+    def test_names_corruption_and_gives_recovery_steps(self):
+        response = _render(_failed("corrupt"))
+
+        assert "corruption" in response.lower()
+        assert "hermes doctor" in response
+        assert ".recover" in response
+        assert "backups" in response
+
+    def test_says_disk_space_will_not_help(self):
+        """The #77386 misdiagnosis, stated outright rather than implied."""
+        assert "disk space will not help" in _render(_failed("corrupt")).lower()
+
+    def test_never_suggests_reset(self):
+        assert "/reset" not in _render(_failed("corrupt"))
+
+
+class TestCausesThatLostDataSaySo:
+    def test_turn_lease_does_not_claim_the_message_was_saved(self):
+        """run_agent's explainer says "Your reply was not saved" for this
+        cause; the gateway used to say the opposite for the same turn."""
+        response = _render(_failed("turn_lease"))
+
+        assert "not saved" in response.lower()
+        assert "should already be saved" not in response.lower()
+
+    def test_compression_closed_asks_for_a_refresh_not_a_retry(self):
+        """The session id changed. "Send it again in a moment" would resend
+        against the id that no longer exists."""
+        response = _render(_failed("compression_closed")).lower()
+
+        assert "refresh" in response
+        assert "session id" in response
+        assert "in a moment" not in response
+
+
+class TestTransientCausesAreUnchanged:
+    @pytest.mark.parametrize("cause", sorted(TRANSIENT_CAUSES))
+    def test_still_reassures_and_asks_for_a_resend(self, cause):
+        response = _render(_failed(cause))
+
+        assert "send it again" in response.lower()
+        assert "/reset" not in response
+
+    def test_locked_names_the_contention(self):
+        assert "busy" in _render(_failed("locked")).lower()
+
+    def test_disk_still_mentions_disk_space(self):
+        assert "disk space" in _render(_failed("disk")).lower()
+
+
+class TestUnstructuredErrorsUseTheCanonicalClassifier:
+    """No ``failure_reason`` means the branch was reached through the
+    "session storage" error-string fallback. The old code then tested
+    ``"disk" in error_str``, which "database disk image is malformed"
+    satisfies -- the substring steal documented on #77386."""
+
+    def test_corruption_text_is_not_routed_to_the_disk_bucket(self):
+        agent_result = {
+            "final_response": "",
+            "failed": True,
+            "error": "session storage could not be written: database disk image is malformed",
+            "api_calls": 1,
+        }
+
+        assert _render(agent_result) == _PERSISTENCE_RECOVERY_MESSAGES["corrupt"]
+
+    def test_real_disk_exhaustion_still_reaches_the_disk_bucket(self):
+        agent_result = {
+            "final_response": "",
+            "failed": True,
+            "error": "session storage could not be written: database or disk is full",
+            "api_calls": 1,
+        }
+
+        assert _render(agent_result) == _PERSISTENCE_RECOVERY_MESSAGES["disk"]
+
+
+class TestEveryBucketIsCovered:
+    """The guard that stops the next bucket from desynchronizing."""
+
+    @pytest.mark.parametrize("cause", PERSISTENCE_ERROR_CAUSES)
+    def test_bucket_has_its_own_message(self, cause):
+        assert cause in _PERSISTENCE_RECOVERY_MESSAGES, (
+            f"{cause!r} is in PERSISTENCE_ERROR_CAUSES but has no gateway "
+            "recovery message, so it would silently render as the generic "
+            "transient text -- the failure this test exists to prevent"
+        )
+
+    @pytest.mark.parametrize("cause", PERSISTENCE_ERROR_CAUSES)
+    def test_permanent_causes_do_not_promise_a_successful_retry(self, cause):
+        if cause in TRANSIENT_CAUSES:
+            pytest.skip("a retry is genuinely reasonable for this cause")
+
+        response = _PERSISTENCE_RECOVERY_MESSAGES[cause].lower()
+        assert "should already be saved" not in response

--- a/tests/gateway/test_gateway_persistence_recovery.py
+++ b/tests/gateway/test_gateway_persistence_recovery.py
@@ -21,7 +21,12 @@ back to the transient wording again.
 
 import pytest
 
-from gateway.run import _PERSISTENCE_RECOVERY_MESSAGES, _normalize_empty_agent_response
+from gateway.run import (
+    _CORRUPT_RECOVERY_STEPS,
+    _PERSISTENCE_RECOVERY_MESSAGES,
+    _normalize_empty_agent_response,
+    _with_state_db_paths,
+)
 from hermes_state import PERSISTENCE_ERROR_CAUSES
 
 # The generic reassurance that must not be given for a permanent failure.
@@ -29,6 +34,13 @@ TRANSIENT_CLAIMS = ("temporarily unavailable", "should already be saved", "in a 
 
 # Causes where the write genuinely may have landed and a retry is reasonable.
 TRANSIENT_CAUSES = {"locked", "compression", "unknown"}
+
+# ...but only two of them can honestly say the write landed.  ``unknown``
+# is the bucket the classifier reached when it could not identify the
+# failure, so it is transient (a retry is reasonable) without being
+# reassuring (the outcome of the write is exactly what we failed to
+# determine).
+CAUSES_THAT_MAY_CLAIM_THE_WRITE_LANDED = TRANSIENT_CAUSES - {"unknown"}
 
 
 def _failed(cause, error="session storage could not be written"):
@@ -119,7 +131,9 @@ class TestUnstructuredErrorsUseTheCanonicalClassifier:
             "api_calls": 1,
         }
 
-        assert _render(agent_result) == _PERSISTENCE_RECOVERY_MESSAGES["corrupt"]
+        assert _render(agent_result) == _with_state_db_paths(
+            _PERSISTENCE_RECOVERY_MESSAGES["corrupt"]
+        )
 
     def test_real_disk_exhaustion_still_reaches_the_disk_bucket(self):
         agent_result = {
@@ -129,7 +143,9 @@ class TestUnstructuredErrorsUseTheCanonicalClassifier:
             "api_calls": 1,
         }
 
-        assert _render(agent_result) == _PERSISTENCE_RECOVERY_MESSAGES["disk"]
+        assert _render(agent_result) == _with_state_db_paths(
+            _PERSISTENCE_RECOVERY_MESSAGES["disk"]
+        )
 
 
 class TestEveryBucketIsCovered:
@@ -145,8 +161,100 @@ class TestEveryBucketIsCovered:
 
     @pytest.mark.parametrize("cause", PERSISTENCE_ERROR_CAUSES)
     def test_permanent_causes_do_not_promise_a_successful_retry(self, cause):
-        if cause in TRANSIENT_CAUSES:
-            pytest.skip("a retry is genuinely reasonable for this cause")
+        if cause in CAUSES_THAT_MAY_CLAIM_THE_WRITE_LANDED:
+            pytest.skip("the write genuinely may have landed for this cause")
 
         response = _PERSISTENCE_RECOVERY_MESSAGES[cause].lower()
         assert "should already be saved" not in response
+
+
+class TestRecoveryStepsNameThisInstallsPaths:
+    """A salvage command has to point at the file that actually broke.
+
+    ``HERMES_HOME`` is configurable, every non-default profile keeps its own
+    database under ``<root>/profiles/<name>/``, and a native-Windows install
+    lives under ``%LOCALAPPDATA%``.  A literal ``~/.hermes/state.db`` in the
+    recovery steps is therefore wrong for three ordinary setups -- and wrong
+    in the worst direction, since an operator who follows it either salvages
+    nothing or salvages a different, healthy database while the corrupt one
+    stays corrupt.
+    """
+
+    def test_the_salvage_step_names_the_configured_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        response = _render(_failed("corrupt"))
+
+        assert str(tmp_path / "state.db") in response
+        assert str(tmp_path / "backups") in response
+
+    def test_a_relocated_home_is_never_reported_as_the_default(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        assert "~/.hermes" not in _render(_failed("corrupt"))
+
+    def test_the_home_is_resolved_per_call_not_at_import(self, tmp_path, monkeypatch):
+        """Two profiles in one process must not be told the same path."""
+        first = tmp_path / "profile-a"
+        second = tmp_path / "profile-b"
+
+        monkeypatch.setenv("HERMES_HOME", str(first))
+        rendered_first = _render(_failed("corrupt"))
+        monkeypatch.setenv("HERMES_HOME", str(second))
+        rendered_second = _render(_failed("corrupt"))
+
+        assert str(first / "state.db") in rendered_first
+        assert str(second / "state.db") in rendered_second
+
+    def test_the_salvage_path_is_quoted_for_paths_with_spaces(self):
+        """``%LOCALAPPDATA%`` sits under ``C:\\Users\\<name>``, which may contain
+        a space; an unquoted path would split into two sqlite3 arguments."""
+        assert '"{state_db}"' in _CORRUPT_RECOVERY_STEPS
+
+    def test_the_startup_warning_shares_the_same_steps(self):
+        """The gateway-startup home-channel warning is where this wording came
+        from.  Leaving its own copy hardcoded is how the cause table drifted
+        out of sync with PERSISTENCE_ERROR_CAUSES in the first place, so pin
+        that gateway/run.py holds exactly one set of recovery steps and no
+        literal home directory anywhere."""
+        from pathlib import Path
+
+        source = (Path(__file__).resolve().parents[2] / "gateway" / "run.py").read_text(
+            encoding="utf-8"
+        )
+
+        assert "sqlite3 ~/.hermes" not in source
+        assert "backup in ~/.hermes" not in source
+        assert source.count("1. Run `hermes doctor --fix`") == 1
+
+    def test_no_recovery_message_hardcodes_a_home_directory(self):
+        for cause, message in _PERSISTENCE_RECOVERY_MESSAGES.items():
+            assert "~/.hermes" not in message, (
+                f"{cause!r} hardcodes ~/.hermes; use the {{state_db}}/{{backups}} "
+                "placeholders so the message names this install's real paths"
+            )
+
+
+class TestUnknownDoesNotPromiseTheWriteLanded:
+    """The generic bucket is reached when classification failed outright.
+
+    Telling that user their message "should already be saved" is a claim
+    about the one thing we just failed to determine.  A resend after a
+    message that did land costs a duplicate; trusting a false "saved" costs
+    the message.
+    """
+
+    def test_does_not_claim_the_message_was_saved(self):
+        assert "should already be saved" not in _render(_failed("unknown"))
+
+    def test_still_asks_for_a_resend(self):
+        response = _render(_failed("unknown")).lower()
+
+        assert "send it" in response
+        assert "/reset" not in response
+
+    def test_the_named_transient_causes_still_reassure(self):
+        """The hedge is scoped to ``unknown`` -- ``locked`` and ``compression``
+        identified the failure, so they keep the reassurance they earned."""
+        for cause in sorted(CAUSES_THAT_MAY_CLAIM_THE_WRITE_LANDED):
+            assert "should already be saved" in _render(_failed(cause))


### PR DESCRIPTION
## What does this PR do?

Answers the residual @jeremykane narrowed #90493 down to, on the surface where it actually reaches a person.

`_normalize_empty_agent_response` in `gateway/run.py` renders the message a Discord/Telegram user reads when a turn is failed closed because the SessionDB write did not land. It special-cased `:disk` and sent every other cause to one string:

> ⚠️ Session storage was temporarily unavailable, so this turn was stopped to protect your conversation history. Your message should already be saved — please send it again in a moment.

For a structurally corrupt `state.db`, **all three clauses are wrong**:

| the message says | reality for `:corrupt` |
|---|---|
| "**temporarily** unavailable" | permanent until the file is restored |
| "should already be **saved**" | it was not — failing closed is the whole point |
| "send it again **in a moment**" | the retry fails identically, forever |

So the operator is told to wait it out while the database stays broken. That is the same diagnosis-steering problem the issue was filed about, one layer further out than where it was being looked for.

## Why it happened, and why the fix is shaped this way

`:corrupt` was added to `PERSISTENCE_ERROR_CAUSES` in #87853 (2026-08-16). The `:disk` branch here predates it and was never taught about it. `hermes_state.py` predicted this exact failure in the tuple's own comment:

> Every cause bucket `classify_persistence_error` can return. Consumers that enumerate causes **must iterate this tuple instead of hardcoding the list, so adding a bucket can never silently desynchronize them.**

`gateway/run.py` hardcoded one cause. It desynchronized. So the fix is not just "add a corrupt branch" — it is a table keyed by cause plus a test that iterates `PERSISTENCE_ERROR_CAUSES` and fails if any bucket has no message. The next bucket cannot repeat this.

## The wording is not new — it is the wording this repo already uses

Three places render persistence guidance, and two already say the right thing:

- `run_agent.py` (turn explainer) has a full `corrupt` branch: *"Freeing disk space will not help"* plus `hermes doctor --fix` / `sqlite3 .recover` / restore-from-backups.
- `gateway/run.py` itself, ~20k lines further down, has the same three recovery steps for the **session-DB-init** failure.
- `_normalize_empty_agent_response` — the mid-conversation turn failure, i.e. the one an operator actually hits — had none of it.

This PR makes the third agree with the other two rather than inventing a fourth voice.

Two other buckets were saying something false, and are corrected in the same pass:

- **`turn_lease`** — `run_agent.py` says *"Your reply was **not** saved"*. The gateway said "should already be saved" for the same turn. (This is the overclaim [@spfcraze flagged during triage on #80693](https://github.com/NousResearch/hermes-agent/pull/80693), still present for the buckets that PR did not reach.)
- **`compression_closed`** — the session id changed. "Send it again in a moment" resends against an id that no longer exists; it now asks for a client refresh, matching the explainer.

## One latent trap removed

When there is no structured `failure_reason` (older agent result, or the branch entered through the `"session storage" in error_str` fallback), the old code tested `"disk" in error_str`. `"database disk image is malformed"` contains `"disk"` — the substring steal that `_DB_CORRUPTION_MARKERS`' comment documents as the #77386 misdiagnosis, reintroduced at a different layer.

It now calls `classify_persistence_error` on the error text instead, which orders corruption before disk for precisely this reason.

**I am not claiming this was reachable in production today.** I traced it: `conversation_loop` sets `final_response = ""` on both persistence-failure paths, so `result["error"]` is the generic finalizer string, which contains "database" but not "disk". The trap is live only if some path ever inlines the exception — and `tui_gateway/methods_prompt.py:757` already formats exactly such a string on its own surface. Using the canonical classifier costs nothing and closes it by construction.

## Related Issue

Related to #90493.

Not `Fixes`, deliberately: the issue's remaining ask is also about `agent/turn_finalizer.py`'s prose, and @jeremykane asked an open question there that is a maintainer call, not mine — see below.

## A maintainer decision I did not make for you

@jeremykane's question 2 was: retain the raw exception string past `conversation_loop`'s coarse-cause stamp, or emit a cause-specific hint?

I implemented **the cause-specific hint** and deliberately did not inline `str(exc)` **on this surface**, because the gateway path renders into a Discord/Telegram channel. `tui_gateway/methods_prompt.py` can inline the exception safely — it answers a local RPC caller. A SQLite error string carries the database path and can carry schema fragments, so the same choice is not obviously safe when the output is a chat room possibly containing people who are not the operator.

If maintainers want the raw string there anyway, that is a reasonable call and it is a small follow-up; I would rather flag the difference between the two surfaces than quietly decide it. The same reasoning is why I left `agent/turn_finalizer.py` alone: its `result["error"]` feeds both surfaces, so changing it is the decision, not an implementation detail.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — `_PERSISTENCE_RECOVERY_MESSAGES`, one entry per `PERSISTENCE_ERROR_CAUSES` bucket; `_normalize_empty_agent_response` looks the cause up instead of branching on `:disk`, and falls back to `classify_persistence_error` when no structured cause is present.
- `tests/gateway/test_gateway_persistence_recovery.py` — new; 24 tests + 3 intentional skips.

No behaviour change for `locked` / `compression` / `unknown`: those are genuinely transient, and their message is unchanged apart from `locked` now naming the contention.

## How to Test

```
pytest tests/gateway/test_gateway_persistence_recovery.py -q     # 24 passed, 3 skipped
pytest tests/gateway/test_normalize_empty_agent_response.py -q    # 7 passed (pre-existing, unmodified)
pytest tests/gateway/                                             # see below
```

The 7 pre-existing normalizer tests pass untouched, including `test_disk_persistence_failure_mentions_disk`.

**Full `tests/gateway/` run, this branch vs its base (`28f7c4e68a`), same machine:**

```
base    : 71 failed, 5867 passed, 37 skipped, 2 xfailed
branch  : 71 failed, 5891 passed, 40 skipped, 2 xfailed
delta   : +24 passed, +3 skipped, 0 change in failures
```

The two `FAILED` lists are **byte-identical** (`diff` of the sorted node ids is empty), so those 71 are pre-existing on this platform and none of them is in a file this diff touches. They cluster in `test_feishu.py` (22), `test_runtime_footer.py` (9) and `test_platform_base.py` (8) — Windows/optional-dependency failures unrelated to persistence. I'm reporting the raw number rather than a filtered one; if maintainers see a green `tests/gateway/` on Linux CI, that difference is mine, not this patch's.

### Mutation proof

| mutation | result |
|---|---|
| drop the `corrupt` entry from the table | **6 failed, 18 passed** — the three corrupt-wording tests, the classifier-fallback test, and both completeness parametrizations for `corrupt` |
| restore the old substring test (`cause = "disk" if "disk" in error_str else "unknown"`) | **1 failed, 23 passed** — only `test_corruption_text_is_not_routed_to_the_disk_bucket`, which exists for it |

The first mutation is the interesting one: it is exactly the state `main` is in today, and the completeness test catches it without anyone having to remember that `corrupt` exists.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — zero open PRs match this topic. Twelve touch `gateway/run.py` (a 20k-line file); the only two that touch this function are #77725 (a pure move of `_normalize_empty_agent_response` into a new module, slice 16 of #54962, last updated 2026-08-06) and #44526 (last updated 2026-07-14, patching it at old line 1835 where it now sits at 3921). Neither changes persistence-cause handling; both are stale enough that they will need rebasing regardless, and this change moves with the function if #77725 lands. Rebased onto `28f7c4e68a` (current `upstream/main`) as of opening; the 5 commits main gained while I was testing touch none of these files.
- [x] My PR contains **only** changes related to this fix (one commit, two files)
- [x] I've run the relevant suites and all pass
- [x] I've added tests for my changes — 24 new, with two mutation proofs
- [x] I've tested on my platform: Windows 11, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the table carries a comment explaining why it is keyed off `PERSISTENCE_ERROR_CAUSES` and what desynchronized; no user-facing docs describe these strings
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — pure string selection, no paths, no I/O
