### PR TITLE
fix(mcp): restrict catalog environment writes

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -219,6 +219,9 @@ _ENV_VAR_NAME_DENYLIST: frozenset[str] = frozenset({
     # MCP catalog trust root. Package-manager wrappers may still provide this
     # in the process environment; only generic persistence writes are blocked.
     "HERMES_OPTIONAL_MCPS",
+    # Local ACP subprocess selection. Existing operator/package-manager values
+    # remain readable; generic writers cannot acquire executable/argv authority.
+    "HERMES_COPILOT_ACP_COMMAND", "HERMES_COPILOT_ACP_ARGS",
     # Hermes security policy / approval-routing context. These remain available
     # through their dedicated CLI/config/session controls, but a generic
     # credential writer must not persist them for the next process startup.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -216,6 +216,9 @@ _ENV_VAR_NAME_DENYLIST: frozenset[str] = frozenset({
     # HERMES_LANGFUSE_*, HERMES_SPOTIFY_*, ...) ARE allowed.
     "HERMES_HOME", "HERMES_PROFILE", "HERMES_CONFIG", "HERMES_ENV",
     "HERMES_CONFIG_PATH", "HERMES_ENV_PATH",
+    # MCP catalog trust root. Package-manager wrappers may still provide this
+    # in the process environment; only generic persistence writes are blocked.
+    "HERMES_OPTIONAL_MCPS",
     # Hermes security policy / approval-routing context. These remain available
     # through their dedicated CLI/config/session controls, but a generic
     # credential writer must not persist them for the next process startup.
@@ -226,13 +229,24 @@ _ENV_VAR_NAME_DENYLIST: frozenset[str] = frozenset({
 })
 
 
+def _env_var_policy_name(key: str, *, is_windows: Optional[bool] = None) -> str:
+    """Return the name used for environment policy comparisons.
+
+    Windows environment names are case-insensitive; POSIX names are not. The
+    explicit override keeps both semantics directly testable without pretending
+    the test interpreter is running on another host OS.
+    """
+    windows = _IS_WINDOWS if is_windows is None else is_windows
+    return key.upper() if windows else key
+
+
 def _reject_denylisted_env_var(key: str) -> None:
     """Raise if ``key`` is in :data:`_ENV_VAR_NAME_DENYLIST`.
 
     Centralised so both the regular and "secure" env writers share the
     same gate, and so the message is consistent for callers.
     """
-    if key in _ENV_VAR_NAME_DENYLIST:
+    if _env_var_policy_name(key) in _ENV_VAR_NAME_DENYLIST:
         raise ValueError(
             f"Environment variable {key!r} is on the writer denylist. "
             "Names that influence subprocess execution (LD_PRELOAD, "
@@ -4210,7 +4224,12 @@ def _quote_env_value(value: str) -> str:
     return f'"{escaped}"'
 
 
-def _env_line_defines_key(line: str, key: str) -> bool:
+def _env_line_defines_key(
+    line: str,
+    key: str,
+    *,
+    is_windows: Optional[bool] = None,
+) -> bool:
     """True when a .env line assigns ``key`` — plain or ``export``-prefixed.
 
     ``load_env()`` accepts the bash-compatible ``export KEY=value`` form
@@ -4221,7 +4240,13 @@ def _env_line_defines_key(line: str, key: str) -> bool:
     stripped = line.strip()
     if stripped.startswith("export "):
         stripped = stripped[7:].lstrip()
-    return stripped.startswith(f"{key}=")
+    assigned_key, separator, _value = stripped.partition("=")
+    if not separator:
+        return False
+    return _env_var_policy_name(
+        assigned_key,
+        is_windows=is_windows,
+    ) == _env_var_policy_name(key, is_windows=is_windows)
 
 
 def save_env_value(key: str, value: str):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -215,6 +215,14 @@ _ENV_VAR_NAME_DENYLIST: frozenset[str] = frozenset({
     # NOT a HERMES_* blanket: integration credentials (HERMES_GEMINI_*,
     # HERMES_LANGFUSE_*, HERMES_SPOTIFY_*, ...) ARE allowed.
     "HERMES_HOME", "HERMES_PROFILE", "HERMES_CONFIG", "HERMES_ENV",
+    "HERMES_CONFIG_PATH", "HERMES_ENV_PATH",
+    # Hermes security policy / approval-routing context. These remain available
+    # through their dedicated CLI/config/session controls, but a generic
+    # credential writer must not persist them for the next process startup.
+    "HERMES_YOLO_MODE", "HERMES_ACCEPT_HOOKS", "HERMES_REDACT_SECRETS",
+    "HERMES_INTERACTIVE", "HERMES_EXEC_ASK", "HERMES_GATEWAY_SESSION",
+    "HERMES_CRON_SESSION", "HERMES_SINGLE_QUERY_SESSION",
+    "HERMES_SESSION_KEY", "HERMES_SESSION_PLATFORM",
 })
 
 
@@ -229,10 +237,22 @@ def _reject_denylisted_env_var(key: str) -> None:
             f"Environment variable {key!r} is on the writer denylist. "
             "Names that influence subprocess execution (LD_PRELOAD, "
             "PYTHONPATH, PATH, EDITOR, ...) or Hermes runtime location "
-            "(HERMES_HOME, HERMES_PROFILE, ...) cannot be persisted via "
+            "and security policy (HERMES_HOME, HERMES_YOLO_MODE, ...) "
+            "cannot be persisted via "
             "the env writer. If you really need this, edit "
             "~/.hermes/.env directly."
         )
+
+
+def validate_env_var_name_for_write(key: str) -> None:
+    """Validate an environment name before a generic persistence write.
+
+    Exposed separately from :func:`save_env_value` so batch-style callers can
+    validate their complete request before writing the first value.
+    """
+    if not _ENV_VAR_NAME_RE.match(key):
+        raise ValueError(f"Invalid environment variable name: {key!r}")
+    _reject_denylisted_env_var(key)
 
 _LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
 # (path, mtime_ns, size) -> cached expanded config dict.
@@ -4222,9 +4242,7 @@ def save_env_value(key: str, value: str):
             file=sys.stderr,
         )
         return
-    if not _ENV_VAR_NAME_RE.match(key):
-        raise ValueError(f"Invalid environment variable name: {key!r}")
-    _reject_denylisted_env_var(key)
+    validate_env_var_name_for_write(key)
     value = value.replace("\n", "").replace("\r", "")
     # API keys / tokens must be ASCII — strip non-ASCII with a warning.
     value = _check_non_ascii_credential(key, value)

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -503,8 +503,31 @@ async def install_mcp_catalog_entry(body: MCPCatalogInstall, profile: Optional[s
     if entry is None:
         raise HTTPException(status_code=404, detail=f"No catalog entry '{name}'")
 
-    # Persist any supplied env vars first (catalog entries declare which names
-    # they need; we only write the ones the user provided).
+    # Catalog credentials are a closed schema: configuring one MCP must not
+    # become a generic write primitive for unrelated process environment.
+    declared_env = {spec.name for spec in (entry.auth.env or [])}
+    undeclared_env = sorted(set(body.env) - declared_env)
+    if undeclared_env:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Catalog entry '{name}' does not declare environment "
+                f"variable(s): {', '.join(undeclared_env)}"
+            ),
+        )
+
+    # Validate the complete map before the first write. This preserves the
+    # existing writer/install flow while ensuring a mixed valid+invalid request
+    # cannot partially persist credentials.
+    from hermes_cli.config import validate_env_var_name_for_write
+
+    try:
+        for key in body.env:
+            validate_env_var_name_for_write(key)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Persist any supplied, declared env vars first.
     effective_profile = body.profile or profile
     if body.env:
         def _write_env():

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1043,7 +1043,7 @@ class TestDiscordChannelPromptsConfig:
 class TestEnvWriteDenylist:
     """``save_env_value`` refuses to persist env-var names that
     influence how subprocesses execute — ``LD_PRELOAD``, ``PYTHONPATH``,
-    ``PATH``, ``EDITOR``, etc. — or any ``HERMES_*`` runtime flag.
+    ``PATH``, ``EDITOR``, etc. — or selected Hermes runtime/security controls.
 
     The dashboard exposes ``PUT /api/env`` to any authed caller (and
     the session token lives in the SPA's HTML where any future plugin
@@ -1073,14 +1073,38 @@ class TestEnvWriteDenylist:
         ],
     )
     def test_hermes_integration_keys_still_writable(self, allowed_key):
-        """``HERMES_*`` overall is NOT blocked — only the four runtime
-        location names (HOME/PROFILE/CONFIG/ENV) are. Integration
-        credentials following the ``HERMES_*`` convention must keep
-        working or we'd regress every provider setup wizard that
-        currently writes one of these (auth.py, Spotify, Langfuse, …)."""
+        """``HERMES_*`` overall is NOT blocked.
+
+        Integration credentials following that convention must keep working
+        or we'd regress provider setup flows (auth.py, Spotify, Langfuse, …).
+        """
         save_env_value(allowed_key, "test-value-123")
         env = load_env()
         assert env[allowed_key] == "test-value-123"
+
+    @pytest.mark.parametrize(
+        "protected_key",
+        [
+            "HERMES_CONFIG_PATH",
+            "HERMES_ENV_PATH",
+            "HERMES_YOLO_MODE",
+            "HERMES_ACCEPT_HOOKS",
+            "HERMES_REDACT_SECRETS",
+            "HERMES_INTERACTIVE",
+            "HERMES_EXEC_ASK",
+            "HERMES_GATEWAY_SESSION",
+            "HERMES_CRON_SESSION",
+            "HERMES_SINGLE_QUERY_SESSION",
+            "HERMES_SESSION_KEY",
+            "HERMES_SESSION_PLATFORM",
+        ],
+    )
+    def test_hermes_security_control_keys_are_not_writable(self, protected_key):
+        """Generic writers must not persist runtime or approval controls."""
+        with pytest.raises(ValueError, match="denylist"):
+            save_env_value(protected_key, "1")
+
+        assert protected_key not in load_env()
 
 
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1087,6 +1087,7 @@ class TestEnvWriteDenylist:
         [
             "HERMES_CONFIG_PATH",
             "HERMES_ENV_PATH",
+            "HERMES_OPTIONAL_MCPS",
             "HERMES_YOLO_MODE",
             "HERMES_ACCEPT_HOOKS",
             "HERMES_REDACT_SECRETS",
@@ -1105,6 +1106,50 @@ class TestEnvWriteDenylist:
             save_env_value(protected_key, "1")
 
         assert protected_key not in load_env()
+
+    def test_preexisting_optional_mcps_override_still_loads(self, tmp_path):
+        """The writer gate must not migrate or ignore operator-owned .env state."""
+        from hermes_cli.config import invalidate_env_cache
+
+        catalog = tmp_path / "custom-mcp-catalog"
+        (tmp_path / ".env").write_text(
+            f"HERMES_OPTIONAL_MCPS={catalog}\n",
+            encoding="utf-8",
+        )
+        invalidate_env_cache()
+
+        assert load_env()["HERMES_OPTIONAL_MCPS"] == str(catalog)
+
+    @pytest.mark.parametrize(
+        ("key", "expected"),
+        [
+            ("Path", "PATH"),
+            ("Hermes_Yolo_Mode", "HERMES_YOLO_MODE"),
+            ("Hermes_Optional_Mcps", "HERMES_OPTIONAL_MCPS"),
+        ],
+    )
+    def test_windows_policy_names_are_case_insensitive(self, key, expected):
+        from hermes_cli.config import _env_var_policy_name
+
+        assert _env_var_policy_name(key, is_windows=True) == expected
+
+    def test_posix_policy_names_remain_case_sensitive(self):
+        from hermes_cli.config import _env_var_policy_name
+
+        assert _env_var_policy_name("Path", is_windows=False) == "Path"
+
+    @pytest.mark.parametrize("prefix", ["", "export "])
+    def test_windows_env_assignment_matching_is_case_insensitive(self, prefix):
+        from hermes_cli.config import _env_line_defines_key
+
+        line = f"{prefix}Path=C:\\Windows\\System32\n"
+        assert _env_line_defines_key(line, "PATH", is_windows=True)
+        assert not _env_line_defines_key(line, "PATH", is_windows=False)
+
+    @pytest.mark.windows_only
+    def test_windows_writer_rejects_mixed_case_protected_name(self):
+        with pytest.raises(ValueError, match="denylist"):
+            save_env_value("Hermes_Yolo_Mode", "1")
 
 
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1088,6 +1088,8 @@ class TestEnvWriteDenylist:
             "HERMES_CONFIG_PATH",
             "HERMES_ENV_PATH",
             "HERMES_OPTIONAL_MCPS",
+            "HERMES_COPILOT_ACP_COMMAND",
+            "HERMES_COPILOT_ACP_ARGS",
             "HERMES_YOLO_MODE",
             "HERMES_ACCEPT_HOOKS",
             "HERMES_REDACT_SECRETS",
@@ -1126,6 +1128,8 @@ class TestEnvWriteDenylist:
             ("Path", "PATH"),
             ("Hermes_Yolo_Mode", "HERMES_YOLO_MODE"),
             ("Hermes_Optional_Mcps", "HERMES_OPTIONAL_MCPS"),
+            ("Hermes_Copilot_Acp_Command", "HERMES_COPILOT_ACP_COMMAND"),
+            ("Hermes_Copilot_Acp_Args", "HERMES_COPILOT_ACP_ARGS"),
         ],
     )
     def test_windows_policy_names_are_case_insensitive(self, key, expected):
@@ -1147,9 +1151,18 @@ class TestEnvWriteDenylist:
         assert not _env_line_defines_key(line, "PATH", is_windows=False)
 
     @pytest.mark.windows_only
-    def test_windows_writer_rejects_mixed_case_protected_name(self):
+    @pytest.mark.parametrize(
+        "protected_key",
+        [
+            "Hermes_Yolo_Mode",
+            "Hermes_Optional_Mcps",
+            "Hermes_Copilot_Acp_Command",
+            "Hermes_Copilot_Acp_Args",
+        ],
+    )
+    def test_windows_writer_rejects_mixed_case_protected_name(self, protected_key):
         with pytest.raises(ValueError, match="denylist"):
-            save_env_value("Hermes_Yolo_Mode", "1")
+            save_env_value(protected_key, "1")
 
 
 

--- a/tests/hermes_cli/test_mcp_catalog_env_boundary.py
+++ b/tests/hermes_cli/test_mcp_catalog_env_boundary.py
@@ -166,7 +166,12 @@ def test_catalog_accepts_declared_credential(
 
 @pytest.mark.parametrize(
     "protected_key",
-    ["HERMES_YOLO_MODE", "HERMES_OPTIONAL_MCPS"],
+    [
+        "HERMES_YOLO_MODE",
+        "HERMES_OPTIONAL_MCPS",
+        "HERMES_COPILOT_ACP_COMMAND",
+        "HERMES_COPILOT_ACP_ARGS",
+    ],
 )
 def test_generic_env_endpoint_rejects_protected_key(
     client: TestClient,
@@ -190,3 +195,60 @@ def test_process_supplied_catalog_root_remains_supported(catalog_env: Path):
     from hermes_cli.mcp_catalog import get_entry
 
     assert get_entry("demo") is not None
+
+
+def test_rejected_copilot_controls_do_not_change_live_resolvers(
+    client: TestClient,
+    catalog_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from agent.copilot_acp_client import _resolve_args, _resolve_command
+
+    monkeypatch.setenv("HERMES_COPILOT_ACP_COMMAND", "/opt/trusted/copilot")
+    monkeypatch.setenv("HERMES_COPILOT_ACP_ARGS", "--acp --stdio")
+    expected_command = _resolve_command()
+    expected_args = _resolve_args()
+
+    attempts = {
+        "HERMES_COPILOT_ACP_COMMAND": "/tmp/attacker-command",
+        "HERMES_COPILOT_ACP_ARGS": "--malicious-transport",
+    }
+    for key, value in attempts.items():
+        response = client.put(
+            "/api/env",
+            headers=HEADERS,
+            json={"key": key, "value": value},
+        )
+        assert response.status_code == 400
+
+    assert _resolve_command() == expected_command
+    assert _resolve_args() == expected_args
+    env_path = catalog_env / ".env"
+    if env_path.exists():
+        env_text = env_path.read_text(encoding="utf-8")
+        assert "/tmp/attacker-command" not in env_text
+        assert "--malicious-transport" not in env_text
+
+
+def test_preexisting_copilot_controls_remain_usable(
+    catalog_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from agent.copilot_acp_client import _resolve_args, _resolve_command
+    from hermes_cli.env_loader import load_hermes_dotenv
+
+    monkeypatch.setenv("HERMES_COPILOT_ACP_COMMAND", "parent-placeholder")
+    monkeypatch.setenv("HERMES_COPILOT_ACP_ARGS", "--parent-placeholder")
+    (catalog_env / ".env").write_text(
+        "HERMES_COPILOT_ACP_COMMAND=/opt/operator/copilot\n"
+        "HERMES_COPILOT_ACP_ARGS=--acp --stdio --operator-mode\n",
+        encoding="utf-8",
+    )
+
+    load_hermes_dotenv(
+        hermes_home=catalog_env,
+        load_external_secrets=False,
+    )
+
+    assert _resolve_command() == "/opt/operator/copilot"
+    assert _resolve_args() == ["--acp", "--stdio", "--operator-mode"]

--- a/tests/hermes_cli/test_mcp_catalog_env_boundary.py
+++ b/tests/hermes_cli/test_mcp_catalog_env_boundary.py
@@ -1,0 +1,181 @@
+"""Security boundary tests for dashboard MCP catalog credential writes."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from hermes_cli.web_server import _SESSION_TOKEN, app
+
+
+HEADERS = {"X-Hermes-Session-Token": _SESSION_TOKEN}
+
+
+@pytest.fixture
+def catalog_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _isolate_hermes_home):
+    """Install one synthetic API-key catalog entry in the isolated test home."""
+    from hermes_constants import get_hermes_home
+    from hermes_cli.config import invalidate_env_cache
+
+    catalog = tmp_path / "optional-mcps"
+    entry_dir = catalog / "demo"
+    entry_dir.mkdir(parents=True)
+    (entry_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "manifest_version": 1,
+                "name": "demo",
+                "description": "Synthetic dashboard boundary fixture",
+                "source": "https://example.test/demo",
+                "transport": {
+                    "type": "stdio",
+                    "command": "demo-mcp",
+                },
+                "auth": {
+                    "type": "api_key",
+                    "env": [
+                        {
+                            "name": "DEMO_API_KEY",
+                            "prompt": "Demo API key",
+                            "secret": True,
+                        }
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_OPTIONAL_MCPS", str(catalog))
+    invalidate_env_cache()
+    return get_hermes_home()
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_catalog_rejects_undeclared_key_before_any_write_or_install(
+    client: TestClient,
+    catalog_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import hermes_cli.mcp_catalog as mcp_catalog
+
+    installs: list[str] = []
+    monkeypatch.setattr(
+        mcp_catalog,
+        "install_entry",
+        lambda entry, enable=True: installs.append(entry.name),
+    )
+
+    response = client.post(
+        "/api/mcp/catalog/install",
+        headers=HEADERS,
+        json={
+            "name": "demo",
+            "env": {
+                "DEMO_API_KEY": "valid-demo-value",
+                "UNRELATED_SETTING": "must-not-land",
+            },
+        },
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "UNRELATED_SETTING" in detail
+    assert "valid-demo-value" not in detail
+    assert "must-not-land" not in detail
+    assert installs == []
+    env_path = catalog_env / ".env"
+    assert not env_path.exists() or env_path.read_text(encoding="utf-8") == ""
+
+
+def test_catalog_cannot_declare_reserved_control_key(
+    client: TestClient,
+    catalog_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import hermes_cli.mcp_catalog as mcp_catalog
+
+    catalog_root = Path(os.environ["HERMES_OPTIONAL_MCPS"])
+    manifest_path = catalog_root / "demo" / "manifest.yaml"
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    manifest["auth"]["env"].append(
+        {
+            "name": "HERMES_YOLO_MODE",
+            "prompt": "Unsafe control",
+            "secret": False,
+        }
+    )
+    manifest_path.write_text(yaml.safe_dump(manifest), encoding="utf-8")
+
+    installs: list[str] = []
+    monkeypatch.setattr(
+        mcp_catalog,
+        "install_entry",
+        lambda entry, enable=True: installs.append(entry.name),
+    )
+
+    response = client.post(
+        "/api/mcp/catalog/install",
+        headers=HEADERS,
+        json={"name": "demo", "env": {"HERMES_YOLO_MODE": "1"}},
+    )
+
+    assert response.status_code == 400
+    assert "denylist" in response.json()["detail"]
+    assert installs == []
+    env_path = catalog_env / ".env"
+    assert not env_path.exists() or "HERMES_YOLO_MODE" not in env_path.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_catalog_accepts_declared_credential(
+    client: TestClient,
+    catalog_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import hermes_cli.mcp_catalog as mcp_catalog
+
+    installs: list[str] = []
+    monkeypatch.setattr(
+        mcp_catalog,
+        "install_entry",
+        lambda entry, enable=True: installs.append(entry.name),
+    )
+
+    response = client.post(
+        "/api/mcp/catalog/install",
+        headers=HEADERS,
+        json={"name": "demo", "env": {"DEMO_API_KEY": "valid-demo-value"}},
+    )
+
+    assert response.status_code == 200
+    assert installs == ["demo"]
+    assert "DEMO_API_KEY=valid-demo-value" in (
+        catalog_env / ".env"
+    ).read_text(encoding="utf-8")
+
+
+def test_generic_env_endpoint_rejects_yolo_control_key(
+    client: TestClient,
+    catalog_env: Path,
+):
+    response = client.put(
+        "/api/env",
+        headers=HEADERS,
+        json={"key": "HERMES_YOLO_MODE", "value": "1"},
+    )
+
+    assert response.status_code == 400
+    env_path = catalog_env / ".env"
+    assert not env_path.exists() or "HERMES_YOLO_MODE" not in env_path.read_text(
+        encoding="utf-8"
+    )

--- a/tests/hermes_cli/test_mcp_catalog_env_boundary.py
+++ b/tests/hermes_cli/test_mcp_catalog_env_boundary.py
@@ -164,18 +164,29 @@ def test_catalog_accepts_declared_credential(
     ).read_text(encoding="utf-8")
 
 
-def test_generic_env_endpoint_rejects_yolo_control_key(
+@pytest.mark.parametrize(
+    "protected_key",
+    ["HERMES_YOLO_MODE", "HERMES_OPTIONAL_MCPS"],
+)
+def test_generic_env_endpoint_rejects_protected_key(
     client: TestClient,
     catalog_env: Path,
+    protected_key: str,
 ):
     response = client.put(
         "/api/env",
         headers=HEADERS,
-        json={"key": "HERMES_YOLO_MODE", "value": "1"},
+        json={"key": protected_key, "value": "must-not-land"},
     )
 
     assert response.status_code == 400
     env_path = catalog_env / ".env"
-    assert not env_path.exists() or "HERMES_YOLO_MODE" not in env_path.read_text(
+    assert not env_path.exists() or protected_key not in env_path.read_text(
         encoding="utf-8"
     )
+
+
+def test_process_supplied_catalog_root_remains_supported(catalog_env: Path):
+    from hermes_cli.mcp_catalog import get_entry
+
+    assert get_entry("demo") is not None


### PR DESCRIPTION
## Summary

- restrict MCP catalog credential submissions to environment variables declared by the selected catalog entry
- block Hermes runtime and approval-control variables at the shared environment writer
- prevent generic persistence from replacing the MCP catalog trust root
- prevent generic persistence from acquiring Copilot ACP executable/argv authority
- apply denylist and `.env` key matching with native Windows case semantics while preserving POSIX behavior
- validate the complete catalog environment map before writing any values
- add endpoint-level regression coverage for valid credentials, undeclared keys, reserved controls, and secret-safe errors

## Security

`POST /api/mcp/catalog/install` previously accepted an arbitrary `env` mapping and persisted each non-empty value to the selected profile's `.env` file before installation. A request could therefore attach a Hermes runtime control such as `HERMES_YOLO_MODE` to an otherwise valid MCP credential submission.

The route now treats each catalog entry's `auth.env` list as a closed schema. Any undeclared name returns HTTP 400 before the first write or install action. The complete submitted name set is also checked against the shared writer denylist, so a malformed catalog entry cannot authorize itself to persist approval or session controls.

Errors report rejected names only; submitted values are not included.

## Compatibility

The Desktop already renders and submits credential fields from the selected catalog entry's `auth.env` declaration, so valid catalog installs retain their current request shape. Existing manually configured MCP servers are unchanged.

The denylist remains name-specific rather than blocking all `HERMES_*` variables. Integration credentials and settings such as `HERMES_LANGFUSE_PUBLIC_KEY`, `HERMES_SPOTIFY_CLIENT_ID`, `HERMES_QWEN_BASE_URL`, and `HERMES_MAX_ITERATIONS` remain writable. Dedicated CLI, config, and session controls continue to manage approval behavior.

`HERMES_OPTIONAL_MCPS` is blocked only through generic persistence writes. Existing `.env` values and package-manager/process-supplied catalog roots continue to resolve. Windows comparisons are case-insensitive, matching the host environment model; POSIX comparisons remain case-sensitive.

`HERMES_COPILOT_ACP_COMMAND` and `HERMES_COPILOT_ACP_ARGS` follow the same write-only restriction. Existing operator or package-manager supplied values remain readable by the ACP client; rejected `/api/env` writes neither persist nor change the live command/argv resolvers.

## Test plan

- [x] `scripts/run_tests.sh tests/hermes_cli/test_config.py tests/hermes_cli/test_mcp_catalog.py tests/hermes_cli/test_mcp_catalog_env_boundary.py tests/hermes_cli/test_credential_lifecycle.py tests/hermes_cli/test_web_server_profile_unification.py tests/agent/test_copilot_acp_client.py tests/agent/test_copilot_acp_deprecation.py -q` — 188 passed, 4 Windows-only cases skipped locally
- [x] `scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog_env_boundary.py -q` — 10 passed
- [x] Ruff on all changed Python files
- [x] `git diff --check`

## Verification note

A broader `scripts/run_tests.sh tests/hermes_cli/ -q` run reached unrelated update/doctor tests that detected the developer machine's live gateway and triggered the suite's live-system guard. The guard blocked attempts to signal those external gateway PIDs, producing 13 failures in update/doctor modules. None of the affected MCP/config/profile modules failed; those modules were rerun separately against the final diff as listed above.

Closes #91565.
