### PR TITLE
fix(desktop): preserve completed replies across stale refreshes

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -267,6 +267,69 @@ describe('reconcileActiveTranscript', () => {
     expect(fixture.updateSessionState).toHaveBeenCalledTimes(1)
   })
 
+  it('does not delete a just-completed assistant when the persisted tail is stale', async () => {
+    const fixture = makeRefresh()
+    fixture.state.messages = [
+      { id: '1-0-user', parts: [{ text: 'question', type: 'text' }], role: 'user' },
+      {
+        completedAt: 3,
+        id: 'assistant-stream-1',
+        parts: [{ completedAt: 3, text: 'just completed', timestamp: 2, type: 'text' }],
+        pending: false,
+        role: 'assistant',
+        timestamp: 2
+      }
+    ]
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({
+      messages: [{ content: 'question', role: 'user', timestamp: 1 }],
+      session_id: ACTIVE_STORED_ID
+    } as never)
+
+    await fixture.refresh()
+
+    expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.map(message => message.id)).toEqual([
+      '1-0-user',
+      'assistant-stream-1'
+    ])
+  })
+
+  it('keeps a completed stream through stale refreshes, then converges on its durable row', async () => {
+    const fixture = makeRefresh()
+    fixture.state.messages = [
+      { id: '1-0-user', parts: [{ text: 'question', type: 'text' }], role: 'user' },
+      {
+        completedAt: 3,
+        id: 'assistant-stream-1',
+        parts: [{ completedAt: 3, text: 'just completed', timestamp: 2, type: 'text' }],
+        pending: false,
+        role: 'assistant',
+        timestamp: 2
+      }
+    ]
+
+    const stale = {
+      messages: [{ content: 'question', role: 'user', timestamp: 1 }],
+      session_id: ACTIVE_STORED_ID
+    }
+
+    vi.mocked(getLatestSessionMessages)
+      .mockResolvedValueOnce(stale as never)
+      .mockResolvedValueOnce(stale as never)
+      .mockResolvedValueOnce(transcript('just completed') as never)
+
+    await fixture.refresh()
+    await fixture.refresh()
+
+    expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.id).toBe('assistant-stream-1')
+
+    await fixture.refresh()
+
+    const messages = fixture.states.get(ACTIVE_RUNTIME_ID)?.messages ?? []
+    expect(messages.map(message => message.role)).toEqual(['user', 'assistant'])
+    expect(messages.at(-1)?.id).not.toBe('assistant-stream-1')
+    expect(messages.at(-1)?.parts).toContainEqual(expect.objectContaining({ text: 'just completed' }))
+  })
+
   it('preserves a local assistant error while hydrating authoritative messages', async () => {
     const fixture = makeRefresh()
     fixture.state.messages = [

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
 import { graftRefreshedTailOntoBackfill } from '@/app/chat/transcript-backfill'
+import { preserveLocalPendingTurnMessages } from '@/app/session/hooks/use-session-actions/utils'
 import { getLatestSessionMessages } from '@/hermes'
 import { preserveLocalAssistantErrors, sealOpenToolParts, toChatMessages } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
@@ -105,13 +106,22 @@ export async function reconcileActiveTranscript({
 
     updateSessionState(
       runtimeSessionId,
-      state => ({
-        ...state,
+      state => {
         // The refresh re-reads only the newest tail page; graft it onto any
         // older pages "Show earlier" already backfilled instead of clobbering
         // them (see transcript-backfill).
-        messages: preserveLocalAssistantErrors(graftRefreshedTailOntoBackfill(messages, state.messages), state.messages)
-      }),
+        const refreshed = graftRefreshedTailOntoBackfill(messages, state.messages)
+        // sessions.changed is global, so its REST read can lag the stream that
+        // just settled locally. Keep that newest stream turn until a matching
+        // durable row arrives; the session resume path uses the same identity /
+        // ordinal proof and still lets rewinds replace unrelated stale history.
+        const withLiveTurn = preserveLocalPendingTurnMessages(refreshed, state.messages)
+
+        return {
+          ...state,
+          messages: preserveLocalAssistantErrors(withLiveTurn, state.messages)
+        }
+      },
       storedSessionId
     )
   } catch {


### PR DESCRIPTION
## Summary

- preserve the renderer's just-completed or pending live turn when a `sessions.changed` REST tail is temporarily stale
- reuse the same identity/ordinal/text reconciliation already used by session resume, so unrelated stale history is still replaceable
- converge on the durable assistant row without duplication once persistence catches up

## Root cause

`reconcileActiveTranscript` accepted any idle REST tail as authoritative. A global `sessions.changed` event could trigger a read after the local stream settled but before the assistant row was visible to that read. The existing backfill graft only preserved older prefixes, and assistant-error reconciliation intentionally dropped normal orphan local messages, so the visible completed reply disappeared even though storage was intact.

## Test plan

- [x] Added a regression that failed before the fix: a completed `assistant-stream-*` row survives a stale persisted tail that omits it
- [x] Added repeated-stale-refresh coverage followed by convergence on the durable row without duplication
- [x] `npx vitest run --project ui src/app/contrib/hooks/use-background-sync.test.ts src/app/session/hooks/use-session-actions/utils.test.ts` (129 passed)
- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors; existing repository warnings remain)

Task: `t_087997ee`
