### PR TITLE
fix(kanban): support reliable local-model workers

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7382,6 +7382,23 @@ def run_conversation(
                                 pass
                     break
 
+                # A dispatcher worker's terminal board mutation is the end of
+                # this process's job. Do not ask the provider for another turn:
+                # local models often re-read or re-complete the now-terminal
+                # card and leave an orphan worker alive behind a Done task.
+                try:
+                    from agent.kanban_stop import dispatcher_worker_run_is_terminal
+
+                    _kanban_run_terminal = dispatcher_worker_run_is_terminal()
+                except Exception:
+                    logger.debug("kanban terminal run-state check failed", exc_info=True)
+                    _kanban_run_terminal = False
+                if _kanban_run_terminal:
+                    _turn_exit_reason = "kanban_terminal"
+                    final_response = ""
+                    agent._emit_status("✓ Kanban worker terminal state recorded")
+                    break
+
                 # Reset per-turn retry counters after successful tool
                 # execution so a single truncation doesn't poison the
                 # entire conversation.

--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -13,6 +13,7 @@ loop continues instead of exiting.
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any, Iterable, Optional
 
@@ -20,6 +21,8 @@ from typing import Any, Iterable, Optional
 _TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
 
 _DEFAULT_MAX_ATTEMPTS = 2
+
+logger = logging.getLogger(__name__)
 
 
 def kanban_stop_nudge_enabled() -> bool:
@@ -66,6 +69,46 @@ def session_called_kanban_terminal(messages: Iterable[dict] | None) -> bool:
     return False
 
 
+def dispatcher_worker_run_is_terminal() -> bool:
+    """Return whether this dispatcher-owned worker's exact run has ended.
+
+    The run row is authoritative rather than the attempted tool name: a failed
+    ``kanban_complete`` must not stop the worker, while dependency blocks may
+    move the task back to ``todo`` even though the worker run is terminal.
+    Read failures preserve the existing conversation behavior.
+    """
+    task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    raw_run_id = (os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
+    if not task_id or not raw_run_id:
+        return False
+    try:
+        run_id = int(raw_run_id)
+    except ValueError:
+        return False
+
+    try:
+        from agent.delegation_context import is_dispatcher_owned_worker_context
+
+        if not is_dispatcher_owned_worker_context():
+            return False
+        from hermes_cli import kanban_db as kb
+
+        conn = kb.connect()
+        try:
+            run = kb.get_run(conn, run_id)
+        finally:
+            conn.close()
+    except Exception:
+        logger.debug("kanban terminal run-state check failed", exc_info=True)
+        return False
+
+    return bool(
+        run is not None
+        and str(run.task_id) == task_id
+        and str(run.status) != "running"
+    )
+
+
 def build_kanban_stop_nudge(
     *,
     messages: Iterable[dict] | None = None,
@@ -103,6 +146,7 @@ def build_kanban_stop_nudge(
 
 __all__ = [
     "build_kanban_stop_nudge",
+    "dispatcher_worker_run_is_terminal",
     "kanban_stop_nudge_enabled",
     "session_called_kanban_terminal",
 ]

--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -35,7 +35,15 @@ def kanban_stop_nudge_enabled() -> bool:
     if env is not None and env.strip().lower() in {"0", "false", "no", "off"}:
         return False
     task = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
-    return bool(task)
+    if not task:
+        return False
+    try:
+        from agent.delegation_context import is_dispatcher_owned_worker_context
+
+        return is_dispatcher_owned_worker_context()
+    except Exception:
+        # Preserve pre-isolation behavior if the context helper is unavailable.
+        return True
 
 
 def _tool_call_name(tc: Any) -> str:

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -142,6 +142,7 @@ def finalize_turn(
     """
     from agent.conversation_loop import logger
 
+    kanban_terminal = str(_turn_exit_reason) == "kanban_terminal"
     budget_exhausted = (
         api_call_count >= agent.max_iterations
         or agent.iteration_budget.remaining <= 0
@@ -207,7 +208,7 @@ def finalize_turn(
             _record_kanban_budget_exhausted(
                 _kanban_task, api_call_count, agent.max_iterations, logger,
             )
-    elif budget_exhausted:
+    elif budget_exhausted and not kanban_terminal:
         # Bounded fallback (#87096): budget was exhausted but none of the
         # normal fallback paths were eligible (interrupted / failed /
         # anomalous exit_reason). If running as a kanban worker we must
@@ -230,6 +231,7 @@ def finalize_turn(
         and (
             api_call_count < agent.max_iterations
             or normal_text_response
+            or kanban_terminal
         )
     )
 
@@ -493,7 +495,7 @@ def finalize_turn(
         agent.session_id or "none",
     )
 
-    if _last_msg_role == "tool" and not interrupted:
+    if _last_msg_role == "tool" and not interrupted and not kanban_terminal:
         # Agent was mid-work — this is the "just stops" case.
         logger.warning(
             "Turn ended with pending tool result (agent may appear stuck). "
@@ -544,7 +546,7 @@ def finalize_turn(
     #     an empty response, the "(empty)" terminal sentinel, or a
     #     suspiciously short partial fragment with no terminating
     #     punctuation (e.g. "The").  A real short answer keeps its text.
-    if not interrupted:
+    if not interrupted and not kanban_terminal:
         try:
             if agent._turn_completion_explainer_enabled():
                 _stripped = (final_response or "").strip()

--- a/model_tools.py
+++ b/model_tools.py
@@ -81,6 +81,62 @@ def _is_dispatcher_owned_worker() -> bool:
         return True
 
 
+_TERMINAL_KANBAN_WORKER_TOOLS = frozenset({"kanban_complete", "kanban_block"})
+
+
+def _configured_worker_kanban_tool_allowlist() -> Optional[set[str]]:
+    """Return the configured dispatcher-worker Kanban surface, if any.
+
+    Normal chat/orchestrator sessions keep the full configured tool surface.
+    Dispatcher workers may opt into a smaller Kanban schema for local models
+    that become unreliable when presented with the full lifecycle catalog.
+    Terminal completion/block tools are always retained so the worker protocol
+    cannot be configured into an impossible-to-finish state.
+    """
+    if (
+        not os.environ.get("HERMES_KANBAN_TASK")
+        or _is_delegated_child_context()
+        or not _is_dispatcher_owned_worker()
+    ):
+        return None
+
+    try:
+        from agent.skill_utils import parse_config_string_list
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        kanban_config = config.get("kanban") or {}
+        if not isinstance(kanban_config, dict) or "worker_tools" not in kanban_config:
+            return None
+        configured = parse_config_string_list(kanban_config.get("worker_tools"))
+    except Exception:
+        logger.warning("could not load kanban.worker_tools; preserving default surface", exc_info=True)
+        return None
+
+    allowed = {
+        str(name).strip()
+        for name in configured
+        if str(name).strip().startswith("kanban_")
+    }
+    allowed.update(_TERMINAL_KANBAN_WORKER_TOOLS)
+    return allowed
+
+
+def _apply_worker_kanban_tool_allowlist(
+    tools: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Filter only Kanban schemas for an explicitly constrained worker."""
+    allowed = _configured_worker_kanban_tool_allowlist()
+    if allowed is None:
+        return tools
+    return [
+        tool
+        for tool in tools
+        if not str(tool.get("function", {}).get("name", "")).startswith("kanban_")
+        or tool.get("function", {}).get("name") in allowed
+    ]
+
+
 # =============================================================================
 # Async Bridging  (single source of truth -- used by registry.dispatch too)
 # =============================================================================
@@ -508,6 +564,7 @@ def _compute_tool_definitions(
 
     # Ask the registry for schemas (only returns tools whose check_fn passes)
     filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
+    filtered_tools = _apply_worker_kanban_tool_allowlist(filtered_tools)
 
     # The set of tool names that actually passed check_fn filtering.
     # Use this (not tools_to_include) for any downstream schema that references

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -37,6 +37,16 @@ def test_env_can_disable(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=[]) is None
 
 
+def test_delegated_child_does_not_receive_worker_stop_nudge(clear_kanban_env):
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_parent")
+    with patch(
+        "agent.delegation_context.is_dispatcher_owned_worker_context",
+        return_value=False,
+    ):
+        assert kanban_stop_nudge_enabled() is False
+        assert build_kanban_stop_nudge(messages=[]) is None
+
+
 def test_dispatcher_run_terminal_only_after_run_ends(clear_kanban_env):
     clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_owned")
     clear_kanban_env.setenv("HERMES_KANBAN_RUN_ID", "42")

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import patch
+
 import pytest
 
 from agent.kanban_stop import (
     build_kanban_stop_nudge,
+    dispatcher_worker_run_is_terminal,
     kanban_stop_nudge_enabled,
     session_called_kanban_terminal,
 )
@@ -13,7 +17,11 @@ from agent.kanban_stop import (
 
 @pytest.fixture
 def clear_kanban_env(monkeypatch):
-    for var in ("HERMES_KANBAN_TASK", "HERMES_KANBAN_STOP_NUDGE"):
+    for var in (
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_RUN_ID",
+        "HERMES_KANBAN_STOP_NUDGE",
+    ):
         monkeypatch.delenv(var, raising=False)
     return monkeypatch
 
@@ -27,6 +35,51 @@ def test_env_can_disable(clear_kanban_env):
     clear_kanban_env.setenv("HERMES_KANBAN_STOP_NUDGE", "0")
     assert kanban_stop_nudge_enabled() is False
     assert build_kanban_stop_nudge(messages=[]) is None
+
+
+def test_dispatcher_run_terminal_only_after_run_ends(clear_kanban_env):
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_owned")
+    clear_kanban_env.setenv("HERMES_KANBAN_RUN_ID", "42")
+    conn = SimpleNamespace(close=lambda: None)
+
+    with (
+        patch("hermes_cli.kanban_db.connect", return_value=conn),
+        patch(
+            "hermes_cli.kanban_db.get_run",
+            return_value=SimpleNamespace(task_id="t_owned", status="running"),
+        ),
+    ):
+        assert dispatcher_worker_run_is_terminal() is False
+
+    with (
+        patch("hermes_cli.kanban_db.connect", return_value=conn),
+        patch(
+            "hermes_cli.kanban_db.get_run",
+            return_value=SimpleNamespace(task_id="t_owned", status="done"),
+        ),
+    ):
+        assert dispatcher_worker_run_is_terminal() is True
+
+    with (
+        patch("hermes_cli.kanban_db.connect", return_value=conn),
+        patch(
+            "hermes_cli.kanban_db.get_run",
+            return_value=SimpleNamespace(task_id="t_owned", status="blocked"),
+        ),
+    ):
+        assert dispatcher_worker_run_is_terminal() is True
+
+
+def test_dispatcher_run_terminal_fails_open_on_missing_identity_or_read_error(clear_kanban_env):
+    assert dispatcher_worker_run_is_terminal() is False
+
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_owned")
+    clear_kanban_env.setenv("HERMES_KANBAN_RUN_ID", "not-an-int")
+    assert dispatcher_worker_run_is_terminal() is False
+
+    clear_kanban_env.setenv("HERMES_KANBAN_RUN_ID", "42")
+    with patch("hermes_cli.kanban_db.connect", side_effect=OSError("unavailable")):
+        assert dispatcher_worker_run_is_terminal() is False
 
 
 def test_nudge_when_no_terminal_tool(clear_kanban_env):

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -171,6 +171,49 @@ def test_run_conversation_flushes_assistant_tool_call_before_execution():
     assert result["final_response"] == "done"
 
 
+def test_run_conversation_stops_after_dispatcher_run_terminal(monkeypatch):
+    """A completed worker must not start another provider turn."""
+    agent = _make_agent()
+    setattr(agent, "max_iterations", 1)
+    setattr(
+        agent,
+        "valid_tool_names",
+        set(getattr(agent, "valid_tool_names", set())) | {"kanban_complete"},
+    )
+    tool_call = _mock_tool_call(name="kanban_complete", call_id="terminal-call")
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[tool_call]),
+        AssertionError("second provider turn after terminal Kanban run"),
+    ]
+
+    def _fake_execute(assistant_message, messages, effective_task_id, api_call_count=0):
+        messages.append(
+            make_tool_result_message(
+                "kanban_complete",
+                '{"ok": true, "task_id": "t_terminal", "run_id": 42}',
+                "terminal-call",
+            )
+        )
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_terminal")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "42")
+    with (
+        patch("agent.kanban_stop.dispatcher_worker_run_is_terminal", return_value=True),
+        patch("agent.turn_finalizer._record_kanban_budget_exhausted") as record_budget_exhausted,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch.object(agent, "_execute_tool_calls", side_effect=_fake_execute),
+    ):
+        result = agent.run_conversation("complete the task")
+
+    assert agent.client.chat.completions.create.call_count == 1
+    record_budget_exhausted.assert_not_called()
+    assert result["failed"] is False
+    assert result["completed"] is True
+    assert result["turn_exit_reason"] == "kanban_terminal"
+
+
 def test_interim_assistant_is_durable_before_ui_projection_on_abnormal_exit(tmp_path):
     """A visible interim assistant row must survive an immediate process exit.
 

--- a/tests/test_kanban_worker_tool_allowlist.py
+++ b/tests/test_kanban_worker_tool_allowlist.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import yaml
+
+
+TERMINAL = {"kanban_complete", "kanban_block"}
+
+
+def _schema(name: str) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": name,
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+def _invalidate_config_cache() -> None:
+    import hermes_cli.config as cfg_mod
+
+    invalidate = getattr(cfg_mod, "_invalidate_load_config_cache", None)
+    if callable(invalidate):
+        invalidate()
+
+
+def test_dispatcher_worker_allowlist_filters_only_kanban_tools(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    home.joinpath("config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "kanban": {
+                    "worker_tools": [
+                        "kanban_show",
+                        "kanban_comment",
+                        "kanban_complete",
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_local")
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+    _invalidate_config_cache()
+
+    import model_tools
+
+    tools = [
+        _schema("kanban_show"),
+        _schema("kanban_comment"),
+        _schema("kanban_complete"),
+        _schema("kanban_block"),
+        _schema("kanban_heartbeat"),
+        _schema("todo"),
+    ]
+    filtered = model_tools._apply_worker_kanban_tool_allowlist(tools)
+    names = {tool["function"]["name"] for tool in filtered}
+
+    assert names == {
+        "kanban_show",
+        "kanban_comment",
+        "kanban_complete",
+        "kanban_block",
+        "todo",
+    }
+
+
+def test_worker_allowlist_always_preserves_terminal_tools(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    home.joinpath("config.yaml").write_text(
+        yaml.safe_dump({"kanban": {"worker_tools": ["kanban_show", "not_a_tool"]}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_local")
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+    _invalidate_config_cache()
+
+    import model_tools
+
+    tools = [
+        _schema("kanban_show"),
+        _schema("kanban_complete"),
+        _schema("kanban_block"),
+        _schema("kanban_heartbeat"),
+    ]
+    names = {
+        tool["function"]["name"]
+        for tool in model_tools._apply_worker_kanban_tool_allowlist(tools)
+    }
+
+    assert TERMINAL <= names
+    assert "kanban_show" in names
+    assert "kanban_heartbeat" not in names
+
+
+def test_allowlist_does_not_change_normal_or_delegated_sessions(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    home.joinpath("config.yaml").write_text(
+        yaml.safe_dump({"kanban": {"worker_tools": ["kanban_complete"]}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _invalidate_config_cache()
+
+    import model_tools
+
+    tools = [
+        _schema("kanban_show"),
+        _schema("kanban_complete"),
+        _schema("kanban_block"),
+        _schema("kanban_heartbeat"),
+    ]
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    assert model_tools._apply_worker_kanban_tool_allowlist(tools) == tools
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_inherited")
+    monkeypatch.setattr(model_tools, "_is_delegated_child_context", lambda: True)
+    assert model_tools._apply_worker_kanban_tool_allowlist(tools) == tools
+
+
+def test_get_tool_definitions_applies_worker_allowlist_end_to_end(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    home.joinpath("config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "kanban": {
+                    "worker_tools": [
+                        "kanban_show",
+                        "kanban_comment",
+                        "kanban_complete",
+                        "kanban_block",
+                        "kanban_heartbeat",
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_e2e")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "1")
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "test-claim")
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+    _invalidate_config_cache()
+
+    import model_tools
+
+    model_tools._tool_defs_cache.clear()
+    definitions = model_tools.get_tool_definitions(
+        enabled_toolsets=["kanban"], quiet_mode=True
+    )
+    kanban_names = {
+        tool["function"]["name"]
+        for tool in definitions
+        if tool["function"]["name"].startswith("kanban_")
+    }
+
+    assert kanban_names == {
+        "kanban_show",
+        "kanban_comment",
+        "kanban_complete",
+        "kanban_block",
+        "kanban_heartbeat",
+    }
+
+
+def test_absent_allowlist_preserves_existing_worker_surface(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    home.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_default")
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+    _invalidate_config_cache()
+
+    import model_tools
+
+    tools = [
+        _schema("kanban_show"),
+        _schema("kanban_complete"),
+        _schema("kanban_block"),
+        _schema("kanban_heartbeat"),
+    ]
+    assert model_tools._apply_worker_kanban_tool_allowlist(tools) == tools

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -358,6 +358,33 @@ Three reasons:
 
 The auto-injected kanban guidance teaches the model which tool to call when and in what order.
 
+### Limit the worker schema for small local models
+
+Dispatcher workers receive the complete task-scoped Kanban lifecycle surface by
+default. Smaller local models can become less reliable when many similar tool schemas
+are present. A profile can opt into a narrower worker-only surface with
+`kanban.worker_tools`:
+
+```yaml
+kanban:
+  worker_tools:
+    - kanban_show
+    - kanban_comment
+    - kanban_heartbeat
+    - kanban_complete
+    - kanban_block
+```
+
+This setting applies only while the profile owns a dispatcher task. Normal chat and
+orchestrator sessions keep their configured toolsets. `kanban_complete` and
+`kanban_block` are always retained even when omitted, so the worker cannot be
+configured without a terminal lifecycle action. Unknown and non-Kanban names do not
+widen the worker surface.
+
+Start with the five tools above for small local models. Add review or attachment tools
+only when that profile's tasks require them. Omitting `kanban_request_review`, for
+example, means that worker must complete or block rather than route same-card review.
+
 ### Recommended handoff evidence
 
 `kanban_complete(summary=..., metadata={...})` is intentionally flexible:


### PR DESCRIPTION
## Summary
- add an opt-in `kanban.worker_tools` allowlist for dispatcher-owned workers so small local models can use a reduced lifecycle schema
- always retain `kanban_complete` and `kanban_block`; normal chat/orchestrator and delegated/cron boundaries are unchanged
- stop dispatcher workers immediately after their exact run becomes terminal
- treat `kanban_terminal` as a healthy finalizer exit, including on the final iteration

## Measured reproduction
With `qwen3:30b-a3b`, the full 14-tool worker schema (26,632 chars) selected the wrong lifecycle tool and took 37.46s. A five-tool schema (8,408 chars) emitted structured `kanban_complete` correctly. Live Kanban runs then completed an Inference -> Reviewer -> Final Synthesis dependency chain.

The live run also showed completed workers continuing into another provider turn and remaining alive after the card was Done. The terminal-run check now exits before that extra turn and avoids false budget-exhaustion receipts at `max_iterations=1`.

## Safety / compatibility
- absent or unreadable allowlist preserves the existing full surface
- filtering applies only to `kanban_*` schemas for an exact dispatcher-owned worker
- exact task ID + run ID + non-running run state are required before terminal exit
- DB read errors fail open to existing behavior
- persistence and guardrail handling remain ahead of terminal exit

## Test plan
- canonical isolated runner: 75 related tests passed
- exact `max_iterations=1` regression: one provider call, no budget receipt, `completed=True`, `turn_exit_reason=kanban_terminal`
- Ruff passed
- `git diff --check` passed
- independent review passed after one boundary defect was found and corrected
