### PR TITLE
feat(profiles): seed holographic memory onto fresh bots

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -512,6 +512,62 @@ def remove_wrapper_script(name: str) -> bool:
     return False
 
 
+def _seed_memory_provider_from_default(profile_dir: Path) -> None:
+    """Activate the default profile's holographic provider on a fresh profile.
+
+    Fresh profiles ship with no ``config.yaml``, so they fall through to
+    ``DEFAULT_CONFIG``'s empty ``memory.provider`` even when the default
+    profile has holographic enabled. Bots *are* profiles — without this,
+    every New Agent starts with built-in MEMORY.md only.
+
+    Copies provider *activation* and holographic plugin knobs only — not
+    ``memory_store.db`` / MEMORY.md, so facts stay isolated per bot.
+    No-op when the new profile already has a config.yaml (clone) or when
+    the default profile has no holographic provider set. Cloud providers
+    are not inherited: they need per-profile credentials we must not copy.
+    """
+    config_path = profile_dir / "config.yaml"
+    if config_path.exists():
+        return
+    default_config_path = _get_default_hermes_home() / "config.yaml"
+    if not default_config_path.is_file():
+        return
+    try:
+        import yaml
+        raw = yaml.safe_load(default_config_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return
+    if not isinstance(raw, dict):
+        return
+    mem = raw.get("memory")
+    if not isinstance(mem, dict):
+        return
+    provider = str(mem.get("provider") or "").strip()
+    if provider != "holographic":
+        return
+    plugin_cfg: dict = {}
+    plugins = raw.get("plugins")
+    store_cfg = plugins.get("hermes-memory-store") if isinstance(plugins, dict) else None
+    if isinstance(store_cfg, dict):
+        for key in ("auto_extract", "default_trust", "hrr_dim"):
+            if key in store_cfg:
+                plugin_cfg[key] = store_cfg[key]
+    if not plugin_cfg:
+        plugin_cfg = {"auto_extract": True, "default_trust": 0.5, "hrr_dim": 1024}
+    seeded = {
+        "memory": {"provider": "holographic"},
+        "plugins": {"hermes-memory-store": plugin_cfg},
+    }
+    try:
+        config_path.write_text(
+            yaml.safe_dump(seeded, default_flow_style=False, sort_keys=False),
+            encoding="utf-8",
+        )
+        os.chmod(str(config_path), 0o600)
+    except Exception:
+        pass  # best-effort — profile creation must not fail over this
+
+
 def _migrate_profile_config_if_outdated(profile_dir: Path) -> None:
     """Bring a copied profile config.yaml up to the current schema.
 
@@ -1219,6 +1275,13 @@ def create_profile(
             soul_path.write_text(DEFAULT_SOUL_MD, encoding="utf-8")
         except Exception:
             pass  # best-effort — don't fail profile creation over this
+
+    # Fresh profiles have no config.yaml. Inherit holographic activation
+    # from the default profile so new bots get their own memory_store.db
+    # instead of silently falling back to built-in MEMORY.md only.
+    # No-op on clones (config.yaml already exists) and when default has
+    # no holographic provider. Must run before config migration.
+    _seed_memory_provider_from_default(profile_dir)
 
     # Write the opt-out marker so seed_profile_skills() and `hermes update`'s
     # all-profile sync loop both skip this profile for bundled-skill seeding.

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -132,8 +132,56 @@ class TestCreateProfile:
         mode = stat.S_IMODE(env_path.stat().st_mode)
         assert mode == 0o600
 
+    def test_fresh_profile_inherits_holographic_from_default(self, profile_env):
+        """New bots/profiles pick up holographic when the default profile has it.
 
+        Activation only — facts stay isolated (no memory_store.db copy).
+        """
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        (default_home / "config.yaml").write_text(
+            "memory:\n"
+            "  provider: holographic\n"
+            "plugins:\n"
+            "  hermes-memory-store:\n"
+            "    auto_extract: true\n"
+            "    default_trust: 0.5\n"
+            "    hrr_dim: 1024\n",
+            encoding="utf-8",
+        )
+        (default_home / "memory_store.db").write_bytes(b"not-copied")
 
+        profile_dir = create_profile("botty", no_alias=True)
+
+        cfg = yaml.safe_load((profile_dir / "config.yaml").read_text(encoding="utf-8"))
+        assert cfg["memory"]["provider"] == "holographic"
+        store = cfg["plugins"]["hermes-memory-store"]
+        assert store["auto_extract"] is True
+        assert store["default_trust"] == 0.5
+        assert store["hrr_dim"] == 1024
+        assert not (profile_dir / "memory_store.db").exists()
+
+    def test_fresh_profile_does_not_invent_holographic(self, profile_env):
+        """No default provider → fresh profile stays built-in-only (no config.yaml)."""
+        profile_dir = create_profile("plain", no_alias=True)
+        assert not (profile_dir / "config.yaml").exists()
+
+    def test_clone_config_not_overwritten_by_holographic_seed(self, profile_env):
+        """Clone copies the source config; holographic seed must not replace it."""
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        (default_home / "config.yaml").write_text(
+            "model: test\n"
+            "memory:\n"
+            "  provider: holographic\n",
+            encoding="utf-8",
+        )
+
+        profile_dir = create_profile("coder", clone_config=True, no_alias=True)
+
+        cloned_config = yaml.safe_load((profile_dir / "config.yaml").read_text())
+        assert cloned_config["model"] == "test"
+        assert cloned_config["memory"]["provider"] == "holographic"
 
     def test_clone_config_copies_files(self, profile_env):
         tmp_path = profile_env


### PR DESCRIPTION
## Summary

- Fresh profiles (including Bot Mode New Agent) now inherit holographic activation from the default profile when that profile has `memory.provider: holographic`.
- Copies provider activation and `plugins.hermes-memory-store` knobs only - not `memory_store.db` / MEMORY.md - so each bot still gets its own fact store.

## Motivation

Bots are profiles. A fresh profile ships with no `config.yaml`, so it fell through to `DEFAULT_CONFIG`'s empty `memory.provider` even when the default profile already had holographic on. New bots started with built-in MEMORY.md only.

## Changes

- `_seed_memory_provider_from_default()` in `hermes_cli/profiles.py`, called from `create_profile()` before config migration.
- No-op on clones (`config.yaml` already exists) and when default has no holographic provider. Cloud providers are not inherited (they need per-profile credentials).
- Tests for inherit / do-not-invent / clone-not-overwritten.

## Test Plan

- [x] `uv run pytest tests/hermes_cli/test_profiles.py::TestCreateProfile -q` (5 passed)
- [ ] Reviewer: create a fresh bot from desktop New Agent and confirm `hermes -p <bot> memory status` shows holographic without copying default `memory_store.db`

## Notes for Reviewers

Intentionally holographic-only. Honcho/Mem0/etc. need API keys we must not copy into a new profile. If default has no holographic provider, behaviour is unchanged (no config.yaml written).
