### PR TITLE
fix(kanban): classify assignee lane saturation

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1948,13 +1948,21 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
             if task is None:
                 print(f"no such task: {args.task}", file=sys.stderr)
                 return 1
+            now = int(time.time())
+            lane_rows = conn.execute(
+                "SELECT id, assignee, status, claim_lock, claim_expires FROM tasks "
+                "WHERE status = 'running'"
+            ).fetchall()
+            lane_context = kd.build_lane_context(lane_rows, now=now)
             diags_by_task = {
                 args.task: kd.compute_task_diagnostics(
                     task,
                     kb.list_events(conn, args.task),
                     kb.list_runs(conn, args.task),
+                    now=now,
                     graph=kb.task_graph_context(conn, args.task),
                     config=diag_config,
+                    lane_context=lane_context,
                 )
             }
         else:
@@ -1980,6 +1988,8 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
                 ):
                     run_by.setdefault(row["task_id"], []).append(row)
                 graph_by = kb.task_graph_contexts(conn, ids)
+                now = int(time.time())
+                lane_context = kd.build_lane_context(rows, now=now)
                 diags_by_task = {}
                 for r in rows:
                     tid = r["id"]
@@ -1987,8 +1997,10 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
                         r,
                         ev_by.get(tid, []),
                         run_by.get(tid, []),
+                        now=now,
                         graph=graph_by.get(tid),
                         config=diag_config,
+                        lane_context=lane_context,
                     )
                     if dl:
                         diags_by_task[tid] = dl

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -322,6 +322,30 @@ def _positive_int(value: Any, default: int) -> int:
     return parsed if parsed >= 1 else default
 
 
+def build_lane_context(tasks: Iterable[Any], *, now: int) -> dict[str, list[str]]:
+    """Index healthy running work by assignee for ready-lane diagnostics.
+
+    A running task occupies a lane only while it still holds an unexpired
+    claim. Stale/dead runs remain actionable through their existing recovery
+    diagnostics rather than reassuring tasks waiting behind them.
+    """
+    active_by_assignee: dict[str, list[str]] = {}
+    for candidate in tasks:
+        if _task_field(candidate, "status") != "running":
+            continue
+        assignee = str(_task_field(candidate, "assignee") or "").strip()
+        task_id = str(_task_field(candidate, "id") or "").strip()
+        try:
+            healthy_claim = bool(_task_field(candidate, "claim_lock")) and (
+                int(_task_field(candidate, "claim_expires", 0) or 0) > now
+            )
+        except (TypeError, ValueError):
+            healthy_claim = False
+        if assignee and task_id and healthy_claim:
+            active_by_assignee.setdefault(assignee, []).append(task_id)
+    return active_by_assignee
+
+
 def _rule_hallucinated_cards(task, events, runs, now, cfg) -> list[Diagnostic]:
     """Blocked-hallucination gate fires: a worker called kanban_complete
     with created_cards that didn't exist or weren't created by the
@@ -1025,6 +1049,31 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
     if age_seconds < threshold_seconds:
         return []
 
+    lane_limit = _positive_int(cfg.get("max_in_progress_per_profile"), 0)
+    active_task_ids = list((cfg.get("_lane_context") or {}).get(assignee, []))
+    if lane_limit and len(active_task_ids) >= lane_limit:
+        active_label = ", ".join(active_task_ids)
+        return [Diagnostic(
+            kind="lane_capacity_full",
+            severity="warning",
+            title=f"{assignee} lane at cap {lane_limit} ({active_label})",
+            detail=(
+                f"This task is queued normally: assignee {assignee!r} has "
+                f"healthy active task(s) {active_label} occupying its "
+                f"per-profile cap {lane_limit}. It will be eligible when "
+                "that lane has capacity; do not reassign solely because it "
+                "has waited."
+            ),
+            first_seen_at=last_ready_ts,
+            last_seen_at=last_ready_ts,
+            count=len(active_task_ids),
+            data={
+                "active_task_ids": active_task_ids,
+                "lane_limit": lane_limit,
+                "assignee": assignee,
+            },
+        )]
+
     # Format the age in the largest sensible unit.
     if age_seconds >= 3600:
         age_str = f"{age_seconds / 3600:.1f}h"
@@ -1104,6 +1153,7 @@ DIAGNOSTIC_KINDS = (
     "review_dependency_deadlock",
     "stuck_in_blocked",
     "block_unblock_cycling",
+    "lane_capacity_full",
     "stranded_in_ready",
 )
 
@@ -1136,6 +1186,10 @@ def config_from_kanban_config(kanban_cfg: Optional[dict]) -> dict:
     diag_cfg.setdefault(
         "failure_limit",
         kanban_cfg.get("failure_limit", DEFAULT_CONFIG["failure_threshold"]),
+    )
+    diag_cfg.setdefault(
+        "max_in_progress_per_profile",
+        kanban_cfg.get("max_in_progress_per_profile"),
     )
     if (
         "failure_threshold" not in diag_cfg
@@ -1176,6 +1230,7 @@ def compute_task_diagnostics(
     now: Optional[int] = None,
     config: Optional[dict] = None,
     graph: Optional[dict] = None,
+    lane_context: Optional[dict[str, list[str]]] = None,
 ) -> list[Diagnostic]:
     """Run every rule against a single task's state and return a
     severity-sorted list of active diagnostics.
@@ -1188,6 +1243,8 @@ def compute_task_diagnostics(
     cfg = {**DEFAULT_CONFIG, **config}
     if graph is not None:
         cfg["_graph"] = graph
+    if lane_context is not None:
+        cfg["_lane_context"] = lane_context
     if (
         "failure_threshold" not in config
         and "spawn_failure_threshold" not in config

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -280,6 +280,15 @@ def _compute_task_diagnostics(
     if not rows:
         return {}
 
+    now = int(time.time())
+    # Lane occupancy is board-wide even for a single-card drawer request.
+    # Fetch it once so diagnostics do not issue a running-task query per card.
+    lane_rows = conn.execute(
+        "SELECT id, assignee, status, claim_lock, claim_expires FROM tasks "
+        "WHERE status = 'running'"
+    ).fetchall()
+    lane_context = kd.build_lane_context(lane_rows, now=now)
+
     # Index events + runs by task id. For very large boards this will
     # slurp a lot — acceptable on the dashboard's typical working set
     # (hundreds of tasks), but we can add pagination / filtering later
@@ -307,8 +316,10 @@ def _compute_task_diagnostics(
             r,
             events_by_task.get(tid, []),
             runs_by_task.get(tid, []),
+            now=now,
             config=diag_config,
             graph=graph_by_task.get(tid),
+            lane_context=lane_context,
         )
         if diags:
             out[tid] = [d.to_dict() for d in diags]

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -198,6 +198,75 @@ def test_stranded_in_ready_fires_when_age_exceeds_threshold():
     assert stranded[0].data["assignee"] == "demo"
 
 
+def test_ready_task_at_healthy_assignee_lane_cap_reports_normal_queueing():
+    """A full per-profile lane is normal queueing, not a missing worker."""
+    now = 100_000
+    queued = _task(id="t_queued", assignee="demo", claim_lock=None)
+    active = _task(
+        id="t_active",
+        assignee="demo",
+        status="running",
+        claim_lock="demo:run",
+        claim_expires=now + 60,
+    )
+
+    diags = kd.compute_task_diagnostics(
+        queued,
+        [_event("promoted", ts=now - 45 * 60)],
+        [],
+        now=now,
+        config={"max_in_progress_per_profile": 1},
+        lane_context=kd.build_lane_context([queued, active], now=now),
+    )
+
+    assert not any(d.kind == "stranded_in_ready" for d in diags)
+    lane = next(d for d in diags if d.kind == "lane_capacity_full")
+    assert lane.data == {
+        "active_task_ids": ["t_active"],
+        "lane_limit": 1,
+        "assignee": "demo",
+    }
+    assert "t_active" in lane.title
+    assert "cap 1" in lane.detail
+    assert not any(action.kind == "reassign" for action in lane.actions)
+
+
+@pytest.mark.parametrize(
+    ("lane_limit", "active_assignee", "claim_expires", "expected_kind"),
+    [
+        (2, "demo", 100_060, "stranded_in_ready"),
+        (1, "other", 100_060, "stranded_in_ready"),
+        (1, "demo", 99_999, "stranded_in_ready"),
+    ],
+)
+def test_ready_task_requires_healthy_same_assignee_lane_at_cap(
+    lane_limit,
+    active_assignee,
+    claim_expires,
+    expected_kind,
+):
+    now = 100_000
+    queued = _task(id="t_queued", assignee="demo", claim_lock=None)
+    active = _task(
+        id="t_active",
+        assignee=active_assignee,
+        status="running",
+        claim_lock="active:run",
+        claim_expires=claim_expires,
+    )
+
+    diags = kd.compute_task_diagnostics(
+        queued,
+        [_event("promoted", ts=now - 45 * 60)],
+        [],
+        now=now,
+        config={"max_in_progress_per_profile": lane_limit},
+        lane_context=kd.build_lane_context([queued, active], now=now),
+    )
+
+    assert [d.kind for d in diags] == [expected_kind]
+
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_review_surfaces.py
+++ b/tests/hermes_cli/test_kanban_review_surfaces.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 
 import pytest
@@ -425,3 +426,47 @@ def test_cli_and_dashboard_receive_graph_aware_deadlock_diagnostic(
         dashboard = _compute_task_diagnostics(conn, task_ids=[parent_id])
     assert dashboard[parent_id][0]["kind"] == "review_dependency_deadlock"
     assert dashboard[parent_id][0]["data"]["waiting_child_ids"] == [child_id]
+
+
+def test_cli_and_dashboard_classify_full_assignee_lane_as_normal_queueing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"max_in_progress_per_profile": 1}},
+    )
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+
+    with kb.connect() as conn:
+        queued_id = kb.create_task(conn, title="Queued", assignee="builder")
+        active_id = kb.create_task(conn, title="Active", assignee="builder")
+        assert kb.claim_task(conn, active_id, claimer="builder:1") is not None
+        conn.execute(
+            "UPDATE task_events SET created_at = ? WHERE task_id = ? AND kind = 'created'",
+            (int(time.time()) - 45 * 60, queued_id),
+        )
+        conn.commit()
+
+    cli_single = json.loads(kc.run_slash(f"diagnostics --task {queued_id} --json"))
+    cli_fleet = json.loads(kc.run_slash("diagnostics --json"))
+    assert cli_single[0]["diagnostics"][0]["kind"] == "lane_capacity_full"
+    fleet_row = next(row for row in cli_fleet if row["task_id"] == queued_id)
+    assert fleet_row["diagnostics"][0]["data"]["active_task_ids"] == [active_id]
+
+    from plugins.kanban.dashboard.plugin_api import _compute_task_diagnostics
+
+    with kb.connect() as conn:
+        dashboard = _compute_task_diagnostics(conn, task_ids=[queued_id])
+    lane = dashboard[queued_id][0]
+    assert lane["kind"] == "lane_capacity_full"
+    assert lane["data"] == {
+        "active_task_ids": [active_id],
+        "lane_limit": 1,
+        "assignee": "builder",
+    }


### PR DESCRIPTION
Fixes lane saturation classification in the Kanban diagnostics tool where saturated assignee lanes were incorrectly categorized.

Commit: ff4c1ccbea42a15597c8e198fecbd6d1d004c9f2