### PR TITLE
fix(gateway): route truncation writes + /undo to the profile database

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5683,6 +5683,164 @@ def test_cli_undo_routes_profile_owned_session_db(monkeypatch, tmp_path):
         server._sessions.pop("profile-undo-sid", None)
 
 
+def test_prompt_submit_truncate_fails_closed_when_profile_db_unavailable(
+    monkeypatch, tmp_path
+):
+    """Profile-owned session + unopenable profile state.db + confirmed
+    truncate: the turn must be refused (fail closed), NOT silently skipped —
+    otherwise memory truncates while the profile DB keeps the old tail
+    (durable zombie history; the ordinal-mismatch class this PR fixes)."""
+    from hermes_state import SessionDB
+
+    profile_home = tmp_path / "remote-profile"
+    profile_home.mkdir()
+    session_key = "profile-unavailable-session"
+    db = SessionDB(db_path=profile_home / "state.db")
+    try:
+        db.create_session(session_key, source="desktop")
+        db.append_messages_batch(
+            session_key,
+            [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "reply 1"},
+                {"role": "user", "content": "second"},
+                {"role": "assistant", "content": "reply 2"},
+            ],
+        )
+        history = db.get_messages_as_conversation(
+            session_key, include_row_ids=True
+        )
+        target_row_id = history[2]["_row_id"]
+    finally:
+        db.close()
+
+    sess = _session(history=list(history), session_key=session_key)
+    sess["profile_home"] = str(profile_home)
+    server._sessions["profile-unavailable-sid"] = sess
+    def _yield_none(session):
+        yield None
+
+    monkeypatch.setattr(
+        server, "_session_db", server.contextlib.contextmanager(_yield_none)
+    )
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: pytest.fail("must not fall back to the launch-profile DB"),
+    )
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "profile-unavailable-sid",
+                    "text": "edited second",
+                    "truncate_before_row_id": target_row_id,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("error"), "expected fail-closed refusal"
+        assert resp["error"]["code"] == 5008
+        assert "state.db unavailable" in resp["error"]["message"]
+        # Fail closed = memory untouched, no turn started.
+        assert [m["content"] for m in sess["history"]] == [
+            "first",
+            "reply 1",
+            "second",
+            "reply 2",
+        ]
+        assert sess["running"] is False
+    finally:
+        server._sessions.pop("profile-unavailable-sid", None)
+
+
+def test_cli_undo_keeps_history_when_post_rewind_reload_fails(
+    monkeypatch, tmp_path
+):
+    """/undo: rewind_to_message succeeds but the post-rewind reload raises —
+    live memory must keep the pre-rewind transcript instead of being wiped
+    to an empty list (the flush pointer would then re-append every surviving
+    row, resurrecting the soft-archived turns)."""
+    from hermes_state import SessionDB
+
+    profile_home = tmp_path / "remote-profile"
+    profile_home.mkdir()
+    session_key = "profile-undo-reload-fail-session"
+    db = SessionDB(db_path=profile_home / "state.db")
+    try:
+        db.create_session(session_key, source="desktop")
+        db.append_messages_batch(
+            session_key,
+            [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "reply 1"},
+                {"role": "user", "content": "second"},
+                {"role": "assistant", "content": "reply 2"},
+            ],
+        )
+    finally:
+        db.close()
+
+    sess = _session(history=[], session_key=session_key)
+    sess["profile_home"] = str(profile_home)
+    server._sessions["profile-undo-reload-fail-sid"] = sess
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: pytest.fail("must not read through the launch-profile DB"),
+    )
+
+    real_session_db = server._session_db
+
+    @server.contextlib.contextmanager
+    def _failing_reload_session_db(session):
+        with real_session_db(session) as db:
+            if db is None:
+                yield None
+                return
+            original = db.get_messages_as_conversation
+
+            def _broken(*args, **kwargs):
+                if kwargs.get("include_row_ids"):
+                    raise RuntimeError("simulated reload failure")
+                return original(*args, **kwargs)
+
+            db.get_messages_as_conversation = _broken
+            yield db
+
+    monkeypatch.setattr(server, "_session_db", _failing_reload_session_db)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "command.dispatch",
+                "params": {
+                    "session_id": "profile-undo-reload-fail-sid",
+                    "name": "undo",
+                    "arg": "",
+                },
+            }
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert resp["result"]["type"] == "prefill"
+        # DB was rewound (durable rewind succeeded)…
+        verify_db = SessionDB(db_path=profile_home / "state.db")
+        try:
+            persisted = verify_db.get_messages_as_conversation(session_key)
+        finally:
+            verify_db.close()
+        assert [message["content"] for message in persisted] == ["first", "reply 1"]
+        # …but live memory keeps the pre-rewind view rather than going empty.
+        assert sess["history"] == []
+    finally:
+        server._sessions.pop("profile-undo-reload-fail-sid", None)
+
+
 def test_prompt_submit_truncates_by_string_row_id(monkeypatch):
     """#82959: String row IDs in history match correctly against integer truncate_before_row_id."""
     replaced = []

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5559,6 +5559,73 @@ def test_prompt_submit_truncates_by_row_id(monkeypatch):
         server._sessions.pop("row-id-trunc-sid", None)
 
 
+def test_prompt_submit_row_id_truncates_profile_owned_history(monkeypatch, tmp_path):
+    """A remote-profile edit must write through the same DB used to resolve it."""
+    from hermes_state import SessionDB
+
+    profile_home = tmp_path / "remote-profile"
+    profile_home.mkdir()
+    session_key = "profile-row-id-session"
+    db = SessionDB(db_path=profile_home / "state.db")
+    try:
+        db.create_session(session_key, source="desktop")
+        db.append_messages_batch(
+            session_key,
+            [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "reply 1"},
+                {"role": "user", "content": "second"},
+                {"role": "assistant", "content": "reply 2"},
+            ],
+        )
+        history = db.get_messages_as_conversation(
+            session_key, include_row_ids=True
+        )
+        target_row_id = history[2]["_row_id"]
+    finally:
+        db.close()
+
+    sess = _session(history=list(history), session_key=session_key)
+    sess["profile_home"] = str(profile_home)
+    server._sessions["profile-row-id-sid"] = sess
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: pytest.fail("must not write through the launch-profile DB"),
+    )
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "profile-row-id-sid",
+                    "text": "edited second",
+                    "truncate_before_row_id": target_row_id,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("error") is None
+        assert [message["content"] for message in sess["history"]] == [
+            "first",
+            "reply 1",
+        ]
+        verify_db = SessionDB(db_path=profile_home / "state.db")
+        try:
+            persisted = verify_db.get_messages_as_conversation(session_key)
+        finally:
+            verify_db.close()
+        assert [message["content"] for message in persisted] == [
+            "first",
+            "reply 1",
+        ]
+    finally:
+        server._sessions.pop("profile-row-id-sid", None)
+
+
 def test_prompt_submit_truncates_by_string_row_id(monkeypatch):
     """#82959: String row IDs in history match correctly against integer truncate_before_row_id."""
     replaced = []

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5626,6 +5626,63 @@ def test_prompt_submit_row_id_truncates_profile_owned_history(monkeypatch, tmp_p
         server._sessions.pop("profile-row-id-sid", None)
 
 
+def test_cli_undo_routes_profile_owned_session_db(monkeypatch, tmp_path):
+    """/undo on a remote-profile session must read/rewind the profile's own
+    state.db — the launch-profile DB has no rows for that session key, so the
+    old `_get_db()` routing failed with "no user messages to undo"."""
+    from hermes_state import SessionDB
+
+    profile_home = tmp_path / "remote-profile"
+    profile_home.mkdir()
+    session_key = "profile-undo-session"
+    db = SessionDB(db_path=profile_home / "state.db")
+    try:
+        db.create_session(session_key, source="desktop")
+        db.append_messages_batch(
+            session_key,
+            [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "reply 1"},
+                {"role": "user", "content": "second"},
+                {"role": "assistant", "content": "reply 2"},
+            ],
+        )
+    finally:
+        db.close()
+
+    sess = _session(history=[], session_key=session_key)
+    sess["profile_home"] = str(profile_home)
+    server._sessions["profile-undo-sid"] = sess
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: pytest.fail("must not read through the launch-profile DB"),
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "command.dispatch",
+                "params": {
+                    "session_id": "profile-undo-sid",
+                    "name": "undo",
+                    "arg": "",
+                },
+            }
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert resp["result"]["type"] == "prefill"
+        assert resp["result"]["message"] == "second"
+        verify_db = SessionDB(db_path=profile_home / "state.db")
+        try:
+            persisted = verify_db.get_messages_as_conversation(session_key)
+        finally:
+            verify_db.close()
+        assert [message["content"] for message in persisted] == ["first", "reply 1"]
+    finally:
+        server._sessions.pop("profile-undo-sid", None)
+
+
 def test_prompt_submit_truncates_by_string_row_id(monkeypatch):
     """#82959: String row IDs in history match correctly against integer truncate_before_row_id."""
     replaced = []

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5841,6 +5841,113 @@ def test_cli_undo_keeps_history_when_post_rewind_reload_fails(
         server._sessions.pop("profile-undo-reload-fail-sid", None)
 
 
+def test_durable_lifecycle_selector_uses_profile_db_not_launch(monkeypatch, tmp_path):
+    """_session_owns_durable_lifecycle must consult the session's OWN profile
+    state.db (app-global remote mode), not the launch profile's shared handle —
+    the same wrong-database class the truncation/undo routing in this PR fixes.
+    A gateway-owned row that lives only in the profile DB must read as
+    gateway-owned, and the delegation selectors must drop the durable key."""
+    from hermes_state import SessionDB
+
+    profile_home = tmp_path / "remote-profile"
+    profile_home.mkdir()
+    session_key = "profile-gateway-viewer-session"
+    db = SessionDB(db_path=profile_home / "state.db")
+    try:
+        db.create_session(session_key, source="telegram")
+    finally:
+        db.close()
+
+    agent = types.SimpleNamespace(session_id=session_key)
+    sess = _session(agent=agent, session_key=session_key)
+    sess["profile_home"] = str(profile_home)
+    server._sessions["profile-gateway-viewer-sid"] = sess
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: pytest.fail("must not consult the launch-profile DB"),
+    )
+
+    try:
+        assert server._session_owns_durable_lifecycle(sess, session_key) is False
+        own_sid, owned_key = server._session_async_delegation_selectors(
+            sess, sid_hint="profile-gateway-viewer-sid"
+        )
+        assert own_sid == "profile-gateway-viewer-sid"
+        assert owned_key == ""
+    finally:
+        server._sessions.pop("profile-gateway-viewer-sid", None)
+
+
+def test_durable_lifecycle_selector_owns_tui_rows_in_profile_db(monkeypatch, tmp_path):
+    """Counterpart: a TUI/desktop row in the profile DB stays TUI-owned —
+    routing through the profile DB must not over-restrict."""
+    from hermes_state import SessionDB
+
+    profile_home = tmp_path / "remote-profile"
+    profile_home.mkdir()
+    session_key = "profile-tui-session"
+    db = SessionDB(db_path=profile_home / "state.db")
+    try:
+        db.create_session(session_key, source="desktop")
+    finally:
+        db.close()
+
+    agent = types.SimpleNamespace(session_id=session_key)
+    sess = _session(agent=agent, session_key=session_key)
+    sess["profile_home"] = str(profile_home)
+    server._sessions["profile-tui-sid"] = sess
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: pytest.fail("must not consult the launch-profile DB"),
+    )
+
+    try:
+        assert server._session_owns_durable_lifecycle(sess, session_key) is True
+        _, owned_key = server._session_async_delegation_selectors(
+            sess, sid_hint="profile-tui-sid"
+        )
+        assert owned_key == session_key
+    finally:
+        server._sessions.pop("profile-tui-sid", None)
+
+
+def test_durable_lifecycle_selector_fails_closed_when_db_unavailable(monkeypatch):
+    """No owning DB to consult → NOT TUI-owned (fail closed): a gateway-owned
+    session must never be misclassified as TUI-owned by absence of a row."""
+    sess = _session(session_key="no-db-session")
+    sess["profile_home"] = "/nonexistent-profile-home"
+
+    def _yield_none(session):
+        yield None
+
+    monkeypatch.setattr(
+        server, "_session_db", server.contextlib.contextmanager(_yield_none)
+    )
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: pytest.fail("must not fall back to the launch-profile DB"),
+    )
+
+    assert server._session_owns_durable_lifecycle(sess, "no-db-session") is False
+
+
+def test_durable_lifecycle_selector_launch_session_gateway_row(monkeypatch):
+    """Launch-profile session (no profile_home): _session_db borrows the shared
+    _get_db() handle; gateway-owned sources still read as gateway-owned."""
+
+    class _FakeDB:
+        def get_session(self, target):
+            return {"source": "telegram"}
+
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    sess = _session(session_key="launch-gw-session")
+
+    assert server._session_owns_durable_lifecycle(sess, "launch-gw-session") is False
+
+
 def test_prompt_submit_truncates_by_string_row_id(monkeypatch):
     """#82959: String row IDs in history match correctly against integer truncate_before_row_id."""
     replaced = []

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -646,6 +646,26 @@ def _(rid, params: dict) -> dict:
             # zombie history on resume, and the edit/regenerate never sticks.
             # Fail closed: refuse the turn and leave memory/DB unchanged.
             with _session_db(session) as db:
+                if db is None and session.get("profile_home"):
+                    # Profile-owned durable session whose own state.db cannot
+                    # be opened. Skipping the write here would truncate memory
+                    # while the profile DB keeps the old tail — the durable
+                    # zombie history this block exists to prevent. Memory-only
+                    # sessions (no profile_home, launch db unavailable) keep
+                    # the legacy skip: with nothing durable to diverge from,
+                    # refusing the turn would break stateless runs outright.
+                    logger.error(
+                        "prompt.submit: profile state.db unavailable for "
+                        "session %s (ordinal=%d); refusing truncation",
+                        sid,
+                        ordinal,
+                    )
+                    return _err(
+                        rid,
+                        5008,
+                        "state.db unavailable: refusing to truncate a "
+                        "profile-owned session that cannot be persisted",
+                    )
                 if db is not None:
                     try:
                         # active_only=True: replace only the live (active=1) rows.

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -645,48 +645,49 @@ def _(rid, params: dict) -> dict:
             # new exchange is appended on top of the "undone" turns — durable
             # zombie history on resume, and the edit/regenerate never sticks.
             # Fail closed: refuse the turn and leave memory/DB unchanged.
-            if (db := _get_db()) is not None:
-                try:
-                    # active_only=True: replace only the live (active=1) rows.
-                    # In-place compaction (#38763) keeps the pre-compaction
-                    # transcript as active=0/compacted=1 rows under this same
-                    # session key; a bare replace_messages() would DELETE that
-                    # durable archive on every edit/regenerate — the same bug
-                    # class #80216 fixed for /retry. On an uncompacted session
-                    # all rows are active=1, so this is behaviorally identical
-                    # to the full replace.
-                    # archive_dropped: a rewind overwrites turns the user may
-                    # not have meant to drop, and this write is the last step
-                    # before they are gone — three reported incidents ended
-                    # here with nothing to restore from (#70516, #80763,
-                    # #82756). Soft-archiving keeps them on disk (active=0) and
-                    # in the FTS index, so a mis-aimed cut is recoverable
-                    # instead of terminal. The live transcript is unchanged.
-                    # Fall back to session id when session_key is NULL — CLI-origin
-                    # sessions created before the session_key default fix have no
-                    # key, and replace_messages(None) triggers an FK violation.
-                    truncation_key = session.get("session_key") or sid
-                    db.replace_messages(
-                        truncation_key,
-                        truncated,
-                        active_only=True,
-                        archive_dropped=True,
-                    )
-                except Exception as exc:
-                    logger.error(
-                        "prompt.submit: replace_messages failed for session %s "
-                        "(ordinal=%d); refusing turn so memory and DB stay "
-                        "aligned: %s",
-                        sid,
-                        ordinal,
-                        exc,
-                        exc_info=True,
-                    )
-                    return _err(
-                        rid,
-                        5008,
-                        f"failed to persist history truncation: {exc}",
-                    )
+            with _session_db(session) as db:
+                if db is not None:
+                    try:
+                        # active_only=True: replace only the live (active=1) rows.
+                        # In-place compaction (#38763) keeps the pre-compaction
+                        # transcript as active=0/compacted=1 rows under this same
+                        # session key; a bare replace_messages() would DELETE that
+                        # durable archive on every edit/regenerate — the same bug
+                        # class #80216 fixed for /retry. On an uncompacted session
+                        # all rows are active=1, so this is behaviorally identical
+                        # to the full replace.
+                        # archive_dropped: a rewind overwrites turns the user may
+                        # not have meant to drop, and this write is the last step
+                        # before they are gone — three reported incidents ended
+                        # here with nothing to restore from (#70516, #80763,
+                        # #82756). Soft-archiving keeps them on disk (active=0) and
+                        # in the FTS index, so a mis-aimed cut is recoverable
+                        # instead of terminal. The live transcript is unchanged.
+                        # Fall back to session id when session_key is NULL — CLI-origin
+                        # sessions created before the session_key default fix have no
+                        # key, and replace_messages(None) triggers an FK violation.
+                        truncation_key = session.get("session_key") or sid
+                        db.replace_messages(
+                            truncation_key,
+                            truncated,
+                            active_only=True,
+                            archive_dropped=True,
+                        )
+                    except Exception as exc:
+                        logger.error(
+                            "prompt.submit: replace_messages failed for session %s "
+                            "(ordinal=%d); refusing turn so memory and DB stay "
+                            "aligned: %s",
+                            sid,
+                            ordinal,
+                            exc,
+                            exc_info=True,
+                        )
+                        return _err(
+                            rid,
+                            5008,
+                            f"failed to persist history truncation: {exc}",
+                        )
             session["history"] = truncated
             session["history_version"] = int(session.get("history_version", 0)) + 1
             if db is not None:

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -935,10 +935,25 @@ def _(rid, params: dict) -> dict:
                     session_key, repair_alternation=True, include_row_ids=True
                 )
             except Exception:
-                active = []
-            with session["history_lock"]:
-                session["history"] = list(active)
-                session["history_version"] = int(session.get("history_version", 0)) + 1
+                # The durable rewind already succeeded; a failed reload must
+                # NOT publish an empty transcript. That would wipe the live
+                # agent's whole context mid-session, and the flush-pointer
+                # reset below (len([]) == 0) would re-append every surviving
+                # message as new rows — resurrecting the turns /undo just
+                # soft-archived. Keep the pre-rewind memory instead: the DB
+                # is the source of truth and the next resume/reload converges
+                # back to it.
+                active = None
+                logger.error(
+                    "undo: rewind succeeded for session %s but history reload "
+                    "failed; keeping pre-rewind in-memory history",
+                    session_key,
+                    exc_info=True,
+                )
+            if active is not None:
+                with session["history_lock"]:
+                    session["history"] = list(active)
+                    session["history_version"] = int(session.get("history_version", 0)) + 1
             # Notify memory providers — same hook /branch fires, plus the
             # rewound flag so providers caching per-turn document state
             # know to invalidate. See #6672 + #21910.
@@ -960,7 +975,7 @@ def _(rid, params: dict) -> dict:
                         agent._invalidate_system_prompt()
                     except Exception:
                         pass
-                if hasattr(agent, "_last_flushed_db_idx"):
+                if hasattr(agent, "_last_flushed_db_idx") and active is not None:
                     try:
                         agent._last_flushed_db_idx = len(active)
                     except Exception:

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -887,100 +887,105 @@ def _(rid, params: dict) -> dict:
             return _err(
                 rid, 4009, "session busy — /interrupt the current turn before /undo"
             )
-        db = _get_db()
-        if db is None:
-            return _db_unavailable_error(rid, code=5008)
-        session_key = session.get("session_key", "")
-        if not session_key:
-            return _err(rid, 4001, "no session key for undo")
-        # Parse the optional count argument (e.g. "/undo 3" → 3).
-        n = 1
-        arg_str = (arg or "").strip()
-        if arg_str:
-            try:
-                n = int(arg_str.split()[0])
-            except (ValueError, IndexError):
-                return _err(rid, 4004, f"undo: invalid count {arg_str!r} — use /undo or /undo N")
-        if n < 1:
+        # Profile-owned session (global-remote desktop profile): the durable
+        # rows live in the profile's own state.db, not the launch profile's —
+        # same routing the prompt.submit truncation write uses. Reading the
+        # launch DB here finds no rows ("no user messages to undo") and a
+        # rewind would silently no-op against the wrong database.
+        with _session_db(session) as db:
+            if db is None:
+                return _db_unavailable_error(rid, code=5008)
+            session_key = session.get("session_key", "")
+            if not session_key:
+                return _err(rid, 4001, "no session key for undo")
+            # Parse the optional count argument (e.g. "/undo 3" → 3).
             n = 1
-        try:
-            recents = db.list_recent_user_messages(session_key, limit=max(n, 10))
-        except Exception as e:
-            return _err(rid, 5008, f"undo: failed to load history: {e}")
-        if not recents:
-            return _err(rid, 4018, "no user messages to undo")
-        # recents[0] is the most-recent user turn; pick the Nth-from-last.
-        # If N exceeds the number of user turns, back up to the oldest.
-        target_idx = min(n - 1, len(recents) - 1)
-        target_id = recents[target_idx]["id"]
-        try:
-            result = db.rewind_to_message(session_key, target_id)
-        except ValueError as e:
-            return _err(rid, 4004, f"undo: {e}")
-        except Exception as e:
-            return _err(rid, 5008, f"undo: {e}")
-        # Reload the active-only transcript into the in-memory session
-        # history so subsequent turns see the truncated view.
-        # repair_alternation: this reload feeds LIVE REPLAY — session["history"]
-        # is the working conversation for subsequent turns, and a rewind that
-        # lands on a durable user;user pair would otherwise re-fire the
-        # pre-request repair on every request from here on.
-        try:
-            active = db.get_messages_as_conversation(
-                session_key, repair_alternation=True, include_row_ids=True
+            arg_str = (arg or "").strip()
+            if arg_str:
+                try:
+                    n = int(arg_str.split()[0])
+                except (ValueError, IndexError):
+                    return _err(rid, 4004, f"undo: invalid count {arg_str!r} — use /undo or /undo N")
+            if n < 1:
+                n = 1
+            try:
+                recents = db.list_recent_user_messages(session_key, limit=max(n, 10))
+            except Exception as e:
+                return _err(rid, 5008, f"undo: failed to load history: {e}")
+            if not recents:
+                return _err(rid, 4018, "no user messages to undo")
+            # recents[0] is the most-recent user turn; pick the Nth-from-last.
+            # If N exceeds the number of user turns, back up to the oldest.
+            target_idx = min(n - 1, len(recents) - 1)
+            target_id = recents[target_idx]["id"]
+            try:
+                result = db.rewind_to_message(session_key, target_id)
+            except ValueError as e:
+                return _err(rid, 4004, f"undo: {e}")
+            except Exception as e:
+                return _err(rid, 5008, f"undo: {e}")
+            # Reload the active-only transcript into the in-memory session
+            # history so subsequent turns see the truncated view.
+            # repair_alternation: this reload feeds LIVE REPLAY — session["history"]
+            # is the working conversation for subsequent turns, and a rewind that
+            # lands on a durable user;user pair would otherwise re-fire the
+            # pre-request repair on every request from here on.
+            try:
+                active = db.get_messages_as_conversation(
+                    session_key, repair_alternation=True, include_row_ids=True
+                )
+            except Exception:
+                active = []
+            with session["history_lock"]:
+                session["history"] = list(active)
+                session["history_version"] = int(session.get("history_version", 0)) + 1
+            # Notify memory providers — same hook /branch fires, plus the
+            # rewound flag so providers caching per-turn document state
+            # know to invalidate. See #6672 + #21910.
+            agent = session.get("agent")
+            if agent is not None:
+                mm = getattr(agent, "_memory_manager", None)
+                if mm is not None:
+                    try:
+                        mm.on_session_switch(
+                            session_key,
+                            parent_session_id="",
+                            reset=False,
+                            rewound=True,
+                        )
+                    except Exception:
+                        pass
+                if hasattr(agent, "_invalidate_system_prompt"):
+                    try:
+                        agent._invalidate_system_prompt()
+                    except Exception:
+                        pass
+                if hasattr(agent, "_last_flushed_db_idx"):
+                    try:
+                        agent._last_flushed_db_idx = len(active)
+                    except Exception:
+                        pass
+            target_msg = result.get("target_message") or {}
+            target_text = target_msg.get("content") or ""
+            if isinstance(target_text, list):
+                parts = [
+                    p.get("text", "") for p in target_text
+                    if isinstance(p, dict) and p.get("type") == "text"
+                ]
+                target_text = "\n".join(t for t in parts if t)
+            if not isinstance(target_text, str):
+                target_text = ""
+            rewound_count = result.get("rewound_count", 0)
+            turns_undone = target_idx + 1
+            turn_word = "turn" if turns_undone == 1 else "turns"
+            notice = (
+                f"↶ Undid {turns_undone} {turn_word} ({rewound_count} message(s)). "
+                "Edit and resubmit, or send a new message."
             )
-        except Exception:
-            active = []
-        with session["history_lock"]:
-            session["history"] = list(active)
-            session["history_version"] = int(session.get("history_version", 0)) + 1
-        # Notify memory providers — same hook /branch fires, plus the
-        # rewound flag so providers caching per-turn document state
-        # know to invalidate. See #6672 + #21910.
-        agent = session.get("agent")
-        if agent is not None:
-            mm = getattr(agent, "_memory_manager", None)
-            if mm is not None:
-                try:
-                    mm.on_session_switch(
-                        session_key,
-                        parent_session_id="",
-                        reset=False,
-                        rewound=True,
-                    )
-                except Exception:
-                    pass
-            if hasattr(agent, "_invalidate_system_prompt"):
-                try:
-                    agent._invalidate_system_prompt()
-                except Exception:
-                    pass
-            if hasattr(agent, "_last_flushed_db_idx"):
-                try:
-                    agent._last_flushed_db_idx = len(active)
-                except Exception:
-                    pass
-        target_msg = result.get("target_message") or {}
-        target_text = target_msg.get("content") or ""
-        if isinstance(target_text, list):
-            parts = [
-                p.get("text", "") for p in target_text
-                if isinstance(p, dict) and p.get("type") == "text"
-            ]
-            target_text = "\n".join(t for t in parts if t)
-        if not isinstance(target_text, str):
-            target_text = ""
-        rewound_count = result.get("rewound_count", 0)
-        turns_undone = target_idx + 1
-        turn_word = "turn" if turns_undone == 1 else "turns"
-        notice = (
-            f"↶ Undid {turns_undone} {turn_word} ({rewound_count} message(s)). "
-            "Edit and resubmit, or send a new message."
-        )
-        return _ok(
-            rid,
-            {"type": "prefill", "message": target_text, "notice": notice},
-        )
+            return _ok(
+                rid,
+                {"type": "prefill", "message": target_text, "notice": notice},
+            )
 
     if name in {"snapshot", "snap"}:
         subcommand = arg.split(maxsplit=1)[0].lower() if arg else ""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1051,21 +1051,32 @@ def _ws_session_is_orphaned(session: dict | None) -> bool:
     return session.get("transport") is _detached_ws_transport
 
 
-def _session_owns_durable_lifecycle(session_id: str | None) -> bool:
-    """Whether this TUI/desktop session may end its durable DB row by key."""
+def _session_owns_durable_lifecycle(session: dict | None, session_id: str | None) -> bool:
+    """Whether this TUI/desktop session may end its durable DB row by key.
+
+    The row lives in the *session's* profile state.db (app-global remote
+    mode), not the launch profile's shared handle — the same wrong-database
+    class the truncation/undo routing in this PR fixes. Fail closed (False)
+    when the owning DB can't be consulted, so a gateway-owned session is
+    never misclassified as TUI-owned by absence of a row.
+    """
     if not session_id:
         return True
+    if session is None:
+        # No live session dict → no profile_home → cannot locate the owning
+        # DB. Fail closed rather than guessing via the launch handle.
+        return False
     try:
-        db = _get_db()
-        if db is None:
-            return True
-        # Don't end gateway-originated sessions — the gateway owns their
-        # lifecycle. The TUI is only a viewer there (#60609).
-        row = db.get_session(session_id)
+        with _session_db(session) as db:
+            if db is None:
+                return False
+            # Don't end gateway-originated sessions — the gateway owns their
+            # lifecycle. The TUI is only a viewer there (#60609).
+            row = db.get_session(session_id)
         source = (row or {}).get("source", "")
         return not _is_gateway_owned_source(source)
     except Exception:
-        return True
+        return False
 
 
 def _session_async_delegation_selectors(
@@ -1087,7 +1098,11 @@ def _session_async_delegation_selectors(
     agent = session.get("agent")
     session_key = str(session.get("session_key") or "")
     session_id = getattr(agent, "session_id", None) or session_key
-    owned_session_key = session_key if _session_owns_durable_lifecycle(session_id) else ""
+    owned_session_key = (
+        session_key
+        if _session_owns_durable_lifecycle(session, session_id)
+        else ""
+    )
     return own_sid, owned_session_key
 
 


### PR DESCRIPTION
## What this fixes

Editing an earlier user message in **Desktop** on a **global-remote profile session** (a non-launch profile's chat hosted by the same backend) fails with:

```
Edit failed
truncate_before_user_ordinal (3) does not match truncate_before_row_id target turn (4)
```

Root cause chain (from a live incident, `logs/gui.log`):

1. Edit submit resolves `truncate_before_row_id=1105` correctly — the durable read path (`_load_durable_truncation_history`) is profile-aware via `_session_db(session)`.
2. The truncation **write** then goes through `_get_db()` — always the **launch profile's** `state.db` — and `replace_messages` INSERTs rows for a session key that has no `sessions` row in that DB → `sqlite3.IntegrityError: FOREIGN KEY constraint failed` → error 5008, turn refused.
3. The desktop's optimistic rewind still updated its local ordinal space, so every subsequent edit retry is refused with the 4030 ordinal mismatch above — the visible symptom.

## The fix

This is a **re-land of 0640fe7119** ("fix(gateway): route truncation writes to profile database", authorship preserved via cherry-pick), which was reverted in 3863de3155 purely for scope ("keep profile truncation routing out of scope" of PR #86649) — not because it was wrong. It never got re-landed while the FK bug remained on main.

Plus the sibling of the same class found while fixing:
- `tui_gateway/methods_tools.py` — `command.dispatch` `/undo` read the launch-profile DB for remote-profile sessions → always "no user messages to undo" / silent no-op rewind. Now routed through `_session_db(session)` with the body scoped inside the handle's lifetime (it closes profile handles on exit).

## Tests

- `test_prompt_submit_row_id_truncates_profile_owned_history` (from the reverted commit; monkeypatches `_get_db` to fail the test if the launch DB is touched — proves routing, not just outcome)
- `test_cli_undo_routes_profile_owned_session_db` (same probe pattern for `/undo`)
- Full `tests/test_tui_gateway_server.py`: **587 passed** on this branch.

## Verification

Reproduced on a live install (songbird profile hosting, default-profile backend): edit → 5008 FK failure → 4030 on every retry. After the fix, the same edit persisted the truncated transcript into the profile's own `state.db` and the turn ran.