### PR TITLE
fix(desktop): always show a Bot's @handle in the roster

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3369,9 +3369,11 @@ function botRosterMeta(bot, metaByName) {
   return bot?.remoteSource ? null : metaByName?.[bot?.name]
 }
 
-function showsHandle(name, meta, bot) {
-  const display = displayName({ name }, meta)
-  return Boolean(name && display.toLowerCase() !== botHandle(name, bot).toLowerCase())
+function showsHandle(name, _meta, bot) {
+  // A handle is the stable, routable identity; the display title is only
+  // presentation. Always render it so single-word titles ("Ada" / @ada) are
+  // as discoverable and copyable as renamed or multi-word Bots.
+  return Boolean(name && botHandle(name, bot))
 }
 
 // ── canonical bot chat ───────────────────────────────────────────────────────

--- a/apps/desktop/src/plugins/hermes-bots/tests/always-show-handle.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/always-show-handle.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function between(start, end, from = 0) {
+  const a = source.indexOf(start, from)
+  const b = source.indexOf(end, a)
+  assert.notEqual(a, -1, `missing ${start}`)
+  assert.notEqual(b, -1, `missing ${end}`)
+  return source.slice(a, b)
+}
+
+function load() {
+  const handle = between('function botHandle(', '/** Taggable @-forms')
+  const visible = between('function showsHandle(', '// ── canonical bot chat')
+  const context = {}
+  vm.runInNewContext(`${handle}\n${visible}\nglobalThis.api = { botHandle, showsHandle }`, context)
+  return context.api
+}
+
+test('every local bot row shows its routable handle even when title and slug match', () => {
+  const { showsHandle } = load()
+  assert.equal(showsHandle('ada', null, { name: 'ada' }), true)
+  assert.equal(showsHandle('zubir', { title: 'Zubir' }, { name: 'zubir' }), true)
+})
+
+test('default and source-qualified bots show their callable handles', () => {
+  const { botHandle, showsHandle } = load()
+  assert.equal(botHandle('default', { name: 'default' }), 'hermes')
+  assert.equal(showsHandle('default', null, { name: 'default' }), true)
+  assert.equal(showsHandle('ops', null, { name: 'ops', handle: 'ops-singapore' }), true)
+})


### PR DESCRIPTION
## What does this PR do?

The Bots roster hides a Bot's `@handle` whenever it matches the display
name, so single-word Bots render with no handle while multi-word ones keep
theirs. It makes the handle look like a property only some Bots have.

| Display | Handle | Rendered today |
| --- | --- | --- |
| Ada | `@ada` | hidden |
| Socrates | `@socrates` | hidden |
| Ada Wong | `@ada-wong` | shown |
| Steve Jobs | `@steve-jobs` | shown |

The handle is the stable, routable identity: it is what `@mention` resolves,
what group rooms address, and what `hermes -p <bot>` takes. The title is
presentation only and freely renameable. The current rule makes the
mentionable name least visible for the Bots whose name is simplest, and
leaves it unavailable to read or copy.

`showsHandle()` is the single chokepoint for both the roster row and the
compact row, so one change covers every surface.

Unchanged on purpose: the default profile still renders `@hermes`, and
multi-source rosters keep the disambiguated `@name-device` form.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `showsHandle()` returns true whenever a handle exists, instead of
  comparing it against the display title
- adds `tests/always-show-handle.test.mjs`

## How to Test

    cd apps/desktop/src/plugins/hermes-bots
    node --test "tests/*.test.mjs"
    # tests 343 | pass 343 | fail 0

Visually: open the Bots tab. Single-word Bots (`@ada`, `@socrates`,
`@zubir`) now show their handle in the same grey mono style multi-word Bots
already use. The default profile still reads `@hermes`.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

Note: this is a desktop renderer change with no Python surface, so
`pytest tests/` is not applicable; the plugin's own Node suite is the
relevant gate and passes 343/343.

## Documentation & Housekeeping

- [x] Documentation: N/A (no user-facing config or API change)
- [x] `cli-config.yaml.example`: N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A (no architecture change)
- [x] Cross-platform impact: N/A (pure renderer logic)
- [x] Tool descriptions/schemas: N/A

## Note for reviewers

This flips a default for everyone rather than adding a preference. I went
this way because the current behavior reads as a bug from the user side, and
a per-user toggle for one label felt like more surface than the problem
deserves. Happy to rework it as a preference if you'd prefer.