### PR TITLE
feat: expose bounded MCP App envelopes in session chat

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -157,6 +157,53 @@ MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 RESPONSES_AUTO_TRUNCATION_HISTORY_LIMIT = 100
 _COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
+_MCP_APP_MIME = "text/html;profile=mcp-app"
+_MAX_MCP_APP_URI_LENGTH = 2048
+_MAX_MCP_APPS_PER_TURN = 16
+
+
+def _extract_mcp_app_envelope(function_name, function_args, function_result):
+    """Return bounded UI metadata from one completed tool result.
+
+    Raw tool output and arbitrary arguments never cross into the host envelope.
+    Only a standard ui:// URI, MCP App MIME, tool name, and a simple peer target
+    are admitted.
+    """
+    if function_name != "honcho_profile":
+        return None
+    payload = function_result
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except Exception:
+            return None
+    if not isinstance(payload, dict):
+        return None
+    meta = payload.get("_meta")
+    if not isinstance(meta, dict):
+        return None
+    ui = meta.get("ui")
+    if not isinstance(ui, dict):
+        return None
+    uri = ui.get("resourceUri")
+    mime = meta.get("mimeType")
+    if not isinstance(uri, str) or not uri.startswith("ui://") or len(uri) > _MAX_MCP_APP_URI_LENGTH:
+        return None
+    if mime != _MCP_APP_MIME:
+        return None
+    envelope = {
+        "resourceUri": uri,
+        "mimeType": mime,
+        "tool": str(function_name or ""),
+    }
+    resolved_peer = payload.get("resolvedPeer")
+    if (
+        isinstance(resolved_peer, str)
+        and 0 < len(resolved_peer) <= 128
+        and resolved_peer.replace("-", "").replace("_", "").isalnum()
+    ):
+        envelope["target"] = resolved_peer
+    return envelope
 
 
 class ThreadSafeAsyncQueue(asyncio.Queue):
@@ -3800,6 +3847,13 @@ class APIServerAdapter(BasePlatformAdapter):
             if selection_error:
                 return web.json_response(_openai_error(selection_error), status=400)
         history = await self._conversation_history_for_session(session_id)
+        apps: List[Dict[str, Any]] = []
+
+        def _on_tool_complete(tool_call_id, function_name, function_args, function_result):
+            app = _extract_mcp_app_envelope(function_name, function_args, function_result)
+            if app is not None and len(apps) < _MAX_MCP_APPS_PER_TURN:
+                apps.append(app)
+
         result, usage = await self._run_agent(
             user_message=user_message,
             conversation_history=history,
@@ -3811,6 +3865,7 @@ class APIServerAdapter(BasePlatformAdapter):
             requested_runtime=runtime_request.get("requested") or {},
             route_source=runtime_request.get("route_source") or "global",
             confirmed_runtime_lock=lock_active,
+            tool_complete_callback=_on_tool_complete,
             **agent_overrides,
         )
         effective_session_id = result.get("session_id") if isinstance(result, dict) else session_id
@@ -3835,16 +3890,16 @@ class APIServerAdapter(BasePlatformAdapter):
                 else ""
             ),
         )
-        return web.json_response(
-            {
-                "object": "hermes.session.chat.completion",
-                "session_id": effective_session_id or session_id,
-                "message": {"role": "assistant", "content": final_response},
-                "usage": usage,
-                "runtime": runtime,
-            },
-            headers=headers,
-        )
+        response_payload = {
+            "object": "hermes.session.chat.completion",
+            "session_id": effective_session_id or session_id,
+            "message": {"role": "assistant", "content": final_response},
+            "usage": usage,
+            "runtime": runtime,
+        }
+        if apps:
+            response_payload["apps"] = apps
+        return web.json_response(response_payload, headers=headers)
 
     @_admit_api_agent_request
     async def _handle_session_chat_stream(self, request: "web.Request") -> "web.StreamResponse":

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import threading
 import time
@@ -57,6 +58,18 @@ def _is_internal_gateway_turn(text: str) -> bool:
 # ---------------------------------------------------------------------------
 # Tool schemas (moved from tools/honcho_tools.py)
 # ---------------------------------------------------------------------------
+
+_MCP_APP_MIME = "text/html;profile=mcp-app"
+
+
+def _profile_app_metadata(platform: str) -> dict | None:
+    """Return optional API-host UI metadata for peer-card reads."""
+    if platform != "api_server":
+        return None
+    uri = os.environ.get("HONCHO_PROFILE_RESOURCE_URI", "").strip()
+    if not uri.startswith("ui://"):
+        return None
+    return {"ui": {"resourceUri": uri}, "mimeType": _MCP_APP_MIME}
 
 PROFILE_SCHEMA = {
     "name": "honcho_profile",
@@ -279,6 +292,7 @@ class HonchoMemoryProvider(MemoryProvider):
         self._manager = None   # HonchoSessionManager
         self._config = None    # HonchoClientConfig
         self._session_key = ""
+        self._platform = "cli"
         self._query_rewriter = query_rewriter
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
@@ -374,6 +388,7 @@ class HonchoMemoryProvider(MemoryProvider):
         try:
             agent_context = kwargs.get("agent_context", "")
             platform = kwargs.get("platform", "cli")
+            self._platform = platform
             if agent_context in {"cron", "flush"} or platform == "cron":
                 logger.debug("Honcho skipped: cron/flush context (agent_context=%s, platform=%s)",
                              agent_context, platform)
@@ -1558,9 +1573,21 @@ class HonchoMemoryProvider(MemoryProvider):
                         return tool_error("Failed to update peer card.")
                     return json.dumps({"result": f"Peer card updated ({len(result)} facts).", "card": result})
                 card = self._manager.get_peer_card(self._session_key, peer=peer)
+                resolver = getattr(self._manager, "resolve_peer_id", None)
+                app_meta = _profile_app_metadata(self._platform)
                 if not card:
-                    return json.dumps(self._empty_profile_hint(peer))
-                return json.dumps({"result": card})
+                    payload = self._empty_profile_hint(peer)
+                    if app_meta:
+                        candidate = resolver(self._session_key, peer) if callable(resolver) else None
+                        resolved_peer = candidate if isinstance(candidate, str) else str(peer or "user")
+                        payload.update({"peer": peer, "resolvedPeer": resolved_peer, "_meta": app_meta})
+                    return json.dumps(payload)
+                payload: Dict[str, Any] = {"result": card}
+                if app_meta:
+                    candidate = resolver(self._session_key, peer) if callable(resolver) else None
+                    resolved_peer = candidate if isinstance(candidate, str) else str(peer or "user")
+                    payload.update({"peer": peer, "resolvedPeer": resolved_peer, "_meta": app_meta})
+                return json.dumps(payload)
 
             elif tool_name == "honcho_search":
                 query = (args.get("query") or "").strip()

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1434,6 +1434,13 @@ class HonchoSessionManager:
 
         return target_peer_id, None
 
+    def resolve_peer_id(self, session_key: str, peer: str = "user") -> str:
+        """Resolve a tool-facing peer alias to the concrete Honcho peer ID."""
+        session = self._cache.get(session_key)
+        if not session:
+            return self._sanitize_id((peer or "user").strip())
+        return self._resolve_peer_id(session, peer)
+
     def get_peer_card(self, session_key: str, peer: str = "user") -> list[str]:
         """
         Fetch a peer card — a curated list of key facts.

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -1,6 +1,7 @@
 """Focused tests for API server session-control endpoints."""
 
 import asyncio
+import json
 import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -9,7 +10,7 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import PlatformConfig
-from gateway.platforms.api_server import APIServerAdapter
+from gateway.platforms.api_server import APIServerAdapter, _extract_mcp_app_envelope
 from hermes_state import SessionDB
 
 
@@ -51,6 +52,91 @@ def _create_session_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/api/sessions/{session_id}/chat", adapter._handle_session_chat)
     app.router.add_post("/api/sessions/{session_id}/chat/stream", adapter._handle_session_chat_stream)
     return app
+
+
+def test_extract_mcp_app_envelope_is_bounded_and_fail_closed():
+    result = {
+        "result": ["IDENTITY: Name: Kenneth"],
+        "resolvedPeer": "kenneth",
+        "_meta": {
+            "ui": {"resourceUri": "ui://hugin/peer-card"},
+            "mimeType": "text/html;profile=mcp-app",
+        },
+    }
+    assert _extract_mcp_app_envelope("honcho_profile", {"peer": "kenneth", "secret": "no"}, result) == {
+        "resourceUri": "ui://hugin/peer-card",
+        "mimeType": "text/html;profile=mcp-app",
+        "tool": "honcho_profile",
+        "target": "kenneth",
+    }
+    assert _extract_mcp_app_envelope("honcho_search", {}, result) is None
+    assert _extract_mcp_app_envelope("terminal", {}, result) is None
+    missing_mime = dict(result, _meta={"ui": {"resourceUri": "ui://hugin/peer-card"}})
+    assert _extract_mcp_app_envelope("honcho_profile", {}, missing_mime) is None
+    oversized = dict(result, _meta={"ui": {"resourceUri": "ui://x/" + "a" * 2048}, "mimeType": "text/html;profile=mcp-app"})
+    assert _extract_mcp_app_envelope("honcho_profile", {}, oversized) is None
+    underscored = dict(result, resolvedPeer="runi_user")
+    envelope = _extract_mcp_app_envelope("honcho_profile", {}, underscored)
+    assert envelope is not None
+    assert envelope["target"] == "runi_user"
+    assert _extract_mcp_app_envelope("honcho_profile", {}, "not-json") is None
+
+
+@pytest.mark.asyncio
+async def test_session_chat_returns_only_bounded_mcp_app_metadata(adapter, session_db):
+    session_id = session_db.create_session("mcp-app-turn", "api_server")
+
+    async def fake_run_agent(**kwargs):
+        for idx in range(20):
+            kwargs["tool_complete_callback"](
+                f"call-{idx}",
+                "honcho_profile",
+                {"peer": "kenneth", "secret": "must-not-cross"},
+                json.dumps({
+                    "result": ["PRIVATE"],
+                    "resolvedPeer": "kenneth",
+                    "_meta": {
+                        "ui": {"resourceUri": "ui://hugin/peer-card"},
+                        "mimeType": "text/html;profile=mcp-app",
+                    },
+                }),
+            )
+        return {"final_response": "Kenneth", "session_id": session_id}, {"total_tokens": 1}
+
+    adapter._run_agent = fake_run_agent
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(f"/api/sessions/{session_id}/chat", json={"message": "Who is Kenneth?"})
+        assert resp.status == 200
+        payload = await resp.json()
+
+    expected_app = {
+        "resourceUri": "ui://hugin/peer-card",
+        "mimeType": "text/html;profile=mcp-app",
+        "tool": "honcho_profile",
+        "target": "kenneth",
+    }
+    assert len(payload["apps"]) == 16
+    assert all(app == expected_app for app in payload["apps"])
+    assert "PRIVATE" not in json.dumps(payload["apps"])
+    assert "must-not-cross" not in json.dumps(payload["apps"])
+
+
+@pytest.mark.asyncio
+async def test_session_chat_omits_apps_when_no_valid_app_metadata(adapter, session_db):
+    session_id = session_db.create_session("no-mcp-app-turn", "api_server")
+
+    async def fake_run_agent(**kwargs):
+        return {"final_response": "plain", "session_id": session_id}, {"total_tokens": 1}
+
+    adapter._run_agent = fake_run_agent
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(f"/api/sessions/{session_id}/chat", json={"message": "plain"})
+        assert resp.status == 200
+        payload = await resp.json()
+
+    assert "apps" not in payload
 
 
 @pytest.mark.asyncio

--- a/tests/honcho_plugin/test_empty_profile_hint.py
+++ b/tests/honcho_plugin/test_empty_profile_hint.py
@@ -12,9 +12,11 @@ def _make_provider(**cfg_overrides) -> HonchoMemoryProvider:
     provider = HonchoMemoryProvider()
     provider._manager = MagicMock()
     provider._manager.get_peer_card.return_value = []  # empty card
+    provider._manager.resolve_peer_id.side_effect = lambda _key, peer: "runi" if peer == "user" else peer
     provider._session_key = "agent:main:test"
     provider._session_initialized = True  # bypass the lazy _ensure_session() gate
     provider._cron_skipped = False
+    provider._platform = cfg_overrides.get("platform", "cli")
 
     cfg = MagicMock()
     # Defaults match HonchoClientConfig defaults
@@ -31,13 +33,23 @@ def _make_provider(**cfg_overrides) -> HonchoMemoryProvider:
 
 
 class TestEmptyProfileHint:
-    def test_returns_hint_not_bare_error_message(self):
-        provider = _make_provider()
+    def test_returns_hint_not_bare_error_message(self, monkeypatch):
+        monkeypatch.delenv("HONCHO_PROFILE_RESOURCE_URI", raising=False)
+        provider = _make_provider(platform="api_server")
         raw = provider.handle_tool_call("honcho_profile", {})
         payload = json.loads(raw)
         assert payload["result"] == "No profile facts available yet."
+        assert "resolvedPeer" not in payload
+        assert "_meta" not in payload
         assert "hint" in payload
         assert "not an error" in payload["hint"].lower()
+
+    def test_empty_card_emits_opt_in_resource_metadata(self, monkeypatch):
+        monkeypatch.setenv("HONCHO_PROFILE_RESOURCE_URI", "ui://hugin/peer-card")
+        provider = _make_provider(platform="api_server")
+        payload = json.loads(provider.handle_tool_call("honcho_profile", {}))
+        assert payload["resolvedPeer"] == "runi"
+        assert payload["_meta"]["ui"]["resourceUri"] == "ui://hugin/peer-card"
 
     def test_hint_mentions_warmup_when_turn_count_below_cadence(self):
         provider = _make_provider(turn_count=1, dialectic_cadence=3)
@@ -47,11 +59,32 @@ class TestEmptyProfileHint:
         assert "cadence" in payload["hint"].lower()
 
 
-    def test_populated_card_returns_card_without_hint(self):
+    def test_resource_metadata_is_api_server_only(self, monkeypatch):
+        monkeypatch.setenv("HONCHO_PROFILE_RESOURCE_URI", "ui://hugin/peer-card")
+        provider = _make_provider(platform="cli")
+        payload = json.loads(provider.handle_tool_call("honcho_profile", {}))
+        assert "_meta" not in payload
+
+    def test_dynamic_manager_resolver_falls_back_to_requested_peer(self, monkeypatch):
+        monkeypatch.setenv("HONCHO_PROFILE_RESOURCE_URI", "ui://hugin/peer-card")
+        provider = _make_provider(platform="api_server")
+        provider._manager = MagicMock()
+        provider._manager.get_peer_card.return_value = ["Fact"]
+        payload = json.loads(provider.handle_tool_call("honcho_profile", {"peer": "runi_user"}))
+        assert payload["resolvedPeer"] == "runi_user"
+
+    def test_populated_card_returns_card_without_hint(self, monkeypatch):
         """Regression: a populated card should NOT trigger the hint path."""
-        provider = _make_provider()
+        monkeypatch.setenv("HONCHO_PROFILE_RESOURCE_URI", "ui://hugin/peer-card")
+        provider = _make_provider(platform="api_server")
         provider._manager.get_peer_card.return_value = ["Fact 1", "Fact 2"]
         raw = provider.handle_tool_call("honcho_profile", {})
         payload = json.loads(raw)
         assert payload["result"] == ["Fact 1", "Fact 2"]
+        assert payload["peer"] == "user"
+        assert payload["resolvedPeer"] == "runi"
+        assert payload["_meta"] == {
+            "ui": {"resourceUri": "ui://hugin/peer-card"},
+            "mimeType": "text/html;profile=mcp-app",
+        }
         assert "hint" not in payload


### PR DESCRIPTION
## Summary

- let API-session chat responses carry a bounded list of validated MCP App envelopes from `honcho_profile`
- resolve concrete Honcho peer identity, including `user` aliases and underscore peer IDs
- keep raw tool arguments and raw tool results out of the HTTP envelope
- make Honcho UI metadata opt-in and limited to the `api_server` platform
- preserve the existing default response shape by omitting `apps` when no validated App exists

## Safety boundaries

- tool allowlist: `honcho_profile` only
- MIME: exact `text/html;profile=mcp-app`
- URI: `ui://`, max 2,048 characters
- Apps: max 16 per turn
- peer target: alphanumeric, hyphen, underscore; max 128 characters
- default-off Honcho result shape remains unchanged

## Verification

- Python compile for all changed source/tests
- Honcho startup compatibility: 1 passed
- Honcho profile metadata/default-off/platform gating: 6 passed
- focused envelope test: passed
- direct async HTTP proof: no-App response omits `apps`; valid App response includes bounded metadata only
- independent exact-tree review: pass (`08e777e1e3cba8e12812d00a420639deb45f0400`)

## Local test environment note

The checkout does not include `pytest-asyncio`, so marked async pytest cases cannot run canonically here. The affected HTTP paths were exercised directly with `aiohttp` and are included as CI tests.
