### PR TITLE
chore(gateway): drop the default scale-to-zero idle timeout to 2 minutes

### DIFF
--- a/gateway/scale_to_zero.py
+++ b/gateway/scale_to_zero.py
@@ -63,7 +63,13 @@ FLY_API_SOCKET = "/.fly/api"
 
 
 # config.yaml default (D2). Behavioural setting -> config, not env.
-DEFAULT_IDLE_TIMEOUT_MINUTES = 5
+# 2 minutes: with the gateway owning the suspend (idle predicate covers agent
+# turns, cron, API runs, and background work; the relay drains + flips before
+# the freeze), a short window is safe — real work always blocks the suspend and
+# resume-from-suspend is sub-second, so the only cost of waking "too eagerly"
+# after a quiet spell is a Fly-proxied poke away. Longer windows just bill idle
+# RAM. Raise per-instance via gateway.scale_to_zero.idle_timeout_minutes.
+DEFAULT_IDLE_TIMEOUT_MINUTES = 2
 
 _TRUTHY = {"1", "true", "yes", "on"}
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2925,7 +2925,7 @@ DEFAULT_CONFIG = {
         # — whether the feature is enabled at all is the Labs toggle, never a
         # config key (decisions.md D2/D11). 0/negative falls back to the default.
         "scale_to_zero": {
-            "idle_timeout_minutes": 5,
+            "idle_timeout_minutes": 2,
         },
 
         # Auto-resume restart-loop breaker (#30719, defense-3). When the

--- a/tests/gateway/test_scale_to_zero.py
+++ b/tests/gateway/test_scale_to_zero.py
@@ -38,6 +38,14 @@ def test_timeout_parses_minutes_to_seconds():
     assert parse_idle_timeout_seconds("5") == 300.0
 
 
+def test_timeout_invalid_values_degrade_to_default():
+    # Behavior contract: bad config falls back to the module default (whatever
+    # its current value), never to zero/negative — an instant-dormant gateway
+    # is never the intent.
+    for bad in (None, "", "nope", 0, -3):
+        assert parse_idle_timeout_seconds(bad) == DEFAULT_IDLE_TIMEOUT_MINUTES * 60.0
+
+
 # ── messaging_is_relay_only_or_absent (F6/D1) ────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Drops the default scale-to-zero idle timeout from 5 minutes to **2 minutes** (`DEFAULT_IDLE_TIMEOUT_MINUTES` + the `config_defaults.py` seed). Per-instance override unchanged: `gateway.scale_to_zero.idle_timeout_minutes` in config.yaml (D2).

## Why 2 minutes is safe now

The original 5-minute default was sized when Fly's proxy owned the suspend and the gateway's idle signal was advisory. After the gateway-owned-suspend series (#84295, #84327, #84339, #84558, #90760, #90761), the timeout is no longer a safety margin:

- The idle predicate covers **every** work source — agent turns, cron jobs, API-server runs, background work — and **fails awake** when a source is unreadable (#90761).
- The relay drains + flips **before** every freeze, and the post-quiesce re-check aborts on late-arriving work (#84295).
- Resume-from-suspend is sub-second (verified repeatedly on staging: 0.36–0.4s proxy-wake → started).

So a shorter window can't freeze work — it only shortens billed idle RAM time. The remaining trade-off is more suspend/resume cycles on bursty-but-quiet channels, which the 0.F re-arm cooldown already dampens.

Verified live on staging before this PR: `hermes-agent-stg-test-6698` running with `idle_timeout_minutes: 2` set per-instance (armed → dormant → flaps 200 → `suspension/suspended` on the 2-minute window).

## Tests

- New behavior-contract test: invalid config values (`None`, `""`, `"nope"`, `0`, `-3`) degrade to `DEFAULT_IDLE_TIMEOUT_MINUTES * 60` — asserts the relation, not a literal, so this PR's change (and any future one) can't silently break the fallback.
- `./scripts/run_tests.sh tests/gateway/test_scale_to_zero.py tests/gateway/test_scale_to_zero_watcher.py tests/test_hermes_constants.py` — **102 passed, 0 failed**; ruff clean.

## Infographic

![nap-faster](https://v3b.fal.media/files/b/0aa7275e/h6TscO0qKAZfapYmxqIMV_GkG93PQr.png)
