### PR TITLE
fix(auth): preserve named-provider headers in auxiliary calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6650,9 +6650,20 @@ def resolve_provider_client(
                     raw_base_for_wrap = custom_base
                 _clean_base2, _dq2 = _extract_url_query_params(openai_base)
                 _extra2 = {"default_query": _dq2} if _dq2 else {}
+                if base_url_host_matches(openai_base, "chatgpt.com"):
+                    _extra2["default_headers"] = _codex_cloudflare_headers(custom_key)
                 _headers2 = _apply_user_default_headers(_extra2.get("default_headers"))
                 if _headers2:
                     _extra2["default_headers"] = _headers2
+                # Match the main-agent construction path: named providers may
+                # require endpoint-specific auth or routing headers. Apply them
+                # last so the most specific config wins over host and global
+                # defaults. Values may be credentials, so never log them.
+                from hermes_cli.config import apply_custom_provider_extra_headers_to_client_kwargs
+                apply_custom_provider_extra_headers_to_client_kwargs(
+                    _extra2,
+                    _clean_base2,
+                )
                 logger.debug(
                     "resolve_provider_client: named custom provider %r (%s, api_mode=%s)",
                     provider, final_model, entry_api_mode or "chat_completions")

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -122,6 +122,41 @@ class TestResolveProviderClientNamedCustom:
         assert client is not None
         # no-key-required should be used
 
+    def test_command_backed_codex_provider_keeps_required_headers(self, tmp_path):
+        """Auxiliary calls must preserve host and per-provider auth headers."""
+        _write_config(tmp_path, {
+            "model": {"default": "gpt-test"},
+            "providers": {
+                "codex-passive": {
+                    "api": "https://chatgpt.com/backend-api/codex",
+                    "transport": "codex_responses",
+                    "key_cmd": "print-token",
+                    "models": {"gpt-test": {}},
+                    "extra_headers": {"ChatGPT-Account-ID": "acct-test"},
+                },
+            },
+        })
+        token_provider = lambda: "header.payload.signature"
+        with (
+            patch(
+                "agent.command_token_source.build_command_token_provider",
+                return_value=token_provider,
+            ),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, model = resolve_provider_client("codex-passive", "gpt-test")
+
+        assert client is not None
+        assert model == "gpt-test"
+        assert mock_openai.call_args.kwargs["api_key"] is token_provider
+        headers = mock_openai.call_args.kwargs["default_headers"]
+        assert headers["User-Agent"].startswith("codex_cli_rs/")
+        assert headers["originator"] == "codex_cli_rs"
+        assert headers["ChatGPT-Account-ID"] == "acct-test"
+
 
 
 class TestResolveProviderClientModelNormalization:


### PR DESCRIPTION
## Summary

- preserve the Codex `User-Agent` and `originator` headers when a named custom provider targets `chatgpt.com`
- apply `providers.<name>.extra_headers` to the auxiliary OpenAI client, matching the main-agent construction path
- keep header precedence explicit: host defaults, global user defaults, then provider-specific headers

## Why

Named custom providers already support command-backed credentials, and the main runtime applies both Codex host headers and provider-specific headers. The auxiliary named-provider branch did neither. A provider could therefore work for normal turns while title generation, compression, vision, or other auxiliary calls failed with 401/403 responses.

Header values are never logged.

## Tests

- `scripts/run_tests.sh tests/agent/test_auxiliary_named_custom_providers.py tests/agent/test_auxiliary_user_default_headers.py tests/agent/test_codex_cloudflare_headers.py -q` — 32 passed
- `python -m ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_named_custom_providers.py` — clean
- `git diff --check upstream/main...HEAD` — clean

## Overlap and exact delta

Open PRs #61346, #84223, and #88474 cover adjacent named-provider header plumbing. This draft should be reviewed as the narrower auxiliary Codex-host follow-up: it adds the ChatGPT/Codex User-Agent and originator defaults and makes the auxiliary precedence chain explicit (host defaults, global user defaults, provider-specific headers). If an older auxiliary PR lands first, this branch should be rebased and reduced to that remaining delta.