### PR TITLE
Fix stream drop attempt numbering

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4838,7 +4838,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         first_delta_fired["done"] = False
                         agent._emit_stream_drop(
                             error=e,
-                            attempt=_stream_attempt + 2,
+                            attempt=_stream_attempt + 1,
                             max_attempts=_max_stream_retries + 1,
                             mid_tool_call=True,
                             diag=request_client_holder.get("diag"),
@@ -4896,7 +4896,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         if _stream_attempt < _max_stream_retries:
                             agent._emit_stream_drop(
                                 error=e,
-                                attempt=_stream_attempt + 2,
+                                attempt=_stream_attempt + 1,
                                 max_attempts=_max_stream_retries + 1,
                                 mid_tool_call=False,
                                 diag=request_client_holder.get("diag"),

--- a/tests/run_agent/test_stream_drop_logging.py
+++ b/tests/run_agent/test_stream_drop_logging.py
@@ -19,8 +19,10 @@ from __future__ import annotations
 
 import logging
 import time
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
+import pytest
 
 from run_agent import AIAgent
 
@@ -32,6 +34,28 @@ def _make_agent() -> AIAgent:
         quiet_mode=True,
         skip_context_files=True,
         skip_memory=True,
+    )
+
+
+def _stream_chunk(content=None, tool_calls=None, finish_reason=None):
+    delta = SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning_content=None,
+        reasoning=None,
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(index=0, delta=delta, finish_reason=finish_reason)],
+        model="test/model",
+        usage=None,
+    )
+
+
+def _tool_call_delta(index=0, tc_id=None, name=None, arguments=None):
+    return SimpleNamespace(
+        index=index,
+        id=tc_id,
+        function=SimpleNamespace(name=name, arguments=arguments),
     )
 
 
@@ -218,3 +242,109 @@ def test_quiet_mode_does_not_clobber_runagent_logger_level():
     for name in ("run_agent", "tools", "trajectory_compressor", "cron", "hermes_cli"):
         logger = logging.getLogger(name)
         assert logger.getEffectiveLevel() <= logging.WARNING
+
+
+class TestStreamDropAttemptNumbers:
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_plain_transient_drop_numbers_first_attempt_and_retries(
+        self, mock_close, mock_create, monkeypatch
+    ):
+        import httpx
+
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+        attempts = {"count": 0}
+
+        def create_stream(*args, **kwargs):
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise httpx.ConnectError("connection dropped")
+            return iter([_stream_chunk(content="ok", finish_reason="stop")])
+
+        client = MagicMock()
+        client.chat.completions.create.side_effect = create_stream
+        mock_create.return_value = client
+        agent = _make_agent()
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        with patch.object(agent, "_emit_stream_drop", wraps=agent._emit_stream_drop) as emit:
+            agent._interruptible_streaming_api_call({})
+
+        assert attempts["count"] == 2
+        assert emit.call_args.kwargs["attempt"] == 1
+        assert emit.call_args.kwargs["max_attempts"] == 3
+        assert emit.call_args.kwargs["mid_tool_call"] is False
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_mid_tool_call_drop_numbers_each_retry(
+        self, mock_close, mock_create, monkeypatch
+    ):
+        import httpx
+
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+        attempts = {"count": 0}
+
+        def create_stream(*args, **kwargs):
+            attempts["count"] += 1
+            if attempts["count"] < 3:
+                def failing_stream():
+                    yield _stream_chunk(content="Working")
+                    yield _stream_chunk(tool_calls=[_tool_call_delta(
+                        tc_id="call_1", name="write_file", arguments='{"path": '
+                    )])
+                    raise httpx.RemoteProtocolError("peer closed")
+                return failing_stream()
+            return iter([
+                _stream_chunk(tool_calls=[_tool_call_delta(
+                    tc_id="call_1", name="write_file", arguments='{"path": "/tmp/x"}'
+                )]),
+                _stream_chunk(finish_reason="tool_calls"),
+            ])
+
+        client = MagicMock()
+        client.chat.completions.create.side_effect = create_stream
+        mock_create.return_value = client
+        agent = _make_agent()
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+        agent._fire_stream_delta = lambda text: None
+
+        with patch.object(agent, "_emit_stream_drop", wraps=agent._emit_stream_drop) as emit:
+            agent._interruptible_streaming_api_call({})
+
+        assert attempts["count"] == 3
+        assert [call.kwargs["attempt"] for call in emit.call_args_list] == [1, 2]
+        assert all(call.kwargs["max_attempts"] == 3 for call in emit.call_args_list)
+        assert all(call.kwargs["mid_tool_call"] is True for call in emit.call_args_list)
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_always_failing_stream_has_retry_and_exhausted_attempt_numbers(
+        self, mock_close, mock_create, monkeypatch
+    ):
+        import httpx
+
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "2")
+
+        def always_fails(*args, **kwargs):
+            raise httpx.ConnectError("connection dropped")
+
+        client = MagicMock()
+        client.chat.completions.create.side_effect = always_fails
+        mock_create.return_value = client
+        agent = _make_agent()
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        with (
+            patch.object(agent, "_emit_stream_drop", wraps=agent._emit_stream_drop) as emit,
+            patch.object(agent, "_log_stream_retry", wraps=agent._log_stream_retry) as log,
+        ):
+            with pytest.raises(httpx.ConnectError):
+                agent._interruptible_streaming_api_call({})
+
+        assert [call.kwargs["attempt"] for call in emit.call_args_list] == [1, 2]
+        assert log.call_args.kwargs["attempt"] == 3
+        assert log.call_args.kwargs["max_attempts"] == 3


### PR DESCRIPTION
## Problem

When a streaming request drops mid-flight and is retried, the stream-drop WARNING log line overstates the attempt number by one: a failure on the very first execution is logged as `attempt=2`.

## Root cause

In `agent/chat_completion_helpers.py`, `_stream_attempt` iterates `range(_max_stream_retries + 1)` (0-indexed: exec 0 is the first attempt). The exhausted path already encodes "the attempt that failed" correctly as execution index N -> N+1 (`attempt=_max_stream_retries + 1`). Both retryable drop paths instead emit `attempt=_stream_attempt + 2`:

- mid_tool_call retryable branch (`agent/chat_completion_helpers.py:4841`)
- plain transient retryable branch (`agent/chat_completion_helpers.py:4899`)

The error, `started_at`, and `elapsed` payloads on the drop record all belong to the execution that just died, so the number must identify that execution.

## Fix

Two expressions only: `attempt=_stream_attempt + 2` -> `attempt=_stream_attempt + 1` on both retryable drop paths. The exhausted path and retry behavior are untouched. `attempt` is log-only and is never fed back into retry control (verified: no programmatic consumer).

## Verification

- Red on main: new regression tests in `tests/run_agent/test_stream_drop_logging.py` failed as expected (`8 passed, 3 failed`; observed `2` and `[2, 3]`, want `1` and `[1, 2]`).
- Green after fix: `11 passed`.
- Sabotage: reverting either site independently makes its tests fail (mid_tool_call site -> `[2, 3]`; plain transient site -> attempt 2).
- Broader suite: `tests/run_agent` 1698 passed, 4 skipped, 2 deselected; 7 failures are pre-existing/unrelated (missing Anthropic dependency, Nous/reasoning-runtime tests).
- Scope sweep confirmed exactly two `+2` sites and no consumers of `attempt`.

Tests cover: plain transient first-failure numbering, mid_tool_call per-retry numbering (exec 0 -> 1, exec 1 -> 2), and the always-failing variant (retryable drops `[1, 2]`, exhausted `attempt=3`).

Observable change: retryable drop log lines now report N+1 instead of N+2 for the failed attempt; the exhausted path and retry behavior are unchanged. Thanks to the reporter for the log reconstruction evidence.

Closes #90215
