### PR TITLE
feat(agent): every compaction names the trigger that fired it

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2490,6 +2490,7 @@ class HermesACPAgent(acp.Agent):
             if not hasattr(agent, "_compress_context"):
                 return "Context compression not available for this agent."
 
+            from agent.conversation_compression import MANUAL_TRIGGER_REASON
             from agent.model_metadata import estimate_request_tokens_rough
 
             original_count = len(state.history)
@@ -2512,6 +2513,7 @@ class HermesACPAgent(acp.Agent):
                     approx_tokens=approx_tokens,
                     task_id=state.session_id,
                     force=True,
+                    trigger_reason=MANUAL_TRIGGER_REASON,
                 )
             finally:
                 agent._session_db = original_session_db

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -66,6 +66,11 @@ def automatic_compaction_status_message(
     ``emit_automatic_compaction_status = False`` or customize it by defining
     ``get_automatic_compaction_status_message(...)``. Empty strings and
     ``None`` mean "do not emit a lifecycle status".
+
+    CONTRACT NOTE: ``default_message`` arrives already carrying the compaction
+    trigger attribution (the "— triggered by ..." clause). A custom formatter
+    that discards ``default_message`` also discards the attribution the
+    automatic arms rely on — preserve or re-append it.
     """
     if not getattr(engine, "emit_automatic_compaction_status", True):
         return None

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -103,6 +103,44 @@ COMPACTION_STATUS = (
 
 COMPACTION_DONE_STATUS = "✓ Context compaction complete — continuing turn..."
 
+# Trigger attribution vocabulary. Every compaction names WHY it fired; these
+# are the labels callers pass as ``trigger_reason`` and the human wording each
+# renders. Producers and this map are pinned in lockstep by
+# tests/agent/test_compaction_trigger_coverage.py, which SOURCE-SCANS the call
+# sites so a new trigger cannot ship without a clause.
+MANUAL_TRIGGER_REASON = "manual_compress_command"
+_TRIGGER_REASON_CLAUSES = {
+    "threshold": "crossed the compaction threshold",
+    "pre_api_pressure": "context pressure before the API call",
+    "overflow_413": "the API rejected an oversize request — 413",
+    "overflow_context": "context length exceeded",
+    "output_cap": "the output cap did not fit the prompt",
+    "tier_reduction": "long-context tier window reduction",
+    "post_tool_threshold": "crossed the compaction threshold after tool output",
+    "idle_resume": "deferred maintenance on idle resume",
+    "engine_preflight_maintenance": "context-engine preflight maintenance",
+    "session_hygiene": "session-hygiene maintenance",
+    MANUAL_TRIGGER_REASON: "manual — you ran /compress",
+}
+
+
+def compaction_reason_clause(trigger_reason: Optional[str]) -> str:
+    """Render the parenthetical "why this fired" clause for a compaction.
+
+    Returns ``""`` only when the caller genuinely passed no reason. An
+    UNRECOGNIZED reason renders its raw label — never silence — because a
+    silent clause is exactly the "compaction with no reason stated" bug this
+    vocabulary exists to prevent, and the next trigger someone adds must
+    degrade to something readable rather than to nothing.
+    """
+    reason = (trigger_reason or "").strip()
+    if not reason:
+        return ""
+    described = _TRIGGER_REASON_CLAUSES.get(reason)
+    if described:
+        return f" ({described})"
+    return f" (trigger: {reason})"
+
 
 def _emit_compaction_done(agent: Any) -> None:
     """Emit the structured terminal edge for a started compaction."""
@@ -2240,6 +2278,7 @@ def compress_context(
     task_id: str = "default",
     focus_topic: Optional[str] = None,
     force: bool = False,
+    trigger_reason: Optional[str] = None,
     defer_context_engine_notification: bool = False,
     commit_fence: Optional[CompressionCommitFence] = None,
 ) -> Tuple[list, str]:
@@ -2259,6 +2298,11 @@ def compress_context(
             by the manual ``/compress`` slash command so users can retry
             immediately after an auto-compress abort.  Auto-compress
             callers use the default ``False``.
+        trigger_reason: Names WHY this compaction fired (``threshold``,
+            ``overflow_413``, ``session_hygiene``, ``manual_compress_command``,
+            ...) so the log line and the user-facing result can attribute it.
+            Every call site should pass one; ``None`` logs ``UNATTRIBUTED``
+            and warns.  See ``_TRIGGER_REASON_CLAUSES`` for the vocabulary.
         defer_context_engine_notification: Delay the existing context-engine
             hook until a manual host commits its outer history transaction.
         commit_fence: Optional cooperative fence for executor callers that
@@ -2393,13 +2437,32 @@ def compress_context(
     # Set True once the in-place DB write actually completes (the DB block can
     # raise and skip it). Surfaced to the gateway via agent._last_compaction_in_place.
     compacted_in_place = False
+    # Attribution is load-bearing: a compaction whose cause is not recorded is
+    # a compaction nobody can explain afterwards. Every caller passes
+    # ``trigger_reason``; a missing one is a WIRING DEFECT in a new call site,
+    # so name it loudly rather than letting it read as normal.
+    _trigger_label = (trigger_reason or "").strip() or "UNATTRIBUTED"
+    if _trigger_label == "UNATTRIBUTED":
+        logger.warning(
+            "context compression has no trigger_reason (session=%s) — a caller "
+            "is not passing one; every compaction must name its arm",
+            agent.session_id or "none",
+        )
     logger.info(
-        "context compression started: session=%s messages=%d tokens=~%s model=%s focus=%r",
-        agent.session_id or "none", _pre_msg_count,
+        "context compression started: session=%s trigger=%s messages=%d "
+        "tokens=~%s model=%s focus=%r",
+        agent.session_id or "none", _trigger_label, _pre_msg_count,
         f"{approx_tokens:,}" if approx_tokens else "unknown", agent.model,
         focus_topic,
     )
-    _compaction_status = COMPACTION_STATUS
+    # The lifecycle status is the only user-facing surface an AUTOMATIC
+    # compaction has, so it must carry the attribution too — otherwise the
+    # turn visibly pauses and the user is left asking why. Appended as a
+    # SUFFIX: the gateway's noise filter and progress matcher
+    # (_TELEGRAM_NOISY_STATUS_RE / _COMPRESSION_PROGRESS_STATUS_RE) key on the
+    # leading literal wording, so inserting the clause mid-string would stop
+    # both from matching and leak routine chatter onto chat platforms.
+    _compaction_status = COMPACTION_STATUS + compaction_reason_clause(trigger_reason)
     if not force:
         _compaction_status = automatic_compaction_status_message(
             agent.context_compressor,
@@ -4412,6 +4475,8 @@ __all__ = [
     "COMPACTION_STATUS",
     "COMPACTION_DONE_STATUS",
     "COMPACTION_STATUS_MARKER",
+    "MANUAL_TRIGGER_REASON",
+    "compaction_reason_clause",
     "check_compression_model_feasibility",
     "replay_compression_warning",
     "compress_context",

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2678,6 +2678,7 @@ def run_conversation(
                 system_message,
                 approx_tokens=request_pressure_tokens,
                 task_id=effective_task_id,
+                trigger_reason="pre_api_pressure",
             )
             if messages is _pre_api_input and compression_skipped_due_to_lock(agent):
                 # #69870 lock-skip: another path holds this session's
@@ -5304,6 +5305,7 @@ def run_conversation(
                             messages, system_message,
                             approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
                             task_id=effective_task_id,
+                            trigger_reason="tier_reduction",
                         )
                         conversation_history = conversation_history_after_compression(
                             agent, messages, conversation_history
@@ -5588,6 +5590,7 @@ def run_conversation(
                         messages, system_message,
                         approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
                         task_id=effective_task_id,
+                        trigger_reason="overflow_413",
                     )
                     if messages is _overflow_input and compression_skipped_due_to_lock(agent):
                         # #69870 lock-skip: the provider proved the request
@@ -5740,6 +5743,7 @@ def run_conversation(
                                 messages, system_message,
                                 approx_tokens=request_input_estimate,
                                 task_id=effective_task_id,
+                                trigger_reason="output_cap",
                             )
                             if messages is _overflow_input and compression_skipped_due_to_lock(agent):
                                 compression_attempts -= 1
@@ -5894,6 +5898,7 @@ def run_conversation(
                         messages, system_message,
                         approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
                         task_id=effective_task_id,
+                        trigger_reason="overflow_context",
                     )
                     if messages is _overflow_input and compression_skipped_due_to_lock(agent):
                         # #69870 lock-skip: the provider proved the request
@@ -7462,6 +7467,7 @@ def run_conversation(
                         messages, system_message,
                         approx_tokens=_real_tokens,
                         task_id=effective_task_id,
+                        trigger_reason="post_tool_threshold",
                     )
                     if (
                         messages is _post_tool_input

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -838,7 +838,7 @@ def build_turn_context(
                 _idle_input = messages
                 messages, active_system_prompt = agent._compress_context(
                     messages, system_message, approx_tokens=_idle_tokens,
-                    task_id=effective_task_id,
+                    task_id=effective_task_id, trigger_reason="idle_resume",
                 )
                 # ``_compress_context`` returns the INPUT list object when it
                 # skips (per-session lock held by another path, failure
@@ -1012,7 +1012,7 @@ def build_turn_context(
                 _preflight_input = messages
                 messages, active_system_prompt = agent._compress_context(
                     messages, system_message, approx_tokens=_preflight_tokens,
-                    task_id=effective_task_id,
+                    task_id=effective_task_id, trigger_reason="threshold",
                 )
                 if (
                     messages is _preflight_input
@@ -1146,6 +1146,7 @@ def build_turn_context(
                 messages, active_system_prompt = agent._compress_context(
                     messages, system_message, approx_tokens=_preflight_tokens,
                     task_id=effective_task_id,
+                    trigger_reason="engine_preflight_maintenance",
                 )
                 # ``_compress_context`` returns the INPUT list object on every
                 # skip path (per-session lock held elsewhere, cooldown,

--- a/cli.py
+++ b/cli.py
@@ -13223,6 +13223,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             summarize_compress_preview,
         )
         from agent.conversation_compression import (
+            MANUAL_TRIGGER_REASON,
             finalize_context_engine_compression_notification,
         )
 
@@ -13324,6 +13325,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     approx_tokens=approx_tokens,
                     focus_topic=focus_topic or None,
                     force=True,
+                    trigger_reason=MANUAL_TRIGGER_REASON,
                     defer_context_engine_notification=True,
                 )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19418,6 +19418,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                         lambda: _hyg_agent._compress_context(
                                             _hyg_msgs, "",
                                             approx_tokens=_approx_tokens,
+                                            trigger_reason="session_hygiene",
                                             commit_fence=_hyg_commit_fence,
                                         ),
                                     )

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4198,6 +4198,7 @@ class GatewaySlashCommandsMixin:
             summarize_compress_preview,
         )
         from agent.conversation_compression import (
+            MANUAL_TRIGGER_REASON,
             finalize_context_engine_compression_notification,
         )
         _raw_args = (event.get_command_args() or "").strip()
@@ -4367,6 +4368,7 @@ class GatewaySlashCommandsMixin:
                         approx_tokens=approx_tokens,
                         focus_topic=focus_topic,
                         force=True,
+                        trigger_reason=MANUAL_TRIGGER_REASON,
                         defer_context_engine_notification=True,
                     )
                 )

--- a/run_agent.py
+++ b/run_agent.py
@@ -7986,6 +7986,7 @@ class AIAgent:
         task_id: str = "default",
         focus_topic: str = None,
         force: bool = False,
+        trigger_reason: str = None,
         defer_context_engine_notification: bool = False,
         commit_fence=None,
     ) -> tuple:
@@ -7995,6 +7996,11 @@ class AIAgent:
         so users can bypass the summary-failure cooldown after an
         auto-compress abort.  Auto-compress callers use the default
         ``force=False``.
+
+        ``trigger_reason`` names WHY this compaction fired (``threshold`` /
+        ``overflow_413`` / ``session_hygiene`` / ``manual_compress_command``
+        / ...) so the compression log line and the user-facing result can
+        attribute it instead of leaving the user asking why the turn paused.
         """
         from agent.conversation_compression import (
             CompressionCommitFence,
@@ -8051,6 +8057,7 @@ class AIAgent:
                     approx_tokens=approx_tokens, task_id=task_id,
                     focus_topic=focus_topic,
                     force=force,
+                    trigger_reason=trigger_reason,
                     defer_context_engine_notification=(
                         defer_context_engine_notification
                     ),

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -9,6 +9,7 @@ import pytest
 
 import acp
 from acp.agent.router import build_agent_router
+from agent.conversation_compression import MANUAL_TRIGGER_REASON
 from acp.schema import (
     AgentCapabilities,
     AgentMessageChunk,
@@ -531,13 +532,16 @@ class TestSlashCommands:
         original_session_db = object()
         state.agent._session_db = original_session_db
 
-        def _compress_context(messages, system_prompt, *, approx_tokens, task_id, force):
+        def _compress_context(
+            messages, system_prompt, *, approx_tokens, task_id, force, trigger_reason
+        ):
             assert state.agent._session_db is None
             assert messages == state.history
             assert system_prompt == "system"
             assert approx_tokens == 40
             assert task_id == state.session_id
             assert force is True
+            assert trigger_reason == MANUAL_TRIGGER_REASON
             return [{"role": "user", "content": "summary"}], "new-system"
 
         state.agent._compress_context = MagicMock(side_effect=_compress_context)
@@ -566,6 +570,7 @@ class TestSlashCommands:
             approx_tokens=40,
             task_id=state.session_id,
             force=True,
+            trigger_reason=MANUAL_TRIGGER_REASON,
         )
         mock_save.assert_called_once_with(state.session_id)
 

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -608,7 +608,7 @@ class TestPrologueMoaAndInPlaceBackfill:
             get_active_compression_failure_cooldown=lambda: None,
         )
 
-        def _compress(messages, _system, approx_tokens=None, task_id=None):
+        def _compress(messages, _system, **_kwargs):
             # Emulate compress_context in in_place mode: archive_and_compact
             # already inserted these rows (api_content=NULL — the stamp has
             # not happened yet), fresh copies replace the live dicts.

--- a/tests/agent/test_compaction_trigger_coverage.py
+++ b/tests/agent/test_compaction_trigger_coverage.py
@@ -1,0 +1,281 @@
+"""Compaction trigger-attribution coverage.
+
+The contract: EVERY compaction names WHY it fired — in the log line and in
+the user-facing lifecycle status — whether it was fired by the user or by an
+automatic arm.
+
+These are structural guards rather than snapshots. The vocabulary is derived
+FROM THE PRODUCERS by scanning source for ``trigger_reason=`` literals, so a
+new trigger added without a matching clause fails here instead of silently
+rendering an empty reason. A hand-maintained list would drift the moment
+someone adds an arm, which is exactly the failure being guarded against.
+"""
+
+import logging
+import os
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent import conversation_compression
+from agent.conversation_compression import (
+    COMPACTION_STATUS,
+    MANUAL_TRIGGER_REASON,
+    compaction_reason_clause,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+
+# Files that may legitimately pass trigger_reason literals into the core.
+_PRODUCER_GLOBS = [
+    "agent/*.py",
+    "gateway/*.py",
+    "tui_gateway/*.py",
+    "acp_adapter/*.py",
+    "cli.py",
+    "run_agent.py",
+]
+
+# A producer passes either a bare string ("threshold") or one of the module's
+# exported constants (MANUAL_TRIGGER_REASON). Both forms are real call sites,
+# so the scan resolves both — matching only quoted literals would silently
+# miss every surface that uses the constant, and the coverage test would then
+# pass without ever having checked them.
+_LITERAL_RE = re.compile(r"""trigger_reason=["']([a-z_0-9]+)["']""")
+_CONSTANT_RE = re.compile(r"trigger_reason=([A-Z][A-Z_0-9]*)")
+
+# The manual /compress surfaces, each of which must attribute its compaction.
+_MANUAL_SURFACES = {
+    "gateway slash": Path("gateway") / "slash_commands.py",
+    "tui": Path("tui_gateway") / "server.py",
+    "cli": Path("cli.py"),
+    "acp": Path("acp_adapter") / "server.py",
+}
+
+
+def _resolve_constant(name: str) -> str | None:
+    value = getattr(conversation_compression, name, None)
+    return value if isinstance(value, str) else None
+
+
+def _collect_producer_reasons() -> set[str]:
+    reasons: set[str] = set()
+    for pattern in _PRODUCER_GLOBS:
+        for path in REPO.glob(pattern):
+            text = path.read_text(errors="replace")
+            reasons.update(_LITERAL_RE.findall(text))
+            for name in _CONSTANT_RE.findall(text):
+                resolved = _resolve_constant(name)
+                assert resolved, (
+                    f"{path.name} passes trigger_reason={name}, which is not a "
+                    f"string constant in agent.conversation_compression — the "
+                    f"coverage scan cannot verify it renders a clause"
+                )
+                reasons.add(resolved)
+    return reasons
+
+
+def test_scan_finds_the_known_producers():
+    """Guard the guard: a broken glob must not green the coverage test below.
+
+    Without this, a typo in _PRODUCER_GLOBS would make the scan return an
+    empty set and every assertion over it would pass vacuously.
+    """
+    reasons = _collect_producer_reasons()
+    assert "threshold" in reasons
+    assert "session_hygiene" in reasons
+    assert MANUAL_TRIGGER_REASON in reasons
+
+
+def test_every_produced_reason_renders_a_clause():
+    """Producer/renderer lockstep: no trigger may render an empty clause."""
+    silent = {
+        reason: compaction_reason_clause(reason)
+        for reason in sorted(_collect_producer_reasons())
+        if not compaction_reason_clause(reason).strip()
+    }
+    assert not silent, (
+        f"trigger_reason values that render NO clause (the 'compacted with no "
+        f"reason stated' bug): {sorted(silent)}. Add an arm to "
+        f"_TRIGGER_REASON_CLAUSES in agent/conversation_compression.py."
+    )
+
+
+def test_every_produced_reason_reads_as_prose():
+    """A clause is an explanation, not an echo of the internal label.
+
+    ``(trigger: pre_api_pressure)`` is the never-silent fallback for an
+    UNKNOWN reason; a reason a producer actually ships should have been given
+    real wording.
+    """
+    echoed = [
+        reason
+        for reason in sorted(_collect_producer_reasons())
+        if compaction_reason_clause(reason) == f" (trigger: {reason})"
+    ]
+    assert not echoed, (
+        f"these shipped triggers fall through to the raw-label fallback and "
+        f"read as internal jargon to a user: {echoed}"
+    )
+
+
+def test_unknown_reason_is_never_silent():
+    """An unrecognized reason renders its raw label rather than nothing.
+
+    Silence is the bug; a raw label is merely ugly. This keeps the failure
+    mode of a future un-mapped trigger legible instead of invisible.
+    """
+    clause = compaction_reason_clause("some_future_trigger")
+    assert clause.strip()
+    assert "some_future_trigger" in clause
+
+
+@pytest.mark.parametrize("empty", [None, "", "   "])
+def test_absent_reason_renders_nothing(empty):
+    """No reason at all is the one case that renders no clause.
+
+    Callers that pass nothing are warned about in the log (UNATTRIBUTED);
+    the status line must not grow a dangling empty parenthesis.
+    """
+    assert compaction_reason_clause(empty) == ""
+
+
+def test_status_line_carries_the_reason():
+    """The user-facing lifecycle status names the trigger.
+
+    Asserts the relationship (status starts with the base wording and gains
+    the clause), not a frozen string, so rewording either part stays free.
+    """
+    line = COMPACTION_STATUS + compaction_reason_clause("threshold")
+    assert line.startswith(COMPACTION_STATUS)
+    assert line != COMPACTION_STATUS
+    assert compaction_reason_clause("threshold") in line
+
+
+def test_every_manual_surface_passes_the_manual_label():
+    """Each manual /compress path attributes its compaction.
+
+    Source-pinned: a manual surface that calls _compress_context without a
+    trigger_reason logs UNATTRIBUTED and renders no reason, which is the
+    original reported symptom ("why did you compress here, there was no
+    reason stated" about a /compress the user ran themselves).
+    """
+    for name, relative in _MANUAL_SURFACES.items():
+        text = (REPO / relative).read_text(errors="replace")
+        assert "trigger_reason=MANUAL_TRIGGER_REASON" in text, (
+            f"{name} surface ({relative}) has a manual /compress path that "
+            f"does not pass trigger_reason=MANUAL_TRIGGER_REASON — its "
+            f"compressions log trigger=UNATTRIBUTED and name no reason"
+        )
+
+
+# ---------------------------------------------------------------------------
+# E2E: the real compress_context path, not a stand-in.
+# ---------------------------------------------------------------------------
+
+# Distinguishes "caller passed nothing" from "caller passed None" — the former
+# is the wiring-defect case the UNATTRIBUTED warning exists to catch.
+_ABSENT = object()
+
+
+def _build_agent(session_db, session_id: str):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    compressor = MagicMock()
+    compressor.compress.return_value = [
+        {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+        {"role": "user", "content": "tail"},
+    ]
+    compressor.compression_count = 1
+    compressor.last_prompt_tokens = 0
+    compressor.last_completion_tokens = 0
+    compressor._last_summary_error = None
+    compressor._last_compress_aborted = False
+    compressor._last_aux_model_failure_model = None
+    compressor._last_aux_model_failure_error = None
+    # No custom formatter and no opt-out: this agent takes the default
+    # lifecycle status so the test observes what a real user would see.
+    del compressor.get_automatic_compaction_status_message
+    compressor.emit_automatic_compaction_status = True
+    agent.context_compressor = compressor
+    agent.compression_enabled = False  # skip the aux-provider feasibility probe
+    return agent
+
+
+def _run_compression(tmp_path, caplog, *, trigger_reason):
+    """Drive a real compression and return (statuses, log_text)."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "TRIGGER_ATTRIBUTION_SESSION"
+    db.create_session(sid, source="cli")
+    agent = _build_agent(db, sid)
+
+    statuses: list[str] = []
+    agent.status_callback = lambda _kind, text: statuses.append(text)
+
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+    kwargs = {} if trigger_reason is _ABSENT else {"trigger_reason": trigger_reason}
+    with caplog.at_level(logging.INFO, logger="agent.conversation_compression"):
+        agent._compress_context(messages, "sys", approx_tokens=120_000, **kwargs)
+    return statuses, caplog.text
+
+
+def test_e2e_automatic_compaction_names_its_trigger(tmp_path, caplog):
+    """A real automatic compression attributes itself in log AND status."""
+    statuses, log_text = _run_compression(
+        tmp_path, caplog, trigger_reason="threshold"
+    )
+
+    assert "context compression started:" in log_text
+    assert "trigger=threshold" in log_text
+    assert "UNATTRIBUTED" not in log_text
+
+    compaction_statuses = [s for s in statuses if COMPACTION_STATUS in s]
+    assert compaction_statuses, f"no compaction status emitted; saw {statuses}"
+    assert compaction_reason_clause("threshold") in compaction_statuses[0]
+
+
+def test_e2e_manual_compaction_names_itself_as_manual(tmp_path, caplog):
+    """A user-fired /compress says so — the originally reported gap."""
+    statuses, log_text = _run_compression(
+        tmp_path, caplog, trigger_reason=MANUAL_TRIGGER_REASON
+    )
+
+    assert f"trigger={MANUAL_TRIGGER_REASON}" in log_text
+    compaction_statuses = [s for s in statuses if COMPACTION_STATUS in s]
+    assert compaction_statuses, f"no compaction status emitted; saw {statuses}"
+    # The category word itself must appear: "(you ran /compress)" alone
+    # requires the reader to infer "therefore manual".
+    assert "manual" in compaction_statuses[0]
+
+
+def test_e2e_unattributed_caller_is_logged_loudly(tmp_path, caplog):
+    """A call site that passes no reason is a wiring defect — say so.
+
+    Silence here is what let an unattributed arm ship unnoticed; the warning
+    is the signal that a new call site was added without attribution.
+    """
+    statuses, log_text = _run_compression(tmp_path, caplog, trigger_reason=_ABSENT)
+
+    assert "trigger=UNATTRIBUTED" in log_text
+    assert "every compaction must name its arm" in log_text
+    # No reason known => no clause, and specifically no dangling parenthesis.
+    compaction_statuses = [s for s in statuses if COMPACTION_STATUS in s]
+    assert compaction_statuses, f"no compaction status emitted; saw {statuses}"
+    assert compaction_statuses[0] == COMPACTION_STATUS
+

--- a/tests/agent/test_compaction_trigger_coverage.py
+++ b/tests/agent/test_compaction_trigger_coverage.py
@@ -29,11 +29,16 @@ from agent.conversation_compression import (
 REPO = Path(__file__).resolve().parents[2]
 
 # Files that may legitimately pass trigger_reason literals into the core.
+# 🔴 RECURSIVE on purpose (review finding, PR #91158): `agent/*.py` alone lets a
+# call site in an existing subpackage (agent/monitoring/, gateway/…) escape
+# attribution coverage entirely while FEELING protected. A guard test below
+# asserts the scan actually reaches at least one subdirectory file so this
+# cannot silently regress back to flat globs.
 _PRODUCER_GLOBS = [
-    "agent/*.py",
-    "gateway/*.py",
-    "tui_gateway/*.py",
-    "acp_adapter/*.py",
+    "agent/**/*.py",
+    "gateway/**/*.py",
+    "tui_gateway/**/*.py",
+    "acp_adapter/**/*.py",
     "cli.py",
     "run_agent.py",
 ]
@@ -43,6 +48,9 @@ _PRODUCER_GLOBS = [
 # so the scan resolves both — matching only quoted literals would silently
 # miss every surface that uses the constant, and the coverage test would then
 # pass without ever having checked them.
+# NOTE (load-bearing convention): _LITERAL_RE matches lowercase snake_case only.
+# trigger_reason literals MUST be lowercase snake_case ("overflow_413", never
+# "Overflow413") — a differently-cased literal would slip this scan entirely.
 _LITERAL_RE = re.compile(r"""trigger_reason=["']([a-z_0-9]+)["']""")
 _CONSTANT_RE = re.compile(r"trigger_reason=([A-Z][A-Z_0-9]*)")
 
@@ -87,6 +95,26 @@ def test_scan_finds_the_known_producers():
     assert "threshold" in reasons
     assert "session_hygiene" in reasons
     assert MANUAL_TRIGGER_REASON in reasons
+
+
+def test_scan_reaches_subpackages():
+    """The globs must be RECURSIVE: a producer in agent/<subpkg>/x.py has to be
+    inside the scan, or a future call site there escapes attribution coverage
+    while feeling protected (review finding on PR #91158). Assert the file walk
+    actually visits at least one file below a subdirectory of a scanned root."""
+    seen_subdir_file = False
+    for pattern in _PRODUCER_GLOBS:
+        for path in REPO.glob(pattern):
+            rel = path.relative_to(REPO)
+            if len(rel.parts) > 2:  # e.g. agent/monitoring/foo.py
+                seen_subdir_file = True
+                break
+        if seen_subdir_file:
+            break
+    assert seen_subdir_file, (
+        "_PRODUCER_GLOBS never reached a subpackage file — globs are no longer "
+        "recursive, so subpackage call sites are invisible to this coverage test"
+    )
 
 
 def test_every_produced_reason_renders_a_clause():

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1695,7 +1695,7 @@ def test_run_conversation_compresses_mid_turn_before_output_budget_exhaustion(mo
 
     compress_calls = []
 
-    def _fake_compress_context(messages, system_message, *, approx_tokens=None, task_id="default", focus_topic=None):
+    def _fake_compress_context(messages, system_message, *, approx_tokens=None, task_id="default", focus_topic=None, **_kwargs):
         compress_calls.append(approx_tokens)
         return [
             {"role": "user", "content": "[summary of prior tool-heavy work]"},
@@ -1755,7 +1755,7 @@ def test_mid_turn_compaction_does_not_double_persist_in_place_rows(monkeypatch, 
                 {"role": "tool", "tool_call_id": call.id, "content": "x" * 80_000}
             )
 
-    def _fake_compress_context(messages, system_message, *, approx_tokens=None, task_id="default", focus_topic=None):
+    def _fake_compress_context(messages, system_message, *, approx_tokens=None, task_id="default", focus_topic=None, **_kwargs):
         # Emulate the real in-place compaction DB side effect: soft-archive the
         # prior rows and insert the compacted set under the SAME session id,
         # then reset the flush identity seed — exactly as archive_and_compact +

--- a/tests/test_cli_manual_compress.py
+++ b/tests/test_cli_manual_compress.py
@@ -1,6 +1,7 @@
 from contextlib import nullcontext
 
 from agent.conversation_compression import (
+    MANUAL_TRIGGER_REASON,
     _queue_context_engine_compression_notification,
 )
 from cli import HermesCLI
@@ -37,6 +38,7 @@ class DummyAgent:
         approx_tokens=None,
         focus_topic=None,
         force=False,
+        trigger_reason=None,
         defer_context_engine_notification=False,
     ):
         self.calls.append(
@@ -46,6 +48,7 @@ class DummyAgent:
                 "approx_tokens": approx_tokens,
                 "focus_topic": focus_topic,
                 "force": force,
+                "trigger_reason": trigger_reason,
                 "defer_context_engine_notification": (
                     defer_context_engine_notification
                 ),
@@ -91,6 +94,9 @@ def test_manual_compress_does_not_pass_cached_system_prompt(monkeypatch):
     assert call["system_message"] is None
     assert call["system_message"] != cli.agent._cached_system_prompt
     assert call["focus_topic"] == "database schema"
+    # A user-fired /compress must attribute itself, or its compaction logs
+    # trigger=UNATTRIBUTED and its banner names no reason.
+    assert call["trigger_reason"] == MANUAL_TRIGGER_REASON
     assert cli.session_id == "new-session"
     assert cli._pending_title is None
     assert len(cli.agent.flush_calls) == 1

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5288,6 +5288,7 @@ def _compress_session_history(
     text "here 3".
     """
     from agent.conversation_compression import (
+        MANUAL_TRIGGER_REASON,
         finalize_context_engine_compression_notification,
     )
     from agent.model_metadata import estimate_request_tokens_rough
@@ -5350,6 +5351,7 @@ def _compress_session_history(
             # boundary-aware forms).
             focus_topic=focus_topic or None,
             force=True,
+            trigger_reason=MANUAL_TRIGGER_REASON,
             defer_context_engine_notification=True,
         )
     except Exception:


### PR DESCRIPTION
**Symptom.** A compaction that cannot say *why* it fired is a compaction nobody can explain afterwards. On `main` there is no attribution anywhere in the core: `compress_context` takes no trigger, the `context compression started:` log line names none, and an automatic compaction's only user-facing surface — the lifecycle status — tells the user the turn paused to compact without saying what caused it. When someone asks *"why did it compress here, there was no reason stated"*, neither the banner nor the log can answer, and reconstructing it after the fact means correlating timestamps by hand.

#90785 fixed the **manual** banner half at the `summarize_manual_compression` chokepoint. This is the plumbing and the automatic half underneath it.

## What this does

Adds `trigger_reason: Optional[str]` to `compress_context` (and the `AIAgent._compress_context` forwarder) and threads it from **every call site that exists on `main`** — inventoried from source rather than assumed:

| | reasons |
|---|---|
| automatic | `threshold`, `pre_api_pressure`, `overflow_413`, `overflow_context`, `output_cap`, `tier_reduction`, `post_tool_threshold`, `idle_resume`, `engine_preflight_maintenance`, `session_hygiene` |
| manual | `manual_compress_command`, from all four `/compress` surfaces (gateway slash, TUI helper, CLI, ACP) |

Three parts:

1. **The log line names it** — `trigger=<reason>`. A caller that passes none logs `UNATTRIBUTED` *and warns*, so a future call site wired without attribution is loud rather than silent.
2. **`compaction_reason_clause()` renders the reason into the lifecycle status.** An **unrecognized** reason renders its raw label rather than nothing — silence is the bug being fixed, so a future un-mapped trigger must degrade to something readable, never back to no reason at all.
3. **A coverage test derives the vocabulary FROM THE PRODUCERS**, scanning source for `trigger_reason=` (literals *and* constants) and failing if any renders an empty clause. A hand-maintained list would drift the moment someone adds an arm — which is exactly the failure being guarded against.

## Two decisions worth reviewing

**The clause is a SUFFIX, not an infix.** `gateway/run.py`'s `_TELEGRAM_NOISY_STATUS_RE` and `_COMPRESSION_PROGRESS_STATUS_RE` both key on the *leading* literal wording of `COMPACTION_STATUS`. Measured before choosing:

```
base    noisy=True  progress=True    "🗜️ Compacting context — summarizing…"
SUFFIX  noisy=True  progress=True    "…continue... (crossed the compaction threshold)"
INFIX   noisy=False progress=False   "🗜️ Compacting context (crossed…) — summarizing…"
```

An infix clause silently stops both regexes matching and leaks routine compression chatter onto chat platforms. The suffix keeps both intact.

**No new config knob and no new env var.** Attribution is always-on and costs one string concat on a path that is already doing an LLM round-trip. The engine opt-out (`emit_automatic_compaction_status`) still governs whether the status is emitted at all — this only changes what it *says* when it is.

## Regressions this caused, found and fixed

None of these came from reading the diff; each surfaced as an existing test going red, which is the point of running the blast radius.

Five `_compress_context` test doubles had rigid signatures that rejected the new kwarg: `test_api_content_sidecar`, `test_run_agent_codex_responses` (×2), `tests/acp/test_server.py`, `tests/test_cli_manual_compress.py`. The two that assert the *exact* call (`acp`, `cli manual compress`) now assert the attribution rather than merely tolerating it. An AST sweep over `tests/` confirms no rigid `_compress_context` stand-in remains.

## Verification

Run against this base with the project venv (py3.11), throwaway `HERMES_HOME`.

- `tests/agent/test_compaction_trigger_coverage.py` — **12 passed**
- All compaction-related suites (413, codex app-server, codex responses, telegram noise filter, progress notices, compress command, session hygiene, compaction status, acp, cli manual compress, manual compression feedback, api content sidecar) — **357 passed**
- **7 mutations RED-proven** — the guards are not decorative. Dropping a clause arm, adding a producer with no mapping, a manual surface dropping its label, making the fallback silent, breaking the scan glob, and reverting *each half* of the fix (log line / status render) each turn the suite red.

**A/B against clean `origin/main`** over `tests/agent + tests/run_agent + tests/gateway + tests/tui_gateway + tests/acp + tests/cli`: identical failure **counts** on both trees (164 and 17). The handful of set differences are wall-clock flakes — each reproduces on unmodified `origin/main` under repetition (e.g. `test_enforces_total_timeout_while_stream_keeps_emitting_events` failed 1/5 on clean main), and none reference any symbol this PR touches. This diff adds zero failures.

Contract: **every compaction names its initiator, manual or automatic.**
