### PR TITLE
feat(desktop): add typed remote folder navigation

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/remote-picker.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/remote-picker.test.tsx
@@ -1,0 +1,213 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { DesktopFsRemotePicker } from '@/lib/desktop-fs'
+
+const fsMocks = vi.hoisted(() => ({
+  picker: null as DesktopFsRemotePicker | null,
+  readDesktopDir: vi.fn(),
+  setDesktopFsRemotePicker: vi.fn((picker: DesktopFsRemotePicker | null) => {
+    fsMocks.picker = picker
+  })
+}))
+
+vi.mock('@/lib/desktop-fs', () => ({
+  readDesktopDir: fsMocks.readDesktopDir,
+  setDesktopFsRemotePicker: fsMocks.setDesktopFsRemotePicker
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      common: { cancel: 'Cancel' },
+      rightSidebar: {
+        emptyBody: 'No folders',
+        loadingFiles: 'Loading',
+        remotePickerDescription: 'Browse folders on the connected backend.',
+        remotePickerPathLabel: 'Folder path',
+        remotePickerPathPlaceholder: 'Type a path or folder name',
+        remotePickerSelect: 'Select folder',
+        remotePickerTitle: 'Choose remote folder',
+        unreadableBody: (error: string) => `Unreadable: ${error}`
+      }
+    }
+  })
+}))
+
+import { filterAndRankFolders, planFolderQuery, RemoteFolderPicker } from './remote-picker'
+
+describe('remote folder picker query planning', () => {
+  it('keeps a simple query in the current directory for fuzzy filtering', () => {
+    expect(planFolderQuery('hagt', '/srv')).toEqual({ browsePath: '/srv', filter: 'hagt' })
+  })
+
+  it('discovers children under the deepest explicit parent path', () => {
+    expect(planFolderQuery('/srv/herm', '/home/kosta')).toEqual({ browsePath: '/srv', filter: 'herm' })
+    expect(planFolderQuery('/srv/hermes/', '/home/kosta')).toEqual({ browsePath: '/srv/hermes', filter: '' })
+    expect(planFolderQuery('~/LocalDev/herm', '/home/kosta')).toEqual({ browsePath: '~/LocalDev', filter: 'herm' })
+    expect(planFolderQuery('C:\\Users\\Kosta\\herm', 'C:\\Users\\Kosta')).toEqual({
+      browsePath: 'C:\\Users\\Kosta',
+      filter: 'herm'
+    })
+    expect(planFolderQuery('C:/Users/Kosta/herm', 'C:/Users/Kosta')).toEqual({
+      browsePath: 'C:/Users/Kosta',
+      filter: 'herm'
+    })
+  })
+
+  it('resolves relative subdirectory queries from the directory being browsed', () => {
+    expect(planFolderQuery('projects/herm', '/home/kosta')).toEqual({
+      browsePath: '/home/kosta/projects',
+      filter: 'herm'
+    })
+  })
+})
+
+describe('remote folder picker fuzzy matching', () => {
+  const folders = [
+    { name: 'hermes-agent', path: '/srv/hermes-agent' },
+    { name: 'home-agent-tools', path: '/srv/home-agent-tools' },
+    { name: 'agent-harness', path: '/srv/agent-harness' },
+    { name: 'docs', path: '/srv/docs' }
+  ]
+
+  it('supports non-contiguous matches and ranks tighter matches first', () => {
+    expect(filterAndRankFolders(folders, 'hagt').map(entry => entry.name)).toEqual([
+      'home-agent-tools',
+      'hermes-agent'
+    ])
+  })
+
+  it('prefers prefix and contiguous matches without changing the unfiltered order', () => {
+    expect(filterAndRankFolders(folders, '').map(entry => entry.name)).toEqual(folders.map(entry => entry.name))
+    expect(filterAndRankFolders(folders, 'agent').map(entry => entry.name)).toEqual([
+      'agent-harness',
+      'home-agent-tools',
+      'hermes-agent'
+    ])
+  })
+})
+
+describe('RemoteFolderPicker', () => {
+  beforeEach(() => {
+    fsMocks.picker = null
+    fsMocks.readDesktopDir.mockReset()
+    fsMocks.setDesktopFsRemotePicker.mockClear()
+    fsMocks.readDesktopDir.mockImplementation(async (path: string) => {
+      if (path === '/srv') {
+        return {
+          entries: [
+            { isDirectory: true, name: 'hermes-agent', path: '/srv/hermes-agent' },
+            { isDirectory: true, name: 'docs', path: '/srv/docs' }
+          ]
+        }
+      }
+
+      if (path === '/srv/hermes-agent') {
+        return {
+          entries: [{ isDirectory: true, name: 'packages', path: '/srv/hermes-agent/packages' }]
+        }
+      }
+
+      return { entries: [], error: 'ENOENT' }
+    })
+  })
+
+  it('accepts a path, fuzzy-matches its final segment, and discovers the selected directory children', async () => {
+    render(<RemoteFolderPicker />)
+    await waitFor(() => expect(fsMocks.picker).not.toBeNull())
+
+    let selection!: Promise<string[]>
+    act(() => {
+      selection = fsMocks.picker!.selectPaths({ defaultPath: '/srv', directories: true })
+    })
+
+    const input = await screen.findByRole('combobox', { name: 'Folder path' })
+    await screen.findByText('docs')
+    fireEvent.change(input, { target: { value: '/srv/herm' } })
+
+    await screen.findByText('hermes-agent')
+    await waitFor(() => expect(screen.queryByText('docs')).toBeNull())
+
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await screen.findByText('packages')
+    expect((input as HTMLInputElement).value).toBe('/srv/hermes-agent')
+    expect(fsMocks.readDesktopDir).toHaveBeenCalledWith('/srv/hermes-agent')
+
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await expect(selection).resolves.toEqual(['/srv/hermes-agent'])
+  })
+
+  it('keeps the initial directory read alive when the user starts fuzzy-searching immediately', async () => {
+    let resolveInitial!: (value: unknown) => void
+    fsMocks.readDesktopDir.mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveInitial = resolve
+        })
+    )
+    render(<RemoteFolderPicker />)
+    await waitFor(() => expect(fsMocks.picker).not.toBeNull())
+
+    act(() => {
+      void fsMocks.picker!.selectPaths({ defaultPath: '/srv', directories: true })
+    })
+    const input = await screen.findByRole('combobox', { name: 'Folder path' })
+    await waitFor(() => expect(fsMocks.readDesktopDir).toHaveBeenCalledWith('/srv'))
+    fireEvent.change(input, { target: { value: 'herm' } })
+
+    await act(async () => {
+      resolveInitial({
+        entries: [{ isDirectory: true, name: 'hermes-agent', path: '/srv/hermes-agent' }]
+      })
+    })
+
+    expect(await screen.findByText('hermes-agent')).toBeTruthy()
+  })
+
+  it('does not allow an unmatched partial path to select its readable parent', async () => {
+    render(<RemoteFolderPicker />)
+    await waitFor(() => expect(fsMocks.picker).not.toBeNull())
+    act(() => {
+      void fsMocks.picker!.selectPaths({ defaultPath: '/srv', directories: true })
+    })
+
+    const input = await screen.findByRole('combobox', { name: 'Folder path' })
+    await screen.findByText('docs')
+    fireEvent.change(input, { target: { value: '/srv/not-a-folder' } })
+    expect((screen.getByRole('button', { name: 'Select folder' }) as HTMLButtonElement).disabled).toBe(true)
+    await screen.findByText('No folders')
+
+    expect((screen.getByRole('button', { name: 'Select folder' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('clears loading when an in-flight path lookup is replaced by a fuzzy query', async () => {
+    let resolveSlow!: (value: unknown) => void
+    fsMocks.readDesktopDir.mockImplementation(async (path: string) => {
+      if (path === '/srv') {
+        return { entries: [{ isDirectory: true, name: 'hermes-agent', path: '/srv/hermes-agent' }] }
+      }
+
+      return new Promise(resolve => {
+        resolveSlow = resolve
+      })
+    })
+    render(<RemoteFolderPicker />)
+    await waitFor(() => expect(fsMocks.picker).not.toBeNull())
+    act(() => {
+      void fsMocks.picker!.selectPaths({ defaultPath: '/srv', directories: true })
+    })
+
+    const input = await screen.findByRole('combobox', { name: 'Folder path' })
+    await screen.findByText('hermes-agent')
+    fireEvent.change(input, { target: { value: '/srv/slow' } })
+    await screen.findByText('Loading')
+    fireEvent.change(input, { target: { value: 'herm' } })
+
+    await waitFor(() => expect(screen.queryByText('Loading')).toBeNull())
+    expect(await screen.findByText('hermes-agent')).toBeTruthy()
+    await act(async () => {
+      resolveSlow({ entries: [] })
+    })
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/files/remote-picker.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/remote-picker.tsx
@@ -1,15 +1,43 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
 import { useI18n } from '@/i18n'
 import { readDesktopDir, setDesktopFsRemotePicker } from '@/lib/desktop-fs'
 import { displayPath, pathLeaf } from '@/lib/display-path'
 import { cn } from '@/lib/utils'
 
+interface FolderEntry {
+  name: string
+  path: string
+}
+
 function clean(path: string) {
-  return path.replace(/\/+$/, '') || '/'
+  const value = path.trim()
+
+  if (!value || value === '/') {
+    return '/'
+  }
+
+  if (/^[a-z]:[\\/]?$/i.test(value)) {
+    return value.length === 2 ? `${value}\\` : value
+  }
+
+  return value.replace(/[\\/]+$/, '')
+}
+
+function separatorFor(path: string) {
+  return path.includes('\\') && !path.includes('/') ? '\\' : '/'
+}
+
+function lastSeparator(path: string) {
+  return Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
+}
+
+function isAbsolutePath(path: string) {
+  return path.startsWith('/') || path.startsWith('~') || path.startsWith('\\\\') || /^[a-z]:[\\/]/i.test(path)
 }
 
 function parentDir(path: string) {
@@ -19,13 +47,151 @@ function parentDir(path: string) {
     return '/'
   }
 
-  const parent = value.slice(0, value.lastIndexOf('/'))
+  const splitAt = lastSeparator(value)
+
+  if (splitAt < 0) {
+    return value
+  }
+
+  const parent = value.slice(0, splitAt)
+
+  if (/^[a-z]:$/i.test(parent)) {
+    return `${parent}${separatorFor(value)}`
+  }
+
+  if (value.startsWith('\\\\')) {
+    const rootParts = value.split('\\').filter(Boolean)
+
+    if (rootParts.length <= 2) {
+      return value
+    }
+  }
 
   return parent || '/'
 }
 
 function pathName(path: string) {
   return pathLeaf(path) || path
+}
+
+function joinPath(base: string, child: string) {
+  const root = clean(base)
+  const separator = separatorFor(root)
+
+  return `${root === '/' ? '' : root.replace(/[\\/]+$/, '')}${separator}${child}`
+}
+
+function queryCandidatePath(query: string, currentPath: string) {
+  const value = clean(query.trim())
+
+  return isAbsolutePath(value) ? value : joinPath(currentPath, value)
+}
+
+export function planFolderQuery(query: string, currentPath: string): { browsePath: string; filter: string } {
+  const value = query.trim()
+
+  if (!value || lastSeparator(value) < 0) {
+    return { browsePath: currentPath, filter: value }
+  }
+
+  if (/[\\/]$/.test(value)) {
+    return { browsePath: clean(value), filter: '' }
+  }
+
+  const splitAt = lastSeparator(value)
+  const parent = value.slice(0, splitAt)
+
+  return {
+    browsePath: isAbsolutePath(value) ? parent || '/' : joinPath(currentPath, parent),
+    filter: value.slice(splitAt + 1)
+  }
+}
+
+function fuzzyScore(value: string, query: string) {
+  const haystack = value.toLocaleLowerCase()
+  const needle = query.toLocaleLowerCase()
+
+  if (!needle) {
+    return 0
+  }
+
+  if (haystack.startsWith(needle)) {
+    return 3_000 - haystack.length
+  }
+
+  const contiguousAt = haystack.indexOf(needle)
+
+  if (contiguousAt >= 0) {
+    return 2_000 - contiguousAt * 10 - haystack.length
+  }
+
+  let first = -1
+  let previous = -1
+  let gaps = 0
+
+  for (const character of needle) {
+    const index = haystack.indexOf(character, previous + 1)
+
+    if (index < 0) {
+      return null
+    }
+
+    if (first < 0) {
+      first = index
+    } else {
+      gaps += index - previous - 1
+    }
+
+    previous = index
+  }
+
+  return 1_000 - first * 10 - gaps * 5 - haystack.length
+}
+
+export function filterAndRankFolders<T extends FolderEntry>(entries: T[], query: string): T[] {
+  const needle = query.trim()
+
+  if (!needle) {
+    return entries
+  }
+
+  return entries
+    .map((entry, index) => ({ entry, index, score: fuzzyScore(entry.name, needle) }))
+    .filter((match): match is { entry: T; index: number; score: number } => match.score !== null)
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map(match => match.entry)
+}
+
+function directoryEntries(result: Awaited<ReturnType<typeof readDesktopDir>>): FolderEntry[] {
+  return result.entries.filter(entry => entry.isDirectory).map(entry => ({ name: entry.name, path: entry.path }))
+}
+
+function pathCrumbs(path: string) {
+  const value = clean(path)
+  let root = '/'
+  let rest = value
+
+  if (/^[a-z]:[\\/]/i.test(value)) {
+    root = value.slice(0, 3)
+    rest = value.slice(3)
+  } else if (value.startsWith('\\\\')) {
+    const parts = value.split('\\').filter(Boolean)
+    root = `\\\\${parts.slice(0, 2).join('\\')}`
+    rest = parts.slice(2).join('\\')
+  } else if (value.startsWith('~')) {
+    root = '~'
+    rest = value.slice(1)
+  }
+
+  const out = [{ label: root, path: root }]
+  let acc = root
+
+  for (const part of rest.split(/[\\/]/).filter(Boolean)) {
+    acc = joinPath(acc, part)
+    out.push({ label: part, path: acc })
+  }
+
+  return out
 }
 
 interface PendingSelection {
@@ -39,9 +205,13 @@ export function RemoteFolderPicker() {
   const r = t.rightSidebar
   const [pending, setPending] = useState<PendingSelection | null>(null)
   const [currentPath, setCurrentPath] = useState('/')
-  const [entries, setEntries] = useState<Array<{ name: string; path: string }>>([])
+  const [pathQuery, setPathQuery] = useState('/')
+  const [queryFilter, setQueryFilter] = useState('')
+  const [entries, setEntries] = useState<FolderEntry[]>([])
+  const [activeIndex, setActiveIndex] = useState(0)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
+  const directoryRequest = useRef(0)
 
   useEffect(() => {
     setDesktopFsRemotePicker({
@@ -49,6 +219,9 @@ export function RemoteFolderPicker() {
         new Promise(resolve => {
           const defaultPath = clean(options?.defaultPath || '/')
           setCurrentPath(defaultPath)
+          setPathQuery(defaultPath)
+          setQueryFilter('')
+          setActiveIndex(0)
           setPending({ defaultPath, resolve, title: options?.title || r.remotePickerTitle })
         })
     })
@@ -62,34 +235,32 @@ export function RemoteFolderPicker() {
     }
 
     let active = true
+    const request = ++directoryRequest.current
     setLoading(true)
     setError(null)
+    setEntries([])
 
     void readDesktopDir(currentPath)
       .then(result => {
-        if (!active) {
+        if (!active || request !== directoryRequest.current) {
           return
         }
 
         if (result.error) {
           setError(result.error)
           setEntries([])
-
-          return
+        } else {
+          setEntries(directoryEntries(result))
         }
-
-        setEntries(
-          result.entries.filter(entry => entry.isDirectory).map(entry => ({ name: entry.name, path: entry.path }))
-        )
       })
       .catch(err => {
-        if (active) {
+        if (active && request === directoryRequest.current) {
           setError(err instanceof Error ? err.message : String(err))
           setEntries([])
         }
       })
       .finally(() => {
-        if (active) {
+        if (active && request === directoryRequest.current) {
           setLoading(false)
         }
       })
@@ -99,18 +270,101 @@ export function RemoteFolderPicker() {
     }
   }, [currentPath, pending])
 
-  const crumbs = useMemo(() => {
-    const parts = clean(currentPath).split('/').filter(Boolean)
-    const out = [{ label: '/', path: '/' }]
-    let acc = ''
-
-    for (const part of parts) {
-      acc += `/${part}`
-      out.push({ label: part, path: acc })
+  useEffect(() => {
+    if (!pending) {
+      return
     }
 
-    return out
-  }, [currentPath])
+    const typed = pathQuery.trim()
+
+    if (!typed || clean(typed) === clean(currentPath) || lastSeparator(typed) < 0) {
+      setQueryFilter(clean(typed) === clean(currentPath) ? '' : typed)
+      setActiveIndex(0)
+      setError(null)
+      setLoading(false)
+
+      return
+    }
+
+    let active = true
+
+    const timer = window.setTimeout(() => {
+      const request = ++directoryRequest.current
+      setLoading(true)
+      setError(null)
+
+      void (async () => {
+        const candidatePath = queryCandidatePath(typed, currentPath)
+        const candidate = await readDesktopDir(candidatePath)
+
+        if (!active || request !== directoryRequest.current) {
+          return
+        }
+
+        if (!candidate.error) {
+          const resolvedPath = candidate.entries[0] ? parentDir(candidate.entries[0].path) : candidatePath
+          setCurrentPath(resolvedPath)
+          setPathQuery(resolvedPath)
+          setQueryFilter('')
+          setEntries(directoryEntries(candidate))
+          setActiveIndex(0)
+          setLoading(false)
+
+          return
+        }
+
+        const plan = planFolderQuery(typed, currentPath)
+        const parent = await readDesktopDir(plan.browsePath)
+
+        if (!active || request !== directoryRequest.current) {
+          return
+        }
+
+        if (parent.error) {
+          setError(parent.error)
+          setEntries([])
+          setQueryFilter('')
+        } else {
+          const resolvedPath = parent.entries[0] ? parentDir(parent.entries[0].path) : plan.browsePath
+          setCurrentPath(resolvedPath)
+          setPathQuery(queryCandidatePath(typed, currentPath))
+          setQueryFilter(plan.filter)
+          setEntries(directoryEntries(parent))
+          setActiveIndex(0)
+        }
+
+        setLoading(false)
+      })().catch(err => {
+        if (active && request === directoryRequest.current) {
+          setError(err instanceof Error ? err.message : String(err))
+          setEntries([])
+          setLoading(false)
+        }
+      })
+    }, 120)
+
+    return () => {
+      active = false
+      window.clearTimeout(timer)
+    }
+  }, [currentPath, pathQuery, pending])
+
+  const crumbs = useMemo(() => pathCrumbs(currentPath), [currentPath])
+
+  const visibleEntries = useMemo(() => filterAndRankFolders(entries, queryFilter), [entries, queryFilter])
+  const selectionReady = !loading && !error && clean(pathQuery) === clean(currentPath)
+
+  useEffect(() => {
+    setActiveIndex(index => Math.min(index, Math.max(0, visibleEntries.length - 1)))
+  }, [visibleEntries.length])
+
+  const navigate = (path: string) => {
+    setPathQuery(path)
+    setCurrentPath(path)
+    setQueryFilter('')
+    setEntries([])
+    setActiveIndex(0)
+  }
 
   const close = (paths: string[] = []) => {
     pending?.resolve(paths)
@@ -131,6 +385,44 @@ export function RemoteFolderPicker() {
         </div>
 
         <div className="flex min-h-0 flex-1 flex-col">
+          <div className="shrink-0 border-b border-border/50 p-3 pb-2">
+            <Input
+              aria-activedescendant={
+                queryFilter && visibleEntries[activeIndex] ? `remote-folder-option-${activeIndex}` : undefined
+              }
+              aria-autocomplete="list"
+              aria-controls="remote-folder-results"
+              aria-expanded={Boolean(queryFilter && visibleEntries.length)}
+              aria-label={r.remotePickerPathLabel}
+              autoFocus
+              className="font-mono"
+              onChange={event => setPathQuery(event.target.value)}
+              onFocus={event => event.currentTarget.select()}
+              onKeyDown={event => {
+                if (event.key === 'ArrowDown' && visibleEntries.length) {
+                  event.preventDefault()
+                  setActiveIndex(index => (index + 1) % visibleEntries.length)
+                } else if (event.key === 'ArrowUp' && visibleEntries.length) {
+                  event.preventDefault()
+                  setActiveIndex(index => (index - 1 + visibleEntries.length) % visibleEntries.length)
+                } else if (event.key === 'Enter') {
+                  event.preventDefault()
+
+                  if (queryFilter && visibleEntries[activeIndex]) {
+                    navigate(visibleEntries[activeIndex].path)
+                  } else if (selectionReady) {
+                    close([currentPath])
+                  }
+                }
+              }}
+              placeholder={r.remotePickerPathPlaceholder}
+              prefix={<Codicon name="search" size="0.8rem" />}
+              role="combobox"
+              size="sm"
+              value={pathQuery}
+            />
+          </div>
+
           <div className="shrink-0 flex flex-wrap items-center gap-1 border-b border-border/50 px-3 py-2 text-xs text-muted-foreground">
             {crumbs.map((crumb, index) => (
               <button
@@ -139,7 +431,7 @@ export function RemoteFolderPicker() {
                   index === crumbs.length - 1 && 'text-foreground'
                 )}
                 key={crumb.path}
-                onClick={() => setCurrentPath(crumb.path)}
+                onClick={() => navigate(crumb.path)}
                 type="button"
               >
                 {crumb.label}
@@ -148,24 +440,39 @@ export function RemoteFolderPicker() {
           </div>
 
           <div className="min-h-0 flex-1 overflow-y-auto p-2">
-            <FolderRow
-              disabled={currentPath === '/'}
-              name=".."
-              onClick={() => setCurrentPath(parentDir(currentPath))}
-            />
+            {!queryFilter && (
+              <FolderRow
+                disabled={parentDir(currentPath) === currentPath}
+                name=".."
+                onClick={() => navigate(parentDir(currentPath))}
+              />
+            )}
             {loading ? (
-              <div className="flex items-center gap-2 px-2 py-3 text-xs text-muted-foreground">
+              <div aria-live="polite" className="flex items-center gap-2 px-2 py-3 text-xs text-muted-foreground">
                 <Codicon name="loading" size="0.8rem" spinning />
                 {r.loadingFiles}
               </div>
             ) : error ? (
-              <div className="px-2 py-3 text-xs text-destructive">{r.unreadableBody(error)}</div>
-            ) : entries.length === 0 ? (
-              <div className="px-2 py-3 text-xs text-muted-foreground">{r.emptyBody}</div>
+              <div aria-live="polite" className="px-2 py-3 text-xs text-destructive">
+                {r.unreadableBody(error)}
+              </div>
+            ) : visibleEntries.length === 0 ? (
+              <div aria-live="polite" className="px-2 py-3 text-xs text-muted-foreground">
+                {r.emptyBody}
+              </div>
             ) : (
-              entries.map(entry => (
-                <FolderRow key={entry.path} name={pathName(entry.path)} onClick={() => setCurrentPath(entry.path)} />
-              ))
+              <div id="remote-folder-results" role="listbox">
+                {visibleEntries.map((entry, index) => (
+                  <FolderRow
+                    active={Boolean(queryFilter) && index === activeIndex}
+                    key={entry.path}
+                    name={pathName(entry.path)}
+                    onClick={() => navigate(entry.path)}
+                    onMouseEnter={() => setActiveIndex(index)}
+                    optionId={`remote-folder-option-${index}`}
+                  />
+                ))}
+              </div>
             )}
           </div>
         </div>
@@ -176,7 +483,7 @@ export function RemoteFolderPicker() {
             <Button onClick={() => close()} size="sm" variant="ghost">
               {t.common.cancel}
             </Button>
-            <Button onClick={() => close([currentPath])} size="sm">
+            <Button disabled={!selectionReady} onClick={() => close([currentPath])} size="sm">
               {r.remotePickerSelect}
             </Button>
           </div>
@@ -186,12 +493,33 @@ export function RemoteFolderPicker() {
   )
 }
 
-function FolderRow({ disabled = false, name, onClick }: { disabled?: boolean; name: string; onClick: () => void }) {
+function FolderRow({
+  active = false,
+  disabled = false,
+  name,
+  onClick,
+  onMouseEnter,
+  optionId
+}: {
+  active?: boolean
+  disabled?: boolean
+  name: string
+  onClick: () => void
+  onMouseEnter?: () => void
+  optionId?: string
+}) {
   return (
     <button
-      className="row-hover flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-(--ui-text-secondary) hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+      aria-selected={optionId ? active : undefined}
+      className={cn(
+        'row-hover flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-(--ui-text-secondary) hover:text-foreground disabled:pointer-events-none disabled:opacity-40',
+        active && 'bg-accent text-accent-foreground'
+      )}
       disabled={disabled}
+      id={optionId}
       onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      role={optionId ? 'option' : undefined}
       type="button"
     >
       <Codicon name="folder" size="0.875rem" />

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2225,6 +2225,8 @@ export const ar = defineLocale({
     changeCwdTitle: 'تغيير مجلد العمل',
     remotePickerTitle: 'اختر مجلدا بعيدا',
     remotePickerDescription: 'استعرض المجلدات على الخادم الخلفي المتصل.',
+    remotePickerPathLabel: 'مسار المجلد',
+    remotePickerPathPlaceholder: 'أدخل مسارا أو اسم مجلد',
     remotePickerSelect: 'تحديد المجلد',
     folderTip: cwd => cwd,
     openFolder: 'فتح مجلد',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2853,6 +2853,8 @@ export const en: Translations = {
     changeCwdTitle: 'Change working directory',
     remotePickerTitle: 'Choose remote folder',
     remotePickerDescription: 'Browse folders on the connected backend.',
+    remotePickerPathLabel: 'Folder path',
+    remotePickerPathPlaceholder: 'Type a path or folder name',
     remotePickerSelect: 'Select folder',
     folderTip: cwd => cwd,
     openFolder: 'Open folder',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2508,6 +2508,8 @@ export const ja = defineLocale({
     changeCwdTitle: '作業ディレクトリを変更',
     remotePickerTitle: 'リモートフォルダーを選択',
     remotePickerDescription: '接続中のバックエンド上のフォルダーを参照します。',
+    remotePickerPathLabel: 'フォルダーのパス',
+    remotePickerPathPlaceholder: 'パスまたはフォルダー名を入力',
     remotePickerSelect: 'フォルダーを選択',
     folderTip: cwd => cwd,
     openFolder: 'フォルダーを開く',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2431,6 +2431,8 @@ export interface Translations {
     changeCwdTitle: string
     remotePickerTitle: string
     remotePickerDescription: string
+    remotePickerPathLabel: string
+    remotePickerPathPlaceholder: string
     remotePickerSelect: string
     folderTip: (cwd: string) => string
     openFolder: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2424,6 +2424,8 @@ export const zhHant = defineLocale({
     changeCwdTitle: '變更工作目錄',
     remotePickerTitle: '選擇遠端資料夾',
     remotePickerDescription: '瀏覽已連線後端上的資料夾。',
+    remotePickerPathLabel: '資料夾路徑',
+    remotePickerPathPlaceholder: '輸入路徑或資料夾名稱',
     remotePickerSelect: '選擇資料夾',
     folderTip: cwd => cwd,
     openFolder: '開啟資料夾',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3022,6 +3022,8 @@ export const zh: Translations = {
     changeCwdTitle: '更改工作目录',
     remotePickerTitle: '选择远程文件夹',
     remotePickerDescription: '浏览已连接后端上的文件夹。',
+    remotePickerPathLabel: '文件夹路径',
+    remotePickerPathPlaceholder: '输入路径或文件夹名称',
     remotePickerSelect: '选择文件夹',
     folderTip: cwd => cwd,
     openFolder: '打开文件夹',


### PR DESCRIPTION
## Summary
- add a focused path field to the remote Cmd/Ctrl+O folder picker
- discover exact paths and parent-directory candidates as the user types
- fuzzy-rank folder names with keyboard navigation across POSIX, Windows drive, and UNC paths
- keep invalid partial paths from silently selecting their parent and expose combobox semantics

## Root cause
The remote picker rendered breadcrumbs and clickable directory rows only. Its only filesystem read was tied to `currentPath`, which could change only through row or breadcrumb clicks, so there was no editable control or query/discovery state.

## Verification
- `npm run test:ui` (558 files, 5,342 tests)
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build`

## Notes
The input starts with the backend cwd selected, so typing immediately replaces it. Enter opens the active fuzzy result; Enter again or **Select folder** confirms an exact readable directory.