### PR TITLE
fix(desktop): preserve commas while editing list settings

### DIFF
--- a/apps/desktop/src/app/settings/config-field.test.ts
+++ b/apps/desktop/src/app/settings/config-field.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseListFieldDraft } from './config-field'
+
+describe('parseListFieldDraft', () => {
+  it('commits comma-separated list values after editing', () => {
+    expect(parseListFieldDraft('C:/gitLibraries, C:/gitProjects')).toEqual(['C:/gitLibraries', 'C:/gitProjects'])
+  })
+
+  it('trims entries and drops empty segments', () => {
+    expect(parseListFieldDraft(' one, , two,   ')).toEqual(['one', 'two'])
+  })
+
+  it('allows an unfinished trailing comma to remain draft-only until commit', () => {
+    expect(parseListFieldDraft('first,')).toEqual(['first'])
+  })
+})

--- a/apps/desktop/src/app/settings/config-field.tsx
+++ b/apps/desktop/src/app/settings/config-field.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { type ReactNode, useEffect, useRef, useState } from 'react'
 
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
@@ -15,6 +15,13 @@ import { FallbackModelsField } from './fallback-models-field'
 import { fieldCopyForSchemaKey } from './field-copy'
 import { ListRow } from './primitives'
 import { SearchableSelect } from './searchable-select'
+
+export function parseListFieldDraft(raw: string): string[] {
+  return raw
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean)
+}
 
 /**
  * One generic config row: label + description resolved from the i18n field
@@ -179,21 +186,7 @@ export function ConfigField({
   }
 
   if (schema.type === 'list') {
-    return row(
-      <Input
-        className={CONTROL_TEXT}
-        onChange={e =>
-          onChange(
-            e.target.value
-              .split(',')
-              .map(s => s.trim())
-              .filter(Boolean)
-          )
-        }
-        placeholder={c.commaSeparated}
-        value={Array.isArray(value) ? value.join(', ') : String(value ?? '')}
-      />
-    )
+    return row(<ListField onChange={onChange} placeholder={c.commaSeparated} value={value} />)
   }
 
   if (typeof value === 'object' && value !== null) {
@@ -234,5 +227,52 @@ export function ConfigField({
       />
     ),
     isLong
+  )
+}
+
+function ListField({
+  value,
+  onChange,
+  placeholder
+}: {
+  value: unknown
+  onChange: (value: unknown) => void
+  placeholder: string
+}) {
+  const normalizedValue = Array.isArray(value) ? value.join(', ') : String(value ?? '')
+  const [draft, setDraft] = useState(normalizedValue)
+  const focusedRef = useRef(false)
+
+  useEffect(() => {
+    if (!focusedRef.current) {
+      setDraft(normalizedValue)
+    }
+  }, [normalizedValue])
+
+  const commitDraft = () => {
+    const parsed = parseListFieldDraft(draft)
+    setDraft(parsed.join(', '))
+    onChange(parsed)
+  }
+
+  return (
+    <Input
+      className={CONTROL_TEXT}
+      onBlur={() => {
+        focusedRef.current = false
+        commitDraft()
+      }}
+      onChange={e => setDraft(e.target.value)}
+      onFocus={() => {
+        focusedRef.current = true
+      }}
+      onKeyDown={e => {
+        if (e.key === 'Enter') {
+          e.currentTarget.blur()
+        }
+      }}
+      placeholder={placeholder}
+      value={draft}
+    />
   )
 }

--- a/apps/desktop/src/app/settings/searchable-select.test.tsx
+++ b/apps/desktop/src/app/settings/searchable-select.test.tsx
@@ -128,3 +128,41 @@ describe('ConfigField searchable routing', () => {
     expect(onChange).toHaveBeenCalledWith('')
   })
 })
+
+describe('ConfigField list editing', () => {
+  const listSchema: ConfigFieldSchema = { type: 'list' }
+
+  it('keeps unfinished comma input as a draft until blur commits it', () => {
+    const onChange = vi.fn()
+
+    render(<ConfigField onChange={onChange} schema={listSchema} schemaKey="test.list" value={['first']} />)
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'first,' } })
+
+    expect(input.value).toBe('first,')
+    expect(onChange).not.toHaveBeenCalled()
+
+    fireEvent.blur(input)
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(['first'])
+    expect(input.value).toBe('first')
+  })
+
+  it('commits exactly once when Enter blurs the list field', () => {
+    const onChange = vi.fn()
+
+    render(<ConfigField onChange={onChange} schema={listSchema} schemaKey="test.list" value={['first']} />)
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'first, second' } })
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' })
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(['first', 'second'])
+    expect(input.value).toBe('first, second')
+  })
+})

--- a/apps/desktop/src/app/settings/searchable-select.test.tsx
+++ b/apps/desktop/src/app/settings/searchable-select.test.tsx
@@ -157,7 +157,7 @@ describe('ConfigField list editing', () => {
     render(<ConfigField onChange={onChange} schema={listSchema} schemaKey="test.list" value={['first']} />)
 
     const input = screen.getByRole('textbox') as HTMLInputElement
-    fireEvent.focus(input)
+    input.focus()
     fireEvent.change(input, { target: { value: 'first, second' } })
     fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' })
 


### PR DESCRIPTION
Fixes #91121

The generic desktop list field was parsing and filtering its controlled value on every keystroke, so a trailing comma disappeared immediately and users could not type a second entry.

This keeps the raw comma-separated text as an input draft while the field is focused, then parses and normalizes the list on blur. Pressing Enter now follows that same blur/commit path, so it commits exactly once instead of risking a duplicate `onChange`. External config updates still resync the draft when the field is not being edited.

Adds focused parser coverage plus component-level regression coverage for draft preservation, blur commit, and the Enter commit lifecycle.