### PR TITLE
test: SQLite descriptor leak regression coverage (DEV-1281)

### DIFF
--- a/tests/gateway/test_readiness.py
+++ b/tests/gateway/test_readiness.py
@@ -4,6 +4,7 @@ import json
 import os
 import sqlite3
 from pathlib import Path
+from types import SimpleNamespace
 
 from gateway import readiness
 from gateway.readiness import collect_runtime_readiness
@@ -64,6 +65,11 @@ def test_collect_runtime_readiness_reports_healthy_local_runtime(tmp_path, monke
     with sqlite3.connect(home / "state.db") as conn:
         conn.execute("CREATE TABLE probe (id INTEGER PRIMARY KEY)")
     monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(
+        readiness.shutil,
+        "disk_usage",
+        lambda _path: SimpleNamespace(total=100, used=10, free=90),
+    )
 
     result = collect_runtime_readiness(
         configured_model="test/model",

--- a/tests/gateway/test_readiness.py
+++ b/tests/gateway/test_readiness.py
@@ -5,7 +5,53 @@ import os
 import sqlite3
 from pathlib import Path
 
+from gateway import readiness
 from gateway.readiness import collect_runtime_readiness
+
+
+def test_probe_state_db_closes_sqlite_connection(tmp_path, monkeypatch):
+    """The state-db readiness probe must release its SQLite descriptors."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    with sqlite3.connect(home / "state.db") as conn:
+        conn.execute("CREATE TABLE probe (id INTEGER PRIMARY KEY)")
+
+    real_connect = sqlite3.connect
+    opened = []
+
+    class CloseTrackingConnection:
+        def __init__(self, connection):
+            self._connection = connection
+            self.closed = False
+
+        def execute(self, *args, **kwargs):
+            return self._connection.execute(*args, **kwargs)
+
+        def close(self):
+            self.closed = True
+            self._connection.close()
+
+        # sqlite3's context manager commits or rolls back but does not close.
+        # Preserve that behavior so this fails if the probe stops using
+        # contextlib.closing().
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    def connect(*args, **kwargs):
+        connection = CloseTrackingConnection(real_connect(*args, **kwargs))
+        opened.append(connection)
+        return connection
+
+    monkeypatch.setattr(readiness.sqlite3, "connect", connect)
+
+    for _ in range(25):
+        assert readiness._probe_state_db(home)["status"] == "ok"
+
+    assert len(opened) == 25
+    assert all(connection.closed for connection in opened)
 
 
 def test_collect_runtime_readiness_reports_healthy_local_runtime(tmp_path, monkeypatch):
@@ -57,5 +103,3 @@ def test_collect_runtime_readiness_degrades_on_invalid_config_and_stopped_gatewa
     assert result["checks"]["gateway"]["status"] == "degraded"
     # Readiness is diagnostic data, not an exception or a destructive repair.
     assert (home / "config.yaml").read_text(encoding="utf-8") == "model: [unterminated"
-
-

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -188,6 +188,10 @@ def mock_session_db(tmp_path, populated_sessions_dir):
         def __init__(self):
             self._db_path = db_path
 
+        def close(self):
+            """Match SessionDB's lifecycle interface for MCP request tests."""
+            return None
+
         def get_messages(self, session_id):
             conn = sqlite3.connect(str(self._db_path))
             conn.row_factory = sqlite3.Row
@@ -628,6 +632,45 @@ class TestE2EConversationGet:
 
 
 class TestE2EMessagesRead:
+    def test_transcript_tools_close_every_request_session_db(
+        self, populated_sessions_dir, monkeypatch, _event_loop
+    ):
+        """Repeated MCP reads must not accumulate state.db file descriptors."""
+        import mcp_serve
+
+        created = []
+
+        class TrackingDB:
+            def __init__(self):
+                self.closed = False
+
+            def get_messages(self, _session_id):
+                return [
+                    {"id": 1, "role": "user", "content": "hello", "timestamp": "now"},
+                ]
+
+            def close(self):
+                self.closed = True
+
+        def new_db():
+            db = TrackingDB()
+            created.append(db)
+            return db
+
+        monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: populated_sessions_dir)
+        monkeypatch.setattr(mcp_serve, "_get_session_db", new_db)
+        monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", True)
+        monkeypatch.setattr(mcp_serve, "MCPServer", _FakeMCPServer)
+        server = mcp_serve.create_mcp_server(event_bridge=mcp_serve.EventBridge())
+        session_key = "agent:main:telegram:dm:123456"
+
+        for _ in range(25):
+            _run_tool(server, "messages_read", {"session_key": session_key})
+            _run_tool(server, "attachments_fetch", {"session_key": session_key, "message_id": "1"})
+
+        assert len(created) >= 50
+        assert all(db.closed for db in created)
+
     def test_read_messages(self, mcp_server_e2e, _event_loop):
         server, _ = mcp_server_e2e
         result = _run_tool(server, "messages_read",
@@ -1085,6 +1128,32 @@ class TestEdgeCases:
         b._running = True
         b.stop()
         assert not b._running
+
+    def test_bridge_stop_closes_its_long_lived_session_db(self, monkeypatch, tmp_path):
+        """The polling connection belongs to EventBridge and must be reaped."""
+        import mcp_serve
+
+        opened = threading.Event()
+        closed = threading.Event()
+
+        class TrackingDB:
+            def get_messages(self, _session_id):
+                return []
+
+            def close(self):
+                closed.set()
+
+        def new_db():
+            opened.set()
+            return TrackingDB()
+
+        monkeypatch.setattr(mcp_serve, "_get_session_db", new_db)
+        monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: tmp_path / "sessions")
+        bridge = mcp_serve.EventBridge()
+        bridge.start()
+        assert opened.wait(timeout=1)
+        bridge.stop()
+        assert closed.wait(timeout=1)
 
     def test_truncation(self):
         assert len(("x" * 5000)[:2000]) == 2000


### PR DESCRIPTION
Adds regression coverage for Hermes SQLite descriptor leaks in readiness and MCP serve paths. Upstream already contains the underlying handle-closure fixes; this PR adds tests to prevent regression.