### PR TITLE
fix(goals): honor auxiliary.goal_judge.timeout in the /goal judge

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -995,6 +995,34 @@ def _goal_judge_max_tokens() -> int:
     return DEFAULT_JUDGE_MAX_TOKENS
 
 
+def _goal_judge_timeout() -> float:
+    """Resolve auxiliary.goal_judge.timeout, falling back to the default.
+
+    ``load_config()`` is cached on the config file's (mtime, size), so calling
+    this once per judge turn is cheap. A non-positive or non-numeric value
+    falls back to the default rather than crashing the goal loop.
+
+    The declared config default (60s) becomes the effective judge timeout when
+    the user has not set the key, so ``DEFAULT_JUDGE_TIMEOUT`` (30s) applies
+    only when the config is unreadable or holds an invalid value.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        value = (
+            (cfg.get("auxiliary") or {})
+            .get("goal_judge", {})
+            .get("timeout", DEFAULT_JUDGE_TIMEOUT)
+        )
+        value = float(value)
+        if value > 0:
+            return value
+    except Exception:
+        pass
+    return DEFAULT_JUDGE_TIMEOUT
+
+
 def _parse_judge_response(raw: str) -> Tuple[str, str, bool, Optional[Dict[str, Any]]]:
     """Parse the judge's reply. Fail-open on unusable output.
 
@@ -1142,7 +1170,7 @@ def judge_goal(
     goal: str,
     last_response: str,
     *,
-    timeout: float = DEFAULT_JUDGE_TIMEOUT,
+    timeout: Optional[float] = None,
     subgoals: Optional[List[str]] = None,
     background_processes: Optional[List[Dict[str, Any]]] = None,
     contract: Optional[GoalContract] = None,
@@ -1240,8 +1268,9 @@ def judge_goal(
 
     try:
         # Route through call_llm so auxiliary.goal_judge.* config
-        # (provider/model/base_url, extra_body, reasoning_effort, retries)
-        # all apply — the direct-create path dropped extra_body (#35566).
+        # (provider/model/base_url, timeout, extra_body, reasoning_effort,
+        # retries) all apply — the direct-create path dropped extra_body
+        # (#35566).
         resp = call_llm(
             task="goal_judge",
             messages=[
@@ -1250,7 +1279,7 @@ def judge_goal(
             ],
             temperature=0,
             max_tokens=_goal_judge_max_tokens(),
-            timeout=timeout,
+            timeout=timeout if timeout is not None else _goal_judge_timeout(),
         )
     except Exception as exc:
         logger.info("goal judge: API call failed (%s) — falling through to continue", exc)
@@ -1290,7 +1319,7 @@ def gather_background_processes(task_id: Optional[str] = None) -> List[Dict[str,
     return [s for s in sessions if isinstance(s, dict) and s.get("status") != "exited"]
 
 
-def draft_contract(objective: str, *, timeout: float = DEFAULT_JUDGE_TIMEOUT) -> Optional[GoalContract]:
+def draft_contract(objective: str, *, timeout: Optional[float] = None) -> Optional[GoalContract]:
     """Expand a plain-language objective into a structured completion contract.
 
     Uses the ``goal_judge`` auxiliary task (main-model-first, cache-safe — it
@@ -1320,7 +1349,7 @@ def draft_contract(objective: str, *, timeout: float = DEFAULT_JUDGE_TIMEOUT) ->
             ],
             temperature=0,
             max_tokens=_goal_judge_max_tokens(),
-            timeout=timeout,
+            timeout=timeout if timeout is not None else _goal_judge_timeout(),
         )
     except Exception as exc:
         logger.info("goal draft: API call failed (%s)", exc)

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -96,6 +96,51 @@ class TestJudgeGoal:
         assert verdict == "done"
         assert reason == "achieved"
 
+    def test_judge_honors_configured_timeout(self, tmp_path, monkeypatch):
+        """judge_goal passes auxiliary.goal_judge.timeout through to call_llm."""
+        from hermes_cli import goals
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "auxiliary:\n  goal_judge:\n    timeout: 41\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        observed = {}
+
+        def _fake_call_llm(**kwargs):
+            observed["timeout"] = kwargs.get("timeout")
+            return MagicMock(
+                choices=[MagicMock(message=MagicMock(content='{"done": true, "reason": "x"}'))]
+            )
+
+        with patch("agent.auxiliary_client.call_llm", side_effect=_fake_call_llm):
+            verdict, _reason, _pf, _wd, _tf = goals.judge_goal("goal", "response")
+        assert verdict == "done"
+        assert observed["timeout"] == 41.0
+
+    def test_judge_timeout_falls_back_on_invalid_config(self, tmp_path, monkeypatch):
+        """A non-numeric judge timeout falls back instead of crashing the loop."""
+        from hermes_cli import goals
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "auxiliary:\n  goal_judge:\n    timeout: fast\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        observed = {}
+
+        def _fake_call_llm(**kwargs):
+            observed["timeout"] = kwargs.get("timeout")
+            return MagicMock(
+                choices=[MagicMock(message=MagicMock(content='{"done": true, "reason": "x"}'))]
+            )
+
+        with patch("agent.auxiliary_client.call_llm", side_effect=_fake_call_llm):
+            goals.judge_goal("goal", "response")
+        assert observed["timeout"] == goals.DEFAULT_JUDGE_TIMEOUT
+
 
 # ──────────────────────────────────────────────────────────────────────
 # GoalManager lifecycle + persistence


### PR DESCRIPTION
## Summary

The `/goal` judge currently hardcodes a 30s request timeout
(`DEFAULT_JUDGE_TIMEOUT` in `hermes_cli/goals.py`) and never reads
`auxiliary.goal_judge.timeout`, even though `DEFAULT_CONFIG` declares that key
and it surfaces in the auxiliary config UI. Users cannot raise the judge
timeout. Fixes #91022.

## Change

- Add `_goal_judge_timeout()`, mirroring `_goal_judge_max_tokens()`: reads
  `auxiliary.goal_judge.timeout` via `load_config()` (cached), falls back to
  `DEFAULT_JUDGE_TIMEOUT` on a missing or invalid value.
- `judge_goal()` and `draft_contract()` now default their `timeout` parameter
  to `None` and resolve it through the helper at the `call_llm` site. Explicit
  timeouts from callers still win.

## Behavior note

`DEFAULT_CONFIG` declares `auxiliary.goal_judge.timeout: 60`, so with this
change the unset effective judge timeout moves from 30s to the declared 60s.
The 30s constant remains as the fallback for unreadable or invalid config.
Fail-open semantics and the 5-strike transport-failure auto-pause are
unchanged, which keeps the worst case bounded when the endpoint is unreachable.

## Tests

- `test_judge_honors_configured_timeout`: a config value of 41 reaches
  `call_llm` as `timeout=41.0`.
- `test_judge_timeout_falls_back_on_invalid_config`: a non-numeric value falls
  back to `DEFAULT_JUDGE_TIMEOUT`.
- Ran via `scripts/run_tests.sh`: `tests/hermes_cli/test_goals.py` (38 pass)
  plus the judge consumers `test_loops.py`, `test_kanban_goal_mode.py`,
  `test_goal_max_turns_config.py`, `test_goal_command.py` (81 pass total).