### PR TITLE
fix(display): don't tag successful tool results as [error] on a null error field

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1332,6 +1332,14 @@ def _trim_error(msg: str) -> str:
     return msg
 
 
+# Success-shaped serialized fields: the key is present but carries an explicit
+# null / false value. Stripped from the lowercased 500-char window in
+# _detect_tool_failure's generic heuristic so an unconditional "error": null
+# on success is not counted as a failure (#91166).
+_NULL_ERROR_FIELD_RE = re.compile(r'"error"\s*:\s*null\b')
+_FALSE_FAILED_FIELD_RE = re.compile(r'"failed"\s*:\s*false\b')
+
+
 def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]:
     """Inspect a tool result string for signs of failure.
 
@@ -1376,7 +1384,14 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
     if not isinstance(result, str):
         return False, ""
     lower = result[:500].lower()
-    if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):
+    # A serialized "error": null / "failed": false is a success shape —
+    # tools like web_extract include the key unconditionally on success, and
+    # a short result can land the field inside the 500-char window. Strip
+    # those field forms first, then look for the literal keys in what's left
+    # (#91166).
+    scrubbed = _NULL_ERROR_FIELD_RE.sub(" ", lower)
+    scrubbed = _FALSE_FAILED_FIELD_RE.sub(" ", scrubbed)
+    if '"error"' in scrubbed or '"failed"' in scrubbed or result.startswith("Error"):
         return True, " [error]"
 
     return False, ""

--- a/tests/agent/test_display_tool_failure.py
+++ b/tests/agent/test_display_tool_failure.py
@@ -119,3 +119,38 @@ class TestGetCuteToolMessageFailureSuffix:
         line = get_cute_tool_message("web_search", {"query": "hi"}, 0.2, result=ok)
         assert "[" not in line.split("0.2s", 1)[1]
 
+
+class TestNullErrorFieldIsSuccess:
+    """A serialized "error": null is a success shape, not a failure (#91166).
+
+    Tools like web_extract include the key unconditionally on success; when the
+    whole result is short enough for the field to land inside the 500-char
+    heuristic window, the literal-"error" match used to tag the result [error]
+    and feed the tool-loop guardrail's failure counter.
+    """
+
+    SHORT_NULL_ERROR = (
+        '{\n  "results": [\n    {\n      "url": "https://example.com",\n'
+        '      "title": "Example Domain",\n      "content": "Example Domain",\n'
+        '      "error": null\n    }\n  ]\n}'
+    )
+
+    def test_null_error_inside_window_is_success(self):
+        assert _detect_tool_failure("web_extract", self.SHORT_NULL_ERROR) == (False, "")
+
+    def test_failed_false_inside_window_is_success(self):
+        assert _detect_tool_failure("web_extract", '{"failed": false}') == (False, "")
+
+    def test_non_null_error_still_flags(self):
+        is_failure, suffix = _detect_tool_failure(
+            "web_extract", '{"results": [{"error": "boom"}]}'
+        )
+        assert is_failure is True
+        assert suffix == " [error]"
+
+    def test_failed_true_still_flags(self):
+        assert _detect_tool_failure("web_extract", '{"failed": true}') == (True, " [error]")
+
+    def test_error_null_with_compact_spacing(self):
+        assert _detect_tool_failure("web_extract", '{"error":null,"data":1}') == (False, "")
+


### PR DESCRIPTION
## What does this PR do?

Stops `_detect_tool_failure`'s generic heuristic from tagging successful tool results as `[error]` when a serialized `"error": null` field lands inside the 500-char scan window. Tools like `web_extract` include the `error` key unconditionally on success, so a short successful result whose `"error": null` falls inside the window was classified as a failure — and the verdict is not cosmetic: it feeds the tool-loop guardrail's per-turn failure counter, which eventually appends "stop retrying this failing tool" guidance to a tool that is actually succeeding (#91166).

The heuristic now strips the success-shaped field forms (`"error": null`, `"failed": false`) from the window before looking for the literal keys, so only a non-null `error` / non-true `failed` (or an `Error`-prefixed string) still flags.

## Related Issue

Fixes #91166

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/display.py` — two module-level regexes (`_NULL_ERROR_FIELD_RE` / `_FALSE_FAILED_FIELD_RE`) matching the null/false-valued field forms; the generic heuristic substitutes them out of the lowercased 500-char window before the literal-key check, with the #91166 rationale documented inline
- `tests/agent/test_display_tool_failure.py` — new `TestNullErrorFieldIsSuccess` class: the issue's exact short-result shape returns success, `"failed": false` returns success (compact and spaced forms), and non-null `"error": "boom"` / `"failed": true` still flag

## How to Test

1. `.venv/bin/python -m pytest tests/agent/test_display_tool_failure.py -q` — should pass (16 passed, including the five new)
2. Observed result: on unmodified main, the short-result shape returns `(True, ' [error]')` — the exact issue repro (`_detect_tool_failure("web_extract", SHORT_NULL_ERROR)`); with this fix it returns `(False, "")`, while a non-null error value inside the same window still flags
3. Regression: `tests/agent/test_display.py` + `test_display_emoji.py` + the full failure-suffix suite — 43 passed (terminal exit-code, memory-full, structured-error, and cute-message suffix behaviors unchanged)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (why null/false-valued fields are stripped rather than looked for)
- [x] Tests added that prove the fix (issue repro + both success shapes + both failure guards)
- [x] All new and existing tests pass locally (16 + 43 passed)
- [x] Platform: macOS (pure string classification, platform-independent)
