### PR TITLE
fix(desktop): stabilize external-store runtime adapter

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -300,18 +300,29 @@ function ChatRuntimeBoundary({
 
   const transcriptWindow = useMemo(() => ({ olderAvailable, expandWindow }), [expandWindow, olderAvailable])
 
-  const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
-    messageRepository: runtimeMessageRepository,
-    isRunning: busy,
-    setMessages: onThreadMessagesChange,
-    onNew: async () => {
-      // Submission is handled explicitly by ChatBar.
-      // Keeping this no-op avoids duplicate prompt.submit calls.
-    },
-    onEdit,
-    onCancel: async () => onCancel(),
-    onReload
-  })
+  // The runtime hook keys its adapter effect by object identity. Recreating
+  // this object (and its callback wrappers) on every render makes the effect
+  // re-install the adapter and notify assistant-ui subscribers again, which
+  // can close a render -> effect -> notification loop during session swaps or
+  // incoming message flushes. Keep the adapter stable until one of its actual
+  // inputs changes.
+  const runtimeAdapter = useMemo(
+    () => ({
+      messageRepository: runtimeMessageRepository,
+      isRunning: busy,
+      setMessages: onThreadMessagesChange,
+      onNew: async () => {
+        // Submission is handled explicitly by ChatBar.
+        // Keeping this no-op avoids duplicate prompt.submit calls.
+      },
+      onEdit,
+      onCancel: async () => onCancel(),
+      onReload
+    }),
+    [busy, onCancel, onEdit, onReload, onThreadMessagesChange, runtimeMessageRepository]
+  )
+
+  const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>(runtimeAdapter)
 
   return (
     <TranscriptWindowProvider value={transcriptWindow}>


### PR DESCRIPTION
## Summary

- memoize the external-store runtime adapter in `ChatRuntimeBoundary`
- keep the no-op/new and cancel callback wrappers stable across unrelated renders
- stop the adapter effect from reinstalling the same logical adapter and synchronously notifying assistant-ui subscribers again

## Root cause

`useIncrementalExternalStoreRuntime` keys its adapter effect by object identity. `ChatRuntimeBoundary` previously passed an inline object containing two inline callbacks, so every render retriggered `runtime.setAdapter(store)`. The runtime then notified subscribers, which could close a render -> effect -> notification loop during session switches and incoming message flushes. React eventually raised `Maximum update depth exceeded` / `getSnapshot should be cached` through the workspace error boundary.

The adapter is now recreated only when one of its actual inputs changes.

## Verification

- `npm run typecheck --workspace hermes`
- `npm run test:ui --workspace hermes -- src/components/assistant-ui/thread/edit-context.test.tsx src/components/assistant-ui/thread/user-message-edit-gesture.test.tsx src/components/assistant-ui/thread/user-message-edit.test.tsx` (3 files, 13 tests)
- `npm run build --workspace hermes`
- Windows Desktop v0.20.4 manual verification: switched repeatedly between historical sessions, including a large transcript, without the workspace error boundary firing; post-fix logs contained zero new matching render-loop errors after launch

Addresses #90795.
