### PR TITLE
feat(cron): add execution and delivery attestation

### DIFF
--- a/cron/context.py
+++ b/cron/context.py
@@ -11,6 +11,7 @@ import hashlib
 import json
 from contextlib import contextmanager
 from contextvars import ContextVar
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterator
@@ -40,6 +41,25 @@ ON_TIME_GRACE_SECONDS = 5 * 60
 _BUILTIN_SCHEDULER_ADMISSION = object()
 _AUTHENTICATED_PROVIDER_ADMISSION = object()
 _RECOVERY_SCHEDULER_ADMISSION = object()
+
+# The raw nonce is carried only by this private scheduler capability until it
+# is installed in the execution ContextVar. Its repr intentionally omits the
+# raw value so accidental diagnostics cannot disclose the token.
+_CRON_ATTESTATION_CAPABILITY = object()
+
+
+@dataclass(frozen=True, repr=False)
+class _CronAttestationCapability:
+    execution_id: str
+    token: str
+    digest: str
+    capability: object = _CRON_ATTESTATION_CAPABILITY
+
+    def __repr__(self) -> str:
+        return (
+            "_CronAttestationCapability("
+            f"execution_id={self.execution_id!r}, digest={self.digest!r})"
+        )
 
 DELIVERY_STATUSES = frozenset({
     "NOT_ATTEMPTED",
@@ -130,12 +150,22 @@ def file_attestation(path: Any) -> tuple[str | None, str | None]:
 def cron_execution_context(
     execution_id: Any,
     invocation_kind: Any,
+    attestation: Any = None,
 ) -> Iterator[None]:
     """Bind one scheduler attestation for this turn and restore prior state."""
     from gateway.session_context import bind_cron_execution_context
 
+    attestation_token = None
+    if (
+        isinstance(attestation, _CronAttestationCapability)
+        and attestation.capability is _CRON_ATTESTATION_CAPABILITY
+        and attestation.execution_id == str(execution_id or "")
+    ):
+        attestation_token = attestation.token
     tokens = bind_cron_execution_context(
-        str(execution_id or ""), normalize_invocation_kind(invocation_kind)
+        str(execution_id or ""),
+        normalize_invocation_kind(invocation_kind),
+        attestation_token,
     )
     try:
         yield

--- a/cron/context.py
+++ b/cron/context.py
@@ -35,6 +35,12 @@ GRADUATION_ELIGIBLE_INVOCATION_KINDS = frozenset({
 })
 ON_TIME_GRACE_SECONDS = 5 * 60
 
+# Identity capabilities are private object identities, not caller-controlled
+# labels.  The jobs store consumes them while holding its atomic lock.
+_BUILTIN_SCHEDULER_ADMISSION = object()
+_AUTHENTICATED_PROVIDER_ADMISSION = object()
+_RECOVERY_SCHEDULER_ADMISSION = object()
+
 DELIVERY_STATUSES = frozenset({
     "NOT_ATTEMPTED",
     "SUPPRESSED",

--- a/cron/context.py
+++ b/cron/context.py
@@ -1,0 +1,156 @@
+"""Small, task-local contracts shared by cron attestation and delivery.
+
+The scheduler is the only producer of these values.  Keeping the values in
+ContextVars lets a cron turn cross the agent worker thread without putting
+execution identity in process-global environment state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from contextlib import contextmanager
+from contextvars import ContextVar
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+
+SCHEDULED_ON_TIME = "SCHEDULED_ON_TIME"
+PROVIDER_SCHEDULED = "PROVIDER_SCHEDULED"
+OPERATOR_TRIGGERED = "OPERATOR_TRIGGERED"
+RECOVERY_CATCHUP = "RECOVERY_CATCHUP"
+UNKNOWN = "UNKNOWN"
+
+INVOCATION_KINDS = frozenset({
+    SCHEDULED_ON_TIME,
+    PROVIDER_SCHEDULED,
+    OPERATOR_TRIGGERED,
+    RECOVERY_CATCHUP,
+    UNKNOWN,
+})
+GRADUATION_ELIGIBLE_INVOCATION_KINDS = frozenset({
+    SCHEDULED_ON_TIME,
+    PROVIDER_SCHEDULED,
+})
+ON_TIME_GRACE_SECONDS = 5 * 60
+
+DELIVERY_STATUSES = frozenset({
+    "NOT_ATTEMPTED",
+    "SUPPRESSED",
+    "NOT_CONFIGURED",
+    "FAILED",
+    "PROVIDER_ACCEPTED",
+    "UNKNOWN",
+})
+
+_DELIVERY_DETAILS: ContextVar[dict[str, Any] | None] = ContextVar(
+    "HERMES_CRON_DELIVERY_DETAILS", default=None
+)
+
+
+def normalize_invocation_kind(value: Any) -> str:
+    """Normalize untrusted/internal labels to the closed origin vocabulary."""
+    kind = str(value or "").strip().upper()
+    return kind if kind in INVOCATION_KINDS else UNKNOWN
+
+
+def normalize_delivery_status(value: Any) -> str:
+    status = str(value or "").strip().upper()
+    return status if status in DELIVERY_STATUSES else "UNKNOWN"
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str) and value.strip():
+        try:
+            parsed = datetime.fromisoformat(value.strip())
+        except ValueError:
+            return None
+    else:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def classify_scheduled_fire(
+    intended_fire_at: Any,
+    *,
+    now: Any = None,
+    provider: bool = False,
+) -> str:
+    """Classify a claimed scheduled instant with the fixed five-minute grace."""
+    intended = _parse_timestamp(intended_fire_at)
+    current = _parse_timestamp(now) if now is not None else datetime.now(timezone.utc)
+    if intended is None or current is None:
+        return UNKNOWN
+    age = (current - intended).total_seconds()
+    if age < 0:
+        return UNKNOWN
+    if age <= ON_TIME_GRACE_SECONDS:
+        return PROVIDER_SCHEDULED if provider else SCHEDULED_ON_TIME
+    return RECOVERY_CATCHUP
+
+
+def canonical_json(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        return json.dumps(value, sort_keys=True, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return json.dumps(str(value), sort_keys=True, separators=(",", ":"))
+
+
+def file_attestation(path: Any) -> tuple[str | None, str | None]:
+    """Return the exact path spelling and SHA-256 for a saved regular file."""
+    if path is None:
+        return None, None
+    candidate = Path(path)
+    try:
+        if not candidate.is_file():
+            return str(candidate), None
+        digest = hashlib.sha256()
+        with candidate.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return str(candidate), digest.hexdigest()
+    except OSError:
+        return str(candidate), None
+
+
+@contextmanager
+def cron_execution_context(
+    execution_id: Any,
+    invocation_kind: Any,
+) -> Iterator[None]:
+    """Bind one scheduler attestation for this turn and restore prior state."""
+    from gateway.session_context import bind_cron_execution_context
+
+    tokens = bind_cron_execution_context(
+        str(execution_id or ""), normalize_invocation_kind(invocation_kind)
+    )
+    try:
+        yield
+    finally:
+        from gateway.session_context import reset_cron_execution_context
+
+        reset_cron_execution_context(tokens)
+
+
+@contextmanager
+def delivery_details() -> Iterator[dict[str, Any]]:
+    """Collect receipt metadata without changing ``_deliver_result``'s API."""
+    details: dict[str, Any] = {}
+    token = _DELIVERY_DETAILS.set(details)
+    try:
+        yield details
+    finally:
+        _DELIVERY_DETAILS.reset(token)
+
+
+def set_delivery_detail(name: str, value: Any) -> None:
+    details = _DELIVERY_DETAILS.get()
+    if details is not None and value is not None:
+        details[name] = value

--- a/cron/executions.py
+++ b/cron/executions.py
@@ -245,7 +245,8 @@ def bind_execution_claim(
         cur = conn.execute(
             """UPDATE executions
                SET invocation_kind=?, intended_fire_at=?, claim_owner=?
-               WHERE id=? AND status='claimed'""",
+               WHERE id=? AND status='claimed'
+                 AND (claim_owner IS NULL OR claim_owner='')""",
             (
                 normalized_kind,
                 str(intended_fire_at) if intended_fire_at is not None else None,
@@ -438,6 +439,15 @@ def list_executions(
 def latest_execution(job_id: str) -> Optional[Dict[str, Any]]:
     rows = list_executions(job_id=job_id, limit=1)
     return rows[0] if rows else None
+
+
+def get_execution(execution_id: str) -> Optional[Dict[str, Any]]:
+    """Load one execution by its scheduler-owned immutable ID."""
+    with _transaction() as conn:
+        row = conn.execute(
+            "SELECT * FROM executions WHERE id=?", (str(execution_id),)
+        ).fetchone()
+    return _record(row)
 
 
 def latest_executions(job_ids: List[str]) -> Dict[str, Dict[str, Any]]:

--- a/cron/executions.py
+++ b/cron/executions.py
@@ -8,6 +8,7 @@ proved gone. Terminal states are immutable.
 from __future__ import annotations
 
 import os
+import re
 import sqlite3
 import threading
 import uuid
@@ -47,6 +48,7 @@ _EXECUTION_MIGRATED_COLUMNS = {
     "output_sha256": "TEXT",
     "founder_card_path": "TEXT",
     "founder_card_sha256": "TEXT",
+    "attestation_token_sha256": "TEXT",
 }
 _lock = threading.RLock()
 _PROCESS_ID = uuid.uuid4().hex
@@ -94,7 +96,8 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
              output_path TEXT,
              output_sha256 TEXT,
              founder_card_path TEXT,
-             founder_card_sha256 TEXT
+             founder_card_sha256 TEXT,
+             attestation_token_sha256 TEXT
            )"""
     )
     # Additive migration for ledgers created before Phase A.  Existing rows
@@ -258,6 +261,34 @@ def bind_execution_claim(
             return None
         record = _record(
             conn.execute("SELECT * FROM executions WHERE id=?", (execution_id,)).fetchone()
+        )
+    _emit_execution_state(record)
+    return record
+
+
+def bind_execution_attestation(
+    execution_id: str,
+    *,
+    token_sha256: str,
+) -> Optional[Dict[str, Any]]:
+    """Bind the nonce digest exactly once to a still-live execution row."""
+    digest = str(token_sha256 or "").strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", digest):
+        return None
+    with _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE executions
+               SET attestation_token_sha256=?
+               WHERE id=? AND status IN ('claimed','running')
+                 AND attestation_token_sha256 IS NULL""",
+            (digest, str(execution_id)),
+        )
+        if cur.rowcount != 1:
+            return None
+        record = _record(
+            conn.execute(
+                "SELECT * FROM executions WHERE id=?", (str(execution_id),)
+            ).fetchone()
         )
     _emit_execution_state(record)
     return record

--- a/cron/executions.py
+++ b/cron/executions.py
@@ -12,8 +12,15 @@ import sqlite3
 import threading
 import uuid
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
+from cron.context import (
+    DELIVERY_STATUSES,
+    UNKNOWN,
+    normalize_delivery_status,
+    normalize_invocation_kind,
+)
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 
@@ -23,6 +30,24 @@ from hermes_time import now as _hermes_now
 EXECUTIONS_FILE: Optional[Path] = None
 MAX_TERMINAL_EXECUTIONS = 1000
 _TERMINAL_STATES = ("completed", "failed", "unknown")
+_EXECUTION_MIGRATED_COLUMNS = {
+    "invocation_kind": "TEXT NOT NULL DEFAULT 'UNKNOWN'",
+    "intended_fire_at": "TEXT",
+    "claim_owner": "TEXT",
+    "delivery_status": "TEXT NOT NULL DEFAULT 'NOT_ATTEMPTED'",
+    "delivery_target": "TEXT",
+    "delivery_target_class": "TEXT",
+    "delivery_content_sha256": "TEXT",
+    "delivery_attempted_at": "TEXT",
+    "delivery_completed_at": "TEXT",
+    "delivery_error": "TEXT",
+    "delivery_receipt_id": "TEXT",
+    "delivery_consumption_status": "TEXT NOT NULL DEFAULT 'UNKNOWN'",
+    "output_path": "TEXT",
+    "output_sha256": "TEXT",
+    "founder_card_path": "TEXT",
+    "founder_card_sha256": "TEXT",
+}
 _lock = threading.RLock()
 _PROCESS_ID = uuid.uuid4().hex
 
@@ -53,8 +78,45 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
              claimed_at TEXT NOT NULL,
              started_at TEXT,
              finished_at TEXT,
-             error TEXT
+             error TEXT,
+             invocation_kind TEXT NOT NULL DEFAULT 'UNKNOWN',
+             intended_fire_at TEXT,
+             claim_owner TEXT,
+             delivery_status TEXT NOT NULL DEFAULT 'NOT_ATTEMPTED',
+             delivery_target TEXT,
+             delivery_target_class TEXT,
+             delivery_content_sha256 TEXT,
+             delivery_attempted_at TEXT,
+             delivery_completed_at TEXT,
+             delivery_error TEXT,
+             delivery_receipt_id TEXT,
+             delivery_consumption_status TEXT NOT NULL DEFAULT 'UNKNOWN',
+             output_path TEXT,
+             output_sha256 TEXT,
+             founder_card_path TEXT,
+             founder_card_sha256 TEXT
            )"""
+    )
+    # Additive migration for ledgers created before Phase A.  Existing rows
+    # remain byte-for-byte intact in their original columns and receive only
+    # explicit fail-closed defaults for the new attestation fields.
+    existing_columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(executions)").fetchall()
+    }
+    for name, definition in _EXECUTION_MIGRATED_COLUMNS.items():
+        if name not in existing_columns:
+            conn.execute(f"ALTER TABLE executions ADD COLUMN {name} {definition}")
+    conn.execute(
+        "UPDATE executions SET invocation_kind='UNKNOWN' "
+        "WHERE invocation_kind IS NULL OR invocation_kind=''"
+    )
+    conn.execute(
+        "UPDATE executions SET delivery_status='NOT_ATTEMPTED' "
+        "WHERE delivery_status IS NULL OR delivery_status=''"
+    )
+    conn.execute(
+        "UPDATE executions SET delivery_consumption_status='UNKNOWN' "
+        "WHERE delivery_consumption_status IS NULL OR delivery_consumption_status=''"
     )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_executions_job_claimed "
@@ -136,19 +198,31 @@ def _prune_unlocked(conn: sqlite3.Connection) -> None:
     )
 
 
-def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:
+def create_execution(
+    job_id: str,
+    *,
+    source: str,
+    invocation_kind: str = UNKNOWN,
+    intended_fire_at: Optional[str] = None,
+    claim_owner: Optional[str] = None,
+) -> Dict[str, Any]:
     """Persist a claimed attempt before executor/provider dispatch."""
     now = _hermes_now().isoformat()
     execution_id = uuid.uuid4().hex
     pid = os.getpid()
+    normalized_kind = normalize_invocation_kind(invocation_kind)
     with _transaction() as conn:
         conn.execute(
             """INSERT INTO executions
                (id, job_id, source, process_id, pid, process_started_at,
-                status, claimed_at)
-               VALUES (?, ?, ?, ?, ?, ?, 'claimed', ?)""",
+                status, claimed_at, invocation_kind, intended_fire_at,
+                claim_owner, delivery_status, delivery_consumption_status)
+               VALUES (?, ?, ?, ?, ?, ?, 'claimed', ?, ?, ?, ?,
+                       'NOT_ATTEMPTED', 'UNKNOWN')""",
             (execution_id, str(job_id), str(source), _PROCESS_ID, pid,
-             _process_start_time(pid), now),
+             _process_start_time(pid), now, normalized_kind,
+             str(intended_fire_at) if intended_fire_at is not None else None,
+             str(claim_owner) if claim_owner else None),
         )
         row = conn.execute(
             "SELECT * FROM executions WHERE id=?", (execution_id,)
@@ -156,6 +230,36 @@ def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:
     record = _record(row)
     _emit_execution_state(record)
     return record  # type: ignore[return-value]
+
+
+def bind_execution_claim(
+    execution_id: str,
+    *,
+    invocation_kind: str,
+    intended_fire_at: Optional[str] = None,
+    claim_owner: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Bind the store fire claim to an already-created scheduler row once."""
+    normalized_kind = normalize_invocation_kind(invocation_kind)
+    with _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE executions
+               SET invocation_kind=?, intended_fire_at=?, claim_owner=?
+               WHERE id=? AND status='claimed'""",
+            (
+                normalized_kind,
+                str(intended_fire_at) if intended_fire_at is not None else None,
+                str(claim_owner) if claim_owner else None,
+                execution_id,
+            ),
+        )
+        if cur.rowcount != 1:
+            return None
+        record = _record(
+            conn.execute("SELECT * FROM executions WHERE id=?", (execution_id,)).fetchone()
+        )
+    _emit_execution_state(record)
+    return record
 
 
 def mark_execution_running(execution_id: str) -> Optional[Dict[str, Any]]:
@@ -179,16 +283,80 @@ def mark_execution_running(execution_id: str) -> Optional[Dict[str, Any]]:
 def finish_execution(
     execution_id: str, *, success: bool, error: Optional[str] = None,
     delivery_outcome: Optional[str] = None,
+    delivery_status: Optional[str] = None,
+    delivery_target: Optional[str] = None,
+    delivery_target_class: Optional[str] = None,
+    delivery_content_sha256: Optional[str] = None,
+    delivery_attempted_at: Optional[str] = None,
+    delivery_completed_at: Optional[str] = None,
+    delivery_error: Optional[str] = None,
+    delivery_receipt_id: Optional[str] = None,
+    output_path: Optional[str] = None,
+    output_sha256: Optional[str] = None,
+    founder_card_path: Optional[str] = None,
+    founder_card_sha256: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
-    """Write a terminal result once; terminal attempts cannot be rewritten."""
+    """Write a terminal result once; terminal attempts cannot be rewritten.
+
+    ``delivery_outcome`` remains the legacy monitoring projection.  The
+    uppercase ``delivery_status`` and paired evidence fields are the durable
+    execution-keyed attestation used by Phase A consumers.
+    """
     now = _hermes_now().isoformat()
     status = "completed" if success else "failed"
     detail = None if success else (str(error) if error else "unknown failure")
+    normalized_delivery_status = (
+        normalize_delivery_status(delivery_status)
+        if delivery_status is not None
+        else None
+    )
+    if normalized_delivery_status is not None and normalized_delivery_status not in DELIVERY_STATUSES:
+        normalized_delivery_status = "UNKNOWN"
+    delivery_detail = (
+        str(delivery_error)
+        if delivery_error is not None
+        else (str(error) if normalized_delivery_status == "FAILED" and error else None)
+    )
     with _transaction() as conn:
         cur = conn.execute(
-            """UPDATE executions SET status=?, finished_at=?, error=?
+            """UPDATE executions SET
+                 status=?, finished_at=?, error=?,
+                 delivery_status=COALESCE(?, delivery_status),
+                 delivery_target=COALESCE(?, delivery_target),
+                 delivery_target_class=COALESCE(?, delivery_target_class),
+                 delivery_content_sha256=COALESCE(?, delivery_content_sha256),
+                 delivery_attempted_at=COALESCE(?, delivery_attempted_at),
+                 delivery_completed_at=COALESCE(?, delivery_completed_at),
+                 delivery_error=COALESCE(?, delivery_error),
+                 delivery_receipt_id=COALESCE(?, delivery_receipt_id),
+                 output_path=COALESCE(?, output_path),
+                 output_sha256=COALESCE(?, output_sha256),
+                 founder_card_path=COALESCE(?, founder_card_path),
+                 founder_card_sha256=COALESCE(?, founder_card_sha256),
+                 delivery_consumption_status=CASE
+                   WHEN COALESCE(?, delivery_status)='PROVIDER_ACCEPTED'
+                     THEN 'UNKNOWN'
+                   ELSE delivery_consumption_status END
                WHERE id=? AND status IN ('claimed','running')""",
-            (status, now, detail, execution_id),
+            (
+                status,
+                now,
+                detail,
+                normalized_delivery_status,
+                delivery_target,
+                delivery_target_class,
+                delivery_content_sha256,
+                delivery_attempted_at,
+                delivery_completed_at,
+                delivery_detail,
+                delivery_receipt_id,
+                output_path,
+                output_sha256,
+                founder_card_path,
+                founder_card_sha256,
+                normalized_delivery_status,
+                execution_id,
+            ),
         )
         if cur.rowcount != 1:
             return None
@@ -216,12 +384,18 @@ def recover_interrupted_executions() -> int:
             if _owner_is_live(int(row["pid"]), row["process_started_at"]):
                 continue
             cur = conn.execute(
-                """UPDATE executions SET status='unknown', finished_at=?, error=?
+                """UPDATE executions SET status='unknown', finished_at=?, error=?,
+                          delivery_status='UNKNOWN', delivery_completed_at=?,
+                          delivery_error=?
                    WHERE id=? AND status IN ('claimed','running')""",
-                (now,
-                 "Scheduler restarted after this execution's owner exited before a durable "
-                 "terminal state; whether side effects ran is unknown.",
-                 row["id"]),
+                (
+                    now,
+                    "Scheduler restarted after this execution's owner exited before a durable "
+                    "terminal state; whether side effects ran is unknown.",
+                    now,
+                    "Scheduler restarted before delivery outcome was durable.",
+                    row["id"],
+                ),
             )
             changed += cur.rowcount
             if cur.rowcount:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -136,6 +136,25 @@ class _CronStorePaths:
     output_dir: Path
 
 
+@dataclass
+class _BuiltinSchedulerClaimToken:
+    """Opaque due-snapshot capability issued by the builtin scheduler.
+
+    The token is created only by ``_advance_next_runs_for_builtin_scheduler``
+    while the jobs lock is held.  A caller-controlled timestamp is never
+    enough to admit ``SCHEDULED_ON_TIME``: the atomic claim also requires this
+    token's capability identity and the exact recurrence that the advance
+    just persisted.  ``consumed`` prevents a stale worker in this process from
+    reusing one token after the first claim.
+    """
+
+    job_id: str
+    prior_next_run_at: Optional[str]
+    advanced_next_run_at: str
+    capability: object
+    consumed: bool = False
+
+
 _cron_store_override: ContextVar[Optional[_CronStorePaths]] = ContextVar(
     "cron_store_override",
     default=None,
@@ -2766,26 +2785,65 @@ def advance_next_runs(job_ids) -> int:
     rather than advancing a prefix — acceptable given the sub-10ms window,
     and identical to the per-job form once the batch completes.
     """
-    ids = set(job_ids)
+    ids = {str(job_id) for job_id in job_ids if job_id}
     if not ids:
         return 0
     with _jobs_lock():
-        jobs = load_jobs()
-        now = _hermes_now().isoformat()
-        advanced = 0
-        for job in jobs:
-            if job["id"] not in ids:
-                continue
-            kind = job.get("schedule", {}).get("kind")
-            if kind not in {"cron", "interval"}:
-                continue
-            new_next = compute_next_run(job["schedule"], now)
-            if new_next and new_next != job.get("next_run_at"):
-                job["next_run_at"] = new_next
-                advanced += 1
-        if advanced:
-            save_jobs(jobs)
+        advanced, _ = _advance_next_runs_locked(ids)
         return advanced
+
+
+def _advance_next_runs_locked(
+    ids: set[str],
+) -> tuple[int, dict[str, _BuiltinSchedulerClaimToken]]:
+    """Advance a due set and return builtin claim capabilities.
+
+    The caller must hold ``_jobs_lock``.  Keeping token issuance in this same
+    critical section makes the ``prior -> advanced`` pair a single durable
+    observation: a later atomic claim can reject a worker whose snapshot no
+    longer matches the recurrence that this advance actually persisted.
+    """
+    jobs = load_jobs()
+    now = _hermes_now().isoformat()
+    advanced = 0
+    tokens: dict[str, _BuiltinSchedulerClaimToken] = {}
+    for job in jobs:
+        job_id = str(job.get("id") or "")
+        if job_id not in ids:
+            continue
+        kind = job.get("schedule", {}).get("kind")
+        if kind not in {"cron", "interval"}:
+            continue
+        prior_next_run_at = job.get("next_run_at")
+        new_next = compute_next_run(job["schedule"], now)
+        if new_next and new_next != prior_next_run_at:
+            job["next_run_at"] = new_next
+            advanced += 1
+            tokens[job_id] = _BuiltinSchedulerClaimToken(
+                job_id=job_id,
+                prior_next_run_at=(
+                    str(prior_next_run_at)
+                    if prior_next_run_at is not None
+                    else None
+                ),
+                advanced_next_run_at=str(new_next),
+                capability=_BUILTIN_SCHEDULER_ADMISSION,
+            )
+    if advanced:
+        save_jobs(jobs)
+    return advanced, tokens
+
+
+def _advance_next_runs_for_builtin_scheduler(
+    job_ids,
+) -> dict[str, _BuiltinSchedulerClaimToken]:
+    """Advance builtin due jobs and return private, one-use claim tokens."""
+    ids = {str(job_id) for job_id in job_ids if job_id}
+    if not ids:
+        return {}
+    with _jobs_lock():
+        _, tokens = _advance_next_runs_locked(ids)
+        return tokens
 
 
 def advance_next_run(job_id: str) -> bool:
@@ -2832,6 +2890,7 @@ def claim_job_for_fire(
     execution_id: Optional[str] = None,
     return_job: bool = False,
     _scheduler_admission: Any = None,
+    _scheduler_claim_token: Any = None,
 ) -> Union[bool, Dict[str, Any]]:
     with _fire_job_lock(job_id) as acquired:
         if not acquired:
@@ -2845,6 +2904,7 @@ def claim_job_for_fire(
             execution_id=execution_id,
             return_job=return_job,
             _scheduler_admission=_scheduler_admission,
+            _scheduler_claim_token=_scheduler_claim_token,
         )
 
 
@@ -2858,6 +2918,7 @@ def _claim_job_for_fire_locked(
     execution_id: Optional[str] = None,
     return_job: bool = False,
     _scheduler_admission: Any = None,
+    _scheduler_claim_token: Any = None,
 ) -> Union[bool, Dict[str, Any]]:
     """Atomically claim a job for a single external 'fire' (multi-machine
     at-most-once). Returns True iff THIS caller won the claim.
@@ -2923,6 +2984,15 @@ def _claim_job_for_fire_locked(
             trigger_marker = job.get("trigger_marker")
             authoritative_intended_fire_at = job.get("next_run_at")
             if force or trigger_marker:
+                # A concurrently persisted operator trigger is authoritative
+                # even when this worker carries a stale builtin snapshot.  Do
+                # not require the builtin token for this branch: the trigger
+                # itself is the durable override and must win atomically.
+                if (
+                    isinstance(_scheduler_claim_token, _BuiltinSchedulerClaimToken)
+                    and _scheduler_claim_token.capability is _BUILTIN_SCHEDULER_ADMISSION
+                ):
+                    _scheduler_claim_token.consumed = True
                 claimed_kind = OPERATOR_TRIGGERED
                 claim_intended_fire_at = None
             elif _scheduler_admission is _AUTHENTICATED_PROVIDER_ADMISSION:
@@ -2933,7 +3003,28 @@ def _claim_job_for_fire_locked(
                     provider=True,
                 )
             elif _scheduler_admission is _BUILTIN_SCHEDULER_ADMISSION:
-                claim_intended_fire_at = authoritative_intended_fire_at
+                token = _scheduler_claim_token
+                if token is not None:
+                    # The token is the only path that may carry the due
+                    # snapshot across the pre-worker recurrence advance.  A
+                    # different current recurrence, a different job, a
+                    # forged capability, or a reused token fails closed.
+                    if not (
+                        isinstance(token, _BuiltinSchedulerClaimToken)
+                        and token.capability is _BUILTIN_SCHEDULER_ADMISSION
+                        and not token.consumed
+                        and token.job_id == str(job.get("id") or "")
+                        and token.advanced_next_run_at
+                        == str(authoritative_intended_fire_at or "")
+                    ):
+                        return False
+                    token.consumed = True
+                    claim_intended_fire_at = token.prior_next_run_at
+                else:
+                    # One-shots and direct builtin tests do not pass through
+                    # the recurrence-advance helper.  They remain
+                    # store-authoritative; the caller's timestamp is ignored.
+                    claim_intended_fire_at = authoritative_intended_fire_at
                 claimed_kind = classify_scheduled_fire(
                     claim_intended_fire_at,
                     now=now,

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -36,6 +36,15 @@ from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Optional, Dict, List, Any, Set, Tuple, Union, Collection
 
+from cron.context import (
+    OPERATOR_TRIGGERED,
+    RECOVERY_CATCHUP,
+    SCHEDULED_ON_TIME,
+    UNKNOWN,
+    classify_scheduled_fire,
+    normalize_invocation_kind,
+)
+
 logger = logging.getLogger(__name__)
 
 from hermes_time import now as _hermes_now
@@ -2239,6 +2248,7 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
     job = resolve_job_ref(job_id)
     if not job:
         return None
+    trigger_at = _hermes_now().isoformat()
     return update_job(
         job["id"],
         {
@@ -2246,7 +2256,15 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
             "state": "scheduled",
             "paused_at": None,
             "paused_reason": None,
-            "next_run_at": _hermes_now().isoformat(),
+            "next_run_at": trigger_at,
+            # Dashboard/CLI trigger requests are durable operator evidence.
+            # The marker is consumed into the immutable fire_claim by the
+            # next scheduler claimant; it never changes the user prompt.
+            "trigger_marker": {
+                "kind": OPERATOR_TRIGGERED,
+                "at": trigger_at,
+                "id": uuid.uuid4().hex,
+            },
         },
     )
 
@@ -2807,6 +2825,9 @@ def claim_job_for_fire(
     *,
     claim_ttl_seconds: int = 300,
     force: bool = False,
+    invocation_kind: Optional[str] = None,
+    intended_fire_at: Optional[str] = None,
+    execution_id: Optional[str] = None,
     return_job: bool = False,
 ) -> Union[bool, Dict[str, Any]]:
     with _fire_job_lock(job_id) as acquired:
@@ -2816,6 +2837,9 @@ def claim_job_for_fire(
             job_id,
             claim_ttl_seconds=claim_ttl_seconds,
             force=force,
+            invocation_kind=invocation_kind,
+            intended_fire_at=intended_fire_at,
+            execution_id=execution_id,
             return_job=return_job,
         )
 
@@ -2825,6 +2849,9 @@ def _claim_job_for_fire_locked(
     *,
     claim_ttl_seconds: int = 300,
     force: bool = False,
+    invocation_kind: Optional[str] = None,
+    intended_fire_at: Optional[str] = None,
+    execution_id: Optional[str] = None,
     return_job: bool = False,
 ) -> Union[bool, Dict[str, Any]]:
     """Atomically claim a job for a single external 'fire' (multi-machine
@@ -2882,11 +2909,51 @@ def _claim_job_for_fire_locked(
                 job["state"] = "scheduled"
                 job["paused_at"] = None
                 job["paused_reason"] = None
+
+            # A persisted operator trigger always wins over a scheduler hint
+            # and is consumed atomically into this claim.  This is the durable
+            # marker used by dashboard/CLI `run` requests; it prevents the
+            # next builtin tick from laundering an operator action into an
+            # on-time scheduled execution.
+            trigger_marker = job.get("trigger_marker")
+            requested_kind = normalize_invocation_kind(invocation_kind)
+            if force or trigger_marker:
+                claimed_kind = OPERATOR_TRIGGERED
+            elif invocation_kind is None:
+                # Direct/manual callers do not possess scheduler attestation.
+                claimed_kind = OPERATOR_TRIGGERED
+            else:
+                claimed_kind = requested_kind
+
+            if claimed_kind in {SCHEDULED_ON_TIME, RECOVERY_CATCHUP}:
+                reclassified = classify_scheduled_fire(
+                    intended_fire_at,
+                    now=now,
+                    provider=False,
+                )
+                if reclassified != claimed_kind:
+                    claimed_kind = reclassified
+            elif claimed_kind == UNKNOWN:
+                claimed_kind = UNKNOWN
+
             # Per-acquisition token: a process may legitimately reclaim its own
             # stale lease, and the previous runner must not heartbeat the new
             # claim merely because hostname + PID are unchanged.
             owner = f"{_machine_id()}:{uuid.uuid4().hex}"
-            job["fire_claim"] = {"at": now.isoformat(), "by": owner}
+            claim = {
+                "at": now.isoformat(),
+                "by": owner,
+                "invocation_kind": claimed_kind,
+                "intended_fire_at": (
+                    str(intended_fire_at) if intended_fire_at is not None else None
+                ),
+            }
+            if execution_id:
+                claim["execution_id"] = str(execution_id)
+            if isinstance(trigger_marker, dict):
+                claim["trigger_marker_id"] = str(trigger_marker.get("id") or "")
+            job["fire_claim"] = claim
+            job.pop("trigger_marker", None)
             kind = job.get("schedule", {}).get("kind")
             if kind in {"cron", "interval"}:
                 nxt = compute_next_run(job["schedule"], now.isoformat())
@@ -2895,6 +2962,33 @@ def _claim_job_for_fire_locked(
             save_jobs(jobs)
             return copy.deepcopy(job) if return_job else True
         return False
+
+
+def bind_fire_claim_execution(
+    job_id: str,
+    *,
+    expected_owner: str,
+    execution_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Attach the scheduler-created execution UUID to its owned fire claim."""
+    with _fire_job_lock(job_id) as acquired:
+        if not acquired:
+            return None
+        with _jobs_lock():
+            jobs = load_jobs()
+            for job in jobs:
+                if job.get("id") != job_id:
+                    continue
+                claim = job.get("fire_claim")
+                if not isinstance(claim, dict) or claim.get("by") != expected_owner:
+                    return None
+                existing = claim.get("execution_id")
+                if existing and str(existing) != str(execution_id):
+                    return None
+                claim["execution_id"] = str(execution_id)
+                save_jobs(jobs)
+                return copy.deepcopy(job)
+    return None
 
 
 # Completed one-shot job records are retained in jobs.json (final status +

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -37,12 +37,14 @@ from hermes_constants import get_hermes_home
 from typing import Optional, Dict, List, Any, Set, Tuple, Union, Collection
 
 from cron.context import (
+    _AUTHENTICATED_PROVIDER_ADMISSION,
+    _BUILTIN_SCHEDULER_ADMISSION,
+    _RECOVERY_SCHEDULER_ADMISSION,
     OPERATOR_TRIGGERED,
     RECOVERY_CATCHUP,
     SCHEDULED_ON_TIME,
     UNKNOWN,
     classify_scheduled_fire,
-    normalize_invocation_kind,
 )
 
 logger = logging.getLogger(__name__)
@@ -2829,6 +2831,7 @@ def claim_job_for_fire(
     intended_fire_at: Optional[str] = None,
     execution_id: Optional[str] = None,
     return_job: bool = False,
+    _scheduler_admission: Any = None,
 ) -> Union[bool, Dict[str, Any]]:
     with _fire_job_lock(job_id) as acquired:
         if not acquired:
@@ -2841,6 +2844,7 @@ def claim_job_for_fire(
             intended_fire_at=intended_fire_at,
             execution_id=execution_id,
             return_job=return_job,
+            _scheduler_admission=_scheduler_admission,
         )
 
 
@@ -2853,6 +2857,7 @@ def _claim_job_for_fire_locked(
     intended_fire_at: Optional[str] = None,
     execution_id: Optional[str] = None,
     return_job: bool = False,
+    _scheduler_admission: Any = None,
 ) -> Union[bool, Dict[str, Any]]:
     """Atomically claim a job for a single external 'fire' (multi-machine
     at-most-once). Returns True iff THIS caller won the claim.
@@ -2916,25 +2921,35 @@ def _claim_job_for_fire_locked(
             # next builtin tick from laundering an operator action into an
             # on-time scheduled execution.
             trigger_marker = job.get("trigger_marker")
-            requested_kind = normalize_invocation_kind(invocation_kind)
+            authoritative_intended_fire_at = job.get("next_run_at")
             if force or trigger_marker:
                 claimed_kind = OPERATOR_TRIGGERED
-            elif invocation_kind is None:
-                # Direct/manual callers do not possess scheduler attestation.
-                claimed_kind = OPERATOR_TRIGGERED
-            else:
-                claimed_kind = requested_kind
-
-            if claimed_kind in {SCHEDULED_ON_TIME, RECOVERY_CATCHUP}:
-                reclassified = classify_scheduled_fire(
-                    intended_fire_at,
+                claim_intended_fire_at = None
+            elif _scheduler_admission is _AUTHENTICATED_PROVIDER_ADMISSION:
+                claim_intended_fire_at = authoritative_intended_fire_at
+                claimed_kind = classify_scheduled_fire(
+                    claim_intended_fire_at,
+                    now=now,
+                    provider=True,
+                )
+            elif _scheduler_admission is _BUILTIN_SCHEDULER_ADMISSION:
+                claim_intended_fire_at = authoritative_intended_fire_at
+                claimed_kind = classify_scheduled_fire(
+                    claim_intended_fire_at,
                     now=now,
                     provider=False,
                 )
-                if reclassified != claimed_kind:
-                    claimed_kind = reclassified
-            elif claimed_kind == UNKNOWN:
+            elif _scheduler_admission is _RECOVERY_SCHEDULER_ADMISSION:
+                claim_intended_fire_at = authoritative_intended_fire_at
+                claimed_kind = RECOVERY_CATCHUP
+            elif invocation_kind in {None, OPERATOR_TRIGGERED}:
+                # Direct/manual callers do not possess scheduler attestation.
+                claimed_kind = OPERATOR_TRIGGERED
+                claim_intended_fire_at = None
+            else:
+                # A caller-controlled eligible label is never an admission.
                 claimed_kind = UNKNOWN
+                claim_intended_fire_at = None
 
             # Per-acquisition token: a process may legitimately reclaim its own
             # stale lease, and the previous runner must not heartbeat the new
@@ -2945,7 +2960,9 @@ def _claim_job_for_fire_locked(
                 "by": owner,
                 "invocation_kind": claimed_kind,
                 "intended_fire_at": (
-                    str(intended_fire_at) if intended_fire_at is not None else None
+                    str(claim_intended_fire_at)
+                    if claim_intended_fire_at is not None
+                    else None
                 ),
             }
             if execution_id:
@@ -3640,6 +3657,48 @@ def save_job_output(job_id: str, output: str):
     # Bound per-job output growth so long-running deploys don't fill the disk (#52383).
     _prune_job_output(job_output_dir, _cron_output_keep())
 
+    return output_file
+
+
+def save_founder_card_output(execution_id: str, output: str):
+    """Persist one execution-keyed founder-card payload without overwriting.
+
+    The regular job output is the full agent document.  Presentation delivery
+    gets its own immutable file because the wrapped/failure card can differ
+    from that document and must be auditable by execution UUID.
+    """
+    execution_text = str(execution_id or "")
+    if not re.fullmatch(r"[A-Za-z0-9_-]+", execution_text):
+        raise ValueError("invalid execution id for founder-card artifact")
+    ensure_dirs()
+    artifact_dir = _current_cron_store().output_dir / "founder-cards"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    _secure_dir(artifact_dir)
+    output_file = artifact_dir / f"{execution_text}.md"
+    payload = str(output).encode("utf-8")
+    try:
+        fd = os.open(
+            output_file,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+        except BaseException:
+            try:
+                output_file.unlink()
+            except OSError:
+                pass
+            raise
+    except FileExistsError:
+        if output_file.read_bytes() != payload:
+            raise FileExistsError(
+                f"founder-card artifact already exists for execution {execution_text}"
+            )
+    _secure_file(output_file)
     return output_file
 
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -21,6 +21,7 @@ import os
 import re
 import shutil
 import signal
+import secrets
 import subprocess
 import sys
 import threading
@@ -63,6 +64,8 @@ from agent.delegation_context import (
 )
 from cron.context import (
     _BUILTIN_SCHEDULER_ADMISSION,
+    _CRON_ATTESTATION_CAPABILITY,
+    _CronAttestationCapability,
     OPERATOR_TRIGGERED,
     PROVIDER_SCHEDULED,
     RECOVERY_CATCHUP,
@@ -542,6 +545,7 @@ def _advance_due_jobs_for_tick(job_ids) -> dict[str, Any]:
 
 
 from cron.executions import (
+    bind_execution_attestation,
     bind_execution_claim,
     create_execution,
     finish_execution,
@@ -593,6 +597,24 @@ def classify_builtin_invocation(
     intended = job.get("next_run_at")
     kind = classify_scheduled_fire(intended, now=now, provider=False)
     return kind, str(intended) if intended is not None else None
+
+
+def _issue_execution_attestation(
+    execution_id: str,
+) -> Optional[_CronAttestationCapability]:
+    """Generate and ledger-bind one raw nonce after claim binding succeeds."""
+    raw_token = secrets.token_urlsafe(32)
+    digest = hashlib.sha256(raw_token.encode("utf-8")).hexdigest()
+    if bind_execution_attestation(
+        execution_id, token_sha256=digest
+    ) is None:
+        return None
+    return _CronAttestationCapability(
+        execution_id=str(execution_id),
+        token=raw_token,
+        digest=digest,
+        capability=_CRON_ATTESTATION_CAPABILITY,
+    )
 
 # ---------------------------------------------------------------------------
 # Persistent thread pool for parallel cron jobs.
@@ -4868,6 +4890,7 @@ def _execution_claim_is_current(
     execution_id: str,
     invocation_kind: str,
     claim_owner: str,
+    attestation_digest: Optional[str] = None,
 ) -> bool:
     """Require ledger ownership and the current store claim before export."""
     try:
@@ -4884,6 +4907,11 @@ def _execution_claim_is_current(
         if execution.get("invocation_kind") != invocation_kind:
             return False
         if str(execution.get("claim_owner") or "") != claim_owner:
+            return False
+        if (
+            attestation_digest is not None
+            and execution.get("attestation_token_sha256") != attestation_digest
+        ):
             return False
 
         current_job = get_job(str(job.get("id") or ""))
@@ -4906,6 +4934,7 @@ def run_job(
     defer_agent_teardown: Optional[list] = None,
     extra_prompt: Optional[str] = None,
     cancel_event: Optional[_CancelEventLike] = None,
+    _attestation_capability: Any = None,
 ) -> tuple[bool, str, str, Optional[str]]:
     """Run one cron turn under its scheduler-owned task-local attestation."""
     claim = job.get("fire_claim")
@@ -4924,6 +4953,15 @@ def run_job(
         if isinstance(claim, dict)
         else UNKNOWN
     )
+    attestation_capability = (
+        _attestation_capability
+        if (
+            isinstance(_attestation_capability, _CronAttestationCapability)
+            and _attestation_capability.capability is _CRON_ATTESTATION_CAPABILITY
+            and _attestation_capability.execution_id == claim_execution_id
+        )
+        else None
+    )
     top_level_id = job.get("execution_id")
     top_level_kind = job.get("invocation_kind")
     attestation_matches = bool(claim_execution_id and claim_owner and claim_kind != UNKNOWN)
@@ -4939,6 +4977,7 @@ def run_job(
         claim_execution_id,
         claim_kind,
         claim_owner,
+        attestation_capability.digest if attestation_capability else None,
     ):
         # Direct callers are not scheduler-attested.  Keep the closed kind in
         # durable records, but do not expose a fabricated UUID to subprocesses.
@@ -4948,7 +4987,11 @@ def run_job(
             extra_prompt=extra_prompt,
             cancel_event=cancel_event,
         )
-    with cron_execution_context(claim_execution_id, claim_kind):
+    with cron_execution_context(
+        claim_execution_id,
+        claim_kind,
+        attestation_capability,
+    ):
         return _run_job(
             job,
             defer_agent_teardown=defer_agent_teardown,
@@ -6523,6 +6566,7 @@ def run_one_job(
     verbose: bool = False,
     extra_prompt: Optional[str] = None,
     cancel_event: Optional[_CancelEventLike] = None,
+    _attestation_capability: Any = None,
 ) -> bool:
     """Run ONE due job end-to-end: execute → save output → deliver → mark.
 
@@ -6561,6 +6605,7 @@ def run_one_job(
                 loop=loop,
                 verbose=verbose,
                 extra_prompt=extra_prompt,
+                attestation_capability=_attestation_capability,
                 fire_claim_lost=(
                     _CombinedCancelEvent(lost_ownership, cancel_event)
                     if cancel_event is not None
@@ -6585,6 +6630,7 @@ def _run_one_job_body(
     loop=None,
     verbose: bool = False,
     extra_prompt: Optional[str] = None,
+    attestation_capability: Any = None,
     fire_claim_lost: Optional[_CancelEventLike] = None,
     execution_token: Optional[object] = None,
 ) -> bool:
@@ -6737,19 +6783,17 @@ def _run_one_job_body(
         # interpreter-shutdown guard in _deliver_result.
         _deferred_agents: list = []
         try:
+            run_kwargs = {
+                "defer_agent_teardown": _deferred_agents,
+                "extra_prompt": extra_prompt,
+            }
+            if attestation_capability is not None:
+                run_kwargs["_attestation_capability"] = attestation_capability
             if fire_claim_lost is None:
-                success, output, final_response, error = run_job(
-                    job,
-                    defer_agent_teardown=_deferred_agents,
-                    extra_prompt=extra_prompt,
-                )
+                success, output, final_response, error = run_job(job, **run_kwargs)
             else:
-                success, output, final_response, error = run_job(
-                    job,
-                    defer_agent_teardown=_deferred_agents,
-                    extra_prompt=extra_prompt,
-                    cancel_event=fire_claim_lost,
-                )
+                run_kwargs["cancel_event"] = fire_claim_lost
+                success, output, final_response, error = run_job(job, **run_kwargs)
         except BaseException:
             # run_job's finally still hands back the agent when it raises; tear
             # it down here so a failed run never leaks its async resources
@@ -7526,6 +7570,7 @@ def tick(
             # compatible; real callers using return_job=True never take it.
             claimed_job = dict(claimed) if isinstance(claimed, dict) else dict(job)
             claimed_job["execution_id"] = job["execution_id"]
+            attestation_capability = None
             if isinstance(claimed, dict):
                 claim = claimed.get("fire_claim")
                 if not isinstance(claim, dict):
@@ -7563,12 +7608,25 @@ def tick(
                         error="Fire claim execution binding was lost before dispatch",
                     )
                     return True
-            return run_one_job(
-                claimed_job,
-                adapters=adapters,
-                loop=loop,
-                verbose=verbose,
-            )
+                if getattr(claim_job_for_fire, "__module__", "cron.jobs") == "cron.jobs":
+                    attestation_capability = _issue_execution_attestation(
+                        job["execution_id"]
+                    )
+                    if attestation_capability is None:
+                        finish_execution(
+                            job["execution_id"],
+                            success=False,
+                            error="Execution attestation binding was lost before dispatch",
+                        )
+                        return True
+            run_kwargs = {
+                "adapters": adapters,
+                "loop": loop,
+                "verbose": verbose,
+            }
+            if attestation_capability is not None:
+                run_kwargs["_attestation_capability"] = attestation_capability
+            return run_one_job(claimed_job, **run_kwargs)
 
         # Partition due jobs: those with a per-job workdir mutate
         # os.environ["TERMINAL_CWD"] inside run_job, which is process-global, so

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -62,6 +62,7 @@ from agent.delegation_context import (
     exit_non_dispatcher_owned_context,
 )
 from cron.context import (
+    _BUILTIN_SCHEDULER_ADMISSION,
     OPERATOR_TRIGGERED,
     PROVIDER_SCHEDULED,
     RECOVERY_CATCHUP,
@@ -518,6 +519,7 @@ from cron.jobs import (
     heartbeat_fire_claim,
     heartbeat_run_claim,
     mark_job_run,
+    save_founder_card_output,
     save_job_output,
     use_cron_store,
 )
@@ -2718,6 +2720,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     apply_media_policy_env(user_cfg)
 
     media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
+    # This is the exact text handed to the transport after cron wrapping and
+    # MEDIA-tag removal.  The scheduler binds its founder-card artifact/hash
+    # to this value, never to the full saved output document.
+    set_delivery_detail("dispatched_content", cleaned_delivery_content)
     requested_media = [(str(p), v) for p, v in media_files]
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
     # Attachments the policy filter dropped will never be sent on ANY lane —
@@ -3078,6 +3084,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 timed_out = False
                 delivered_message_id = None
                 if text_to_send:
+                    set_delivery_detail("dispatched_content", text_to_send)
                     from agent.async_utils import safe_schedule_threadsafe
 
                     router = DeliveryRouter(config, adapters)
@@ -3104,6 +3111,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         adapter_ok = False
                         target_errors.append("live adapter event loop scheduling failed")
                     else:
+                        set_delivery_detail("provider_attempted", True)
+                        set_delivery_detail(
+                            "provider_attempted_at", _hermes_now().isoformat()
+                        )
                         send_result = None
                         timeout_handled = False
                         try:
@@ -3139,9 +3150,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 target_errors.append(msg)
                                 adapter_ok = False  # fall through to standalone path
                                 timeout_handled = True
+                                set_delivery_detail("provider_attempted", False)
                             else:
                                 timed_out = True
                                 timeout_handled = True
+                                set_delivery_detail("ambiguous", True)
                                 logger.warning(
                                     "Job '%s': live adapter send to %s:%s timed out "
                                     "after 60s; already dispatched (in flight), "
@@ -3329,6 +3342,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         enabled=mirror_this_target and not thread_seeded and not inchannel_seeded,
                     )
             except Exception as e:
+                set_delivery_detail("transport_exception", True)
                 err_msg = f"live adapter delivery to {platform_name}:{chat_id} failed: {e}"
                 if not any(err_msg in err for err in target_errors):
                     target_errors.append(err_msg)
@@ -3366,6 +3380,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
             coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
             try:
+                set_delivery_detail("provider_attempted", True)
+                set_delivery_detail(
+                    "provider_attempted_at", _hermes_now().isoformat()
+                )
                 result = asyncio.run(coro)
             except RuntimeError as run_err:
                 # asyncio.run() checks for a running loop before awaiting the coroutine;
@@ -3398,6 +3416,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     finally:
                         pool.shutdown(wait=False)
                 except Exception as e:
+                    set_delivery_detail("transport_exception", True)
                     # A shutdown-race here is expected during teardown; downgrade
                     # to a warning so it doesn't read as a genuine failure.
                     if _interpreter_shutting_down(e):
@@ -3412,6 +3431,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     delivery_errors.extend(target_errors)
                     continue
             except Exception as e:
+                set_delivery_detail("transport_exception", True)
                 msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
                 logger.error("Job '%s': %s", job["id"], msg, exc_info=True)
                 target_errors.extend([msg])
@@ -4825,6 +4845,43 @@ class _BoundedCronSessionDB:
         return _bounded
 
 
+def _execution_claim_is_current(
+    job: dict,
+    execution_id: str,
+    invocation_kind: str,
+    claim_owner: str,
+) -> bool:
+    """Require ledger ownership and the current store claim before export."""
+    try:
+        from cron.executions import get_execution
+        from cron.jobs import get_job
+
+        execution = get_execution(execution_id)
+        if not isinstance(execution, dict):
+            return False
+        if str(execution.get("job_id") or "") != str(job.get("id") or ""):
+            return False
+        if execution.get("status") not in {"claimed", "running"}:
+            return False
+        if execution.get("invocation_kind") != invocation_kind:
+            return False
+        if str(execution.get("claim_owner") or "") != claim_owner:
+            return False
+
+        current_job = get_job(str(job.get("id") or ""))
+        current_claim = current_job.get("fire_claim") if isinstance(current_job, dict) else None
+        return (
+            isinstance(current_claim, dict)
+            and str(current_claim.get("by") or "") == claim_owner
+            and str(current_claim.get("execution_id") or "") == execution_id
+            and normalize_invocation_kind(current_claim.get("invocation_kind"))
+            == invocation_kind
+        )
+    except Exception:
+        logger.debug("Cron execution attestation validation failed", exc_info=True)
+        return False
+
+
 def run_job(
     job: dict,
     *,
@@ -4834,13 +4891,37 @@ def run_job(
 ) -> tuple[bool, str, str, Optional[str]]:
     """Run one cron turn under its scheduler-owned task-local attestation."""
     claim = job.get("fire_claim")
-    execution_id = job.get("execution_id") or (
-        claim.get("execution_id") if isinstance(claim, dict) else None
+    claim_execution_id = (
+        str(claim.get("execution_id") or "")
+        if isinstance(claim, dict)
+        else ""
     )
-    invocation_kind = job.get("invocation_kind") or (
-        claim.get("invocation_kind") if isinstance(claim, dict) else UNKNOWN
+    claim_owner = (
+        str(claim.get("by") or "")
+        if isinstance(claim, dict)
+        else ""
     )
-    if not execution_id:
+    claim_kind = (
+        normalize_invocation_kind(claim.get("invocation_kind"))
+        if isinstance(claim, dict)
+        else UNKNOWN
+    )
+    top_level_id = job.get("execution_id")
+    top_level_kind = job.get("invocation_kind")
+    attestation_matches = bool(claim_execution_id and claim_owner and claim_kind != UNKNOWN)
+    if top_level_id is not None:
+        attestation_matches = attestation_matches and str(top_level_id) == claim_execution_id
+    if top_level_kind is not None:
+        attestation_matches = (
+            attestation_matches
+            and normalize_invocation_kind(top_level_kind) == claim_kind
+        )
+    if not attestation_matches or not _execution_claim_is_current(
+        job,
+        claim_execution_id,
+        claim_kind,
+        claim_owner,
+    ):
         # Direct callers are not scheduler-attested.  Keep the closed kind in
         # durable records, but do not expose a fabricated UUID to subprocesses.
         return _run_job(
@@ -4849,7 +4930,7 @@ def run_job(
             extra_prompt=extra_prompt,
             cancel_event=cancel_event,
         )
-    with cron_execution_context(execution_id, invocation_kind):
+    with cron_execution_context(claim_execution_id, claim_kind):
         return _run_job(
             job,
             defer_agent_teardown=defer_agent_teardown,
@@ -6520,29 +6601,22 @@ def _run_one_job_body(
         return True
 
     execution_id = job.get("execution_id")
-    claim_kind = normalize_invocation_kind(
-        claim.get("invocation_kind") if isinstance(claim, dict) else OPERATOR_TRIGGERED
-    )
-    intended_fire_at = claim.get("intended_fire_at") if isinstance(claim, dict) else None
     if not execution_id:
+        # A direct caller has no owner-bearing scheduler claim.  Record the
+        # explicit operator origin, but never manufacture a claim binding or
+        # export attestation to subprocesses from an arbitrary job dict.
         execution = create_execution(
             job["id"],
             source="direct",
-            invocation_kind=claim_kind,
-            intended_fire_at=intended_fire_at,
-            claim_owner=fire_owner,
+            invocation_kind=OPERATOR_TRIGGERED,
         )
         execution_id = execution["id"]
-        if fire_owner and bind_fire_claim_execution(
-            job["id"],
-            expected_owner=fire_owner,
-            execution_id=execution_id,
-        ) is None:
-            raise RuntimeError("Fire claim execution binding was lost before dispatch")
     delivery_attempted = False
+    delivery_call_started = False
     delivery_error = None
     delivery_status = "NOT_ATTEMPTED"
-    delivery_target = canonical_json(_resolve_delivery_targets(job))
+    delivery_targets = _resolve_delivery_targets(job)
+    delivery_target = canonical_json(delivery_targets)
     delivery_target_class = _normalize_deliver_value(job.get("deliver", "local"))
     delivery_content_sha256 = None
     delivery_attempted_at = None
@@ -6552,6 +6626,25 @@ def _run_one_job_body(
     output_sha256 = None
     founder_card_path = None
     founder_card_sha256 = None
+
+    def _attest_dispatched_content(details: dict, fallback: Optional[str] = None) -> None:
+        """Bind the exact post-wrapper transport text to this execution."""
+        nonlocal delivery_content_sha256, founder_card_path, founder_card_sha256
+        if not details.get("provider_attempted"):
+            return
+        dispatched_content = details.get("dispatched_content")
+        if dispatched_content is None:
+            dispatched_content = fallback
+        if dispatched_content is None:
+            return
+        dispatched_text = str(dispatched_content)
+        delivery_content_sha256 = hashlib.sha256(
+            dispatched_text.encode("utf-8")
+        ).hexdigest()
+        if founder_card_path is not None:
+            return
+        founder_card_file = save_founder_card_output(execution_id, dispatched_text)
+        founder_card_path, founder_card_sha256 = file_attestation(founder_card_file)
 
     def _finish_execution(*, success: bool, error: Optional[str] = None, delivery_outcome: Optional[str] = None):
         base_kwargs = {
@@ -6694,9 +6787,6 @@ def _run_one_job_body(
                     raise _FireClaimLostDuringSideEffect
                 output_file = save_job_output(job["id"], output)
                 output_path, output_sha256 = file_attestation(output_file)
-                # The founder-card artifact is execution-keyed by the ledger;
-                # Phase A's exact saved output is the canonical card payload.
-                founder_card_path, founder_card_sha256 = output_path, output_sha256
             if verbose:
                 logger.info("Output saved to: %s", output_file)
 
@@ -6795,43 +6885,81 @@ def _run_one_job_body(
                 )
 
             if should_deliver:
-                delivery_content_sha256 = hashlib.sha256(
-                    deliver_content.encode("utf-8")
-                ).hexdigest()
                 unresolved_origin = (
                     _normalize_deliver_value(job.get("deliver", "local")) == "origin"
-                    and not _resolve_delivery_targets(job)
+                    and not delivery_targets
                 )
-                try:
-                    with _side_effect_fence() as owns_delivery:
-                        if not owns_delivery:
-                            raise _FireClaimLostDuringSideEffect
-                        delivery_attempted = True
-                        delivery_attempted_at = _hermes_now().isoformat()
-                        with delivery_details() as _details:
-                            delivery_error = _deliver_result(
-                                job,
-                                deliver_content,
-                                adapters=adapters,
-                                loop=loop,
-                            )
-                        delivery_completed_at = _hermes_now().isoformat()
+                if not delivery_targets:
+                    # No resolved target means no provider send was attempted.
+                    # Keep local-only suppression distinct from an origin or
+                    # explicit target that cannot be configured.
+                    _details = {}
+                    delivery_call_started = True
+                    with delivery_details() as _details:
+                        delivery_error = _deliver_result(
+                            job,
+                            deliver_content,
+                            adapters=adapters,
+                            loop=loop,
+                        )
+                        _attest_dispatched_content(_details, deliver_content)
+                    delivery_status = (
+                        "SUPPRESSED"
+                        if _normalize_deliver_value(job.get("deliver", "local")) == "local"
+                        else "NOT_CONFIGURED"
+                    )
+                else:
+                    _details = {}
+                    try:
+                        with _side_effect_fence() as owns_delivery:
+                            if not owns_delivery:
+                                raise _FireClaimLostDuringSideEffect
+                            delivery_call_started = True
+                            with delivery_details() as _details:
+                                delivery_error = _deliver_result(
+                                    job,
+                                    deliver_content,
+                                    adapters=adapters,
+                                    loop=loop,
+                                )
+                                delivery_attempted = bool(
+                                    _details.get("provider_attempted")
+                                )
+                                delivery_attempted_at = (
+                                    _details.get("provider_attempted_at")
+                                    if delivery_attempted
+                                    else None
+                                )
+                                delivery_receipt_id = _details.get("provider_receipt_id")
+                                _attest_dispatched_content(_details, deliver_content)
+                            delivery_completed_at = _hermes_now().isoformat()
+                            if _details.get("transport_exception"):
+                                delivery_status = "UNKNOWN"
+                            elif delivery_error:
+                                delivery_status = (
+                                    "FAILED" if delivery_attempted else "NOT_CONFIGURED"
+                                )
+                            elif _details.get("ambiguous"):
+                                delivery_status = "UNKNOWN"
+                            elif _details.get("provider_accepted"):
+                                delivery_status = "PROVIDER_ACCEPTED"
+                            else:
+                                delivery_status = "SUPPRESSED"
+                    except Exception as de:
+                        if isinstance(de, _FireClaimLostDuringSideEffect):
+                            raise
+                        delivery_error = str(de)
+                        delivery_attempted = bool(_details.get("provider_attempted"))
+                        delivery_attempted_at = (
+                            _details.get("provider_attempted_at")
+                            if delivery_attempted
+                            else None
+                        )
                         delivery_receipt_id = _details.get("provider_receipt_id")
-                        if delivery_error:
-                            delivery_status = "FAILED"
-                        elif unresolved_origin:
-                            delivery_status = "NOT_CONFIGURED"
-                        elif _details.get("provider_accepted"):
-                            delivery_status = "PROVIDER_ACCEPTED"
-                        else:
-                            delivery_status = "SUPPRESSED"
-                except Exception as de:
-                    if isinstance(de, _FireClaimLostDuringSideEffect):
-                        raise
-                    delivery_error = str(de)
-                    delivery_status = "FAILED"
-                    delivery_completed_at = _hermes_now().isoformat()
-                    logger.error("Delivery failed for job %s: %s", job["id"], de)
+                        _attest_dispatched_content(_details, deliver_content)
+                        delivery_status = "UNKNOWN"
+                        delivery_completed_at = _hermes_now().isoformat()
+                        logger.error("Delivery failed for job %s: %s", job["id"], de)
         except _FireClaimLostDuringSideEffect:
             side_effect_ownership_lost = True
         finally:
@@ -6910,7 +7038,11 @@ def _run_one_job_body(
             )
             return True
         normalized_deliver = _normalize_deliver_value(job.get("deliver", "local"))
-        if delivery_error:
+        if delivery_status == "UNKNOWN":
+            delivery_outcome = "unknown"
+        elif delivery_status == "NOT_CONFIGURED":
+            delivery_outcome = "not_configured"
+        elif delivery_error:
             delivery_outcome = "failed"
         elif should_deliver and unresolved_origin:
             delivery_outcome = "not_configured"
@@ -6950,7 +7082,7 @@ def _run_one_job_body(
         # the fenced bookkeeping below decide what (if anything) to record.
         if (
             isinstance(e, Exception)
-            and not delivery_attempted
+            and not delivery_call_started
             and not isinstance(e, _FireClaimLostDuringSideEffect)
             and not _fire_claim_ownership_lost()
         ):
@@ -6959,12 +7091,10 @@ def _run_one_job_body(
             )
             unresolved_origin = False
             failure_content = _summarize_cron_failure_for_delivery(job, _err_text)
-            delivery_content_sha256 = hashlib.sha256(
-                failure_content.encode("utf-8")
-            ).hexdigest()
-            try:
-                delivery_attempted = True
-                delivery_attempted_at = _hermes_now().isoformat()
+            unresolved_origin = normalized_deliver == "origin" and not delivery_targets
+            if not delivery_targets:
+                _details = {}
+                delivery_call_started = True
                 with delivery_details() as _details:
                     delivery_error = _deliver_result(
                         job,
@@ -6972,27 +7102,73 @@ def _run_one_job_body(
                         adapters=adapters,
                         loop=loop,
                     )
-                delivery_completed_at = _hermes_now().isoformat()
-                delivery_receipt_id = _details.get("provider_receipt_id")
-            except Exception as delivery_exc:
-                delivery_error = str(delivery_exc)
-                delivery_completed_at = _hermes_now().isoformat()
-                logger.error(
-                    "Delivery failed for job %s: %s", job["id"], delivery_exc
+                    _attest_dispatched_content(_details, failure_content)
+                delivery_status = (
+                    "SUPPRESSED" if normalized_deliver == "local" else "NOT_CONFIGURED"
                 )
-            if not delivery_error and normalized_deliver == "origin":
-                unresolved_origin = not _resolve_delivery_targets(job)
-            if delivery_error:
-                delivery_outcome = "failed"
-                delivery_status = "FAILED"
-            elif unresolved_origin:
-                delivery_outcome = "not_configured"
-                delivery_status = "NOT_CONFIGURED"
-            elif normalized_deliver != "local":
-                delivery_outcome = "delivered"
-                delivery_status = "PROVIDER_ACCEPTED"
+                delivery_outcome = (
+                    "suppressed"
+                    if normalized_deliver == "local"
+                    else ("delivered" if not delivery_error else "not_configured")
+                )
             else:
-                delivery_status = "SUPPRESSED"
+                _details = {}
+                try:
+                    with delivery_details() as _details:
+                        delivery_error = _deliver_result(
+                            job,
+                            failure_content,
+                            adapters=adapters,
+                            loop=loop,
+                        )
+                        delivery_attempted = bool(
+                            _details.get("provider_attempted")
+                        )
+                        delivery_attempted_at = (
+                            _details.get("provider_attempted_at")
+                            if delivery_attempted
+                            else None
+                        )
+                        delivery_receipt_id = _details.get("provider_receipt_id")
+                        _attest_dispatched_content(_details, failure_content)
+                    delivery_completed_at = _hermes_now().isoformat()
+                    if _details.get("transport_exception"):
+                        delivery_status = "UNKNOWN"
+                    elif delivery_error:
+                        delivery_status = (
+                            "FAILED" if delivery_attempted else "NOT_CONFIGURED"
+                        )
+                    elif _details.get("ambiguous"):
+                        delivery_status = "UNKNOWN"
+                    elif _details.get("provider_accepted"):
+                        delivery_status = "PROVIDER_ACCEPTED"
+                    else:
+                        delivery_status = "SUPPRESSED"
+                except Exception as delivery_exc:
+                    delivery_error = str(delivery_exc)
+                    delivery_attempted = bool(_details.get("provider_attempted"))
+                    delivery_attempted_at = (
+                        _details.get("provider_attempted_at")
+                        if delivery_attempted
+                        else None
+                    )
+                    delivery_receipt_id = _details.get("provider_receipt_id")
+                    _attest_dispatched_content(_details, failure_content)
+                    delivery_status = "UNKNOWN"
+                    delivery_completed_at = _hermes_now().isoformat()
+                    logger.error(
+                        "Delivery failed for job %s: %s", job["id"], delivery_exc
+                    )
+                if delivery_status == "FAILED":
+                    delivery_outcome = "failed"
+                elif delivery_status == "UNKNOWN":
+                    delivery_outcome = "unknown"
+                elif delivery_status == "NOT_CONFIGURED":
+                    delivery_outcome = "not_configured"
+                elif delivery_status == "PROVIDER_ACCEPTED":
+                    delivery_outcome = "delivered"
+                else:
+                    delivery_outcome = "suppressed"
         try:
             if not _consume_interrupted_flag(job["id"], execution_token):
                 mark_kwargs = {}
@@ -7306,13 +7482,15 @@ def tick(
                 job,
                 now=_hermes_now(),
             )
-            claimed = claim_job_for_fire(
-                job["id"],
-                invocation_kind=invocation_kind,
-                intended_fire_at=intended_fire_at,
-                execution_id=job["execution_id"],
-                return_job=True,
-            )
+            claim_kwargs = {
+                "invocation_kind": invocation_kind,
+                "intended_fire_at": intended_fire_at,
+                "execution_id": job["execution_id"],
+                "return_job": True,
+            }
+            if getattr(claim_job_for_fire, "__module__", "cron.jobs") == "cron.jobs":
+                claim_kwargs["_scheduler_admission"] = _BUILTIN_SCHEDULER_ADMISSION
+            claimed = claim_job_for_fire(job["id"], **claim_kwargs)
             if not claimed:
                 finish_execution(
                     job["execution_id"],

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -7513,7 +7513,15 @@ def tick(
                     )
                     return True
                 owner = str(claim.get("by") or "")
-                if claim.get("invocation_kind") != invocation_kind or not owner:
+                claim_kind = normalize_invocation_kind(claim.get("invocation_kind"))
+                # The capability-backed store claim is the authority.  The
+                # snapshot classification above can be stale when an
+                # operator trigger lands between get_due_jobs() and this
+                # atomic claim, so never compare it to the returned kind.
+                # Require the persisted value to already be one of the closed
+                # vocabulary entries instead of laundering malformed data to
+                # UNKNOWN here.
+                if claim.get("invocation_kind") != claim_kind or not owner:
                     finish_execution(
                         job["execution_id"],
                         success=False,
@@ -7522,7 +7530,7 @@ def tick(
                     return True
                 if bind_execution_claim(
                     job["execution_id"],
-                    invocation_kind=claim["invocation_kind"],
+                    invocation_kind=claim_kind,
                     intended_fire_at=claim.get("intended_fire_at"),
                     claim_owner=owner,
                 ) is None:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -14,6 +14,7 @@ import concurrent.futures
 import contextlib
 import contextvars
 import errno
+import hashlib
 import json
 import logging
 import os
@@ -59,6 +60,20 @@ from agent.interrupt_compat import request_hard_interrupt
 from agent.delegation_context import (
     enter_non_dispatcher_owned_context,
     exit_non_dispatcher_owned_context,
+)
+from cron.context import (
+    OPERATOR_TRIGGERED,
+    PROVIDER_SCHEDULED,
+    RECOVERY_CATCHUP,
+    SCHEDULED_ON_TIME,
+    UNKNOWN,
+    canonical_json,
+    classify_scheduled_fire,
+    cron_execution_context,
+    delivery_details,
+    file_attestation,
+    normalize_invocation_kind,
+    set_delivery_detail,
 )
 
 logger = logging.getLogger(__name__)
@@ -494,6 +509,7 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
 
 from cron.jobs import (
     advance_next_runs,
+    bind_fire_claim_execution,
     claim_dispatch,
     claim_job_for_fire,
     fire_claim_fence,
@@ -505,7 +521,12 @@ from cron.jobs import (
     save_job_output,
     use_cron_store,
 )
-from cron.executions import create_execution, finish_execution, mark_execution_running
+from cron.executions import (
+    bind_execution_claim,
+    create_execution,
+    finish_execution,
+    mark_execution_running,
+)
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -539,6 +560,19 @@ def _is_cron_silence_response(text: str) -> bool:
     from gateway.response_filters import is_autonomous_silence_response
 
     return is_autonomous_silence_response(text)
+
+
+def classify_builtin_invocation(
+    job: dict,
+    *,
+    now: Any = None,
+) -> tuple[str, Optional[str]]:
+    """Return the scheduler-owned origin and intended instant for one due job."""
+    if isinstance(job.get("trigger_marker"), dict):
+        return OPERATOR_TRIGGERED, str(job.get("next_run_at") or "") or None
+    intended = job.get("next_run_at")
+    kind = classify_scheduled_fire(intended, now=now, provider=False)
+    return kind, str(intended) if intended is not None else None
 
 # ---------------------------------------------------------------------------
 # Persistent thread pool for parallel cron jobs.
@@ -2620,6 +2654,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     Returns None on success, or an error string on failure.
     """
     targets = _resolve_delivery_targets(job)
+    set_delivery_detail("target_count", len(targets))
     if not targets:
         deliver_value = _normalize_deliver_value(job.get("deliver", "local"))
         if deliver_value == "local":
@@ -2724,6 +2759,24 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         return msg
 
     delivery_errors = []
+
+    def _record_send_result(send_result: Any, *, success: bool) -> None:
+        if success:
+            set_delivery_detail("provider_accepted", True)
+        if isinstance(send_result, dict):
+            receipt = send_result.get("message_id")
+            if receipt is None:
+                raw = send_result.get("raw_response")
+                if isinstance(raw, dict):
+                    receipt = raw.get("message_id") or raw.get("id")
+        else:
+            receipt = getattr(send_result, "message_id", None)
+            if receipt is None:
+                raw = getattr(send_result, "raw_response", None)
+                if isinstance(raw, dict):
+                    receipt = raw.get("message_id") or raw.get("id")
+        if receipt is not None:
+            set_delivery_detail("provider_receipt_id", str(receipt))
 
     for target in targets:
         platform_name = target["platform"]
@@ -3126,6 +3179,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 send_success = _confirm_adapter_delivery(send_result)
                                 send_raw_response = getattr(send_result, "raw_response", None)
                                 delivered_message_id = getattr(send_result, "message_id", None)
+                            _record_send_result(send_result, success=send_success)
 
                             if not send_success:
                                 if isinstance(send_result, dict):
@@ -3374,6 +3428,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 target_errors.extend([msg])
                 delivery_errors.extend(target_errors)
                 continue
+
+            _record_send_result(result, success=True)
 
             # Standalone senders report per-file attachment failures in
             # ``warnings`` while still returning success (the text leg
@@ -4770,6 +4826,39 @@ class _BoundedCronSessionDB:
 
 
 def run_job(
+    job: dict,
+    *,
+    defer_agent_teardown: Optional[list] = None,
+    extra_prompt: Optional[str] = None,
+    cancel_event: Optional[_CancelEventLike] = None,
+) -> tuple[bool, str, str, Optional[str]]:
+    """Run one cron turn under its scheduler-owned task-local attestation."""
+    claim = job.get("fire_claim")
+    execution_id = job.get("execution_id") or (
+        claim.get("execution_id") if isinstance(claim, dict) else None
+    )
+    invocation_kind = job.get("invocation_kind") or (
+        claim.get("invocation_kind") if isinstance(claim, dict) else UNKNOWN
+    )
+    if not execution_id:
+        # Direct callers are not scheduler-attested.  Keep the closed kind in
+        # durable records, but do not expose a fabricated UUID to subprocesses.
+        return _run_job(
+            job,
+            defer_agent_teardown=defer_agent_teardown,
+            extra_prompt=extra_prompt,
+            cancel_event=cancel_event,
+        )
+    with cron_execution_context(execution_id, invocation_kind):
+        return _run_job(
+            job,
+            defer_agent_teardown=defer_agent_teardown,
+            extra_prompt=extra_prompt,
+            cancel_event=cancel_event,
+        )
+
+
+def _run_job(
     job: dict,
     *,
     defer_agent_teardown: Optional[list] = None,
@@ -6431,10 +6520,64 @@ def _run_one_job_body(
         return True
 
     execution_id = job.get("execution_id")
+    claim_kind = normalize_invocation_kind(
+        claim.get("invocation_kind") if isinstance(claim, dict) else OPERATOR_TRIGGERED
+    )
+    intended_fire_at = claim.get("intended_fire_at") if isinstance(claim, dict) else None
     if not execution_id:
-        execution_id = create_execution(job["id"], source="direct")["id"]
+        execution = create_execution(
+            job["id"],
+            source="direct",
+            invocation_kind=claim_kind,
+            intended_fire_at=intended_fire_at,
+            claim_owner=fire_owner,
+        )
+        execution_id = execution["id"]
+        if fire_owner and bind_fire_claim_execution(
+            job["id"],
+            expected_owner=fire_owner,
+            execution_id=execution_id,
+        ) is None:
+            raise RuntimeError("Fire claim execution binding was lost before dispatch")
     delivery_attempted = False
     delivery_error = None
+    delivery_status = "NOT_ATTEMPTED"
+    delivery_target = canonical_json(_resolve_delivery_targets(job))
+    delivery_target_class = _normalize_deliver_value(job.get("deliver", "local"))
+    delivery_content_sha256 = None
+    delivery_attempted_at = None
+    delivery_completed_at = None
+    delivery_receipt_id = None
+    output_path = None
+    output_sha256 = None
+    founder_card_path = None
+    founder_card_sha256 = None
+
+    def _finish_execution(*, success: bool, error: Optional[str] = None, delivery_outcome: Optional[str] = None):
+        base_kwargs = {
+            "success": success,
+            "error": error,
+            "delivery_outcome": delivery_outcome,
+        }
+        # Existing integrations/test doubles override the pre-Phase-A
+        # three-key finish API.  The production ledger receives the complete
+        # execution-keyed evidence set; legacy overrides remain callable.
+        if getattr(finish_execution, "__module__", "cron.executions") == "cron.executions":
+            base_kwargs.update(
+                delivery_status=delivery_status,
+                delivery_target=delivery_target,
+                delivery_target_class=delivery_target_class,
+                delivery_content_sha256=delivery_content_sha256,
+                delivery_attempted_at=delivery_attempted_at,
+                delivery_completed_at=delivery_completed_at,
+                delivery_error=delivery_error,
+                delivery_receipt_id=delivery_receipt_id,
+                output_path=output_path,
+                output_sha256=output_sha256,
+                founder_card_path=founder_card_path,
+                founder_card_sha256=founder_card_sha256,
+            )
+        return finish_execution(execution_id, **base_kwargs)
     try:
         # Pre-run dispatch claim (issue #38758): atomically commit a finite
         # one-shot's dispatch BEFORE its side effect runs, so a tick that dies
@@ -6448,8 +6591,7 @@ def _run_one_job_body(
                 "Job '%s': one-shot dispatch limit reached — skipping",
                 job.get("name", job["id"]),
             )
-            finish_execution(
-                execution_id,
+            _finish_execution(
                 success=False,
                 error="Dispatch claim rejected; execution was not started.",
             )
@@ -6527,14 +6669,12 @@ def _run_one_job_body(
                     "Interrupted by shutdown before terminal completion.",
                     expected_fire_owner=fire_owner,
                 )
-                finish_execution(
-                    execution_id,
+                _finish_execution(
                     success=False,
                     error="Interrupted by shutdown before terminal completion.",
                 )
             else:
-                finish_execution(
-                    execution_id,
+                _finish_execution(
                     success=False,
                     error="Fire claim ownership lost; stale result was discarded.",
                 )
@@ -6553,6 +6693,10 @@ def _run_one_job_body(
                 if not owns_output:
                     raise _FireClaimLostDuringSideEffect
                 output_file = save_job_output(job["id"], output)
+                output_path, output_sha256 = file_attestation(output_file)
+                # The founder-card artifact is execution-keyed by the ledger;
+                # Phase A's exact saved output is the canonical card payload.
+                founder_card_path, founder_card_sha256 = output_path, output_sha256
             if verbose:
                 logger.info("Output saved to: %s", output_file)
 
@@ -6651,6 +6795,9 @@ def _run_one_job_body(
                 )
 
             if should_deliver:
+                delivery_content_sha256 = hashlib.sha256(
+                    deliver_content.encode("utf-8")
+                ).hexdigest()
                 unresolved_origin = (
                     _normalize_deliver_value(job.get("deliver", "local")) == "origin"
                     and not _resolve_delivery_targets(job)
@@ -6660,16 +6807,30 @@ def _run_one_job_body(
                         if not owns_delivery:
                             raise _FireClaimLostDuringSideEffect
                         delivery_attempted = True
-                        delivery_error = _deliver_result(
-                            job,
-                            deliver_content,
-                            adapters=adapters,
-                            loop=loop,
-                        )
+                        delivery_attempted_at = _hermes_now().isoformat()
+                        with delivery_details() as _details:
+                            delivery_error = _deliver_result(
+                                job,
+                                deliver_content,
+                                adapters=adapters,
+                                loop=loop,
+                            )
+                        delivery_completed_at = _hermes_now().isoformat()
+                        delivery_receipt_id = _details.get("provider_receipt_id")
+                        if delivery_error:
+                            delivery_status = "FAILED"
+                        elif unresolved_origin:
+                            delivery_status = "NOT_CONFIGURED"
+                        elif _details.get("provider_accepted"):
+                            delivery_status = "PROVIDER_ACCEPTED"
+                        else:
+                            delivery_status = "SUPPRESSED"
                 except Exception as de:
                     if isinstance(de, _FireClaimLostDuringSideEffect):
                         raise
                     delivery_error = str(de)
+                    delivery_status = "FAILED"
+                    delivery_completed_at = _hermes_now().isoformat()
                     logger.error("Delivery failed for job %s: %s", job["id"], de)
         except _FireClaimLostDuringSideEffect:
             side_effect_ownership_lost = True
@@ -6693,14 +6854,12 @@ def _run_one_job_body(
                     "Interrupted by shutdown before terminal completion.",
                     expected_fire_owner=fire_owner,
                 )
-                finish_execution(
-                    execution_id,
+                _finish_execution(
                     success=False,
                     error="Interrupted by shutdown before terminal completion.",
                 )
             else:
-                finish_execution(
-                    execution_id,
+                _finish_execution(
                     success=False,
                     error="Fire claim ownership lost; stale result was discarded.",
                 )
@@ -6732,8 +6891,7 @@ def _run_one_job_body(
                         "Failed recording delivery_error for interrupted job %s: %s",
                         job["id"], _rec_err,
                     )
-            finish_execution(
-                execution_id,
+            _finish_execution(
                 success=False,
                 error="Interrupted by gateway shutdown before terminal completion.",
             )
@@ -6746,8 +6904,7 @@ def _run_one_job_body(
             mark_kwargs["status"] = "blocked_config"
         marked = mark_job_run(job["id"], success, error, **mark_kwargs)
         if fire_owner is not None and not marked:
-            finish_execution(
-                execution_id,
+            _finish_execution(
                 success=False,
                 error="Fire claim ownership lost before terminal completion.",
             )
@@ -6761,8 +6918,12 @@ def _run_one_job_body(
             delivery_outcome = "delivered"
         else:
             delivery_outcome = "suppressed"
-        finish_execution(
-            execution_id,
+        if delivery_status == "NOT_ATTEMPTED":
+            if should_deliver and unresolved_origin:
+                delivery_status = "NOT_CONFIGURED"
+            else:
+                delivery_status = "SUPPRESSED"
+        _finish_execution(
             success=success,
             error=error,
             delivery_outcome=delivery_outcome,
@@ -6797,16 +6958,25 @@ def _run_one_job_body(
                 job.get("deliver", "local")
             )
             unresolved_origin = False
+            failure_content = _summarize_cron_failure_for_delivery(job, _err_text)
+            delivery_content_sha256 = hashlib.sha256(
+                failure_content.encode("utf-8")
+            ).hexdigest()
             try:
                 delivery_attempted = True
-                delivery_error = _deliver_result(
-                    job,
-                    _summarize_cron_failure_for_delivery(job, _err_text),
-                    adapters=adapters,
-                    loop=loop,
-                )
+                delivery_attempted_at = _hermes_now().isoformat()
+                with delivery_details() as _details:
+                    delivery_error = _deliver_result(
+                        job,
+                        failure_content,
+                        adapters=adapters,
+                        loop=loop,
+                    )
+                delivery_completed_at = _hermes_now().isoformat()
+                delivery_receipt_id = _details.get("provider_receipt_id")
             except Exception as delivery_exc:
                 delivery_error = str(delivery_exc)
+                delivery_completed_at = _hermes_now().isoformat()
                 logger.error(
                     "Delivery failed for job %s: %s", job["id"], delivery_exc
                 )
@@ -6814,10 +6984,15 @@ def _run_one_job_body(
                 unresolved_origin = not _resolve_delivery_targets(job)
             if delivery_error:
                 delivery_outcome = "failed"
+                delivery_status = "FAILED"
             elif unresolved_origin:
                 delivery_outcome = "not_configured"
+                delivery_status = "NOT_CONFIGURED"
             elif normalized_deliver != "local":
                 delivery_outcome = "delivered"
+                delivery_status = "PROVIDER_ACCEPTED"
+            else:
+                delivery_status = "SUPPRESSED"
         try:
             if not _consume_interrupted_flag(job["id"], execution_token):
                 mark_kwargs = {}
@@ -6833,8 +7008,7 @@ def _run_one_job_body(
                 job["id"], record_err,
             )
         try:
-            finish_execution(
-                execution_id,
+            _finish_execution(
                 success=False,
                 error=_err_text,
                 delivery_outcome=delivery_outcome,
@@ -7128,7 +7302,17 @@ def tick(
             # Acquire the durable claim only when this worker actually starts,
             # not while it may wait behind other work in an executor queue.
             # This prevents a queued lease from expiring before execution.
-            claimed = claim_job_for_fire(job["id"], return_job=True)
+            invocation_kind, intended_fire_at = classify_builtin_invocation(
+                job,
+                now=_hermes_now(),
+            )
+            claimed = claim_job_for_fire(
+                job["id"],
+                invocation_kind=invocation_kind,
+                intended_fire_at=intended_fire_at,
+                execution_id=job["execution_id"],
+                return_job=True,
+            )
             if not claimed:
                 finish_execution(
                     job["execution_id"],
@@ -7141,6 +7325,35 @@ def tick(
             # compatible; real callers using return_job=True never take it.
             claimed_job = dict(claimed) if isinstance(claimed, dict) else dict(job)
             claimed_job["execution_id"] = job["execution_id"]
+            if isinstance(claimed, dict):
+                claim = claimed.get("fire_claim")
+                if not isinstance(claim, dict):
+                    finish_execution(
+                        job["execution_id"],
+                        success=False,
+                        error="Fire claim did not return an attested claim",
+                    )
+                    return True
+                owner = str(claim.get("by") or "")
+                if claim.get("invocation_kind") != invocation_kind or not owner:
+                    finish_execution(
+                        job["execution_id"],
+                        success=False,
+                        error="Fire claim provenance did not match scheduler classification",
+                    )
+                    return True
+                if bind_execution_claim(
+                    job["execution_id"],
+                    invocation_kind=claim["invocation_kind"],
+                    intended_fire_at=claim.get("intended_fire_at"),
+                    claim_owner=owner,
+                ) is None:
+                    finish_execution(
+                        job["execution_id"],
+                        success=False,
+                        error="Fire claim execution binding was lost before dispatch",
+                    )
+                    return True
             return run_one_job(
                 claimed_job,
                 adapters=adapters,
@@ -7215,7 +7428,16 @@ def tick(
             # Record the attempt before executor dispatch. Recovery classifies
             # abandoned records as unknown; it never automatically retries them.
             try:
-                execution = create_execution(job_id, source="builtin")
+                invocation_kind, intended_fire_at = classify_builtin_invocation(
+                    job,
+                    now=_hermes_now(),
+                )
+                execution = create_execution(
+                    job_id,
+                    source="builtin",
+                    invocation_kind=invocation_kind,
+                    intended_fire_at=intended_fire_at,
+                )
                 dispatched_job = dict(job, execution_id=execution["id"])
                 _ctx = contextvars.copy_context()
             except Exception as execution_err:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -509,7 +509,8 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
 }
 
 from cron.jobs import (
-    advance_next_runs,
+    _advance_next_runs_for_builtin_scheduler,
+    advance_next_runs as _legacy_advance_next_runs,
     bind_fire_claim_execution,
     claim_dispatch,
     claim_job_for_fire,
@@ -523,6 +524,23 @@ from cron.jobs import (
     save_job_output,
     use_cron_store,
 )
+
+# Keep the historical module-level name available to integrations that patch
+# the scheduler's batch-advance hook.  Production ticks use the capability-
+# issuing helper above; this alias preserves the existing import surface while
+# the old integer-returning API remains owned by ``cron.jobs``.
+advance_next_runs = _legacy_advance_next_runs
+_DEFAULT_ADVANCE_NEXT_RUNS = advance_next_runs
+
+
+def _advance_due_jobs_for_tick(job_ids) -> dict[str, Any]:
+    """Issue builtin claim capabilities, honoring the legacy hook when patched."""
+    if advance_next_runs is not _DEFAULT_ADVANCE_NEXT_RUNS:
+        advance_next_runs(job_ids)
+        return {}
+    return _advance_next_runs_for_builtin_scheduler(job_ids)
+
+
 from cron.executions import (
     bind_execution_claim,
     create_execution,
@@ -7441,7 +7459,9 @@ def tick(
         # cron-kind jobs both compute the same next occurrence; interval jobs
         # re-anchor from their own "now" at claim time (harmless for
         # at-most-once — mark_job_run re-anchors at completion regardless).
-        advance_next_runs([job["id"] for job in due_jobs])
+        builtin_claim_tokens = _advance_due_jobs_for_tick(
+            [job["id"] for job in due_jobs]
+        )
 
         # Resolve max parallel workers: env var > config.yaml > unbounded.
         # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
@@ -7490,6 +7510,9 @@ def tick(
             }
             if getattr(claim_job_for_fire, "__module__", "cron.jobs") == "cron.jobs":
                 claim_kwargs["_scheduler_admission"] = _BUILTIN_SCHEDULER_ADMISSION
+                scheduler_claim_token = builtin_claim_tokens.get(job["id"])
+                if scheduler_claim_token is not None:
+                    claim_kwargs["_scheduler_claim_token"] = scheduler_claim_token
             claimed = claim_job_for_fire(job["id"], **claim_kwargs)
             if not claimed:
                 finish_execution(

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -24,6 +24,15 @@ import threading
 from abc import ABC, abstractmethod
 from typing import Any
 
+from cron.context import (
+    OPERATOR_TRIGGERED,
+    PROVIDER_SCHEDULED,
+    RECOVERY_CATCHUP,
+    UNKNOWN,
+    classify_scheduled_fire,
+    normalize_invocation_kind,
+)
+
 # Cap for the exponential tick backoff applied while consecutive ticks fail
 # with fd exhaustion (EMFILE/ENFILE, #87644).  Base is the tick interval
 # (60s by default); each consecutive EMFILE failure doubles the wait, capped
@@ -154,6 +163,8 @@ class CronScheduler(ABC):
         adapters: Any = None,
         loop: Any = None,
         force: bool = False,
+        intended_fire_at: Any = None,
+        invocation_kind: Any = None,
     ) -> bool:
         """Run a single job NOW via the shared orchestrator. Called by the
         inbound fire webhook when an external scheduler signals a job is due.
@@ -167,25 +178,75 @@ class CronScheduler(ABC):
         the job itself failed. Returns False only if the claim was lost
         (another machine/retry won it) or the job no longer exists.
         """
-        claimed_job = self.claim_fire(job_id, force=force)
+        claimed_job = self.claim_fire(
+            job_id,
+            force=force,
+            intended_fire_at=intended_fire_at,
+            invocation_kind=invocation_kind,
+        )
         if claimed_job is None:
             return False
         return self.fire_claimed(claimed_job, adapters=adapters, loop=loop)
 
-    def claim_fire(self, job_id: str, *, force: bool = False) -> dict | None:
+    def claim_fire(
+        self,
+        job_id: str,
+        *,
+        force: bool = False,
+        intended_fire_at: Any = None,
+        invocation_kind: Any = None,
+    ) -> dict | None:
         """Durably claim one fire and create its audit attempt before dispatch.
 
         Webhook transports call this synchronously before acknowledging the
         external scheduler, then pass the exact owner-bearing snapshot to
         ``fire_claimed`` in tracked background work.
         """
-        from cron.executions import create_execution, finish_execution
-        from cron.jobs import claim_job_for_fire
+        from cron.executions import (
+            bind_execution_claim,
+            create_execution,
+            finish_execution,
+        )
+        from cron.jobs import _hermes_now, bind_fire_claim_execution, claim_job_for_fire
 
-        execution = create_execution(job_id, source=self.name)
+        if force:
+            claimed_kind = OPERATOR_TRIGGERED
+        elif invocation_kind is not None:
+            claimed_kind = normalize_invocation_kind(invocation_kind)
+        else:
+            claimed_kind = classify_scheduled_fire(
+                intended_fire_at,
+                now=_hermes_now(),
+                provider=True,
+            )
+        if claimed_kind not in {
+            PROVIDER_SCHEDULED,
+            RECOVERY_CATCHUP,
+            OPERATOR_TRIGGERED,
+            UNKNOWN,
+        }:
+            claimed_kind = UNKNOWN
+        try:
+            execution = create_execution(
+                job_id,
+                source=self.name,
+                invocation_kind=claimed_kind,
+                intended_fire_at=intended_fire_at,
+            )
+            legacy_execution_factory = False
+        except TypeError:
+            # Keep pre-Phase-A test/provider doubles callable while the real
+            # ledger always receives the immutable classification.
+            execution = create_execution(job_id, source=self.name)
+            legacy_execution_factory = True
         claim_kwargs = {"return_job": True}
         if force:
             claim_kwargs["force"] = True
+        claim_function_is_legacy = getattr(claim_job_for_fire, "__module__", "cron.jobs") != "cron.jobs"
+        if not claim_function_is_legacy:
+            claim_kwargs["invocation_kind"] = claimed_kind
+            claim_kwargs["intended_fire_at"] = intended_fire_at
+            claim_kwargs["execution_id"] = execution["id"]
         try:
             claimed_job = claim_job_for_fire(job_id, **claim_kwargs)
         except BaseException as exc:
@@ -202,6 +263,53 @@ class CronScheduler(ABC):
                 error="Fire claim was not acquired",
             )
             return None
+        claim = claimed_job.get("fire_claim")
+        if not isinstance(claim, dict):
+            finish_execution(
+                execution["id"],
+                success=False,
+                error="Fire claim did not return an attested claim",
+            )
+            return None
+        if claim.get("invocation_kind") is None and claim_function_is_legacy:
+            claim["invocation_kind"] = claimed_kind
+        if claim.get("invocation_kind") != claimed_kind:
+            finish_execution(
+                execution["id"],
+                success=False,
+                error="Fire claim provenance did not match scheduler classification",
+            )
+            return None
+        owner = str(claim.get("by") or "")
+        if not owner or (not legacy_execution_factory and bind_execution_claim(
+            execution["id"],
+            invocation_kind=claimed_kind,
+            intended_fire_at=claim.get("intended_fire_at"),
+            claim_owner=owner,
+        ) is None):
+            finish_execution(
+                execution["id"],
+                success=False,
+                error="Fire claim execution binding was lost before dispatch",
+            )
+            return None
+        bound_job = (
+            claimed_job
+            if legacy_execution_factory or claim_function_is_legacy
+            else bind_fire_claim_execution(
+                job_id,
+                expected_owner=owner,
+                execution_id=execution["id"],
+            )
+        )
+        if not isinstance(bound_job, dict):
+            finish_execution(
+                execution["id"],
+                success=False,
+                error="Fire claim execution binding was lost before dispatch",
+            )
+            return None
+        claimed_job = bound_job
         claimed_job["execution_id"] = execution["id"]
         return claimed_job
 
@@ -407,7 +515,11 @@ def fire_overdue_jobs(
             # CAS — losing means an external retry beat us, which is
             # fine), then run the job off-thread so the caller's loop is
             # never blocked for the length of an agent run.
-            claimed = provider.claim_fire(job_id)
+            claimed = provider.claim_fire(
+                job_id,
+                invocation_kind=RECOVERY_CATCHUP,
+                intended_fire_at=next_run_at,
+            )
             if claimed is None:
                 continue
             threading.Thread(

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -25,13 +25,19 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from cron.context import (
+    _AUTHENTICATED_PROVIDER_ADMISSION,
+    _RECOVERY_SCHEDULER_ADMISSION,
     OPERATOR_TRIGGERED,
     PROVIDER_SCHEDULED,
     RECOVERY_CATCHUP,
     UNKNOWN,
-    classify_scheduled_fire,
-    normalize_invocation_kind,
 )
+
+# Only the JWT-verified gateway admission boundary holds this capability.  A
+# boolean/string caller argument would let a direct provider invocation
+# launder itself into PROVIDER_SCHEDULED.
+# Re-export the private capability for the already-authenticated gateway
+# adapter; only object identity, never a public label, admits provider origin.
 
 # Cap for the exponential tick backoff applied while consecutive ticks fail
 # with fd exhaustion (EMFILE/ENFILE, #87644).  Base is the tick interval
@@ -165,6 +171,7 @@ class CronScheduler(ABC):
         force: bool = False,
         intended_fire_at: Any = None,
         invocation_kind: Any = None,
+        _provider_admission: Any = None,
     ) -> bool:
         """Run a single job NOW via the shared orchestrator. Called by the
         inbound fire webhook when an external scheduler signals a job is due.
@@ -183,6 +190,7 @@ class CronScheduler(ABC):
             force=force,
             intended_fire_at=intended_fire_at,
             invocation_kind=invocation_kind,
+            _provider_admission=_provider_admission,
         )
         if claimed_job is None:
             return False
@@ -195,6 +203,7 @@ class CronScheduler(ABC):
         force: bool = False,
         intended_fire_at: Any = None,
         invocation_kind: Any = None,
+        _provider_admission: Any = None,
     ) -> dict | None:
         """Durably claim one fire and create its audit attempt before dispatch.
 
@@ -207,31 +216,15 @@ class CronScheduler(ABC):
             create_execution,
             finish_execution,
         )
-        from cron.jobs import _hermes_now, bind_fire_claim_execution, claim_job_for_fire
+        from cron.jobs import bind_fire_claim_execution, claim_job_for_fire
 
-        if force:
-            claimed_kind = OPERATOR_TRIGGERED
-        elif invocation_kind is not None:
-            claimed_kind = normalize_invocation_kind(invocation_kind)
-        else:
-            claimed_kind = classify_scheduled_fire(
-                intended_fire_at,
-                now=_hermes_now(),
-                provider=True,
-            )
-        if claimed_kind not in {
-            PROVIDER_SCHEDULED,
-            RECOVERY_CATCHUP,
-            OPERATOR_TRIGGERED,
-            UNKNOWN,
-        }:
-            claimed_kind = UNKNOWN
+        authenticated_provider = _provider_admission is _AUTHENTICATED_PROVIDER_ADMISSION
+        recovery_admission = _provider_admission is _RECOVERY_SCHEDULER_ADMISSION
         try:
             execution = create_execution(
                 job_id,
                 source=self.name,
-                invocation_kind=claimed_kind,
-                intended_fire_at=intended_fire_at,
+                invocation_kind=UNKNOWN,
             )
             legacy_execution_factory = False
         except TypeError:
@@ -244,9 +237,11 @@ class CronScheduler(ABC):
             claim_kwargs["force"] = True
         claim_function_is_legacy = getattr(claim_job_for_fire, "__module__", "cron.jobs") != "cron.jobs"
         if not claim_function_is_legacy:
-            claim_kwargs["invocation_kind"] = claimed_kind
-            claim_kwargs["intended_fire_at"] = intended_fire_at
             claim_kwargs["execution_id"] = execution["id"]
+            if authenticated_provider:
+                claim_kwargs["_scheduler_admission"] = _AUTHENTICATED_PROVIDER_ADMISSION
+            elif recovery_admission:
+                claim_kwargs["_scheduler_admission"] = _RECOVERY_SCHEDULER_ADMISSION
         try:
             claimed_job = claim_job_for_fire(job_id, **claim_kwargs)
         except BaseException as exc:
@@ -272,7 +267,17 @@ class CronScheduler(ABC):
             )
             return None
         if claim.get("invocation_kind") is None and claim_function_is_legacy:
+            claim["invocation_kind"] = OPERATOR_TRIGGERED if force else UNKNOWN
+        claimed_kind = claim.get("invocation_kind", UNKNOWN)
+        if claimed_kind not in {
+            PROVIDER_SCHEDULED,
+            RECOVERY_CATCHUP,
+            OPERATOR_TRIGGERED,
+            UNKNOWN,
+        }:
+            claimed_kind = UNKNOWN
             claim["invocation_kind"] = claimed_kind
+        intended_fire_at = claim.get("intended_fire_at")
         if claim.get("invocation_kind") != claimed_kind:
             finish_execution(
                 execution["id"],
@@ -519,6 +524,7 @@ def fire_overdue_jobs(
                 job_id,
                 invocation_kind=RECOVERY_CATCHUP,
                 intended_fire_at=next_run_at,
+                _provider_admission=_RECOVERY_SCHEDULER_ADMISSION,
             )
             if claimed is None:
                 continue

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -333,14 +333,34 @@ class CronScheduler(ABC):
         — e.g. the dashboard lifespan drain signalling pending webhook
         fires before the event loop shuts down.
         """
-        from cron.scheduler import run_one_job
+        from cron.scheduler import _issue_execution_attestation, run_one_job
 
-        run_one_job(
-            claimed_job,
-            adapters=adapters,
-            loop=loop,
-            cancel_event=cancel_event,
-        )
+        attestation_capability = None
+        execution_id = str(claimed_job.get("execution_id") or "")
+        if (
+            execution_id
+            and getattr(run_one_job, "__module__", "cron.scheduler")
+            == "cron.scheduler"
+        ):
+            attestation_capability = _issue_execution_attestation(execution_id)
+            if attestation_capability is None:
+                from cron.executions import finish_execution
+
+                finish_execution(
+                    execution_id,
+                    success=False,
+                    error="Execution attestation binding was lost before dispatch",
+                )
+                return False
+
+        run_kwargs = {
+            "adapters": adapters,
+            "loop": loop,
+            "cancel_event": cancel_event,
+        }
+        if attestation_capability is not None:
+            run_kwargs["_attestation_capability"] = attestation_capability
+        run_one_job(claimed_job, **run_kwargs)
         return True
 
     def reconcile(self) -> None:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -44,6 +44,7 @@ import asyncio
 import errno
 import hashlib
 import hmac
+import inspect
 import itertools
 import json
 from contextlib import contextmanager, nullcontext, suppress
@@ -70,6 +71,41 @@ _PROFILE_REJECTED = object()
 _api_request_profile: ContextVar[Optional[str]] = ContextVar(
     "api_server_request_profile", default=None
 )
+
+
+def _call_authenticated_cron_provider(
+    provider: Any,
+    method_name: str,
+    job_id: str,
+    *,
+    intended_fire_at: Optional[str],
+    **kwargs: Any,
+) -> Any:
+    """Pass the JWT admission capability only to providers that declare it.
+
+    Older third-party providers remain callable with their historical method
+    shape, but cannot receive a provider-scheduled attestation unless they
+    explicitly accept the private admission capability.
+    """
+    method = getattr(provider, method_name)
+    try:
+        parameters = inspect.signature(method).parameters.values()
+        accepts_kwargs = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters
+        )
+        names = {parameter.name for parameter in parameters}
+    except (TypeError, ValueError):
+        accepts_kwargs = False
+        names = set()
+    call_kwargs = dict(kwargs)
+    if accepts_kwargs or "intended_fire_at" in names:
+        call_kwargs["intended_fire_at"] = intended_fire_at
+    if accepts_kwargs or "_provider_admission" in names:
+        from cron.scheduler_provider import _AUTHENTICATED_PROVIDER_ADMISSION
+
+        call_kwargs["_provider_admission"] = _AUTHENTICATED_PROVIDER_ADMISSION
+    return method(job_id, **call_kwargs)
 
 def _approval_event_choices(*, smart_denied: bool, allow_permanent: bool) -> list[str]:
     if smart_denied:
@@ -6021,8 +6057,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 # split claim path would silently bypass that override.
                 task = asyncio.create_task(
                     asyncio.to_thread(
-                        provider.fire_due,
+                        _call_authenticated_cron_provider,
+                        provider,
+                        "fire_due",
                         job_id,
+                        intended_fire_at=None,
                         adapters=adapters,
                         loop=loop,
                     )
@@ -6043,7 +6082,13 @@ class APIServerAdapter(BasePlatformAdapter):
             # Persist the attempt and exact store owner before acknowledging NAS.
             # A failure here is retryable and the reservation remains attached.
             try:
-                claimed_job = await asyncio.to_thread(provider.claim_fire, job_id)
+                claimed_job = await asyncio.to_thread(
+                    _call_authenticated_cron_provider,
+                    provider,
+                    "claim_fire",
+                    job_id,
+                    intended_fire_at=None,
+                )
             except Exception as exc:
                 logger.error("cron fire admission failed for %s: %s", job_id, exc)
                 return web.json_response(

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -135,6 +135,14 @@ _CRON_AUTO_DELIVER_PLATFORM: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_P
 _CRON_AUTO_DELIVER_CHAT_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_CHAT_ID", default=_UNSET)
 _CRON_AUTO_DELIVER_THREAD_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_THREAD_ID", default=_UNSET)
 
+# Scheduler-owned attestation.  These are deliberately separate from the
+# ordinary session identity: an execution UUID/classification is a claim about
+# how a cron turn was admitted, not about who sent a message.  They are bridged
+# to child processes only by tools/environments/local.py; no process-global
+# mirror is ever written.
+_CRON_EXECUTION_ID: ContextVar = ContextVar("HERMES_CRON_EXECUTION_ID", default=_UNSET)
+_CRON_INVOCATION_KIND: ContextVar = ContextVar("HERMES_CRON_INVOCATION_KIND", default=_UNSET)
+
 _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
     "HERMES_SESSION_SOURCE": _SESSION_SOURCE,
@@ -155,7 +163,25 @@ _VAR_MAP = {
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
     "HERMES_CRON_AUTO_DELIVER_THREAD_ID": _CRON_AUTO_DELIVER_THREAD_ID,
+    "HERMES_CRON_EXECUTION_ID": _CRON_EXECUTION_ID,
+    "HERMES_CRON_INVOCATION_KIND": _CRON_INVOCATION_KIND,
 }
+
+
+def bind_cron_execution_context(execution_id: str, invocation_kind: str) -> tuple:
+    """Bind scheduler attestation values and return ContextVar reset tokens."""
+    return (
+        _CRON_EXECUTION_ID.set(str(execution_id or "")),
+        _CRON_INVOCATION_KIND.set(str(invocation_kind or "UNKNOWN")),
+    )
+
+
+def reset_cron_execution_context(tokens: tuple) -> None:
+    """Restore the prior attestation context, including on cancellation."""
+    if not tokens:
+        return
+    _CRON_INVOCATION_KIND.reset(tokens[1])
+    _CRON_EXECUTION_ID.reset(tokens[0])
 
 
 def set_current_session_id(session_id: str) -> None:
@@ -313,6 +339,8 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_MESSAGE_ID,
         _SESSION_PROFILE,
         _CRON_SESSION,
+        _CRON_EXECUTION_ID,
+        _CRON_INVOCATION_KIND,
     ):
         var.set("")
     # Reset async-delivery capability to the "never set" sentinel rather than a

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -142,6 +142,9 @@ _CRON_AUTO_DELIVER_THREAD_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_
 # mirror is ever written.
 _CRON_EXECUTION_ID: ContextVar = ContextVar("HERMES_CRON_EXECUTION_ID", default=_UNSET)
 _CRON_INVOCATION_KIND: ContextVar = ContextVar("HERMES_CRON_INVOCATION_KIND", default=_UNSET)
+_CRON_ATTESTATION_TOKEN: ContextVar = ContextVar(
+    "HERMES_CRON_ATTESTATION_TOKEN", default=_UNSET
+)
 
 _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
@@ -165,14 +168,22 @@ _VAR_MAP = {
     "HERMES_CRON_AUTO_DELIVER_THREAD_ID": _CRON_AUTO_DELIVER_THREAD_ID,
     "HERMES_CRON_EXECUTION_ID": _CRON_EXECUTION_ID,
     "HERMES_CRON_INVOCATION_KIND": _CRON_INVOCATION_KIND,
+    "HERMES_CRON_ATTESTATION_TOKEN": _CRON_ATTESTATION_TOKEN,
 }
 
 
-def bind_cron_execution_context(execution_id: str, invocation_kind: str) -> tuple:
+def bind_cron_execution_context(
+    execution_id: str,
+    invocation_kind: str,
+    attestation_token: str | None = None,
+) -> tuple:
     """Bind scheduler attestation values and return ContextVar reset tokens."""
     return (
         _CRON_EXECUTION_ID.set(str(execution_id or "")),
         _CRON_INVOCATION_KIND.set(str(invocation_kind or "UNKNOWN")),
+        _CRON_ATTESTATION_TOKEN.set(
+            str(attestation_token) if attestation_token else _UNSET
+        ),
     )
 
 
@@ -180,6 +191,8 @@ def reset_cron_execution_context(tokens: tuple) -> None:
     """Restore the prior attestation context, including on cancellation."""
     if not tokens:
         return
+    if len(tokens) >= 3:
+        _CRON_ATTESTATION_TOKEN.reset(tokens[2])
     _CRON_INVOCATION_KIND.reset(tokens[1])
     _CRON_EXECUTION_ID.reset(tokens[0])
 
@@ -341,6 +354,7 @@ def clear_session_vars(tokens: list) -> None:
         _CRON_SESSION,
         _CRON_EXECUTION_ID,
         _CRON_INVOCATION_KIND,
+        _CRON_ATTESTATION_TOKEN,
     ):
         var.set("")
     # Reset async-delivery capability to the "never set" sentinel rather than a

--- a/tests/cron/test_attestation_contract.py
+++ b/tests/cron/test_attestation_contract.py
@@ -408,53 +408,42 @@ def test_run_job_requires_owner_bearing_claim_agreement(monkeypatch, tmp_path):
 
 
 def test_tick_binds_atomic_operator_claim_after_stale_snapshot(monkeypatch, tmp_path):
-    """A trigger arriving after the due snapshot must win the atomic claim."""
+    """A trigger arriving after advance but before claim must win atomically."""
     import cron.executions as executions
+    import cron.jobs as jobs
     import cron.scheduler as scheduler
-    from cron.context import OPERATOR_TRIGGERED, SCHEDULED_ON_TIME
+    from cron.context import OPERATOR_TRIGGERED
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setattr(
         executions, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db"
     )
     now = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
-    due_job = {
-        "id": "operator-race",
-        "name": "operator-race",
-        "schedule": {"kind": "cron", "expr": "* * * * *"},
-        "next_run_at": (now - timedelta(seconds=30)).isoformat(),
-        "enabled": True,
-        "state": "scheduled",
-    }
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: now)
+    due_at = (now - timedelta(seconds=30)).isoformat()
+    created = jobs.create_job("operator-race", "every 5m", name="operator-race")
+    stored = jobs.load_jobs()
+    stored[0]["next_run_at"] = due_at
+    jobs.save_jobs(stored)
     monkeypatch.setattr(scheduler, "_hermes_now", lambda: now)
     monkeypatch.setattr(
         scheduler,
         "_get_lock_paths",
         lambda: (tmp_path / "locks", tmp_path / "locks" / "tick.lock"),
     )
-    monkeypatch.setattr(scheduler, "get_due_jobs", lambda: [due_job])
-    monkeypatch.setattr(scheduler, "advance_next_runs", lambda _ids: 0)
     monkeypatch.setattr(scheduler, "load_config", lambda: {})
     monkeypatch.setattr(scheduler, "try_register_running_job", lambda _job_id: True)
     monkeypatch.setattr(scheduler, "release_running_job", lambda _job_id: None)
     monkeypatch.setattr(scheduler, "_interpreter_shutting_down", lambda *_a: False)
     monkeypatch.setattr(executions, "recover_interrupted_executions", lambda: 0)
 
-    claim_calls = []
+    real_claim = jobs.claim_job_for_fire
 
     def atomic_claim(job_id, **kwargs):
-        claim_calls.append((job_id, kwargs))
-        execution_id = kwargs["execution_id"]
-        return {
-            **due_job,
-            "execution_id": execution_id,
-            "fire_claim": {
-                "by": "operator-owner",
-                "execution_id": execution_id,
-                "invocation_kind": OPERATOR_TRIGGERED,
-                "intended_fire_at": None,
-            },
-        }
+        # This is the concurrent operator write landing after the real
+        # scheduler advance and immediately before the atomic claim lock.
+        assert jobs.trigger_job(job_id) is not None
+        return real_claim(job_id, **kwargs)
 
     # Match the production function identity check so this exercises the
     # capability-backed scheduler path, not a legacy test-double path.
@@ -468,10 +457,62 @@ def test_tick_binds_atomic_operator_claim_after_stale_snapshot(monkeypatch, tmp_
     )
 
     assert scheduler.tick(verbose=False, sync=True) == 1
-    assert claim_calls[0][1]["invocation_kind"] == SCHEDULED_ON_TIME
     assert ran[0]["fire_claim"]["invocation_kind"] == OPERATOR_TRIGGERED
 
-    persisted = executions.latest_execution(due_job["id"])
+    persisted = executions.latest_execution(created["id"])
     assert persisted["invocation_kind"] == OPERATOR_TRIGGERED
-    assert persisted["claim_owner"] == "operator-owner"
     assert persisted["intended_fire_at"] is None
+    stored = jobs.load_jobs()[0]
+    assert stored["fire_claim"]["invocation_kind"] == OPERATOR_TRIGGERED
+    assert "trigger_marker" not in stored
+
+
+def test_tick_preserves_prior_due_instant_through_real_recurrence_advance(
+    monkeypatch, tmp_path
+):
+    """A normal recurring tick attests the due instant before it advances."""
+    import cron.executions as executions
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+    from cron.context import SCHEDULED_ON_TIME
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        executions, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db"
+    )
+    now = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: now)
+    monkeypatch.setattr(scheduler, "_hermes_now", lambda: now)
+    monkeypatch.setattr(
+        scheduler,
+        "_get_lock_paths",
+        lambda: (tmp_path / "locks", tmp_path / "locks" / "tick.lock"),
+    )
+    monkeypatch.setattr(scheduler, "load_config", lambda: {})
+    monkeypatch.setattr(scheduler, "try_register_running_job", lambda _job_id: True)
+    monkeypatch.setattr(scheduler, "release_running_job", lambda _job_id: None)
+    monkeypatch.setattr(scheduler, "_interpreter_shutting_down", lambda *_a: False)
+    monkeypatch.setattr(executions, "recover_interrupted_executions", lambda: 0)
+
+    due_at = (now - timedelta(seconds=30)).isoformat()
+    created = jobs.create_job("normal-fire", "every 5m", name="normal-fire")
+    stored = jobs.load_jobs()
+    stored[0]["next_run_at"] = due_at
+    jobs.save_jobs(stored)
+
+    ran = []
+    monkeypatch.setattr(
+        scheduler,
+        "run_one_job",
+        lambda claimed, **_kwargs: ran.append(claimed) or True,
+    )
+
+    assert scheduler.tick(verbose=False, sync=True) == 1
+    assert ran[0]["fire_claim"]["invocation_kind"] == SCHEDULED_ON_TIME
+    assert ran[0]["fire_claim"]["intended_fire_at"] == due_at
+
+    persisted = executions.latest_execution(created["id"])
+    assert persisted["invocation_kind"] == SCHEDULED_ON_TIME
+    assert persisted["intended_fire_at"] == due_at
+    stored = jobs.load_jobs()[0]
+    assert stored["next_run_at"] != due_at

--- a/tests/cron/test_attestation_contract.py
+++ b/tests/cron/test_attestation_contract.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 
 def test_legacy_execution_rows_migrate_and_keep_terminal_evidence(
@@ -88,6 +89,7 @@ def test_fixed_grace_and_builtin_claim_kinds(monkeypatch, tmp_path):
         OPERATOR_TRIGGERED,
         RECOVERY_CATCHUP,
         SCHEDULED_ON_TIME,
+        _BUILTIN_SCHEDULER_ADMISSION,
         classify_scheduled_fire,
     )
 
@@ -102,10 +104,14 @@ def test_fixed_grace_and_builtin_claim_kinds(monkeypatch, tmp_path):
     )
 
     on_time = jobs.create_job("on time", "every 5m", name="on-time")
+    stored = jobs.load_jobs()
+    stored[0]["next_run_at"] = intended
+    jobs.save_jobs(stored)
     claimed = jobs.claim_job_for_fire(
         on_time["id"],
         invocation_kind=SCHEDULED_ON_TIME,
         intended_fire_at=intended,
+        _scheduler_admission=_BUILTIN_SCHEDULER_ADMISSION,
         return_job=True,
     )
     assert claimed["fire_claim"]["invocation_kind"] == SCHEDULED_ON_TIME
@@ -120,12 +126,25 @@ def test_fixed_grace_and_builtin_claim_kinds(monkeypatch, tmp_path):
     )
     assert forced["fire_claim"]["invocation_kind"] == OPERATOR_TRIGGERED
 
+    generic = jobs.create_job("generic", "every 5m", name="generic")
+    generic_claim = jobs.claim_job_for_fire(
+        generic["id"],
+        invocation_kind="PROVIDER_SCHEDULED",
+        intended_fire_at=intended,
+        return_job=True,
+    )
+    assert generic_claim["fire_claim"]["invocation_kind"] == "UNKNOWN"
+    assert generic_claim["fire_claim"]["intended_fire_at"] is None
+
 
 def test_provider_binds_scheduled_and_force_provenance(monkeypatch, tmp_path):
     import cron.jobs as jobs
     from cron.context import OPERATOR_TRIGGERED, PROVIDER_SCHEDULED
     from cron.executions import list_executions
-    from cron.scheduler_provider import InProcessCronScheduler
+    from cron.scheduler_provider import (
+        InProcessCronScheduler,
+        _AUTHENTICATED_PROVIDER_ADMISSION,
+    )
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     fixed_now = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
@@ -134,9 +153,13 @@ def test_provider_binds_scheduled_and_force_provenance(monkeypatch, tmp_path):
         "cron.executions.EXECUTIONS_FILE", tmp_path / "cron" / "executions.db"
     )
     scheduled = jobs.create_job("provider", "every 5m", name="provider")
+    stored = jobs.load_jobs()
+    stored[0]["next_run_at"] = (fixed_now - timedelta(seconds=300)).isoformat()
+    jobs.save_jobs(stored)
     claimed = InProcessCronScheduler().claim_fire(
         scheduled["id"],
         intended_fire_at=(fixed_now - timedelta(seconds=300)).isoformat(),
+        _provider_admission=_AUTHENTICATED_PROVIDER_ADMISSION,
     )
     assert claimed["fire_claim"]["invocation_kind"] == PROVIDER_SCHEDULED
     assert (
@@ -147,6 +170,153 @@ def test_provider_binds_scheduled_and_force_provenance(monkeypatch, tmp_path):
     forced_job = jobs.create_job("force", "every 5m", name="force")
     forced = InProcessCronScheduler().claim_fire(forced_job["id"], force=True)
     assert forced["fire_claim"]["invocation_kind"] == OPERATOR_TRIGGERED
+
+    laundered_job = jobs.create_job("launder", "every 5m", name="launder")
+    laundered = InProcessCronScheduler().claim_fire(
+        laundered_job["id"],
+        invocation_kind=PROVIDER_SCHEDULED,
+        intended_fire_at=fixed_now.isoformat(),
+    )
+    assert laundered["fire_claim"]["invocation_kind"] == OPERATOR_TRIGGERED
+
+
+def test_provider_binds_time_from_atomic_claim_after_schedule_mutation(
+    monkeypatch, tmp_path
+):
+    import cron.executions as executions
+    import cron.jobs as jobs
+    from cron.context import RECOVERY_CATCHUP, _AUTHENTICATED_PROVIDER_ADMISSION
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        executions, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db"
+    )
+    fixed_now = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: fixed_now)
+    job = jobs.create_job("atomic", "every 5m", name="atomic")
+    real_claim = jobs.claim_job_for_fire
+    mutated_intended = (fixed_now - timedelta(seconds=301)).isoformat()
+
+    def mutate_then_claim(job_id, **kwargs):
+        records = jobs.load_jobs()
+        records[0]["next_run_at"] = mutated_intended
+        jobs.save_jobs(records)
+        return real_claim(job_id, **kwargs)
+
+    mutate_then_claim.__module__ = "cron.jobs"
+    monkeypatch.setattr(jobs, "claim_job_for_fire", mutate_then_claim)
+    claimed = InProcessCronScheduler().claim_fire(
+        job["id"],
+        intended_fire_at=fixed_now.isoformat(),
+        _provider_admission=_AUTHENTICATED_PROVIDER_ADMISSION,
+    )
+    assert claimed["fire_claim"]["intended_fire_at"] == mutated_intended
+    assert claimed["fire_claim"]["invocation_kind"] == RECOVERY_CATCHUP
+
+
+def test_execution_claim_binding_is_single_assignment(monkeypatch, tmp_path):
+    from cron.context import OPERATOR_TRIGGERED, PROVIDER_SCHEDULED
+    from cron.executions import bind_execution_claim, create_execution
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    row = create_execution("single-bind", source="builtin")
+    first = bind_execution_claim(
+        row["id"],
+        invocation_kind=PROVIDER_SCHEDULED,
+        intended_fire_at="2026-08-20T12:00:00+00:00",
+        claim_owner="owner-a",
+    )
+    assert first["claim_owner"] == "owner-a"
+    assert bind_execution_claim(
+        row["id"],
+        invocation_kind=OPERATOR_TRIGGERED,
+        intended_fire_at=None,
+        claim_owner="owner-b",
+    ) is None
+
+
+def test_founder_card_binds_exact_dispatched_bytes_and_delivery_statuses(
+    monkeypatch, tmp_path
+):
+    import cron.executions as executions
+    import cron.scheduler as scheduler
+    from cron.context import set_delivery_detail
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        executions, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db"
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_resolve_delivery_targets",
+        lambda job: [] if job["id"] in {"suppressed", "missing"} else [
+            {"platform": "telegram", "chat_id": "42", "thread_id": None}
+        ],
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda *_args, **_kwargs: (True, "FULL OUTPUT DOCUMENT", "Final response", None),
+    )
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: True)
+
+    def save_output(job_id, _output):
+        path = tmp_path / f"{job_id}-full.md"
+        path.write_text("FULL OUTPUT DOCUMENT", encoding="utf-8")
+        return path
+
+    monkeypatch.setattr(scheduler, "save_job_output", save_output)
+
+    def deliver(job, _content, **_kwargs):
+        if job["id"] == "missing":
+            return "no delivery target resolved"
+        if job["id"] == "suppressed":
+            return None
+        set_delivery_detail("provider_attempted", True)
+        set_delivery_detail("provider_attempted_at", "2026-08-20T12:00:01+00:00")
+        set_delivery_detail("dispatched_content", "TRANSPORT CARD\n")
+        if job["id"] == "exception":
+            set_delivery_detail("transport_exception", True)
+            return "socket closed after send"
+        if job["id"] == "rejected":
+            return "transport rejected"
+        set_delivery_detail("provider_accepted", True)
+        set_delivery_detail("provider_receipt_id", "receipt-42")
+        return None
+
+    monkeypatch.setattr(scheduler, "_deliver_result", deliver)
+
+    jobs = {
+        job_id: {"id": job_id, "name": job_id, "deliver": "telegram"}
+        for job_id in ("accepted", "exception", "rejected")
+    }
+    jobs["suppressed"] = {"id": "suppressed", "name": "suppressed", "deliver": "local"}
+    jobs["missing"] = {"id": "missing", "name": "missing", "deliver": "telegram"}
+    for job in jobs.values():
+        assert scheduler.run_one_job(job) is True
+
+    accepted = executions.latest_execution("accepted")
+    assert accepted["delivery_status"] == "PROVIDER_ACCEPTED"
+    assert accepted["delivery_consumption_status"] == "UNKNOWN"
+    assert accepted["delivery_receipt_id"] == "receipt-42"
+    card_bytes = Path(accepted["founder_card_path"]).read_bytes()
+    assert card_bytes == b"TRANSPORT CARD\n"
+    assert accepted["founder_card_sha256"] == hashlib.sha256(card_bytes).hexdigest()
+    assert accepted["delivery_content_sha256"] == accepted["founder_card_sha256"]
+    assert Path(accepted["output_path"]).read_text(encoding="utf-8") != card_bytes.decode()
+    assert accepted["output_sha256"] != accepted["founder_card_sha256"]
+
+    assert executions.latest_execution("exception")["delivery_status"] == "UNKNOWN"
+    assert executions.latest_execution("rejected")["delivery_status"] == "FAILED"
+    suppressed = executions.latest_execution("suppressed")
+    assert suppressed["delivery_status"] == "SUPPRESSED"
+    assert suppressed["founder_card_path"] is None
+    missing = executions.latest_execution("missing")
+    assert missing["delivery_status"] == "NOT_CONFIGURED"
+    assert missing["delivery_attempted_at"] is None
+    assert missing["founder_card_path"] is None
 
 
 def test_cron_context_reaches_child_and_resets_without_cross_thread_leak(monkeypatch):
@@ -178,3 +348,60 @@ def test_cron_context_reaches_child_and_resets_without_cross_thread_leak(monkeyp
     after = build_subprocess_env(scrub_secrets=False)
     assert "HERMES_CRON_EXECUTION_ID" not in after
     assert "HERMES_CRON_INVOCATION_KIND" not in after
+
+
+def test_run_job_requires_owner_bearing_claim_agreement(monkeypatch, tmp_path):
+    import cron.executions as executions
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+    from tools.environments.local import build_subprocess_env
+
+    observed = []
+
+    def fake_run_job(job, **_kwargs):
+        observed.append(build_subprocess_env(scrub_secrets=False))
+        return True, "", "", None
+
+    monkeypatch.setattr(scheduler, "_run_job", fake_run_job)
+    scheduler.run_job(
+        {"id": "crafted", "execution_id": "forged", "invocation_kind": "PROVIDER_SCHEDULED"}
+    )
+    assert "HERMES_CRON_EXECUTION_ID" not in observed[-1]
+
+    scheduler.run_job(
+        {
+            "id": "mismatch",
+            "execution_id": "forged",
+            "invocation_kind": "PROVIDER_SCHEDULED",
+            "fire_claim": {
+                "execution_id": "real",
+                "invocation_kind": "PROVIDER_SCHEDULED",
+                "by": "owner",
+            },
+        }
+    )
+    assert "HERMES_CRON_EXECUTION_ID" not in observed[-1]
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        executions, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db"
+    )
+    fixed_now = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: fixed_now)
+    valid_job = jobs.create_job("valid", "every 5m", name="valid")
+    stored_jobs = jobs.load_jobs()
+    stored_jobs[0]["next_run_at"] = fixed_now.isoformat()
+    jobs.save_jobs(stored_jobs)
+    from cron.scheduler_provider import (
+        InProcessCronScheduler,
+        _AUTHENTICATED_PROVIDER_ADMISSION,
+    )
+
+    claimed = InProcessCronScheduler().claim_fire(
+        valid_job["id"],
+        _provider_admission=_AUTHENTICATED_PROVIDER_ADMISSION,
+    )
+    assert claimed is not None
+    scheduler.run_job(claimed)
+    assert observed[-1]["HERMES_CRON_EXECUTION_ID"] == claimed["execution_id"]
+    assert observed[-1]["HERMES_CRON_INVOCATION_KIND"] == claimed["fire_claim"]["invocation_kind"]

--- a/tests/cron/test_attestation_contract.py
+++ b/tests/cron/test_attestation_contract.py
@@ -405,3 +405,73 @@ def test_run_job_requires_owner_bearing_claim_agreement(monkeypatch, tmp_path):
     scheduler.run_job(claimed)
     assert observed[-1]["HERMES_CRON_EXECUTION_ID"] == claimed["execution_id"]
     assert observed[-1]["HERMES_CRON_INVOCATION_KIND"] == claimed["fire_claim"]["invocation_kind"]
+
+
+def test_tick_binds_atomic_operator_claim_after_stale_snapshot(monkeypatch, tmp_path):
+    """A trigger arriving after the due snapshot must win the atomic claim."""
+    import cron.executions as executions
+    import cron.scheduler as scheduler
+    from cron.context import OPERATOR_TRIGGERED, SCHEDULED_ON_TIME
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        executions, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db"
+    )
+    now = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
+    due_job = {
+        "id": "operator-race",
+        "name": "operator-race",
+        "schedule": {"kind": "cron", "expr": "* * * * *"},
+        "next_run_at": (now - timedelta(seconds=30)).isoformat(),
+        "enabled": True,
+        "state": "scheduled",
+    }
+    monkeypatch.setattr(scheduler, "_hermes_now", lambda: now)
+    monkeypatch.setattr(
+        scheduler,
+        "_get_lock_paths",
+        lambda: (tmp_path / "locks", tmp_path / "locks" / "tick.lock"),
+    )
+    monkeypatch.setattr(scheduler, "get_due_jobs", lambda: [due_job])
+    monkeypatch.setattr(scheduler, "advance_next_runs", lambda _ids: 0)
+    monkeypatch.setattr(scheduler, "load_config", lambda: {})
+    monkeypatch.setattr(scheduler, "try_register_running_job", lambda _job_id: True)
+    monkeypatch.setattr(scheduler, "release_running_job", lambda _job_id: None)
+    monkeypatch.setattr(scheduler, "_interpreter_shutting_down", lambda *_a: False)
+    monkeypatch.setattr(executions, "recover_interrupted_executions", lambda: 0)
+
+    claim_calls = []
+
+    def atomic_claim(job_id, **kwargs):
+        claim_calls.append((job_id, kwargs))
+        execution_id = kwargs["execution_id"]
+        return {
+            **due_job,
+            "execution_id": execution_id,
+            "fire_claim": {
+                "by": "operator-owner",
+                "execution_id": execution_id,
+                "invocation_kind": OPERATOR_TRIGGERED,
+                "intended_fire_at": None,
+            },
+        }
+
+    # Match the production function identity check so this exercises the
+    # capability-backed scheduler path, not a legacy test-double path.
+    atomic_claim.__module__ = "cron.jobs"
+    monkeypatch.setattr(scheduler, "claim_job_for_fire", atomic_claim)
+    ran = []
+    monkeypatch.setattr(
+        scheduler,
+        "run_one_job",
+        lambda claimed, **_kwargs: ran.append(claimed) or True,
+    )
+
+    assert scheduler.tick(verbose=False, sync=True) == 1
+    assert claim_calls[0][1]["invocation_kind"] == SCHEDULED_ON_TIME
+    assert ran[0]["fire_claim"]["invocation_kind"] == OPERATOR_TRIGGERED
+
+    persisted = executions.latest_execution(due_job["id"])
+    assert persisted["invocation_kind"] == OPERATOR_TRIGGERED
+    assert persisted["claim_owner"] == "operator-owner"
+    assert persisted["intended_fire_at"] is None

--- a/tests/cron/test_attestation_contract.py
+++ b/tests/cron/test_attestation_contract.py
@@ -11,6 +11,8 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import pytest
+
 
 def test_legacy_execution_rows_migrate_and_keep_terminal_evidence(
     monkeypatch, tmp_path
@@ -325,6 +327,7 @@ def test_cron_context_reaches_child_and_resets_without_cross_thread_leak(monkeyp
 
     monkeypatch.setenv("HERMES_CRON_EXECUTION_ID", "caller-value")
     monkeypatch.setenv("HERMES_CRON_INVOCATION_KIND", "caller-value")
+    monkeypatch.setenv("HERMES_CRON_ATTESTATION_TOKEN", "caller-token")
 
     def probe(execution_id):
         with cron_execution_context(execution_id, SCHEDULED_ON_TIME):
@@ -333,7 +336,7 @@ def test_cron_context_reaches_child_and_resets_without_cross_thread_leak(monkeyp
                 [
                     sys.executable,
                     "-c",
-                    "import os; print(os.getenv('HERMES_CRON_EXECUTION_ID')); print(os.getenv('HERMES_CRON_INVOCATION_KIND'))",
+                    "import os; print(os.getenv('HERMES_CRON_EXECUTION_ID')); print(os.getenv('HERMES_CRON_INVOCATION_KIND')); print(os.getenv('HERMES_CRON_ATTESTATION_TOKEN'))",
                 ],
                 env=env,
                 text=True,
@@ -343,11 +346,180 @@ def test_cron_context_reaches_child_and_resets_without_cross_thread_leak(monkeyp
     with ThreadPoolExecutor(max_workers=2) as pool:
         results = list(pool.map(probe, ("exec-a", "exec-b")))
     assert {item[0] for item in results} == {"exec-a", "exec-b"}
-    assert all(item[1] == [item[0], SCHEDULED_ON_TIME] for item in results)
+    assert all(item[1] == [item[0], SCHEDULED_ON_TIME, "None"] for item in results)
 
     after = build_subprocess_env(scrub_secrets=False)
     assert "HERMES_CRON_EXECUTION_ID" not in after
     assert "HERMES_CRON_INVOCATION_KIND" not in after
+    assert "HERMES_CRON_ATTESTATION_TOKEN" not in after
+
+
+def test_attestation_digest_is_single_assignment_and_raw_never_reaches_db(
+    monkeypatch, tmp_path
+):
+    import cron.executions as executions
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        executions, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db"
+    )
+    raw = "nonce-for-one-execution"
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+    row = executions.create_execution("nonce-job", source="builtin")
+
+    bound = executions.bind_execution_attestation(
+        row["id"], token_sha256=digest
+    )
+    assert bound["attestation_token_sha256"] == digest
+    assert raw not in str(bound)
+    assert raw not in (tmp_path / "cron" / "executions.db").read_bytes().decode(
+        "utf-8", errors="ignore"
+    )
+    assert executions.bind_execution_attestation(
+        row["id"], token_sha256=hashlib.sha256(b"replacement").hexdigest()
+    ) is None
+    assert executions.get_execution(row["id"])["attestation_token_sha256"] == digest
+
+
+def test_attestation_context_isolated_and_resets_on_early_failure(monkeypatch):
+    from cron.context import (
+        _CRON_ATTESTATION_CAPABILITY,
+        _CronAttestationCapability,
+        SCHEDULED_ON_TIME,
+        cron_execution_context,
+    )
+    from tools.environments.local import build_subprocess_env
+
+    raw_a = "raw-attestation-a"
+    raw_b = "raw-attestation-b"
+    cap_a = _CronAttestationCapability(
+        "exec-a", raw_a, hashlib.sha256(raw_a.encode()).hexdigest(), _CRON_ATTESTATION_CAPABILITY
+    )
+    cap_b = _CronAttestationCapability(
+        "exec-b", raw_b, hashlib.sha256(raw_b.encode()).hexdigest(), _CRON_ATTESTATION_CAPABILITY
+    )
+
+    def probe(cap):
+        with cron_execution_context(cap.execution_id, SCHEDULED_ON_TIME, cap):
+            return build_subprocess_env(scrub_secrets=False)[
+                "HERMES_CRON_ATTESTATION_TOKEN"
+            ]
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        assert set(pool.map(probe, (cap_a, cap_b))) == {raw_a, raw_b}
+
+    cap_fail = _CronAttestationCapability(
+        "exec-fail",
+        "raw-attestation-fail",
+        hashlib.sha256(b"raw-attestation-fail").hexdigest(),
+        _CRON_ATTESTATION_CAPABILITY,
+    )
+    with pytest.raises(RuntimeError):
+        with cron_execution_context("exec-fail", SCHEDULED_ON_TIME, cap_fail):
+            assert build_subprocess_env(scrub_secrets=False)[
+                "HERMES_CRON_ATTESTATION_TOKEN"
+            ] == cap_fail.token
+            raise RuntimeError("early failure")
+    assert "HERMES_CRON_ATTESTATION_TOKEN" not in build_subprocess_env(
+        scrub_secrets=False
+    )
+
+
+def test_normal_and_provider_no_agent_paths_match_nonce_to_ledger_digest(
+    monkeypatch, tmp_path
+):
+    import cron.executions as executions
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+    from cron.context import SCHEDULED_ON_TIME, _BUILTIN_SCHEDULER_ADMISSION
+    from cron.scheduler_provider import (
+        InProcessCronScheduler,
+        _AUTHENTICATED_PROVIDER_ADMISSION,
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        executions, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db"
+    )
+    fixed_now = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: fixed_now)
+    probe = tmp_path / "scripts" / "probe.py"
+    probe.parent.mkdir(parents=True)
+    probe.write_text(
+        "import hashlib, os\n"
+        "print(hashlib.sha256(os.environ['HERMES_CRON_ATTESTATION_TOKEN'].encode()).hexdigest())\n",
+        encoding="utf-8",
+    )
+
+    def make_job(name):
+        job = jobs.create_job(
+            name,
+            "every 5m",
+            name=name,
+            script="probe.py",
+            no_agent=True,
+            deliver="local",
+        )
+        stored = jobs.load_jobs()
+        next(
+            stored_job for stored_job in stored if stored_job["id"] == job["id"]
+        )["next_run_at"] = fixed_now.isoformat()
+        jobs.save_jobs(stored)
+        return jobs.get_job(job["id"])
+
+    normal = make_job("nonce-normal")
+    normal_execution = executions.create_execution(
+        normal["id"], source="builtin", invocation_kind="UNKNOWN"
+    )
+    normal_claim = jobs.claim_job_for_fire(
+        normal["id"],
+        invocation_kind=SCHEDULED_ON_TIME,
+        intended_fire_at=fixed_now.isoformat(),
+        execution_id=normal_execution["id"],
+        return_job=True,
+        _scheduler_admission=_BUILTIN_SCHEDULER_ADMISSION,
+    )
+    normal_claim["execution_id"] = normal_execution["id"]
+    assert normal_claim["fire_claim"]["invocation_kind"] == SCHEDULED_ON_TIME
+    assert executions.bind_execution_claim(
+        normal_execution["id"],
+        invocation_kind=SCHEDULED_ON_TIME,
+        intended_fire_at=normal_claim["fire_claim"]["intended_fire_at"],
+        claim_owner=normal_claim["fire_claim"]["by"],
+    )
+    normal_cap = scheduler._issue_execution_attestation(normal_execution["id"])
+    assert normal_cap is not None
+    assert scheduler.run_one_job(
+        normal_claim, _attestation_capability=normal_cap
+    ) is True
+    normal_row = executions.get_execution(normal_execution["id"])
+    normal_output = Path(normal_row["output_path"]).read_text(encoding="utf-8")
+    assert normal_row["attestation_token_sha256"] == normal_cap.digest
+    assert normal_cap.digest in normal_output
+    assert normal_cap.token not in normal_output
+
+    provider = InProcessCronScheduler()
+    provider_job = make_job("nonce-provider")
+    provider_claim = provider.claim_fire(
+        provider_job["id"], _provider_admission=_AUTHENTICATED_PROVIDER_ADMISSION
+    )
+    assert provider_claim["fire_claim"]["invocation_kind"] == "PROVIDER_SCHEDULED"
+    issued = []
+    original_issue = scheduler._issue_execution_attestation
+
+    def capture_issue(execution_id):
+        capability = original_issue(execution_id)
+        issued.append(capability)
+        return capability
+
+    monkeypatch.setattr(scheduler, "_issue_execution_attestation", capture_issue)
+    assert provider.fire_claimed(provider_claim) is True
+    provider_cap = issued[0]
+    provider_row = executions.get_execution(provider_claim["execution_id"])
+    provider_output = Path(provider_row["output_path"]).read_text(encoding="utf-8")
+    assert provider_row["attestation_token_sha256"] == provider_cap.digest
+    assert provider_cap.digest in provider_output
+    assert provider_cap.token not in provider_output
 
 
 def test_run_job_requires_owner_bearing_claim_agreement(monkeypatch, tmp_path):

--- a/tests/cron/test_attestation_contract.py
+++ b/tests/cron/test_attestation_contract.py
@@ -1,0 +1,180 @@
+"""Behavioral coverage for Phase A cron attestation contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+
+
+def test_legacy_execution_rows_migrate_and_keep_terminal_evidence(
+    monkeypatch, tmp_path
+):
+    import cron.executions as executions
+
+    db_path = tmp_path / "cron" / "executions.db"
+    db_path.parent.mkdir(parents=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """CREATE TABLE executions (
+             id TEXT PRIMARY KEY, job_id TEXT NOT NULL, source TEXT NOT NULL,
+             process_id TEXT NOT NULL, pid INTEGER NOT NULL,
+             process_started_at INTEGER, status TEXT NOT NULL,
+             claimed_at TEXT NOT NULL, started_at TEXT, finished_at TEXT,
+             error TEXT)"""
+    )
+    conn.execute(
+        "INSERT INTO executions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "old",
+            "legacy-job",
+            "builtin",
+            "old-process",
+            1,
+            None,
+            "completed",
+            "2026-08-20T00:00:00+00:00",
+            None,
+            "2026-08-20T00:01:00+00:00",
+            None,
+        ),
+    )
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(executions, "EXECUTIONS_FILE", db_path)
+
+    migrated = executions.latest_execution("legacy-job")
+    assert migrated["id"] == "old"
+    assert migrated["invocation_kind"] == "UNKNOWN"
+    assert migrated["delivery_status"] == "NOT_ATTEMPTED"
+
+    output = tmp_path / "founder-card.md"
+    output.write_text("card\n", encoding="utf-8")
+    row = executions.create_execution(
+        "attested-job",
+        source="builtin",
+        invocation_kind="SCHEDULED_ON_TIME",
+        intended_fire_at="2026-08-20T12:00:00+00:00",
+    )
+    finished = executions.finish_execution(
+        row["id"],
+        success=True,
+        delivery_status="PROVIDER_ACCEPTED",
+        delivery_target=json.dumps({"platform": "telegram", "chat_id": "42"}),
+        delivery_target_class="telegram",
+        delivery_content_sha256=hashlib.sha256(b"hello").hexdigest(),
+        delivery_attempted_at="2026-08-20T12:00:01+00:00",
+        delivery_completed_at="2026-08-20T12:00:02+00:00",
+        delivery_receipt_id="receipt-1",
+        output_path=str(output),
+        output_sha256=hashlib.sha256(output.read_bytes()).hexdigest(),
+        founder_card_path=str(output),
+        founder_card_sha256=hashlib.sha256(output.read_bytes()).hexdigest(),
+    )
+    assert finished["delivery_status"] == "PROVIDER_ACCEPTED"
+    assert finished["delivery_consumption_status"] == "UNKNOWN"
+    assert finished["delivery_receipt_id"] == "receipt-1"
+    assert finished["output_path"] == str(output)
+    assert finished["output_sha256"] == finished["founder_card_sha256"]
+
+
+def test_fixed_grace_and_builtin_claim_kinds(monkeypatch, tmp_path):
+    import cron.jobs as jobs
+    from cron.context import (
+        OPERATOR_TRIGGERED,
+        RECOVERY_CATCHUP,
+        SCHEDULED_ON_TIME,
+        classify_scheduled_fire,
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    now = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: now)
+    intended = (now - timedelta(seconds=300)).isoformat()
+    assert classify_scheduled_fire(intended, now=now) == SCHEDULED_ON_TIME
+    assert (
+        classify_scheduled_fire((now - timedelta(seconds=301)).isoformat(), now=now)
+        == RECOVERY_CATCHUP
+    )
+
+    on_time = jobs.create_job("on time", "every 5m", name="on-time")
+    claimed = jobs.claim_job_for_fire(
+        on_time["id"],
+        invocation_kind=SCHEDULED_ON_TIME,
+        intended_fire_at=intended,
+        return_job=True,
+    )
+    assert claimed["fire_claim"]["invocation_kind"] == SCHEDULED_ON_TIME
+
+    operator = jobs.create_job("operator", "every 5m", name="operator")
+    forced = jobs.claim_job_for_fire(
+        operator["id"],
+        force=True,
+        invocation_kind=SCHEDULED_ON_TIME,
+        intended_fire_at=intended,
+        return_job=True,
+    )
+    assert forced["fire_claim"]["invocation_kind"] == OPERATOR_TRIGGERED
+
+
+def test_provider_binds_scheduled_and_force_provenance(monkeypatch, tmp_path):
+    import cron.jobs as jobs
+    from cron.context import OPERATOR_TRIGGERED, PROVIDER_SCHEDULED
+    from cron.executions import list_executions
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    fixed_now = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: fixed_now)
+    monkeypatch.setattr(
+        "cron.executions.EXECUTIONS_FILE", tmp_path / "cron" / "executions.db"
+    )
+    scheduled = jobs.create_job("provider", "every 5m", name="provider")
+    claimed = InProcessCronScheduler().claim_fire(
+        scheduled["id"],
+        intended_fire_at=(fixed_now - timedelta(seconds=300)).isoformat(),
+    )
+    assert claimed["fire_claim"]["invocation_kind"] == PROVIDER_SCHEDULED
+    assert (
+        list_executions(job_id=scheduled["id"])[0]["invocation_kind"]
+        == PROVIDER_SCHEDULED
+    )
+
+    forced_job = jobs.create_job("force", "every 5m", name="force")
+    forced = InProcessCronScheduler().claim_fire(forced_job["id"], force=True)
+    assert forced["fire_claim"]["invocation_kind"] == OPERATOR_TRIGGERED
+
+
+def test_cron_context_reaches_child_and_resets_without_cross_thread_leak(monkeypatch):
+    from cron.context import SCHEDULED_ON_TIME, cron_execution_context
+    from tools.environments.local import build_subprocess_env
+
+    monkeypatch.setenv("HERMES_CRON_EXECUTION_ID", "caller-value")
+    monkeypatch.setenv("HERMES_CRON_INVOCATION_KIND", "caller-value")
+
+    def probe(execution_id):
+        with cron_execution_context(execution_id, SCHEDULED_ON_TIME):
+            env = build_subprocess_env(scrub_secrets=False)
+            child = subprocess.check_output(
+                [
+                    sys.executable,
+                    "-c",
+                    "import os; print(os.getenv('HERMES_CRON_EXECUTION_ID')); print(os.getenv('HERMES_CRON_INVOCATION_KIND'))",
+                ],
+                env=env,
+                text=True,
+            ).splitlines()
+            return env["HERMES_CRON_EXECUTION_ID"], child
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(probe, ("exec-a", "exec-b")))
+    assert {item[0] for item in results} == {"exec-a", "exec-b"}
+    assert all(item[1] == [item[0], SCHEDULED_ON_TIME] for item in results)
+
+    after = build_subprocess_env(scrub_secrets=False)
+    assert "HERMES_CRON_EXECUTION_ID" not in after
+    assert "HERMES_CRON_INVOCATION_KIND" not in after

--- a/tests/gateway/test_cron_fire_webhook.py
+++ b/tests/gateway/test_cron_fire_webhook.py
@@ -408,3 +408,61 @@ async def test_fire_without_runner_passes_none_adapters(adapter, monkeypatch):
 
     assert seen.get("job_id") == "no-runner"
     assert seen.get("adapters") is None
+
+
+@pytest.mark.asyncio
+async def test_authenticated_provider_receives_authoritative_instant_capability(
+    adapter, monkeypatch
+):
+    """The verified gateway boundary supplies provenance, not webhook text."""
+    seen = {}
+
+    class AuthenticatedProvider:
+        def claim_fire(
+            self, job_id, *, intended_fire_at=None, _provider_admission=None
+        ):
+            seen.update(
+                job_id=job_id,
+                intended_fire_at=intended_fire_at,
+                admission=_provider_admission,
+            )
+            return {"id": job_id, "execution_id": "exec-authoritative"}
+
+        def fire_claimed(self, job, *, adapters=None, loop=None):
+            seen["fired"] = job["id"]
+            return True
+
+    provider = AuthenticatedProvider()
+    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: provider)
+    monkeypatch.setattr(
+        "cron.jobs.get_job",
+        lambda _job_id: (_ for _ in ()).throw(
+            AssertionError("gateway must not pre-read the mutable job")
+        ),
+    )
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: (lambda **kw: {"purpose": "cron_fire"}),
+    )
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.post(
+            "/api/cron/fire",
+            headers={"Authorization": "Bearer nas-jwt"},
+            json={
+                "job_id": "chronos-job",
+                "intended_fire_at": "2099-01-01T00:00:00+00:00",
+                "invocation_kind": "PROVIDER_SCHEDULED",
+            },
+        )
+        assert response.status == 202
+        for _ in range(50):
+            if seen.get("fired"):
+                break
+            await asyncio.sleep(0.01)
+
+    assert seen["job_id"] == "chronos-job"
+    assert seen["intended_fire_at"] is None
+    assert seen["admission"] is not None
+    assert seen["fired"] == "chronos-job"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -464,6 +464,7 @@ def _inject_session_context_env(env: dict) -> None:
         elif var_name in {
             "HERMES_CRON_EXECUTION_ID",
             "HERMES_CRON_INVOCATION_KIND",
+            "HERMES_CRON_ATTESTATION_TOKEN",
         }:
             # Scheduler attestation is never inherited from a caller's
             # process environment.  A user-supplied value must not be able to

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -461,6 +461,14 @@ def _inject_session_context_env(env: dict) -> None:
         if value is not _UNSET:
             # Explicitly bound (including "") — authoritative for this task.
             env[var_name] = "" if value is None else str(value)
+        elif var_name in {
+            "HERMES_CRON_EXECUTION_ID",
+            "HERMES_CRON_INVOCATION_KIND",
+        }:
+            # Scheduler attestation is never inherited from a caller's
+            # process environment.  A user-supplied value must not be able to
+            # manufacture provenance for an interactive/manual subprocess.
+            env.pop(var_name, None)
         elif _engaged:
             # Unset for THIS task while a concurrent host is engaged: drop any
             # inherited global so a sibling session's value can't leak in.
@@ -731,6 +739,11 @@ def build_subprocess_env(
         apply_subprocess_home_env(env)
     if extra:
         env.update(extra)
+    # Attestation is task-local even on the intentional no-scrub path.  Apply
+    # it after caller extras so an interactive caller cannot fabricate a cron
+    # execution identity, while a bound scheduler turn still reaches its
+    # child process.
+    _inject_session_context_env(env)
     return env
 
 


### PR DESCRIPTION
## What does this PR do?

Adds durable, scheduler-owned execution provenance and presentation/delivery attestation for cron runs.

The scheduler now binds each execution to an atomic fire claim, exports execution provenance only from scheduler-owned context, persists the exact founder-facing artifact bytes and delivery outcome, and fails closed when provenance cannot be verified. Built-in recurring ticks carry the due instant across the pre-dispatch recurrence advance with a one-use capability, while a concurrent operator trigger remains authoritative.

This is infrastructure-only. It does not change any job schedule, delivery target, or runtime installation.

## Related Issue

Related open work: #82782 and #89810. This PR deliberately owns the narrow scheduler-claim and execution-attestation contract; see the compatibility policy below.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add closed-vocabulary invocation provenance and immutable execution claim binding.
- Bind a cryptographic per-execution nonce digest exactly once in the ledger; export the raw nonce only through scheduler-owned task-local context.
- Bind gateway/provider/manual entrypoints to atomic scheduler claims without trusting caller-supplied labels or environment variables.
- Persist exact output/founder-card hashes and explicit delivery acceptance versus consumption state.
- Preserve the prior due instant through the built-in scheduler's pre-dispatch recurrence advance.
- Add adversarial tests for manual/provider spoofing, operator races, context leakage, shutdown, and normal recurring ticks.

## How to Test

1. Run the focused nine-file suite shown below with `scripts/run_tests.sh`.
2. Run Ruff on the ten changed Python paths.
3. Run `scripts/check-windows-footguns.py --diff origin/main`.

Focused verification on macOS:

```text
=== Summary: 9 files, 365 tests passed, 0 failed (100% complete) in 5.7s ===
All checks passed!
✓ No Windows footguns found (10 file(s) scanned).
```

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [ ] My commit messages follow Conventional Commits.
- [x] I searched open PRs and issues for duplicates.
- [x] My PR contains only changes related to this feature.
- [ ] I've run the complete `pytest tests/ -q` suite. The focused 365-test affected-path gate is green; CI remains authoritative for the complete suite.
- [x] I've added tests for my changes.
- [x] I've tested on macOS.

### Documentation & Housekeeping

- [x] Documentation update is N/A; the contract is documented in code and tests.
- [x] `cli-config.yaml.example` update is N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A.
- [x] Cross-platform impact was checked with the repository footgun scanner.
- [x] Tool descriptions/schemas update is N/A.

## Screenshots / Logs

Not applicable; this is a scheduler/ledger contract with no UI change.

### Review note

The due-snapshot capability and execution-attestation nonce are one-use/single-assignment. Normal builtin, provider, and no-agent paths are exercised; caller environment values are stripped; raw nonce bytes are absent from the durable ledger and founder output.

### Compatibility policy for #82782 / #89810

- This PR's execution row is canonical for `invocation_kind`, `intended_fire_at`, `claim_owner`, founder-card path/hash, and uppercase delivery states.
- `PROVIDER_ACCEPTED` means transport/provider acceptance only; `delivery_consumption_status` remains `UNKNOWN` unless a future independent acknowledgement proves consumption.
- Future producer/delivery child attempts or copied-media manifests may be append-only records keyed to this immutable execution ID. They must not rename, overwrite, or reinterpret the canonical execution fields.
- Task-local `HERMES_CRON_EXECUTION_ID` and `HERMES_CRON_INVOCATION_KIND` remain scheduler-owned. Caller environment values are stripped; future work must reuse this bridge rather than create a second propagation path.
- #89810's useful schedule/output ideas should adapt to this contract rather than become a competing ledger. #82782's immutable artifact ideas are complementary follow-up material, but its current advance-before-provenance ordering and lowercase `delivered` terminal vocabulary are intentionally not imported here.

