### PR TITLE
fix(browser-use): harden the CLI 3 one-tool runtime

### DIFF
--- a/contributors/emails/mamagnus00@gmail.com
+++ b/contributors/emails/mamagnus00@gmail.com
@@ -1,0 +1,1 @@
+MagMueller

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -102,7 +102,6 @@ class TestSubprocessEnvironment:
         assert env["ANONYMIZED_TELEMETRY"] == "false"
         assert env["BH_TELEMETRY"] == "0"
         assert env["BROWSER_HARNESS_TELEMETRY"] == "0"
-        assert env["BH_RECORD"] == "0"
         assert env["BH_UPDATE_CHECK"] == "0"
         assert env["BH_OPEN_LIVE_URL"] == "0"
 

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -187,6 +187,22 @@ class TestToolSurfaceSwap:
         names = {t["function"]["name"] for t in defs}
         assert "browser_exec" in names
 
+    def test_browser_use_toolset_exposes_only_browser_exec(self, monkeypatch):
+        monkeypatch.setattr(bu_cli, "is_browser_use_cli_mode", lambda: True)
+        from tools.registry import registry
+
+        entry = registry.get_entry("browser_exec")
+        monkeypatch.setattr(entry, "check_fn", lambda: True)
+        import model_tools
+
+        defs = model_tools.get_tool_definitions(
+            enabled_toolsets=["browser-use", "file", "terminal"], quiet_mode=False
+        )
+        names = {tool["function"]["name"] for tool in defs}
+        browser_names = {name for name in names if name.startswith("browser_")}
+        assert browser_names == {"browser_exec"}
+        assert "web_search" not in names
+
 
 class TestFindCli:
     """The tests/tools conftest pins _find_cli to None (host isolation);

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -799,12 +799,6 @@ class TestSkillTextDescription:
         ):
             assert helper in bu_cli._HELPERS_DIGEST
 
-    def test_native_vision_requires_final_screenshot_verification(self, monkeypatch):
-        monkeypatch.setattr(
-            "tools.vision_tools._should_use_native_vision_fast_path", lambda: True
-        )
-        assert "fresh final screenshot" in bu_cli._description_header()
-
     def test_static_fallback_carries_digest_and_install_hint(self):
         desc = bu_cli.BROWSER_EXEC_SCHEMA["description"]
         assert bu_cli._HELPERS_DIGEST in desc

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -150,6 +150,12 @@ class TestToolSurfaceSwap:
         assert "browser_exec" in _HERMES_CORE_TOOLS
         assert "browser_exec" in TOOLSETS["browser"]["tools"]
         assert "browser_exec" in TOOLSETS["coding"]["tools"]
+        assert TOOLSETS["browser-use"]["tools"] == ["browser_exec"]
+
+    def test_browser_use_toolset_validates_before_plugin_discovery(self):
+        from hermes_cli.oneshot import _validate_explicit_toolsets
+
+        assert _validate_explicit_toolsets("browser-use") == (["browser-use"], None)
 
     def test_browser_exec_stripped_without_terminal(self, monkeypatch):
         """Sessions without the terminal surface must not regain host code

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -100,6 +100,11 @@ class TestSubprocessEnvironment:
         monkeypatch.setitem(sys.modules, "tools.browser_tool", browser_tool)
         env = bu_cli._base_subprocess_env()
         assert env["ANONYMIZED_TELEMETRY"] == "false"
+        assert env["BH_TELEMETRY"] == "0"
+        assert env["BROWSER_HARNESS_TELEMETRY"] == "0"
+        assert env["BH_RECORD"] == "0"
+        assert env["BH_UPDATE_CHECK"] == "0"
+        assert env["BH_OPEN_LIVE_URL"] == "0"
 
     def test_subprocess_env_strips_parent_python_import_paths(self, monkeypatch):
         """#83427/#84841/#86006/#86104: the browser-use CLI runs under its
@@ -777,9 +782,29 @@ class TestSkillTextDescription:
         assert overrides["description"].endswith(bu_cli._HELPERS_DIGEST)
 
     def test_digest_names_core_helpers(self):
-        for helper in ("new_tab(", "page_info()", "js(", "fill_input(",
-                       "click_at_xy(", "capture_screenshot()", "cdp("):
+        for helper in (
+            "new_tab(",
+            "page_info()",
+            "js(",
+            "fill_input(",
+            "click_at_xy(",
+            "capture_screenshot()",
+            "wait_for_element(",
+            "wait_for_network_idle(",
+            "list_tabs()",
+            "current_tab()",
+            "activate_tab(",
+            "close_tab(",
+            "upload_file(",
+            "cdp(",
+        ):
             assert helper in bu_cli._HELPERS_DIGEST
+
+    def test_native_vision_requires_final_screenshot_verification(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.vision_tools._should_use_native_vision_fast_path", lambda: True
+        )
+        assert "fresh final screenshot" in bu_cli._description_header()
 
     def test_static_fallback_carries_digest_and_install_hint(self):
         desc = bu_cli.BROWSER_EXEC_SCHEMA["description"]

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -119,6 +119,16 @@ def _base_subprocess_env() -> dict:
     env.pop("PYTHONPATH", None)
     env.pop("PYTHONHOME", None)
     env.setdefault("ANONYMIZED_TELEMETRY", "false")
+    # Browser Use CLI 3 delegates to Browser Harness. Keep every supported
+    # telemetry alias off, avoid background recording/update traffic, and
+    # never foreground or print a credential-bearing Cloud live-view URL.
+    # Older Harness releases ignore unknown variables; 0.1.10+ honors all of
+    # them, so this remains safe across the Browser Use release transition.
+    env.setdefault("BH_TELEMETRY", "0")
+    env.setdefault("BROWSER_HARNESS_TELEMETRY", "0")
+    env.setdefault("BH_RECORD", "0")
+    env.setdefault("BH_UPDATE_CHECK", "0")
+    env.setdefault("BH_OPEN_LIVE_URL", "0")
     return env
 
 
@@ -707,7 +717,9 @@ _HEADER_VISION = (
     " Screenshots are attached to your context automatically: when the exec "
     "output contains a capture_screenshot() path, the image arrives with "
     "this tool's result and you inspect it directly with your own vision — "
-    "never send browser screenshots to a separate vision tool."
+    "never send browser screenshots to a separate vision tool. Inspect a "
+    "screenshot before coordinate-based actions, then capture and inspect a "
+    "fresh final screenshot before claiming the requested end state."
 )
 
 _HEADER_TEXT_ONLY = (
@@ -758,7 +770,11 @@ _HELPERS_DIGEST = (
     "a bare '() => {...}' returns the function itself, uncalled), "
     "fill_input(selector, text) types into inputs, click_at_xy(x, y) clicks "
     "viewport coordinates, capture_screenshot() saves and prints a "
-    "screenshot path, cdp('Domain.method', **kwargs) is raw CDP — "
+    "screenshot path, wait_for_element(selector, timeout=10, visible=False) "
+    "waits for DOM readiness, wait_for_network_idle(timeout=10, idle_ms=500) "
+    "waits for quiet network activity, list_tabs()/current_tab() inspect tab "
+    "state, activate_tab(tab)/close_tab(tab) manage tabs, upload_file(selector, "
+    "path) uploads a workspace file, cdp('Domain.method', **kwargs) is raw CDP — "
     "cdp('Accessibility.getFullAXTree')['nodes'] lists every element's "
     "role/name/backendDOMNodeId (filter in Python before printing; it is "
     "thousands of nodes), then cdp('DOM.getBoxModel', backendNodeId=n) gives "

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -120,13 +120,12 @@ def _base_subprocess_env() -> dict:
     env.pop("PYTHONHOME", None)
     env.setdefault("ANONYMIZED_TELEMETRY", "false")
     # Browser Use CLI 3 delegates to Browser Harness. Keep every supported
-    # telemetry alias off, avoid background recording/update traffic, and
+    # telemetry alias off, avoid background update traffic, and
     # never foreground or print a credential-bearing Cloud live-view URL.
     # Older Harness releases ignore unknown variables; 0.1.10+ honors all of
     # them, so this remains safe across the Browser Use release transition.
     env.setdefault("BH_TELEMETRY", "0")
     env.setdefault("BROWSER_HARNESS_TELEMETRY", "0")
-    env.setdefault("BH_RECORD", "0")
     env.setdefault("BH_UPDATE_CHECK", "0")
     env.setdefault("BH_OPEN_LIVE_URL", "0")
     return env

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -716,9 +716,7 @@ _HEADER_VISION = (
     " Screenshots are attached to your context automatically: when the exec "
     "output contains a capture_screenshot() path, the image arrives with "
     "this tool's result and you inspect it directly with your own vision — "
-    "never send browser screenshots to a separate vision tool. Inspect a "
-    "screenshot before coordinate-based actions, then capture and inspect a "
-    "fresh final screenshot before claiming the requested end state."
+    "never send browser screenshots to a separate vision tool."
 )
 
 _HEADER_TEXT_ONLY = (

--- a/toolsets.py
+++ b/toolsets.py
@@ -213,6 +213,17 @@ TOOLSETS = {
         ],
         "includes": []
     },
+
+    # Stable direct surface for Browser Use CLI 3.0 one-shot/worker runs.
+    # The bundled registry entry also declares this toolset, but explicit
+    # --toolsets validation happens before late plugin discovery in some CLI
+    # paths. Keeping the one-tool definition here avoids silently dropping
+    # browser_exec and does not expose web_search or the legacy browser_* set.
+    "browser-use": {
+        "description": "Browser Use CLI 3.0 automation via browser_exec",
+        "tools": ["browser_exec"],
+        "includes": []
+    },
     
     "cronjob": {
         "description": "Cronjob management tool - create, list, update, pause, resume, remove, and trigger scheduled tasks",


### PR DESCRIPTION
## What Problem This Solves

Hermes already ships Laith's Browser Use CLI 3.0 `browser_exec` integration, but explicit one-shot runs can validate `--toolsets` before the bundled Browser Use plugin is discovered. The intended `browser-use` toolset is then silently rejected and the model never receives `browser_exec`. The runtime guidance also omits several Browser Harness 0.1.10 helpers, and Harness telemetry, update checks, or Cloud live-view foregrounding can escape Hermes's privacy posture.

## Why This Change Was Made

- Preserve the existing one-tool `browser_exec` architecture instead of replacing Laith's proven CLI 3.0 contract.
- Make `browser-use` a stable core one-tool toolset, so explicit one-shot/worker selection cannot race plugin discovery and cannot expose `web_search` or legacy `browser_*` tools.
- Add the exact Browser Harness 0.1.10 helper surface needed for multi-step recovery and tab/file workflows.
- Disable supported Browser Harness telemetry aliases, update checks, and credential-bearing live-view foregrounding in Hermes child processes.
- Preserve the user's existing Browser Harness recording preference.

## User Impact

Explicit Browser Use one-shot runs reliably receive `browser_exec` and no alternate web tool. Browser tasks get the complete Browser Harness 0.1.10 helper contract without changing the public tool name or backend selection. Harness runs stay in the background and avoid optional telemetry/update traffic. Existing recordings remain user-controlled.

## Evidence

- Focused Browser Use, toolset, provider, and one-shot matrix: 321 passed, 7 skipped after rebasing onto current Hermes main.
- Full GitHub CI on the rebased current-upstream head is green, including all 12 Python test slices, E2E, macOS, Windows, Nix, Ruff, supply-chain, and build checks.
- Changed-file Ruff and `git diff --check`: passed.
- Exact-source 106-task hard benchmark: **92/106 pass (86.79%)**, 14 fail, 0 judge errors. This is +10 passes over the earlier 82/106 Hermes reference and +5 over the separately verified 87/106 BrowserCode reference. Model `claude-opus-5`, reasoning `high`, browser-only (`enable_web_research=false`), 60-minute task budget, Browser Use Cloud, Laith judge (`gpt-5.5`). Exact pins: Hermes `5634cf83e6193c12ea3337830679142f2424d987`, Browser Use `85ddbfedf609166b2d2c76c3d80506649fee82a9`, Browser Harness combined release candidate `d98ccca17a17c362fe315cc220ddb1cb069b7b4b`, eval platform `c00d0668ad625a51cf58b738689d37f373590d98`.
- The final run used Browser Use Cloud for all 106 tasks. Every task attached, listened, and explicitly stopped its Cloud browser; all 106 retained browser screenshots had valid PNG signatures; there were zero Harness IPC or screenshot-capture timeout/error signatures. Agent outcomes were 103 clean and 3 runner errors; none of the runner errors carried a Browser Harness failure signature.
- Accounting captured for the 103 clean tasks: 3,061 model calls and 135,375,999 tokens. The three runner-error envelopes did not retain usage, so those totals are lower bounds.
- Final run: https://github.com/browser-use/new-eval-platform/actions/runs/32474988674
- Laith's earlier hard-benchmark Hermes reference was 82/106; the separately verified same-judge BrowserCode reference was 87/106.

After the full run, Hermes upstream replaced `main` history with the current v0.20.5 line. The six feature commits were replayed onto current `origin/main` as head `6df02ae09549c4a25e1d6af4b2805b30a41a60e0`. The four changed files are byte-for-byte identical to evaluated head `5634cf83e6193c12ea3337830679142f2424d987`; only the upstream base changed. Fresh focused tests pass as recorded above, and GitHub CI is attached to the rebased head.

## Release Dependencies

- [Browser Use Cloud #5609](https://github.com/browser-use/cloud/pull/5609) must deploy first with its gate disabled, then be enabled after backend and cleanup workers are live.
- Merge Browser Harness #626 and #634.
- Rebase/retarget and merge Browser Harness #636 only after the Cloud API gate is enabled.
- Publish Browser Harness 0.1.10 (PyPI currently has 0.1.9).
- Merge Browser Use #5507 so CLI 3.0 installs Browser Harness 0.1.10.
