### PR TITLE
fix(desktop): prefer PATH hermes over env-shebang argv[0] in launcher entry

### DIFF
--- a/hermes_cli/relaunch.py
+++ b/hermes_cli/relaunch.py
@@ -101,9 +101,27 @@ def resolve_hermes_bin() -> Optional[str]:
     def _is_python_script(p: str) -> bool:
         return p.lower().endswith((".py", ".pyc"))
 
+    def _has_env_shebang(p: str) -> bool:
+        # A script with a "#!/usr/bin/env python3" shebang resolves python3
+        # through the caller's PATH. That works from a login shell (venv on
+        # PATH) but breaks when a desktop launcher runs the entry with a
+        # bare environment: the system python3 lacks Hermes' deps. The PATH
+        # entry point (venv wrapper) has an absolute interpreter shebang, so
+        # prefer it whenever argv[0] is an env-shebang script.
+        try:
+            with open(p, "rb") as fh:
+                return fh.readline().startswith(b"#!/usr/bin/env")
+        except OSError:
+            return False
+
     # Absolute path to an executable (covers nix store, venv wrappers, etc.)
     if os.path.isabs(argv0) and os.path.isfile(argv0) and os.access(argv0, os.X_OK):
         if not (_is_windows and _is_python_script(argv0)):
+            if not _has_env_shebang(argv0):
+                return argv0
+            path_bin = shutil.which("hermes")
+            if path_bin:
+                return path_bin
             return argv0
 
     # Relative path — resolve against CWD


### PR DESCRIPTION
## Summary

On Linux, the XDG desktop entry installed by `hermes desktop` (via `hermes_cli/linux_desktop_entry.py`) gets its `Exec=` line from `resolve_hermes_bin()` in `hermes_cli/relaunch.py`. That function prefers `sys.argv[0]` when it resolves to an executable file.

When the user launches `hermes desktop` from a terminal through the repo's raw launcher script (`<repo>/hermes`, shebang `#!/usr/bin/env python3`), argv[0] is that script — so the generated `hermes.desktop` entry points back at it. That works from a login shell (the venv is on PATH), but **desktop launchers run with a bare environment**: `/usr/bin/env python3` resolves to the system interpreter, which lacks Hermes' dependencies. The app dies on the first import (`ModuleNotFoundError: No module named 'dotenv'`) before any window appears — clicking the icon silently does nothing, while launching from a terminal works fine.

Since `hermes desktop` rewrites the entry on every launch, hand-editing `Exec=` doesn't stick; the fix has to be in the resolver.

## Fix

In `resolve_hermes_bin()`: when argv[0] is an absolute executable whose shebang is `#!/usr/bin/env ...`, prefer the PATH-resolved `hermes` entry point (the venv wrapper, whose shebang carries an absolute interpreter path), falling back to argv[0] when the PATH lookup finds nothing. Behavior is unchanged for real binaries (venv wrappers, nix store paths, etc.).

## Reproduction

1. Run `./hermes desktop` from a checkout (repo script, not the venv binary).
2. Check `~/.local/share/applications/hermes.desktop` → `Exec=<repo>/hermes desktop`.
3. Simulate the launcher environment: `env -i HOME=$HOME PATH=/usr/bin:/bin <repo>/hermes desktop` → `ModuleNotFoundError: No module named 'dotenv'`.
4. After the fix, the entry regenerates as `Exec=<repo>/venv/bin/hermes desktop` and the same bare-env launch starts the app (verified with `gtk-launch hermes.desktop` on Fedora 44 / GNOME).

## Test plan

- [x] `resolve_exec_command()` returns the venv binary when argv[0] is the repo script
- [x] Regenerated entry launches via `gtk-launch` (the icon's mechanism)
- [x] Entry content is stable across subsequent `hermes desktop` runs (regeneration now produces the same correct value)