### PR TITLE
fix(kanban): make --initial-status blocked sticky from birth

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3555,6 +3555,28 @@ def create_task(
                     },
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
+                if initial_status == "blocked":
+                    # The sticky-block gate (_has_sticky_block, #28712) keys on
+                    # the latest "blocked"/"unblocked" event row. A task born
+                    # blocked via --initial-status carried only the status
+                    # column, so recompute_ready treated it as event-less and
+                    # auto-promoted it on the next dispatch tick — spawning an
+                    # assignee past the activation gate the caller set up
+                    # (#91178). Emit the block transition atomically with the
+                    # create so the task stays blocked until an explicit
+                    # unblock, exactly like a post-create `kanban block`.
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {
+                            "reason": None,
+                            "kind": None,
+                            "recurrences": 0,
+                            "source_status": "blocked",
+                            "initial": True,
+                        },
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -76,6 +76,49 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
             assert kb.get_task(conn, tid).status == "blocked"
 
 
+# ---------------------------------------------------------------------------
+# --initial-status blocked must be sticky from birth (#91178)
+# ---------------------------------------------------------------------------
+
+
+def test_initial_status_blocked_is_not_auto_promoted(kanban_home: Path) -> None:
+    """A task BORN blocked via --initial-status blocked is an operator
+    activation gate (setup/credential/deployment prerequisite). Before the
+    fix, create wrote only the status column with no "blocked" event row, so
+    _has_sticky_block saw an event-less task and recompute_ready auto-promoted
+    it on the next dispatch tick — spawning an assignee past the gate."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="gated on setup", initial_status="blocked")
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert kb._has_sticky_block(conn, tid) is True, (
+            "initial blocked must leave a durable block transition in the "
+            "event stream, exactly like a post-create kanban block"
+        )
+        for _ in range(5):
+            promoted = kb.recompute_ready(conn)
+            assert promoted == 0, "initial-blocked task must not auto-promote"
+            assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_initial_status_blocked_unblock_still_promotes(kanban_home: Path) -> None:
+    """The gate is explicitly clearable: an unblock fires the "unblocked"
+    event and the task returns to the normal promotion path."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="gated", initial_status="blocked")
+        assert kb.unblock_task(conn, tid)
+        assert kb.get_task(conn, tid).status != "blocked"
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, tid).status in ("ready", "todo")
+
+
+def test_default_create_still_auto_promotes(kanban_home: Path) -> None:
+    """Guard: ordinary tasks (no initial block) keep the event-less
+    auto-recover semantics — the fix must not make every task sticky."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="plain work")
+        assert kb._has_sticky_block(conn, tid) is False
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Makes `hermes kanban create --initial-status blocked` actually stick. The sticky-block gate (`_has_sticky_block`, from #28712) keys on the latest `"blocked"`/`"unblocked"` event row, but a task born blocked only ever wrote the status column — no event row. On the next dispatch tick, `recompute_ready` therefore treated it as event-less and auto-promoted it through `promoted → claimed → spawned`, starting the assignee ~21s after creation and bypassing exactly the setup/credential/deployment activation gate the caller had expressed (#91178). An explicit post-create `hermes kanban block` did persist, confirming the initial-block path was the only one missing the event.

The fix emits the block transition atomically inside the create transaction, with the same payload shape `block_task` writes (`reason`/`kind`/`recurrences`/`source_status`, plus `initial: True` to mark the origin), so an initial-blocked task follows the same lifecycle as a post-create block: sticky until an explicit `unblock`, invisible to the dispatcher's auto-recovery.

## Related Issue

Fixes #91178

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` — `create_task`'s post-create hook now appends a `"blocked"` event row when `initial_status == "blocked"`, inside the same write transaction as the create, with the #91178 rationale documented inline
- `tests/hermes_cli/test_kanban_blocked_sticky.py` — three regressions beside the existing #28712 sticky tests: an initial-blocked task has a durable sticky event and survives five `recompute_ready` ticks un-promoted; an explicit `unblock` still clears the gate and returns the task to the normal promotion path; and a plain created task stays event-less (the fix must not make every task sticky)

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_cli/test_kanban_blocked_sticky.py -q` — should pass (5 passed, including the three new)
2. Observed result: on unmodified main, `test_initial_status_blocked_is_not_auto_promoted` fails at the first sticky assertion — `create_task(..., initial_status="blocked")` leaves no `"blocked"` event row, `_has_sticky_block` returns False, and `recompute_ready` promotes the task on the first tick (the #91178 spawn-past-the-gate shape)
3. Regression: `tests/hermes_cli/test_kanban_block_kinds.py` + `test_kanban_cli_dispatch_passthrough.py` — 4 passed (block-kind routing and dispatch passthrough unchanged); the existing #28712 worker-block sticky tests still pass

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (why the event row is required for the sticky gate, and why it is atomic with the create)
- [x] Tests added that prove the fix (sticky-from-birth + unblock clears + plain tasks stay auto-recover)
- [x] All new and existing tests pass locally (5 + 4 passed)
- [x] Platform: macOS (pure DB/event logic, platform-independent)
