### PR TITLE
fix(tui): honor per-platform context-file policy for Desktop

### DIFF
--- a/tests/tui_gateway/test_desktop_skip_context_files.py
+++ b/tests/tui_gateway/test_desktop_skip_context_files.py
@@ -1,0 +1,99 @@
+"""Desktop context-file policy mirrors the messaging gateway.
+
+Desktop backends launch from the Hermes install tree, so a profile must be
+able to skip that tree's project instructions without losing its SOUL identity.
+"""
+
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+
+def _runtime():
+    return {
+        "provider": None,
+        "base_url": None,
+        "api_key": None,
+        "api_mode": None,
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+
+
+def _make_agent_kwargs(cfg, monkeypatch, *, platform="desktop"):
+    monkeypatch.delenv("HERMES_IGNORE_RULES", raising=False)
+    with ExitStack() as stack:
+        stack.enter_context(patch("tui_gateway.server._load_cfg", return_value=cfg))
+        stack.enter_context(patch("tui_gateway.server._get_db", return_value=MagicMock()))
+        stack.enter_context(
+            patch("tui_gateway.server._load_tool_progress_mode", return_value="compact")
+        )
+        stack.enter_context(
+            patch("tui_gateway.server._load_reasoning_config", return_value=None)
+        )
+        stack.enter_context(patch("tui_gateway.server._load_service_tier", return_value=None))
+        stack.enter_context(
+            patch("tui_gateway.server._load_enabled_toolsets", return_value=None)
+        )
+        stack.enter_context(
+            patch(
+                "tui_gateway.server._resolve_startup_runtime",
+                return_value=("test-model", None),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value=_runtime(),
+            )
+        )
+        mock_agent = stack.enter_context(patch("run_agent.AIAgent"))
+        from tui_gateway.server import _make_agent
+
+        _make_agent("sid-1", "key-1", platform_override=platform)
+        return mock_agent.call_args.kwargs
+
+
+def test_desktop_config_skips_project_context_but_keeps_soul_and_memory(monkeypatch):
+    kwargs = _make_agent_kwargs(
+        {"gateway": {"platforms": {"desktop": {"skip_context_files": True}}}},
+        monkeypatch,
+    )
+
+    assert kwargs["skip_context_files"] is True
+    assert kwargs["load_soul_identity"] is True
+    assert kwargs["skip_memory"] is False
+
+
+def test_desktop_skip_context_setting_does_not_apply_to_tui(monkeypatch):
+    kwargs = _make_agent_kwargs(
+        {"gateway": {"platforms": {"desktop": {"skip_context_files": True}}}},
+        monkeypatch,
+        platform="tui",
+    )
+
+    assert kwargs["skip_context_files"] is False
+    assert kwargs["load_soul_identity"] is False
+    assert kwargs["skip_memory"] is False
+
+
+def test_platforms_list_shape_is_tolerated(monkeypatch):
+    # The messaging gateway uses gateway.platforms as a plain list of enabled
+    # platform names. Desktop must not crash on that shape and must not read a
+    # skip out of it.
+    kwargs = _make_agent_kwargs(
+        {"gateway": {"platforms": ["desktop", "telegram"]}},
+        monkeypatch,
+    )
+
+    assert kwargs["skip_context_files"] is False
+    assert kwargs["load_soul_identity"] is False
+    assert kwargs["skip_memory"] is False
+
+
+def test_ignore_rules_still_skips_soul_and_memory(monkeypatch):
+    monkeypatch.setenv("HERMES_IGNORE_RULES", "1")
+    with patch("tui_gateway.server._load_cfg", return_value={}):
+        from tui_gateway.server import _context_file_policy
+
+        assert _context_file_policy({}, "desktop") == (True, False, True)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1407,6 +1407,33 @@ def _resolve_agent_platform(source: str | None) -> str:
     return _resolve_session_source(source)
 
 
+def _context_file_policy(cfg: dict, platform: str) -> tuple[bool, bool, bool]:
+    """Resolve context-file loading for a TUI/Desktop session.
+
+    ``HERMES_IGNORE_RULES`` is the explicit all-rules escape hatch: it omits
+    project context, SOUL, and memory.  The per-platform setting is narrower:
+    it skips only cwd context files while keeping the profile SOUL identity and
+    memory intact.  Match the messaging gateway's ``gateway.platforms`` shape
+    so Desktop does not inject the install tree's AGENTS.md into a profile that
+    opts out.
+    """
+    ignore_rules = is_truthy_value(os.environ.get("HERMES_IGNORE_RULES"))
+    if ignore_rules:
+        return True, False, True
+
+    gateway = cfg.get("gateway") if isinstance(cfg, dict) else {}
+    platforms = gateway.get("platforms") if isinstance(gateway, dict) else {}
+    if not isinstance(platforms, dict):
+        platforms = {}
+    platform_cfg = platforms.get(platform) or {}
+    skip_context_files = (
+        bool(platform_cfg.get("skip_context_files"))
+        if isinstance(platform_cfg, dict)
+        else False
+    )
+    return skip_context_files, skip_context_files, False
+
+
 def _config_model_target() -> tuple[str, str]:
     """(model, provider) selected by config.yaml — and ONLY config: the HERMES_MODEL launch seed fed into
     the per-turn sync would be replayed as a /model switch and persisted globally, or pin the session so
@@ -2282,7 +2309,12 @@ def _make_agent(
     model, runtime = _resolve_agent_model_runtime(model_override, provider_override)
     _pr = _load_provider_routing()
     platform = _resolve_agent_platform(platform_override)
-    ignore_rules = is_truthy_value(os.environ.get("HERMES_IGNORE_RULES"))
+    # Per-platform context-file policy (gateway parity): a profile that opts out of
+    # cwd context files must not inherit the install tree's AGENTS.md. HERMES_IGNORE_RULES
+    # stays the stronger all-rules escape hatch.
+    skip_context_files, load_soul_identity, skip_memory = _context_file_policy(
+        cfg, platform
+    )
     agent = AIAgent(
         model=model, max_iterations=_cfg_max_turns(cfg, 500), provider=runtime.get("provider"),
         base_url=runtime.get("base_url"), api_key=runtime.get("api_key"), api_mode=runtime.get("api_mode"),
@@ -2300,7 +2332,8 @@ def _make_agent(
         session_db=session_db if session_db is not None else _get_db(), ephemeral_system_prompt=system_prompt or None,
         checkpoints_enabled=is_truthy_value(os.environ.get("HERMES_TUI_CHECKPOINTS")),
         pass_session_id=is_truthy_value(os.environ.get("HERMES_TUI_PASS_SESSION_ID")),
-        skip_context_files=ignore_rules, skip_memory=ignore_rules, fallback_model=_load_fallback_model(),
+        skip_context_files=skip_context_files, load_soul_identity=load_soul_identity,
+        skip_memory=skip_memory, fallback_model=_load_fallback_model(),
         **_agent_cbs(sid))
     if context_cwd_is_launch_artifact is None:
         with _sessions_lock:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2763,6 +2763,25 @@ Hermes uses two different context scopes:
 - Hermes automatically seeds a default `SOUL.md` if one does not already exist.
 - All loaded context files are capped at `context_file_max_chars` characters (default 20,000) with smart truncation.
 
+Context-file loading can also be skipped per platform while keeping the
+profile SOUL identity and memory:
+
+```yaml
+gateway:
+  platforms:
+    desktop:
+      skip_context_files: true
+```
+
+`gateway.platforms.<platform>.skip_context_files` (honored by the messaging
+gateway and the Desktop app) skips the working directory's project
+instructions — `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, etc. — for sessions
+on that platform while still loading the profile `SOUL.md` and memory. This
+is useful when a Desktop backend launches from the Hermes install tree and a
+non-coding profile would otherwise inherit the repository's contributor
+instructions. `HERMES_IGNORE_RULES` remains the stronger all-rules escape
+hatch: it skips project context, SOUL, and memory together.
+
 See also:
 - [Personality & SOUL.md](/user-guide/features/personality)
 - [Context Files](/user-guide/features/context-files)


### PR DESCRIPTION
## Summary

Desktop sessions launched from the Hermes install tree can inherit that tree's `AGENTS.md`, even when the active profile is not a coding profile. Honor the existing `gateway.platforms.<platform>.skip_context_files` policy in the TUI/Desktop agent factory, preserving SOUL identity and memory for configuration-driven skips. Keep `HERMES_IGNORE_RULES` as the deliberately stronger all-rules escape hatch.

## Changes

- `tui_gateway/server.py` — add `_context_file_policy()` and wire it into `_make_agent`. The resolution mirrors the messaging gateway's per-platform handling in `gateway/run.py` (including tolerating the list shape `hermes gateway setup` writes for `gateway.platforms`).
- `tests/tui_gateway/test_desktop_skip_context_files.py` — new regression tests: config-driven skip (SOUL + memory retained), TUI non-application, `gateway.platforms` list-shape compatibility, and `HERMES_IGNORE_RULES` precedence.
- `website/docs/user-guide/configuration.md` — document the per-platform `skip_context_files` setting under Context Files.

## Motivation

A Desktop backend launched from the Hermes install tree resolves its cwd as the repo root, so the contributor `AGENTS.md` (~85KB) gets injected into every fresh session even for non-coding profiles. The profile-level `agent.skip_project_context` key is not consumed by the Desktop factory; the existing generic mechanism is the gateway's per-platform policy. Wiring Desktop to that same policy fixes the class of problem without adding a profile-specific pathway, and protects prompt-cache performance — the skip happens at construction, not by mutating prompts afterward.

## Test Plan

- `scripts/run_tests.sh tests/tui_gateway/test_desktop_skip_context_files.py` — 4/4 pass
- `scripts/run_tests.sh tests/tui_gateway/` — 70 files, 524 tests passed, 0 failed
- Live verification on a profile with the setting enabled: system prompt 112,295 → 23,620 chars; repo `AGENTS.md` absent; profile SOUL retained.