### PR TITLE
feat(kanban): add opt-in wrapped board view (Wide ⇄ Wrapped toggle)

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -301,6 +301,26 @@
     } catch (_e) { /* ignore quota / private mode */ }
   }
 
+  // localStorage key for the user's board layout preference.
+  // "wide" (default) = single horizontal row with grab-pan; "wrapped" =
+  // columns wrap to rows, no horizontal scrolling, page-level vertical
+  // scroll. Independent of board: one preference applies to all boards.
+  const LS_VIEW_KEY = "hermes.kanban.boardView";
+
+  function readBoardView() {
+    try {
+      const v = window.localStorage.getItem(LS_VIEW_KEY);
+      return v === "wrapped" ? "wrapped" : "wide";
+    } catch (_e) { return "wide"; }
+  }
+
+  function writeBoardView(view) {
+    try {
+      if (view === "wrapped") window.localStorage.setItem(LS_VIEW_KEY, "wrapped");
+      else window.localStorage.removeItem(LS_VIEW_KEY);
+    } catch (_e) { /* ignore quota / private mode */ }
+  }
+
   function withBoard(url, board) {
     // Always append ?board=<slug> when we have one picked — including
     // "default". Omitting the param would fall through to the backend's
@@ -604,6 +624,7 @@
     const { t } = useI18n();
     const kanbanDialogs = useKanbanDialogs(t);
     const [board, setBoard] = useState(() => readSelectedBoard() || null);
+    const [boardView, setBoardView] = useState(() => readBoardView());
     const [boardList, setBoardList] = useState([]);      // [{slug, name, counts, ...}]
     const [showNewBoard, setShowNewBoard] = useState(false);
     const [showBoardSettings, setShowBoardSettings] = useState(false);
@@ -1287,6 +1308,7 @@
         }),
         h(BoardToolbar, {
           board: boardData,
+          boardView, setBoardView,
           tenantFilter, setTenantFilter,
           assigneeFilter, setAssigneeFilter,
           includeArchived, setIncludeArchived,
@@ -1314,6 +1336,7 @@
         }),
         h(BoardColumns, {
           board: filteredBoard,
+          view: boardView,
           boardMeta: boardList.find(function (item) { return item.slug === board; }) || null,
           laneByProfile,
           selectedIds,
@@ -2471,6 +2494,24 @@
         }),
         tx(t, "lanesByProfile", "Lanes by profile"),
       ),
+      h("div", { className: "flex flex-col gap-1",
+                 title: "Wide: all columns in one horizontal row (scroll/pan sideways). Wrapped: columns wrap to rows that fit the window — no horizontal scrolling, page scrolls vertically." },
+        h(Label, { className: "text-xs text-muted-foreground" }, tx(t, "boardView", "Board view")),
+        h("div", { className: "flex items-center gap-1" },
+          h(Button, {
+            size: "sm",
+            variant: props.boardView === "wide" ? "default" : "outline",
+            onClick: function () { props.setBoardView("wide"); writeBoardView("wide"); },
+            title: "One horizontal row; pan or scroll sideways.",
+          }, tx(t, "viewWide", "Wide")),
+          h(Button, {
+            size: "sm",
+            variant: props.boardView === "wrapped" ? "default" : "outline",
+            onClick: function () { props.setBoardView("wrapped"); writeBoardView("wrapped"); },
+            title: "Columns wrap to rows; no horizontal scrolling.",
+          }, tx(t, "viewWrapped", "Wrapped")),
+        ),
+      ),
       h("div", { className: "flex-1" }),
       h(Button, {
         onClick: props.onNudgeDispatch,
@@ -2694,8 +2735,14 @@
 
     const checkScrollable = useCallback(function () {
       const el = columnsRef.current;
+      // Wrapped mode never scrolls horizontally: wrap means content always
+      // fits the container width, so report not-scrollable and disable pan.
+      if (props.view === "wrapped") {
+        setIsScrollable(false);
+        return;
+      }
       setIsScrollable(!!el && el.scrollWidth > el.clientWidth + 1);
-    }, []);
+    }, [props.view]);
 
     useEffect(function () {
       checkScrollable();
@@ -2739,6 +2786,8 @@
 
     const handleMouseDown = useCallback(function (e) {
       if (e.button !== 0) return;
+      // Wrapped mode: no horizontal panning (columns wrap instead).
+      if (props.view === "wrapped") return;
       if (isPanBlockedTarget(e.target)) return;
       const el = columnsRef.current;
       if (!el) return;
@@ -2787,6 +2836,7 @@
       ref: columnsRef,
       className: cn(
         "hermes-kanban-columns",
+        props.view === "wrapped" ? "hermes-kanban-columns--wrapped" : "",
         isScrollable ? "hermes-kanban-columns--scrollable" : "",
         isPanning ? "hermes-kanban-columns--panning" : "",
       ),

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -2495,20 +2495,21 @@
         tx(t, "lanesByProfile", "Lanes by profile"),
       ),
       h("div", { className: "flex flex-col gap-1",
-                 title: "Wide: all columns in one horizontal row (scroll/pan sideways). Wrapped: columns wrap to rows that fit the window — no horizontal scrolling, page scrolls vertically." },
+                 title: tx(t, "boardViewTitle",
+                   "Wide: all columns in one horizontal row (scroll/pan sideways). Wrapped: columns wrap to rows that fit the window — no horizontal scrolling, page scrolls vertically.") },
         h(Label, { className: "text-xs text-muted-foreground" }, tx(t, "boardView", "Board view")),
         h("div", { className: "flex items-center gap-1" },
           h(Button, {
             size: "sm",
             variant: props.boardView === "wide" ? "default" : "outline",
             onClick: function () { props.setBoardView("wide"); writeBoardView("wide"); },
-            title: "One horizontal row; pan or scroll sideways.",
+            title: tx(t, "viewWideTitle", "One horizontal row; pan or scroll sideways."),
           }, tx(t, "viewWide", "Wide")),
           h(Button, {
             size: "sm",
             variant: props.boardView === "wrapped" ? "default" : "outline",
             onClick: function () { props.setBoardView("wrapped"); writeBoardView("wrapped"); },
-            title: "Columns wrap to rows; no horizontal scrolling.",
+            title: tx(t, "viewWrappedTitle", "Columns wrap to rows; no horizontal scrolling."),
           }, tx(t, "viewWrapped", "Wrapped")),
         ),
       ),
@@ -2821,7 +2822,7 @@
         window.removeEventListener("blur", onMouseUp);
       };
       e.preventDefault();
-    }, [isPanBlockedTarget, stopPan]);
+    }, [isPanBlockedTarget, stopPan, props.view]);
 
     const handleDragStart = useCallback(function (e) {
       const card = e.target.closest && e.target.closest(".hermes-kanban-card");

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -69,6 +69,20 @@
   overflow-x: auto;
 }
 
+/* Wrapped (multi-row) board view: columns wrap to the container width,
+   no horizontal scroll ever, columns grow to their content height. */
+.hermes-kanban-columns--wrapped {
+  flex-wrap: wrap;
+  overflow-x: hidden;
+  /* Extra vertical space between wrapped rows so rows read as distinct bands */
+  row-gap: 2.5rem;
+}
+.hermes-kanban-columns--wrapped .hermes-kanban-column {
+  flex: 1 1 280px;
+  max-width: 420px;
+  max-height: none;
+}
+
 .hermes-kanban-columns--scrollable {
   cursor: grab;
 }


### PR DESCRIPTION
## Summary

- Adds an opt-in **Wrapped** board view to the Kanban dashboard plugin: columns wrap into rows that fit the window width, so nothing requires horizontal scrolling.
- Adds a **Wide ⇄ Wrapped** toggle to the board toolbar; the preference persists in `localStorage` (`hermes.kanban.boardView`) and applies to every board.
- Default layout (**Wide**) is bit-for-bit unchanged — this is purely additive.

## Motivation

On smaller screens the single-row board (7–8 fixed-width columns) requires horizontal scrolling/panning to reach Review/Blocked/Done. A wrapped multi-row layout with page-level vertical scrolling and variable-height cards is a common kanban UX (and matches how people read a board top-to-bottom). This change makes it available as an opt-in view mode.

## Changes

- `plugins/kanban/dashboard/dist/index.js`
  - `readBoardView()` / `writeBoardView()` localStorage helpers (mirrors the existing `selectedBoard` pattern, `hermes.kanban.boardView` key).
  - `boardView` state in the board root, passed to `BoardToolbar` (toggle) and `BoardColumns` (layout).
  - Wrapped mode disables grab-pan deterministically: `checkScrollable` reports not-scrollable and `handleMouseDown` early-returns, so no horizontal pan affordance appears.
  - Columns container gets `hermes-kanban-columns--wrapped` modifier class.
  - Toolbar toggle: two labeled buttons ("Wide" / "Wrapped") using the SDK `Button` with `variant` switching, i18n keys with fallbacks.
- `plugins/kanban/dashboard/dist/style.css`
  - `.hermes-kanban-columns--wrapped`: `flex-wrap: wrap`, `overflow-x: hidden`, generous `row-gap` (2.5rem) between wrapped rows.
  - Wrapped columns: `flex: 1 1 280px` (basis same as today's 280px), `max-width: 420px`, `max-height: none` (variable-height cards; page scroll only).

## Test Plan

Verified live in the dashboard (not just code review):

- [x] Default view (fresh localStorage) is Wide with today's exact behavior (`nowrap`, `0 0 280px`, horizontal scroll present, grab-pan works)
- [x] Toggling Wrapped: columns wrap to rows that fit the container (8 columns → 2 rows at ~1400px, 4 rows at 820px)
- [x] Zero horizontal overflow in Wrapped at every width tested (`scrollWidth == clientWidth`, `overflow-x: hidden`)
- [x] Columns grow to content height (`max-height: none`); long descriptions render fully
- [x] Card drag-and-drop works across rows (moved a card Ready → Blocked across row boundary through the real confirm-dialog flow; verified in DB)
- [x] "Lanes by profile" rendering inside the Running column works in Wrapped mode
- [x] Preference persists across reloads; Wide also persists; fresh browser profile defaults to Wide
- [x] `node --check` passes on the bundle
- [ ] Unit tests — the dashboard bundle has no in-repo JS test harness; testing is browser-E2E as above

## Screenshots / Examples

Wrapped mode (2 rows, all 8 columns visible, no horizontal scroll):

[Wrapped board view screenshot](https://raw.githubusercontent.com/AsharFatmi/hermes-agent/kanban-wrapped-screenshot/kanban-wrapped-view.png)

## Notes for Reviewers

- No backend changes; `manifest.json` and `plugin_api.py` untouched.
- The bundle is committed directly (matches how the kanban plugin ships today); happy to regenerate via the repo's toolchain if that's preferred.
- Default behavior is unchanged; the toggle is off unless the user opts in.
- The `variant` prop on the SDK `Button` is already used elsewhere in this file (`destructive`, `outline`), so the toggle matches existing conventions.
