### PR TITLE
fix(gateway): make Windows Scheduled Task install valid on workgroup hosts

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -580,13 +580,20 @@ def _write_task_script() -> Path:
 # ---------------------------------------------------------------------------
 
 def _resolve_task_user() -> str | None:
-    """Return ``DOMAIN\\USER`` if available, else bare USERNAME, else None."""
+    """Return ``DOMAIN\\USER`` if available, else bare USERNAME, else None.
+
+    Workgroup machines report ``USERDOMAIN=WORKGROUP``; schtasks rejects
+    ``WORKGROUP\\user`` as a task principal ("No mapping between account
+    names and security IDs"), so local accounts must use the bare username.
+    """
     username = os.environ.get("USERNAME") or os.environ.get("USER") or os.environ.get("LOGNAME")
     if not username:
         return None
     if "\\" in username:
         return username
     domain = os.environ.get("USERDOMAIN")
+    if not domain or domain.upper() in {"WORKGROUP", "MICROSOFTACCOUNT"}:
+        return username
     return f"{domain}\\{username}" if domain else username
 
 
@@ -679,7 +686,12 @@ def _install_scheduled_task(task_name: str, script_path: Path) -> tuple[bool, st
     launcher_path = script_path.with_suffix(".vbs")
     xml_path = _write_scheduled_task_xml(task_name, launcher_path, user)
     base = ["/Create", "/F", "/TN", task_name, "/XML", str(xml_path)]
-    variants = [[*base, "/RU", user, "/NP", "/IT"]] if user else []
+    # Do not combine /NP with /IT: newer Windows builds reject the pair
+    # ("/IT switch cannot be used with /NP"), and /NP alone makes schtasks
+    # prompt for a run-as password instead of creating the task. The XML
+    # already declares the principal (InteractiveToken), so /IT alone keeps
+    # the task interactive without requiring a stored password.
+    variants = [[*base, "/RU", user, "/IT"]] if user else []
     variants.append(base)
 
     last_code = 1

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -340,6 +340,45 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
     assert content.endswith("\r\n")
 
 
+@pytest.mark.parametrize(
+    ("userdomain", "username", "expected"),
+    [
+        ("WORKGROUP", "alice", "alice"),
+        ("workgroup", "alice", "alice"),
+        ("MICROSOFTACCOUNT", "alice", "alice"),
+        (None, "alice", "alice"),
+        ("CORP", "alice", r"CORP\alice"),
+        ("HELEN_REDMI", "qiaoa", r"HELEN_REDMI\qiaoa"),
+    ],
+)
+def test_resolve_task_user_workgroup_uses_bare_username(monkeypatch, userdomain, username, expected):
+    """Workgroup/local accounts must not be prefixed with the WORKGROUP domain:
+    schtasks cannot map ``WORKGROUP\\user`` to a SID, so the task principal
+    falls back to the bare username (issue #89807)."""
+
+    monkeypatch.delenv("USER", raising=False)
+    monkeypatch.delenv("LOGNAME", raising=False)
+    monkeypatch.setenv("USERNAME", username)
+    if userdomain is None:
+        monkeypatch.delenv("USERDOMAIN", raising=False)
+    else:
+        monkeypatch.setenv("USERDOMAIN", userdomain)
+    assert gateway_windows._resolve_task_user() == expected
+
+
+def test_resolve_task_user_returns_none_without_username(monkeypatch):
+    monkeypatch.delenv("USERNAME", raising=False)
+    monkeypatch.delenv("USER", raising=False)
+    monkeypatch.delenv("LOGNAME", raising=False)
+    assert gateway_windows._resolve_task_user() is None
+
+
+def test_resolve_task_user_passes_through_qualified_username(monkeypatch):
+    monkeypatch.delenv("USERDOMAIN", raising=False)
+    monkeypatch.setenv("USERNAME", r"DOMAIN\bob")
+    assert gateway_windows._resolve_task_user() == r"DOMAIN\bob"
+
+
 
 
 
@@ -362,7 +401,6 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
 # the gateway's marker-watcher thread to drain + exit cleanly, then escalates
 # to taskkill if drain times out.
 # ---------------------------------------------------------------------------
-
 
 
 


### PR DESCRIPTION
## Summary

Closes #89807 and supersedes stale/conflicting PR #89824 while preserving its implementation and contributor credit.

`hermes gateway install` has two Windows principal/flag defects on current `main`:

1. workgroup hosts can produce `WORKGROUP\\user`, which Task Scheduler cannot map to a SID;
2. the first `schtasks /Create` variant combines `/NP` with `/IT`, which newer Windows builds reject, while `/NP` alone can prompt for a password in a non-interactive install.

This rebased implementation:

- uses the bare username for unset domain, `WORKGROUP`, and `MICROSOFTACCOUNT` identities;
- preserves explicitly qualified `DOMAIN\\user` identities;
- uses `/RU <user> /IT` without `/NP`;
- retains the XML-only fallback;
- adds focused tests for local/workgroup/domain/unset/pre-qualified principals.

## Provenance

The code and tests are the exact implementation from #89824 by @liujuanjuan1984, rebased without semantic changes because both touched files are byte-identical between #89824's base and current `main`.

Commit: [`45a7042fb7826297db04a6c16b34ec66d13b5805`](https://github.com/andrexibiza/hermes-agent/commit/45a7042fb7826297db04a6c16b34ec66d13b5805)

The commit carries an explicit `Co-authored-by` trailer for @liujuanjuan1984. This PR restores a clean current-main merge path; it does not replace the original contributor's provenance.

## Exact-head verification

All hosted workflows attached directly to `45a7042f...` are green:

- [CI 32433125674](https://github.com/NousResearch/hermes-agent/actions/runs/32433125674)
- [Docker 32433125369](https://github.com/NousResearch/hermes-agent/actions/runs/32433125369)
- [Nix 32433125358](https://github.com/NousResearch/hermes-agent/actions/runs/32433125358)

No status is inherited from #89824 or an earlier base.

## Scope

This closes the Scheduled Task principal/flag installation failure only. It does not claim the broader Windows lifecycle transaction in #88683 is complete.