### PR TITLE
fix(discord): thread explicit reply mentions

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -8099,6 +8099,7 @@ class DiscordAdapter(BasePlatformAdapter):
             if snapshot_text_parts and not raw_content:
                 raw_content = "\n".join(snapshot_text_parts)
                 normalized_content = raw_content
+        inline_mention = self._self_is_raw_mentioned(message)
         if self._self_is_explicitly_mentioned(message):
             mention_prefix = True
             if self._client.user:
@@ -8162,7 +8163,11 @@ class DiscordAdapter(BasePlatformAdapter):
             skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
-            if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
+            # #9399 preserves unmentioned quote-replies inline. Discord can add
+            # a reply-ping to resolved mentions, so only a raw <@bot> token
+            # makes a reply a new thread-first task.
+            skip_for_reply = is_reply_message and not inline_mention
+            if auto_thread and not skip_thread and not is_voice_linked_channel and not skip_for_reply:
                 thread = await self._auto_create_thread(message)
                 if thread:
                     parent_channel_id = str(message.channel.id)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -8099,7 +8099,10 @@ class DiscordAdapter(BasePlatformAdapter):
             if snapshot_text_parts and not raw_content:
                 raw_content = "\n".join(snapshot_text_parts)
                 normalized_content = raw_content
-        inline_mention = self._self_is_raw_mentioned(message)
+        is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
+        # Reply routing alone needs the raw token, so do not scan ordinary
+        # messages before their content is stripped for display.
+        inline_mention = is_reply_message and self._self_is_raw_mentioned(message)
         if self._self_is_explicitly_mentioned(message):
             mention_prefix = True
             if self._client.user:
@@ -8162,7 +8165,6 @@ class DiscordAdapter(BasePlatformAdapter):
             no_thread_channels = self._get_no_thread_channels()
             skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
-            is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             # #9399 preserves unmentioned quote-replies inline. Discord can add
             # a reply-ping to resolved mentions, so only a raw <@bot> token
             # makes a reply a new thread-first task.

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -253,6 +253,61 @@ async def test_discord_reply_message_skips_auto_thread(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_discord_explicit_mention_reply_threads_to_new_thread(adapter, monkeypatch):
+    """A direct bot mention in a quote-reply is a new thread-first task."""
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+
+    parent = FakeTextChannel(channel_id=456)
+    created_thread = FakeThread(channel_id=90002, name="reply-task", parent=parent)
+    adapter._auto_create_thread = AsyncMock(return_value=created_thread)
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=parent,
+        content=f"<@{bot_user.id}> review this task",
+        mentions=[bot_user],
+        msg_type=discord_platform.discord.MessageType.reply,
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once_with(message)
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "review this task"
+    assert event.source.chat_id == "90002"
+    assert event.source.thread_id == "90002"
+    assert event.source.chat_type == "thread"
+
+
+@pytest.mark.asyncio
+async def test_discord_reply_ping_without_inline_mention_stays_inline(adapter, monkeypatch):
+    """Discord's automatic reply-ping is not a new explicit invocation."""
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+
+    parent = FakeTextChannel(channel_id=457)
+    adapter._auto_create_thread = AsyncMock()
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=parent,
+        content="continuing the earlier discussion",
+        # Discord can resolve a reply-ping into mentions without an inline
+        # <@bot> token in content.
+        mentions=[bot_user],
+        msg_type=discord_platform.discord.MessageType.reply,
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_id == "457"
+    assert event.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
 async def test_discord_voice_linked_channel_skips_mention_requirement_and_auto_thread(adapter, monkeypatch):
     """Active voice-linked text channels should behave like free-response channels."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")


### PR DESCRIPTION
## Summary

- Preserve #9399: an unmentioned quote-reply remains an inline continuation.
- Treat a quote-reply with a direct Hermes mention as a new task in a thread-first channel.
- Treat Discord's automatic reply-ping as context, not as a typed invocation.
- Add a regression at the Discord free-response boundary that proves the emitted Hermes event targets the newly created thread, not the parent channel.

## Why

The merged #11629 fix excluded every quote-reply from auto-threading to protect free-response continuations. That broad exclusion also routed an explicit `@Hermes` task reply into the parent channel. A direct mention is already Hermes' explicit invocation signal; this change makes that case follow the configured auto-thread route while retaining the unmentioned continuation behaviour. The adapter captures the raw `<@Hermes>` token before it strips display text: Discord can add the replied-to bot to `message.mentions` automatically, but that reply-ping alone must not create a new thread. The raw-token check runs only for reply messages, avoiding an unnecessary scan on ordinary Discord traffic.

This is intentionally narrower than #80658, which routes all eligible quote-replies through a thread and would change #9399's unmentioned free-response behaviour.

## Test plan

```bash
scripts/run_tests.sh tests/gateway/test_discord_free_response.py -k explicit_mention_reply_threads_to_new_thread -q
scripts/run_tests.sh tests/gateway/test_discord_free_response.py -k reply_ping_without_inline_mention_stays_inline -q
scripts/run_tests.sh tests/gateway/test_discord_free_response.py tests/e2e/test_discord_adapter.py -q
```

All commands passed on the current `main` base (`8794e5a…`): 35 focused tests, Ruff on both changed files, and the Windows-footgun scan (994 files).
