### PR TITLE
fix(projects): make board-bound tasks inherit their project

### DIFF
--- a/hermes_cli/projects_cmd.py
+++ b/hermes_cli/projects_cmd.py
@@ -305,23 +305,25 @@ def _cmd_restore(args, conn, proj) -> int:
 
 @_with_project
 def _cmd_bind_board(args, conn, proj) -> int:
+    previous_board = proj.board_slug
     pdb.update_project(conn, proj.id, board_slug=args.board)
     if args.board.strip():
         print(f"Bound {proj.slug} -> board {args.board}")
-        _sync_board_default_workdir(proj, args.board)
+        _sync_board_binding(proj, args.board, bound=True)
     else:
         print(f"Unbound board from {proj.slug}")
+    if previous_board and pdb.normalize_slug(previous_board) != pdb.normalize_slug(args.board):
+        _sync_board_binding(proj, previous_board, bound=False)
     return 0
 
 
-def _sync_board_default_workdir(proj, board_slug: str) -> None:
-    """Best-effort: point the bound board's default_workdir at the primary repo.
+def _sync_board_binding(proj, board_slug: str, *, bound: bool) -> None:
+    """Best-effort: keep the board's reciprocal Project metadata in sync.
 
-    Keeps kanban task worktrees anchored to the project's repo. Failures here
-    are non-fatal — the binding itself already succeeded.
+    A bound board also inherits the project's primary repo as its default
+    workdir. Failures here are non-fatal — the Project binding already
+    succeeded.
     """
-    if not proj.primary_path:
-        return
     try:
         from hermes_cli import kanban_db as kb
 
@@ -330,6 +332,14 @@ def _sync_board_default_workdir(proj, board_slug: str) -> None:
             return
         if slug != kb.DEFAULT_BOARD and not kb.board_exists(slug):
             return
-        kb.write_board_metadata(slug, default_workdir=proj.primary_path)
+        if not bound:
+            if kb.read_board_metadata(slug).get("project_id") != proj.id:
+                return
+            kb.write_board_metadata(slug, project_id="")
+            return
+        updates = {"project_id": proj.id}
+        if proj.primary_path:
+            updates["default_workdir"] = proj.primary_path
+        kb.write_board_metadata(slug, **updates)
     except Exception:
         pass

--- a/hermes_cli/projects_cmd.py
+++ b/hermes_cli/projects_cmd.py
@@ -211,6 +211,8 @@ def _cmd_create(args: argparse.Namespace) -> int:
     if proj is None:
         print("project: vanished after create", file=sys.stderr)
         return 2
+    if args.board:
+        _sync_board_binding(proj, args.board, bound=True)
     print(f"Created project {proj.slug} ({pid})")
     _print_project(proj)
     return 0

--- a/tests/hermes_cli/test_projects_cli.py
+++ b/tests/hermes_cli/test_projects_cli.py
@@ -101,5 +101,22 @@ def test_bind_board_updates_both_sides_and_unbind_preserves_board(tmp_path):
     assert metadata["description"] == "Keep me"
 
 
+def test_create_with_board_updates_reciprocal_metadata(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    kb.create_board("widget")
+
+    assert _run(["create", "Widget", str(repo), "--board", "widget"]) == 0
+
+    with pdb.connect_closing() as conn:
+        project = pdb.get_project(conn, "widget")
+        assert project is not None
+        assert project.board_slug == "widget"
+
+    metadata = kb.read_board_metadata("widget")
+    assert metadata["project_id"] == project.id
+    assert metadata["default_workdir"] == str(repo)
+
+
 
 

--- a/tests/hermes_cli/test_projects_cli.py
+++ b/tests/hermes_cli/test_projects_cli.py
@@ -6,6 +6,7 @@ import argparse
 
 import pytest
 
+from hermes_cli import kanban_db as kb
 from hermes_cli import projects_cmd
 from hermes_cli import projects_db as pdb
 
@@ -55,6 +56,49 @@ def test_rename_and_archive(tmp_path):
     assert _run(["restore", "old-name"]) == 0
     with pdb.connect_closing() as conn:
         assert len(pdb.list_projects(conn)) == 1
+
+
+def test_bind_board_updates_both_sides_and_unbind_preserves_board(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    kb.create_board("widget", name="Widget Board", description="Keep me")
+    board_conn = kb.connect(board="widget")
+    try:
+        existing_task = kb.create_task(board_conn, title="existing", board="widget")
+    finally:
+        board_conn.close()
+
+    assert _run(["create", "Widget", str(repo)]) == 0
+    assert _run(["bind-board", "widget", "widget"]) == 0
+
+    with pdb.connect_closing() as conn:
+        project = pdb.get_project(conn, "widget")
+        assert project is not None
+        assert project.board_slug == "widget"
+
+    metadata = kb.read_board_metadata("widget")
+    assert metadata["project_id"] == project.id
+    assert metadata["default_workdir"] == str(repo)
+    assert metadata["name"] == "Widget Board"
+    assert metadata["description"] == "Keep me"
+
+    board_conn = kb.connect(board="widget")
+    try:
+        inherited_task = kb.create_task(board_conn, title="inherited", board="widget")
+        assert kb.get_task(board_conn, existing_task) is not None
+        assert kb.get_task(board_conn, inherited_task).project_id == project.id
+    finally:
+        board_conn.close()
+
+    assert _run(["bind-board", "widget"]) == 0
+    with pdb.connect_closing() as conn:
+        assert pdb.get_project(conn, "widget").board_slug is None
+
+    metadata = kb.read_board_metadata("widget")
+    assert metadata["project_id"] is None
+    assert metadata["default_workdir"] == str(repo)
+    assert metadata["name"] == "Widget Board"
+    assert metadata["description"] == "Keep me"
 
 
 


### PR DESCRIPTION
## What does this PR do?

This fixes reciprocal Project-to-board bindings so tasks created on a bound board inherit the Project instead of falling back to an unscoped worktree. It also keeps the `project create --board` path consistent and safely clears reciprocal metadata when a Project is unbound or switched to another board.

### Symptom

After `hermes project bind-board <project> <board>`, the Project displayed the board and the board's default workdir was updated, but the board metadata still had a null `project_id`. Tasks created on that board without `--project` therefore did not inherit the Project.

### Impact

Users who rely on board binding can get tasks without the expected Project ID, deterministic Project worktree path, or Project branch convention. The same inconsistency also affected Projects created with `--board`.

### Bug Cause

**Trigger:** `hermes_cli/projects_cmd.py:_cmd_bind_board` and `_cmd_create`

**Causal chain:**
1. A user binds a Project to a board, or creates a Project with `--board`.
2. The CLI persists `projects.board_slug`, but the board metadata writer does not receive the Project ID on these paths.
3. `kanban_db.create_task` sees no board-level `project_id`, so new board tasks remain unscoped unless callers repeat `--project`.

**Why it is wrong:** The binding was persisted in only one store, leaving the reciprocal metadata used by task inheritance stale. Unbinding likewise did not clear that reciprocal field.

**Working sibling / contrast:** The dashboard board API already writes `project_id` into board metadata. This change aligns both CLI binding entry paths with that persistence contract.

**Ruled out:** Task inheritance itself is not the cause. It already reads a board metadata `project_id` correctly, and the regression test proves inheritance starts working once reciprocal metadata is present.

### Fix

Centralize best-effort reciprocal board synchronization in `_sync_board_binding`. Binding now writes the Project ID and primary workdir, Project creation with `--board` uses the same path, and unbinding or switching clears only a previous binding that still belongs to that Project. Existing board metadata, task history, and default workdir are preserved.

## Related Issue

Closes #91169

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/projects_cmd.py` - synchronize reciprocal board metadata for create, bind, switch, and unbind paths.
- `tests/hermes_cli/test_projects_cli.py` - cover reciprocal persistence, task inheritance, Project creation with a board, and metadata preservation.

## How to Test

1. Create a named board and a Project with a primary folder.
2. Bind the Project to the board, then create a board task without `--project`; confirm it inherits the Project ID.
3. Unbind the Project and confirm the reciprocal Project ID is cleared while board metadata and history remain intact.
4. Automated verification already run locally (8 passed):

```bash
scripts/run_tests.sh tests/hermes_cli/test_projects_cli.py tests/hermes_cli/test_kanban_board_project.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry point on the relevant test files and all tests pass
- [x] I've added regression tests for the bug
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - no user-facing command or configuration changed
- [x] `cli-config.yaml.example`: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - the change uses existing Python and SQLite abstractions
- [x] Tool descriptions/schemas: N/A - no model tool behavior changed
