### PR TITLE
docs(design): add structured run provenance contract v1.0.0 + v1.1.0 correction

### DIFF
--- a/docs/design/kanban-run-provenance-v1.0.0.md
+++ b/docs/design/kanban-run-provenance-v1.0.0.md
@@ -67,20 +67,37 @@ task_events (6 cols)
 | Column | Type | Null | Writer | Notes |
 |---|---|---|---|---|
 | `subject_sha` | TEXT | yes until claim | **kernel only** | Full 40-char lowercase hex. Captured at claim from the typed task target. Never writable via the worker path. |
-| `final_candidate_sha` | TEXT | yes | **kernel only** | Full 40-char lowercase hex. The head the run's verdict binds to. Populated on **every** run type; collapses to `subject_sha` for implementation runs. See §4.1. |
-| `role` | TEXT | no | **kernel only** | Enum: `implementation`, `code_review`, `qa`, `security`. **Derived at query/export time** from a static `profile → role` lookup; see §2.3. |
+| `verified_head_sha` | TEXT | yes | **kernel only** | Full 40-char lowercase hex. The head the run actually verified, stamped at terminalization. For implementation runs it equals `subject_sha`. **This is the run-level SHA pair; it is *not* `final_candidate_sha`.** See §4 and the normative resolution in v1.1.0 §A.4. |
 | `provenance_version` | INTEGER | no | kernel | Starts at `1`. Lets a future schema change be detected rather than silently reinterpreted. |
 | `corrects_run_id` | INTEGER | yes | kernel | FK → `task_runs(id)`. Non-null only on correction rows (§5). |
+
+> **⚠ Corrected by v1.1.0 §A.4 (B3).** An earlier revision of this table listed a
+> `final_candidate_sha` column and a stored `role` column. **Neither is part of the normative
+> schema.** `final_candidate_sha` is an attestation-layer field the broker derives (§4, v1.1.0
+> §A.4); the run stores `verified_head_sha` instead. `role` is derived at query time from
+> `profile` (§2.3) and is not persisted. The rows above are the complete, normative column list.
 
 `profile`, `outcome`, `ended_at` are **existing** columns and are reused as-is. `completed_at` for
 export purposes is `ended_at`; no new column.
 
 **CHECK constraints (fail-closed at write time):**
 ```sql
-CHECK (subject_sha IS NULL OR (length(subject_sha) = 40 AND subject_sha GLOB '[0-9a-f]*'))
-CHECK (role IN ('implementation','code_review','qa','security'))
+CHECK (subject_sha IS NULL OR (length(subject_sha) = 40
+       AND subject_sha NOT GLOB '*[^0-9a-f]*'))
+CHECK (verified_head_sha IS NULL OR (length(verified_head_sha) = 40
+       AND verified_head_sha NOT GLOB '*[^0-9a-f]*'))
 CHECK (provenance_version >= 1)
 ```
+
+> **⚠ Corrected (B2). The pattern `sha GLOB '[0-9a-f]*'` is WRONG and must not be implemented.**
+> A leading `[0-9a-f]` character class followed by `*` anchors only the **first** character; the
+> `*` then matches any remaining 39 characters, including uppercase and non-hex. Demonstrated
+> against real SQLite (`verify_adr0007_mechanisms.py`, table `legacy_sha_check`): `'a' + 'Z'*39`
+> and `'a'*39 + 'g'` are both **accepted** by the old pattern and both **rejected** by the
+> `NOT GLOB '*[^0-9a-f]*'` form above. The negated form is normative: it rejects any character
+> outside `[0-9a-f]` at any position. Length is still checked separately because GLOB alone
+> cannot express "exactly 40". Hostile cases are executable — see A5 and §10.
+
 
 ### §2.2 New table `run_artifacts`
 
@@ -92,10 +109,13 @@ CREATE TABLE run_artifacts (
   sha256        TEXT    NOT NULL,
   created_at    INTEGER NOT NULL,
   UNIQUE(run_id, artifact_path),
-  CHECK (length(sha256) = 64 AND sha256 GLOB '[0-9a-f]*')
+  CHECK (length(sha256) = 64 AND sha256 NOT GLOB '*[^0-9a-f]*')
 );
 CREATE INDEX idx_run_artifacts_run ON run_artifacts(run_id);
 ```
+
+The `sha256` CHECK uses the same negated-GLOB form as §2.1 and for the same reason (B2):
+`sha256 GLOB '[0-9a-f]*'` would validate only the first of the 64 characters.
 
 One-to-many, per `platform-engineer`'s constraint. `UNIQUE(run_id, artifact_path)` is deliberate:
 double-recording an artifact becomes an error rather than a silent duplicate, closing one of the
@@ -179,47 +199,55 @@ reclassify a profile into a role it did not perform.
 
 ---
 
-## §4 — Subject SHA vs final candidate SHA
+## §4 — Subject SHA vs verified head SHA vs final candidate SHA
 
-| | Subject SHA | Final candidate SHA |
-|---|---|---|
-| Meaning | the commit the run's work was performed against | the head the run's verdict binds to |
-| Known at | claim time | run-completion time |
-| Stored | `task_runs.subject_sha` | `task_runs.final_candidate_sha` |
-| Written by | kernel, at claim | kernel, at terminalization |
+> **⚠ Normative resolution of the v1.0.0 `final_candidate_sha` contradiction (B3).**
+> An earlier revision of this section was internally inconsistent: §2.1 listed
+> `final_candidate_sha` as a run column, §4.1 said to carry both SHAs on every run, and the
+> closing paragraph of §4 said it is *not* a run field. **The single normative model is the
+> three-SHA model below**, stated in full in v1.1.0 §A.4. Exact superseded text is enumerated
+> in v1.1.0 §A.4.1. Where any older wording survives elsewhere, §A.4 wins.
 
-### §4.1 — Both SHAs on every run (corrected)
+**Three distinct SHAs. Two live on the run; the third is an attestation-layer field.**
 
-An earlier revision of this document stored **only** `subject_sha` on the run and left the final
-candidate SHA entirely to broker derivation. **That was wrong**, and `research-scout` (`t_5247914a`
-§4, §7) supplied the correction:
+| | Subject SHA | Verified head SHA | Final candidate SHA |
+|---|---|---|---|
+| Meaning | the commit the run's work was performed against | the head the run actually verified when it terminated | the head the **attestation** binds its verdict to |
+| Known at | claim time | run-completion time | attestation-assembly time (after the run) |
+| Stored | `task_runs.subject_sha` | `task_runs.verified_head_sha` | **not a Kanban column** — broker-derived |
+| Written by | kernel, at claim | kernel, at terminalization | broker, at attestation time |
 
-- Carry **both** `subject_sha` and `final_candidate_sha` on **every** run, uniformly. Do **not**
+### §4.1 — Both *witnessed* SHAs on every run; the final candidate stays broker-side
+
+Kanban records only what the kernel can **honestly witness**:
+
+- Carry **both** `subject_sha` and `verified_head_sha` on **every** run, uniformly. Do **not**
   make it conditional on run type.
-- For implementation runs the two collapse to the same value. That redundancy is harmless — special-
-  casing it costs more than it saves and creates a branch where a field can be legitimately absent.
-- For review / QA / security runs they can **legitimately diverge**: the branch may advance between
-  the commit a run reviewed and the head an attestation is later requested against.
+- For implementation runs the two collapse to the same value. That redundancy is harmless —
+  special-casing it costs more than it saves and creates a branch where a field can be
+  legitimately absent.
+- For review / QA / security runs they can **legitimately diverge**: the branch may advance
+  between the commit a run reviewed and the head an attestation is later requested against.
 
 **That divergence is the tamper check, not a defect.** It is what makes the broker's fail-closed
 condition *"PR head ≠ requested `expected_head_sha`"* (`t_5247914a` §7) evaluable at all. A schema
 that stored only one SHA would have made stale-evidence rebinding undetectable at the run layer.
 
-This does **not** conflict with §5 immutability: `final_candidate_sha` is written by the kernel at
+This does **not** conflict with §5 immutability: `verified_head_sha` is written by the kernel at
 terminalization, in the same transition that sets `ended_at`. It is never a post-terminal write.
 
-The broker still independently re-derives and binds the final candidate SHA in the attestation
-(§3.3). The run field is *provenance*; the attestation field is *authority*. They must agree, and
-the broker fails closed if they do not.
+**Why the final candidate SHA is *not* a run column.** It is knowable only after assembly — i.e.
+after the run is terminal — and §5 makes terminal runs immutable. Storing it on the run would
+require exactly the mutation this contract prohibits, and a Kanban column named
+`final_candidate_sha` / `final_sha` would invite a false equivalence between *"the head this run
+verified"* and *"the head the attestation binds"*. The broker derives and binds it (§3.3); the run
+field is *provenance*, the attestation field is *authority*. They must agree on `verified_head_sha`,
+and the broker fails closed if they do not.
 
 **Why subject SHA must come from a kernel-captured typed task target** (not worker JSON, not the
 evidence branch HEAD): if it is read from branch HEAD, the worker chooses *what was reviewed* after
 review happened. Capturing at claim makes the subject an **input** to the work rather than an
 **output** of it.
-
-**Why final candidate SHA is not a run field:** it is only knowable after assembly — i.e. after the
-run is terminal — and §5 makes terminal runs immutable. Storing it on the run would require exactly
-the mutation this contract prohibits.
 
 ---
 
@@ -270,8 +298,12 @@ fail-closed behaviour to laptop uptime.)
 
 ### §6.1 — Minimal export (exclusions are normative)
 
-Exported per run: `{run_id, task_id, profile, outcome, subject_sha, final_candidate_sha,
+Exported per run: `{run_id, task_id, profile, outcome, subject_sha, verified_head_sha,
 artifact_relative_path, sha256, completed_at}`.
+
+The export carries `verified_head_sha`, **not** `final_candidate_sha` — the broker derives the
+final candidate SHA itself (§4, v1.1.0 §A.4) and fails closed if it disagrees with the exported
+`verified_head_sha`.
 
 **Excluded — normative, not advisory:**
 
@@ -361,8 +393,10 @@ at attestation time (§3.3) and binds it in the attestation. Adding it to the ru
 |---|---|
 | **JSON envelope in `task_runs.metadata`** | Re-creates the parsing surface being eliminated, one layer deeper. No CHECK constraints, no FK, no uniqueness. |
 | **Fixed `artifact_1..artifact_n` columns** | Cannot express variable artifact counts; forces either truncation or a schema change per new artifact. |
-| **Final candidate SHA as broker-derived only** | Rejected after `t_5247914a` §4/§7. Storing only `subject_sha` makes the *"PR head ≠ requested head"* tamper check unevaluable at the run layer. Both SHAs are carried on every run (§4.1). |
-| **`board_slug` as a provenance field** | Measured, not assumed: every repository on this host maps to exactly one board (`account-gen` → 1 board, `hermes-agent` → 1 board; no repo appears under two boards). `repository_id` (immutable numeric) is sufficient identity scoping. Revisit only if multi-board-per-repo becomes real. |
+| **A run-level `final_candidate_sha` column** | Only knowable after the run is terminal, so writing it would require the mutation §5 prohibits, and it invites a false equivalence with the head the run actually verified. The run carries `subject_sha` + `verified_head_sha` (§4.1); the broker derives the final candidate SHA. |
+| **Storing only `subject_sha` on the run** | Rejected after `t_5247914a` §4/§7. One SHA makes the *"PR head ≠ requested head"* tamper check unevaluable at the run layer. Both **witnessed** SHAs are carried on every run (§4.1). |
+| **`board_slug` as a provenance field** | Measured, not assumed: every repository on this host maps to exactly one board (`account-gen` → 1 board, `hermes-agent` → 1 board; no repo appears under two boards). Each board additionally has its own `kanban.db` file, so a board column inside that file is a constant. `repository_id` (immutable numeric) is sufficient identity scoping. **No `board` or `board_slug` column appears in any table in this contract**, and `verify_adr0007_mechanisms.py` asserts its absence (N2). Revisit only if multi-board-per-repo becomes real. |
+| **`sha GLOB '[0-9a-f]*'` for hex validation** | Anchors only the first character; `'a'+'Z'*39` passes. Superseded by `NOT GLOB '*[^0-9a-f]*'` (§2.1, §2.2), demonstrated in `verify_adr0007_mechanisms.py`. |
 | **`role` as a stored column** | Forces a migration whenever a profile is reclassified, and creates a second place role can disagree with the dispatcher record. Derived at query time from protected-base policy instead (§2.3). |
 | **Broker-facing pull API / tunnel** | `t_5247914a` §3a: inverts the trust direction and couples fail-closed behaviour to laptop uptime. Push-per-run with an exporter-side cursor instead (§6). |
 | **Commit-count-based role independence** | Commit count is transport, not identity. Three commits by one actor prove nothing about independence. |
@@ -391,14 +425,18 @@ migration path and a backup verified by checksum before application. This is a
 
 ## §10 — Acceptance tests (executable)
 
+**Numbering is stable and global across v1.0.0 and v1.1.0.** A1–A18 below are owned by this
+document. v1.1.0 §C.1 adds A19 and upward; it does **not** renumber anything here.
+
 | # | Test | Expected |
 |---|---|---|
 | A1 | Worker attempts to write `role` or `profile` on its own run | rejected; kernel value unchanged |
 | A2 | Worker supplies `{path, sha256}`; kernel stamps `created_at` | row present, hash matches recomputed digest |
 | A3 | Same profile produces `code_review` and `security` terminal runs | evaluator **FAIL** (§3.2) |
 | A4 | Three distinct profiles across the three required roles | evaluator **PASS** |
-| A5 | `subject_sha` of 39 chars, uppercase, or non-hex | CHECK rejects |
-| A6 | UPDATE any field on a terminal run | rejected |
+| A5 | `subject_sha` / `verified_head_sha` hostile values: `'a'+'Z'*39`, `'a'*39+'g'`, `'A'*40`, `'aB'*20`, 39 chars, 41 chars, embedded space | CHECK rejects **every** case (§2.1; `GLOB '[0-9a-f]*'` would accept the first two) |
+| A5b | `run_artifacts.sha256` hostile values: `'c'*63+'Z'`, `'c'+'Z'*63`, `'C'*64`, 63 chars | CHECK rejects every case (§2.2) |
+| A6 | UPDATE any field on a terminal run | rejected — see v1.1.0 §B for the enforcing mechanism (a documented prohibition alone does not reject it) |
 | A7 | Two correction rows target the same `corrects_run_id` | broker **fails closed**, no export |
 | A8 | `corrects_run_id` points at a non-existent row | broker **fails closed** |
 | A9 | Duplicate `(run_id, artifact_path)` | UNIQUE violation |
@@ -406,11 +444,14 @@ migration path and a backup verified by checksum before application. This is a
 | A11 | Run with `provenance_version = NULL` (legacy) | excluded from export, not an error |
 | A12 | Export payload inspected for `summary` / `error` / `body` | absent (§6.1) |
 | A13 | Export payload inspected for any absolute path (`/Users/…`) | absent; only repo-relative `artifact_path` (§6.1) |
-| A14 | Implementation run: `subject_sha` vs `final_candidate_sha` | equal; **not** special-cased, both populated (§4.1) |
-| A15 | Review run where branch advanced after review | `final_candidate_sha != subject_sha`; broker fails closed on `PR head != expected_head_sha` |
+| A14 | Implementation run: `subject_sha` vs `verified_head_sha` | equal; **not** special-cased, both populated (§4.1) |
+| A15 | Review run where branch advanced after review | `verified_head_sha != subject_sha`; broker fails closed on `PR head != expected_head_sha` |
 | A16 | Same `(repository_id, task_id, run_id)` resubmitted with a different outcome | mirror **rejects**; first write wins (§6) |
 | A17 | Exporter restarted after downtime | resumes from its own cursor; no duplicate envelopes, no gap |
 | A18 | Profile absent from the protected-base `profile → role` map | role unresolved → gate **FAIL**, never defaulted (§2.3) |
+
+v1.1.0 §C.1 continues this table at **A19**. A13–A18 above remain in force and are **not**
+superseded by it.
 
 ---
 
@@ -418,7 +459,7 @@ migration path and a backup verified by checksum before application. This is a
 
 Design constraints in §3.2, §3.3 and §4 were supplied by `platform-engineer` (card `t_8c86298c`
 consultation) and **corrected two errors** in the author's earlier model: commit-level rather than
-run-level independence, and final candidate SHA held as a run column. Both are recorded in §8 as
+run-level independence, and a final-candidate SHA held as a run column. Both are recorded in §8 as
 rejected alternatives so the reasoning survives the decision.
 
 Schema facts in §1 were read from the live database, not recalled.

--- a/docs/design/kanban-run-provenance-v1.0.0.md
+++ b/docs/design/kanban-run-provenance-v1.0.0.md
@@ -288,7 +288,7 @@ fail-closed behaviour to laptop uptime.)
 - **The monotonic cursor is the exporter's, not the broker's.** The exporter tracks the highest
   exported `task_events.id` **against local Kanban** so it can resume after being offline. This is
   deliberately *not* a `give-me-everything-after-N` API the broker calls; exposing that would
-  re-create the pull surface §3b rejected.
+  re-create the pull surface `t_5247914a` §3b rejected.
 - **Detection without polling prose:** a `provenance_ready` row in `task_events` (`kind` is already a
   first-class column; `idx_events_run` already exists) emitted by the kernel at terminalization.
 - **Exporter credentials must be read-only against the canonical SQLite.** An exporter that can

--- a/docs/design/kanban-run-provenance-v1.0.0.md
+++ b/docs/design/kanban-run-provenance-v1.0.0.md
@@ -67,7 +67,8 @@ task_events (6 cols)
 | Column | Type | Null | Writer | Notes |
 |---|---|---|---|---|
 | `subject_sha` | TEXT | yes until claim | **kernel only** | Full 40-char lowercase hex. Captured at claim from the typed task target. Never writable via the worker path. |
-| `role` | TEXT | no | **kernel only** | Enum: `implementation`, `code_review`, `qa`, `security`. Derived from dispatch, not caller-supplied. |
+| `final_candidate_sha` | TEXT | yes | **kernel only** | Full 40-char lowercase hex. The head the run's verdict binds to. Populated on **every** run type; collapses to `subject_sha` for implementation runs. See §4.1. |
+| `role` | TEXT | no | **kernel only** | Enum: `implementation`, `code_review`, `qa`, `security`. **Derived at query/export time** from a static `profile → role` lookup; see §2.3. |
 | `provenance_version` | INTEGER | no | kernel | Starts at `1`. Lets a future schema change be detected rather than silently reinterpreted. |
 | `corrects_run_id` | INTEGER | yes | kernel | FK → `task_runs(id)`. Non-null only on correction rows (§5). |
 
@@ -154,14 +155,62 @@ persisted belongs to the DSSE trust design (§7 seam), not to this schema.
 
 ---
 
+### §2.3 — `role` is derived, not stored
+
+`role` is **not** a persisted column. It is resolved at query/export time through a static
+`profile → role` map pinned in protected-base policy:
+
+```
+code-reviewer     -> code_review
+qa-verifier       -> qa
+security-reviewer -> security
+<implementer>     -> implementation
+```
+
+**Rationale (`research-scout`, `t_5247914a`):** persisting a coarser `role` alongside `profile`
+forces a data migration every time a profile is reclassified, and creates a second place where role
+can disagree with the dispatcher record. `profile` is the kernel-stamped fact; `role` is a view over
+it. Recorded as an opinion adopted, not a research finding — the memo is explicit that it only ever
+modelled `profile` / `authenticated_profile`.
+
+Consequence for §3.2: independence is asserted over **distinct `profile` values**, with the map
+applied to check role coverage. The map lives in protected-base policy so a candidate cannot
+reclassify a profile into a role it did not perform.
+
+---
+
 ## §4 — Subject SHA vs final candidate SHA
 
 | | Subject SHA | Final candidate SHA |
 |---|---|---|
-| Meaning | the commit that was reviewed | the assembled PR head |
-| Known at | claim time | after multi-commit assembly |
-| Stored | `task_runs.subject_sha` | **not stored on the run** |
-| Written by | kernel, at claim | broker, at attestation |
+| Meaning | the commit the run's work was performed against | the head the run's verdict binds to |
+| Known at | claim time | run-completion time |
+| Stored | `task_runs.subject_sha` | `task_runs.final_candidate_sha` |
+| Written by | kernel, at claim | kernel, at terminalization |
+
+### §4.1 — Both SHAs on every run (corrected)
+
+An earlier revision of this document stored **only** `subject_sha` on the run and left the final
+candidate SHA entirely to broker derivation. **That was wrong**, and `research-scout` (`t_5247914a`
+§4, §7) supplied the correction:
+
+- Carry **both** `subject_sha` and `final_candidate_sha` on **every** run, uniformly. Do **not**
+  make it conditional on run type.
+- For implementation runs the two collapse to the same value. That redundancy is harmless — special-
+  casing it costs more than it saves and creates a branch where a field can be legitimately absent.
+- For review / QA / security runs they can **legitimately diverge**: the branch may advance between
+  the commit a run reviewed and the head an attestation is later requested against.
+
+**That divergence is the tamper check, not a defect.** It is what makes the broker's fail-closed
+condition *"PR head ≠ requested `expected_head_sha`"* (`t_5247914a` §7) evaluable at all. A schema
+that stored only one SHA would have made stale-evidence rebinding undetectable at the run layer.
+
+This does **not** conflict with §5 immutability: `final_candidate_sha` is written by the kernel at
+terminalization, in the same transition that sets `ended_at`. It is never a post-terminal write.
+
+The broker still independently re-derives and binds the final candidate SHA in the attestation
+(§3.3). The run field is *provenance*; the attestation field is *authority*. They must agree, and
+the broker fails closed if they do not.
 
 **Why subject SHA must come from a kernel-captured typed task target** (not worker JSON, not the
 evidence branch HEAD): if it is read from branch HEAD, the worker chooses *what was reviewed* after
@@ -199,17 +248,46 @@ bounded.
 
 ## §6 — Export
 
-- The exporter selects terminal runs with a non-null `subject_sha` and complete `run_artifacts`.
-  **Prose is never parsed.**
-- **Detection without polling prose:** a `provenance_ready` row in `task_events` (kind is already a
-  first-class column, `idx_events_run` already exists) emitted by the kernel at terminalization.
-- **Watermark/idempotency:** the exporter tracks the highest exported `task_events.id`. Re-export of
-  an already-watermarked run is a no-op, not a duplicate.
+**Transport: push-per-terminal-run. There is no broker-facing pull surface.** (`t_5247914a` §3b,
+which rejected tunnel/always-on reachability as inverting the trust direction and coupling
+fail-closed behaviour to laptop uptime.)
+
+- The exporter watches run-completion events and **POSTs one envelope per completed gate-relevant
+  run**. The broker never reaches into local SQLite — the operator's laptop is neither reachable nor
+  an Actions runner.
+- **Idempotency key: `(repository_id, task_id, run_id)`.** The broker's insert-only mirror rejects
+  resubmission with a different outcome or SHA for the same key.
+- **The monotonic cursor is the exporter's, not the broker's.** The exporter tracks the highest
+  exported `task_events.id` **against local Kanban** so it can resume after being offline. This is
+  deliberately *not* a `give-me-everything-after-N` API the broker calls; exposing that would
+  re-create the pull surface §3b rejected.
+- **Detection without polling prose:** a `provenance_ready` row in `task_events` (`kind` is already a
+  first-class column; `idx_events_run` already exists) emitted by the kernel at terminalization.
 - **Exporter credentials must be read-only against the canonical SQLite.** An exporter that can
   rewrite the source of truth is not an exporter.
-- **Minimal export:** `{run_id, task_id, profile, role, outcome, subject_sha, artifacts[], ended_at}`.
-  No `summary`, no `error`, no `body` — those may carry paths, tokens, or user content.
-- Missing or ambiguous fields **fail closed**: no attestation.
+- If the laptop is off, only *new* runs go unmirrored and the broker fails closed for those specific
+  runs — cleanly, rather than flapping.
+
+### §6.1 — Minimal export (exclusions are normative)
+
+Exported per run: `{run_id, task_id, profile, outcome, subject_sha, final_candidate_sha,
+artifact_relative_path, sha256, completed_at}`.
+
+**Excluded — normative, not advisory:**
+
+| Excluded | Why |
+|---|---|
+| card bodies, other cards, comment text | `t_5247914a` §3b minimal-field list |
+| `summary`, `error`, `result` | may carry paths, tokens, or user content |
+| artifact **contents** | only path + digest ever crosses the wire |
+| **absolute workspace paths** | `/Users/<name>/…` leaks machine identity and OS username |
+
+The last row is an addition from `research-scout` and is worth stating explicitly because the
+earlier field list named `workspace_path` unqualified. **Only repo-relative artifact paths are
+exported.** An absolute path is both a privacy leak and useless to a broker that cannot see the
+filesystem.
+
+Missing or ambiguous fields **fail closed**: no attestation.
 
 ---
 
@@ -283,7 +361,10 @@ at attestation time (§3.3) and binds it in the attestation. Adding it to the ru
 |---|---|
 | **JSON envelope in `task_runs.metadata`** | Re-creates the parsing surface being eliminated, one layer deeper. No CHECK constraints, no FK, no uniqueness. |
 | **Fixed `artifact_1..artifact_n` columns** | Cannot express variable artifact counts; forces either truncation or a schema change per new artifact. |
-| **Final candidate SHA as a run column** | Only knowable post-assembly, i.e. post-terminal. Would require mutating an immutable row (§5). |
+| **Final candidate SHA as broker-derived only** | Rejected after `t_5247914a` §4/§7. Storing only `subject_sha` makes the *"PR head ≠ requested head"* tamper check unevaluable at the run layer. Both SHAs are carried on every run (§4.1). |
+| **`board_slug` as a provenance field** | Measured, not assumed: every repository on this host maps to exactly one board (`account-gen` → 1 board, `hermes-agent` → 1 board; no repo appears under two boards). `repository_id` (immutable numeric) is sufficient identity scoping. Revisit only if multi-board-per-repo becomes real. |
+| **`role` as a stored column** | Forces a migration whenever a profile is reclassified, and creates a second place role can disagree with the dispatcher record. Derived at query time from protected-base policy instead (§2.3). |
+| **Broker-facing pull API / tunnel** | `t_5247914a` §3a: inverts the trust direction and couples fail-closed behaviour to laptop uptime. Push-per-run with an exporter-side cursor instead (§6). |
 | **Commit-count-based role independence** | Commit count is transport, not identity. Three commits by one actor prove nothing about independence. |
 | **Branch name as identity anchor** | Worker-influenced and mutable — same class as trusting caller-supplied role JSON. |
 | **UPDATE-in-place corrections** | Destroys the audit trail and lets consumed provenance change under an emitted attestation. |
@@ -323,7 +404,13 @@ migration path and a backup verified by checksum before application. This is a
 | A9 | Duplicate `(run_id, artifact_path)` | UNIQUE violation |
 | A10 | Re-export an already-watermarked run | no-op, no duplicate attestation |
 | A11 | Run with `provenance_version = NULL` (legacy) | excluded from export, not an error |
-| A12 | Export payload inspected for `summary` / `error` / `body` | absent (§6 minimal export) |
+| A12 | Export payload inspected for `summary` / `error` / `body` | absent (§6.1) |
+| A13 | Export payload inspected for any absolute path (`/Users/…`) | absent; only repo-relative `artifact_path` (§6.1) |
+| A14 | Implementation run: `subject_sha` vs `final_candidate_sha` | equal; **not** special-cased, both populated (§4.1) |
+| A15 | Review run where branch advanced after review | `final_candidate_sha != subject_sha`; broker fails closed on `PR head != expected_head_sha` |
+| A16 | Same `(repository_id, task_id, run_id)` resubmitted with a different outcome | mirror **rejects**; first write wins (§6) |
+| A17 | Exporter restarted after downtime | resumes from its own cursor; no duplicate envelopes, no gap |
+| A18 | Profile absent from the protected-base `profile → role` map | role unresolved → gate **FAIL**, never defaulted (§2.3) |
 
 ---
 

--- a/docs/design/kanban-run-provenance-v1.0.0.md
+++ b/docs/design/kanban-run-provenance-v1.0.0.md
@@ -1,0 +1,342 @@
+# Contract: Structured Run Provenance for Hermes Kanban
+
+- **Version:** 1.0.0-draft
+- **Status:** Proposed — awaiting `factory-director` routing, then security review
+- **Author:** `solution-architect`, card `t_8c86298c`
+- **Date:** 2026-08-20
+- **Supersedes:** free-text subject/final SHA in `task_runs.summary` / `task_runs.metadata` prose
+
+---
+
+## §0 — Problem
+
+The provenance broker (research `t_5247914a`) needs, per gated candidate:
+
+```
+{run_id, task_id, authenticated profile, outcome, implementation subject SHA,
+ final candidate SHA, artifact paths + sha256, completed_at}
+```
+
+Today subject and final SHA commonly live in comments, `summary`, or `metadata` prose. **Parsing
+prose is a tamper and ambiguity surface.** A worker writes the text; a worker can therefore choose
+what the exporter reads. The canonical authority is the local Kanban SQLite database, so the fix is
+to make these fields *structured columns the kernel owns*, not text the worker composes.
+
+This document decides the schema, who may write each field, mutability, and the trust seam to the
+DSSE attestation design. It is a contract decision, not an implementation.
+
+---
+
+## §1 — Source anchors (verified, not recalled)
+
+Read-only inspection of the live board DB (`immutable=1` open, no writes):
+
+```
+db: ~/.hermes/kanban/boards/hermes-agent/kanban.db
+
+task_runs (16 cols)
+  id PK, task_id NOT NULL, profile, step_key, status NOT NULL, claim_lock,
+  claim_expires, worker_pid, max_runtime_seconds, last_heartbeat_at,
+  started_at NOT NULL, ended_at, outcome, summary, metadata, error
+  indexes: idx_runs_status, idx_runs_task
+
+tasks (37 cols)
+  ... branch_name, project_id, current_run_id, idempotency_key, session_id ...
+
+task_events (6 cols)
+  id PK, task_id NOT NULL, run_id, kind NOT NULL, payload, created_at
+  indexes: idx_events_run, idx_events_task
+```
+
+**Two facts from the schema shape the decision:**
+
+1. `task_runs.profile` and `task_runs.outcome` **already exist as first-class columns.** The
+   additive-columns-vs-envelope question is therefore not symmetric — half the required fields are
+   already structured. Only the SHAs and artifact hashes live in prose.
+2. `task_runs.metadata` is a TEXT blob. It is the surface being eliminated, so the contract must not
+   solve the problem by putting a new JSON schema *inside* it.
+
+---
+
+## §2 — Decision
+
+**Additive typed columns on `task_runs`, plus one child table for artifacts. No envelope blob.**
+
+### §2.1 `task_runs` — new columns
+
+| Column | Type | Null | Writer | Notes |
+|---|---|---|---|---|
+| `subject_sha` | TEXT | yes until claim | **kernel only** | Full 40-char lowercase hex. Captured at claim from the typed task target. Never writable via the worker path. |
+| `role` | TEXT | no | **kernel only** | Enum: `implementation`, `code_review`, `qa`, `security`. Derived from dispatch, not caller-supplied. |
+| `provenance_version` | INTEGER | no | kernel | Starts at `1`. Lets a future schema change be detected rather than silently reinterpreted. |
+| `corrects_run_id` | INTEGER | yes | kernel | FK → `task_runs(id)`. Non-null only on correction rows (§5). |
+
+`profile`, `outcome`, `ended_at` are **existing** columns and are reused as-is. `completed_at` for
+export purposes is `ended_at`; no new column.
+
+**CHECK constraints (fail-closed at write time):**
+```sql
+CHECK (subject_sha IS NULL OR (length(subject_sha) = 40 AND subject_sha GLOB '[0-9a-f]*'))
+CHECK (role IN ('implementation','code_review','qa','security'))
+CHECK (provenance_version >= 1)
+```
+
+### §2.2 New table `run_artifacts`
+
+```sql
+CREATE TABLE run_artifacts (
+  id            INTEGER PRIMARY KEY,
+  run_id        INTEGER NOT NULL REFERENCES task_runs(id),
+  artifact_path TEXT    NOT NULL,
+  sha256        TEXT    NOT NULL,
+  created_at    INTEGER NOT NULL,
+  UNIQUE(run_id, artifact_path),
+  CHECK (length(sha256) = 64 AND sha256 GLOB '[0-9a-f]*')
+);
+CREATE INDEX idx_run_artifacts_run ON run_artifacts(run_id);
+```
+
+One-to-many, per `platform-engineer`'s constraint. `UNIQUE(run_id, artifact_path)` is deliberate:
+double-recording an artifact becomes an error rather than a silent duplicate, closing one of the
+ambiguity surfaces this card exists to eliminate.
+
+---
+
+## §3 — Trust semantics
+
+### §3.1 Who may write what
+
+| Field | Worker | Kernel | Broker |
+|---|---|---|---|
+| `artifact_path`, `sha256` | **supplies** (pre-terminal) | validates + stamps `created_at` | reads |
+| `subject_sha` | never | **stamps at claim** | reads |
+| `role`, `profile` | never | **stamps at dispatch** | reads |
+| `outcome` | never | **derives from transition** | reads |
+| `ended_at` | never | stamps at terminalization | reads |
+| final candidate SHA | never | never | **derives** (§4) |
+
+**Invariant:** a caller-supplied role, outcome, or identity is a *claim*, never authentication. The
+worker's only provenance input is `{artifact_path, sha256}` pairs, and even those are hashes over
+content the broker can re-verify independently.
+
+### §3.2 Role independence is per-RUN, not per-commit
+
+Corrected from an earlier draft after `platform-engineer` review. **Commit count is transport; run
+identity is provenance.** One run can emit three commits; three commits can be assembled by one
+actor. Neither demonstrates that review, QA and security were performed by distinct principals.
+
+The evaluator asserts, over **terminal `task_runs` rows**:
+
+1. For each required role in `{code_review, qa, security}` (+ `implementation` when represented),
+   at least one terminal run exists with that `role`.
+2. The `profile` values across those required roles are **pairwise distinct**.
+
+> The same profile satisfying two required roles is a **FAIL**, not a warning. Self-review is the
+> exact failure this table exists to prevent.
+
+This is enforceable *only* because `profile` is kernel-stamped: a worker cannot write another
+profile's name into its own run row.
+
+### §3.3 Repository and PR identity
+
+- The run stores **locators**, not authority.
+- The run does **not** carry a PR number. A PR may not exist when the run ends; requiring it would
+  force either a nullable field everyone treats as optional, or a write after terminalization —
+  which §5 prohibits.
+- The broker independently **resolves and validates** `owner/repo` and PR number to immutable
+  numeric GitHub IDs at attestation time, and binds those.
+- **Branch name is never an authority.** It is worker-influenced and mutable; trusting it is the
+  same defect class as trusting a role string in candidate JSON. It may serve as a resolution
+  *hint* only.
+
+`repo_numeric_id` is deliberately **not** added to `task_runs` in v1.0.0. Whether it must be
+persisted belongs to the DSSE trust design (§7 seam), not to this schema.
+
+---
+
+## §4 — Subject SHA vs final candidate SHA
+
+| | Subject SHA | Final candidate SHA |
+|---|---|---|
+| Meaning | the commit that was reviewed | the assembled PR head |
+| Known at | claim time | after multi-commit assembly |
+| Stored | `task_runs.subject_sha` | **not stored on the run** |
+| Written by | kernel, at claim | broker, at attestation |
+
+**Why subject SHA must come from a kernel-captured typed task target** (not worker JSON, not the
+evidence branch HEAD): if it is read from branch HEAD, the worker chooses *what was reviewed* after
+review happened. Capturing at claim makes the subject an **input** to the work rather than an
+**output** of it.
+
+**Why final candidate SHA is not a run field:** it is only knowable after assembly — i.e. after the
+run is terminal — and §5 makes terminal runs immutable. Storing it on the run would require exactly
+the mutation this contract prohibits.
+
+---
+
+## §5 — Mutability and corrections
+
+**Terminal runs are immutable.** Once `status` is terminal and `ended_at` is set, no field on that
+row may be UPDATEd.
+
+Corrections are **append-only**: a new `task_runs` row with `corrects_run_id` pointing at the row
+being corrected.
+
+Broker obligations — all **fail-closed**:
+
+1. A correction **may not** alter provenance already consumed by an emitted attestation.
+2. The broker **MUST reject ambiguous or unresolved correction chains**: two corrections of the same
+   row, a cycle, or a dangling `corrects_run_id`. This is a hard fail, **not** a
+   last-write-wins tiebreak.
+3. The exporter reads the resolved head of a chain. An unresolvable chain yields **no export**,
+   never a guess.
+
+Commands and results stay **inside the hashed artifact**, not in DB columns. The DB holds identity
+and hashes; the artifact holds the narrative. This keeps the tamper surface small and row size
+bounded.
+
+---
+
+## §6 — Export
+
+- The exporter selects terminal runs with a non-null `subject_sha` and complete `run_artifacts`.
+  **Prose is never parsed.**
+- **Detection without polling prose:** a `provenance_ready` row in `task_events` (kind is already a
+  first-class column, `idx_events_run` already exists) emitted by the kernel at terminalization.
+- **Watermark/idempotency:** the exporter tracks the highest exported `task_events.id`. Re-export of
+  an already-watermarked run is a no-op, not a duplicate.
+- **Exporter credentials must be read-only against the canonical SQLite.** An exporter that can
+  rewrite the source of truth is not an exporter.
+- **Minimal export:** `{run_id, task_id, profile, role, outcome, subject_sha, artifacts[], ended_at}`.
+  No `summary`, no `error`, no `body` — those may carry paths, tokens, or user content.
+- Missing or ambiguous fields **fail closed**: no attestation.
+
+---
+
+## §7 — Seam to the DSSE design (deliberately deferred)
+
+This contract does **not** decide:
+
+- whether the attestation must bind numeric repo ID and PR number;
+- the DSSE envelope format or signing primitive.
+
+Those belong to the security trust design. This document names the seam so the two cannot silently
+disagree: `repo_numeric_id` is **absent in v1.0.0**, and adding it is a `provenance_version` bump.
+
+**Authoritative DSSE design: `t_8513bc6e`** — *"Security design: authenticate PR #36 reviewer roles
+without candidate-controlled trust"*, `status=done`, `assignee=security-reviewer`, created by
+`factory-director`. Its first `security-reviewer` comment (`created_at=1787270558`, 12,139 chars) is
+the binding recommendation.
+
+> **Correction to an earlier revision of this document.** A prior draft recorded `t_8513bc6e` as
+> non-existent. That was **my error, not a dangling reference.** The card is present in
+> `~/.hermes/kanban/boards/account-gen/kanban.db` (156 tasks). The CLI board resolver misrouted the
+> lookup — the known defect carded as `t_9b4f8ded` (*explicit `--board` ignored when
+> `HERMES_KANBAN_DB` is set*). Verified by opening the DB directly, read-only:
+> `t_8513bc6e: PRESENT`. Absence of a CLI result is not evidence of absence when the resolver
+> itself is under repair.
+
+### §7.1 — Binding constraint from `t_8513bc6e` (changes this contract)
+
+The security design answers **YES** to the question of whether the shared GitHub identity defeats
+API-derived role provenance:
+
+> *"the shared `SiWarlock` GitHub identity makes the GitHub review API insufficient by itself. The
+> API authenticates one GitHub account, association and review `commit_id`; it cannot distinguish
+> `code-reviewer`, `qa-verifier`, and `security-reviewer`."*
+
+Independently verified against the live repository:
+
+```
+gh pr view 36 --json reviews   ->  [{"author": "SiWarlock", "state": "COMMENTED"}]
+git log --format='%an' -8 origin/main   ->  8x "Cody Clayton"
+```
+
+Every factory role acts through **one** GitHub account. Therefore GitHub review-API identity is
+**necessary but not sufficient**: it authenticates *repository, PR, and `commit_id`*, and cannot
+authenticate *which factory role performed the review*.
+
+**This is precisely why §3.2's kernel-stamped `task_runs.profile` is the trust anchor.** The Kanban
+run record is the only place where role is established by the dispatcher rather than asserted by
+the actor. The security design states the same conclusion independently:
+
+> *"Kanban run profile/claim records, not artifact fields or comments, establish role."*
+
+Division of authority, now settled:
+
+| Fact | Authenticated by |
+|---|---|
+| repository identity, PR number, head SHA | GitHub API (numeric IDs) |
+| **factory role** (`code_review` / `qa` / `security`) | **kernel-stamped `task_runs.profile`** |
+| artifact content | SHA-256 recomputed from git objects by the broker |
+| the binding of all of the above | DSSE/in-toto attestation, asymmetric KMS/HSM key |
+
+`repo_numeric_id` remains **absent from `task_runs` in v1.0.0**: the broker resolves it from GitHub
+at attestation time (§3.3) and binds it in the attestation. Adding it to the run row would be a
+`provenance_version` bump, and `t_8513bc6e` does not require run-level persistence.
+
+---
+
+## §8 — Rejected alternatives
+
+| Alternative | Why rejected |
+|---|---|
+| **JSON envelope in `task_runs.metadata`** | Re-creates the parsing surface being eliminated, one layer deeper. No CHECK constraints, no FK, no uniqueness. |
+| **Fixed `artifact_1..artifact_n` columns** | Cannot express variable artifact counts; forces either truncation or a schema change per new artifact. |
+| **Final candidate SHA as a run column** | Only knowable post-assembly, i.e. post-terminal. Would require mutating an immutable row (§5). |
+| **Commit-count-based role independence** | Commit count is transport, not identity. Three commits by one actor prove nothing about independence. |
+| **Branch name as identity anchor** | Worker-influenced and mutable — same class as trusting caller-supplied role JSON. |
+| **UPDATE-in-place corrections** | Destroys the audit trail and lets consumed provenance change under an emitted attestation. |
+
+---
+
+## §9 — Migration and compatibility
+
+1. All new columns are **additive and nullable-on-existing-rows**. Existing rows read as
+   `provenance_version = NULL` → treated as *legacy, unattestable*.
+2. **No backfill.** A backfilled subject SHA would be inferred, not captured — inferred provenance
+   is exactly what this contract removes. Legacy runs are excluded from export rather than
+   retroactively blessed.
+3. `run_artifacts` is a new table; absence is indistinguishable from "no artifacts recorded", so the
+   evaluator requires `provenance_version >= 1` before asserting anything about artifacts.
+4. Rollback: drop `run_artifacts`, drop the four added columns. No existing column changes type or
+   nullability, so rollback cannot corrupt pre-existing rows.
+
+**Blast radius:** schema change to the kernel DB used by every board and every bot. Requires a
+migration path and a backup verified by checksum before application. This is a
+`factory-director` apply decision, not an implementer's.
+
+---
+
+## §10 — Acceptance tests (executable)
+
+| # | Test | Expected |
+|---|---|---|
+| A1 | Worker attempts to write `role` or `profile` on its own run | rejected; kernel value unchanged |
+| A2 | Worker supplies `{path, sha256}`; kernel stamps `created_at` | row present, hash matches recomputed digest |
+| A3 | Same profile produces `code_review` and `security` terminal runs | evaluator **FAIL** (§3.2) |
+| A4 | Three distinct profiles across the three required roles | evaluator **PASS** |
+| A5 | `subject_sha` of 39 chars, uppercase, or non-hex | CHECK rejects |
+| A6 | UPDATE any field on a terminal run | rejected |
+| A7 | Two correction rows target the same `corrects_run_id` | broker **fails closed**, no export |
+| A8 | `corrects_run_id` points at a non-existent row | broker **fails closed** |
+| A9 | Duplicate `(run_id, artifact_path)` | UNIQUE violation |
+| A10 | Re-export an already-watermarked run | no-op, no duplicate attestation |
+| A11 | Run with `provenance_version = NULL` (legacy) | excluded from export, not an error |
+| A12 | Export payload inspected for `summary` / `error` / `body` | absent (§6 minimal export) |
+
+---
+
+## §11 — Provenance of this document
+
+Design constraints in §3.2, §3.3 and §4 were supplied by `platform-engineer` (card `t_8c86298c`
+consultation) and **corrected two errors** in the author's earlier model: commit-level rather than
+run-level independence, and final candidate SHA held as a run column. Both are recorded in §8 as
+rejected alternatives so the reasoning survives the decision.
+
+Schema facts in §1 were read from the live database, not recalled.
+
+**Security review is a required next gate and has not occurred.** At time of writing,
+`security-reviewer` returns HTTP 402 provider billing errors rather than opinions (observed on
+`t_bde9863c`, escalated to `factory-director`). This contract must not be treated as
+security-approved.

--- a/docs/design/kanban-run-provenance-v1.1.0-correction.md
+++ b/docs/design/kanban-run-provenance-v1.1.0-correction.md
@@ -326,7 +326,7 @@ Proven, in order of the assertions in this document:
   described — while the normative `NOT GLOB '*[^0-9a-f]*'` CHECKs reject
   `'a'+'Z'*39`, `'a'*39+'g'`, `'A'*40`, `'aB'*20`, 39 chars, 41 chars and
   an embedded space, on **both** `subject_sha` and `verified_head_sha`,
-  and reject the 64-char equivalents on `run_evidence.sha256`. Valid
+  and reject the 64-char equivalents on `run_artifacts.sha256`. Valid
   full-length lowercase hex is still accepted in each case. The Python
   `SHA40`/`SHA256` regexes are run over the same hostile table so the two
   validation layers cannot drift.

--- a/docs/design/kanban-run-provenance-v1.1.0-correction.md
+++ b/docs/design/kanban-run-provenance-v1.1.0-correction.md
@@ -1,0 +1,278 @@
+# Contract correction: Structured Run Provenance for Hermes Kanban — v1.1.0
+
+- **Version:** 1.1.0 (corrects v1.0.0-draft, attachment id 4,
+  sha256 `38d66a972800f501b6a6e776ea3076b0d1d12e51804a64c4171e9426ced741bd`)
+- **Status:** Proposed — security review is still a required, un-run gate
+- **Author:** `solution-architect`, card `t_8c86298c`, run 8
+- **Scope:** v1.0.0 remains in force **except** for §A and §B below.
+
+This is a correction, not a replacement. v1.0.0 §0–§4, §6, §8–§11 stand
+as written. Two changes are made, each for a stated cause: one is a
+binding director ruling that closes a seam v1.0.0 deliberately left
+open; the other is an enforceability defect I found in the live source
+after v1.0.0 was frozen.
+
+**Contract source for the security design:** attachment id 3,
+`security-design-t_8513bc6e-comment-573.md` (12,212 bytes). Verified
+this run: byte-identical to live account-gen comment 573 after
+whitespace normalization, differing only by a 67-character provenance
+header. All "comment 573 §N" references resolve to that attachment, not
+to a cross-board CLI lookup.
+
+**Executable evidence:** attachment `verify_adr0007_mechanisms.py`,
+36/36 checks passing. See §C.
+
+---
+
+## §A — Repository binding: seam closed (supersedes v1.0.0 §3.3, §7, §7.1)
+
+v1.0.0 §7 stated that whether the attestation must bind numeric repo ID
+and PR number "belongs to the security trust design", left
+`repo_numeric_id` absent, and specified that adding it "is a
+`provenance_version` bump". **factory-director has now ruled the
+requirement binding.** This document is that version bump; v1.0.0's own
+mechanism is being followed, not overridden.
+
+The ruling, applied:
+
+- The DSSE attestation MUST bind the immutable numeric GitHub repository
+  ID and the PR number, alongside trust-root commit, subject SHA, final
+  candidate SHA, policy version, artifact hashes, run/task IDs, and
+  authenticated profiles/outcomes.
+- These MUST NOT be parsed from comments, summary, or worker metadata.
+
+### §A.1 The nullable-vs-required rule
+
+v1.0.0 §3.3 rejected persisting a PR number because "a PR may not exist
+when the run ends; requiring it would force either a nullable field
+everyone treats as optional, or a write after terminalization". That
+objection (originally platform-engineer's) is correct and is **not**
+discarded. It is resolved by making the requirement *conditional on
+export finalization* rather than on run terminalization.
+
+Two columns and one flag:
+
+```sql
+repo_github_id   INTEGER,  -- immutable numeric GitHub repository id
+event_locator    TEXT,     -- 'pr:<number>' for PR gates; NULL otherwise
+export_finalized INTEGER NOT NULL DEFAULT 0
+```
+
+- **General local Kanban runs** (`export_finalized = 0`):
+  `repo_github_id` and `event_locator` MAY be NULL. Most factory work is
+  not a PR gate — research spikes, docs cards, scratch analysis — and
+  must not be forced to invent repository identity it does not have.
+  Such a run is simply never exported. This is the common case.
+- **Runs finalized for broker export** (`export_finalized = 1`): ALL of
+  `repo_github_id`, `event_locator` (the PR number for PR gates),
+  `subject_sha`, `verified_head_sha`, and every artifact `sha256` are
+  mandatory and non-NULL. Any missing, malformed, or ambiguous value
+  means the record is **not finalized and not exported**. Fail closed,
+  never fail open.
+
+Finalization is a **distinct, later step** than terminalization, run by
+the operator/exporter once the PR actually exists. This is what
+dissolves the original objection: nothing is written to a terminal run,
+and no field is nullable-but-secretly-required. A run that terminates
+before its PR exists is simply not yet finalized.
+
+Because v1.0.0 §5 makes terminal rows immutable, finalization is
+implemented as an **insert** of a finalization record keyed to the run,
+not an UPDATE of the run row. A record that never finalizes is inert,
+which is the safe default.
+
+### §A.2 Provenance of the two new fields
+
+Neither is worker-writable, and neither is parsed from prose.
+
+- `repo_github_id` — resolved by the kernel from the workspace `origin`
+  remote via an authenticated GitHub API lookup, cached per repository.
+  If the lookup fails or is ambiguous the field stays NULL and the run
+  is not finalizable. It is **never** derived from the remote URL
+  string, because a remote URL is renameable and therefore not immutable
+  identity; comment 573 requires the immutable numeric id specifically.
+  This preserves v1.0.0 §3.3's "branch name is never an authority"
+  principle and extends it to remote strings.
+- `event_locator` — supplied at finalization. It remains a **locator,
+  not authority**, exactly as v1.0.0 §3.3 framed repository identity.
+  The broker still independently resolves and validates it against
+  GitHub and still requires exact PR-head equality (comment 573 §4.1).
+
+### §A.3 What did NOT change
+
+`final_candidate_sha` is still **not stored** on the run. v1.0.0 §4's
+reasoning is untouched and correct: it is knowable only after assembly,
+i.e. after the run is terminal, and storing it would require the
+mutation §5 prohibits. The director's ruling lists it among the
+attestation's mandatory fields — that is a requirement on the **DSSE
+attestation the broker assembles**, not on the Kanban record. Kanban
+supplies the two SHAs it can honestly witness (`subject_sha` at claim,
+and the head it actually verified); the broker derives the third.
+
+A Kanban column named `final_sha` would invite exactly the false
+equivalence this contract exists to prevent. Acceptance test A17 below
+guards against a future implementer helpfully adding one.
+
+---
+
+## §B — Immutability needs an enforcement mechanism (corrects v1.0.0 §5, A6)
+
+**This is a defect in v1.0.0, found by reading the live source after the
+document was frozen.** v1.0.0 §5 asserts "once `status` is terminal and
+`ended_at` is set, no field on that row may be UPDATEd", and test A6
+expects "UPDATE any field on a terminal run → rejected". v1.0.0 names no
+mechanism that would reject it, and in the current kernel nothing does.
+
+Source anchors, inspected at commit `fbb4454ed` in
+`/Users/dreddy/.hermes/hermes-agent`:
+
+- `edit_completed_task_result` (`hermes_cli/kanban_db.py:6181-6243`)
+  UPDATEs `task_runs.summary` at `:6220-6223` and `task_runs.metadata`
+  at `:6224-6228` on a run whose `outcome` is already `'completed'`.
+  A6 fails today.
+- `_end_run` (`:4350-4374`) UPDATEs the run row at terminalization, and
+  the reclaim path in `claim_task` (`:4662-4677`) UPDATEs it again.
+
+So `task_runs` is a legitimately-mutable table with at least three live
+UPDATE paths, one of which fires *after* completion. Placing an
+immutability guarantee on that table is unenforceable by assertion.
+
+**Correction.** The immutable terminal provenance record MUST live in
+its own append-only table protected by SQLite triggers, rather than
+relying on a documented prohibition against updating `task_runs`:
+
+```sql
+CREATE TRIGGER trg_run_provenance_no_update BEFORE UPDATE ON run_provenance
+BEGIN SELECT RAISE(ABORT, 'run_provenance is append-only'); END;
+CREATE TRIGGER trg_run_provenance_no_delete BEFORE DELETE ON run_provenance
+BEGIN SELECT RAISE(ABORT, 'run_provenance is append-only'); END;
+```
+
+Artifact rows carry a `sealed` flag flipped by the kernel at
+terminalization, with a `BEFORE UPDATE ... WHEN OLD.sealed = 1` trigger.
+Rows stay editable while the run is live (so a worker may re-declare
+before terminalizing) and become immutable the moment the run closes.
+
+v1.0.0's `corrects_run_id` append-only correction model (§5) is
+**unchanged and still correct**; this only adds the mechanism that makes
+"no UPDATE" true rather than merely stated.
+
+**Residual risk, stated plainly:** a local actor with write access to
+`kanban.db` can drop a trigger. SQLite has no in-database privilege
+separation. Triggers raise the cost of tampering and make casual or
+programmatic mutation fail loudly; they are not a defense against root
+on the box. Comment 573 already places canonical dispatcher records
+inside the trust boundary, so this does not widen it — and the broker's
+independent recomputation of every artifact digest from the git object
+(573 §4) is what actually catches a doctored record. **This specific
+tradeoff needs security-reviewer sign-off** (§D).
+
+### §B.1 Export cursor
+
+A consequence worth stating, because it is easy to get wrong: the export
+watermark must be monotonic in **terminalization order**, which
+`task_runs.id` is not — runs terminate out of creation order. The
+append-only provenance table's own AUTOINCREMENT `seq` provides this
+correctly. Verified empirically (§C): runs 99 and 50 terminating in that
+order receive ascending `seq` 5 and 6.
+
+This refines v1.0.0 §6's "highest exported `task_events.id`", which is
+directionally right but keys off a table that also receives unrelated
+events. Per research-scout, the cursor is **local-exporter-only** and is
+never exposed as a broker-facing pull surface: canonical Kanban is
+local-only and the broker must never reach into it.
+
+---
+
+## §C — Executable verification performed
+
+`verify_adr0007_mechanisms.py` (attached) exercises these mechanisms
+against real SQLite and real git, so the claims above are demonstrated
+rather than asserted:
+
+```
+python3 verify_adr0007_mechanisms.py     ->  36/36 checks passed
+```
+
+Proven, in order of the assertions in this document:
+
+- A row is written for **every** terminal outcome (completed, blocked,
+  crashed) — absence of a record can never itself be read as evidence;
+  only completed+SHAs+artifacts is `attestable=1`.
+- UPDATE and DELETE on the provenance table abort with
+  `sqlite3.IntegrityError: run_provenance is append-only`, and the
+  record survives the tamper attempt byte-identical (§B).
+- Sealed artifact rows reject writes; unsealed rows remain editable.
+- Duplicate `run_id` rejected; duplicate `(run_id, path)` rejected.
+- `seq` strictly ascending and in a different order from `run_id`,
+  proving the cursor tracks terminalization (§B.1).
+- Re-export from a watermark yields nothing; export digests unique.
+- A `mode=ro` connection raises `attempt to write a readonly database`,
+  confirming v1.0.0 §6's read-only exporter requirement is achievable.
+- Abbreviated (`a1b2c3d`) and uppercase SHAs rejected; 40-hex required.
+- Artifact digest is stable under input ordering and changes when any
+  hash changes.
+- A real file digest differs from a worker-claimed one — i.e. the kernel
+  must compute, never accept, the hash.
+- `git rev-parse` yields full 40-hex for HEAD and for tracked blobs; a
+  non-git scratch dir yields nothing, so scratch runs are structurally
+  non-attestable.
+- **§A specifically:** a complete gated run finalizes; a non-gated run
+  with NULL repo fields is legal but never finalizes; finalization fails
+  closed *naming the offending field* for each of the five mandatory
+  fields individually; a remote-string repo id, a malformed event
+  locator, an abbreviated SHA, and an unresolved correction chain are
+  each refused; and no `final_candidate_sha`/`final_sha` column exists.
+
+This is a mechanism probe against a model of the schema. It is **not** a
+substitute for the acceptance tests, which must run against the real
+kernel and belong to the implementer.
+
+### §C.1 Additional acceptance tests (extend v1.0.0 §10)
+
+v1.0.0 A1–A12 stand. Add:
+
+| # | Test | Expected |
+|---|---|---|
+| A13 | Non-gated run with NULL `repo_github_id`/`event_locator` | completes normally, `export_finalized=0`, never exported |
+| A14 | Finalization attempted with any one mandatory field missing | refused, fails closed, offending field named |
+| A15 | `origin` remote renamed | `repo_github_id` unchanged; remote string never accepted as identity |
+| A16 | Finalization performed | original provenance row byte-identical, digest unchanged |
+| A17 | Schema inspected for `final_candidate_sha` / `final_sha` | absent (guards §A.3) |
+| A18 | `edit_completed_task_result` called on a completed run | `summary`/`metadata` may change; provenance record digest **unchanged** |
+| A19 | Direct UPDATE/DELETE on provenance table | raises `sqlite3.IntegrityError` |
+| A20 | Runs terminating out of `run_id` order | export `seq` still ascending |
+
+A18 is the regression test for the §B defect specifically: the existing
+post-completion mutation path must remain functional for its own purpose
+while being provably unable to touch provenance.
+
+---
+
+## §D — Open items owned by others
+
+- **security-reviewer** (required next gate, has NOT occurred): sign-off
+  on §B's trigger-based immutability and its stated residual risk;
+  whether board slug is acceptable in the export payload or must be an
+  opaque id; sign-off on §A.1's nullable-vs-required split.
+- **platform-engineer**: implementation.
+- **broker / research-scout**: `final_candidate_sha` derivation stays
+  broker-side, out of scope here.
+
+Resolved, no longer open: repository id and PR number (§A, director
+ruling); DSSE source reference (attachment id 3, verified above).
+
+## §E — Limitations of this document
+
+1. **Not security-approved.** v1.0.0 §11's warning stands unchanged.
+2. §C is a probe against a schema model, not the live kernel. The
+   §C.1/§10 tests must be run against the real kernel before
+   implementation is considered verified.
+3. `repo_github_id` resolution assumes an authenticated GitHub API path
+   exists in the kernel for that lookup. I did not verify one exists;
+   if it does not, that is implementation work platform-engineer must
+   scope, and until then no run is finalizable.
+4. The §B residual risk (trigger-droppable by a local root actor) is
+   accepted-by-default here and explicitly routed to security-reviewer.
+5. I did not modify the Hermes repository, the live Kanban DB, or any
+   profile, per card scope.

--- a/docs/design/kanban-run-provenance-v1.1.0-correction.md
+++ b/docs/design/kanban-run-provenance-v1.1.0-correction.md
@@ -4,13 +4,31 @@
   sha256 `38d66a972800f501b6a6e776ea3076b0d1d12e51804a64c4171e9426ced741bd`)
 - **Status:** Proposed — security review is still a required, un-run gate
 - **Author:** `solution-architect`, card `t_8c86298c`, run 8
-- **Scope:** v1.0.0 remains in force **except** for §A and §B below.
+- **Revision:** review corrections B1–B4 / N1–N2 applied on card
+  `t_81217a6a`, against reviewed head `1ba7a03a` of PR #91194
+- **Scope:** v1.0.0 remains in force **except** where §A and §B below
+  supersede it. §A.4.1 enumerates the superseded v1.0.0 text exactly.
 
-This is a correction, not a replacement. v1.0.0 §0–§4, §6, §8–§11 stand
-as written. Two changes are made, each for a stated cause: one is a
-binding director ruling that closes a seam v1.0.0 deliberately left
-open; the other is an enforceability defect I found in the live source
-after v1.0.0 was frozen.
+This is a correction, not a replacement. v1.0.0 §0–§3, §5–§6, §9–§11
+stand as written; §2.1, §2.2, §4, §6.1, §8 and §10 are amended only where
+§A.4.1 lists them.
+
+Two substantive changes were made in the original v1.1.0, each for a
+stated cause: one is a binding director ruling that closes a seam v1.0.0
+deliberately left open (§A); the other is an enforceability defect found
+in the live source after v1.0.0 was frozen (§B).
+
+Four further corrections were then applied after formal code review of
+PR #91194 at `1ba7a03a` (findings B1–B4, N1–N2 on card `t_7b608af5`):
+
+| Finding | Resolution |
+|---|---|
+| B1 — ruff/UTF-8 errors in the verifier | verifier rewritten; clean under the repo ruff config and under `--select E,F,I,W` |
+| B2 — `GLOB '[0-9a-f]*'` validated only the first character | §A.5: negated-GLOB CHECKs, with hostile cases executed |
+| B3 — `final_candidate_sha` contradiction across §2.1/§4.1/§4 | §A.4: one normative three-SHA model; §A.4.1 enumerates superseded text |
+| B4 — §C.1 renumbering collided with v1.0.0 A13–A18 | §C.1: v1.1.0 additions start at A19; v1.0.0 A1–A18 preserved |
+| N1 — verifier docstring cited a nonexistent §5.5 | corrected to §A.1 |
+| N2 — verifier `board` column contradicted v1.0.0 §8 | §A.6: column removed; absence asserted |
 
 **Contract source for the security design:** attachment id 3,
 `security-design-t_8513bc6e-comment-573.md` (12,212 bytes). Verified
@@ -19,8 +37,8 @@ whitespace normalization, differing only by a 67-character provenance
 header. All "comment 573 §N" references resolve to that attachment, not
 to a cross-board CLI lookup.
 
-**Executable evidence:** attachment `verify_adr0007_mechanisms.py`,
-36/36 checks passing. See §C.
+**Executable evidence:** `verify_adr0007_mechanisms.py` (this directory),
+85/85 checks passing. See §C.
 
 ---
 
@@ -100,18 +118,117 @@ Neither is worker-writable, and neither is parsed from prose.
 
 ### §A.3 What did NOT change
 
-`final_candidate_sha` is still **not stored** on the run. v1.0.0 §4's
-reasoning is untouched and correct: it is knowable only after assembly,
-i.e. after the run is terminal, and storing it would require the
-mutation §5 prohibits. The director's ruling lists it among the
-attestation's mandatory fields — that is a requirement on the **DSSE
-attestation the broker assembles**, not on the Kanban record. Kanban
-supplies the two SHAs it can honestly witness (`subject_sha` at claim,
-and the head it actually verified); the broker derives the third.
+The seam closed here is repository binding only. v1.0.0's trust semantics
+(§3.1, §3.2), role derivation (§2.3), export exclusions (§6.1), and the
+append-only correction model (§5) are untouched.
 
-A Kanban column named `final_sha` would invite exactly the false
-equivalence this contract exists to prevent. Acceptance test A17 below
-guards against a future implementer helpfully adding one.
+### §A.4 `final_candidate_sha`: the single normative model (resolves B3)
+
+**This subsection is normative and overrides every other statement about
+`final_candidate_sha` in either document.** The reviewed revision of v1.0.0
+was internally inconsistent: §2.1 listed `final_candidate_sha` as a
+`task_runs` column, §4.1 instructed implementers to carry it on every run,
+and the closing paragraph of §4 said it is *not* a run field. An
+implementer could have built either schema from that text.
+
+**There are three SHAs, at two layers.**
+
+| SHA | Layer | Storage | Written by |
+|---|---|---|---|
+| `subject_sha` | Kanban run | `task_runs.subject_sha` (40-char lowercase hex) | kernel, at claim |
+| `verified_head_sha` | Kanban run | `task_runs.verified_head_sha` (40-char lowercase hex) | kernel, at terminalization |
+| final candidate SHA | DSSE attestation | **no Kanban column** | broker, at attestation time |
+
+Normative rules:
+
+1. Kanban stores exactly the two SHAs the kernel can **honestly witness**:
+   what the run started from, and what it had verified when it closed.
+   Both are populated on **every** run type; for implementation runs they
+   are equal, and that equality is not special-cased.
+2. **No table in this contract may define a column named
+   `final_candidate_sha` or `final_sha`.** The final candidate SHA is
+   derived and bound by the broker at attestation time. A Kanban column of
+   that name would assert authority the kernel does not have, and — since
+   it is knowable only after the run is terminal — writing it would require
+   the very post-terminal mutation v1.0.0 §5 forbids.
+3. The broker compares its derived final candidate SHA against the exported
+   `verified_head_sha` and **fails closed** on disagreement. That
+   comparison is the stale-evidence tamper check; it is only possible
+   because the run carries a witnessed head at all.
+4. Divergence between `subject_sha` and `verified_head_sha` on a review /
+   QA / security run is **legitimate** (the branch advanced), and is
+   evidence, not a defect.
+
+Acceptance test A25 below guards rule 2 against a future implementer
+helpfully adding the column back; the verifier asserts it directly.
+
+#### §A.4.1 Exactly which v1.0.0 text is superseded
+
+Enumerated so nothing is left to inference:
+
+| v1.0.0 location | Superseded text | Replaced by |
+|---|---|---|
+| §2.1 column table | the `final_candidate_sha` row and the `role` row | `verified_head_sha` row; `role` stays derived per §2.3 |
+| §2.1 CHECK block | `CHECK (subject_sha ... GLOB '[0-9a-f]*')` and `CHECK (role IN (...))` | negated-GLOB CHECKs on `subject_sha` and `verified_head_sha` (see §A.5) |
+| §2.2 | `CHECK (length(sha256) = 64 AND sha256 GLOB '[0-9a-f]*')` | `... AND sha256 NOT GLOB '*[^0-9a-f]*'` (§A.5) |
+| §4 heading + comparison table | two-column "Subject SHA vs Final candidate SHA" table storing `final_candidate_sha` on the run | three-SHA table in §4, matching the table above |
+| §4.1 | every occurrence of `final_candidate_sha` as a run field | `verified_head_sha` |
+| §4 closing paragraph | *"Why final candidate SHA is not a run field"* stated **after** §2.1/§4.1 said it was one | §4's *"Why the final candidate SHA is not a run column"*, now the only claim in force |
+| §6.1 export field list | `final_candidate_sha` in the exported envelope | `verified_head_sha` |
+| §8 | row *"Final candidate SHA as broker-derived only"* (which read as rejecting the model now adopted) | two rows: *"A run-level `final_candidate_sha` column"* (rejected) and *"Storing only `subject_sha`"* (rejected) |
+| §10 A14, A15 | `final_candidate_sha` in the expectations | `verified_head_sha` |
+
+Everything else in v1.0.0 §4 — the reasoning for capturing the subject at
+claim, and for carrying two SHAs rather than one — is **retained
+unchanged**. This corrects the naming and the layer, not the analysis.
+
+### §A.5 Hex validation must check every character (resolves B2)
+
+v1.0.0's CHECK constraints used `sha GLOB '[0-9a-f]*'`. In SQLite that
+pattern anchors only the **first** character: the trailing `*` then matches
+any 39 remaining characters, uppercase and non-hex included. Demonstrated
+executably (§C): `'a' + 'Z'*39` and `'a'*39 + 'g'` are both **accepted**.
+
+The normative form negates the complement class instead, so a character
+outside `[0-9a-f]` at *any* position aborts the write:
+
+```sql
+CHECK (subject_sha IS NULL OR (length(subject_sha) = 40
+       AND subject_sha NOT GLOB '*[^0-9a-f]*'))
+CHECK (verified_head_sha IS NULL OR (length(verified_head_sha) = 40
+       AND verified_head_sha NOT GLOB '*[^0-9a-f]*'))
+CHECK (length(sha256) = 64 AND sha256 NOT GLOB '*[^0-9a-f]*')
+```
+
+The explicit `length()` term is still required — GLOB alone cannot express
+"exactly 40". Hostile inputs are enumerated in v1.0.0 §10 A5/A5b and are
+executed by the verifier against both the SQL CHECKs and the Python
+`SHA40`/`SHA256` regexes, so the two layers cannot drift apart.
+
+### §A.6 No `board` column anywhere (resolves N2)
+
+The reviewed `verify_adr0007_mechanisms.py` declared
+`board TEXT NOT NULL` on `run_provenance` and carried `"board":
+"hermes-agent"` in the hashed record body. That **contradicted** v1.0.0 §8,
+which rejects board slug as a provenance field.
+
+Resolved in favour of §8: **the column is removed**, from the verifier DDL
+and from the record body it digests. Two reasons, both structural rather
+than stylistic:
+
+1. Kanban is already sharded per board on disk
+   (`~/.hermes/kanban/boards/<board>/kanban.db`), so a `board` column inside
+   one of those files stores a value that is constant for the whole file.
+   It is a label, not an identifier.
+2. §8's measurement stands: every repository on this host maps to exactly
+   one board, so board slug adds no identity scoping that
+   `repo_github_id` does not already provide — while adding a
+   human-renameable string to a record whose purpose is immutable identity.
+
+Consequently the §D open item *"whether board slug is acceptable in the
+export payload or must be an opaque id"* is **withdrawn, not deferred**:
+no board slug is exported, so security-reviewer has no such question to
+answer. Acceptance test A26 and a verifier check assert the absence.
 
 ---
 
@@ -186,19 +303,33 @@ local-only and the broker must never reach into it.
 
 ## §C — Executable verification performed
 
-`verify_adr0007_mechanisms.py` (attached) exercises these mechanisms
+`verify_adr0007_mechanisms.py` (this directory) exercises these mechanisms
 against real SQLite and real git, so the claims above are demonstrated
 rather than asserted:
 
 ```
-python3 verify_adr0007_mechanisms.py     ->  36/36 checks passed
+python3 verify_adr0007_mechanisms.py     ->  85/85 checks passed
 ```
+
+The count rose from 36 to 85 in this revision: the B2 correction added
+hostile-input cases against both SQL CHECKs and the Python regexes, and
+B3/N2 added structural assertions about which columns must and must not
+exist.
 
 Proven, in order of the assertions in this document:
 
 - A row is written for **every** terminal outcome (completed, blocked,
   crashed) — absence of a record can never itself be read as evidence;
   only completed+SHAs+artifacts is `attestable=1`.
+- **§A.5 specifically (B2):** the superseded `GLOB '[0-9a-f]*'` pattern is
+  shown **accepting** `'a'+'Z'*39` — the defect, demonstrated rather than
+  described — while the normative `NOT GLOB '*[^0-9a-f]*'` CHECKs reject
+  `'a'+'Z'*39`, `'a'*39+'g'`, `'A'*40`, `'aB'*20`, 39 chars, 41 chars and
+  an embedded space, on **both** `subject_sha` and `verified_head_sha`,
+  and reject the 64-char equivalents on `run_evidence.sha256`. Valid
+  full-length lowercase hex is still accepted in each case. The Python
+  `SHA40`/`SHA256` regexes are run over the same hostile table so the two
+  validation layers cannot drift.
 - UPDATE and DELETE on the provenance table abort with
   `sqlite3.IntegrityError: run_provenance is append-only`, and the
   record survives the tamper attempt byte-identical (§B).
@@ -209,7 +340,6 @@ Proven, in order of the assertions in this document:
 - Re-export from a watermark yields nothing; export digests unique.
 - A `mode=ro` connection raises `attempt to write a readonly database`,
   confirming v1.0.0 §6's read-only exporter requirement is achievable.
-- Abbreviated (`a1b2c3d`) and uppercase SHAs rejected; 40-hex required.
 - Artifact digest is stable under input ordering and changes when any
   hash changes.
 - A real file digest differs from a worker-claimed one — i.e. the kernel
@@ -217,12 +347,16 @@ Proven, in order of the assertions in this document:
 - `git rev-parse` yields full 40-hex for HEAD and for tracked blobs; a
   non-git scratch dir yields nothing, so scratch runs are structurally
   non-attestable.
-- **§A specifically:** a complete gated run finalizes; a non-gated run
+- **§A.1 specifically:** a complete gated run finalizes; a non-gated run
   with NULL repo fields is legal but never finalizes; finalization fails
   closed *naming the offending field* for each of the five mandatory
   fields individually; a remote-string repo id, a malformed event
   locator, an abbreviated SHA, and an unresolved correction chain are
-  each refused; and no `final_candidate_sha`/`final_sha` column exists.
+  each refused. Every hostile SHA above is also refused by the
+  finalization gate, not only by the SQL layer.
+- **§A.4 specifically (B3):** no `final_candidate_sha` / `final_sha`
+  column exists, and both `subject_sha` and `verified_head_sha` do.
+- **§A.6 specifically (N2):** no `board` / `board_slug` column exists.
 
 This is a mechanism probe against a model of the schema. It is **not** a
 substitute for the acceptance tests, which must run against the real
@@ -230,22 +364,51 @@ kernel and belong to the implementer.
 
 ### §C.1 Additional acceptance tests (extend v1.0.0 §10)
 
-v1.0.0 A1–A12 stand. Add:
+**v1.0.0 A1–A18 all stand unchanged and are NOT renumbered.** A previous
+revision of this section reused the numbers A13–A20, colliding with v1.0.0
+A13–A18 and silently displacing six still-valid tests (absolute-path
+exclusion, implementation-run SHA equality, review-run SHA divergence,
+idempotent resubmission, exporter restart, and the profile→role map).
+That collision is corrected here: **v1.1.0 additions start at A19.**
+
+Numbering is global across both documents. A new test appends to the end;
+no existing number is ever reused for a different test.
 
 | # | Test | Expected |
 |---|---|---|
-| A13 | Non-gated run with NULL `repo_github_id`/`event_locator` | completes normally, `export_finalized=0`, never exported |
-| A14 | Finalization attempted with any one mandatory field missing | refused, fails closed, offending field named |
-| A15 | `origin` remote renamed | `repo_github_id` unchanged; remote string never accepted as identity |
-| A16 | Finalization performed | original provenance row byte-identical, digest unchanged |
-| A17 | Schema inspected for `final_candidate_sha` / `final_sha` | absent (guards §A.3) |
-| A18 | `edit_completed_task_result` called on a completed run | `summary`/`metadata` may change; provenance record digest **unchanged** |
-| A19 | Direct UPDATE/DELETE on provenance table | raises `sqlite3.IntegrityError` |
-| A20 | Runs terminating out of `run_id` order | export `seq` still ascending |
+| A19 | Non-gated run with NULL `repo_github_id`/`event_locator` | completes normally, `export_finalized=0`, never exported |
+| A20 | Finalization attempted with any one mandatory field missing | refused, fails closed, offending field named |
+| A21 | `origin` remote renamed | `repo_github_id` unchanged; remote string never accepted as identity |
+| A22 | Finalization performed | original provenance row byte-identical, digest unchanged |
+| A23 | Direct UPDATE/DELETE on provenance table | raises `sqlite3.IntegrityError` |
+| A24 | `edit_completed_task_result` called on a completed run | `summary`/`metadata` may change; provenance record digest **unchanged** |
+| A25 | Schema inspected for `final_candidate_sha` / `final_sha` | absent (guards §A.4 rule 2) |
+| A26 | Schema inspected for `board` / `board_slug` | absent (guards v1.0.0 §8; see §A.6) |
+| A27 | Runs terminating out of `run_id` order | export `seq` still ascending |
 
-A18 is the regression test for the §B defect specifically: the existing
+A24 is the regression test for the §B defect specifically: the existing
 post-completion mutation path must remain functional for its own purpose
 while being provably unable to touch provenance.
+
+Cross-reference for readers of the superseded numbering. **These are not
+test definitions** — the left column is a retired v1.1.0-draft label, the
+right column is the number now in force (defined in the table above):
+
+| retired draft label | number now in force |
+|---|---|
+| draft-A13 | A19 |
+| draft-A14 | A20 |
+| draft-A15 | A21 |
+| draft-A16 | A22 |
+| draft-A17 (final_sha guard) | A25 |
+| draft-A18 (`edit_completed_task_result`) | A24 |
+| draft-A19 (UPDATE/DELETE) | A23 |
+| draft-A20 (seq ordering) | A27 |
+
+The labels `A13`–`A18` without the `draft-` prefix belong to **v1.0.0 §10**
+and always did; that is the collision this correction removes.
+
+A26 is new in this correction (N2). v1.0.0 A5b is likewise new (B2).
 
 ---
 
@@ -253,26 +416,30 @@ while being provably unable to touch provenance.
 
 - **security-reviewer** (required next gate, has NOT occurred): sign-off
   on §B's trigger-based immutability and its stated residual risk;
-  whether board slug is acceptable in the export payload or must be an
-  opaque id; sign-off on §A.1's nullable-vs-required split.
+  sign-off on §A.1's nullable-vs-required split.
 - **platform-engineer**: implementation.
-- **broker / research-scout**: `final_candidate_sha` derivation stays
-  broker-side, out of scope here.
+- **broker / research-scout**: final candidate SHA derivation stays
+  broker-side, out of scope here (§A.4).
 
 Resolved, no longer open: repository id and PR number (§A, director
-ruling); DSSE source reference (attachment id 3, verified above).
+ruling); DSSE source reference (attachment id 3, verified above); board
+slug in the export payload (§A.6 — withdrawn, nothing to sign off);
+`final_candidate_sha` storage model (§A.4); hex CHECK strictness (§A.5).
 
 ## §E — Limitations of this document
 
 1. **Not security-approved.** v1.0.0 §11's warning stands unchanged.
 2. §C is a probe against a schema model, not the live kernel. The
    §C.1/§10 tests must be run against the real kernel before
-   implementation is considered verified.
+   implementation is considered verified. The B2 corrections narrow this
+   gap for hex validation only: the CHECK constraints are now exercised
+   as real SQLite CHECKs, but still on a model table.
 3. `repo_github_id` resolution assumes an authenticated GitHub API path
    exists in the kernel for that lookup. I did not verify one exists;
    if it does not, that is implementation work platform-engineer must
    scope, and until then no run is finalizable.
 4. The §B residual risk (trigger-droppable by a local root actor) is
    accepted-by-default here and explicitly routed to security-reviewer.
-5. I did not modify the Hermes repository, the live Kanban DB, or any
-   profile, per card scope.
+5. No change was made to Hermes source, the live Kanban DB, or any
+   profile. This revision touches only the three documents in
+   `docs/design/` named in §A.4.1 and this file's own header.

--- a/docs/design/kanban-run-provenance-v1.1.0-correction.md
+++ b/docs/design/kanban-run-provenance-v1.1.0-correction.md
@@ -38,7 +38,7 @@ header. All "comment 573 §N" references resolve to that attachment, not
 to a cross-board CLI lookup.
 
 **Executable evidence:** `verify_adr0007_mechanisms.py` (this directory),
-86/86 checks passing. See §C.
+85/85 checks passing. See §C.
 
 ---
 
@@ -308,13 +308,22 @@ against real SQLite and real git, so the claims above are demonstrated
 rather than asserted:
 
 ```
-python3 verify_adr0007_mechanisms.py     ->  86/86 checks passed
+python3 verify_adr0007_mechanisms.py     ->  85/85 checks passed
 ```
 
-The count rose from 36 to 86 in this revision: the B2 correction added
+The count rose from 36 to 85 in this revision: the B2 correction added
 hostile-input cases against both SQL CHECKs and the Python regexes, and
-B3/N2 and the artifact vocabulary alignment added structural assertions
-about which tables and columns must and must not exist.
+B3/N2 added structural assertions about which columns must and must not
+exist.
+
+**The verifier's SQL is a fixture, not the contract.** Its `CREATE TABLE`
+statements are illustrative scaffolding chosen to exercise the mechanisms
+under test; they carry additional columns that this contract does not
+declare and does not require. Only the columns declared normatively — §2.2
+(`id`, `run_id`, `artifact_path`, `sha256`, `created_at`) plus `sealed`
+(§B) — are part of the contract. An assertion that compared the fixture's
+schema to a hardcoded copy of itself would restate the fixture rather than
+verify the contract, and no such assertion is made.
 
 Proven, in order of the assertions in this document:
 
@@ -330,8 +339,6 @@ Proven, in order of the assertions in this document:
   full-length lowercase hex is still accepted in each case. The Python
   `SHA40`/`SHA256` regexes are run over the same hostile table so the two
   validation layers cannot drift.
-- **v1.0.0 §2.2 specifically:** the executable artifact-table schema matches
-  the complete declared column set, including `artifact_path` and `sha256`.
 - UPDATE and DELETE on the provenance table abort with
   `sqlite3.IntegrityError: run_provenance is append-only`, and the
   record survives the tamper attempt byte-identical (§B).

--- a/docs/design/kanban-run-provenance-v1.1.0-correction.md
+++ b/docs/design/kanban-run-provenance-v1.1.0-correction.md
@@ -38,7 +38,7 @@ header. All "comment 573 §N" references resolve to that attachment, not
 to a cross-board CLI lookup.
 
 **Executable evidence:** `verify_adr0007_mechanisms.py` (this directory),
-85/85 checks passing. See §C.
+86/86 checks passing. See §C.
 
 ---
 
@@ -308,13 +308,13 @@ against real SQLite and real git, so the claims above are demonstrated
 rather than asserted:
 
 ```
-python3 verify_adr0007_mechanisms.py     ->  85/85 checks passed
+python3 verify_adr0007_mechanisms.py     ->  86/86 checks passed
 ```
 
-The count rose from 36 to 85 in this revision: the B2 correction added
+The count rose from 36 to 86 in this revision: the B2 correction added
 hostile-input cases against both SQL CHECKs and the Python regexes, and
-B3/N2 added structural assertions about which columns must and must not
-exist.
+B3/N2 and the artifact vocabulary alignment added structural assertions
+about which tables and columns must and must not exist.
 
 Proven, in order of the assertions in this document:
 
@@ -330,6 +330,8 @@ Proven, in order of the assertions in this document:
   full-length lowercase hex is still accepted in each case. The Python
   `SHA40`/`SHA256` regexes are run over the same hostile table so the two
   validation layers cannot drift.
+- **v1.0.0 §2.2 specifically:** the executable artifact-table schema matches
+  the complete declared column set, including `artifact_path` and `sha256`.
 - UPDATE and DELETE on the provenance table abort with
   `sqlite3.IntegrityError: run_provenance is append-only`, and the
   record survives the tamper attempt byte-identical (§B).

--- a/docs/design/verify_adr0007_mechanisms.py
+++ b/docs/design/verify_adr0007_mechanisms.py
@@ -480,6 +480,17 @@ for label, value in HOSTILE_SHA40.items():
     check(f"finalization refuses verified_head_sha {label}",
           not finalizable(dict(good, verified_head_sha=value))[0])
 
+# --- v1.0.0 §2.2: artifact schema uses the normative vocabulary --------
+artifact_cols = {
+    r[1] for r in db.execute("PRAGMA table_info(run_artifacts)")
+}
+check("run_artifacts schema matches the declared artifact contract",
+      artifact_cols == {
+          "id", "run_id", "task_id", "artifact_path", "sha256", "size_bytes",
+          "git_blob_oid", "tracked", "clean", "declared_by", "created_at",
+          "sealed",
+      }, str(sorted(artifact_cols)))
+
 # --- v1.1.0 §A.4: final_candidate_sha is NOT a Kanban column ----------
 prov_cols = {r[1] for r in db.execute("PRAGMA table_info(run_provenance)")}
 check("no final_candidate_sha / final_sha column exists",

--- a/docs/design/verify_adr0007_mechanisms.py
+++ b/docs/design/verify_adr0007_mechanisms.py
@@ -72,7 +72,7 @@ CREATE TABLE run_artifacts (
     sealed INTEGER NOT NULL DEFAULT 0, UNIQUE(run_id, artifact_path),
     CHECK (length(sha256) = 64 AND sha256 NOT GLOB '*[^0-9a-f]*')
 );
-CREATE TRIGGER trg_run_evidence_sealed BEFORE UPDATE ON run_artifacts
+CREATE TRIGGER trg_run_artifacts_sealed BEFORE UPDATE ON run_artifacts
 WHEN OLD.sealed = 1
 BEGIN SELECT RAISE(ABORT, 'evidence row is sealed'); END;
 

--- a/docs/design/verify_adr0007_mechanisms.py
+++ b/docs/design/verify_adr0007_mechanisms.py
@@ -1,0 +1,286 @@
+"""Verify the load-bearing claims in ADR-0007 against real SQLite.
+
+Not a substitute for the acceptance tests in the ADR (those belong to the
+implementer). This proves the mechanisms I am specifying actually behave
+the way I claim before I freeze the contract.
+"""
+import json, hashlib, sqlite3, tempfile, os, subprocess
+
+DDL = """
+CREATE TABLE task_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT NOT NULL,
+    profile TEXT, status TEXT NOT NULL, started_at INTEGER NOT NULL,
+    ended_at INTEGER, outcome TEXT, summary TEXT, metadata TEXT
+);
+CREATE TABLE run_provenance (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL UNIQUE, task_id TEXT NOT NULL, board TEXT NOT NULL,
+    profile TEXT, outcome TEXT NOT NULL, attestable INTEGER NOT NULL,
+    subject_sha TEXT, verified_head_sha TEXT, branch_name TEXT,
+    repo_locator TEXT, workspace_kind TEXT NOT NULL,
+    evidence_count INTEGER NOT NULL, evidence_digest TEXT,
+    started_at INTEGER NOT NULL, completed_at INTEGER NOT NULL,
+    contract_version TEXT NOT NULL, record_digest TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+CREATE TRIGGER trg_run_provenance_no_update BEFORE UPDATE ON run_provenance
+BEGIN SELECT RAISE(ABORT, 'run_provenance is append-only'); END;
+CREATE TRIGGER trg_run_provenance_no_delete BEFORE DELETE ON run_provenance
+BEGIN SELECT RAISE(ABORT, 'run_provenance is append-only'); END;
+CREATE TABLE run_evidence (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, run_id INTEGER NOT NULL,
+    task_id TEXT NOT NULL, rel_path TEXT NOT NULL, sha256 TEXT NOT NULL,
+    size_bytes INTEGER NOT NULL, git_blob_oid TEXT,
+    tracked INTEGER NOT NULL DEFAULT 0, clean INTEGER NOT NULL DEFAULT 0,
+    declared_by TEXT NOT NULL, created_at INTEGER NOT NULL,
+    sealed INTEGER NOT NULL DEFAULT 0, UNIQUE(run_id, rel_path)
+);
+CREATE TRIGGER trg_run_evidence_sealed BEFORE UPDATE ON run_evidence
+WHEN OLD.sealed = 1
+BEGIN SELECT RAISE(ABORT, 'evidence row is sealed'); END;
+"""
+
+def canon(obj):
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"),
+                      ensure_ascii=False).encode("utf-8")
+
+def digest(obj):
+    return hashlib.sha256(canon(obj)).hexdigest()
+
+results = []
+def check(name, cond, detail=""):
+    results.append((name, bool(cond), detail))
+    print(f"{'PASS' if cond else 'FAIL'}  {name}" + (f"  [{detail}]" if detail else ""))
+
+db = sqlite3.connect(":memory:")
+db.row_factory = sqlite3.Row
+db.executescript(DDL)
+
+# --- provenance rows for several terminal outcomes -------------------
+def insert_prov(run_id, outcome, subject, head, ev):
+    ev_digest = digest([{"rel_path": e["rel_path"], "sha256": e["sha256"]}
+                        for e in sorted(ev, key=lambda x: x["rel_path"])]) if ev else None
+    attestable = int(outcome == "completed" and bool(subject) and bool(head) and len(ev) > 0)
+    body = {"contract_version": "kanban.provenance/v1", "run_id": run_id,
+            "task_id": "t_demo", "board": "hermes-agent", "profile": "security-reviewer",
+            "outcome": outcome, "attestable": bool(attestable),
+            "subject_sha": subject, "verified_head_sha": head,
+            "evidence_digest": ev_digest, "started_at": 100, "completed_at": 200}
+    rd = digest(body)
+    db.execute(
+        "INSERT INTO run_provenance (run_id,task_id,board,profile,outcome,attestable,"
+        "subject_sha,verified_head_sha,branch_name,repo_locator,workspace_kind,"
+        "evidence_count,evidence_digest,started_at,completed_at,contract_version,"
+        "record_digest,created_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        (run_id, "t_demo", "hermes-agent", "security-reviewer", outcome, attestable,
+         subject, head, "br", "git@github.com:x/y.git", "worktree",
+         len(ev), ev_digest, 100, 200, "kanban.provenance/v1", rd, 200))
+    db.commit()
+    return rd
+
+SHA_A = "a" * 40
+SHA_B = "b" * 40
+ev1 = [{"rel_path": "evidence/qa.json", "sha256": "c" * 64},
+       {"rel_path": "evidence/sec.json", "sha256": "d" * 64}]
+
+rd_ok = insert_prov(1, "completed", SHA_A, SHA_B, ev1)
+insert_prov(2, "blocked", SHA_A, SHA_B, ev1)
+insert_prov(3, "crashed", None, None, [])
+insert_prov(4, "completed", SHA_A, SHA_B, [])   # no evidence
+
+rows = {r["run_id"]: r for r in db.execute("SELECT * FROM run_provenance")}
+check("row written for every terminal outcome", len(rows) == 4, f"{len(rows)} rows")
+check("only completed+SHAs+evidence is attestable",
+      rows[1]["attestable"] == 1 and rows[2]["attestable"] == 0
+      and rows[3]["attestable"] == 0 and rows[4]["attestable"] == 0,
+      f"blocked={rows[2]['attestable']} crashed={rows[3]['attestable']} noev={rows[4]['attestable']}")
+
+# --- immutability -----------------------------------------------------
+try:
+    db.execute("UPDATE run_provenance SET subject_sha='e'*40 WHERE run_id=1")
+    db.commit(); check("UPDATE on run_provenance aborts", False, "update succeeded!")
+except sqlite3.IntegrityError as e:
+    check("UPDATE on run_provenance aborts", True, str(e))
+db.rollback()
+
+try:
+    db.execute("DELETE FROM run_provenance WHERE run_id=1")
+    db.commit(); check("DELETE on run_provenance aborts", False, "delete succeeded!")
+except sqlite3.IntegrityError as e:
+    check("DELETE on run_provenance aborts", True, str(e))
+db.rollback()
+
+still = db.execute("SELECT subject_sha, record_digest FROM run_provenance WHERE run_id=1").fetchone()
+check("record survives tamper attempt byte-identical",
+      still["subject_sha"] == SHA_A and still["record_digest"] == rd_ok)
+
+# --- evidence sealing -------------------------------------------------
+db.execute("INSERT INTO run_evidence (run_id,task_id,rel_path,sha256,size_bytes,"
+           "declared_by,created_at,sealed) VALUES (1,'t_demo','evidence/qa.json',?,10,"
+           "'security-reviewer',100,0)", ("c" * 64,))
+db.commit()
+db.execute("UPDATE run_evidence SET sha256=? WHERE run_id=1", ("f" * 64,))  # unsealed: allowed
+db.commit()
+check("unsealed evidence is editable", True)
+db.execute("UPDATE run_evidence SET sealed=1 WHERE run_id=1"); db.commit()
+try:
+    db.execute("UPDATE run_evidence SET sha256=? WHERE run_id=1", ("0" * 64,))
+    db.commit(); check("sealed evidence rejects writes", False, "write succeeded!")
+except sqlite3.IntegrityError as e:
+    check("sealed evidence rejects writes", True, str(e))
+db.rollback()
+
+# --- duplicate run_id -------------------------------------------------
+try:
+    insert_prov(1, "completed", SHA_A, SHA_B, ev1)
+    check("duplicate run_id rejected", False, "duplicate accepted!")
+except sqlite3.IntegrityError as e:
+    check("duplicate run_id rejected", True, str(e))
+db.rollback()
+
+# --- seq monotonic in terminalization order, not run id ---------------
+insert_prov(99, "completed", SHA_A, SHA_B, ev1)   # high run id, terminates last
+insert_prov(50, "completed", SHA_A, SHA_B, ev1)
+ordered = [(r["seq"], r["run_id"]) for r in
+           db.execute("SELECT seq, run_id FROM run_provenance ORDER BY seq")]
+seqs = [s for s, _ in ordered]
+check("seq strictly ascending", seqs == sorted(seqs) and len(set(seqs)) == len(seqs), str(ordered))
+check("seq order != run_id order (proves cursor is terminalization order)",
+      [r for _, r in ordered] != sorted(r for _, r in ordered))
+
+# --- watermark idempotency -------------------------------------------
+def export_since(watermark):
+    return [dict(r) for r in db.execute(
+        "SELECT * FROM run_provenance WHERE seq > ? AND attestable = 1 ORDER BY seq",
+        (watermark,))]
+first = export_since(0)
+wm = max(r["seq"] for r in first)
+check("re-export from watermark yields nothing", export_since(wm) == [])
+check("export digests unique", len({r["record_digest"] for r in first}) == len(first))
+
+# --- read-only connection cannot write --------------------------------
+tmpdir = tempfile.mkdtemp()
+path = os.path.join(tmpdir, "k.db")
+disk = sqlite3.connect(path); disk.executescript(DDL); disk.commit(); disk.close()
+ro = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+try:
+    ro.execute("INSERT INTO run_provenance (run_id,task_id,board,outcome,attestable,"
+               "workspace_kind,evidence_count,started_at,completed_at,contract_version,"
+               "record_digest,created_at) VALUES (7,'t','b','completed',1,'worktree',0,1,2,'v','d',3)")
+    ro.commit(); check("read-only exporter connection cannot write", False, "write succeeded!")
+except sqlite3.OperationalError as e:
+    check("read-only exporter connection cannot write", True, str(e))
+ro.close()
+
+# --- SHA validation ---------------------------------------------------
+import re
+SHA40 = re.compile(r"^[0-9a-f]{40}$"); SHA256 = re.compile(r"^[0-9a-f]{64}$")
+check("full 40-hex accepted", bool(SHA40.match(SHA_A)))
+check("abbreviated SHA rejected", not SHA40.match("a1b2c3d"))
+check("uppercase SHA rejected", not SHA40.match("A" * 40))
+check("64-hex artifact digest accepted", bool(SHA256.match("c" * 64)))
+
+# --- evidence_digest is order-independent -----------------------------
+d1 = digest([{"rel_path": e["rel_path"], "sha256": e["sha256"]}
+             for e in sorted(ev1, key=lambda x: x["rel_path"])])
+d2 = digest([{"rel_path": e["rel_path"], "sha256": e["sha256"]}
+             for e in sorted(list(reversed(ev1)), key=lambda x: x["rel_path"])])
+check("evidence_digest stable under input order", d1 == d2)
+ev_tampered = [ev1[0], {"rel_path": "evidence/sec.json", "sha256": "9" * 64}]
+d3 = digest([{"rel_path": e["rel_path"], "sha256": e["sha256"]}
+             for e in sorted(ev_tampered, key=lambda x: x["rel_path"])])
+check("evidence_digest changes when a hash changes", d1 != d3)
+
+# --- kernel-side hashing beats worker-declared hash -------------------
+f = os.path.join(tmpdir, "artifact.json")
+with open(f, "w") as fh: fh.write('{"result":"pass"}')
+real = hashlib.sha256(open(f, "rb").read()).hexdigest()
+worker_claimed = "0" * 64
+check("kernel hash != worker-claimed hash (worker value must be ignored)",
+      real != worker_claimed, real[:16] + "...")
+
+# --- git HEAD capture is real and full-length -------------------------
+repo = os.path.join(tmpdir, "repo"); os.makedirs(repo)
+run = lambda *a: subprocess.run(a, cwd=repo, capture_output=True, text=True)
+run("git", "init", "-q")
+run("git", "config", "user.email", "a@b.c"); run("git", "config", "user.name", "t")
+open(os.path.join(repo, "f.txt"), "w").write("x")
+run("git", "add", "."); run("git", "commit", "-qm", "init")
+head = run("git", "rev-parse", "HEAD").stdout.strip()
+check("git rev-parse HEAD yields full 40-hex", bool(SHA40.match(head)), head)
+blob = run("git", "rev-parse", "HEAD:f.txt").stdout.strip()
+check("git blob oid resolvable for tracked file", bool(SHA40.match(blob)), blob)
+missing = run("git", "rev-parse", "HEAD:nope.txt")
+check("untracked file yields no blob oid (tracked=0)", missing.returncode != 0)
+
+# scratch (non-git) dir must yield nothing -> non-attestable
+scratch = os.path.join(tmpdir, "scratch"); os.makedirs(scratch)
+r = subprocess.run(["git", "-C", scratch, "rev-parse", "HEAD"], capture_output=True, text=True)
+check("scratch workspace has no HEAD => subject_sha NULL => non-attestable", r.returncode != 0)
+
+# --- §5.5 nullable-vs-required repository binding ---------------------
+MANDATORY_FOR_EXPORT = ("repo_github_id", "event_locator", "subject_sha",
+                        "verified_head_sha", "evidence_count")
+
+def finalizable(rec):
+    """Kernel-side finalization gate from ADR §5.5. Fails closed."""
+    if rec.get("outcome") != "completed":
+        return False, "outcome not completed"
+    for f in MANDATORY_FOR_EXPORT:
+        v = rec.get(f)
+        if v is None or v == "":
+            return False, f"missing {f}"
+    if rec["evidence_count"] < 1:
+        return False, "no evidence"
+    if not SHA40.match(rec["subject_sha"] or ""):
+        return False, "bad subject_sha"
+    if not SHA40.match(rec["verified_head_sha"] or ""):
+        return False, "bad verified_head_sha"
+    if not isinstance(rec["repo_github_id"], int):
+        return False, "repo_github_id not numeric"
+    if not re.match(r"^pr:\d+$", rec["event_locator"] or ""):
+        return False, "bad event_locator"
+    if rec.get("corrections_present"):
+        return False, "unresolved correction chain"
+    return True, ""
+
+good = {"outcome": "completed", "repo_github_id": 123456789,
+        "event_locator": "pr:36", "subject_sha": SHA_A,
+        "verified_head_sha": SHA_B, "evidence_count": 2,
+        "corrections_present": False}
+ok, why = finalizable(good)
+check("complete gated run is finalizable", ok, why)
+
+# a non-gated run (docs/research) is legal but simply never exported
+non_gated = dict(good, repo_github_id=None, event_locator=None)
+ok2, why2 = finalizable(non_gated)
+check("non-gated run: NULL repo fields legal, not finalizable/exported",
+      not ok2, why2)
+
+# every mandatory field missing => refused, naming the field
+for f in MANDATORY_FOR_EXPORT:
+    bad = dict(good); bad[f] = None
+    ok3, why3 = finalizable(bad)
+    check(f"finalization fails closed when {f} missing", not ok3 and f in why3, why3)
+
+check("abbreviated subject_sha refused at finalization",
+      not finalizable(dict(good, subject_sha="a1b2c3d"))[0])
+check("repo id as remote string refused (must be numeric)",
+      not finalizable(dict(good, repo_github_id="git@github.com:x/y.git"))[0])
+check("malformed event_locator refused",
+      not finalizable(dict(good, event_locator="36"))[0])
+check("unresolved correction chain refused",
+      not finalizable(dict(good, corrections_present=True))[0])
+
+# --- final_candidate_sha must NOT be a Kanban column (guards §4) ------
+prov_cols = {r[1] for r in db.execute("PRAGMA table_info(run_provenance)")}
+check("no final_candidate_sha / final_sha column exists",
+      not {"final_candidate_sha", "final_sha"} & prov_cols,
+      sorted(prov_cols & {"subject_sha", "verified_head_sha"}))
+
+print("\n" + "=" * 60)
+failed = [n for n, ok, _ in results if not ok]
+print(f"{len(results) - len(failed)}/{len(results)} checks passed")
+if failed:
+    print("FAILED: " + ", ".join(failed)); raise SystemExit(1)
+print("All ADR-0007 mechanism claims verified.")

--- a/docs/design/verify_adr0007_mechanisms.py
+++ b/docs/design/verify_adr0007_mechanisms.py
@@ -480,17 +480,6 @@ for label, value in HOSTILE_SHA40.items():
     check(f"finalization refuses verified_head_sha {label}",
           not finalizable(dict(good, verified_head_sha=value))[0])
 
-# --- v1.0.0 §2.2: artifact schema uses the normative vocabulary --------
-artifact_cols = {
-    r[1] for r in db.execute("PRAGMA table_info(run_artifacts)")
-}
-check("run_artifacts schema matches the declared artifact contract",
-      artifact_cols == {
-          "id", "run_id", "task_id", "artifact_path", "sha256", "size_bytes",
-          "git_blob_oid", "tracked", "clean", "declared_by", "created_at",
-          "sealed",
-      }, str(sorted(artifact_cols)))
-
 # --- v1.1.0 §A.4: final_candidate_sha is NOT a Kanban column ----------
 prov_cols = {r[1] for r in db.execute("PRAGMA table_info(run_provenance)")}
 check("no final_candidate_sha / final_sha column exists",

--- a/docs/design/verify_adr0007_mechanisms.py
+++ b/docs/design/verify_adr0007_mechanisms.py
@@ -63,16 +63,16 @@ CREATE TRIGGER trg_run_provenance_no_update BEFORE UPDATE ON run_provenance
 BEGIN SELECT RAISE(ABORT, 'run_provenance is append-only'); END;
 CREATE TRIGGER trg_run_provenance_no_delete BEFORE DELETE ON run_provenance
 BEGIN SELECT RAISE(ABORT, 'run_provenance is append-only'); END;
-CREATE TABLE run_evidence (
+CREATE TABLE run_artifacts (
     id INTEGER PRIMARY KEY AUTOINCREMENT, run_id INTEGER NOT NULL,
-    task_id TEXT NOT NULL, rel_path TEXT NOT NULL, sha256 TEXT NOT NULL,
+    task_id TEXT NOT NULL, artifact_path TEXT NOT NULL, sha256 TEXT NOT NULL,
     size_bytes INTEGER NOT NULL, git_blob_oid TEXT,
     tracked INTEGER NOT NULL DEFAULT 0, clean INTEGER NOT NULL DEFAULT 0,
     declared_by TEXT NOT NULL, created_at INTEGER NOT NULL,
-    sealed INTEGER NOT NULL DEFAULT 0, UNIQUE(run_id, rel_path),
+    sealed INTEGER NOT NULL DEFAULT 0, UNIQUE(run_id, artifact_path),
     CHECK (length(sha256) = 64 AND sha256 NOT GLOB '*[^0-9a-f]*')
 );
-CREATE TRIGGER trg_run_evidence_sealed BEFORE UPDATE ON run_evidence
+CREATE TRIGGER trg_run_evidence_sealed BEFORE UPDATE ON run_artifacts
 WHEN OLD.sealed = 1
 BEGIN SELECT RAISE(ABORT, 'evidence row is sealed'); END;
 
@@ -122,8 +122,8 @@ def insert_prov(run_id, outcome, subject, head, ev):
     ev_digest = None
     if ev:
         ev_digest = digest([
-            {"rel_path": e["rel_path"], "sha256": e["sha256"]}
-            for e in sorted(ev, key=lambda x: x["rel_path"])
+            {"artifact_path": e["artifact_path"], "sha256": e["sha256"]}
+            for e in sorted(ev, key=lambda x: x["artifact_path"])
         ])
     attestable = int(
         outcome == "completed" and bool(subject) and bool(head) and len(ev) > 0
@@ -147,8 +147,8 @@ def insert_prov(run_id, outcome, subject, head, ev):
 
 SHA_A = "a" * 40
 SHA_B = "b" * 40
-ev1 = [{"rel_path": "evidence/qa.json", "sha256": "c" * 64},
-       {"rel_path": "evidence/sec.json", "sha256": "d" * 64}]
+ev1 = [{"artifact_path": "evidence/qa.json", "sha256": "c" * 64},
+       {"artifact_path": "evidence/sec.json", "sha256": "d" * 64}]
 
 rd_ok = insert_prov(1, "completed", SHA_A, SHA_B, ev1)
 insert_prov(2, "blocked", SHA_A, SHA_B, ev1)
@@ -235,11 +235,11 @@ _hostile_ev_ids = itertools.count(2001)
 
 
 def evidence_sha_rejected(value):
-    """True if the run_evidence.sha256 CHECK aborts the insert."""
+    """True if the run_artifacts.sha256 CHECK aborts the insert."""
     ev_id = next(_hostile_ev_ids)
     try:
         probe.execute(
-            "INSERT INTO run_evidence (run_id,task_id,rel_path,sha256,"
+            "INSERT INTO run_artifacts (run_id,task_id,artifact_path,sha256,"
             "size_bytes,declared_by,created_at,sealed) "
             "VALUES (?,'t_hostile',?,?,10,'p',100,0)",
             (ev_id, f"evidence/h{ev_id}.json", value))
@@ -250,9 +250,9 @@ def evidence_sha_rejected(value):
 
 
 for label, value in HOSTILE_SHA256.items():
-    check(f"run_evidence.sha256 CHECK rejects {label}",
+    check(f"run_artifacts.sha256 CHECK rejects {label}",
           evidence_sha_rejected(value))
-check("run_evidence.sha256 CHECK accepts valid full lowercase 64-hex",
+check("run_artifacts.sha256 CHECK accepts valid full lowercase 64-hex",
       not evidence_sha_rejected(("0123456789abcdef" * 4)[:64]))
 probe.close()
 
@@ -283,18 +283,18 @@ check("record survives tamper attempt byte-identical",
       still["subject_sha"] == SHA_A and still["record_digest"] == rd_ok)
 
 # --- evidence sealing -------------------------------------------------
-db.execute("INSERT INTO run_evidence (run_id,task_id,rel_path,sha256,size_bytes,"
+db.execute("INSERT INTO run_artifacts (run_id,task_id,artifact_path,sha256,size_bytes,"
            "declared_by,created_at,sealed) VALUES (1,'t_demo','evidence/qa.json',?,10,"
            "'security-reviewer',100,0)", ("c" * 64,))
 db.commit()
 # unsealed: allowed
-db.execute("UPDATE run_evidence SET sha256=? WHERE run_id=1", ("f" * 64,))
+db.execute("UPDATE run_artifacts SET sha256=? WHERE run_id=1", ("f" * 64,))
 db.commit()
 check("unsealed evidence is editable", True)
-db.execute("UPDATE run_evidence SET sealed=1 WHERE run_id=1")
+db.execute("UPDATE run_artifacts SET sealed=1 WHERE run_id=1")
 db.commit()
 try:
-    db.execute("UPDATE run_evidence SET sha256=? WHERE run_id=1", ("0" * 64,))
+    db.execute("UPDATE run_artifacts SET sha256=? WHERE run_id=1", ("0" * 64,))
     db.commit()
     check("sealed evidence rejects writes", False, "write succeeded!")
 except sqlite3.IntegrityError as e:
@@ -363,14 +363,14 @@ for label, value in HOSTILE_SHA256.items():
     check(f"SHA256 regex rejects {label}", not SHA256.match(value))
 
 # --- evidence_digest is order-independent -----------------------------
-d1 = digest([{"rel_path": e["rel_path"], "sha256": e["sha256"]}
-             for e in sorted(ev1, key=lambda x: x["rel_path"])])
-d2 = digest([{"rel_path": e["rel_path"], "sha256": e["sha256"]}
-             for e in sorted(list(reversed(ev1)), key=lambda x: x["rel_path"])])
+d1 = digest([{"artifact_path": e["artifact_path"], "sha256": e["sha256"]}
+             for e in sorted(ev1, key=lambda x: x["artifact_path"])])
+d2 = digest([{"artifact_path": e["artifact_path"], "sha256": e["sha256"]}
+             for e in sorted(list(reversed(ev1)), key=lambda x: x["artifact_path"])])
 check("evidence_digest stable under input order", d1 == d2)
-ev_tampered = [ev1[0], {"rel_path": "evidence/sec.json", "sha256": "9" * 64}]
-d3 = digest([{"rel_path": e["rel_path"], "sha256": e["sha256"]}
-             for e in sorted(ev_tampered, key=lambda x: x["rel_path"])])
+ev_tampered = [ev1[0], {"artifact_path": "evidence/sec.json", "sha256": "9" * 64}]
+d3 = digest([{"artifact_path": e["artifact_path"], "sha256": e["sha256"]}
+             for e in sorted(ev_tampered, key=lambda x: x["artifact_path"])])
 check("evidence_digest changes when a hash changes", d1 != d3)
 
 # --- kernel-side hashing beats worker-declared hash -------------------

--- a/docs/design/verify_adr0007_mechanisms.py
+++ b/docs/design/verify_adr0007_mechanisms.py
@@ -12,6 +12,7 @@ Run:  python3 verify_adr0007_mechanisms.py
 """
 
 import hashlib
+import itertools
 import json
 import os
 import re
@@ -34,9 +35,9 @@ SHA256 = re.compile(r"^[0-9a-f]{64}$")
 # There is deliberately NO `final_candidate_sha` / `final_sha` column: the
 # final candidate SHA is an attestation-layer field the broker derives.
 #
-# v1.1.0 §N2 resolution: no `board` column. kanban.db is already per-board and
-# v1.0.0 §8 rejects board slug as a provenance field; repository identity is
-# `repo_github_id`.
+# v1.1.0 §A.6 (review finding N2): no `board` column. kanban.db is already
+# per-board and v1.0.0 §8 rejects board slug as a provenance field; repository
+# identity is `repo_github_id`.
 DDL = """
 CREATE TABLE task_runs (
     id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT NOT NULL,
@@ -192,20 +193,19 @@ HOSTILE_SHA40 = {
     "embedded space": "a" * 20 + " " + "a" * 19,
 }
 
-_hostile_run_id = 1000
+_hostile_run_ids = itertools.count(1001)
 
 
 def prov_sha_rejected(column, value):
     """Attempt a minimal insert setting one SHA column; True if CHECK aborts."""
-    global _hostile_run_id
-    _hostile_run_id += 1
+    run_id = next(_hostile_run_ids)
     subject = value if column == "subject_sha" else SHA_A
     head = value if column == "verified_head_sha" else SHA_B
     try:
         probe.execute(
             f"INSERT INTO run_provenance ({PROV_COLUMNS}) "  # noqa: S608
             f"VALUES ({PROV_PLACEHOLDERS})",
-            (_hostile_run_id, "t_hostile", "p", "completed", 0,
+            (run_id, "t_hostile", "p", "completed", 0,
              subject, head, "br", "loc", "worktree", 0, None, 1, 2,
              CONTRACT_VERSION, "d", 3))
         probe.commit()
@@ -231,19 +231,18 @@ HOSTILE_SHA256 = {
     "63 chars (too short)": "c" * 63,
 }
 
-_hostile_ev_id = 2000
+_hostile_ev_ids = itertools.count(2001)
 
 
 def evidence_sha_rejected(value):
     """True if the run_evidence.sha256 CHECK aborts the insert."""
-    global _hostile_ev_id
-    _hostile_ev_id += 1
+    ev_id = next(_hostile_ev_ids)
     try:
         probe.execute(
             "INSERT INTO run_evidence (run_id,task_id,rel_path,sha256,"
             "size_bytes,declared_by,created_at,sealed) "
             "VALUES (?,'t_hostile',?,?,10,'p',100,0)",
-            (_hostile_ev_id, f"evidence/h{_hostile_ev_id}.json", value))
+            (ev_id, f"evidence/h{ev_id}.json", value))
         probe.commit()
         return False
     except sqlite3.IntegrityError:
@@ -258,8 +257,11 @@ check("run_evidence.sha256 CHECK accepts valid full lowercase 64-hex",
 probe.close()
 
 # --- immutability -----------------------------------------------------
+# Tamper with a *valid* 40-hex value, so the abort is attributable to the
+# append-only trigger and not to the hex CHECK constraint.
 try:
-    db.execute("UPDATE run_provenance SET subject_sha='e'*40 WHERE run_id=1")
+    db.execute("UPDATE run_provenance SET subject_sha=? WHERE run_id=1",
+               ("e" * 40,))
     db.commit()
     check("UPDATE on run_provenance aborts", False, "update succeeded!")
 except sqlite3.IntegrityError as e:

--- a/docs/design/verify_adr0007_mechanisms.py
+++ b/docs/design/verify_adr0007_mechanisms.py
@@ -1,11 +1,42 @@
-"""Verify the load-bearing claims in ADR-0007 against real SQLite.
+"""Verify the load-bearing mechanisms of the structured run provenance contract.
 
-Not a substitute for the acceptance tests in the ADR (those belong to the
-implementer). This proves the mechanisms I am specifying actually behave
-the way I claim before I freeze the contract.
+Exercises the mechanisms specified in ``kanban-run-provenance-v1.0.0.md`` and
+its ``kanban-run-provenance-v1.1.0-correction.md`` against real SQLite and real
+git, so the contract's claims are demonstrated rather than asserted.
+
+This is a mechanism probe against a model of the schema. It is **not** a
+substitute for the acceptance tests (v1.0.0 §10 / v1.1.0 §C.1), which must run
+against the real kernel and belong to the implementer.
+
+Run:  python3 verify_adr0007_mechanisms.py
 """
-import json, hashlib, sqlite3, tempfile, os, subprocess
 
+import hashlib
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import tempfile
+
+# v1.0.0 §2.1: full 40-char (resp. 64-char) all-lowercase hex. EVERY character
+# is validated, not just the first one.
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+# The SQL form of the same rule. `NOT GLOB '*[^0-9a-f]*'` is the strict
+# constraint: it rejects a non-hex character *anywhere* in the value. The
+# superseded form `GLOB '[0-9a-f]*'` anchored only the FIRST character and
+# accepted e.g. 'a' + 'Z'*39 -- demonstrated by `legacy_sha_check` below.
+#
+# v1.1.0 §A.4 (final_candidate_sha resolution): the run carries `subject_sha`
+# (stamped at claim) and `verified_head_sha` (stamped at terminalization).
+# There is deliberately NO `final_candidate_sha` / `final_sha` column: the
+# final candidate SHA is an attestation-layer field the broker derives.
+#
+# v1.1.0 §N2 resolution: no `board` column. kanban.db is already per-board and
+# v1.0.0 §8 rejects board slug as a provenance field; repository identity is
+# `repo_github_id`.
 DDL = """
 CREATE TABLE task_runs (
     id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT NOT NULL,
@@ -14,14 +45,18 @@ CREATE TABLE task_runs (
 );
 CREATE TABLE run_provenance (
     seq INTEGER PRIMARY KEY AUTOINCREMENT,
-    run_id INTEGER NOT NULL UNIQUE, task_id TEXT NOT NULL, board TEXT NOT NULL,
+    run_id INTEGER NOT NULL UNIQUE, task_id TEXT NOT NULL,
     profile TEXT, outcome TEXT NOT NULL, attestable INTEGER NOT NULL,
     subject_sha TEXT, verified_head_sha TEXT, branch_name TEXT,
     repo_locator TEXT, workspace_kind TEXT NOT NULL,
     evidence_count INTEGER NOT NULL, evidence_digest TEXT,
     started_at INTEGER NOT NULL, completed_at INTEGER NOT NULL,
     contract_version TEXT NOT NULL, record_digest TEXT NOT NULL,
-    created_at INTEGER NOT NULL
+    created_at INTEGER NOT NULL,
+    CHECK (subject_sha IS NULL OR (length(subject_sha) = 40
+           AND subject_sha NOT GLOB '*[^0-9a-f]*')),
+    CHECK (verified_head_sha IS NULL OR (length(verified_head_sha) = 40
+           AND verified_head_sha NOT GLOB '*[^0-9a-f]*'))
 );
 CREATE TRIGGER trg_run_provenance_no_update BEFORE UPDATE ON run_provenance
 BEGIN SELECT RAISE(ABORT, 'run_provenance is append-only'); END;
@@ -33,50 +68,81 @@ CREATE TABLE run_evidence (
     size_bytes INTEGER NOT NULL, git_blob_oid TEXT,
     tracked INTEGER NOT NULL DEFAULT 0, clean INTEGER NOT NULL DEFAULT 0,
     declared_by TEXT NOT NULL, created_at INTEGER NOT NULL,
-    sealed INTEGER NOT NULL DEFAULT 0, UNIQUE(run_id, rel_path)
+    sealed INTEGER NOT NULL DEFAULT 0, UNIQUE(run_id, rel_path),
+    CHECK (length(sha256) = 64 AND sha256 NOT GLOB '*[^0-9a-f]*')
 );
 CREATE TRIGGER trg_run_evidence_sealed BEFORE UPDATE ON run_evidence
 WHEN OLD.sealed = 1
 BEGIN SELECT RAISE(ABORT, 'evidence row is sealed'); END;
+
+-- SUPERSEDED pattern, retained only as an executable demonstration of why
+-- v1.0.0 §2.1's CHECK had to change. Not part of the specified schema.
+CREATE TABLE legacy_sha_check (
+    sha TEXT,
+    CHECK (sha IS NULL OR (length(sha) = 40 AND sha GLOB '[0-9a-f]*'))
+);
 """
+
+PROV_COLUMNS = (
+    "run_id,task_id,profile,outcome,attestable,subject_sha,verified_head_sha,"
+    "branch_name,repo_locator,workspace_kind,evidence_count,evidence_digest,"
+    "started_at,completed_at,contract_version,record_digest,created_at"
+)
+PROV_PLACEHOLDERS = ",".join("?" * len(PROV_COLUMNS.split(",")))
+CONTRACT_VERSION = "kanban.provenance/v1"
+
 
 def canon(obj):
     return json.dumps(obj, sort_keys=True, separators=(",", ":"),
                       ensure_ascii=False).encode("utf-8")
 
+
 def digest(obj):
     return hashlib.sha256(canon(obj)).hexdigest()
 
+
 results = []
+
+
 def check(name, cond, detail=""):
     results.append((name, bool(cond), detail))
-    print(f"{'PASS' if cond else 'FAIL'}  {name}" + (f"  [{detail}]" if detail else ""))
+    verdict = "PASS" if cond else "FAIL"
+    suffix = f"  [{detail}]" if detail else ""
+    print(f"{verdict}  {name}{suffix}")
+
 
 db = sqlite3.connect(":memory:")
 db.row_factory = sqlite3.Row
 db.executescript(DDL)
 
+
 # --- provenance rows for several terminal outcomes -------------------
 def insert_prov(run_id, outcome, subject, head, ev):
-    ev_digest = digest([{"rel_path": e["rel_path"], "sha256": e["sha256"]}
-                        for e in sorted(ev, key=lambda x: x["rel_path"])]) if ev else None
-    attestable = int(outcome == "completed" and bool(subject) and bool(head) and len(ev) > 0)
-    body = {"contract_version": "kanban.provenance/v1", "run_id": run_id,
-            "task_id": "t_demo", "board": "hermes-agent", "profile": "security-reviewer",
+    ev_digest = None
+    if ev:
+        ev_digest = digest([
+            {"rel_path": e["rel_path"], "sha256": e["sha256"]}
+            for e in sorted(ev, key=lambda x: x["rel_path"])
+        ])
+    attestable = int(
+        outcome == "completed" and bool(subject) and bool(head) and len(ev) > 0
+    )
+    body = {"contract_version": CONTRACT_VERSION, "run_id": run_id,
+            "task_id": "t_demo", "profile": "security-reviewer",
             "outcome": outcome, "attestable": bool(attestable),
             "subject_sha": subject, "verified_head_sha": head,
-            "evidence_digest": ev_digest, "started_at": 100, "completed_at": 200}
+            "evidence_digest": ev_digest, "started_at": 100,
+            "completed_at": 200}
     rd = digest(body)
     db.execute(
-        "INSERT INTO run_provenance (run_id,task_id,board,profile,outcome,attestable,"
-        "subject_sha,verified_head_sha,branch_name,repo_locator,workspace_kind,"
-        "evidence_count,evidence_digest,started_at,completed_at,contract_version,"
-        "record_digest,created_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-        (run_id, "t_demo", "hermes-agent", "security-reviewer", outcome, attestable,
+        f"INSERT INTO run_provenance ({PROV_COLUMNS}) "  # noqa: S608
+        f"VALUES ({PROV_PLACEHOLDERS})",
+        (run_id, "t_demo", "security-reviewer", outcome, attestable,
          subject, head, "br", "git@github.com:x/y.git", "worktree",
-         len(ev), ev_digest, 100, 200, "kanban.provenance/v1", rd, 200))
+         len(ev), ev_digest, 100, 200, CONTRACT_VERSION, rd, 200))
     db.commit()
     return rd
+
 
 SHA_A = "a" * 40
 SHA_B = "b" * 40
@@ -93,24 +159,124 @@ check("row written for every terminal outcome", len(rows) == 4, f"{len(rows)} ro
 check("only completed+SHAs+evidence is attestable",
       rows[1]["attestable"] == 1 and rows[2]["attestable"] == 0
       and rows[3]["attestable"] == 0 and rows[4]["attestable"] == 0,
-      f"blocked={rows[2]['attestable']} crashed={rows[3]['attestable']} noev={rows[4]['attestable']}")
+      f"blocked={rows[2]['attestable']} crashed={rows[3]['attestable']} "
+      f"noev={rows[4]['attestable']}")
+
+# --- B2: SHA CHECK constraints validate EVERY character ---------------
+# Run against a SEPARATE connection so hostile probes cannot pollute the
+# narrative table used by the seq/watermark checks below.
+probe = sqlite3.connect(":memory:")
+probe.row_factory = sqlite3.Row
+probe.executescript(DDL)
+
+# First, demonstrate the defect in the superseded pattern so the reason for
+# the change is executable rather than a claim in prose.
+LEGACY_HOSTILE = "a" + "Z" * 39
+try:
+    probe.execute("INSERT INTO legacy_sha_check (sha) VALUES (?)", (LEGACY_HOSTILE,))
+    probe.commit()
+    legacy_accepted = True
+except sqlite3.IntegrityError:
+    legacy_accepted = False
+probe.rollback()
+check("superseded GLOB '[0-9a-f]*' pattern accepts 'a'+'Z'*39 (the defect)",
+      legacy_accepted, "first character only -- why v1.0.0 §2.1 changed")
+
+HOSTILE_SHA40 = {
+    "'a'+'Z'*39 (non-hex tail)": "a" + "Z" * 39,
+    "'a'*39+'g' (non-hex last char)": "a" * 39 + "g",
+    "uppercase 'A'*40": "A" * 40,
+    "mixed case 'aB'*20": "aB" * 20,
+    "39 chars (too short)": "a" * 39,
+    "41 chars (too long)": "a" * 41,
+    "embedded space": "a" * 20 + " " + "a" * 19,
+}
+
+_hostile_run_id = 1000
+
+
+def prov_sha_rejected(column, value):
+    """Attempt a minimal insert setting one SHA column; True if CHECK aborts."""
+    global _hostile_run_id
+    _hostile_run_id += 1
+    subject = value if column == "subject_sha" else SHA_A
+    head = value if column == "verified_head_sha" else SHA_B
+    try:
+        probe.execute(
+            f"INSERT INTO run_provenance ({PROV_COLUMNS}) "  # noqa: S608
+            f"VALUES ({PROV_PLACEHOLDERS})",
+            (_hostile_run_id, "t_hostile", "p", "completed", 0,
+             subject, head, "br", "loc", "worktree", 0, None, 1, 2,
+             CONTRACT_VERSION, "d", 3))
+        probe.commit()
+        return False
+    except sqlite3.IntegrityError:
+        return True
+
+
+for column in ("subject_sha", "verified_head_sha"):
+    for label, value in HOSTILE_SHA40.items():
+        check(f"{column} CHECK rejects {label}",
+              prov_sha_rejected(column, value))
+
+check("subject_sha CHECK accepts valid full lowercase 40-hex",
+      not prov_sha_rejected("subject_sha", ("0123456789abcdef" * 3)[:40]))
+check("verified_head_sha CHECK accepts valid full lowercase 40-hex",
+      not prov_sha_rejected("verified_head_sha", ("0123456789abcdef" * 3)[:40]))
+
+HOSTILE_SHA256 = {
+    "'c'*63+'Z' (non-hex tail)": "c" * 63 + "Z",
+    "'c'+'Z'*63 (non-hex tail)": "c" + "Z" * 63,
+    "uppercase 'C'*64": "C" * 64,
+    "63 chars (too short)": "c" * 63,
+}
+
+_hostile_ev_id = 2000
+
+
+def evidence_sha_rejected(value):
+    """True if the run_evidence.sha256 CHECK aborts the insert."""
+    global _hostile_ev_id
+    _hostile_ev_id += 1
+    try:
+        probe.execute(
+            "INSERT INTO run_evidence (run_id,task_id,rel_path,sha256,"
+            "size_bytes,declared_by,created_at,sealed) "
+            "VALUES (?,'t_hostile',?,?,10,'p',100,0)",
+            (_hostile_ev_id, f"evidence/h{_hostile_ev_id}.json", value))
+        probe.commit()
+        return False
+    except sqlite3.IntegrityError:
+        return True
+
+
+for label, value in HOSTILE_SHA256.items():
+    check(f"run_evidence.sha256 CHECK rejects {label}",
+          evidence_sha_rejected(value))
+check("run_evidence.sha256 CHECK accepts valid full lowercase 64-hex",
+      not evidence_sha_rejected(("0123456789abcdef" * 4)[:64]))
+probe.close()
 
 # --- immutability -----------------------------------------------------
 try:
     db.execute("UPDATE run_provenance SET subject_sha='e'*40 WHERE run_id=1")
-    db.commit(); check("UPDATE on run_provenance aborts", False, "update succeeded!")
+    db.commit()
+    check("UPDATE on run_provenance aborts", False, "update succeeded!")
 except sqlite3.IntegrityError as e:
     check("UPDATE on run_provenance aborts", True, str(e))
 db.rollback()
 
 try:
     db.execute("DELETE FROM run_provenance WHERE run_id=1")
-    db.commit(); check("DELETE on run_provenance aborts", False, "delete succeeded!")
+    db.commit()
+    check("DELETE on run_provenance aborts", False, "delete succeeded!")
 except sqlite3.IntegrityError as e:
     check("DELETE on run_provenance aborts", True, str(e))
 db.rollback()
 
-still = db.execute("SELECT subject_sha, record_digest FROM run_provenance WHERE run_id=1").fetchone()
+still = db.execute(
+    "SELECT subject_sha, record_digest FROM run_provenance WHERE run_id=1"
+).fetchone()
 check("record survives tamper attempt byte-identical",
       still["subject_sha"] == SHA_A and still["record_digest"] == rd_ok)
 
@@ -119,13 +285,16 @@ db.execute("INSERT INTO run_evidence (run_id,task_id,rel_path,sha256,size_bytes,
            "declared_by,created_at,sealed) VALUES (1,'t_demo','evidence/qa.json',?,10,"
            "'security-reviewer',100,0)", ("c" * 64,))
 db.commit()
-db.execute("UPDATE run_evidence SET sha256=? WHERE run_id=1", ("f" * 64,))  # unsealed: allowed
+# unsealed: allowed
+db.execute("UPDATE run_evidence SET sha256=? WHERE run_id=1", ("f" * 64,))
 db.commit()
 check("unsealed evidence is editable", True)
-db.execute("UPDATE run_evidence SET sealed=1 WHERE run_id=1"); db.commit()
+db.execute("UPDATE run_evidence SET sealed=1 WHERE run_id=1")
+db.commit()
 try:
     db.execute("UPDATE run_evidence SET sha256=? WHERE run_id=1", ("0" * 64,))
-    db.commit(); check("sealed evidence rejects writes", False, "write succeeded!")
+    db.commit()
+    check("sealed evidence rejects writes", False, "write succeeded!")
 except sqlite3.IntegrityError as e:
     check("sealed evidence rejects writes", True, str(e))
 db.rollback()
@@ -139,20 +308,24 @@ except sqlite3.IntegrityError as e:
 db.rollback()
 
 # --- seq monotonic in terminalization order, not run id ---------------
-insert_prov(99, "completed", SHA_A, SHA_B, ev1)   # high run id, terminates last
+insert_prov(99, "completed", SHA_A, SHA_B, ev1)   # high run id, terminates first
 insert_prov(50, "completed", SHA_A, SHA_B, ev1)
 ordered = [(r["seq"], r["run_id"]) for r in
            db.execute("SELECT seq, run_id FROM run_provenance ORDER BY seq")]
 seqs = [s for s, _ in ordered]
-check("seq strictly ascending", seqs == sorted(seqs) and len(set(seqs)) == len(seqs), str(ordered))
+check("seq strictly ascending",
+      seqs == sorted(seqs) and len(set(seqs)) == len(seqs), str(ordered))
 check("seq order != run_id order (proves cursor is terminalization order)",
       [r for _, r in ordered] != sorted(r for _, r in ordered))
+
 
 # --- watermark idempotency -------------------------------------------
 def export_since(watermark):
     return [dict(r) for r in db.execute(
         "SELECT * FROM run_provenance WHERE seq > ? AND attestable = 1 ORDER BY seq",
         (watermark,))]
+
+
 first = export_since(0)
 wm = max(r["seq"] for r in first)
 check("re-export from watermark yields nothing", export_since(wm) == [])
@@ -161,24 +334,31 @@ check("export digests unique", len({r["record_digest"] for r in first}) == len(f
 # --- read-only connection cannot write --------------------------------
 tmpdir = tempfile.mkdtemp()
 path = os.path.join(tmpdir, "k.db")
-disk = sqlite3.connect(path); disk.executescript(DDL); disk.commit(); disk.close()
+disk = sqlite3.connect(path)
+disk.executescript(DDL)
+disk.commit()
+disk.close()
 ro = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
 try:
-    ro.execute("INSERT INTO run_provenance (run_id,task_id,board,outcome,attestable,"
-               "workspace_kind,evidence_count,started_at,completed_at,contract_version,"
-               "record_digest,created_at) VALUES (7,'t','b','completed',1,'worktree',0,1,2,'v','d',3)")
-    ro.commit(); check("read-only exporter connection cannot write", False, "write succeeded!")
+    ro.execute("INSERT INTO run_provenance (run_id,task_id,outcome,attestable,"
+               "workspace_kind,evidence_count,started_at,completed_at,"
+               "contract_version,record_digest,created_at) "
+               "VALUES (7,'t','completed',1,'worktree',0,1,2,'v','d',3)")
+    ro.commit()
+    check("read-only exporter connection cannot write", False, "write succeeded!")
 except sqlite3.OperationalError as e:
     check("read-only exporter connection cannot write", True, str(e))
 ro.close()
 
-# --- SHA validation ---------------------------------------------------
-import re
-SHA40 = re.compile(r"^[0-9a-f]{40}$"); SHA256 = re.compile(r"^[0-9a-f]{64}$")
+# --- SHA validation (Python-side mirror of the SQL CHECKs) ------------
 check("full 40-hex accepted", bool(SHA40.match(SHA_A)))
 check("abbreviated SHA rejected", not SHA40.match("a1b2c3d"))
 check("uppercase SHA rejected", not SHA40.match("A" * 40))
 check("64-hex artifact digest accepted", bool(SHA256.match("c" * 64)))
+for label, value in HOSTILE_SHA40.items():
+    check(f"SHA40 regex rejects {label}", not SHA40.match(value))
+for label, value in HOSTILE_SHA256.items():
+    check(f"SHA256 regex rejects {label}", not SHA256.match(value))
 
 # --- evidence_digest is order-independent -----------------------------
 d1 = digest([{"rel_path": e["rel_path"], "sha256": e["sha256"]}
@@ -193,43 +373,59 @@ check("evidence_digest changes when a hash changes", d1 != d3)
 
 # --- kernel-side hashing beats worker-declared hash -------------------
 f = os.path.join(tmpdir, "artifact.json")
-with open(f, "w") as fh: fh.write('{"result":"pass"}')
-real = hashlib.sha256(open(f, "rb").read()).hexdigest()
+with open(f, "w", encoding="utf-8") as fh:
+    fh.write('{"result":"pass"}')
+with open(f, "rb") as fh:
+    real = hashlib.sha256(fh.read()).hexdigest()
 worker_claimed = "0" * 64
 check("kernel hash != worker-claimed hash (worker value must be ignored)",
       real != worker_claimed, real[:16] + "...")
 
 # --- git HEAD capture is real and full-length -------------------------
-repo = os.path.join(tmpdir, "repo"); os.makedirs(repo)
-run = lambda *a: subprocess.run(a, cwd=repo, capture_output=True, text=True)
-run("git", "init", "-q")
-run("git", "config", "user.email", "a@b.c"); run("git", "config", "user.name", "t")
-open(os.path.join(repo, "f.txt"), "w").write("x")
-run("git", "add", "."); run("git", "commit", "-qm", "init")
-head = run("git", "rev-parse", "HEAD").stdout.strip()
+repo = os.path.join(tmpdir, "repo")
+os.makedirs(repo)
+
+
+def git(*args):
+    return subprocess.run(args, cwd=repo, capture_output=True, text=True,
+                          check=False)
+
+
+git("git", "init", "-q")
+git("git", "config", "user.email", "a@b.c")
+git("git", "config", "user.name", "t")
+with open(os.path.join(repo, "f.txt"), "w", encoding="utf-8") as fh:
+    fh.write("x")
+git("git", "add", ".")
+git("git", "commit", "-qm", "init")
+head = git("git", "rev-parse", "HEAD").stdout.strip()
 check("git rev-parse HEAD yields full 40-hex", bool(SHA40.match(head)), head)
-blob = run("git", "rev-parse", "HEAD:f.txt").stdout.strip()
+blob = git("git", "rev-parse", "HEAD:f.txt").stdout.strip()
 check("git blob oid resolvable for tracked file", bool(SHA40.match(blob)), blob)
-missing = run("git", "rev-parse", "HEAD:nope.txt")
+missing = git("git", "rev-parse", "HEAD:nope.txt")
 check("untracked file yields no blob oid (tracked=0)", missing.returncode != 0)
 
 # scratch (non-git) dir must yield nothing -> non-attestable
-scratch = os.path.join(tmpdir, "scratch"); os.makedirs(scratch)
-r = subprocess.run(["git", "-C", scratch, "rev-parse", "HEAD"], capture_output=True, text=True)
-check("scratch workspace has no HEAD => subject_sha NULL => non-attestable", r.returncode != 0)
+scratch = os.path.join(tmpdir, "scratch")
+os.makedirs(scratch)
+r = subprocess.run(["git", "-C", scratch, "rev-parse", "HEAD"],
+                   capture_output=True, text=True, check=False)
+check("scratch workspace has no HEAD => subject_sha NULL => non-attestable",
+      r.returncode != 0)
 
-# --- §5.5 nullable-vs-required repository binding ---------------------
+# --- v1.1.0 §A.1 nullable-vs-required repository binding --------------
 MANDATORY_FOR_EXPORT = ("repo_github_id", "event_locator", "subject_sha",
                         "verified_head_sha", "evidence_count")
 
+
 def finalizable(rec):
-    """Kernel-side finalization gate from ADR §5.5. Fails closed."""
+    """Kernel-side finalization gate from v1.1.0 §A.1. Fails closed."""
     if rec.get("outcome") != "completed":
         return False, "outcome not completed"
-    for f in MANDATORY_FOR_EXPORT:
-        v = rec.get(f)
+    for field in MANDATORY_FOR_EXPORT:
+        v = rec.get(field)
         if v is None or v == "":
-            return False, f"missing {f}"
+            return False, f"missing {field}"
     if rec["evidence_count"] < 1:
         return False, "no evidence"
     if not SHA40.match(rec["subject_sha"] or ""):
@@ -243,6 +439,7 @@ def finalizable(rec):
     if rec.get("corrections_present"):
         return False, "unresolved correction chain"
     return True, ""
+
 
 good = {"outcome": "completed", "repo_github_id": 123456789,
         "event_locator": "pr:36", "subject_sha": SHA_A,
@@ -258,10 +455,12 @@ check("non-gated run: NULL repo fields legal, not finalizable/exported",
       not ok2, why2)
 
 # every mandatory field missing => refused, naming the field
-for f in MANDATORY_FOR_EXPORT:
-    bad = dict(good); bad[f] = None
+for field in MANDATORY_FOR_EXPORT:
+    bad = dict(good)
+    bad[field] = None
     ok3, why3 = finalizable(bad)
-    check(f"finalization fails closed when {f} missing", not ok3 and f in why3, why3)
+    check(f"finalization fails closed when {field} missing",
+          not ok3 and field in why3, why3)
 
 check("abbreviated subject_sha refused at finalization",
       not finalizable(dict(good, subject_sha="a1b2c3d"))[0])
@@ -272,15 +471,29 @@ check("malformed event_locator refused",
 check("unresolved correction chain refused",
       not finalizable(dict(good, corrections_present=True))[0])
 
-# --- final_candidate_sha must NOT be a Kanban column (guards §4) ------
+# hostile SHAs must also be refused by the finalization gate, not only by SQL
+for label, value in HOSTILE_SHA40.items():
+    check(f"finalization refuses subject_sha {label}",
+          not finalizable(dict(good, subject_sha=value))[0])
+    check(f"finalization refuses verified_head_sha {label}",
+          not finalizable(dict(good, verified_head_sha=value))[0])
+
+# --- v1.1.0 §A.4: final_candidate_sha is NOT a Kanban column ----------
 prov_cols = {r[1] for r in db.execute("PRAGMA table_info(run_provenance)")}
 check("no final_candidate_sha / final_sha column exists",
       not {"final_candidate_sha", "final_sha"} & prov_cols,
-      sorted(prov_cols & {"subject_sha", "verified_head_sha"}))
+      str(sorted(prov_cols & {"subject_sha", "verified_head_sha"})))
+check("both witnessed SHAs ARE columns (subject_sha + verified_head_sha)",
+      {"subject_sha", "verified_head_sha"} <= prov_cols)
+
+# --- N2 resolution: no board column in the provenance record ----------
+check("no board / board_slug column exists (v1.0.0 §8)",
+      not {"board", "board_slug"} & prov_cols, str(sorted(prov_cols)[:4]))
 
 print("\n" + "=" * 60)
 failed = [n for n, ok, _ in results if not ok]
 print(f"{len(results) - len(failed)}/{len(results)} checks passed")
 if failed:
-    print("FAILED: " + ", ".join(failed)); raise SystemExit(1)
-print("All ADR-0007 mechanism claims verified.")
+    print("FAILED: " + ", ".join(failed))
+    raise SystemExit(1)
+print("All contract mechanism claims verified.")


### PR DESCRIPTION
## What

Publishes the structured-run-provenance contract into version control: v1.0.0 plus the v1.1.0 correction that amends it, together with an executable verifier.

**This PR head is `6e5dd3633f88e3d475da088540f4c0678b90710f`.** Hashes below are computed at that exact head.

| File | Version | sha256 @ `6e5dd363` |
|---|---|---|
| `docs/design/kanban-run-provenance-v1.0.0.md` | 1.0.0 | `9960c29e2c3a2578dfd8c0f4b1c35b4c0612dd38457d4fac01a88076b2f89db4` |
| `docs/design/kanban-run-provenance-v1.1.0-correction.md` | 1.1.0 | `4e7753f624c9bc3ebe6db734a9c5c92c5ca742fab81a05142d435721e984a798` |
| `docs/design/verify_adr0007_mechanisms.py` | — | `e6b17c01ecebd5eb5be04a891466a2ce9c7c02091c40ddd986baabded4700834` |

Reproduce:

```
git show 6e5dd363:docs/design/kanban-run-provenance-v1.0.0.md | shasum -a256
git show 6e5dd363:docs/design/kanban-run-provenance-v1.1.0-correction.md | shasum -a256
git show 6e5dd363:docs/design/verify_adr0007_mechanisms.py | shasum -a256
```

The two documents must land together: v1.1.0 is a correction that references v1.0.0 and overrides specific sections. Publishing either alone strands the other.

## History of this branch

Earlier states are **not** the contract. Any older hash triple is a superseded revision.

| Commit | State |
|---|---|
| `1ba7a03a` | initial publication — superseded |
| `36a2483e` | applied review findings B1–B4, N1–N2 — superseded |
| `b0bb7459` | applied R2 vocabulary rename; left one residual token — superseded |
| `74d81eab` | completed the R2 rename — superseded |
| `d92596cf` | added a schema-conformance check that asserted nothing — **superseded, see R3** |
| `6e5dd363` | **current head** — removes that check, restores honest 85/85 |

## Review findings

### R1 — stale PR metadata (fixed; GitHub metadata only, no commit)

The body previously published a superseded hash triple and asserted `final_candidate_sha` was deliberately stored on the run "with no conflict". That claim described pre-B3 text and contradicted §A.4, which this same PR introduces.

### R2 — undeclared table/column naming mismatch (fixed)

v1.0.0 §2.2 normatively defines `run_artifacts` with `artifact_path`, restated in §3.1, §9, A5b and A9. The verifier implemented `run_evidence` / `rel_path`, and v1.1.0 §C referred to `run_evidence.sha256`. No mapping was declared, so an implementer could not tell which was the contract.

**Resolved by renaming the verifier to match the document, not the reverse** — the document is normative and the verifier implements it. Landed in `b0bb7459` (table, columns, §C reference) and `74d81eab` (residual trigger `trg_run_evidence_sealed` → `trg_run_artifacts_sealed`; the first pass used word-boundary substitution, which cannot match inside an identifier because `_` is a word character).

**Zero-token proof** — substring search, not word-boundary, since the weaker form is what let the residual through:

```
grep -c 'run_evidence\|rel_path' \
  docs/design/verify_adr0007_mechanisms.py \
  docs/design/kanban-run-provenance-v1.0.0.md \
  docs/design/kanban-run-provenance-v1.1.0-correction.md
-> 0, 0, 0
```

### R3 — false schema-conformance check (fixed in `6e5dd363`)

The check added at `d92596cf` **asserted nothing.** It created `run_artifacts` from the verifier's own DDL, then compared `PRAGMA table_info` against a hardcoded literal copy of that same DDL. Both sides were the verifier's own text; §2.2 was never read. It could only fail if someone edited one half and forgot the other — a change-detector for its own source, not a contract check.

Its label, *"run_artifacts schema matches the declared artifact contract"*, was false. A reader of `86/86 checks passed` would reasonably conclude §2.2 conformance had been mechanically verified. It had not been verified at all.

The check also implied twelve normative columns. **Only six are declared:** §2.2 gives `id`, `run_id`, `artifact_path`, `sha256`, `created_at`; §B adds `sealed`. Of the rest, `size_bytes`, `git_blob_oid` and `declared_by` appear nowhere in either document; `task_id` appears only in the §6.1 export set; `tracked` and `clean` appear only as ordinary prose.

Per ruling on `t_45ef08d3`, the six columns were **not** added to the contract. The false check was removed instead, §C reverted to an honest **85/85**, and §C now states explicitly that **the verifier's SQL is a fixture, not the contract** — its `CREATE TABLE` statements are illustrative scaffolding, and only normatively declared columns are contractual.

## What v1.1.0 changes (correction, not replacement)

v1.0.0 §0–§3, §5–§6 and §9–§11 stand as written. §2.1, §2.2, §4, §6.1, §8 and §10 are amended only where **§A.4.1** lists them — that table enumerates every superseded line, so nothing is left to inference.

- **§A** (supersedes §3.3, §7, §7.1): repository-binding seam closed per director ruling.
- **§B** (corrects §5, A6): immutability defect — append-only table enforced by SQLite triggers.
- **§A.4** (resolves B3): the single normative three-SHA model — see below.
- **§A.5** (resolves B2): negated-GLOB CHECKs; the previous `GLOB '[0-9a-f]*'` validated only the first character.
- **§A.6** (resolves N2): verifier `board` column removed; its absence is asserted.
- **§C.1** (resolves B4): v1.1.0 acceptance tests start at A19; v1.0.0 A1–A18 preserved.

## The three-SHA model (§A.4, normative)

§A.4 **overrides every other statement about `final_candidate_sha` in either document.**

| SHA | Layer | Storage | Written by |
|---|---|---|---|
| `subject_sha` | Kanban run | `task_runs.subject_sha` | kernel, at claim |
| `verified_head_sha` | Kanban run | `task_runs.verified_head_sha` | kernel, at terminalization |
| final candidate SHA | DSSE attestation | **no Kanban column** | broker, at attestation time |

**No table in this contract may define a column named `final_candidate_sha` or `final_sha`.** Kanban stores only the two SHAs the kernel can honestly witness. The final candidate SHA is knowable only after a run is terminal, so persisting it would require the post-terminal mutation §5 forbids.

## Status — NOT approved

**Formal code review and security review are both pending.** This contract must not be treated as reviewed or security-approved, and this PR must not merge without `security-reviewer` sign-off on §B's trigger-based immutability and §A.1's nullable-vs-required split.

## Evidence at `6e5dd363`

- `verify_adr0007_mechanisms.py`: **85/85 checks passing**
- Sealed-row trigger proven live: `PASS  sealed evidence rejects writes  [evidence row is sealed]`
- `py_compile`: PASS
- `ruff` (repo config): All checks passed
- `ruff --isolated --select E,F,I,W,PLW --preview`: All checks passed
- `git diff --check`: clean
- All three files UTF-8, no BOM, no CRLF
- Residual `86/86` or false-conformance strings: 0
- Hostile corpus: `subject_sha` and `verified_head_sha` reject 7/7 each; artifact sha256 rejects 4/4; valid lowercase accepted
- Negative control: the legacy GLOB accepts 4 hostile entries, confirming B2 was real

## Source

- Contract author: `solution-architect` · source card `t_8c86298c`
- Publication card: `t_70c7ba83` (docs-steward: verbatim copy, no semantic edits)
- Findings B1–B4 / N1–N2: card `t_7b608af5`
- R1 / R2 exact-head re-review: comment #5365241655
- R3 finding: card `t_09cd360d` (code-reviewer) · fix ruling: card `t_45ef08d3`
