### PR TITLE
fix(install): fail clearly before PowerShell ConstrainedLanguage mutates anything

### DIFF
--- a/.github/workflows/installer-tests.yml
+++ b/.github/workflows/installer-tests.yml
@@ -36,3 +36,16 @@ jobs:
       - name: 8.3 short-path normalization (Windows PowerShell 5.1)
         shell: powershell
         run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-longpath.ps1
+
+      # The language mode preflight (#89857) is the one guard that must hold on a
+      # host where almost nothing else in install.ps1 can run, so it is worth
+      # asserting on both shells too: the child runspace is dropped into
+      # ConstrainedLanguage by the test itself, so no AppLocker/WDAC policy is
+      # needed on the runner.
+      - name: Language mode preflight (pwsh 7)
+        shell: pwsh
+        run: pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-language-mode.ps1
+
+      - name: Language mode preflight (Windows PowerShell 5.1)
+        shell: powershell
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-language-mode.ps1

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -77,6 +77,63 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# ============================================================================
+# PowerShell language mode preflight
+# ============================================================================
+# AppLocker and WDAC in enforcement mode drop PowerShell into
+# ConstrainedLanguage, which refuses method calls on anything but a short list
+# of core types: [Environment]::GetEnvironmentVariable, [Environment]::
+# GetFolderPath, [Console]::Error.WriteLine, New-Object on a .NET type and
+# [System.IO.File]::WriteAllText all throw
+# MethodInvocationNotSupportedInConstrainedLanguage. This installer makes more
+# than forty of those calls.
+#
+# The first one runs at SCRIPT scope in Set-LongProfileEnvVars a couple of
+# hundred lines below, so the script dies before any parameter is honored --
+# including -Manifest and -ProtocolVersion, which are read-only queries that
+# touch nothing. What the operator gets instead is a raw .NET error, localized
+# into the host language, naming a line number inside a cached copy of a
+# script they never wrote (#89857).
+#
+# Fail here instead, while we still can, and say what is wrong. This is a
+# refusal, not a workaround: there is no flag that makes the rest of the file
+# run, because the restriction is on the language, not on this script.
+#
+# Every construct below is legal under ConstrainedLanguage: a property read on
+# an automatic variable, string concatenation, Write-Host and Write-Error.
+# $host.UI.WriteErrorLine is NOT -- it is a method call on a non-core type and
+# throws the exact error this block exists to explain -- so the detail goes
+# out through Write-Error, whose cmdlet form is allowed.
+$DetectedLanguageMode = [string]$ExecutionContext.SessionState.LanguageMode
+if ($DetectedLanguageMode -and $DetectedLanguageMode -ne 'FullLanguage') {
+    Write-Host ""
+    Write-Host "[X] Hermes cannot install in PowerShell $DetectedLanguageMode mode." -ForegroundColor Red
+    Write-Host ""
+    Write-Host "    This session is restricted by an application control policy" -ForegroundColor Yellow
+    Write-Host "    (AppLocker, WDAC, or Windows Defender Application Control)." -ForegroundColor Yellow
+    Write-Host "    In this mode PowerShell refuses the .NET calls the installer" -ForegroundColor Yellow
+    Write-Host "    needs to read environment variables and locate profile folders." -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "    -ExecutionPolicy Bypass does not help. Execution policy and" -ForegroundColor Yellow
+    Write-Host "    language mode are separate controls; bypassing the first" -ForegroundColor Yellow
+    Write-Host "    leaves the second exactly as it was." -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "    PowerShell applies the restriction because this script sits in" -ForegroundColor Yellow
+    Write-Host "    a user-writable directory that the policy does not trust. Ask" -ForegroundColor Yellow
+    Write-Host "    whoever administers the policy to either:" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "      * allow-list the installer's path, or" -ForegroundColor Yellow
+    Write-Host "      * let you run it from a directory the policy already trusts" -ForegroundColor Yellow
+    Write-Host "        (typically %ProgramFiles% or %SystemRoot%)." -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "    Confirm the fix worked before re-running:" -ForegroundColor Yellow
+    Write-Host "      `$ExecutionContext.SessionState.LanguageMode" -ForegroundColor Yellow
+    Write-Host "    must print FullLanguage." -ForegroundColor Yellow
+    Write-Host ""
+    Write-Error -Message ("install.ps1 requires FullLanguage; this session is " + $DetectedLanguageMode) -ErrorAction Continue
+    exit 1
+}
+
 # Suppress Invoke-WebRequest's per-chunk progress bar.  Windows PowerShell
 # 5.1's progress UI repaints synchronously on every received byte, which
 # pegs CPU on a single core and throttles downloads by 10-100x (a 57MB

--- a/scripts/tests/test-install-ps1-language-mode.ps1
+++ b/scripts/tests/test-install-ps1-language-mode.ps1
@@ -1,0 +1,165 @@
+# Regression tests for install.ps1's PowerShell language mode preflight (#89857).
+#
+# Run from a PowerShell prompt:
+#
+#   powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-language-mode.ps1
+#
+# AppLocker / WDAC enforcement puts PowerShell in ConstrainedLanguage, where
+# method calls on non-core .NET types are refused. install.ps1 makes one at
+# script scope long before it looks at its own parameters, so without the
+# preflight even -ProtocolVersion -- a read-only query that touches nothing --
+# dies with a raw, host-localized .NET error pointing into a cached copy of a
+# script the operator never wrote.
+#
+# These tests run the installer as a real subprocess in a runspace that has
+# been put into ConstrainedLanguage, which is the same restriction the policy
+# applies. They do NOT need AppLocker configured on the runner.
+#
+# Nothing here installs anything: both invocations use -ProtocolVersion, which
+# returns before Main / Invoke-AllStages.
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$installScript = Join-Path $repoRoot "scripts\install.ps1"
+
+if (-not (Test-Path $installScript)) {
+    throw "Could not locate install.ps1 at $installScript"
+}
+
+$failures = 0
+function Assert-Equal {
+    param([Parameter(Mandatory=$true)] $Expected,
+          [Parameter(Mandatory=$true)] $Actual,
+          [Parameter(Mandatory=$true)] [string]$Label)
+    if ($Expected -ne $Actual) {
+        Write-Host "FAIL: $Label" -ForegroundColor Red
+        Write-Host "  expected: $Expected"
+        Write-Host "  actual:   $Actual"
+        $script:failures++
+    } else {
+        Write-Host "OK: $Label" -ForegroundColor Green
+    }
+}
+function Assert-True {
+    param([Parameter(Mandatory=$true)] $Condition,
+          [Parameter(Mandatory=$true)] [string]$Label)
+    if (-not $Condition) {
+        Write-Host "FAIL: $Label" -ForegroundColor Red
+        $script:failures++
+    } else {
+        Write-Host "OK: $Label" -ForegroundColor Green
+    }
+}
+
+# The shell that delivers install.ps1 is whatever the user already has, so the
+# child must be the SAME host this test is running under -- 5.1 and 7 differ in
+# how they surface a terminating error from a child script, and the CI job runs
+# this file under both.
+$psExe = (Get-Process -Id $PID).Path
+
+# Run a scriptblock's worth of PowerShell as a subprocess whose runspace has
+# been dropped into ConstrainedLanguage first. Streams go to files rather than
+# through the pipeline: Windows PowerShell 5.1 wraps a child's stderr in a
+# NativeCommandError and folds it into the caller's own error stream, which
+# would make an ordinary 2>&1 capture look like a failure of this test.
+function Invoke-Constrained {
+    param([Parameter(Mandatory=$true)] [string]$Body)
+
+    $dir = Join-Path ([System.IO.Path]::GetTempPath()) ("hermes-clm-" + [Guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    $wrapper = Join-Path $dir "wrapper.ps1"
+    $outFile = Join-Path $dir "out.txt"
+    $errFile = Join-Path $dir "err.txt"
+
+    # The mode assignment is one-way within a session, so it must happen in the
+    # child rather than here -- this test process stays FullLanguage.
+    $script = "`$ExecutionContext.SessionState.LanguageMode = 'ConstrainedLanguage'" + [Environment]::NewLine + $Body
+    Set-Content -LiteralPath $wrapper -Value $script -Encoding ascii
+
+    $proc = Start-Process -FilePath $psExe `
+        -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $wrapper) `
+        -Wait -PassThru -NoNewWindow `
+        -RedirectStandardOutput $outFile -RedirectStandardError $errFile
+
+    $result = [pscustomobject]@{
+        ExitCode = $proc.ExitCode
+        Output   = ((Get-Content -LiteralPath $outFile -Raw -ErrorAction SilentlyContinue) + [Environment]::NewLine +
+                    (Get-Content -LiteralPath $errFile -Raw -ErrorAction SilentlyContinue))
+    }
+    Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+    return $result
+}
+
+# -----------------------------------------------------------------------------
+# Guardrail: the harness really is constrained.
+#
+# Without this the whole file passes vacuously on any host where the mode
+# assignment silently does not take -- every assertion below would be checking
+# FullLanguage behavior while claiming to check ConstrainedLanguage.
+# -----------------------------------------------------------------------------
+Write-Host ""
+Write-Host "-- harness --"
+$probe = Invoke-Constrained -Body @'
+Write-Output ("mode=" + $ExecutionContext.SessionState.LanguageMode)
+try { $null = [Environment]::GetEnvironmentVariable('TEMP'); Write-Output 'dotnet=ALLOWED' }
+catch { Write-Output ('dotnet=' + $_.FullyQualifiedErrorId) }
+'@
+Assert-True ($probe.Output -match 'mode=ConstrainedLanguage') `
+    -Label "harness runspace reports ConstrainedLanguage"
+Assert-True ($probe.Output -match 'dotnet=MethodInvocationNotSupportedInConstrainedLanguage') `
+    -Label "harness refuses [Environment]::GetEnvironmentVariable (the call install.ps1 dies on)"
+
+# -----------------------------------------------------------------------------
+# Test: the preflight fires before anything else can throw.
+#
+# -ProtocolVersion is the strongest form of this: it is a read-only query, so
+# the ONLY reason it can fail is the language mode.
+# -----------------------------------------------------------------------------
+Write-Host ""
+Write-Host "-- ConstrainedLanguage --"
+$constrained = Invoke-Constrained -Body ("& '" + $installScript + "' -ProtocolVersion" + [Environment]::NewLine + "exit `$LASTEXITCODE")
+
+Assert-Equal -Expected 1 -Actual $constrained.ExitCode `
+    -Label "-ProtocolVersion exits 1 under ConstrainedLanguage"
+Assert-True ($constrained.Output -match 'ConstrainedLanguage mode') `
+    -Label "the message names the language mode"
+Assert-True ($constrained.Output -match 'ExecutionPolicy Bypass does not help') `
+    -Label "the message pre-empts the -ExecutionPolicy Bypass attempt (#89857's step 2)"
+Assert-True ($constrained.Output -match 'allow-list') `
+    -Label "the message says what an administrator has to change"
+
+# This is the regression itself: before the preflight, the run died inside
+# Set-LongProfileEnvVars with a .NET error and no mention of why.
+Assert-True (-not ($constrained.Output -match 'MethodInvocationNotSupportedInConstrainedLanguage')) `
+    -Label "the raw .NET error never reaches the operator"
+Assert-True (-not ($constrained.Output -match 'GetEnvironmentVariable')) `
+    -Label "the failure does not surface an install.ps1 line number"
+
+# -----------------------------------------------------------------------------
+# Test: FullLanguage is untouched.
+#
+# The guard is a refusal, so the thing most worth pinning is that it does not
+# fire on the hosts every other user has.
+# -----------------------------------------------------------------------------
+Write-Host ""
+Write-Host "-- FullLanguage --"
+$version = & $psExe -NoProfile -ExecutionPolicy Bypass -File $installScript -ProtocolVersion
+Assert-Equal -Expected 0 -Actual $LASTEXITCODE -Label "-ProtocolVersion still exits 0 under FullLanguage"
+Assert-True ($version -match '^\d+$') -Label "-ProtocolVersion still emits an integer (got: $version)"
+
+$manifest = & $psExe -NoProfile -ExecutionPolicy Bypass -File $installScript -Manifest
+Assert-Equal -Expected 0 -Actual $LASTEXITCODE -Label "-Manifest still exits 0 under FullLanguage"
+Assert-True (($manifest -join '') -match '"protocol_version"') `
+    -Label "-Manifest still emits the manifest, so the guard did not pollute stdout"
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+Write-Host ""
+if ($failures -gt 0) {
+    Write-Host "FAILED: $failures assertion(s) failed" -ForegroundColor Red
+    exit 1
+} else {
+    Write-Host "All language mode tests passed." -ForegroundColor Green
+    exit 0
+}


### PR DESCRIPTION
## Summary

Refs #89857. Supersedes stale/conflicting PR #90128 while preserving its exact implementation and original author identity.

This does **not** make Hermes install under PowerShell ConstrainedLanguage Mode. The current installer performs more than forty method calls on non-core .NET types; a partial conversion would only move the failure deeper into a mutating install.

The correct bounded behavior today is fail-before-mutation with an accurate diagnosis. This current-main rebase adds a CLM-legal preflight before script-scope environment normalization, explaining:

- that AppLocker/WDAC/application-control policy imposed the restriction;
- why `-ExecutionPolicy Bypass` cannot change language mode;
- which policy/path changes can make the script trusted;
- how to verify `FullLanguage` before retrying.

The test suite creates a real constrained child runspace, proves the restriction is active, and locks the preflight's placement ahead of the first forbidden .NET call. Installer workflow coverage runs under both Windows PowerShell 5.1 and pwsh 7.

## Provenance

This is the exact #90128 commit by @jackulau rebased cleanly through GitHub onto current `main`. The original Git author is preserved:

- [`11599ccf28a39b0b062944d4023d71df3c7405eb`](https://github.com/andrexibiza/hermes-agent/commit/11599ccf28a39b0b062944d4023d71df3c7405eb)

## Exact-head verification

All hosted workflows attached directly to `11599ccf...` are green:

- [CI 32433654721](https://github.com/NousResearch/hermes-agent/actions/runs/32433654721)
- [Docker 32433654284](https://github.com/NousResearch/hermes-agent/actions/runs/32433654284)
- [Nix 32433654286](https://github.com/NousResearch/hermes-agent/actions/runs/32433654286)

No status is inherited from #90128 or its former base.

## Scope and follow-on

This closes the misleading/raw-failure class and prevents partial installation under an unsupported policy context. A true CLM-compatible installer remains a separate product decision because PATH broadcasts, folder resolution, process capture, and BOM-free writes have no behavior-identical CLM replacements. This PR does not claim that capability.