### PR TITLE
fix(cli): keep resumed session cwd precedence consistent

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2958,7 +2958,32 @@ def cmd_chat(args):
         except OSError as e:
             print(f"Error: cannot enter --in directory {in_dir}: {e}")
             sys.exit(1)
+        # ``resolve_agent_cwd`` and every tool prefer TERMINAL_CWD over the
+        # process cwd. A relay launched from a kanban worker inherits that
+        # worker's workspace here, so chdir alone leaves the resumed Bot Chat
+        # logically anchored to the parent task. Keep the runtime carrier in
+        # sync with the explicit command-line override.
+        os.environ["TERMINAL_CWD"] = _target_dir
         args.no_restore_cwd = True
+    elif os.environ.get("HERMES_KANBAN_TASK"):
+        # Dispatcher workers are already launched with cwd=workspace and a
+        # matching TERMINAL_CWD. Preserve that current task boundary when a
+        # worker resumes a named session: a valid cwd stored by another board
+        # must not chdir this process out of the task it currently owns.
+        _task_workspace = os.environ.get("HERMES_KANBAN_WORKSPACE", "").strip()
+        if (
+            _task_workspace
+            and os.path.isabs(_task_workspace)
+            and os.path.isdir(_task_workspace)
+        ):
+            _task_workspace = os.path.abspath(_task_workspace)
+            try:
+                os.chdir(_task_workspace)
+            except OSError:
+                pass
+            else:
+                os.environ["TERMINAL_CWD"] = _task_workspace
+                args.no_restore_cwd = True
 
     # --resume latest: keyword for "most recent session" — same resolution
     # as `-c` with no name (workspace-scoped MRU, then global fallback).
@@ -3034,7 +3059,12 @@ def cmd_chat(args):
                 print(f"⚠ session's recorded dir is gone ({_saved_cwd}); staying in {os.getcwd()}")
             elif _saved_cwd and os.path.realpath(_saved_cwd) != os.path.realpath(os.getcwd()):
                 os.chdir(_saved_cwd)
+                os.environ["TERMINAL_CWD"] = os.path.abspath(_saved_cwd)
                 print(f"↪ restored workspace dir: {_saved_cwd}")
+            elif _saved_cwd:
+                # Keep the runtime carrier aligned even when no chdir was
+                # needed; an inherited value otherwise outranks os.getcwd().
+                os.environ["TERMINAL_CWD"] = os.path.abspath(_saved_cwd)
         except Exception:
             pass  # never let cwd-restore break a resume
         finally:

--- a/tests/hermes_cli/test_resume_latest_and_in_dir.py
+++ b/tests/hermes_cli/test_resume_latest_and_in_dir.py
@@ -229,3 +229,153 @@ def test_in_dir_expands_user_home(main_mod, launched, monkeypatch, tmp_path):
         assert os.getcwd() == str((home / "proj").resolve())
     finally:
         os.chdir(start)
+
+
+def test_in_dir_overrides_inherited_terminal_cwd(
+    main_mod, launched, monkeypatch, tmp_path
+):
+    """A relay's explicit --in must beat its worker parent's TERMINAL_CWD."""
+    import os
+
+    from agent.runtime_cwd import resolve_agent_cwd
+
+    relay_home = tmp_path / "relay-home"
+    worker_workspace = tmp_path / "kanban" / "boards" / "other" / "workspaces" / "t_old"
+    relay_home.mkdir()
+    worker_workspace.mkdir(parents=True)
+    monkeypatch.setenv("TERMINAL_CWD", str(worker_workspace))
+    start = os.getcwd()
+
+    try:
+        with pytest.raises(SystemExit):
+            main_mod.cmd_chat(_args(in_dir=str(relay_home)))
+        assert os.getcwd() == str(relay_home)
+        assert resolve_agent_cwd() == relay_home
+    finally:
+        os.chdir(start)
+
+
+def test_dispatcher_workspace_overrides_resumed_session_cwd(
+    main_mod, launched, monkeypatch, tmp_path
+):
+    """A dispatcher-owned run stays in its current task workspace on resume."""
+    import os
+
+    from agent.runtime_cwd import resolve_agent_cwd
+    from hermes_state import SessionDB
+
+    home = tmp_path / "home"
+    workspace = tmp_path / "current-board" / "workspaces" / "t_current"
+    saved = tmp_path / "other-board" / "workspaces" / "t_stale"
+    home.mkdir()
+    workspace.mkdir(parents=True)
+    saved.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_current")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+    monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+    db = SessionDB()
+    db.create_session("resume-me", source="cli", cwd=str(saved))
+    db.close()
+    start = os.getcwd()
+
+    try:
+        monkeypatch.chdir(workspace)
+        with pytest.raises(SystemExit):
+            main_mod.cmd_chat(_args(resume="resume-me"))
+        assert os.getcwd() == str(workspace)
+        assert resolve_agent_cwd() == workspace
+    finally:
+        os.chdir(start)
+
+
+def test_resume_restores_existing_saved_cwd(main_mod, launched, monkeypatch, tmp_path):
+    import os
+
+    from agent.runtime_cwd import resolve_agent_cwd
+    from hermes_state import SessionDB
+
+    home = tmp_path / "home"
+    launch = tmp_path / "launch"
+    saved = tmp_path / "saved"
+    home.mkdir()
+    launch.mkdir()
+    saved.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    db = SessionDB()
+    db.create_session("resume-me", source="cli", cwd=str(saved))
+    db.close()
+    start = os.getcwd()
+
+    try:
+        monkeypatch.chdir(launch)
+        with pytest.raises(SystemExit):
+            main_mod.cmd_chat(_args(resume="resume-me"))
+        assert os.getcwd() == str(saved)
+        assert resolve_agent_cwd() == saved
+    finally:
+        os.chdir(start)
+
+
+def test_resume_saved_cwd_overrides_inherited_terminal_cwd(
+    main_mod, launched, monkeypatch, tmp_path
+):
+    """Process cwd and the runtime resolver must agree after a normal resume."""
+    import os
+
+    from agent.runtime_cwd import resolve_agent_cwd
+    from hermes_state import SessionDB
+
+    home = tmp_path / "home"
+    launch = tmp_path / "launch"
+    inherited = tmp_path / "inherited"
+    saved = tmp_path / "saved"
+    for directory in (home, launch, inherited, saved):
+        directory.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("TERMINAL_CWD", str(inherited))
+    db = SessionDB()
+    db.create_session("resume-me", source="cli", cwd=str(saved))
+    db.close()
+    start = os.getcwd()
+
+    try:
+        monkeypatch.chdir(launch)
+        with pytest.raises(SystemExit):
+            main_mod.cmd_chat(_args(resume="resume-me"))
+        assert os.getcwd() == str(saved)
+        assert resolve_agent_cwd() == saved
+    finally:
+        os.chdir(start)
+
+
+def test_resume_with_missing_saved_cwd_stays_put_without_creating_it(
+    main_mod, launched, monkeypatch, tmp_path
+):
+    import os
+
+    from agent.runtime_cwd import resolve_agent_cwd
+    from hermes_state import SessionDB
+
+    home = tmp_path / "home"
+    launch = tmp_path / "launch"
+    missing = tmp_path / "kanban" / "boards" / "bogus" / "workspaces" / "t_old"
+    home.mkdir()
+    launch.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    db = SessionDB()
+    db.create_session("resume-me", source="cli", cwd=str(missing))
+    db.close()
+    start = os.getcwd()
+
+    try:
+        monkeypatch.chdir(launch)
+        with pytest.raises(SystemExit):
+            main_mod.cmd_chat(_args(resume="resume-me"))
+        assert os.getcwd() == str(launch)
+        assert resolve_agent_cwd() == launch
+        assert not missing.exists()
+    finally:
+        os.chdir(start)


### PR DESCRIPTION
## Summary
- keep explicit `--in` authoritative over inherited `TERMINAL_CWD`
- keep dispatcher-owned resumes in the current valid task workspace
- synchronize normal saved-CWD restores with the runtime CWD carrier
- preserve safe fallback when a saved directory no longer exists

## Root cause
`cmd_chat` changed the process directory but did not update `TERMINAL_CWD`. `resolve_agent_cwd()` and the tool surfaces prefer `TERMINAL_CWD`, so a Bot Chat resumed by `factory-message` could remain logically anchored to the parent worker's cross-board workspace even after `--in` changed `os.getcwd()`.

## Test plan
- `scripts/run_tests.sh tests/hermes_cli/test_resume_latest_and_in_dir.py tests/hermes_cli/test_chat_c_fail_loudly.py -q` (23 passed)
- `scripts/run_tests.sh tests/hermes_cli/test_tui_resume_flow.py tests/agent/test_runtime_cwd.py tests/hermes_cli/test_argparse_flag_propagation.py tests/hermes_cli/test_chat_c_fail_loudly.py tests/hermes_cli/test_resume_latest_and_in_dir.py -q` (41 passed)
- `.venv/bin/ruff check hermes_cli/main.py tests/hermes_cli/test_resume_latest_and_in_dir.py` (passed)
- `git diff --check` (passed)

A broader `scripts/run_tests.sh tests/hermes_cli/ -q` completed with three unrelated standing failures: one missing optional `acp` module and two provider catalog/model-discovery assertions. Re-running those two files reproduced the same three failures independently of the changed path.

## Review
Independent `code-reviewer` verdict: PASS, no blocking security or logic findings.
