### PR TITLE
fix(discord): apply YAML allow_bots to ingress policy

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4965,7 +4965,8 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def _get_allow_bots(self) -> str:
         """Per-profile DISCORD_ALLOW_BOTS mode (none|mentions|all)."""
-        return self._gate_env("DISCORD_ALLOW_BOTS", "none").lower().strip() or "none"
+        raw = self._gate_raw("allow_bots", "DISCORD_ALLOW_BOTS")
+        return str(raw or "none").lower().strip() or "none"
 
     def _discord_free_response_channels(self) -> set:
         """Channel IDs/names needing no mention; a lone "*" is preserved for wildcard short-circuit."""
@@ -7265,6 +7266,7 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     _gate("allow_from", "DISCORD_ALLOWED_USERS", from_platform_extra=True)
     _gate("allowed_roles", "DISCORD_ALLOWED_ROLES", from_platform_extra=True)
     _gate("allow_all_users", "DISCORD_ALLOW_ALL_USERS", from_platform_extra=True, lower=True)
+    _gate("allow_bots", "DISCORD_ALLOW_BOTS", from_platform_extra=True, lower=True)
     approval_mentions_cfg = (
         discord_cfg["approval_mentions"] if "approval_mentions" in discord_cfg
         else platform_extra_cfg.get("approval_mentions")

--- a/tests/gateway/test_discord_allow_bots_yaml_config.py
+++ b/tests/gateway/test_discord_allow_bots_yaml_config.py
@@ -1,0 +1,67 @@
+"""config.yaml `discord.allow_bots` must reach the adapter's bot gate.
+
+Invariant: every Discord allowlist gate configurable in `config.yaml` resolves through
+`PlatformConfig.extra` even when no `DISCORD_*` env var is set. `allow_bots` regressed
+because `_get_allow_bots()` read env only, so a YAML-configured value was silently
+ignored and bot-to-bot handoffs stayed blocked.
+"""
+
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture
+def adapter_mod():
+    sys.modules.pop("plugins.platforms.discord.adapter", None)
+    return importlib.import_module("plugins.platforms.discord.adapter")
+
+
+def _seed(adapter_mod, yaml_cfg, discord_cfg):
+    return adapter_mod._apply_yaml_config(yaml_cfg, discord_cfg)
+
+
+def test_yaml_allow_bots_is_seeded_into_extra(adapter_mod, monkeypatch):
+    monkeypatch.delenv("DISCORD_ALLOW_BOTS", raising=False)
+    seeded = _seed(adapter_mod, {}, {"allow_bots": "mentions"})
+    assert seeded is not None
+    assert seeded.get("allow_bots") == "mentions"
+
+
+def _fake_adapter(adapter_mod, extra, env_overrides=None):
+    """A DiscordAdapter shell with only the gate-resolution state populated."""
+    adapter = object.__new__(adapter_mod.DiscordAdapter)
+    adapter.config = types.SimpleNamespace(extra=extra)
+    snapshot = {key: "" for key in adapter_mod._GATE_ENV_KEYS}
+    snapshot.update(env_overrides or {})
+    adapter._gate_env_snapshot = snapshot
+    return adapter
+
+
+def test_adapter_reads_allow_bots_from_extra_without_env(adapter_mod, monkeypatch):
+    monkeypatch.delenv("DISCORD_ALLOW_BOTS", raising=False)
+    monkeypatch.setattr(adapter_mod, "_scoped_gate_env", lambda name, default="": default)
+
+    adapter = _fake_adapter(adapter_mod, {"allow_bots": "mentions"})
+
+    assert adapter._get_allow_bots() == "mentions"
+
+
+def test_env_still_wins_over_yaml_for_allow_bots(adapter_mod, monkeypatch):
+    monkeypatch.setattr(adapter_mod, "_scoped_gate_env", lambda name, default="": default)
+
+    adapter = _fake_adapter(
+        adapter_mod, {"allow_bots": "mentions"}, {"DISCORD_ALLOW_BOTS": "all"}
+    )
+
+    assert adapter._get_allow_bots() == "all"
+
+
+def test_allow_bots_defaults_to_none_when_unconfigured(adapter_mod, monkeypatch):
+    monkeypatch.setattr(adapter_mod, "_scoped_gate_env", lambda name, default="": default)
+
+    adapter = _fake_adapter(adapter_mod, {})
+
+    assert adapter._get_allow_bots() == "none"


### PR DESCRIPTION
## Summary

- seed `discord.allow_bots` into each Discord adapter's profile-scoped configuration
- preserve existing `DISCORD_ALLOW_BOTS` environment-variable precedence
- make the live bot-ingress policy fall back to per-profile YAML instead of silently defaulting to `none`
- add regression coverage for both YAML propagation and env-over-YAML precedence

## Problem

Hermes accepts and validates:

```yaml
discord:
  allow_bots: mentions
```

but the Discord adapter's live ingress check only reads the legacy environment snapshot. In a YAML-only deployment, bot-authored messages are therefore rejected as if the policy were `none`.

## Implementation

The bridge stays inside the Discord plugin's `_apply_yaml_config` hook, where current platform-specific config seeding belongs. The adapter resolves `DISCORD_ALLOW_BOTS` first through `_gate_raw`, then falls back to its profile-local `PlatformConfig.extra` value. This keeps multiplexed profiles isolated and retains documented env precedence.

## Tests

- RED on clean upstream: YAML regression failed because `_apply_yaml_config` returned no adapter configuration
- focused Discord bot-ingress suite: **11 passed**
- Ruff and `git diff --check`: passed
- broader Discord suite: **249 passed, 1 skipped**; three unrelated media tests fail in this environment because the optional Discord media import resolves to `None`

## Prior art

Related to #35810 by @garethterb, which identified the same configuration gap. This PR incorporates the maintainer-bot feedback there: use the Discord plugin bridge rather than `gateway/config.py`, preserve env-over-YAML precedence, and add regression tests.

The change is intentionally limited to the Discord adapter and tests; no deployment config or credentials are included.