### PR TITLE
feat(proxy): add loopback OpenAI Codex OAuth adapter

### DIFF
--- a/hermes_cli/proxy/adapters/__init__.py
+++ b/hermes_cli/proxy/adapters/__init__.py
@@ -8,15 +8,19 @@ token. See :class:`UpstreamAdapter` for the contract.
 from typing import Dict, Type
 
 from hermes_cli.proxy.adapters.base import UpstreamAdapter
+from hermes_cli.proxy.adapters.codex import OpenAICodexAdapter
 from hermes_cli.proxy.adapters.nous_portal import NousPortalAdapter
 from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
 
 # Registry of available adapter classes keyed by provider name as used on
 # the ``hermes proxy start --provider <name>`` CLI flag.
 ADAPTERS: Dict[str, Type[UpstreamAdapter]] = {
+    "openai-codex": OpenAICodexAdapter,
     "nous": NousPortalAdapter,
     "xai": XAIGrokAdapter,
 }
+
+_ALIASES = {"codex": "openai-codex"}
 
 
 def get_adapter(name: str) -> UpstreamAdapter:
@@ -26,6 +30,7 @@ def get_adapter(name: str) -> UpstreamAdapter:
         ValueError: if ``name`` is not a registered adapter.
     """
     key = (name or "").strip().lower()
+    key = _ALIASES.get(key, key)
     if key not in ADAPTERS:
         available = ", ".join(sorted(ADAPTERS)) or "(none)"
         raise ValueError(

--- a/hermes_cli/proxy/adapters/base.py
+++ b/hermes_cli/proxy/adapters/base.py
@@ -81,6 +81,27 @@ class UpstreamAdapter(ABC):
               refresh fails. The proxy will return 401 to the client.
         """
 
+    @property
+    def loopback_only(self) -> bool:
+        """Whether this credential must never bind beyond loopback."""
+        return False
+
+    def get_owned_upstream_header_names(self) -> frozenset[str]:
+        """Headers whose inbound client values must always be removed."""
+        return frozenset()
+
+    def get_upstream_headers(
+        self,
+        credential: UpstreamCredential,
+    ) -> dict[str, str]:
+        """Return provider-required headers in addition to Authorization.
+
+        The server applies these after filtering inbound client headers, so an
+        untrusted loopback client cannot spoof provider identity/account fields.
+        """
+        _ = credential
+        return {}
+
     def get_retry_credential(
         self,
         *,

--- a/hermes_cli/proxy/adapters/codex.py
+++ b/hermes_cli/proxy/adapters/codex.py
@@ -1,0 +1,166 @@
+"""OpenAI Codex OAuth upstream adapter for the loopback Hermes proxy."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import FrozenSet, Optional
+
+from agent.credential_pool import CredentialPool, PooledCredential, load_pool
+from hermes_cli.auth import DEFAULT_CODEX_BASE_URL
+from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
+
+logger = logging.getLogger(__name__)
+
+_POOL_PROVIDER = "openai-codex"
+_ALLOWED_PATHS: FrozenSet[str] = frozenset({"/responses", "/models"})
+_OWNED_HEADERS: FrozenSet[str] = frozenset(
+    {"User-Agent", "originator", "ChatGPT-Account-ID"}
+)
+
+
+class OpenAICodexAdapter(UpstreamAdapter):
+    """Attach the main Hermes Codex OAuth credential to Responses requests."""
+
+    auth_hint = "hermes auth add openai-codex --type oauth"
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._pool: Optional[CredentialPool] = None
+
+    @property
+    def name(self) -> str:
+        return "openai-codex"
+
+    @property
+    def display_name(self) -> str:
+        return "OpenAI Codex OAuth"
+
+    @property
+    def loopback_only(self) -> bool:
+        return True
+
+    @property
+    def allowed_paths(self) -> FrozenSet[str]:
+        return _ALLOWED_PATHS
+
+    def is_authenticated(self) -> bool:
+        """Check local pool state only; never call the network."""
+        pool = self._load_pool()
+        return bool(pool and pool.has_available())
+
+    def get_credential(self) -> UpstreamCredential:
+        with self._lock:
+            pool = self._load_pool()
+            if pool is None or not pool.has_credentials():
+                raise RuntimeError(
+                    "No OpenAI Codex OAuth credentials found. Run "
+                    "`hermes auth add openai-codex --type oauth` first."
+                )
+            entry = pool.select()
+            if entry is None:
+                raise RuntimeError(
+                    "No available OpenAI Codex OAuth credentials. Reset the "
+                    "pool cooldown or re-authenticate."
+                )
+            self._pool = pool
+            return self._credential_from_entry(entry)
+
+    def get_retry_credential(
+        self,
+        *,
+        failed_credential: UpstreamCredential,
+        status_code: int,
+    ) -> Optional[UpstreamCredential]:
+        if status_code not in {401, 429}:
+            return None
+
+        with self._lock:
+            pool = self._pool or self._load_pool()
+            if pool is None:
+                return None
+
+            if status_code == 401:
+                refreshed = pool.try_refresh_matching(
+                    api_key_hint=failed_credential.bearer
+                )
+                if refreshed is None:
+                    # A concurrent request may have queued behind the adapter
+                    # lock with the same now-stale bearer. If the first request
+                    # already refreshed/rotated the pool, coalesce onto that
+                    # current credential instead of failing or exhausting the
+                    # obsolete token a second time.
+                    current = pool.select()
+                    if (
+                        current is not None
+                        and str(current.runtime_api_key or "").strip()
+                        != failed_credential.bearer
+                    ):
+                        refreshed = current
+                if refreshed is None:
+                    refreshed = pool.mark_exhausted_and_rotate(
+                        status_code=401,
+                        api_key_hint=failed_credential.bearer,
+                    )
+            else:
+                refreshed = pool.mark_exhausted_and_rotate(
+                    status_code=429,
+                    api_key_hint=failed_credential.bearer,
+                )
+
+            if refreshed is None:
+                return None
+            retry = self._credential_from_entry(refreshed)
+            if retry.bearer == failed_credential.bearer:
+                return None
+            logger.info(
+                "proxy: Codex upstream returned %s; retrying with refreshed/rotated credential",
+                status_code,
+            )
+            return retry
+
+    def get_owned_upstream_header_names(self) -> frozenset[str]:
+        return _OWNED_HEADERS
+
+    def get_upstream_headers(
+        self,
+        credential: UpstreamCredential,
+    ) -> dict[str, str]:
+        # Reuse the native Codex request identity contract: originator and
+        # User-Agent avoid Cloudflare challenges on VPS traffic, while the
+        # account header is extracted from the JWT when present.
+        from agent.auxiliary_client import _codex_cloudflare_headers
+
+        return _codex_cloudflare_headers(credential.bearer)
+
+    def _load_pool(self) -> Optional[CredentialPool]:
+        try:
+            return load_pool(_POOL_PROVIDER)
+        except Exception:
+            logger.warning("proxy: failed to load Codex OAuth credential pool", exc_info=True)
+            return None
+
+    def _credential_from_entry(self, entry: PooledCredential) -> UpstreamCredential:
+        bearer = str(entry.runtime_api_key or "").strip()
+        if not bearer:
+            raise RuntimeError(
+                "Codex OAuth pool entry has no access token. Re-authenticate "
+                "with `hermes auth add openai-codex --type oauth`."
+            )
+        base_url = str(
+            entry.runtime_base_url or entry.base_url or DEFAULT_CODEX_BASE_URL
+        ).strip().rstrip("/")
+        trusted_base = DEFAULT_CODEX_BASE_URL.rstrip("/")
+        if base_url != trusted_base:
+            raise RuntimeError(
+                "Refusing to attach OpenAI Codex OAuth credentials to untrusted "
+                f"upstream {base_url!r}; expected {trusted_base!r}."
+            )
+        return UpstreamCredential(
+            bearer=bearer,
+            base_url=trusted_base,
+            expires_at=entry.expires_at,
+        )
+
+
+__all__ = ["OpenAICodexAdapter"]

--- a/hermes_cli/proxy/cli.py
+++ b/hermes_cli/proxy/cli.py
@@ -12,6 +12,7 @@ from hermes_cli.proxy.server import (
     AIOHTTP_AVAILABLE,
     DEFAULT_HOST,
     DEFAULT_PORT,
+    is_loopback_host,
     run_server,
 )
 
@@ -52,6 +53,13 @@ def cmd_proxy_start(args: Any) -> int:
 
     host = getattr(args, "host", None) or DEFAULT_HOST
     port = getattr(args, "port", None) or DEFAULT_PORT
+    if adapter.loopback_only and not is_loopback_host(host):
+        print(
+            f"Error: {adapter.display_name} proxy is loopback-only; "
+            f"refusing bind host {host!r}.",
+            file=sys.stderr,
+        )
+        return 2
 
     print(
         f"Starting Hermes proxy for {adapter.display_name}\n"
@@ -121,7 +129,7 @@ def cmd_proxy(args: Any) -> int:
         "OAuth-authenticated provider credentials to outbound requests.\n"
         "\n"
         "Subcommands:\n"
-        "  hermes proxy start [--provider nous|xai] [--host 127.0.0.1] [--port 8645]\n"
+        "  hermes proxy start [--provider codex|nous|xai] [--host 127.0.0.1] [--port 8645]\n"
         "      Run the proxy in the foreground.\n"
         "  hermes proxy status\n"
         "      Show which upstream adapters are ready.\n"

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -12,6 +12,7 @@ or rewrite request/response bodies. It's a credential-attaching forwarder.
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import logging
 import signal
 from typing import Optional
@@ -19,10 +20,12 @@ from typing import Optional
 try:
     import aiohttp
     from aiohttp import web
+    from yarl import URL
     AIOHTTP_AVAILABLE = True
 except ImportError:
     aiohttp = None  # type: ignore[assignment]
     web = None  # type: ignore[assignment]
+    URL = None  # type: ignore[assignment,misc]
     AIOHTTP_AVAILABLE = False
 
 from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
@@ -56,6 +59,17 @@ DEFAULT_HOST = "127.0.0.1"
 MAX_REQUEST_BYTES = 10_000_000
 
 
+def is_loopback_host(host: str) -> bool:
+    """True only for explicit loopback literals or localhost."""
+    value = str(host or "").strip().lower()
+    if value == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(value).is_loopback
+    except ValueError:
+        return False
+
+
 def _json_error(status: int, message: str, code: str = "proxy_error") -> "web.Response":
     """Return an OpenAI-style error JSON response."""
     body = {"error": {"message": message, "type": code, "code": code}}
@@ -72,6 +86,38 @@ def _filter_request_headers(headers: "aiohttp.typedefs.LooseHeaders") -> dict:
     return out
 
 
+def _strip_owned_headers(headers: dict, owned_names: frozenset[str]) -> dict:
+    """Remove all client spellings of adapter-owned identity headers."""
+    owned = {str(name).strip().lower() for name in owned_names if str(name).strip()}
+    return {
+        key: value
+        for key, value in headers.items()
+        if str(key).lower() not in owned
+    }
+
+
+def _merge_adapter_headers(
+    headers: dict,
+    adapter_headers: dict[str, str],
+) -> dict:
+    """Overlay trusted adapter headers case-insensitively.
+
+    Client-controlled values with alternate casing must not survive alongside
+    Codex account/originator headers. Authorization remains owned exclusively
+    by the server's credential path.
+    """
+    merged = dict(headers)
+    for key, value in adapter_headers.items():
+        normalized = str(key).strip()
+        if not normalized or normalized.lower() in _HOP_BY_HOP_HEADERS:
+            continue
+        for existing in list(merged):
+            if str(existing).lower() == normalized.lower():
+                merged.pop(existing, None)
+        merged[normalized] = str(value)
+    return merged
+
+
 def _filter_response_headers(headers) -> dict:
     """Strip hop-by-hop headers from the upstream response."""
     out = {}
@@ -83,6 +129,73 @@ def _filter_response_headers(headers) -> dict:
             continue
         out[key] = value
     return out
+
+
+async def _open_upstream_request(
+    *,
+    method: str,
+    url,
+    body: bytes,
+    headers: dict,
+    timeout,
+):
+    """Open one upstream request and close its session on every failed setup."""
+    try:
+        session = aiohttp.ClientSession(timeout=timeout)
+    except Exception as exc:  # pragma: no cover - aiohttp setup issue
+        raise RuntimeError(f"proxy session init failed: {exc}") from exc
+
+    try:
+        response = await session.request(
+            method,
+            url,
+            data=body if body else None,
+            headers=headers,
+            allow_redirects=False,
+        )
+    except asyncio.CancelledError:
+        await session.close()
+        raise
+    except Exception:
+        await session.close()
+        raise
+    return session, response
+
+
+async def _stream_upstream_response(
+    request: "web.Request",
+    upstream_resp,
+    session,
+) -> "web.StreamResponse":
+    """Bridge one upstream response and always release transport resources."""
+    resp = web.StreamResponse(
+        status=upstream_resp.status,
+        headers=_filter_response_headers(upstream_resp.headers),
+    )
+    try:
+        # Cleanup ownership starts before prepare: downstream disconnects while
+        # sending headers must still release the already-open upstream response.
+        await resp.prepare(request)
+        try:
+            async for chunk in upstream_resp.content.iter_any():
+                if chunk:
+                    await resp.write(chunk)
+        except asyncio.CancelledError:
+            raise
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            logger.warning(
+                "proxy: upstream stream interrupted; aborting downstream: %s",
+                exc,
+            )
+            transport = request.transport
+            if transport is not None:
+                transport.abort()
+            raise
+        await resp.write_eof()
+        return resp
+    finally:
+        upstream_resp.release()
+        await session.close()
 
 
 def create_app(adapter: UpstreamAdapter) -> "web.Application":
@@ -137,35 +250,42 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
 
         async def _send_upstream(active_cred: UpstreamCredential):
             upstream_url = f"{active_cred.base_url.rstrip('/')}{rel_path}"
-            # Preserve query string verbatim.
-            if request.query_string:
-                upstream_url = f"{upstream_url}?{request.query_string}"
+            # Preserve the raw percent-encoded query. ``request.query_string``
+            # is decoded by aiohttp and corrupts values when interpolated into
+            # a new URL (for example %252f -> /). Never log query contents.
+            raw_path = str(request.raw_path or "")
+            if "?" in raw_path:
+                raw_query = raw_path.split("?", 1)[1]
+                if raw_query:
+                    upstream_url = f"{upstream_url}?{raw_query}"
 
             fwd_headers = _filter_request_headers(request.headers)
+            fwd_headers = _strip_owned_headers(
+                fwd_headers,
+                adapter.get_owned_upstream_header_names(),
+            )
+            fwd_headers = _merge_adapter_headers(
+                fwd_headers,
+                adapter.get_upstream_headers(active_cred),
+            )
             fwd_headers["Authorization"] = f"{active_cred.token_type} {active_cred.bearer}"
 
             logger.debug(
-                "proxy: forwarding %s %s -> %s (body=%d bytes)",
-                request.method, rel_path, upstream_url, len(body),
+                "proxy: forwarding %s %s -> %s%s (body=%d bytes)",
+                request.method,
+                rel_path,
+                active_cred.base_url.rstrip("/"),
+                rel_path,
+                len(body),
             )
 
-            try:
-                session = aiohttp.ClientSession(timeout=timeout)
-            except Exception as exc:  # pragma: no cover - aiohttp setup issue
-                raise RuntimeError(f"proxy session init failed: {exc}") from exc
-
-            try:
-                upstream_resp = await session.request(
-                    request.method,
-                    upstream_url,
-                    data=body if body else None,
-                    headers=fwd_headers,
-                    allow_redirects=False,
-                )
-            except Exception:
-                await session.close()
-                raise
-            return session, upstream_resp
+            return await _open_upstream_request(
+                method=request.method,
+                url=URL(upstream_url, encoded=True),
+                body=body,
+                headers=fwd_headers,
+                timeout=timeout,
+            )
 
         async def _open_upstream(active_cred: UpstreamCredential):
             try:
@@ -215,25 +335,7 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
                     return session_or_response
                 session = session_or_response
 
-        # Stream response back. Headers first, then chunked body.
-        resp = web.StreamResponse(
-            status=upstream_resp.status,
-            headers=_filter_response_headers(upstream_resp.headers),
-        )
-        await resp.prepare(request)
-
-        try:
-            async for chunk in upstream_resp.content.iter_any():
-                if chunk:
-                    await resp.write(chunk)
-        except (aiohttp.ClientError, asyncio.CancelledError) as exc:
-            logger.warning("proxy: streaming interrupted: %s", exc)
-        finally:
-            upstream_resp.release()
-            await session.close()
-
-        await resp.write_eof()
-        return resp
+        return await _stream_upstream_response(request, upstream_resp, session)
 
     # /health doesn't go through the upstream
     app.router.add_get("/health", handle_health)
@@ -256,6 +358,11 @@ async def run_server(
     if not AIOHTTP_AVAILABLE:
         raise RuntimeError(
             "aiohttp is required for `hermes proxy`. Run `hermes setup` to install it."
+        )
+
+    if adapter.loopback_only and not is_loopback_host(host):
+        raise RuntimeError(
+            f"{adapter.display_name} proxy is loopback-only; refusing bind host {host!r}."
         )
 
     app = create_app(adapter)

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -331,7 +331,7 @@ def build_gateway_parser(
     proxy_start.add_argument(
         "--provider",
         default="nous",
-        help="Upstream provider: nous or xai (default: nous). See `hermes proxy providers`.",
+        help="Upstream provider: codex, nous, or xai (default: nous). See `hermes proxy providers`.",
     )
     proxy_start.add_argument(
         "--host",

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -6,8 +6,9 @@ import asyncio
 import json
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -229,8 +230,13 @@ def test_xai_adapter_retry_rotates_pool_entry_on_429(tmp_path, monkeypatch):
 
 aiohttp = pytest.importorskip("aiohttp")
 from aiohttp import web  # noqa: E402
+from yarl import URL  # noqa: E402
 
-from hermes_cli.proxy.server import create_app  # noqa: E402
+from hermes_cli.proxy.server import (  # noqa: E402
+    _open_upstream_request,
+    _stream_upstream_response,
+    create_app,
+)
 
 
 class FakeAdapter(UpstreamAdapter):
@@ -238,12 +244,16 @@ class FakeAdapter(UpstreamAdapter):
 
     def __init__(self, base_url: str, bearer: str = "test-bearer",
                  allowed=None, raise_on_credential=False,
-                 retry_bearer: str | None = None):
+                 retry_bearer: str | None = None,
+                 upstream_headers: dict[str, str] | None = None,
+                 owned_headers: set[str] | None = None):
         self._base_url = base_url
         self._bearer = bearer
         self._allowed = frozenset(allowed or ["/chat/completions"])
         self._raise = raise_on_credential
         self._retry_bearer = retry_bearer
+        self._upstream_headers = dict(upstream_headers or {})
+        self._owned_headers = frozenset(owned_headers or self._upstream_headers)
         self.calls = 0
         self.retry_calls = 0
 
@@ -266,6 +276,13 @@ class FakeAdapter(UpstreamAdapter):
             bearer=self._bearer, base_url=self._base_url,
             expires_at="2099-01-01T00:00:00Z",
         )
+
+    def get_owned_upstream_header_names(self):
+        return self._owned_headers
+
+    def get_upstream_headers(self, credential):
+        _ = credential
+        return dict(self._upstream_headers)
 
     def get_retry_credential(self, *, failed_credential, status_code):
         _ = failed_credential
@@ -296,7 +313,9 @@ def _build_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
         captured["requests"].append({
             "method": request.method,
             "path": request.path,
+            "raw_path": request.raw_path,
             "auth": request.headers.get("Authorization"),
+            "headers": dict(request.headers),
             "body": body.decode("utf-8") if body else "",
         })
         return web.json_response({"echoed": True, "path": request.path})
@@ -313,6 +332,7 @@ def _build_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
 
     app = web.Application()
     app.router.add_route("*", "/v1/chat/completions", echo)
+    app.router.add_route("*", "/v1/responses", echo)
     app.router.add_route("*", "/v1/embeddings", echo)
     app.router.add_route("*", "/v1/sse", sse)
     return app
@@ -341,6 +361,100 @@ def _build_retrying_fake_upstream(captured: Dict[str, Any]) -> "web.Application"
 
 
 
+def _build_rate_limited_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
+    async def rate_limited(request):
+        captured["requests"].append(
+            {
+                "auth": request.headers.get("Authorization"),
+                "path": request.path,
+            }
+        )
+        return web.json_response({"error": "rate limited"}, status=429)
+
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", rate_limited)
+    return app
+
+
+def _build_codex_sse_upstream(expected_chunks: list[bytes]) -> "web.Application":
+    async def responses(request):
+        await request.read()
+        resp = web.StreamResponse(
+            status=200,
+            headers={"Content-Type": "text/event-stream"},
+        )
+        await resp.prepare(request)
+        for chunk in expected_chunks:
+            await resp.write(chunk)
+        await resp.write_eof()
+        return resp
+
+    app = web.Application()
+    app.router.add_post("/v1/responses", responses)
+    return app
+
+
+def _build_truncated_sse_upstream() -> "web.Application":
+    async def responses(request):
+        resp = web.StreamResponse(
+            status=200,
+            headers={
+                "Content-Type": "text/event-stream",
+                "Content-Length": "512",
+            },
+        )
+        await resp.prepare(request)
+        await resp.write(b"event: response.output_text.delta\ndata: partial\n\n")
+        if request.transport is not None:
+            request.transport.abort()
+        return resp
+
+    app = web.Application()
+    app.router.add_post("/v1/responses", responses)
+    return app
+
+
+def test_cancelled_upstream_request_closes_new_client_session():
+    session = SimpleNamespace(
+        request=AsyncMock(side_effect=asyncio.CancelledError()),
+        close=AsyncMock(),
+    )
+    with patch(
+        "hermes_cli.proxy.server.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(
+                _open_upstream_request(
+                    method="POST",
+                    url=URL("http://127.0.0.1:1/v1/responses", encoded=True),
+                    body=b"{}",
+                    headers={},
+                    timeout=None,
+                )
+            )
+    session.close.assert_awaited_once_with()
+
+
+def test_prepare_failure_releases_upstream_response_and_session():
+    upstream = MagicMock()
+    upstream.status = 200
+    upstream.headers = {}
+    session = SimpleNamespace(close=AsyncMock())
+    request = SimpleNamespace(transport=None)
+
+    with patch.object(
+        web.StreamResponse,
+        "prepare",
+        new=AsyncMock(side_effect=ConnectionResetError("downstream gone")),
+    ):
+        with pytest.raises(ConnectionResetError, match="downstream gone"):
+            asyncio.run(_stream_upstream_response(request, upstream, session))
+
+    upstream.release.assert_called_once_with()
+    session.close.assert_awaited_once_with()
+
+
 def test_server_strips_client_auth_header():
     """The client's Authorization header MUST NOT reach the upstream."""
     async def run():
@@ -358,6 +472,282 @@ def test_server_strips_client_auth_header():
                     await resp.read()
             assert captured["requests"][0]["auth"] == "Bearer ours"
             assert "SHOULD_NOT_LEAK" not in captured["requests"][0]["auth"]
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_retries_once_with_adapter_credential_after_401():
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(
+            _build_retrying_fake_upstream(captured)
+        )
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            bearer="jwt-bearer",
+            retry_bearer="refreshed-bearer",
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={"model": "test"},
+                ) as resp:
+                    assert resp.status == 200
+                    await resp.read()
+            assert [row["auth"] for row in captured["requests"]] == [
+                "Bearer jwt-bearer",
+                "Bearer refreshed-bearer",
+            ]
+            assert adapter.retry_calls == 1
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_returns_429_when_adapter_has_no_rotation():
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(
+            _build_rate_limited_fake_upstream(captured)
+        )
+        adapter = FakeAdapter(f"{upstream_base}/v1", bearer="only-bearer")
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={"model": "test"},
+                ) as resp:
+                    assert resp.status == 429
+                    await resp.read()
+            assert len(captured["requests"]) == 1
+            assert adapter.retry_calls == 1
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_preserves_raw_query_and_does_not_log_it(caplog):
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            allowed=["/responses"],
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        raw_query = "x=%252f&a=%2F&secret=do-not-log"
+        try:
+            async with aiohttp.ClientSession() as session:
+                url = URL(f"{proxy_base}/v1/responses?{raw_query}", encoded=True)
+                async with session.post(url, json={"model": "gpt-5.6-sol"}) as resp:
+                    assert resp.status == 200
+                    await resp.read()
+            assert captured["requests"][0]["raw_path"] == (
+                f"/v1/responses?{raw_query}"
+            )
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    caplog.set_level("DEBUG", logger="hermes_cli.proxy.server")
+    asyncio.run(run())
+    assert "do-not-log" not in caplog.text
+    assert "%252f" not in caplog.text
+
+
+def test_server_preserves_codex_responses_body_bytes():
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            allowed=["/responses"],
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        payload = (
+            b'{"model":"gpt-5.6-sol","input":['
+            b'{"type":"function_call_output","call_id":"call_1",'
+            b'"output":"exact bytes"}],"stream":false}'
+        )
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/responses",
+                    data=payload,
+                    headers={"Content-Type": "application/json"},
+                ) as resp:
+                    assert resp.status == 200
+                    await resp.read()
+            assert captured["requests"][0]["body"].encode() == payload
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_preserves_codex_responses_sse_bytes():
+    async def run():
+        chunks = [
+            b'event: response.output_item.added\ndata: {"type":"response.output_item.added"}\n\n',
+            b'event: response.completed\ndata: {"type":"response.completed"}\n\n',
+        ]
+        upstream_runner, upstream_base = await _start_runner(
+            _build_codex_sse_upstream(chunks)
+        )
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            allowed=["/responses"],
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/responses",
+                    json={"model": "gpt-5.6-sol", "stream": True, "input": []},
+                ) as resp:
+                    assert resp.status == 200
+                    assert await resp.read() == b"".join(chunks)
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_aborts_downstream_on_truncated_upstream_sse():
+    async def run():
+        upstream_runner, upstream_base = await _start_runner(
+            _build_truncated_sse_upstream()
+        )
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            allowed=["/responses"],
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                with pytest.raises(
+                    (
+                        aiohttp.ClientPayloadError,
+                        aiohttp.ServerDisconnectedError,
+                        aiohttp.ClientConnectionError,
+                    )
+                ):
+                    async with session.post(
+                        f"{proxy_base}/v1/responses",
+                        json={"model": "gpt-5.6-sol", "stream": True, "input": []},
+                    ) as resp:
+                        await resp.read()
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_codex_proxy_rejects_chat_completions():
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            allowed=["/responses", "/models"],
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={"model": "gpt-5.6-sol"},
+                ) as resp:
+                    body = await resp.json()
+                    assert resp.status == 404
+                    assert body["error"]["code"] == "path_not_allowed"
+            assert captured["requests"] == []
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_strips_owned_account_header_when_adapter_has_no_value():
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            allowed=["/responses"],
+            upstream_headers={
+                "User-Agent": "codex_cli_rs/0.0.0 (Hermes Agent)",
+                "originator": "codex_cli_rs",
+            },
+            owned_headers={"User-Agent", "originator", "ChatGPT-Account-ID"},
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/responses",
+                    json={"model": "gpt-5.6-sol", "input": []},
+                    headers={"chatgpt-account-id": "attacker"},
+                ) as resp:
+                    assert resp.status == 200
+                    await resp.read()
+            headers = {k.lower(): v for k, v in captured["requests"][0]["headers"].items()}
+            assert "chatgpt-account-id" not in headers
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_adapter_headers_override_spoofed_client_values():
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            bearer="codex-token",
+            allowed=["/responses"],
+            upstream_headers={
+                "User-Agent": "codex_cli_rs/0.0.0 (Hermes Agent)",
+                "originator": "codex_cli_rs",
+                "ChatGPT-Account-ID": "acct-real",
+            },
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/responses",
+                    json={"model": "gpt-5.6-sol", "input": []},
+                    headers={
+                        "Authorization": "Bearer CLIENT",
+                        "User-Agent": "spoofed",
+                        "originator": "spoofed",
+                        "ChatGPT-Account-ID": "acct-spoofed",
+                    },
+                ) as resp:
+                    assert resp.status == 200
+                    await resp.read()
+            headers = {k.lower(): v for k, v in captured["requests"][0]["headers"].items()}
+            assert headers["authorization"] == "Bearer codex-token"
+            assert headers["user-agent"] == "codex_cli_rs/0.0.0 (Hermes Agent)"
+            assert headers["originator"] == "codex_cli_rs"
+            assert headers["chatgpt-account-id"] == "acct-real"
         finally:
             await proxy_runner.cleanup()
             await upstream_runner.cleanup()

--- a/tests/hermes_cli/test_proxy_codex.py
+++ b/tests/hermes_cli/test_proxy_codex.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from hermes_cli.proxy.adapters import ADAPTERS, get_adapter
+from hermes_cli.proxy.adapters.codex import OpenAICodexAdapter
+from hermes_cli.proxy.cli import cmd_proxy_start
+from hermes_cli.proxy.server import is_loopback_host, run_server
+
+
+def _jwt_with_account(account_id: str = "acct-123") -> str:
+    payload = {
+        "exp": 4_102_444_800,
+        "https://api.openai.com/auth": {"chatgpt_account_id": account_id},
+    }
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    return f"header.{encoded}.signature"
+
+
+def _entry(account_id: str = "acct-123"):
+    return SimpleNamespace(
+        runtime_api_key=_jwt_with_account(account_id),
+        runtime_base_url="https://chatgpt.com/backend-api/codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        expires_at="2099-01-01T00:00:00Z",
+    )
+
+
+def test_registry_exposes_one_canonical_codex_adapter_and_alias():
+    assert ADAPTERS["openai-codex"] is OpenAICodexAdapter
+    assert "codex" not in ADAPTERS
+    assert isinstance(get_adapter("openai-codex"), OpenAICodexAdapter)
+    assert isinstance(get_adapter("codex"), OpenAICodexAdapter)
+
+
+def test_codex_loopback_host_validation_and_cli_rejection(capsys):
+    assert is_loopback_host("127.0.0.1")
+    assert is_loopback_host("::1")
+    assert is_loopback_host("localhost")
+    assert not is_loopback_host("0.0.0.0")
+    assert not is_loopback_host("192.168.1.5")
+    assert not is_loopback_host("example.com")
+
+    adapter = OpenAICodexAdapter()
+    args = SimpleNamespace(provider="codex", host="0.0.0.0", port=8645)
+    with (
+        patch("hermes_cli.proxy.cli.get_adapter", return_value=adapter),
+        patch.object(adapter, "is_authenticated", return_value=True),
+        patch("hermes_cli.proxy.cli.run_server") as run,
+    ):
+        assert cmd_proxy_start(args) == 2
+    run.assert_not_called()
+    assert "loopback-only" in capsys.readouterr().err
+
+
+def test_codex_server_rejects_non_loopback_programmatic_bind():
+    adapter = OpenAICodexAdapter()
+    try:
+        asyncio.run(run_server(adapter, host="0.0.0.0", port=0))
+    except RuntimeError as exc:
+        assert "loopback-only" in str(exc)
+    else:
+        raise AssertionError("programmatic non-loopback Codex bind was accepted")
+
+
+def test_codex_adapter_authentication_is_pool_backed():
+    pool = MagicMock()
+    pool.has_available.return_value = True
+    with patch("hermes_cli.proxy.adapters.codex.load_pool", return_value=pool):
+        assert OpenAICodexAdapter().is_authenticated() is True
+
+
+def test_codex_adapter_selects_responses_credential_and_required_headers():
+    pool = MagicMock()
+    pool.has_credentials.return_value = True
+    pool.select.return_value = _entry()
+    adapter = OpenAICodexAdapter()
+    with patch("hermes_cli.proxy.adapters.codex.load_pool", return_value=pool):
+        credential = adapter.get_credential()
+
+    assert credential.bearer == _jwt_with_account()
+    assert credential.base_url == "https://chatgpt.com/backend-api/codex"
+    assert adapter.allowed_paths == frozenset({"/responses", "/models"})
+    assert adapter.get_upstream_headers(credential) == {
+        "User-Agent": "codex_cli_rs/0.0.0 (Hermes Agent)",
+        "originator": "codex_cli_rs",
+        "ChatGPT-Account-ID": "acct-123",
+    }
+
+
+def test_codex_adapter_rejects_untrusted_upstream_before_returning_bearer():
+    pool = MagicMock()
+    pool.has_credentials.return_value = True
+    bad = _entry()
+    bad.runtime_base_url = "http://127.0.0.1:9999/steal"
+    bad.base_url = "http://127.0.0.1:9999/steal"
+    pool.select.return_value = bad
+    adapter = OpenAICodexAdapter()
+    with patch("hermes_cli.proxy.adapters.codex.load_pool", return_value=pool):
+        try:
+            adapter.get_credential()
+        except RuntimeError as exc:
+            assert "untrusted" in str(exc).lower()
+        else:
+            raise AssertionError("untrusted Codex upstream was accepted")
+
+
+def test_codex_owned_account_header_survives_missing_jwt_claim_as_owned_only():
+    adapter = OpenAICodexAdapter()
+    credential = SimpleNamespace(bearer="malformed-token")
+    headers = adapter.get_upstream_headers(credential)
+    assert "ChatGPT-Account-ID" not in headers
+    assert "ChatGPT-Account-ID" in adapter.get_owned_upstream_header_names()
+
+
+def test_codex_adapter_401_refreshes_matching_credential():
+    pool = MagicMock()
+    pool.has_credentials.return_value = True
+    pool.select.return_value = _entry("first")
+    pool.try_refresh_matching.return_value = _entry("refreshed")
+    adapter = OpenAICodexAdapter()
+    with patch("hermes_cli.proxy.adapters.codex.load_pool", return_value=pool):
+        failed = adapter.get_credential()
+        retry = adapter.get_retry_credential(
+            failed_credential=failed,
+            status_code=401,
+        )
+
+    assert retry is not None
+    assert retry.bearer == _jwt_with_account("refreshed")
+    pool.try_refresh_matching.assert_called_once_with(api_key_hint=failed.bearer)
+    pool.mark_exhausted_and_rotate.assert_not_called()
+
+
+def test_codex_adapter_reuses_concurrently_refreshed_current_credential():
+    pool = MagicMock()
+    refreshed = _entry("new-token")
+    pool.try_refresh_matching.side_effect = [refreshed, None]
+    pool.select.return_value = refreshed
+    adapter = OpenAICodexAdapter()
+    adapter._pool = pool
+    failed = SimpleNamespace(bearer=_jwt_with_account("old-token"))
+
+    first = adapter.get_retry_credential(
+        failed_credential=failed,
+        status_code=401,
+    )
+    second = adapter.get_retry_credential(
+        failed_credential=failed,
+        status_code=401,
+    )
+
+    assert first is not None and first.bearer == refreshed.runtime_api_key
+    assert second is not None and second.bearer == refreshed.runtime_api_key
+    pool.mark_exhausted_and_rotate.assert_not_called()
+
+
+def test_codex_adapter_concurrent_401_refresh_is_serialized():
+    pool = MagicMock()
+    in_flight = threading.Event()
+    overlap = threading.Event()
+    counter = {"n": 0}
+
+    def refresh(*, api_key_hint):
+        _ = api_key_hint
+        if in_flight.is_set():
+            overlap.set()
+        in_flight.set()
+        try:
+            time.sleep(0.03)
+            counter["n"] += 1
+            return _entry(f"refreshed-{counter['n']}")
+        finally:
+            in_flight.clear()
+
+    pool.try_refresh_matching.side_effect = refresh
+    adapter = OpenAICodexAdapter()
+    adapter._pool = pool
+    failed = SimpleNamespace(bearer=_jwt_with_account("failed"))
+    results = []
+
+    def worker():
+        results.append(
+            adapter.get_retry_credential(
+                failed_credential=failed,
+                status_code=401,
+            )
+        )
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(results) == 3
+    assert not overlap.is_set()
+
+
+def test_codex_adapter_429_marks_failed_credential_and_rotates():
+    pool = MagicMock()
+    pool.has_credentials.return_value = True
+    pool.select.return_value = _entry("first")
+    pool.mark_exhausted_and_rotate.return_value = _entry("second")
+    adapter = OpenAICodexAdapter()
+    with patch("hermes_cli.proxy.adapters.codex.load_pool", return_value=pool):
+        failed = adapter.get_credential()
+        retry = adapter.get_retry_credential(
+            failed_credential=failed,
+            status_code=429,
+        )
+
+    assert retry is not None
+    assert retry.bearer == _jwt_with_account("second")
+    pool.mark_exhausted_and_rotate.assert_called_once_with(
+        status_code=429,
+        api_key_hint=failed.bearer,
+    )
+    pool.try_refresh_matching.assert_not_called()

--- a/website/docs/user-guide/features/subscription-proxy.md
+++ b/website/docs/user-guide/features/subscription-proxy.md
@@ -72,9 +72,41 @@ automatically when the bearer approaches expiry.
 hermes proxy providers
 ```
 
-Currently shipped: `nous` (Nous Portal) and `xai` (xAI / Grok). More
-OAuth providers can be added by implementing the `UpstreamAdapter`
+Currently shipped:
+
+- `openai-codex` (`codex` alias) — OpenAI Codex / ChatGPT OAuth, Responses API only
+- `nous` — Nous Portal
+- `xai` — xAI / Grok OAuth
+
+More OAuth providers can be added by implementing the `UpstreamAdapter`
 interface in `hermes_cli/proxy/adapters/`.
+
+### OpenAI Codex / ChatGPT OAuth
+
+Start the proxy from the Hermes profile that owns the Codex OAuth credential:
+
+```bash
+hermes proxy start --provider codex
+```
+
+Codex forwards only `/v1/responses` and `/v1/models`. The adapter attaches the
+native Codex `originator`, `User-Agent`, and JWT-derived
+`ChatGPT-Account-ID` headers after stripping client-supplied values, so a
+loopback client cannot spoof account identity. A 401 refreshes the exact failed
+pool credential and rotates when refresh fails; a 429 marks the failed credential
+exhausted and rotates to another available account.
+
+Point a Responses-compatible client at:
+
+```text
+Base URL: http://127.0.0.1:8645/v1
+API key:  any non-empty placeholder
+Model:    a model available to your ChatGPT/Codex account
+Transport: OpenAI Responses API
+```
+
+Keep this proxy on `127.0.0.1`. It accepts any inbound bearer and spends the
+OAuth account owned by the profile that started it.
 
 ## Check status
 
@@ -172,6 +204,11 @@ hermes proxy start --host 0.0.0.0 --port 8645
 subscription. The proxy has no auth of its own — it accepts any bearer.
 Use a firewall, VPN, or reverse proxy with proper auth if you expose
 this beyond your trusted network.
+
+The `openai-codex` adapter is stricter: it rejects every non-loopback bind,
+including `0.0.0.0`, because the proxy would otherwise expose a ChatGPT OAuth
+subscription to any reachable client. Codex must remain on `127.0.0.1`, `::1`,
+or `localhost`.
 
 ## Rate limits
 


### PR DESCRIPTION
## Summary
- add canonical `openai-codex` subscription-proxy adapter with `codex` alias
- forward Responses API and models only; reject Chat Completions
- use the existing Codex credential pool with exact 401 refresh/coalescing and 429 rotation
- synthesize native Codex account/origin headers while stripping client spoofing
- enforce exact trusted Codex upstream and loopback-only bind at CLI and server layers
- preserve raw query encoding and request/SSE bytes; abort truncated downstream streams
- close upstream sessions/responses across cancellation, prepare failure, streaming failure, and EOF

## Security findings closed
- arbitrary base URL OAuth-bearer exfiltration
- client `ChatGPT-Account-ID` spoof when JWT claim is absent
- LAN/public bind spending the ChatGPT subscription
- queued concurrent 401 race after token refresh
- percent-decoded query corruption and query-secret debug logging
- truncated SSE reported as clean success
- ClientSession leak on request cancellation
- upstream response/session leak on downstream prepare failure

## Verification
- canonical isolated runner: 46 related tests passed
- exact raw `%252f` / `%2F` query preservation
- byte-identical function-call-output request and Responses SSE
- deterministic cancellation/prepare/truncated-stream cleanup tests
- Ruff passed
- `git diff --check` passed
- real main Codex pool resolved exact trusted backend and required identity headers without printing token material
- live loopback proxy returned `PROXY_GPT_SOL_READY`
- live GPT Sol Controller spawned two parallel GPT Sol Hermes agents and completed `CONTROLLER_DELEGATION_PASS`
- live GPT Sol Controller routed one child to Belgariad and a dependent GPT Sol verifier completed `LOCAL_ROUTE_VERIFIED_BY_GPT_SOL`

## Operational boundary
Codex proxy is hard-blocked from non-loopback binds. It has no inbound authentication and must remain on `127.0.0.1`/`::1`.
