### PR TITLE
feat(goals): show standing goals carried through compression

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2289,6 +2289,10 @@ def compress_context(
     # boundary, so the previous flush baseline remains authoritative.
     agent._last_compression_attempt_recorded = True
     agent._last_compression_attempt_in_place = None
+    # Per-attempt UI signal consumed by manual compression surfaces. Clear it
+    # before every early-return path so a previous migration is never reported
+    # again by an unrelated compression attempt.
+    agent._last_compression_goal_notice = None
     # Clear the lock-skip signal at the VERY TOP, before the codex route and
     # the breaker gates below can early-return (per-attempt state rule,
     # #58630/#69853). A stale ``True``/holder value from a prior lock-skip
@@ -3658,8 +3662,22 @@ def compress_context(
                     # per-session lookup with no parent walk, so without this an
                     # active goal silently dies at the boundary (#33618).
                     try:
-                        from hermes_cli.goals import migrate_goal_to_session
-                        migrate_goal_to_session(old_session_id, agent.session_id, reason="compression")
+                        from hermes_cli.goals import (
+                            format_goal_migration_notice,
+                            load_goal,
+                            migrate_goal_to_session,
+                        )
+
+                        if migrate_goal_to_session(
+                            old_session_id,
+                            agent.session_id,
+                            reason="compression",
+                        ):
+                            _migrated_goal = load_goal(agent.session_id)
+                            if _migrated_goal is not None:
+                                agent._last_compression_goal_notice = (
+                                    format_goal_migration_notice(_migrated_goal)
+                                )
                     except Exception as _goal_err:
                         logger.debug("Could not migrate goal on compression: %s", _goal_err)
                     # Same boundary hazard for /heartbeat state — carry it too.

--- a/cli.py
+++ b/cli.py
@@ -13409,6 +13409,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 print(f"     {summary['token_line']}")
                 if summary["note"]:
                     print(f"     {summary['note']}")
+                goal_notice = getattr(
+                    self.agent, "_last_compression_goal_notice", None
+                )
+                if isinstance(goal_notice, str) and goal_notice:
+                    print(f"     ℹ️ {goal_notice}")
 
             except Exception as e:
                 finalize_context_engine_compression_notification(

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4510,6 +4510,11 @@ class GatewaySlashCommandsMixin:
             lines.append(summary["token_line"])
             if summary["note"]:
                 lines.append(summary["note"])
+            goal_notice = getattr(
+                tmp_agent, "_last_compression_goal_notice", None
+            )
+            if isinstance(goal_notice, str) and goal_notice:
+                lines.append(f"ℹ️ {goal_notice}")
             if _summary_aborted:
                 lines.append(
                     t(

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -922,6 +922,24 @@ def _truncate(text: str, limit: int) -> str:
     return text[:limit] + "… [truncated]"
 
 
+def format_goal_migration_notice(state: GoalState) -> str:
+    """Describe a carried-forward goal for compression command output."""
+    goal = re.sub(r"\s+", " ", state.goal or "").strip()
+    goal = _truncate(goal, 160)
+    created = ""
+    if state.created_at:
+        try:
+            created = datetime.fromtimestamp(
+                state.created_at, tz=timezone.utc
+            ).strftime(" (set %Y-%m-%d UTC)")
+        except (OverflowError, OSError, ValueError):
+            created = ""
+    return (
+        f'Standing goal carried forward{created}: "{goal}". '
+        "Use /goal status to review it or /goal clear to stop it."
+    )
+
+
 def _pid_alive(pid: int) -> bool:
     """Return True if a process with ``pid`` is currently alive.
 
@@ -2321,6 +2339,7 @@ __all__ = [
     "save_goal",
     "clear_goal",
     "migrate_goal_to_session",
+    "format_goal_migration_notice",
     "judge_goal",
     "run_kanban_goal_loop",
 ]

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -116,6 +116,10 @@ class TestGoalMigratesOnRotation:
                 migrated = goals.load_goal(child)
                 assert migrated is not None
                 assert migrated.goal == "finish the migration"
+                notice = agent._last_compression_goal_notice
+                assert "finish the migration" in notice
+                assert "/goal status" in notice
+                assert "/goal clear" in notice
             goals._DB_CACHE.clear()
 
 

--- a/tests/cli/test_compress_here.py
+++ b/tests/cli/test_compress_here.py
@@ -27,6 +27,7 @@ def _wire_agent(shell, compressed_head):
     shell.agent.tools = None
     shell.agent._compress_context.return_value = (compressed_head, "")
     shell.agent._compression_skipped_due_to_lock = False
+    shell.agent._last_compression_goal_notice = None
 
 
 def test_compress_here_compresses_head_only(capsys):
@@ -103,6 +104,26 @@ def test_bare_compress_still_full(capsys):
     assert call.args[0] == history
     out = capsys.readouterr().out
     assert "Summarizing up to here" not in out
+
+
+def test_bare_compress_surfaces_migrated_standing_goal(capsys):
+    shell = _make_cli()
+    history = _make_history()
+    shell.conversation_history = history
+    _wire_agent(shell, list(history))
+    shell.agent._last_compression_goal_notice = (
+        'Standing goal carried forward: "finish the migration". '
+        "Use /goal status to review it or /goal clear to stop it."
+    )
+
+    with patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100):
+        shell._manual_compress("/compress")
+
+    out = capsys.readouterr().out
+    assert "Standing goal carried forward" in out
+    assert "finish the migration" in out
+    assert "/goal status" in out
+    assert "/goal clear" in out
 
 
 def test_focus_still_works(capsys):

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -86,6 +86,7 @@ async def test_compress_command_works_when_auto_compaction_disabled():
     agent_instance._compress_context.return_value = (compressed, "")
     # Explicit non-lock-skip: MagicMock getattr would return a truthy mock.
     agent_instance._compression_skipped_due_to_lock = False
+    agent_instance._last_compression_goal_notice = None
 
     def _estimate(messages, **_kwargs):
         return 100 if messages == history else 60
@@ -102,6 +103,46 @@ async def test_compress_command_works_when_auto_compaction_disabled():
     assert "Compressed:" in result
     agent_instance._compress_context.assert_called_once()
     assert agent_instance._compress_context.call_args.kwargs.get("force") is True
+
+
+@pytest.mark.asyncio
+async def test_compress_command_surfaces_migrated_standing_goal():
+    history = _make_history()
+    compressed = [
+        history[0],
+        {"role": "assistant", "content": "compressed summary"},
+        history[-1],
+    ]
+    runner = _make_runner(history)
+    agent_instance = MagicMock()
+    agent_instance.shutdown_memory_provider = MagicMock()
+    agent_instance.close = MagicMock()
+    agent_instance._cached_system_prompt = ""
+    agent_instance.tools = None
+    agent_instance.context_compressor.has_content_to_compress.return_value = True
+    agent_instance.session_id = "sess-1"
+    agent_instance._compress_context.return_value = (compressed, "")
+    agent_instance._compression_skipped_due_to_lock = False
+    agent_instance._last_compression_goal_notice = (
+        'Standing goal carried forward: "finish the migration". '
+        "Use /goal status to review it or /goal clear to stop it."
+    )
+
+    def _estimate(messages, **_kwargs):
+        return 100 if messages == history else 60
+
+    with (
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}),
+        patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+        patch("run_agent.AIAgent", return_value=agent_instance),
+        patch("agent.model_metadata.estimate_request_tokens_rough", side_effect=_estimate),
+    ):
+        result = await runner._handle_compress_command(_make_event())
+
+    assert "Standing goal carried forward" in result
+    assert "finish the migration" in result
+    assert "/goal status" in result
+    assert "/goal clear" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Manual compression can carry an active standing goal into the continuation session without telling the user. This change adds a bounded notice to classic CLI and gateway `/compress` results whenever that migration succeeds, so users can review or stop autonomous work that remains active.

### Motivation

Standing goals intentionally survive compression, but the silent handoff makes persistent autonomous behavior hard to discover after a session rotates. Users need an explicit reminder at the boundary where the goal is carried forward.

### Behavior

After a rotation-mode compression migrates an active standing goal, the command result shows the goal text, its set date when available, and the `/goal status` and `/goal clear` recovery actions. The notice is omitted for in-place compression, aborted attempts, and sessions without a migrated goal. Existing goal persistence and continuation behavior remain unchanged.

### Implementation

The compression attempt records a short-lived notice only after `migrate_goal_to_session` reports a successful move. A shared formatter normalizes and bounds the goal text. The classic CLI and gateway append the notice to their existing manual-compression summaries without changing prompts, conversation history, or message-role alternation.

## Related Issue

Closes #91165

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/conversation_compression.py` - capture and clear the per-attempt carried-goal notice around session rotation.
- `hermes_cli/goals.py` - format a bounded, user-facing migration notice with goal recovery actions.
- `cli.py` - display the notice in classic CLI manual-compression output.
- `gateway/slash_commands.py` - include the notice in gateway `/compress` responses.
- `tests/agent/test_compression_rotation_state.py` - verify successful rotation captures the notice.
- `tests/cli/test_compress_here.py` - verify classic CLI surfaces the notice.
- `tests/gateway/test_compress_command.py` - verify gateway output includes the notice only when present.

## How to Test

1. Set a standing goal with `/goal set`, then run `/compress` on a session that rotates to a continuation session.
2. Verify the compression result reports the carried goal and suggests `/goal status` and `/goal clear`.
3. Run the focused automated suite (71 passed locally):

```bash
scripts/run_tests.sh tests/agent/test_compression_rotation_state.py tests/cli/test_compress_here.py tests/gateway/test_compress_command.py tests/hermes_cli/test_goals.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A because the command output is self-explanatory and no configuration changed
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; the formatter and output paths use platform-independent Python
- [x] Tool description and schema updates are N/A because no model tool behavior changed

## Screenshots / Logs

N/A - focused behavior tests cover the classic CLI and gateway output paths.
