### PR TITLE
fix(update): surface config-module reload failure instead of reporting config current

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -162,7 +162,7 @@ def _reload_updated_runtime_modules() -> None:
         logger.debug("Could not refresh update runtime modules: %s", exc)
 
 
-def _reload_config_modules() -> None:
+def _reload_config_modules() -> list[str]:
     """Force-reload modules from disk after git pull.
 
     ``hermes update`` runs in the PRE-pull Python process. After ``git pull``
@@ -187,6 +187,7 @@ def _reload_config_modules() -> None:
     import importlib
 
     importlib.invalidate_caches()
+    failed: list[str] = []
     for mod_name in (
         "hermes_cli.config_defaults",
         "hermes_cli.config",
@@ -199,7 +200,16 @@ def _reload_config_modules() -> None:
             try:
                 importlib.reload(mod)
             except Exception as exc:
-                logger.debug("Could not reload %s for fresh post-update code: %s", mod_name, exc)
+                # warning, not debug: a failed reload here surfaces seconds
+                # later as a stale version check and a silently skipped
+                # migration (#90945) — leave a trail.
+                logger.warning(
+                    "Could not reload %s for fresh post-update code: %s",
+                    mod_name,
+                    exc,
+                )
+                failed.append(mod_name)
+    return failed
 
 
 def _run_config_check_fresh() -> tuple:
@@ -207,11 +217,27 @@ def _run_config_check_fresh() -> tuple:
 
     See ``_reload_config_modules`` for why this is necessary.
     Returns ``(current_ver, latest_ver)``.
+
+    If a required module failed to reload, the version check runs against the
+    STALE module — it would report the config as current and silently skip a
+    migration (#90945). Print an explicit warning so the user knows to run
+    ``hermes doctor --fix`` after the update instead of trusting the check.
     """
-    _reload_config_modules()
+    failed = _reload_config_modules()
     from hermes_cli.config import check_config_version
 
-    return check_config_version()
+    current_ver, latest_ver = check_config_version()
+    if failed:
+        print()
+        print(
+            "  ⚠ Could not reload updated config modules: "
+            + ", ".join(failed)
+        )
+        print(
+            "    The config-version check may be stale. After the update, "
+            "run `hermes doctor --fix` to apply any pending config migration."
+        )
+    return current_ver, latest_ver
 
 
 def _run_migrate_config_fresh(*, interactive: bool = False, quiet: bool = False) -> dict:
@@ -219,8 +245,23 @@ def _run_migrate_config_fresh(*, interactive: bool = False, quiet: bool = False)
 
     See ``_reload_config_modules`` for why this is necessary.
     Returns the migration results dict.
+
+    If a required module failed to reload, migrating against the STALE
+    modules would apply the wrong schema step — refuse and point the user at
+    ``hermes doctor --fix`` (fresh process) instead (#90945).
     """
-    _reload_config_modules()
+    failed = _reload_config_modules()
+    if failed:
+        print()
+        print(
+            "  ⚠ Could not reload updated config modules: "
+            + ", ".join(failed)
+        )
+        print(
+            "    Config migration skipped. Run `hermes doctor --fix` in a "
+            "fresh process to apply any pending config migration."
+        )
+        return {"skipped": True, "reason": "config-module reload failed"}
     from hermes_cli.config import migrate_config
 
     return migrate_config(interactive=interactive, quiet=quiet)

--- a/tests/hermes_cli/test_update_config_reload_warning.py
+++ b/tests/hermes_cli/test_update_config_reload_warning.py
@@ -1,0 +1,86 @@
+"""Tests for the post-update config-module reload failure warning (#90945).
+
+``hermes update`` runs in the PRE-pull Python process, so after ``git pull``
+the cached ``sys.modules`` still holds the OLD config code.  If
+``_reload_config_modules()`` fails to reload a module, the version check runs
+against the STALE module and reports the config as "up to date" — silently
+skipping the pending migration (the exact failure in #90945).
+
+The fix: reload failures are surfaced (warning log + a printed hint to run
+``hermes doctor --fix``) instead of swallowed at debug level, so an update
+never claims "Configuration is up to date" while a migration is pending.
+"""
+
+from unittest.mock import patch
+
+import hermes_cli.update_cmd as update_cmd
+
+
+def test_reload_config_modules_returns_failed_modules():
+    """A failed reload must be collected and returned, not swallowed."""
+    import types
+
+    fake = types.ModuleType("hermes_cli.config")
+    with patch.object(update_cmd.sys, "modules", {"hermes_cli.config": fake}):
+        with patch("importlib.reload", side_effect=RuntimeError("boom")):
+            failed = update_cmd._reload_config_modules()
+    assert "hermes_cli.config" in failed
+
+
+def test_reload_config_modules_success_returns_empty():
+    """A clean reload returns an empty failure list."""
+    # Use a real, already-imported module (importlib itself) so reload()
+    # succeeds; patch reload to a no-op so no actual re-import happens.
+    with patch("importlib.reload", side_effect=lambda mod: mod):
+        failed = update_cmd._reload_config_modules()
+    assert failed == []
+
+
+def test_config_check_fresh_warns_on_reload_failure(capsys):
+    """_run_config_check_fresh prints a doctor --fix hint when reload fails."""
+    with patch.object(
+        update_cmd, "_reload_config_modules", return_value=["hermes_cli.config"]
+    ):
+        with patch(
+            "hermes_cli.config.check_config_version", return_value=(33, 37)
+        ):
+            current, latest = update_cmd._run_config_check_fresh()
+    assert (current, latest) == (33, 37)
+    out = capsys.readouterr().out
+    assert "Could not reload updated config modules" in out
+    assert "hermes doctor --fix" in out
+
+
+def test_config_check_fresh_silent_on_success(capsys):
+    """No warning printed when reload succeeds."""
+    with patch.object(update_cmd, "_reload_config_modules", return_value=[]):
+        with patch(
+            "hermes_cli.config.check_config_version", return_value=(37, 37)
+        ):
+            update_cmd._run_config_check_fresh()
+    out = capsys.readouterr().out
+    assert "Could not reload" not in out
+    assert "hermes doctor --fix" not in out
+
+
+def test_migrate_config_fresh_skips_on_reload_failure(capsys):
+    """_run_migrate_config_fresh refuses to migrate against stale modules."""
+    with patch.object(
+        update_cmd, "_reload_config_modules", return_value=["hermes_cli.config"]
+    ):
+        result = update_cmd._run_migrate_config_fresh()
+    assert result == {"skipped": True, "reason": "config-module reload failed"}
+    out = capsys.readouterr().out
+    assert "Config migration skipped" in out
+    assert "hermes doctor --fix" in out
+
+
+def test_migrate_config_fresh_runs_on_success():
+    """_run_migrate_config_fresh migrates normally when reload succeeds."""
+    with patch.object(update_cmd, "_reload_config_modules", return_value=[]):
+        with patch(
+            "hermes_cli.config.migrate_config",
+            return_value={"migrated": True},
+        ):
+            result = update_cmd._run_migrate_config_fresh()
+    assert result == {"migrated": True}


### PR DESCRIPTION
## What does this PR do?

Fixes the residual silent-failure path in #90945: `hermes update` can report `Configuration is up to date` while a config schema migration is still pending.

The update runs in the **pre-pull** Python process, so `_reload_config_modules()` force-reloads the config modules after `git pull` to make `check_config_version()` read the freshly-pulled schema. But a reload failure was swallowed at `logger.debug` (update_cmd.py ~line 202) — the OLD module stays in `sys.modules`, the version check reports `(current_ver, current_ver)`, and the migration is silently skipped with no trail. `hermes doctor` only works because it runs in a fresh process.

The reload mechanism itself already exists on main (per the issue comments); this PR makes a reload failure *visible and actionable* instead of silently trusted.

## Related Issue

Fixes #90945

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd.py` — `_reload_config_modules()` now returns the list of modules whose reload **failed** and logs at **WARNING** instead of debug (matching the in-file standard already used by `_finish_dashboard_update_cleanup`: "warning, not debug: a failed reload here surfaces seconds later as an ImportError in the same process — leave a trail").
- `hermes_cli/update_cmd.py` — `_run_config_check_fresh()` prints an explicit `⚠ Could not reload updated config modules: ...` warning plus a `hermes doctor --fix` hint when reload failed, so the stale version check is never silently trusted.
- `hermes_cli/update_cmd.py` — `_run_migrate_config_fresh()` (sibling call path, same bug class) refuses to migrate against stale modules, prints the same warning, and returns `{"skipped": True, "reason": "config-module reload failed"}`.
- `tests/hermes_cli/test_update_config_reload_warning.py` — new, 6 tests.

## How to Test

Reproduction on current main (before): simulate a reload failure (e.g. an import error in freshly-pulled code) and `hermes update` prints:

```
→ Checking configuration for new options...
  ✓ Configuration is up to date        ← WRONG: migration pending, no trail
```

After:

```
→ Checking configuration for new options...
  ⚠ Could not reload updated config modules: hermes_cli.config
    The config-version check may be stale. After the update, run `hermes doctor --fix` to apply any pending config migration.
```

Tests:

```
pytest tests/hermes_cli/test_update_config_reload_warning.py -v        # 6 passed
pytest tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_stale_dashboard.py tests/hermes_cli/test_update_yes_flag.py  # 71 passed, 11 skipped (clean env)
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (CLI warning text shown above in How to Test)
