### PR TITLE
fix(kanban): preserve worktree repository bindings

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3155,6 +3155,52 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+def validate_workspace_binding(
+    *,
+    workspace_kind: str,
+    workspace_path: Optional[str],
+    project_repo: Optional[str],
+    board: Optional[str],
+    identity: str,
+    board_default: Optional[str] = None,
+) -> None:
+    """Reject an unresolvable worktree before its task row is persisted."""
+    if workspace_kind != "worktree":
+        return
+    board_slug = board if board else get_current_board()
+    if board_default is None:
+        board_default = read_board_metadata(board_slug).get("default_workdir")
+    task_path = str(workspace_path or "").strip() or None
+    project_path = str(project_repo or "").strip() or None
+    default_path = str(board_default or "").strip() or None
+    if task_path or project_path or default_path:
+        return
+    raise ValueError(
+        f"{identity} has workspace_kind=worktree but its workspace resolution "
+        f"chain is unresolved: task workspace_path=<absent>; "
+        f"project repository=<absent>; board {board_slug!r} "
+        "default_workdir=<absent>. Set an explicit absolute workspace_path, "
+        "link the task to a project repository, or configure this board's "
+        "default_workdir. No task was created."
+    )
+
+
+def _project_repository(project_id: Optional[str]) -> Optional[str]:
+    """Resolve a project id/slug to its primary repository, if visible."""
+    if not project_id:
+        return None
+    from hermes_cli import projects_db as _pdb
+
+    try:
+        with _pdb.connect_closing() as project_conn:
+            project = _pdb.get_project(project_conn, str(project_id))
+    except Exception:
+        return None
+    if project is None or not project.primary_path:
+        return None
+    return str(project.primary_path)
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -3419,16 +3465,24 @@ def create_task(
     # task would point cleanup at the user's source tree (#28818). The
     # containment guard in ``_cleanup_workspace`` is the safety rail, but
     # we also stop the bad state from being created in the first place.
+    board_slug = board if board else get_current_board()
+    board_default = read_board_metadata(board_slug).get("default_workdir")
     if (
         workspace_path is None
         and project_repo is None
         and workspace_kind in {"dir", "worktree"}
     ):
-        board_slug = board if board else get_current_board()
-        board_meta = read_board_metadata(board_slug)
-        board_default = board_meta.get("default_workdir")
         if board_default:
             workspace_path = str(board_default)
+
+    validate_workspace_binding(
+        workspace_kind=workspace_kind,
+        workspace_path=workspace_path,
+        project_repo=project_repo,
+        board=board_slug,
+        board_default=board_default,
+        identity=f"proposed task {title.strip()!r}",
+    )
 
     # Retry once on the extremely unlikely id collision.
     for attempt in range(2):
@@ -7370,7 +7424,7 @@ def decompose_triage_task(
     child_ids: list[str] = []
     with write_txn(conn):
         root_row = conn.execute(
-            "SELECT id, status, tenant, workspace_kind, workspace_path "
+            "SELECT id, status, tenant, workspace_kind, workspace_path, project_id "
             "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
@@ -7385,6 +7439,15 @@ def decompose_triage_task(
         # override with its own 'workspace_kind' / 'workspace_path'.
         root_ws_kind = root_row["workspace_kind"] or "scratch"
         root_ws_path = root_row["workspace_path"]
+        root_project_id = root_row["project_id"]
+        board_slug = get_current_board()
+        board_default = read_board_metadata(board_slug).get("default_workdir")
+        root_repo_binding: Optional[str] = None
+        if root_ws_kind == "worktree" and root_ws_path:
+            repo_root = _common_repo_root_for_workspace(Path(root_ws_path))
+            if repo_root is not None:
+                root_repo_binding = str(repo_root)
+        root_project_repo = _project_repository(root_project_id)
 
         # Create children. Status is 'todo' regardless of parents — we
         # link them under the root AFTER creation so the dispatcher
@@ -7401,26 +7464,40 @@ def decompose_triage_task(
             # child can't accidentally point a 'dir' at the root's
             # worktree path or vice versa).
             child_ws_kind = child.get("workspace_kind") or root_ws_kind
+            child_project_id = child.get("project_id") or root_project_id
+            child_project_repo = (
+                _project_repository(child_project_id)
+                if child_project_id != root_project_id
+                else root_project_repo
+            )
             if child.get("workspace_path"):
                 child_ws_path = child.get("workspace_path")
             elif child_ws_kind == "worktree":
-                # Never share one worktree checkout between siblings: the
-                # root's literal path would put every child in the same
-                # directory on the first-dispatched sibling's branch, with
-                # no lock — siblings can be promoted and dispatched
-                # concurrently. Leave the path unset so dispatch
-                # materializes a fresh <repo>/.worktrees/<child-id> per
-                # child from the board anchor.
-                child_ws_path = None
+                # Bind every child to the common repository root, never to the
+                # root task's literal checkout. Dispatch turns this repo-root
+                # binding into a fresh <repo>/.worktrees/<child-id> checkout.
+                child_ws_path = root_repo_binding or child_project_repo
             elif child_ws_kind == root_ws_kind:
                 child_ws_path = root_ws_path
             else:
                 child_ws_path = None
+            validate_workspace_binding(
+                workspace_kind=child_ws_kind,
+                workspace_path=child_ws_path,
+                project_repo=child_project_repo,
+                board=board_slug,
+                board_default=board_default,
+                identity=(
+                    f"proposed child {new_id} ({title!r}), inherited from root "
+                    f"{task_id} workspace_path={root_ws_path!r} "
+                    f"common_repository={root_repo_binding or '<unresolved>'}"
+                ),
+            )
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " workspace_path, tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+                " workspace_path, project_id, tenant, created_at, created_by) "
+                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
@@ -7428,6 +7505,7 @@ def decompose_triage_task(
                     assignee,
                     child_ws_kind,
                     child_ws_path,
+                    child_project_id,
                     tenant,
                     now,
                     (author or "decomposer"),
@@ -7708,6 +7786,19 @@ def _repo_root_for_worktree_target(path: Path) -> Optional[Path]:
         if current == current.parent:
             return None
         current = current.parent
+
+
+def _common_repo_root_for_workspace(path: Path) -> Optional[Path]:
+    """Return the repository-root checkout for a root or linked worktree path."""
+    expanded = path.expanduser()
+    common_dir = _git_common_dir(expanded)
+    git_dir = _git_dir(expanded)
+    if common_dir is not None and git_dir is not None and common_dir != git_dir:
+        # Standard non-bare repositories keep the common git dir at
+        # <repository-root>/.git even when ``path`` is a linked worktree.
+        if common_dir.name == ".git":
+            return common_dir.parent.resolve(strict=False)
+    return _repo_root_for_worktree_target(expanded)
 
 
 def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> None:

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -116,6 +116,35 @@ def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch
     assert beta_titles == ["beta-task"]
 
 
+def test_cli_rejects_unbound_worktree_before_persistence(kanban_home):
+    output = kc.run_slash(
+        "create 'unbound cli task' --assignee engineer --workspace worktree"
+    )
+
+    assert "unbound cli task" in output
+    assert "task workspace_path=<absent>" in output
+    assert "project repository=<absent>" in output
+    assert "board 'default' default_workdir=<absent>" in output
+    with kb.connect() as conn:
+        assert kb.list_tasks(conn, include_archived=True, limit=100) == []
+
+
+def test_cli_allows_board_default_bound_worktree(kanban_home, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    kb.write_board_metadata("default", default_workdir=str(repo))
+
+    output = kc.run_slash(
+        "create 'default-bound cli task' --assignee engineer --workspace worktree"
+    )
+
+    assert "Created" in output
+    with kb.connect() as conn:
+        tasks = kb.list_tasks(conn, include_archived=True, limit=100)
+        assert len(tasks) == 1
+        assert tasks[0].workspace_path == str(repo)
+
+
 # ---------------------------------------------------------------------------
 # Integration with the COMMAND_REGISTRY
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -88,5 +88,38 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
     assert any(ev.kind == "decomposed" for ev in events)
 
 
+def test_decompose_rejects_unbound_legacy_worktree_atomically(kanban_home):
+    with kb.connect() as conn:
+        root = _create_triage(conn, title="legacy malformed root")
+        conn.execute(
+            "UPDATE tasks SET workspace_kind='worktree', workspace_path=NULL "
+            "WHERE id = ?",
+            (root,),
+        )
+        conn.commit()
+
+        with pytest.raises(ValueError) as excinfo:
+            kb.decompose_triage_task(
+                conn,
+                root,
+                root_assignee="orchestrator",
+                children=[{"title": "new child", "assignee": "engineer"}],
+                author="decomposer",
+            )
+
+        message = str(excinfo.value)
+        assert "proposed child" in message
+        assert "new child" in message
+        assert "task workspace_path=<absent>" in message
+        assert "project repository=<absent>" in message
+        assert "board 'default' default_workdir=<absent>" in message
+        tasks = kb.list_tasks(conn, include_archived=True, limit=100)
+        assert [task.id for task in tasks] == [root]
+        root_task = kb.get_task(conn, root)
+        assert root_task is not None
+        assert root_task.status == "triage"
+        assert kb.read_board_metadata("default")["default_workdir"] is None
+
+
 
 

--- a/tests/hermes_cli/test_kanban_project_link.py
+++ b/tests/hermes_cli/test_kanban_project_link.py
@@ -53,6 +53,31 @@ def test_explicit_branch_overrides_project_default(kanban_conn):
     assert task.branch_name == "feature/custom"
 
 
+def test_decompose_propagates_project_repository_without_board_default(kanban_conn):
+    proj = _make_project(name="Decompose App", repo="/tmp/decompose-app")
+    assert proj is not None
+    root_id = kb.create_task(
+        kanban_conn,
+        title="build app",
+        project_id=proj.slug,
+        triage=True,
+    )
+
+    child_ids = kb.decompose_triage_task(
+        kanban_conn,
+        root_id,
+        root_assignee="orchestrator",
+        children=[{"title": "implement app", "assignee": "engineer"}],
+    )
+
+    assert child_ids is not None and len(child_ids) == 1
+    child = kb.get_task(kanban_conn, child_ids[0])
+    assert child is not None
+    assert child.project_id == proj.id
+    assert child.workspace_path == proj.primary_path
+    assert kb.read_board_metadata("default")["default_workdir"] is None
+
+
 def test_unlinked_task_unchanged(kanban_conn):
     tid = kb.create_task(kanban_conn, title="plain")
     task = kb.get_task(kanban_conn, tid)

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -1,4 +1,4 @@
-"""Per-task worktree isolation for decompose siblings.
+"""Per-task worktree isolation and repository binding propagation.
 
 Decompose children used to inherit the root's literal ``workspace_path``,
 so every sibling of a worktree-kind root pointed at the SAME checkout —
@@ -7,8 +7,9 @@ on whatever branch was there, letting sibling workers run concurrently in
 one directory on one branch (cross-task provenance corruption, no lock).
 
 Two-part fix under test:
-- ``decompose_triage_task`` leaves worktree children's ``workspace_path``
-  unset so each child materializes its own ``<repo>/.worktrees/<child-id>``.
+- ``decompose_triage_task`` stores the common repository root as each
+  worktree child's binding, so each child materializes its own
+  ``<repo>/.worktrees/<child-id>`` without depending on a board default.
 - ``_resolve_worktree_workspace`` falls back to a fresh per-task worktree
   when the requested path is occupied by another task's branch (heals
   pre-existing rows that still carry a shared path).
@@ -35,8 +36,8 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
-def _git(cwd: Path, *args: str) -> None:
-    subprocess.run(
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
         [
             "git", "-C", str(cwd),
             "-c", "user.name=Test User",
@@ -45,7 +46,7 @@ def _git(cwd: Path, *args: str) -> None:
             *args,
         ],
         check=True, capture_output=True, text=True,
-    )
+    ).stdout.strip()
 
 
 def _make_repo(tmp_path: Path) -> Path:
@@ -66,16 +67,16 @@ def _add_worktree(repo: Path, target: Path, branch: str) -> Path:
     return target
 
 
-def test_decompose_worktree_children_get_own_workspace(kanban_home):
+def test_decompose_repo_root_propagates_resolvable_binding(kanban_home, tmp_path):
+    repo = _make_repo(tmp_path)
     with kb.connect() as conn:
-        root = kb.create_task(conn, title="build the feature", triage=True)
-        conn.execute(
-            "UPDATE tasks SET workspace_kind='worktree', "
-            "workspace_path='/repo/.worktrees/root' WHERE id = ?",
-            (root,),
+        root = kb.create_task(
+            conn,
+            title="build the feature",
+            triage=True,
+            workspace_kind="worktree",
+            workspace_path=str(repo),
         )
-        conn.commit()
-
         child_ids = kb.decompose_triage_task(
             conn,
             root,
@@ -89,16 +90,53 @@ def test_decompose_worktree_children_get_own_workspace(kanban_home):
         assert child_ids is not None and len(child_ids) == 2
 
         for cid in child_ids:
-            row = conn.execute(
-                "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
-                (cid,),
-            ).fetchone()
-            assert row["workspace_kind"] == "worktree"
-            # Each child resolves its own <repo>/.worktrees/<child-id> at
-            # dispatch; the root's literal path must never be shared.
-            assert row["workspace_path"] is None
+            child = kb.get_task(conn, cid)
+            assert child is not None
+            assert child.workspace_path is not None
+            assert child.workspace_kind == "worktree"
+            assert Path(child.workspace_path).resolve() == repo.resolve()
+            workspace, branch = kb._resolve_worktree_workspace(child)
+            assert workspace == (repo / ".worktrees" / cid).resolve()
+            assert branch == f"wt/{cid}"
 
 
+def test_decompose_linked_worktree_uses_common_repo_root_head(
+    kanban_home, tmp_path
+):
+    repo = _make_repo(tmp_path)
+    repo_head = _git(repo, "rev-parse", "HEAD")
+    sibling = _add_worktree(repo, repo / ".worktrees" / "root", "wt/root")
+    (sibling / "sibling.txt").write_text("sibling-only\n", encoding="utf-8")
+    _git(sibling, "add", "sibling.txt")
+    _git(sibling, "commit", "-m", "sibling commit")
+    sibling_head = _git(sibling, "rev-parse", "HEAD")
+    assert sibling_head != repo_head
+
+    with kb.connect() as conn:
+        root = kb.create_task(
+            conn,
+            title="correct sibling work",
+            triage=True,
+            workspace_kind="worktree",
+            workspace_path=str(sibling),
+        )
+        child_ids = kb.decompose_triage_task(
+            conn,
+            root,
+            root_assignee="orchestrator",
+            children=[{"title": "implement correction", "assignee": "alice"}],
+            author="decomposer",
+        )
+        assert child_ids is not None and len(child_ids) == 1
+        child = kb.get_task(conn, child_ids[0])
+
+    assert child is not None
+    assert child.workspace_path is not None
+    assert Path(child.workspace_path).resolve() == repo.resolve()
+    workspace, _branch = kb._resolve_worktree_workspace(child)
+    child_head = _git(workspace, "rev-parse", "HEAD")
+    assert child_head == repo_head
+    assert child_head != sibling_head
 
 
 def test_resolve_worktree_falls_back_when_path_occupied(kanban_home, tmp_path):
@@ -124,7 +162,3 @@ def test_resolve_worktree_falls_back_when_path_occupied(kanban_home, tmp_path):
         capture_output=True, text=True, check=True,
     ).stdout.strip()
     assert head == "wt/sibling"
-
-
-
-

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -116,6 +116,26 @@ def test_create_task_appears_on_board(client):
     assert "researcher" in data["assignees"]
 
 
+def test_create_task_rejects_unbound_worktree_before_persistence(client):
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "unbound dashboard task",
+            "assignee": "engineer",
+            "workspace_kind": "worktree",
+        },
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "unbound dashboard task" in detail
+    assert "task workspace_path=<absent>" in detail
+    assert "project repository=<absent>" in detail
+    assert "board 'default' default_workdir=<absent>" in detail
+    with kb.connect() as conn:
+        assert kb.list_tasks(conn, include_archived=True, limit=100) == []
+
+
 def test_patch_board_sets_project_directory(client, tmp_path):
     """Board-level default_workdir must be editable after creation."""
     kb.create_board("late-config")

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -65,9 +65,49 @@ They coexist: a kanban worker may call `delegate_task` internally during its run
 - **Workspace** — the directory a worker operates in. Three kinds:
   - `scratch` (default) — fresh tmp dir under `~/.hermes/kanban/workspaces/<id>/` (or `~/.hermes/kanban/boards/<slug>/workspaces/<id>/` on non-default boards). **Deleted when the task completes** — scratch is ephemeral by design. Files explicitly declared through `kanban_complete(artifacts=[...])` are copied into durable per-task attachment storage before cleanup; existing deliverable paths in legacy completion summaries receive the same treatment. Other scratch files are removed. A missing declared scratch artifact keeps the task in-flight so the worker can correct the path and retry. Use `worktree:` or `dir:<path>` when the whole workspace should remain available. The first time a scratch workspace is created on an install, the dispatcher logs a warning and emits a `tip_scratch_workspace` event on the task (visible via `hermes kanban show <id>`).
   - `dir:<path>` — an existing shared directory (Obsidian vault, mail ops dir, per-account folder). **Must be an absolute path.** Relative paths like `dir:../tenants/foo/` are rejected at dispatch because they'd resolve against whatever CWD the dispatcher happens to be in, which is ambiguous and a confused-deputy escape vector. The path is otherwise trusted — it's your box, your filesystem, the worker runs with your uid. This is the trusted-local-user threat model; kanban is single-host by design. **Preserved on completion.**
-  - `worktree` — a git worktree under `.worktrees/<id>/` for coding tasks. Use `worktree:<path>` to pin the exact target path. Worker-side `git worktree add` creates it, using `--branch` when provided. **Preserved on completion.**
+  - `worktree` — a git worktree under `.worktrees/<id>/` for coding tasks. Use `worktree:<path>` to bind the task to a repository root or requested task-worktree path. Worker-side `git worktree add` creates the task checkout, using `--branch` when provided. A worktree task is rejected at creation if it has no explicit path, project repository, or board `default_workdir`; Hermes never guesses a repository from the gateway's current directory. **Preserved on completion.**
 - **Dispatcher** — a long-lived loop that, every N seconds (default 60): reclaims stale claims, reclaims crashed workers (PID gone but TTL not yet expired), promotes ready tasks, atomically claims, spawns assigned profiles. Runs **inside the gateway** by default (`kanban.dispatch_in_gateway: true`). One dispatcher sweeps all boards per tick; workers are spawned with `HERMES_KANBAN_BOARD` pinned so they can't see other boards. After `kanban.failure_limit` consecutive spawn failures on the same task (default: 2) the dispatcher auto-blocks it with the last error as the reason — prevents thrashing on tasks whose profile doesn't exist, workspace can't mount, etc.
 - **Tenant** — optional string namespace *within* a board. One specialist fleet can serve multiple businesses (`--tenant business-a`) with data isolation by workspace path and memory key prefix. Tenants are a soft filter; boards are the hard isolation boundary.
+
+### Worktree repository binding and baseline semantics
+
+Auto-decomposition propagates a repository binding to every worktree child.
+If the root path is a repository-root checkout, children store that root. If
+the root path is an existing linked worktree, Hermes resolves its common
+repository and stores the common repository-root checkout instead. Each child
+still receives a fresh `<repo>/.worktrees/<child-id>` checkout; siblings never
+share the root's literal worktree directory.
+
+Repository binding does **not** imply commit inheritance. When the requested
+path points to another task's linked worktree, a fresh task branch is created
+from `HEAD` of the common repository-root checkout. It is not created from the
+sibling worktree's `HEAD`. Path inheritance is not commit inheritance.
+
+Hermes does not currently expose an explicit task baseline field. Corrective
+or dependent work that must start from a non-default commit should remain a
+separate follow-up feature rather than overloading `workspace_path` or asking a
+worker to reset after dispatch. The follow-up contract is:
+
+- Persist nullable `base_sha` on tasks; accept `base_ref` only as creation-time
+  input and resolve it to an immutable full commit SHA before persistence.
+- Add `base_ref` / `base_sha` inputs to the dashboard API, CLI create command,
+  worker `kanban_create` tool, and decomposer child schema. Explicit child
+  baseline wins; otherwise a child may inherit the root's persisted
+  `base_sha`. Repository binding and baseline remain separate fields.
+- Reject conflicting `base_ref` plus `base_sha`, nonexistent or ambiguous
+  revisions, SHAs outside the bound repository, and any baseline request made
+  before a repository can be resolved. Errors must identify the proposed task
+  or child and show both the workspace-resolution and revision-resolution
+  chains. Never pass untrusted revision text to a shell.
+- Materialize a new branch with
+  `git worktree add -b <task-branch> <path> <base_sha>`. Existing tasks with
+  `base_sha=NULL` retain today's repository-
+  root `HEAD` behavior. Movable refs are resolved once at creation, so retries
+  and delayed dispatches remain reproducible.
+- Migration adds one nullable column and requires no backfill. Regression tests
+  must cover API/CLI/tool/decomposer propagation, immutable ref resolution,
+  invalid and cross-repository revisions, root-vs-linked-worktree baselines,
+  delayed dispatch after a branch moves, and backward-compatible NULL behavior.
 
 ## Boards (multi-project)
 


### PR DESCRIPTION
## Summary

Fixes a recurring Kanban failure where auto-decomposed worktree tasks were persisted without any repository binding, then entered `spawn_failed` / `gave_up` loops when the board intentionally had no `default_workdir`.

- propagates a resolvable common-repository binding to decomposed worktree children
- rejects unresolved worktree tasks before persistence or claim
- preserves task-specific worktree isolation
- does not synthesize a board-wide default
- documents that linked-worktree inheritance supplies a repository binding, not commit inheritance

## Reproduction

A valid root task used an explicit linked-worktree path on a multi-project board with no default repository. Auto-decomposition created children with:

```text
workspace_kind=worktree
workspace_path=NULL
project_id=NULL
```

Each promoted child failed before its worker process started.

## Tests

```text
python -m pytest -q \
  tests/hermes_cli/test_kanban_cli.py \
  tests/hermes_cli/test_kanban_decompose_db.py \
  tests/hermes_cli/test_kanban_project_link.py \
  tests/hermes_cli/test_kanban_worktree_isolation.py \
  tests/plugins/test_kanban_dashboard_plugin.py

55 passed, 1 existing Starlette deprecation warning
git diff --check: pass
```

## Safety

- no board default is inferred or written
- malformed decomposition is rejected atomically
- existing project-bound and board-default-bound resolution remains supported
- no live board SQLite mutation is part of the implementation
