### PR TITLE
fix(desktop): preserve Electron Framework JIT entitlements

### DIFF
--- a/hermes_cli/main_desktop.py
+++ b/hermes_cli/main_desktop.py
@@ -797,8 +797,10 @@ def _desktop_macos_local_codesign(app: Path, *, desktop_dir: Path, identity: str
             if p.suffix in {".framework", ".app"}:
                 bundles.add(p)
     for bundle in sorted(bundles, key=lambda p: len(p.parts), reverse=True):
-        ent = ent_inherit if bundle.suffix == ".app" and "Helper" in bundle.name else None
-        sign_path(bundle, entitlements=ent, identifier=_desktop_macos_bundle_id(bundle))
+        # Every nested bundle takes the inherit plist, frameworks included: under the hardened
+        # runtime Electron Framework needs allow-jit in its own signature, and signing it with
+        # no entitlements strips what electron-builder's afterSign step applies in a real build.
+        sign_path(bundle, entitlements=ent_inherit, identifier=_desktop_macos_bundle_id(bundle))
 
     # 3) The main bundle, with the app's own entitlements.
     sign_path(app, entitlements=ent_main, identifier=_desktop_macos_bundle_id(app))

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -467,6 +467,9 @@ def _make_signable_app(desktop_dir: Path) -> Path:
     helper = app / "Contents" / "Frameworks" / "Hermes Helper.app"
     _write_info_plist(helper, "com.nousresearch.hermes.helper")
 
+    framework = app / "Contents" / "Frameworks" / "Electron Framework.framework"
+    _write_info_plist(framework, "com.github.Electron.framework")
+
     native_dir = app / "Contents" / "Resources" / "app.asar.unpacked" / "node_modules" / "pty"
     native_dir.mkdir(parents=True)
     (native_dir / "pty.node").write_text("", encoding="utf-8")
@@ -504,6 +507,23 @@ def test_desktop_macos_local_codesign_signs_native_binaries(tmp_path, monkeypatc
     signed = [c[-1] for c in calls if c[:3] == ["/usr/bin/codesign", "--force", "--sign"]]
     assert str(app / "Contents" / "Resources" / "app.asar.unpacked" / "node_modules" / "pty" / "pty.node") in signed
     assert str(app / "Contents" / "Frameworks" / "chrome_crashpad_handler") in signed
+
+
+def test_desktop_macos_local_codesign_preserves_framework_entitlements(tmp_path, monkeypatch):
+    """Hardened runtime frameworks must retain Electron's JIT entitlements."""
+    desktop_dir = tmp_path / "apps" / "desktop"
+    app = _make_signable_app(desktop_dir)
+    calls = _collect_codesign_calls(monkeypatch)
+
+    assert main_desktop._desktop_macos_local_codesign(app, desktop_dir=desktop_dir) is True
+
+    framework = app / "Contents" / "Frameworks" / "Electron Framework.framework"
+    framework_call = next(call for call in calls if call[-1] == str(framework))
+    assert framework_call[5:7] == ["--options", "runtime"]
+    assert framework_call[7:9] == [
+        "--entitlements",
+        str(desktop_dir / "electron" / "entitlements.mac.inherit.plist"),
+    ]
 
 
 


### PR DESCRIPTION
## Summary

Hermes Desktop can fail to restart after a macOS self-update because the local re-signing pass strips the inherited entitlements Electron's V8 runtime needs for JIT execution.

## Root cause

The updater re-signs nested bundles with the hardened runtime, but only Helper apps received `entitlements.mac.inherit.plist`. `Electron Framework.framework` was therefore signed without `com.apple.security.cs.allow-jit` and `com.apple.security.cs.allow-unsigned-executable-memory`, causing V8 to trap during startup.

## Fix

- Pass `entitlements.mac.inherit.plist` to every nested `.app` and `.framework` bundle in the existing inside-out signing pass.
- Add an `Electron Framework.framework` fixture and a regression assertion that pins both the hardened-runtime option and inherited entitlements.

The main application bundle continues to use `entitlements.mac.plist`; this change only corrects the nested-bundle signing policy.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_gui_command.py -q -k 'desktop_macos_local_codesign'` — 2 passed, 30 deselected
- `python3 -m py_compile hermes_cli/main.py tests/hermes_cli/test_gui_command.py`
- `git diff --check`

Fixes #85620.
