### PR TITLE
fix(agent): ignore null errors in structured tool results

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1367,8 +1367,10 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
 
     # Structured error in JSON result (any tool that surfaces {"error": ...}).
     if isinstance(data, dict):
-        err = data.get("error") or data.get("message")
-        if err and (data.get("success") is False or "error" in data):
+        err = data.get("error")
+        if not err and data.get("success") is False:
+            err = data.get("message")
+        if err:
             return True, f" [{_trim_error(str(err))}]"
 
     # Generic heuristic for non-terminal tools

--- a/agent/display.py
+++ b/agent/display.py
@@ -1312,6 +1312,7 @@ class KawaiiSpinner:
 # =========================================================================
 
 _ERROR_SUFFIX_MAX_LEN = 48
+_NULL_ERROR_FIELD_RE = re.compile(r'"error"\s*:\s*null\b', re.IGNORECASE)
 
 
 def _trim_error(msg: str) -> str:
@@ -1370,17 +1371,16 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
         if err and (data.get("success") is False or "error" in data):
             return True, f" [{_trim_error(str(err))}]"
 
-    # A successfully parsed structured result has already been classified
-    # above. Do not let field names such as `"error": null` override it.
-    if isinstance(data, (dict, list)):
-        return False, ""
-
     # Generic heuristic for non-terminal tools
     # Multimodal tool results (dicts with _multimodal=True) are not strings —
     # treat them as successes since failures would be JSON-encoded strings.
     if not isinstance(result, str):
         return False, ""
     lower = result[:500].lower()
+    if isinstance(data, (dict, list)):
+        # Ignore only the parsed success shape from #91166. Keep the legacy
+        # fallback for every other error/failed key and value.
+        lower = _NULL_ERROR_FIELD_RE.sub("", lower)
     if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):
         return True, " [error]"
 

--- a/agent/display.py
+++ b/agent/display.py
@@ -1370,6 +1370,11 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
         if err and (data.get("success") is False or "error" in data):
             return True, f" [{_trim_error(str(err))}]"
 
+    # A successfully parsed structured result has already been classified
+    # above. Do not let field names such as `"error": null` override it.
+    if isinstance(data, (dict, list)):
+        return False, ""
+
     # Generic heuristic for non-terminal tools
     # Multimodal tool results (dicts with _multimodal=True) are not strings —
     # treat them as successes since failures would be JSON-encoded strings.

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -10,11 +10,15 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 from utils import safe_json_loads
 from agent.tool_result_classification import file_mutation_result_landed
+
+
+_NULL_ERROR_FIELD_RE = re.compile(r'"error"\s*:\s*null\b', re.IGNORECASE)
 
 
 IDEMPOTENT_TOOL_NAMES = frozenset(
@@ -329,10 +333,11 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
         err = data.get("error") or data.get("message")
         if err and (data.get("success") is False or "error" in data):
             return True, " [error]"
-    if isinstance(data, (dict, list)):
-        return False, ""
-
     lower = result[:500].lower()
+    if isinstance(data, (dict, list)):
+        # Ignore only the parsed success shape from #91166. Keep the legacy
+        # fallback for every other error/failed key and value.
+        lower = _NULL_ERROR_FIELD_RE.sub("", lower)
     if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):
         return True, " [error]"
 

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -330,8 +330,10 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
 
     data = safe_json_loads(result)
     if isinstance(data, dict):
-        err = data.get("error") or data.get("message")
-        if err and (data.get("success") is False or "error" in data):
+        err = data.get("error")
+        if not err and data.get("success") is False:
+            err = data.get("message")
+        if err:
             return True, " [error]"
     lower = result[:500].lower()
     if isinstance(data, (dict, list)):

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -324,6 +324,14 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
             if data.get("success") is False and "exceed the limit" in data.get("error", ""):
                 return True, " [full]"
 
+    data = safe_json_loads(result)
+    if isinstance(data, dict):
+        err = data.get("error") or data.get("message")
+        if err and (data.get("success") is False or "error" in data):
+            return True, " [error]"
+    if isinstance(data, (dict, list)):
+        return False, ""
+
     lower = result[:500].lower()
     if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):
         return True, " [error]"

--- a/tests/agent/test_display_tool_failure.py
+++ b/tests/agent/test_display_tool_failure.py
@@ -106,6 +106,10 @@ class TestDetectToolFailureStructured:
         result = '{"results":[{"error": \n\t null,"content":"short page"}]}'
         assert _detect_tool_failure("web_extract", result) == (False, "")
 
+    def test_null_error_with_success_message_not_flagged(self):
+        result = '{"success":true,"error":null,"message":"done"}'
+        assert _detect_tool_failure("web_extract", result) == (False, "")
+
     def test_other_structured_failure_markers_keep_legacy_fallback(self):
         results = (
             '{"results":[{"error":"timeout"}]}',

--- a/tests/agent/test_display_tool_failure.py
+++ b/tests/agent/test_display_tool_failure.py
@@ -96,6 +96,18 @@ class TestDetectToolFailureStructured:
         result = json.dumps({"success": True, "data": "hello"})
         assert _detect_tool_failure("web_search", result) == (False, "")
 
+    def test_null_error_field_not_flagged(self):
+        result = json.dumps({
+            "results": [{"content": "short page", "error": None}],
+        })
+        assert _detect_tool_failure("web_extract", result) == (False, "")
+
+    def test_unstructured_error_text_still_flagged(self):
+        assert _detect_tool_failure("web_extract", 'request {"error"} occurred') == (
+            True,
+            " [error]",
+        )
+
 
 
 class TestGetCuteToolMessageFailureSuffix:
@@ -118,4 +130,3 @@ class TestGetCuteToolMessageFailureSuffix:
         ok = json.dumps({"success": True, "data": "hi"})
         line = get_cute_tool_message("web_search", {"query": "hi"}, 0.2, result=ok)
         assert "[" not in line.split("0.2s", 1)[1]
-

--- a/tests/agent/test_display_tool_failure.py
+++ b/tests/agent/test_display_tool_failure.py
@@ -102,6 +102,20 @@ class TestDetectToolFailureStructured:
         })
         assert _detect_tool_failure("web_extract", result) == (False, "")
 
+    def test_null_error_field_with_json_whitespace_not_flagged(self):
+        result = '{"results":[{"error": \n\t null,"content":"short page"}]}'
+        assert _detect_tool_failure("web_extract", result) == (False, "")
+
+    def test_other_structured_failure_markers_keep_legacy_fallback(self):
+        results = (
+            '{"results":[{"error":"timeout"}]}',
+            '{"error":null,"results":[{"error":"timeout"}]}',
+            '{"failed":1}',
+            '{"failed":0}',
+        )
+        for result in results:
+            assert _detect_tool_failure("web_extract", result) == (True, " [error]")
+
     def test_unstructured_error_text_still_flagged(self):
         assert _detect_tool_failure("web_extract", 'request {"error"} occurred') == (
             True,

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -11,6 +11,22 @@ from agent.tool_guardrails import (
 )
 
 
+def test_classify_tool_failure_ignores_null_error_in_structured_success():
+    result = '{"results":[{"content":"short page","error":null}]}'
+    assert classify_tool_failure("web_extract", result) == (False, "")
+
+
+def test_classify_tool_failure_keeps_structured_and_unstructured_errors():
+    assert classify_tool_failure("web_extract", '{"error":"boom"}') == (
+        True,
+        " [error]",
+    )
+    assert classify_tool_failure("web_extract", 'request {"error"} occurred') == (
+        True,
+        " [error]",
+    )
+
+
 def test_tool_call_signature_hashes_canonical_nested_unicode_args_without_exposing_raw_args():
     args_a = {
         "z": [{"β": "☤", "a": 1}],
@@ -167,7 +183,6 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     assert decision.action == "block"
     assert decision.code == "loop_web_search_cap"
     assert decision.should_halt is True
-
 
 
 

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -12,19 +12,25 @@ from agent.tool_guardrails import (
 
 
 def test_classify_tool_failure_ignores_null_error_in_structured_success():
-    result = '{"results":[{"content":"short page","error":null}]}'
-    assert classify_tool_failure("web_extract", result) == (False, "")
+    results = (
+        '{"results":[{"content":"short page","error":null}]}',
+        '{"results":[{"error": \n\t null,"content":"short page"}]}',
+    )
+    for result in results:
+        assert classify_tool_failure("web_extract", result) == (False, "")
 
 
 def test_classify_tool_failure_keeps_structured_and_unstructured_errors():
-    assert classify_tool_failure("web_extract", '{"error":"boom"}') == (
-        True,
-        " [error]",
+    results = (
+        '{"error":"boom"}',
+        '{"results":[{"error":"timeout"}]}',
+        '{"error":null,"results":[{"error":"timeout"}]}',
+        '{"failed":1}',
+        '{"failed":0}',
+        'request {"error"} occurred',
     )
-    assert classify_tool_failure("web_extract", 'request {"error"} occurred') == (
-        True,
-        " [error]",
-    )
+    for result in results:
+        assert classify_tool_failure("web_extract", result) == (True, " [error]")
 
 
 def test_tool_call_signature_hashes_canonical_nested_unicode_args_without_exposing_raw_args():
@@ -183,7 +189,6 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     assert decision.action == "block"
     assert decision.code == "loop_web_search_cap"
     assert decision.should_halt is True
-
 
 
 

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -15,6 +15,7 @@ def test_classify_tool_failure_ignores_null_error_in_structured_success():
     results = (
         '{"results":[{"content":"short page","error":null}]}',
         '{"results":[{"error": \n\t null,"content":"short page"}]}',
+        '{"success":true,"error":null,"message":"done"}',
     )
     for result in results:
         assert classify_tool_failure("web_extract", result) == (False, "")
@@ -189,7 +190,6 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     assert decision.action == "block"
     assert decision.code == "loop_web_search_cap"
     assert decision.should_halt is True
-
 
 
 


### PR DESCRIPTION
## Summary

- stop the text fallback from overriding the specific parsed-JSON success case `"error": null`
- keep the display and guardrail classifiers aligned
- preserve the existing fallback for every other `"error"` / `"failed"` key and value

Fixes #91166.

## Evidence

- Exact proof base: `8794e5a21c980a0f26532cb4883284b786cb3f25`
- Exact current head: `efd0c77b0caf9b78c8609629c3236192705bffe8`

On the proof base, both production classifiers returned `(True, " [error]")` for a short parsed result containing a nested `"error": null`. This head returns `(False, "")` in both paths, including valid JSON whitespace between the colon and `null`.

The compatibility counterexamples remain failures in both paths, matching the proof base:

- nested `{"error": "timeout"}`
- `{"error": null}` followed by a nested non-null error
- `{"failed": 1}`
- `{"failed": 0}`
- unstructured text containing `"error"`

The follow-up is deliberately narrow: after parsing succeeds, it removes only `"error": null` fields from the existing 500-character text-fallback window. It does not define broader truthiness semantics for `failed` or other error values.

## Related ownership

Earlier PR #59049 proposes a broader value-aware matcher for the shared display classifier and has an outstanding current-head review about JSON whitespace handling. This PR keeps the narrower #91166 behavior boundary and also aligns the guardrail classifier. The PR remains labeled `needs-decision` so maintainers can choose the canonical ownership route.

## Validation

- `scripts/run_tests.sh tests/agent/test_display_tool_failure.py tests/agent/test_tool_guardrails.py -q` (24 passed)
- `scripts/run_tests.sh tests/agent/test_display.py tests/agent/test_display_emoji.py tests/agent/test_display_todo_progress.py -q` (40 passed)
- Ruff check on all four changed files: passed
- `git diff --check`: passed
- TruffleHog filesystem scan of all four changed files: 0 verified / 0 unknown
- Hosted fork workflows require upstream approval before they can execute

`ruff format --check` reports extensive pre-existing whole-file formatting drift in these files, so this PR deliberately excludes unrelated formatting changes.
