### PR TITLE
fix(logging): recover from POSIX rollover backup races

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -540,7 +540,17 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         return stream
 
     def doRollover(self):
-        super().doRollover()
+        try:
+            super().doRollover()
+        except FileNotFoundError:
+            # On POSIX, several Hermes processes may enter the stdlib backup
+            # rename chain together. A sibling can consume ``.1`` after our
+            # existence check but before ``os.rename(.1, .2)``. The stdlib has
+            # already closed our stream at that point; reopen the canonical
+            # base path so the current emit remains writable; a later emit can
+            # retry rotation without reporting this harmless backup race.
+            if self.stream is None and not self.delay:
+                self.stream = self._open()
         self._chmod_if_managed()
         # Our own rollover writes a new baseFilename; refresh the snapshot
         # so the next emit doesn't mistake it for external rotation.

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -555,6 +555,36 @@ class TestExternalRotationRecovery:
         finally:
             handler.close()
 
+    @pytest.mark.linux_only
+    def test_rollover_recovers_when_a_sibling_moves_a_backup(self, tmp_path, monkeypatch):
+        """A POSIX sibling may consume ``.1`` during stdlib's rename chain."""
+        log_path = tmp_path / "errors.log"
+        backup = tmp_path / "errors.log.1"
+        log_path.write_text("current\n")
+        backup.write_text("sibling backup\n")
+        handler = hermes_logging._ManagedRotatingFileHandler(
+            str(log_path), maxBytes=1, backupCount=2, encoding="utf-8",
+        )
+        original_rename = hermes_logging.os.rename
+        moved = False
+
+        def sibling_wins(source, destination):
+            nonlocal moved
+            if source == str(backup) and not moved:
+                moved = True
+                backup.unlink()
+                raise FileNotFoundError(source)
+            return original_rename(source, destination)
+
+        try:
+            monkeypatch.setattr(hermes_logging.os, "rename", sibling_wins)
+            handler.doRollover()
+            self._emit(handler, "after sibling rollover")
+            assert log_path.exists()
+            assert "after sibling rollover" in log_path.read_text()
+        finally:
+            handler.close()
+
 
     def test_gateway_log_attached_after_external_rotation_then_re_setup(
         self, hermes_home,


### PR DESCRIPTION
## Summary

Fixes the remaining POSIX backup-chain race described in #27649.

Multiple Hermes processes can enter stdlib `RotatingFileHandler.doRollover()` concurrently. One process may move `errors.log.1` after another process has checked that it exists but before that process calls `os.rename(errors.log.1, errors.log.2)`. The second handler raises `FileNotFoundError` on its QueueListener thread and loses the expected logging path.

The handler now catches only that missing-file race. If stdlib already closed the stream, it reopens the canonical base file and lets a later emit retry rotation. Permission errors and unrelated failures remain visible. Windows behavior is unchanged and continues to use `ConcurrentRotatingFileHandler`.

## Test plan

- RED on upstream `ee000768cef4dc9399f32c88b507104ce15400dd`: deterministic `.1 -> .2` sibling race fails at `super().doRollover()`
- GREEN focused rotation recovery: 3 passed
- `pytest -q tests/test_log_isolation.py tests/hermes_cli/test_logs.py tests/test_hermes_logging.py`: 44 passed, 2 platform skips
- `ruff check hermes_logging.py tests/test_hermes_logging.py`: passed
- `git diff --check`: passed

## Scope

Two files only; no dependency, config, migration, service, Windows-handler, or runtime promotion change.
