### PR TITLE
fix(kanban): keep needs-input escalations human-gated

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1640,7 +1640,7 @@ class GatewayKanbanWatchersMixin:
                         attempted += 1
                         try:
                             outcome = _decomp.decompose_task(
-                                tid, author="auto-decomposer",
+                                tid, author=_decomp.AUTO_DECOMPOSER_AUTHOR,
                             )
                         except Exception:
                             logger.exception(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -132,6 +132,26 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # spirit (default 2) but counts a different signal: manual unblock recurrences,
 # not dispatcher spawn/crash/timeout failures.
 BLOCK_RECURRENCE_LIMIT = 2
+
+# Event-derived predicate for a block-loop escalation that has not been
+# explicitly acknowledged. Mutable task columns are insufficient: reassignment
+# and restarts must not erase the human gate.
+_BLOCK_LOOP_ESCALATED_SQL = """
+    EXISTS (
+        SELECT 1
+        FROM task_events AS escalated
+        WHERE escalated.task_id = tasks.id
+          AND escalated.kind = 'block_loop_detected'
+          AND NOT EXISTS (
+              SELECT 1
+              FROM task_events AS recovered
+              WHERE recovered.task_id = escalated.task_id
+                AND recovered.kind = 'triage_escalation_recovered'
+                AND recovered.id > escalated.id
+          )
+    )
+"""
+
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 
 
@@ -4297,6 +4317,60 @@ def list_events(conn: sqlite3.Connection, task_id: str) -> list[Event]:
     return out
 
 
+def is_block_loop_escalated(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Return whether the task has an unacknowledged block-loop escalation."""
+    row = conn.execute(
+        f"SELECT {_BLOCK_LOOP_ESCALATED_SQL} AS escalated "
+        "FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    return bool(row and row["escalated"])
+
+
+def list_decomposable_triage_task_ids(
+    conn: sqlite3.Connection,
+    *,
+    tenant: Optional[str] = None,
+    limit: int = 50,
+) -> list[str]:
+    """Return triage ids that are not waiting on explicit human recovery."""
+    where = ["tasks.status = 'triage'", f"NOT {_BLOCK_LOOP_ESCALATED_SQL}"]
+    params: list[Any] = []
+    if tenant:
+        where.append("tasks.tenant = ?")
+        params.append(tenant)
+    params.append(max(1, min(int(limit), 1000)))
+    rows = conn.execute(
+        "SELECT tasks.id FROM tasks WHERE "
+        + " AND ".join(where)
+        + " ORDER BY tasks.priority DESC, tasks.created_at ASC LIMIT ?",
+        tuple(params),
+    ).fetchall()
+    return [str(row["id"]) for row in rows]
+
+
+def _recover_triage_escalation(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    author: Optional[str],
+) -> bool:
+    """Acknowledge an escalation inside the caller's existing write txn."""
+    if not is_block_loop_escalated(conn, task_id):
+        return False
+    conn.execute(
+        "UPDATE tasks SET block_kind = NULL, block_recurrences = 0 WHERE id = ?",
+        (task_id,),
+    )
+    _append_event(
+        conn,
+        task_id,
+        "triage_escalation_recovered",
+        {"author": author} if author else None,
+    )
+    return True
+
+
 def _append_event(
     conn: sqlite3.Connection,
     task_id: str,
@@ -7268,6 +7342,7 @@ def specify_triage_task(
             "specified",
             {"changed_fields": changed_fields} if changed_fields else None,
         )
+        _recover_triage_escalation(conn, task_id, author=author)
     # Outside the write_txn above, so we don't nest BEGIN IMMEDIATE — the
     # ready-promotion pass opens its own IMMEDIATE txn. This runs the same
     # logic the dispatcher would on its next tick, so a specified task
@@ -7499,6 +7574,7 @@ def decompose_triage_task(
                 "root_assignee": root_assignee,
             },
         )
+        _recover_triage_escalation(conn, task_id, author=author)
 
     # Outside the write_txn: promote parent-free children to 'ready'
     # so the dispatcher picks them up on its next tick. Same pattern

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -48,6 +48,8 @@ from hermes_cli import profiles as profiles_mod
 
 logger = logging.getLogger(__name__)
 
+AUTO_DECOMPOSER_AUTHOR = "auto-decomposer"
+
 
 _SYSTEM_PROMPT = """You are the Kanban decomposer for the Hermes Agent board.
 
@@ -283,11 +285,18 @@ def decompose_task(
     """
     with kb.connect_closing() as conn:
         task = kb.get_task(conn, task_id)
+        escalated = bool(task and kb.is_block_loop_escalated(conn, task_id))
     if task is None:
         return DecomposeOutcome(task_id, False, "unknown task id")
     if task.status != "triage":
         return DecomposeOutcome(
             task_id, False, f"task is not in triage (status={task.status!r})"
+        )
+    if escalated and author == AUTO_DECOMPOSER_AUTHOR:
+        return DecomposeOutcome(
+            task_id,
+            False,
+            "task is waiting for explicit human recovery after a block loop",
         )
 
     cfg = _load_config()
@@ -457,12 +466,10 @@ def decompose_task(
 
 
 def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
-    """Return task ids currently in the triage column."""
+    """Return triage ids that may be decomposed without human recovery."""
     with kb.connect_closing() as conn:
-        rows = kb.list_tasks(
+        return kb.list_decomposable_triage_task_ids(
             conn,
-            status="triage",
             tenant=tenant,
             limit=1000,
         )
-    return [row.id for row in rows]

--- a/tests/gateway/test_kanban_needs_input_redispatch.py
+++ b/tests/gateway/test_kanban_needs_input_redispatch.py
@@ -1,0 +1,105 @@
+"""Gateway auto-decompose must leave needs_input escalations untouched."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.run import GatewayRunner
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_decompose as decomp
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = kb.kanban_db_path(board="default")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db()
+    return home
+
+
+def _escalate_needs_input(conn, task_id: str) -> None:
+    assert kb.block_task(conn, task_id, reason="answer required", kind="needs_input")
+    assert kb.unblock_task(conn, task_id)
+    assert kb.block_task(conn, task_id, reason="answer required", kind="needs_input")
+
+
+def test_gateway_tick_does_not_redispatch_escalated_needs_input(
+    kanban_home: Path,
+    tmp_path: Path,
+) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="wait for operator",
+            assignee="worker",
+            workspace_kind="worktree",
+            workspace_path=str(tmp_path / "repo" / "checkout"),
+            branch_name="feature/wait-for-operator",
+        )
+        _escalate_needs_input(conn, task_id)
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "triage"
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner._kanban_dispatcher_lock_handle = None
+    sleep_calls: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+        if len(sleep_calls) >= 2:
+            runner._running = False
+        await real_sleep(0)
+
+    async def fake_to_thread(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    config = {
+        "kanban": {
+            "dispatch_in_gateway": True,
+            "auto_decompose": True,
+            "auto_decompose_per_tick": 3,
+            "dispatch_interval_seconds": 1,
+            "reconcile_orphans": False,
+        }
+    }
+    spawn = MagicMock(name="spawn")
+    decompose = MagicMock(name="decompose")
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch(
+            "gateway.kanban_watchers._acquire_singleton_lock",
+            return_value=(object(), "held"),
+        ),
+        patch("gateway.kanban_watchers._release_singleton_lock"),
+        patch(
+            "gateway.kanban_watchers._kanban_dispatch_allowed",
+            return_value=True,
+        ),
+        patch.object(kb, "_default_spawn", spawn),
+        patch.object(decomp, "decompose_task", decompose),
+        patch("asyncio.sleep", side_effect=fake_sleep),
+        patch("asyncio.to_thread", side_effect=fake_to_thread),
+    ):
+        asyncio.run(runner._kanban_dispatcher_watcher())
+
+    decompose.assert_not_called()
+    spawn.assert_not_called()
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "triage"
+        assert kb.child_ids(conn, task_id) == []
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1

--- a/tests/hermes_cli/test_kanban_needs_input_redispatch.py
+++ b/tests/hermes_cli/test_kanban_needs_input_redispatch.py
@@ -1,0 +1,172 @@
+"""Regression coverage for needs_input escalation redispatch (#191)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_decompose as decomp
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _escalate_needs_input(conn, task_id: str) -> None:
+    assert kb.block_task(conn, task_id, reason="answer required", kind="needs_input")
+    assert kb.unblock_task(conn, task_id)
+    assert kb.block_task(conn, task_id, reason="answer required", kind="needs_input")
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.status == "triage"
+
+
+def _fake_response(payload: dict[str, object]) -> MagicMock:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = json.dumps(payload)
+    return response
+
+
+def test_escalated_needs_input_is_not_auto_decomposed_after_reassignment(
+    kanban_home: Path,
+) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="wait for answer", assignee="worker-a")
+        _escalate_needs_input(conn, task_id)
+        assert kb.is_block_loop_escalated(conn, task_id)
+        conn.execute(
+            "UPDATE tasks SET assignee = ? WHERE id = ?",
+            ("worker-b", task_id),
+        )
+        conn.commit()
+
+    assert task_id not in decomp.list_triage_ids()
+    with patch("agent.auxiliary_client.call_llm") as call_llm:
+        outcome = decomp.decompose_task(
+            task_id,
+            author=decomp.AUTO_DECOMPOSER_AUTHOR,
+        )
+    assert outcome.ok is False
+    assert "human recovery" in outcome.reason
+    call_llm.assert_not_called()
+
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "triage"
+        assert task.assignee == "worker-b"
+        assert kb.is_block_loop_escalated(conn, task_id)
+
+
+def test_manual_decompose_recovers_only_after_success(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="needs decision", assignee="worker")
+        _escalate_needs_input(conn, task_id)
+
+    payload: dict[str, object] = {
+        "fanout": False,
+        "title": "Decision supplied",
+        "body": "Proceed using the operator decision.",
+    }
+    with (
+        patch("agent.auxiliary_client.call_llm", return_value=_fake_response(payload)),
+        patch.object(decomp, "_load_config", return_value={}),
+        patch.object(decomp, "_build_roster", return_value=([], {"worker"})),
+        patch.object(decomp, "_resolve_orchestrator_profile", return_value="worker"),
+        patch.object(decomp, "_resolve_default_assignee", return_value="worker"),
+    ):
+        outcome = decomp.decompose_task(task_id, author="operator")
+
+    assert outcome.ok, outcome.reason
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "ready"
+        assert task.block_kind is None
+        assert task.block_recurrences == 0
+        assert not kb.is_block_loop_escalated(conn, task_id)
+        assert any(
+            event.kind == "triage_escalation_recovered"
+            for event in kb.list_events(conn, task_id)
+        )
+
+
+def test_manual_fanout_recovers_only_after_success(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="needs routing", assignee="worker")
+        _escalate_needs_input(conn, task_id)
+
+    payload: dict[str, object] = {
+        "fanout": True,
+        "tasks": [
+            {
+                "title": "Execute operator decision",
+                "body": "Proceed with the supplied choice.",
+                "assignee": "worker",
+                "parents": [],
+            }
+        ],
+    }
+    with (
+        patch("agent.auxiliary_client.call_llm", return_value=_fake_response(payload)),
+        patch.object(decomp, "_load_config", return_value={}),
+        patch.object(decomp, "_build_roster", return_value=([], {"worker"})),
+        patch.object(decomp, "_resolve_orchestrator_profile", return_value="worker"),
+        patch.object(decomp, "_resolve_default_assignee", return_value="worker"),
+    ):
+        outcome = decomp.decompose_task(task_id, author="operator")
+
+    assert outcome.ok, outcome.reason
+    assert outcome.fanout is True
+    assert outcome.child_ids and len(outcome.child_ids) == 1
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.block_kind is None
+        assert task.block_recurrences == 0
+        assert not kb.is_block_loop_escalated(conn, task_id)
+        assert any(
+            event.kind == "triage_escalation_recovered"
+            for event in kb.list_events(conn, task_id)
+        )
+
+
+def test_failed_manual_decompose_keeps_human_gate(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="still waiting", assignee="worker")
+        _escalate_needs_input(conn, task_id)
+
+    with patch(
+        "agent.auxiliary_client.call_llm",
+        side_effect=RuntimeError("auxiliary unavailable"),
+    ):
+        outcome = decomp.decompose_task(task_id, author="operator")
+
+    assert outcome.ok is False
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "triage"
+        assert kb.is_block_loop_escalated(conn, task_id)
+        assert not any(
+            event.kind == "triage_escalation_recovered"
+            for event in kb.list_events(conn, task_id)
+        )
+
+
+def test_fresh_triage_remains_auto_decomposable(kanban_home: Path) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="fresh idea", triage=True)
+    assert task_id in decomp.list_triage_ids()


### PR DESCRIPTION
## Problem

The block-loop breaker deliberately moves a repeatedly unblocked `needs_input` task to `triage`, but the auto-decomposer currently treats every triage card as runnable. On its next tick it can call the LLM and requeue or fan out the task, bypassing the human-decision gate. Reassignment and a fresh process do not make that safe.

Tracked downstream as DarkArty07/Aether-Agents#191.

## Fix

- derive an active block-loop escalation from durable `block_loop_detected` / `triage_escalation_recovered` events
- exclude active escalations from the auto-decomposer before any LLM call
- keep a defense in `decompose_task` for direct automatic calls
- recover only after a successful manual specify/fanout, in the same DB transaction
- reset block-loop fields and append an auditable recovery event
- share the auto-decomposer author constant with the gateway watcher

## Verification

- RED reproduced on upstream `main`: 4 material failures, fresh-triage control passed
- GREEN: `13 passed` across the new regressions plus adjacent decompose/block-kind/sticky suites
- separate-process probe: escalation remained active after restart and reassignment and stayed absent from the auto-decompose list
- `ruff check`: passed
- `python -m py_compile`: passed
- `git diff --check`: passed

No model call is made by the automatic refusal path.