### PR TITLE
feat(desktop): separate Bot Mode direct messages and groups

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -210,7 +210,7 @@ const ROSTER_SECTION_KEYS = ['direct', 'groups']
 const $rosterSectionsOpen = atom({ direct: true, groups: true })
 let rosterSectionMutationGeneration = 0
 
-function beginRosterSectionHydration() {
+function currentRosterSectionGeneration() {
   return rosterSectionMutationGeneration
 }
 
@@ -224,6 +224,8 @@ function setRosterSectionOpen(section, open) {
   $rosterSectionsOpen.set(next)
 
   try {
+    // Plugin storage has no cross-window subscription here; disclosure state
+    // is intentionally scoped to this window until the next plugin boot.
     Promise.resolve(pluginCtx?.storage?.set?.('roster-sections-open', next)).catch(() => undefined)
   } catch {
     /* storage unavailable — disclosure state lasts for this window */
@@ -10335,7 +10337,7 @@ function RosterSection({ children, section, open, onToggle, toggleDisabled = fal
           attentionCount
             ? jsx('span', {
                 className:
-                  'shrink-0 rounded-full bg-(--ui-accent,#4f9cf9) px-1.5 text-[0.6rem] font-semibold normal-case text-white',
+                  'shrink-0 rounded-full bg-(--ui-accent) px-1.5 text-[0.6rem] font-semibold normal-case text-white',
                 title: `${attentionCount} ${attentionLabel}`,
                 'aria-label': `${attentionCount} ${attentionLabel}`,
                 children: attentionCount
@@ -10361,6 +10363,8 @@ function RosterSection({ children, section, open, onToggle, toggleDisabled = fal
 }
 
 function rosterSectionIsOpen(section, saved, query = '') {
+  // Search is a temporary reveal: clearing it deliberately restores each
+  // section's saved disclosure state instead of changing the user's layout.
   return Boolean(String(query || '').trim()) || saved?.[section] !== false
 }
 
@@ -10963,7 +10967,7 @@ export default {
     // Restore Direct Messages / Groups disclosure state without allowing a
     // delayed hydration read to overwrite a newer click in this window.
     try {
-      const hydrationGeneration = beginRosterSectionHydration()
+      const hydrationGeneration = currentRosterSectionGeneration()
       Promise.resolve(ctx.storage?.get?.('roster-sections-open'))
         .then(value => hydrateRosterSectionsOpen(value, hydrationGeneration))
         .catch(() => undefined)

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -205,6 +205,49 @@ const $groupChats = atom({})
 const $groupChatWorkspace = atom(null)
 /** Groups whose latest room activity mentions @user — the needs-you badge. */
 const $groupNeedsYou = atom({})
+const ROSTER_SECTION_KEYS = ['direct', 'groups']
+/** Persisted disclosure state for the Direct Messages and Groups sections. */
+const $rosterSectionsOpen = atom({ direct: true, groups: true })
+let rosterSectionMutationGeneration = 0
+
+function beginRosterSectionHydration() {
+  return rosterSectionMutationGeneration
+}
+
+function setRosterSectionOpen(section, open) {
+  if (!ROSTER_SECTION_KEYS.includes(section)) {
+    return
+  }
+
+  const next = { ...$rosterSectionsOpen.get(), [section]: Boolean(open) }
+  rosterSectionMutationGeneration += 1
+  $rosterSectionsOpen.set(next)
+
+  try {
+    Promise.resolve(pluginCtx?.storage?.set?.('roster-sections-open', next)).catch(() => undefined)
+  } catch {
+    /* storage unavailable — disclosure state lasts for this window */
+  }
+}
+
+function hydrateRosterSectionsOpen(value, expectedGeneration = rosterSectionMutationGeneration) {
+  if (expectedGeneration !== rosterSectionMutationGeneration) {
+    return
+  }
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return
+  }
+
+  const current = $rosterSectionsOpen.get()
+  const next = {}
+
+  for (const key of ROSTER_SECTION_KEYS) {
+    next[key] = typeof value[key] === 'boolean' ? value[key] : current[key]
+  }
+
+  $rosterSectionsOpen.set(next)
+}
 // Pending prompts (clarify questions AND command approvals) raised inside
 // hidden group-member sessions, keyed `${group}::${memberKey}` (#90694).
 // Members run in invisible plumbing sessions, so a member's blocking prompt
@@ -10262,6 +10305,65 @@ function GroupRow({ active, group, members, needsYou, onOpen, onDisband }) {
   })
 }
 
+function RosterSection({ children, section, open, onToggle, toggleDisabled = false }) {
+  const contentId = `hermes-bots-section-${section.key}`
+  const count = section.rows.length
+  const attentionCount = Number(section.attentionCount || 0)
+  const attentionLabel = section.attentionLabel || 'attention item'
+  const headerLabel = `${section.label}: ${count} ${count === 1 ? 'item' : 'items'}${
+    attentionCount ? `, ${attentionCount} ${attentionLabel}` : ''
+  }`
+
+  return jsxs('section', {
+    'aria-labelledby': `${contentId}-heading`,
+    className: section.key === 'groups' ? 'border-t border-(--ui-stroke-secondary) pt-1.5' : undefined,
+    children: [
+      jsxs('button', {
+        type: 'button',
+        'aria-controls': contentId,
+        'aria-expanded': open,
+        'aria-label': headerLabel,
+        disabled: toggleDisabled,
+        title: toggleDisabled ? 'Clear search to change this section' : undefined,
+        className:
+          'flex w-full items-center gap-1.5 px-2 py-1 text-left text-[0.6875rem] font-semibold uppercase tracking-wider text-(--ui-text-quaternary) transition-colors hover:text-foreground disabled:cursor-default disabled:hover:text-(--ui-text-quaternary)',
+        onClick: () => onToggle(!open),
+        children: [
+          jsx(Codicon, { name: open ? 'chevron-down' : 'chevron-right', className: 'text-[0.65rem]' }),
+          jsx('span', { id: `${contentId}-heading`, className: 'min-w-0 flex-1 truncate', children: section.label }),
+          jsx('span', { className: 'font-normal tabular-nums', children: String(count) }),
+          attentionCount
+            ? jsx('span', {
+                className:
+                  'shrink-0 rounded-full bg-(--ui-accent,#4f9cf9) px-1.5 text-[0.6rem] font-semibold normal-case text-white',
+                title: `${attentionCount} ${attentionLabel}`,
+                'aria-label': `${attentionCount} ${attentionLabel}`,
+                children: attentionCount
+              })
+            : null
+        ]
+      }),
+      jsx('div', {
+        id: contentId,
+        hidden: !open,
+        className: 'grid gap-0.5',
+        children: open
+          ? count
+            ? children
+            : jsx('div', {
+                className: 'px-2 py-1.5 text-[0.6875rem] text-(--ui-text-quaternary)',
+                children: `No ${section.label.toLowerCase()} yet.`
+              })
+          : null
+      })
+    ]
+  })
+}
+
+function rosterSectionIsOpen(section, saved, query = '') {
+  return Boolean(String(query || '').trim()) || saved?.[section] !== false
+}
+
 function BotsPane() {
   const { data, error, isLoading, refetch } = useRoster()
   const gatewayState = useValue(host.state.gateway)
@@ -10283,6 +10385,7 @@ function BotsPane() {
   useValue($groupMainTabsRev)
   const groupNeedsYou = useValue($groupNeedsYou)
   const groupRooms = useValue($groupChats)
+  const sectionsOpen = useValue($rosterSectionsOpen)
 
   // The socket opening (boot, SSH reconnect, sleep/wake) is the signal to
   // retry immediately instead of waiting out the poll interval.
@@ -10333,10 +10436,8 @@ function BotsPane() {
   const hiddenUnread = hiddenBots.some(bot => !bot.remoteSource && unreadByName[bot.name])
   const visibleRoster = showHidden ? roster : roster.filter(bot => !isBotHidden(bot, allMeta))
   const filteredRoster = filterBots(visibleRoster, allMeta, query)
-  // Group chats are first-class roster rows (Discord-style): one standalone
-  // row per room, competing in the SAME recency ordering as bot rows — a
-  // group's activity is its newest room-log line. Pinned bots still lead;
-  // groups and unpinned bots interleave by recency below them.
+  // Direct chats and group rooms have independent, collapsible sections.
+  // Each section preserves its existing pin/recency ordering.
   const needle = query.trim().toLowerCase()
   const groupRows = groupChatNames(allMeta, groupRooms)
     .filter(name => !needle || name.toLowerCase().includes(needle))
@@ -10346,10 +10447,14 @@ function BotsPane() {
       members: groupChatMemberBots(name, roster, allMeta),
       activity: groupLastActivity(groupRooms[name])
     }))
-  const rosterRows = [
-    ...filteredRoster.map(bot => ({ kind: 'bot', bot, pinned: isPinned(bot), activity: activityOf(bot) })),
-    ...groupRows
-  ].sort((a, b) => {
+  groupRows.sort((a, b) => b.activity - a.activity)
+  const directRows = filteredRoster.map(bot => ({
+    kind: 'bot',
+    bot,
+    pinned: isPinned(bot),
+    activity: activityOf(bot)
+  }))
+  directRows.sort((a, b) => {
     const pa = a.pinned ? 1 : 0
     const pb = b.pinned ? 1 : 0
 
@@ -10359,6 +10464,23 @@ function BotsPane() {
 
     return b.activity - a.activity
   })
+  const rosterSections = [
+    {
+      key: 'direct',
+      label: 'Direct Messages',
+      rows: directRows,
+      attentionCount: directRows.filter(row => !row.bot.remoteSource && unreadByName[row.bot.name]).length,
+      attentionLabel: 'unread'
+    },
+    {
+      key: 'groups',
+      label: 'Groups',
+      rows: groupRows,
+      attentionCount: groupRows.filter(row => groupNeedsYou[row.name]).length,
+      attentionLabel: 'needs you'
+    }
+  ]
+  const matchingRows = directRows.length + groupRows.length
 
   if (live) {
     $lastRoster.set(roster)
@@ -10536,14 +10658,14 @@ function BotsPane() {
           })()
         }
       }),
-      roster.length
+      roster.length || groupRows.length
         ? jsx('div', {
             className: 'px-2.5 pb-1.5',
             children: jsx(SearchField, {
-              'aria-label': 'Search bots',
+              'aria-label': 'Search direct messages and groups',
               containerClassName: 'w-full',
               inputClassName: 'w-full',
-              placeholder: 'Search bots…',
+              placeholder: 'Search chats…',
               value: query,
               onChange: setQuery
             })
@@ -10555,12 +10677,12 @@ function BotsPane() {
             children: staleNotice
           })
         : null,
-      isLoading && !roster.length
+      isLoading && !roster.length && !groupRows.length
         ? jsx('div', {
             className: 'flex flex-1 items-center justify-center',
             children: jsx(GlyphSpinner, { spinner: 'breathe', className: 'text-(--ui-text-tertiary)' })
           })
-        : error && !roster.length
+        : error && !roster.length && !groupRows.length
           ? jsxs('div', {
               className: 'grid gap-2 px-3 py-4 text-xs text-(--ui-text-tertiary)',
               children: [
@@ -10578,47 +10700,57 @@ function BotsPane() {
                 })
               ]
             })
-          : roster.length === 0
+          : roster.length === 0 && groupRows.length === 0
             ? jsx(EmptyState, {
                 icon: 'hubot',
                 title: 'No agents yet',
                 description: 'Create your first teammate.'
               })
-            : filteredRoster.length === 0 && rosterRows.length === 0
+            : matchingRows === 0
               ? jsx('div', {
                   'aria-live': 'polite',
                   className:
                     'flex flex-1 items-center justify-center px-4 text-center text-xs text-(--ui-text-tertiary)',
                   role: 'status',
                   children: query.trim()
-                    ? `No bots match “${query.trim()}”`
+                    ? `No chats match “${query.trim()}”`
                     : 'All bots are hidden — use the eye button above to show them.'
                 })
               : jsx(ScrollArea, {
                   className: 'hermes-bots-roster min-h-0 flex-1',
                   children: jsx('div', {
-                    className: 'grid w-full min-w-0 gap-0.5 px-1.5 pb-2',
-                    // Flat, Discord-style list: bot rows and group rows
-                    // interleaved by recency — no section headers.
-                    children: rosterRows.map(row =>
-                      row.kind === 'group'
-                        ? jsx(
-                            GroupRow,
-                            {
-                              active: groupChatName === row.name,
-                              group: row.name,
-                              members: row.members,
-                              needsYou: Boolean(groupNeedsYou[row.name]),
-                              onOpen: openGroupChat,
-                              onDisband: setDeletingGroup
-                            },
-                            `group:${row.name}`
+                    className: 'grid w-full min-w-0 gap-1 px-1.5 pb-2',
+                    children: rosterSections.map(section =>
+                      jsx(
+                        RosterSection,
+                        {
+                          section,
+                          open: rosterSectionIsOpen(section.key, sectionsOpen, query),
+                          toggleDisabled: Boolean(query.trim()),
+                          onToggle: open => setRosterSectionOpen(section.key, open),
+                          children: section.rows.map(row =>
+                            section.key === 'groups'
+                              ? jsx(
+                                  GroupRow,
+                                  {
+                                    active: groupChatName === row.name,
+                                    group: row.name,
+                                    members: row.members,
+                                    needsYou: Boolean(groupNeedsYou[row.name]),
+                                    onOpen: openGroupChat,
+                                    onDisband: setDeletingGroup
+                                  },
+                                  `group:${row.name}`
+                                )
+                              : jsx(
+                                  BotRow,
+                                  { bot: row.bot, onDelete: setDeleting, onEdit: setEditing, onGroup: setGrouping },
+                                  botRosterKey(row.bot)
+                                )
                           )
-                        : jsx(
-                            BotRow,
-                            { bot: row.bot, onDelete: setDeleting, onEdit: setEditing, onGroup: setGrouping },
-                            botRosterKey(row.bot)
-                          )
+                        },
+                        section.key
+                      )
                     )
                   })
                 }),
@@ -10826,6 +10958,17 @@ export default {
         .catch(() => undefined)
     } catch {
       /* no storage — default (silent) stays */
+    }
+
+    // Restore Direct Messages / Groups disclosure state without allowing a
+    // delayed hydration read to overwrite a newer click in this window.
+    try {
+      const hydrationGeneration = beginRosterSectionHydration()
+      Promise.resolve(ctx.storage?.get?.('roster-sections-open'))
+        .then(value => hydrateRosterSectionsOpen(value, hydrationGeneration))
+        .catch(() => undefined)
+    } catch {
+      /* no storage — both sections start expanded */
     }
 
     // Hydrate persisted group-chat room logs (epoch/running are runtime-only

--- a/apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs
@@ -164,7 +164,7 @@ test('activeBots ignores a finished worker outside the liveness window', () => {
 test('ActiveNowStrip renders above the roster, is a live region, and is click-accessible', () => {
   // Strip is placed between the pane header and the search field.
   const headerEnd = source.indexOf("children: 'Bots'")
-  const searchField = source.indexOf("placeholder: 'Search bots…'")
+  const searchField = source.indexOf("placeholder: 'Search chats…'")
   assert.ok(headerEnd >= 0 && searchField > headerEnd)
 
   const stripStart = source.indexOf('jsx(ActiveNowStrip')

--- a/apps/desktop/src/plugins/hermes-bots/tests/bots-search.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bots-search.test.mjs
@@ -63,7 +63,7 @@ test('blank bot search returns the existing roster reference', () => {
 })
 
 test('Bot pane renders the canonical search field and no-match state', () => {
-  assert.match(source, /jsx\(SearchField,\s*\{[\s\S]*?placeholder: 'Search bots…'/)
+  assert.match(source, /jsx\(SearchField,\s*\{[\s\S]*?placeholder: 'Search chats…'/)
   assert.match(source, /'aria-live': 'polite'/)
-  assert.match(source, /No bots match “\$\{query\.trim\(\)\}”/)
+  assert.match(source, /No chats match “\$\{query\.trim\(\)\}”/)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-groups.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-groups.test.mjs
@@ -212,6 +212,13 @@ test('source contract: direct messages and groups render as separate roster sect
   assert.match(pluginSource, /onGroup: setGrouping/)
 })
 
+test('source contract: section disclosure is hidden and disabled while searching', () => {
+  assert.match(pluginSource, /hidden: !open/)
+  assert.match(pluginSource, /disabled: toggleDisabled/)
+  assert.match(pluginSource, /toggleDisabled: Boolean\(query\.trim\(\)\)/)
+  assert.match(pluginSource, /clearing it deliberately restores each/)
+})
+
 test('source contract: group rows carry the needs-you badge and open via openGroupChat', () => {
   assert.match(pluginSource, /needsYou: Boolean\(groupNeedsYou\[row\.name\]\)/)
   assert.match(pluginSource, /onOpen: openGroupChat/)

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-groups.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-groups.test.mjs
@@ -30,7 +30,7 @@ function load() {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__groups = { botGroups, groupMembershipPatch, groupChatNames, groupLastActivity, groupChatMemberBots, durableGroupChatMembers, knownGroups, stripPreviewMarkdown, $groupChats };\n'
+      '\nglobalThis.__groups = { botGroups, groupMembershipPatch, groupChatNames, groupLastActivity, groupChatMemberBots, durableGroupChatMembers, knownGroups, stripPreviewMarkdown, rosterSectionIsOpen, hydrateRosterSectionsOpen, setRosterSectionOpen, $groupChats, $rosterSectionsOpen };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   return context.__groups
@@ -189,10 +189,25 @@ test('stripPreviewMarkdown: flattens bold, quotes, code, and links out of previe
   assert.equal(stripPreviewMarkdown(''), '')
 })
 
-test('source contract: the roster stays a flat list of bot and group rows', () => {
-  // Ordering is deliberately unchanged in this PR; sectioned ordering follows separately.
+test('roster sections: saved disclosure state is independent and search reveals both sections', () => {
+  const { rosterSectionIsOpen, $rosterSectionsOpen, setRosterSectionOpen } = load()
+
+  assert.equal(rosterSectionIsOpen('direct', { direct: false, groups: true }), false)
+  assert.equal(rosterSectionIsOpen('groups', { direct: false, groups: true }), true)
+  assert.equal(rosterSectionIsOpen('groups', { direct: false, groups: false }, 'topic'), true)
+  setRosterSectionOpen('direct', false)
+  assert.equal(JSON.stringify($rosterSectionsOpen.get()), JSON.stringify({ direct: false, groups: true }))
+  setRosterSectionOpen('groups', false)
+  assert.equal(JSON.stringify($rosterSectionsOpen.get()), JSON.stringify({ direct: false, groups: false }))
+})
+
+test('source contract: direct messages and groups render as separate roster sections', () => {
   assert.doesNotMatch(pluginSource, /function groupRoster\(/)
-  assert.match(pluginSource, /rosterRows\.map\(row =>/)
+  assert.match(pluginSource, /function RosterSection\(/)
+  assert.match(pluginSource, /label: 'Direct Messages'/)
+  assert.match(pluginSource, /label: 'Groups'/)
+  assert.match(pluginSource, /rosterSections\.map\(section =>/)
+  assert.match(pluginSource, /border-t border-\(--ui-stroke-secondary\)/)
   assert.match(pluginSource, /function GroupRow\(/)
   assert.match(pluginSource, /onGroup: setGrouping/)
 })


### PR DESCRIPTION
## Summary

Bot Mode currently presents direct-message and group-chat rows in one flat roster. This keeps the first-class group-row model introduced by #88738, while adding lightweight, independently collapsible **Direct Messages** and **Groups** sections so the two workflows remain easy to scan.

## What changed

- Adds separate Direct Messages and Groups roster headings without reverting #88738's flat, first-class group rows.
- Persists each section's disclosure state independently.
- Keeps Groups visible when Direct Messages are collapsed.
- Preserves attention visibility in collapsed section headers.
- Uses accessible disclosure controls and theme-native separation.
- Keeps search behavior useful by revealing matching content across both sections.

## Scope

This PR is intentionally limited to the Bot Mode roster source and focused tests. It excludes Selection Actions, mention-handle changes, Telegram routing, release artifacts, backups, and unrelated local work.

## Validation

- `node --check apps/desktop/src/plugins/hermes-bots/plugin.js`
- `node --test apps/desktop/src/plugins/hermes-bots/tests/roster-groups.test.mjs` — 11/11 passed
- `npm run check:test:plugins` — 352 passed, 0 failed
- `git diff --check`

`npm run check:lint` could not start in the clean worktree because `tsc` was unavailable; CI remains authoritative for the full lint/typecheck surface.

## Relationship to #88738

#88738 intentionally removed the old group section-header presentation and made each group a first-class row. This PR preserves that row model and ordering behavior. The headings here are presentation-level disclosure boundaries between direct-message rows and group rows, not a return to member sub-rows or the former group-detail section UI.
