### PR TITLE
feat(pricing): add MiniMax M3 direct-provider entries with cache_write rate

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -217,6 +217,15 @@ _SNAPSHOTS: tuple[tuple[str, Optional[str], str, dict], ...] = (
     }),
     ("minimax", None, "minimax-pricing-2026-04", {"minimax-m2.7": ("0.30", "1.20")}),
     ("minimax-cn", None, "minimax-pricing-2026-04", {"minimax-m2.7": ("0.30", "1.20")}),
+    # MiniMax-M3 on the DIRECT providers. The ("fireworks", "minimax-m3") row below
+    # covers Fireworks-routed traffic; these cover provider: minimax / minimax-cn,
+    # which is what the live lookup keys off. MiniMax bills cache WRITES at
+    # input-equivalent (1.0x), unlike Anthropic's 1.25x convention.
+    # Cache-write rate verified against the live API 2026-08-19.
+    ("minimax", "https://platform.minimax.io/docs/guides/pricing-token-plan",
+     "minimax-pricing-2026-08", {"minimax-m3": ("0.30", "1.20", "0.06", "0.30")}),
+    ("minimax-cn", "https://platform.minimax.io/docs/guides/pricing-token-plan",
+     "minimax-pricing-2026-08", {"minimax-m3": ("0.30", "1.20", "0.06", "0.30")}),
     # Fireworks AI serverless (Standard tier) publishes a per-model cached_input
     # rate (→ cache_read) but no separate cache_write rate. Fast/turbo tiers are
     # exposed as accounts/fireworks/routers/<name>, so rsplit("/", 1) yields

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -962,3 +962,46 @@ def test_flat_entries_unaffected_by_tier_machinery():
     )
     # 250k * $0.25/M + 10k * $1.50/M
     assert result.amount_usd == Decimal("0.0775")
+
+# =============================================================================
+# MiniMax M3 direct-provider pricing entries
+# =============================================================================
+
+def test_minimax_direct_provider_m3_entry_resolves():
+    """`provider: minimax` + `model: minimax-m3` returns the direct entry, not the
+    upstream Fireworks one and not the M2.7 entry (which has no cache fields)."""
+    entry = get_pricing_entry("minimax-m3", provider="minimax")
+    assert entry is not None, "minimax/minimax-m3 lookup returned None"
+    assert entry.input_cost_per_million == Decimal("0.30")
+    assert entry.output_cost_per_million == Decimal("1.20")
+    assert entry.cache_read_cost_per_million == Decimal("0.06")
+    # The point of this PR - the fireworks entry has no cache_write rate:
+    assert entry.cache_write_cost_per_million == Decimal("0.30")
+
+
+def test_minimax_cn_direct_provider_m3_entry_resolves():
+    """`provider: minimax-cn` + `model: minimax-m3` returns the cn entry."""
+    entry = get_pricing_entry("minimax-m3", provider="minimax-cn")
+    assert entry is not None, "minimax-cn/minimax-m3 lookup returned None"
+    assert entry.input_cost_per_million == Decimal("0.30")
+    assert entry.output_cost_per_million == Decimal("1.20")
+    assert entry.cache_read_cost_per_million == Decimal("0.06")
+    assert entry.cache_write_cost_per_million == Decimal("0.30")
+
+
+def test_minimax_m2_7_entry_unchanged():
+    """Adding the M3 entries must not perturb the existing M2.7 entry."""
+    entry = get_pricing_entry("minimax-m2.7", provider="minimax")
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("0.30")
+    assert entry.output_cost_per_million == Decimal("1.20")
+    assert entry.cache_write_cost_per_million is None
+
+
+def test_fireworks_m3_entry_still_resolves_independently():
+    """Direct-provider entries must not shadow the existing fireworks row."""
+    entry = get_pricing_entry("minimax-m3", provider="fireworks")
+    assert entry is not None, "fireworks/minimax-m3 lookup returned None"
+    assert entry.input_cost_per_million == Decimal("0.30")
+    assert entry.output_cost_per_million == Decimal("1.20")
+    assert entry.cache_read_cost_per_million == Decimal("0.06")


### PR DESCRIPTION
## Problem

The existing upstream `("fireworks", "minimax-m3")` pricing entry covers Fireworks-routed traffic, but the live pricing lookup in `agent/usage_pricing.py:_lookup_pricing` keys off `provider_name in {"minimax", "minimax-cn"}`. When users configure `provider: minimax` in `config.yaml`, the lookup misses the fireworks entry entirely and falls back to "no pricing" — silently under-reporting cost on every M3 turn.

## Fix

Adds two pricing entries:

- `("minimax", "minimax-m3")` — for `provider: minimax` config (Anthropic-compatible endpoint at api.minimax.io)
- `("minimax-cn", "minimax-m3")` — for `provider: minimax-cn` config (Anthropic-compatible endpoint at api.minimaxi.com)

Both entries carry the verified rate card against the live MiniMax API (2026-08-19):

```
input:     0.30 / million
output:    1.20 / million  
cache_read:  0.06 / million
cache_write: 0.30 / million  (1.0x input — MiniMax convention; NOT 1.25x like Anthropic)
```

The new `cache_write_cost_per_million` field is the substantive addition over the existing fireworks entry, which doesn't carry it.

## Source

https://platform.minimax.io/docs/guides/pricing-token-plan (verified 2026-08-19).

## Tests

Added 4 regression tests in `tests/agent/test_usage_pricing.py`:

1. `test_minimax_direct_provider_m3_entry_resolves` — `provider: minimax` + `model: minimax-m3` returns the new entry with cache_write field
2. `test_minimax_cn_direct_provider_m3_entry_resolves` — same for `provider: minimax-cn`
3. `test_minimax_m2_7_entry_unchanged` — adding the M3 entries does not perturb the existing M2.7 entry
4. `test_fireworks_m3_entry_still_resolves_independently` — the existing Fireworks-routed entry is unchanged

All 44 tests in `tests/agent/test_usage_pricing.py` pass.