### PR TITLE
fix(constants): bound the Node toolchain probes so a shim grandchild cannot hang the turn

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -448,6 +448,7 @@ def bounded_probe_run(
     *,
     timeout: float,
     errors: str = "replace",
+    env: "Mapping[str, str] | None" = None,
 ) -> "subprocess.CompletedProcess[str] | None":
     """Deadlock-safe ``subprocess.run(argv, capture_output=True, timeout=...)``
     for fail-open probe call sites. Returns a ``CompletedProcess`` when the
@@ -474,8 +475,17 @@ def bounded_probe_run(
     POSIX the child is placed in its own process group (``process_group=0``,
     Python ≥3.11) so timeout cleanup can take down descendants with the
     launcher instead of orphaning them.
+
+    *env*, when given, replaces the child's environment exactly as
+    ``subprocess.run(env=...)`` would. The Node-toolchain probes in
+    ``hermes_constants`` need it to put the Hermes-managed Node directory on
+    ``PATH`` so a managed ``npm``/``npx`` shim can find its own ``node``;
+    without it those call sites could not adopt this helper and were left on
+    the unbounded ``run()`` that this function exists to replace (#91087).
     """
     _popen_kwargs: dict = {"creationflags": windows_hide_flags()} if IS_WINDOWS else {"process_group": 0}
+    if env is not None:
+        _popen_kwargs["env"] = env
     try:
         proc = subprocess.Popen(
             list(argv),

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -787,6 +787,18 @@ def _managed_node_tree_outdated(home: Path | None = None) -> bool:
             # Bounded for the same reason as node_tool_runnable (#91087). A
             # None result is a spawn failure or a timeout, both of which mean
             # "broken" — exactly what the old except-arm returned.
+            #
+            # No ``env=with_hermes_node_path()`` here, unlike the other two
+            # probe sites, and the asymmetry is deliberate rather than an
+            # oversight. Those two spawn a *tool* that needs ``node`` on PATH
+            # to do its work: on Windows the resolved candidate is an
+            # npm-installed ``.cmd`` shim whose real work happens in a node
+            # grandchild, which is the #91087 shape. This site spawns ``node``
+            # itself, by absolute path, and ``_candidate_node_command_names
+            # ("node")`` returns ``["node.exe", "node"]`` — the one branch
+            # that never offers a ``.cmd`` — so there is no shim layer to
+            # feed and nothing in this spawn reads PATH. Adding the env would
+            # be inert, not harmful; it is left off so the call says that.
             result = bounded_probe_run([str(candidate), "--version"], timeout=10)
             if result is None:
                 return False  # broken, not outdated — the runnable probe handles it

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -373,19 +373,20 @@ def node_tool_runnable(path: str | None) -> bool:
     elif not os.path.exists(path) or not os.access(path, os.X_OK):
         return False
 
-    import subprocess
+    from hermes_cli._subprocess_compat import bounded_probe_run
 
-    try:
-        from hermes_cli._subprocess_compat import windows_hide_flags
-
-        result = subprocess.run(
-            [path, "--version"],
-            capture_output=True,
-            timeout=10,
-            env=with_hermes_node_path(),
-            creationflags=windows_hide_flags(),
-        )
-    except (OSError, subprocess.TimeoutExpired, ValueError):
+    # bounded_probe_run, not subprocess.run: a managed npm/npx shim is a
+    # cmd.exe wrapper whose node grandchild inherits the captured pipes, and
+    # run()'s post-timeout cleanup drains them *without* a timeout, so the
+    # nominal 10s bound never fires and this probe hangs the whole turn
+    # (#91087 — observed on the ACP system-prompt path, where it blocks
+    # before the first API call and the editor just spins).
+    result = bounded_probe_run(
+        [path, "--version"],
+        timeout=10,
+        env=with_hermes_node_path(),
+    )
+    if result is None:
         return False
     return result.returncode == 0
 
@@ -774,8 +775,6 @@ def _managed_node_tree_outdated(home: Path | None = None) -> bool:
     on next launch, not just on the next installer re-run. Mirrors
     ``_nb_managed_node_outdated`` in ``scripts/lib/node-bootstrap.sh``.
     """
-    import subprocess
-
     for directory in iter_hermes_node_dirs(home):
         for name in _candidate_node_command_names("node"):
             candidate = directory / name
@@ -783,17 +782,17 @@ def _managed_node_tree_outdated(home: Path | None = None) -> bool:
                 sys.platform != "win32" and not os.access(candidate, os.X_OK)
             ):
                 continue
-            try:
-                from hermes_cli._subprocess_compat import windows_hide_flags
+            from hermes_cli._subprocess_compat import bounded_probe_run
 
-                result = subprocess.run(
-                    [str(candidate), "--version"],
-                    capture_output=True,
-                    timeout=10,
-                    creationflags=windows_hide_flags(),
-                )
-                major = int(result.stdout.decode().strip().lstrip("v").split(".")[0])
-            except (OSError, subprocess.TimeoutExpired, ValueError, IndexError):
+            # Bounded for the same reason as node_tool_runnable (#91087). A
+            # None result is a spawn failure or a timeout, both of which mean
+            # "broken" — exactly what the old except-arm returned.
+            result = bounded_probe_run([str(candidate), "--version"], timeout=10)
+            if result is None:
+                return False  # broken, not outdated — the runnable probe handles it
+            try:
+                major = int((result.stdout or "").strip().lstrip("v").split(".")[0])
+            except (ValueError, IndexError):
                 return False  # broken, not outdated — the runnable probe handles it
             return major < _HERMES_NODE_TARGET_MAJOR
     return False
@@ -923,19 +922,19 @@ def agent_browser_runnable(path: str | None) -> bool:
     # never even spawn a subprocess for the broken-link case.
     if not os.path.exists(path) or not os.access(path, os.X_OK):
         return False
-    import subprocess
+    from hermes_cli._subprocess_compat import bounded_probe_run
 
-    try:
-        from hermes_cli._subprocess_compat import windows_hide_flags
-
-        result = subprocess.run(
-            [path, "--version"],
-            capture_output=True,
-            timeout=10,
-            env=with_hermes_node_path(),
-            creationflags=windows_hide_flags(),
-        )
-    except (OSError, subprocess.TimeoutExpired, ValueError):
+    # Bounded for the same reason as node_tool_runnable (#91087). This is the
+    # probe the docstring above calls "a short timeout". The npx fallback form
+    # returned above without spawning, so what reaches here is the resolved
+    # CLI - on Windows an npm-installed agent-browser.cmd, i.e. the same
+    # cmd.exe-shim-plus-node-grandchild shape.
+    result = bounded_probe_run(
+        [path, "--version"],
+        timeout=10,
+        env=with_hermes_node_path(),
+    )
+    if result is None:
         return False
     return result.returncode == 0
 

--- a/tests/hermes_cli/test_bounded_probe_run.py
+++ b/tests/hermes_cli/test_bounded_probe_run.py
@@ -20,6 +20,7 @@ descendant-survival cases live in ``test_git_probe_tree_kill.py`` and now
 exercise the same code path through the ``bounded_git_probe`` delegation.
 """
 
+import os
 import subprocess
 import sys
 import time
@@ -110,3 +111,35 @@ def test_posix_child_gets_own_process_group():
     )
     assert result is not None
     assert result.stdout.strip() == "True"
+
+
+def test_env_is_passed_through_to_the_child():
+    """``env`` replaces the child's environment, exactly as ``run(env=...)`` did.
+
+    The Node-toolchain probes in ``hermes_constants`` need this to put the
+    Hermes-managed Node directory on ``PATH`` so a managed ``npm``/``npx`` shim
+    can resolve its own ``node``. Without it those call sites could not adopt
+    this helper and stayed on the unbounded ``run()`` that hung the ACP
+    system-prompt build (#91087).
+    """
+    result = bounded_probe_run(
+        [_PY, "-c", "import os; print(os.environ.get('HERMES_PROBE_MARKER', 'MISSING'))"],
+        timeout=30,
+        env={**os.environ, "HERMES_PROBE_MARKER": "present-91087"},
+    )
+    assert result is not None
+    assert result.stdout.strip() == "present-91087"
+
+
+def test_env_defaults_to_inheriting_the_parent_environment():
+    """Omitting ``env`` must not change the historical spawn contract."""
+    os.environ["HERMES_PROBE_INHERIT"] = "inherited-91087"
+    try:
+        result = bounded_probe_run(
+            [_PY, "-c", "import os; print(os.environ.get('HERMES_PROBE_INHERIT', 'MISSING'))"],
+            timeout=30,
+        )
+    finally:
+        os.environ.pop("HERMES_PROBE_INHERIT", None)
+    assert result is not None
+    assert result.stdout.strip() == "inherited-91087"

--- a/tests/hermes_cli/test_bounded_probe_run.py
+++ b/tests/hermes_cli/test_bounded_probe_run.py
@@ -27,6 +27,7 @@ import time
 
 import pytest
 
+import hermes_cli._subprocess_compat as compat
 from hermes_cli._subprocess_compat import bounded_git_probe, bounded_probe_run
 
 _PY = sys.executable
@@ -143,3 +144,49 @@ def test_env_defaults_to_inheriting_the_parent_environment():
         os.environ.pop("HERMES_PROBE_INHERIT", None)
     assert result is not None
     assert result.stdout.strip() == "inherited-91087"
+
+
+def test_spawn_kwargs_are_platform_correct(monkeypatch):
+    """The hidden-window flag on Windows / own process group on POSIX.
+
+    This is the one assertion in this file that mocks the spawn, and
+    deliberately so: unlike timeout and pipe-inheritance behaviour, a
+    ``creationflags`` value has no observable runtime effect a real subprocess
+    could report back, so there is nothing to assert against otherwise.
+
+    It lives here rather than at the call sites because this is where the flag
+    is chosen. ``hermes_constants``'s agent-browser probe used to assert
+    ``creationflags`` on its own ``subprocess.run`` call; when those probes
+    adopted this helper for #91087 the contract moved down here, and pinning it
+    at the layer that sets it means all three probes are covered by one test
+    instead of each re-asserting a spawn detail it no longer controls.
+    """
+    seen = {}
+
+    class _FakeProc:
+        returncode = 0
+
+        def communicate(self, timeout=None):
+            return ("", "")
+
+    def fake_popen(argv, **kwargs):
+        seen.update(kwargs)
+        return _FakeProc()
+
+    monkeypatch.setattr(compat.subprocess, "Popen", fake_popen)
+
+    result = bounded_probe_run(["irrelevant"], timeout=5)
+    assert result is not None
+
+    if sys.platform == "win32":
+        assert seen["creationflags"] == compat.windows_hide_flags()
+        assert "process_group" not in seen
+    else:
+        assert seen["process_group"] == 0
+        assert "creationflags" not in seen
+
+    # The capture contract the probes depend on, on both platforms.
+    assert seen["stdout"] is subprocess.PIPE
+    assert seen["stderr"] is subprocess.PIPE
+    assert seen["stdin"] is subprocess.DEVNULL
+    assert seen["text"] is True

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -1,6 +1,8 @@
 """Tests for hermes_constants module."""
 
 import os
+import sys
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -1099,3 +1101,119 @@ class TestHealAttemptFlagSemantics:
         # The flag is set, so the once-per-process budget is spent.
         assert heal_hermes_managed_node() is False
         assert calls["n"] == 1
+
+
+class TestNodeProbesAreBounded:
+    """The Node/agent-browser ``--version`` probes must return within their
+    nominal timeout even when a descendant holds the captured pipes (#91087).
+
+    ``subprocess.run(capture_output=True, timeout=N)`` does not guarantee that.
+    When it times out, ``run()`` kills the direct child and then drains the
+    pipes with an *unbounded* ``communicate()``. A managed ``npm``/``npx`` shim
+    is a ``cmd.exe`` wrapper whose ``node`` grandchild inherits those pipe
+    handles, so they never reach EOF and the drain never returns. The reported
+    symptom was an ACP ``session/prompt`` that hung forever before the first
+    API call, because these probes run while the system prompt is being built.
+    """
+
+    @staticmethod
+    def _lingering_shim(tmp_path, seconds: int):
+        """A launcher that exits immediately, leaving a grandchild holding the
+        inherited stdout/stderr — the ``npx.CMD`` → ``node`` shape."""
+        py = sys.executable
+        if sys.platform == "win32":
+            shim = tmp_path / "npx-probe.cmd"
+            shim.write_text(
+                "@echo off\r\n"
+                f'start /b "" "{py}" -c "import time; time.sleep({seconds})"\r\n'
+                "exit /b 0\r\n"
+            )
+        else:
+            shim = tmp_path / "npx-probe.sh"
+            shim.write_text(
+                "#!/bin/sh\n"
+                f'"{py}" -c "import time; time.sleep({seconds})" &\n'
+                "exit 0\n"
+            )
+            shim.chmod(0o755)
+        return shim
+
+    def test_node_tool_runnable_is_bounded_when_a_grandchild_holds_the_pipes(
+        self, tmp_path
+    ):
+        """The regression test for the reported hang.
+
+        The grandchild outlives the probe's 10s budget by a wide margin, so
+        before the fix this call returned only when the grandchild exited —
+        i.e. the 10s bound did nothing. The assertion is deliberately loose
+        (the pre-fix failure mode is "waits for the grandchild", so any real
+        bound distinguishes them) but far below the grandchild's lifetime.
+        """
+        shim = self._lingering_shim(tmp_path, 120)
+
+        start = time.monotonic()
+        result = node_tool_runnable(str(shim))
+        elapsed = time.monotonic() - start
+
+        assert result is False
+        assert elapsed < 40, (
+            f"probe took {elapsed:.1f}s; the 10s timeout is not being enforced "
+            "(pre-fix this waits for the 120s grandchild)"
+        )
+
+    def test_probes_no_longer_depend_on_subprocess_run(self, tmp_path, monkeypatch):
+        """Pins the mechanism, not just the timing.
+
+        ``subprocess.run`` is the unbounded primitive these call sites used.
+        Detonating it proves they route through ``bounded_probe_run`` instead —
+        and this stays true if someone reintroduces ``run`` with a timeout that
+        again cannot be enforced.
+        """
+        def _detonate(*args, **kwargs):
+            raise AssertionError("probe used subprocess.run instead of bounded_probe_run")
+
+        import subprocess
+
+        monkeypatch.setattr(subprocess, "run", _detonate)
+
+        real = tmp_path / ("ok.cmd" if sys.platform == "win32" else "ok.sh")
+        if sys.platform == "win32":
+            real.write_text("@echo off\r\necho v1.0.0\r\nexit /b 0\r\n")
+        else:
+            real.write_text("#!/bin/sh\necho v1.0.0\nexit 0\n")
+            real.chmod(0o755)
+
+        assert node_tool_runnable(str(real)) is True
+        assert agent_browser_runnable(str(real)) is True
+
+    def test_timeout_is_reported_as_not_runnable(self, tmp_path, monkeypatch):
+        """A ``None`` from the helper (spawn failure OR timeout) is a refusal.
+
+        Fail-closed matters here: a probe that cannot prove the binary runs
+        must not claim it does, or the caller commits to a hung toolchain.
+        """
+        import hermes_cli._subprocess_compat as compat
+
+        monkeypatch.setattr(compat, "bounded_probe_run", lambda *a, **k: None)
+
+        real = tmp_path / ("ok.cmd" if sys.platform == "win32" else "ok.sh")
+        if sys.platform == "win32":
+            real.write_text("@echo off\r\nexit /b 0\r\n")
+        else:
+            real.write_text("#!/bin/sh\nexit 0\n")
+            real.chmod(0o755)
+
+        assert node_tool_runnable(str(real)) is False
+        assert agent_browser_runnable(str(real)) is False
+
+    def test_nonzero_exit_still_means_not_runnable(self, tmp_path):
+        """The success contract is unchanged: only a clean exit 0 counts."""
+        bad = tmp_path / ("bad.cmd" if sys.platform == "win32" else "bad.sh")
+        if sys.platform == "win32":
+            bad.write_text("@echo off\r\nexit /b 3\r\n")
+        else:
+            bad.write_text("#!/bin/sh\nexit 3\n")
+            bad.chmod(0o755)
+
+        assert node_tool_runnable(str(bad)) is False
+        assert agent_browser_runnable(str(bad)) is False

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -618,23 +618,38 @@ class TestAgentBrowserRunnable:
 
 
 
-    def test_version_probe_uses_windows_hide_flags(self, tmp_path, monkeypatch):
+    def test_version_probe_delegates_to_the_bounded_helper(self, tmp_path, monkeypatch):
+        """The probe spawns through ``bounded_probe_run``, with the argv and the
+        managed-Node environment intact.
+
+        This replaces a test that asserted ``creationflags`` on the
+        ``subprocess.run`` call directly. That contract did not disappear, it
+        MOVED: the hidden-window flag is now set inside ``bounded_probe_run``
+        and is pinned by ``test_spawn_kwargs_are_platform_correct`` in that
+        helper's own suite, which is the layer that actually sets it. Asserting
+        it from here was always a little false anyway: this class is POSIX-only,
+        and on POSIX the old call passed ``creationflags=0``, a no-op. What
+        matters at THIS layer is that the probe still routes through the
+        bounded helper (#91087) instead of falling back to the unbounded
+        ``run()``, and that ``env`` survives the hand-off.
+        """
         good = self._stub(tmp_path, "agent-browser", "#!/bin/sh\necho hi\n")
         captured = []
 
-        def fake_run(cmd, **kwargs):
-            captured.append((cmd, kwargs))
-            return SimpleNamespace(returncode=0)
+        def fake_bounded(argv, **kwargs):
+            captured.append((argv, kwargs))
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         import hermes_cli._subprocess_compat as subprocess_compat
-        import subprocess as subprocess_mod
 
-        monkeypatch.setattr(subprocess_compat, "windows_hide_flags", lambda: 0x08000000)
-        monkeypatch.setattr(subprocess_mod, "run", fake_run)
+        monkeypatch.setattr(subprocess_compat, "bounded_probe_run", fake_bounded)
 
         assert agent_browser_runnable(str(good)) is True
         assert captured[0][0] == [str(good), "--version"]
-        assert captured[0][1]["creationflags"] == 0x08000000
+        assert captured[0][1]["timeout"] == 10
+        # The managed Node directory has to reach the child, or a managed
+        # npm/npx shim cannot resolve its own node.
+        assert captured[0][1]["env"] == with_hermes_node_path()
 
 
 


### PR DESCRIPTION
## What does this PR do?

Makes the Node-toolchain `--version` probes in `hermes_constants.py` actually honor their timeout, by adopting the helper this repo already wrote for exactly this failure class.

`node_tool_runnable`, `agent_browser_runnable` and the Node major-version check each ran:

```python
result = subprocess.run([path, "--version"], capture_output=True, timeout=10, env=...)
```

That `timeout=10` does not bound the call. On expiry `run()` kills **only the direct child**, then calls `communicate()` in its `finally` arm **with no timeout of its own**. If a grandchild inherited the captured pipe handles, the pipes never reach EOF and the probe blocks forever — with the nominal bound already spent.

A Hermes-managed `npm`/`npx` is precisely that shape on Windows: a `cmd.exe` shim whose `node` grandchild inherits the pipes. On the ACP path this probe runs during the Nous-subscription feature gate, before the first API call, so the editor spins with no output and no error — the hang in #91087, whose py-spy stack lands in `node_tool_runnable`.

### Measured, on Windows 11 / Python 3.12

A `.cmd` shim that spawns a 45s grandchild and returns immediately, driven through the real call site:

| | wall clock | verdict |
|---|---|---|
| `main` (`8794e5a2`) | **45.4s** | UNBOUNDED — returns when the *grandchild* exits, not on the timeout |
| this branch | **13.1s** | BOUNDED — 10s timeout + the helper's 1s drain + spawn overhead |

Isolated, the underlying primitive is starker: `subprocess.run(timeout=3)` against a pipe-holding grandchild returned after **60.8s**.

## Why the helper instead of a bespoke fix

`hermes_cli/_subprocess_compat.py::bounded_probe_run` is this repo's canonical answer to this bug class — added for #87134 and reused for #68609 and #66037. It passes an explicit timeout to `communicate()`, tree-kills on failure, drains for at most a second, and then abandons the pipes rather than waiting on them.

These three call sites were never converted for one concrete reason: they need `env=` to put the Hermes-managed Node directory on `PATH` so a managed `npm`/`npx` shim can find its own `node`, and the helper had no way to accept one. So this PR adds the parameter (10 lines, passthrough to `Popen`, defaulting to inherit) and adopts the helper. That keeps one implementation of the drain logic instead of a fourth open-coded variant.

### Return-value mapping is deliberately unchanged

`bounded_probe_run` returns `None` for both spawn failure and timeout. Both already meant "not runnable" at these sites, so:

- the two `runnable` probes return `False` — same as the old `except (OSError, subprocess.SubprocessError)` arm;
- the version probe returns `False` for **"broken", not "outdated"** — same as the arm it replaces, and the comment says so, because the runnable probe is what reports brokenness.

No call site sees a new outcome; the difference is only that the timeout now fires.

## Related Issue

Fixes #91087.

## Overlap with #80500 — orthogonal, and I would rather flag it than silently conflict

**#80500** (@lgwacker, open, last updated 2026-08-06) edits the *argv* of these same two `subprocess.run` calls, routing `npm`/`npx` `.cmd` shims through `node.exe` so cmd.exe cannot mangle a U+00A0 in a profile path. Same two functions, same two statements. Whoever merges second gets a conflict, so here is the analysis rather than a surprise.

**They are not the same fix, and neither subsumes the other.** #80500 changes *what is launched*; this changes *whether the call is bounded*. Three places where #80500 leaves the hang live:

1. Its `node_cli_launch_for_shim` falls back to `[path]` whenever `node.exe` or the CLI `.js` is missing — the broken/partial-tree case, which is the situation #91087's reporter is actually in (agent-browser not installed, npx resolution).
2. It only rewrites names matching `npm`/`npx`. `agent_browser_runnable` receives a resolved `agent-browser.cmd`, which does not match, so that probe keeps the full shim shape.
3. It is a no-op off Windows, and a directly-launched `node.exe` can still spawn a pipe-inheriting child.

Conversely this PR does nothing about Unicode-whitespace paths. They want to land together.

**The merged form is mechanical**, if it helps whoever goes second:

```python
result = bounded_probe_run(
    [*node_cli_launch_for_shim(path), "--version"],
    timeout=10,
    env=with_hermes_node_path(),
)
```

I am happy to rebase onto #80500 whenever it lands, or to have it rebase onto this — no preference, just say which.

The other three open PRs touching `hermes_constants.py` do not overlap: **#89725** (`_first_runnable`, ~line 815), **#72621** (`_heal_managed_node_windows` / `find_hermes_node_executable`), **#54211** (`_candidate_node_command_names`) are different functions. **#75003** fixes the same *bug class* for #74982 but in `tools/environments/local.py` only, and open-codes `Popen`+kill there rather than using the helper — worth folding into `bounded_probe_run` eventually, out of scope here.

No open or merged PR references #91087, and the issue has no PR-claim comment.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/_subprocess_compat.py` — `bounded_probe_run` gains an optional `env`, documented with why it exists (these call sites could not adopt the helper without it). Default `None` preserves environment inheritance exactly.
- `hermes_constants.py` — the three probes call `bounded_probe_run`; each carries a comment naming the shim/grandchild mechanism and #91087. Removes a now-dead function-local `import subprocess`.
- `tests/test_hermes_constants.py` — new `TestNodeProbesAreBounded` (4 tests).
- `tests/hermes_cli/test_bounded_probe_run.py` — 2 tests for the new parameter.

## How to Test

```
pytest tests/test_hermes_constants.py -q
pytest tests/hermes_cli/test_bounded_probe_run.py -q
```

**This branch vs its base (`8794e5a21c`), same machine:**

```
tests/test_hermes_constants.py        base: 1 failed, 56 passed, 9 skipped
                                    branch: 1 failed, 60 passed, 9 skipped   (+4)

tests/hermes_cli/test_bounded_probe_run.py   base: 7 passed, 1 skipped
                                           branch: 9 passed, 1 skipped       (+2)
```

**Disclosing the one failure rather than filtering it:** `TestGetDefaultHermesRoot::test_no_hermes_home_returns_native` fails **identically on the base commit** with this diff absent. It is a Windows `LOCALAPPDATA` default-root environment issue in a file this change does not touch. If CI is green on Linux, that difference is my machine, not this patch.

The boundedness test spawns a real 120s-lingering grandchild and asserts the probe returns in under 40s, so it proves the bound end to end rather than mocking it. It is skipped on platforms without the shim form.

### Mutation proof

| mutation | result |
|---|---|
| revert `node_tool_runnable` to `subprocess.run(capture_output=True, timeout=10)` | **3 failed, 1 passed** — and the run took **123.15s** instead of ~41s, because the hang itself reproduces inside the test |
| drop `if env is not None: _popen_kwargs["env"] = env` from the helper | **1 failed, 8 passed** — exactly `test_env_is_passed_through_to_the_child`; the inherit-by-default test still passes |

The first mutation's three failures are the boundedness test, `test_probes_no_longer_depend_on_subprocess_run` (monkeypatches `subprocess.run` to raise, so any straggler call site is caught), and `test_timeout_is_reported_as_not_runnable`. The fourth test in that class passes under mutation by design — it pins the pre-existing nonzero-exit contract, so it *should* be insensitive to this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(constants): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate — see the overlap section above; the one textual conflict (#80500) is analyzed rather than ignored
- [x] My PR contains **only** changes related to this fix (one commit, four files)
- [x] I've run the relevant suites — deltas and the pre-existing failure are stated verbatim above
- [x] I've added tests for my changes — 6 new, with two mutation proofs and an end-to-end timing measurement
- [x] I've tested on my platform: Windows 11, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `bounded_probe_run`'s docstring now explains the `env` parameter and why it was added; no user-facing docs describe these probes
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — the helper already branches (`creationflags` on Windows, `process_group=0` on POSIX) and this change adds no new platform-specific code. The new POSIX test uses a `.sh` background-job shim for the same grandchild shape. Behaviour off Windows is unchanged except that the timeout is now enforced there too, which is the point.
