### PR TITLE
fix(kanban): require one durable terminal handoff

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1915,6 +1915,7 @@ def run_conversation(
     final_response = None
     interrupted = False
     failed = False
+    _failure_reason: Optional[str] = None
     codex_ack_continuations = 0
     length_continue_retries = 0
     truncated_tool_call_retries = 0
@@ -8246,17 +8247,15 @@ def run_conversation(
                 # Models sometimes narrate the next step ("Let me write the
                 # report") and stop with finish_reason=stop — a clean exit
                 # that the dispatcher records as protocol_violation. Nudge
-                # once or twice before allowing that exit.
-                try:
-                    from agent.kanban_stop import build_kanban_stop_nudge
+                # once or twice, then fail closed with a structured protocol
+                # result instead of permitting rc=0.
+                from agent.kanban_stop import StopAction, evaluate_kanban_stop
 
-                    _kanban_nudge = build_kanban_stop_nudge(
-                        messages=messages,
-                        attempts=getattr(agent, "_kanban_stop_nudges", 0),
-                    )
-                except Exception:
-                    logger.debug("kanban stop-loop check failed", exc_info=True)
-                    _kanban_nudge = None
+                _kanban_decision = evaluate_kanban_stop(
+                    messages=messages,
+                    attempts=getattr(agent, "_kanban_stop_nudges", 0),
+                )
+                _kanban_nudge = _kanban_decision.nudge
 
                 if _kanban_nudge:
                     agent._kanban_stop_nudges = (
@@ -8277,8 +8276,8 @@ def run_conversation(
                         os.environ.get("HERMES_KANBAN_TASK", ""),
                     )
                     agent._emit_status(
-                        "⚠️ Kanban worker tried to exit without "
-                        "kanban_complete/kanban_block — nudging to finish"
+                        "⚠️ Kanban worker tried to exit without a valid "
+                        "terminal lifecycle receipt — nudging to finish"
                     )
                     # Same finalizer contract as verify-on-stop: clear
                     # final_response while continuing so a later budget
@@ -8290,6 +8289,26 @@ def run_conversation(
                     )
                     final_response = None
                     continue
+
+                if _kanban_decision.action is StopAction.VIOLATION:
+                    failed = True
+                    _failure_reason = "kanban_protocol"
+                    _turn_exit_reason = "kanban_protocol_violation"
+                    final_response = (
+                        "Kanban protocol violation: "
+                        + _kanban_decision.reason
+                    )
+                    final_msg["content"] = final_response
+                    final_msg["finish_reason"] = "kanban_protocol_violation"
+                    final_msg["_kanban_stop_synthetic"] = True
+                    append_message(messages, final_msg)
+                    logger.error(
+                        "kanban worker refused clean exit task=%s reason=%s",
+                        os.environ.get("HERMES_KANBAN_TASK", ""),
+                        _kanban_decision.reason,
+                    )
+                    agent._emit_status("❌ Kanban terminal handoff protocol violation")
+                    break
 
                 append_message(messages, final_msg)
                 # Make the completed answer durable before leaving the loop —
@@ -8427,6 +8446,7 @@ def run_conversation(
         original_user_message=original_user_message,
         _should_review_memory=_should_review_memory,
         _turn_exit_reason=_turn_exit_reason,
+        failure_reason=_failure_reason,
         _pending_verification_response=_pending_verification_response,
         _pending_verification_response_previewed=_pending_verification_response_previewed,
     )

--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -1,33 +1,67 @@
-"""Turn-end guard for kanban workers.
+"""Turn-end guard for Kanban workers.
 
-Kanban workers must end with ``kanban_complete`` or ``kanban_block``. Models
-(especially GLM / Qwen families) sometimes narrate the next step
-("Let me write the report now") and stop with ``finish_reason=stop`` and no
-tool calls. Hermes treats that as a clean exit → ``rc=0`` → dispatcher
-``protocol_violation``.
-
-This module is policy-only: when a kanban worker tries to finish without a
-terminal board tool, return a bounded synthetic nudge so the conversation
-loop continues instead of exiting.
+A Kanban worker may leave normally only after exactly one successful terminal
+board transition. A model naming a terminal tool is not evidence: the matching
+tool result must carry Hermes' durable JSON receipt for this task/run.
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import Enum
+import json
 import os
-from typing import Any, Iterable, Optional
+from typing import Any, Optional
 
 
-_TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
+_TERMINAL_KANBAN_TOOLS = frozenset(
+    {
+        "kanban_complete",
+        "kanban_block",
+        "kanban_request_review",
+        "kanban_request_changes",
+    }
+)
 
 _DEFAULT_MAX_ATTEMPTS = 2
 
 
-def kanban_stop_nudge_enabled() -> bool:
-    """Return whether the kanban stop-guard is active for this process.
+class HandoffStatus(str, Enum):
+    """State of the durable terminal receipts in a worker transcript."""
 
-    On when ``HERMES_KANBAN_TASK`` is set (dispatcher-spawned worker), unless
-    ``HERMES_KANBAN_STOP_NUDGE`` explicitly disables it.
-    """
+    NOT_REQUIRED = "not_required"
+    MISSING = "missing"
+    VALID = "valid"
+    CONFLICT = "conflict"
+
+
+class StopAction(str, Enum):
+    """Action the conversation loop must take at a candidate stop."""
+
+    ALLOW = "allow"
+    NUDGE = "nudge"
+    VIOLATION = "violation"
+
+
+@dataclass(frozen=True)
+class HandoffAssessment:
+    status: HandoffStatus
+    successful_count: int
+    tool_name: Optional[str] = None
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class StopDecision:
+    action: StopAction
+    assessment: HandoffAssessment
+    nudge: Optional[str] = None
+    reason: str = ""
+
+
+def kanban_stop_nudge_enabled() -> bool:
+    """Return whether the Kanban stop guard is active for this process."""
     env = os.environ.get("HERMES_KANBAN_STOP_NUDGE")
     if env is not None and env.strip().lower() in {"0", "false", "no", "off"}:
         return False
@@ -47,23 +81,192 @@ def _tool_call_name(tc: Any) -> str:
     return str(getattr(tc, "name", "") or "")
 
 
-def session_called_kanban_terminal(messages: Iterable[dict] | None) -> bool:
-    """True if this conversation already invoked a terminal kanban tool."""
-    if not messages:
+def _tool_call_id(tc: Any) -> str:
+    if isinstance(tc, dict):
+        return str(tc.get("id") or "")
+    return str(getattr(tc, "id", "") or "")
+
+
+def _receipt_payload(content: Any) -> Optional[dict]:
+    if isinstance(content, dict):
+        return content
+    if not isinstance(content, str):
+        return None
+    try:
+        payload = json.loads(content)
+    except (TypeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _receipt_matches_worker(
+    payload: dict,
+    *,
+    task_id: str,
+    run_id: str,
+) -> bool:
+    if payload.get("ok") is not True:
         return False
-    for msg in messages:
-        if not isinstance(msg, dict):
+    receipt_task = str(payload.get("task_id") or "").strip()
+    if not receipt_task or (task_id and receipt_task != task_id):
+        return False
+    if run_id:
+        receipt_run = str(payload.get("run_id") or "").strip()
+        if receipt_run != run_id:
+            return False
+    return True
+
+
+def assess_kanban_handoff(
+    messages: Iterable[dict] | None,
+    *,
+    task_id: Optional[str] = None,
+    run_id: Optional[str | int] = None,
+) -> HandoffAssessment:
+    """Validate exactly one successful terminal receipt for this worker run."""
+    history = list(messages or [])
+    expected_task = (
+        task_id or os.environ.get("HERMES_KANBAN_TASK") or ""
+    ).strip()
+    expected_run = str(
+        run_id if run_id is not None else os.environ.get("HERMES_KANBAN_RUN_ID") or ""
+    ).strip()
+
+    terminal_calls: dict[str, str] = {}
+    duplicate_terminal_call_ids: set[str] = set()
+    for msg in history:
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
             continue
-        role = msg.get("role")
-        if role == "assistant":
-            for tc in msg.get("tool_calls") or []:
-                if _tool_call_name(tc) in _TERMINAL_KANBAN_TOOLS:
-                    return True
-        elif role == "tool":
-            name = str(msg.get("name") or "")
-            if name in _TERMINAL_KANBAN_TOOLS:
-                return True
-    return False
+        for tool_call in msg.get("tool_calls") or []:
+            name = _tool_call_name(tool_call)
+            call_id = _tool_call_id(tool_call)
+            if name in _TERMINAL_KANBAN_TOOLS and call_id:
+                if call_id in terminal_calls:
+                    duplicate_terminal_call_ids.add(call_id)
+                terminal_calls[call_id] = name
+
+    successful: list[tuple[str, str]] = []
+    for msg in history:
+        if not isinstance(msg, dict) or msg.get("role") != "tool":
+            continue
+        call_id = str(msg.get("tool_call_id") or "")
+        called_name = terminal_calls.get(call_id)
+        result_name = str(msg.get("name") or msg.get("tool_name") or "")
+        if not called_name or result_name != called_name:
+            continue
+        payload = _receipt_payload(msg.get("content"))
+        if payload is None:
+            continue
+        if _receipt_matches_worker(
+            payload,
+            task_id=expected_task,
+            run_id=expected_run,
+        ):
+            successful.append((call_id, called_name))
+
+    if duplicate_terminal_call_ids:
+        return HandoffAssessment(
+            status=HandoffStatus.CONFLICT,
+            successful_count=len(successful),
+            reason=(
+                "duplicate terminal tool_call_id values make the handoff "
+                "transcript ambiguous"
+            ),
+        )
+    if len(successful) == 1:
+        return HandoffAssessment(
+            status=HandoffStatus.VALID,
+            successful_count=1,
+            tool_name=successful[0][1],
+            reason="exactly one successful durable terminal receipt",
+        )
+    if len(successful) > 1:
+        return HandoffAssessment(
+            status=HandoffStatus.CONFLICT,
+            successful_count=len(successful),
+            reason=(
+                "expected exactly one successful durable terminal receipt, "
+                f"found {len(successful)}"
+            ),
+        )
+    if terminal_calls:
+        reason = "terminal tool call had no matching successful durable receipt"
+    else:
+        reason = "no terminal Kanban tool call was made"
+    return HandoffAssessment(
+        status=HandoffStatus.MISSING,
+        successful_count=0,
+        reason=reason,
+    )
+
+
+def session_called_kanban_terminal(messages: Iterable[dict] | None) -> bool:
+    """Compatibility helper: true only for one valid durable handoff receipt."""
+    return assess_kanban_handoff(messages).status is HandoffStatus.VALID
+
+
+def _nudge_text(*, task_id: str, reason: str) -> str:
+    return (
+        "[System: You are a Hermes Kanban worker. A plain-text reply is NOT a "
+        "terminal state for the board.\n\n"
+        f"Task `{task_id}` is still `running`. Handoff validation failed: "
+        f"{reason}.\n\n"
+        "Do this immediately in your next response — do not narrate intent:\n"
+        "1. Finish any remaining deliverable (write the required file(s) now).\n"
+        "2. Call exactly one lifecycle tool appropriate to the task: "
+        "`kanban_complete`, `kanban_block`, `kanban_request_review`, or "
+        "`kanban_request_changes`.\n"
+        "3. If a lifecycle tool returns an error, correct it and retry; a rejected "
+        "tool call is not a handoff.\n\n"
+        "Never end a turn with only a promise of future action. Exhausting this "
+        "retry budget is an explicit Kanban protocol failure, not a clean exit.]"
+    )
+
+
+def evaluate_kanban_stop(
+    *,
+    messages: Iterable[dict] | None = None,
+    attempts: int = 0,
+    max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
+    task_id: Optional[str] = None,
+    run_id: Optional[str | int] = None,
+) -> StopDecision:
+    """Return the fail-closed action for a candidate Kanban worker stop."""
+    if not kanban_stop_nudge_enabled():
+        assessment = HandoffAssessment(
+            HandoffStatus.NOT_REQUIRED,
+            successful_count=0,
+            reason="Kanban stop guard disabled for this process",
+        )
+        return StopDecision(StopAction.ALLOW, assessment, reason=assessment.reason)
+
+    assessment = assess_kanban_handoff(
+        messages,
+        task_id=task_id,
+        run_id=run_id,
+    )
+    if assessment.status is HandoffStatus.VALID:
+        return StopDecision(StopAction.ALLOW, assessment, reason=assessment.reason)
+    if assessment.status is HandoffStatus.CONFLICT:
+        return StopDecision(
+            StopAction.VIOLATION,
+            assessment,
+            reason=assessment.reason,
+        )
+    if attempts >= max_attempts:
+        reason = f"Kanban terminal retry budget exhausted: {assessment.reason}"
+        return StopDecision(StopAction.VIOLATION, assessment, reason=reason)
+
+    tid = (
+        task_id or os.environ.get("HERMES_KANBAN_TASK") or "this task"
+    ).strip()
+    nudge = _nudge_text(task_id=tid, reason=assessment.reason)
+    return StopDecision(
+        StopAction.NUDGE,
+        assessment,
+        nudge=nudge,
+        reason=assessment.reason,
+    )
 
 
 def build_kanban_stop_nudge(
@@ -73,36 +276,23 @@ def build_kanban_stop_nudge(
     max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
     task_id: Optional[str] = None,
 ) -> Optional[str]:
-    """Return a synthetic follow-up when a kanban worker exits without a terminal tool.
-
-    Returns ``None`` when the guard should not fire (not a kanban worker,
-    already completed/blocked, or nudge budget exhausted).
-    """
-    if not kanban_stop_nudge_enabled():
-        return None
-    if attempts >= max_attempts:
-        return None
-    if session_called_kanban_terminal(messages):
-        return None
-
-    tid = (task_id or os.environ.get("HERMES_KANBAN_TASK") or "").strip() or "this task"
-    return (
-        "[System: You are a Hermes kanban worker. A plain-text reply is NOT a "
-        "terminal state for the board.\n\n"
-        f"Task `{tid}` is still `running`. Ending now without a board tool "
-        "causes a protocol violation (clean exit with no "
-        "`kanban_complete` / `kanban_block`).\n\n"
-        "Do this immediately in your next response — do not narrate intent:\n"
-        "1. Finish any remaining deliverable (write the required file(s) now).\n"
-        "2. Call `kanban_complete(summary=..., artifacts=[...])` if the work "
-        "is done, OR `kanban_block(reason=...)` if you are blocked.\n\n"
-        "Never end a turn with only a promise of future action. Repeated "
-        "protocol violations will block this task and require manual intervention.]"
-    )
+    """Backward-compatible nudge-only view of :func:`evaluate_kanban_stop`."""
+    return evaluate_kanban_stop(
+        messages=messages,
+        attempts=attempts,
+        max_attempts=max_attempts,
+        task_id=task_id,
+    ).nudge
 
 
 __all__ = [
+    "HandoffAssessment",
+    "HandoffStatus",
+    "StopAction",
+    "StopDecision",
+    "assess_kanban_handoff",
     "build_kanban_stop_nudge",
+    "evaluate_kanban_stop",
     "kanban_stop_nudge_enabled",
     "session_called_kanban_terminal",
 ]

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -132,6 +132,7 @@ def finalize_turn(
     original_user_message,
     _should_review_memory,
     _turn_exit_reason,
+    failure_reason=None,
     _pending_verification_response=None,
     _pending_verification_response_previewed=False,
 ):
@@ -726,6 +727,9 @@ def finalize_turn(
         ).get("service_tier"),
         "session_id": agent.session_id,
     }
+    if failure_reason:
+        result["failure_reason"] = str(failure_reason)
+        result["error"] = final_response or str(failure_reason)
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
     # Persistence failures already set failed=True + an explanation in

--- a/cli.py
+++ b/cli.py
@@ -21382,29 +21382,19 @@ def main(
 
                         # Ensure proper exit code for automation wrappers.
                         #
-                        # Kanban workers get a special case: when the run failed
-                        # purely because the provider rate-limited / exhausted
-                        # quota (not because the task itself is broken), exit with
-                        # the EX_TEMPFAIL sentinel instead of the generic 1. The
-                        # dispatcher's reap classifier maps that code to a
-                        # ``rate_limited`` exit and releases the task back to
-                        # ``ready`` WITHOUT incrementing the failure counter, so a
-                        # 5-hour quota window can't trip the circuit breaker and
-                        # permanently block the card. Non-kanban runs keep the
-                        # plain 0/1 contract automation wrappers expect.
-                        _exit_code = 0
-                        if isinstance(result, dict) and result.get("failed"):
-                            _exit_code = 1
-                            if os.environ.get("HERMES_KANBAN_TASK") and result.get(
-                                "failure_reason"
-                            ) in ("rate_limit", "billing"):
-                                try:
-                                    from hermes_cli.kanban_db import (
-                                        KANBAN_RATE_LIMIT_EXIT_CODE as _RL_CODE,
-                                    )
-                                    _exit_code = _RL_CODE
-                                except Exception:
-                                    _exit_code = 1
+                        # Kanban workers use stable sentinels for provider quota
+                        # walls and terminal-handoff protocol violations. The
+                        # dispatcher classifies those separately from generic
+                        # process crashes; non-kanban runs retain the plain 0/1
+                        # contract automation wrappers expect.
+                        from hermes_cli.kanban_exit_codes import (
+                            single_query_exit_code as _single_query_exit_code,
+                        )
+
+                        _exit_code = _single_query_exit_code(
+                            result,
+                            kanban_worker=bool(os.environ.get("HERMES_KANBAN_TASK")),
+                        )
                         sys.exit(_exit_code)
 
                 # Exit with error code if credentials or agent init fails

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -89,6 +89,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional
 
+from hermes_cli.kanban_exit_codes import (
+    KANBAN_PROTOCOL_EXIT_CODE,
+    KANBAN_RATE_LIMIT_EXIT_CODE,
+)
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
 
@@ -419,15 +423,8 @@ def _resolve_claim_ttl_seconds(ttl_seconds: Optional[int] = None) -> int:
 DEFAULT_CRASH_GRACE_SECONDS = 30
 
 
-# Sentinel exit code a kanban worker uses to signal "I bailed because the
-# provider rate-limited / exhausted quota, not because the task failed."
-# The dispatcher's reap classifier maps this to a ``rate_limited`` exit kind
-# so ``detect_crashed_workers`` can release the task back to ``ready``
-# WITHOUT counting a failure (the circuit breaker must never trip on a
-# transient throttle). 75 == BSD ``EX_TEMPFAIL`` (sysexits.h) — the
-# conventional "temporary failure, retry later" code, and well clear of the
-# 0/1/2 codes the worker uses for success / generic failure / usage error.
-KANBAN_RATE_LIMIT_EXIT_CODE = 75
+# Worker sentinel exit codes are imported from ``kanban_exit_codes`` so the
+# quiet CLI and this reap classifier share one source of truth.
 
 
 def _resolve_crash_grace_seconds() -> int:
@@ -8051,6 +8048,8 @@ class DispatchResult:
     "task is genuinely stuck"."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
+    protocol_violations: list[str] = field(default_factory=list)
+    """Reclaimed worker ids whose turn ended without one valid durable handoff."""
     auto_blocked: list[str] = field(default_factory=list)
     """Task ids auto-blocked by the spawn-failure circuit breaker."""
     timed_out: list[str] = field(default_factory=list)
@@ -8129,6 +8128,9 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
       task is still ``running`` in the DB, this is a protocol violation
       (worker exited without calling ``kanban_complete`` / ``kanban_block``)
       and should be auto-blocked immediately — retrying will just loop.
+    * ``"protocol_violation"`` — ``WIFEXITED`` with the explicit
+      ``KANBAN_PROTOCOL_EXIT_CODE`` sentinel. The conversation loop exhausted
+      its terminal-handoff guard and refused a clean exit.
     * ``"rate_limited"`` — ``WIFEXITED`` with status
       ``KANBAN_RATE_LIMIT_EXIT_CODE``. The worker bailed because the
       provider rate-limited / exhausted quota, NOT because the task failed.
@@ -8140,9 +8142,9 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
       something else, or died between reap tick and liveness check). Fall
       back to existing crashed-counter behavior.
 
-    ``code`` is the exit status (for ``clean_exit`` / ``rate_limited`` /
-    ``nonzero_exit``) or the signal number (for ``signaled``), or ``None``
-    for ``unknown``.
+    ``code`` is the exit status (for ``clean_exit`` /
+    ``protocol_violation`` / ``rate_limited`` / ``nonzero_exit``), the signal
+    number (for ``signaled``), or ``None`` for ``unknown``.
     """
     entry = _recent_worker_exits.get(int(pid))
     if entry is None:
@@ -8153,6 +8155,8 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
             code = os.WEXITSTATUS(raw)
             if code == 0:
                 return ("clean_exit", 0)
+            if code == KANBAN_PROTOCOL_EXIT_CODE:
+                return ("protocol_violation", code)
             if code == KANBAN_RATE_LIMIT_EXIT_CODE:
                 return ("rate_limited", code)
             return ("nonzero_exit", code)
@@ -8830,10 +8834,10 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
         outcome = row["outcome"] or ""
         if outcome == "rate_limited":
             continue
-        if outcome == "crashed":
-            is_violation = False
+        if outcome in {"crashed", "protocol_violation"}:
+            is_violation = outcome == "protocol_violation"
             raw_meta = row["metadata"]
-            if raw_meta:
+            if raw_meta and not is_violation:
                 try:
                     is_violation = bool(
                         json.loads(raw_meta).get("protocol_violation")
@@ -8878,6 +8882,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     (the public return stays the crashed-only ``list[str]``).
     """
     crashed: list[str] = []
+    protocol_violations: list[str] = []
     rate_limited: list[str] = []
     # Per-crash details collected inside the main txn, used after it
     # closes to run ``_record_task_failure`` (which needs its own
@@ -8916,28 +8921,31 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             pid = int(row["worker_pid"])
             kind, code = _classify_worker_exit(pid)
             rate_limited_exit = False
-            if kind == "clean_exit":
-                # Worker subprocess returned 0 but its task is still
-                # ``running`` in the DB — it exited without calling
-                # ``kanban_complete`` / ``kanban_block``. Overwhelmingly the
-                # work itself succeeded and only the paperwork was skipped, so
-                # a retry usually completes; the corrective sentence below is
-                # surfaced to the retry worker via the prior-attempt error in
-                # ``build_worker_context`` (guidance approach from #61817).
+            if kind in {"clean_exit", "protocol_violation"}:
+                # Either the explicit EX_PROTOCOL sentinel or the legacy rc=0
+                # backstop reached the reaper while the task was still running.
+                # The sentinel proves the agent exhausted its own fail-closed
+                # terminal-receipt guard; rc=0 remains a compatibility backstop.
                 protocol_violation = True
-                error_text = (
-                    "worker exited cleanly (rc=0) without calling "
-                    "kanban_complete or kanban_block — protocol violation. "
-                    "If the prior run already did the work, verify it and "
-                    "report the result via kanban_complete; a run that ends "
-                    "without a terminal kanban call counts as failed no "
-                    "matter what it did."
-                )
+                if kind == "protocol_violation":
+                    error_text = (
+                        f"worker refused clean exit with rc={code}: terminal "
+                        "Kanban retry budget exhausted without exactly one "
+                        "successful durable handoff receipt — protocol violation."
+                    )
+                else:
+                    error_text = (
+                        "worker exited cleanly (rc=0) without exactly one "
+                        "successful durable terminal Kanban handoff — protocol "
+                        "violation. If the prior run already did the work, verify "
+                        "it and submit one successful lifecycle tool call."
+                    )
                 event_kind = "protocol_violation"
                 event_payload = {
                     "pid": pid,
                     "claimer": row["claim_lock"],
                     "exit_code": code,
+                    "exit_kind": kind,
                     # Durable marker for _protocol_violation_streak: _end_run
                     # copies this payload into the run metadata, which is how
                     # the violation-only retry budget is derived later.
@@ -8990,7 +8998,12 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 # Rate-limited requeues are a clean release, not a crash —
                 # record the run outcome as ``rate_limited`` so the board
                 # history doesn't show a phantom crash for a quota wall.
-                _run_outcome = "rate_limited" if rate_limited_exit else "crashed"
+                if rate_limited_exit:
+                    _run_outcome = "rate_limited"
+                elif protocol_violation:
+                    _run_outcome = "protocol_violation"
+                else:
+                    _run_outcome = "crashed"
                 run_id = _end_run(
                     conn, row["id"],
                     outcome=_run_outcome, status=_run_outcome,
@@ -9025,6 +9038,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     rate_limited.append(row["id"])
                 else:
                     if protocol_violation:
+                        protocol_violations.append(row["id"])
                         # Stamp the failure error now: a below-budget
                         # violation never reaches ``_record_task_failure``
                         # (which stamps this column for every other failure
@@ -9096,7 +9110,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 tripped = _record_task_failure(
                     conn, tid,
                     error=error_text,
-                    outcome="crashed",
+                    outcome="protocol_violation",
                     failure_limit=violation_limit,
                     force_trip=True,
                     release_claim=False,
@@ -9129,6 +9143,14 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # and tests that destructure the result; ``dispatch_once`` reads this
     # side-channel attribute to populate ``DispatchResult.auto_blocked``.
     detect_crashed_workers._last_auto_blocked = auto_blocked  # type: ignore[attr-defined]
+    # Explicit subset for telemetry: these are lifecycle protocol failures,
+    # not execution crashes, even though they remain in the compatibility
+    # ``crashed`` return list because their worker process was reclaimed.
+    setattr(
+        detect_crashed_workers,
+        "_last_protocol_violations",
+        protocol_violations,
+    )
     # Same side-channel for rate-limited requeues — these did NOT count a
     # failure and are NOT crashes, so they stay out of the ``crashed`` return.
     detect_crashed_workers._last_rate_limited = rate_limited  # type: ignore[attr-defined]
@@ -9952,6 +9974,9 @@ def _dispatch_once_locked(
         conn, stale_timeout_seconds=stale_timeout_seconds,
     )
     result.crashed = detect_crashed_workers(conn)
+    result.protocol_violations = list(
+        getattr(detect_crashed_workers, "_last_protocol_violations", [])
+    )
     # detect_crashed_workers stashes protocol-violation auto-blocks on
     # itself so the public list-return stays stable. Pull them into the
     # DispatchResult here so telemetry / tests see the trip.

--- a/hermes_cli/kanban_exit_codes.py
+++ b/hermes_cli/kanban_exit_codes.py
@@ -1,0 +1,33 @@
+"""Stable process exit codes for dispatcher-spawned Kanban workers."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+# BSD sysexits values, with portable fallbacks for platforms that do not expose
+# the names through ``os`` (notably Windows).
+KANBAN_RATE_LIMIT_EXIT_CODE = getattr(os, "EX_TEMPFAIL", 75)
+KANBAN_PROTOCOL_EXIT_CODE = getattr(os, "EX_PROTOCOL", 76)
+
+
+def single_query_exit_code(result: Any, *, kanban_worker: bool) -> int:
+    """Map a quiet single-query result to a process exit code."""
+    if not isinstance(result, dict) or not result.get("failed"):
+        return 0
+    if not kanban_worker:
+        return 1
+    reason = str(result.get("failure_reason") or "")
+    if reason in {"rate_limit", "billing"}:
+        return KANBAN_RATE_LIMIT_EXIT_CODE
+    if reason == "kanban_protocol":
+        return KANBAN_PROTOCOL_EXIT_CODE
+    return 1
+
+
+__all__ = [
+    "KANBAN_PROTOCOL_EXIT_CODE",
+    "KANBAN_RATE_LIMIT_EXIT_CODE",
+    "single_query_exit_code",
+]

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -1,11 +1,17 @@
-"""Tests for the kanban worker turn-end stop guard."""
+"""Tests for the kanban worker terminal-handoff stop guard."""
 
 from __future__ import annotations
+
+import json
 
 import pytest
 
 from agent.kanban_stop import (
+    HandoffStatus,
+    StopAction,
+    assess_kanban_handoff,
     build_kanban_stop_nudge,
+    evaluate_kanban_stop,
     kanban_stop_nudge_enabled,
     session_called_kanban_terminal,
 )
@@ -13,78 +19,193 @@ from agent.kanban_stop import (
 
 @pytest.fixture
 def clear_kanban_env(monkeypatch):
-    for var in ("HERMES_KANBAN_TASK", "HERMES_KANBAN_STOP_NUDGE"):
+    for var in (
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_RUN_ID",
+        "HERMES_KANBAN_STOP_NUDGE",
+    ):
         monkeypatch.delenv(var, raising=False)
     return monkeypatch
 
 
+def _terminal_messages(
+    name: str,
+    content: str | dict,
+    *,
+    call_id: str = "call-1",
+) -> list[dict]:
+    if isinstance(content, dict):
+        content = json.dumps(content)
+    return [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": name, "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": name,
+            "tool_call_id": call_id,
+            "content": content,
+        },
+    ]
 
 
+def _ok_receipt(task_id: str = "t_abc", run_id: int = 7) -> dict:
+    return {"ok": True, "task_id": task_id, "run_id": run_id}
 
 
 def test_env_can_disable(clear_kanban_env):
     clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
     clear_kanban_env.setenv("HERMES_KANBAN_STOP_NUDGE", "0")
     assert kanban_stop_nudge_enabled() is False
+    decision = evaluate_kanban_stop(messages=[])
+    assert decision.action is StopAction.ALLOW
+    assert decision.assessment.status is HandoffStatus.NOT_REQUIRED
     assert build_kanban_stop_nudge(messages=[]) is None
 
 
 def test_nudge_when_no_terminal_tool(clear_kanban_env):
     clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_46be8aa5")
-    messages = [
-        {"role": "user", "content": "work kanban task"},
-        {
-            "role": "assistant",
-            "content": "Let me write the comprehensive recipe.",
-            "tool_calls": [
-                {
-                    "id": "1",
-                    "type": "function",
-                    "function": {"name": "kanban_heartbeat", "arguments": "{}"},
-                }
-            ],
-        },
-        {"role": "tool", "name": "kanban_heartbeat", "tool_call_id": "1", "content": "ok"},
-    ]
-    nudge = build_kanban_stop_nudge(messages=messages, attempts=0)
-    assert nudge is not None
-    assert "kanban_complete" in nudge
-    assert "kanban_block" in nudge
-    assert "t_46be8aa5" in nudge
-    assert "protocol violation" in nudge.lower() or "protocol" in nudge.lower()
+    messages = _terminal_messages(
+        "kanban_heartbeat",
+        {"ok": True, "task_id": "t_46be8aa5"},
+    )
+    decision = evaluate_kanban_stop(messages=messages, attempts=0)
+    assert decision.action is StopAction.NUDGE
+    assert decision.nudge is not None
+    assert "kanban_complete" in decision.nudge
+    assert "kanban_block" in decision.nudge
+    assert "t_46be8aa5" in decision.nudge
 
 
-def test_no_nudge_after_kanban_complete(clear_kanban_env):
+@pytest.mark.parametrize(
+    "name",
+    [
+        "kanban_complete",
+        "kanban_block",
+        "kanban_request_review",
+        "kanban_request_changes",
+    ],
+)
+def test_valid_receipt_is_exact_terminal_handoff(clear_kanban_env, name):
     clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
-    messages = [
-        {
-            "role": "assistant",
-            "content": "",
-            "tool_calls": [
-                {
-                    "id": "1",
-                    "type": "function",
-                    "function": {"name": "kanban_complete", "arguments": "{}"},
-                }
-            ],
-        },
-        {"role": "tool", "name": "kanban_complete", "tool_call_id": "1", "content": "done"},
-    ]
+    clear_kanban_env.setenv("HERMES_KANBAN_RUN_ID", "7")
+    messages = _terminal_messages(name, _ok_receipt())
+
+    assessment = assess_kanban_handoff(messages)
+    assert assessment.status is HandoffStatus.VALID
+    assert assessment.successful_count == 1
+    assert assessment.tool_name == name
     assert session_called_kanban_terminal(messages) is True
+    assert evaluate_kanban_stop(messages=messages).action is StopAction.ALLOW
     assert build_kanban_stop_nudge(messages=messages) is None
 
 
+def test_rejected_terminal_call_does_not_count(clear_kanban_env):
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    messages = _terminal_messages(
+        "kanban_complete",
+        {"error": "could not complete t_abc (already terminal)"},
+    )
+    assessment = assess_kanban_handoff(messages)
+    assert assessment.status is HandoffStatus.MISSING
+    assert assessment.successful_count == 0
+    assert session_called_kanban_terminal(messages) is False
+    assert evaluate_kanban_stop(messages=messages).action is StopAction.NUDGE
 
 
+def test_plain_text_tool_result_is_not_a_durable_receipt(clear_kanban_env):
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    messages = _terminal_messages("kanban_complete", "done")
+    assert assess_kanban_handoff(messages).status is HandoffStatus.MISSING
 
 
-# ── Integration: agent nudge + dispatcher bounded retry ──────────────
-# These tests verify the two layers compose correctly: the agent-side
-# nudge fires first (up to 2 attempts), and if the worker still exits
-# without a terminal call, the dispatcher's bounded retry (streak of 3)
-# handles it.  See also tests/hermes_cli/test_kanban_core_functionality.py
-# for the dispatcher-side streak tests.
+def test_stale_task_or_run_receipt_does_not_count(clear_kanban_env):
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    clear_kanban_env.setenv("HERMES_KANBAN_RUN_ID", "7")
+    for receipt in (
+        _ok_receipt(task_id="t_other", run_id=7),
+        _ok_receipt(task_id="t_abc", run_id=6),
+    ):
+        assessment = assess_kanban_handoff(
+            _terminal_messages("kanban_complete", receipt)
+        )
+        assert assessment.status is HandoffStatus.MISSING
 
 
+def test_tool_result_without_matching_assistant_call_does_not_count(clear_kanban_env):
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    messages = [
+        {
+            "role": "tool",
+            "name": "kanban_complete",
+            "tool_call_id": "forged",
+            "content": json.dumps(_ok_receipt()),
+        }
+    ]
+    assert assess_kanban_handoff(messages).status is HandoffStatus.MISSING
 
 
+def test_two_successful_terminal_receipts_are_conflict(clear_kanban_env):
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    clear_kanban_env.setenv("HERMES_KANBAN_RUN_ID", "7")
+    messages = [
+        *_terminal_messages("kanban_complete", _ok_receipt(), call_id="complete"),
+        *_terminal_messages("kanban_block", _ok_receipt(), call_id="block"),
+    ]
+    assessment = assess_kanban_handoff(messages)
+    assert assessment.status is HandoffStatus.CONFLICT
+    assert assessment.successful_count == 2
+    decision = evaluate_kanban_stop(messages=messages, attempts=0)
+    assert decision.action is StopAction.VIOLATION
+    assert "exactly one" in decision.reason
+
+
+def test_duplicate_terminal_call_id_is_ambiguous_conflict(clear_kanban_env):
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    clear_kanban_env.setenv("HERMES_KANBAN_RUN_ID", "7")
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "duplicate",
+                    "type": "function",
+                    "function": {"name": "kanban_complete", "arguments": "{}"},
+                },
+                {
+                    "id": "duplicate",
+                    "type": "function",
+                    "function": {"name": "kanban_block", "arguments": "{}"},
+                },
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "kanban_block",
+            "tool_call_id": "duplicate",
+            "content": json.dumps(_ok_receipt()),
+        },
+    ]
+    assessment = assess_kanban_handoff(messages)
+    assert assessment.status is HandoffStatus.CONFLICT
+    assert "duplicate" in assessment.reason
+    assert evaluate_kanban_stop(messages=messages).action is StopAction.VIOLATION
+
+
+def test_budget_exhaustion_is_violation_not_clean_exit(clear_kanban_env):
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    decision = evaluate_kanban_stop(messages=[], attempts=2, max_attempts=2)
+    assert decision.action is StopAction.VIOLATION
+    assert decision.nudge is None
+    assert "exhausted" in decision.reason
+    # Backward-compatible builder still has no nudge after budget exhaustion;
+    # conversation_loop must use the structured decision to fail the turn.
+    assert build_kanban_stop_nudge(messages=[], attempts=2, max_attempts=2) is None

--- a/tests/hermes_cli/test_kanban_protocol_exit.py
+++ b/tests/hermes_cli/test_kanban_protocol_exit.py
@@ -1,0 +1,276 @@
+"""Worker exit-code and dispatcher classification for Kanban protocol failures."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import signal
+import time
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_exit_codes import (
+    KANBAN_PROTOCOL_EXIT_CODE,
+    KANBAN_RATE_LIMIT_EXIT_CODE,
+    single_query_exit_code,
+)
+from agent.kanban_stop import HandoffStatus, assess_kanban_handoff
+from tools.kanban_tools import _handle_block, _handle_complete
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(kb.Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _terminal_messages(name: str, content: str) -> list[dict]:
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call-real",
+                    "type": "function",
+                    "function": {"name": name, "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": name,
+            "tool_call_id": "call-real",
+            "content": content,
+        },
+    ]
+
+
+def _claim_with_pid(conn, *, title: str, pid: int, max_runtime: int | None = None):
+    task_id = kb.create_task(
+        conn,
+        title=title,
+        assignee="worker",
+        max_runtime_seconds=max_runtime,
+    )
+    claimed = kb.claim_task(conn, task_id, claimer=kb._claimer_id())
+    assert claimed is not None
+    conn.execute(
+        "UPDATE tasks SET worker_pid = ? WHERE id = ?",
+        (pid, task_id),
+    )
+    conn.commit()
+    return task_id, claimed.current_run_id
+
+
+def test_single_query_exit_code_distinguishes_worker_outcomes() -> None:
+    assert single_query_exit_code({"failed": False}, kanban_worker=True) == 0
+    assert single_query_exit_code({"failed": True}, kanban_worker=True) == 1
+    assert (
+        single_query_exit_code(
+            {"failed": True, "failure_reason": "rate_limit"},
+            kanban_worker=True,
+        )
+        == KANBAN_RATE_LIMIT_EXIT_CODE
+    )
+    assert (
+        single_query_exit_code(
+            {"failed": True, "failure_reason": "kanban_protocol"},
+            kanban_worker=True,
+        )
+        == KANBAN_PROTOCOL_EXIT_CODE
+    )
+    assert (
+        single_query_exit_code(
+            {"failed": True, "failure_reason": "kanban_protocol"},
+            kanban_worker=False,
+        )
+        == 1
+    )
+
+
+def test_real_complete_handler_emits_a_valid_post_commit_receipt(
+    kanban_home: Path,
+    monkeypatch,
+) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="finish me", assignee="worker")
+        claimed = kb.claim_task(conn, task_id, claimer=kb._claimer_id())
+        assert claimed is not None
+        assert claimed.current_run_id is not None
+        run_id = claimed.current_run_id
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    content = _handle_complete({"summary": "verified"})
+    assessment = assess_kanban_handoff(
+        _terminal_messages("kanban_complete", content)
+    )
+    assert assessment.status is HandoffStatus.VALID
+    assert assessment.successful_count == 1
+
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "done"
+        run = kb.latest_run(conn, task_id)
+        assert run is not None
+        assert run.id == run_id
+        assert run.outcome == "completed"
+
+
+def test_real_block_handler_is_a_valid_external_blocker_handoff(
+    kanban_home: Path,
+    monkeypatch,
+) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="need a decision", assignee="worker")
+        claimed = kb.claim_task(conn, task_id, claimer=kb._claimer_id())
+        assert claimed is not None
+        assert claimed.current_run_id is not None
+        run_id = claimed.current_run_id
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    content = _handle_block(
+        {"reason": "operator decision required", "kind": "needs_input"}
+    )
+    assessment = assess_kanban_handoff(
+        _terminal_messages("kanban_block", content)
+    )
+    assert assessment.status is HandoffStatus.VALID
+
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "blocked"
+        run = kb.latest_run(conn, task_id)
+        assert run is not None
+        assert run.outcome == "blocked"
+
+
+def test_protocol_exit_is_not_classified_as_process_crash(
+    kanban_home: Path,
+    monkeypatch,
+) -> None:
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="handoff required", assignee="worker")
+        host_prefix = kb._claimer_id().split(":", 1)[0]
+        claimed = kb.claim_task(conn, task_id, claimer=f"{host_prefix}:test")
+        assert claimed is not None
+        fake_pid = 991940
+        kb._set_worker_pid(conn, task_id, fake_pid)
+        kb._record_worker_exit(fake_pid, KANBAN_PROTOCOL_EXIT_CODE << 8)
+        monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+        monkeypatch.setattr(kb, "_resolve_crash_grace_seconds", lambda: 0)
+
+        reclaimed = kb.detect_crashed_workers(conn)
+
+        assert task_id in reclaimed  # compatibility: reaped worker ids
+        assert task_id in getattr(kb.detect_crashed_workers, "_last_protocol_violations")
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "ready"
+        events = kb.list_events(conn, task_id)
+        protocol = [event for event in events if event.kind == "protocol_violation"]
+        assert len(protocol) == 1
+        payload = protocol[0].payload
+        assert payload is not None
+        assert payload["exit_code"] == KANBAN_PROTOCOL_EXIT_CODE
+        run = kb.latest_run(conn, task_id)
+        assert run is not None
+        assert run.outcome == "protocol_violation"
+        assert not any(event.kind == "crashed" for event in events)
+
+
+@pytest.mark.parametrize(
+    ("label", "raw_status", "event_kind", "run_outcome", "exit_kind"),
+    [
+        ("clean-output-0", 0, "protocol_violation", "protocol_violation", "clean_exit"),
+        ("exception-exit-1", 1 << 8, "crashed", "crashed", "nonzero_exit"),
+        ("sigterm", int(signal.SIGTERM), "crashed", "crashed", "signaled"),
+    ],
+)
+def test_reaper_distinguishes_output_zero_exception_and_signal(
+    kanban_home: Path,
+    monkeypatch,
+    label: str,
+    raw_status: int,
+    event_kind: str,
+    run_outcome: str,
+    exit_kind: str,
+) -> None:
+    pid = {
+        "clean-output-0": 991950,
+        "exception-exit-1": 991951,
+        "sigterm": 991952,
+    }[label]
+    with kb.connect_closing() as conn:
+        task_id, _ = _claim_with_pid(conn, title=label, pid=pid)
+        kb._record_worker_exit(pid, raw_status)
+        monkeypatch.setattr(kb, "_pid_alive", lambda candidate: False)
+        monkeypatch.setattr(kb, "_resolve_crash_grace_seconds", lambda: 0)
+
+        reclaimed = kb.detect_crashed_workers(conn)
+        assert task_id in reclaimed
+        events = kb.list_events(conn, task_id)
+        terminal = [event for event in events if event.kind == event_kind]
+        assert len(terminal) == 1
+        payload = terminal[0].payload
+        assert payload is not None
+        assert payload["exit_kind"] == exit_kind
+        run = kb.latest_run(conn, task_id)
+        assert run is not None
+        assert run.outcome == run_outcome
+
+        protocol_ids = getattr(
+            kb.detect_crashed_workers,
+            "_last_protocol_violations",
+            [],
+        )
+        assert (task_id in protocol_ids) is (raw_status == 0)
+
+
+def test_timeout_remains_distinct_from_protocol_violation(
+    kanban_home: Path,
+    monkeypatch,
+) -> None:
+    pid = 991960
+    sent: list[tuple[int, int]] = []
+    with kb.connect_closing() as conn:
+        task_id, run_id = _claim_with_pid(
+            conn,
+            title="deadline",
+            pid=pid,
+            max_runtime=1,
+        )
+        assert run_id is not None
+        conn.execute(
+            "UPDATE task_runs SET started_at = ? WHERE id = ?",
+            (int(time.time()) - 5, run_id),
+        )
+        conn.commit()
+        monkeypatch.setattr(kb, "_pid_alive", lambda candidate: False)
+
+        timed_out = kb.enforce_max_runtime(
+            conn,
+            signal_fn=lambda candidate, sig: sent.append((candidate, int(sig))),
+        )
+        assert timed_out == [task_id]
+        assert sent == [(pid, int(signal.SIGTERM))]
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "ready"
+        events = kb.list_events(conn, task_id)
+        assert any(event.kind == "timed_out" for event in events)
+        assert not any(event.kind == "protocol_violation" for event in events)
+        run = kb.latest_run(conn, task_id)
+        assert run is not None
+        assert run.outcome == "timed_out"
+
+
+def test_protocol_exit_code_matches_posix_ex_protocol() -> None:
+    assert KANBAN_PROTOCOL_EXIT_CODE == getattr(os, "EX_PROTOCOL", 76)

--- a/tests/run_agent/test_kanban_terminal_guard_integration.py
+++ b/tests/run_agent/test_kanban_terminal_guard_integration.py
@@ -1,0 +1,79 @@
+"""Integration coverage for fail-closed Kanban turn finalization."""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *args, **kwargs: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+
+def _plain_stop_response() -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content="The work is done.",
+                    reasoning=None,
+                    reasoning_content=None,
+                    reasoning_details=None,
+                    tool_calls=None,
+                ),
+                finish_reason="stop",
+            )
+        ],
+        usage=None,
+        model="test-model",
+    )
+
+
+def test_plain_text_stops_exhaust_to_structured_protocol_failure(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+    from hermes_cli.kanban_exit_codes import (
+        KANBAN_PROTOCOL_EXIT_CODE,
+        single_query_exit_code,
+    )
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        model="test-model",
+        api_key="sk-dummy",
+        base_url="https://example.invalid/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+    )
+    agent._disable_streaming = True
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda api_kwargs: _plain_stop_response(),
+    )
+    # Set worker identity only after construction so this test exercises the
+    # stop guard without requiring a real board during agent initialization.
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_guard")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "17")
+
+    result = agent.run_conversation("finish the assigned task")
+
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["failure_reason"] == "kanban_protocol"
+    assert result["turn_exit_reason"] == "kanban_protocol_violation"
+    assert single_query_exit_code(result, kanban_worker=True) == (
+        KANBAN_PROTOCOL_EXIT_CODE
+    )
+    assert result["api_calls"] == 3
+    assert "protocol violation" in result["final_response"].lower()
+    assert result["error"] == result["final_response"]


### PR DESCRIPTION
## Problem

A dispatcher-spawned Kanban worker can currently exit normally after the stop-nudge budget even when it never completed a durable lifecycle transition. The guard also treats a rejected terminal call as success because it only scans assistant tool names, and it cannot distinguish contradictory terminal receipts.

This is tracked downstream as DarkArty07/Aether-Agents#194.

## Changes

- validate a matching post-commit JSON receipt (`ok`, `task_id`, `run_id`) for terminal lifecycle tools;
- require exactly one valid receipt and reject stale, forged, duplicate-id, rejected, or conflicting receipts;
- return a structured `kanban_protocol` failure when nudges are exhausted instead of allowing logical success;
- map that failure to portable `EX_PROTOCOL` (76) in quiet CLI mode;
- classify it separately from process crash, signal, timeout, rate-limit, and external blocking in the dispatcher/event/run telemetry;
- preserve legacy rc=0-with-running-task detection as a backstop;
- accept the current terminal lifecycle set: complete, block, request-review, request-changes.

## Verification

- `77 passed, 1 skipped` across the new guard/integration suites and adjacent Kanban core/DB suites;
- Ruff passed on all nine changed files;
- `py_compile` passed;
- `git diff --check` passed.

Coverage includes real complete/block handler receipts, no handoff, rejected/stale/forged receipt, duplicate call id, two successful contradictory receipts, exhausted nudge budget, quiet CLI exit mapping, rc=0, nonzero/exception, SIGTERM, timeout, rate-limit compatibility, and dispatcher telemetry.