### PR TITLE
fix(cli): map Shift+<symbol> under xterm modifyOtherKeys=2

### DIFF
--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -321,9 +321,7 @@ def install_modify_other_keys_aliases() -> int:
     # combo is broken" symptom (#87711).
     # Map Shift+letter to the uppercase character so typing works normally.
     # This is safe across all Latin keyboard layouts: Shift always uppercases
-    # letters.  Shift+digit symbols are layout-specific (US: '!', AZERTY: '¹',
-    # etc.) so they are NOT mapped here — if the terminal sends those under
-    # modifyOtherKeys, they will leak, but that's better than wrong input.
+    # letters.
     # Map both the lowercase and uppercase codepoints — some terminals send
     # the already-shifted codepoint (65 for 'A') with modifier=2.
     shift_map: dict[int, str] = {}
@@ -332,6 +330,34 @@ def install_modify_other_keys_aliases() -> int:
         shift_map[ch] = upper_char
         shift_map[ch - 32] = upper_char
     _install_paired(2, shift_map)
+
+    # -- Shift+<printable symbol> → that symbol ----
+    # Same leak as Shift+letter above, for every non-letter printable: on
+    # Ghostty 1.3.x, Shift+/ arrives as ESC[27;2;63~ and lands in the prompt
+    # buffer as literal "^[[27;2;63~" instead of "?". Same for ! : " _ + < >
+    # ( ) etc. — i.e. most punctuation is untypeable while modifyOtherKeys=2
+    # is active, which is exactly the mode _enable_extended_enter_keys()
+    # pushes to Ghostty/iTerm2/WezTerm/VS Code/tmux/Windows Terminal.
+    #
+    # These were previously left unmapped on the grounds that shifted symbols
+    # are layout-specific (US Shift+1 = '!', AZERTY = '¹'). That is true when
+    # deriving the shifted character from an UNSHIFTED codepoint — but the
+    # xterm modifyOtherKeys encoding reports the codepoint ALREADY SHIFTED by
+    # the terminal, which has applied the user's real keymap. Echoing
+    # chr(codepoint) is therefore not a layout guess; it is what the terminal
+    # says was typed, and is correct on every layout.
+    #
+    # Only the modifyOtherKeys (tilde) spelling is registered here — NOT the
+    # CSI-u one. The Kitty protocol reports the UNSHIFTED codepoint plus a
+    # shift bit, so mapping ESC[47;2u to chr(47) would type '/' for Shift+/.
+    # Kitty-protocol terminals deliver printable keys as plain text anyway.
+    # Letters and Space are already registered above and are skipped by the
+    # membership check, so this only fills genuinely unmapped codepoints.
+    for codepoint in range(0x20, 0x7F):
+        seq = f"\x1b[27;2;{codepoint}~"
+        if seq not in ANSI_SEQUENCES:
+            ANSI_SEQUENCES[seq] = chr(codepoint)
+            changed += 1
 
     # -- Multi-modifier letters: Shift+Alt (4), Ctrl+Shift (6),
     # Ctrl+Alt (7), Ctrl+Alt+Shift (8) ----

--- a/tests/cli/test_cli_shift_symbol_keys.py
+++ b/tests/cli/test_cli_shift_symbol_keys.py
@@ -1,0 +1,102 @@
+"""Regression tests for Shift+<symbol> under xterm modifyOtherKeys=2.
+
+``_enable_extended_enter_keys()`` pushes modifyOtherKeys level 2 (CSI >4;2m)
+to Ghostty/iTerm2/WezTerm/VS Code/tmux/Windows Terminal. Those terminals then
+re-encode modified keys as ``ESC[27;<mod>;<codepoint>~``.
+
+``install_modify_other_keys_aliases()`` mapped Shift+letter but not
+Shift+symbol, so on Ghostty 1.3.x every shifted punctuation key leaked into
+the prompt buffer as literal ``^[[27;2;NN~`` text — '?', '!', ':', '"', '_',
+'+', '<' and friends were untypeable while the mode was active.
+"""
+
+from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+from prompt_toolkit.input.vt100_parser import Vt100Parser
+from prompt_toolkit.keys import Keys
+
+from hermes_cli.pt_input_extras import install_modify_other_keys_aliases
+
+
+def _parse_keys(data: str):
+    events = []
+    parser = Vt100Parser(events.append)
+    parser.feed_and_flush(data)
+    return [event.key for event in events]
+
+
+# US-layout shifted punctuation, as Ghostty reports it: the codepoint is
+# already shifted by the terminal, so 63 is '?' and not '/'.
+SHIFTED_SYMBOLS = [
+    (63, "?"),   # Shift+/
+    (33, "!"),   # Shift+1
+    (64, "@"),   # Shift+2
+    (58, ":"),   # Shift+;
+    (34, '"'),   # Shift+'
+    (95, "_"),   # Shift+-
+    (43, "+"),   # Shift+=
+    (60, "<"),   # Shift+,
+    (62, ">"),   # Shift+.
+    (40, "("),   # Shift+9
+    (126, "~"),  # Shift+`
+]
+
+
+def test_shift_symbols_parse_as_the_symbol():
+    install_modify_other_keys_aliases()
+
+    for codepoint, char in SHIFTED_SYMBOLS:
+        assert _parse_keys(f"\x1b[27;2;{codepoint}~") == [char], (
+            f"Shift+{char} (codepoint {codepoint}) did not parse as {char!r}"
+        )
+
+
+def test_no_printable_codepoint_leaks_as_literal_text():
+    """Every printable ASCII must be mapped — a leak yields many key events."""
+    install_modify_other_keys_aliases()
+
+    leaked = [
+        codepoint
+        for codepoint in range(0x20, 0x7F)
+        if len(_parse_keys(f"\x1b[27;2;{codepoint}~")) != 1
+    ]
+    assert leaked == [], f"codepoints still leaking as literal text: {leaked}"
+
+
+def test_shift_letters_still_map_to_uppercase():
+    """The pre-existing Shift+letter behaviour must be unchanged."""
+    install_modify_other_keys_aliases()
+
+    assert _parse_keys("\x1b[27;2;97~") == ["A"]   # lowercase codepoint
+    assert _parse_keys("\x1b[27;2;65~") == ["A"]   # already-shifted codepoint
+    assert _parse_keys("\x1b[27;2;122~") == ["Z"]
+
+
+def test_space_and_tab_and_backspace_are_not_clobbered():
+    """Codepoints 32/9/127 have dedicated meanings that must win."""
+    install_modify_other_keys_aliases()
+
+    assert _parse_keys("\x1b[27;2;32~") == [" "]
+    assert _parse_keys("\x1b[27;2;9~") == [Keys.BackTab]
+    assert _parse_keys("\x1b[27;2;127~") == [Keys.ControlH]
+
+
+def test_csi_u_spelling_is_left_alone():
+    """Kitty reports the UNSHIFTED codepoint, so chr() would be wrong there.
+
+    Registering ESC[47;2u -> '/' would type '/' for Shift+/ on kitty. Printable
+    keys arrive as plain text under the Kitty protocol, so there is nothing to
+    map; this asserts we did not opportunistically add them.
+    """
+    install_modify_other_keys_aliases()
+
+    for codepoint in (47, 49, 50, 59, 39, 45, 61, 44, 46, 57, 96):
+        assert f"\x1b[{codepoint};2u" not in ANSI_SEQUENCES
+
+
+def test_install_is_idempotent():
+    install_modify_other_keys_aliases()
+    snapshot = dict(ANSI_SEQUENCES)
+
+    install_modify_other_keys_aliases()
+
+    assert ANSI_SEQUENCES == snapshot


### PR DESCRIPTION
## What does this PR do?

Fixes shifted punctuation being untypeable in the interactive CLI on terminals
that speak xterm `modifyOtherKeys`.

`_enable_extended_enter_keys()` pushes modifyOtherKeys level 2 (`CSI >4;2m`) to
Ghostty, iTerm2, WezTerm, VS Code, tmux and Windows Terminal. Those terminals
then re-encode modified keys as `ESC[27;<mod>;<codepoint>~`.
`install_modify_other_keys_aliases()` maps Shift+letter but not Shift+symbol, so
on Ghostty 1.3.x pressing <kbd>Shift</kbd>+<kbd>/</kbd> inserts the literal text
`^[[27;2;63~` into the prompt instead of `?`. Same for `!` `:` `"` `_` `+` `<`
`>` `(` `)` `~` — i.e. most punctuation is unusable while the mode is active.

This is the same class of bug as #87711, which fixed it for letters only.

The symbols were skipped deliberately, with this comment:

> `Shift+digit symbols are layout-specific (US: '!', AZERTY: '¹', etc.) so they
> are NOT mapped here — if the terminal sends those under modifyOtherKeys, they
> will leak, but that's better than wrong input.`

That reasoning holds when deriving a shifted character from an **unshifted**
codepoint. But the modifyOtherKeys encoding reports the codepoint **already
shifted by the terminal**, which has applied the user's real keymap — Shift+/
on a US layout arrives as `63` (`?`), not `47` (`/`). So echoing
`chr(codepoint)` is not a layout guess; it is exactly what the terminal says was
typed, and is correct on every layout. There is no "wrong input" risk to trade
against here.

## Related Issue

Related to #87711 (same leak, letters only). No separate issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/pt_input_extras.py` — in `install_modify_other_keys_aliases()`,
  register `ESC[27;2;<cp>~` → `chr(cp)` for every printable ASCII codepoint
  (0x20–0x7E) that is not already mapped. Removed the now-obsolete "symbols are
  layout-specific" note and documented why the shifted-codepoint encoding makes
  this layout-safe.
- `tests/cli/test_cli_shift_symbol_keys.py` — new, 6 tests.

**Deliberately scoped to the modifyOtherKeys (tilde) spelling only — not
CSI-u.** The Kitty protocol reports the *unshifted* codepoint plus a shift bit,
so registering `ESC[47;2u` → `chr(47)` would type `/` for Shift+/. Kitty-protocol
terminals deliver printable keys as plain text anyway, so there is nothing to map.
A test pins this so a later "make it symmetric" refactor cannot silently break it.

Letters and Space are registered earlier in the same function and are skipped by
the `if seq not in ANSI_SEQUENCES` membership check, so this only fills genuinely
unmapped codepoints. Codepoints 9/32/127 keep their dedicated `BackTab` / `" "` /
`ControlH` meanings.

## How to Test

Reproduce (before this patch), in Ghostty:

1. Start the interactive CLI: `hermes`
2. Press <kbd>Shift</kbd>+<kbd>/</kbd> — the prompt shows `^[[27;2;63~` instead of `?`.
3. Same for <kbd>Shift</kbd>+<kbd>1</kbd>, <kbd>Shift</kbd>+<kbd>;</kbd>, <kbd>Shift</kbd>+<kbd>'</kbd> …

With the patch, each inserts the expected character.

Headless equivalent:

```python
from prompt_toolkit.input.vt100_parser import Vt100Parser
from hermes_cli.pt_input_extras import install_modify_other_keys_aliases

install_modify_other_keys_aliases()
events = []
Vt100Parser(events.append).feed_and_flush("\x1b[27;2;63~")
print([e.key for e in events])   # ['?']  (was: Escape + 9 literal chars)
```

Test suite:

```
pytest tests/cli/test_cli_shift_symbol_keys.py -q          # 6 passed
pytest tests/cli/test_ctrl_enter_newline.py \
       tests/cli/test_cli_shift_enter_newline.py \
       tests/cli/test_cli_terminal_shortcuts.py -q          # 21 passed, 2 skipped
```

The new suite covers: the shifted-symbol table; an exhaustive no-leak sweep over
all printable ASCII; Shift+letter non-regression; Space/Tab/Backspace not being
clobbered; CSI-u spellings left untouched; and installer idempotency.

Verified end-to-end on Ghostty 1.3.1 / macOS with prompt_toolkit 3.0.52.
