### PR TITLE
fix(tui): re-read profile .env on every interactive turn

### DIFF
--- a/tests/tools/test_homeassistant_tool.py
+++ b/tests/tools/test_homeassistant_tool.py
@@ -320,6 +320,34 @@ class TestCheckAvailable:
             secret_scope.reset_secret_scope(token)
             secret_scope.set_multiplex_active(False)
 
+    def test_stale_process_env_misses_env_file_until_scope_installed(
+        self, monkeypatch, tmp_path
+    ):
+        """Unscoped get_secret keeps the startup snapshot; a per-turn scope does not."""
+        from agent import secret_scope
+        from tools.homeassistant_tool import _get_config
+
+        monkeypatch.setattr("tools.homeassistant_tool._HASS_URL", "")
+        monkeypatch.setattr("tools.homeassistant_tool._HASS_TOKEN", "")
+        monkeypatch.delenv("HASS_TOKEN", raising=False)
+        monkeypatch.setenv("HASS_URL", "http://127.0.0.1:8123")
+        (tmp_path / ".env").write_text(
+            "HASS_URL=http://127.0.0.1:8123\nHASS_TOKEN=from-dotenv\n",
+            encoding="utf-8",
+        )
+
+        assert _get_config()[1] == ""
+
+        token = secret_scope.set_secret_scope(
+            secret_scope.build_profile_secret_scope(tmp_path)
+        )
+        try:
+            assert _get_config() == ("http://127.0.0.1:8123", "from-dotenv")
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+        assert _get_config()[1] == ""
+
     def test_multiplex_scope_supplies_profile_url_and_token(self, monkeypatch):
         from agent import secret_scope
         from tools.homeassistant_tool import _get_config

--- a/tests/tui_gateway/test_launch_profile_secret_scope.py
+++ b/tests/tui_gateway/test_launch_profile_secret_scope.py
@@ -1,0 +1,44 @@
+"""Launch/default-profile turns must re-read .env via secret scope (#91147)."""
+
+from pathlib import Path
+
+from agent.secret_scope import get_secret, reset_secret_scope
+from tui_gateway.server import (
+    _install_session_secret_scope,
+    _profile_home,
+    _session_home,
+)
+
+
+def test_profile_home_is_none_for_launch_profile():
+    """Unnamed/launch sessions store profile_home=None and skip the override."""
+    assert _profile_home(None) is None
+    assert _profile_home("") is None
+
+
+def test_session_home_falls_back_to_launch_home(monkeypatch, tmp_path):
+    monkeypatch.setattr("tui_gateway.server._hermes_home", tmp_path)
+    assert _session_home({"profile_home": None}) == Path(tmp_path)
+    assert _session_home({}) == Path(tmp_path)
+    other = tmp_path / "other"
+    other.mkdir()
+    assert _session_home({"profile_home": str(other)}) == other
+
+
+def test_install_session_secret_scope_rereads_env_without_process_reload(
+    monkeypatch, tmp_path
+):
+    """Edits to .env are visible on the next turn even if os.environ is stale."""
+    monkeypatch.setattr("tui_gateway.server._hermes_home", tmp_path)
+    monkeypatch.delenv("HASS_TOKEN", raising=False)
+    (tmp_path / ".env").write_text("HASS_TOKEN=added-after-start\n", encoding="utf-8")
+
+    assert get_secret("HASS_TOKEN") in (None, "")
+
+    token = _install_session_secret_scope({"profile_home": None})
+    try:
+        assert get_secret("HASS_TOKEN") == "added-after-start"
+    finally:
+        reset_secret_scope(token)
+
+    assert get_secret("HASS_TOKEN") in (None, "")

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -551,13 +551,16 @@ class ComputeHost:
         home_token = None
         secret_token = None
         try:
+            from agent.secret_scope import build_profile_secret_scope, set_secret_scope
+            from hermes_constants import get_hermes_home
+
+            secret_home = Path(profile_home) if profile_home else Path(get_hermes_home())
+            secret_token = set_secret_scope(build_profile_secret_scope(secret_home))
             if profile_home:
                 from hermes_constants import set_hermes_home_override
-                from agent.secret_scope import build_profile_secret_scope, set_secret_scope
                 from hermes_state import SessionDB
 
                 home_token = set_hermes_home_override(profile_home)
-                secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
                 # DEDICATED handle — ours only until _make_agent succeeds. Every
                 # path after that keeps the agent registered in
                 # server._sessions[sid] (via _init_session, or the fallback dict
@@ -584,9 +587,14 @@ class ComputeHost:
             if home_token is not None:
                 try:
                     from hermes_constants import reset_hermes_home_override
-                    from agent.secret_scope import reset_secret_scope
 
                     reset_hermes_home_override(home_token)
+                except Exception:
+                    pass
+            if secret_token is not None:
+                try:
+                    from agent.secret_scope import reset_secret_scope
+
                     reset_secret_scope(secret_token)
                 except Exception:
                     pass

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2332,14 +2332,12 @@ def _start_agent_build(sid: str, session: dict) -> None:
             # HERMES_HOME so config/skills/model resolve to it, and hand the
             # agent that profile's db so turns persist to the right state.db.
             session_db = None
+            try:
+                secret_token = _install_session_secret_scope(current)
+            except Exception:
+                pass
             if profile_home:
                 home_token = set_hermes_home_override(profile_home)
-                try:
-                    from agent.secret_scope import build_profile_secret_scope, set_secret_scope
-
-                    secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
-                except Exception:
-                    pass
                 try:
                     from hermes_state import SessionDB
 
@@ -7952,6 +7950,19 @@ def _session_home(session: dict) -> Path:
     return Path(profile_home) if profile_home else Path(_hermes_home)
 
 
+def _install_session_secret_scope(session: dict):
+    """Re-read this session's ``.env`` into the per-turn secret scope.
+
+    ``_profile_home`` returns None for the launch/default profile, and
+    interactive turns previously skipped ``set_secret_scope`` in that case.
+    ``get_secret`` then fell through to the process-start ``os.environ``
+    snapshot, so adding ``HASS_TOKEN`` (or any other key) to ``.env`` had no
+    effect until a full app relaunch — a gateway restart does not re-spawn
+    the desktop ``hermes serve`` backend (#91147).
+    """
+    return set_secret_scope(build_profile_secret_scope(_session_home(session)))
+
+
 def _retire_turn_marker(session: dict, *keys: str) -> None:
     """Drop the crash marker for a turn whose outcome is about to reach the client.
 
@@ -10761,7 +10772,7 @@ def _run_prompt_submit(
             _profile_home_str = session.get("profile_home")
             if _profile_home_str:
                 home_token = set_hermes_home_override(_profile_home_str)
-                secret_token = set_secret_scope(build_profile_secret_scope(Path(_profile_home_str)))
+            secret_token = _install_session_secret_scope(session)
             # The sudo password callback is thread-local (tools.terminal_tool
             # _callback_tls), so wiring it on the build thread doesn't reach this
             # turn thread — terminal sudo prompts would fall through to /dev/tty


### PR DESCRIPTION
## What does this PR do?

Desktop and `hermes serve` keep a long-lived backend whose process environment is loaded from `.env` at startup. Interactive turns for the launch/default profile never installed a per-turn secret mapping (`profile_home` is None, so `set_secret_scope` was skipped). `get_secret("HASS_TOKEN")` therefore kept the startup snapshot: adding a token to `.env` and restarting the gateway still left Home Assistant tools returning HTTP 401 until a full app quit-and-relaunch.

This installs `build_profile_secret_scope(_session_home(session))` on every interactive turn, and on compute-host agent builds, so `.env` is re-read each turn without mutating process-global `os.environ`. The compute-host `finally` resets that mapping even when there is no `profile_home` override.

## Related Issue

Fixes #91147

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py` — `_install_session_secret_scope` re-reads `<session home>/.env` on every interactive turn, including launch/default sessions with `profile_home=None`.
- `tui_gateway/compute_host.py` — same mapping when building an agent without `profile_home`; `reset_secret_scope` runs whenever a mapping was installed, not only when a home override exists.
- `tests/tui_gateway/test_launch_profile_secret_scope.py` — launch-home fallback and `.env` re-read without reloading `os.environ`.
- `tests/tools/test_homeassistant_tool.py` — `_get_config()` still sees a stale process env until the mapping is installed.

## How to Test

1. Start a long-lived backend (`hermes serve` / desktop) with `HASS_URL` set and `HASS_TOKEN` absent.
2. Call `ha_list_entities` — expect `Failed to list entities` / HTTP 401 (empty Bearer).
3. Write a valid `HASS_TOKEN` into the profile `.env` without quitting the app.
4. Call `ha_list_entities` again on the next turn — expect a successful entity list (HTTP 200). A gateway-only restart should not be required.
5. `pytest tests/tui_gateway/test_launch_profile_secret_scope.py tests/tools/test_homeassistant_tool.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
AFTER STARTUP LOAD
  os.environ HASS_TOKEN= None
  get_secret HASS_TOKEN= None
AFTER .env EDIT (no restart, no reload)
  get_secret HASS_TOKEN= None
ha_list_entities unscoped after .env edit: EXC:ClientResponseError: 401 ... auth= Bearer
ha_list_entities WITH build_profile_secret_scope: {'count': 1, ...} auth= Bearer valid-test-token
```

After the turn-path change, `_install_session_secret_scope({"profile_home": None})` returns the token from `.env` on the same process.