### PR TITLE
fix(cli): make agent_view the default for hermes slack manifest (#90979)

### DIFF
--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -42,18 +42,18 @@ def _build_full_manifest(
     for a Hermes deployment — users can tweak them in the Slack UI after
     pasting.
 
-    By default, this keeps Hermes on Slack's older Assistant messaging
-    experience (``assistant_view``) for backward compatibility. Pass
-    ``messaging_experience="agent"`` (``--agent-view``) to emit Slack's Agent
-    messaging experience (``agent_view`` + ``app_home_opened``). Pass
-    ``include_assistant=False`` or ``messaging_experience="none"``
+    By default, this emits Slack's Agent messaging experience
+    (``agent_view`` + ``app_home_opened``).  Pass
+    ``messaging_experience="assistant"`` (``--assistant-view``) to use the
+    legacy Assistant messaging experience (``assistant_view``) for existing
+    apps.  Pass ``include_assistant=False`` or ``messaging_experience="none"``
     (``--no-assistant``) to omit Slack AI messaging features and get a flat DM
     surface where ``/help``, ``/new``, etc. work inline.
     """
     from hermes_cli.commands import slack_app_manifest
 
     if messaging_experience is None:
-        messaging_experience = "assistant" if include_assistant else "none"
+        messaging_experience = "agent" if include_assistant else "none"
     messaging_experience = str(messaging_experience).strip().lower()
     if messaging_experience not in {"assistant", "agent", "none"}:
         raise ValueError(
@@ -175,13 +175,13 @@ def slack_manifest_command(args) -> int:
       --long-description-file PATH  Read the long app description from a UTF-8 file
       --slashes-only  Emit only the ``features.slash_commands`` array (for
                       merging into an existing manifest manually)
-      --no-assistant  Omit Slack AI Assistant mode (assistant_view feature,
-                      assistant:write scope, assistant_thread_* events) so
-                      DMs render as a flat chat where bare slash commands
-                      work inline instead of the Assistant thread pane.
-      --agent-view    Use Slack's Agent messaging experience (agent_view,
-                      app_home_opened + message.im) instead of the legacy
-                      Assistant messaging experience.
+      --no-assistant    Omit Slack AI messaging features (agent_view or
+                      assistant_view) so DMs render as a flat chat where
+                      bare slash commands work inline.
+      --assistant-view  Use the legacy Assistant messaging experience
+                      (assistant_view) instead of the default Agent
+                      experience.  For existing apps only — Slack no longer
+                      permits assistant_view on new apps.
     """
     name = getattr(args, "name", None) or "Hermes"
     description = getattr(args, "description", None) or "Your Hermes agent on Slack"
@@ -231,12 +231,12 @@ def slack_manifest_command(args) -> int:
             file=sys.stderr,
         )
         return 2
-    if getattr(args, "agent_view", False):
-        messaging_experience = "agent"
-    elif getattr(args, "no_assistant", False):
+    if getattr(args, "no_assistant", False):
         messaging_experience = "none"
-    else:
+    elif getattr(args, "assistant_view", False):
         messaging_experience = "assistant"
+    else:
+        messaging_experience = "agent"
 
     if getattr(args, "slashes_only", False):
         from hermes_cli.commands import slack_app_manifest

--- a/hermes_cli/subcommands/slack.py
+++ b/hermes_cli/subcommands/slack.py
@@ -83,11 +83,10 @@ def build_slack_parser(subparsers, *, cmd_slack: Callable) -> None:
         "Slack's Assistant thread pane.",
     )
     slack_messaging.add_argument(
-        "--agent-view",
+        "--assistant-view",
         action="store_true",
-        help="Emit Slack's Agent messaging experience (agent_view, "
-        "app_home_opened + message.im) instead of the legacy assistant_view "
-        "experience. This changes Slack's app messaging surface and cannot "
-        "be reversed in Slack after applying the manifest.",
+        help="Use the legacy Assistant messaging experience (assistant_view) "
+        "instead of the default Agent experience (agent_view). For existing "
+        "apps only — Slack no longer permits assistant_view on new apps.",
     )
     slack_parser.set_defaults(func=cmd_slack)


### PR DESCRIPTION
## Summary

Fixes #90979.

Slack no longer permits `assistant_view` on new apps (deprecated, removal Feb 2027). The current default sends new users to the path that Slack rejects.

Change the default messaging experience from `"assistant"` to `"agent"` so `hermes slack manifest` produces a working manifest out of the box.

## Changes

- `hermes_cli/slack_cli.py`: Default `messaging_experience` to `"agent"` instead of `"assistant"` in both `_build_full_manifest()` and the CLI handler
- `hermes_cli/slack_cli.py`: Replace `--agent-view` flag with `--assistant-view` for backward compat (existing `assistant_view` apps)
- `hermes_cli/subcommands/slack.py`: Update arg parser to match
- Update docstrings and help text to reflect new default

## Testing

- `python3 -m py_compile hermes_cli/slack_cli.py` — OK
- `python3 -m py_compile hermes_cli/subcommands/slack.py` — OK
