### PR TITLE
fix(agent): avoid false-positive tool failure on {"error": null} (#91166)

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1376,7 +1376,11 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
     if not isinstance(result, str):
         return False, ""
     lower = result[:500].lower()
-    if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):
+    if '"failed"' in lower or result.startswith("Error"):
+        return True, " [error]"
+    # Avoid false-positive on tools that serialize {"error": null} on success.
+    # Only flag when "error" appears with a truthy (non-null) value.
+    if '"error"' in lower and '"error":null' not in lower.replace(" ", ""):
         return True, " [error]"
 
     return False, ""


### PR DESCRIPTION
## Summary

Fixes #91166.

`_detect_tool_failure` string heuristic flagged any result containing the literal `"error"` in the first 500 characters. Tools like `web_extract` that serialize `{"error": null}` on success were incorrectly classified as failures, counting toward retry thresholds and triggering "stop retrying this failing tool" guidance.

## Root Cause

The generic heuristic at the end of `_detect_tool_failure()`:
```python
if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):
    return True, " [error]"
```

This matches `"error": null` — a valid success response — because it only checks for the key name, not the value.

## Fix

Add a null-value exclusion: `"error"` followed by `: null` (after whitespace collapse) is not a failure. The structured JSON check above already handles this correctly for parseable JSON; this fix closes the gap for the string heuristic fallback.

## Changes

- `agent/display.py`: Add `"error":null` exclusion to the string heuristic in `_detect_tool_failure()`

## Testing

- `python3 -m py_compile agent/display.py` — OK
- Reproducer from issue now returns `(False, "")` instead of `(True, " [error]")`
