### PR TITLE
fix(gateway,cron): split inherited PYTHONPATH before dedupe to prevent exponential growth on restart

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3533,8 +3533,8 @@ def _windows_cron_python_invocation(python_exe: str) -> tuple[str, dict[str, str
             ]
             existing_pythonpath = os.environ.get("PYTHONPATH", "")
             if existing_pythonpath:
-                pythonpath_entries.append(existing_pythonpath)
-            env_overlay["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+                pythonpath_entries.extend(existing_pythonpath.split(os.pathsep))
+            env_overlay["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath_entries))
 
     return str(interpreter), env_overlay
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -507,7 +507,7 @@ def _ensure_windows_gateway_venv_imports() -> None:
         os.environ["VIRTUAL_ENV"] = str(resolved_venv)
         pythonpath = [project_entry, site_entry]
         if os.environ.get("PYTHONPATH"):
-            pythonpath.append(os.environ["PYTHONPATH"])
+            pythonpath.extend(os.environ["PYTHONPATH"].split(os.pathsep))
         os.environ["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath))
         return
 
@@ -11392,7 +11392,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 watcher_env["VIRTUAL_ENV"] = str(venv_dir)
                 pythonpath = [str(project_root), str(site_packages)]
                 if watcher_env.get("PYTHONPATH"):
-                    pythonpath.append(watcher_env["PYTHONPATH"])
+                    pythonpath.extend(watcher_env["PYTHONPATH"].split(os.pathsep))
                 watcher_env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath))
             watcher_argv = [
                 watcher_python,


### PR DESCRIPTION
## Problem

Issue #91222: When a gateway or cron watcher inherits a non-empty `PYTHONPATH`, the inherited value was appended as a **single string element** to the candidate list. `dict.fromkeys` cannot decompose it, so every restart added another full copy. On Windows (pathsep ";") this was especially visible — `PYTHONPATH` doubled on each restart.

Example (Windows):
- Start: `PYTHONPATH=/hermes;/hermes/venv/Lib/site-packages`
- 1st restart: `/hermes;/hermes/venv/Lib/site-packages;/hermes;/hermes/venv/Lib/site-packages`
- 2nd restart: keeps doubling...

## Root Cause

The inherited `PYTHONPATH` string was appended wholesale:
```python
pythonpath = [project_entry, site_entry]
if os.environ.get("PYTHONPATH"):
    pythonpath.append(os.environ["PYTHONPATH"])  # one string, never deduped
```

`dict.fromkeys` deduplicates by whole-element identity. The composite string never equals the individual entries, so it always survives and grows.

## Fix

Split the inherited `PYTHONPATH` on `os.pathsep` **before** extending the candidate list. Each path entry then dedupes individually against the fresh entries.

```python
pythonpath = [project_entry, site_entry]
if os.environ.get("PYTHONPATH"):
    pythonpath.extend(os.environ["PYTHONPATH"].split(os.pathsep))
os.environ["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath))
```

Applied to all three affected sites:
- `gateway/run.py::_ensure_windows_gateway_venv_imports`
- `gateway/run.py::GatewayRunner._start_detached_restart_helper`
- `cron/scheduler.py::_windows_cron_python_invocation` (also adds missing `dict.fromkeys` dedupe)

## Testing

- Reproduced the bug locally: confirmed PYTHONPATH doubles each restart on the old code, stays stable on the fixed code.
- All related tests pass: `tests/gateway/test_restart_drain.py` (13 passed), `tests/hermes_cli/test_gateway_restart_loop.py` (131 passed), `tests/hermes_cli/test_spawn_gateway_restart_cooldown.py` (9 passed), `tests/hermes_cli/test_spawn_gateway_restart_reap.py` (2 passed), `tests/cron/test_cron_script.py` (27 passed), `tests/cron/` full suite (805 passed).