### PR TITLE
fix(desktop): collapse Skills Hub browser by default

### DIFF
--- a/apps/desktop/src/app/skills/embedded-hub-picker.tsx
+++ b/apps/desktop/src/app/skills/embedded-hub-picker.tsx
@@ -78,6 +78,10 @@ export const EmbeddedHubPicker = memo(function EmbeddedHubPicker({
   // every visit. Same contract as DetailPane, including the "seed collapsed
   // once, then the user's own choice always wins" defaultCollapsed pattern:
   // only a profile that has NEVER touched this pane gets the collapsed seed.
+  // Safe against a returning user's expanded choice only because $paneStates
+  // (store/panes.ts) hydrates from localStorage synchronously at module load,
+  // not in an effect — the check below always sees the real persisted value,
+  // never a pre-hydration placeholder.
   useEffect(() => {
     if ($paneState(HUB_PANE_ID).get() === undefined) {
       setPaneHeightOverride(HUB_PANE_ID, 0)

--- a/apps/desktop/src/app/skills/embedded-hub-picker.tsx
+++ b/apps/desktop/src/app/skills/embedded-hub-picker.tsx
@@ -9,7 +9,7 @@ import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
 import { $hubActions, installHubSkill, UPDATE_ALL_KEY, updateHubSkills } from '@/store/hub-actions'
 import { notify, notifyError } from '@/store/notifications'
-import { $paneHeightOverride, setPaneHeightOverride } from '@/store/panes'
+import { $paneHeightOverride, $paneState, setPaneHeightOverride } from '@/store/panes'
 
 // The REAL Skills Hub page (docs site) embedded as a one-click picker — the
 // same trick the Bot Mode agent editor uses. `?embed=picker` hides the docs
@@ -58,10 +58,10 @@ interface EmbeddedHubPickerProps {
 }
 
 /** The Skills Hub browser for the Skills tab: a resizable iframe of the live
- *  hub where every card installs with one click. Expanded by default —
- *  discovery IS the point — with a collapse toggle (persisted, like every
- *  other pane) and an update-all action. Memoized: the iframe must not sit in
- *  the parent's keystroke/re-render path. */
+ *  hub where every card installs with one click. Collapsed by default — the
+ *  installed list gets the full page until the user opts in — with an expand
+ *  toggle (persisted, like every other pane) and an update-all action.
+ *  Memoized: the iframe must not sit in the parent's keystroke/re-render path. */
 export const EmbeddedHubPicker = memo(function EmbeddedHubPicker({
   hidden = false,
   installedNames,
@@ -73,9 +73,16 @@ export const EmbeddedHubPicker = memo(function EmbeddedHubPicker({
   // $hubActions churns on every tailed log line during an install.
   const updating = useStoreSelector($hubActions, actions => actions[UPDATE_ALL_KEY]?.running ?? false)
   // Collapse state rides the same persisted height override the sash writes
-  // (0 = collapsed to the header), so "Hide the hub browser" survives tab
-  // switches and restarts instead of re-expanding — and re-loading the docs
-  // site — on every visit. Same contract as DetailPane.
+  // (0 = collapsed to the header), so "Hide"/"Browse" survives tab switches
+  // and restarts instead of resetting — and re-loading the docs site — on
+  // every visit. Same contract as DetailPane, including the "seed collapsed
+  // once, then the user's own choice always wins" defaultCollapsed pattern:
+  // only a profile that has NEVER touched this pane gets the collapsed seed.
+  useEffect(() => {
+    if ($paneState(HUB_PANE_ID).get() === undefined) {
+      setPaneHeightOverride(HUB_PANE_ID, 0)
+    }
+  }, [])
   const heightOverride = useStore($paneHeightOverride(HUB_PANE_ID))
   const height = heightOverride ?? HUB_DEFAULT_PX
   const open = height > HUB_COLLAPSED_PX

--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as HermesApi from '@/hermes'
 import { queryClient } from '@/lib/query-client'
+import { $paneStates } from '@/store/panes'
 
 const getSkills = vi.fn()
 const getToolsets = vi.fn()
@@ -95,6 +96,10 @@ beforeEach(() => {
   // Single profile by default → the scope selector stays hidden (>1 gate),
   // so existing tests see unchanged single-profile behavior.
   getProfiles.mockResolvedValue({ profiles: [{ name: 'default', is_default: true }] })
+  // The hub picker's collapsed-by-default seed only fires once per pane id
+  // (no saved state) — reset it so every test sees a fresh "never touched
+  // this pane" user, regardless of what an earlier test left behind.
+  $paneStates.set({})
 })
 
 afterEach(() => {
@@ -266,13 +271,39 @@ describe('SkillsView toolset management', () => {
     expect(await screen.findByText(/Deep research steps/)).toBeTruthy()
   })
 
+  it('hub picker starts collapsed — no iframe until the user opens it', async () => {
+    const { EmbeddedHubPicker } = await import('./embedded-hub-picker')
+
+    await act(async () => {
+      render(<EmbeddedHubPicker installedNames={new Set()} profile={null} />)
+    })
+
+    // A profile that has never touched this pane sees the full-height
+    // installed list, not the hub iframe stacked underneath it.
+    expect(document.querySelector('iframe')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Browse the full hub' })).toBeTruthy()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Browse the full hub' }))
+    })
+
+    // Opening is a real, persisted choice — the iframe mounts once asked for.
+    expect(document.querySelector('iframe')).toBeTruthy()
+  })
+
   it('hub picker refuses to reinstall an already-installed skill', async () => {
     const { notify } = await import('@/store/notifications')
     const { EmbeddedHubPicker } = await import('./embedded-hub-picker')
 
-    render(<EmbeddedHubPicker installedNames={new Set(['web-research'])} profile={null} />)
+    await act(async () => {
+      render(<EmbeddedHubPicker installedNames={new Set(['web-research'])} profile={null} />)
+    })
 
-    // The picker is expanded by default — the hub iframe is live on mount.
+    // Open the hub explicitly — it starts collapsed — before it can post any
+    // pick messages.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Browse the full hub' }))
+    })
     expect(document.querySelector('iframe')).toBeTruthy()
 
     await act(async () => {
@@ -311,6 +342,13 @@ describe('SkillsView toolset management', () => {
           </MemoryRouter>
         </QueryClientProvider>
       )
+    })
+
+    // Collapsed by default — the hub section is there but no iframe yet.
+    expect(document.querySelector('iframe')).toBeNull()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Browse the full hub' }))
     })
 
     const iframe = document.querySelector('iframe')

--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -291,6 +291,21 @@ describe('SkillsView toolset management', () => {
     expect(document.querySelector('iframe')).toBeTruthy()
   })
 
+  it('hub picker leaves an existing pane preference alone — no re-collapse on mount', async () => {
+    // A profile that already expanded the hub (persisted height override)
+    // must NOT get silently re-collapsed by the seed-once effect — only a
+    // pane with NO saved state at all gets the collapsed default.
+    $paneStates.set({ 'capabilities-hub': { open: true, heightOverride: 400 } })
+    const { EmbeddedHubPicker } = await import('./embedded-hub-picker')
+
+    await act(async () => {
+      render(<EmbeddedHubPicker installedNames={new Set()} profile={null} />)
+    })
+
+    expect(document.querySelector('iframe')).toBeTruthy()
+    expect($paneStates.get()['capabilities-hub']?.heightOverride).toBe(400)
+  })
+
   it('hub picker refuses to reinstall an already-installed skill', async () => {
     const { notify } = await import('@/store/notifications')
     const { EmbeddedHubPicker } = await import('./embedded-hub-picker')


### PR DESCRIPTION
## What does this PR do?

The Skills & Tools page renders the installed-skills list and the embedded
Skills Hub browser (an iframe of the live docs site) stacked in the same
vertical space, with the Hub **expanded by default**. On a typical laptop
screen this squeezes both into a "half page" — a cramped list on top and a
small Hub viewport below.

The hub's expand/collapse choice already persists across sessions (it rides
`$paneHeightOverride('capabilities-hub')` in the shared pane store,
`apps/desktop/src/store/panes.ts`, which is backed by `localStorage`) — the
only thing missing was starting from collapsed. This implements option 2
from the issue: "Collapse the embedded Hub by default (remember the
hide/show choice across sessions)".

The fix reuses a pattern that already exists in this codebase for exactly
this purpose — `DetailPane`'s `defaultCollapsed` prop
(`apps/desktop/src/app/master-detail.tsx:238-242`) seeds a pane's persisted
height to `0` the first time its id has no saved state, then gets out of the
way; any later user expand/collapse persists and wins from then on.
`EmbeddedHubPicker` gets the same one-time seed for its `capabilities-hub`
pane id.

Nothing else changes: the resizable sash, the "Browse the full hub" / "Hide
the hub browser" toggle, and the update-all action all work exactly as
before — only the *default* state when a profile has never touched the pane.

## Related Issue

Fixes #90767

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/skills/embedded-hub-picker.tsx`: seed the hub pane's
  persisted height to `0` (collapsed) on first touch, mirroring
  `DetailPane`'s `defaultCollapsed` pattern. Updated the file's own comments,
  which explicitly documented "expanded by default" as intentional.
- `apps/desktop/src/app/skills/index.test.tsx`: added a test that a
  never-touched profile sees no hub iframe until it clicks "Browse the full
  hub" (and that opening it is a real, persisted choice); updated two
  existing tests that asserted the iframe was live on mount to open the hub
  explicitly first; added a `beforeEach` reset of the pane store so tests
  don't leak persisted state into each other.

## How to Test

1. Open Desktop → sidebar → Skills & Tools (Skills tab) as a profile that
   has never opened this page before.
2. Before: the Hub iframe loads immediately below the installed list,
   splitting the page in half.
3. After: the installed list gets the full page; a "Browse the full hub"
   button is shown instead. Clicking it opens the Hub, and that choice
   persists across tab switches and app restarts, same as before.

Automated: `npx vitest run src/app/skills/index.test.tsx src/store/panes.test.ts`

```
 Test Files  2 passed (2)
      Tests  26 passed (26)
```

Confirmed the new/updated tests fail without the fix (reverted only
`embedded-hub-picker.tsx` to HEAD, source file only, kept the updated
tests):

```
 Test Files  1 failed (1)
      Tests  3 failed | 9 passed (12)

 FAIL  hub picker starts collapsed — no iframe until the user opens it
 FAIL  hub picker refuses to reinstall an already-installed skill
 FAIL  mounts the hub iframe lazily and keeps it (hidden) across tab switches
```

Also ran, both clean:
- `npx tsc -p . --noEmit`
- `npx eslint src/app/skills/embedded-hub-picker.tsx src/app/skills/index.test.tsx` (0 errors; pre-existing `no-restricted-globals` warnings for `document.querySelector`, consistent with the rest of the file)
- Broader regression sweep: `npx vitest run src/store/ src/app/skills/` → 94 files / 1051 tests passed

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes
- [ ] I've tested on my platform — ran in a Linux CI-style sandbox only; not manually verified on Windows (the reporter's OS) or macOS

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas changed

---
Note: this PR was prepared with AI assistance (an autonomous coding agent),
with the diff, tests, and verification steps reviewed before opening.
