### PR TITLE
fix(desktop): right rail dead at boot - self-heal visibility drift and reload a wiped in-flight tree read

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -9,9 +9,11 @@ import { type StatusbarItem } from '@/app/shell/statusbar-controls'
 import { InlinePreviewDirective } from '@/components/assistant-ui/inline-preview-directive'
 import { IdleMount } from '@/components/idle-mount'
 import { $layoutEditMode, toggleLayoutEditMode } from '@/components/pane-shell/edit-mode'
-import { allPaneIds, group, groupLeafIds, split } from '@/components/pane-shell/tree/model'
+import { allPaneIds, findGroupOfPane, group, groupLeafIds, split } from '@/components/pane-shell/tree/model'
 import { LayoutTreeRoot } from '@/components/pane-shell/tree/renderer'
 import {
+  $collapsedTreeSides,
+  $hiddenTreePanes,
   $layoutTree,
   bindPaneVisibility,
   bindToolPaneCollapse,
@@ -54,6 +56,7 @@ import {
   FILE_BROWSER_DEFAULT_WIDTH,
   FILE_BROWSER_MAX_WIDTH,
   FILE_BROWSER_MIN_WIDTH,
+  FILES_PANE_ID,
   setFileBrowserOpen,
   setSidebarOpen,
   SIDEBAR_DEFAULT_WIDTH,
@@ -594,6 +597,70 @@ bindPaneVisibility(
   () => setFileBrowserOpen(false),
   () => setFileBrowserOpen(true)
 )
+
+// Boot self-heal for the right rail. The persisted layout tree can drift out
+// of sync with the file-browser toggle (the v0.20.3 dock-enforcement
+// regressions wrote mangled trees), leaving ⌘J reading "open" over a rail
+// that renders nothing: the side collapsed, the pane chrome-hidden while a
+// workspace is active, or the pane missing from the tree entirely. When the
+// toggle says OPEN and a workspace is present, detect exactly those
+// contradictory states and route through revealTreePane — the same path a
+// layout reset takes. An explicit ⌘J collapse writes the toggle false, so
+// deliberate closes are never fought.
+const $rightRailShouldShow = computed([$hasWorkspace, $fileBrowserOpen], (ws, open) => ws && open)
+
+// Heal only during the boot / adoption window. The drift (⌘J reads open over a
+// rail that renders nothing) is a startup race, so once the app has settled we
+// must not fight a deliberate collapse — a drag on the splitter, or a workspace
+// layout that docks files away. An explicit ⌘J collapse writes the toggle
+// false and never reaches here anyway.
+const bootHealDeadline = Date.now() + 10000
+
+$rightRailShouldShow.subscribe(show => {
+  if (!show || typeof window === 'undefined') {
+    return
+  }
+
+  // Let adoption / dock enforcement settle, then judge the tree.
+  window.setTimeout(() => {
+    if (Date.now() > bootHealDeadline || !$rightRailShouldShow.get()) {
+      return
+    }
+
+    const drifted = (() => {
+      const tree = $layoutTree.get()
+      return (
+        !tree ||
+        !findGroupOfPane(tree, FILES_PANE_ID) ||
+        $collapsedTreeSides.get().has('right') ||
+        $hiddenTreePanes.get().has(FILES_PANE_ID)
+      )
+    })()
+
+    if (!drifted) {
+      return
+    }
+
+    // Re-confirm on the next tick: adoption / dock enforcement may still be
+    // flipping state, and we must not reveal against a transient.
+    window.setTimeout(() => {
+      if (Date.now() > bootHealDeadline || !$rightRailShouldShow.get()) {
+        return
+      }
+
+      const tree = $layoutTree.get()
+      const stillDrifted =
+        !tree ||
+        !findGroupOfPane(tree, FILES_PANE_ID) ||
+        $collapsedTreeSides.get().has('right') ||
+        $hiddenTreePanes.get().has(FILES_PANE_ID)
+
+      if (stillDrifted) {
+        revealTreePane(FILES_PANE_ID)
+      }
+    }, 0)
+  }, 0)
+})
 // ⌘G — the review sidebar appears/disappears (and comes to the front).
 bindPaneVisibility(
   'review',

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
@@ -440,6 +440,28 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
     void loadRoot(cwd)
   }, [connectionKey, cwd])
 
+  // Self-heal: boot-time connection events (gatewayScope change,
+  // beforeConnectionSwitch) call resetProjectTreeState(), which can invalidate
+  // an in-flight root read mid-flight; the rejected commit leaves the tree
+  // cleared (cwd='') while the workspace is still active, and nothing
+  // schedules a retry — the pane shows its loading skeleton forever. React to
+  // the cleared state itself (not just connection changes): any wipe while a
+  // cwd is present forces exactly one reload. Deliberate clears (profile
+  // switch, Home) also clear the session cwd, so the guard stays hands-off
+  // there; a same-cwd reload across a connection switch is desirable anyway.
+  useEffect(() => {
+    // A persistent load failure sets state.rootError, which the slow re-probe
+    // below already owns with multi-second backoff — bow out there so a broken
+    // backend degrades into that retry instead of this 50ms spin.
+    if (!cwd || state.rootError || state.cwd !== '' || state.rootLoading) {
+      return
+    }
+
+    const timer = window.setTimeout(() => void loadRoot(cwd, { force: true }), 50)
+
+    return () => window.clearTimeout(timer)
+  }, [cwd, state.cwd, state.rootLoading])
+
   // Self-heal: an errored root re-probes every few seconds while the tree is
   // mounted. Each attempt bumps requestId, so a persistent error re-arms the
   // timer; a success clears rootError and stops it.


### PR DESCRIPTION
Fixes #91245

## Summary

Two bounded boot-time self-heals for the right-hand file rail, each routed
through an existing recovery path:

1. **controller.tsx - rail visibility drift**: when
   `$hasWorkspace && $fileBrowserOpen` turn true, let adoption/dock-enforcement
   settle (`setTimeout 0`), then detect the contradictory states where the
   toggle reads OPEN but the rail cannot render - pane missing from the tree,
   right side collapsed, or `files` chrome-hidden - and call
   `revealTreePane(FILES_PANE_ID)`, the same path a layout reset takes. An
   explicit Cmd-J collapse writes the toggle false, so deliberate closes are
   never fought.

2. **use-project-tree.ts - skeleton stuck forever**: react to the tree atom
   being wiped while a cwd is present. Boot-time connection events
   (`gatewayScope` change, `beforeConnectionSwitch`) call
   `resetProjectTreeState()`, which can invalidate a root read that is already
   in flight; the requestId guard rejects its commit and nothing schedules a
   retry, so the pane shows `[data-slot="tree-skeleton"]` forever. The new
   effect keys on `[cwd, state.cwd, state.rootLoading]` and forces exactly one
   reload 50ms after any wipe-with-active-cwd. Deliberate clears (profile
   switch, Home) also clear the session cwd, so the guard stays hands-off
   there; a same-cwd reload across a connection switch is desirable anyway
   since the filesystem may differ.

## Root causes (details in #91245)

- `setTreePaneHidden(false)` only fronts the tab; it never un-collapses a side
  nor re-adopts a pane that left the tree, so persisted drift between
  `paneStates.v1`'s `"file-browser":{"open":true}` and `"files":{"open":false}`
  is never reconciled outside of `resetLayoutTree`.
- The requestId guard correctly rejects stale commits, but with no retry path
  a mid-flight wipe leaves `cwd=''`/`loaded=false` permanently.

## Verification

Tested on Windows 11 x64 against current `main`, desktop app rebuilt and run
with CDP instrumentation:

- Before: right rail absent, or present with `treeitems: 0` + skeleton; console
  capture shows `commit REJECTED {requestId:2, latestReq:3}` with no retry.
- After: same boot sequence logs the self-heal reload; DOM shows
  `treeitems: 22` (project dirs render), skeleton gone.
- Manual `window.hermesDesktop.readDir(cwd)` resolves in both cases, confirming
  the data layer was never at fault.
- Explicit Cmd-J close still persists `"file-browser":{"open":false}` and stays
  closed across restarts (heal condition requires the toggle true).
- `npm run typecheck` exit 0; `npx eslint` on both changed files exit 0.

## Notes

- No schema/persistence changes; both heals are runtime-only.
- The controller heal intentionally excludes the zone-minimized dimension:
  minimizing the rail row is a deliberate user gesture, and revealTreePane's
  un-minimize would fight it.
