### PR TITLE
fix(desktop): duplicate profile rows no longer appear in @ autocomplete with Bot Mode active (#88915, salvage #89019)

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-at-completions-contrib.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-at-completions-contrib.test.tsx
@@ -25,11 +25,9 @@ function addSource(id: string, provide: ComposerAtCompletionSource['provide']) {
   )
 }
 
-function gatewayStub() {
+function gatewayStub(items = [{ text: '@file:src/research-notes.md', display: 'research-notes.md', meta: 'file' }]) {
   return {
-    request: vi.fn(async () => ({
-      items: [{ text: '@file:src/research-notes.md', display: 'research-notes.md', meta: 'file' }]
-    }))
+    request: vi.fn(async () => ({ items }))
   }
 }
 
@@ -73,6 +71,24 @@ describe('contributed @ completion sources', () => {
     const rows = await searchAndRead(result, 'rese')
     expect(rows[0]).toBe('@researcher')
     expect(rows.some(l => l.includes('research-notes.md'))).toBe(true)
+  })
+
+  it('deduplicates contributed and core profile handles without collapsing distinct references', async () => {
+    vi.useFakeTimers()
+    addSource('bots', q => ('researcher'.startsWith(q) ? [{ insert: '@Researcher', meta: 'Bot · Researcher' }] : []))
+
+    const gateway = gatewayStub([
+      { text: '@researcher', display: '@researcher', meta: 'Research and intelligence analyst' },
+      { text: '@researcher-homelab', display: '@researcher-homelab', meta: 'agent profile' },
+      { text: '@file:src/researcher.md', display: 'researcher.md', meta: 'file' }
+    ])
+
+    const { result } = renderHook(() => useAtCompletions({ gateway: gateway as never, sessionId: 's1', cwd: '/repo' }))
+
+    const rows = await searchAndRead(result, 'rese')
+    expect(rows.filter(label => label.toLowerCase() === '@researcher')).toEqual(['@Researcher'])
+    expect(rows).toContain('@researcher-homelab')
+    expect(rows.some(label => label.includes('researcher.md'))).toBe(true)
   })
 
   it('drops rows when the query does not match the source filter', async () => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-at-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-at-completions.ts
@@ -15,6 +15,8 @@ import { useLiveCompletionAdapter } from './use-live-completion-adapter'
 
 const KIND_RE = /^@(file|folder|url|image|tool|git):(.*)$/
 const REF_STARTERS = new Set(['file', 'folder', 'url', 'image', 'tool', 'git'])
+// These bare tokens are context actions, not profile handles.
+const SIMPLE_CONTEXT_REFS = new Set(['@diff', '@staged'])
 
 const STARTER_META: Record<string, string> = {
   file: 'Attach a file reference',
@@ -35,6 +37,26 @@ function starterEntries(query: string): CompletionEntry[] {
     display: `@${kind}:`,
     meta: STARTER_META[kind] || ''
   }))
+}
+
+function mergeCompletionEntries(preferred: CompletionEntry[], fallback: CompletionEntry[]): CompletionEntry[] {
+  const seenHandles = new Set<string>()
+
+  return [...preferred, ...fallback].filter(entry => {
+    const key = normalize(entry.text)
+
+    if (!/^@[^:\s]+$/.test(key) || SIMPLE_CONTEXT_REFS.has(key)) {
+      return true
+    }
+
+    if (seenHandles.has(key)) {
+      return false
+    }
+
+    seenHandles.add(key)
+
+    return true
+  })
 }
 
 interface AtItemMetadata extends Record<string, string> {
@@ -147,7 +169,7 @@ export function useAtCompletions(options: {
       const extras = contributedEntries(query)
 
       if (!gateway) {
-        return { items: [...extras, ...starters], query }
+        return { items: mergeCompletionEntries(extras, starters), query }
       }
 
       const word = REF_STARTERS.has(query) ? `@${query}:` : `@${query}`
@@ -174,9 +196,9 @@ export function useAtCompletions(options: {
         const items = result.items ?? []
         const base = items.length > 0 ? items : starters
 
-        return { items: [...extras, ...base], query }
+        return { items: mergeCompletionEntries(extras, base), query }
       } catch {
-        return { items: [...extras, ...starters], query }
+        return { items: mergeCompletionEntries(extras, starters), query }
       }
     },
     [cacheKey, contributedEntries, gateway, sessionId, cwd]

--- a/contributors/emails/805041391@qq.com
+++ b/contributors/emails/805041391@qq.com
@@ -1,0 +1,1 @@
+zhongwater123


### PR DESCRIPTION
## Summary
The Desktop `@` autocomplete no longer offers the same profile handle twice when Bot Mode is active (fixes #88915). Salvages @zhongwater123's draft #89019 onto current main with authorship preserved.

Root cause: `useAtCompletions` concatenated Bot-plugin contributed rows and core gateway profile rows with no identity reconciliation, so the same bare `@handle` rendered as two selectable rows inserting identical text.

## Changes
- `use-at-completions.ts`: `mergeCompletionEntries()` dedupes case-insensitive bare `@handle` overlaps at the contributed/core merge seam — contribution order preserved (richer Bot row wins). Typed refs (`@file:`…), distinct multi-source handles (`@researcher-homelab`), and context actions (`@diff`/`@staged`) are deliberately untouched.
- `use-at-completions-contrib.test.tsx`: regression — contributed `@Researcher` + core `@researcher` collapse to one row while `@researcher-homelab` and file refs survive.

## Validation
| | Result |
|---|---|
| use-at-completions-contrib tests | 4/4 pass |
| Cherry-pick vs main | clean, 0 behind |

## Infographic

![Mention autocomplete duplicates removed](https://v3b.fal.media/files/b/0aa72be1/7UKgMV8L06X0PD7J8wCR1_vmkFEcQ7.png)
