### PR TITLE
feat(sessions): group conversations into channel-bindable spaces

### DIFF
--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -5,7 +5,8 @@ import type {
   SessionInfo,
   SessionMessage,
   SessionMessagesResponse,
-  SessionSearchResponse
+  SessionSearchResponse,
+  SessionSpace
 } from '@/types/hermes'
 
 import { hermesApi } from './client'
@@ -286,6 +287,36 @@ export function setSessionUnreadRemote(id: string, unread: boolean, profile?: st
     path: `/api/sessions/${encodeURIComponent(id)}`,
     method: 'PATCH',
     body: { unread }
+  })
+}
+
+export function listSessionSpaces(profile?: string | null): Promise<{ spaces: SessionSpace[] }> {
+  const suffix = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+
+  return hermesApi<{ spaces: SessionSpace[] }>({
+    ...(profile ? { profile } : {}),
+    path: `/api/session-spaces${suffix}`
+  })
+}
+
+export function createSessionSpace(
+  input: Pick<SessionSpace, 'name'> & Partial<Pick<SessionSpace, 'chat_id' | 'color' | 'icon' | 'platform'>>,
+  profile?: string | null
+): Promise<{ space: SessionSpace }> {
+  return hermesApi<{ space: SessionSpace }>({
+    ...(profile ? { profile } : {}),
+    path: '/api/session-spaces',
+    method: 'POST',
+    body: { ...input, ...(profile ? { profile } : {}) }
+  })
+}
+
+export function setSessionSpace(id: string, spaceId: null | string, profile?: string | null): Promise<{ ok: boolean }> {
+  return hermesApi<{ ok: boolean }>({
+    ...(profile ? { profile } : {}),
+    path: `/api/sessions/${encodeURIComponent(id)}`,
+    method: 'PATCH',
+    body: { space_id: spaceId, ...(profile ? { profile } : {}) }
   })
 }
 

--- a/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
@@ -74,6 +74,7 @@ interface Option<T extends string = string> {
 const GROUPINGS: Option<SidebarGrouping>[] = [
   { icon: 'clock', id: 'date', label: 'Updated' },
   { icon: 'root-folder', id: 'project', label: 'Project' },
+  { icon: 'symbol-namespace', id: 'space', label: 'Space' },
   { icon: 'pulse', id: 'status', label: 'Status' },
   { icon: 'account', id: 'profile', label: 'Profile' }
 ]
@@ -238,7 +239,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
                 onValueChange={value => setSidebarGrouping(value as SidebarGrouping)}
                 value={grouping}
               >
-                {GROUPINGS.map(option => (
+                {GROUPINGS.filter(option => option.id !== 'space' || !showAllProfiles).map(option => (
                   <OptionRadio key={option.id} option={option} />
                 ))}
               </DropdownMenuRadioGroup>

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -126,6 +126,7 @@ import {
   setCurrentCwd
 } from '@/store/session'
 import { $sessionDotStateById, sessionStatusBucket } from '@/store/session-dot-state'
+import { $sessionSpaces, refreshSessionSpaces } from '@/store/session-spaces'
 import { $focusedStoredSessionId, $workingSessionIds, type SplitDir } from '@/store/session-states'
 import { ackAllSessionsRead } from '@/store/session-unread'
 import { markSessionUnread } from '@/store/session-unread-remote'
@@ -388,6 +389,7 @@ export function ChatSidebar({
   const profiles = useStore($profiles)
   const profileColors = useStore($profileColors)
   const profileScope = useStore($profileScope)
+  const sessionSpaces = useStore($sessionSpaces)
   const activeConnectionId = useStore($activeConnectionId)
 
   // Toggle the persisted read-state watermark from a row menu. The row's own
@@ -411,6 +413,15 @@ export function ChatSidebar({
   // otherwise be stuck in the grouped view with no way out.
   const showAllProfiles = multiProfile && profileScope === ALL_PROFILES
   const messagingProfile = sidebarProfileForScope(profileScope)
+
+  useEffect(() => {
+    if (showAllProfiles) {
+      return
+    }
+
+    void refreshSessionSpaces(messagingProfile).catch(() => $sessionSpaces.set([]))
+  }, [messagingProfile, showAllProfiles])
+
   const agentOrderIds = useStore($sidebarSessionOrderIds)
   const agentOrderManual = useStore($sidebarSessionOrderManual)
   const workspaceOrderIds = useStore($sidebarWorkspaceOrderIds)
@@ -1274,6 +1285,36 @@ export function ChatSidebar({
     )
   }, [profileGrouped, agentSessions, profileColors])
 
+  const spaceGroups = useMemo<SidebarSessionGroup[] | undefined>(() => {
+    if (showAllProfiles || grouping !== 'space') {
+      return undefined
+    }
+
+    const names = new Map(sessionSpaces.map(space => [space.id, space]))
+    const groups = new Map<string, SidebarSessionGroup>()
+
+    for (const session of agentSessions) {
+      const id = session.space_id || '__unassigned__'
+      const space = session.space_id ? names.get(session.space_id) : undefined
+
+      const group = groups.get(id) ?? {
+        color: space?.color,
+        id,
+        label: space?.name || 'Unassigned',
+        mode: 'profile',
+        path: null,
+        sessions: []
+      }
+
+      group.sessions.push(session)
+      groups.set(id, group)
+    }
+
+    return [...groups.values()].sort((a, b) =>
+      a.id === '__unassigned__' ? 1 : b.id === '__unassigned__' ? -1 : a.label.localeCompare(b.label)
+    )
+  }, [agentSessions, grouping, sessionSpaces, showAllProfiles])
+
   // The flat Sessions list always shows ALL recent sessions; Projects is a
   // parallel grouped view, not a filter on this one — nothing is hidden here.
   const displayAgentSessions = agentSessions
@@ -1350,7 +1391,7 @@ export function ChatSidebar({
   // state-based keys stay bucketed, where they read correctly per day.
   const rankedGlobally = ordering === 'cost' || ordering === 'tokens'
 
-  const displayAgentGroups = profileGroups
+  const displayAgentGroups = spaceGroups ?? profileGroups
 
   // The recents list owns its own (virtualized) scroll container only when it's a
   // long flat list. In that case it must keep its scroller even in short mode, so

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -126,7 +126,7 @@ import {
   setCurrentCwd
 } from '@/store/session'
 import { $sessionDotStateById, sessionStatusBucket } from '@/store/session-dot-state'
-import { $sessionSpaces, refreshSessionSpaces } from '@/store/session-spaces'
+import { $sessionSpacesByScope, refreshSessionSpaces, sessionSpacesScopeKey } from '@/store/session-spaces'
 import { $focusedStoredSessionId, $workingSessionIds, type SplitDir } from '@/store/session-states'
 import { ackAllSessionsRead } from '@/store/session-unread'
 import { markSessionUnread } from '@/store/session-unread-remote'
@@ -389,7 +389,6 @@ export function ChatSidebar({
   const profiles = useStore($profiles)
   const profileColors = useStore($profileColors)
   const profileScope = useStore($profileScope)
-  const sessionSpaces = useStore($sessionSpaces)
   const activeConnectionId = useStore($activeConnectionId)
 
   // Toggle the persisted read-state watermark from a row menu. The row's own
@@ -413,14 +412,16 @@ export function ChatSidebar({
   // otherwise be stuck in the grouped view with no way out.
   const showAllProfiles = multiProfile && profileScope === ALL_PROFILES
   const messagingProfile = sidebarProfileForScope(profileScope)
+  const sessionSpacesByScope = useStore($sessionSpacesByScope)
+  const sessionSpaces = sessionSpacesByScope[sessionSpacesScopeKey(messagingProfile, activeConnectionId)] ?? []
 
   useEffect(() => {
     if (showAllProfiles) {
       return
     }
 
-    void refreshSessionSpaces(messagingProfile).catch(() => $sessionSpaces.set([]))
-  }, [messagingProfile, showAllProfiles])
+    void refreshSessionSpaces(messagingProfile).catch(() => undefined)
+  }, [activeConnectionId, messagingProfile, showAllProfiles])
 
   const agentOrderIds = useStore($sidebarSessionOrderIds)
   const agentOrderManual = useStore($sidebarSessionOrderManual)

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -44,7 +44,13 @@ import {
   setSessions
 } from '@/store/session'
 import { $sessionColorOverrides, setSessionColorOverride } from '@/store/session-color'
-import { $sessionSpaces, assignSessionSpace, createAndAssignSessionSpace } from '@/store/session-spaces'
+import {
+  $sessionSpacesByScope,
+  assignSessionSpace,
+  createAndAssignSessionSpace,
+  refreshSessionSpaces,
+  sessionSpacesScopeKey
+} from '@/store/session-spaces'
 import { $sessionTiles } from '@/store/session-states'
 import { ackStoredSessionId } from '@/store/session-unread'
 import { canOpenSessionInTerminal, canOpenSessionWindow, openSessionInTerminal } from '@/store/windows'
@@ -193,8 +199,13 @@ function MoveToSpaceItems({
   profile?: string
   sessionId: string
 }) {
-  const spaces = useStore($sessionSpaces)
+  const spacesByScope = useStore($sessionSpacesByScope)
+  const spaces = spacesByScope[sessionSpacesScopeKey(profile)] ?? []
   const session = useStore($sessions).find(item => sessionMatchesStoredId(item, sessionId))
+
+  useEffect(() => {
+    void refreshSessionSpaces(profile).catch(() => undefined)
+  }, [profile])
 
   const assign = (spaceId: null | string, label: string) => {
     triggerHaptic('selection')

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -44,6 +44,7 @@ import {
   setSessions
 } from '@/store/session'
 import { $sessionColorOverrides, setSessionColorOverride } from '@/store/session-color'
+import { $sessionSpaces, assignSessionSpace, createAndAssignSessionSpace } from '@/store/session-spaces'
 import { $sessionTiles } from '@/store/session-states'
 import { ackStoredSessionId } from '@/store/session-unread'
 import { canOpenSessionInTerminal, canOpenSessionWindow, openSessionInTerminal } from '@/store/windows'
@@ -181,6 +182,47 @@ function MoveToProjectItems({ kit, sessionId, profile }: { kit: MenuKit; session
   )
 }
 
+function MoveToSpaceItems({
+  kit,
+  onCreate,
+  profile,
+  sessionId
+}: {
+  kit: MenuKit
+  onCreate: () => void
+  profile?: string
+  sessionId: string
+}) {
+  const spaces = useStore($sessionSpaces)
+  const session = useStore($sessions).find(item => sessionMatchesStoredId(item, sessionId))
+
+  const assign = (spaceId: null | string, label: string) => {
+    triggerHaptic('selection')
+    assignSessionSpace(sessionId, spaceId, profile)
+      .then(() => notify({ durationMs: 2_000, kind: 'success', message: `Moved to ${label}` }))
+      .catch(err => notifyError(err, 'Could not update session space'))
+  }
+
+  return (
+    <>
+      {spaces.length === 0 ? (
+        <kit.Item disabled>No spaces</kit.Item>
+      ) : (
+        <kit.Item disabled={!session?.space_id} onSelect={() => assign(null, 'Unassigned')}>
+          Unassigned
+        </kit.Item>
+      )}
+      {spaces.map(space => (
+        <kit.Item disabled={space.id === session?.space_id} key={space.id} onSelect={() => assign(space.id, space.name)}>
+          {space.name}
+        </kit.Item>
+      ))}
+      <kit.Separator />
+      <kit.Item onSelect={onCreate}>New space…</kit.Item>
+    </>
+  )
+}
+
 function useSessionActions({
   sessionId,
   title,
@@ -209,6 +251,7 @@ function useSessionActions({
   // the project menu's appearance-popover guard.
   const suppressCloseFocusRef = useRef(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
+  const [createSpaceOpen, setCreateSpaceOpen] = useState(false)
   const tiles = useStore($sessionTiles)
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
   const isRemote = useStore($connection)?.mode === 'remote'
@@ -490,6 +533,23 @@ function useSessionActions({
           <MoveToProjectItems kit={kit} profile={profile} sessionId={sessionId} />
         </kit.SubContent>
       </kit.Sub>
+      <kit.Sub>
+        <kit.SubTrigger disabled={!sessionId}>
+          <Codicon name="symbol-namespace" size="0.875rem" />
+          <span>Move to space</span>
+        </kit.SubTrigger>
+        <kit.SubContent>
+          <MoveToSpaceItems
+            kit={kit}
+            onCreate={() => {
+              suppressCloseFocusRef.current = true
+              setCreateSpaceOpen(true)
+            }}
+            profile={profile}
+            sessionId={sessionId}
+          />
+        </kit.SubContent>
+      </kit.Sub>
       {tabItems.length > 0 && (
         <>
           <kit.Separator />
@@ -545,7 +605,89 @@ function useSessionActions({
     />
   )
 
-  return { deleteDialog, onCloseAutoFocus, renameDialog, renderItems }
+  const createSpaceDialog = (
+    <CreateSpaceDialog
+      onOpenChange={setCreateSpaceOpen}
+      open={createSpaceOpen}
+      profile={profile}
+      sessionId={sessionId}
+    />
+  )
+
+  return { createSpaceDialog, deleteDialog, onCloseAutoFocus, renameDialog, renderItems }
+}
+
+function CreateSpaceDialog({
+  onOpenChange,
+  open,
+  profile,
+  sessionId
+}: {
+  onOpenChange: (open: boolean) => void
+  open: boolean
+  profile?: string
+  sessionId: string
+}) {
+  const { t } = useI18n()
+  const [name, setName] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (open) {
+      setName('')
+    }
+  }, [open])
+
+  const submit = async () => {
+    const clean = name.trim()
+
+    if (!clean || submitting) {
+      return
+    }
+
+    setSubmitting(true)
+
+    try {
+      await createAndAssignSessionSpace(sessionId, clean, profile)
+      notify({ durationMs: 2_000, kind: 'success', message: `Moved to ${clean}` })
+      onOpenChange(false)
+    } catch (err) {
+      notifyError(err, 'Could not create session space')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>New session space</DialogTitle>
+        </DialogHeader>
+        <Input
+          autoFocus
+          disabled={submitting}
+          onChange={event => setName(event.target.value)}
+          onKeyDown={event => {
+            if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
+              event.preventDefault()
+              void submit()
+            }
+          }}
+          placeholder="Space name"
+          value={name}
+        />
+        <DialogFooter>
+          <Button disabled={submitting} onClick={() => onOpenChange(false)} type="button" variant="ghost">
+            {t.common.cancel}
+          </Button>
+          <Button disabled={!name.trim() || submitting} onClick={() => void submit()} type="button">
+            {t.common.save}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
 }
 
 interface DeleteSessionDialogProps {
@@ -586,7 +728,7 @@ interface SessionActionsMenuProps
 
 export function SessionActionsMenu({ children, align = 'end', sideOffset = 6, ...actions }: SessionActionsMenuProps) {
   const { t } = useI18n()
-  const { deleteDialog, onCloseAutoFocus, renameDialog, renderItems } = useSessionActions(actions)
+  const { createSpaceDialog, deleteDialog, onCloseAutoFocus, renameDialog, renderItems } = useSessionActions(actions)
 
   return (
     <>
@@ -602,6 +744,7 @@ export function SessionActionsMenu({ children, align = 'end', sideOffset = 6, ..
       </ActionsMenu>
       {renameDialog}
       {deleteDialog}
+      {createSpaceDialog}
     </>
   )
 }
@@ -612,7 +755,7 @@ interface SessionContextMenuProps extends SessionActions {
 
 export function SessionContextMenu({ children, ...actions }: SessionContextMenuProps) {
   const { t } = useI18n()
-  const { deleteDialog, onCloseAutoFocus, renameDialog, renderItems } = useSessionActions(actions)
+  const { createSpaceDialog, deleteDialog, onCloseAutoFocus, renameDialog, renderItems } = useSessionActions(actions)
 
   return (
     <>
@@ -626,6 +769,7 @@ export function SessionContextMenu({ children, ...actions }: SessionContextMenuP
       </ActionsContextMenu>
       {renameDialog}
       {deleteDialog}
+      {createSpaceDialog}
     </>
   )
 }

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -107,6 +107,7 @@ export type {
   SessionRuntimeInfo,
   SessionSearchResponse,
   SessionSearchResult,
+  SessionSpace,
   SkillHubInstalledEntry,
   SkillHubPreview,
   SkillHubResult,

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -238,7 +238,7 @@ export const $sidebarAgentsGrouped: ReadableAtom<boolean> = computed(
 /** How the recents list is divided. `date` is the sidebar's long-standing
  *  default (Today / Yesterday / Last week dividers). `profile` only means
  *  anything while the sidebar is showing every profile at once. */
-export type SidebarGrouping = 'date' | 'profile' | 'project' | 'status'
+export type SidebarGrouping = 'date' | 'profile' | 'project' | 'space' | 'status'
 /** What ranks rows within whatever grouping is active. */
 export type SidebarOrdering = 'cost' | 'created' | 'manual' | 'status' | 'tokens' | 'updated'
 /** The sort keys the menu offers; `manual` is entered by dragging, not picked. */
@@ -273,7 +273,7 @@ export const SIDEBAR_SORT_KEYS: readonly SidebarSortKey[] = ['updated', 'created
 const $sidebarFlatGrouping = persistentAtom<SidebarGrouping>(
   SIDEBAR_GROUPING_STORAGE_KEY,
   'date',
-  oneOf(['date', 'status'], 'date')
+  oneOf(['date', 'space', 'status'], 'date')
 )
 
 // All-profiles keeps its own grouping: `profile` only means anything there, and

--- a/apps/desktop/src/store/session-spaces.test.ts
+++ b/apps/desktop/src/store/session-spaces.test.ts
@@ -9,7 +9,14 @@ const state = vi.hoisted(() => ({
 
 vi.mock('@/hermes', () => ({
   createSessionSpace: state.createSessionSpace,
+  getApiRequestConnection: () => null,
   listSessionSpaces: state.listSessionSpaces,
+  profileScopeKey: (scope?: { connectionId?: null | string; profile?: null | string }) => {
+    const profile = scope?.profile?.trim() || 'default'
+    const connectionId = scope?.connectionId?.trim()
+
+    return connectionId && connectionId !== 'local' ? `${connectionId}::${profile}` : profile
+  },
   setSessionSpace: state.setSessionSpace
 }))
 
@@ -20,10 +27,11 @@ vi.mock('./session', () => ({
 }))
 
 import {
-  $sessionSpaces,
+  $sessionSpacesByScope,
   assignSessionSpace,
   createAndAssignSessionSpace,
-  refreshSessionSpaces
+  refreshSessionSpaces,
+  sessionSpacesForScope
 } from './session-spaces'
 
 const space = {
@@ -38,7 +46,7 @@ afterEach(() => {
   state.listSessionSpaces.mockReset()
   state.setSessionSpace.mockReset()
   state.sessions = [{ id: 's1', space_id: null }]
-  $sessionSpaces.set([])
+  $sessionSpacesByScope.set({})
 })
 
 describe('session spaces', () => {
@@ -48,7 +56,34 @@ describe('session spaces', () => {
     await refreshSessionSpaces('default')
 
     expect(state.listSessionSpaces).toHaveBeenCalledWith('default')
-    expect($sessionSpaces.get()).toEqual([space])
+    expect(sessionSpacesForScope('default')).toEqual([space])
+  })
+
+  it('keeps profile registries isolated when refreshes resolve out of order', async () => {
+    let resolveDefault!: (value: { spaces: typeof space[] }) => void
+    let resolveWork!: (value: { spaces: typeof space[] }) => void
+    const workSpace = { ...space, id: 'space_work', name: 'Work' }
+
+    state.listSessionSpaces.mockImplementation((profile: string) =>
+      new Promise(resolve => {
+        if (profile === 'work') {
+          resolveWork = resolve
+        } else {
+          resolveDefault = resolve
+        }
+      })
+    )
+
+    const defaultRefresh = refreshSessionSpaces('default')
+    const workRefresh = refreshSessionSpaces('work')
+
+    resolveWork({ spaces: [workSpace] })
+    await workRefresh
+    resolveDefault({ spaces: [space] })
+    await defaultRefresh
+
+    expect(sessionSpacesForScope('default')).toEqual([space])
+    expect(sessionSpacesForScope('work')).toEqual([workSpace])
   })
 
   it('rolls an optimistic assignment back when persistence fails', async () => {
@@ -68,5 +103,6 @@ describe('session spaces', () => {
     expect(state.createSessionSpace).toHaveBeenCalledWith({ name: 'Infrastructure' }, undefined)
     expect(state.setSessionSpace).toHaveBeenCalledWith('s1', 'space_1', undefined)
     expect(state.sessions[0].space_id).toBe('space_1')
+    expect(sessionSpacesForScope()).toEqual([space])
   })
 })

--- a/apps/desktop/src/store/session-spaces.test.ts
+++ b/apps/desktop/src/store/session-spaces.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const state = vi.hoisted(() => ({
+  createSessionSpace: vi.fn(),
+  listSessionSpaces: vi.fn(),
+  sessions: [{ id: 's1', space_id: null as null | string }],
+  setSessionSpace: vi.fn()
+}))
+
+vi.mock('@/hermes', () => ({
+  createSessionSpace: state.createSessionSpace,
+  listSessionSpaces: state.listSessionSpaces,
+  setSessionSpace: state.setSessionSpace
+}))
+
+vi.mock('./session', () => ({
+  setSessions: (update: (sessions: typeof state.sessions) => typeof state.sessions) => {
+    state.sessions = update(state.sessions)
+  }
+}))
+
+import {
+  $sessionSpaces,
+  assignSessionSpace,
+  createAndAssignSessionSpace,
+  refreshSessionSpaces
+} from './session-spaces'
+
+const space = {
+  created_at: 1,
+  id: 'space_1',
+  name: 'Infrastructure',
+  updated_at: 1
+}
+
+afterEach(() => {
+  state.createSessionSpace.mockReset()
+  state.listSessionSpaces.mockReset()
+  state.setSessionSpace.mockReset()
+  state.sessions = [{ id: 's1', space_id: null }]
+  $sessionSpaces.set([])
+})
+
+describe('session spaces', () => {
+  it('hydrates the backend-owned registry', async () => {
+    state.listSessionSpaces.mockResolvedValue({ spaces: [space] })
+
+    await refreshSessionSpaces('default')
+
+    expect(state.listSessionSpaces).toHaveBeenCalledWith('default')
+    expect($sessionSpaces.get()).toEqual([space])
+  })
+
+  it('rolls an optimistic assignment back when persistence fails', async () => {
+    state.setSessionSpace.mockRejectedValue(new Error('offline'))
+
+    await expect(assignSessionSpace('s1', 'space_1')).rejects.toThrow('offline')
+
+    expect(state.sessions[0].space_id).toBeNull()
+  })
+
+  it('creates a space and assigns the session without touching cwd', async () => {
+    state.createSessionSpace.mockResolvedValue({ space })
+    state.setSessionSpace.mockResolvedValue({ ok: true })
+
+    await createAndAssignSessionSpace('s1', 'Infrastructure')
+
+    expect(state.createSessionSpace).toHaveBeenCalledWith({ name: 'Infrastructure' }, undefined)
+    expect(state.setSessionSpace).toHaveBeenCalledWith('s1', 'space_1', undefined)
+    expect(state.sessions[0].space_id).toBe('space_1')
+  })
+})

--- a/apps/desktop/src/store/session-spaces.ts
+++ b/apps/desktop/src/store/session-spaces.ts
@@ -1,0 +1,52 @@
+import { atom } from 'nanostores'
+
+import { createSessionSpace, listSessionSpaces, setSessionSpace } from '@/hermes'
+import type { SessionSpace } from '@/hermes'
+
+import { setSessions } from './session'
+
+export const $sessionSpaces = atom<SessionSpace[]>([])
+
+export async function refreshSessionSpaces(profile?: string | null): Promise<void> {
+  const result = await listSessionSpaces(profile)
+
+  $sessionSpaces.set(result.spaces)
+}
+
+export async function assignSessionSpace(sessionId: string, spaceId: null | string, profile?: string): Promise<void> {
+  let previous: null | string | undefined
+
+  setSessions(current =>
+    current.map(session => {
+      if (session.id !== sessionId) {
+        return session
+      }
+
+      previous = session.space_id
+
+      return { ...session, space_id: spaceId }
+    })
+  )
+
+  try {
+    await setSessionSpace(sessionId, spaceId, profile)
+  } catch (error) {
+    setSessions(current =>
+      current.map(session => (session.id === sessionId ? { ...session, space_id: previous ?? null } : session))
+    )
+    throw error
+  }
+}
+
+export async function createAndAssignSessionSpace(
+  sessionId: string,
+  name: string,
+  profile?: string
+): Promise<SessionSpace> {
+  const { space } = await createSessionSpace({ name }, profile)
+
+  $sessionSpaces.set([...$sessionSpaces.get(), space].sort((a, b) => a.name.localeCompare(b.name)))
+  await assignSessionSpace(sessionId, space.id, profile)
+
+  return space
+}

--- a/apps/desktop/src/store/session-spaces.ts
+++ b/apps/desktop/src/store/session-spaces.ts
@@ -1,16 +1,40 @@
 import { atom } from 'nanostores'
 
-import { createSessionSpace, listSessionSpaces, setSessionSpace } from '@/hermes'
+import {
+  createSessionSpace,
+  getApiRequestConnection,
+  listSessionSpaces,
+  profileScopeKey,
+  setSessionSpace
+} from '@/hermes'
 import type { SessionSpace } from '@/hermes'
 
 import { setSessions } from './session'
 
-export const $sessionSpaces = atom<SessionSpace[]>([])
+export const $sessionSpacesByScope = atom<Record<string, SessionSpace[]>>({})
+
+const refreshRevisions = new Map<string, number>()
+
+export function sessionSpacesScopeKey(profile?: string | null, connectionId = getApiRequestConnection()): string {
+  return profileScopeKey({ connectionId, profile })
+}
+
+export function sessionSpacesForScope(profile?: string | null, connectionId = getApiRequestConnection()): SessionSpace[] {
+  return $sessionSpacesByScope.get()[sessionSpacesScopeKey(profile, connectionId)] ?? []
+}
 
 export async function refreshSessionSpaces(profile?: string | null): Promise<void> {
+  const key = sessionSpacesScopeKey(profile)
+  const revision = (refreshRevisions.get(key) ?? 0) + 1
+
+  refreshRevisions.set(key, revision)
   const result = await listSessionSpaces(profile)
 
-  $sessionSpaces.set(result.spaces)
+  if (refreshRevisions.get(key) !== revision) {
+    return
+  }
+
+  $sessionSpacesByScope.set({ ...$sessionSpacesByScope.get(), [key]: result.spaces })
 }
 
 export async function assignSessionSpace(sessionId: string, spaceId: null | string, profile?: string): Promise<void> {
@@ -44,8 +68,13 @@ export async function createAndAssignSessionSpace(
   profile?: string
 ): Promise<SessionSpace> {
   const { space } = await createSessionSpace({ name }, profile)
+  const key = sessionSpacesScopeKey(profile)
+  const current = $sessionSpacesByScope.get()[key] ?? []
 
-  $sessionSpaces.set([...$sessionSpaces.get(), space].sort((a, b) => a.name.localeCompare(b.name)))
+  $sessionSpacesByScope.set({
+    ...$sessionSpacesByScope.get(),
+    [key]: [...current, space].sort((a, b) => a.name.localeCompare(b.name))
+  })
   await assignSessionSpace(sessionId, space.id, profile)
 
   return space

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -514,6 +514,8 @@ export interface SessionInfo {
    *  elsewhere. Undefined against a backend predating the flag; treat that as
    *  "no opinion" and leave the local pin set alone. */
   pinned?: boolean
+  /** Backend-owned attention label, independent of cwd/project membership. */
+  space_id?: null | string
   /** Derived read state (backend watermark: `last_read_at` vs `last_active`,
    *  see `SessionDB.session_unread`). True when the conversation was
    *  explicitly marked unread or a response arrived after it was last read.
@@ -543,6 +545,17 @@ export interface SessionInfo {
    *  rows served by the primary/local backend. Opens must route through the
    *  connection-scoped gateway (`ensureGatewayAgent`) when present. */
   connection_id?: string
+}
+
+export interface SessionSpace {
+  chat_id?: null | string
+  color?: null | string
+  created_at: number
+  icon?: null | string
+  id: string
+  name: string
+  platform?: null | string
+  updated_at: number
 }
 
 export type TimelineDisplayMetadata =

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2075,6 +2075,10 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/v1/toolsets", self._handle_toolsets),
             ("GET", "/api/sessions", self._handle_list_sessions),
             ("POST", "/api/sessions", self._handle_create_session),
+            ("GET", "/api/session-spaces", self._handle_list_session_spaces),
+            ("POST", "/api/session-spaces", self._handle_create_session_space),
+            ("PATCH", "/api/session-spaces/{space_id}", self._handle_patch_session_space),
+            ("DELETE", "/api/session-spaces/{space_id}", self._handle_delete_session_space),
             ("GET", "/api/sessions/{session_id}", self._handle_get_session),
             ("PATCH", "/api/sessions/{session_id}", self._handle_patch_session),
             ("DELETE", "/api/sessions/{session_id}", self._handle_delete_session),
@@ -3343,7 +3347,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "output_tokens", "cache_read_tokens", "cache_write_tokens",
             "reasoning_tokens", "estimated_cost_usd", "actual_cost_usd",
             "api_call_count", "parent_session_id", "last_active", "preview",
-            "_lineage_root_id", "pinned", "archived", "hidden",
+            "_lineage_root_id", "pinned", "archived", "hidden", "space_id",
         )
         payload = {key: session.get(key) for key in safe_keys if key in session}
         # SQLite stores these as 0/1; clients reconcile against a real boolean.
@@ -3431,6 +3435,69 @@ class APIServerAdapter(BasePlatformAdapter):
             "offset": offset,
             "has_more": windowed >= limit,
         })
+
+    async def _handle_list_session_spaces(self, request: "web.Request") -> "web.Response":
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        db = await self._ensure_session_db_async()
+        if db is None:
+            return web.json_response(_openai_error("Session database unavailable", code="session_db_unavailable"), status=503)
+        return web.json_response({"spaces": await asyncio.to_thread(db.list_session_spaces)})
+
+    async def _handle_create_session_space(self, request: "web.Request") -> "web.Response":
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        body, err = await self._read_json_body(request)
+        if err:
+            return err
+        db = await self._ensure_session_db_async()
+        if db is None:
+            return web.json_response(_openai_error("Session database unavailable", code="session_db_unavailable"), status=503)
+        try:
+            space = await asyncio.to_thread(
+                db.create_session_space,
+                body.get("name"),
+                space_id=body.get("id"),
+                color=body.get("color"),
+                icon=body.get("icon"),
+                platform=body.get("platform"),
+                chat_id=body.get("chat_id"),
+            )
+        except ValueError as exc:
+            return web.json_response(_openai_error(str(exc), code="invalid_session_space"), status=400)
+        return web.json_response({"space": space}, status=201)
+
+    async def _handle_patch_session_space(self, request: "web.Request") -> "web.Response":
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        body, err = await self._read_json_body(request)
+        if err:
+            return err
+        db = await self._ensure_session_db_async()
+        if db is None:
+            return web.json_response(_openai_error("Session database unavailable", code="session_db_unavailable"), status=503)
+        try:
+            space = await asyncio.to_thread(db.update_session_space, request.match_info["space_id"], **body)
+        except KeyError:
+            return web.json_response(_openai_error("Session space not found", code="session_space_not_found"), status=404)
+        except ValueError as exc:
+            return web.json_response(_openai_error(str(exc), code="invalid_session_space"), status=400)
+        return web.json_response({"space": space})
+
+    async def _handle_delete_session_space(self, request: "web.Request") -> "web.Response":
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        db = await self._ensure_session_db_async()
+        if db is None:
+            return web.json_response(_openai_error("Session database unavailable", code="session_db_unavailable"), status=503)
+        space_id = request.match_info["space_id"]
+        if not await asyncio.to_thread(db.delete_session_space, space_id):
+            return web.json_response(_openai_error("Session space not found", code="session_space_not_found"), status=404)
+        return web.json_response({"deleted": True, "id": space_id})
 
     async def _handle_create_session(self, request: "web.Request") -> "web.Response":
         """POST /api/sessions -- create an empty Hermes session row.
@@ -3580,7 +3647,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # sweep). Rejecting them here was silently 400ing every pin the desktop
         # made, so pins only ever lived in that one app's localStorage.
         # `unread` is the read-state watermark toggle (same desktop owner).
-        allowed = {"title", "end_reason", "pinned", "archived", "hidden", "unread"}
+        allowed = {"title", "end_reason", "pinned", "archived", "hidden", "unread", "space_id"}
         unknown = sorted(set(body) - allowed)
         if unknown:
             return web.json_response(_openai_error(f"Unsupported session fields: {', '.join(unknown)}", code="unsupported_session_field"), status=400)
@@ -3605,6 +3672,13 @@ class APIServerAdapter(BasePlatformAdapter):
             await asyncio.to_thread(db.set_session_hidden, session_id, body["hidden"])
         if "unread" in body:
             await asyncio.to_thread(db.set_session_read, session_id, read=not body["unread"])
+        if "space_id" in body:
+            if body["space_id"] is not None and not isinstance(body["space_id"], str):
+                return web.json_response(_openai_error("'space_id' must be a string or null", code="invalid_session_field"), status=400)
+            try:
+                await asyncio.to_thread(db.set_session_space, session_id, body["space_id"])
+            except KeyError:
+                return web.json_response(_openai_error("Session space not found", code="session_space_not_found"), status=404)
         if body.get("end_reason"):
             await asyncio.to_thread(db.end_session, session_id, str(body["end_reason"]))
         session = await asyncio.to_thread(db.get_session, session_id) or session

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13658,6 +13658,23 @@ def main():
     sessions_rename.add_argument("session_id", help="Session ID to rename")
     sessions_rename.add_argument("title", nargs="+", help="New title for the session")
 
+    sessions_subparsers.add_parser("spaces", help="List cwd-independent session spaces")
+    sessions_space_create = sessions_subparsers.add_parser(
+        "space-create", help="Create a session space"
+    )
+    sessions_space_create.add_argument("name", help="Space name")
+    sessions_space_create.add_argument("--platform", help="Gateway platform to bind")
+    sessions_space_create.add_argument("--chat-id", help="Gateway chat/channel ID to bind")
+    sessions_space_assign = sessions_subparsers.add_parser(
+        "space-assign", help="Assign or unassign a session space"
+    )
+    sessions_space_assign.add_argument("session_id", help="Session ID or unique prefix")
+    sessions_space_assign.add_argument("space", help="Space ID/name, or 'none' to unassign")
+    sessions_space_delete = sessions_subparsers.add_parser(
+        "space-delete", help="Delete a space and unassign its sessions"
+    )
+    sessions_space_delete.add_argument("space", help="Space ID or name")
+
     sessions_pin = sessions_subparsers.add_parser(
         "pin",
         help="Pin session(s) — durable keep flag, exempt from auto-archive",

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -32,6 +32,7 @@ ProgressCallback = Callable[[dict[str, Any]], None]
 
 _CANONICAL_TABLES = (
     "system_prompts",
+    "session_spaces",
     "sessions",
     "messages",
     "session_model_usage",

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -1056,6 +1056,62 @@ def cmd_sessions(args, sessions_parser=None):
                 "but fully recoverable (nothing was deleted)."
             )
 
+    elif action in ("spaces", "space-create", "space-assign", "space-delete"):
+        def _resolve_space(value):
+            needle = str(value).strip().casefold()
+            matches = [
+                space for space in db.list_session_spaces()
+                if space["id"].casefold() == needle or space["name"].casefold() == needle
+            ]
+            return matches[0] if len(matches) == 1 else None
+
+        if action == "spaces":
+            spaces = db.list_session_spaces()
+            if not spaces:
+                print("No session spaces.")
+            for space in spaces:
+                binding = (
+                    f"  {space['platform']}:{space['chat_id']}"
+                    if space.get("platform") and space.get("chat_id")
+                    else ""
+                )
+                print(f"{space['id']}  {space['name']}{binding}")
+        elif action == "space-create":
+            try:
+                space = db.create_session_space(
+                    args.name,
+                    platform=args.platform,
+                    chat_id=args.chat_id,
+                )
+            except ValueError as exc:
+                print(f"Error: {exc}")
+                return 1
+            print(f"Created session space '{space['name']}' ({space['id']}).")
+        elif action == "space-assign":
+            session_id = db.resolve_session_id(args.session_id)
+            if not session_id:
+                print(f"Session '{args.session_id}' not found.")
+                return 1
+            if args.space.casefold() in {"none", "unassigned"}:
+                space_id = None
+                label = "Unassigned"
+            else:
+                space = _resolve_space(args.space)
+                if not space:
+                    print(f"Session space '{args.space}' not found.")
+                    return 1
+                space_id = space["id"]
+                label = space["name"]
+            db.set_session_space(session_id, space_id)
+            print(f"Assigned session '{session_id}' to {label}.")
+        else:
+            space = _resolve_space(args.space)
+            if not space:
+                print(f"Session space '{args.space}' not found.")
+                return 1
+            db.delete_session_space(space["id"])
+            print(f"Deleted session space '{space['name']}'.")
+
     elif action == "rename":
         resolved_session_id = db.resolve_session_id(args.session_id)
         if not resolved_session_id:

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -337,6 +337,8 @@ class SessionRename(BaseModel):
     # session explicitly unread, False marks it read up to now. Mirrored from
     # the Desktop sidebar's "Mark as unread"/"Mark as read". None = leave alone.
     unread: Optional[bool] = None
+    # Explicit null unassigns; omission leaves the current space untouched.
+    space_id: Optional[str] = None
     # Mutate a session belonging to another profile (opens its state.db). Omit
     # for the current/default profile.
     profile: Optional[str] = None

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -552,6 +552,60 @@ async def get_session_stats(profile: Optional[str] = None):
         db.close()
 
 
+@manage_router.get("/api/session-spaces")
+async def list_session_spaces_endpoint(profile: Optional[str] = None):
+    db = _open_session_db_for_profile(profile, read_only=True)
+    try:
+        return {"spaces": db.list_session_spaces()}
+    finally:
+        db.close()
+
+
+@manage_router.post("/api/session-spaces", status_code=201)
+async def create_session_space_endpoint(body: Dict[str, Any]):
+    payload = dict(body)
+    profile = payload.pop("profile", None)
+    db = _open_session_db_for_profile(profile, read_only=False)
+    try:
+        try:
+            return {"space": db.create_session_space(
+                payload.pop("name", None),
+                space_id=payload.pop("id", None),
+                **payload,
+            )}
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+    finally:
+        db.close()
+
+
+@manage_router.patch("/api/session-spaces/{space_id}")
+async def patch_session_space_endpoint(space_id: str, body: Dict[str, Any]):
+    payload = dict(body)
+    profile = payload.pop("profile", None)
+    db = _open_session_db_for_profile(profile, read_only=False)
+    try:
+        try:
+            return {"space": db.update_session_space(space_id, **payload)}
+        except KeyError:
+            raise HTTPException(status_code=404, detail="Session space not found")
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+    finally:
+        db.close()
+
+
+@manage_router.delete("/api/session-spaces/{space_id}")
+async def delete_session_space_endpoint(space_id: str, profile: Optional[str] = None):
+    db = _open_session_db_for_profile(profile, read_only=False)
+    try:
+        if not db.delete_session_space(space_id):
+            raise HTTPException(status_code=404, detail="Session space not found")
+        return {"ok": True}
+    finally:
+        db.close()
+
+
 @manage_router.get("/api/sessions/{session_id}")
 async def get_session_detail(session_id: str, profile: Optional[str] = None):
     db = _open_session_db_for_profile(profile, read_only=True)
@@ -703,10 +757,11 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
             and body.archived is None
             and body.pinned is None
             and body.unread is None
+            and "space_id" not in body.model_fields_set
         ):
             raise HTTPException(
                 status_code=400,
-                detail="Nothing to update; provide 'title', 'archived', 'pinned', and/or 'unread'.",
+                detail="Nothing to update; provide session metadata to change.",
             )
         if body.title is not None:
             try:
@@ -720,6 +775,11 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
             db.set_session_pinned(sid, body.pinned)
         if body.unread is not None:
             db.set_session_read(sid, read=not body.unread)
+        if "space_id" in body.model_fields_set:
+            try:
+                db.set_session_space(sid, body.space_id)
+            except KeyError:
+                raise HTTPException(status_code=404, detail="Session space not found")
         result = {"ok": True, "title": db.get_session_title(sid) or ""}
         if body.archived is not None:
             result["archived"] = bool(body.archived)
@@ -727,6 +787,8 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
             result["pinned"] = bool(body.pinned)
         if body.unread is not None:
             result["unread"] = bool(body.unread)
+        if "space_id" in body.model_fields_set:
+            result["space_id"] = body.space_id
         return result
     finally:
         db.close()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -29,6 +29,7 @@ import sqlite3
 import sys
 import threading
 import time
+import uuid
 import weakref
 from collections import deque
 from contextlib import contextmanager
@@ -4537,6 +4538,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         git_repo_root: str = None,
         origin_json: str = None,
         display_name: str = None,
+        space_id: str = None,
     ) -> None:
         """Insert a session row, enriching NULL metadata on conflict.
 
@@ -4580,9 +4582,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                    id, source, user_id, session_key, chat_id, chat_type, thread_id,
                    model, model_config, system_prompt, system_prompt_hash,
                    parent_session_id, cwd, profile_name, git_repo_root,
-                   origin_json, display_name, started_at
+                   origin_json, display_name, space_id, started_at
                 )
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?,
+                           COALESCE(?, (SELECT id FROM session_spaces
+                                        WHERE platform = ? AND chat_id = ?)), ?)
                    ON CONFLICT(id) DO UPDATE SET
                        model = COALESCE(sessions.model, excluded.model),
                        model_config = CASE
@@ -4623,7 +4627,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                        profile_name = COALESCE(sessions.profile_name, excluded.profile_name),
                        git_repo_root = COALESCE(sessions.git_repo_root, excluded.git_repo_root),
                        origin_json = COALESCE(sessions.origin_json, excluded.origin_json),
-                       display_name = COALESCE(sessions.display_name, excluded.display_name)""",
+                       display_name = COALESCE(sessions.display_name, excluded.display_name),
+                       space_id = COALESCE(sessions.space_id, excluded.space_id)""",
                 (
                     session_id,
                     source,
@@ -4641,6 +4646,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     git_repo_root,
                     origin_json,
                     display_name,
+                    space_id,
+                    source,
+                    chat_id,
                     time.time(),
                 ),
             )
@@ -4660,7 +4668,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                                           WHERE p.id = sessions.parent_session_id)),
                            profile_name = COALESCE(sessions.profile_name,
                                           (SELECT p.profile_name FROM sessions p
-                                            WHERE p.id = sessions.parent_session_id))
+                                            WHERE p.id = sessions.parent_session_id)),
+                           space_id = CASE
+                               WHEN json_type(
+                                   COALESCE(sessions.model_config, '{}'),
+                                   '$._reset_from'
+                               ) IS NULL
+                               THEN COALESCE(sessions.space_id,
+                                    (SELECT p.space_id FROM sessions p
+                                      WHERE p.id = sessions.parent_session_id))
+                               ELSE sessions.space_id
+                           END
                      WHERE id = ? AND parent_session_id IS NOT NULL""",
                     (session_id,),
                 )
@@ -4715,6 +4733,122 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """Create a new session record. Returns the session_id."""
         self._insert_session_row(session_id, source, **kwargs)
         return session_id
+
+    @staticmethod
+    def _clean_space_field(value: Optional[str], *, field: str, maximum: int) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = str(value).strip()
+        if not cleaned:
+            return None
+        if len(cleaned) > maximum or any(ch in cleaned for ch in "\r\n\x00"):
+            raise ValueError(f"Invalid space {field}")
+        return cleaned
+
+    def list_session_spaces(self) -> List[Dict[str, Any]]:
+        """Return the profile-local, cwd-independent session labels."""
+        with self._read_ctx() as conn:
+            rows = conn.execute(
+                "SELECT id, name, color, icon, platform, chat_id, created_at, updated_at "
+                "FROM session_spaces ORDER BY name COLLATE NOCASE, id"
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def create_session_space(
+        self,
+        name: str,
+        *,
+        space_id: Optional[str] = None,
+        color: Optional[str] = None,
+        icon: Optional[str] = None,
+        platform: Optional[str] = None,
+        chat_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        clean_name = self._clean_space_field(name, field="name", maximum=80)
+        if clean_name is None:
+            raise ValueError("Space name is required")
+        clean_id = self._clean_space_field(space_id, field="id", maximum=128) or f"space_{uuid.uuid4().hex}"
+        clean_color = self._clean_space_field(color, field="color", maximum=64)
+        clean_icon = self._clean_space_field(icon, field="icon", maximum=64)
+        clean_platform = self._clean_space_field(platform, field="platform", maximum=64)
+        clean_chat_id = self._clean_space_field(chat_id, field="chat_id", maximum=512)
+        if (clean_platform is None) != (clean_chat_id is None):
+            raise ValueError("platform and chat_id must be set together")
+
+        def _do(conn):
+            now = time.time()
+            try:
+                conn.execute(
+                    "INSERT INTO session_spaces "
+                    "(id, name, color, icon, platform, chat_id, created_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (clean_id, clean_name, clean_color, clean_icon, clean_platform, clean_chat_id, now, now),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise ValueError("Space name or channel binding already exists") from exc
+            if clean_platform and clean_chat_id:
+                conn.execute(
+                    "UPDATE sessions SET space_id = ? WHERE source = ? AND chat_id = ?",
+                    (clean_id, clean_platform, clean_chat_id),
+                )
+            return dict(conn.execute("SELECT * FROM session_spaces WHERE id = ?", (clean_id,)).fetchone())
+
+        return self._execute_write(_do)
+
+    def update_session_space(self, space_id: str, **changes) -> Dict[str, Any]:
+        allowed = {"name", "color", "icon", "platform", "chat_id"}
+        if not changes or set(changes) - allowed:
+            raise ValueError("Unsupported space fields")
+
+        def _do(conn):
+            current = conn.execute("SELECT * FROM session_spaces WHERE id = ?", (space_id,)).fetchone()
+            if current is None:
+                raise KeyError(space_id)
+            values = dict(current)
+            values.update(changes)
+            name = self._clean_space_field(values.get("name"), field="name", maximum=80)
+            if name is None:
+                raise ValueError("Space name is required")
+            color = self._clean_space_field(values.get("color"), field="color", maximum=64)
+            icon = self._clean_space_field(values.get("icon"), field="icon", maximum=64)
+            platform = self._clean_space_field(values.get("platform"), field="platform", maximum=64)
+            chat_id = self._clean_space_field(values.get("chat_id"), field="chat_id", maximum=512)
+            if (platform is None) != (chat_id is None):
+                raise ValueError("platform and chat_id must be set together")
+            try:
+                conn.execute(
+                    "UPDATE session_spaces SET name=?, color=?, icon=?, platform=?, chat_id=?, updated_at=? WHERE id=?",
+                    (name, color, icon, platform, chat_id, time.time(), space_id),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise ValueError("Space name or channel binding already exists") from exc
+            if platform and chat_id:
+                conn.execute(
+                    "UPDATE sessions SET space_id = ? WHERE source = ? AND chat_id = ?",
+                    (space_id, platform, chat_id),
+                )
+            return dict(conn.execute("SELECT * FROM session_spaces WHERE id = ?", (space_id,)).fetchone())
+
+        return self._execute_write(_do)
+
+    def delete_session_space(self, space_id: str) -> bool:
+        def _do(conn):
+            conn.execute("UPDATE sessions SET space_id = NULL WHERE space_id = ?", (space_id,))
+            return conn.execute("DELETE FROM session_spaces WHERE id = ?", (space_id,)).rowcount > 0
+
+        return bool(self._execute_write(_do))
+
+    def set_session_space(self, session_id: str, space_id: Optional[str]) -> bool:
+        def _do(conn):
+            if space_id is not None and conn.execute(
+                "SELECT 1 FROM session_spaces WHERE id = ?", (space_id,)
+            ).fetchone() is None:
+                raise KeyError(space_id)
+            return conn.execute(
+                "UPDATE sessions SET space_id = ? WHERE id = ?", (space_id, session_id)
+            ).rowcount > 0
+
+        return bool(self._execute_write(_do))
 
     def record_gateway_session_peer(
         self,
@@ -4802,9 +4936,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                    SET session_key = ?, source = ?, user_id = ?, chat_id = ?,
                        chat_type = ?, thread_id = ?,
                        display_name = COALESCE(?, display_name),
-                       origin_json = COALESCE(?, origin_json)
+                       origin_json = COALESCE(?, origin_json),
+                       space_id = COALESCE(space_id, (
+                           SELECT id FROM session_spaces
+                           WHERE platform = ? AND chat_id = ?
+                       ))
                    {target_clause}""",
-                query_params,
+                query_params[:-1] + [source, chat_id] + query_params[-1:]
+                if not include_compression_ancestors
+                else query_params + [source, chat_id],
             )
             # Self-heal (#82616): the UPDATE is a silent no-op when the row
             # is missing (create_session failed earlier, or a crash landed
@@ -4820,9 +4960,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         """INSERT INTO sessions (
                                id, source, user_id, session_key, chat_id,
                                chat_type, thread_id, display_name, origin_json,
-                               started_at
+                               space_id, started_at
                            )
-                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
+                                   (SELECT id FROM session_spaces
+                                    WHERE platform = ? AND chat_id = ?), ?)
                            ON CONFLICT(id) DO UPDATE SET
                                session_key = COALESCE(sessions.session_key, excluded.session_key),
                                chat_id = COALESCE(sessions.chat_id, excluded.chat_id),
@@ -4840,6 +4982,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                             thread_id,
                             display_name,
                             origin_json,
+                            source,
+                            chat_id,
                             time.time(),
                         ),
                     )

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -313,9 +313,25 @@ CREATE TABLE IF NOT EXISTS sessions (
     pinned INTEGER NOT NULL DEFAULT 0,
     hidden INTEGER NOT NULL DEFAULT 0,
     last_read_at REAL,
+    space_id TEXT,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id),
     FOREIGN KEY (system_prompt_hash) REFERENCES system_prompts(hash)
 );
+
+CREATE TABLE IF NOT EXISTS session_spaces (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL COLLATE NOCASE UNIQUE,
+    color TEXT,
+    icon TEXT,
+    platform TEXT,
+    chat_id TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_session_spaces_channel
+ON session_spaces(platform, chat_id)
+WHERE platform IS NOT NULL AND chat_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS messages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -43,6 +43,10 @@ def _create_session_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
     app.router.add_get("/api/sessions", adapter._handle_list_sessions)
     app.router.add_post("/api/sessions", adapter._handle_create_session)
+    app.router.add_get("/api/session-spaces", adapter._handle_list_session_spaces)
+    app.router.add_post("/api/session-spaces", adapter._handle_create_session_space)
+    app.router.add_patch("/api/session-spaces/{space_id}", adapter._handle_patch_session_space)
+    app.router.add_delete("/api/session-spaces/{space_id}", adapter._handle_delete_session_space)
     app.router.add_get("/api/sessions/{session_id}", adapter._handle_get_session)
     app.router.add_patch("/api/sessions/{session_id}", adapter._handle_patch_session)
     app.router.add_delete("/api/sessions/{session_id}", adapter._handle_delete_session)
@@ -80,6 +84,33 @@ async def test_capabilities_advertises_session_control_surface(adapter):
         "method": "POST",
         "path": "/v1/runs/{run_id}/steer",
     }
+
+
+@pytest.mark.asyncio
+async def test_session_space_api_assigns_session_and_rejects_duplicate_binding(adapter, session_db):
+    session_db.create_session("gateway-row", "discord", chat_id="channel-1")
+    app = _create_session_app(adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        created = await cli.post(
+            "/api/session-spaces",
+            json={"name": "Infrastructure", "platform": "discord", "chat_id": "channel-1"},
+        )
+        assert created.status == 201
+        space = (await created.json())["space"]
+
+        duplicate = await cli.post(
+            "/api/session-spaces",
+            json={"name": "Other", "platform": "discord", "chat_id": "channel-1"},
+        )
+        assert duplicate.status == 400
+
+        patched = await cli.patch("/api/sessions/gateway-row", json={"space_id": None})
+        assert patched.status == 200
+        assert (await patched.json())["session"]["space_id"] is None
+
+        listed = await cli.get("/api/session-spaces")
+        assert (await listed.json())["spaces"] == [space]
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -112,6 +112,33 @@ def _orphan_fts_schema(path: Path) -> None:
         conn.execute("PRAGMA writable_schema=OFF")
     finally:
         conn.close()
+
+
+def test_recovery_preserves_session_spaces_and_assignments(tmp_path: Path) -> None:
+    source = tmp_path / "spaces-state.db"
+    output = tmp_path / "spaces-recovered.db"
+    db = SessionDB(db_path=source)
+    try:
+        space = db.create_session_space(
+            "Infrastructure",
+            platform="discord",
+            chat_id="channel-1",
+        )
+        db.create_session("space-session", "discord", chat_id="channel-1")
+    finally:
+        db.close()
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+
+    assert report["complete"] is True
+    recovered = SessionDB(db_path=output)
+    try:
+        assert recovered.list_session_spaces() == [space]
+        assert recovered.get_session("space-session")["space_id"] == space["id"]
+    finally:
+        recovered.close()
+
+
 def _make_page_spanning_source(
     path: Path,
     message_count: int = 320,

--- a/tests/hermes_cli/test_web_session_spaces.py
+++ b/tests/hermes_cli/test_web_session_spaces.py
@@ -1,0 +1,41 @@
+import pytest
+
+from hermes_cli.web_models import SessionRename
+from hermes_cli.web_routers import sessions as routes
+from hermes_state import SessionDB
+
+
+@pytest.mark.asyncio
+async def test_dashboard_space_routes_share_assignment_with_session_rows(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path)
+    db.create_session("desktop-session", "desktop", cwd=str(tmp_path))
+    db.close()
+
+    monkeypatch.setattr(
+        routes,
+        "_open_session_db_for_profile",
+        lambda _profile=None, read_only=False: SessionDB(db_path, read_only=read_only),
+    )
+
+    created = await routes.create_session_space_endpoint(
+        {"name": "Health", "platform": "buzz", "chat_id": "channel-42"}
+    )
+    space = created["space"]
+
+    assigned = await routes.rename_session_endpoint(
+        "desktop-session",
+        SessionRename(space_id=space["id"]),
+    )
+    assert assigned["space_id"] == space["id"]
+
+    listed = await routes.list_session_spaces_endpoint()
+    assert listed["spaces"][0]["name"] == "Health"
+
+    verify = SessionDB(db_path)
+    try:
+        row = verify.get_session("desktop-session")
+        assert row["cwd"] == str(tmp_path)
+        assert row["space_id"] == space["id"]
+    finally:
+        verify.close()

--- a/tests/hermes_state/test_session_spaces.py
+++ b/tests/hermes_state/test_session_spaces.py
@@ -1,0 +1,96 @@
+from hermes_state import SessionDB
+
+
+def test_channel_binding_assigns_existing_and_future_sessions(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        db.create_session("before", "discord", chat_id="channel-1")
+        space = db.create_session_space(
+            "Infrastructure",
+            platform="discord",
+            chat_id="channel-1",
+        )
+
+        assert db.get_session("before")["space_id"] == space["id"]
+
+        db.create_session("after", "discord", chat_id="channel-1")
+        db.create_session("other", "discord", chat_id="channel-2")
+
+        assert db.get_session("after")["space_id"] == space["id"]
+        assert db.get_session("other")["space_id"] is None
+    finally:
+        db.close()
+
+
+def test_space_assignment_is_cwd_independent_and_inherited_by_children(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        space = db.create_session_space("Health")
+        db.create_session("parent", "desktop", cwd="C:/shared/repo")
+        assert db.set_session_space("parent", space["id"])
+
+        db.create_session("child", "desktop", parent_session_id="parent")
+
+        parent = db.get_session("parent")
+        child = db.get_session("child")
+        assert parent["cwd"] == child["cwd"] == "C:/shared/repo"
+        assert parent["space_id"] == child["space_id"] == space["id"]
+    finally:
+        db.close()
+
+
+def test_space_binding_is_unique_and_delete_unassigns(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        first = db.create_session_space("One", platform="telegram", chat_id="42")
+        db.create_session("bound", "telegram", chat_id="42")
+
+        try:
+            db.create_session_space("Two", platform="telegram", chat_id="42")
+        except ValueError as exc:
+            assert "already exists" in str(exc)
+        else:
+            raise AssertionError("duplicate channel binding was accepted")
+
+        assert db.delete_session_space(first["id"])
+        assert db.get_session("bound")["space_id"] is None
+    finally:
+        db.close()
+
+
+def test_gateway_peer_refresh_assigns_recovered_row(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        space = db.create_session_space("Investing", platform="slack", chat_id="C123")
+        db.create_session("recovered", "slack")
+
+        db.record_gateway_session_peer(
+            "recovered",
+            source="slack",
+            session_key="agent:main:slack:channel:C123",
+            chat_id="C123",
+            chat_type="channel",
+        )
+
+        assert db.get_session("recovered")["space_id"] == space["id"]
+    finally:
+        db.close()
+
+
+def test_reset_child_does_not_inherit_space_without_channel_binding(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        space = db.create_session_space("Health")
+        db.create_session("parent", "desktop")
+        db.set_session_space("parent", space["id"])
+
+        db.create_session(
+            "fresh",
+            "desktop",
+            parent_session_id="parent",
+            model_config={"_reset_from": "parent"},
+        )
+
+        assert db.get_session("fresh")["space_id"] is None
+    finally:
+        db.close()


### PR DESCRIPTION
## What does this PR do?

Adds backend-owned session spaces that group conversations independently of cwd. Spaces can optionally bind to one gateway channel, so inbound sessions are assigned without changing their existing session identity, while Desktop and CLI share the same persisted organization.

### Motivation

Projects model code workspaces with a unique primary path, so they cannot represent multiple attention contexts that share one cwd. Users need lightweight session grouping that remains available across CLI, gateway, REST, recovery, and Desktop instead of a renderer-only overlay.

### Behavior

- Sessions can be assigned to a named Space or left Unassigned without changing their cwd or project.
- A Space can bind to one `platform` and `chat_id`; matching gateway sessions are assigned automatically while retaining the existing gateway session key.
- Desktop groups sessions by Space and exposes create/assign actions in the session menu.
- CLI and REST clients can list, create, update, delete, and assign Spaces.
- Offline recovery preserves both the Space registry and session assignments.
- Spaces do not add per-space prompts, memory, skills, or project path semantics.

### Implementation

The shared session database owns the Space registry, nullable session assignment, and unique channel binding. Gateway ingest, recovery, CLI, and REST APIs use that shared state. Desktop caches Space data by connection and profile, guards against stale refreshes, and renders backend-owned groups.

## Related Issue

Closes #91182

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_state.py` and `hermes_state_common.py` - persist Spaces, channel bindings, and session assignments with migration-safe schema reconciliation.
- `gateway/platforms/api_server.py` - apply channel-bound Spaces to gateway-created and recovered sessions.
- `hermes_cli/` - expose Space commands, REST models/routes, and recovery support.
- `apps/desktop/src/` - add typed Space APIs, profile/connection-scoped caching, sidebar grouping, and create/assign actions.
- `tests/` and `apps/desktop/src/store/session-spaces.test.ts` - cover persistence, gateway behavior, REST, recovery, and renderer cache isolation.

## How to Test

1. Run `hermes sessions space-create Work --platform telegram --chat-id <chat-id>` and confirm `hermes sessions spaces` shows the binding.
2. Start or recover a session for that channel and confirm it retains its normal session id while receiving the Space assignment.
3. Open Desktop, group the sidebar by Space, and create, assign, or unassign a session from its action menu.
4. Automated verification already run on the final committed tip:

```bash
scripts/run_tests.sh tests/hermes_state/test_session_spaces.py tests/gateway/test_session_api.py tests/hermes_cli/test_web_session_spaces.py tests/hermes_cli/test_session_recovery.py -q
cd apps/desktop
npx vitest run src/store/session-spaces.test.ts
npm run typecheck
```

Results: 32 Python tests passed, 4 Desktop tests passed, and Desktop typecheck passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant test files and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A; CLI help and API types describe the new surface
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; existing session-store ownership is preserved
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model tool behavior changed

## Screenshots / Logs

N/A; automated backend and Desktop state tests cover the behavior.
