### PR TITLE
feat(delegation): subagents can fork the parent conversation (port of kimi-code#3007)

### DIFF
--- a/tests/tools/test_delegation_fork.py
+++ b/tests/tools/test_delegation_fork.py
@@ -1,0 +1,166 @@
+"""Tests for delegate_task fork-context snapshots (kimi-code#3007 port).
+
+Covers tools/delegation_fork.py (snapshot building, tail trimming, capping,
+inheritance framing) and the delegate_tool wiring (fork flag resolution,
+snapshot attachment, degrade-to-blank behavior).
+"""
+
+import copy
+import unittest
+from unittest.mock import MagicMock
+
+from tools.delegation_fork import (
+    DEFAULT_FORK_MAX_MESSAGES,
+    INHERITANCE_NOTICE,
+    _fork_cap,
+    _trim_incomplete_tail,
+    build_fork_snapshot,
+    frame_forked_goal,
+)
+
+
+def _mk_parent(history):
+    parent = MagicMock()
+    parent.session_id = "sess-parent"
+    db = MagicMock()
+    db.get_messages_as_conversation.return_value = history
+    parent._session_db = db
+    return parent
+
+
+class TestTrimIncompleteTail(unittest.TestCase):
+    def test_trailing_tool_results_and_dangling_call_removed(self):
+        msgs = [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "a"},
+            {"role": "user", "content": "do it"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "t1"}]},
+            {"role": "tool", "content": "partial", "tool_call_id": "t1"},
+        ]
+        trimmed = _trim_incomplete_tail(msgs)
+        # Ends at the last completed assistant reply: the trailing user
+        # prompt is dropped too, because the child's kickoff goal arrives
+        # as a user message and user;user would violate alternation.
+        self.assertEqual(len(trimmed), 2)
+        self.assertEqual(trimmed[-1]["content"], "a")
+
+    def test_clean_tail_untouched(self):
+        msgs = [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "done"},
+        ]
+        self.assertEqual(_trim_incomplete_tail(msgs), msgs)
+
+    def test_completed_tool_round_trip_kept(self):
+        msgs = [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "t1"}]},
+            {"role": "tool", "content": "res", "tool_call_id": "t1"},
+            {"role": "assistant", "content": "final answer"},
+        ]
+        self.assertEqual(_trim_incomplete_tail(msgs), msgs)
+
+
+class TestBuildForkSnapshot(unittest.TestCase):
+    def test_snapshot_strips_system_and_bookkeeping(self):
+        parent = _mk_parent([
+            {"role": "system", "content": "SYSTEM PROMPT"},
+            {"role": "user", "content": "hello", "_row_id": 5,
+             "display_kind": "x", "observed": True},
+            {"role": "assistant", "content": "hi", "message_id": "m1"},
+        ])
+        snap = build_fork_snapshot(parent)
+        self.assertEqual([m["role"] for m in snap], ["user", "assistant"])
+        for m in snap:
+            for k in ("_row_id", "display_kind", "observed", "message_id"):
+                self.assertNotIn(k, m)
+
+    def test_snapshot_trims_in_flight_delegate_call(self):
+        parent = _mk_parent([
+            {"role": "user", "content": "investigate"},
+            {"role": "assistant", "content": "findings"},
+            {"role": "user", "content": "now delegate"},
+            {"role": "assistant", "content": "",
+             "tool_calls": [{"id": "dt", "function": {"name": "delegate_task"}}]},
+        ])
+        snap = build_fork_snapshot(parent)
+        # In-flight delegate call, and the user prompt that triggered it,
+        # are trimmed to the last completed assistant reply.
+        self.assertEqual(snap[-1]["content"], "findings")
+
+    def test_no_session_db_returns_none(self):
+        parent = MagicMock()
+        parent.session_id = "s"
+        parent._session_db = None
+        self.assertIsNone(build_fork_snapshot(parent))
+
+    def test_empty_history_returns_none(self):
+        self.assertIsNone(build_fork_snapshot(_mk_parent([])))
+
+    def test_db_error_returns_none(self):
+        parent = _mk_parent([])
+        parent._session_db.get_messages_as_conversation.side_effect = RuntimeError("boom")
+        self.assertIsNone(build_fork_snapshot(parent))
+
+    def test_cap_keeps_most_recent_and_repairs_leading_tool(self):
+        history = [{"role": "user", "content": "start"}]
+        for i in range(300):
+            history.append({"role": "assistant", "content": "",
+                            "tool_calls": [{"id": f"t{i}"}]})
+            history.append({"role": "tool", "content": f"r{i}",
+                            "tool_call_id": f"t{i}"})
+        history.append({"role": "assistant", "content": "done"})
+        parent = _mk_parent(history)
+        snap = build_fork_snapshot(parent, cfg={"fork_max_messages": 50})
+        self.assertLessEqual(len(snap), 50)
+        # Must not open on a tool result without its call.
+        self.assertNotEqual(snap[0]["role"], "tool")
+        self.assertEqual(snap[-1]["content"], "done")
+
+    def test_snapshot_deep_copies(self):
+        inner = {"role": "user", "content": "x", "meta": {"a": 1}}
+        parent = _mk_parent([inner, {"role": "assistant", "content": "y"}])
+        snap = build_fork_snapshot(parent)
+        snap[0]["meta"]["a"] = 999
+        self.assertEqual(inner["meta"]["a"], 1)
+
+    def test_fork_cap_resolution(self):
+        self.assertEqual(_fork_cap(None), DEFAULT_FORK_MAX_MESSAGES)
+        self.assertEqual(_fork_cap({"fork_max_messages": 80}), 80)
+        self.assertEqual(_fork_cap({"fork_max_messages": "junk"}),
+                         DEFAULT_FORK_MAX_MESSAGES)
+        # floor
+        self.assertEqual(_fork_cap({"fork_max_messages": 1}), 10)
+
+
+class TestFrameForkedGoal(unittest.TestCase):
+    def test_notice_prefixes_goal(self):
+        framed = frame_forked_goal("summarize the findings")
+        self.assertTrue(framed.startswith(INHERITANCE_NOTICE))
+        self.assertIn("summarize the findings", framed)
+
+
+class TestDelegateToolWiring(unittest.TestCase):
+    """The fork kwarg flows registry → delegate_task → child attachment."""
+
+    def test_registry_handler_passes_fork(self):
+        import inspect
+        from tools.delegate_tool import delegate_task
+        sig = inspect.signature(delegate_task)
+        self.assertIn("fork", sig.parameters)
+
+    def test_schema_declares_fork(self):
+        from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("fork", props)
+        self.assertEqual(props["fork"]["type"], "boolean")
+        task_props = props["tasks"]["items"]["properties"]
+        self.assertIn("fork", task_props)
+
+    def test_fork_not_model_hidden(self):
+        from tools.delegate_tool import _MODEL_HIDDEN_TASK_FIELDS
+        self.assertNotIn("fork", _MODEL_HIDDEN_TASK_FIELDS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2788,10 +2788,25 @@ def _run_single_child(
             from agent.delegation_context import delegated_child_context
 
             with delegated_child_context(str(getattr(child, "session_id", "") or "")):
+                _fork_history = getattr(child, "_fork_history", None)
+                _run_kwargs: Dict[str, Any] = {}
+                _run_goal = goal
+                if isinstance(_fork_history, list) and _fork_history:
+                    # Forked spawn (kimi-code#3007 port): seed the parent's
+                    # sanitized transcript through the same
+                    # conversation_history parameter the gateway uses for
+                    # session restore, and frame the kickoff goal with the
+                    # inheritance notice so the child reads the snapshot as
+                    # reference material, not its own past actions.
+                    from tools.delegation_fork import frame_forked_goal
+
+                    _run_kwargs["conversation_history"] = _fork_history
+                    _run_goal = frame_forked_goal(goal)
                 return child.run_conversation(
-                    user_message=goal,
+                    user_message=_run_goal,
                     task_id=child_task_id,
                     stream_callback=_relay_child_text,
+                    **_run_kwargs,
                 )
 
         _child_context = contextvars.copy_context()
@@ -3605,6 +3620,7 @@ def delegate_task(
     action: Optional[str] = None,
     subagent_id: Optional[str] = None,
     message: Optional[str] = None,
+    fork: Optional[bool] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -3780,6 +3796,28 @@ def delegate_task(
     results = []
 
     n_tasks = len(task_list)
+
+    # ── Fork snapshots (kimi-code#3007 port) ────────────────────────────
+    # Top-level fork applies to the single-goal form and acts as the batch
+    # default; per-task {"fork": true/false} overrides it. The parent
+    # transcript snapshot is built ONCE and shared read-only by every
+    # forked child (each child deep-copies at seed time via the snapshot
+    # builder, and run_conversation copies again into its message list).
+    fork_flags = [
+        is_truthy_value(t.get("fork"), default=False)
+        if t.get("fork") is not None
+        else (is_truthy_value(fork, default=False) if fork is not None else False)
+        for t in task_list
+    ]
+    fork_snapshot = None
+    if any(fork_flags):
+        from tools.delegation_fork import build_fork_snapshot
+
+        fork_snapshot = build_fork_snapshot(parent_agent, cfg=cfg)
+        if fork_snapshot is None:
+            # Degrade loudly-but-safely: children spawn with blank context.
+            fork_flags = [False] * n_tasks
+
     # Track goal labels for progress display (truncated for readability)
     task_labels = [t["goal"][:40] for t in task_list]
 
@@ -3870,6 +3908,14 @@ def delegate_task(
                 child._delegate_output_schema = _task_schema
             except Exception:
                 logger.debug("Could not attach output schema to child %d", i)
+        # Forked spawn: attach the shared parent-transcript snapshot; the
+        # child seeds it via run_conversation(conversation_history=...) in
+        # _run_single_child. Absent on non-forked tasks.
+        if fork_snapshot is not None and i < len(fork_flags) and fork_flags[i]:
+            try:
+                setattr(child, "_fork_history", fork_snapshot)
+            except Exception:
+                logger.debug("Could not attach fork snapshot to child %d", i)
         # Tee the child's progress events into its live transcript log.
         # wrap_progress_callback preserves the inner callback contract
         # (including the _flush attribute) and never lets writer failures
@@ -4776,6 +4822,13 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "fork": {
+                            "type": "boolean",
+                            "description": (
+                                "Per-task fork override. See top-level 'fork' "
+                                "for semantics."
+                            ),
+                        },
                         "output_schema": {
                             "type": "object",
                             "description": (
@@ -4801,6 +4854,22 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
+            },
+            "fork": {
+                "type": "boolean",
+                "description": (
+                    "Default false: subagents start with a BLANK context and "
+                    "know nothing of this conversation. Set true to fork "
+                    "instead: the child starts from a one-time snapshot of "
+                    "this conversation's history (framed as inherited "
+                    "reference material), so work that builds on what was "
+                    "already established here needs no re-briefing. Use for "
+                    "continuations of the current investigation; keep false "
+                    "for independent tasks — a fork re-sends the parent "
+                    "transcript on the child's first request and costs "
+                    "accordingly. Per-task 'fork' in the tasks array "
+                    "overrides this default."
+                ),
             },
             "output_schema": {
                 "type": "object",
@@ -4918,6 +4987,7 @@ registry.register(
         action=args.get("action"),
         subagent_id=args.get("subagent_id"),
         message=args.get("message"),
+        fork=args.get("fork"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/delegation_fork.py
+++ b/tools/delegation_fork.py
@@ -1,0 +1,175 @@
+"""Fork-context snapshots for delegate_task subagents.
+
+Port of MoonshotAI/kimi-code#3007 ("add a fork parameter to the Agent
+tool", MIT) adapted to Hermes' delegation architecture.
+
+With ``fork: true`` on ``delegate_task`` (or on an individual batch task),
+the child starts from a one-time snapshot of the calling agent's
+conversation history instead of a blank context. The snapshot is:
+
+* read from the PARENT's session in the session DB (``hermes_state``),
+  which incremental turn persistence keeps current up to the tool calls
+  of the in-flight turn — the same durable transcript the gateway uses
+  for session restore;
+* sanitized so the child never replays live scaffolding: the parent's
+  trailing assistant message carrying the in-flight ``delegate_task``
+  tool_call can never close inside the child, so the tail is trimmed to
+  the last coherent boundary and alternation is repaired with the same
+  ``repair_message_sequence`` used for gateway session replay;
+* framed with an inheritance notice so the child treats the seeded
+  messages as reference material from its parent, not as its own past
+  actions (mirrors kimi-code's inheritance-notice framing).
+
+The snapshot is seeded through ``run_conversation(conversation_history=...)``
+— the exact parameter the gateway uses to restore sessions — so no new
+message-injection path exists and role-alternation invariants hold.
+
+Cost note: a forked child's first request re-sends the parent transcript,
+so fork is opt-in per call and bounded by ``delegation.fork_max_messages``
+(default 200 most-recent messages).
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Default cap on how many trailing parent messages a fork snapshot carries.
+DEFAULT_FORK_MAX_MESSAGES = 200
+
+# Message keys that are parent-session bookkeeping, not model context.
+_STRIP_KEYS = {"_row_id", "display_kind", "display_metadata", "observed", "message_id"}
+
+INHERITANCE_NOTICE = (
+    "You were forked from your parent agent's conversation. The messages "
+    "above are an inherited snapshot of the parent's session — treat them "
+    "as reference material describing what has already been established, "
+    "NOT as actions you performed yourself. Tool results in the snapshot "
+    "were produced by the parent. Your task follows."
+)
+
+
+def _fork_cap(cfg: Optional[Dict[str, Any]]) -> int:
+    """Resolve delegation.fork_max_messages with a safe floor."""
+    try:
+        raw = (cfg or {}).get("fork_max_messages", DEFAULT_FORK_MAX_MESSAGES)
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_FORK_MAX_MESSAGES
+    return max(10, value)
+
+
+def _trim_incomplete_tail(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Drop the parent's in-flight scaffolding from the snapshot tail.
+
+    The fork happens mid-turn: the parent's transcript ends with the
+    assistant message whose ``tool_calls`` include the very
+    ``delegate_task`` call being executed (and possibly tool results for
+    sibling calls in the same batch). Those calls can never be closed
+    inside the child, and an assistant tool_calls message without a
+    complete set of tool responses is a wire-invalid tail. Trim
+    backwards past any trailing tool results and the dangling
+    assistant-with-tool_calls message to the last coherent boundary.
+    """
+    msgs = list(messages)
+    while msgs:
+        tail = msgs[-1]
+        role = tail.get("role")
+        if role == "assistant" and not tail.get("tool_calls"):
+            # Coherent boundary: a completed assistant reply. The child's
+            # kickoff goal is appended as a user message by
+            # run_conversation, so the snapshot must end here — a trailing
+            # user message (the parent-turn prompt that triggered this
+            # delegation) or a dangling tool_calls/tool tail would break
+            # role alternation or tool-call adjacency in the child.
+            break
+        if role == "assistant" and tail.get("tool_calls"):
+            # Dangling call (the in-flight delegate_task itself, or a call
+            # whose responses were trimmed below it). Drop and continue —
+            # this can expose another incomplete boundary above.
+            msgs.pop()
+            continue
+        # tool results without their call kept, user prompts, anything else.
+        msgs.pop()
+    return msgs
+
+
+def build_fork_snapshot(
+    parent_agent: Any,
+    *,
+    cfg: Optional[Dict[str, Any]] = None,
+) -> Optional[List[Dict[str, Any]]]:
+    """Build a sanitized copy of the parent's conversation for a forked child.
+
+    Returns ``None`` (fork degrades to a normal blank-context spawn, with a
+    log line) when the parent has no session DB, no session id, or an empty
+    transcript — never raises into the delegation path.
+    """
+    session_db = getattr(parent_agent, "_session_db", None)
+    session_id = getattr(parent_agent, "session_id", None)
+    if session_db is None or not session_id:
+        logger.info(
+            "fork requested but parent has no session DB/session id; "
+            "spawning with blank context"
+        )
+        return None
+
+    try:
+        history = session_db.get_messages_as_conversation(
+            str(session_id),
+            include_ancestors=True,
+            repair_alternation=True,
+        )
+    except Exception as exc:
+        logger.warning(
+            "fork snapshot read failed for session %s: %s; spawning with "
+            "blank context",
+            session_id,
+            exc,
+        )
+        return None
+
+    if not history:
+        logger.info(
+            "fork requested but parent session %s has no persisted messages; "
+            "spawning with blank context",
+            session_id,
+        )
+        return None
+
+    snapshot: List[Dict[str, Any]] = []
+    for msg in history:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if role == "system":
+            # The child builds its own system prompt; the parent's must not
+            # be replayed as history.
+            continue
+        clean = {k: v for k, v in msg.items() if k not in _STRIP_KEYS}
+        snapshot.append(copy.deepcopy(clean))
+
+    snapshot = _trim_incomplete_tail(snapshot)
+    if not snapshot:
+        return None
+
+    cap = _fork_cap(cfg)
+    if len(snapshot) > cap:
+        snapshot = snapshot[-cap:]
+        # Never open on a dangling tool/assistant-tool_calls boundary after
+        # the cut: drop leading tool results without a preceding call.
+        while snapshot and snapshot[0].get("role") == "tool":
+            snapshot.pop(0)
+        snapshot = _trim_incomplete_tail(snapshot)
+        if not snapshot:
+            return None
+
+    return snapshot
+
+
+def frame_forked_goal(goal: str) -> str:
+    """Prefix the child's kickoff goal with the inheritance notice."""
+    return f"{INHERITANCE_NOTICE}\n\nYOUR TASK:\n{goal}"

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2499,6 +2499,7 @@ delegation:
   worktree_isolation: false                 # Give each child its own git worktree branched from HEAD (local backend + git repos only; inspired by Muse Code). See Subagent Delegation → Worktree Isolation.
   max_spawn_depth: 1                        # Delegation tree depth cap (1-3, clamped). 1 = flat (default): parent spawns leaves that cannot delegate. 2 = orchestrator children can spawn leaf grandchildren. 3 = three levels.
   orchestrator_enabled: true                # Global kill switch. When false, role="orchestrator" is ignored and every child is forced to leaf regardless of max_spawn_depth.
+  fork_max_messages: 200                    # Cap on parent-transcript messages seeded into a forked child (delegate_task fork: true). Floor 10. See Subagent Delegation → Forked Subagents.
 ```
 
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -33,8 +33,8 @@ delegate_task(tasks=[
 
 ## How Subagent Context Works
 
-:::warning Critical: Subagents Know Nothing
-Subagents start with a **completely fresh conversation**. They have zero knowledge of the parent's conversation history, prior tool calls, or anything discussed before delegation. The subagent's only context comes from the `goal` and `context` fields the parent agent populates when it calls `delegate_task`.
+:::warning Critical: Subagents Know Nothing (unless you fork)
+Subagents start with a **completely fresh conversation**. They have zero knowledge of the parent's conversation history, prior tool calls, or anything discussed before delegation. The subagent's only context comes from the `goal` and `context` fields the parent agent populates when it calls `delegate_task` — unless the call sets `fork: true` (see below).
 :::
 
 This means the parent agent must pass **everything** the subagent needs in the call:
@@ -55,6 +55,29 @@ delegate_task(
 ```
 
 The subagent receives a focused system prompt built from your goal and context, instructing it to complete the task and provide a structured summary of what it did, what it found, any files modified, and any issues encountered.
+
+## Forked Subagents (`fork: true`)
+
+For work that *builds on the current conversation* — continuing an investigation, acting on findings already established — re-briefing everything into `context` is lossy and token-expensive. Set `fork: true` and the child instead starts from a one-time snapshot of the parent's conversation history:
+
+```python
+delegate_task(
+    goal="Write the full report on option B using everything we established above",
+    fork=True,
+)
+```
+
+How it works:
+
+- The snapshot is read from the parent's persisted session transcript and trimmed to the last *completed* assistant reply — the in-flight `delegate_task` tool call (which can never close inside the child), dangling tool results, and the triggering user prompt are removed so message-role alternation stays valid.
+- The parent's system prompt is never replayed; the child builds its own focused system prompt as usual.
+- The child's kickoff message is prefixed with an inheritance notice framing the seeded messages as *reference material produced by the parent*, not the child's own actions.
+- In a batch, top-level `fork` is the default and each task may override it with its own `fork` field — so one fan-out can mix forked continuations with blank-context workers.
+- The snapshot is capped to the most recent messages (`delegation.fork_max_messages` in `config.yaml`, default 200).
+
+**Cost note:** a forked child's first request re-sends the parent transcript. Keep `fork` off (the default) for independent tasks; use it when re-briefing would lose important nuance.
+
+If the parent has no persisted session (rare: in-memory only runs), fork degrades gracefully to a normal blank-context spawn and logs the reason.
 
 ## Practical Examples
 


### PR DESCRIPTION
## Summary

`delegate_task` gains a `fork` parameter: subagents can now start from a one-time snapshot of the parent's conversation instead of a blank context, so work that builds on the current session no longer needs lossy, token-expensive re-briefing. Port of MoonshotAI/kimi-code#3007 (this week's flagship feature in their Agent tool, MIT) adapted to Hermes' delegation architecture.

## Changes

- `tools/delegation_fork.py` (new, ~180 LOC): builds the sanitized parent snapshot —
  - read from the parent's **persisted session transcript** (`get_messages_as_conversation(include_ancestors=True, repair_alternation=True)`), the same durable source the gateway uses for session restore;
  - parent's system prompt stripped (the child builds its own focused prompt); per-row bookkeeping keys (`_row_id`, `display_kind`, …) removed; deep-copied;
  - tail trimmed to the last **completed assistant reply**: the in-flight `delegate_task` tool_call (which can never close inside the child), dangling tool results, and the triggering user prompt are removed so role alternation and tool-call adjacency stay wire-valid — mirrors kimi-code's mid-turn trailing-message handling;
  - capped to `delegation.fork_max_messages` most-recent messages (default 200, floor 10), with post-cut boundary repair;
  - kickoff goal framed with an inheritance notice (snapshot = parent's reference material, not the child's own actions) — kimi-code's framing, adapted.
- `tools/delegate_tool.py`: `fork` kwarg end-to-end (registry handler → `delegate_task` → child attachment → `_run_single_child` seeds via `run_conversation(conversation_history=...)` — the existing gateway-restore parameter, no new injection path). Top-level `fork` is the batch default; per-task `fork` overrides. Missing session DB / empty transcript degrades to a blank-context spawn with a log line. Schema documents the cost trade-off so models keep fork off for independent tasks.
- Docs in the same PR: `features/delegation.md` (new "Forked Subagents" section, warning-box update) and `configuration.md` (`delegation.fork_max_messages`).
- `tests/tools/test_delegation_fork.py`: 15 tests — tail trimming (dangling call, completed round-trip, trailing user prompt), system/bookkeeping stripping, cap + post-cut repair, deep-copy isolation, degrade paths (no DB, empty history, DB error), schema/signature wiring.

## Validation

| | Before | After |
|---|---|---|
| Continue-the-investigation delegation | full manual re-brief in `context` | `fork: true` seeds parent transcript |
| Independent tasks | blank context | unchanged (fork defaults off) |
| Mid-turn scaffolding in snapshot | n/a | trimmed to last completed assistant reply |
| Parent prompt cache | n/a | untouched (parent context never mutated) |

Targeted suites: 128 passed (`test_delegation_fork`, `test_delegate`, `test_delegate_summary_budget`, `test_delegate_toolset_scope`, `test_delegate_composite_toolsets`, `test_delegate_control_actions`). E2E through the real `delegate_task` → `_run_single_child` → `run_conversation` chain with a session-DB-backed parent: snapshot seeded, roles `[user, assistant]`, system prompt absent, kickoff prefixed with the inheritance notice.

Source: [MoonshotAI/kimi-code#3007](https://github.com/MoonshotAI/kimi-code/pull/3007)

## Infographic

![Forked subagents schematic](https://v3b.fal.media/files/b/0aa72c16/oMLgc2x2_WjHFWb0EQunD_m8fpLwu4.png)
