### PR TITLE
fix(browser): provision headless Chrome for browser-use on headless Linux

### DIFF
--- a/tests/tools/test_browser_headless.py
+++ b/tests/tools/test_browser_headless.py
@@ -1,0 +1,132 @@
+"""Tests for headless-Chrome provisioning for the Browser Use backend.
+
+Regression guard for the "browser_exec fails on a headless VPS with
+'chrome-not-running'" bug — the browser-use harness's local mode needs a GUI
+Chrome, so on Linux with no display Hermes must provision a detached headless
+Chrome and point the harness at it via BU_CDP_URL.
+"""
+
+import pytest
+
+from tools import browser_headless as bh
+
+
+class TestIsHeadlessLinux:
+    def test_true_on_linux_without_display(self, monkeypatch):
+        monkeypatch.setattr(bh.sys, "platform", "linux")
+        monkeypatch.delenv("DISPLAY", raising=False)
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        assert bh.is_headless_linux() is True
+
+    def test_false_with_display(self, monkeypatch):
+        monkeypatch.setattr(bh.sys, "platform", "linux")
+        monkeypatch.setenv("DISPLAY", ":0")
+        assert bh.is_headless_linux() is False
+
+    def test_false_on_non_linux(self, monkeypatch):
+        monkeypatch.setattr(bh.sys, "platform", "darwin")
+        monkeypatch.delenv("DISPLAY", raising=False)
+        assert bh.is_headless_linux() is False
+
+
+class TestFindChromiumBinary:
+    def test_env_override_wins(self, monkeypatch, tmp_path):
+        fake = tmp_path / "chrome"
+        fake.write_text("")
+        monkeypatch.setenv("BH_CHROME_PATH", str(fake))
+        assert bh._find_chromium_binary() == str(fake)
+
+    def test_system_chrome_in_path(self, monkeypatch):
+        for key in ("AGENT_BROWSER_EXECUTABLE_PATH", "BH_CHROME_PATH", "CHROME_PATH"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setattr(
+            bh.shutil,
+            "which",
+            lambda name: "/usr/bin/google-chrome" if name == "google-chrome" else None,
+        )
+        assert bh._find_chromium_binary() == "/usr/bin/google-chrome"
+
+    def test_playwright_cache_fallback(self, monkeypatch, tmp_path):
+        for key in ("AGENT_BROWSER_EXECUTABLE_PATH", "BH_CHROME_PATH", "CHROME_PATH"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setattr(bh.shutil, "which", lambda name: None)
+        build = tmp_path / "chromium-1208" / "chrome-linux64"
+        build.mkdir(parents=True)
+        binary = build / "chrome"
+        binary.write_text("")
+        # _find_chromium_binary imports _chromium_search_roots lazily from
+        # browser_tool, so patch it at the source.
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_chromium_search_roots", lambda: [str(tmp_path)])
+        assert bh._find_chromium_binary() == str(binary)
+
+
+class TestEnsureHeadlessChrome:
+    def test_noop_when_not_headless(self, monkeypatch):
+        monkeypatch.setattr(bh, "is_headless_linux", lambda: False)
+        env = {}
+        assert bh.ensure_headless_chrome(env) is None
+        assert "BU_CDP_URL" not in env
+
+    def test_noop_when_cdp_url_already_set(self, monkeypatch):
+        monkeypatch.setattr(bh, "is_headless_linux", lambda: True)
+        env = {"BU_CDP_URL": "http://127.0.0.1:9222"}
+        assert bh.ensure_headless_chrome(env) is None
+        assert env["BU_CDP_URL"] == "http://127.0.0.1:9222"
+
+    def test_noop_when_cloud_autospawn_set(self, monkeypatch):
+        monkeypatch.setattr(bh, "is_headless_linux", lambda: True)
+        env = {"BU_AUTOSPAWN": "1"}
+        assert bh.ensure_headless_chrome(env) is None
+        assert "BU_CDP_URL" not in env
+
+    def test_reuses_running_chrome_without_relaunch(self, monkeypatch):
+        monkeypatch.setattr(bh, "is_headless_linux", lambda: True)
+        monkeypatch.setattr(bh, "_cdp_ready", lambda: True)
+        launched = []
+        monkeypatch.setattr(bh, "_launch", lambda binary: launched.append(binary) or True)
+        env = {}
+        assert bh.ensure_headless_chrome(env) is None
+        assert env["BU_CDP_URL"] == bh._CDP_URL
+        assert launched == []  # nothing re-launched
+
+    def test_launches_and_sets_env_when_cdp_comes_up(self, monkeypatch):
+        monkeypatch.setattr(bh, "is_headless_linux", lambda: True)
+        monkeypatch.setattr(bh, "_find_chromium_binary", lambda: "/usr/bin/chromium")
+        states = {"ready": False}
+
+        def launch_then_ready(binary):
+            states["ready"] = True
+            return True
+
+        monkeypatch.setattr(bh, "_launch", launch_then_ready)
+        monkeypatch.setattr(bh, "_cdp_ready", lambda: states["ready"])
+
+        env = {}
+        assert bh.ensure_headless_chrome(env) is None
+        assert env["BU_CDP_URL"] == bh._CDP_URL
+
+    def test_error_when_no_chromium_and_no_autoinstall(self, monkeypatch):
+        monkeypatch.setattr(bh, "is_headless_linux", lambda: True)
+        monkeypatch.setattr(bh, "_cdp_ready", lambda: False)
+        monkeypatch.setattr(bh, "_find_chromium_binary", lambda: None)
+
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_chromium_installed", lambda: False)
+        monkeypatch.setattr(bt, "_maybe_autoinstall_chromium", lambda: False)
+
+        err = bh.ensure_headless_chrome({})
+        assert err is not None
+        assert "Chrome/Chromium" in err
+
+    def test_error_when_launch_fails(self, monkeypatch):
+        monkeypatch.setattr(bh, "is_headless_linux", lambda: True)
+        monkeypatch.setattr(bh, "_cdp_ready", lambda: False)
+        monkeypatch.setattr(bh, "_find_chromium_binary", lambda: "/usr/bin/chromium")
+        monkeypatch.setattr(bh, "_launch", lambda binary: False)
+
+        err = bh.ensure_headless_chrome({})
+        assert err is not None
+        assert "failed to launch" in err

--- a/tools/browser_headless.py
+++ b/tools/browser_headless.py
@@ -1,0 +1,192 @@
+"""Provision a local headless Chrome for the Browser Use backend on headless Linux.
+
+The browser-use harness's "local" mode assumes a GUI: it launches a windowed
+Chrome and waits for the user to click "Allow remote debugging". On a headless
+Linux VPS there is no ``DISPLAY``, so that path can never work and
+``browser_exec`` fails with "chrome-not-running".
+
+This module closes that gap. When Hermes runs on headless Linux with no
+cloud/CDP backend configured, it provisions a detached headless Chrome on a
+local CDP port (a non-default ``--user-data-dir``, since Chrome 136+ refuses
+``--remote-debugging-port`` on the default profile) and points the harness at
+it via ``BU_CDP_URL``. Concurrent calls reuse the already-running Chrome
+instead of spawning duplicates.
+"""
+
+import glob
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+import urllib.request
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Fixed port so later calls detect and reuse an already-running Chrome. It
+# matches the browser-harness daemon's own default local probe port.
+_HEADLESS_PORT = 9222
+_CDP_URL = f"http://127.0.0.1:{_HEADLESS_PORT}"
+
+_SYSTEM_CHROME_NAMES = (
+    "google-chrome",
+    "google-chrome-stable",
+    "chromium",
+    "chromium-browser",
+    "chrome",
+)
+
+
+def is_headless_linux() -> bool:
+    """True on Linux with no display server (a VPS/container over SSH)."""
+    return (
+        sys.platform == "linux"
+        and not os.environ.get("DISPLAY")
+        and not os.environ.get("WAYLAND_DISPLAY")
+    )
+
+
+def _profile_dir() -> str:
+    from hermes_constants import get_hermes_home
+
+    return os.path.join(get_hermes_home(), "cache", "browser-use", "headless-chrome")
+
+
+def _find_chromium_binary() -> Optional[str]:
+    """Locate a Chrome/Chromium binary: env override → PATH → Playwright cache."""
+    for key in ("AGENT_BROWSER_EXECUTABLE_PATH", "BH_CHROME_PATH", "CHROME_PATH"):
+        path = (os.environ.get(key) or "").strip()
+        if path and os.path.isfile(path):
+            return path
+
+    for name in _SYSTEM_CHROME_NAMES:
+        path = shutil.which(name)
+        if path:
+            return path
+
+    from tools.browser_tool import _chromium_search_roots
+
+    for root in _chromium_search_roots():
+        for pattern in (
+            os.path.join("chromium-*", "chrome-linux*", "chrome"),
+            os.path.join("chromium_headless_shell-*", "chrome-linux*", "headless_shell"),
+        ):
+            try:
+                hits = sorted(glob.glob(os.path.join(root, pattern)))
+            except OSError:
+                continue
+            if hits:
+                return hits[-1]
+    return None
+
+
+def _cdp_ready(timeout: float = 1.0) -> bool:
+    try:
+        with urllib.request.urlopen(_CDP_URL + "/json/version", timeout=timeout) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+def _launch(binary: str) -> bool:
+    from tools.browser_tool import _needs_chromium_sandbox_bypass
+
+    profile = _profile_dir()
+    os.makedirs(profile, exist_ok=True)
+
+    args = [binary]
+    if _needs_chromium_sandbox_bypass():
+        args.append("--no-sandbox")
+    args += [
+        "--headless=new",
+        "--disable-gpu",
+        "--disable-dev-shm-usage",
+        "--no-first-run",
+        "--no-default-browser-check",
+        "--disable-background-networking",
+        "--disable-component-update",
+        "--disable-sync",
+        "--metrics-recording-only",
+        "--mute-audio",
+        "--remote-debugging-address=127.0.0.1",
+        f"--remote-debugging-port={_HEADLESS_PORT}",
+        f"--user-data-dir={profile}",
+        "about:blank",
+    ]
+
+    try:
+        # Detach: the Chrome must outlive the browser_exec subprocess (and even
+        # the agent process) so subsequent calls reuse it.
+        subprocess.Popen(
+            args,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
+        return True
+    except OSError as e:
+        logger.warning("browser: headless Chrome launch failed: %s", e)
+        return False
+
+
+def ensure_headless_chrome(env: dict) -> Optional[str]:
+    """Ensure a headless Chrome is serving CDP and set ``BU_CDP_URL`` on ``env``.
+
+    No-op when a display server is present (the harness's GUI path works) or
+    when a CDP endpoint is already resolved (explicit override / cloud). On
+    failure returns a human-readable error string; on success/no-op returns
+    None.
+    """
+    if not is_headless_linux():
+        return None
+    # Already resolved: explicit CDP override, a cloud provider, or Browser Use
+    # cloud autospawn (BU_AUTOSPAWN) — the harness will attach elsewhere.
+    if env.get("BU_CDP_WS") or env.get("BU_CDP_URL") or env.get("BU_AUTOSPAWN"):
+        return None
+
+    # Already running (launched by a previous call) — just point at it.
+    if _cdp_ready():
+        env["BU_CDP_URL"] = _CDP_URL
+        return None
+
+    binary = _find_chromium_binary()
+    if not binary:
+        from tools.browser_tool import _chromium_installed, _maybe_autoinstall_chromium
+
+        if _chromium_installed():
+            return (
+                "browser-use: a Chromium browser was detected but its binary path "
+                "could not be resolved; set browser.cdp_url (or BU_CDP_URL) to a "
+                "running browser."
+            )
+        if not _maybe_autoinstall_chromium():
+            return (
+                "browser-use: no Chrome/Chromium browser is available on this "
+                "headless server. Install one (e.g. `sudo apt-get install -y "
+                "chromium`) or set browser.cdp_url / BU_CDP_URL to an existing "
+                "browser."
+            )
+        binary = _find_chromium_binary()
+        if not binary:
+            return (
+                "browser-use: Chromium auto-install completed but no binary could "
+                "be resolved; set browser.cdp_url / BU_CDP_URL manually."
+            )
+
+    if not _launch(binary):
+        return f"browser-use: failed to launch headless Chrome ({binary})."
+
+    deadline = time.time() + 20.0
+    while time.time() < deadline:
+        if _cdp_ready():
+            env["BU_CDP_URL"] = _CDP_URL
+            return None
+        time.sleep(0.2)
+
+    return (
+        "browser-use: launched headless Chrome but its CDP endpoint did not come "
+        "up; set browser.cdp_url / BU_CDP_URL manually."
+    )

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -609,6 +609,16 @@ def browser_exec(
     if "BU_AUTOSPAWN" not in env and is_legacy_browser_use_cloud_config(_read_browser_cfg()):
         env["BU_AUTOSPAWN"] = "1"
 
+    # On headless Linux with no resolved backend, provision a local headless
+    # Chrome and point the harness at it via BU_CDP_URL. The harness's own
+    # "local Chrome" path launches a GUI and can't work over SSH, so without
+    # this every browser_exec on a VPS fails with "chrome-not-running".
+    from tools.browser_headless import ensure_headless_chrome
+
+    headless_err = ensure_headless_chrome(env)
+    if headless_err:
+        return tool_error(headless_err)
+
     try:
         timeout = max(_MIN_TIMEOUT_S, min(int(timeout_s), _MAX_TIMEOUT_S))
     except (TypeError, ValueError):


### PR DESCRIPTION
## Summary

`browser_exec` (the default Browser Use backend) fails on headless Linux
servers/VPSs with:

    chrome-not-running: no supported Chromium-family browser is running

Root cause: the browser-use harness's "local" mode assumes a GUI — it launches
a windowed Chrome and waits for the user to click "Allow remote debugging",
which is impossible with no `$DISPLAY`. The built-in browser stack
auto-installs Chromium via Playwright, but the Browser Use backend had no
equivalent, so every `browser_exec` on a headless box died with that cryptic
error.

This PR adds headless provisioning to the Browser Use backend: on Linux with no
display and no cloud/CDP backend configured, Hermes launches a detached
headless Chrome on a local CDP port (using a non-default `--user-data-dir`,
since Chrome 136+ refuses `--remote-debugging-port` on the default profile) and
points the harness at it via `BU_CDP_URL`. Later calls reuse the already-running
Chrome instead of spawning duplicates.

## Changes

- `tools/browser_headless.py` (new): `is_headless_linux()`, Chromium discovery
  (env override → `PATH` → Playwright cache), detached headless launch, and
  `ensure_headless_chrome(env)`.
- `tools/browser_use_cli.py`: call `ensure_headless_chrome` in `browser_exec`
  after backend resolution and before launching the CLI.
- `tests/tools/test_browser_headless.py`: unit tests for the above.

## Behavior

- No-op when a display server is present, or when `BU_CDP_URL` / `BU_CDP_WS` /
  `BU_AUTOSPAWN` is already set (explicit CDP override, cloud provider, or
  Browser Use cloud autospawn).
- Reuses the existing Chromium auto-install path (`_maybe_autoinstall_chromium`)
  and returns a clear, actionable error if no browser can be provisioned.
- Reuses `_chromium_search_roots` / `_needs_chromium_sandbox_bypass` so sandbox
  and cache-location behavior stay consistent with the built-in stack.

## Test Plan

- [x] `scripts/run_tests.sh tests/tools/test_browser_headless.py`
- [x] Manually verified `browser_exec` works on a headless Linux VPS (no DISPLAY)
