### PR TITLE
feat(kanban): complete per-profile concurrency cap overrides

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1387,6 +1387,17 @@ class GatewayKanbanWatchersMixin:
                         max_in_progress_per_profile,
                     )
 
+        max_in_progress_per_profile_overrides = (
+            _kb.normalize_profile_cap_overrides(
+                kanban_cfg.get("max_in_progress_per_profile_overrides")
+            )
+        )
+        if max_in_progress_per_profile_overrides:
+            logger.info(
+                "kanban dispatcher: max_in_progress_per_profile_overrides=%r",
+                max_in_progress_per_profile_overrides,
+            )
+
         # Initial delay so the gateway finishes wiring adapters before the
         # dispatcher spawns workers (those workers may hit gateway notify
         # subscriptions etc.). Matches the notifier watcher's delay.
@@ -1480,6 +1491,9 @@ class GatewayKanbanWatchersMixin:
                     stale_timeout_seconds=stale_timeout_seconds,
                     default_assignee=default_assignee,
                     max_in_progress_per_profile=max_in_progress_per_profile,
+                    max_in_progress_per_profile_overrides=(
+                        max_in_progress_per_profile_overrides
+                    ),
                     reconcile_orphans=reconcile_orphans,
                 )
             except sqlite3.DatabaseError as exc:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2649,6 +2649,10 @@ DEFAULT_CONFIG = {
         # otherwise saturate one profile's local model / API quota /
         # browser pool while leaving other profiles idle.
         "max_in_progress_per_profile": None,
+        # Optional per-profile overrides for the uniform cap above. Explicit
+        # entries win; unlisted profiles fall back to the uniform cap. An empty
+        # map preserves existing behavior.
+        "max_in_progress_per_profile_overrides": {},
         # When true, the kanban dispatcher auto-runs the decomposer on
         # tasks that land in Triage (every dispatcher tick). When false,
         # decomposition is manual via `hermes kanban decompose <id>` or

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2642,6 +2642,11 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         max_in_progress_per_profile = _coerce_positive_int(
             _kanban_cfg.get("max_in_progress_per_profile")
         )
+        max_in_progress_per_profile_overrides = (
+            kb.normalize_profile_cap_overrides(
+                _kanban_cfg.get("max_in_progress_per_profile_overrides")
+            )
+        )
         max_in_progress = _coerce_positive_int(_kanban_cfg.get("max_in_progress"))
         # Memory-derived default when unset (OOF-30/OOF-77) — same
         # fallback the gateway-embedded dispatcher applies, so behaviour
@@ -2656,6 +2661,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
     except Exception:
         default_assignee = None
         max_in_progress_per_profile = None
+        max_in_progress_per_profile_overrides = {}
         max_in_progress = None
         max_spawn = getattr(args, "max", None)
     with kb.connect_closing() as conn:
@@ -2667,6 +2673,9 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            max_in_progress_per_profile_overrides=(
+                max_in_progress_per_profile_overrides
+            ),
         )
     if getattr(args, "json", False):
         print(json.dumps({

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9805,6 +9805,56 @@ def _memory_pressure_level(sample: Optional[Mapping[str, Any]] = None) -> str:
         return "unknown"
 
 
+def normalize_profile_cap_overrides(raw: Any) -> dict[str, int]:
+    """Return valid ``{profile: positive_limit}`` concurrency overrides.
+
+    Gateway, CLI, and direct dispatcher callers share this parser so every
+    dispatch surface applies identical precedence and validation. Invalid
+    entries are ignored individually; one typo must not disable valid limits
+    for other profiles.
+    """
+    if raw is None:
+        return {}
+    if not isinstance(raw, Mapping):
+        _log.warning(
+            "kanban dispatcher: invalid "
+            "kanban.max_in_progress_per_profile_overrides=%r; expected a mapping",
+            raw,
+        )
+        return {}
+
+    normalized: dict[str, int] = {}
+    for raw_profile, raw_limit in raw.items():
+        if not isinstance(raw_profile, str) or not raw_profile.strip():
+            _log.warning(
+                "kanban dispatcher: invalid profile name %r in "
+                "kanban.max_in_progress_per_profile_overrides; ignoring",
+                raw_profile,
+            )
+            continue
+        profile = raw_profile.strip()
+        try:
+            limit = int(raw_limit)
+        except (TypeError, ValueError):
+            _log.warning(
+                "kanban dispatcher: invalid concurrency override for profile "
+                "%r: %r; ignoring",
+                profile,
+                raw_limit,
+            )
+            continue
+        if limit < 1:
+            _log.warning(
+                "kanban dispatcher: concurrency override for profile %r is "
+                "below 1: %r; ignoring",
+                profile,
+                raw_limit,
+            )
+            continue
+        normalized[profile] = limit
+    return normalized
+
+
 def dispatch_once(
     conn: sqlite3.Connection,
     *,
@@ -9818,6 +9868,7 @@ def dispatch_once(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
+    max_in_progress_per_profile_overrides: Optional[Mapping[str, Any]] = None,
     reconcile_orphans: bool = True,
 ) -> DispatchResult:
     """Run one dispatcher tick under the board's single-writer lock.
@@ -9853,6 +9904,9 @@ def dispatch_once(
             board=board,
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            max_in_progress_per_profile_overrides=(
+                max_in_progress_per_profile_overrides
+            ),
             reconcile_orphans=reconcile_orphans,
         )
         _fire_dispatch_tick_hook(result, board=board, dry_run=dry_run)
@@ -9873,6 +9927,9 @@ def dispatch_once(
                 board=board,
                 default_assignee=default_assignee,
                 max_in_progress_per_profile=max_in_progress_per_profile,
+                max_in_progress_per_profile_overrides=(
+                    max_in_progress_per_profile_overrides
+                ),
                 reconcile_orphans=reconcile_orphans,
             )
             # Still under the dispatch lock: run the periodic PASSIVE WAL
@@ -9900,6 +9957,7 @@ def _dispatch_once_locked(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
+    max_in_progress_per_profile_overrides: Optional[Mapping[str, Any]] = None,
     reconcile_orphans: bool = True,
 ) -> DispatchResult:
     """Run one dispatcher tick.
@@ -10087,8 +10145,18 @@ def _dispatch_once_locked(
         isinstance(max_in_progress_per_profile, int)
         and max_in_progress_per_profile > 0
     ) else None
+    _per_profile_overrides = normalize_profile_cap_overrides(
+        max_in_progress_per_profile_overrides
+    )
+    _profile_limits_enabled = (
+        _per_profile_cap is not None or bool(_per_profile_overrides)
+    )
+
+    def _profile_cap(assignee: str) -> Optional[int]:
+        return _per_profile_overrides.get(assignee, _per_profile_cap)
+
     _per_profile_running: dict[str, int] = {}
-    if _per_profile_cap is not None:
+    if _profile_limits_enabled:
         for prow in conn.execute(
             "SELECT assignee, COUNT(*) AS n FROM tasks "
             "WHERE status = 'running' AND assignee IS NOT NULL "
@@ -10187,9 +10255,10 @@ def _dispatch_once_locked(
         # quota / browser pool from being overwhelmed by a fan-out
         # while the global max_in_progress / max_spawn caps still allow
         # work on OTHER profiles.
-        if _per_profile_cap is not None:
+        profile_cap = _profile_cap(row_assignee)
+        if profile_cap is not None:
             current = _per_profile_running.get(row_assignee, 0)
-            if current >= _per_profile_cap:
+            if current >= profile_cap:
                 result.skipped_per_profile_capped.append(
                     (row["id"], row_assignee, current)
                 )
@@ -10222,7 +10291,7 @@ def _dispatch_once_locked(
             # check sees the would-be spawn on subsequent iterations.
             # Without this, dry_run reports every task as spawnable and
             # under-reports the capped subset (#21582).
-            if _per_profile_cap is not None and row_assignee:
+            if _profile_limits_enabled and row_assignee:
                 _per_profile_running[row_assignee] = (
                     _per_profile_running.get(row_assignee, 0) + 1
                 )
@@ -10284,7 +10353,7 @@ def _dispatch_once_locked(
             # Track the new in-flight count for this profile so later
             # iterations in this same tick respect the per-profile cap
             # (#21582). Subsequent ticks re-query from the DB.
-            if _per_profile_cap is not None and claimed.assignee:
+            if _profile_limits_enabled and claimed.assignee:
                 _per_profile_running[claimed.assignee] = (
                     _per_profile_running.get(claimed.assignee, 0) + 1
                 )
@@ -10329,9 +10398,10 @@ def _dispatch_once_locked(
         if profile_exists is not None and not profile_exists(row["assignee"]):
             result.skipped_nonspawnable.append(row["id"])
             continue
-        if _per_profile_cap is not None:
+        profile_cap = _profile_cap(row["assignee"])
+        if profile_cap is not None:
             current = _per_profile_running.get(row["assignee"], 0)
-            if current >= _per_profile_cap:
+            if current >= profile_cap:
                 result.skipped_per_profile_capped.append(
                     (row["id"], row["assignee"], current)
                 )
@@ -10349,7 +10419,7 @@ def _dispatch_once_locked(
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
             spawned += 1
-            if _per_profile_cap is not None:
+            if _profile_limits_enabled:
                 _per_profile_running[row["assignee"]] = (
                     _per_profile_running.get(row["assignee"], 0) + 1
                 )
@@ -10404,7 +10474,7 @@ def _dispatch_once_locked(
             )
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
-            if _per_profile_cap is not None and claimed.assignee:
+            if _profile_limits_enabled and claimed.assignee:
                 _per_profile_running[claimed.assignee] = (
                     _per_profile_running.get(claimed.assignee, 0) + 1
                 )

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -7,8 +7,11 @@ that GatewayRunner picks them up via the MRO (behavior-neutral relocation).
 
 from __future__ import annotations
 
+import asyncio
 import inspect
+from types import SimpleNamespace
 
+import gateway.kanban_watchers as watchers_module
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 
 KANBAN_METHODS = [
@@ -24,5 +27,75 @@ KANBAN_METHODS = [
 def test_mixin_defines_kanban_methods():
     for m in KANBAN_METHODS:
         assert hasattr(GatewayKanbanWatchersMixin, m), f"mixin missing {m}"
+
+
+def test_dispatcher_watcher_forwards_profile_cap_overrides(
+    monkeypatch,
+    tmp_path,
+):
+    """The embedded dispatcher passes normalized overrides to every board tick."""
+    from hermes_cli import kanban_db as kb
+
+    config = {
+        "kanban": {
+            "dispatch_in_gateway": True,
+            "dispatch_interval_seconds": 1,
+            "auto_decompose": False,
+            "max_in_progress": 4,
+            "max_in_progress_per_profile": 3,
+            "max_in_progress_per_profile_overrides": {
+                "supervisor": 1,
+                "implementer": "3",
+            },
+        }
+    }
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+    monkeypatch.setattr(
+        watchers_module,
+        "_acquire_singleton_lock",
+        lambda path: (None, "unavailable"),
+    )
+
+    async def no_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(watchers_module.asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(kb, "kanban_home", lambda: tmp_path)
+    monkeypatch.setattr(kb, "list_boards", lambda **kwargs: [{"slug": "default"}])
+    monkeypatch.setattr(kb, "reap_worker_zombies", lambda: [])
+    monkeypatch.setattr(kb, "has_spawnable_ready", lambda conn: False)
+    monkeypatch.setattr(kb, "review_dispatch_enabled", lambda: False)
+
+    class FakeConnection:
+        def close(self):
+            return None
+
+    monkeypatch.setattr(kb, "connect", lambda **kwargs: FakeConnection())
+    captured = {}
+    watcher = GatewayKanbanWatchersMixin()
+    setattr(watcher, "_running", True)
+
+    def fake_dispatch_once(conn, **kwargs):
+        captured.update(kwargs)
+        setattr(watcher, "_running", False)
+        return SimpleNamespace(
+            spawned=[],
+            reclaimed=0,
+            crashed=[],
+            timed_out=[],
+            promoted=0,
+            auto_blocked=[],
+        )
+
+    monkeypatch.setattr(kb, "dispatch_once", fake_dispatch_once)
+
+    asyncio.run(watcher._kanban_dispatcher_watcher())
+
+    assert captured["max_in_progress"] == 4
+    assert captured["max_in_progress_per_profile"] == 3
+    assert captured["max_in_progress_per_profile_overrides"] == {
+        "supervisor": 1,
+        "implementer": 3,
+    }
 
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1486,6 +1486,7 @@ def test_default_config_kanban_block_not_dropped_by_duplicate_key():
     # From the second block:
     assert "dispatch_in_gateway" in kanban
     assert "auto_decompose" in kanban
+    assert kanban.get("max_in_progress_per_profile_overrides") == {}
 
 
 def test_default_config_has_no_duplicate_top_level_keys():

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -43,6 +43,10 @@ def test_cli_dispatch_passes_max_in_progress_from_config(isolated_kanban_home, m
             "max_spawn": 5,
             "default_assignee": "default",
             "max_in_progress_per_profile": 2,
+            "max_in_progress_per_profile_overrides": {
+                "supervisor": 1,
+                "implementer": 3,
+            },
         }
     }
     monkeypatch.setattr(
@@ -69,6 +73,10 @@ def test_cli_dispatch_passes_max_in_progress_from_config(isolated_kanban_home, m
     )
     assert captured.get("default_assignee") == "default"
     assert captured.get("max_in_progress_per_profile") == 2
+    assert captured.get("max_in_progress_per_profile_overrides") == {
+        "supervisor": 1,
+        "implementer": 3,
+    }
 
 
 def test_cli_max_flag_overrides_config_max_spawn(isolated_kanban_home, monkeypatch):

--- a/tests/hermes_cli/test_kanban_per_profile_cap.py
+++ b/tests/hermes_cli/test_kanban_per_profile_cap.py
@@ -114,12 +114,8 @@ def test_profile_overrides_share_capacity_across_ready_and_review(
             kb.create_task(conn, title=f"beta-{i}", assignee="beta")
             for i in range(4)
         ]
+        assert kb.claim_task(conn, running_alpha) is not None
         with kb.write_txn(conn):
-            conn.execute(
-                "UPDATE tasks SET status = 'running', claim_lock = 'test:1' "
-                "WHERE id = ?",
-                (running_alpha,),
-            )
             conn.execute(
                 "UPDATE tasks SET status = 'review' WHERE id = ?",
                 (review_alpha,),
@@ -139,6 +135,7 @@ def test_profile_overrides_share_capacity_across_ready_and_review(
     assert ready_alpha in capped_ids
     assert review_alpha in capped_ids
     assert not {ready_alpha, review_alpha}.intersection(spawned_ids)
+    assert not [task_id for task_id, assignee, _ in res.spawned if assignee == "alpha"]
     assert len(spawned_ids.intersection(beta_ids)) == 3
 
 

--- a/tests/hermes_cli/test_kanban_per_profile_cap.py
+++ b/tests/hermes_cli/test_kanban_per_profile_cap.py
@@ -98,3 +98,71 @@ def test_capped_tasks_dispatched_on_subsequent_tick(isolated_kanban_home_with_pr
     assert res2.spawned[0][0] != spawned_id  # different task this time
 
 
+@pytest.mark.parametrize("dry_run", [True, False])
+def test_profile_overrides_share_capacity_across_ready_and_review(
+    isolated_kanban_home_with_profiles,
+    dry_run,
+):
+    """An assignee override is one ceiling shared by both dispatch lanes."""
+    kb = isolated_kanban_home_with_profiles
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        running_alpha = kb.create_task(conn, title="running", assignee="alpha")
+        ready_alpha = kb.create_task(conn, title="ready", assignee="alpha")
+        review_alpha = kb.create_task(conn, title="review", assignee="alpha")
+        beta_ids = [
+            kb.create_task(conn, title=f"beta-{i}", assignee="beta")
+            for i in range(4)
+        ]
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'running', claim_lock = 'test:1' "
+                "WHERE id = ?",
+                (running_alpha,),
+            )
+            conn.execute(
+                "UPDATE tasks SET status = 'review' WHERE id = ?",
+                (review_alpha,),
+            )
+
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            dry_run=dry_run,
+            max_in_progress_per_profile=3,
+            max_in_progress_per_profile_overrides={"alpha": 1},
+        )
+
+    spawned_ids = {task_id for task_id, _, _ in res.spawned}
+    capped_ids = {task_id for task_id, _, _ in res.skipped_per_profile_capped}
+    assert ready_alpha in capped_ids
+    assert review_alpha in capped_ids
+    assert not {ready_alpha, review_alpha}.intersection(spawned_ids)
+    assert len(spawned_ids.intersection(beta_ids)) == 3
+
+
+def test_normalize_profile_cap_overrides_warns_and_keeps_valid_entries(caplog):
+    """Gateway and CLI share one parser with actionable invalid-entry warnings."""
+    import logging
+
+    from hermes_cli import kanban_db as kb
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.kanban_db"):
+        parsed = kb.normalize_profile_cap_overrides(
+            {
+                "supervisor": 1,
+                "implementer": "3",
+                "zero": 0,
+                "bad": "many",
+                "": 2,
+            }
+        )
+
+    assert parsed == {"supervisor": 1, "implementer": 3}
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("zero" in message and "below 1" in message for message in messages)
+    assert any("bad" in message and "invalid" in message for message in messages)
+    assert any("profile name" in message for message in messages)
+
+

--- a/tests/hermes_cli/test_kanban_per_profile_overrides.py
+++ b/tests/hermes_cli/test_kanban_per_profile_overrides.py
@@ -1,0 +1,132 @@
+"""Tests for per-profile concurrency cap OVERRIDES in the kanban dispatcher.
+
+``kanban.max_in_progress_per_profile_overrides`` is a dict of
+``{profile_name: int}`` that overrides the global
+``kanban.max_in_progress_per_profile`` for the listed profiles only:
+
+- Override takes priority over the global cap for listed profiles.
+- Unlisted profiles fall back to the global cap.
+- When the global cap is unset (null), only listed profiles are capped;
+  unlisted profiles run unconstrained.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_kanban_home_with_profiles(monkeypatch):
+    """Spin up a fresh HERMES_HOME with kanban DB + alpha/beta profiles."""
+    test_home = tempfile.mkdtemp(prefix="kanban_per_profile_overrides_test_")
+    for prof in ("alpha", "beta", "default"):
+        os.makedirs(os.path.join(test_home, "profiles", prof), exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", test_home)
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
+            del sys.modules[mod]
+    from hermes_cli import kanban_db
+    yield kanban_db
+
+
+def _fake_spawn(*args, **kwargs):
+    return 12345
+
+
+def _seed_tasks(kb, alpha: int = 5, beta: int = 5):
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        for i in range(alpha):
+            kb.create_task(conn, title=f"a{i}", assignee="alpha")
+        for i in range(beta):
+            kb.create_task(conn, title=f"b{i}", assignee="beta")
+
+
+def test_override_caps_only_listed_profile_when_global_unset(
+    isolated_kanban_home_with_profiles,
+):
+    """Global cap null + override {alpha: 2}: alpha capped at 2, beta
+    unconstrained (all 5 dispatch)."""
+    kb = isolated_kanban_home_with_profiles
+    _seed_tasks(kb)
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=True,
+            max_in_progress_per_profile=None,
+            max_in_progress_per_profile_overrides={"alpha": 2},
+        )
+    spawn_assignees = [s[1] for s in res.spawned]
+    capped_assignees = [c[1] for c in res.skipped_per_profile_capped]
+    assert spawn_assignees.count("alpha") == 2
+    assert spawn_assignees.count("beta") == 5
+    assert capped_assignees.count("alpha") == 3
+    assert "beta" not in capped_assignees
+
+
+def test_override_takes_priority_over_global_cap(
+    isolated_kanban_home_with_profiles,
+):
+    """Global cap=4 but override {alpha: 1}: alpha gets 1 (override wins),
+    beta falls back to the global cap of 4."""
+    kb = isolated_kanban_home_with_profiles
+    _seed_tasks(kb)
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=True,
+            max_in_progress_per_profile=4,
+            max_in_progress_per_profile_overrides={"alpha": 1},
+        )
+    spawn_assignees = [s[1] for s in res.spawned]
+    capped_assignees = [c[1] for c in res.skipped_per_profile_capped]
+    assert spawn_assignees.count("alpha") == 1
+    assert spawn_assignees.count("beta") == 4
+    assert capped_assignees.count("alpha") == 4
+    assert capped_assignees.count("beta") == 1
+
+
+def test_invalid_override_entries_are_ignored(
+    isolated_kanban_home_with_profiles,
+):
+    """Non-numeric / <1 override values are ignored; the valid entry still
+    applies. Overrides dict entirely invalid == no overrides."""
+    kb = isolated_kanban_home_with_profiles
+    _seed_tasks(kb, alpha=3, beta=3)
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=True,
+            max_in_progress_per_profile_overrides={
+                "alpha": 2,
+                "beta": "not-a-number",
+                "gamma": 0,
+            },
+        )
+    spawn_assignees = [s[1] for s in res.spawned]
+    assert spawn_assignees.count("alpha") == 2
+    # beta's invalid override is ignored -> unconstrained
+    assert spawn_assignees.count("beta") == 3
+
+
+def test_override_counts_pre_existing_running(
+    isolated_kanban_home_with_profiles,
+):
+    """A task already in 'running' status counts toward the override cap."""
+    kb = isolated_kanban_home_with_profiles
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        running_alpha = kb.create_task(conn, title="running alpha", assignee="alpha")
+        conn.execute(
+            "UPDATE tasks SET status = 'running', claim_lock = 'test:1' WHERE id = ?",
+            (running_alpha,),
+        )
+        for i in range(3):
+            kb.create_task(conn, title=f"a{i}", assignee="alpha")
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=True,
+            max_in_progress_per_profile_overrides={"alpha": 1},
+        )
+    assert not [s for s in res.spawned if s[1] == "alpha"]
+    assert len(res.skipped_per_profile_capped) == 3

--- a/tests/hermes_cli/test_kanban_per_profile_overrides.py
+++ b/tests/hermes_cli/test_kanban_per_profile_overrides.py
@@ -117,10 +117,7 @@ def test_override_counts_pre_existing_running(
     with kb.connect_closing() as conn:
         kb.create_board(slug="default", name="Test")
         running_alpha = kb.create_task(conn, title="running alpha", assignee="alpha")
-        conn.execute(
-            "UPDATE tasks SET status = 'running', claim_lock = 'test:1' WHERE id = ?",
-            (running_alpha,),
-        )
+        assert kb.claim_task(conn, running_alpha) is not None
         for i in range(3):
             kb.create_task(conn, title=f"a{i}", assignee="alpha")
     with kb.connect_closing() as conn:

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -793,12 +793,17 @@ All commands are also available as a slash command in the interactive CLI and in
 |------------|---------|--------------|
 | `kanban.max_in_progress` | unset (unlimited) | Caps the number of simultaneously running tasks. When the board already has N running, the dispatcher skips spawning more — useful for slow workers (local LLMs, resource-constrained hosts) so they finish what they have before more pile up and time out. Invalid or below-1 values log a warning and behave as unlimited. |
 | `kanban.max_in_progress_per_profile` | unset (unlimited) | Per-profile variant of `max_in_progress` — caps how many tasks any single assignee profile may run concurrently. Useful when one profile is slow or rate-limited but others should keep flowing. Applies alongside the board-wide `max_in_progress`; both must allow a spawn for it to proceed. |
+| `kanban.max_in_progress_per_profile_overrides` | `{}` | Optional map of profile-specific caps. A listed profile uses its override; unlisted profiles fall back to `max_in_progress_per_profile`. Ready and review workers share the same count. Invalid names and values below 1 are ignored with a warning. |
 | `kanban.auto_promote_children` | `true` | After `decompose_triage_task()` produces children with no parent-blocker dependencies, they're automatically promoted to `ready` so the dispatcher can pick them up. Set to `false` to require manual review — children stay in `todo` until you promote them. |
 | `kanban.default_workdir` | unset | Board-level default working directory applied to new tasks when neither `--workspace` nor the task itself overrides it. Per-task `workspace:` still wins. |
 
 ```yaml
 kanban:
-  max_in_progress: 2
+  max_in_progress: 4
+  max_in_progress_per_profile: 3
+  max_in_progress_per_profile_overrides:
+    supervisor: 1
+    implementer: 3
   auto_promote_children: false
   default_workdir: ~/work/active-project
 ```


### PR DESCRIPTION
## Summary

Adds `kanban.max_in_progress_per_profile_overrides`, a backward-compatible profile → positive integer map layered over the existing uniform `max_in_progress_per_profile` cap.

Example:

```yaml
kanban:
  max_in_progress: 4
  max_in_progress_per_profile: 3
  max_in_progress_per_profile_overrides:
    supervisor: 1
    implementer: 3
```

## Behavior

- Explicit profile override wins.
- Unlisted profiles fall back to the uniform cap.
- With no uniform cap, only listed profiles are capped.
- Ready and review dispatch share one count, including pre-existing running tasks and same-tick dry-run/real spawns.
- Invalid maps, names, non-numeric values, and values below 1 are ignored with actionable warnings.
- Gateway and direct CLI dispatch use the same normalization function.
- Empty/absent map preserves prior behavior.

## Prior work and attribution

Supersedes stale partial PR #70674 and incorporates its original regression tests via a cherry-picked commit retaining `twutc88` as author. This version addresses the automated review feedback on #70674: CLI passthrough, defaults, docs, below-one warnings, and coverage. It also adapts the feature to current main, where ready and review dispatch share the scalar cap.

## Tests

- RED before implementation: 5 expected failures on current main.
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_per_profile_cap.py tests/hermes_cli/test_kanban_per_profile_overrides.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py tests/hermes_cli/test_config.py tests/gateway/test_kanban_watchers_mixin.py -q` → 91 passed.
- Ruff → passed.
- `py_compile` → passed.
- Windows-footgun check on all changed executable/test files except pre-existing `test_config.py` findings → passed (8 files).
- `git diff --check` → passed.

## Risk

Low and opt-in. The new mapping defaults to `{}`. Existing scalar-only configurations execute the same branches as before.

## Exclusions

This PR does not change model routing, global board caps, worker lifecycle, or dashboard behavior.

Fixes #91259

Downstream tracking: DarkArty07/Aether-Agents#204 and #205.