### PR TITLE
feat(api): add locked request-scoped model runtimes

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3491,6 +3491,7 @@ def set_runtime_main(
     auth_mode: str = "",
     session_id: str = "",
     cache_scope: str = "",
+    model_locked: bool = False,
 ) -> contextvars.Token:
     """Record the current context's live main runtime for auxiliary routing.
 
@@ -3519,6 +3520,7 @@ def set_runtime_main(
         "auth_mode": (auth_mode or "").strip().lower(),
         "session_id": (session_id or "").strip(),
         "cache_scope": (cache_scope or "").strip(),
+        "model_locked": model_locked is True,
     }
     # Publish authoritative context before updating locked compatibility
     # mirrors; concurrent sessions never read those mirrors at runtime.
@@ -3992,7 +3994,10 @@ _AUTO_PROVIDER_LABELS = {
 }
 
 _MAIN_RUNTIME_FIELDS = ("provider", "model", "base_url", "api_key", "api_mode", "auth_mode")
-_MAIN_RUNTIME_CONTEXT_FIELDS = _MAIN_RUNTIME_FIELDS + ("requested_provider",)
+_MAIN_RUNTIME_CONTEXT_FIELDS = _MAIN_RUNTIME_FIELDS + (
+    "requested_provider",
+    "model_locked",
+)
 
 
 def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str, Any]:
@@ -4017,6 +4022,12 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
     normalized: Dict[str, Any] = {}
     for field in _MAIN_RUNTIME_CONTEXT_FIELDS:
         value = main_runtime.get(field)
+        if field == "model_locked":
+            # Only an explicit boolean True activates the fail-closed route.
+            # Truthy mocks/strings must not silently enable auxiliary policy.
+            if value is True:
+                normalized[field] = True
+            continue
         # Preserve a callable api_key (Entra ID bearer provider) unchanged.
         if field == "api_key" and callable(value) and not isinstance(value, str):
             normalized[field] = value
@@ -5935,6 +5946,7 @@ def _resolve_auto_route(
     runtime_base_url = str(runtime.get("base_url") or "")
     runtime_api_key = runtime.get("api_key", "")
     runtime_api_mode = str(runtime.get("api_mode") or "")
+    runtime_model_locked = runtime.get("model_locked") is True
 
     # ── Warn once if OPENAI_BASE_URL is set but config.yaml uses a named
     #    provider (not 'custom').  This catches the common "env poisoning"
@@ -5971,7 +5983,12 @@ def _resolve_auto_route(
     # frontier reasoning model costs seconds per new session. This remains an
     # opt-in because every settings surface defines "auto" as using the main
     # model; silently overriding that choice makes the selected model cosmetic.
-    if _task_prefers_fast_model(task) and main_provider and main_provider not in {"auto", ""}:
+    if (
+        not runtime_model_locked
+        and _task_prefers_fast_model(task)
+        and main_provider
+        and main_provider not in {"auto", ""}
+    ):
         fast_model = _get_aux_model_for_provider(main_provider, prefer_fast=True)
         if fast_model and fast_model != main_model:
             logger.debug(
@@ -6066,6 +6083,17 @@ def _resolve_auto_route(
                 logger.info("Auxiliary auto-detect: using main provider %s (%s)",
                             main_provider, resolved or main_model)
                 return client, resolved or main_model, resolved_provider
+
+    # A model-locked run is an externally supplied, immutable execution
+    # boundary. If that exact runtime cannot be resolved, fail closed instead
+    # of consulting task config, the profile fallback chain, or ambient
+    # provider credentials.
+    if runtime_model_locked:
+        logger.warning(
+            "Auxiliary %s: locked main runtime is unavailable; fallback disabled",
+            task or "call",
+        )
+        return None, None, ""
 
     # ── Step 2: user-configured fallback policy ─────────────────────────
     # In auto mode, respect the task-specific fallback chain first, then the
@@ -7629,10 +7657,15 @@ def _client_cache_key(
     model: Optional[str] = None,
 ) -> tuple:
     runtime = _normalize_main_runtime(main_runtime)
-    runtime_key = tuple(
-        _runtime_cache_discriminator(field, runtime.get(field, ""))
-        for field in _MAIN_RUNTIME_FIELDS
-    ) if provider == "auto" else ()
+    runtime_key = (
+        tuple(
+            _runtime_cache_discriminator(field, runtime.get(field, ""))
+            for field in _MAIN_RUNTIME_FIELDS
+        )
+        + (("model_locked",) if runtime.get("model_locked") is True else ())
+        if provider == "auto"
+        else ()
+    )
     # `auto` can now resolve through task-specific or main fallback policy,
     # so the task participates in the cache key. Non-auto providers keep the
     # old cache shape because the explicit provider/model tuple is sufficient.
@@ -9427,15 +9460,31 @@ def _call_llm_impl(
     # concurrent /model switch produce a key for one runtime and a client for
     # another.
     main_runtime = _normalize_main_runtime(main_runtime)
-    resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
-        task, provider, model, base_url, api_key)
-    if api_mode:
+    runtime_model_locked = main_runtime.get("model_locked") is True
+    if runtime_model_locked:
+        # Ignore per-task and explicit auxiliary model routes: a locked run's
+        # exact main runtime is the sole model authority for every nested LLM
+        # operation. ``auto`` resolves only that snapshot in the locked path.
+        resolved_provider = "auto"
+        resolved_model = str(main_runtime.get("model") or "") or None
+        resolved_base_url = None
+        resolved_api_key = None
+        resolved_api_mode = str(main_runtime.get("api_mode") or "") or None
+    else:
+        (
+            resolved_provider,
+            resolved_model,
+            resolved_base_url,
+            resolved_api_key,
+            resolved_api_mode,
+        ) = _resolve_task_provider_model(task, provider, model, base_url, api_key)
+    if api_mode and not runtime_model_locked:
         resolved_api_mode = api_mode
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
     effective_provider = resolved_provider
 
-    if task == "vision":
+    if task == "vision" and not runtime_model_locked:
         effective_provider, client, final_model = resolve_vision_provider_client(
             provider=resolved_provider if resolved_provider != "auto" else provider,
             model=resolved_model or model,
@@ -9475,6 +9524,10 @@ def _call_llm_impl(
             client, resolved_provider,
         )
         if client is None:
+            if runtime_model_locked:
+                raise RuntimeError(
+                    f"Locked model runtime is unavailable for auxiliary task={task}"
+                )
             # When the user explicitly chose a non-OpenRouter provider but no
             # credentials were found, honor the task fallback_chain before
             # raising.  Missing raw env keys are recoverable for auxiliary
@@ -9766,6 +9819,21 @@ def _call_llm_impl(
                 if not (_is_payment_error(retry_err) or _is_connection_error(retry_err) or _is_rate_limit_error(retry_err)):
                     raise
                 first_err = retry_err
+
+        if runtime_model_locked:
+            # Parameter-shaping retries above stay on the exact same client.
+            # Everything below may change model, endpoint, or credential
+            # (catalog healing, pool rotation, configured/global fallback),
+            # which is forbidden for an immutable request runtime.
+            if _is_connection_error(first_err):
+                try:
+                    _evict_cached_client_instance(client)
+                except Exception:
+                    logger.debug(
+                        "Auxiliary: locked-runtime cache eviction failed",
+                        exc_info=True,
+                    )
+            raise first_err
 
         # ── Stale-model self-heal (Nous Portal recommendation drift) ───
         # A long-lived process can pin a Portal-recommended model that has
@@ -10252,13 +10320,26 @@ async def _async_call_llm_impl(
     # Keep every async phase on the same runtime identity, even if another
     # session switches models while this task is awaiting network I/O.
     main_runtime = _normalize_main_runtime(main_runtime)
-    resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
-        task, provider, model, base_url, api_key)
+    runtime_model_locked = main_runtime.get("model_locked") is True
+    if runtime_model_locked:
+        resolved_provider = "auto"
+        resolved_model = str(main_runtime.get("model") or "") or None
+        resolved_base_url = None
+        resolved_api_key = None
+        resolved_api_mode = str(main_runtime.get("api_mode") or "") or None
+    else:
+        (
+            resolved_provider,
+            resolved_model,
+            resolved_base_url,
+            resolved_api_key,
+            resolved_api_mode,
+        ) = _resolve_task_provider_model(task, provider, model, base_url, api_key)
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
     effective_provider = resolved_provider
 
-    if task == "vision":
+    if task == "vision" and not runtime_model_locked:
         effective_provider, client, final_model = resolve_vision_provider_client(
             provider=resolved_provider if resolved_provider != "auto" else provider,
             model=resolved_model or model,
@@ -10299,6 +10380,10 @@ async def _async_call_llm_impl(
             client, resolved_provider,
         )
         if client is None:
+            if runtime_model_locked:
+                raise RuntimeError(
+                    f"Locked model runtime is unavailable for auxiliary task={task}"
+                )
             _explicit = (resolved_provider or "").strip().lower()
             if _explicit and _explicit not in {"auto", "openrouter", "custom"}:
                 fb_client, fb_model, fb_label = _try_configured_fallback_for_unavailable_client(
@@ -10512,6 +10597,17 @@ async def _async_call_llm_impl(
                 if not (_is_payment_error(retry_err) or _is_connection_error(retry_err) or _is_rate_limit_error(retry_err)):
                     raise
                 first_err = retry_err
+
+        if runtime_model_locked:
+            if _is_connection_error(first_err):
+                try:
+                    _evict_cached_client_instance(client)
+                except Exception:
+                    logger.debug(
+                        "Auxiliary (async): locked-runtime cache eviction failed",
+                        exc_info=True,
+                    )
+            raise first_err
 
         # ── Stale-model self-heal (Nous Portal recommendation drift) ───
         # See the sync call_llm() path for the rationale: a long-lived process

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -247,6 +247,9 @@ def _maybe_title_session_at_turn_start(agent: Any, messages: List[Any]) -> None:
                 "base_url": getattr(agent, "base_url", None),
                 "api_key": getattr(agent, "api_key", None),
                 "api_mode": getattr(agent, "api_mode", None),
+                "model_locked": (
+                    getattr(agent, "_runtime_model_locked", False) is True
+                ),
             },
             title_callback=getattr(agent, "_on_session_title", None),
             runtime_validator=lambda: (
@@ -525,6 +528,9 @@ def build_turn_context(
             auth_mode=getattr(agent, "auth_mode", "") or "",
             session_id=getattr(agent, "session_id", "") or "",
             cache_scope=_cache_scope,
+            model_locked=(
+                getattr(agent, "_runtime_model_locked", False) is True
+            ),
         )
     except Exception:
         pass

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -909,6 +909,10 @@ group_sessions_per_user: true
 #       enabled: true
 #       extra:
 #         key: "your-api-server-secret"
+#         # Allow authenticated POST /v1/runs callers to supply one immutable
+#         # model endpoint/credential snapshot. Disabled by default because it
+#         # grants the API caller control over the upstream network destination.
+#         allow_request_model_runtime: false
 #         model_routes:
 #           # Xiaozhi clients send model="minimax-m2" → routed to MiniMax via OpenRouter
 #           minimax-m2:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -168,6 +168,12 @@ from gateway.browser_control_broker import (
     filter_browser_control_capabilities,
     get_browser_control_broker,
 )
+from gateway.request_model_runtime import (
+    MODEL_API_KEY_HEADER,
+    RequestModelRuntime,
+    RequestModelRuntimeError,
+    parse_request_model_runtime,
+)
 
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
 from agent.secret_scope import get_secret as _scoped_get_secret
@@ -1543,6 +1549,12 @@ class APIServerAdapter(BasePlatformAdapter):
         self._direct_model_requests: bool = _coerce_request_bool(
             extra.get("direct_model_requests"), default=False
         )
+        # External control planes may supply an immutable model transport for
+        # one /v1/runs execution.  Off by default because this grants an
+        # authenticated caller control over the upstream HTTP destination.
+        self._allow_request_model_runtime: bool = _coerce_request_bool(
+            extra.get("allow_request_model_runtime"), default=False
+        )
         self._app: Optional["web.Application"] = None
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
@@ -2826,6 +2838,7 @@ class APIServerAdapter(BasePlatformAdapter):
         route: Optional[Dict[str, Any]] = None,
         session_model: Optional[str] = None,
         confirmed_runtime_lock: bool = False,
+        request_model_runtime: Optional[RequestModelRuntime] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -2859,6 +2872,11 @@ class APIServerAdapter(BasePlatformAdapter):
         session ``/model`` override, disables the global fallback model
         chain, and fails closed if the locked provider's credentials cannot
         be resolved.
+
+        ``request_model_runtime`` is an authenticated, request-scoped model
+        transport accepted only by ``/v1/runs``.  It is already complete and
+        validated, so it bypasses profile/global provider resolution and is
+        always treated as a confirmed runtime lock.
         """
         from run_agent import AIAgent
         from gateway.run import (
@@ -2871,31 +2889,40 @@ class APIServerAdapter(BasePlatformAdapter):
         )
         from hermes_cli.tools_config import _get_platform_tools
 
-        # Catch RuntimeError ONLY around this call, not the wider
-        # _create_agent()+run_conversation() span --
-        # _resolve_runtime_agent_kwargs() is the sole raiser of
-        # RuntimeError(format_runtime_provider_error(...)) for provider
-        # auth/credential failure.  Re-raising as
-        # _ProviderAuthResolutionError lets _run_agent() (and
-        # _handle_runs()) distinguish this from an unrelated RuntimeError
-        # elsewhere in the call graph.
-        try:
-            runtime_kwargs = _resolve_runtime_agent_kwargs()
-        except RuntimeError as exc:
-            raise _ProviderAuthResolutionError(str(exc)) from exc
-        model = _resolve_gateway_model()
+        if request_model_runtime is not None:
+            # This path must not touch the profile's provider catalog or
+            # fallback chain.  A hosted control plane is the source of truth
+            # for this run, and requiring a second local model configuration
+            # would defeat request-scoped execution.
+            runtime_kwargs = request_model_runtime.agent_kwargs()
+            model = request_model_runtime.model
+            confirmed_runtime_lock = True
+        else:
+            # Catch RuntimeError ONLY around this call, not the wider
+            # _create_agent()+run_conversation() span --
+            # _resolve_runtime_agent_kwargs() is the sole raiser of
+            # RuntimeError(format_runtime_provider_error(...)) for provider
+            # auth/credential failure.  Re-raising as
+            # _ProviderAuthResolutionError lets _run_agent() (and
+            # _handle_runs()) distinguish this from an unrelated RuntimeError
+            # elsewhere in the call graph.
+            try:
+                runtime_kwargs = _resolve_runtime_agent_kwargs()
+            except RuntimeError as exc:
+                raise _ProviderAuthResolutionError(str(exc)) from exc
+            model = _resolve_gateway_model()
 
-        # When the primary provider's auth fails (expired token / 429 quota
-        # cap), _resolve_runtime_agent_kwargs() falls through to the fallback
-        # provider chain, whose runtime dict carries its own ``model`` key.
-        # Pop it and let it override the config model, mirroring the native
-        # gateway path (_resolve_session_agent_runtime in run.py). Otherwise
-        # the explicit ``model=model`` below collides with the ``**runtime_kwargs``
-        # spread → "got multiple values for keyword argument 'model'", 500ing
-        # every /v1/chat/completions request while a fallback is active.
-        runtime_model = runtime_kwargs.pop("model", None)
-        if runtime_model:
-            model = runtime_model
+            # When the primary provider's auth fails (expired token / 429 quota
+            # cap), _resolve_runtime_agent_kwargs() falls through to the fallback
+            # provider chain, whose runtime dict carries its own ``model`` key.
+            # Pop it and let it override the config model, mirroring the native
+            # gateway path (_resolve_session_agent_runtime in run.py). Otherwise
+            # the explicit ``model=model`` below collides with the ``**runtime_kwargs``
+            # spread → "got multiple values for keyword argument 'model'", 500ing
+            # every /v1/chat/completions request while a fallback is active.
+            resolved_runtime_model = runtime_kwargs.pop("model", None)
+            if resolved_runtime_model:
+                model = resolved_runtime_model
 
         request_reasoning_config = _request_reasoning_config(model_options)
         request_service_tier = _request_service_tier(model_options)
@@ -2960,7 +2987,12 @@ class APIServerAdapter(BasePlatformAdapter):
         # override > session-persisted model > global) — the rule 7dd00bb47d
         # had to re-fix here after it diverged from gateway/run.py.
         from hermes_cli.model_switch import resolve_effective_model
-        if session_override:
+        if request_model_runtime is not None:
+            # The validated request runtime is the complete execution contract.
+            # Never let a prior /model switch, persisted session model, static
+            # route, or process-global default replace any part of it.
+            pass
+        elif session_override:
             override_model = resolve_effective_model(session_override, None, model)
             session_provider = _clean_request_string(session_override.get("provider"))
             current_provider = _clean_request_string(runtime_kwargs.get("provider"))
@@ -3072,23 +3104,24 @@ class APIServerAdapter(BasePlatformAdapter):
         # (/v1/responses, /v1/runs when no explicit session is supplied).
         # Keying on session_id would leave one permanent dict entry per
         # stateless request, growing unbounded for the life of the process.
-        _resolved_key = gateway_session_key or ""
-        if not model:
-            _recovered = (self._last_resolved_model.get(_resolved_key)
-                          or self._last_resolved_model.get("*"))
-            if _recovered and _recovered != self._model_name:
-                logger.warning(
-                    "Empty model resolved for session=%s — recovering "
-                    "last-known-good model %s (config read likely returned "
-                    "empty; see #35314)",
-                    _resolved_key, _recovered,
-                )
-                model = _recovered
-        elif model:
-            if model != self._model_name:
-                if _resolved_key:
-                    self._last_resolved_model[_resolved_key] = model
-                self._last_resolved_model["*"] = model
+        if request_model_runtime is None:
+            _resolved_key = gateway_session_key or ""
+            if not model:
+                _recovered = (self._last_resolved_model.get(_resolved_key)
+                              or self._last_resolved_model.get("*"))
+                if _recovered and _recovered != self._model_name:
+                    logger.warning(
+                        "Empty model resolved for session=%s — recovering "
+                        "last-known-good model %s (config read likely returned "
+                        "empty; see #35314)",
+                        _resolved_key, _recovered,
+                    )
+                    model = _recovered
+            elif model:
+                if model != self._model_name:
+                    if _resolved_key:
+                        self._last_resolved_model[_resolved_key] = model
+                    self._last_resolved_model["*"] = model
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
@@ -3111,11 +3144,12 @@ class APIServerAdapter(BasePlatformAdapter):
         # ``model.default`` instead — the defect e81d18dfb removed from the
         # native gateway paths. An explicit per-request reasoning parameter
         # still wins over config.
-        reasoning_config = (
-            request_reasoning_config
-            if request_reasoning_config is not None
-            else GatewayRunner._load_reasoning_config(model)
-        )
+        if request_reasoning_config is not None:
+            reasoning_config = request_reasoning_config
+        elif request_model_runtime is not None:
+            reasoning_config = None
+        else:
+            reasoning_config = GatewayRunner._load_reasoning_config(model)
 
         agent_kwargs = {
             "model": model,
@@ -3141,11 +3175,23 @@ class APIServerAdapter(BasePlatformAdapter):
             agent_kwargs["service_tier"] = request_service_tier
 
         agent = AIAgent(**agent_kwargs)
+        # Subagents consult this marker before applying delegation-level model
+        # overrides.  It is deliberately runtime-only and never persisted.
+        agent._runtime_model_locked = bool(confirmed_runtime_lock)
+        agent._runtime_model_lock_source = (
+            "request_runtime"
+            if request_model_runtime is not None
+            else "session_model_lock"
+            if confirmed_runtime_lock
+            else ""
+        )
         agent._hermes_api_runtime = {
             "provider": runtime_kwargs.get("provider") or getattr(agent, "provider", "") or "",
             "model": getattr(agent, "model", None) or model,
             "route_source": (
-                "session_model_lock"
+                "request_runtime"
+                if request_model_runtime is not None
+                else "session_model_lock"
                 if confirmed_runtime_lock
                 else "session_model_override"
                 if session_override
@@ -3350,6 +3396,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_stop": True,
                 "run_steer": True,
                 "run_approval_response": True,
+                "run_request_model_runtime": self._allow_request_model_runtime,
+                "run_request_model_credential_header": (
+                    MODEL_API_KEY_HEADER if self._allow_request_model_runtime else None
+                ),
                 "tool_progress_events": True,
                 "approval_events": True,
                 "session_resources": True,
@@ -7587,6 +7637,77 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
 
+        request_model_runtime: Optional[RequestModelRuntime] = None
+        runtime_requested = body.get("runtime_model") is not None
+        runtime_credential = request.headers.get(MODEL_API_KEY_HEADER)
+        if runtime_requested or runtime_credential:
+            if not self._allow_request_model_runtime:
+                return web.json_response(
+                    _openai_error(
+                        "Request-scoped model runtimes are disabled on this API server",
+                        code="request_model_runtime_disabled",
+                        param="runtime_model",
+                    ),
+                    status=403,
+                )
+            # connect() requires a strong API_SERVER_KEY, but direct handler
+            # wiring in embedders/tests can bypass startup.  Dynamic upstream
+            # routing must never become available on that unauthenticated path.
+            if not self._expected_api_key():
+                return web.json_response(
+                    _openai_error(
+                        "Request-scoped model runtimes require API_SERVER_KEY authentication",
+                        code="request_model_runtime_requires_auth",
+                        param="runtime_model",
+                    ),
+                    status=403,
+                )
+            if body.get("require_model_lock") is not None and not _coerce_request_bool(
+                body.get("require_model_lock"), default=True
+            ):
+                return web.json_response(
+                    _openai_error(
+                        "runtime_model is always model-locked; require_model_lock cannot be false",
+                        code="request_model_runtime_requires_lock",
+                        param="require_model_lock",
+                    ),
+                    status=400,
+                )
+            try:
+                request_model_runtime = parse_request_model_runtime(
+                    body,
+                    api_key_header=runtime_credential,
+                )
+            except RequestModelRuntimeError as exc:
+                return web.json_response(
+                    _openai_error(str(exc), code=exc.code, param=exc.param),
+                    status=400,
+                )
+            if (
+                request_model_runtime is not None
+                and request_model_runtime.model == self._model_name
+            ):
+                return web.json_response(
+                    _openai_error(
+                        "runtime_model requires a concrete provider model id, not the API virtual model",
+                        code="request_model_runtime_alias_conflict",
+                        param="model",
+                    ),
+                    status=400,
+                )
+            if (
+                request_model_runtime is not None
+                and self._resolve_route(request_model_runtime.model) is not None
+            ):
+                return web.json_response(
+                    _openai_error(
+                        "runtime_model requires a concrete provider model id, not a model_routes alias",
+                        code="request_model_runtime_alias_conflict",
+                        param="model",
+                    ),
+                    status=400,
+                )
+
         raw_input = body.get("input")
         if not raw_input:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
@@ -7643,7 +7764,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
         session_id = body.get("session_id") or stored_session_id
-        route = self._resolve_route(body.get("model"))
+        route = (
+            None
+            if request_model_runtime is not None
+            else self._resolve_route(body.get("model"))
+        )
         agent_overrides = _request_agent_overrides(body, virtual_model=self._model_name)
         selection_error = self._request_route_conflict_error(
             session_id=session_id,
@@ -7699,7 +7824,11 @@ class APIServerAdapter(BasePlatformAdapter):
             "queued",
             created_at=created_at,
             session_id=session_id,
-            model=body.get("model", self._model_name),
+            model=(
+                request_model_runtime.model
+                if request_model_runtime is not None
+                else body.get("model", self._model_name)
+            ),
         )
 
         # Background task outlives the HTTP response (and thus the middleware
@@ -7738,6 +7867,8 @@ class APIServerAdapter(BasePlatformAdapter):
                         requested_provider=agent_overrides.get("requested_provider"),
                         model_options=agent_overrides.get("model_options"),
                         route=route,
+                        confirmed_runtime_lock=request_model_runtime is not None,
+                        request_model_runtime=request_model_runtime,
                     )
                 self._active_run_agents[run_id] = agent
 

--- a/gateway/request_model_runtime.py
+++ b/gateway/request_model_runtime.py
@@ -1,0 +1,321 @@
+"""Validated, request-scoped model runtimes for the API server.
+
+The API server normally resolves provider credentials from the active Hermes
+profile.  External control planes sometimes already own that configuration and
+need to submit one run against an ephemeral upstream without mutating
+``config.yaml`` or process-global environment variables.  This module keeps
+that boundary small and explicit.
+
+Runtime credentials are accepted only through ``MODEL_API_KEY_HEADER``.  They
+are deliberately excluded from the request JSON so ordinary body capture,
+status payloads, and response stores cannot retain them accidentally.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping, Optional
+from urllib.parse import urlsplit
+
+
+MODEL_API_KEY_HEADER = "X-Hermes-Model-Api-Key"
+
+_SUPPORTED_API_MODES = frozenset(
+    {"chat_completions", "codex_responses", "anthropic_messages"}
+)
+_ALLOWED_RUNTIME_KEYS = frozenset(
+    {"base_url", "api_mode", "max_tokens", "request_overrides"}
+)
+_ALLOWED_REQUEST_OVERRIDE_KEYS = frozenset(
+    {
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "parallel_tool_calls",
+        "tool_choice",
+        "seed",
+    }
+)
+_NUMERIC_OVERRIDE_KEYS = frozenset(
+    {"temperature", "top_p", "frequency_penalty", "presence_penalty"}
+)
+_PROVIDER_RE = re.compile(r"^[A-Za-z0-9_.-]{2,80}$")
+
+
+class RequestModelRuntimeError(ValueError):
+    """A client-supplied request runtime failed validation."""
+
+    def __init__(self, message: str, *, code: str, param: str = "runtime_model"):
+        super().__init__(message)
+        self.code = code
+        self.param = param
+
+
+@dataclass(frozen=True, repr=False)
+class RequestModelRuntime:
+    """Immutable model transport snapshot for exactly one API run."""
+
+    model: str
+    provider: str
+    base_url: str
+    api_key: str
+    api_mode: str
+    max_tokens: Optional[int]
+    request_overrides: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        # Request-scoped endpoints are caller-controlled.  A missing key must
+        # never reach AIAgent, where normal provider resolution could borrow
+        # an ambient profile credential and send it to that endpoint.
+        if not isinstance(self.api_key, str) or not self.api_key.strip():
+            raise RequestModelRuntimeError(
+                f"'{MODEL_API_KEY_HEADER}' is required when runtime_model is provided",
+                code="missing_runtime_model_credential",
+                param=MODEL_API_KEY_HEADER,
+            )
+
+    def __repr__(self) -> str:
+        # Credentials and endpoint paths can both be sensitive in hosted
+        # deployments.  Keep repr safe even if a caller logs this object.
+        return (
+            "RequestModelRuntime("
+            f"model={self.model!r}, provider={self.provider!r}, "
+            f"api_mode={self.api_mode!r}, max_tokens={self.max_tokens!r}, "
+            f"has_api_key={bool(self.api_key)})"
+        )
+
+    def agent_kwargs(self) -> dict[str, Any]:
+        """Return the request-only kwargs consumed by ``AIAgent``."""
+        request_overrides = dict(self.request_overrides)
+        if isinstance(request_overrides.get("stop"), tuple):
+            request_overrides["stop"] = list(request_overrides["stop"])
+        kwargs: dict[str, Any] = {
+            "provider": self.provider,
+            "base_url": self.base_url,
+            "api_mode": self.api_mode,
+            "request_overrides": request_overrides,
+        }
+        kwargs["api_key"] = self.api_key
+        if self.max_tokens is not None:
+            kwargs["max_tokens"] = self.max_tokens
+        return kwargs
+
+
+def _clean_runtime_id(value: Any, *, field: str, max_len: int) -> str:
+    if not isinstance(value, str):
+        raise RequestModelRuntimeError(
+            f"'{field}' must be a string",
+            code="invalid_runtime_model",
+            param=field,
+        )
+    cleaned = value.strip()
+    if not cleaned or len(cleaned) > max_len or re.search(r"[\r\n\x00]", cleaned):
+        raise RequestModelRuntimeError(
+            f"'{field}' is empty or invalid",
+            code="invalid_runtime_model",
+            param=field,
+        )
+    return cleaned
+
+
+def _validate_base_url(value: Any) -> str:
+    base_url = _clean_runtime_id(value, field="runtime_model.base_url", max_len=2048)
+    try:
+        parsed = urlsplit(base_url)
+        port = parsed.port
+    except ValueError as exc:
+        raise RequestModelRuntimeError(
+            "'runtime_model.base_url' is not a valid URL",
+            code="invalid_runtime_model",
+            param="runtime_model.base_url",
+        ) from exc
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or (port is not None and not 1 <= port <= 65535)
+    ):
+        raise RequestModelRuntimeError(
+            "'runtime_model.base_url' must be an HTTP(S) URL without credentials, query, or fragment",
+            code="invalid_runtime_model",
+            param="runtime_model.base_url",
+        )
+    return base_url.rstrip("/")
+
+
+def _validate_stop(value: Any) -> str | tuple[str, ...]:
+    if isinstance(value, str):
+        if len(value) <= 1024:
+            return value
+    elif isinstance(value, list) and len(value) <= 16:
+        if all(isinstance(item, str) and len(item) <= 1024 for item in value):
+            return tuple(value)
+    raise RequestModelRuntimeError(
+        "'runtime_model.request_overrides.stop' must be a string or up to 16 strings",
+        code="invalid_runtime_model",
+        param="runtime_model.request_overrides.stop",
+    )
+
+
+def _validate_request_overrides(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise RequestModelRuntimeError(
+            "'runtime_model.request_overrides' must be an object",
+            code="invalid_runtime_model",
+            param="runtime_model.request_overrides",
+        )
+
+    unknown = sorted(set(value) - _ALLOWED_REQUEST_OVERRIDE_KEYS)
+    if unknown:
+        raise RequestModelRuntimeError(
+            "Unsupported runtime_model.request_overrides field(s): " + ", ".join(unknown),
+            code="unsupported_runtime_model_option",
+            param="runtime_model.request_overrides",
+        )
+
+    result: dict[str, Any] = {}
+    for key, raw in value.items():
+        param = f"runtime_model.request_overrides.{key}"
+        if key in _NUMERIC_OVERRIDE_KEYS:
+            if isinstance(raw, bool) or not isinstance(raw, (int, float)) or not math.isfinite(raw):
+                raise RequestModelRuntimeError(
+                    f"'{param}' must be a finite number",
+                    code="invalid_runtime_model",
+                    param=param,
+                )
+            result[key] = raw
+        elif key == "stop":
+            result[key] = _validate_stop(raw)
+        elif key == "parallel_tool_calls":
+            if not isinstance(raw, bool):
+                raise RequestModelRuntimeError(
+                    f"'{param}' must be a boolean",
+                    code="invalid_runtime_model",
+                    param=param,
+                )
+            result[key] = raw
+        elif key == "tool_choice":
+            if not isinstance(raw, str) or raw not in {"auto", "none", "required"}:
+                raise RequestModelRuntimeError(
+                    f"'{param}' must be one of auto, none, required",
+                    code="invalid_runtime_model",
+                    param=param,
+                )
+            result[key] = raw
+        elif key == "seed":
+            if isinstance(raw, bool) or not isinstance(raw, int):
+                raise RequestModelRuntimeError(
+                    f"'{param}' must be an integer",
+                    code="invalid_runtime_model",
+                    param=param,
+                )
+            result[key] = raw
+    return result
+
+
+def parse_request_model_runtime(
+    body: Mapping[str, Any],
+    *,
+    api_key_header: Optional[str],
+) -> Optional[RequestModelRuntime]:
+    """Parse ``runtime_model`` from a ``/v1/runs`` request.
+
+    ``None`` means the request did not opt into the feature.  Presence is
+    strict: malformed or unknown values fail closed rather than falling back
+    to the profile's global model.
+    """
+    raw = body.get("runtime_model")
+    if raw is None:
+        if api_key_header:
+            raise RequestModelRuntimeError(
+                f"'{MODEL_API_KEY_HEADER}' requires a runtime_model object",
+                code="missing_runtime_model",
+                param="runtime_model",
+            )
+        return None
+    if not isinstance(raw, dict):
+        raise RequestModelRuntimeError(
+            "'runtime_model' must be an object",
+            code="invalid_runtime_model",
+            param="runtime_model",
+        )
+
+    unknown = sorted(set(raw) - _ALLOWED_RUNTIME_KEYS)
+    if unknown:
+        hint = " Use X-Hermes-Model-Api-Key for credentials." if "api_key" in unknown else ""
+        raise RequestModelRuntimeError(
+            "Unsupported runtime_model field(s): " + ", ".join(unknown) + hint,
+            code="unsupported_runtime_model_option",
+            param="runtime_model",
+        )
+
+    model = _clean_runtime_id(body.get("model"), field="model", max_len=200)
+    provider = _clean_runtime_id(body.get("provider"), field="provider", max_len=80)
+    if not _PROVIDER_RE.fullmatch(provider):
+        raise RequestModelRuntimeError(
+            "'provider' contains unsupported characters",
+            code="invalid_runtime_model",
+            param="provider",
+        )
+
+    api_mode = raw.get("api_mode", "chat_completions")
+    api_mode = _clean_runtime_id(
+        api_mode,
+        field="runtime_model.api_mode",
+        max_len=40,
+    ).lower()
+    if api_mode not in _SUPPORTED_API_MODES:
+        raise RequestModelRuntimeError(
+            "'runtime_model.api_mode' must be chat_completions, codex_responses, or anthropic_messages",
+            code="invalid_runtime_model",
+            param="runtime_model.api_mode",
+        )
+
+    max_tokens = raw.get("max_tokens")
+    if max_tokens is not None:
+        if isinstance(max_tokens, bool) or not isinstance(max_tokens, int) or not 1 <= max_tokens <= 10_000_000:
+            raise RequestModelRuntimeError(
+                "'runtime_model.max_tokens' must be an integer between 1 and 10000000",
+                code="invalid_runtime_model",
+                param="runtime_model.max_tokens",
+            )
+
+    api_key = (api_key_header or "").strip()
+    if api_key.lower() == "bearer":
+        api_key = ""
+    elif api_key.lower().startswith("bearer "):
+        api_key = api_key[7:].strip()
+    if not api_key:
+        raise RequestModelRuntimeError(
+            f"'{MODEL_API_KEY_HEADER}' is required when runtime_model is provided",
+            code="missing_runtime_model_credential",
+            param=MODEL_API_KEY_HEADER,
+        )
+    if len(api_key) > 8192:
+        raise RequestModelRuntimeError(
+            f"'{MODEL_API_KEY_HEADER}' is too long",
+            code="invalid_runtime_model_credential",
+            param=MODEL_API_KEY_HEADER,
+        )
+
+    return RequestModelRuntime(
+        model=model,
+        provider=provider,
+        base_url=_validate_base_url(raw.get("base_url")),
+        api_key=api_key,
+        api_mode=api_mode,
+        max_tokens=max_tokens,
+        request_overrides=MappingProxyType(
+            _validate_request_overrides(raw.get("request_overrides"))
+        ),
+    )

--- a/tests/gateway/test_request_model_runtime.py
+++ b/tests/gateway/test_request_model_runtime.py
@@ -1,0 +1,763 @@
+"""Contracts for request-scoped, model-locked ``/v1/runs`` execution."""
+
+import asyncio
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+from gateway.request_model_runtime import (
+    MODEL_API_KEY_HEADER,
+    RequestModelRuntimeError,
+    parse_request_model_runtime,
+)
+
+
+_SERVER_KEY = "server-auth-key-that-is-long-enough"
+_UPSTREAM_KEY = "tenant-upstream-secret"
+
+
+def _runtime_body(*, model: str = "tenant-model", provider: str = "custom"):
+    return {
+        "input": "hello",
+        "model": model,
+        "provider": provider,
+        "model_options": {"reasoning_effort": "high"},
+        "runtime_model": {
+            "base_url": "https://models.example.test/v1",
+            "api_mode": "chat_completions",
+            "max_tokens": 4096,
+            "request_overrides": {
+                "temperature": 0.2,
+                "top_p": 0.9,
+                "parallel_tool_calls": False,
+            },
+        },
+    }
+
+
+def _headers(*, upstream_key: str = _UPSTREAM_KEY):
+    return {
+        "Authorization": f"Bearer {_SERVER_KEY}",
+        MODEL_API_KEY_HEADER: upstream_key,
+    }
+
+
+def _adapter(*, enabled: bool = True):
+    return APIServerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "key": _SERVER_KEY,
+                "allow_request_model_runtime": enabled,
+            },
+        )
+    )
+
+
+def _runs_app(adapter: APIServerAdapter):
+    app = web.Application()
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    return app
+
+
+class TestRequestModelRuntimeParsing:
+    def test_valid_runtime_is_immutable_and_repr_redacts_transport(self):
+        runtime = parse_request_model_runtime(
+            _runtime_body(),
+            api_key_header=f"Bearer {_UPSTREAM_KEY}",
+        )
+
+        assert runtime is not None
+        assert runtime.model == "tenant-model"
+        assert runtime.provider == "custom"
+        assert runtime.api_key == _UPSTREAM_KEY
+        assert runtime.agent_kwargs() == {
+            "provider": "custom",
+            "base_url": "https://models.example.test/v1",
+            "api_key": _UPSTREAM_KEY,
+            "api_mode": "chat_completions",
+            "max_tokens": 4096,
+            "request_overrides": {
+                "temperature": 0.2,
+                "top_p": 0.9,
+                "parallel_tool_calls": False,
+            },
+        }
+        assert _UPSTREAM_KEY not in repr(runtime)
+        assert "models.example.test" not in repr(runtime)
+        with pytest.raises(TypeError):
+            runtime.request_overrides["temperature"] = 0.9
+
+    @pytest.mark.parametrize("api_key_header", [None, "", "   ", "Bearer "])
+    def test_runtime_requires_an_explicit_credential(self, api_key_header):
+        with pytest.raises(RequestModelRuntimeError) as exc_info:
+            parse_request_model_runtime(
+                _runtime_body(),
+                api_key_header=api_key_header,
+            )
+
+        assert exc_info.value.code == "missing_runtime_model_credential"
+        assert exc_info.value.param == MODEL_API_KEY_HEADER
+
+    @pytest.mark.parametrize(
+        ("mutation", "expected_param"),
+        [
+            (lambda body: body["runtime_model"].update(api_key="in-body"), "runtime_model"),
+            (lambda body: body["runtime_model"].update(base_url="file:///etc/passwd"), "runtime_model.base_url"),
+            (lambda body: body["runtime_model"].update(api_mode="unknown"), "runtime_model.api_mode"),
+            (
+                lambda body: body["runtime_model"]["request_overrides"].update(messages=[]),
+                "runtime_model.request_overrides",
+            ),
+        ],
+    )
+    def test_unsafe_or_unknown_fields_fail_closed(self, mutation, expected_param):
+        body = _runtime_body()
+        mutation(body)
+        with pytest.raises(RequestModelRuntimeError) as exc_info:
+            parse_request_model_runtime(body, api_key_header=_UPSTREAM_KEY)
+        assert exc_info.value.param == expected_param
+
+
+class TestRequestModelRuntimeRunsContract:
+    @pytest.mark.asyncio
+    async def test_disabled_feature_rejects_before_agent_creation(self):
+        adapter = _adapter(enabled=False)
+        async with TestClient(TestServer(_runs_app(adapter))) as client:
+            with patch.object(adapter, "_create_agent") as create_agent:
+                response = await client.post(
+                    "/v1/runs",
+                    json=_runtime_body(),
+                    headers=_headers(),
+                )
+                payload = await response.json()
+
+        assert response.status == 403
+        assert payload["error"]["code"] == "request_model_runtime_disabled"
+        create_agent.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_feature_requires_api_server_auth_even_when_handler_is_embedded(self):
+        adapter = APIServerAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={"allow_request_model_runtime": True},
+            )
+        )
+        async with TestClient(TestServer(_runs_app(adapter))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json=_runtime_body(),
+                headers={MODEL_API_KEY_HEADER: _UPSTREAM_KEY},
+            )
+            payload = await response.json()
+
+        assert response.status == 403
+        assert payload["error"]["code"] == "request_model_runtime_requires_auth"
+
+    @pytest.mark.asyncio
+    async def test_runtime_lock_cannot_be_disabled(self):
+        body = _runtime_body()
+        body["require_model_lock"] = False
+        async with TestClient(TestServer(_runs_app(_adapter()))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json=body,
+                headers=_headers(),
+            )
+            payload = await response.json()
+
+        assert response.status == 400
+        assert payload["error"]["code"] == "request_model_runtime_requires_lock"
+
+    @pytest.mark.asyncio
+    async def test_missing_runtime_credential_is_rejected_before_agent_creation(
+        self, monkeypatch
+    ):
+        # An ambient provider credential must not make a caller-controlled
+        # endpoint usable.  The API boundary rejects before AIAgent (and thus
+        # any provider resolver or outbound transport) can run.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-profile-secret")
+        adapter = _adapter()
+        body = _runtime_body(provider="anthropic")
+        body["runtime_model"]["api_mode"] = "anthropic_messages"
+
+        async with TestClient(TestServer(_runs_app(adapter))) as client:
+            with patch.object(adapter, "_create_agent") as create_agent:
+                response = await client.post(
+                    "/v1/runs",
+                    json=body,
+                    headers={"Authorization": f"Bearer {_SERVER_KEY}"},
+                )
+                payload = await response.json()
+
+        assert response.status == 400
+        assert payload["error"]["code"] == "missing_runtime_model_credential"
+        assert payload["error"]["param"] == MODEL_API_KEY_HEADER
+        create_agent.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_virtual_model_alias_is_rejected(self):
+        adapter = _adapter()
+        body = _runtime_body(model=adapter._model_name)
+        async with TestClient(TestServer(_runs_app(adapter))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json=body,
+                headers=_headers(),
+            )
+            payload = await response.json()
+
+        assert response.status == 400
+        assert payload["error"]["code"] == "request_model_runtime_alias_conflict"
+        assert "API virtual model" in payload["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_configured_model_route_alias_is_rejected(self):
+        adapter = _adapter()
+        adapter._model_routes = {
+            "tenant-route": {
+                "model": "tenant-model",
+                "provider": "custom",
+            }
+        }
+        body = _runtime_body(model="tenant-route")
+        async with TestClient(TestServer(_runs_app(adapter))) as client:
+            response = await client.post(
+                "/v1/runs",
+                json=body,
+                headers=_headers(),
+            )
+            payload = await response.json()
+
+        assert response.status == 400
+        assert payload["error"]["code"] == "request_model_runtime_alias_conflict"
+        assert "model_routes alias" in payload["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_run_receives_complete_locked_runtime_without_secret_egress(self):
+        adapter = _adapter()
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "done"}
+        mock_agent.session_prompt_tokens = 1
+        mock_agent.session_completion_tokens = 1
+        mock_agent.session_total_tokens = 2
+
+        async with TestClient(TestServer(_runs_app(adapter))) as client:
+            with patch.object(adapter, "_create_agent", return_value=mock_agent) as create_agent:
+                response = await client.post(
+                    "/v1/runs",
+                    json=_runtime_body(),
+                    headers=_headers(),
+                )
+                assert response.status == 202
+                run_id = (await response.json())["run_id"]
+
+                for _ in range(40):
+                    if create_agent.call_args is not None:
+                        break
+                    await asyncio.sleep(0.05)
+
+                status_response = await client.get(
+                    f"/v1/runs/{run_id}",
+                    headers={"Authorization": f"Bearer {_SERVER_KEY}"},
+                )
+                status_payload = await status_response.json()
+
+        kwargs = create_agent.call_args.kwargs
+        runtime = kwargs["request_model_runtime"]
+        assert kwargs["confirmed_runtime_lock"] is True
+        assert kwargs["route"] is None
+        assert runtime.api_key == _UPSTREAM_KEY
+        assert runtime.model == "tenant-model"
+        assert runtime.request_overrides["temperature"] == 0.2
+        assert _UPSTREAM_KEY not in json.dumps(status_payload)
+
+    @pytest.mark.asyncio
+    async def test_capabilities_advertise_opt_in_and_credential_header(self):
+        adapter = _adapter()
+        async with TestClient(TestServer(_runs_app(adapter))) as client:
+            response = await client.get(
+                "/v1/capabilities",
+                headers={"Authorization": f"Bearer {_SERVER_KEY}"},
+            )
+            payload = await response.json()
+
+        assert payload["features"]["run_request_model_runtime"] is True
+        assert (
+            payload["features"]["run_request_model_credential_header"]
+            == MODEL_API_KEY_HEADER
+        )
+
+
+class TestRequestModelRuntimeAgentCreation:
+    def test_request_runtime_bypasses_global_resolution_and_disables_fallback(
+        self,
+        monkeypatch,
+    ):
+        adapter = _adapter()
+        runtime = parse_request_model_runtime(
+            _runtime_body(),
+            api_key_header=_UPSTREAM_KEY,
+        )
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.__dict__.update(kwargs)
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: (_ for _ in ()).throw(AssertionError("global runtime was resolved")),
+        )
+        monkeypatch.setattr(
+            "gateway.run._resolve_gateway_model",
+            lambda: (_ for _ in ()).throw(AssertionError("global model was resolved")),
+        )
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr("gateway.run._checkpoint_agent_kwargs", lambda _cfg: {})
+        monkeypatch.setattr("gateway.run._current_max_iterations", lambda: 90)
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+        monkeypatch.setattr(
+            adapter,
+            "_session_model_override_for",
+            lambda *_: (_ for _ in ()).throw(AssertionError("session override was read")),
+        )
+
+        agent = adapter._create_agent(
+            session_id="tenant-session",
+            gateway_session_key="tenant-memory-scope",
+            requested_model=runtime.model,
+            requested_provider=runtime.provider,
+            model_options={"reasoning_effort": "high"},
+            confirmed_runtime_lock=True,
+            request_model_runtime=runtime,
+        )
+
+        assert captured["model"] == "tenant-model"
+        assert captured["provider"] == "custom"
+        assert captured["base_url"] == "https://models.example.test/v1"
+        assert captured["api_key"] == _UPSTREAM_KEY
+        assert captured["api_mode"] == "chat_completions"
+        assert captured["max_tokens"] == 4096
+        assert captured["request_overrides"]["temperature"] == 0.2
+        assert captured["fallback_model"] is None
+        assert captured["reasoning_config"] == {"enabled": True, "effort": "high"}
+        assert agent._runtime_model_locked is True
+        assert agent._runtime_model_lock_source == "request_runtime"
+        assert agent._hermes_api_runtime == {
+            "provider": "custom",
+            "model": "tenant-model",
+            "route_source": "request_runtime",
+        }
+        assert adapter._last_resolved_model == {}
+
+    def test_locked_anthropic_runtime_never_resolves_ambient_token(
+        self, monkeypatch
+    ):
+        """Exercise the real AIAgent constructor at the credential boundary."""
+        adapter = _adapter()
+        body = _runtime_body(
+            model="claude-sonnet-4-20250514",
+            provider="anthropic",
+        )
+        body["runtime_model"]["api_mode"] = "anthropic_messages"
+        runtime = parse_request_model_runtime(
+            body,
+            api_key_header=_UPSTREAM_KEY,
+        )
+        built = {}
+
+        def build_client(api_key, base_url, **kwargs):
+            built.update(api_key=api_key, base_url=base_url, kwargs=kwargs)
+            return MagicMock()
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-profile-secret")
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.resolve_anthropic_token",
+            lambda: (_ for _ in ()).throw(
+                AssertionError("ambient Anthropic credentials were resolved")
+            ),
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.build_anthropic_client",
+            build_client,
+        )
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr("gateway.run._checkpoint_agent_kwargs", lambda _cfg: {})
+        monkeypatch.setattr("gateway.run._current_max_iterations", lambda: 90)
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        agent = adapter._create_agent(
+            session_id="tenant-session",
+            gateway_session_key="tenant-memory-scope",
+            requested_model=runtime.model,
+            requested_provider=runtime.provider,
+            confirmed_runtime_lock=True,
+            request_model_runtime=runtime,
+        )
+        try:
+            assert built["api_key"] == _UPSTREAM_KEY
+            assert built["base_url"] == "https://models.example.test/v1"
+            assert agent._anthropic_api_key == _UPSTREAM_KEY
+            assert agent.api_key == _UPSTREAM_KEY
+            assert agent._runtime_model_locked is True
+        finally:
+            agent.close()
+
+    def test_locked_auxiliary_failure_never_uses_profile_fallback(self, monkeypatch):
+        from agent import auxiliary_client as auxiliary
+
+        invalid_response = MagicMock()
+        invalid_response.choices = []
+        client = MagicMock()
+
+        monkeypatch.setattr(
+            auxiliary,
+            "_get_cached_client",
+            lambda provider, model=None, **kwargs: (client, model),
+        )
+        monkeypatch.setattr(
+            auxiliary,
+            "_relay_sync_completion",
+            lambda *_args, **_kwargs: invalid_response,
+        )
+        monkeypatch.setattr(
+            auxiliary,
+            "_resolve_task_provider_model",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("auxiliary task route was resolved")
+            ),
+        )
+        for fallback_name in (
+            "_try_configured_fallback_chain",
+            "_try_main_fallback_chain",
+            "_try_payment_fallback",
+            "_try_main_agent_model_fallback",
+        ):
+            monkeypatch.setattr(
+                auxiliary,
+                fallback_name,
+                lambda *_args, _name=fallback_name, **_kwargs: (
+                    _ for _ in ()
+                ).throw(AssertionError(f"{_name} was called")),
+            )
+
+        with pytest.raises(RuntimeError):
+            auxiliary.call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "hello"}],
+                main_runtime={
+                    "provider": "custom",
+                    "model": "locked-model",
+                    "base_url": "https://locked.example.test/v1",
+                    "api_key": "locked-secret",
+                    "api_mode": "chat_completions",
+                    "model_locked": True,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_locked_async_auxiliary_failure_never_uses_profile_fallback(
+        self, monkeypatch
+    ):
+        from agent import auxiliary_client as auxiliary
+
+        invalid_response = MagicMock()
+        invalid_response.choices = []
+        client = MagicMock()
+        monkeypatch.setattr(
+            auxiliary,
+            "_get_cached_client",
+            lambda provider, model=None, **kwargs: (client, model),
+        )
+        monkeypatch.setattr(
+            auxiliary,
+            "_relay_async_completion",
+            AsyncMock(return_value=invalid_response),
+        )
+        monkeypatch.setattr(
+            auxiliary,
+            "_resolve_task_provider_model",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("auxiliary task route was resolved")
+            ),
+        )
+        for fallback_name in (
+            "_try_configured_fallback_chain",
+            "_try_main_fallback_chain",
+            "_try_payment_fallback",
+            "_try_main_agent_model_fallback",
+        ):
+            monkeypatch.setattr(
+                auxiliary,
+                fallback_name,
+                lambda *_args, _name=fallback_name, **_kwargs: (
+                    _ for _ in ()
+                ).throw(AssertionError(f"{_name} was called")),
+            )
+
+        with pytest.raises(RuntimeError):
+            await auxiliary.async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hello"}],
+                main_runtime={
+                    "provider": "custom",
+                    "model": "locked-model",
+                    "base_url": "https://locked.example.test/v1",
+                    "api_key": "locked-secret",
+                    "api_mode": "chat_completions",
+                    "model_locked": True,
+                },
+            )
+
+
+class TestRequestModelRuntimeEndToEnd:
+    @pytest.mark.asyncio
+    async def test_concurrent_runs_reach_only_their_locked_upstream(self, monkeypatch):
+        """Exercise the real APIServerAdapter -> AIAgent -> OpenAI transport.
+
+        Two simultaneous callers intentionally use the same provider slug but
+        different endpoints, keys, model ids, and generation parameters.  A
+        process-global mutation or fallback would make the recorded requests
+        cross; the invariant is that each fake upstream sees exactly its own
+        complete runtime snapshot.
+        """
+
+        def start_upstream(name: str, expected_key: str, calls: list[dict]):
+            # AIAgent construction performs a synchronous endpoint probe.  A
+            # stdlib thread-backed server keeps that real request independent
+            # of the aiohttp event loop serving /v1/runs.
+            class Handler(BaseHTTPRequestHandler):
+                protocol_version = "HTTP/1.0"
+
+                def do_POST(self):
+                    length = int(self.headers.get("Content-Length", "0"))
+                    payload = json.loads(self.rfile.read(length))
+                    if self.path != "/v1/chat/completions":
+                        self.send_response(404)
+                        self.send_header("Content-Length", "0")
+                        self.end_headers()
+                        return
+
+                    calls.append(
+                        {
+                            "authorization": self.headers.get("Authorization"),
+                            "payload": payload,
+                        }
+                    )
+                    if self.headers.get("Authorization") != f"Bearer {expected_key}":
+                        raw = b'{"error":"wrong key"}'
+                        self.send_response(401)
+                        self.send_header("Content-Type", "application/json")
+                        self.send_header("Content-Length", str(len(raw)))
+                        self.end_headers()
+                        self.wfile.write(raw)
+                        return
+
+                    if not payload.get("stream"):
+                        response_payload = {
+                            "id": f"chatcmpl-{name}-aux",
+                            "object": "chat.completion",
+                            "created": 1,
+                            "model": payload.get("model"),
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "message": {
+                                        "role": "assistant",
+                                        "content": json.dumps(
+                                            {"title": f"Tenant {name.upper()} task"}
+                                        ),
+                                    },
+                                    "finish_reason": "stop",
+                                }
+                            ],
+                            "usage": {
+                                "prompt_tokens": 3,
+                                "completion_tokens": 2,
+                                "total_tokens": 5,
+                            },
+                        }
+                        raw = json.dumps(response_payload).encode()
+                        self.send_response(200)
+                        self.send_header("Content-Type", "application/json")
+                        self.send_header("Content-Length", str(len(raw)))
+                        self.end_headers()
+                        self.wfile.write(raw)
+                        return
+
+                    chunks = [
+                        {
+                            "id": f"chatcmpl-{name}",
+                            "object": "chat.completion.chunk",
+                            "created": 1,
+                            "model": payload.get("model"),
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "delta": {
+                                        "role": "assistant",
+                                        "content": f"served-{name}",
+                                    },
+                                    "finish_reason": None,
+                                }
+                            ],
+                        },
+                        {
+                            "id": f"chatcmpl-{name}",
+                            "object": "chat.completion.chunk",
+                            "created": 1,
+                            "model": payload.get("model"),
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "delta": {},
+                                    "finish_reason": "stop",
+                                }
+                            ],
+                            "usage": {
+                                "prompt_tokens": 3,
+                                "completion_tokens": 2,
+                                "total_tokens": 5,
+                            },
+                        },
+                    ]
+                    raw = (
+                        "".join(f"data: {json.dumps(chunk)}\n\n" for chunk in chunks)
+                        + "data: [DONE]\n\n"
+                    ).encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/event-stream")
+                    self.send_header("Content-Length", str(len(raw)))
+                    self.end_headers()
+                    self.wfile.write(raw)
+
+                def log_message(self, _format, *args):
+                    return
+
+            server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            return server
+
+        calls_a: list[dict] = []
+        calls_b: list[dict] = []
+        key_a = "tenant-a-runtime-key"
+        key_b = "tenant-b-runtime-key"
+
+        # The request-runtime path must remain independent of global provider
+        # resolution even under real AIAgent construction.
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: (_ for _ in ()).throw(AssertionError("global runtime was resolved")),
+        )
+
+        upstream_a = start_upstream("a", key_a, calls_a)
+        upstream_b = start_upstream("b", key_b, calls_b)
+        agents = []
+        try:
+            adapter = _adapter()
+            real_create_agent = adapter._create_agent
+
+            def capture_agent(**kwargs):
+                agent = real_create_agent(**kwargs)
+                agents.append(agent)
+                return agent
+
+            async with TestClient(TestServer(_runs_app(adapter))) as client:
+                def body(name: str, base_url: str, temperature: float):
+                    payload = _runtime_body(model=f"tenant-{name}-model")
+                    payload["runtime_model"]["base_url"] = base_url
+                    payload["runtime_model"]["request_overrides"]["temperature"] = temperature
+                    return payload
+
+                base_a = f"http://127.0.0.1:{upstream_a.server_port}/v1"
+                base_b = f"http://127.0.0.1:{upstream_b.server_port}/v1"
+                with patch.object(adapter, "_create_agent", side_effect=capture_agent):
+                    response_a, response_b = await asyncio.gather(
+                        client.post(
+                            "/v1/runs",
+                            json=body("a", base_a, 0.1),
+                            headers=_headers(upstream_key=key_a),
+                        ),
+                        client.post(
+                            "/v1/runs",
+                            json=body("b", base_b, 0.8),
+                            headers=_headers(upstream_key=key_b),
+                        ),
+                    )
+                    assert response_a.status == 202
+                    assert response_b.status == 202
+                    run_a = (await response_a.json())["run_id"]
+                    run_b = (await response_b.json())["run_id"]
+
+                    statuses = {}
+                    for _ in range(100):
+                        for name, run_id in (("a", run_a), ("b", run_b)):
+                            response = await client.get(
+                                f"/v1/runs/{run_id}",
+                                headers={"Authorization": f"Bearer {_SERVER_KEY}"},
+                            )
+                            statuses[name] = await response.json()
+                        if all(
+                            statuses[name].get("status") == "completed"
+                            for name in ("a", "b")
+                        ):
+                            break
+                        await asyncio.sleep(0.05)
+
+                    # Auto-title runs in a background worker. Wait for its
+                    # auxiliary request so the E2E proves nested LLM calls are
+                    # locked to the same tenant runtime as the main stream.
+                    for _ in range(40):
+                        if all(
+                            any(not call["payload"].get("stream") for call in calls)
+                            for calls in (calls_a, calls_b)
+                        ):
+                            break
+                        await asyncio.sleep(0.05)
+        finally:
+            for agent in agents:
+                agent.close()
+            upstream_a.shutdown()
+            upstream_a.server_close()
+            upstream_b.shutdown()
+            upstream_b.server_close()
+
+        assert statuses["a"]["status"] == "completed", statuses["a"]
+        assert statuses["b"]["status"] == "completed", statuses["b"]
+        assert statuses["a"]["output"] == "served-a"
+        assert statuses["b"]["output"] == "served-b"
+        assert calls_a
+        assert calls_b
+        assert all(call["authorization"] == f"Bearer {key_a}" for call in calls_a)
+        assert all(call["authorization"] == f"Bearer {key_b}" for call in calls_b)
+        assert all(call["payload"]["model"] == "tenant-a-model" for call in calls_a)
+        assert all(call["payload"]["model"] == "tenant-b-model" for call in calls_b)
+        main_calls_a = [call for call in calls_a if call["payload"].get("stream")]
+        main_calls_b = [call for call in calls_b if call["payload"].get("stream")]
+        aux_calls_a = [call for call in calls_a if not call["payload"].get("stream")]
+        aux_calls_b = [call for call in calls_b if not call["payload"].get("stream")]
+        assert len(main_calls_a) == 1
+        assert len(main_calls_b) == 1
+        assert aux_calls_a
+        assert aux_calls_b
+        assert main_calls_a[0]["payload"]["temperature"] == 0.1
+        assert main_calls_b[0]["payload"]["temperature"] == 0.8
+        serialized_status = json.dumps(statuses)
+        assert key_a not in serialized_status
+        assert key_b not in serialized_status

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -786,6 +786,27 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["api_mode"])
         self.assertIsNone(creds["model"])
 
+    def test_request_model_lock_ignores_delegation_provider_config(self):
+        """A hosted run's immutable model transport must reach every child;
+        process-global delegation config cannot reroute a tenant subagent."""
+        parent = _make_mock_parent(depth=0)
+        parent._runtime_model_locked = True
+        parent._runtime_model_lock_source = "request_runtime"
+        cfg = {
+            "model": "other-model",
+            "provider": "other-provider",
+            "base_url": "https://other.example/v1",
+            "api_key": "other-secret",
+        }
+
+        creds = _resolve_delegation_credentials(cfg, parent)
+
+        self.assertEqual(creds["model"], parent.model)
+        self.assertIsNone(creds["provider"])
+        self.assertIsNone(creds["base_url"])
+        self.assertIsNone(creds["api_key"])
+        self.assertIsNone(creds["api_mode"])
+
     def test_direct_endpoint_uses_configured_base_url_and_api_key(self):
         parent = _make_mock_parent(depth=0)
         cfg = {
@@ -997,6 +1018,17 @@ class TestDelegationProviderIntegration(unittest.TestCase):
         self.assertIn("nonexistent", result["error"])
 
 class TestChildCredentialPoolResolution(unittest.TestCase):
+    def test_model_locked_parent_never_loads_or_shares_a_pool(self):
+        parent = _make_mock_parent()
+        parent._runtime_model_locked = True
+        parent._credential_pool = MagicMock()
+
+        with patch("agent.credential_pool.load_pool") as load_pool:
+            result = _resolve_child_credential_pool("openrouter", parent)
+
+        self.assertIsNone(result)
+        load_pool.assert_not_called()
+
     def test_same_provider_shares_parent_pool(self):
         parent = _make_mock_parent()
         mock_pool = MagicMock()
@@ -1872,6 +1904,30 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
         _, kwargs = MockAgent.call_args
         self.assertIsNone(kwargs["fallback_model"])
+
+    def test_child_inherits_request_model_lock_marker(self):
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = []
+        parent._runtime_model_locked = True
+        parent._runtime_model_lock_source = "request_runtime"
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            child = MagicMock()
+            MockAgent.return_value = child
+            result = _build_child_agent(
+                task_index=0,
+                goal="test request runtime lock inheritance",
+                context=None,
+                toolsets=None,
+                model=parent.model,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertIs(result, child)
+        self.assertIs(child._runtime_model_locked, True)
+        self.assertEqual(child._runtime_model_lock_source, "request_runtime")
 
     def test_pinned_provider_disables_parent_fallback_chain(self):
         """An explicit delegation.provider pin must NOT inherit the parent

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2003,6 +2003,18 @@ def _build_child_agent(
                 iteration_budget=None,  # fresh budget per subagent
                 **child_optional_kwargs,
             )
+            # A request-scoped model lock is an execution contract, not just a
+            # root-agent hint.  Propagate the marker so nested orchestrators
+            # also inherit the same model transport and cannot activate a
+            # delegation-level provider override.
+            child._runtime_model_locked = (
+                getattr(parent_agent, "_runtime_model_locked", False) is True
+            )
+            child._runtime_model_lock_source = getattr(
+                parent_agent,
+                "_runtime_model_lock_source",
+                "",
+            )
         except BaseException:
             # Construction failed: the dedicated handle has no owner and no
             # child close() will ever run — release it here so the sqlite fds
@@ -4389,6 +4401,12 @@ def _resolve_child_credential_pool(
     ``custom:<name>`` pool key derived from the base_url) and only share the
     parent's pool when both resolve to the *same* custom endpoint.
     """
+    if getattr(parent_agent, "_runtime_model_locked", False) is True:
+        # A locked request carries one fixed credential snapshot. Never attach
+        # a profile-scoped pool that could rotate the child onto a different
+        # key or endpoint after a provider error.
+        return None
+
     if not effective_provider:
         return getattr(parent_agent, "_credential_pool", None)
 
@@ -4472,6 +4490,25 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
     Raises ValueError with a user-friendly message on credential failure.
     """
+    if getattr(parent_agent, "_runtime_model_locked", False) is True:
+        # The parent was admitted with an immutable request/session runtime.
+        # Returning no override values makes _build_child_agent inherit the
+        # parent's model, provider, endpoint, key, API mode, request options,
+        # token ceiling, and empty fallback chain verbatim.  This also prevents
+        # a process-global delegation.* config from crossing tenant/model
+        # boundaries in a hosted API server.
+        return {
+            "model": getattr(parent_agent, "model", None),
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "request_overrides": None,
+            "max_output_tokens": None,
+            "command": None,
+            "args": [],
+        }
+
     configured_model = str(cfg.get("model") or "").strip() or None
     configured_provider = str(cfg.get("provider") or "").strip() or None
     configured_base_url = str(cfg.get("base_url") or "").strip() or None

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -252,7 +252,9 @@ Returns a machine-readable description of the API server's stable surface for ex
     "run_submission": true,
     "run_status": true,
     "run_events_sse": true,
-    "run_stop": true
+    "run_stop": true,
+    "run_request_model_runtime": false,
+    "run_request_model_credential_header": null
   }
 }
 ```
@@ -410,6 +412,69 @@ Example:
   ]
 }
 ```
+
+## Request-scoped model runtimes for `/v1/runs`
+
+Hosted control planes can keep model endpoints and credentials in their own
+database while using Hermes only as the execution runtime. Enable the opt-in
+API-server boundary:
+
+```yaml
+gateway:
+  platforms:
+    api_server:
+      allow_request_model_runtime: true
+```
+
+Then submit a concrete model/provider plus a `runtime_model` transport. The
+upstream credential is required and uses a dedicated header because
+`Authorization` already authenticates the caller to Hermes. Hermes rejects the
+request before agent creation when this header is missing; it never falls back
+to credentials from the active profile for a caller-supplied endpoint:
+
+```bash
+curl -X POST http://127.0.0.1:8642/v1/runs \
+  -H "Authorization: Bearer $API_SERVER_KEY" \
+  -H "X-Hermes-Model-Api-Key: $UPSTREAM_MODEL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": "Inspect this repository and summarize its state.",
+    "model": "my-model",
+    "provider": "custom",
+    "model_options": {"reasoning_effort": "high"},
+    "runtime_model": {
+      "base_url": "https://models.example.com/v1",
+      "api_mode": "chat_completions",
+      "max_tokens": 8192,
+      "request_overrides": {
+        "temperature": 0.2,
+        "top_p": 0.9
+      }
+    }
+  }'
+```
+
+This contract is intentionally narrow:
+
+- it is accepted only on `POST /v1/runs` and only when explicitly enabled;
+- `model` must be a concrete provider model id, not a `model_routes` alias;
+- `X-Hermes-Model-Api-Key` is required for every `runtime_model` request;
+- `base_url` must be HTTP(S), while arbitrary SDK kwargs are rejected;
+- the runtime is immutable for the run and always model-locked;
+- session `/model` overrides, profile defaults, and the global fallback chain
+  cannot replace it;
+- auxiliary LLM work such as title generation and compression uses the same
+  model transport; task-specific fast models, credential pools, and provider
+  fallbacks are disabled for the locked run;
+- delegated subagents inherit the same model transport even if
+  `delegation.provider` is configured globally;
+- the upstream credential is never added to run status, events, response
+  payloads, or persisted model configuration.
+
+Enabling this option lets an authenticated caller choose an upstream network
+destination. Treat `API_SERVER_KEY` as a privileged control-plane credential,
+keep the API server on a trusted network, and apply outbound network policy at
+the deployment boundary when only specific model hosts should be reachable.
 
 ### GET /health
 


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in, authenticated `/v1/runs` contract for external control planes that already own model endpoints and credentials. A caller can provide one validated model transport for a run without mutating `config.yaml`, environment variables, or process-global provider state.

The submitted runtime is immutable and fail-closed: the root agent, auxiliary LLM work, and delegated subagents stay on the same model, endpoint, credential, and API mode. Session model overrides, task-specific fast models, credential pools, and provider fallback chains cannot replace it.

## Related Issue

No linked issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a strict `RequestModelRuntime` parser with an immutable, redacted runtime snapshot and a dedicated upstream credential header.
- Gate dynamic upstream routing behind `allow_request_model_runtime` and API Server bearer authentication; reject unsafe URLs, unknown options, virtual aliases, and unlocked requests.
- Bypass profile/session/global model resolution and disable the root fallback chain for locked runs.
- Propagate the lock through auxiliary LLM routing and subagent construction, including credential-pool isolation.
- Advertise the capability through `/v1/capabilities` and document the config and request contract.
- Add a real concurrent two-runtime HTTP E2E covering the main ReAct stream and background title generation, plus fail-closed sync/async and subagent tests.

## How to Test

1. Set `platforms.api_server.extra.allow_request_model_runtime: true` with a strong API Server key.
2. Submit `POST /v1/runs` with `model`, `provider`, `runtime_model`, and `X-Hermes-Model-Api-Key` as documented in `website/docs/user-guide/features/api-server.md`.
3. Run:

   ```bash
   scripts/run_tests.sh tests/gateway/test_request_model_runtime.py tests/tools/test_delegate.py -q
   scripts/run_tests.sh tests/agent/test_auxiliary*.py tests/agent/test_title_generator.py tests/agent/test_turn_context.py tests/gateway/test_request_model_runtime.py tests/gateway/test_api_server_runs.py tests/gateway/test_api_server.py tests/gateway/test_session_api.py tests/tools/test_delegate.py -q -k 'not test_health_detailed_returns_ok'
   ```

The focused post-rebase run passed 637 tests across 29 files. The omitted existing health assertion is environment-dependent: this development host is at 99% disk usage, and Hermes intentionally reports `degraded` at 90% or higher; the health handler is unchanged by this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide; `scripts/check-windows-footguns.py --diff origin/main` passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

- Request runtime E2E: 15 passed.
- Affected regression suite after rebasing onto current `main`: 637 passed, 0 failed.
- Ruff checks: passed.
