### PR TITLE
hermes -z pipelines can now attribute spend per subagent (Copilot CLI 1.0.81 port)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2877,6 +2877,10 @@ def init_agent(
     agent.session_estimated_cost_usd = 0.0
     agent.session_cost_status = "unknown"
     agent.session_cost_source = "none"
+    # Per-delegation usage ledger (see reset_session_state in run_agent.py):
+    # appended by tools/delegate_tool._finalize_child_results, surfaced via
+    # the `delegations` block in turn results and `hermes -z --usage-file`.
+    agent.session_delegation_usage = []
     
     # ── Ollama num_ctx injection ──
     # Ollama defaults to 2048 context regardless of the model's capabilities.

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -726,6 +726,13 @@ def finalize_turn(
         ).get("service_tier"),
         "session_id": agent.session_id,
     }
+    # Per-delegation usage attribution (delegate_task children this session).
+    # Only present when at least one delegation completed — keeps legacy
+    # result shapes byte-identical for delegation-free runs.  Consumed by
+    # `hermes -z --usage-file` and available to any run_conversation caller.
+    _delegation_usage = getattr(agent, "session_delegation_usage", None)
+    if _delegation_usage:
+        result["delegations"] = list(_delegation_usage)
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
     # Persistence failures already set failed=True + an explanation in

--- a/cli.py
+++ b/cli.py
@@ -13582,6 +13582,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         print(f"  Messages:         {msg_count}")
         print(f"  Compressions:     {compressions}")
 
+        # ── Per-delegation usage (delegate_task children this session) ──
+        _delegations = getattr(agent, "session_delegation_usage", None) or []
+        if _delegations:
+            print(f"  {'─' * 40}")
+            print(f"  Delegations:      {len(_delegations)}")
+            for d in _delegations[-10:]:
+                _goal = (d.get("goal") or "").strip().replace("\n", " ")
+                if len(_goal) > 44:
+                    _goal = _goal[:41] + "..."
+                _in = d.get("input_tokens", 0) or 0
+                _out = d.get("output_tokens", 0) or 0
+                _cost = d.get("cost_usd", 0.0) or 0.0
+                _cost_str = f" ${_cost:.4f}" if _cost else ""
+                print(
+                    f"    • {_goal or '(no goal)'} — "
+                    f"{_in:,} in / {_out:,} out{_cost_str}"
+                )
+            if len(_delegations) > 10:
+                print(f"    … and {len(_delegations) - 10} earlier")
+
         # Account limits -- fetched off-thread with a hard timeout so slow
         # provider APIs don't hang the prompt.
         provider = getattr(agent, "provider", None) or getattr(self, "provider", None)

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -190,6 +190,12 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
             # a config-matching bug silently dropped flex -> 2.3x billing).
             "service_tier": result.get("service_tier"),
         }
+        # Per-delegation usage attribution (one entry per delegate_task
+        # child: model, tokens, api_calls, cost).  Present only when the run
+        # actually delegated — mirrors the turn result's `delegations` block.
+        # Inspired by Copilot CLI 1.0.81 per-agent usage metrics.
+        if result.get("delegations"):
+            report["delegations"] = result["delegations"]
         if failure is not None:
             report["failure"] = failure
         out = Path(path).expanduser()

--- a/run_agent.py
+++ b/run_agent.py
@@ -788,6 +788,14 @@ class AIAgent:
         self.session_estimated_cost_usd = 0.0
         self.session_cost_status = "unknown"
         self.session_cost_source = "none"
+        # Per-delegation usage ledger: one entry per completed delegate_task
+        # child (model, tokens, api_calls, cost) appended by
+        # tools/delegate_tool._finalize_child_results.  Powers the
+        # `delegations` block in turn results and `hermes -z --usage-file`
+        # so pipelines can attribute spend per subagent, not just the
+        # parent-session rollup.  Inspired by Copilot CLI 1.0.81's
+        # per-agent usage metrics in --usage-output-file.
+        self.session_delegation_usage: list = []
         
         # Turn counter (added after reset_session_state was first written — #2635)
         self._user_turn_count = 0

--- a/tests/tools/test_delegate_usage_ledger.py
+++ b/tests/tools/test_delegate_usage_ledger.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Per-delegation usage ledger on the parent agent.
+
+Every completed delegate_task child appends one attribution entry
+(model, tokens, api_calls, cost, goal) to
+``parent_agent.session_delegation_usage``.  The ledger is surfaced by
+``agent/turn_finalizer.py`` as the turn result's ``delegations`` block and
+forwarded by ``hermes -z --usage-file`` so batch pipelines can attribute
+spend per subagent instead of only seeing the parent-session rollup.
+
+Inspired by: GitHub Copilot CLI 1.0.81 — per-agent usage metrics in
+--usage-output-file JSON output.
+"""
+
+import json
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tools.delegate_tool import delegate_task
+
+
+def _make_mock_parent(depth=0):
+    parent = MagicMock()
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "test-key"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-sonnet-4"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent._session_db = None
+    parent._delegate_depth = depth
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent.session_estimated_cost_usd = 0.0
+    parent.session_cost_source = "none"
+    parent.session_cost_status = "unknown"
+    # Real list (not a MagicMock auto-attribute) so appends are observable.
+    parent.session_delegation_usage = []
+    return parent
+
+
+def _make_mock_child(cost=0.1234567, cost_status="estimated"):
+    child = MagicMock()
+    child.run_conversation.return_value = {
+        "final_response": "done",
+        "completed": True,
+        "api_calls": 2,
+        "messages": [],
+    }
+    child.session_prompt_tokens = 100
+    child.session_completion_tokens = 50
+    child.session_estimated_cost_usd = cost
+    child.session_cost_status = cost_status
+    child.model = "anthropic/claude-sonnet-4"
+    child.session_id = "child-session"
+    child._delegate_role = "leaf"
+    return child
+
+
+class TestDelegationUsageLedger(unittest.TestCase):
+    def _run(self, child, goal="Test ledger attribution"):
+        parent = _make_mock_parent()
+        with patch("run_agent.AIAgent", return_value=child):
+            result = json.loads(delegate_task(goal=goal, parent_agent=parent))
+        return parent, result
+
+    def test_ledger_entry_appended_with_attribution_fields(self):
+        child = _make_mock_child(cost=0.25)
+        parent, _ = self._run(child)
+        self.assertEqual(len(parent.session_delegation_usage), 1)
+        entry = parent.session_delegation_usage[0]
+        self.assertEqual(entry["goal"], "Test ledger attribution")
+        self.assertEqual(entry["model"], "anthropic/claude-sonnet-4")
+        self.assertEqual(entry["status"], "completed")
+        self.assertEqual(entry["api_calls"], 2)
+        self.assertEqual(entry["input_tokens"], 100)
+        self.assertEqual(entry["output_tokens"], 50)
+        self.assertAlmostEqual(entry["cost_usd"], 0.25, places=6)
+        self.assertEqual(entry["cost_status"], "estimated")
+        self.assertEqual(entry["child_session_id"], "child-session")
+        self.assertEqual(entry["role"], "leaf")
+
+    def test_long_goal_is_capped(self):
+        child = _make_mock_child()
+        parent, _ = self._run(child, goal="x" * 500)
+        entry = parent.session_delegation_usage[0]
+        self.assertEqual(len(entry["goal"]), 200)
+
+    def test_missing_ledger_attribute_is_created(self):
+        child = _make_mock_child()
+        parent = _make_mock_parent()
+        # Simulate an agent built before the ledger existed.
+        parent.session_delegation_usage = None
+        with patch("run_agent.AIAgent", return_value=child):
+            delegate_task(goal="legacy parent", parent_agent=parent)
+        self.assertIsInstance(parent.session_delegation_usage, list)
+        self.assertEqual(len(parent.session_delegation_usage), 1)
+
+    def test_ledger_never_breaks_delegation_result(self):
+        child = _make_mock_child()
+        parent = _make_mock_parent()
+
+        class _Boom(list):
+            def append(self, *_a, **_k):
+                raise RuntimeError("ledger boom")
+
+        parent.session_delegation_usage = _Boom()
+        with patch("run_agent.AIAgent", return_value=child):
+            result = json.loads(
+                delegate_task(goal="ledger failure isolated", parent_agent=parent)
+            )
+        # Delegation still succeeds even when accounting fails.
+        self.assertEqual(result["results"][0]["status"], "completed")
+
+
+class TestTurnFinalizerDelegationsBlock(unittest.TestCase):
+    def test_result_omits_delegations_when_empty(self):
+        # Contract: delegation-free turns keep the legacy result shape.
+        agent = MagicMock()
+        agent.session_delegation_usage = []
+        block = getattr(agent, "session_delegation_usage", None)
+        self.assertFalse(bool(block))
+
+    def test_usage_file_forwards_delegations(self):
+        import tempfile
+        from pathlib import Path
+
+        from hermes_cli.oneshot import _write_usage_file
+
+        delegations = [
+            {
+                "task_index": 0,
+                "goal": "sub work",
+                "model": "m",
+                "api_calls": 3,
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "cost_usd": 0.01,
+            }
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "usage.json"
+            _write_usage_file(str(path), {"delegations": delegations})
+            report = json.loads(path.read_text())
+            self.assertEqual(report["delegations"], delegations)
+
+    def test_usage_file_omits_delegations_when_absent(self):
+        import tempfile
+        from pathlib import Path
+
+        from hermes_cli.oneshot import _write_usage_file
+
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "usage.json"
+            _write_usage_file(str(path), {"estimated_cost_usd": 0.5})
+            report = json.loads(path.read_text())
+            self.assertNotIn("delegations", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3445,6 +3445,48 @@ def _finalize_child_results(
                     children_cost_total += float(child_cost)
             except (TypeError, ValueError):
                 pass
+            # Per-delegation usage ledger for the parent session.  Surfaced
+            # via the turn result's `delegations` block and `hermes -z
+            # --usage-file` so pipelines can attribute spend per subagent
+            # (inspired by Copilot CLI 1.0.81 per-agent usage metrics in
+            # --usage-output-file).  Best-effort: never let accounting break
+            # the delegation result itself.
+            try:
+                if parent_agent is not None:
+                    ledger = getattr(
+                        parent_agent, "session_delegation_usage", None
+                    )
+                    if ledger is None:
+                        ledger = []
+                        parent_agent.session_delegation_usage = ledger
+                    _tokens = entry.get("tokens") or {}
+                    task_index = entry.get("task_index", -1)
+                    goal = ""
+                    if (
+                        isinstance(task_index, int)
+                        and 0 <= task_index < len(task_list)
+                    ):
+                        goal = str(task_list[task_index].get("goal", "") or "")
+                    ledger.append(
+                        {
+                            "task_index": task_index,
+                            "goal": goal[:200],
+                            "role": child_role,
+                            "model": entry.get("model"),
+                            "status": entry.get("status"),
+                            "api_calls": entry.get("api_calls", 0),
+                            "input_tokens": _tokens.get("input", 0),
+                            "output_tokens": _tokens.get("output", 0),
+                            "cost_usd": entry.get("cost_usd", 0.0),
+                            "cost_status": entry.get("cost_status", "unknown"),
+                            "duration_seconds": entry.get("duration_seconds"),
+                            "child_session_id": getattr(
+                                child_by_index.get(task_index), "session_id", None
+                            ),
+                        }
+                    )
+            except Exception:
+                logger.debug("delegation usage ledger append failed", exc_info=True)
             if invoke_hook is None:
                 continue
             try:

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -174,7 +174,7 @@ Same agent, same tools, same skills — just strips every interactive / cosmetic
 
 #### `--usage-file` — JSON usage report for pipelines
 
-`hermes -z "…" --usage-file /path/report.json` writes a machine-readable usage report after the run: `estimated_cost_usd`, `input_tokens` / `output_tokens` / `cache_read_tokens` / `cache_write_tokens` / `reasoning_tokens` / `total_tokens`, `api_calls`, `model`, `provider`, `session_id`, `service_tier`, and `completed` / `failed` flags. The report is written **even when the run fails**, so batch pipelines can always account for spend. It has no effect outside `-z`/`--oneshot`, and a broken usage write never masks the run's own outcome.
+`hermes -z "…" --usage-file /path/report.json` writes a machine-readable usage report after the run: `estimated_cost_usd`, `input_tokens` / `output_tokens` / `cache_read_tokens` / `cache_write_tokens` / `reasoning_tokens` / `total_tokens`, `api_calls`, `model`, `provider`, `session_id`, `service_tier`, and `completed` / `failed` flags. When the run used `delegate_task`, the report also carries a `delegations` array — one entry per subagent with its `goal`, `role`, `model`, `status`, `api_calls`, `input_tokens` / `output_tokens`, `cost_usd`, and `duration_seconds` — so pipelines can attribute spend per subagent instead of only seeing the parent-session rollup. The report is written **even when the run fails**, so batch pipelines can always account for spend. It has no effect outside `-z`/`--oneshot`, and a broken usage write never masks the run's own outcome.
 
 ```bash
 hermes -z "summarize this repo" --usage-file /tmp/usage.json


### PR DESCRIPTION
## Summary

Delegated subagent spend is now attributable per child: `delegate_task` runs record one usage entry per completed child (goal, role, model, status, api_calls, tokens, cost, duration, child session id), and the ledger surfaces in the turn result, `/usage`, and `hermes -z --usage-file`.

Inspired by GitHub Copilot CLI [v1.0.81-1](https://github.com/github/copilot-cli/releases/tag/v1.0.81-1): *"Add per-agent usage metrics to --usage-output-file JSON output."*

**Their mechanism:** Copilot CLI's `--usage-output-file` JSON gained a per-agent breakdown so batch/CI callers can see which subagent consumed what, not just the run total.

**Our gap:** Hermes already folded subagent cost into the parent's `session_estimated_cost_usd` (delegate_tool rollup, kilocode#9448 port) and returned per-entry `cost_usd` to the *model*, but the host-side surfaces — turn result, `/usage`, `--usage-file` — only ever saw the aggregated total. A `hermes -z` pipeline that fans out via `delegate_task` could not attribute spend.

## Changes

- `run_agent.py` / `agent/agent_init.py`: `session_delegation_usage` ledger, reset alongside the other `session_*` counters at both init sites
- `tools/delegate_tool.py` (`_finalize_child_results`): append one attribution entry per completed child — best-effort (`try/except`), accounting can never break the delegation result
- `agent/turn_finalizer.py`: `delegations` block in the turn result, emitted **only when non-empty** so delegation-free runs keep the exact legacy result shape
- `hermes_cli/oneshot.py`: forward `delegations` into `--usage-file` reports
- `cli.py` `/usage`: per-delegation lines (last 10) with goal, tokens in/out, cost
- `website/docs/reference/cli-commands.md`: `--usage-file` field list updated

Cache-safe: no system-prompt, toolset, or history mutation — purely additive accounting on existing counters.

## Validation

| | Before | After |
|---|---|---|
| `--usage-file` after fan-out | run totals only | + `delegations[]` per child |
| `/usage` | session totals | + per-delegation lines |
| delegation-free result shape | legacy | byte-identical (block omitted) |
| tests | — | `tests/tools/test_delegate_usage_ledger.py` (7 new) + existing cost-footer/usage-file suites, 16+73 passed |

## Infographic

![Per-delegation usage attribution](https://v3b.fal.media/files/b/0aa72d08/ViAeRsTqdMEDLmZUyvT6a_yFb4c3rc.png)
