### PR TITLE
fix(kanban): enforce shared dispatch pause at claim and spawn

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -135,6 +135,10 @@ BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 
 
+class DispatchPausedError(RuntimeError):
+    """Raised when a manual pause closes the final worker-spawn edge."""
+
+
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
     """Normalize a per-task reasoning effort into a storable level.
 
@@ -584,6 +588,19 @@ def kanban_home() -> Path:
         return Path(override).expanduser()
     from hermes_constants import get_default_hermes_root
     return get_default_hermes_root()
+
+
+def dispatch_pause_path() -> Path:
+    """Return the shared-root manual dispatch-pause sentinel path."""
+    return kanban_home() / "state" / "dispatch_pause.json"
+
+
+def dispatch_is_paused() -> bool:
+    """Fail closed while the shared-root manual dispatch pause exists."""
+    try:
+        return dispatch_pause_path().exists()
+    except OSError:
+        return True
 
 
 def boards_root() -> Path:
@@ -4626,6 +4643,8 @@ def claim_task(
     Returns the claimed ``Task`` on success, ``None`` if the task was
     already claimed (or is not in ``ready`` status).
     """
+    if dispatch_is_paused():
+        return None
     now = int(time.time())
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
@@ -4754,6 +4773,8 @@ def claim_review_task(
     Creates a new run entry so the review agent's lifecycle is tracked
     independently from the original worker run.
     """
+    if dispatch_is_paused():
+        return None
     now = int(time.time())
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
@@ -9343,6 +9364,40 @@ def _record_spawn_failure(
     )
 
 
+def _release_paused_claim(conn: sqlite3.Connection, task_id: str) -> None:
+    """Return a claimed task to its source lane without counting a failure."""
+    now = int(time.time())
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT current_run_id FROM tasks WHERE id = ? AND status = 'running'",
+            (task_id,),
+        ).fetchone()
+        if row is None:
+            return
+        run_id = row["current_run_id"]
+        retry_status = _retry_status_for_run(conn, task_id, run_id)
+        if run_id is not None:
+            conn.execute(
+                "UPDATE task_runs SET status = 'reclaimed', outcome = 'reclaimed', "
+                "summary = 'dispatch paused before worker spawn', ended_at = ?, "
+                "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
+                "WHERE id = ? AND ended_at IS NULL",
+                (now, run_id),
+            )
+        conn.execute(
+            "UPDATE tasks SET status = ?, claim_lock = NULL, claim_expires = NULL, "
+            "worker_pid = NULL, current_run_id = NULL WHERE id = ? AND status = 'running'",
+            (retry_status, task_id),
+        )
+        _append_event(
+            conn,
+            task_id,
+            "dispatch_paused",
+            {"retry_status": retry_status, "failure_counted": False},
+            run_id=run_id,
+        )
+
+
 def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
     """Record the spawned child's pid + emit a ``spawned`` event.
 
@@ -9835,6 +9890,10 @@ def dispatch_once(
     boards tick in parallel. See :func:`_dispatch_tick_lock` for the
     cross-process / cross-platform mechanics.
     """
+    if dispatch_is_paused():
+        result = DispatchResult()
+        _fire_dispatch_tick_hook(result, board=board, dry_run=dry_run)
+        return result
     try:
         db_path = kanban_db_path(board=board)
     except Exception:
@@ -10236,6 +10295,8 @@ def _dispatch_once_locked(
                 workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
             else:
                 workspace = resolve_workspace(claimed, board=board)
+        except DispatchPausedError:
+            _release_paused_claim(conn, claimed.id)
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",
@@ -10288,6 +10349,8 @@ def _dispatch_once_locked(
                 _per_profile_running[claimed.assignee] = (
                     _per_profile_running.get(claimed.assignee, 0) + 1
                 )
+        except DispatchPausedError:
+            _release_paused_claim(conn, claimed.id)
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),
@@ -10408,6 +10471,8 @@ def _dispatch_once_locked(
                 _per_profile_running[claimed.assignee] = (
                     _per_profile_running.get(claimed.assignee, 0) + 1
                 )
+        except DispatchPausedError:
+            _release_paused_claim(conn, claimed.id)
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),
@@ -10724,6 +10789,10 @@ def _default_spawn(
     vars all resolve to the same board the dispatcher claimed the task
     from. Workers cannot accidentally see other boards.
     """
+    if dispatch_is_paused():
+        raise DispatchPausedError(
+            f"Kanban dispatch is paused by {dispatch_pause_path()}"
+        )
     import subprocess
     if not task.assignee:
         raise ValueError(f"task {task.id} has no assignee")

--- a/tests/hermes_cli/test_kanban_pause_boundary.py
+++ b/tests/hermes_cli/test_kanban_pause_boundary.py
@@ -1,0 +1,117 @@
+import json
+
+import hermes_cli.kanban_db as kb
+
+
+class _UnreadablePausePath:
+    def exists(self):
+        raise OSError("pause state unavailable")
+
+
+def _pause(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    path = tmp_path / "state" / "dispatch_pause.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"reason": "test pause"}), encoding="utf-8")
+    return path
+
+
+def test_pause_blocks_ready_and_review_claims_without_run_rows(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path=db_path)
+    conn = kb.connect(db_path=db_path)
+    ready_id = kb.create_task(conn, title="ready", assignee="default")
+    review_id = kb.create_task(conn, title="review", assignee="default")
+    conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (review_id,))
+    conn.commit()
+    pause = _pause(tmp_path, monkeypatch)
+
+    assert kb.claim_task(conn, ready_id) is None
+    assert kb.claim_review_task(conn, review_id) is None
+    assert conn.execute("SELECT COUNT(*) FROM task_runs").fetchone()[0] == 0
+
+    pause.unlink()
+    assert kb.claim_task(conn, ready_id) is not None
+    assert kb.claim_review_task(conn, review_id) is not None
+
+
+def test_pause_lookup_error_fails_closed(monkeypatch):
+    monkeypatch.setattr(kb, "dispatch_pause_path", lambda: _UnreadablePausePath())
+    assert kb.dispatch_is_paused() is True
+
+
+def test_pause_blocks_dispatch_and_final_spawn_edge(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path=db_path)
+    conn = kb.connect(db_path=db_path)
+    task_id = kb.create_task(conn, title="ready", assignee="default")
+    pause = _pause(tmp_path, monkeypatch)
+    spawned = []
+
+    result = kb.dispatch_once(
+        conn,
+        spawn_fn=lambda *args, **kwargs: spawned.append((args, kwargs)),
+        max_spawn=1,
+    )
+    assert result.spawned == []
+    assert spawned == []
+    assert conn.execute("SELECT COUNT(*) FROM task_runs").fetchone()[0] == 0
+
+    task = kb.get_task(conn, task_id)
+    try:
+        kb._default_spawn(task, str(tmp_path))
+    except RuntimeError as exc:
+        assert str(pause) in str(exc)
+    else:
+        raise AssertionError("paused final spawn edge did not fail closed")
+
+    pause.unlink()
+    resumed = kb.dispatch_once(
+        conn,
+        spawn_fn=lambda *args, **kwargs: 4242,
+        max_spawn=1,
+    )
+    assert [item[0] for item in resumed.spawned] == [task_id]
+
+
+def test_pause_arriving_after_ready_claim_requeues_without_failure(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path=db_path)
+    conn = kb.connect(db_path=db_path)
+    task_id = kb.create_task(conn, title="ready", assignee="default")
+
+    def pause_at_spawn(*_args, **_kwargs):
+        _pause(tmp_path, monkeypatch)
+        raise kb.DispatchPausedError("paused at final edge")
+
+    result = kb.dispatch_once(conn, spawn_fn=pause_at_spawn, max_spawn=1)
+    task = kb.get_task(conn, task_id)
+    assert result.spawned == []
+    assert task.status == "ready"
+    assert task.consecutive_failures == 0
+    run = conn.execute(
+        "SELECT status, outcome, ended_at FROM task_runs WHERE task_id = ?",
+        (task_id,),
+    ).fetchone()
+    assert (run["status"], run["outcome"]) == ("reclaimed", "reclaimed")
+    assert run["ended_at"] is not None
+
+
+def test_pause_arriving_after_review_claim_returns_to_review(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path=db_path)
+    conn = kb.connect(db_path=db_path)
+    task_id = kb.create_task(conn, title="review", assignee="default")
+    conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (task_id,))
+    conn.commit()
+    monkeypatch.setattr(kb, "review_dispatch_enabled", lambda: True)
+
+    def pause_at_spawn(*_args, **_kwargs):
+        _pause(tmp_path, monkeypatch)
+        raise kb.DispatchPausedError("paused at final edge")
+
+    result = kb.dispatch_once(conn, spawn_fn=pause_at_spawn, max_spawn=1)
+    task = kb.get_task(conn, task_id)
+    assert result.spawned == []
+    assert task.status == "review"
+    assert task.consecutive_failures == 0


### PR DESCRIPTION
## What changed

- Check the shared dispatch pause before ready and review claims.
- Check it again before the final default worker spawn.
- If a pause lands after claim, return the card to its original lane without adding a failure.
- Fail closed when the pause state cannot be read.

## Why

A control-plane pause previously depended on higher-level callers. A direct claim or a pause arriving between claim and spawn could still start work or wrongly count as a worker crash.

## Verification

- `ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_pause_boundary.py`
- Focused dispatch, review lifecycle, database, gateway shutdown, iteration-limit, and restart-loop tests: 198 passed, 1 skipped.
- Independent exact-commit review: GO.

This changes Hermes control-plane behavior only. It does not add any ClausEye application runtime dependency.