### PR TITLE
fix: recover Photon poll votes with missing titles

### DIFF
--- a/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
+++ b/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
@@ -19,6 +19,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const MARKER = "Hermes patch: Preserve mixed text + attachment iMessage payloads";
+const POLL_MARKER = "Hermes patch: Recover iMessage poll votes with missing titles";
 
 function scriptDir() {
   return path.dirname(fileURLToPath(import.meta.url));
@@ -115,6 +116,19 @@ function patchChildIndices(source) {
   );
 }
 
+function patchPollTitle(source) {
+  // Photon can omit the title while hydrating an inbound vote. spectrum-ts
+  // validates that display field before it surfaces the selected option, so a
+  // missing title otherwise drops the answer and leaves clarify blocked. Hermes
+  // resolves from the option text, making a neutral internal title sufficient.
+  return replaceOnce(
+    source,
+    `\t\ttitle: input.title,\n\t\toptions: input.options.map((optionInfo) => ({ title: optionInfo.text }))`,
+    `\t\ttitle: input.title || "Poll",\n\t\toptions: input.options.map((optionInfo) => ({ title: optionInfo.text }))`,
+    "poll title fallback"
+  );
+}
+
 export function patchSpectrumTs(root = scriptDir()) {
   const dist = path.join(
     root,
@@ -132,7 +146,7 @@ export function patchSpectrumTs(root = scriptDir()) {
 
   for (const file of files) {
     const raw = fs.readFileSync(file, "utf8");
-    if (raw.includes(MARKER)) {
+    if (raw.includes(MARKER) && raw.includes(POLL_MARKER)) {
       return { patched: false, file, reason: "already patched" };
     }
     // Normalize to LF for matching so the patch works regardless of the
@@ -149,10 +163,16 @@ export function patchSpectrumTs(root = scriptDir()) {
       continue;
     }
     let patched = original;
-    patched = patchRebuild(patched);
-    patched = patchInbound(patched);
-    patched = patchChildIndices(patched);
-    patched = `// ${MARKER}\n${patched}`;
+    if (!original.includes(MARKER)) {
+      patched = patchRebuild(patched);
+      patched = patchInbound(patched);
+      patched = patchChildIndices(patched);
+      patched = `// ${MARKER}\n${patched}`;
+    }
+    if (!original.includes(POLL_MARKER)) {
+      patched = patchPollTitle(patched);
+      patched = `// ${POLL_MARKER}\n${patched}`;
+    }
     if (usedCRLF) {
       patched = patched.split("\n").join(CRLF);
     }

--- a/tests/plugins/platforms/photon/test_spectrum_patch.py
+++ b/tests/plugins/platforms/photon/test_spectrum_patch.py
@@ -161,6 +161,17 @@ const buildAttachmentMessage = async (client, base, info, id, partIndex, parentI
   return msg;
 };
 const cacheMessage = (cache, message) => { cache.set(message.id, message); };
+const asPoll = (input) => {
+  if (!input.title) throw new Error("poll title is required");
+  return { type: "poll", ...input };
+};
+const toCachedPoll = (input) => {
+  const poll = asPoll({
+    title: input.title,
+    options: input.options.map((optionInfo) => ({ title: optionInfo.text }))
+  });
+  return { poll };
+};
 const rebuildFromAppleMessage = async (client, message, phone, chatGuidHint) => {
   const messageGuidStr = message.guid;
   const base = buildMessageBase(message, chatGuidHint, message.dateCreated ?? /* @__PURE__ */ new Date(), phone);
@@ -225,7 +236,7 @@ const toInboundMessages = async (client, cache, event, phone) => {
   cacheMessage(cache, msg);
   return [msg];
 };
-export { rebuildFromAppleMessage, toInboundMessages };
+export { rebuildFromAppleMessage, toCachedPoll, toInboundMessages };
 """
 
 
@@ -273,5 +284,46 @@ def test_spectrum_patch_rewrites_the_imessage_mapper(tmp_path: Path) -> None:
     )
     assert again.returncode == 0, again.stderr
     assert chunk.read_text(encoding="utf-8") == patched
+
+
+def test_spectrum_patch_recovers_poll_votes_with_missing_titles(tmp_path: Path) -> None:
+    """Photon may omit the poll title on vote events; the SDK must still emit
+    the selected option so a pending clarify can resolve."""
+    chunk = _write_fixture(tmp_path)
+
+    result = subprocess.run(
+        ["node", str(_PATCHER), str(tmp_path)],
+        cwd=Path.cwd(),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+    probe = subprocess.run(
+        [
+            "node",
+            "--input-type=module",
+            "--eval",
+            (
+                f'import {{ toCachedPoll }} from "{chunk.resolve().as_uri()}"; '
+                'const cached = toCachedPoll({title: "", options: '
+                '[{text: "Audit defects"}, {text: "Fix CI"}]}); '
+                'process.stdout.write(JSON.stringify(cached.poll));'
+            ),
+        ],
+        cwd=Path.cwd(),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert probe.returncode == 0, probe.stderr
+    poll = json.loads(probe.stdout)
+    assert poll["title"] == "Poll"
+    assert [option["title"] for option in poll["options"]] == [
+        "Audit defects",
+        "Fix CI",
+    ]
 
 


### PR DESCRIPTION
## Summary
- Patch spectrum-ts' iMessage poll hydration when Photon omits the poll title.
- Preserve the selected option so Photon clarify polls resolve instead of hanging.
- Keep the dependency patch idempotent for already-running installations.

## Reproduction
Live Photon logs showed `spectrum.imessage.poll` rejecting inbound vote events with a Zod error because `title` was empty. The gateway then captured the user's next typed sentence as the clarify answer instead of the selected poll option.

## Tests
- RED confirmed: the new regression failed with `Error: poll title is required`.
- `tests/plugins/platforms/photon/test_spectrum_patch.py` and `test_poll_clarify.py`: 5 passed.
- Full Photon plugin suite: 130 passed.
- Patch applied twice to the installed spectrum-ts 8.0.0 tree: first run patched, second run was idempotent.

The fallback title is internal only. Hermes resolves the clarify from the selected option text; the outgoing poll still displays the original question.
