### PR TITLE
fix(kanban): clear crash alerts after operator recovery

### DIFF
--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -688,11 +688,44 @@ def _rule_repeated_crashes(task, events, runs, now, cfg) -> list[Diagnostic]:
         return []
 
     threshold = int(cfg.get("crash_threshold", 2))
+    # An operator recovery after the last crash starts a new diagnostic
+    # window.  Keep the failed runs as incident history, but do not scan back
+    # through a deliberate unblock, schedule, reassign, decomposition, or
+    # other recovery transition and present those old crashes as current.
+    # This matters after kanban-doctor routes a card to triage: the run rows
+    # are intentionally preserved, while the intervention is recorded as an
+    # event rather than a synthetic successful run.
+    recovery_kinds = {
+        "unblocked",
+        "auto_triage_routed",
+        "decomposed",
+        "blocked",
+        "scheduled",
+        "reassigned",
+        "review_requested",
+        "changes_requested",
+        "review_reopened",
+        "promoted_manual",
+    }
+    recovery_at = max(
+        (
+            _event_ts(event)
+            for event in events
+            if _event_kind(event) in recovery_kinds
+        ),
+        default=0,
+    )
     ordered = sorted(runs, key=lambda r: _task_field(r, "id", 0))
     # Count trailing consecutive 'crashed' outcomes.
     consecutive = 0
     last_err = None
     for r in reversed(ordered):
+        ended_at = _task_field(r, "ended_at", None)
+        # Timestamps have one-second resolution. Equality is ambiguous: a
+        # retry can crash later in the same second as the recovery event. Bias
+        # toward showing that crash rather than hiding a new failure.
+        if recovery_at and ended_at is not None and int(ended_at) < recovery_at:
+            break
         outcome = _task_field(r, "outcome")
         if outcome == "crashed":
             consecutive += 1

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -54,11 +54,12 @@ def _event(kind, ts=None, **payload):
     }
 
 
-def _run(outcome="completed", run_id=1, error=None):
+def _run(outcome="completed", run_id=1, error=None, ended_at=None):
     return {
         "id": run_id,
         "outcome": outcome,
         "error": error,
+        "ended_at": ended_at,
     }
 
 
@@ -118,6 +119,53 @@ def test_repeated_crashes_truncates_huge_tracebacks():
     assert len(d.title) < 250
     # Detail contains the snippet with ellipsis.
     assert d.detail.endswith("…") or len(d.detail) < 700
+
+
+def test_repeated_crashes_clear_after_operator_recovery_event():
+    task = _task(status="todo")
+    runs = [
+        _run(outcome="crashed", run_id=1, ended_at=100),
+        _run(outcome="crashed", run_id=2, ended_at=200),
+    ]
+    events = [_event("auto_triage_routed", ts=201)]
+
+    diags = kd.compute_task_diagnostics(task, events, runs, now=300)
+
+    assert not [d for d in diags if d.kind == "repeated_crashes"]
+
+
+def test_repeated_crashes_restart_after_operator_recovery_event():
+    task = _task(status="todo")
+    runs = [
+        _run(outcome="crashed", run_id=1, ended_at=100),
+        _run(outcome="crashed", run_id=2, ended_at=200),
+        _run(outcome="crashed", run_id=3, ended_at=300),
+        _run(outcome="crashed", run_id=4, ended_at=400),
+    ]
+    events = [_event("unblocked", ts=250)]
+
+    diags = kd.compute_task_diagnostics(task, events, runs, now=500)
+    crashes = [d for d in diags if d.kind == "repeated_crashes"]
+
+    assert len(crashes) == 1
+    assert crashes[0].count == 2
+
+
+def test_repeated_crashes_do_not_hide_same_second_retry_failures():
+    task = _task(status="todo")
+    runs = [
+        _run(outcome="crashed", run_id=1, ended_at=100),
+        _run(outcome="crashed", run_id=2, ended_at=200),
+        _run(outcome="crashed", run_id=3, ended_at=250),
+        _run(outcome="crashed", run_id=4, ended_at=250),
+    ]
+    events = [_event("unblocked", ts=250)]
+
+    diags = kd.compute_task_diagnostics(task, events, runs, now=500)
+    crashes = [d for d in diags if d.kind == "repeated_crashes"]
+
+    assert len(crashes) == 1
+    assert crashes[0].count == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- Stop repeated-crash diagnostics at a later operator recovery event.
- Preserve every failed run as incident history.
- Keep same-second crashes visible because event and run times have one-second resolution.

## Why

Recovered or decomposed cards still showed historical crashes as current problems because the diagnostic scanned past later operator actions.

## Verification

- Ruff passed.
- Focused diagnostic and Kanban suites: 62 passed, 1 skipped.
- Independent exact-commit critic: GO.
- Same-second recovery/crash regression included.

This changes Hermes control-plane diagnostics only. It does not add any ClausEye application runtime dependency.