### PR TITLE
feat: stealth/ox-alpha free model in the OpenRouter catalog

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -559,6 +559,9 @@ DEFAULT_CONTEXT_LENGTHS = {
     # OpenCode Zen — "Ox Alpha" stealth model (x-preview-f-free). 1M context
     # per OpenCode's launch announcement (2026-08-20); free, ZDR.
     "x-preview-f": 1_048_576,
+    # OpenRouter — same "Ox Alpha" stealth model under its OpenRouter slug
+    # (stealth/ox-alpha). 1M context per OpenRouter live metadata (2026-08-20).
+    "ox-alpha": 1_048_576,
     # Nemotron — NVIDIA's open-weights series (128K context across all sizes)
     "nemotron": 131072,
     # Arcee

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -125,6 +125,12 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     ("grok-4.5", 300),
     ("grok-4.6", 300),
     ("grok-4-fast-non-reasoning", 180),
+    # "Ox Alpha" stealth reasoning model (stealth/ox-alpha on OpenRouter,
+    # x-preview-f-free on OpenCode Zen).  Marketed as a reasoning model for
+    # long-horizon coding/agentic work; 1M context — same tier as the Grok
+    # reasoning variants.
+    ("ox-alpha", 300),
+    ("x-preview-f-free", 300),
 )
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -133,6 +133,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # OpenRouter routers
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
     # Free tier
+    ("stealth/ox-alpha",                       "free"),  # "Ox Alpha" stealth reasoning model — 1M ctx
     ("openrouter/elephant-alpha",              "free"),
     ("poolside/laguna-m.1:free",               "free"),
     ("tencent/hy3:free",                       "free"),

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-17T19:11:38Z",
+  "updated_at": "2026-08-21T03:50:21Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -152,6 +152,10 @@
         {
           "id": "openrouter/pareto-code",
           "description": "auto-routes to cheapest coder meeting openrouter.min_coding_score"
+        },
+        {
+          "id": "stealth/ox-alpha",
+          "description": "free"
         },
         {
           "id": "openrouter/elephant-alpha",


### PR DESCRIPTION
## Summary
`stealth/ox-alpha` — OpenRouter's free "Ox Alpha" stealth reasoning model — now shows up in the OpenRouter picker with correct 1M-context and reasoning-timeout metadata.

## Changes
- `hermes_cli/models.py`: free-tier entry in `OPENROUTER_MODELS`
- `agent/model_metadata.py`: `ox-alpha` → 1,048,576 (verified against OpenRouter live `/api/v1/models`; the slug previously fell through with no match)
- `agent/reasoning_timeouts.py`: 300s stale floor for `ox-alpha` and the OpenCode Zen twin slug `x-preview-f-free` (reasoning model, long-horizon agentic work)
- `website/static/api/model-catalog.json`: regenerated

Scoped skips, per convention: pricing snapshot not needed (`resolve_billing_route` → `official_models_api`, and the model is free); `_ANTHROPIC_OUTPUT_LIMITS` N/A. The OpenCode Zen surfaces (`x-preview-f-free`) already landed in #91250 — this PR only adds the reasoning floor that PR didn't carry.

## Validation
| Check | Result |
|---|---|
| `provider_model_ids` contains slug, no dupes | ✔ (E2E, temp HERMES_HOME, keys stripped) |
| `DEFAULT_CONTEXT_LENGTHS` fuzzy match | `('ox-alpha', 1048576)` |
| `get_reasoning_stale_timeout_floor` | 300.0 for both slugs; negatives unaffected |
| Targeted suites | 263 passed; 1 pre-existing batch-only failure (`TestMoAContextLength`, fails identically on clean base — cross-file pollution, unrelated) |

## Infographic

![stealth/ox-alpha catalog rollout](https://v3b.fal.media/files/b/0aa72df7/zlrhHBAWtKuuqlI01j9Lr_rblfm8XK.png)
