### PR TITLE
feat(kanban): add guarded admin archive workflows

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2678,6 +2678,16 @@ DEFAULT_CONFIG = {
         # so stale rows don't accumulate and get scanned on every notifier
         # tick forever. Set 0 to disable the sweep.
         "done_sub_retention_days": 30,
+        # DESTRUCTIVE-ADMIN ALLOWLIST: profiles allowed to run the guarded
+        # admin archive integration (the `kanban_admin_archive` agent tool and
+        # the `hermes kanban archive-graph` / `unarchive` CLI verbs). Only
+        # profiles listed here (normalized: lowercased, trimmed) can invoke
+        # the agent tool; empty list exposes it to nobody. archive-graph
+        # persists an actor+reason on every archived task and its comments,
+        # so adding a profile here is a real privilege grant. The CLI verbs
+        # remain available independently of this list (a deliberate CLI-vs-
+        # agent-tool asymmetry) but still refuse in delegated-child contexts.
+        "admin_profiles": [],
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -743,6 +743,72 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Permanently delete already-archived task ids from the board",
     )
 
+    # --- archive-graph (admin) ---
+    # Admin archive of a whole dominated closure. This is a destructive,
+    # allowlist-gated operation with a persisted reason (comments/events).
+    p_ag = sub.add_parser(
+        "archive-graph",
+        help="Admin-archive a task and its dominated closure with a reason",
+    )
+    p_ag.add_argument(
+        "task_ids",
+        nargs="+",
+        metavar="<task_id>",
+        help="Root task ids whose dominated closure to archive",
+    )
+    p_ag.add_argument(
+        "--reason",
+        required=True,
+        help=(
+            "Reason for the archive. PERSISTED as comments/events on the "
+            "archived tasks. NEVER include secrets, tokens, or credentials."
+        ),
+    )
+    p_ag.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Plan only: print the deterministic JSON plan to stdout and "
+             "write nothing (no mutation, no archive group).",
+    )
+    p_ag.add_argument(
+        "--allow-promotions",
+        action="store_true",
+        help=(
+            "Permit recompute_ready after archiving. WARNING: recompute_ready "
+            "is global and may also promote unrelated already-eligible tasks "
+            "on the board, not just this graph's boundary."
+        ),
+    )
+    p_ag.add_argument(
+        "--force-running",
+        action="store_true",
+        help="Terminate and archive closure tasks that have active runs/claims.",
+    )
+
+    # --- unarchive (admin) ---
+    p_un = sub.add_parser(
+        "unarchive",
+        help="Restore tasks previously archived via `hermes kanban archive-graph`",
+    )
+    p_un.add_argument(
+        "task_ids",
+        nargs="*",
+        metavar="<task_id>",
+        help=(
+            "Task ids to restore (direct mode, all-or-nothing). "
+            "Mutually exclusive with --group."
+        ),
+    )
+    p_un.add_argument(
+        "--group",
+        default=None,
+        metavar="<ag_...>",
+        help=(
+            "Restore every task in this admin archive group (e.g. ag_<hex>). "
+            "Mutually exclusive with task ids. Exactly one mode is required."
+        ),
+    )
+
     # --- tail ---
     p_tail = sub.add_parser("tail", help="Follow a task's event stream")
     p_tail.add_argument("task_id")
@@ -1135,6 +1201,8 @@ def kanban_command(args: argparse.Namespace) -> int:
             "reopen-review":  _cmd_reopen_review,
             "promote":  _cmd_promote,
             "archive":  _cmd_archive,
+            "archive-graph": _cmd_archive_graph,
+            "unarchive": _cmd_unarchive,
             "tail":     _cmd_tail,
             "dispatch": _cmd_dispatch,
             "daemon":   _cmd_daemon,
@@ -1200,6 +1268,8 @@ _DELEGATED_CHILD_DENIED_ACTIONS: frozenset[str] = frozenset({
     "unblock",
     "promote",
     "archive",
+    "archive-graph",
+    "unarchive",
     "dispatch",
     "daemon",
     "repair",
@@ -2596,6 +2666,111 @@ def _cmd_archive(args: argparse.Namespace) -> int:
             else:
                 print(f"Archived {tid}")
     return 0 if not failed else 1
+
+
+def _report_admin_archive_warnings(result: dict) -> None:
+    """Report I1 (live_external_parent) warnings to stderr without refusing."""
+    for warning in result.get("warnings") or []:
+        code = warning.get("code", "unknown")
+        print(
+            f"kanban: warning ({code}): root id {warning.get('root_id')} "
+            f"has live external parent {warning.get('parent_id')} "
+            "outside the archived closure",
+            file=sys.stderr,
+        )
+
+
+def _cmd_archive_graph(args: argparse.Namespace) -> int:
+    ids = list(getattr(args, "task_ids", None) or [])
+    reason = (getattr(args, "reason", None) or "").strip()
+    if not ids:
+        print("kanban: archive-graph requires at least one task id", file=sys.stderr)
+        return 1
+    if not reason:
+        print("kanban: archive-graph requires --reason <text>", file=sys.stderr)
+        return 1
+    actor = _profile_author()
+    dry_run = bool(getattr(args, "dry_run", False))
+    allow_promotions = bool(getattr(args, "allow_promotions", False))
+    force_running = bool(getattr(args, "force_running", False))
+    with kb.connect_closing() as conn:
+        try:
+            result = kb.admin_archive_graph(
+                conn,
+                ids,
+                reason=reason,
+                actor=actor,
+                dry_run=dry_run,
+                allow_promotions=allow_promotions,
+                force_running=force_running,
+            )
+        except ValueError as exc:
+            print(f"kanban: archive-graph refused: {exc}", file=sys.stderr)
+            return 1
+    _report_admin_archive_warnings(result)
+    if result.get("error"):
+        print(f"kanban: archive-graph refused: {result['error']}", file=sys.stderr)
+        return 1
+    if dry_run:
+        # Exactly one deterministic JSON object on stdout; human summary
+        # goes to stderr so machine consumers can parse stdout verbatim.
+        print(json.dumps(result, sort_keys=True))
+        print(
+            "dry run: "
+            f"{len(result['root_ids'])} root id(s), "
+            f"{len(result['archived_ids'])} to archive, "
+            f"{len(result['skipped_archived'])} already archived",
+            file=sys.stderr,
+        )
+        return 0
+    print(
+        f"Archive group {result['archive_group_id']}: "
+        f"{len(result['archived_ids'])} transitioned, "
+        f"{len(result['skipped_archived'])} skipped"
+    )
+    return 0
+
+
+def _cmd_unarchive(args: argparse.Namespace) -> int:
+    ids = list(getattr(args, "task_ids", None) or [])
+    group = (getattr(args, "group", None) or "").strip() or None
+    if ids and group:
+        print(
+            "kanban: unarchive takes exactly one mode: task_ids OR --group",
+            file=sys.stderr,
+        )
+        return 2
+    if not ids and not group:
+        print(
+            "kanban: unarchive requires task_ids or --group <ag_...>",
+            file=sys.stderr,
+        )
+        return 2
+    actor = _profile_author()
+    with kb.connect_closing() as conn:
+        try:
+            result = kb.admin_unarchive(
+                conn,
+                task_ids=ids if ids else None,
+                group_id=group,
+                actor=actor,
+            )
+        except ValueError as exc:
+            print(f"kanban: unarchive refused: {exc}", file=sys.stderr)
+            return 1
+    group_label = result["group_id"] or (group or "direct")
+    print(
+        f"Unarchive group {group_label}: "
+        f"{len(result['restored_ids'])} restored, "
+        f"{len(result['skipped_ids'])} skipped"
+    )
+    if result["missing_workspaces"]:
+        print(
+            "kanban: missing workspace(s) reported without recreation: "
+            + ", ".join(result["missing_workspaces"]),
+            file=sys.stderr,
+        )
+    return 0
 
 
 def _cmd_tail(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7539,6 +7539,359 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
     return True
 
 
+# ---------------------------------------------------------------------------
+# Admin archive graph (dominated closure)
+# ---------------------------------------------------------------------------
+
+_ADMIN_GROUP_PREFIX = "ag_"
+
+
+def _admin_group_id() -> str:
+    """Generate an admin archive group id: ``ag_`` + 16 lowercase hex."""
+    return _ADMIN_GROUP_PREFIX + secrets.token_hex(8)
+
+
+def _dominated_closure(conn, roots):
+    """Compute the dominated closure of ``roots`` over the task graph.
+
+    Roots enter unconditionally. A non-root task enters only when every
+    parent is already in the closure or already ``archived``. Iterates to
+    a fixed point. Returns ``(closure, statuses)`` where ``statuses`` maps
+    every task id in the board to its current status.
+    """
+    statuses = {
+        row["id"]: row["status"]
+        for row in conn.execute("SELECT id, status FROM tasks").fetchall()
+    }
+    parents: dict = {}
+    for row in conn.execute(
+        "SELECT parent_id, child_id FROM task_links"
+    ).fetchall():
+        parents.setdefault(row["child_id"], set()).add(row["parent_id"])
+    closure = set(roots)
+    changed = True
+    while changed:
+        changed = False
+        for child, ps in parents.items():
+            if child in closure or child not in statuses:
+                continue
+            if all(
+                (p in closure) or (statuses.get(p) == "archived")
+                for p in ps
+            ):
+                closure.add(child)
+                changed = True
+    return closure, statuses
+
+
+def _task_active(conn, task_id) -> bool:
+    row = conn.execute(
+        "SELECT status, current_run_id, claim_lock, claim_expires, worker_pid "
+        "FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if not row:
+        return False
+    if row["status"] == "running":
+        return True
+    return bool(
+        row["current_run_id"]
+        or row["claim_lock"]
+        or row["claim_expires"]
+        or row["worker_pid"]
+    )
+
+
+def _task_would_promote(conn, task_id, closure) -> bool:
+    """Mirror ``recompute_ready``'s promotion decision for one task.
+
+    ``closure`` tasks are treated as already archived (their ``inside``
+    parents are about to become terminal), matching the post-commit state
+    that ``recompute_ready`` will observe.
+    """
+    row = conn.execute(
+        "SELECT status, consecutive_failures, max_retries "
+        "FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if not row or row["status"] not in ("todo", "blocked"):
+        return False
+    cur_status = row["status"]
+    if cur_status == "blocked" and _has_sticky_block(conn, task_id):
+        return False
+    parents = conn.execute(
+        "SELECT t.id, t.status FROM tasks t "
+        "JOIN task_links l ON l.parent_id = t.id "
+        "WHERE l.child_id = ?",
+        (task_id,),
+    ).fetchall()
+    if not all(
+        (p["id"] in closure) or (p["status"] in ("done", "archived"))
+        for p in parents
+    ):
+        return False
+    if cur_status == "blocked":
+        failures = int(row["consecutive_failures"] or 0)
+        task_limit = row["max_retries"]
+        effective_limit = (
+            int(task_limit) if task_limit is not None
+            else int(DEFAULT_FAILURE_LIMIT)
+        )
+        if failures >= effective_limit:
+            return False
+    return True
+
+
+def _empty_admin_graph_result(roots, dry_run) -> dict:
+    return {
+        "dry_run": bool(dry_run),
+        "archive_group_id": None,
+        "root_ids": sorted(roots),
+        "tasks": [],
+        "skipped_archived": [],
+        "internal_edges": [],
+        "external_edges": [],
+        "would_promote": [],
+        "active_runs": [],
+        "archived_ids": [],
+        "warnings": [],
+    }
+
+
+def _admin_refuse(result, message) -> dict:
+    out = dict(result)
+    out["error"] = message
+    out["archived_ids"] = []
+    return out
+
+
+def admin_archive_graph(
+    conn,
+    root_ids,
+    *,
+    reason,
+    actor,
+    dry_run=False,
+    allow_promotions=False,
+    force_running=False,
+) -> dict:
+    """Safely archive a dominated closure of tasks under ``root_ids``.
+
+    Returns a structured report dict (see the card contract). Refusals
+    (unknown ids, a promotion hazard without ``allow_promotions``, or a
+    live run without ``force_running``) return an error-carrying dict and
+    write nothing.
+    """
+    if not root_ids:
+        raise ValueError("root_ids must be non-empty")
+    reason_s = (reason or "").strip()
+    actor_s = (actor or "").strip()
+    if not reason_s:
+        raise ValueError("reason must be non-empty")
+    if not actor_s:
+        raise ValueError("actor must be non-empty")
+
+    roots = sorted(set(root_ids))
+    existing = {
+        row["id"] for row in conn.execute("SELECT id FROM tasks").fetchall()
+    }
+    missing = [rid for rid in roots if rid not in existing]
+    if missing:
+        return _admin_refuse(
+            _empty_admin_graph_result(roots, bool(dry_run)),
+            f"unknown task id(s), nothing archived: {sorted(missing)}",
+        )
+
+    closure, statuses = _dominated_closure(conn, roots)
+
+    id_placeholders = ",".join("?" * len(closure))
+    meta = {
+        row["id"]: row
+        for row in conn.execute(
+            "SELECT id, title, status, workspace_path, workspace_kind "
+            f"FROM tasks WHERE id IN ({id_placeholders})",
+            tuple(sorted(closure)),
+        ).fetchall()
+    }
+    tasks_rows = []
+    for tid in sorted(closure):
+        r = meta[tid]
+        ws = r["workspace_path"]
+        tasks_rows.append(
+            {
+                "id": tid,
+                "title": r["title"],
+                "status": r["status"],
+                "workspace_path": ws,
+                "workspace_exists": bool(ws) and Path(ws).exists(),
+            }
+        )
+
+    all_links = [
+        (row["parent_id"], row["child_id"])
+        for row in conn.execute(
+            "SELECT parent_id, child_id FROM task_links"
+        ).fetchall()
+    ]
+    internal_edges = []
+    external_edges = []
+    for pid, cid in all_links:
+        pin = pid in closure
+        cin = cid in closure
+        if pin and cin:
+            internal_edges.append({"parent_id": pid, "child_id": cid})
+        elif pin and not cin:
+            external_edges.append(
+                {"direction": "outbound", "parent_id": pid, "child_id": cid}
+            )
+        elif not pin and cin:
+            external_edges.append(
+                {"direction": "inbound", "parent_id": pid, "child_id": cid}
+            )
+    internal_edges.sort(key=lambda e: (e["parent_id"], e["child_id"]))
+    external_edges.sort(
+        key=lambda e: (e["parent_id"], e["child_id"], e["direction"])
+    )
+
+    root_set = set(roots)
+    warnings = []
+    for pid, cid in all_links:
+        if cid in closure and pid not in closure:
+            if statuses.get(pid) != "archived" and cid in root_set:
+                warnings.append(
+                    {
+                        "code": "live_external_parent",
+                        "parent_id": pid,
+                        "root_id": cid,
+                    }
+                )
+    warnings.sort(key=lambda w: (w["root_id"], w["parent_id"]))
+
+    active_runs = sorted(tid for tid in closure if _task_active(conn, tid))
+    boundary = sorted(
+        {
+            cid
+            for pid, cid in all_links
+            if pid in closure and cid not in closure and cid in statuses
+        }
+    )
+    would_promote = sorted(
+        tid for tid in boundary if _task_would_promote(conn, tid, closure)
+    )
+    skipped_archived = sorted(
+        tid for tid in closure if statuses.get(tid) == "archived"
+    )
+    to_archive = sorted(
+        tid for tid in closure if statuses.get(tid) != "archived"
+    )
+
+    result = {
+        "dry_run": bool(dry_run),
+        "archive_group_id": None,
+        "root_ids": roots,
+        "tasks": tasks_rows,
+        "skipped_archived": skipped_archived,
+        "internal_edges": internal_edges,
+        "external_edges": external_edges,
+        "would_promote": would_promote,
+        "active_runs": active_runs,
+        "archived_ids": [],
+        "warnings": warnings,
+    }
+
+    if dry_run:
+        return result
+
+    if would_promote and not allow_promotions:
+        return _admin_refuse(
+            result,
+            "graph would promote detached boundary task(s); pass "
+            f"--allow-promotions to proceed: {would_promote}",
+        )
+    if active_runs and not force_running:
+        return _admin_refuse(
+            result,
+            "closure contains active run(s); pass --force-running to "
+            f"terminate and archive: {active_runs}",
+        )
+
+    if active_runs:
+        survivors = []
+        for tid in active_runs:
+            prow = conn.execute(
+                "SELECT worker_pid, claim_lock FROM tasks WHERE id = ?", (tid,)
+            ).fetchone()
+            termination = _terminate_reclaimed_worker(
+                prow["worker_pid"], prow["claim_lock"]
+            )
+            if _worker_survived_termination(termination):
+                survivors.append(tid)
+        if survivors:
+            return _admin_refuse(
+                result,
+                "worker(s) survived termination; refusing to archive: "
+                f"{survivors}",
+            )
+
+    group_id = _admin_group_id()
+    n = len(to_archive)
+    with write_txn(conn):
+        for tid in to_archive:
+            prior_status = statuses.get(tid)
+            run_id = _end_run(
+                conn,
+                tid,
+                outcome="reclaimed",
+                status="reclaimed",
+                error="admin_archived with run active",
+            )
+            conn.execute(
+                "UPDATE tasks SET status = 'archived', claim_lock = NULL, "
+                "claim_expires = NULL, worker_pid = NULL WHERE id = ?",
+                (tid,),
+            )
+            if run_id is not None:
+                _append_event(
+                    conn,
+                    tid,
+                    "reclaimed",
+                    {
+                        "admin_archive": True,
+                        "archive_group_id": group_id,
+                        "actor": actor_s,
+                        "reason": reason_s,
+                    },
+                    run_id=run_id,
+                )
+            _append_event(
+                conn,
+                tid,
+                "admin_archived",
+                {
+                    "archive_group_id": group_id,
+                    "actor": actor_s,
+                    "reason": reason_s,
+                    "prior_status": prior_status,
+                },
+                run_id=run_id,
+            )
+        for rid in roots:
+            body = f"Admin-archived graph {group_id} ({n} tasks): {reason_s}"
+            add_comment(conn, rid, actor_s, body)
+
+    if allow_promotions:
+        recompute_ready(conn)
+
+    result["archive_group_id"] = group_id
+    result["archived_ids"] = to_archive
+    arched = set(to_archive)
+    result["tasks"] = [
+        {**t, "status": "archived" if t["id"] in arched else t["status"]}
+        for t in result["tasks"]
+    ]
+    return result
+
+
 def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
     """Permanently remove an already-archived task and its related rows.
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4470,12 +4470,32 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     for that path.
     """
     row = conn.execute(
-        "SELECT kind FROM task_events "
+        "SELECT kind, payload FROM task_events "
         "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
         "ORDER BY id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
+    if not row or row["kind"] != "blocked":
+        return False
+    # Payload-aware: a ``blocked`` event that records only a durable
+    # resumption phase (``resume_status`` / ``retry_status`` /
+    # ``source_status``) and carries no ``reason`` is a dependency or review
+    # resumption, not a worker/operator handoff, so ``recompute_ready`` may
+    # auto-recover it. A reason-bearing worker/operator block (and an
+    # event with no recognizable payload) remains sticky, preserving the
+    # historical behavior for true sticky blocks.
+    try:
+        payload = json.loads(row["payload"]) if row["payload"] else {}
+    except (json.JSONDecodeError, TypeError):
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+    if "reason" not in payload and any(
+        key in payload
+        for key in ("resume_status", "retry_status", "source_status")
+    ):
+        return False
+    return True
 
 
 def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:
@@ -7642,22 +7662,6 @@ def _task_would_promote(conn, task_id, closure) -> bool:
     return True
 
 
-def _empty_admin_graph_result(roots, dry_run) -> dict:
-    return {
-        "dry_run": bool(dry_run),
-        "archive_group_id": None,
-        "root_ids": sorted(roots),
-        "tasks": [],
-        "skipped_archived": [],
-        "internal_edges": [],
-        "external_edges": [],
-        "would_promote": [],
-        "active_runs": [],
-        "archived_ids": [],
-        "warnings": [],
-    }
-
-
 def _admin_refuse(result, message) -> dict:
     out = dict(result)
     out["error"] = message
@@ -7665,22 +7669,32 @@ def _admin_refuse(result, message) -> dict:
     return out
 
 
-def admin_archive_graph(
+def _plan_admin_archive_graph(
     conn,
     root_ids,
     *,
     reason,
     actor,
-    dry_run=False,
-    allow_promotions=False,
-    force_running=False,
-) -> dict:
-    """Safely archive a dominated closure of tasks under ``root_ids``.
+) -> tuple:
+    """Build the dominated-closure admin archive plan without writing.
 
-    Returns a structured report dict (see the card contract). Refusals
-    (unknown ids, a promotion hazard without ``allow_promotions``, or a
-    live run without ``force_running``) return an error-carrying dict and
-    write nothing.
+    Read-only planning shared by both the dry-run and the execution paths.
+    Returns ``(result, statuses, to_archive)``:
+
+    * ``result`` — the report dict carrying only the fixed public keys
+      (``dry_run``, ``archive_group_id``, ``root_ids``, ``tasks``,
+      ``skipped_archived``, ``internal_edges``, ``external_edges``,
+      ``would_promote``, ``active_runs``, ``archived_ids``, ``warnings``).
+      ``archived_ids`` is always ``[]`` here; only a successful write sets it.
+    * ``statuses`` — maps every task id in the board to its current status.
+    * ``to_archive`` — the ordered (sorted) list of closure tasks not yet
+      archived.
+
+    Validation happens here, before any write: non-empty ``root_ids``,
+      stripped non-empty ``reason``/``actor``, and every root id a non-empty
+      string.  Unknown root ids raise ``ValueError``.  The planner never
+      mutates the DB, never generates a group id, never calls
+      termination/recompute, and never touches the filesystem.
     """
     if not root_ids:
         raise ValueError("root_ids must be non-empty")
@@ -7690,16 +7704,17 @@ def admin_archive_graph(
         raise ValueError("reason must be non-empty")
     if not actor_s:
         raise ValueError("actor must be non-empty")
-
+    for rid in root_ids:
+        if not isinstance(rid, str) or not rid.strip():
+            raise ValueError("root_ids must be non-empty strings")
     roots = sorted(set(root_ids))
     existing = {
         row["id"] for row in conn.execute("SELECT id FROM tasks").fetchall()
     }
     missing = [rid for rid in roots if rid not in existing]
     if missing:
-        return _admin_refuse(
-            _empty_admin_graph_result(roots, bool(dry_run)),
-            f"unknown task id(s), nothing archived: {sorted(missing)}",
+        raise ValueError(
+            f"unknown task id(s), nothing archived: {sorted(missing)}"
         )
 
     closure, statuses = _dominated_closure(conn, roots)
@@ -7786,7 +7801,7 @@ def admin_archive_graph(
     )
 
     result = {
-        "dry_run": bool(dry_run),
+        "dry_run": False,
         "archive_group_id": None,
         "root_ids": roots,
         "tasks": tasks_rows,
@@ -7798,26 +7813,55 @@ def admin_archive_graph(
         "archived_ids": [],
         "warnings": warnings,
     }
+    return result, statuses, to_archive
+
+
+def admin_archive_graph(
+    conn,
+    root_ids,
+    *,
+    reason,
+    actor,
+    dry_run=False,
+    allow_promotions=False,
+    force_running=False,
+) -> dict:
+    """Safely archive a dominated closure of tasks under ``root_ids``.
+
+    Returns a structured report dict (see the card contract). Refusals
+    (unknown ids, a promotion hazard without ``allow_promotions``, or a
+    live run without ``force_running``) return an error-carrying dict and
+    write nothing.
+    """
+    # Read-only planning is shared by the dry-run and execution paths.  The
+    # planner performs all validation and may raise ``ValueError`` (empty
+    # roots / reason / actor, or unknown root ids) before any write.
+    result, statuses, to_archive = _plan_admin_archive_graph(
+        conn, root_ids, reason=reason, actor=actor
+    )
+    reason_s = (reason or "").strip()
+    actor_s = (actor or "").strip()
 
     if dry_run:
+        result["dry_run"] = True
         return result
 
-    if would_promote and not allow_promotions:
+    if result["would_promote"] and not allow_promotions:
         return _admin_refuse(
             result,
             "graph would promote detached boundary task(s); pass "
-            f"--allow-promotions to proceed: {would_promote}",
+            f"--allow-promotions to proceed: {result['would_promote']}",
         )
-    if active_runs and not force_running:
+    if result["active_runs"] and not force_running:
         return _admin_refuse(
             result,
             "closure contains active run(s); pass --force-running to "
-            f"terminate and archive: {active_runs}",
+            f"terminate and archive: {result['active_runs']}",
         )
 
-    if active_runs:
+    if result["active_runs"]:
         survivors = []
-        for tid in active_runs:
+        for tid in result["active_runs"]:
             prow = conn.execute(
                 "SELECT worker_pid, claim_lock FROM tasks WHERE id = ?", (tid,)
             ).fetchone()
@@ -7875,7 +7919,7 @@ def admin_archive_graph(
                 },
                 run_id=run_id,
             )
-        for rid in roots:
+        for rid in result["root_ids"]:
             body = f"Admin-archived graph {group_id} ({n} tasks): {reason_s}"
             add_comment(conn, rid, actor_s, body)
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7936,6 +7936,218 @@ def admin_archive_graph(
     return result
 
 
+_ARCHIVE_EVENT_KINDS = ("admin_archived", "archived")
+
+
+def _latest_archive_event(conn: sqlite3.Connection, task_id: str):
+    """Return the most recent archiving event row for ``task_id``.
+
+    Archive events are ``task_events`` rows whose ``kind`` is
+    ``admin_archived`` or ``archived``, ordered by event id ascending;
+    the "latest" is the highest event id. Returns a row with ``id``,
+    ``kind`` and ``payload``, or ``None`` if the task was never archived.
+    """
+    return conn.execute(
+        "SELECT id, kind, payload FROM task_events "
+        "WHERE task_id = ? AND kind IN (?, ?) "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id, *_ARCHIVE_EVENT_KINDS),
+    ).fetchone()
+
+
+def _parse_payload(raw) -> Optional[dict]:
+    """Parse an event payload column into a dict, or ``None`` if invalid."""
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _direct_restore_plan(conn, task_ids, actor_s):
+    """Validate a direct unarchive request; return ``(restores, invalid)``.
+
+    All-or-nothing: every id must exist, currently be archived, and have a
+    latest archive event that is an ``admin_archived`` event whose payload
+    parses and carries ``archive_group_id`` and ``prior_status``. Any
+    violation lands the id in ``invalid`` (with a reason) and nothing is
+    written. ``restores`` carries ``(task_id, prior_status, group,
+    workspace_path)`` for the valid subset.
+    """
+    existing = {
+        row["id"] for row in conn.execute("SELECT id FROM tasks").fetchall()
+    }
+    restores = []
+    invalid = []
+    for tid in sorted(set(task_ids)):
+        if tid not in existing:
+            invalid.append((tid, "unknown task id"))
+            continue
+        row = conn.execute(
+            "SELECT status, workspace_path FROM tasks WHERE id = ?", (tid,)
+        ).fetchone()
+        if row["status"] != "archived":
+            invalid.append((tid, "not currently archived"))
+            continue
+        ev = _latest_archive_event(conn, tid)
+        if ev is None:
+            invalid.append((tid, "no archive event"))
+            continue
+        if ev["kind"] != "admin_archived":
+            invalid.append((tid, "latest archive event is not admin_archived"))
+            continue
+        payload = _parse_payload(ev["payload"])
+        if not payload:
+            invalid.append((tid, "malformed admin_archived payload"))
+            continue
+        if "archive_group_id" not in payload or "prior_status" not in payload:
+            invalid.append((tid, "admin_archived payload missing required keys"))
+            continue
+        restores.append(
+            (tid, payload["prior_status"], payload["archive_group_id"],
+             row["workspace_path"])
+        )
+    return restores, invalid
+
+
+def _group_restore_plan(conn, group, actor_s):
+    """Plan a group unarchive; return ``(restores, skipped)``.
+
+    Finds every task ever carrying an ``admin_archived`` event for
+    ``group``. A member is restored only when it is currently archived and
+    its latest archive event is that same group's admin event; every other
+    member (already unarchived, individually re-archived, or archived under
+    a later group) is skipped untouched. Raises ``ValueError`` for an
+    unknown group (no task ever carried an ``admin_archived`` for it).
+    ``restores`` carries ``(task_id, prior_status, group, workspace_path)``.
+    """
+    members = set()
+    for row in conn.execute(
+        "SELECT task_id, payload FROM task_events "
+        "WHERE kind = 'admin_archived'"
+    ).fetchall():
+        payload = _parse_payload(row["payload"])
+        if payload and payload.get("archive_group_id") == group:
+            members.add(row["task_id"])
+    if not members:
+        raise ValueError(f"unknown archive group: {group}")
+    restores = []
+    skipped = []
+    for tid in sorted(members):
+        row = conn.execute(
+            "SELECT status, workspace_path FROM tasks WHERE id = ?", (tid,)
+        ).fetchone()
+        if row is None or row["status"] != "archived":
+            skipped.append(tid)
+            continue
+        ev = _latest_archive_event(conn, tid)
+        payload = _parse_payload(ev["payload"]) if ev is not None else None
+        if (
+            ev is None or ev["kind"] != "admin_archived"
+            or not payload or payload.get("archive_group_id") != group
+        ):
+            skipped.append(tid)
+            continue
+        restores.append(
+            (tid, payload.get("prior_status"), group, row["workspace_path"])
+        )
+    return restores, skipped
+
+
+def admin_unarchive(conn, task_ids=None, *, group_id=None, actor) -> dict:
+    """Transactionally restore tasks archived via ``admin_archive_graph``.
+
+    Exactly one mode is allowed: a non-empty ``task_ids`` iterable (direct,
+    all-or-nothing) or a single non-empty ``group_id`` (group mode).
+    ``actor`` is required and stripped. All validation happens before any
+    write; refusals raise ``ValueError`` with zero writes and no recompute.
+
+    Restored tasks return to their pre-archive status (``running`` becomes
+    ``ready``), have their claim/run pointers cleared, and get an
+    ``admin_unarchived`` event carrying ``archive_group_id``, ``actor`` and
+    ``restored_status``. Comments, prior events, attachments, links, runs and
+    workspace data/directories are preserved. Missing nonempty workspace
+    paths are reported without being recreated.
+
+    Returns the fixed dict with keys ``group_id``, ``restored_ids``,
+    ``skipped_ids`` and ``missing_workspaces`` (all lists sorted).
+    """
+    actor_s = (actor or "").strip()
+    if not actor_s:
+        raise ValueError("actor must be non-empty")
+
+    direct_ids = list(task_ids) if task_ids is not None else None
+    group_s = (group_id or "").strip() if group_id is not None else None
+
+    if direct_ids is not None and group_s is not None:
+        raise ValueError("specify exactly one of task_ids or group_id, not both")
+    if direct_ids is not None:
+        if not direct_ids:
+            raise ValueError("task_ids must be non-empty")
+        for tid in direct_ids:
+            if not isinstance(tid, str) or not tid.strip():
+                raise ValueError("task_ids must be non-empty strings")
+    elif group_s is not None:
+        if not group_s:
+            raise ValueError("group_id must be non-empty")
+    else:
+        raise ValueError("specify exactly one of task_ids or group_id")
+
+    # Read-only planning before any write.
+    if direct_ids is not None:
+        restores, invalid = _direct_restore_plan(conn, direct_ids, actor_s)
+        if invalid:
+            reasons = "; ".join(f"{tid} ({why})" for tid, why in invalid)
+            raise ValueError(
+                f"nothing unarchived, invalid task(s): {reasons}"
+            )
+        skipped = []
+    else:
+        restores, skipped = _group_restore_plan(conn, group_s, actor_s)
+
+    missing_workspaces = sorted(
+        str(ws) for (_, _, _, ws) in restores
+        if ws and not Path(ws).exists()
+    )
+    restored_ids = []
+    if restores:
+        with write_txn(conn):
+            for tid, prior_status, grp, _ws in restores:
+                restored_status = (
+                    prior_status if prior_status != "running" else "ready"
+                )
+                conn.execute(
+                    "UPDATE tasks SET status = ?, claim_lock = NULL, "
+                    "claim_expires = NULL, worker_pid = NULL, "
+                    "current_run_id = NULL WHERE id = ?",
+                    (restored_status, tid),
+                )
+                _append_event(
+                    conn,
+                    tid,
+                    "admin_unarchived",
+                    {
+                        "archive_group_id": grp,
+                        "actor": actor_s,
+                        "restored_status": restored_status,
+                    },
+                )
+                restored_ids.append(tid)
+    # Recompute exactly once after the commit (group success included),
+    # never on refusal. Restored parents are ``ready`` (not ``done``), so
+    # gating keeps their children in ``todo``.
+    recompute_ready(conn)
+
+    return {
+        "group_id": group_s if group_s is not None else None,
+        "restored_ids": sorted(restored_ids),
+        "skipped_ids": sorted(skipped),
+        "missing_workspaces": missing_workspaces,
+    }
+
+
 def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
     """Permanently remove an already-archived task and its related rows.
 

--- a/tests/hermes_cli/test_kanban_admin_archive.py
+++ b/tests/hermes_cli/test_kanban_admin_archive.py
@@ -906,10 +906,8 @@ class TestAdminArchiveGraph:
             kb.recompute_ready(db2)
         oracle = {key: kb.get_task(db2, built2[key]).status
                   for key in built2 if key not in ("r", "d")}
-        promoted_oracle = sorted(
-            built2[key] for key, status in oracle.items()
-            if status in ("ready", "review")
-        )
+        promoted_keys = {key for key, status in oracle.items()
+                         if status in ("ready", "review")}
         db2.close()
 
         db = make_conn(board)
@@ -930,7 +928,12 @@ class TestAdminArchiveGraph:
         assert result["would_promote"] == sorted(
             children[key] for key in ("c1", "c4", "c7", "c8")
         )
-        assert set(result["would_promote"]) == set(promoted_oracle)
+        # The kernel board's random task ids can never equal the oracle
+        # board's random ids (each board generates an independent id space),
+        # so compare promoted fixture KEYS instead: the canonical set is
+        # exactly {c1, c4, c7, c8}.
+        id_to_key = {tid: key for key, tid in children.items()}
+        assert {id_to_key[tid] for tid in result["would_promote"]} == promoted_keys
         statuses = _statuses(db)
         assert statuses[r] == "archived"
         for key in ("c1", "c4", "c5", "c6", "c7", "c8"):

--- a/tests/hermes_cli/test_kanban_admin_archive.py
+++ b/tests/hermes_cli/test_kanban_admin_archive.py
@@ -439,6 +439,42 @@ def board(tmp_path, monkeypatch):
     return db_path
 
 
+@pytest.fixture(autouse=True)
+def _guard_db_connect(tmp_path, monkeypatch):
+    """Fail-closed per-test guard over ``kb.connect``.
+
+    Refuses to open ANY connection whose resolved DB path lies outside
+    this test's ``tmp_path``, *before* :func:`kb.connect` can create the
+    file/sidecars. This is deliberately stricter than
+    ``tests/conftest.py``'s production-root deny-list: it refuses by the
+    test's own temporary root without needing to know the real home root
+    ahead of time, so a stray path pointing anywhere outside the current
+    test's temporary tree is refused on every platform.
+    """
+    original = kb.connect
+    root = Path(tmp_path).resolve()
+
+    def guarded(db_path=None, *, board=None):
+        if db_path is None:
+            # No explicit path -> kb.connect would resolve via env/board
+            # defaults. Under the guard that resolution is never allowed to
+            # run, because the resolved target is unknowable ahead of time.
+            pytest.fail(
+                "FAIL-CLOSED: kb.connect called without an explicit db_path "
+                "(default/board-path resolution is not permitted under the "
+                "archive guard)"
+            )
+        resolved = Path(db_path).resolve()
+        if not resolved.is_relative_to(root):
+            pytest.fail(
+                f"FAIL-CLOSED: refused kb.connect to DB path outside this "
+                f"test's tmp_path: {resolved}"
+            )
+        return original(db_path=db_path, board=board)
+
+    monkeypatch.setattr(kb, "connect", guarded)
+
+
 def assert_result_keys(result, keys):
     missing = set(keys) - set(result.keys())
     assert not missing, f"result missing keys: {sorted(missing)}"
@@ -560,6 +596,21 @@ class TestFixtureSelfChecks:
                     "VALUES ('t_x', 'note', NULL, 0)"
                 )
             assert conn2.write_count == 1
+
+    def test_guard_refuses_db_path_outside_tmp_path(self, board, tmp_path):
+        # A resolved DB path outside THIS test's tmp_path must be refused
+        # by the fail-closed guard before sqlite3 can create anything.
+        outside = tmp_path.parent / "guard-escape"
+        db_target = outside / "escaped.db"
+        outside.mkdir(parents=True, exist_ok=True)
+        assert not db_target.is_relative_to(Path(tmp_path).resolve())
+        for suffix in ("", "-wal", "-shm"):
+            assert not Path(str(db_target) + suffix).exists()
+        with pytest.raises(pytest.fail.Exception):
+            kb.connect(db_path=db_target)
+        # The refused call created no DB, WAL, or SHM file.
+        for suffix in ("", "-wal", "-shm"):
+            assert not Path(str(db_target) + suffix).exists()
 
     @pytest.mark.parametrize("builder_name", ["h1", "h2", "n1", "i1", "dm", "ap"])
     def test_graph_builder_topology_by_direct_sql(self, board, builder_name):
@@ -969,6 +1020,13 @@ class TestAdminArchiveGraph:
     def test_dry(self, board, tmp_path):
         db = make_conn(board)
         built = build_h1(db)
+        # Establish a stable read transaction and read mark BEFORE the
+        # before-snapshot, so ordinary SQLite read-lock bookkeeping in the
+        # WAL/SHM cannot perturb the byte comparison of a write-free (dry)
+        # planner. Without the mark, the kernel's first read would itself
+        # create a WAL/SHM read mark between the two snapshots.
+        db.execute("BEGIN")
+        db.execute("SELECT COUNT(*) FROM tasks")
         files = []
         for suffix in ("", "-wal", "-shm"):
             candidate = Path(str(board) + suffix)
@@ -1107,11 +1165,15 @@ class TestAdminArchiveGraph:
         assert len(_events_by_kind(db, a, "admin_archived")) == 1
         assert len(_events_by_kind(db, b, "admin_archived")) == 1
         assert len(new_events) >= 2
-        # Archive audit comment carries the exact root body.
+        # Archive audit comment carries the exact root body. _comments_of
+        # orders by id ascending, so "[0]" is the pre-archive note and the
+        # audit comment is the NEWEST row ("[-1]").
         comments_a = _comments_of(db, a)
-        assert comments_a[0]["author"] == ACTOR
+        assert len(comments_a) == 2  # the pre-archive note + exactly one audit
+        assert comments_a[0]["body"] == "note before archive"  # prior row intact
+        assert comments_a[-1]["author"] == ACTOR
         group = result["archive_group_id"]
-        assert comments_a[0]["body"] == (
+        assert comments_a[-1]["body"] == (
             f"Admin-archived graph {group} (2 tasks): {REASON}"
         )
         assert _statuses(db)[a] == "archived"
@@ -1410,6 +1472,11 @@ class TestAdminUnarchive:
         # only observes the unarchive calls under test.
         r1 = assert_success(*_call(_archive, db, [a]))
         r2 = assert_success(*_call(_archive, db, [b]))
+        # Direct setup transition: b keeps its latest admin_archived event
+        # but is brought back to the NON-archived "ready" status, preserving
+        # the latest-admin-event-but-currently-nonarchived refusal case used
+        # below as the all-or-nothing mixed target.
+        set_status(db, b, "ready")
         rx = assert_success(*_call(_archive, db, [x]))
         kb.archive_task(db, m)  # ordinary archive, not admin
         assert _statuses(db)[m] == "archived"

--- a/tests/hermes_cli/test_kanban_admin_archive.py
+++ b/tests/hermes_cli/test_kanban_admin_archive.py
@@ -1,0 +1,1640 @@
+"""Contract tests for the safe Kanban admin archive/unarchive kernel.
+
+Public kernel under test (added by a later lane; absent at write time):
+
+    admin_archive_graph(
+        conn, root_ids, *, reason, actor,
+        dry_run=False, allow_promotions=False, force_running=False,
+    ) -> dict
+    admin_unarchive(conn, task_ids=None, *, group_id=None, actor) -> dict
+
+Lane-1 pre-kernel gate: TestFixtureSelfChecks must pass today against
+direct SQL only; TestAdminArchiveGraph and TestAdminUnarchive must fail
+exclusively through the single kernel shim (KERNEL-MISSING marker),
+never through import, fixture, or runtime errors. Every FAILED short
+summary line must contain the marker, so kernel test method names are
+deliberately short enough that the reason survives `-rf` width
+truncation next to the node id.
+
+Isolation: every connection is opened on an explicit db_path under a
+per-test temporary HERMES_HOME. Nothing in this module resolves the
+real ~/.hermes kanban root, the develop-builds board, or another
+worktree DB.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+GROUP_ID_RE = re.compile(r"^ag_[0-9a-f]{16}$")
+KERNEL_MISS = "KERNEL-MISSING: admin_archive_graph"
+REASON = "admin archive contract lane 1"
+ACTOR = "dozer"
+DEAD_PID = 424242
+
+
+# ---------------------------------------------------------------------------
+# Kernel access: exactly one shim. No direct kb.admin_* calls anywhere else.
+# ---------------------------------------------------------------------------
+
+
+def _kernel(name, *args, **kwargs):
+    try:
+        fn = getattr(kb, name)
+    except AttributeError:
+        # Pre-kernel gate: every kernel op fails with the exact card marker.
+        # The try/except AttributeError shape (not hasattr) leaves unrelated
+        # implementation failures unmasked once the kernel exists.
+        pytest.fail("KERNEL-MISSING: admin_archive_graph")
+    return fn(*args, **kwargs)
+
+
+def _archive(conn, root_ids, **kwargs):
+    kwargs.setdefault("reason", REASON)
+    kwargs.setdefault("actor", ACTOR)
+    return _kernel("admin_archive_graph", conn, list(root_ids), **kwargs)
+
+
+def _unarchive(conn, **kwargs):
+    kwargs.setdefault("actor", ACTOR)
+    return _kernel("admin_unarchive", conn, **kwargs)
+
+
+def _call(fn, *args, **kwargs):
+    """Invoke a kernel op; return (result, exception) without raising.
+
+    The one exception: a pre-kernel shim miss (KERNEL-MISSING marker)
+    is re-raised verbatim so every kernel test fails with exactly that
+    marker before the kernel exists.
+    """
+    try:
+        return fn(*args, **kwargs), None
+    except Exception as exc:  # noqa: BLE001 - contract: any refusal form
+        if KERNEL_MISS in str(exc):
+            raise
+        return None, exc
+
+
+def assert_refused(result, exc, *needles):
+    """A refusal must surface (error dict or raised exception) and list
+    every id / flag named in ``needles``."""
+    if exc is not None:
+        blob = str(exc)
+    else:
+        assert result is not None
+        blob = json.dumps(result)
+    for needle in needles:
+        assert needle in blob, f"{needle!r} missing from refusal: {blob}"
+
+
+def assert_success(result, exc) -> dict:
+    """Assert kernel success; return the result narrowed to dict."""
+    assert exc is None, f"expected success, kernel raised: {exc!r}"
+    assert result is not None
+    assert not result.get("error"), f"unexpected error: {result.get('error')}"
+    return result
+
+
+def assert_failed(result, exc):
+    """Assert a refusal of any form (error dict or raised exception)."""
+    assert exc is not None or (result is not None and result.get("error")), (
+        "expected a refusal, got success"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Connection, graph-building, and inspection helpers (direct SQL only).
+# ---------------------------------------------------------------------------
+
+
+def make_conn(db_path):
+    """Open a board DB at an explicit path. No default-path resolution."""
+    conn = kb.connect(db_path=Path(db_path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+class FailConn:
+    """Attribute-forwarding connection that raises on its Nth execute.
+
+    ``fail_at`` is 1-based: the Nth ``execute`` call raises
+    sqlite3.OperationalError; earlier and later calls pass through.
+    Counts every execute, including read-only and transaction-control
+    statements.
+    """
+
+    def __init__(self, conn, fail_at):
+        self._conn = conn
+        self._fail_at = int(fail_at)
+        self.execute_count = 0
+
+    def execute(self, sql, *args, **kwargs):
+        self.execute_count += 1
+        if self.execute_count == self._fail_at:
+            raise sqlite3.OperationalError("injected failure")
+        return self._conn.execute(sql, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self._conn.close()
+        return False
+
+
+def make_fail_once_conn(db_path, fail_at):
+    return FailConn(kb.connect(db_path=Path(db_path)), fail_at)
+
+
+class FailWriteConn:
+    """Attribute-forwarding connection that fails on the Nth data write.
+
+    ``fail_on_write`` is 1-based over INSERT/UPDATE/DELETE statements
+    only (read-only and transaction-control statements pass through).
+    Failing on the Nth write guarantees at least one earlier data
+    mutation succeeded inside the transaction window, so a correct
+    transactional kernel must roll it all back.
+    """
+
+    def __init__(self, conn, fail_on_write):
+        self._conn = conn
+        self._fail_on_write = int(fail_on_write)
+        self.write_count = 0
+
+    def execute(self, sql, *args, **kwargs):
+        head = (sql or "").lstrip().split(None, 1)
+        if head and head[0].upper() in ("INSERT", "UPDATE", "DELETE"):
+            self.write_count += 1
+            if self.write_count == self._fail_on_write:
+                raise sqlite3.OperationalError("injected write failure")
+        return self._conn.execute(sql, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self._conn.close()
+        return False
+
+
+def make_fail_write_conn(db_path, fail_on_write):
+    return FailWriteConn(kb.connect(db_path=Path(db_path)), fail_on_write)
+
+
+def create(db, title, **kwargs):
+    return kb.create_task(db, title=title, **kwargs)
+
+
+def link(db, parent, child):
+    kb.link_tasks(db, parent, child)
+
+
+def _statuses(db):
+    return {
+        row["id"]: row["status"]
+        for row in db.execute("SELECT id, status FROM tasks").fetchall()
+    }
+
+
+def _links_of(db):
+    return {
+        (row["parent_id"], row["child_id"])
+        for row in db.execute("SELECT parent_id, child_id FROM task_links").fetchall()
+    }
+
+
+def _events_by_kind(db, task_id, kind):
+    return db.execute(
+        "SELECT id, payload FROM task_events WHERE task_id = ? AND kind = ? "
+        "ORDER BY id",
+        (task_id, kind),
+    ).fetchall()
+
+
+def _payloads(db, task_id, kind):
+    out = []
+    for row in _events_by_kind(db, task_id, kind):
+        out.append(json.loads(row["payload"]) if row["payload"] else None)
+    return out
+
+
+def _admin_event_rows(db):
+    return db.execute(
+        "SELECT task_id, payload FROM task_events WHERE kind = 'admin_archived' "
+        "ORDER BY task_id, id"
+    ).fetchall()
+
+
+def _comments_of(db, task_id):
+    return db.execute(
+        "SELECT id, author, body FROM task_comments WHERE task_id = ? "
+        "ORDER BY id",
+        (task_id,),
+    ).fetchall()
+
+
+def _runs_of(db, task_id):
+    return db.execute(
+        "SELECT id, status, outcome, ended_at FROM task_runs WHERE task_id = ? "
+        "ORDER BY id",
+        (task_id,),
+    ).fetchall()
+
+
+def _table_snapshot(db, table, task_id=None):
+    """Set of full-row value tuples from ``table``.
+
+    Optionally restricted to rows whose ``task_id`` column equals
+    ``task_id``. Keyed by the row's values (not a named ``id`` column,
+    which some join tables like ``task_links`` lack) so it is
+    schema-agnostic and usable for byte/row-identical preservation
+    checks.
+    """
+    sql = f"SELECT * FROM {table}"
+    params = ()
+    if task_id is not None:
+        sql += " WHERE task_id = ?"
+        params = (task_id,)
+    return {
+        tuple(r[k] for k in r.keys())
+        for r in db.execute(sql, params).fetchall()
+    }
+
+
+def set_status(db, task_id, status):
+    db.execute("UPDATE tasks SET status = ? WHERE id = ?", (status, task_id))
+
+
+def make_task_running(db, task_id):
+    """Promote to ready, claim it, then stamp a fake (dead) worker pid."""
+    set_status(db, task_id, "ready")
+    claimed = kb.claim_task(db, task_id)
+    assert claimed is not None and claimed.status == "running"
+    db.execute("UPDATE tasks SET worker_pid = ? WHERE id = ?", (DEAD_PID, task_id))
+
+
+def make_task_blocked_nonsticky(db, task_id, failures):
+    """status=blocked with NO 'blocked' event -> not a sticky block."""
+    db.execute(
+        "UPDATE tasks SET status = 'blocked', consecutive_failures = ? "
+        "WHERE id = ?",
+        (failures, task_id),
+    )
+
+
+def make_task_blocked_sticky(db, task_id, failures):
+    """status=blocked preceded by a worker 'blocked' event -> sticky."""
+    db.execute(
+        "INSERT INTO task_events (task_id, kind, payload, created_at) "
+        "VALUES (?, 'blocked', ?, ?)",
+        (task_id, json.dumps({"reason": "sticky handoff"}), int(time.time())),
+    )
+    make_task_blocked_nonsticky(db, task_id, failures)
+
+
+def make_task_blocked_with_resume(db, task_id, failures, resume_status):
+    """status=blocked whose newest covered event carries resume_status."""
+    db.execute(
+        "INSERT INTO task_events (task_id, kind, payload, created_at) "
+        "VALUES (?, 'blocked', ?, ?)",
+        (task_id, json.dumps({"resume_status": resume_status}), int(time.time())),
+    )
+    make_task_blocked_nonsticky(db, task_id, failures)
+
+
+def assert_topology(db, expected_statuses, expected_links, expected_task_count):
+    assert _statuses(db) == expected_statuses
+    assert _links_of(db) == expected_links
+    n = db.execute("SELECT COUNT(*) AS n FROM tasks").fetchone()["n"]
+    assert n == expected_task_count
+
+
+def spy_recompute(monkeypatch):
+    """Patch kb.recompute_ready with a counting spy; return the call log."""
+    calls = []
+    original = kb.recompute_ready
+
+    def spy(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(kb, "recompute_ready", spy)
+    return calls
+
+
+def new_board(tmp_path, monkeypatch, index):
+    """A second (or Nth) isolated board inside the same test."""
+    home = tmp_path / f"hermes-home-{index}"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return kb.kanban_db_path(f"contractboard{index}")
+
+
+# ---------------------------------------------------------------------------
+# Canonical graph builders (normative topologies).
+# External (non-closure) tasks are created via the blocked initial status
+# and moved to their normative status by direct UPDATE: create_task only
+# accepts initial_status in {"running", "blocked"}.
+# ---------------------------------------------------------------------------
+
+
+def build_h1(db):
+    """A(todo)->B(todo); A->C1(todo); D(done external)->C1."""
+    a = create(db, "h1 A", initial_status="blocked")
+    b = create(db, "h1 B", parents=[a])
+    c1 = create(db, "h1 C1", parents=[a])
+    d = create(db, "h1 D", initial_status="blocked")
+    link(db, d, c1)
+    set_status(db, a, "todo")
+    set_status(db, d, "done")
+    return {"a": a, "b": b, "c1": c1, "d": d}
+
+
+def build_h2(db):
+    """H1 plus A->C3, B->C3, D2(done external)->C3. No archived E."""
+    ids = build_h1(db)
+    c3 = create(db, "h2 C3", parents=[ids["a"], ids["b"]])
+    d2 = create(db, "h2 D2", initial_status="blocked")
+    link(db, d2, c3)
+    set_status(db, d2, "done")
+    return {**ids, "c3": c3, "d2": d2}
+
+
+def build_n1(db):
+    """A->C2(todo); Q(todo external)->C2. Q MUST be todo, never ready."""
+    a = create(db, "n1 A", initial_status="blocked")
+    c2 = create(db, "n1 C2", parents=[a])
+    q = create(db, "n1 Q", initial_status="blocked")
+    link(db, q, c2)
+    set_status(db, a, "todo")
+    set_status(db, q, "todo")
+    return {"a": a, "c2": c2, "q": q}
+
+
+def build_i1(db):
+    """P(done external)->A(root) ONLY. No extra A->B edge or task."""
+    p = create(db, "i1 P", initial_status="blocked")
+    a = create(db, "i1 A")
+    link(db, p, a)
+    set_status(db, a, "todo")
+    set_status(db, p, "done")
+    return {"p": p, "a": a}
+
+
+def build_dm(db):
+    """A->B, A->C, B->D, C->D, all todo."""
+    a = create(db, "dm A", initial_status="blocked")
+    b = create(db, "dm B", parents=[a])
+    c = create(db, "dm C", parents=[a])
+    d = create(db, "dm D", parents=[b, c])
+    set_status(db, a, "todo")
+    return {"a": a, "b": b, "c": c, "d": d}
+
+
+def build_ap(db):
+    """A->X; E(archived external)->X."""
+    a = create(db, "ap A", initial_status="blocked")
+    x = create(db, "ap X", parents=[a])
+    e = create(db, "ap E", initial_status="blocked")
+    link(db, e, x)
+    set_status(db, a, "todo")
+    set_status(db, e, "archived")
+    return {"a": a, "x": x, "e": e}
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    """Primary isolated board: explicit DB path under a temp HERMES_HOME."""
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    db_path = kb.kanban_db_path("contractboard")
+    assert db_path.parent == home / "kanban" / "boards" / "contractboard"
+    init = make_conn(db_path)
+    init.close()
+    return db_path
+
+
+def assert_result_keys(result, keys):
+    missing = set(keys) - set(result.keys())
+    assert not missing, f"result missing keys: {sorted(missing)}"
+
+
+def assert_execution_shape(result):
+    assert_result_keys(
+        result,
+        {
+            "dry_run",
+            "archive_group_id",
+            "root_ids",
+            "tasks",
+            "skipped_archived",
+            "internal_edges",
+            "external_edges",
+            "would_promote",
+            "active_runs",
+            "archived_ids",
+            "warnings",
+        },
+    )
+    for key in ("root_ids", "skipped_archived", "would_promote", "active_runs",
+                "archived_ids"):
+        assert result[key] == sorted(result[key]), key
+    ids = [t["id"] for t in result["tasks"]]
+    assert ids == sorted(ids)
+    for entry in result["tasks"]:
+        assert set(entry.keys()) == {
+            "id", "title", "status", "workspace_path", "workspace_exists",
+        }
+        assert isinstance(entry["workspace_exists"], bool)
+    for edge in result["internal_edges"]:
+        assert set(edge.keys()) == {"parent_id", "child_id"}
+    assert result["internal_edges"] == sorted(
+        result["internal_edges"], key=lambda e: (e["parent_id"], e["child_id"])
+    )
+    for edge in result["external_edges"]:
+        assert set(edge.keys()) == {"direction", "parent_id", "child_id"}
+        assert edge["direction"] in ("inbound", "outbound")
+    assert result["external_edges"] == sorted(
+        result["external_edges"],
+        key=lambda e: (e["parent_id"], e["child_id"], e["direction"]),
+    )
+    for warning in result["warnings"]:
+        assert set(warning.keys()) == {"code", "parent_id", "root_id"}
+        assert warning["code"] == "live_external_parent"
+    assert result["warnings"] == sorted(
+        result["warnings"], key=lambda w: (w["root_id"], w["parent_id"])
+    )
+    json.dumps(result)
+
+
+# ---------------------------------------------------------------------------
+# TestFixtureSelfChecks — no kernel calls; must pass pre-kernel.
+# ---------------------------------------------------------------------------
+
+
+class TestFixtureSelfChecks:
+    def test_db_connection_is_isolated_under_temp_home(self, board):
+        home = Path(os.environ["HERMES_HOME"])
+        real_home = Path.home() / ".hermes"
+        real_kanban = real_home / "kanban"
+        db_path = Path(board)
+        assert db_path.is_file()
+        # The DB sits inside this test's temporary HERMES_HOME tree...
+        assert db_path.is_relative_to(home)
+        assert home == db_path.parents[3]
+        # ...and outside the real home / real kanban root.
+        assert home != real_home
+        assert not db_path.is_relative_to(real_home)
+        assert not real_kanban.is_relative_to(home)
+        # The connection the test opens must actually point at this file.
+        db = make_conn(board)
+        with db:
+            file_path = db.execute("PRAGMA database_list").fetchone()[2]
+        assert Path(file_path).resolve() == db_path.resolve()
+
+    def test_board_path_cannot_resolve_live_roots(self, board):
+        home = Path(os.environ["HERMES_HOME"])
+        real_home = Path.home() / ".hermes"
+        slug = Path(board).parent.name
+        assert kb.kanban_db_path(slug) == Path(board)
+        assert kb.boards_root() == home / "kanban" / "boards"
+        # A request for the live develop-builds board must resolve inside
+        # this test's temporary home, never into the real kanban root.
+        dev_builds = kb.kanban_db_path("develop-builds")
+        assert dev_builds == home / "kanban" / "boards" / "develop-builds" / "kanban.db"
+        assert not dev_builds.is_relative_to(real_home)
+        assert real_home not in home.parents
+
+    def test_make_fail_once_conn_raises_exactly_on_nth_execute(self, board):
+        conn = make_fail_once_conn(board, fail_at=3)
+        with conn:
+            conn.execute("SELECT 1")
+            conn.execute("SELECT 2")
+            assert conn.execute_count == 2
+            with pytest.raises(sqlite3.OperationalError):
+                conn.execute("SELECT 3")
+            assert conn.execute_count == 3
+            # Later executes pass through.
+            conn.execute("SELECT 4")
+            conn.execute("SELECT 5")
+        assert conn.execute_count == 5
+
+    def test_make_fail_write_conn_raises_on_nth_write(self, board):
+        # Reads and transaction-control statements never count toward the
+        # write counter; a real data write does, and fails on the Nth one.
+        conn2 = make_fail_write_conn(board, fail_on_write=1)
+        with conn2:
+            conn2.execute("SELECT 1")
+            conn2.execute("BEGIN")
+            conn2.execute("COMMIT")
+            assert conn2.write_count == 0
+            with pytest.raises(sqlite3.OperationalError):
+                # A real INSERT counts as write #1 and trips the failure.
+                conn2.execute(
+                    "INSERT INTO task_events (task_id, kind, payload, created_at) "
+                    "VALUES ('t_x', 'note', NULL, 0)"
+                )
+            assert conn2.write_count == 1
+
+    @pytest.mark.parametrize("builder_name", ["h1", "h2", "n1", "i1", "dm", "ap"])
+    def test_graph_builder_topology_by_direct_sql(self, board, builder_name):
+        db = make_conn(board)
+        with db:
+            ids = getattr(self, f"_build_{builder_name}")(db)
+            self._expect_topology(builder_name, db, ids)
+
+    # -- builder wrappers + exact-topology expectations -------------------
+
+    def _build_h1(self, db):
+        return build_h1(db)
+
+    def _build_h2(self, db):
+        return build_h2(db)
+
+    def _build_n1(self, db):
+        return build_n1(db)
+
+    def _build_i1(self, db):
+        return build_i1(db)
+
+    def _build_dm(self, db):
+        return build_dm(db)
+
+    def _build_ap(self, db):
+        return build_ap(db)
+
+    def _expect_topology(self, name, db, ids):
+        if name == "h1":
+            assert_topology(
+                db,
+                {ids["a"]: "todo", ids["b"]: "todo",
+                 ids["c1"]: "todo", ids["d"]: "done"},
+                {(ids["a"], ids["b"]), (ids["a"], ids["c1"]),
+                 (ids["d"], ids["c1"])},
+                4,
+            )
+        elif name == "h2":
+            assert_topology(
+                db,
+                {ids["a"]: "todo", ids["b"]: "todo",
+                 ids["c1"]: "todo", ids["d"]: "done",
+                 ids["c3"]: "todo", ids["d2"]: "done"},
+                {(ids["a"], ids["b"]), (ids["a"], ids["c1"]),
+                 (ids["d"], ids["c1"]),
+                 (ids["a"], ids["c3"]), (ids["b"], ids["c3"]),
+                 (ids["d2"], ids["c3"])},
+                6,
+            )
+        elif name == "n1":
+            assert_topology(
+                db,
+                {ids["a"]: "todo", ids["c2"]: "todo", ids["q"]: "todo"},
+                {(ids["a"], ids["c2"]), (ids["q"], ids["c2"])},
+                3,
+            )
+        elif name == "i1":
+            assert_topology(
+                db,
+                {ids["p"]: "done", ids["a"]: "todo"},
+                {(ids["p"], ids["a"])},
+                2,
+            )
+        elif name == "dm":
+            assert_topology(
+                db,
+                {ids[k]: "todo" for k in ("a", "b", "c", "d")},
+                {(ids["a"], ids["b"]), (ids["a"], ids["c"]),
+                 (ids["b"], ids["d"]), (ids["c"], ids["d"])},
+                4,
+            )
+        elif name == "ap":
+            assert_topology(
+                db,
+                {ids["a"]: "todo", ids["x"]: "todo", ids["e"]: "archived"},
+                {(ids["a"], ids["x"]), (ids["e"], ids["x"])},
+                3,
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestAdminArchiveGraph — dominated-closure archive kernel contract.
+# ---------------------------------------------------------------------------
+
+
+class TestAdminArchiveGraph:
+    @pytest.fixture
+    def ids(self, board):
+        db = make_conn(board)
+        built = build_h1(db)
+        db.close()
+        return built
+
+    def test_dm(self, board, tmp_path, monkeypatch):
+        # Deterministic task ids so two independent runs produce
+        # byte-comparable results (the random group id is normalized out).
+        counter = {"i": 0}
+
+        def det_id():
+            counter["i"] += 1
+            return f"t_det{counter['i']:04d}"
+
+        monkeypatch.setattr(kb, "_new_task_id", det_id)
+
+        def run_once(db_path):
+            db = make_conn(db_path)
+            built = build_dm(db)
+            result = assert_success(*_call(_archive, db, [built["a"], built["a"]]))
+            db.close()
+            return result, built
+
+        result, built = run_once(board)
+        assert result["dry_run"] is False
+        assert GROUP_ID_RE.fullmatch(result["archive_group_id"])
+        assert_execution_shape(result)
+        assert result["root_ids"] == [built["a"]]
+        assert result["skipped_archived"] == []
+        assert result["warnings"] == []
+        assert result["would_promote"] == []
+        assert result["active_runs"] == []
+        assert result["archived_ids"] == sorted(
+            [built[k] for k in ("a", "b", "c", "d")]
+        )
+        assert [t["id"] for t in result["tasks"]] == sorted(
+            [built[k] for k in ("a", "b", "c", "d")]
+        )
+        assert result["internal_edges"] == sorted(
+            [
+                {"parent_id": built["a"], "child_id": built["b"]},
+                {"parent_id": built["a"], "child_id": built["c"]},
+                {"parent_id": built["b"], "child_id": built["d"]},
+                {"parent_id": built["c"], "child_id": built["d"]},
+            ],
+            key=lambda e: (e["parent_id"], e["child_id"]),
+        )
+        assert result["external_edges"] == []
+
+        counter["i"] = 0
+        second_path = new_board(tmp_path, monkeypatch, "dm2")
+        result2, built2 = run_once(second_path)
+        assert built == built2  # deterministic ids across runs
+        normalized_a = dict(result)
+        normalized_a["archive_group_id"] = None
+        normalized_b = dict(result2)
+        normalized_b["archive_group_id"] = None
+        assert json.loads(json.dumps(normalized_a)) == json.loads(
+            json.dumps(normalized_b)
+        )
+
+    def test_h1_ref(self, board, ids, monkeypatch):
+        db = make_conn(board)
+        calls = spy_recompute(monkeypatch)
+        result, exc = _call(_archive, db, [ids["a"]])
+        assert_refused(result, exc, ids["c1"], "--allow-promotions")
+        if result is not None:
+            assert result["archived_ids"] == []
+        statuses = _statuses(db)
+        assert statuses[ids["a"]] == "todo"
+        assert statuses[ids["b"]] == "todo"
+        assert statuses[ids["c1"]] == "todo"
+        assert statuses[ids["d"]] == "done"
+        assert len(_admin_event_rows(db)) == 0
+        assert calls == []  # a refusal never recomputes
+        db.close()
+
+    def test_h1_up(self, board, ids, monkeypatch):
+        db = make_conn(board)
+        calls = spy_recompute(monkeypatch)
+        result = assert_success(
+            *_call(_archive, db, [ids["a"]], allow_promotions=True)
+        )
+        assert result["dry_run"] is False
+        assert GROUP_ID_RE.fullmatch(result["archive_group_id"])
+        assert result["archived_ids"] == sorted([ids["a"], ids["b"]])
+        assert result["would_promote"] == [ids["c1"]]
+        statuses = _statuses(db)
+        assert statuses[ids["a"]] == "archived"
+        assert statuses[ids["b"]] == "archived"
+        assert statuses[ids["c1"]] == "ready"
+        assert statuses[ids["d"]] == "done"
+        assert len(calls) == 1  # recompute runs exactly once, after commit
+        group = result["archive_group_id"]
+        for task_id in (ids["a"], ids["b"]):
+            payloads = _payloads(db, task_id, "admin_archived")
+            assert len(payloads) == 1
+            assert payloads[0]["archive_group_id"] == group
+        db.close()
+
+    def test_h2(self, board, tmp_path, monkeypatch):
+        db = make_conn(board)
+        built = build_h2(db)
+        result, exc = _call(_archive, db, [built["a"]])
+        assert_refused(result, exc, built["c1"], built["c3"],
+                       "--allow-promotions")
+        statuses = _statuses(db)
+        assert statuses[built["a"]] == "todo"
+        assert statuses[built["b"]] == "todo"
+
+        result2 = assert_success(
+            *_call(_archive, db, [built["a"]], allow_promotions=True)
+        )
+        assert result2["would_promote"] == sorted([built["c1"], built["c3"]])
+        statuses = _statuses(db)
+        assert statuses[built["a"]] == "archived"
+        assert statuses[built["b"]] == "archived"
+        assert statuses[built["c1"]] == "ready"
+        assert statuses[built["c3"]] == "ready"
+        assert statuses[built["d"]] == "done"
+        assert statuses[built["d2"]] == "done"
+        db.close()
+
+    def test_n1(self, board, tmp_path, monkeypatch):
+        db = make_conn(board)
+        built = build_n1(db)
+        result = assert_success(*_call(_archive, db, [built["a"]]))
+        assert result["would_promote"] == []
+        statuses = _statuses(db)
+        assert statuses[built["a"]] == "archived"
+        assert statuses[built["c2"]] == "todo"
+        assert statuses[built["q"]] == "todo"
+        assert result["external_edges"] == [
+            {"direction": "outbound", "parent_id": built["a"],
+             "child_id": built["c2"]}
+        ]
+        assert result["warnings"] == []
+        db.close()
+
+    def test_i1(self, board, tmp_path, monkeypatch):
+        db = make_conn(board)
+        built = build_i1(db)
+        result = assert_success(*_call(_archive, db, [built["a"]]))
+        assert result["warnings"] == [
+            {"code": "live_external_parent", "parent_id": built["p"],
+             "root_id": built["a"]}
+        ]
+        assert result["external_edges"] == [
+            {"direction": "inbound", "parent_id": built["p"],
+             "child_id": built["a"]}
+        ]
+        assert result["archived_ids"] == [built["a"]]
+        statuses = _statuses(db)
+        assert statuses[built["a"]] == "archived"
+        assert statuses[built["p"]] == "done"
+        db.close()
+
+    def test_ap(self, board, tmp_path, monkeypatch):
+        db = make_conn(board)
+        built = build_ap(db)
+        result = assert_success(*_call(_archive, db, [built["a"]]))
+        assert result["archived_ids"] == sorted([built["a"], built["x"]])
+        assert result["warnings"] == []
+        assert result["external_edges"] == [
+            {"direction": "inbound", "parent_id": built["e"],
+             "child_id": built["x"]}
+        ]
+        statuses = _statuses(db)
+        assert statuses[built["x"]] == "archived"
+        assert statuses[built["e"]] == "archived"
+        db.close()
+
+    def _build_eligibility_board(self, db):
+        """R(ready) + D(done external); six boundary children (parents R + D)
+        covering every recompute_ready eligibility branch."""
+        r = create(db, "elig R")
+        d = create(db, "elig D", initial_status="blocked")
+        set_status(db, d, "done")
+        c1 = create(db, "elig C1 todo", parents=[r, d])
+        c4 = create(db, "elig C4 nonsticky", parents=[r, d])
+        c5 = create(db, "elig C5 sticky", parents=[r, d])
+        c6 = create(db, "elig C6 at limit", parents=[r, d])
+        c7 = create(db, "elig C7 resume", parents=[r, d])
+        c8 = create(db, "elig C8 per-task limit", parents=[r, d],
+                    max_retries=5)
+        make_task_blocked_nonsticky(db, c4, failures=1)
+        make_task_blocked_sticky(db, c5, failures=0)
+        make_task_blocked_nonsticky(db, c6, failures=kb.DEFAULT_FAILURE_LIMIT)
+        make_task_blocked_with_resume(db, c7, failures=0, resume_status="review")
+        make_task_blocked_nonsticky(db, c8, failures=3)
+        children = {
+            "c1": c1, "c4": c4, "c5": c5, "c6": c6, "c7": c7, "c8": c8,
+        }
+        return {"r": r, "d": d, **children}, r, children
+
+    def test_elig(self, board, tmp_path, monkeypatch):
+        # Independent oracle: same topology in a second board; archive the
+        # root with direct SQL, then run the stock recompute_ready.
+        db2_path = new_board(tmp_path, monkeypatch, "elig-oracle")
+        db2 = make_conn(db2_path)
+        built2, r2, _ = self._build_eligibility_board(db2)
+        set_status(db2, r2, "archived")
+        for key in sorted(k for k in built2 if k not in ("r", "d")):
+            kb.recompute_ready(db2)
+        oracle = {key: kb.get_task(db2, built2[key]).status
+                  for key in built2 if key not in ("r", "d")}
+        promoted_oracle = sorted(
+            built2[key] for key, status in oracle.items()
+            if status in ("ready", "review")
+        )
+        db2.close()
+
+        db = make_conn(board)
+        built, r, children = self._build_eligibility_board(db)
+
+        # Refusal phase: hazards present -> default refuses, no recompute.
+        calls = spy_recompute(monkeypatch)
+        result, exc = _call(_archive, db, [r])
+        assert_refused(result, exc, "--allow-promotions")
+        assert calls == []
+        assert _statuses(db)[r] == "ready"
+
+        # Override phase: would_promote must equal the oracle's promoted set.
+        calls = spy_recompute(monkeypatch)
+        result = assert_success(
+            *_call(_archive, db, [r], allow_promotions=True)
+        )
+        assert result["would_promote"] == sorted(
+            children[key] for key in ("c1", "c4", "c7", "c8")
+        )
+        assert set(result["would_promote"]) == set(promoted_oracle)
+        statuses = _statuses(db)
+        assert statuses[r] == "archived"
+        for key in ("c1", "c4", "c5", "c6", "c7", "c8"):
+            assert statuses[children[key]] == oracle[key], key
+        assert statuses[children["c1"]] == "ready"
+        assert statuses[children["c4"]] == "ready"
+        assert statuses[children["c5"]] == "blocked"
+        assert statuses[children["c6"]] == "blocked"
+        assert statuses[children["c7"]] == "review"
+        assert statuses[children["c8"]] == "ready"
+        assert len(calls) == 1
+        db.close()
+
+    def test_run(self, board, tmp_path, monkeypatch):
+        db = make_conn(board)
+        a = create(db, "run A")
+        b = create(db, "run B", parents=[a])
+        make_task_running(db, a)
+        calls = spy_recompute(monkeypatch)
+        result, exc = _call(_archive, db, [a])
+        assert_refused(result, exc, a, "--force-running")
+        if result is not None:
+            assert result["active_runs"] == [a]
+            assert result["archived_ids"] == []
+        statuses = _statuses(db)
+        assert statuses[a] == "running"
+        assert statuses[b] == "todo"
+        assert calls == []
+        db.close()
+
+    def test_claim(self, board, tmp_path, monkeypatch):
+        # Active claim/run detection must fire even when task status alone
+        # is no longer "running" (a corrupted/stale status field).
+        db = make_conn(board)
+        a = create(db, "claim A")
+        b = create(db, "claim B", parents=[a])
+        make_task_running(db, a)
+        set_status(db, a, "ready")  # status is NOT running now...
+        row = db.execute(
+            "SELECT status, current_run_id, claim_lock, worker_pid "
+            "FROM tasks WHERE id = ?",
+            (a,),
+        ).fetchone()
+        assert row["status"] == "ready"
+        assert row["current_run_id"] is not None  # ...but the claim/run remain
+        assert row["claim_lock"] is not None
+        calls = spy_recompute(monkeypatch)
+        result, exc = _call(_archive, db, [a])
+        assert_refused(result, exc, a, "--force-running")
+        if result is not None:
+            assert result["active_runs"] == [a]
+            assert result["archived_ids"] == []
+        assert _statuses(db)[a] == "ready"
+        assert calls == []
+        db.close()
+
+    def test_force(self, board, tmp_path, monkeypatch):
+        db = make_conn(board)
+        a = create(db, "force A")
+        b = create(db, "force B", parents=[a])
+        make_task_running(db, a)
+        monkeypatch.setattr(
+            kb, "_terminate_reclaimed_worker", lambda *a, **k: {},
+        )
+        monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+        result = assert_success(*_call(_archive, db, [a], force_running=True))
+        assert result["active_runs"] == [a]
+        assert a in result["archived_ids"]
+        assert b in result["archived_ids"]
+        statuses = _statuses(db)
+        assert statuses[a] == "archived"
+        assert statuses[b] == "archived"
+        row = db.execute(
+            "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?",
+            (a,),
+        ).fetchone()
+        assert row["claim_lock"] is None
+        assert row["worker_pid"] is None
+        runs = _runs_of(db, a)
+        assert runs[-1]["outcome"] == "reclaimed"
+        assert runs[-1]["ended_at"] is not None
+        payloads = _payloads(db, a, "admin_archived")
+        assert len(payloads) == 1
+        assert payloads[0]["prior_status"] == "running"
+        db.close()
+
+    def test_dry(self, board, tmp_path):
+        db = make_conn(board)
+        built = build_h1(db)
+        files = []
+        for suffix in ("", "-wal", "-shm"):
+            candidate = Path(str(board) + suffix)
+            if candidate.exists():
+                files.append(candidate)
+        before = {str(p): p.read_bytes() for p in files}
+        result = assert_success(*_call(_archive, db, [built["a"]], dry_run=True))
+        after = {str(p): p.read_bytes() for p in files}
+        assert before == after
+        assert result["dry_run"] is True
+        assert result["archive_group_id"] is None
+        assert result["archived_ids"] == []
+        assert result["root_ids"] == [built["a"]]
+        assert result["would_promote"] == [built["c1"]]
+        assert result["active_runs"] == []
+        group_ids = [
+            row["id"]
+            for row in db.execute("SELECT id FROM tasks").fetchall()
+            if row["id"].startswith("ag_")
+        ]
+        assert group_ids == []
+        assert len(_admin_event_rows(db)) == 0
+        assert _statuses(db)[built["a"]] == "todo"
+        db.close()
+
+    def test_pres(self, board, tmp_path, monkeypatch):
+        db = make_conn(board)
+        # A real child link A->B plus per-task workspace directories.
+        ws_a = Path(board).parent / "workspaces" / "pres-a"
+        ws_a.mkdir(parents=True)
+        (ws_a / "a.txt").write_bytes(b"A-workspace\x00bytes\n")
+        a = create(db, "pres A", workspace_kind="dir", workspace_path=str(ws_a))
+        b = create(db, "pres B", parents=[a])
+        ws_b = Path(board).parent / "workspaces" / "pres-b"
+        ws_b.mkdir(parents=True)
+        (ws_b / "b.txt").write_bytes(b"B-workspace\n")
+        db.execute(
+            "UPDATE tasks SET workspace_kind = 'dir', workspace_path = ? "
+            "WHERE id = ?",
+            (str(ws_b), b),
+        )
+        # Comment + prior event + attachment on A; prior event on B.
+        kb.add_comment(db, a, ACTOR, "note before archive")
+        db.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'edited', ?, ?)",
+            (a, json.dumps({"field": "title"}), int(time.time())),
+        )
+        db.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'scoped', ?, ?)",
+            (b, json.dumps({"scope": 7}), int(time.time())),
+        )
+        att_dir = kb.attachments_root(Path(board).parent.name) / a
+        att_dir.mkdir(parents=True)
+        blob = att_dir / "spec.pdf"
+        blob.write_bytes(b"%PDF-fake-bytes")
+        db.execute(
+            "INSERT INTO task_attachments "
+            "(task_id, filename, stored_path, content_type, size, uploaded_by, "
+            "created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (a, "spec.pdf", str(blob), "application/pdf",
+             blob.stat().st_size, ACTOR, int(time.time())),
+        )
+        # One real run row on A (a task_runs row, not just a status).
+        db.execute(
+            "INSERT INTO task_runs (task_id, profile, step_key, status, "
+            "outcome, started_at) VALUES (?, ?, NULL, 'running', 'running', ?)",
+            (a, ACTOR, int(time.time())),
+        )
+
+        before = {
+            "comments": _table_snapshot(db, "task_comments"),
+            "events": _table_snapshot(db, "task_events"),
+            "atts": _table_snapshot(db, "task_attachments"),
+            "links": _table_snapshot(db, "task_links"),
+            "runs": _table_snapshot(db, "task_runs"),
+        }
+        a_bytes_before = (ws_a / "a.txt").read_bytes()
+        b_bytes_before = (ws_b / "b.txt").read_bytes()
+        blob_before = blob.read_bytes()
+        row_before_a = tuple(
+            db.execute("SELECT workspace_path, workspace_kind FROM tasks WHERE id=?",
+                       (a,)).fetchone()
+        )
+        row_before_b = tuple(
+            db.execute("SELECT workspace_path, workspace_kind FROM tasks WHERE id=?",
+                       (b,)).fetchone()
+        )
+
+        cleanup_calls = []
+        monkeypatch.setattr(
+            kb, "_cleanup_workspace",
+            lambda conn, task_id: cleanup_calls.append(task_id),
+        )
+        result = assert_success(*_call(_archive, db, [a]))
+
+        assert cleanup_calls == []  # archive never reapplies the completer
+        assert _statuses(db)[a] == "archived"
+        assert _statuses(db)[b] == "archived"
+        # Files byte-identical.
+        assert (ws_a / "a.txt").read_bytes() == a_bytes_before
+        assert (ws_b / "b.txt").read_bytes() == b_bytes_before
+        assert blob.is_file() and blob.read_bytes() == blob_before
+        # Workspace fields row-identical.
+        row_after_a = tuple(
+            db.execute("SELECT workspace_path, workspace_kind FROM tasks WHERE id=?",
+                       (a,)).fetchone()
+        )
+        row_after_b = tuple(
+            db.execute("SELECT workspace_path, workspace_kind FROM tasks WHERE id=?",
+                       (b,)).fetchone()
+        )
+        assert row_after_a == row_before_a
+        assert row_after_b == row_before_b
+        # Every pre-archive row survives identically (subset of after).
+        after = {
+            "comments": _table_snapshot(db, "task_comments"),
+            "events": _table_snapshot(db, "task_events"),
+            "atts": _table_snapshot(db, "task_attachments"),
+            "links": _table_snapshot(db, "task_links"),
+            "runs": _table_snapshot(db, "task_runs"),
+        }
+        for key in before:
+            assert before[key] <= after[key], key
+        # The ONLY allowed additions: one audit comment on root a, and the
+        # admin_archived events (one per archived task).
+        new_comments = after["comments"] - before["comments"]
+        new_events = after["events"] - before["events"]
+        assert len(new_comments) == 1
+        new_admin_count = (
+            len([r for r in db.execute(
+                "SELECT 1 FROM task_events WHERE kind='admin_archived'").fetchall()])
+        )
+        assert new_admin_count == 2  # a and b
+        assert len(_events_by_kind(db, a, "admin_archived")) == 1
+        assert len(_events_by_kind(db, b, "admin_archived")) == 1
+        assert len(new_events) >= 2
+        # Archive audit comment carries the exact root body.
+        comments_a = _comments_of(db, a)
+        assert comments_a[0]["author"] == ACTOR
+        group = result["archive_group_id"]
+        assert comments_a[0]["body"] == (
+            f"Admin-archived graph {group} (2 tasks): {REASON}"
+        )
+        assert _statuses(db)[a] == "archived"
+        db.close()
+
+    def test_ghost(self, board, ids):
+        db = make_conn(board)
+        snapshot_statuses = _statuses(db)
+        snapshot_admin = len(_admin_event_rows(db))
+        snapshot_links = _links_of(db)
+        result, exc = _call(_archive, db, [ids["a"], "zz_ghost_1"])
+        assert_refused(result, exc, "zz_ghost_1")
+        if result is not None:
+            assert result["archived_ids"] == []
+        assert _statuses(db) == snapshot_statuses
+        assert len(_admin_event_rows(db)) == snapshot_admin
+        assert _links_of(db) == snapshot_links
+        result2, exc2 = _call(_archive, db, ["zz_ghost_2"])
+        assert_refused(result2, exc2, "zz_ghost_2")
+        assert _statuses(db) == snapshot_statuses
+        db.close()
+
+    def test_skip(self, board, ids):
+        db = make_conn(board)
+        result1 = assert_success(
+            *_call(_archive, db, [ids["a"]], allow_promotions=True)
+        )
+        admin_count = len(_admin_event_rows(db))
+        assert admin_count == 2  # a and b each carry one admin_archived
+        b_admin_events = len(_events_by_kind(db, ids["b"], "admin_archived"))
+        assert b_admin_events == 1
+        result2 = assert_success(*_call(_archive, db, [ids["a"]]))
+        assert result2["skipped_archived"] == sorted([ids["a"], ids["b"]])
+        assert result2["archived_ids"] == []
+        assert len(_admin_event_rows(db)) == admin_count
+        assert len(_events_by_kind(db, ids["b"], "admin_archived")) == (
+            b_admin_events
+        )
+        assert _statuses(db)[ids["b"]] == "archived"
+        db.close()
+
+    def test_edges(self, board, tmp_path, monkeypatch):
+        db = make_conn(board)
+        built = build_h2(db)
+        result = assert_success(
+            *_call(_archive, db, [built["a"]], allow_promotions=True)
+        )
+        expected_outbound = sorted(
+            [
+                {"direction": "outbound", "parent_id": built["a"],
+                 "child_id": built["c1"]},
+                {"direction": "outbound", "parent_id": built["a"],
+                 "child_id": built["c3"]},
+                {"direction": "outbound", "parent_id": built["b"],
+                 "child_id": built["c3"]},
+            ],
+            key=lambda e: (e["parent_id"], e["child_id"], e["direction"]),
+        )
+        assert result["external_edges"] == expected_outbound
+        assert result["internal_edges"] == [
+            {"parent_id": built["a"], "child_id": built["b"]},
+        ]
+        # D->C1 touches no closure member: it must not appear at all.
+        assert (built["d"], built["c1"]) not in {
+            (e["parent_id"], e["child_id"]) for e in result["external_edges"]
+        }
+        # Inbound side: I1 topology.
+        db_i1 = make_conn(new_board(tmp_path, monkeypatch, "i1-edges"))
+        i1 = build_i1(db_i1)
+        result_i1 = assert_success(*_call(_archive, db_i1, [i1["a"]]))
+        assert result_i1["external_edges"] == [
+            {"direction": "inbound", "parent_id": i1["p"],
+             "child_id": i1["a"]}
+        ]
+        # Invariant: a non-archived inbound parent targets only a root.
+        for warning in result_i1["warnings"]:
+            assert warning["root_id"] in result_i1["root_ids"]
+            assert warning["parent_id"] not in result_i1["archived_ids"]
+        db.close()
+        db_i1.close()
+
+    def test_reason(self, board, ids):
+        db = make_conn(board)
+        result, exc = _call(_archive, db, [ids["a"]], reason="   ",
+                            actor=ACTOR)
+        assert_failed(result, exc)
+        result2, exc2 = _call(_archive, db, [ids["a"]], reason=REASON,
+                              actor="  ")
+        assert_failed(result2, exc2)
+        assert _statuses(db)[ids["a"]] == "todo"
+        assert len(_admin_event_rows(db)) == 0
+        db.close()
+
+    def test_rb_sql(self, board, tmp_path, monkeypatch):
+        db_path = new_board(tmp_path, monkeypatch, "rollback")
+        db = make_conn(db_path)
+        built = build_dm(db)
+        statuses_before = _statuses(db)
+        events_before = db.execute(
+            "SELECT COUNT(*) AS n FROM task_events"
+        ).fetchone()["n"]
+        comments_before = db.execute(
+            "SELECT COUNT(*) AS n FROM task_comments"
+        ).fetchone()["n"]
+        db.close()
+        failing = make_fail_write_conn(db_path, fail_on_write=2)
+        calls = spy_recompute(monkeypatch)
+        result, exc = _call(_archive, failing, [built["a"]])
+        assert_failed(result, exc)
+        probe = make_conn(db_path)
+        assert _statuses(probe) == statuses_before
+        assert (
+            probe.execute("SELECT COUNT(*) AS n FROM task_events")
+            .fetchone()["n"] == events_before
+        )
+        assert (
+            probe.execute("SELECT COUNT(*) AS n FROM task_comments")
+            .fetchone()["n"] == comments_before
+        )
+        assert len(_admin_event_rows(probe)) == 0
+        assert calls == []  # recompute never runs on a rolled-back archive
+        probe.close()
+
+    def test_rbev(self, board, tmp_path, monkeypatch):
+        db_path = new_board(tmp_path, monkeypatch, "rollback-ev")
+        db = make_conn(db_path)
+        built = build_dm(db)
+        statuses_before = _statuses(db)
+        events_before = db.execute(
+            "SELECT COUNT(*) AS n FROM task_events"
+        ).fetchone()["n"]
+        comments_before = db.execute(
+            "SELECT COUNT(*) AS n FROM task_comments"
+        ).fetchone()["n"]
+        db.close()
+        db = make_conn(db_path)
+        calls = spy_recompute(monkeypatch)
+        orig = kb._append_event
+
+        def boom(conn, task_id, kind, payload=None, **kwargs):
+            if kind == "admin_archived":
+                raise RuntimeError("injected admin_archived failure")
+            return orig(conn, task_id, kind, payload=payload, **kwargs)
+
+        monkeypatch.setattr(kb, "_append_event", boom)
+        result, exc = _call(_archive, db, [built["a"]])
+        assert_failed(result, exc)
+        probe = make_conn(db_path)
+        assert _statuses(probe) == statuses_before
+        assert (
+            probe.execute("SELECT COUNT(*) AS n FROM task_events")
+            .fetchone()["n"] == events_before
+        )
+        assert (
+            probe.execute("SELECT COUNT(*) AS n FROM task_comments")
+            .fetchone()["n"] == comments_before
+        )
+        assert len(_admin_event_rows(probe)) == 0
+        assert calls == []
+        db.close()
+        probe.close()
+
+    def test_rbc(self, board, tmp_path, monkeypatch):
+        db_path = new_board(tmp_path, monkeypatch, "rollback-cmt")
+        db = make_conn(db_path)
+        built = build_dm(db)
+        statuses_before = _statuses(db)
+        events_before = db.execute(
+            "SELECT COUNT(*) AS n FROM task_events"
+        ).fetchone()["n"]
+        comments_before = db.execute(
+            "SELECT COUNT(*) AS n FROM task_comments"
+        ).fetchone()["n"]
+        db.close()
+        db = make_conn(db_path)
+        calls = spy_recompute(monkeypatch)
+
+        def boom(conn, task_id, author, body):
+            raise RuntimeError("injected audit comment failure")
+
+        monkeypatch.setattr(kb, "add_comment", boom)
+        result, exc = _call(_archive, db, [built["a"]])
+        assert_failed(result, exc)
+        probe = make_conn(db_path)
+        assert _statuses(probe) == statuses_before
+        assert (
+            probe.execute("SELECT COUNT(*) AS n FROM task_events")
+            .fetchone()["n"] == events_before
+        )
+        assert (
+            probe.execute("SELECT COUNT(*) AS n FROM task_comments")
+            .fetchone()["n"] == comments_before
+        )
+        assert len(_admin_event_rows(probe)) == 0
+        assert calls == []
+        db.close()
+        probe.close()
+
+    def test_audit(self, board, ids):
+        db = make_conn(board)
+        result = assert_success(
+            *_call(_archive, db, [ids["a"], ids["a"]], allow_promotions=True)
+        )
+        group = result["archive_group_id"]
+        root_comments = _comments_of(db, ids["a"])
+        # Exactly one audit comment on the deduped root, exact body.
+        assert len(root_comments) == 1
+        assert root_comments[0]["author"] == ACTOR
+        assert root_comments[0]["body"] == (
+            f"Admin-archived graph {group} (2 tasks): {REASON}"
+        )
+        for other in (ids["b"], ids["c1"], ids["d"]):
+            assert _comments_of(db, other) == []
+        payloads = _payloads(db, ids["a"], "admin_archived")
+        assert len(payloads) == 1
+        assert payloads[0]["archive_group_id"] == group
+        assert payloads[0]["actor"] == ACTOR
+        assert payloads[0]["reason"] == REASON
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# TestAdminUnarchive — transactional group/direct unarchive kernel contract.
+# ---------------------------------------------------------------------------
+
+
+class TestAdminUnarchive:
+    def test_group_rt(self, board, tmp_path, monkeypatch):
+        db = make_conn(board)
+        a = create(db, "unr A")
+        c = create(db, "unr C", parents=[a])
+        # c lands todo (parent a not done) -> the gated-todo restore case.
+        result_a = assert_success(*_call(_archive, db, [a]))
+        group = result_a["archive_group_id"]
+        assert GROUP_ID_RE.fullmatch(group)
+        assert set(result_a["archived_ids"]) == {a, c}
+
+        calls = spy_recompute(monkeypatch)
+        result = assert_success(*_call(_unarchive, db, group_id=group))
+        assert set(result.keys()) >= {
+            "group_id", "restored_ids", "skipped_ids", "missing_workspaces",
+        }
+        assert result["group_id"] == group
+        assert result["restored_ids"] == sorted([a, c])
+        assert result["restored_ids"] == sorted(result["restored_ids"])
+        assert result["skipped_ids"] == []
+        assert result["missing_workspaces"] == []
+        assert len(calls) == 1  # recompute runs exactly once, after commit
+        statuses = _statuses(db)
+        assert statuses[a] == "ready"
+        assert statuses[c] == "todo"  # parent restored ready, not done
+        for task_id in (a, c):
+            unarchived = _payloads(db, task_id, "admin_unarchived")
+            assert len(unarchived) == 1
+            assert unarchived[0]["archive_group_id"] == group
+            assert unarchived[0]["actor"] == ACTOR
+        db.close()
+
+    def test_prior(self, board, tmp_path, monkeypatch):
+        db = make_conn(board)
+        a = create(db, "prior A")
+        make_task_running(db, a)
+        result_a = assert_success(*_call(_archive, db, [a], force_running=True))
+        group = result_a["archive_group_id"]
+        assert GROUP_ID_RE.fullmatch(group)
+        payloads = _payloads(db, a, "admin_archived")
+        assert payloads[0]["prior_status"] == "running"
+        result = assert_success(*_call(_unarchive, db, group_id=group))
+        assert result["restored_ids"] == [a]
+        assert _statuses(db)[a] == "ready"  # restored ready, not running
+        db.close()
+
+    def test_missing(self, board, tmp_path, monkeypatch):
+        db = make_conn(board)
+        ws = Path(board).parent / "workspaces" / "gone"
+        ws.mkdir(parents=True)
+        (ws / "x.txt").write_text("x\n", encoding="utf-8")
+        a = create(db, "ws A", workspace_kind="dir", workspace_path=str(ws))
+        result_a = assert_success(*_call(_archive, db, [a]))
+        group = result_a["archive_group_id"]
+        shutil.rmtree(ws)
+        result = assert_success(*_call(_unarchive, db, group_id=group))
+        assert result["restored_ids"] == [a]
+        assert result["missing_workspaces"] == [str(ws)]
+        assert all(isinstance(p, str) for p in result["missing_workspaces"])
+        assert _statuses(db)[a] == "ready"
+        db.close()
+
+    def test_direct(self, board, tmp_path, monkeypatch):
+        db = make_conn(board)
+        a = create(db, "d A")
+        b = create(db, "d B")
+        m = create(db, "d M")
+        x = create(db, "d X")
+        # All archiving happens BEFORE the spy is installed so the spy
+        # only observes the unarchive calls under test.
+        r1 = assert_success(*_call(_archive, db, [a]))
+        r2 = assert_success(*_call(_archive, db, [b]))
+        rx = assert_success(*_call(_archive, db, [x]))
+        kb.archive_task(db, m)  # ordinary archive, not admin
+        assert _statuses(db)[m] == "archived"
+        assert _statuses(db)[b] == "ready"
+        # Latest-archive-mismatch: a plain 'archived' event now sits on
+        # top of x's admin archive event.
+        db.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'archived', NULL, ?)",
+            (x, int(time.time())),
+        )
+
+        calls = spy_recompute(monkeypatch)
+
+        # Unknown id mixed with a valid one: all-or-nothing.
+        result, exc = _call(_unarchive, db, task_ids=[a, "zz_nope"])
+        assert_refused(result, exc, "zz_nope")
+        if result is not None:
+            assert result["restored_ids"] == []
+        assert _statuses(db)[a] == "archived"
+
+        # Non-admin-archived target.
+        result, exc = _call(_unarchive, db, task_ids=[m])
+        assert_refused(result, exc, m)
+        if result is not None:
+            assert result["restored_ids"] == []
+        assert _statuses(db)[m] == "archived"
+
+        # Non-archived target mixed with a valid archived one.
+        result, exc = _call(_unarchive, db, task_ids=[a, b])
+        assert_refused(result, exc, b)
+        if result is not None:
+            assert result["restored_ids"] == []
+        assert _statuses(db)[a] == "archived"
+        assert _statuses(db)[b] == "ready"
+
+        # Latest-archive-mismatch target.
+        result, exc = _call(_unarchive, db, task_ids=[x])
+        assert_refused(result, exc, x)
+        if result is not None:
+            assert result["restored_ids"] == []
+        assert _statuses(db)[x] == "archived"
+        assert calls == []  # refusals never recompute
+
+        # Valid direct-id success: recomputes exactly once after commit.
+        result = assert_success(*_call(_unarchive, db, task_ids=[a]))
+        assert result["restored_ids"] == [a]
+        assert _statuses(db)[a] == "ready"
+        assert len(calls) == 1
+        db.close()
+
+    def test_supersede(self, board, tmp_path, monkeypatch):
+        db = make_conn(board)
+        a = create(db, "sup A")
+        b = create(db, "sup B")
+        r1 = assert_success(*_call(_archive, db, [a, b]))
+        g1 = r1["archive_group_id"]
+        restored = assert_success(*_call(_unarchive, db, group_id=g1))
+        assert restored["restored_ids"] == sorted([a, b])
+        r2 = assert_success(*_call(_archive, db, [b]))
+        g2 = r2["archive_group_id"]
+        assert g1 != g2
+
+        # b's latest admin archive is g2; a is no longer archived. The group
+        # g1 unarchive must report BOTH the already-unarchived member (a)
+        # and the member superseded by a newer archive (b) in sorted order.
+        result = assert_success(*_call(_unarchive, db, group_id=g1))
+        assert result["restored_ids"] == []
+        assert result["skipped_ids"] == sorted([a, b])
+        statuses = _statuses(db)
+        assert statuses[a] == "ready"
+        assert statuses[b] == "archived"
+
+        # The newer group still restores b.
+        result2 = assert_success(*_call(_unarchive, db, group_id=g2))
+        assert result2["restored_ids"] == [b]
+        assert _statuses(db)[b] == "ready"
+        db.close()
+
+    def test_unk(self, board, tmp_path, monkeypatch):
+        db = make_conn(board)
+        a = create(db, "ug A")
+        r = assert_success(*_call(_archive, db, [a]))
+        group = r["archive_group_id"]
+        calls = spy_recompute(monkeypatch)
+        ghost_group = "ag_" + "f" * 16
+        result, exc = _call(_unarchive, db, group_id=ghost_group)
+        assert_refused(result, exc, ghost_group)
+        if result is not None:
+            assert result["restored_ids"] == []
+        assert _statuses(db)[a] == "archived"
+        assert calls == []
+        db.close()
+
+    def test_modes(self, board, tmp_path, monkeypatch):
+        db = make_conn(board)
+        a = create(db, "mm A")
+        r = assert_success(*_call(_archive, db, [a]))
+        group = r["archive_group_id"]
+        # Both modes at once.
+        with pytest.raises((ValueError, TypeError)):
+            _kernel("admin_unarchive", db, task_ids=[a], group_id=group,
+                    actor=ACTOR)
+        # Empty direct-id mode.
+        with pytest.raises((ValueError, TypeError)):
+            _kernel("admin_unarchive", db, task_ids=[], actor=ACTOR)
+        # Whitespace-only actor: group and direct modes.
+        with pytest.raises((ValueError, TypeError)):
+            _unarchive(db, group_id=group, actor="   ")
+        with pytest.raises((ValueError, TypeError)):
+            _kernel("admin_unarchive", db, task_ids=[a], actor="  ")
+        # No mode at all / no actor at all.
+        with pytest.raises((ValueError, TypeError)):
+            _kernel("admin_unarchive", db, task_ids=[a])
+        assert _statuses(db)[a] == "archived"
+        db.close()
+
+    def test_malformed(self, board, tmp_path, monkeypatch):
+        db = make_conn(board)
+        a = create(db, "mal A")
+        c = create(db, "mal C", parents=[a])
+        r = assert_success(*_call(_archive, db, [a]))
+        group = r["archive_group_id"]
+        assert set(r["archived_ids"]) == {a, c}
+        # Corrupt a's latest admin_archived payload to invalid JSON.
+        db.execute(
+            "UPDATE task_events SET payload = ? "
+            "WHERE task_id = ? AND kind = 'admin_archived' "
+            "AND id = (SELECT MAX(id) FROM task_events "
+            "          WHERE task_id = ? AND kind = 'admin_archived')",
+            ("not-valid-json{{", a, a),
+        )
+        calls = spy_recompute(monkeypatch)
+        result, exc = _call(_unarchive, db, task_ids=[a])
+        assert_failed(result, exc)
+        if result is not None:
+            assert result["restored_ids"] == []
+        assert _statuses(db)[a] == "archived"
+        assert _statuses(db)[c] == "archived"
+        assert len(_events_by_kind(db, a, "admin_unarchived")) == 0
+        assert len(_events_by_kind(db, c, "admin_unarchived")) == 0
+        assert calls == []
+        # Now a decodeable-but-incomplete payload (missing archive_group_id).
+        db.execute(
+            "UPDATE task_events SET payload = ? "
+            "WHERE task_id = ? AND kind = 'admin_archived' "
+            "AND id = (SELECT MAX(id) FROM task_events "
+            "          WHERE task_id = ? AND kind = 'admin_archived')",
+            (json.dumps({"prior_status": "todo"}), a, a),
+        )
+        result2, exc2 = _call(_unarchive, db, task_ids=[a])
+        assert_failed(result2, exc2)
+        if result2 is not None:
+            assert result2["restored_ids"] == []
+        assert _statuses(db)[a] == "archived"
+        assert _statuses(db)[c] == "archived"
+        assert calls == []
+        db.close()
+
+    def test_rb_sql(self, board, tmp_path, monkeypatch):
+        db_path = new_board(tmp_path, monkeypatch, "unrollback")
+        db = make_conn(db_path)
+        a = create(db, "rb A")
+        c = create(db, "rb C", parents=[a])
+        r = assert_success(*_call(_archive, db, [a]))
+        group = r["archive_group_id"]
+        statuses_before = _statuses(db)
+        events_before = db.execute(
+            "SELECT COUNT(*) AS n FROM task_events"
+        ).fetchone()["n"]
+        comments_before = db.execute(
+            "SELECT COUNT(*) AS n FROM task_comments"
+        ).fetchone()["n"]
+        db.close()
+        failing = make_fail_write_conn(db_path, fail_on_write=2)
+        calls = spy_recompute(monkeypatch)
+        result, exc = _call(_unarchive, failing, group_id=group)
+        assert_failed(result, exc)
+        probe = make_conn(db_path)
+        assert _statuses(probe) == statuses_before
+        assert (
+            probe.execute("SELECT COUNT(*) AS n FROM task_events")
+            .fetchone()["n"] == events_before
+        )
+        assert (
+            probe.execute("SELECT COUNT(*) AS n FROM task_comments")
+            .fetchone()["n"] == comments_before
+        )
+        assert len(_events_by_kind(probe, a, "admin_unarchived")) == 0
+        assert len(_events_by_kind(probe, c, "admin_unarchived")) == 0
+        assert calls == []  # recompute never runs on a rolled-back unarchive
+        probe.close()
+
+    def test_rbev(self, board, tmp_path, monkeypatch):
+        db_path = new_board(tmp_path, monkeypatch, "unrollback-ev")
+        db = make_conn(db_path)
+        a = create(db, "rb2 A")
+        c = create(db, "rb2 C", parents=[a])
+        r = assert_success(*_call(_archive, db, [a]))
+        group = r["archive_group_id"]
+        statuses_before = _statuses(db)
+        events_before = db.execute(
+            "SELECT COUNT(*) AS n FROM task_events"
+        ).fetchone()["n"]
+        db.close()
+        db = make_conn(db_path)
+        calls = spy_recompute(monkeypatch)
+        orig = kb._append_event
+
+        def boom(conn, task_id, kind, payload=None, **kwargs):
+            if kind == "admin_unarchived":
+                raise RuntimeError("injected admin_unarchived failure")
+            return orig(conn, task_id, kind, payload=payload, **kwargs)
+
+        monkeypatch.setattr(kb, "_append_event", boom)
+        result, exc = _call(_unarchive, db, group_id=group)
+        assert_failed(result, exc)
+        probe = make_conn(db_path)
+        assert _statuses(probe) == statuses_before
+        assert (
+            probe.execute("SELECT COUNT(*) AS n FROM task_events")
+            .fetchone()["n"] == events_before
+        )
+        assert len(_events_by_kind(probe, a, "admin_unarchived")) == 0
+        assert len(_events_by_kind(probe, c, "admin_unarchived")) == 0
+        assert calls == []
+        db.close()
+        probe.close()

--- a/tests/hermes_cli/test_kanban_admin_cli.py
+++ b/tests/hermes_cli/test_kanban_admin_cli.py
@@ -1,0 +1,413 @@
+"""CLI tests for the guarded admin archive integration.
+
+Covers the two new ``hermes kanban`` verbs -- ``archive-graph`` and
+``unarchive`` -- end-to-end through ``kanban_command`` on scratch boards
+created under pytest ``tmp_path``. All DB access in these tests resolves
+inside the temporary HERMES_HOME (the fixture deletes any ambient
+HERMES_KANBAN_DB / HERMES_KANBAN_HOME pin), so live board data is never
+touched.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban as kc
+
+
+# ---------------------------------------------------------------------------
+# Harness: scratch board under tmp_path + CLI runner
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def kanban_scratch(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with a scratch 'recovery' board + an 'alt' board.
+
+    Deletes ambient HERMES_KANBAN_DB / HERMES_KANBAN_HOME pins so DB
+    resolution always stays under tmp_path/.hermes/kanban/boards/*.
+    HERMES_KANBAN_BOARD defaults to the 'recovery' scratch board.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "admin-tester")
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "recovery")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db(board="recovery")
+    kb.init_db(board="alt")
+    return home
+
+
+def run_cli(*argv: str):
+    """Invoke ``hermes kanban <argv...>`` via the real argparse entry."""
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    args = parser.parse_args(["kanban", *argv])
+    return kc.kanban_command(args)
+
+
+def _id(db, title):
+    return kb.create_task(db, title=title, initial_status="blocked")
+
+
+def _link(db, parent, child):
+    kb.link_tasks(db, parent, child)
+
+
+def _statuses(db):
+    return {
+        row["id"]: row["status"]
+        for row in db.execute("SELECT id, status FROM tasks").fetchall()
+    }
+
+
+def build_dm(db):
+    """A->B, A->C, B->D, C->D, all todo (closed dominated closure)."""
+    a = _id(db, "dm A")
+    b = kb.create_task(db, title="dm B", parents=[a])
+    c = kb.create_task(db, title="dm C", parents=[a])
+    d = kb.create_task(db, title="dm D", parents=[b, c])
+    db.execute("UPDATE tasks SET status='todo' WHERE id=?", (a,))
+    return {"a": a, "b": b, "c": c, "d": d}
+
+
+def build_h1(db):
+    """A->B; A->C1; D(done external)->C1. Archiving A would promote C1."""
+    a = _id(db, "h1 A")
+    b = kb.create_task(db, title="h1 B", parents=[a])
+    c1 = kb.create_task(db, title="h1 C1", parents=[a])
+    d = _id(db, "h1 D")
+    _link(db, d, c1)
+    db.execute("UPDATE tasks SET status='todo' WHERE id=?", (a,))
+    db.execute("UPDATE tasks SET status='done' WHERE id=?", (d,))
+    return {"a": a, "b": b, "c1": c1, "d": d}
+
+
+def build_i1(db):
+    """P(done external)->A(root) only. I1 live_external_parent warning."""
+    p = _id(db, "i1 P")
+    a = kb.create_task(db, title="i1 A")
+    _link(db, p, a)
+    db.execute("UPDATE tasks SET status='todo' WHERE id=?", (a,))
+    db.execute("UPDATE tasks SET status='done' WHERE id=?", (p,))
+    return {"p": p, "a": a}
+
+
+def add_running(db, task_id):
+    """Put task_id into a claimed/running state with a dead worker pid."""
+    db.execute("UPDATE tasks SET status='ready' WHERE id=?", (task_id,))
+    claimed = kb.claim_task(db, task_id)
+    assert claimed is not None and claimed.status == "running"
+    db.execute(
+        "UPDATE tasks SET worker_pid=? WHERE id=?", (999999, task_id)
+    )
+
+
+def _single_json(stdout: str) -> dict:
+    """Exactly one JSON object on stdout; anything else is a failure."""
+    lines = [ln for ln in stdout.splitlines() if ln.strip()]
+    assert len(lines) == 1, f"expected exactly one stdout line, got: {stdout!r}"
+    return json.loads(lines[0])
+
+
+# ---------------------------------------------------------------------------
+# Parser / required-args / help text
+# ---------------------------------------------------------------------------
+
+def test_build_parser_has_archive_graph_and_unarchive(kanban_scratch):
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    args = parser.parse_args(["kanban"])
+    kanban_sub = args._kanban_parser
+    choices = set()
+    for act in kanban_sub._actions:
+        if isinstance(act, argparse._SubParsersAction):
+            choices.update(act.choices)
+    assert "archive-graph" in choices
+    assert "unarchive" in choices
+
+
+def test_archive_graph_help_warns_secrets_and_promotions(kanban_scratch, capsys):
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["kanban", "archive-graph", "--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    # --reason help warns the text is PERSISTED and must hold no secrets.
+    assert "PERSISTED" in out
+    assert "secrets" in out.lower()
+    # --allow-promotions help warns recompute_ready is global / may promote
+    # unrelated tasks.
+    assert "global" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# archive-graph
+# ---------------------------------------------------------------------------
+
+def test_archive_graph_dry_run_is_deterministic_and_non_mutating(
+    kanban_scratch, capsys
+):
+    with kb.connect_closing(board="recovery") as db:
+        built = build_dm(db)
+    rc1 = run_cli("archive-graph", built["a"], "--reason", "cleanup",
+                  "--dry-run")
+    captured1 = capsys.readouterr()
+    rc2 = run_cli("archive-graph", built["a"], "--reason", "cleanup",
+                  "--dry-run")
+    captured2 = capsys.readouterr()
+    assert rc1 == 0 and rc2 == 0
+    # Byte-identical, exactly one deterministic JSON object on stdout.
+    assert captured1.out == captured2.out
+    plan = _single_json(captured1.out)
+    assert plan["dry_run"] is True
+    assert plan["archive_group_id"] is None
+    assert sorted(plan["root_ids"]) == [built["a"]]
+    # Human summary goes to stderr, not stdout.
+    assert captured1.err  # non-empty stderr summary
+    assert not captured1.out.splitlines()[0].startswith("dry run")
+    # No mutation, no group.
+    with kb.connect_closing(board="recovery") as db:
+        st = _statuses(db)
+        for tid in (built["a"], built["b"], built["c"], built["d"]):
+            assert st[tid] == "todo"
+        assert db.execute(
+            "SELECT COUNT(*) AS n FROM task_events "
+            "WHERE kind='admin_archived'"
+        ).fetchone()["n"] == 0
+
+
+def test_archive_graph_h1_refusal_then_override(kanban_scratch, capsys):
+    with kb.connect_closing(board="recovery") as db:
+        built = build_h1(db)
+    # H1: without --allow-promotions the command refuses (names id + flag).
+    rc = run_cli("archive-graph", built["a"], "--reason", "cleanup")
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "refused" in err
+    assert "--allow-promotions" in err
+    assert built["c1"] in err
+    # Nothing was archived by the refusal.
+    with kb.connect_closing(board="recovery") as db:
+        assert _statuses(db)[built["a"]] == "todo"
+        assert db.execute(
+            "SELECT COUNT(*) AS n FROM task_events "
+            "WHERE kind='admin_archived'"
+        ).fetchone()["n"] == 0
+    # Override with --allow-promotions succeeds; C1 is promoted to ready.
+    rc = run_cli("archive-graph", built["a"], "--reason", "cleanup",
+                 "--allow-promotions")
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Archive group" in out
+    with kb.connect_closing(board="recovery") as db:
+        st = _statuses(db)
+        assert st[built["a"]] == "archived"
+        assert st[built["b"]] == "archived"
+        assert st[built["c1"]] == "ready"
+
+
+def test_archive_graph_running_refusal_then_force(kanban_scratch, capsys,
+                                                  monkeypatch):
+    monkeypatch.setattr(kb, "_terminate_reclaimed_worker",
+                        lambda *a, **k: {})
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+    with kb.connect_closing(board="recovery") as db:
+        a = _id(db, "run A")
+        b = kb.create_task(db, title="run B", parents=[a])
+        add_running(db, a)
+    rc = run_cli("archive-graph", a, "--reason", "cleanup")
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "refused" in err
+    assert "--force-running" in err
+    assert a in err
+    with kb.connect_closing(board="recovery") as db:
+        assert _statuses(db)[a] == "running"
+    rc = run_cli("archive-graph", a, "--reason", "cleanup", "--force-running")
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Archive group" in out
+    with kb.connect_closing(board="recovery") as db:
+        st = _statuses(db)
+        assert st[a] == "archived"
+        assert st[b] == "archived"
+
+
+def test_archive_graph_execution_names_group_and_counts(kanban_scratch, capsys):
+    with kb.connect_closing(board="recovery") as db:
+        built = build_dm(db)
+    rc = run_cli("archive-graph", built["a"], "--reason", "cleanup")
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Archive group ag_" in out
+    assert "4 transitioned, 0 skipped" in out
+
+
+def test_archive_graph_unknown_id_all_or_nothing(kanban_scratch, capsys):
+    with kb.connect_closing(board="recovery") as db:
+        built = build_dm(db)
+    bogus = "t_doesnotexist"
+    rc = run_cli("archive-graph", bogus, "--reason", "cleanup")
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "refused" in err
+    assert bogus in err
+    # All-or-nothing: nothing was archived, even with a valid sibling id.
+    rc2 = run_cli("archive-graph", built["a"], bogus, "--reason", "cleanup")
+    err2 = capsys.readouterr().err
+    assert rc2 == 1
+    assert bogus in err2
+    with kb.connect_closing(board="recovery") as db:
+        assert _statuses(db)[built["a"]] == "todo"
+
+
+def test_archive_graph_i1_warning_reports_not_refuses(kanban_scratch, capsys):
+    with kb.connect_closing(board="recovery") as db:
+        built = build_i1(db)
+    # I1 (live external parent p) warns on stderr but does NOT refuse.
+    rc = run_cli("archive-graph", built["a"], "--reason", "cleanup")
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "Archive group" in captured.out
+    assert "live_external_parent" in captured.err
+    assert built["p"] in captured.err
+    with kb.connect_closing(board="recovery") as db:
+        assert _statuses(db)[built["a"]] == "archived"
+
+
+# ---------------------------------------------------------------------------
+# unarchive
+# ---------------------------------------------------------------------------
+
+def test_unarchive_modes_mutual_exclusion(kanban_scratch, capsys, monkeypatch):
+    monkeypatch.setattr(kb, "_terminate_reclaimed_worker",
+                        lambda *a, **k: {})
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+    with kb.connect_closing(board="recovery") as db:
+        built = build_dm(db)
+    # Seed a group to unarchive against.
+    rc = run_cli("archive-graph", built["a"], "--reason", "cleanup")
+    assert rc == 0
+    capsys.readouterr()
+    # Both task_ids and --group -> refused with "exactly one mode".
+    rc = run_cli("unarchive", built["a"], "--group", "ag_whatever")
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "exactly one mode" in err
+    # Neither mode -> refused.
+    rc = run_cli("unarchive")
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "requires task_ids or --group" in err
+
+
+def test_unarchive_direct_restores(kanban_scratch, capsys):
+    with kb.connect_closing(board="recovery") as db:
+        built = build_dm(db)
+    rc = run_cli("archive-graph", built["a"], "--reason", "cleanup")
+    assert rc == 0
+    capsys.readouterr()
+    rc = run_cli("unarchive", built["a"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Unarchive group direct: 1 restored, 0 skipped" in out
+    with kb.connect_closing(board="recovery") as db:
+        st = _statuses(db)
+        # Restored out of 'archived'; recompute_ready may promote a root
+        # task to 'ready'. It must not be 'archived'.
+        assert st[built["a"]] != "archived"
+        assert st[built["a"]] in ("todo", "ready")
+
+
+def test_unarchive_group_restores_all_members(kanban_scratch, capsys):
+    with kb.connect_closing(board="recovery") as db:
+        built = build_dm(db)
+    run_cli("archive-graph", built["a"], "--reason", "cleanup")
+    out = capsys.readouterr().out
+    import re
+    m = re.search(r"Archive group (ag_[a-f0-9]+)", out)
+    assert m
+    group = m.group(1)
+    capsys.readouterr()
+    rc = run_cli("unarchive", "--group", group)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert f"Unarchive group {group}: 4 restored, 0 skipped" in out
+    with kb.connect_closing(board="recovery") as db:
+        for tid in (built["a"], built["b"], built["c"], built["d"]):
+            # All restored out of 'archived' (recompute may promote some).
+            assert _statuses(db)[tid] != "archived"
+
+
+def test_unarchive_unknown_group_refused(kanban_scratch, capsys):
+    with kb.connect_closing(board="recovery") as db:
+        _id(db, "unrelated")
+    rc = run_cli("unarchive", "--group", "ag_missing")
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "refused" in err
+    assert "ag_missing" in err
+
+
+def test_unarchive_missing_workspace_reported_without_recreation(
+    kanban_scratch, capsys
+):
+    missing_ws = str(Path(kanban_scratch) / "gone-workspace")
+    assert not Path(missing_ws).exists()
+    with kb.connect_closing(board="recovery") as db:
+        a = _id(db, "ws A")
+        db.execute("UPDATE tasks SET workspace_path=? WHERE id=?",
+                   (missing_ws, a))
+    run_cli("archive-graph", a, "--reason", "cleanup")
+    capsys.readouterr()
+    rc = run_cli("unarchive", a)
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "1 restored, 0 skipped" in captured.out
+    assert "missing workspace" in captured.err.lower()
+    # Reported without recreation: the directory still does not exist.
+    assert not Path(missing_ws).exists()
+
+
+# ---------------------------------------------------------------------------
+# --board scoping end-to-end
+# ---------------------------------------------------------------------------
+
+def test_end_to_end_board_scoping(kanban_scratch, capsys):
+    with kb.connect_closing(board="recovery") as db:
+        r_a = _id(db, "recovery A")
+        db.execute("UPDATE tasks SET status='todo' WHERE id=?", (r_a,))
+    with kb.connect_closing(board="alt") as db:
+        alt = _id(db, "alt A")
+        db.execute("UPDATE tasks SET status='todo' WHERE id=?", (alt,))
+    # Archive on 'recovery' with an explicit --board; the alt board's task
+    # must remain untouched.
+    rc = run_cli("--board", "recovery", "archive-graph", r_a, "--reason",
+                 "cleanup", "--dry-run")
+    assert rc == 0
+    with kb.connect_closing(board="recovery") as db:
+        assert _statuses(db)[r_a] == "todo"
+    with kb.connect_closing(board="alt") as db:
+        assert _statuses(db)[alt] == "todo"
+    # Real execution scoped to recovery.
+    rc = run_cli("--board", "recovery", "archive-graph", r_a, "--reason",
+                 "cleanup")
+    assert rc == 0
+    capsys.readouterr()
+    with kb.connect_closing(board="recovery") as db:
+        assert _statuses(db)[r_a] == "archived"
+    with kb.connect_closing(board="alt") as db:
+        assert _statuses(db)[alt] == "todo"

--- a/tests/tools/test_kanban_admin_archive_tool.py
+++ b/tests/tools/test_kanban_admin_archive_tool.py
@@ -1,0 +1,423 @@
+"""Tests for the guarded destructive-admin archive agent tool.
+
+Covers ``kanban_admin_archive`` (tools/kanban_tools.py) and its config gate
+``kanban.admin_profiles`` (hermes_cli/config_defaults.py). The tool is
+security-sensitive and archive-only:
+
+  - Absent unless ALL hold: not a delegate_task child, not a dispatcher task
+    worker, the active profile is normalized-allowlisted in
+    ``kanban.admin_profiles``, and the profile's config has the kanban
+    toolset active. ``HERMES_KANBAN_TASK`` alone never exposes it; an
+    empty/default allowlist exposes nobody.
+  - The handler rechecks authorization at runtime and explicitly names the
+    ``kanban.admin_profiles`` key in refusals; delegated children are
+    explicitly refused.
+  - There is deliberately NO unarchive agent tool or schema.
+
+All board DB traffic resolves under pytest ``tmp_path`` scratch boards; no
+live board is ever touched. Every test controls the registry ``check_fn``
+TTL cache deterministically via ``invalidate_check_fn_cache()`` after any
+config/env change.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+# ---------------------------------------------------------------------------
+# Harness: config + scratch boards under tmp_path
+# ---------------------------------------------------------------------------
+
+def _write_config(home: Path, *, toolsets, admin_profiles):
+    """Write a minimal config.yaml with the kanban toolset + allowlist."""
+    home.mkdir(parents=True, exist_ok=True)
+    ts = "\n".join(f"    - {t}" for t in toolsets)
+    ap = "\n".join(f"    - {p!r}" for p in admin_profiles)
+    (home / "config.yaml").write_text(
+        f"toolsets:\n{ts}\n"
+        f"kanban:\n  admin_profiles:\n{ap}\n"
+    )
+
+
+@pytest.fixture
+def allowlisted_env(monkeypatch, tmp_path):
+    """An allowlisted orchestrator: kanban toolset + allowlisted profile +
+    unset HERMES_KANBAN_TASK (not a dispatcher worker). Returns the home."""
+    home = tmp_path / ".hermes"
+    _write_config(home, toolsets=["kanban"], admin_profiles=["adminpro"])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "adminpro")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db(board="recovery")
+    kb.init_db(board="alt")
+    return home
+
+
+def _check():
+    from tools import kanban_tools as kt
+    return kt._check_kanban_admin_archive()
+
+
+def _schema(tool_name="kanban_admin_archive"):
+    """Return the tool's schema via the real registry gating (check_fn)."""
+    from tools.registry import invalidate_check_fn_cache, registry
+    invalidate_check_fn_cache()
+    return registry.get_definitions({tool_name}, quiet=True)
+
+
+def _id(db, title):
+    return kb.create_task(db, title=title, initial_status="blocked")
+
+
+def build_dm(db):
+    """A->B, A->C, B->D, C->D, all todo (closed dominated closure)."""
+    a = _id(db, "dm A")
+    b = kb.create_task(db, title="dm B", parents=[a])
+    c = kb.create_task(db, title="dm C", parents=[a])
+    d = kb.create_task(db, title="dm D", parents=[b, c])
+    db.execute("UPDATE tasks SET status='todo' WHERE id=?", (a,))
+    return {"a": a, "b": b, "c": c, "d": d}
+
+
+def _statuses(db):
+    return {
+        row["id"]: row["status"]
+        for row in db.execute("SELECT id, status FROM tasks").fetchall()
+    }
+
+
+# ---------------------------------------------------------------------------
+# Gating: schema absent / present
+# ---------------------------------------------------------------------------
+
+def test_archive_tool_absent_by_default_empty_allowlist(monkeypatch, tmp_path):
+    """Default config (admin_profiles=[] / absent) exposes the tool to nobody,
+    even with the kanban toolset active and an orchestrator actor."""
+    home = tmp_path / ".hermes"
+    _write_config(home, toolsets=["kanban"], admin_profiles=[])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "someone")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    assert _check() is False
+    assert _schema() == []
+
+
+def test_archive_tool_absent_when_not_allowlisted(monkeypatch, tmp_path):
+    """A profile not on the allowlist must not see the tool, even with the
+    kanban toolset active."""
+    home = tmp_path / ".hermes"
+    _write_config(home, toolsets=["kanban"], admin_profiles=["techlead"])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "someother")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    assert _check() is False
+    assert _schema() == []
+
+
+def test_archive_tool_present_for_allowlisted_orchestrator(allowlisted_env):
+    """An allowlisted, kanban-toolset orchestrator (no HERMES_KANBAN_TASK)
+    sees the tool in the real registry schema."""
+    assert _check() is True
+    schema = _schema()
+    assert len(schema) == 1
+    fn = schema[0]["function"]
+    assert fn["name"] == "kanban_admin_archive"
+
+
+def test_hermes_kanban_task_alone_never_exposes(monkeypatch, tmp_path):
+    """HERMES_KANBAN_TASK set (a dispatcher worker) never grants the tool,
+    even when the actor is allowlisted."""
+    home = tmp_path / ".hermes"
+    _write_config(home, toolsets=["kanban"], admin_profiles=["adminpro"])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "adminpro")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worker_task")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    assert _check() is False
+    assert _schema() == []
+
+
+def test_archive_tool_absent_when_kanban_toolset_inactive(monkeypatch, tmp_path):
+    """Without the kanban toolset in config, the tool is hidden even for an
+    allowlisted profile."""
+    home = tmp_path / ".hermes"
+    _write_config(home, toolsets=["hermes-cli"], admin_profiles=["adminpro"])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "adminpro")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    assert _check() is False
+    assert _schema() == []
+
+
+def test_archive_tool_absent_for_delegated_child(monkeypatch, allowlisted_env):
+    """A delegate_task child must not see the tool even when allowlisted."""
+    import tools.kanban_tools as kt
+    monkeypatch.setattr(kt, "_is_delegated_child_context", lambda: True)
+    assert _check() is False
+    assert _schema() == []
+
+
+# ---------------------------------------------------------------------------
+# Allowlist normalization
+# ---------------------------------------------------------------------------
+
+def test_allowlist_case_and_whitespace_normalization(monkeypatch, tmp_path):
+    """Both directions of the allowlist comparison are case-insensitive and
+    whitespace-stripped, so ``" AdminPro "`` matches active profile
+    ``"adminpro"`` and vice versa."""
+    home = tmp_path / ".hermes"
+    _write_config(home, toolsets=["kanban"], admin_profiles=["  AdminPro  "])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "adminpro")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from tools import kanban_tools as kt
+    assert kt._normalize_admin_profile("  AdminPro  ") == "adminpro"
+    assert kt._normalize_admin_profile(None) == ""
+    assert kt._admin_actor_authorized() is True
+    assert _check() is True
+
+
+def test_empty_allowlist_entry_never_authorizes(monkeypatch, tmp_path):
+    """'' / None allowlist entries must be dropped, never matching anybody."""
+    from tools import kanban_tools as kt
+    assert kt._normalize_admin_profile("") == ""
+    assert kt._normalize_admin_profile(None) == ""
+    # Directly exercise the set-builder on a mixed list via _admin_allowlist
+    # after writing a config with a blank entry.
+    home = tmp_path / ".hermes"
+    _write_config(home, toolsets=["kanban"], admin_profiles=["", "adminpro"])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "adminpro")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    assert _admin_allowlist_set() == {"adminpro"}
+
+
+def _admin_allowlist_set():
+    from tools import kanban_tools as kt
+    return kt._admin_allowlist()
+
+
+# ---------------------------------------------------------------------------
+# Handler refusal / authorization recheck
+# ---------------------------------------------------------------------------
+
+def test_handler_rejects_non_allowlisted_actor_naming_config_key(
+    monkeypatch, tmp_path
+):
+    """A non-allowlisted actor calling the handler gets a structured refusal
+    that explicitly names the ``kanban.admin_profiles`` config key."""
+    home = tmp_path / ".hermes"
+    _write_config(home, toolsets=["kanban"], admin_profiles=["techlead"])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "intruder")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db(board="recovery")
+
+    from tools import kanban_tools as kt
+    out = kt._handle_admin_archive({
+        "root_ids": ["t_x"],
+        "reason": "cleanup",
+    })
+    d = json.loads(out)
+    assert "error" in d
+    assert "kanban.admin_profiles" in d["error"]
+    # The actor is the profile, and it is named in the refusal.
+    assert "intruder" in d["error"]
+
+
+def test_handler_refuses_delegated_child(monkeypatch, allowlisted_env):
+    """Delegated children are explicitly refused in the handler, regardless
+    of allowlist status (defense in depth over the schema gate)."""
+    from tools import kanban_tools as kt
+    monkeypatch.setattr(kt, "_is_delegated_child_context", lambda: True)
+    out = kt._handle_admin_archive({
+        "root_ids": ["t_x"],
+        "reason": "cleanup",
+    })
+    d = json.loads(out)
+    assert "error" in d
+    assert "delegate_task" in d["error"]
+
+
+def test_handler_validates_root_ids_and_reason(allowlisted_env):
+    from tools import kanban_tools as kt
+    # Empty / non-string root_ids.
+    for bad in ([] , None, ["  "], [123]):
+        d = json.loads(kt._handle_admin_archive({
+            "root_ids": bad, "reason": "cleanup",
+        }))
+        assert "error" in d and "root_ids" in d["error"], bad
+    # Missing reason.
+    d = json.loads(kt._handle_admin_archive({"root_ids": ["t_x"]}))
+    assert "error" in d and "reason" in d["error"]
+
+
+def test_handler_unknown_root_all_or_nothing(allowlisted_env):
+    with kb.connect_closing(board="recovery") as db:
+        built = build_dm(db)
+    from tools import kanban_tools as kt
+    bogus = "t_doesnotexist"
+    out = kt._handle_admin_archive({
+        "root_ids": [built["a"], bogus],
+        "reason": "cleanup",
+        "dry_run": True,
+    })
+    d = json.loads(out)
+    assert d.get("error")
+    assert bogus in d["error"]
+    # All-or-nothing: nothing archived even though a valid sibling id was
+    # supplied.
+    with kb.connect_closing(board="recovery") as db:
+        st = _statuses(db)
+        assert st[built["a"]] == "todo"
+
+
+# ---------------------------------------------------------------------------
+# tmp_path board scoping / dry-run / execution
+# ---------------------------------------------------------------------------
+
+def test_dry_run_deterministic_and_non_mutating(allowlisted_env):
+    with kb.connect_closing(board="recovery") as db:
+        built = build_dm(db)
+    from tools import kanban_tools as kt
+    a1 = json.loads(kt._handle_admin_archive({
+        "root_ids": [built["a"]], "reason": "cleanup", "dry_run": True,
+        "board": "recovery",
+    }))
+    a2 = json.loads(kt._handle_admin_archive({
+        "root_ids": [built["a"]], "reason": "cleanup", "dry_run": True,
+        "board": "recovery",
+    }))
+    # Deterministic: byte-identical plans.
+    assert a1 == a2
+    assert a1["dry_run"] is True
+    assert a1["archive_group_id"] is None
+    assert sorted(a1["root_ids"]) == [built["a"]]
+    with kb.connect_closing(board="recovery") as db:
+        st = _statuses(db)
+        for tid in (built["a"], built["b"], built["c"], built["d"]):
+            assert st[tid] == "todo"
+        assert db.execute(
+            "SELECT COUNT(*) AS n FROM task_events "
+            "WHERE kind='admin_archived'"
+        ).fetchone()["n"] == 0
+
+
+def test_execution_archives_closure_and_names_group(allowlisted_env):
+    with kb.connect_closing(board="recovery") as db:
+        built = build_dm(db)
+    from tools import kanban_tools as kt
+    out = json.loads(kt._handle_admin_archive({
+        "root_ids": [built["a"]], "reason": "cleanup", "board": "recovery",
+    }))
+    assert out.get("error") is None
+    assert out["archive_group_id"].startswith("ag_")
+    assert sorted(out["archived_ids"]) == sorted(
+        [built["a"], built["b"], built["c"], built["d"]]
+    )
+    with kb.connect_closing(board="recovery") as db:
+        st = _statuses(db)
+        for tid in (built["a"], built["b"], built["c"], built["d"]):
+            assert st[tid] == "archived"
+
+
+def test_board_scoping_uses_requested_board(allowlisted_env):
+    """Data on the 'alt' board must be untouched when archiving on
+    'recovery' (and vice-versa), proving the tool resolves per-board DBs."""
+    with kb.connect_closing(board="recovery") as db:
+        built = build_dm(db)
+    with kb.connect_closing(board="alt") as db:
+        alt_ids = [_id(db, "alt task")]
+    from tools import kanban_tools as kt
+    out = json.loads(kt._handle_admin_archive({
+        "root_ids": [built["a"]], "reason": "cleanup", "board": "recovery",
+    }))
+    assert out.get("error") is None
+    with kb.connect_closing(board="recovery") as db:
+        assert _statuses(db)[built["a"]] == "archived"
+    with kb.connect_closing(board="alt") as db:
+        assert _statuses(db)[alt_ids[0]] == "blocked"
+
+
+# ---------------------------------------------------------------------------
+# No unarchive surface; existing lifecycle registrations unchanged
+# ---------------------------------------------------------------------------
+
+def test_no_unarchive_agent_tool_or_schema():
+    from tools.registry import registry
+    names = registry.get_tool_names_for_toolset("kanban")
+    assert not any("unarchive" in n for n in names)
+    # No entry anywhere in the registry carries an unarchive tool name.
+    all_names = {e.name for e in registry.get_all_entries()}
+    assert not any("unarchive" in n for n in all_names)
+    # The archive tool's schema carries no unarchive/restore field.
+    schema = _schema()
+    if schema:
+        fn = schema[0]["function"]
+        for key in ("unarchive", "restore"):
+            assert key not in fn
+
+
+def test_existing_lifecycle_registrations_unchanged():
+    """Adding the admin tool must not alter the existing lifecycle toolset
+    registrations (names + gating survived recovery)."""
+    from tools.registry import registry
+    names = set(registry.get_tool_names_for_toolset("kanban"))
+    for expected in ("kanban_show", "kanban_complete", "kanban_block",
+                     "kanban_heartbeat", "kanban_comment", "kanban_create",
+                     "kanban_link", "kanban_attach", "kanban_attach_url",
+                     "kanban_attachments", "kanban_unblock",
+                     "kanban_request_review", "kanban_request_changes"):
+        assert expected in names, expected
+    # kanban_admin_archive is present, and it is the only admin_* tool.
+    assert "kanban_admin_archive" in names
+    admin_tools = [n for n in names if n.startswith("kanban_admin_")]
+    assert admin_tools == ["kanban_admin_archive"]
+
+
+# ---------------------------------------------------------------------------
+# Deterministic config-cache handling
+# ---------------------------------------------------------------------------
+
+def test_registry_check_fn_cache_respects_allowlist_change(monkeypatch, tmp_path):
+    """The check_fn TTL cache must not leak a stale authorization across
+    config changes: after invalidate_check_fn_cache() the new allowlist is
+    reflected."""
+    home = tmp_path / ".hermes"
+    _write_config(home, toolsets=["kanban"], admin_profiles=["techlead"])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "adminpro")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    # Not allowlisted -> absent.
+    assert _check() is False
+    assert _schema() == []
+
+    # Add adminpro to the allowlist -> present after cache invalidate.
+    _write_config(home, toolsets=["kanban"], admin_profiles=["techlead", "adminpro"])
+    from tools import kanban_tools as kt
+    assert kt._admin_actor_authorized() is True
+    assert _check() is True
+    assert len(_schema()) == 1

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -135,6 +135,77 @@ def _check_kanban_orchestrator_mode() -> bool:
     return _profile_has_kanban_toolset()
 
 
+def _normalize_admin_profile(value: Any) -> str:
+    """Normalize a kanban.admin_profiles entry / active profile for comparison.
+
+    Allowlist matching is case-insensitive and whitespace-stripped in both
+    directions so a config entry like ``" Apoc "`` matches an active profile
+    ``"apoc"``. Returns ``""`` for empty/None so an empty entry can never
+    accidentally authorize somebody.
+    """
+    if value is None:
+        return ""
+    return str(value).strip().lower()
+
+
+def _admin_actor() -> str:
+    """The active profile identity used for admin authorization + attribution.
+
+    Mirrors the tool surface's existing author derivation
+    (``HERMES_PROFILE`` env, which the dispatcher sets for workers and the
+    profile machinery sets for ``hermes -p <name>``), falling back to the
+    HERMES_HOME-derived active profile name. Never accepts a caller-supplied
+    arg — the actor is the runtime profile, not something the model can forge.
+    """
+    profile = (os.environ.get("HERMES_PROFILE") or "").strip()
+    if profile:
+        return profile
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        return get_active_profile_name() or "default"
+    except Exception:
+        return "default"
+
+
+def _admin_allowlist() -> set:
+    """Normalized set of profiles allowed to run destructive admin tools."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+    except Exception:
+        cfg = {}
+    allowlist = (cfg.get("kanban") or {}).get("admin_profiles") or []
+    return {
+        _normalize_admin_profile(v)
+        for v in allowlist
+        if _normalize_admin_profile(v)
+    }
+
+
+def _admin_actor_authorized() -> bool:
+    """True when the active profile is allowlisted in ``kanban.admin_profiles``."""
+    return _normalize_admin_profile(_admin_actor()) in _admin_allowlist()
+
+
+def _check_kanban_admin_archive() -> bool:
+    """Destructive admin archive tool is exposed only to allowlisted, normal
+    Kanban orchestrator contexts.
+
+    Absent (returns False) for: delegate_task children, dispatcher task
+    workers, profiles without the kanban toolset, and — critically — any
+    profile not explicitly allowlisted in ``kanban.admin_profiles``. An
+    empty/default allowlist exposes it to nobody, and ``HERMES_KANBAN_TASK``
+    alone never grants it.
+    """
+    if _is_delegated_child_context():
+        return False
+    if os.environ.get("HERMES_KANBAN_TASK") and _is_dispatcher_owned_worker():
+        return False
+    if not _profile_has_kanban_toolset():
+        return False
+    return _admin_actor_authorized()
+
+
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
@@ -2348,6 +2419,134 @@ KANBAN_LINK_SCHEMA = {
     },
 }
 
+KANBAN_ADMIN_ARCHIVE_SCHEMA = {
+    "name": "kanban_admin_archive",
+    "description": (
+        "DESTRUCTIVE admin archive of a task and its dominated closure "
+        "(verified parent→child ancestors plus descendants) with a persisted "
+        "reason comment. Available ONLY to orchestrator profiles allowlisted "
+        "in `kanban.admin_profiles` (the response denial names that key). "
+        "Refuses when the closure would promote detached boundary tasks "
+        "unless allow_promotions, or contains active runs unless "
+        "force_running. Archive-only by design — there is NO unarchive agent "
+        "tool; restores happen via `hermes kanban unarchive`. dry_run=true "
+        "returns the deterministic plan without writing anything."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "root_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Root task ids whose dominated closure to archive. "
+                    "Must be a non-empty string array."
+                ),
+            },
+            "reason": {
+                "type": "string",
+                "description": (
+                    "Reason for the archive. PERSISTED as comments/events on "
+                    "every archived task. NEVER include secrets, tokens, or "
+                    "credentials."
+                ),
+            },
+            "dry_run": {
+                "type": "boolean",
+                "description": (
+                    "Plan only: return the deterministic JSON plan and write "
+                    "nothing (no mutation, no archive group)."
+                ),
+                "default": False,
+            },
+            "allow_promotions": {
+                "type": "boolean",
+                "description": (
+                    "Permit recompute_ready after archiving. WARNING: "
+                    "recompute_ready is global and may also promote unrelated "
+                    "already-eligible tasks on the board, not just this "
+                    "graph's boundary."
+                ),
+                "default": False,
+            },
+            "force_running": {
+                "type": "boolean",
+                "description": (
+                    "Terminate and archive closure tasks that have active "
+                    "runs/claims."
+                ),
+                "default": False,
+            },
+            "board": _board_schema_prop(),
+        },
+        "required": ["root_ids", "reason"],
+    },
+}
+
+
+def _handle_admin_archive(args: dict, **kw) -> str:
+    """Handler for the destructive ``kanban_admin_archive`` tool.
+
+    Authorization is rechecked here (never trusted from the schema alone):
+    the active profile must be allowlisted in ``kanban.admin_profiles``, and
+    delegated children are explicitly refused. The actor is derived from the
+    runtime profile, never from caller-supplied args.
+    """
+    delegated_err = _reject_delegated_child_mutation("kanban_admin_archive")
+    if delegated_err:
+        return delegated_err
+    actor = _admin_actor()
+    if not _admin_actor_authorized():
+        return tool_error(
+            f"kanban_admin_archive refused for profile {actor!r}: not "
+            "allowlisted in `kanban.admin_profiles`. Add this profile to that "
+            "config list to enable destructive admin archiving; an empty list "
+            "exposes nobody."
+        )
+    board = args.get("board")
+    root_ids = args.get("root_ids") or []
+    if (
+        not isinstance(root_ids, list)
+        or not root_ids
+        or not all(isinstance(r, str) and r.strip() for r in root_ids)
+    ):
+        return tool_error("root_ids must be a non-empty string array")
+    reason = str(args.get("reason") or "").strip()
+    if not reason:
+        return tool_error("reason is required")
+    dry_run, e1 = _parse_bool_arg(args, "dry_run")
+    if e1:
+        return tool_error(e1)
+    allow_promotions, e2 = _parse_bool_arg(args, "allow_promotions")
+    if e2:
+        return tool_error(e2)
+    force_running, e3 = _parse_bool_arg(args, "force_running")
+    if e3:
+        return tool_error(e3)
+    try:
+        kb, conn = _connect(board=board)
+        try:
+            try:
+                result = kb.admin_archive_graph(
+                    conn,
+                    root_ids,
+                    reason=reason,
+                    actor=actor,
+                    dry_run=dry_run,
+                    allow_promotions=allow_promotions,
+                    force_running=force_running,
+                )
+            except ValueError as exc:
+                return tool_error(f"kanban_admin_archive refused: {exc}")
+            if result.get("error"):
+                return tool_error(f"kanban_admin_archive refused: {result['error']}")
+            return json.dumps(result, sort_keys=True)
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.exception("kanban_admin_archive failed")
+        return tool_error(f"kanban_admin_archive: {e}")
+
 
 # ---------------------------------------------------------------------------
 # Registration
@@ -2477,4 +2676,13 @@ registry.register(
     handler=_handle_link,
     check_fn=_check_kanban_mode,
     emoji="🔗",
+)
+
+registry.register(
+    name="kanban_admin_archive",
+    toolset="kanban",
+    schema=KANBAN_ADMIN_ARCHIVE_SCHEMA,
+    handler=_handle_admin_archive,
+    check_fn=_check_kanban_admin_archive,
+    emoji="🗄️",
 )


### PR DESCRIPTION
## Summary

- Adds guarded Kanban archive-graph and unarchive CLI workflows with transactional closure handling and test-isolated safety guards.
- Adds an archive-only agent tool gated by `kanban.admin_profiles`, orchestrator context, active Kanban toolset, and runtime profile identity.
- Keeps `kanban.admin_profiles` empty by default and adds no agent unarchive tool or schema.

## Reviewed provenance

Seraph independently approved reviewed HEAD `2ea9de954053edcf052fa04eb052a67462ad7492`.

This PR reapplies the exact eight reviewed patches onto current `origin/main` `533886c8b8eb67ff8b389b7f48e7d5e5d9c575b9` without conflict:

- candidate HEAD: `83cc49e4a1e431455ceeb61c80b8c9789bd644f1`
- `git range-diff`: all eight commits are patch-equivalent (`=`)
- reviewed and rebased net patch-id: `9d0a175bbd0031c437664b7768b2171423a52057`
- diff scope: exactly 7 files, 3,550 insertions, 2 deletions

## Verification

All checks ran in an isolated `TEST_ROOT` with scratch `HOME`, `HERMES_HOME`, `HERMES_KANBAN_HOME`, `HERMES_KANBAN_DB`, workspaces, and logs. No sandbox database was created outside pytest `tmp_path`.

- 74 tests collected
- 74 focused archive integration tests passed
- 30 Kanban DB tests passed, 1 platform-specific test skipped
- 36 existing CLI and tool regression tests passed
- `git diff --check origin/main..HEAD` passed
- worktree is clean

## CI status

GitHub created the CI, Nix, and Docker workflow runs for this fork PR, but all three are in `action_required` with zero jobs. An upstream NousResearch maintainer must approve the first-time fork workflows before CI can execute.

## Release safety

This PR does not install into a running Hermes instance, restart services, touch a live Kanban board, or deploy. Merge and rollout remain subject to explicit maintainer approval.
