### PR TITLE
fix(approval): identify pending approval requests

### DIFF
--- a/tests/tools/test_pending_approval_identity.py
+++ b/tests/tools/test_pending_approval_identity.py
@@ -1,0 +1,20 @@
+from tools import approval
+
+
+def test_submit_pending_assigns_stable_approval_id():
+    session_key = "test-pending-approval-identity"
+    try:
+        approval.submit_pending(session_key, {"command": "echo ok"})
+        first = dict(approval._pending[session_key])
+
+        assert first["approval_id"]
+        assert len(first["approval_id"]) == 32
+
+        approval.submit_pending(
+            session_key,
+            {"command": "echo preserved", "approval_id": "upstream-id"},
+        )
+        assert approval._pending[session_key]["approval_id"] == "upstream-id"
+    finally:
+        with approval._lock:
+            approval._pending.pop(session_key, None)

--- a/tests/tools/test_pending_approval_identity.py
+++ b/tests/tools/test_pending_approval_identity.py
@@ -18,3 +18,21 @@ def test_submit_pending_assigns_stable_approval_id():
     finally:
         with approval._lock:
             approval._pending.pop(session_key, None)
+
+
+def test_submit_pending_isolates_stored_entry_from_caller_mutation():
+    session_key = "test-pending-approval-copy-isolation"
+    payload = {"command": "echo original"}
+    try:
+        approval.submit_pending(session_key, payload)
+        stored_id = approval._pending[session_key]["approval_id"]
+
+        payload["command"] = "echo mutated"
+        payload["approval_id"] = "caller-rewrite"
+
+        stored = approval._pending[session_key]
+        assert stored["command"] == "echo original"
+        assert stored["approval_id"] == stored_id
+    finally:
+        with approval._lock:
+            approval._pending.pop(session_key, None)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2712,9 +2712,11 @@ def get_pending_gateway_approval(session_key: str) -> dict | None:
 
 
 def submit_pending(session_key: str, approval: dict):
-    """Store a pending approval request for a session."""
+    """Store a pending approval request with a stable response identity."""
+    entry = dict(approval)
+    entry.setdefault("approval_id", uuid.uuid4().hex)
     with _lock:
-        _pending[session_key] = approval
+        _pending[session_key] = entry
 
 
 def approve_session(session_key: str, pattern_key: str):


### PR DESCRIPTION
## Summary
- assign a stable `approval_id` to pending approval requests at the native producer
- preserve identities supplied by an upstream transport
- cover generated/preserved identities and caller-copy isolation with focused regression tests

## Why
Browser clients must target the exact pending request they rendered. Agent fallback paths currently write idless requests directly to the shared approval queue; strict WebUI clients consequently display a card whose buttons cannot form an actionable response.

## Test
- `python -m pytest tests/tools/test_pending_approval_identity.py -q` (2 passed)