### PR TITLE
feat(cron): defer monitor state commit until delivery succeeds

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1639,6 +1639,24 @@ def _normalized_inference_axes(
     )
 
 
+_MONITOR_COMMIT_POLICIES = {"detection_time", "after_delivery"}
+
+
+def _normalize_monitor_commit_policy(
+    value: Optional[str], *, monitor_script: Optional[str], monitor_url: Optional[str],
+) -> Optional[str]:
+    """Validate the optional monitor commit boundary shared by create_job/update_job."""
+    normalized = str(value).strip().lower() if value is not None else ""
+    if not normalized:
+        return None
+    if normalized not in _MONITOR_COMMIT_POLICIES:
+        choices = ", ".join(sorted(_MONITOR_COMMIT_POLICIES))
+        raise ValueError(f"monitor_commit_policy must be one of: {choices}")
+    if not (monitor_script or monitor_url):
+        raise ValueError("monitor_commit_policy requires monitor_script or monitor_url")
+    return normalized
+
+
 def _validate_job_mode_invariants(
     monitor_script: Optional[str],
     monitor_url: Optional[str],
@@ -1705,6 +1723,7 @@ def create_job(
     failure_deliver: Optional[str] = None,
     paused: bool = False,
     paused_reason: Optional[str] = None,
+    monitor_commit_policy: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Create a new cron job and return the stored record.
 
@@ -1713,7 +1732,9 @@ def create_job(
     delivered verbatim, requires ``script``). context_from: job id(s) whose latest output is
     injected. workdir: absolute cwd for tools/scripts. monitor_script/monitor_url: cheap monitor
     source run FIRST each tick; unchanged output suppresses the agent run (mutually exclusive,
-    incompatible with ``no_agent``). reasoning_effort: per-job pin; capability NOT validated."""
+    incompatible with ``no_agent``). monitor_commit_policy: ``detection_time`` (default, eager) or
+    ``after_delivery``, which retries a changed observation until the triggered agent run AND its
+    delivery succeed. reasoning_effort: per-job pin; capability NOT validated."""
     if not isinstance(paused, bool):
         raise ValueError("paused must be a boolean.")
     if paused_reason is not None and not isinstance(paused_reason, str):
@@ -1737,6 +1758,11 @@ def create_job(
     normalized_skills = _normalize_skill_list(skill, skills)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
     normalized_reasoning_effort = _normalize_reasoning_effort(reasoning_effort)
+    normalized_monitor_commit_policy = _normalize_monitor_commit_policy(
+        monitor_commit_policy,
+        monitor_script=f["monitor_script"],
+        monitor_url=f["monitor_url"],
+    )
 
     _validate_job_mode_invariants(f["monitor_script"], f["monitor_url"], f["no_agent"], f["script"])
     prompt_text = _coerce_job_text(prompt).strip()
@@ -1801,6 +1827,7 @@ def create_job(
     for key, value in (
         ("attach_to_session", normalized_attach), ("reasoning_effort", normalized_reasoning_effort),
         ("failure_deliver", f["failure_deliver"]),
+        ("monitor_commit_policy", normalized_monitor_commit_policy),
     ):
         if value is not None:
             job[key] = value
@@ -1939,6 +1966,18 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
         previous_inference_axes = _normalized_inference_axes(job)
         updated = _apply_skill_fields({**job, **updates})
         _reject_terminal_activation(job, updated, job_id)
+        if {"monitor_script", "monitor_url", "monitor_commit_policy"}.intersection(updates):
+            # Re-validate on the MERGED record: clearing the last monitor source must also drop a
+            # policy that is only meaningful for monitor jobs.
+            normalized_policy = _normalize_monitor_commit_policy(
+                updated.get("monitor_commit_policy"),
+                monitor_script=updated.get("monitor_script") or None,
+                monitor_url=updated.get("monitor_url") or None,
+            )
+            if normalized_policy is None:
+                updated.pop("monitor_commit_policy", None)
+            else:
+                updated["monitor_commit_policy"] = normalized_policy
         # Re-check on the MERGED record; scoped to changed fields so legacy records keep loading.
         if {"monitor_script", "monitor_url", "no_agent", "script"}.intersection(updates):
             _validate_job_mode_invariants(

--- a/cron/monitor.py
+++ b/cron/monitor.py
@@ -237,6 +237,11 @@ def commit_monitor_state(job_id: str, new_hash: str, output: str) -> None:
             snapshot_path.unlink(missing_ok=True)
 
     try:
+        # update_job rewrites the job dict and persists jobs.json in one
+        # step; hash and last_changed_at are therefore applied together or
+        # not at all (a failed update_job raises before any partial state
+        # survives). The rollback below only has to cover the snapshot
+        # file, which is why it does not restore a timestamp.
         updated = update_job(
             job_id,
             {

--- a/cron/monitor.py
+++ b/cron/monitor.py
@@ -8,6 +8,12 @@ CHANGE DETECTED" block (capped unified diff + new output) is injected into the p
 failure → an ERROR, never a change, and the stored hash is left untouched. State:
 ``job["monitor_state"]`` in jobs.json (hash + last_changed_at) and
 ``OUTPUT_DIR/<job_id>/monitor_last_output.txt`` (for the diff).
+
+The default commit boundary is detection time. Jobs with
+``monitor_commit_policy="after_delivery"`` defer the hash/snapshot commit until the agent finishes
+AND delivery succeeds, so a failed run re-offers the same observation instead of consuming it. Such
+a job may return the exact marker ``[MONITOR_RETRY]`` to suppress delivery and leave the prior hash
+intact.
 """
 
 from __future__ import annotations
@@ -15,6 +21,8 @@ from __future__ import annotations
 import difflib
 import hashlib
 import logging
+import os
+import uuid
 from dataclasses import dataclass
 from typing import Optional
 
@@ -39,6 +47,8 @@ class MonitorOutcome:
     first_run: bool = False
     context_block: Optional[str] = None
     error: Optional[str] = None
+    new_hash: Optional[str] = None
+    output: Optional[str] = None
 
 
 def hash_monitor_output(output: str) -> str:
@@ -74,13 +84,25 @@ def _read_last_output(job_id: str) -> str:
     return ""
 
 
+def _write_last_output_strict(job_id: str, output: str) -> None:
+    path = _snapshot_path(job_id)
+    from cron.jobs import _ensure_cron_dir
+
+    _ensure_cron_dir(path.parent)
+    temp_path = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        temp_path.write_text(output, encoding="utf-8")
+        os.replace(temp_path, path)
+    finally:
+        try:
+            temp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
 def _write_last_output(job_id: str, output: str) -> None:
     try:
-        from cron.jobs import _ensure_cron_dir
-
-        path = _snapshot_path(job_id)
-        _ensure_cron_dir(path.parent)
-        path.write_text(output, encoding="utf-8")
+        _write_last_output_strict(job_id, output)
     except Exception as exc:
         logger.warning("Monitor: failed to persist last output for %r: %s", job_id, exc)
 
@@ -125,8 +147,10 @@ def job_has_monitor(job: dict) -> bool:
 def check_monitor(job: dict) -> MonitorOutcome:
     """Run the monitor source and decide whether the agent should run.
 
-    On change (or first run) the new hash + snapshot are persisted BEFORE the agent runs — detection
-    time is the state boundary, so a failed agent run doesn't re-alert on the same content forever.
+    By default, on change (or first run) the new hash + snapshot are persisted BEFORE the agent
+    runs — detection time is the state boundary, so a failed agent run doesn't re-alert on the same
+    content forever. ``monitor_commit_policy='after_delivery'`` instead returns the new hash/output
+    to the scheduler for a downstream commit once the agent AND delivery both succeeded.
     On failure nothing is persisted.
     """
     job_id = str(job.get("id") or "")
@@ -163,8 +187,16 @@ def check_monitor(job: dict) -> MonitorOutcome:
             f"### Diff (previous → current)\n\n```diff\n{diff}\n```\n\n" + current
         )
 
-    _persist_monitor_state(job_id, new_hash, output)
-    return MonitorOutcome(ok=True, changed=True, first_run=first_run, context_block=context_block)
+    if job.get("monitor_commit_policy") != "after_delivery":
+        _persist_monitor_state(job_id, new_hash, output)
+    return MonitorOutcome(
+        ok=True,
+        changed=True,
+        first_run=first_run,
+        context_block=context_block,
+        new_hash=new_hash,
+        output=output,
+    )
 
 
 def _persist_monitor_state(job_id: str, new_hash: str, output: str) -> None:
@@ -183,3 +215,45 @@ def _persist_monitor_state(job_id: str, new_hash: str, output: str) -> None:
         )
     except Exception as exc:
         logger.warning("Monitor: failed to persist state for %r: %s", job_id, exc)
+
+
+def commit_monitor_state(job_id: str, new_hash: str, output: str) -> None:
+    """Commit a deferred monitor observation after downstream success."""
+    if not new_hash:
+        raise ValueError("new_hash is required to commit monitor state")
+    from cron.jobs import _hermes_now, update_job
+
+    snapshot_path = _snapshot_path(job_id)
+    old_snapshot_exists = snapshot_path.exists()
+    old_output = (
+        snapshot_path.read_text(encoding="utf-8") if old_snapshot_exists else ""
+    )
+    _write_last_output_strict(job_id, output)
+
+    def rollback_snapshot() -> None:
+        if old_snapshot_exists:
+            _write_last_output_strict(job_id, old_output)
+        else:
+            snapshot_path.unlink(missing_ok=True)
+
+    try:
+        updated = update_job(
+            job_id,
+            {
+                "monitor_state": {
+                    "last_output_hash": new_hash,
+                    "last_changed_at": _hermes_now().isoformat(),
+                }
+            },
+        )
+        if updated is None:
+            raise RuntimeError(f"monitor job {job_id!r} disappeared during commit")
+    except Exception:
+        try:
+            rollback_snapshot()
+        except Exception:
+            logger.exception(
+                "Monitor: failed to roll back snapshot for %r after hash commit failure",
+                job_id,
+            )
+        raise

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1365,6 +1365,10 @@ def _apply_monitor_gate(
         # bookkeeping tail can commit it only after the agent succeeded AND delivery reported no
         # error; anything short of that leaves the old hash so this observation retries.
         pending_commit = {"new_hash": _mon.new_hash, "output": _mon.output}
+        # The defer list is the only channel that crosses the process boundary; the job-dict
+        # key is a same-process fallback for callers that don't pass `defer_monitor_commit`,
+        # popped by the decision point in the same execution. Never persist this key — it is
+        # scratch state for one run.
         job["_monitor_pending_commit"] = pending_commit
         if defer_monitor_commit is not None:
             defer_monitor_commit.append(pending_commit)
@@ -2827,7 +2831,7 @@ def _save_compose_deliver(
     requires_delivery = _monitor_event_requires_delivery(pending_monitor)
     if job.get("monitor_commit_policy") == "after_delivery" and pending_monitor and d.success:
         d.monitor_retry = (
-            deliver_content.strip().upper() == MONITOR_RETRY_MARKER
+            deliver_content.strip() == MONITOR_RETRY_MARKER
             or (
                 requires_delivery
                 and (

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -489,6 +489,10 @@ from cron.executions import (
 
 # Response marker that suppresses delivery (output is still saved locally for audit).
 SILENT_MARKER = "[SILENT]"
+# Deferred-commit monitors use this exact marker for a transient verification
+# failure: no delivery and no hash commit, so the same observation retries on the
+# next tick instead of being consumed by a run that could not verify it.
+MONITOR_RETRY_MARKER = "[MONITOR_RETRY]"
 
 
 def _is_cron_silence_response(text: str) -> bool:
@@ -545,6 +549,10 @@ _INFLIGHT_MIN_ALLOWANCE_MINUTES = 30.0
 # false "ok" (#60432). Token keying keeps an interruption scoped to that exact execution: a later run of the
 # same job ID (recurring jobs reuse the ID every fire) must not inherit the stale flag.
 _interrupted_job_ids: set = set()
+# Executions that crossed the post-delivery monitor-commit linearization point. A
+# shutdown arriving after this point must not retroactively interrupt them, or the
+# committed hash and the recorded run status would disagree.
+_monitor_commit_in_progress: set = set()
 
 
 class _CancelEventLike(Protocol):
@@ -869,7 +877,21 @@ def mark_running_jobs_interrupted(
         ]
         if only_owners is not None:
             active_fires = [fire for fire in active_fires if (fire[1], fire[2]) in only_owners]
-        registered_ids = {job_id for _t, job_id, _o, _p in active_fires}
+        # Executions past the monitor-commit linearization point are logically complete:
+        # flagging them interrupted would make the run report failure after its hash was
+        # already committed. Keep them out of the flag set but still report the job ID so
+        # shutdown's interrupted-cron notice stays accurate.
+        committing_job_ids = {
+            fire[1]
+            for fire in active_fires
+            if fire[0] is not None and fire[0] in _monitor_commit_in_progress
+        }
+        active_fires = [
+            fire
+            for fire in active_fires
+            if fire[0] is None or fire[0] not in _monitor_commit_in_progress
+        ]
+        registered_ids = {job_id for _t, job_id, _o, _p in active_fires} | committing_job_ids
         if only_owners is None:
             active_fires.extend(
                 (None, job_id, None, _get_hermes_home())
@@ -1306,6 +1328,7 @@ def _run_no_agent_job(
 
 def _apply_monitor_gate(
     job: dict, job_id: str, job_name: str, extra_prompt: Optional[str],
+    defer_monitor_commit: Optional[list] = None,
 ) -> tuple[Optional[tuple], Optional[str]]:
     """Monitor gate (hash-suppressed change detection). Must run BEFORE any agent machinery so an
     unchanged tick costs no LLM/delivery. Returns ``(early_result | None, extra_prompt)``; when
@@ -1337,6 +1360,17 @@ def _apply_monitor_gate(
             True, f"{header}**Status:** no_change (agent run suppressed)\n", SILENT_MARKER, None,
         ), extra_prompt
     # Changed (or first run): inject monitor context via the per-run seam, then normal agent run.
+    if job.get("monitor_commit_policy") == "after_delivery":
+        # Deferred commit: check_monitor deliberately did NOT persist the hash. Stage it so the
+        # bookkeeping tail can commit it only after the agent succeeded AND delivery reported no
+        # error; anything short of that leaves the old hash so this observation retries.
+        pending_commit = {"new_hash": _mon.new_hash, "output": _mon.output}
+        job["_monitor_pending_commit"] = pending_commit
+        if defer_monitor_commit is not None:
+            defer_monitor_commit.append(pending_commit)
+        logger.info(
+            "Job '%s': staged deferred monitor commit hash=%s",
+            job_id, str(_mon.new_hash or "")[:12])
     if _mon.context_block:
         extra_prompt = (
             f"{_mon.context_block}\n\n{extra_prompt}" if extra_prompt else _mon.context_block
@@ -2015,6 +2049,7 @@ _RunResult = tuple[bool, str, str, Optional[str]]
 
 def _prepare_job_prompt(
     job: dict, job_id: str, job_name: str, extra_prompt: Optional[str], cancel_event,
+    defer_monitor_commit: Optional[list] = None,
 ) -> tuple[Optional[_RunResult], Optional[str]]:
     """Run every pre-agent gate and build the prompt. Returns ``(early_result, prompt)``: an early
     result short-circuits ``run_job`` (no_agent job, empty payload, monitor gate, wake gate,
@@ -2040,7 +2075,8 @@ def _prepare_job_prompt(
     if job_payload_is_empty(job):
         return _block_and_pause_job(job_id, job_name, EMPTY_PAYLOAD_ERROR), None
 
-    _early, extra_prompt = _apply_monitor_gate(job, job_id, job_name, extra_prompt)
+    _early, extra_prompt = _apply_monitor_gate(
+        job, job_id, job_name, extra_prompt, defer_monitor_commit)
     if _early is not None:
         return _early, None
 
@@ -2301,6 +2337,7 @@ class _FireAudit:
 def run_job(
     job: dict, *, defer_agent_teardown: Optional[list] = None, extra_prompt: Optional[str] = None,
     cancel_event: Optional[_CancelEventLike] = None, execution_id: Optional[str] = None,
+    defer_monitor_commit: Optional[list] = None,
 ) -> tuple[bool, str, str, Optional[str]]:
     """Execute a single cron job. Returns (success, full_output_doc, final_response, error).
     ``defer_agent_teardown``: if a list, the live agent is appended instead of torn down; the caller
@@ -2316,11 +2353,16 @@ def run_job(
     existing caller is unchanged.
     ``extra_prompt``: optional per-run context from ``cronjob(action='run', prompt=...)`` (#57331). Appended
     to the stored prompt for this fire only — never persisted to the job definition.
+
+    ``defer_monitor_commit``: if a list, a ``monitor_commit_policy='after_delivery'`` job's pending
+    hash/snapshot is appended instead of being persisted at detection time; the caller commits it
+    via ``cron.monitor.commit_monitor_state`` only after delivery succeeded.
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
 
-    early, prompt = _prepare_job_prompt(job, job_id, job_name, extra_prompt, cancel_event)
+    early, prompt = _prepare_job_prompt(
+        job, job_id, job_name, extra_prompt, cancel_event, defer_monitor_commit)
     if early is not None:
         return early
     from run_agent import AIAgent
@@ -2573,11 +2615,14 @@ def run_one_job(
                 execution_token=execution_token))
     finally:
         with _running_lock:
+            _monitor_commit_in_progress.discard(execution_token)
+            _interrupted_job_ids.discard(execution_token)
             executions = _running_fire_owners.get(job["id"])
             if executions is not None:
                 executions.pop(execution_token, None)
                 if not executions:
                     _running_fire_owners.pop(job["id"], None)
+                    _interrupted_job_ids.discard(job["id"])
 
 
 _OWNERSHIP_LOST_INTERRUPTED = "Interrupted by shutdown before terminal completion."
@@ -2711,6 +2756,28 @@ class _RunDelivery:
     incident_acked: bool = False
     failure_incident_id: Optional[str] = None
     side_effect_ownership_lost: bool = False
+    # Delivery failed for real. Separate from ``delivery_error`` because an exception can
+    # stringify to "" (``str(de)`` on a bare custom error), which would read as "no failure"
+    # and let a deferred monitor commit ACK an alert that never left the process.
+    delivery_failed: bool = False
+    # Deferred-commit monitors only: this observation must NOT be acknowledged, so the same
+    # event is re-offered on the next tick.
+    monitor_retry: bool = False
+
+
+def _monitor_event_requires_delivery(pending: Any) -> bool:
+    """True when a staged monitor observation carries ``events.event.requires_delivery``.
+
+    Health/system events must actually reach the operator; if the agent answers ``[SILENT]``
+    (or the job delivers locally) the observation is retried instead of silently acknowledged.
+    """
+    if not isinstance(pending, dict):
+        return False
+    try:
+        doc = json.loads(str(pending.get("output") or ""))
+        return doc.get("events", {}).get("event", {}).get("requires_delivery") is True
+    except (json.JSONDecodeError, AttributeError, TypeError):
+        return False
 
 
 def _save_compose_deliver(
@@ -2752,6 +2819,29 @@ def _save_compose_deliver(
         logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
         d.should_deliver = False
 
+    # Deferred-commit monitors: decide whether this observation may be acknowledged at all.
+    # The exact [MONITOR_RETRY] marker is the agent's "I could not verify this" answer; a
+    # requires_delivery event that was silenced (or routed to a local-only lane) must also
+    # retry rather than be consumed by a run the operator never saw.
+    pending_monitor = job.get("_monitor_pending_commit")
+    requires_delivery = _monitor_event_requires_delivery(pending_monitor)
+    if job.get("monitor_commit_policy") == "after_delivery" and pending_monitor and d.success:
+        d.monitor_retry = (
+            deliver_content.strip().upper() == MONITOR_RETRY_MARKER
+            or (
+                requires_delivery
+                and (
+                    _is_cron_silence_response(deliver_content)
+                    or _normalize_deliver_value(job.get("deliver", "local")) == "local"
+                )
+            )
+        )
+        if d.monitor_retry:
+            logger.info(
+                "Job '%s': monitor retry requested — suppressing delivery and hash commit",
+                job["id"])
+            d.should_deliver = False
+
     if d.should_deliver and fence.lost():
         d.should_deliver = False
         logger.warning("Job '%s': skipping delivery after fire claim ownership loss", job["id"])
@@ -2776,11 +2866,19 @@ def _save_compose_deliver(
                 # on the failure path) honor the job's failure_deliver override (NS-788).
                 for_failure=not d.success,
             )
+            if d.delivery_error is not None:
+                d.delivery_failed = True
+                d.delivery_error = str(d.delivery_error) or "DeliveryError"
     except Exception as de:
         if isinstance(de, _FireClaimLostDuringSideEffect):
             raise
-        d.delivery_error = str(de)
+        d.delivery_failed = True
+        d.delivery_error = str(de) or type(de).__name__
         logger.error("Delivery failed for job %s: %s", job["id"], de)
+    # A required alert that never resolved a target or failed to send must retry, whatever the
+    # agent answered.
+    if requires_delivery and (d.unresolved_origin or d.delivery_failed):
+        d.monitor_retry = True
 
 
 def _finish_interrupted_run(job: dict, execution_id: str, delivery_error: Optional[str]) -> None:
@@ -2803,6 +2901,57 @@ def _finish_interrupted_run(job: dict, execution_id: str, delivery_error: Option
         error="Interrupted by gateway shutdown before terminal completion.")
 
 
+def _commit_deferred_monitor_state(
+    d: _RunDelivery, execution_token: Optional[object], fence: _FireOwnership,
+    staged: Optional[list] = None,
+) -> bool:
+    """Commit a deferred monitor observation. Returns False if ownership was lost first.
+
+    Runs AFTER delivery: the hash advances only when the agent succeeded, no retry was
+    requested, and the notice actually left the process. Anything else leaves the previous
+    hash so the same event is re-offered next tick.
+    """
+    job = d.job
+    pending = job.pop("_monitor_pending_commit", None)
+    if staged:
+        pending = staged[-1]
+    if not (pending and d.success and not d.monitor_retry
+            and not d.delivery_failed and not d.unresolved_origin):
+        logger.info(
+            "Job '%s': deferred monitor commit skipped pending=%s success=%s retry=%s "
+            "delivery_failed=%s unresolved_origin=%s",
+            job["id"], bool(pending), d.success, d.monitor_retry, d.delivery_failed,
+            d.unresolved_origin)
+        return True
+
+    from cron.monitor import commit_monitor_state
+
+    with fence.side_effect_fence() as owns_commit:
+        # Ownership revalidation does file I/O (heartbeat_fire_claim); do it BEFORE taking
+        # _running_lock. Shutdown holds that lock while marking jobs interrupted, so blocking
+        # on the jobs-store fence underneath it would invert the lock order.
+        claim_lost = fence.lost()
+        with _running_lock:
+            # Consume any interrupt flag under the same lock that publishes the commit
+            # marker, so shutdown either wins outright or is excluded from this execution.
+            interrupted_at_commit = (
+                execution_token is not None and execution_token in _interrupted_job_ids
+            ) or job["id"] in _interrupted_job_ids
+            if interrupted_at_commit:
+                if execution_token is not None:
+                    _interrupted_job_ids.discard(execution_token)
+                _interrupted_job_ids.discard(job["id"])
+            if not owns_commit or claim_lost or interrupted_at_commit:
+                return False
+            if execution_token is not None:
+                _monitor_commit_in_progress.add(execution_token)
+        commit_monitor_state(job["id"], pending.get("new_hash"), pending.get("output") or "")
+        logger.info(
+            "Job '%s': deferred monitor commit persisted hash=%s",
+            job["id"], str(pending.get("new_hash") or "")[:12])
+    return True
+
+
 def _finish_completed_run(d: _RunDelivery, fire_owner: Optional[str], execution_id: str) -> bool:
     """mark_job_run (owner-fenced) + execution ledger row for a run that reached delivery."""
     job = d.job
@@ -2817,6 +2966,9 @@ def _finish_completed_run(d: _RunDelivery, fire_owner: Optional[str], execution_
         mark_kwargs["expected_fire_owner"] = fire_owner
     if d.blocked_config:
         mark_kwargs["status"] = "blocked_config"
+    elif d.monitor_retry:
+        # Not "ok": the observation was not acknowledged and will be re-offered.
+        mark_kwargs["status"] = "monitor_retry"
     marked = mark_job_run(job["id"], d.success, d.error, **mark_kwargs)
     if fire_owner is not None and not marked:
         finish_execution(
@@ -2953,6 +3105,9 @@ def _run_one_job_body(
         # hand the agent back instead, and we tear it down below once delivery is done. Defense-in-depth
         # alongside the interpreter-shutdown guard in _deliver_result.
         _deferred_agents: list = []
+        # Staged after-delivery monitor commit(s); see _commit_deferred_monitor_state. Held here
+        # (not only on the job dict) so the pending hash survives any later mutation of `job`.
+        _deferred_monitor_commits: list = []
 
         def _teardown_deferred() -> None:
             # run_job's finally still hands back the agent when it raises; tear it down here so a failed run
@@ -2968,6 +3123,10 @@ def _run_one_job_body(
             "defer_agent_teardown": _deferred_agents,
             "extra_prompt": extra_prompt,
             "execution_id": execution_id}
+        if job.get("monitor_commit_policy") == "after_delivery":
+            # Only deferred-commit monitors need the staging list; keeping it off the default
+            # call keeps the signature that every other caller (and test double) expects.
+            _run_kwargs["defer_monitor_commit"] = _deferred_monitor_commits
         if fire_claim_lost is not None:
             _run_kwargs["cancel_event"] = fire_claim_lost
         try:
@@ -3009,6 +3168,15 @@ def _run_one_job_body(
         if _consume_interrupted_flag(job["id"], execution_token):
             _finish_interrupted_run(job, execution_id, delivery_error)
             return True
+
+        # Post-delivery monitor commit (monitor_commit_policy='after_delivery'). Must run after
+        # the interrupted check and before mark_job_run: the hash may only advance for a run that
+        # both succeeded and delivered, and the recorded status must match what was committed.
+        if not _commit_deferred_monitor_state(
+            d, execution_token, fence, _deferred_monitor_commits
+        ):
+            d.success = False
+            d.error = "Fire claim ownership lost before monitor state commit."
 
         return _finish_completed_run(d, fire_owner, execution_id)
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -544,6 +544,7 @@ _JOB_ARG_FIELDS = (("name", "name"), ("deliver", "deliver"), ("failure_deliver",
                    ("repeat", "repeat"), ("script", "script"), ("workdir", "workdir"),
                    ("model", "model"), ("provider", "model_provider"),
                    ("monitor_script", "monitor_script"), ("monitor_url", "monitor_url"),
+                   ("monitor_commit_policy", "monitor_commit_policy"),
                    ("continuity", "continuity"), ("reasoning_effort", "reasoning_effort"))
 
 
@@ -556,6 +557,7 @@ _JOB_DETAIL_LINES = (
     ("script", "  Script: {}"),
     ("monitor_script", "  Monitor: {} (agent runs only on output change)"),
     ("monitor_url", "  Monitor: {} (agent runs only on output change)"),
+    ("monitor_commit_policy", "  Monitor commit: {}"),
     ("no_agent", "  Mode: no-agent (script stdout delivered directly)"),
     ("continuity", "  Continuity: on (each run sees the previous run's output)"),
     ("workdir", "  Workdir: {}"))

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -60,6 +60,11 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         help="Monitor mode: http(s) URL fetched with a bounded GET each tick "
             "instead of a script. Same hash-suppression semantics as "
             "--monitor-script.")
+    cron_create.add_argument("--monitor-commit-policy",
+        choices=("detection_time", "after_delivery"),
+        help="Monitor state commit boundary. detection_time (default) commits the new hash as "
+            "soon as the change is detected; after_delivery retries the same change until the "
+            "triggered agent run and its delivery succeed.")
     cron_create.add_argument("--workdir",
         help="Absolute path for the job to run from. Injects AGENTS.md / CLAUDE.md / .cursorrules from that directory and uses it as the cwd for terminal/file/code_exec tools. Omit to preserve old behaviour (no project context files).",
     )
@@ -123,6 +128,9 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
             "--monitor-script`). Pass empty string to clear.")
     cron_edit.add_argument("--monitor-url", dest="monitor_url",
         help=("Set/replace the monitor source URL. Pass empty string to clear."))
+    cron_edit.add_argument("--monitor-commit-policy",
+        choices=("detection_time", "after_delivery"),
+        help="Set the monitor state commit boundary.")
     cron_edit.add_argument("--workdir",
         help="Absolute path for the job to run from (injects AGENTS.md etc. and sets terminal cwd). Pass empty string to clear.",
     )

--- a/tests/cron/test_monitor_kind.py
+++ b/tests/cron/test_monitor_kind.py
@@ -22,8 +22,10 @@ enabler: #80774.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import sys
+import threading
 
 import pytest
 
@@ -77,7 +79,12 @@ def _install_agent_stubs(monkeypatch, observed: dict):
         def run_conversation(self, prompt, *_a, **_kw):
             observed["agent_runs"] += 1
             observed["prompts"].append(prompt)
-            return {"final_response": "agent done", "messages": []}
+            if observed.get("raise_error"):
+                raise RuntimeError(str(observed["raise_error"]))
+            return {
+                "final_response": observed.get("final_response", "agent done"),
+                "messages": [],
+            }
 
         def get_activity_summary(self):
             return {"seconds_since_activity": 0.0}
@@ -251,6 +258,99 @@ def test_hash_is_exact_bytes(hermes_env):
     assert hash_monitor_output("a\nb") != hash_monitor_output("a\nb ")
 
 
+def test_deferred_monitor_commit_propagates_snapshot_write_failure(
+    hermes_env, monkeypatch
+):
+    from pathlib import Path
+
+    from cron.jobs import create_job, get_job
+    from cron.monitor import commit_monitor_state
+
+    job = create_job(prompt="p", schedule="every 5m", deliver="local")
+
+    def fail_write(*_args, **_kwargs):
+        raise OSError("simulated snapshot write failure")
+
+    monkeypatch.setattr(Path, "write_text", fail_write)
+
+    with pytest.raises(OSError, match="snapshot write failure"):
+        commit_monitor_state(job["id"], "abc123", "state A")
+
+    assert get_job(job["id"]).get("monitor_state") is None
+
+
+def test_deferred_monitor_commit_rolls_back_snapshot_when_hash_update_fails(
+    hermes_env, monkeypatch
+):
+    import cron.jobs as jobs
+    from cron.jobs import create_job, get_job
+    from cron.monitor import _read_last_output, commit_monitor_state
+
+    job = create_job(prompt="p", schedule="every 5m", deliver="local")
+    commit_monitor_state(job["id"], "a" * 64, "state A")
+
+    def fail_update(*_args, **_kwargs):
+        raise OSError("simulated jobs write failure")
+
+    monkeypatch.setattr(jobs, "update_job", fail_update)
+    with pytest.raises(OSError, match="jobs write failure"):
+        commit_monitor_state(job["id"], "b" * 64, "state B")
+
+    assert _read_last_output(job["id"]) == "state A"
+    assert get_job(job["id"])["monitor_state"]["last_output_hash"] == "a" * 64
+
+
+def test_deferred_monitor_commit_fails_before_write_if_old_snapshot_is_unreadable(
+    hermes_env, monkeypatch
+):
+    from pathlib import Path
+
+    from cron.jobs import create_job, get_job
+    from cron.monitor import _read_last_output, commit_monitor_state
+
+    job = create_job(prompt="p", schedule="every 5m", deliver="local")
+    commit_monitor_state(job["id"], "a" * 64, "state A")
+    real_read_text = Path.read_text
+
+    def fail_snapshot_read(path, *args, **kwargs):
+        if path.name == "monitor_last_output.txt":
+            raise OSError("simulated snapshot read failure")
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fail_snapshot_read)
+    with pytest.raises(OSError, match="snapshot read failure"):
+        commit_monitor_state(job["id"], "b" * 64, "state B")
+    monkeypatch.setattr(Path, "read_text", real_read_text)
+
+    assert _read_last_output(job["id"]) == "state A"
+    assert get_job(job["id"])["monitor_state"]["last_output_hash"] == "a" * 64
+
+
+def test_after_delivery_policy_records_commit_failure_without_advancing_hash(
+    hermes_env, monkeypatch
+):
+    import cron.monitor as monitor
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+
+    def fail_commit(*_args, **_kwargs):
+        raise OSError("simulated commit failure")
+
+    monkeypatch.setattr(monitor, "commit_monitor_state", fail_commit)
+
+    assert sched.run_one_job(job) is False
+
+    stored = get_job(job["id"])
+    assert stored.get("monitor_state") is None
+    assert stored["last_status"] == "error"
+
+
 def test_unified_diff_is_capped(hermes_env):
     from cron.monitor import MAX_DIFF_CHARS, build_monitor_diff
 
@@ -291,6 +391,560 @@ def test_first_run_always_runs_agent(hermes_env, monkeypatch):
     assert observed["agent_runs"] == 1
     # First run: new output is injected as monitor context.
     assert "state A" in observed["prompts"][0]
+
+
+def test_after_delivery_policy_defers_monitor_hash_commit(hermes_env, monkeypatch):
+    from cron.jobs import get_job, update_job
+    from cron.scheduler import run_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+    pending_commits = []
+
+    success, doc, final, error = run_job(
+        job, defer_monitor_commit=pending_commits
+    )
+
+    assert success is True
+    assert error is None
+    assert observed["agent_runs"] == 1
+    assert get_job(job["id"]).get("monitor_state") is None
+    pending = job.get("_monitor_pending_commit")
+    assert pending and pending["new_hash"] and pending["output"] == "state A"
+    assert pending_commits == [pending]
+
+
+def test_after_delivery_policy_commits_after_successful_end_to_end_run(
+    hermes_env, monkeypatch
+):
+    from cron.jobs import get_job, update_job
+    from cron.scheduler import run_one_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+
+    assert run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored["last_status"] == "ok"
+    assert stored["monitor_state"]["last_output_hash"]
+
+
+def test_after_delivery_policy_silent_success_commits_without_delivery(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed = {"final_response": "[SILENT]"}
+    _install_agent_stubs(monkeypatch, observed)
+    deliveries = []
+    monkeypatch.setattr(
+        sched,
+        "_deliver_result",
+        lambda *_a, **_kw: deliveries.append(_a[1]) or None,
+    )
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored["last_status"] == "ok"
+    assert stored["monitor_state"]["last_output_hash"]
+    assert deliveries == []
+
+
+def test_required_delivery_event_rejects_silent_agent_response(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    body = (
+        "echo '{\"version\":4,\"events\":{\"event\":"
+        "{\"event_id\":\"health-1\",\"requires_delivery\":true}}}'\n"
+    )
+    job = _make_monitor_job(hermes_env, body)
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed = {"final_response": "[SILENT]"}
+    _install_agent_stubs(monkeypatch, observed)
+    deliveries = []
+    monkeypatch.setattr(
+        sched,
+        "_deliver_result",
+        lambda *_a, **_kw: deliveries.append(_a[1]) or None,
+    )
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored["last_status"] == "monitor_retry"
+    assert stored.get("monitor_state") is None
+    assert deliveries == []
+
+
+def test_required_delivery_event_rejects_local_only_delivery(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    body = (
+        "echo '{\"version\":4,\"events\":{\"event\":"
+        "{\"event_id\":\"health-1\",\"requires_delivery\":true}}}'\n"
+    )
+    job = _make_monitor_job(hermes_env, body)
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed = {"final_response": "health alert"}
+    _install_agent_stubs(monkeypatch, observed)
+    monkeypatch.setattr(sched, "_deliver_result", lambda *_a, **_kw: None)
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored["last_status"] == "monitor_retry"
+    assert stored.get("monitor_state") is None
+
+
+def test_after_delivery_policy_retry_marker_suppresses_delivery_and_commit(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed = {"final_response": "[MONITOR_RETRY]"}
+    _install_agent_stubs(monkeypatch, observed)
+    deliveries = []
+    monkeypatch.setattr(
+        sched,
+        "_deliver_result",
+        lambda *_a, **_kw: deliveries.append(_a[1]) or None,
+    )
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored["last_status"] == "monitor_retry"
+    assert stored.get("monitor_state") is None
+    assert deliveries == []
+
+
+def test_after_delivery_policy_retry_then_success_commits_and_suppresses_next_tick(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed = {"final_response": "[MONITOR_RETRY]"}
+    _install_agent_stubs(monkeypatch, observed)
+    deliveries = []
+    monkeypatch.setattr(
+        sched,
+        "_deliver_result",
+        lambda *_a, **_kw: deliveries.append(_a[1]) or None,
+    )
+
+    assert sched.run_one_job(job) is True
+    assert get_job(job["id"]).get("monitor_state") is None
+    assert observed["agent_runs"] == 1
+
+    observed["final_response"] = "verified report"
+    assert sched.run_one_job(get_job(job["id"])) is True
+    assert get_job(job["id"])["monitor_state"]["last_output_hash"]
+    assert observed["agent_runs"] == 2
+
+    assert sched.run_one_job(get_job(job["id"])) is True
+    assert observed["agent_runs"] == 2
+    assert deliveries == ["verified report"]
+
+
+def test_plain_cron_treats_monitor_retry_marker_as_normal_output(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import create_job, get_job
+
+    job = create_job(
+        prompt="ordinary job",
+        schedule="every 5m",
+        deliver="local",
+    )
+    observed = {"final_response": "[MONITOR_RETRY]"}
+    _install_agent_stubs(monkeypatch, observed)
+    deliveries = []
+    monkeypatch.setattr(
+        sched,
+        "_deliver_result",
+        lambda *_a, **_kw: deliveries.append(_a[1]) or None,
+    )
+
+    assert sched.run_one_job(job) is True
+
+    assert deliveries == ["[MONITOR_RETRY]"]
+    assert get_job(job["id"])["last_status"] == "ok"
+
+
+def test_default_eager_monitor_treats_retry_marker_as_normal_output(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    observed = {"final_response": "[MONITOR_RETRY]"}
+    _install_agent_stubs(monkeypatch, observed)
+    deliveries = []
+    monkeypatch.setattr(
+        sched,
+        "_deliver_result",
+        lambda *_a, **_kw: deliveries.append(_a[1]) or None,
+    )
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert deliveries == ["[MONITOR_RETRY]"]
+    assert stored["monitor_state"]["last_output_hash"]
+
+
+def test_after_delivery_policy_does_not_commit_on_delivery_failure(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+    monkeypatch.setattr(
+        sched,
+        "_deliver_result",
+        lambda *_a, **_kw: "simulated delivery failure",
+    )
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored.get("monitor_state") is None
+    assert stored["last_delivery_error"] == "simulated delivery failure"
+
+
+def test_after_delivery_policy_does_not_commit_on_empty_message_delivery_exception(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+
+    def fail_delivery(*_a, **_kw):
+        raise TimeoutError()
+
+    monkeypatch.setattr(sched, "_deliver_result", fail_delivery)
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored.get("monitor_state") is None
+    assert stored["last_delivery_error"] == "TimeoutError"
+
+
+def test_after_delivery_policy_does_not_commit_when_origin_is_unresolved(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(
+        job["id"],
+        {"monitor_commit_policy": "after_delivery", "deliver": "origin"},
+    )
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored.get("monitor_state") is None
+
+
+def test_after_delivery_policy_fences_monitor_commit_against_owner_loss(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(
+        job["id"],
+        {
+            "monitor_commit_policy": "after_delivery",
+            "fire_claim": {"by": "owner-a", "at": "2026-01-01T00:00:00+00:00"},
+        },
+    )
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+    fence_calls = []
+
+    @contextlib.contextmanager
+    def lose_owner_before_commit(_job_id, *, expected_owner):
+        fence_calls.append(expected_owner)
+        # Saving output and delivery still belong to owner-a. The claim is
+        # lost only at the deferred monitor-commit boundary.
+        yield len(fence_calls) <= 2
+
+    monkeypatch.setattr(sched, "fire_claim_fence", lose_owner_before_commit)
+
+    assert sched._run_one_job_body(
+        job,
+        fire_claim_lost=threading.Event(),
+        execution_token=object(),
+    ) is True
+
+    assert len(fence_calls) >= 3
+    assert get_job(job["id"]).get("monitor_state") is None
+
+
+def test_after_delivery_policy_real_fire_owner_commits_without_nested_fence(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(
+        job["id"],
+        {
+            "monitor_commit_policy": "after_delivery",
+            "fire_claim": {"by": "owner-a", "at": "2026-08-20T00:00:00+00:00"},
+        },
+    )
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+
+    assert sched._run_one_job_body(
+        job,
+        fire_claim_lost=threading.Event(),
+        execution_token=object(),
+    ) is True
+
+    stored = get_job(job["id"])
+    assert stored["last_status"] == "ok"
+    assert stored["monitor_state"]["last_output_hash"]
+
+
+def test_after_delivery_policy_rechecks_interrupt_inside_commit_fence(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(
+        job["id"],
+        {
+            "monitor_commit_policy": "after_delivery",
+            "fire_claim": {"by": "owner-a", "at": "2026-01-01T00:00:00+00:00"},
+        },
+    )
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+    cancellation = threading.Event()
+    fence_calls = []
+
+    @contextlib.contextmanager
+    def interrupt_at_commit(_job_id, *, expected_owner):
+        fence_calls.append(expected_owner)
+        if len(fence_calls) == 3:
+            cancellation.set()
+        yield True
+
+    monkeypatch.setattr(sched, "fire_claim_fence", interrupt_at_commit)
+
+    assert sched._run_one_job_body(
+        job,
+        fire_claim_lost=cancellation,
+        execution_token=object(),
+    ) is True
+
+    assert len(fence_calls) >= 3
+    assert get_job(job["id"]).get("monitor_state") is None
+
+
+def test_after_delivery_commit_serializes_against_shutdown_interrupt_flag(
+    hermes_env, monkeypatch
+):
+    import cron.monitor as monitor
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(
+        job["id"],
+        {
+            "monitor_commit_policy": "after_delivery",
+            "fire_claim": {"by": "owner-a", "at": "2026-01-01T00:00:00+00:00"},
+        },
+    )
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+    commit_entered = threading.Event()
+    allow_commit = threading.Event()
+    interrupt_mark_called = threading.Event()
+
+    def slow_commit(*_args, **_kwargs):
+        commit_entered.set()
+        assert allow_commit.wait(timeout=2)
+
+    def record_mark(_job_id, success, *_args, **_kwargs):
+        if success is False:
+            interrupt_mark_called.set()
+        return True
+
+    monkeypatch.setattr(monitor, "commit_monitor_state", slow_commit)
+    monkeypatch.setattr(sched, "mark_job_run", record_mark)
+
+    @contextlib.contextmanager
+    def in_memory_fire_fence(*_args, **_kwargs):
+        yield True
+
+    monkeypatch.setattr(sched, "fire_claim_fence", in_memory_fire_fence)
+
+    execution_token = object()
+    with sched._running_lock:
+        sched._running_fire_owners.setdefault(job["id"], {})[execution_token] = (
+            "owner-a",
+            hermes_env,
+        )
+
+    run_thread = threading.Thread(
+        target=sched._run_one_job_body,
+        kwargs={
+            "job": job,
+            "fire_claim_lost": threading.Event(),
+            "execution_token": execution_token,
+        },
+    )
+    run_thread.start()
+    assert commit_entered.wait(timeout=2)
+
+    interrupt_thread = threading.Thread(
+        target=sched.mark_running_jobs_interrupted,
+        args=("simulated shutdown",),
+    )
+    interrupt_thread.start()
+    interrupt_reached_terminal_mark_before_commit = interrupt_mark_called.wait(
+        timeout=0.2
+    )
+
+    allow_commit.set()
+    run_thread.join(timeout=3)
+    interrupt_thread.join(timeout=3)
+    with sched._running_lock:
+        sched._running_fire_owners.pop(job["id"], None)
+
+    assert not run_thread.is_alive()
+    assert not interrupt_thread.is_alive()
+    assert interrupt_reached_terminal_mark_before_commit is False
+
+
+def test_after_delivery_commit_stays_linearized_through_terminal_mark(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+    execution_token = object()
+    protected_at_mark = []
+
+    def record_mark(_job_id, success, *_args, **_kwargs):
+        if success:
+            protected_at_mark.append(
+                execution_token in sched._monitor_commit_in_progress
+            )
+        return True
+
+    monkeypatch.setattr(sched, "mark_job_run", record_mark)
+
+    assert sched._run_one_job_body(
+        job,
+        fire_claim_lost=threading.Event(),
+        execution_token=execution_token,
+    ) is True
+    sched._monitor_commit_in_progress.discard(execution_token)
+
+    assert protected_at_mark == [True]
+
+
+def test_after_delivery_policy_does_not_commit_on_agent_failure(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed = {"raise_error": "simulated agent failure"}
+    _install_agent_stubs(monkeypatch, observed)
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored.get("monitor_state") is None
+    assert stored["last_status"] == "error"
+
+
+def test_after_delivery_policy_does_not_commit_on_empty_agent_response(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed = {"final_response": ""}
+    _install_agent_stubs(monkeypatch, observed)
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored.get("monitor_state") is None
+    assert stored["last_status"] == "error"
 
 
 def test_unchanged_output_suppresses_agent_run(hermes_env, monkeypatch):

--- a/tests/cron/test_monitor_kind.py
+++ b/tests/cron/test_monitor_kind.py
@@ -135,6 +135,75 @@ def test_create_job_stores_monitor_script(hermes_env):
     assert reloaded.get("monitor_state") is None
 
 
+def test_create_job_persists_after_delivery_commit_policy(hermes_env):
+    from cron.jobs import create_job, get_job
+
+    job = create_job(
+        prompt="React",
+        schedule="every 5m",
+        monitor_script="mon.sh",
+        monitor_commit_policy="after_delivery",
+    )
+
+    assert job["monitor_commit_policy"] == "after_delivery"
+    assert get_job(job["id"])["monitor_commit_policy"] == "after_delivery"
+
+
+def test_update_job_sets_and_clears_monitor_commit_policy(hermes_env):
+    from cron.jobs import create_job, get_job, update_job
+
+    job = create_job(
+        prompt="React",
+        schedule="every 5m",
+        monitor_script="mon.sh",
+    )
+
+    updated = update_job(
+        job["id"], {"monitor_commit_policy": "after_delivery"}
+    )
+    assert updated["monitor_commit_policy"] == "after_delivery"
+    assert get_job(job["id"])["monitor_commit_policy"] == "after_delivery"
+
+    cleared = update_job(job["id"], {"monitor_commit_policy": ""})
+    assert cleared.get("monitor_commit_policy") is None
+
+
+def test_monitor_commit_policy_rejects_invalid_or_non_monitor_jobs(hermes_env):
+    from cron.jobs import create_job, update_job
+
+    with pytest.raises(ValueError, match="monitor_commit_policy must be one of"):
+        create_job(
+            prompt="React",
+            schedule="every 5m",
+            monitor_script="mon.sh",
+            monitor_commit_policy="eventually",
+        )
+
+    with pytest.raises(ValueError, match="requires monitor_script or monitor_url"):
+        create_job(
+            prompt="React",
+            schedule="every 5m",
+            monitor_commit_policy="after_delivery",
+        )
+
+    job = create_job(prompt="React", schedule="every 5m")
+    with pytest.raises(ValueError, match="requires monitor_script or monitor_url"):
+        update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+
+
+def test_update_job_rejects_clearing_monitor_with_after_delivery_policy(hermes_env):
+    from cron.jobs import create_job, update_job
+
+    job = create_job(
+        prompt="React",
+        schedule="every 5m",
+        monitor_script="mon.sh",
+        monitor_commit_policy="after_delivery",
+    )
+    with pytest.raises(ValueError, match="requires monitor_script or monitor_url"):
+        update_job(job["id"], {"monitor_script": ""})
+
+
 def test_create_job_monitor_script_and_url_mutually_exclusive(hermes_env):
     from cron.jobs import create_job
 
@@ -1046,6 +1115,44 @@ def test_monitor_script_failure_is_error_not_change(hermes_env, monkeypatch):
 # ---------------------------------------------------------------------------
 # cronjob tool: API-layer wiring
 # ---------------------------------------------------------------------------
+
+
+def test_cronjob_tool_create_and_update_monitor_commit_policy(hermes_env):
+    from cron.jobs import get_job
+    from tools.cronjob_tools import CRONJOB_SCHEMA, _cronjob_handler
+
+    policy_schema = CRONJOB_SCHEMA["parameters"]["properties"][
+        "monitor_commit_policy"
+    ]
+    assert policy_schema["enum"] == ["detection_time", "after_delivery"]
+
+    _write_script(hermes_env, "mon.sh", "echo hi\n")
+    created = json.loads(
+        _cronjob_handler(
+            {
+                "action": "create",
+                "prompt": "React",
+                "schedule": "every 5m",
+                "monitor": "mon.sh",
+                "monitor_commit_policy": "after_delivery",
+                "deliver": "local",
+            }
+        )
+    )
+    assert created["success"] is True
+    assert get_job(created["job_id"])["monitor_commit_policy"] == "after_delivery"
+
+    updated = json.loads(
+        _cronjob_handler(
+            {
+                "action": "update",
+                "job_id": created["job_id"],
+                "monitor_commit_policy": "detection_time",
+            }
+        )
+    )
+    assert updated["success"] is True
+    assert get_job(created["job_id"])["monitor_commit_policy"] == "detection_time"
 
 
 def test_cronjob_tool_create_with_monitor_script(hermes_env):

--- a/tests/cron/test_monitor_kind.py
+++ b/tests/cron/test_monitor_kind.py
@@ -81,6 +81,8 @@ def _install_agent_stubs(monkeypatch, observed: dict):
             observed["prompts"].append(prompt)
             if observed.get("raise_error"):
                 raise RuntimeError(str(observed["raise_error"]))
+            if "result" in observed:
+                return dict(observed["result"])
             return {
                 "final_response": observed.get("final_response", "agent done"),
                 "messages": [],
@@ -976,6 +978,99 @@ def test_after_delivery_commit_stays_linearized_through_terminal_mark(
     sched._monitor_commit_in_progress.discard(execution_token)
 
     assert protected_at_mark == [True]
+
+
+@pytest.mark.parametrize(
+    "agent_result",
+    [
+        {
+            "failed": True,
+            "completed": False,
+            "error": "HTTP 429",
+            "final_response": "",
+            "messages": [],
+        },
+        {
+            "completed": False,
+            "turn_exit_reason": "interrupted",
+            "final_response": "",
+            "messages": [],
+        },
+    ],
+    ids=("reported-failure", "interrupted-result"),
+)
+def test_after_delivery_retries_agent_reported_failure_results(
+    hermes_env, monkeypatch, agent_result
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+    from cron.monitor import _read_last_output
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    observed = {"result": agent_result}
+    _install_agent_stubs(monkeypatch, observed)
+
+    # A failure RESULT (not a raised exception) must leave the observation
+    # unacknowledged so the identical next tick runs the agent again.
+    assert sched.run_one_job(get_job(job["id"])) is True
+    failed = get_job(job["id"])
+    assert failed.get("monitor_state") is None
+    assert _read_last_output(job["id"]) == ""
+    assert failed["last_status"] == "error"
+    assert observed["agent_runs"] == 1
+
+    observed["result"] = {
+        "failed": False,
+        "completed": True,
+        "final_response": "handled",
+        "messages": [],
+    }
+    assert sched.run_one_job(get_job(job["id"])) is True
+    committed = get_job(job["id"])
+    assert committed["monitor_state"]["last_output_hash"]
+    assert _read_last_output(job["id"]) == "state A"
+    assert observed["agent_runs"] == 2
+
+    # Once the retry succeeds, the next identical observation suppresses.
+    assert sched.run_one_job(get_job(job["id"])) is True
+    assert observed["agent_runs"] == 2
+
+
+def test_after_delivery_failed_change_preserves_prior_hash_and_snapshot(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+    from cron.monitor import _read_last_output
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+
+    assert sched.run_one_job(get_job(job["id"])) is True
+    committed_a = get_job(job["id"])
+    hash_a = committed_a["monitor_state"]["last_output_hash"]
+    assert _read_last_output(job["id"]) == "state A"
+
+    _write_script(hermes_env, "mon.sh", "echo 'state B'\n")
+    observed["raise_error"] = "HTTP 429"
+    assert sched.run_one_job(get_job(job["id"])) is True
+    failed_b = get_job(job["id"])
+    assert failed_b["monitor_state"]["last_output_hash"] == hash_a
+    assert _read_last_output(job["id"]) == "state A"
+    assert observed["agent_runs"] == 2
+
+    observed.pop("raise_error")
+    assert sched.run_one_job(get_job(job["id"])) is True
+    committed_b = get_job(job["id"])
+    assert committed_b["monitor_state"]["last_output_hash"] != hash_a
+    assert _read_last_output(job["id"]) == "state B"
+    assert observed["agent_runs"] == 3
+
+    assert sched.run_one_job(get_job(job["id"])) is True
+    assert observed["agent_runs"] == 3
 
 
 def test_after_delivery_policy_does_not_commit_on_agent_failure(

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -380,6 +380,7 @@ def test_lost_fire_claim_stops_stale_delivery(monkeypatch):
         job,
         *,
         defer_agent_teardown=None,
+        defer_monitor_commit=None,
         extra_prompt=None,
         cancel_event=None,
         execution_id=None,

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -104,6 +104,40 @@ class TestCronCommandLifecycle:
         out = capsys.readouterr().out
         assert "Updated job" in out
 
+    def test_create_and_edit_monitor_commit_policy(self, tmp_cron_dir, capsys):
+        parser = argparse.ArgumentParser(prog="hermes")
+        subparsers = parser.add_subparsers(dest="command")
+        build_cron_parser(subparsers, cmd_cron=cron_command)
+
+        create_args = parser.parse_args(
+            [
+                "cron",
+                "create",
+                "every 5m",
+                "React",
+                "--monitor-url",
+                "https://example.com/status",
+                "--monitor-commit-policy",
+                "after_delivery",
+            ]
+        )
+        assert cron_command(create_args) == 0
+        job = list_jobs()[0]
+        assert job["monitor_commit_policy"] == "after_delivery"
+
+        edit_args = parser.parse_args(
+            [
+                "cron",
+                "edit",
+                job["id"],
+                "--monitor-commit-policy",
+                "detection_time",
+            ]
+        )
+        assert cron_command(edit_args) == 0
+        assert get_job(job["id"])["monitor_commit_policy"] == "detection_time"
+        assert "Updated job" in capsys.readouterr().out
+
     def test_create_with_multiple_skills(self, tmp_cron_dir, capsys):
         cron_command(
             Namespace(

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -41,6 +41,34 @@ def test_cron_edit_no_agent_tristate():
     assert parser.parse_args(["cron", "edit", "j"]).no_agent is None
 
 
+def test_cron_monitor_commit_policy_create_and_edit_options():
+    parser = _build()
+    created = parser.parse_args(
+        [
+            "cron",
+            "create",
+            "every 5m",
+            "React",
+            "--monitor-url",
+            "https://example.com/status",
+            "--monitor-commit-policy",
+            "after_delivery",
+        ]
+    )
+    assert created.monitor_commit_policy == "after_delivery"
+
+    edited = parser.parse_args(
+        [
+            "cron",
+            "edit",
+            "job-id",
+            "--monitor-commit-policy",
+            "detection_time",
+        ]
+    )
+    assert edited.monitor_commit_policy == "detection_time"
+
+
 def test_cron_accept_hooks_flag_on_run_and_tick():
     parser = _build()
     # --accept-hooks is suppressed-default; present only when passed.

--- a/tools/cronjob_job_args.py
+++ b/tools/cronjob_job_args.py
@@ -340,7 +340,7 @@ def _validate_context_from_refs(refs: List[Any]) -> Optional[str]:
 # Optional fields echoed by _format_job only when truthy (order = JSON key order).
 _FORMAT_JOB_OPTIONAL_KEYS = (
     "script", "reasoning_effort", "monitor_script", "monitor_url",
-    "monitor_state", "no_agent", "enabled_toolsets", "workdir")
+    "monitor_commit_policy", "monitor_state", "no_agent", "enabled_toolsets", "workdir")
 
 
 def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -572,6 +572,7 @@ def _action_create(a: Dict[str, Any]) -> str:
             no_agent=_no_agent, attach_to_session=a["attach_to_session"],
             monitor_script=_normalize_optional_job_value(a["monitor_script"]),
             monitor_url=_normalize_optional_job_value(a["monitor_url"]),
+            monitor_commit_policy=a["monitor_commit_policy"],
             # CLI-only lane: absent from CRONJOB_SCHEMA and the model dispatch (models don't pick models).
             reasoning_effort=a["reasoning_effort"],
             failure_deliver=_resolve_cron_context_deliver(_normalize_deliver_param(a["failure_deliver"])),
@@ -747,6 +748,9 @@ def _update_script_fields(job: Dict[str, Any], a: Dict[str, Any], updates: Dict[
     if (monitor_script is not None or monitor_url is not None) and (
         _pick(updates, job, "monitor_script") and _pick(updates, job, "monitor_url")):
         return("monitor_script and monitor_url are mutually exclusive — clear one before setting the other.")
+    if a["monitor_commit_policy"] is not None:
+        # update_job validates the value and drops it when no monitor source survives the merge.
+        updates["monitor_commit_policy"] = a["monitor_commit_policy"]
     return None
 
 
@@ -875,6 +879,7 @@ def cronjob(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    monitor_commit_policy: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     failure_deliver: Optional[Union[str, List[str]]] = None,
     task_id: str = None,
@@ -960,6 +965,11 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
                 "type": "string",
                 "description": "Optional change-detector that gates the agent: an http(s) URL (fetched each tick) or a script path (same rules as `script`, run each tick) — cheap, no LLM. Output identical to the previous tick skips the agent run entirely; changed output wakes the agent with a diff injected into the prompt. First tick always runs (baseline). Output must be deterministic (no timestamps) or every tick looks changed. Incompatible with no_agent. On update, '' clears."
             },
+            "monitor_commit_policy": {
+                "type": "string",
+                "enum": ["detection_time", "after_delivery"],
+                "description": "Optional commit boundary for monitor state. detection_time (default) advances the stored hash as soon as the change is detected. after_delivery keeps the prior hash until the triggered agent run AND its delivery succeed, so a transient failure retries the same change next tick instead of losing it. Requires a monitor."
+            },
             "no_agent": {
                 "type": "boolean",
                 "default": False,
@@ -1011,7 +1021,7 @@ def check_cronjob_requirements() -> bool:
 _HANDLER_FORWARDED_ARGS = (
     "job_id", "prompt", "schedule", "name", "repeat", "deliver", "failure_deliver", "skill", "skills", "reason",
     "script", "context_from", "continuity", "enabled_toolsets", "workdir", "no_agent", "attach_to_session",
-    "paused_reason")
+    "monitor_commit_policy", "paused_reason")
 
 
 def _cronjob_handler(args, **kw):


### PR DESCRIPTION
## What does this PR do?

Monitor jobs (`kind: monitor`) currently persist their state — the output hash and snapshot — at **detection time**, before the agent run and before platform delivery. If anything downstream fails (model error, provider outage, cancellation, or delivery failure), the observation is already marked "seen": on the next tick the output matches the committed hash and the monitor treats it as "no change". The alert is silently lost.

This PR adds an opt-in per-job policy:

```json
{
  "monitor_commit_policy": "after_delivery"
}
```

- The default remains `detection_time` (the field is absent), so existing jobs keep their current behavior.
- With `after_delivery`, the scheduler stages the hash/snapshot commit and persists it only after the triggered agent run and required delivery succeed.
- On run errors, delivery errors, unresolved origin targets, cancellation, or fire-claim ownership loss, the prior hash stays intact so the same changed observation fires again next tick.
- The exact marker `[MONITOR_RETRY]` suppresses delivery and leaves the prior hash intact when the agent determines the observation is not yet trustworthy.
- The deferred commit is linearized against the fire-claim ownership check and interrupt set using the existing `_side_effect_fence` discipline, so a stale worker cannot commit state after losing ownership.

### Why not just retry delivery?

Delivery retry alone does not cover failures before delivery: model/provider errors and cancellation can occur after detection-time state was committed but before any message exists. The robust boundary is to acknowledge the observation only after downstream handling succeeds.

## Related Issue

#91287

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Supported configuration paths

The policy is available without hand-editing `jobs.json`:

```bash
hermes cron create 'every 5m' 'React to the change' \
  --monitor-script monitor.py \
  --monitor-commit-policy after_delivery

hermes cron edit <job_id> \
  --monitor-commit-policy detection_time
```

The same field is exposed through:

- `cron.jobs.create_job()` / `update_job()`
- the model-facing `cronjob` tool schema and handler
- `hermes cron create` / `hermes cron edit`
- formatted `cronjob list` output and `hermes cron list`

Validation rejects unknown policies, policies on non-monitor jobs, and clearing the monitor source while an `after_delivery` policy remains active.

## Changes made

- `cron/monitor.py`: carry staged output/hash, atomic snapshot writes, and explicit deferred state commit with compensating snapshot rollback.
- `cron/scheduler.py`: stage monitor commits, evaluate retry/delivery gates, and commit under ownership/shutdown fencing only after successful downstream handling.
- `cron/jobs.py`: validate and persist `monitor_commit_policy` through supported create/update APIs while keeping absence as the backward-compatible default.
- `tools/cronjob_tools.py`: expose the policy in the model tool schema/handler and formatted job output.
- `hermes_cli/cron.py`, `hermes_cli/subcommands/cron.py`: create/edit flags plus list/status visibility.
- Tests cover commit deferral, retry markers, delivery failures, crash/ownership/shutdown races, backward compatibility, validation, model-tool round trips, and CLI round trips.

## Validation

- Focused monitor/core/tool/CLI/gateway tests: **77 passed**
- Broader cron/CLI/gateway regression set: **1078 passed, 10 skipped**
- Two `test_media_send_timeout` cases fail only under the broad shared-process run; that file passes **10/10 in isolation on both this branch and unmodified current `main`**, confirming pre-existing cross-test state pollution rather than a branch regression.
- Ruff: passed
- Python compile check: passed
- `git diff --check`: passed

## Platforms tested

- Linux x86_64 (Ubuntu 22.04, Python 3.12)
