### PR TITLE
fix(kanban): preserve worker requeue semantics

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1436,6 +1436,56 @@ def _flush_one_shot_session_store(cli) -> None:
         logger.debug("one-shot end_session failed", exc_info=True)
 
 
+_KANBAN_SIGTERM_EXIT_CODE = 143
+
+
+def _terminate_kanban_worker_on_signal(
+    cli,
+    *,
+    exit_fn=os._exit,
+    signal_module=None,
+    logging_shutdown=None,
+    streams=None,
+) -> None:
+    """Flush one-shot worker state and terminate with the SIGTERM sentinel.
+
+    ``os._exit`` is required because dispatcher workers can still have a
+    non-daemon tool thread alive after the main thread receives SIGTERM. The
+    injectable boundaries keep the production path directly behavior-testable
+    without reading this source file or terminating the test runner.
+    """
+    if signal_module is None:
+        import signal as signal_module
+    if logging_shutdown is None:
+        logging_shutdown = logging.shutdown
+    if streams is None:
+        streams = (sys.stdout, sys.stderr)
+
+    try:
+        if hasattr(signal_module, "SIGALRM"):
+            signal_module.signal(
+                signal_module.SIGALRM,
+                lambda *_: exit_fn(_KANBAN_SIGTERM_EXIT_CODE),
+            )
+            signal_module.alarm(5)
+    except Exception:
+        pass
+    try:
+        _flush_one_shot_session_store(cli)
+    except Exception:
+        pass
+    try:
+        logging_shutdown()
+    except Exception:
+        pass
+    for stream in streams:
+        try:
+            stream.flush()
+        except Exception:
+            pass
+    exit_fn(_KANBAN_SIGTERM_EXIT_CODE)
+
+
 def _finalize_single_query(cli) -> None:
     """Close one-shot CLI resources before releasing the active session lease."""
     try:
@@ -1463,7 +1513,7 @@ def _reset_terminal_input_modes_on_exit() -> None:
     (#36823). Called from ``_run_cleanup`` (atexit-registered + invoked on the
     normal / EOF / interrupt exit paths) this covers normal quit, Ctrl+C and
     SIGTERM/SIGHUP. ``kill -9`` is uncatchable, and the kanban worker's
-    ``os._exit(0)`` path bypasses ``atexit``; neither runs this — but both are
+    ``os._exit(143)`` path bypasses ``atexit``; neither runs this — but both are
     non-TTY / non-TUI, so there is nothing to reset there.
 
     Gated on ``_tui_input_modes_active`` so one-shot non-TUI CLI runs (which
@@ -21155,41 +21205,19 @@ def main(
         # unwinds the main thread; the worker thread keeps running, the
         # process gets reparented to init, and the dispatcher's _pid_alive
         # check returns True forever — task stuck in 'running' indefinitely.
-        # Skip the controlled-unwind dance and call os._exit(0) so the kernel
+        # Skip the controlled-unwind dance and call os._exit(143) so the kernel
         # reclaims the PID immediately and detect_crashed_workers can reclaim
-        # the stale claim on the next tick. Flush logging + stdout/stderr
+        # the stale claim on the next tick without mistaking termination for
+        # a clean protocol-violating exit. Flush logging + stdout/stderr
         # first so the final debug trace isn't lost; SIGALRM deadman guards
         # the flush against any rare blocking-I/O case (the reporter measured
         # flush in <1ms; the alarm is a failsafe, not the common path).
         if os.environ.get("HERMES_KANBAN_TASK"):
-            try:
-                import signal as _sig_mod
-                if hasattr(_sig_mod, "SIGALRM"):
-                    # Cancel any pre-existing alarm to avoid colliding with
-                    # caller-installed timers.
-                    _sig_mod.signal(_sig_mod.SIGALRM, lambda *_: os._exit(0))
-                    _sig_mod.alarm(5)
-            except Exception:
-                pass
-            # os._exit(0) skips atexit AND SessionDB's token-drain hook, so
+            # os._exit(143) skips atexit AND SessionDB's token-drain hook, so
             # flush + finalize the session store here or the worker's turn
             # (and its usage deltas) never become durable (#88583 / #50881
             # class). Best-effort under the SIGALRM deadman above.
-            try:
-                _flush_one_shot_session_store(cli)
-            except Exception:
-                pass
-            try:
-                import logging as _lg
-                _lg.shutdown()
-            except Exception:
-                pass
-            for _stream in (sys.stdout, sys.stderr):
-                try:
-                    _stream.flush()
-                except Exception:
-                    pass
-            os._exit(0)
+            _terminate_kanban_worker_on_signal(cli)
         raise KeyboardInterrupt()
     try:
         import signal as _signal
@@ -21397,14 +21425,14 @@ def main(
                         _exit_code = 0
                         if isinstance(result, dict) and result.get("failed"):
                             _exit_code = 1
-                            if os.environ.get("HERMES_KANBAN_TASK") and result.get(
-                                "failure_reason"
-                            ) in ("rate_limit", "billing"):
+                            if os.environ.get("HERMES_KANBAN_TASK"):
                                 try:
                                     from hermes_cli.kanban_db import (
                                         KANBAN_RATE_LIMIT_EXIT_CODE as _RL_CODE,
+                                        KANBAN_TRANSIENT_FAILURE_REASONS as _TRANSIENT_REASONS,
                                     )
-                                    _exit_code = _RL_CODE
+                                    if result.get("failure_reason") in _TRANSIENT_REASONS:
+                                        _exit_code = _RL_CODE
                                 except Exception:
                                     _exit_code = 1
                         sys.exit(_exit_code)

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -20,9 +20,28 @@ from typing import Any, Callable, Optional
 
 from agent.i18n import t
 
+_KANBAN_BOARD_ROTATION = 0
+
 # Match the logger run.py uses (logging.getLogger(__name__) where __name__ ==
 # "gateway.run") so extracted log records keep their original logger name.
 logger = logging.getLogger("gateway.run")
+
+
+def _rotate_boards_for_dispatch(boards: list[dict]) -> list[dict]:
+    """Rotate stable board order so the shared host cap is distributed."""
+    if len(boards) <= 1:
+        return boards
+    global _KANBAN_BOARD_ROTATION
+    _KANBAN_BOARD_ROTATION = (_KANBAN_BOARD_ROTATION + 1) % len(boards)
+    offset = _KANBAN_BOARD_ROTATION
+    return boards[offset:] + boards[:offset]
+
+
+def _dispatch_skip_counts(result: object) -> tuple[int, int]:
+    """Return nonspawnable and unassigned skip counts for tick telemetry."""
+    nonspawnable = getattr(result, "skipped_nonspawnable", None) or []
+    unassigned = getattr(result, "skipped_unassigned", None) or []
+    return len(nonspawnable), len(unassigned)
 
 
 def _resolve_auto_decompose_settings(
@@ -1530,6 +1549,7 @@ class GatewayKanbanWatchersMixin:
                 boards = _kb.list_boards(include_archived=False)
             except Exception:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
+            boards = _rotate_boards_for_dispatch(boards)
             out: list[tuple[str, "Optional[object]"]] = []
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
@@ -1708,20 +1728,32 @@ class GatewayKanbanWatchersMixin:
                     results = await asyncio.to_thread(_tick_once)
                     any_spawned = False
                     for slug, res in (results or []):
-                        if res is not None and getattr(res, "spawned", None):
-                            any_spawned = True
+                        if res is not None:
+                            skipped_nonspawnable, skipped_unassigned = (
+                                _dispatch_skip_counts(res)
+                            )
+                            spawned = getattr(res, "spawned", None) or []
+                            if spawned:
+                                any_spawned = True
+                            if not (spawned or skipped_nonspawnable or skipped_unassigned):
+                                continue
                             # Quiet by default — only log when something actually
-                            # happened, so an idle gateway stays silent.
+                            # happened or a task was deliberately skipped, so an
+                            # entirely idle gateway stays silent while skip
+                            # telemetry remains visible.
                             logger.info(
                                 "kanban dispatcher [%s]: spawned=%d reclaimed=%d "
-                                "crashed=%d timed_out=%d promoted=%d auto_blocked=%d",
+                                "crashed=%d timed_out=%d promoted=%d auto_blocked=%d "
+                                "skipped_nonspawnable=%d skipped_unassigned=%d",
                                 slug,
-                                len(res.spawned),
+                                len(spawned),
                                 res.reclaimed,
                                 len(res.crashed) if hasattr(res.crashed, "__len__") else 0,
                                 len(res.timed_out) if hasattr(res.timed_out, "__len__") else 0,
                                 res.promoted,
                                 len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
+                                skipped_nonspawnable,
+                                skipped_unassigned,
                             )
                     # Health telemetry (aggregate across boards)
                     ready_pending = await asyncio.to_thread(_ready_nonempty)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -429,6 +429,18 @@ DEFAULT_CRASH_GRACE_SECONDS = 30
 # 0/1/2 codes the worker uses for success / generic failure / usage error.
 KANBAN_RATE_LIMIT_EXIT_CODE = 75
 
+# Exit code used by dispatcher workers when their SIGTERM handler must bypass
+# Python's normal unwind path. The handler has to use ``os._exit`` to avoid
+# leaving non-daemon tool threads alive, which otherwise erases the fact that
+# the process was terminated. 143 is the conventional 128 + SIGTERM sentinel.
+KANBAN_SIGTERM_EXIT_CODE = 143
+
+# Backend/infrastructure failures that should use EX_TEMPFAIL rather than burn
+# a task's failure budget. Unknown and format errors are intentionally absent.
+KANBAN_TRANSIENT_FAILURE_REASONS = frozenset(
+    {"rate_limit", "billing", "timeout", "overloaded"}
+)
+
 
 def _resolve_crash_grace_seconds() -> int:
     """Return the crash-detection grace period in seconds.
@@ -8134,6 +8146,9 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
       provider rate-limited / exhausted quota, NOT because the task failed.
       ``detect_crashed_workers`` releases the task back to ``ready`` without
       counting a failure, so a long quota window can't trip the breaker.
+    * ``"terminated"`` — ``WIFEXITED`` with status
+      ``KANBAN_SIGTERM_EXIT_CODE``. The worker was terminated externally and
+      is requeued without counting a failure or a protocol violation.
     * ``"nonzero_exit"`` — ``WIFEXITED`` with non-zero status. Real error.
     * ``"signaled"`` — ``WIFSIGNALED`` (OOM killer, SIGKILL, etc). Real crash.
     * ``"unknown"`` — pid was not in the reap registry (either reaped by
@@ -8155,6 +8170,8 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
                 return ("clean_exit", 0)
             if code == KANBAN_RATE_LIMIT_EXIT_CODE:
                 return ("rate_limited", code)
+            if code == KANBAN_SIGTERM_EXIT_CODE:
+                return ("terminated", code)
             return ("nonzero_exit", code)
         if os.WIFSIGNALED(raw):
             return ("signaled", os.WTERMSIG(raw))
@@ -8876,9 +8893,14 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     ``check_respawn_guard`` defers their respawn until the window clears.
     The ids are returned via the ``_last_rate_limited`` function attribute
     (the public return stays the crashed-only ``list[str]``).
+
+    A worker that exits with ``KANBAN_SIGTERM_EXIT_CODE`` is likewise
+    requeued without failure accounting. It records a ``terminated`` event
+    and a ``reclaimed`` run outcome rather than a crash or protocol violation.
     """
     crashed: list[str] = []
     rate_limited: list[str] = []
+    terminated: list[str] = []
     # Per-crash details collected inside the main txn, used after it
     # closes to run ``_record_task_failure`` (which needs its own
     # write_txn so can't nest). ``protocol_violation`` flags the
@@ -8916,6 +8938,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             pid = int(row["worker_pid"])
             kind, code = _classify_worker_exit(pid)
             rate_limited_exit = False
+            terminated_exit = False
             if kind == "clean_exit":
                 # Worker subprocess returned 0 but its task is still
                 # ``running`` in the DB — it exited without calling
@@ -8963,6 +8986,21 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     "claimer": row["claim_lock"],
                     "exit_code": code,
                 }
+            elif kind == "terminated":
+                # SIGTERM is an external lifecycle event, not evidence that
+                # either the task or its terminal-kanban contract failed.
+                protocol_violation = False
+                terminated_exit = True
+                error_text = (
+                    f"pid {pid} exited on SIGTERM (termination, not a task "
+                    "failure) — requeued"
+                )
+                event_kind = "terminated"
+                event_payload = {
+                    "pid": pid,
+                    "claimer": row["claim_lock"],
+                    "exit_code": code,
+                }
             else:
                 protocol_violation = False
                 if kind == "nonzero_exit":
@@ -8990,7 +9028,12 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 # Rate-limited requeues are a clean release, not a crash —
                 # record the run outcome as ``rate_limited`` so the board
                 # history doesn't show a phantom crash for a quota wall.
-                _run_outcome = "rate_limited" if rate_limited_exit else "crashed"
+                if rate_limited_exit:
+                    _run_outcome = "rate_limited"
+                elif terminated_exit:
+                    _run_outcome = "reclaimed"
+                else:
+                    _run_outcome = "crashed"
                 run_id = _end_run(
                     conn, row["id"],
                     outcome=_run_outcome, status=_run_outcome,
@@ -9023,6 +9066,8 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                         (error_text[:500], row["id"]),
                     )
                     rate_limited.append(row["id"])
+                elif terminated_exit:
+                    terminated.append(row["id"])
                 else:
                     if protocol_violation:
                         # Stamp the failure error now: a below-budget
@@ -9132,6 +9177,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # Same side-channel for rate-limited requeues — these did NOT count a
     # failure and are NOT crashes, so they stay out of the ``crashed`` return.
     detect_crashed_workers._last_rate_limited = rate_limited  # type: ignore[attr-defined]
+    detect_crashed_workers._last_terminated = terminated  # type: ignore[attr-defined]
     # Worker-lifecycle observer (RFC #58548): exit events are tick-derived
     # from this reclaim pass — fired only now, after the main reclaim txn
     # AND the breaker accounting above have committed, so subscribers always
@@ -10876,14 +10922,12 @@ def _default_spawn(
     cmd.extend([
         "chat",
         "-q", prompt,
+        # Every dispatcher worker must use fully quiet single-query mode so
+        # cli.py returns the explicit 0/1/75/143 worker-exit contract. This is
+        # not goal-mode-specific: a non-goal worker also has to complete or
+        # block its card before a clean exit is considered terminal.
+        "-Q",
     ])
-    if task.goal_mode:
-        # Goal-mode workers must take the fully-quiet single-query path:
-        # the kanban goal-loop hook (_run_kanban_goal_loop_q) only runs in
-        # cli.py's quiet branch. Without -Q the worker gets exactly one
-        # turn, prints text, exits rc=0, and the dispatcher records a
-        # protocol violation (incident 2026-06-09 t_d9cbe312).
-        cmd.append("-Q")
     # Redirect output to a per-task log under <board-root>/logs/.
     # Anchored at the board root (not the shared kanban root), so
     # `hermes kanban log` on a specific board reads its own file and

--- a/tests/gateway/test_kanban_dispatch_observability.py
+++ b/tests/gateway/test_kanban_dispatch_observability.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from gateway import kanban_watchers
+
+
+def test_board_rotation_gives_every_board_the_first_slot(monkeypatch):
+    monkeypatch.setattr(kanban_watchers, "_KANBAN_BOARD_ROTATION", 0)
+    boards = [{"slug": slug} for slug in ("default", "alpha", "beta")]
+
+    first_slots = [
+        kanban_watchers._rotate_boards_for_dispatch(boards)[0]["slug"]
+        for _ in range(len(boards))
+    ]
+
+    assert set(first_slots) == {"default", "alpha", "beta"}
+    assert boards == [
+        {"slug": "default"}, {"slug": "alpha"}, {"slug": "beta"},
+    ]
+
+
+def test_dispatch_skip_counts_are_visible():
+    result = SimpleNamespace(
+        skipped_nonspawnable=["a", "b"],
+        skipped_unassigned=["c"],
+    )
+
+    assert kanban_watchers._dispatch_skip_counts(result) == (2, 1)
+    assert kanban_watchers._dispatch_skip_counts(SimpleNamespace()) == (0, 0)

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -736,6 +736,7 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
     assert cmd.index("--accept-hooks") < cmd.index("chat"), (
         f"--accept-hooks must come before 'chat' in argv: {cmd}"
     )
+    assert "-Q" in cmd, f"every kanban worker must use the exit contract: {cmd}"
     # Assignee + task env are still present
     assert "some-profile" in cmd
     env = captured["env"]
@@ -1193,7 +1194,6 @@ def test_complete_can_retry_after_phantom_rejection(kanban_home):
 
 
 
-
 # ---------------------------------------------------------------------------
 # Recovery helpers (reclaim + reassign)
 # ---------------------------------------------------------------------------
@@ -1406,5 +1406,4 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         assert events == [], "historical events must not replay to a new sub"
     finally:
         conn.close()
-
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -326,6 +326,77 @@ def test_rate_limit_exit_requeues_without_counting_failure(
         assert "crashed" not in outcomes
 
 
+def test_sigterm_exit_requeues_without_counting_failure(
+    kanban_home, monkeypatch,
+):
+    """The SIGTERM sentinel is a reclaimed run, not a crash or violation."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="terminated", assignee="a")
+        kb.claim_task(conn, tid, claimer=f"{host}:worker")
+        pid = 71000
+        conn.execute("UPDATE tasks SET worker_pid=? WHERE id=?", (pid, tid))
+        conn.commit()
+        _kb._record_worker_exit(
+            pid, _exited_status(_kb.KANBAN_SIGTERM_EXIT_CODE)
+        )
+
+        crashed = kb.detect_crashed_workers(conn)
+        assert tid not in crashed
+        assert tid in getattr(_kb.detect_crashed_workers, "_last_terminated", [])
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 0
+        assert not task.last_failure_error
+
+        events = kb.list_events(conn, tid)
+        terminated = [event for event in events if event.kind == "terminated"]
+        assert len(terminated) == 1
+        assert terminated[0].payload["exit_code"] == _kb.KANBAN_SIGTERM_EXIT_CODE
+        outcomes = [
+            row["outcome"] for row in conn.execute(
+                "SELECT outcome FROM task_runs WHERE task_id=?", (tid,),
+            ).fetchall()
+        ]
+        assert "reclaimed" in outcomes
+        assert "crashed" not in outcomes
+
+
+def test_transient_failure_reasons_are_bounded():
+    import hermes_cli.kanban_db as _kb
+
+    assert _kb.KANBAN_TRANSIENT_FAILURE_REASONS == {
+        "rate_limit", "billing", "timeout", "overloaded",
+    }
+    assert "unknown" not in _kb.KANBAN_TRANSIENT_FAILURE_REASONS
+    assert "format_error" not in _kb.KANBAN_TRANSIENT_FAILURE_REASONS
+
+
+def test_worker_exit_contract_classifies_zero_one_tempfail_and_sigterm():
+    import hermes_cli.kanban_db as _kb
+
+    expected = {
+        0: ("clean_exit", 0),
+        1: ("nonzero_exit", 1),
+        _kb.KANBAN_RATE_LIMIT_EXIT_CODE: (
+            "rate_limited", _kb.KANBAN_RATE_LIMIT_EXIT_CODE,
+        ),
+        _kb.KANBAN_SIGTERM_EXIT_CODE: (
+            "terminated", _kb.KANBAN_SIGTERM_EXIT_CODE,
+        ),
+    }
+    for index, (exit_code, classification) in enumerate(expected.items()):
+        pid = 72000 + index
+        _kb._record_worker_exit(pid, _exited_status(exit_code))
+        assert _kb._classify_worker_exit(pid) == classification
+
+
 
 
 def test_respawn_guard_defers_rate_limited_within_cooldown(

--- a/tests/hermes_cli/test_signal_handler_kanban_worker.py
+++ b/tests/hermes_cli/test_signal_handler_kanban_worker.py
@@ -11,9 +11,9 @@ dispatcher's ``_pid_alive`` check returns True forever, and the task stays
 ``running`` indefinitely.
 
 The fix: when the process is a dispatcher-spawned worker (``HERMES_KANBAN_TASK``
-env var set), flush logging + stdout/stderr and call ``os._exit(0)`` instead.
+env var set), flush logging + stdout/stderr and call ``os._exit(143)`` instead.
 The kernel reclaims the PID immediately, and ``detect_crashed_workers``
-reclaims the stale claim on the next dispatcher tick.
+classifies it as a termination and reclaims the stale claim on the next tick.
 
 These tests use a synthetic Python script that mirrors the cli.py signal
 handler shape so we can exercise the exit-path contract without booting the
@@ -27,6 +27,7 @@ import subprocess
 import sys
 import textwrap
 import time
+from types import SimpleNamespace
 
 import pytest
 
@@ -59,13 +60,13 @@ def _synthetic_worker_script() -> str:
             if os.environ.get("HERMES_KANBAN_TASK"):
                 try:
                     if hasattr(signal, "SIGALRM"):
-                        signal.signal(signal.SIGALRM, lambda *_: os._exit(0))
+                        signal.signal(signal.SIGALRM, lambda *_: os._exit(143))
                         signal.alarm(2)
                 except Exception:
                     pass
                 sys.stdout.flush()
                 sys.stderr.flush()
-                os._exit(0)
+                os._exit(143)
             raise KeyboardInterrupt()
 
         signal.signal(signal.SIGTERM, handler)
@@ -166,13 +167,14 @@ def test_sigterm_with_kanban_task_env_terminates_quickly():
         t0 = time.time()
         os.kill(proc.pid, signal.SIGTERM)
 
-        # Should die in <2s. The handler sleeps ~50ms, then os._exit(0)
+        # Should die in <2s. The handler sleeps ~50ms, then os._exit(143)
         # is immediate. Give generous headroom for slow CI runners.
         deadline = t0 + 2.0
         while time.time() < deadline:
             if not _is_alive_like_dispatcher(proc.pid):
                 elapsed = time.time() - t0
                 assert elapsed < 2.0
+                assert proc.wait(timeout=2) == 143
                 return
             time.sleep(0.02)
         pytest.fail(
@@ -181,6 +183,53 @@ def test_sigterm_with_kanban_task_env_terminates_quickly():
         )
     finally:
         _cleanup(proc)
+
+
+def test_real_handler_uses_termination_sentinel():
+    """Exercise the production termination helper without killing pytest."""
+    import cli as cli_module
+
+    events = []
+
+    class FakeSignal:
+        SIGALRM = 14
+
+        def signal(self, signum, handler):
+            events.append(("signal", signum))
+            self.handler = handler
+
+        def alarm(self, seconds):
+            events.append(("alarm", seconds))
+
+    fake_signal = FakeSignal()
+    streams = (
+        SimpleNamespace(flush=lambda: events.append(("flush", "stdout"))),
+        SimpleNamespace(flush=lambda: events.append(("flush", "stderr"))),
+    )
+
+    def exit_fn(code):
+        events.append(("exit", code))
+        raise SystemExit(code)
+
+    with pytest.raises(SystemExit) as exc:
+        cli_module._terminate_kanban_worker_on_signal(
+            SimpleNamespace(),
+            exit_fn=exit_fn,
+            signal_module=fake_signal,
+            logging_shutdown=lambda: events.append(("logging", "shutdown")),
+            streams=streams,
+        )
+
+    assert exc.value.code == 143
+    assert events[-1] == ("exit", 143)
+    assert ("alarm", 5) in events
+    assert ("logging", "shutdown") in events
+    assert ("flush", "stdout") in events
+    assert ("flush", "stderr") in events
+
+    with pytest.raises(SystemExit) as alarm_exc:
+        fake_signal.handler(fake_signal.SIGALRM, None)
+    assert alarm_exc.value.code == 143
 
 
 @pytest.mark.skipif(
@@ -214,5 +263,3 @@ def test_sigterm_without_kanban_task_env_uses_keyboard_interrupt_path():
             pass
     finally:
         _cleanup(proc)
-
-


### PR DESCRIPTION
## Summary

- run every dispatcher worker in fully quiet single-query mode so the worker exit contract applies consistently
- classify transient backend exits as 75 and SIGTERM shutdown as 143 without burning the task failure budget or creating a protocol violation
- preserve the existing one-shot session flush before the immediate termination exit
- rotate board dispatch order and expose skipped nonspawnable and unassigned counts

## Verification

- 87 tests passed with file retries disabled across the affected Kanban files and the declared ACP environment lane; 2 host-specific tests skipped on macOS
- Ruff passed for every changed Python file
- Python byte-compilation, diff check, and redacted Gitleaks scan passed
- branch is based on upstream main 533886c8b8eb67ff8b389b7f48e7d5e5d9c575b9

Related downstream durability tracking: https://github.com/lightcloud00/claudecode-workspace/issues/1247

This PR does not switch or restart any installed Hermes release.
