### PR TITLE
feat(desktop): preview session density in live sidebar

### DIFF
--- a/apps/desktop/src/app/overlays/peek-scope.test.ts
+++ b/apps/desktop/src/app/overlays/peek-scope.test.ts
@@ -1,19 +1,19 @@
 // @vitest-environment jsdom
 /**
  * The peek is scoped with :has() so only the settings overlay that owns the
- * translucency row pays for an opacity transition. jsdom implements :has() in
+ * Appearance preview pays for an opacity transition. jsdom implements :has() in
  * matches(), so the scoping claim is checkable directly: the marked overlay
  * matches the peek selector and an unmarked one does not.
  */
 import { describe, expect, it } from 'vitest'
 
-const PEEK_SELECTOR = '[data-overlay-surface]:has([data-translucency-peek-scope])'
+const PEEK_SELECTOR = '[data-overlay-surface]:has([data-overlay-peek-scope])'
 
 describe('peek scoping', () => {
   it('matches only the overlay that armed the interaction', () => {
     document.body.innerHTML = `
       <div data-overlay-surface id="settings">
-        <div data-translucency-peek-scope></div>
+        <div data-overlay-peek-scope></div>
       </div>
       <div data-overlay-surface id="command-center">
         <div></div>

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -17,22 +17,18 @@ import { $backdrop, setBackdrop } from '@/store/backdrop'
 import { $composerPopoutGesturesEnabled, setComposerPopoutGesturesEnabled } from '@/store/composer-popout'
 import { $embedAllowed, $embedMode, clearEmbedAllowed, type EmbedMode, setEmbedMode } from '@/store/embed-consent'
 import { $introSplash, setIntroSplash } from '@/store/intro-splash'
+import { beginOverlayPeek, endOverlayPeek, pulseOverlayPeek, resetOverlayPeek } from '@/store/overlay-peek'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enabled'
 import { $reasoningCollapsedByDefault, setReasoningCollapsedByDefault } from '@/store/reasoning-disclosure'
-import { $sessionListDensity, type SessionListDensity, setSessionListDensity } from '@/store/session-list-density'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import {
   $translucency,
-  beginTranslucencyPeek,
-  endTranslucencyPeek,
   GLASS_IS_WINDOWS,
   GLASS_SCOPES,
   GLASS_SUPPORTED,
   glassMaterialForPicker,
   glassMaterialsFor,
-  pulseTranslucencyPeek,
-  resetTranslucencyPeek,
   setTranslucency,
   setTranslucencyFade,
   setTranslucencyMaterial,
@@ -52,6 +48,7 @@ import { $marketplaceInstalls, isUserTheme, removeUserTheme } from '@/themes/use
 import { MODE_OPTIONS } from './constants'
 import { PetSettings } from './pet-settings'
 import { ListRow, SectionHeading, SettingsContent, ToggleRow } from './primitives'
+import { SessionDensitySetting } from './session-density-setting'
 import { APPEARANCE_SETTING_IDS } from './settings-search'
 import { TerminalFontSetting } from './terminal-font-setting'
 import { useDeepLinkHighlight } from './use-deep-link-highlight'
@@ -297,19 +294,19 @@ function TranslucencySlider({ label, onChange, value }: TranslucencySliderProps)
         className="h-1 w-40 cursor-pointer appearance-none rounded-full bg-(--ui-stroke-tertiary)"
         max={TRANSLUCENCY_MAX}
         min={TRANSLUCENCY_MIN}
-        onBlur={endTranslucencyPeek}
+        onBlur={endOverlayPeek}
         onChange={event => {
           triggerHaptic('selection')
           onChange(Number(event.target.value))
         }}
         onKeyDown={event => {
           if (SLIDER_STEP_KEYS.has(event.key)) {
-            pulseTranslucencyPeek()
+            pulseOverlayPeek()
           }
         }}
-        onLostPointerCapture={endTranslucencyPeek}
-        onPointerDown={beginTranslucencyPeek}
-        onPointerUp={endTranslucencyPeek}
+        onLostPointerCapture={endOverlayPeek}
+        onPointerDown={beginOverlayPeek}
+        onPointerUp={endOverlayPeek}
         step={TRANSLUCENCY_STEP}
         style={{ accentColor: 'var(--dt-primary)' }}
         type="range"
@@ -344,7 +341,6 @@ export function AppearanceSettings() {
   const { themeName, mode, resolvedMode, availableThemes, setTheme, setMode } = useTheme()
   const toolViewMode = useStore($toolViewMode)
   const reasoningCollapsedByDefault = useStore($reasoningCollapsedByDefault)
-  const sessionListDensity = useStore($sessionListDensity)
   const zoomPercent = useStore($zoomPercent)
   const embedMode = useStore($embedMode)
   const embedAllowed = useStore($embedAllowed)
@@ -359,11 +355,10 @@ export function AppearanceSettings() {
   const activeProfileKey = normalizeProfileKey(useStore($activeGatewayProfile))
   const a = t.settings.appearance
 
-  // A pointer held on the intensity slider when this overlay closes (Escape
-  // mid-drag) never delivers its pointerup here, which would strand the peek
-  // counter above zero and ghost the NEXT settings overlay. Unmount drops
-  // every outstanding hold.
-  useEffect(() => resetTranslucencyPeek, [])
+  // A held preview control can unmount before pointerup/keyup (Escape or a
+  // route change), which would strand the shared counter and ghost the NEXT
+  // settings overlay. Unmount drops every outstanding hold and pulse.
+  useEffect(() => resetOverlayPeek, [])
 
   // Shared by the mode/frost/area pickers: apply the choice, then show it
   // through the overlay it just altered (a pulse, not a hold — see the peek
@@ -375,7 +370,7 @@ export function AppearanceSettings() {
       set(value)
 
       if (translucency.intensity > 0) {
-        pulseTranslucencyPeek()
+        pulseOverlayPeek()
       }
     }
 
@@ -416,12 +411,6 @@ export function AppearanceSettings() {
     { id: 'product', label: a.product },
     { id: 'technical', label: a.technical }
   ] as const
-
-  const sessionDensityOptions = [
-    { id: 'compact', label: a.sessionDensityCompact },
-    { id: 'comfortable', label: a.sessionDensityComfortable },
-    { id: 'detailed', label: a.sessionDensityDetailed }
-  ] as const satisfies readonly { id: SessionListDensity; label: string }[]
 
   const embedOptions = [
     { id: 'ask', label: a.embedsAsk },
@@ -568,20 +557,7 @@ export function AppearanceSettings() {
 
           <TerminalFontSetting />
 
-          <ListRow
-            action={
-              <SegmentedControl
-                onChange={id => {
-                  triggerHaptic('selection')
-                  setSessionListDensity(id)
-                }}
-                options={sessionDensityOptions}
-                value={sessionListDensity}
-              />
-            }
-            description={a.sessionDensityDesc}
-            title={a.sessionDensityTitle}
-          />
+          <SessionDensitySetting />
 
           {/* Linux has neither half of this setting (see TRANSLUCENCY_SUPPORTED),
               so the row is absent there rather than offering a dead lever. */}
@@ -593,7 +569,7 @@ export function AppearanceSettings() {
                   // Arms the peek for the overlay this row lives in — the
                   // ghosting rules in styles.css scope to it, so no other
                   // overlay pays for an opacity transition it never uses.
-                  data-translucency-peek-scope=""
+                  data-overlay-peek-scope=""
                 >
                   {GLASS_SUPPORTED && (
                     <SegmentedControl
@@ -620,7 +596,7 @@ export function AppearanceSettings() {
               }
               below={
                 glassMode ? (
-                  <div className="mt-3 flex flex-col gap-2.5" data-translucency-peek-scope="">
+                  <div className="mt-3 flex flex-col gap-2.5" data-overlay-peek-scope="">
                     <GlassRow label={a.translucencyTintTitle}>
                       <TranslucencySlider
                         label={a.translucencyTintTitle}

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { useDebounced } from '@/app/hooks/use-debounced'
 import { LanguageSwitcher } from '@/components/language-switcher'
@@ -17,7 +17,7 @@ import { $backdrop, setBackdrop } from '@/store/backdrop'
 import { $composerPopoutGesturesEnabled, setComposerPopoutGesturesEnabled } from '@/store/composer-popout'
 import { $embedAllowed, $embedMode, clearEmbedAllowed, type EmbedMode, setEmbedMode } from '@/store/embed-consent'
 import { $introSplash, setIntroSplash } from '@/store/intro-splash'
-import { beginOverlayPeek, endOverlayPeek, pulseOverlayPeek, resetOverlayPeek } from '@/store/overlay-peek'
+import { beginOverlayPeek, pulseOverlayPeek, resetOverlayPeek } from '@/store/overlay-peek'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enabled'
 import { $reasoningCollapsedByDefault, setReasoningCollapsedByDefault } from '@/store/reasoning-disclosure'
@@ -287,6 +287,19 @@ interface TranslucencySliderProps {
  * any residual hold.
  */
 function TranslucencySlider({ label, onChange, value }: TranslucencySliderProps) {
+  const releasePeek = useRef<null | (() => void)>(null)
+
+  const beginPeek = () => {
+    releasePeek.current ??= beginOverlayPeek()
+  }
+
+  const endPeek = () => {
+    releasePeek.current?.()
+    releasePeek.current = null
+  }
+
+  useEffect(() => endPeek, [])
+
   return (
     <>
       <input
@@ -294,7 +307,7 @@ function TranslucencySlider({ label, onChange, value }: TranslucencySliderProps)
         className="h-1 w-40 cursor-pointer appearance-none rounded-full bg-(--ui-stroke-tertiary)"
         max={TRANSLUCENCY_MAX}
         min={TRANSLUCENCY_MIN}
-        onBlur={endOverlayPeek}
+        onBlur={endPeek}
         onChange={event => {
           triggerHaptic('selection')
           onChange(Number(event.target.value))
@@ -304,9 +317,10 @@ function TranslucencySlider({ label, onChange, value }: TranslucencySliderProps)
             pulseOverlayPeek()
           }
         }}
-        onLostPointerCapture={endOverlayPeek}
-        onPointerDown={beginOverlayPeek}
-        onPointerUp={endOverlayPeek}
+        onLostPointerCapture={endPeek}
+        onPointerCancel={endPeek}
+        onPointerDown={beginPeek}
+        onPointerUp={endPeek}
         step={TRANSLUCENCY_STEP}
         style={{ accentColor: 'var(--dt-primary)' }}
         type="range"
@@ -356,8 +370,8 @@ export function AppearanceSettings() {
   const a = t.settings.appearance
 
   // A held preview control can unmount before pointerup/keyup (Escape or a
-  // route change), which would strand the shared counter and ghost the NEXT
-  // settings overlay. Unmount drops every outstanding hold and pulse.
+  // route change), which would strand an owner and ghost the NEXT settings
+  // overlay. Unmount drops every outstanding hold and pulse.
   useEffect(() => resetOverlayPeek, [])
 
   // Shared by the mode/frost/area pickers: apply the choice, then show it

--- a/apps/desktop/src/app/settings/session-density-setting.test.tsx
+++ b/apps/desktop/src/app/settings/session-density-setting.test.tsx
@@ -18,7 +18,7 @@ vi.mock('@/i18n', () => ({
           sessionDensityComfortable: 'Comfortable',
           sessionDensityDesc: 'Choose how much context appears beneath session titles in the sidebar.',
           sessionDensityDetailed: 'Detailed',
-          sessionDensityPreview: 'Hold to preview your current session list',
+          sessionDensityPreview: 'Preview current session list. Hold to keep open.',
           sessionDensityTitle: 'Session List Density'
         }
       }
@@ -62,7 +62,7 @@ describe('SessionDensitySetting', () => {
 
   it('keeps the overlay ghosted for the duration of a pointer hold', () => {
     render(<SessionDensitySetting />)
-    const preview = screen.getByRole('button', { name: 'Hold to preview your current session list' })
+    const preview = screen.getByRole('button', { name: 'Preview current session list. Hold to keep open.' })
 
     fireEvent.pointerDown(preview, { button: 0, pointerId: 1 })
     expect($overlayPeek.get()).toBe(1)
@@ -76,7 +76,7 @@ describe('SessionDensitySetting', () => {
 
   it('turns a quick pointer tap into a bounded preview', () => {
     render(<SessionDensitySetting />)
-    const preview = screen.getByRole('button', { name: 'Hold to preview your current session list' })
+    const preview = screen.getByRole('button', { name: 'Preview current session list. Hold to keep open.' })
 
     fireEvent.pointerDown(preview, { button: 0, pointerId: 1 })
     fireEvent.pointerUp(preview, { button: 0, pointerId: 1 })
@@ -90,7 +90,7 @@ describe('SessionDensitySetting', () => {
 
   it('supports a keyboard hold without counting key repeat twice', () => {
     render(<SessionDensitySetting />)
-    const preview = screen.getByRole('button', { name: 'Hold to preview your current session list' })
+    const preview = screen.getByRole('button', { name: 'Preview current session list. Hold to keep open.' })
 
     fireEvent.keyDown(preview, { key: ' ', repeat: false })
     fireEvent.keyDown(preview, { key: ' ', repeat: true })
@@ -110,7 +110,7 @@ describe('SessionDensitySetting', () => {
 
   it('turns a quick keyboard tap into one bounded preview', () => {
     render(<SessionDensitySetting />)
-    const preview = screen.getByRole('button', { name: 'Hold to preview your current session list' })
+    const preview = screen.getByRole('button', { name: 'Preview current session list. Hold to keep open.' })
 
     fireEvent.keyDown(preview, { key: 'Enter', repeat: false })
     fireEvent.click(preview, { detail: 0 })
@@ -126,7 +126,7 @@ describe('SessionDensitySetting', () => {
 
   it('cancels keyboard state on blur so the next hold still works', () => {
     render(<SessionDensitySetting />)
-    const preview = screen.getByRole('button', { name: 'Hold to preview your current session list' })
+    const preview = screen.getByRole('button', { name: 'Preview current session list. Hold to keep open.' })
 
     fireEvent.keyDown(preview, { key: ' ', repeat: false })
     expect(active()).toBe(true)
@@ -145,7 +145,7 @@ describe('SessionDensitySetting', () => {
 
   it('offers a bounded preview for click and assistive activation', () => {
     render(<SessionDensitySetting />)
-    const preview = screen.getByRole('button', { name: 'Hold to preview your current session list' })
+    const preview = screen.getByRole('button', { name: 'Preview current session list. Hold to keep open.' })
 
     fireEvent.click(preview)
     expect(active()).toBe(true)
@@ -156,7 +156,7 @@ describe('SessionDensitySetting', () => {
 
   it('fails closed when the setting unmounts during a hold', () => {
     const view = render(<SessionDensitySetting />)
-    const preview = screen.getByRole('button', { name: 'Hold to preview your current session list' })
+    const preview = screen.getByRole('button', { name: 'Preview current session list. Hold to keep open.' })
 
     fireEvent.pointerDown(preview, { button: 0, pointerId: 1 })
     expect(active()).toBe(true)

--- a/apps/desktop/src/app/settings/session-density-setting.test.tsx
+++ b/apps/desktop/src/app/settings/session-density-setting.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $overlayPeek, resetOverlayPeek } from '@/store/overlay-peek'
+import { $sessionListDensity } from '@/store/session-list-density'
+
+import { SessionDensitySetting } from './session-density-setting'
+
+const haptic = vi.fn()
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      settings: {
+        appearance: {
+          sessionDensityCompact: 'Compact',
+          sessionDensityComfortable: 'Comfortable',
+          sessionDensityDesc: 'Choose how much context appears beneath session titles in the sidebar.',
+          sessionDensityDetailed: 'Detailed',
+          sessionDensityPreview: 'Hold to preview your current session list',
+          sessionDensityTitle: 'Session List Density'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/lib/haptics', () => ({
+  triggerHaptic: (...args: unknown[]) => haptic(...args)
+}))
+
+const active = () => window.document.documentElement.hasAttribute('data-hermes-overlay-peek')
+
+describe('SessionDensitySetting', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    window.localStorage.clear()
+    $sessionListDensity.set('compact')
+    resetOverlayPeek()
+  })
+
+  afterEach(() => {
+    cleanup()
+    resetOverlayPeek()
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('applies a density choice and briefly reveals the real sidebar', () => {
+    render(<SessionDensitySetting />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Comfortable' }))
+
+    expect($sessionListDensity.get()).toBe('comfortable')
+    expect(haptic).toHaveBeenCalledWith('selection')
+    expect(active()).toBe(true)
+
+    act(() => vi.runAllTimers())
+    expect(active()).toBe(false)
+  })
+
+  it('keeps the overlay ghosted for the duration of a pointer hold', () => {
+    render(<SessionDensitySetting />)
+    const preview = screen.getByRole('button', { name: 'Hold to preview your current session list' })
+
+    fireEvent.pointerDown(preview, { button: 0, pointerId: 1 })
+    expect($overlayPeek.get()).toBe(1)
+    expect(active()).toBe(true)
+
+    act(() => vi.advanceTimersByTime(300))
+    fireEvent.pointerUp(preview, { button: 0, pointerId: 1 })
+    expect($overlayPeek.get()).toBe(0)
+    expect(active()).toBe(false)
+  })
+
+  it('turns a quick pointer tap into a bounded preview', () => {
+    render(<SessionDensitySetting />)
+    const preview = screen.getByRole('button', { name: 'Hold to preview your current session list' })
+
+    fireEvent.pointerDown(preview, { button: 0, pointerId: 1 })
+    fireEvent.pointerUp(preview, { button: 0, pointerId: 1 })
+
+    expect($overlayPeek.get()).toBe(1)
+    expect(active()).toBe(true)
+
+    act(() => vi.runAllTimers())
+    expect(active()).toBe(false)
+  })
+
+  it('supports a keyboard hold without counting key repeat twice', () => {
+    render(<SessionDensitySetting />)
+    const preview = screen.getByRole('button', { name: 'Hold to preview your current session list' })
+
+    fireEvent.keyDown(preview, { key: ' ', repeat: false })
+    fireEvent.keyDown(preview, { key: ' ', repeat: true })
+
+    expect($overlayPeek.get()).toBe(1)
+    expect(active()).toBe(true)
+
+    // Enter may emit click on keydown; Space may emit it after keyup. Neither
+    // may turn a long hold into a second timed pulse.
+    fireEvent.click(preview, { detail: 0 })
+    act(() => vi.advanceTimersByTime(300))
+    fireEvent.keyUp(preview, { key: ' ' })
+    fireEvent.click(preview, { detail: 0 })
+    expect($overlayPeek.get()).toBe(0)
+    expect(active()).toBe(false)
+  })
+
+  it('turns a quick keyboard tap into one bounded preview', () => {
+    render(<SessionDensitySetting />)
+    const preview = screen.getByRole('button', { name: 'Hold to preview your current session list' })
+
+    fireEvent.keyDown(preview, { key: 'Enter', repeat: false })
+    fireEvent.click(preview, { detail: 0 })
+    fireEvent.keyUp(preview, { key: 'Enter' })
+    fireEvent.click(preview, { detail: 0 })
+
+    expect($overlayPeek.get()).toBe(1)
+    expect(active()).toBe(true)
+
+    act(() => vi.runAllTimers())
+    expect(active()).toBe(false)
+  })
+
+  it('cancels keyboard state on blur so the next hold still works', () => {
+    render(<SessionDensitySetting />)
+    const preview = screen.getByRole('button', { name: 'Hold to preview your current session list' })
+
+    fireEvent.keyDown(preview, { key: ' ', repeat: false })
+    expect(active()).toBe(true)
+
+    fireEvent.blur(preview)
+    expect($overlayPeek.get()).toBe(0)
+    expect(active()).toBe(false)
+
+    fireEvent.keyDown(preview, { key: ' ', repeat: false })
+    act(() => vi.advanceTimersByTime(300))
+    fireEvent.keyUp(preview, { key: ' ' })
+
+    expect($overlayPeek.get()).toBe(0)
+    expect(active()).toBe(false)
+  })
+
+  it('offers a bounded preview for click and assistive activation', () => {
+    render(<SessionDensitySetting />)
+    const preview = screen.getByRole('button', { name: 'Hold to preview your current session list' })
+
+    fireEvent.click(preview)
+    expect(active()).toBe(true)
+
+    act(() => vi.runAllTimers())
+    expect(active()).toBe(false)
+  })
+
+  it('fails closed when the setting unmounts during a hold', () => {
+    const view = render(<SessionDensitySetting />)
+    const preview = screen.getByRole('button', { name: 'Hold to preview your current session list' })
+
+    fireEvent.pointerDown(preview, { button: 0, pointerId: 1 })
+    expect(active()).toBe(true)
+
+    view.unmount()
+    expect($overlayPeek.get()).toBe(0)
+    expect(active()).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/settings/session-density-setting.tsx
+++ b/apps/desktop/src/app/settings/session-density-setting.tsx
@@ -7,7 +7,7 @@ import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { Eye } from '@/lib/icons'
-import { beginOverlayPeek, endOverlayPeek, pulseOverlayPeek } from '@/store/overlay-peek'
+import { beginOverlayPeek, pulseOverlayPeek } from '@/store/overlay-peek'
 import { $sessionListDensity, type SessionListDensity, setSessionListDensity } from '@/store/session-list-density'
 
 import { ListRow } from './primitives'
@@ -20,9 +20,9 @@ export function SessionDensitySetting() {
   const { t } = useI18n()
   const copy = t.settings.appearance
   const density = useStore($sessionListDensity)
-  const holding = useRef(false)
   const keyboardStartedAt = useRef<null | number>(null)
   const pointerStartedAt = useRef<null | number>(null)
+  const releaseHold = useRef<null | (() => void)>(null)
   const suppressNextSemanticClick = useRef(false)
 
   const options = [
@@ -32,21 +32,16 @@ export function SessionDensitySetting() {
   ] as const satisfies readonly { id: SessionListDensity; label: string }[]
 
   const beginHold = () => {
-    if (holding.current) {
+    if (releaseHold.current) {
       return
     }
 
-    holding.current = true
-    beginOverlayPeek()
+    releaseHold.current = beginOverlayPeek()
   }
 
   const endHold = () => {
-    if (!holding.current) {
-      return
-    }
-
-    holding.current = false
-    endOverlayPeek()
+    releaseHold.current?.()
+    releaseHold.current = null
   }
 
   const cancelPointerHold = () => {

--- a/apps/desktop/src/app/settings/session-density-setting.tsx
+++ b/apps/desktop/src/app/settings/session-density-setting.tsx
@@ -1,0 +1,184 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useRef } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { SegmentedControl } from '@/components/ui/segmented-control'
+import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
+import { triggerHaptic } from '@/lib/haptics'
+import { Eye } from '@/lib/icons'
+import { beginOverlayPeek, endOverlayPeek, pulseOverlayPeek } from '@/store/overlay-peek'
+import { $sessionListDensity, type SessionListDensity, setSessionListDensity } from '@/store/session-list-density'
+
+import { ListRow } from './primitives'
+
+const DENSITY_PREVIEW_MS = 1_200
+const HOLD_KEYS = new Set([' ', 'Enter'])
+const POINTER_HOLD_MS = 250
+
+export function SessionDensitySetting() {
+  const { t } = useI18n()
+  const copy = t.settings.appearance
+  const density = useStore($sessionListDensity)
+  const holding = useRef(false)
+  const keyboardStartedAt = useRef<null | number>(null)
+  const pointerStartedAt = useRef<null | number>(null)
+  const suppressNextSemanticClick = useRef(false)
+
+  const options = [
+    { id: 'compact', label: copy.sessionDensityCompact },
+    { id: 'comfortable', label: copy.sessionDensityComfortable },
+    { id: 'detailed', label: copy.sessionDensityDetailed }
+  ] as const satisfies readonly { id: SessionListDensity; label: string }[]
+
+  const beginHold = () => {
+    if (holding.current) {
+      return
+    }
+
+    holding.current = true
+    beginOverlayPeek()
+  }
+
+  const endHold = () => {
+    if (!holding.current) {
+      return
+    }
+
+    holding.current = false
+    endOverlayPeek()
+  }
+
+  const cancelPointerHold = () => {
+    pointerStartedAt.current = null
+    endHold()
+  }
+
+  const cancelAllHolds = () => {
+    keyboardStartedAt.current = null
+    pointerStartedAt.current = null
+    suppressNextSemanticClick.current = false
+    endHold()
+  }
+
+  const endPointerHold = () => {
+    const startedAt = pointerStartedAt.current
+
+    pointerStartedAt.current = null
+    endHold()
+
+    // A quick tap behaves like ordinary activation; a deliberate hold returns
+    // Settings immediately on release instead of starting a second pulse from
+    // the click event that browsers dispatch after pointerup.
+    if (startedAt !== null && Date.now() - startedAt < POINTER_HOLD_MS) {
+      pulseOverlayPeek(DENSITY_PREVIEW_MS)
+    }
+  }
+
+  const beginKeyboardHold = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (!HOLD_KEYS.has(event.key)) {
+      return
+    }
+
+    // Own activation instead of letting the native button emit an Enter click
+    // on keydown or a Space click after keyup. Assistive click activation still
+    // reaches onClick because it has no preceding keyboard event.
+    event.preventDefault()
+
+    if (event.repeat || keyboardStartedAt.current !== null) {
+      return
+    }
+
+    keyboardStartedAt.current = Date.now()
+    suppressNextSemanticClick.current = true
+    beginHold()
+  }
+
+  const endKeyboardHold = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (!HOLD_KEYS.has(event.key)) {
+      return
+    }
+
+    event.preventDefault()
+    const startedAt = keyboardStartedAt.current
+
+    keyboardStartedAt.current = null
+    endHold()
+
+    if (startedAt !== null && Date.now() - startedAt < POINTER_HOLD_MS) {
+      pulseOverlayPeek(DENSITY_PREVIEW_MS)
+    }
+
+    // A browser-generated click, if one survives preventDefault, runs in this
+    // activation turn and is suppressed. Clear on the next task so a later
+    // assistive click remains a valid bounded preview.
+    suppressNextSemanticClick.current = true
+    window.setTimeout(() => {
+      suppressNextSemanticClick.current = false
+    }, 0)
+  }
+
+  // A route change or Escape can unmount the button before pointerup/keyup.
+  // Release only this control's hold; another appearance control may still own
+  // a pulse on the shared counter.
+  useEffect(() => endHold, [])
+
+  return (
+    <ListRow
+      action={
+        <div className="flex items-center gap-1.5" data-overlay-peek-scope="">
+          <SegmentedControl
+            onChange={next => {
+              triggerHaptic('selection')
+              setSessionListDensity(next)
+              pulseOverlayPeek(DENSITY_PREVIEW_MS)
+            }}
+            options={options}
+            value={density}
+          />
+          <Tip label={copy.sessionDensityPreview}>
+            <Button
+              aria-label={copy.sessionDensityPreview}
+              onBlur={cancelAllHolds}
+              onClick={event => {
+                // Pointer activation is resolved on pointerup so a long hold
+                // does not pulse again. detail=0 covers keyboard and assistive
+                // activation, where click is the semantic event.
+                if (suppressNextSemanticClick.current) {
+                  suppressNextSemanticClick.current = false
+
+                  return
+                }
+
+                if (event.detail === 0) {
+                  pulseOverlayPeek(DENSITY_PREVIEW_MS)
+                }
+              }}
+              onKeyDown={beginKeyboardHold}
+              onKeyUp={endKeyboardHold}
+              onLostPointerCapture={cancelPointerHold}
+              onPointerCancel={cancelPointerHold}
+              onPointerDown={event => {
+                if (event.button !== 0) {
+                  return
+                }
+
+                pointerStartedAt.current = Date.now()
+                event.currentTarget.setPointerCapture?.(event.pointerId)
+                beginHold()
+              }}
+              onPointerUp={endPointerHold}
+              size="icon-xs"
+              type="button"
+              variant="ghost"
+            >
+              <Eye />
+            </Button>
+          </Tip>
+        </div>
+      }
+      description={copy.sessionDensityDesc}
+      title={copy.sessionDensityTitle}
+    />
+  )
+}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -516,7 +516,7 @@ export const en: Translations = {
       sessionDensityCompact: 'Compact',
       sessionDensityComfortable: 'Comfortable',
       sessionDensityDetailed: 'Detailed',
-      sessionDensityPreview: 'Hold to preview your current session list',
+      sessionDensityPreview: 'Preview current session list. Hold to keep open.',
       terminalFontTitle: 'Terminal Font',
       terminalFontDesc:
         'Choose an installed font for Desktop terminals. Nerd Fonts render Powerlevel10k and shell icons; leave blank to use bundled JetBrains Mono.',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -516,6 +516,7 @@ export const en: Translations = {
       sessionDensityCompact: 'Compact',
       sessionDensityComfortable: 'Comfortable',
       sessionDensityDetailed: 'Detailed',
+      sessionDensityPreview: 'Hold to preview your current session list',
       terminalFontTitle: 'Terminal Font',
       terminalFontDesc:
         'Choose an installed font for Desktop terminals. Nerd Fonts render Powerlevel10k and shell icons; leave blank to use bundled JetBrains Mono.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -340,7 +340,7 @@ export const ja = defineLocale({
       sessionDensityCompact: 'コンパクト',
       sessionDensityComfortable: '標準',
       sessionDensityDetailed: '詳細',
-      sessionDensityPreview: '長押しして現在のセッションリストをプレビュー',
+      sessionDensityPreview: '現在のセッションリストをプレビュー。長押しで表示を維持します。',
       terminalFontTitle: 'ターミナルフォント',
       terminalFontDesc:
         'Desktop のターミナルで使用するインストール済みフォントを選びます。Nerd Font は Powerlevel10k とシェルアイコンを表示できます。空欄では内蔵の JetBrains Mono を使用します。',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -340,6 +340,7 @@ export const ja = defineLocale({
       sessionDensityCompact: 'コンパクト',
       sessionDensityComfortable: '標準',
       sessionDensityDetailed: '詳細',
+      sessionDensityPreview: '長押しして現在のセッションリストをプレビュー',
       terminalFontTitle: 'ターミナルフォント',
       terminalFontDesc:
         'Desktop のターミナルで使用するインストール済みフォントを選びます。Nerd Font は Powerlevel10k とシェルアイコンを表示できます。空欄では内蔵の JetBrains Mono を使用します。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -415,6 +415,7 @@ export interface Translations {
       sessionDensityCompact: string
       sessionDensityComfortable: string
       sessionDensityDetailed: string
+      sessionDensityPreview: string
       terminalFontTitle: string
       terminalFontDesc: string
       terminalFontPlaceholder: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -332,6 +332,7 @@ export const zhHant = defineLocale({
       sessionDensityCompact: '緊湊',
       sessionDensityComfortable: '舒適',
       sessionDensityDetailed: '詳細',
+      sessionDensityPreview: '按住以預覽目前的工作階段列表',
       terminalFontTitle: '終端機字型',
       terminalFontDesc:
         '選擇已安裝的字型用於桌面端終端機。Nerd Font 可正確顯示 Powerlevel10k 與 Shell 圖示；留空則使用內建的 JetBrains Mono。',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -332,7 +332,7 @@ export const zhHant = defineLocale({
       sessionDensityCompact: '緊湊',
       sessionDensityComfortable: '舒適',
       sessionDensityDetailed: '詳細',
-      sessionDensityPreview: '按住以預覽目前的工作階段列表',
+      sessionDensityPreview: '預覽目前的工作階段列表。按住可保持顯示。',
       terminalFontTitle: '終端機字型',
       terminalFontDesc:
         '選擇已安裝的字型用於桌面端終端機。Nerd Font 可正確顯示 Powerlevel10k 與 Shell 圖示；留空則使用內建的 JetBrains Mono。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -505,6 +505,7 @@ export const zh: Translations = {
       sessionDensityCompact: '紧凑',
       sessionDensityComfortable: '舒适',
       sessionDensityDetailed: '详细',
+      sessionDensityPreview: '按住以预览当前会话列表',
       terminalFontTitle: '终端字体',
       terminalFontDesc:
         '选择已安装的字体用于桌面端终端。Nerd Font 可正确显示 Powerlevel10k 和 Shell 图标；留空则使用内置的 JetBrains Mono。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -505,7 +505,7 @@ export const zh: Translations = {
       sessionDensityCompact: '紧凑',
       sessionDensityComfortable: '舒适',
       sessionDensityDetailed: '详细',
-      sessionDensityPreview: '按住以预览当前会话列表',
+      sessionDensityPreview: '预览当前会话列表。按住可保持显示。',
       terminalFontTitle: '终端字体',
       terminalFontDesc:
         '选择已安装的字体用于桌面端终端。Nerd Font 可正确显示 Powerlevel10k 和 Shell 图标；留空则使用内置的 JetBrains Mono。',

--- a/apps/desktop/src/store/overlay-peek.test.ts
+++ b/apps/desktop/src/store/overlay-peek.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $overlayPeek, beginOverlayPeek, endOverlayPeek, pulseOverlayPeek, resetOverlayPeek } from './overlay-peek'
+
+const active = () => document.documentElement.hasAttribute('data-hermes-overlay-peek')
+
+describe('overlay peek lifecycle', () => {
+  beforeEach(() => resetOverlayPeek())
+
+  afterEach(() => {
+    resetOverlayPeek()
+    vi.useRealTimers()
+  })
+
+  it('stays active until every overlapping hold has ended', () => {
+    beginOverlayPeek()
+    beginOverlayPeek()
+
+    expect($overlayPeek.get()).toBe(2)
+    expect(active()).toBe(true)
+
+    endOverlayPeek()
+    expect(active()).toBe(true)
+
+    endOverlayPeek()
+    expect($overlayPeek.get()).toBe(0)
+    expect(active()).toBe(false)
+  })
+
+  it('never goes negative after a stray release', () => {
+    endOverlayPeek()
+    endOverlayPeek()
+
+    expect($overlayPeek.get()).toBe(0)
+    expect(active()).toBe(false)
+  })
+
+  it('pulses for a bounded duration', () => {
+    vi.useFakeTimers()
+
+    pulseOverlayPeek(1_200)
+    expect(active()).toBe(true)
+
+    vi.advanceTimersByTime(1_199)
+    expect(active()).toBe(true)
+
+    vi.advanceTimersByTime(1)
+    expect(active()).toBe(false)
+  })
+
+  it('lets a held preview outlive an overlapping pulse', () => {
+    vi.useFakeTimers()
+
+    beginOverlayPeek()
+    pulseOverlayPeek(900)
+    vi.advanceTimersByTime(900)
+
+    expect($overlayPeek.get()).toBe(1)
+    expect(active()).toBe(true)
+
+    endOverlayPeek()
+    expect(active()).toBe(false)
+  })
+
+  it('reset clears every hold and late pulse expiry stays harmless', () => {
+    vi.useFakeTimers()
+
+    beginOverlayPeek()
+    pulseOverlayPeek(900)
+    resetOverlayPeek()
+
+    expect($overlayPeek.get()).toBe(0)
+    expect(active()).toBe(false)
+
+    vi.advanceTimersByTime(900)
+    expect($overlayPeek.get()).toBe(0)
+    expect(active()).toBe(false)
+  })
+
+  it('a stale pulse cannot consume a new hold after reset', () => {
+    vi.useFakeTimers()
+
+    pulseOverlayPeek(900)
+    resetOverlayPeek()
+    beginOverlayPeek()
+
+    vi.advanceTimersByTime(900)
+    expect($overlayPeek.get()).toBe(1)
+    expect(active()).toBe(true)
+
+    endOverlayPeek()
+    expect(active()).toBe(false)
+  })
+})

--- a/apps/desktop/src/store/overlay-peek.test.ts
+++ b/apps/desktop/src/store/overlay-peek.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { $overlayPeek, beginOverlayPeek, endOverlayPeek, pulseOverlayPeek, resetOverlayPeek } from './overlay-peek'
+import { $overlayPeek, beginOverlayPeek, pulseOverlayPeek, resetOverlayPeek } from './overlay-peek'
 
 const active = () => document.documentElement.hasAttribute('data-hermes-overlay-peek')
 
@@ -13,26 +13,33 @@ describe('overlay peek lifecycle', () => {
     vi.useRealTimers()
   })
 
-  it('stays active until every overlapping hold has ended', () => {
-    beginOverlayPeek()
-    beginOverlayPeek()
+  it('stays active until every overlapping owner has released', () => {
+    const releaseA = beginOverlayPeek()
+    const releaseB = beginOverlayPeek()
 
     expect($overlayPeek.get()).toBe(2)
     expect(active()).toBe(true)
 
-    endOverlayPeek()
+    releaseA()
+    expect($overlayPeek.get()).toBe(1)
     expect(active()).toBe(true)
 
-    endOverlayPeek()
+    releaseB()
     expect($overlayPeek.get()).toBe(0)
     expect(active()).toBe(false)
   })
 
-  it('never goes negative after a stray release', () => {
-    endOverlayPeek()
-    endOverlayPeek()
+  it('makes each owner release idempotent without consuming another owner', () => {
+    const releaseA = beginOverlayPeek()
+    const releaseB = beginOverlayPeek()
 
-    expect($overlayPeek.get()).toBe(0)
+    releaseA()
+    releaseA()
+
+    expect($overlayPeek.get()).toBe(1)
+    expect(active()).toBe(true)
+
+    releaseB()
     expect(active()).toBe(false)
   })
 
@@ -51,45 +58,44 @@ describe('overlay peek lifecycle', () => {
 
   it('lets a held preview outlive an overlapping pulse', () => {
     vi.useFakeTimers()
+    const releaseHold = beginOverlayPeek()
 
-    beginOverlayPeek()
     pulseOverlayPeek(900)
     vi.advanceTimersByTime(900)
 
     expect($overlayPeek.get()).toBe(1)
     expect(active()).toBe(true)
 
-    endOverlayPeek()
+    releaseHold()
     expect(active()).toBe(false)
   })
 
-  it('reset clears every hold and late pulse expiry stays harmless', () => {
-    vi.useFakeTimers()
+  it('reset clears every owner and late releases stay harmless', () => {
+    const releaseA = beginOverlayPeek()
+    const releaseB = beginOverlayPeek()
 
-    beginOverlayPeek()
-    pulseOverlayPeek(900)
     resetOverlayPeek()
-
     expect($overlayPeek.get()).toBe(0)
     expect(active()).toBe(false)
 
-    vi.advanceTimersByTime(900)
+    releaseA()
+    releaseB()
     expect($overlayPeek.get()).toBe(0)
     expect(active()).toBe(false)
   })
 
-  it('a stale pulse cannot consume a new hold after reset', () => {
+  it('a stale pulse cannot consume a new owner after reset', () => {
     vi.useFakeTimers()
 
     pulseOverlayPeek(900)
     resetOverlayPeek()
-    beginOverlayPeek()
+    const releaseNewHold = beginOverlayPeek()
 
     vi.advanceTimersByTime(900)
     expect($overlayPeek.get()).toBe(1)
     expect(active()).toBe(true)
 
-    endOverlayPeek()
+    releaseNewHold()
     expect(active()).toBe(false)
   })
 })

--- a/apps/desktop/src/store/overlay-peek.ts
+++ b/apps/desktop/src/store/overlay-peek.ts
@@ -1,0 +1,54 @@
+import { atom } from 'nanostores'
+
+// A settings overlay can cover the surface a user is tuning. Peeking ghosts the
+// armed overlay while retaining its pointer/keyboard ownership, so the live app
+// beneath becomes the preview without duplicating that surface in Settings.
+// Count rather than toggle: a held control and one or more timed pulses may
+// overlap, and no pulse may close a preview that the user is still holding.
+const PEEK_ATTR = 'data-hermes-overlay-peek'
+let generation = 0
+
+export const $overlayPeek = atom<number>(0)
+
+export function beginOverlayPeek(): void {
+  $overlayPeek.set($overlayPeek.get() + 1)
+}
+
+export function endOverlayPeek(): void {
+  $overlayPeek.set(Math.max(0, $overlayPeek.get() - 1))
+}
+
+/** Drop every outstanding hold/pulse, normally when the owning overlay closes. */
+export function resetOverlayPeek(): void {
+  generation += 1
+  $overlayPeek.set(0)
+}
+
+/** Briefly reveal the live surface after a one-shot appearance change. */
+export function pulseOverlayPeek(ms = 900): void {
+  const pulseGeneration = generation
+  beginOverlayPeek()
+
+  if (typeof window === 'undefined') {
+    endOverlayPeek()
+
+    return
+  }
+
+  window.setTimeout(() => {
+    // Reset invalidates every outstanding pulse. Without a generation guard,
+    // a stale timer from a closed Settings route could consume a NEW hold after
+    // the overlay was reopened.
+    if (pulseGeneration === generation) {
+      endOverlayPeek()
+    }
+  }, ms)
+}
+
+$overlayPeek.subscribe(count => {
+  if (typeof document === 'undefined') {
+    return
+  }
+
+  document.documentElement.toggleAttribute(PEEK_ATTR, count > 0)
+})

--- a/apps/desktop/src/store/overlay-peek.ts
+++ b/apps/desktop/src/store/overlay-peek.ts
@@ -3,46 +3,50 @@ import { atom } from 'nanostores'
 // A settings overlay can cover the surface a user is tuning. Peeking ghosts the
 // armed overlay while retaining its pointer/keyboard ownership, so the live app
 // beneath becomes the preview without duplicating that surface in Settings.
-// Count rather than toggle: a held control and one or more timed pulses may
-// overlap, and no pulse may close a preview that the user is still holding.
+// Each owner receives an idempotent disposer: pointerup + lost-capture, stale
+// pulse timers, and unrelated controls can never release somebody else's peek.
 const PEEK_ATTR = 'data-hermes-overlay-peek'
-let generation = 0
+const owners = new Set<symbol>()
 
 export const $overlayPeek = atom<number>(0)
 
-export function beginOverlayPeek(): void {
-  $overlayPeek.set($overlayPeek.get() + 1)
+const publish = () => $overlayPeek.set(owners.size)
+
+export function beginOverlayPeek(): () => void {
+  const owner = Symbol('overlay-peek')
+  let active = true
+
+  owners.add(owner)
+  publish()
+
+  return () => {
+    if (!active) {
+      return
+    }
+
+    active = false
+    owners.delete(owner)
+    publish()
+  }
 }
 
-export function endOverlayPeek(): void {
-  $overlayPeek.set(Math.max(0, $overlayPeek.get() - 1))
-}
-
-/** Drop every outstanding hold/pulse, normally when the owning overlay closes. */
+/** Drop every outstanding owner, normally when the Appearance overlay closes. */
 export function resetOverlayPeek(): void {
-  generation += 1
-  $overlayPeek.set(0)
+  owners.clear()
+  publish()
 }
 
 /** Briefly reveal the live surface after a one-shot appearance change. */
 export function pulseOverlayPeek(ms = 900): void {
-  const pulseGeneration = generation
-  beginOverlayPeek()
+  const release = beginOverlayPeek()
 
   if (typeof window === 'undefined') {
-    endOverlayPeek()
+    release()
 
     return
   }
 
-  window.setTimeout(() => {
-    // Reset invalidates every outstanding pulse. Without a generation guard,
-    // a stale timer from a closed Settings route could consume a NEW hold after
-    // the overlay was reopened.
-    if (pulseGeneration === generation) {
-      endOverlayPeek()
-    }
-  }, ms)
+  window.setTimeout(release, ms)
 }
 
 $overlayPeek.subscribe(count => {

--- a/apps/desktop/src/store/translucency.test.ts
+++ b/apps/desktop/src/store/translucency.test.ts
@@ -17,13 +17,9 @@ import { onPersistenceEvent, type PersistenceEvent } from '@/lib/storage'
 import {
   $translucency,
   $translucencyBook,
-  $translucencyPeek,
-  beginTranslucencyPeek,
   defaultTranslucencyValues,
-  endTranslucencyPeek,
   GLASS_SUPPORTED,
   isChatWindow,
-  resetTranslucencyPeek,
   setAppearance,
   setTranslucency,
   setTranslucencyFade,
@@ -286,56 +282,6 @@ describe('frost and area', () => {
 
     setTranslucencyMode('clear')
     expect(document.documentElement.hasAttribute('data-hermes-glass-scope')).toBe(false)
-  })
-})
-
-// A held slider drag and a timed pulse from a picker click can overlap, which
-// is why the peek counts rather than toggling: the drag must not be cancelled
-// by a pulse expiring underneath it.
-describe('translucency peek', () => {
-  it('stays open until every overlapping hold has ended', () => {
-    beginTranslucencyPeek()
-    beginTranslucencyPeek()
-    expect(document.documentElement.hasAttribute('data-hermes-translucency-peek')).toBe(true)
-
-    endTranslucencyPeek()
-    expect(document.documentElement.hasAttribute('data-hermes-translucency-peek')).toBe(true)
-
-    endTranslucencyPeek()
-    expect(document.documentElement.hasAttribute('data-hermes-translucency-peek')).toBe(false)
-  })
-
-  it('never goes negative, so a stray release cannot wedge the next peek open', () => {
-    endTranslucencyPeek()
-    endTranslucencyPeek()
-    expect($translucencyPeek.get()).toBe(0)
-
-    beginTranslucencyPeek()
-    expect(document.documentElement.hasAttribute('data-hermes-translucency-peek')).toBe(true)
-    endTranslucencyPeek()
-    expect(document.documentElement.hasAttribute('data-hermes-translucency-peek')).toBe(false)
-  })
-})
-
-describe('peek reset', () => {
-  // Escape mid-drag unmounts the slider before its pointerup ever fires; the
-  // settings surface calls reset on unmount so the counter can't stay wedged
-  // and ghost the next overlay at 8% opacity.
-  it('drops every outstanding hold at once', () => {
-    beginTranslucencyPeek()
-    beginTranslucencyPeek()
-    beginTranslucencyPeek()
-    expect(document.documentElement.hasAttribute('data-hermes-translucency-peek')).toBe(true)
-
-    resetTranslucencyPeek()
-    expect($translucencyPeek.get()).toBe(0)
-    expect(document.documentElement.hasAttribute('data-hermes-translucency-peek')).toBe(false)
-
-    // A pulse timer expiring after the reset must not push the counter negative
-    // or resurrect the attribute.
-    endTranslucencyPeek()
-    expect($translucencyPeek.get()).toBe(0)
-    expect(document.documentElement.hasAttribute('data-hermes-translucency-peek')).toBe(false)
   })
 })
 

--- a/apps/desktop/src/store/translucency.ts
+++ b/apps/desktop/src/store/translucency.ts
@@ -249,55 +249,6 @@ const stopRailTracking = (): void => {
   document.documentElement.style.removeProperty('--glass-rail-edge')
 }
 
-/* Peek: while the user is actively adjusting translucency from Settings, the
-   overlay they stand in covers the very effect they're tuning — the scrim
-   plus a deliberately near-opaque card ([data-glass-raised]). A peek ghosts
-   the whole overlay layer so the live window IS the preview (see the
-   [data-hermes-translucency-peek] rules in styles.css). A counter rather
-   than a boolean: a held slider drag and a timed pulse from a picker click
-   can overlap. */
-const PEEK_ATTR = 'data-hermes-translucency-peek'
-
-export const $translucencyPeek = atom<number>(0)
-
-export function beginTranslucencyPeek(): void {
-  $translucencyPeek.set($translucencyPeek.get() + 1)
-}
-
-export function endTranslucencyPeek(): void {
-  $translucencyPeek.set(Math.max(0, $translucencyPeek.get() - 1))
-}
-
-/**
- * Drop every outstanding hold at once. The settings surface calls this on
- * unmount: a pointer held on the slider when the overlay closes (Escape
- * mid-drag) never delivers its pointerup to the unmounted element, and a
- * counter stuck above zero would leave the peek attribute on <html> —
- * rendering the NEXT settings overlay ghosted at 8% opacity. Outstanding
- * pulse timers still fire endTranslucencyPeek later; the zero floor makes
- * them no-ops.
- */
-export function resetTranslucencyPeek(): void {
-  $translucencyPeek.set(0)
-}
-
-/**
- * Timed peek for one-shot changes (frost / area / mode clicks, keyboard
- * slider steps): long enough to read the effect, short enough to hand the
- * settings back without feeling stuck.
- */
-export function pulseTranslucencyPeek(ms = 900): void {
-  beginTranslucencyPeek()
-
-  if (typeof window === 'undefined') {
-    endTranslucencyPeek()
-
-    return
-  }
-
-  window.setTimeout(endTranslucencyPeek, ms)
-}
-
 const applyGlassSurfaces = ({ intensity, mode, scope }: TranslucencyState): void => {
   if (typeof document === 'undefined') {
     return
@@ -399,13 +350,5 @@ if (typeof window !== 'undefined') {
     if (JSON.stringify(next) !== JSON.stringify($translucencyBook.get())) {
       $translucencyBook.set(next)
     }
-  })
-
-  $translucencyPeek.subscribe(count => {
-    if (typeof document === 'undefined') {
-      return
-    }
-
-    document.documentElement.toggleAttribute(PEEK_ATTR, count > 0)
   })
 }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -679,8 +679,8 @@
     backdrop-filter: blur(0.5rem) !important;
   }
 
-  /* Translucency peek: while the user holds the intensity slider (or for a
-     short pulse after a frost/area/mode click) the entire overlay layer —
+  /* Appearance preview: while the user holds a preview control (or for a
+     short pulse after an appearance choice) the entire overlay layer —
      scrim, blur and near-opaque card as ONE group — ghosts down so the live
      window behind it becomes the preview. The layer keeps pointer events:
      a held drag keeps delivering to the slider it started on. Opacity is
@@ -689,16 +689,16 @@
      hand is on the control, unhurried return.
 
      Both the peek and its return are scoped to a settings overlay that has
-     ARMED the interaction ([data-translucency-peek-scope], set by the
+     ARMED the interaction ([data-overlay-peek-scope], set by the
      appearance row). An unscoped `[data-overlay-surface] { transition:
      opacity … }` would tax every overlay in the app — command center, cron,
      agents, model picker — with a 420ms opacity transition for the life of
-     the process, to serve one slider. */
-  :root [data-overlay-surface]:has([data-translucency-peek-scope]) {
+     the process, to serve Appearance previews alone. */
+  :root [data-overlay-surface]:has([data-overlay-peek-scope]) {
     transition: opacity 420ms cubic-bezier(0.22, 1, 0.36, 1);
   }
 
-  :root[data-hermes-translucency-peek] [data-overlay-surface]:has([data-translucency-peek-scope]) {
+  :root[data-hermes-overlay-peek] [data-overlay-surface]:has([data-overlay-peek-scope]) {
     opacity: 0.08;
     transition: opacity 160ms cubic-bezier(0.32, 0.72, 0, 1);
   }


### PR DESCRIPTION
## Summary

- reveal the already-mounted production sidebar after each Session List Density choice, so Compact, Comfortable and Detailed can be judged without closing Settings
- add an accessible Preview control: quick tap/click gives a bounded reveal, pointer/keyboard hold keeps it open, and release/cancel/unmount restores Settings safely
- generalise the existing translucency peek into a shared Appearance overlay lifecycle with owner-specific, idempotent releases
- keep the existing density persistence, session-row renderer and virtualisation as the single source of truth

Closes #91291

## Problem

Session List Density already applies immediately, but Settings is a near-full-window overlay and hides the only surface that demonstrates the choice. The current workaround is choose → close Settings → inspect → reopen → repeat.

## Approach

The preview does not render sample sessions or duplicate sidebar markup. It ghosts the armed Settings overlay while retaining its input ownership, exposing the live sidebar underneath with the user's real sessions.

The lifecycle is owner-scoped: every hold and timed pulse receives its own idempotent disposer, so duplicate pointer cleanup, stale timers and unrelated controls can never release another preview. Reset clears all owners, while stale disposers remain harmless after Settings is reopened. Pointer quick taps and deliberate holds are distinguished so releasing a long hold restores Settings immediately rather than dispatching a second pulse through the browser's follow-up click.

This follows the existing Window Translucency precedent where the live window itself is the preview.

## Verification

- `npm exec --workspace=apps/desktop vitest -- run --project ui src/store/overlay-peek.test.ts src/store/translucency.test.ts src/store/session-list-density.test.ts src/app/settings/session-density-setting.test.tsx src/app/overlays/peek-scope.test.ts src/app/chat/sidebar/session-row-details.test.ts src/app/chat/sidebar/virtual-session-list.test.tsx src/i18n/runtime.test.ts`
- sabotage run: removing the density-change pulse makes `applies a density choice and briefly reveals the real sidebar` fail; restoring it passes
- `npm run test:ui --workspace=apps/desktop` — 559 files / 5,345 tests passed on the final staged snapshot
- `npm run check:lint --workspace=apps/desktop` — typecheck passed; lint has 120 pre-existing warnings and no errors
- `npm run build --workspace=apps/desktop` — production renderer and Electron bundles built successfully
- `npm run builder --workspace=apps/desktop -- --dir --publish never` — isolated macOS QA package built successfully
- hands-on packaged QA: Compact, Comfortable and Detailed each revealed the real session list; auto-preview restored after 1.2 seconds; Preview activation revealed the selected mode; Carl approved the interaction
- `git diff --check`

## Scope and risk

- renderer-only; no backend/API, config schema, Electron IPC, model call or Dashboard change
- pointer events stay on the translucent overlay, so the revealed workspace cannot receive accidental input
- all user-facing copy is localised in en/ja/zh/zh-hant
- #88499 owns session-row height alignment; this PR does not edit row geometry or virtualisation
- #66103 is adjacent command-palette preview-on-highlight work, not a duplicate of this Settings-overlay problem

## Priority

P3 — the setting works today and has a manual workaround; this improves discoverability and decision quality rather than fixing a reliability, security or data-integrity failure.

## Lineage

The density modes landed through #86771 from David Metcalfe's #68124, closing #68119. This change builds on that existing implementation without replacing its renderer or persistence.
