### PR TITLE
fix(desktop): reclaim pre-update state.db backups even when the backup fails

### DIFF
--- a/apps/desktop/electron/emergency-backup-retention.test.ts
+++ b/apps/desktop/electron/emergency-backup-retention.test.ts
@@ -1,0 +1,154 @@
+// Retention policy for pre-update emergency state.db backups (#91229).
+//
+// The reported symptom was 2.5-3 GB of `state.db.pre-update-emergency-*.bak`
+// files that "are never cleaned up". A prune did exist, but it was nested
+// inside the `try` whose first statement wrote the new backup, so it only ran
+// when that write succeeded. These tests pin the selection rule; the
+// unconditional-call half is asserted structurally at the bottom.
+
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  EMERGENCY_BACKUP_PREFIX,
+  EMERGENCY_BACKUP_RETENTION,
+  EMERGENCY_BACKUP_SUFFIX,
+  isEmergencyBackup,
+  selectEmergencyBackupsToDelete,
+} from './emergency-backup-retention'
+
+/** Build the exact filename `preflightStateDb` writes for a given instant. */
+function backupName(iso: string): string {
+  return `${EMERGENCY_BACKUP_PREFIX}${iso.replace(/[:.]/g, '-')}${EMERGENCY_BACKUP_SUFFIX}`
+}
+
+const OLDEST = backupName('2026-08-15T03:11:52.004Z')
+const OLDER = backupName('2026-08-17T09:02:00.900Z')
+const NEWER = backupName('2026-08-20T22:45:10.120Z')
+const NEWEST = backupName('2026-08-21T01:30:00.000Z')
+
+describe('isEmergencyBackup', () => {
+  it('accepts exactly the filenames preflightStateDb writes', () => {
+    expect(isEmergencyBackup(NEWEST)).toBe(true)
+  })
+
+  it('leaves the live database and its sidecars alone', () => {
+    // The single most important negative: this sweep runs in HERMES_HOME, so
+    // a loose predicate deletes the database the backups exist to protect.
+    expect(isEmergencyBackup('state.db')).toBe(false)
+    expect(isEmergencyBackup('state.db-wal')).toBe(false)
+    expect(isEmergencyBackup('state.db-shm')).toBe(false)
+  })
+
+  it('leaves other .bak files alone', () => {
+    // The Python-level snapshot is a different mechanism with a different
+    // lifetime; this policy does not own it.
+    expect(isEmergencyBackup('state.db.bak')).toBe(false)
+    expect(isEmergencyBackup('config.yaml.bak')).toBe(false)
+    expect(isEmergencyBackup(`${EMERGENCY_BACKUP_PREFIX}2026-08-21.tmp`)).toBe(false)
+  })
+
+  it('does not match a prefixed name embedded mid-filename', () => {
+    expect(isEmergencyBackup(`copy-of-${NEWEST}`)).toBe(false)
+  })
+})
+
+describe('selectEmergencyBackupsToDelete', () => {
+  it('keeps the newest RETENTION backups and returns the rest', () => {
+    const doomed = selectEmergencyBackupsToDelete([OLDER, NEWEST, OLDEST, NEWER])
+
+    expect(EMERGENCY_BACKUP_RETENTION).toBe(3)
+    expect(doomed).toEqual([OLDEST])
+  })
+
+  it('returns nothing while at or under the budget', () => {
+    expect(selectEmergencyBackupsToDelete([])).toEqual([])
+    expect(selectEmergencyBackupsToDelete([NEWEST])).toEqual([])
+    expect(selectEmergencyBackupsToDelete([NEWEST, NEWER, OLDER])).toEqual([])
+  })
+
+  it('counts the just-written backup toward the budget', () => {
+    // The old code excluded the new file before slicing, so three survived
+    // while the comment said two. Whatever the number is, the newest file has
+    // to be inside it or the budget is off by one forever.
+    const listing = [OLDEST, OLDER, NEWER, NEWEST]
+    const kept = listing.filter(f => !selectEmergencyBackupsToDelete(listing).includes(f))
+
+    expect(kept).toHaveLength(EMERGENCY_BACKUP_RETENTION)
+    expect(kept).toContain(NEWEST)
+  })
+
+  it('orders by name, not by array order or mtime', () => {
+    // Sorting is lexicographic because the ISO timestamp is fixed-width; a
+    // shuffled listing (readdir gives no ordering guarantee) must not change
+    // which files survive.
+    const shuffled = [NEWER, OLDEST, NEWEST, OLDER]
+
+    expect(selectEmergencyBackupsToDelete(shuffled)).toEqual([OLDEST])
+  })
+
+  it('ignores unrelated files when choosing what to delete', () => {
+    const doomed = selectEmergencyBackupsToDelete([
+      'state.db',
+      'state.db-wal',
+      'config.yaml',
+      OLDEST,
+      OLDER,
+      NEWER,
+      NEWEST,
+    ])
+
+    expect(doomed).toEqual([OLDEST])
+  })
+
+  it('deletes everything when told to retain none', () => {
+    expect(selectEmergencyBackupsToDelete([NEWEST, OLDEST], 0)).toEqual([NEWEST, OLDEST])
+  })
+
+  it('treats a nonsensical retention as retain-none rather than deleting at random', () => {
+    expect(selectEmergencyBackupsToDelete([NEWEST, OLDEST], -1)).toEqual([NEWEST, OLDEST])
+    expect(selectEmergencyBackupsToDelete([NEWEST, OLDEST], Number.NaN)).toEqual([NEWEST, OLDEST])
+  })
+
+  it('scales past the budget without dropping any candidate', () => {
+    const many = Array.from({ length: 40 }, (_, i) =>
+      backupName(`2026-08-21T0${Math.floor(i / 10)}:${String(i % 10).padStart(2, '0')}:00.000Z`)
+    )
+
+    const doomed = selectEmergencyBackupsToDelete(many)
+
+    expect(doomed).toHaveLength(many.length - EMERGENCY_BACKUP_RETENTION)
+    // Nothing kept is also deleted, and nothing is listed twice.
+    expect(new Set(doomed).size).toBe(doomed.length)
+  })
+})
+
+describe('preflightStateDb wiring', () => {
+  // The selection rule above is only half the fix. The bug was WHERE the
+  // sweep was called from, and that is a property of main.ts, which cannot be
+  // imported here (it boots Electron). So assert it against the source, the
+  // same way the repo pins other cross-module invariants.
+  const main = readFileSync(new URL('./main.ts', import.meta.url), 'utf8')
+  const body = main.slice(main.indexOf('function preflightStateDb('))
+
+  it('sweeps before the first early return, not after the copy succeeds', () => {
+    const call = body.indexOf('pruneEmergencyStateDbBackups(hermesHome, rememberLog)')
+    // Anchor on the guard itself, not on the word "return": the surrounding
+    // comments say "early return" and would satisfy a naive search.
+    const firstGuard = body.indexOf('if (!fileExists(stateDbPath))')
+    const copy = body.indexOf('fs.copyFileSync(stateDbPath, emergencyPath)')
+
+    expect(call).toBeGreaterThan(-1)
+    expect(firstGuard).toBeGreaterThan(-1)
+    // Before the first guard => a missing or too-small state.db still reclaims.
+    expect(call).toBeLessThan(firstGuard)
+    // Before the copy => ENOSPC and EBUSY still reclaim. This is the assertion
+    // that fails if anyone re-nests the sweep inside the copy's try block.
+    expect(call).toBeLessThan(copy)
+  })
+
+  it('no longer carries the inline prune that was coupled to the copy', () => {
+    expect(body).not.toContain("f.startsWith('state.db.pre-update-emergency-')")
+  })
+})

--- a/apps/desktop/electron/emergency-backup-retention.ts
+++ b/apps/desktop/electron/emergency-backup-retention.ts
@@ -1,0 +1,78 @@
+// Retention policy for the pre-update emergency copies of `state.db`.
+//
+// Before an update, `preflightStateDb` copies `state.db` to
+// `state.db.pre-update-emergency-<timestamp>.bak` so a torn update can be
+// recovered from. Those copies are the size of the live database, which on a
+// busy install is comfortably several hundred MB, so they have to be reclaimed
+// or they eat the disk (issue #91229 reported 2.5-3 GB of accumulated .bak
+// files and ~6.5 GB of week-over-week C: growth).
+//
+// The sweep used to live inline in `preflightStateDb`, nested inside the `try`
+// whose first statement was the `copyFileSync`. That coupled reclaiming old
+// backups to successfully writing a new one, so every failure mode that
+// *prevents* the copy also skipped the cleanup:
+//
+//   * the copy throws ENOSPC because the disk is full -- and it is full partly
+//     because these backups were never reclaimed;
+//   * the copy throws EBUSY/EPERM because another process holds `state.db`,
+//     which on Windows is the ordinary state during a failed self-update and
+//     the exact scenario #91229 is filed about;
+//   * `state.db` is missing or too small to be a real database, both of which
+//     `return` before the copy is ever attempted.
+//
+// In other words the janitor only ran on the days nothing needed cleaning.
+// Splitting the selection out here lets `preflightStateDb` run it
+// unconditionally, and lets it be tested without Electron or a real disk.
+
+/** Filename prefix written by `preflightStateDb`. */
+export const EMERGENCY_BACKUP_PREFIX = 'state.db.pre-update-emergency-'
+
+/** Filename suffix written by `preflightStateDb`. */
+export const EMERGENCY_BACKUP_SUFFIX = '.bak'
+
+/**
+ * How many emergency backups to keep, newest first, counting the one just
+ * written.
+ *
+ * This preserves the effective behaviour of the previous implementation
+ * rather than the behaviour its comment claimed. That comment said "Prune to
+ * the 2 most recent", but the filter excluded the backup it had just created
+ * before slicing, so three files survived: the new one plus two older. At the
+ * reported ~650-750 MB apiece that is the difference between ~1.4 GB and
+ * ~2.1 GB retained, so it is not a rounding error, and picking the smaller
+ * number would delete recovery data users currently have. Deciding which
+ * number is actually wanted is a maintainer call; this change only makes the
+ * number explicit and honest.
+ */
+export const EMERGENCY_BACKUP_RETENTION = 3
+
+/** True when *name* is one of the emergency backups this module manages. */
+export function isEmergencyBackup(name: string): boolean {
+  return (
+    typeof name === 'string' &&
+    name.startsWith(EMERGENCY_BACKUP_PREFIX) &&
+    name.endsWith(EMERGENCY_BACKUP_SUFFIX)
+  )
+}
+
+/**
+ * Given every filename in the Hermes home directory, return the emergency
+ * backups that should be deleted -- everything past the newest *retain*.
+ *
+ * Ordering is lexicographic and deliberately so: the timestamp is
+ * `new Date().toISOString()` with `:` and `.` replaced by `-`, which is
+ * fixed-width and zero-padded, so byte order and chronological order agree.
+ * That keeps the sweep independent of file mtimes, which a backup/restore or
+ * a sync client can rewrite.
+ *
+ * Non-backup files are ignored, so this is safe to hand a whole directory
+ * listing. Returns names, not paths; the caller owns the directory.
+ */
+export function selectEmergencyBackupsToDelete(
+  names: readonly string[],
+  retain: number = EMERGENCY_BACKUP_RETENTION
+): string[] {
+  const keep = Number.isFinite(retain) && retain > 0 ? Math.floor(retain) : 0
+
+  return names.filter(isEmergencyBackup).sort().reverse().slice(keep)
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -132,6 +132,10 @@ import {
   uninstallArgsForMode
 } from './desktop-uninstall'
 import { describeDevCdpDecision, resolveDevCdpPort } from './dev-cdp'
+import {
+  EMERGENCY_BACKUP_RETENTION,
+  selectEmergencyBackupsToDelete,
+} from './emergency-backup-retention'
 import { installEmbedReferer } from './embed-referer'
 import { createEventDeduper } from './event-dedupe'
 import {
@@ -3898,8 +3902,47 @@ function runningAppBundle() {
 // desktop Electron process itself, before the backend is killed and
 // before the updater is spawned — a separate safety net from the
 // Python-level pre-update snapshot inside `hermes update`.
+// Delete emergency state.db backups past the retention budget. Never throws:
+// this is disk hygiene on the update path, and a failure to reclaim must not
+// be able to abort an update.
+function pruneEmergencyStateDbBackups(hermesHome, rememberLog) {
+  try {
+    const stale = selectEmergencyBackupsToDelete(fs.readdirSync(hermesHome), EMERGENCY_BACKUP_RETENTION)
+
+    let reclaimed = 0
+
+    for (const name of stale) {
+      const target = path.join(hermesHome, name)
+
+      try {
+        const bytes = fs.statSync(target).size
+
+        fs.unlinkSync(target)
+        reclaimed += bytes
+      } catch {
+        // Held open, already gone, or not ours to delete. The next update
+        // tries again; one unremovable file must not stop the rest.
+        void 0
+      }
+    }
+
+    if (reclaimed > 0) {
+      rememberLog(`[updates] reclaimed ${reclaimed} bytes from ${stale.length} old state.db backup(s)`)
+    }
+  } catch {
+    void 0
+  }
+}
+
 function preflightStateDb(hermesHome, rememberLog) {
   const stateDbPath = path.join(hermesHome, 'state.db')
+
+  // Unconditionally, and BEFORE any early return. Every reason this function
+  // gives up (no state.db, too small to be a database, stat throws) and every
+  // reason the copy below fails (ENOSPC on a disk these very files filled,
+  // EBUSY from the running app on Windows) used to skip the sweep, so the
+  // backups accumulated precisely when reclaiming mattered most (#91229).
+  pruneEmergencyStateDbBackups(hermesHome, rememberLog)
 
   if (!fileExists(stateDbPath)) {
     rememberLog('[updates] state.db pre-flight: not found (fresh install?)')
@@ -3943,30 +3986,12 @@ function preflightStateDb(hermesHome, rememberLog) {
 
         rememberLog(`[updates] emergency state.db backup: ${emergencyPath} ` + `(${emergStat.size} bytes)`)
 
-        // Prune to the 2 most recent emergency backups.
-        try {
-          const homeDir = fs.readdirSync(hermesHome)
-
-          const backups = homeDir
-            .filter(
-              f =>
-                f.startsWith('state.db.pre-update-emergency-') &&
-                f.endsWith('.bak') &&
-                f !== path.basename(emergencyPath)
-            )
-            .sort()
-            .reverse()
-
-          for (const old of backups.slice(2)) {
-            try {
-              fs.unlinkSync(path.join(hermesHome, old))
-            } catch {
-              void 0
-            }
-          }
-        } catch {
-          void 0
-        }
+        // Reclaim now that a new backup exists, so the newest one counts
+        // toward the retention budget. The unconditional sweep at the top of
+        // preflightStateDb is what guarantees this happens at all; this second
+        // call only keeps the budget from being exceeded by one until the next
+        // update runs.
+        pruneEmergencyStateDbBackups(hermesHome, rememberLog)
       } catch (copyErr) {
         rememberLog(`[updates] emergency state.db backup failed: ${copyErr.message}`)
       }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -132,11 +132,11 @@ import {
   uninstallArgsForMode
 } from './desktop-uninstall'
 import { describeDevCdpDecision, resolveDevCdpPort } from './dev-cdp'
+import { installEmbedReferer } from './embed-referer'
 import {
   EMERGENCY_BACKUP_RETENTION,
   selectEmergencyBackupsToDelete,
 } from './emergency-backup-retention'
-import { installEmbedReferer } from './embed-referer'
 import { createEventDeduper } from './event-dedupe'
 import {
   buildTerminalScript,


### PR DESCRIPTION
## What does this PR do?

Fixes the residue half of #91229: `state.db.pre-update-emergency-*.bak` files that accumulate to gigabytes.

There *is* already a prune. The bug is where it sits. In `preflightStateDb`:

```js
try {
  fs.copyFileSync(stateDbPath, emergencyPath)   // <- new backup
  ...
  // Prune to the 2 most recent emergency backups.
  ...                                            // <- sweep, INSIDE this try
} catch (copyErr) {
  rememberLog(`[updates] emergency state.db backup failed: ${copyErr.message}`)
}
```

Reclaiming old backups is nested inside the success path of writing a new one. So every path that stops the copy also skips the cleanup:

| what stops the copy | why it matters here |
|---|---|
| `ENOSPC` — disk full | the disk is full *partly because these backups were never reclaimed*. The cleanup is disabled by the condition it exists to prevent. |
| `EBUSY` / `EPERM` — another process holds `state.db` | on Windows this is the ordinary state during a failed self-update, i.e. the exact scenario this issue is filed about |
| `state.db` missing, or ≤100 bytes | both `return` before the copy is attempted |
| `statSync` throws | lands in the outer catch |

The janitor only ran on the days nothing needed cleaning. With a ~650-750 MB database and a self-update that fails repeatedly (the reporter lists 8/15, 8/17, 8/20), that is exactly the reported 2.5-3 GB.

## The fix

Hoist the sweep into `pruneEmergencyStateDbBackups` and call it **unconditionally at the top of `preflightStateDb`** — before any early return, before the copy. Both update entry points (`main.ts:3565` and `main.ts:4034`) funnel through that function, so both reclaim.

Selection logic moves to `emergency-backup-retention.ts` so it can be tested without booting Electron, matching how the other extracted electron helpers (`profile-delete-routing.ts`, `bundle-skew.ts`, …) are structured. `main.ts` keeps the I/O.

Two behaviours are preserved deliberately:

- **The sweep still never throws.** This is disk hygiene on the update path; failing to reclaim must not be able to abort an update. One unremovable file doesn't stop the rest.
- **Retention stays at three.** See below — this one is a decision, not an oversight.

## A maintainer decision I did not make for you

The old comment said *"Prune to the 2 most recent emergency backups"*. The code kept **three**: the filter excluded the just-written backup before `.slice(2)`, so the new one plus two older ones survived.

At ~700 MB apiece that is ~1.4 GB versus ~2.1 GB retained, so it isn't a rounding error. I kept the **effective** behaviour (three) rather than the documented one (two), because lowering it deletes recovery data users currently have, and that is a data-retention call rather than a bug fix. It's now a named constant with the discrepancy written down:

```ts
export const EMERGENCY_BACKUP_RETENTION = 3
```

If maintainers want two, it's a one-line change and the tests read the constant rather than hardcoding counts, so they follow it. I'd rather surface the disagreement than silently pick.

## What I deliberately did NOT fix, and why

The issue also reports `win-unpacked.bak` (~380 MB) as uncleaned residue. **It isn't residue.** `apps/desktop/scripts/before-pack.mjs` preserves the previous unpacked tree as `<appOutDir>.bak` specifically so a corrupt pack can be rolled back — that's #53040's rename-instead-of-delete, and `_ensure_desktop_exe_launchable` restores from it. It is one copy, replaced on each pack, not an accumulating set.

So "clean up the .bak files" would have deleted a recovery mechanism. Two artifacts that look alike, opposite lifecycles. Flagging it rather than acting on it.

The other two proposals in the issue — staged/atomic update and self-shutdown before replace — are the *locking* half and are not touched here. Note that **#70477** (@JonthanaHanh) is already doing the stop-before-replace work in this same file; its hunks are at ~2494/2687 and never touch the prune at ~3843, so there's no conflict between them. That PR and this one address different halves of #91229 and are complementary.

## Related Issue

Fixes #91229 — partially. The residue half is fixed here; the file-locking half remains open and is the larger piece. If maintainers would rather this not auto-close the issue, say so and I'll change the keyword to `Related to`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/emergency-backup-retention.ts` — **new.** `isEmergencyBackup`, `selectEmergencyBackupsToDelete`, and the retention constant. Pure, no `fs`.
- `apps/desktop/electron/main.ts` — new `pruneEmergencyStateDbBackups` (does the I/O, never throws), called unconditionally at the top of `preflightStateDb`; the inline prune is removed. The post-copy call is kept so the newly written backup counts toward the budget immediately.
- `apps/desktop/electron/emergency-backup-retention.test.ts` — **new**, 14 tests.

## How to Test

```
cd apps/desktop
npx vitest run --project electron emergency-backup-retention    # 14 passed
npx tsc --noEmit -p tsconfig.json                                # clean
npx eslint electron/emergency-backup-retention*.ts               # clean
```

**Full `--project electron` run, this branch vs its base (`533886c8b8`), same machine (Windows 11):**

```
base    : 32 failed, 1514 passed, 4 skipped  (111 files)
branch  : 31 failed, 1529 passed, 4 skipped  (112 files)
```

**On the failure delta, stated honestly rather than rounded off.** Diffing the sorted `FAIL` lists gives one branch-only failure — `git-worktree-ops.test.ts > ensureGitRepo: inits a plain dir with a root commit` — and two base-only ones. None is anywhere near this diff, and I did not want to wave that away, so I re-ran `git-worktree-ops` three times against unchanged branch code: it passed, then failed, then the run timed out. **It is flaky, not a regression.** The remaining ~31 are Windows-environment failures (chmod/symlink permission semantics in `hardening.test.ts`, ssh control sockets in `ssh-connection.test.ts`) that fail identically on the base commit.

### Mutation proof

| mutation | result |
|---|---|
| remove the unconditional call, restoring the sweep to the copy's success path (the bug) | **1 failed, 13 passed** — the wiring test, which is the only one that can see it |
| exclude the newest backup before slicing, restoring the original off-by-one | **7 failed, 7 passed** |

The first mutation is the important one: it is exactly the state `main` is in today. Note that it only breaks **one** test, and that test is a source-level assertion rather than a behavioural one — the selection logic is completely correct in both states, because the defect was never in *what* to delete, only in *when the sweep runs*. A purely behavioural test suite would have passed the buggy code. That's why the wiring assertion exists and why it anchors on `if (!fileExists(stateDbPath))` rather than on the word `return`, which appears in the surrounding comments.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(desktop): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate — no open or merged PR references #91229, and **zero** open PRs touch the `pre-update-emergency` prune (checked the diffs of #24938, #89127, #54295, #78288, #91079, all 0 hunks). #70477 is the nearest neighbour in this file and is analysed above.
- [x] My PR contains **only** changes related to this fix (one commit, three files)
- [x] I've run the relevant suites — deltas and the flaky test are stated verbatim above
- [x] I've added tests for my changes — 14 new, with two mutation proofs
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the new module's header documents each failure path that used to skip the sweep, and the retention constant documents the comment/code disagreement it inherited
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — the sweep is plain `readdir`/`unlink` with no platform branches and runs on every OS. The bug is worst on Windows (file locking makes the copy fail most often there) but the coupling was never Windows-specific: an ENOSPC on Linux disabled cleanup the same way.
