### PR TITLE
fix(computer-use): honor element token input schema

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -2046,8 +2046,8 @@ class TestCapabilityDiscovery:
     what cua-driver supports from the per-tool `capabilities[]` array on
     `tools/list` (trycua/cua#1961) instead of name-checking. The infra
     here is consumed by other surfaces (e.g. Surface 6 only carries
-    element_token when `accessibility.element_tokens` is advertised);
-    these tests freeze the supports_capability contract.
+    element_token when capability or schema support is advertised);
+    these tests freeze both discovery contracts.
     """
 
     def test_supports_capability_global_match_any_tool(self):
@@ -2080,6 +2080,37 @@ class TestCapabilityDiscovery:
         # Unknown tool → False (instead of KeyError).
         assert session.supports_capability("anything", tool="never_registered") is False
 
+    def test_strict_schema_declared_element_token_is_supported(self):
+        from tools.computer_use.cua_backend import _CuaDriverSession, _AsyncBridge
+
+        session = _CuaDriverSession(_AsyncBridge())
+        session._tool_schemas = {
+            "click": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "element_index": {"type": "integer"},
+                    "element_token": {"type": "string"},
+                },
+            },
+        }
+
+        assert session.supports_input_property("click", "element_token") is True
+
+    def test_strict_schema_missing_element_token_fails_closed(self):
+        from tools.computer_use.cua_backend import _CuaDriverSession, _AsyncBridge
+
+        session = _CuaDriverSession(_AsyncBridge())
+        session._tool_schemas = {
+            "click": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {"element_index": {"type": "integer"}},
+            },
+        }
+
+        assert session.supports_input_property("click", "element_token") is False
+
 
 class TestElementTokenAttachment:
     """Surface 6 (NousResearch/hermes-agent#47072): trycua/cua#1961 added
@@ -2091,9 +2122,9 @@ class TestElementTokenAttachment:
     1. capture() refreshes a per-snapshot {index -> token} map from
        structuredContent.elements.
     2. Whenever an action carrying element_index is about to hit cua-driver,
-       look up the matching token and attach it — but ONLY for tools that
-       advertise `accessibility.element_tokens` (Surface 4 gate). Older
-       drivers reject unknown args via additionalProperties=false.
+       look up the matching token and attach it only for tools that advertise
+       either `accessibility.element_tokens` or an `element_token` input
+       property. Older drivers reject unknown args via additionalProperties=false.
     3. cua-driver prefers token over index when both are supplied, so
        sending both is safe and stale-detection becomes explicit.
     """
@@ -2129,6 +2160,20 @@ class TestElementTokenAttachment:
         assert name == "click"
         assert args["element_index"] == 5
         # The matching token rode along — cua-driver will prefer it.
+        assert args["element_token"] == "s0001:5"
+
+    def test_capability_path_remains_authoritative_when_schema_lacks_property(self):
+        """Preserve the pre-existing explicit capability contract."""
+        backend = self._backend_with_session({
+            "click": {"accessibility.element_tokens"},
+        })
+        session = cast(Any, backend._session)
+        session.supports_input_property = lambda tool, property_name: False
+        backend._snapshot_tokens = {5: "s0001:5"}
+
+        backend.click(element=5, button="left")
+
+        _name, args = session.call_tool.call_args.args
         assert args["element_token"] == "s0001:5"
 
     def test_token_attached_when_live_schema_advertises_property(self):

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -2131,6 +2131,37 @@ class TestElementTokenAttachment:
         # The matching token rode along — cua-driver will prefer it.
         assert args["element_token"] == "s0001:5"
 
+    def test_token_attached_when_live_schema_advertises_property(self):
+        """The live schema is sufficient compatibility proof."""
+        backend = self._backend_with_session({"click": set()})
+        session = cast(Any, backend._session)
+        session.supports_input_property = (
+            lambda tool, property_name: (
+                tool == "click" and property_name == "element_token"
+            )
+        )
+        backend._snapshot_tokens = {5: "s0001:5"}
+
+        backend.click(element=5, button="left")
+
+        name, args = session.call_tool.call_args.args
+        assert name == "click"
+        assert args["element_index"] == 5
+        assert args["element_token"] == "s0001:5"
+
+    def test_token_omitted_when_capability_and_schema_are_absent(self):
+        """Older strict schemas must not receive an unknown token field."""
+        backend = self._backend_with_session({"click": set()})
+        session = cast(Any, backend._session)
+        session.supports_input_property = lambda tool, property_name: False
+        backend._snapshot_tokens = {5: "s0001:5"}
+
+        backend.click(element=5, button="left")
+
+        _name, args = session.call_tool.call_args.args
+        assert args["element_index"] == 5
+        assert "element_token" not in args
+
 
     def test_capture_refreshes_snapshot_tokens(self):
         """A fresh capture should overwrite any stale tokens from a

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -3909,8 +3909,9 @@ class CuaDriverBackend(ComputerUseBackend):
             return
         # Modern cua-driver releases expose element_token in the live input
         # schema but do not necessarily repeat it as a custom capability
-        # string. Treat either signal as authoritative. The schema check
-        # keeps this safe for older drivers with additionalProperties=false.
+        # string. Treat either signal as authoritative to preserve the
+        # existing capability-based path. When that capability is absent,
+        # the schema check remains fail-closed for strict older drivers.
         supports_token = self._session.supports_capability(
             "accessibility.element_tokens", tool=tool
         ) or self._session.supports_input_property(tool, "element_token")

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -3897,9 +3897,9 @@ class CuaDriverBackend(ComputerUseBackend):
            supplied. Returns an explicit 'stale' error if the snapshot
            has been superseded."
 
-        Gated on the per-tool capability claim so we don't send the
-        field to drivers that predate the surface (which would reject
-        the schema with `additionalProperties: false`).
+        Gated on either the per-tool capability claim or the live input
+        schema property so we don't send the field to drivers that predate
+        the surface (which would reject it with `additionalProperties: false`).
         """
         idx = args.get("element_index")
         if not isinstance(idx, int):
@@ -3907,9 +3907,14 @@ class CuaDriverBackend(ComputerUseBackend):
         token = self._snapshot_tokens.get(idx)
         if not token:
             return
-        if not self._session.supports_capability(
+        # Modern cua-driver releases expose element_token in the live input
+        # schema but do not necessarily repeat it as a custom capability
+        # string. Treat either signal as authoritative. The schema check
+        # keeps this safe for older drivers with additionalProperties=false.
+        supports_token = self._session.supports_capability(
             "accessibility.element_tokens", tool=tool
-        ):
+        ) or self._session.supports_input_property(tool, "element_token")
+        if not supports_token:
             return
         args["element_token"] = token
 


### PR DESCRIPTION
## What does this PR do?

Allows the Computer Use wrapper to attach a captured `element_token` when the live cua-driver input schema advertises the `element_token` property, even if the driver does not repeat support through the custom `accessibility.element_tokens` capability list.

cua-driver 0.21 exposes tokens in `get_window_state` and requires `element_token` or `snapshot_id` for safe element-index actions. Without this fallback, Hermes sends a bare `element_index`; the driver refuses it, and agents fall back to slower and less reliable coordinate input.

The live input schema remains a fail-closed compatibility gate: older drivers whose strict schemas do not accept `element_token` still receive no extra field.

## Related Issue

No existing issue found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `tools/computer_use/cua_backend.py` to accept either the capability token or the live input-schema property as proof that `element_token` is supported.
- Add regression coverage for schema-only support.
- Preserve the existing fail-closed behavior when neither compatibility signal is present.

## How to Test

1. Run `pytest tests/tools/test_computer_use.py::TestCapabilityDiscovery tests/tools/test_computer_use.py::TestElementTokenAttachment -q`.
2. Run `pytest tests/tools/test_computer_use_cua_0_9.py tests/tools/test_computer_use.py::TestElementTokenAttachment -q`.
3. Run `pytest tests/tools/test_computer_use.py -q -k 'not linux_default_capture_skips_gnome_shell_helper'` on macOS.
4. With cua-driver 0.21, capture a Chrome window and click an AX element by index. Confirm the action uses `AXPress` rather than failing with `snapshot_id_required` and falling back to coordinates.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on macOS 26.5.2 with cua-driver 0.21.0

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing configuration changes
- [x] `cli-config.yaml.example` update — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A
- [x] Cross-platform impact considered: the live schema gate preserves strict older-driver compatibility
- [x] Tool descriptions/schemas update — N/A; public tool behavior is unchanged

## Screenshots / Logs

Reviewer-suggested focused capability, strict-schema, conflict, and legacy tests: `51 passed`.
Computer Use module on macOS: `105 passed, 1 Linux-only test deselected`.
`scripts/run_tests.sh` was attempted but did not complete cleanly in this local environment: it reported broad unrelated failures across gateway, voice, web-tool, and collection/import paths, plus 42 files where no tests ran. No full-suite success is claimed.
Live verification: an exact Amazon wishlist AX link opened successfully on the first element-index click using background `AXPress`, with no coordinate or foreground fallback.
