### PR TITLE
fix(agent): clean cached request pool sockets

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -4163,47 +4163,101 @@ def _iter_pool_sockets(client: Any):
                 yield sock
 
 
-def cleanup_dead_connections(agent) -> bool:
-    """Detect and clean up dead TCP connections on the primary client.
+def _count_dead_pool_sockets(client: Any) -> int:
+    """Return the number of sockets in ``client`` that have reached EOF."""
+    import socket as _socket
 
-    Inspects the httpx connection pool for sockets in unhealthy states
-    (CLOSE-WAIT, errors).  If any are found, force-closes all sockets
-    and rebuilds the primary client from scratch.
-
-    Returns True if dead connections were found and cleaned up.
-    """
-    client = getattr(agent, "client", None)
-    if client is None:
-        return False
-    try:
-        dead_count = 0
-        for sock in _iter_pool_sockets(client):
-            # Probe socket health with a non-blocking recv peek
-            import socket as _socket
-            try:
-                sock.setblocking(False)
-                data = sock.recv(1, _socket.MSG_PEEK | _socket.MSG_DONTWAIT)
-                if data == b"":
-                    dead_count += 1
-            except BlockingIOError:
-                pass  # No data available — socket is healthy
-            except OSError:
+    dead_count = 0
+    for sock in _iter_pool_sockets(client):
+        # Probe socket health with a non-blocking recv peek.  A zero-length
+        # read means the provider sent FIN and the connection is in
+        # CLOSE-WAIT until the client closes its side.
+        try:
+            sock.setblocking(False)
+            data = sock.recv(1, _socket.MSG_PEEK | _socket.MSG_DONTWAIT)
+            if data == b"":
                 dead_count += 1
-            finally:
-                try:
-                    sock.setblocking(True)
-                except OSError:
-                    pass
-        if dead_count > 0:
-            _ra().logger.warning(
-                "Found %d dead connection(s) in client pool — rebuilding client",
-                dead_count,
+        except BlockingIOError:
+            pass  # No data available — socket is healthy
+        except OSError:
+            dead_count += 1
+        finally:
+            try:
+                sock.setblocking(True)
+            except OSError:
+                pass
+    return dead_count
+
+
+def cleanup_dead_connections(agent) -> bool:
+    """Detect and clean up dead TCP connections owned by an agent.
+
+    Long-lived chat-completion turns use a cached per-request OpenAI client
+    for sequential calls, while ``agent.client`` remains the primary client
+    used for runtime rebuilds and provider management.  Inspect both pools:
+    a provider FIN on the cached client otherwise stays in CLOSE-WAIT until
+    session teardown and can be handed back to the next request.
+
+    Dead sockets on the primary client rebuild that client.  Dead sockets on
+    the request cache go through the cache's ownership-aware teardown hook so
+    an in-flight worker is aborted safely and an idle client is closed by its
+    owner.  Returns True if dead connections were found and cleaned up.
+    """
+    primary = getattr(agent, "client", None)
+    cache = getattr(agent, "_request_client_cache", None)
+    request_client = cache.get("client") if isinstance(cache, dict) else None
+
+    clients: list[tuple[str, Any]] = []
+    if primary is not None:
+        clients.append(("primary", primary))
+    if request_client is not None and request_client is not primary:
+        clients.append(("request", request_client))
+    if not clients:
+        return False
+
+    dead_clients: list[tuple[str, Any, int]] = []
+    for label, client in clients:
+        try:
+            dead_count = _count_dead_pool_sockets(client)
+            if dead_count:
+                dead_clients.append((label, client, dead_count))
+        except Exception as exc:
+            _ra().logger.debug(
+                "Dead connection check error for %s client: %s",
+                label,
+                exc,
             )
-            agent._replace_primary_openai_client(reason="dead_connection_cleanup")
-            return True
-    except Exception as exc:
-        _ra().logger.debug("Dead connection check error: %s", exc)
-    return False
+
+    if not dead_clients:
+        return False
+
+    total_dead = sum(count for _label, _client, count in dead_clients)
+    labels = ", ".join(label for label, _client, _count in dead_clients)
+    _ra().logger.warning(
+        "Found %d dead connection(s) in %s client pool(s) — cleaning up",
+        total_dead,
+        labels,
+    )
+
+    for label, _client, _count in dead_clients:
+        try:
+            if label == "primary":
+                agent._replace_primary_openai_client(
+                    reason="dead_connection_cleanup"
+                )
+            else:
+                # This hook clears the cache and chooses close() vs socket
+                # shutdown based on whether another worker owns the client.
+                agent._close_cached_request_openai_client(
+                    reason="dead_connection_cleanup"
+                )
+        except Exception as exc:
+            _ra().logger.debug(
+                "Dead connection cleanup error for %s client: %s",
+                label,
+                exc,
+            )
+    return True
 
 
 

--- a/tests/agent/test_dead_connection_cleanup.py
+++ b/tests/agent/test_dead_connection_cleanup.py
@@ -1,0 +1,65 @@
+"""Regression tests for stale provider sockets in agent-owned client pools."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent.agent_runtime_helpers import cleanup_dead_connections
+
+
+class _ProbeSocket:
+    def __init__(self, *, dead):
+        self.dead = dead
+
+    def setblocking(self, _enabled):
+        pass
+
+    def recv(self, _size, _flags):
+        if self.dead:
+            return b""
+        raise BlockingIOError
+
+
+def _client_with_socket(sock):
+    stream = SimpleNamespace(_sock=sock)
+    http11 = SimpleNamespace(_network_stream=stream)
+    pool_entry = SimpleNamespace(_connection=http11)
+    pool = SimpleNamespace(_connections=[pool_entry])
+    transport = SimpleNamespace(_pool=pool)
+    http_client = SimpleNamespace(_transport=transport)
+    return SimpleNamespace(_client=http_client)
+
+
+def test_cleanup_retires_dead_cached_request_client():
+    """A half-closed request pool must not be hidden by a healthy primary."""
+    primary = _client_with_socket(_ProbeSocket(dead=False))
+    request = _client_with_socket(_ProbeSocket(dead=True))
+    agent = SimpleNamespace(
+        client=primary,
+        _request_client_cache={"client": request},
+        _replace_primary_openai_client=MagicMock(),
+        _close_cached_request_openai_client=MagicMock(),
+    )
+
+    assert cleanup_dead_connections(agent) is True
+    agent._replace_primary_openai_client.assert_not_called()
+    agent._close_cached_request_openai_client.assert_called_once_with(
+        reason="dead_connection_cleanup"
+    )
+
+
+def test_cleanup_rebuilds_dead_primary_client():
+    """The existing primary-client recovery remains the cleanup path."""
+    primary = _client_with_socket(_ProbeSocket(dead=True))
+    request = _client_with_socket(_ProbeSocket(dead=False))
+    agent = SimpleNamespace(
+        client=primary,
+        _request_client_cache={"client": request},
+        _replace_primary_openai_client=MagicMock(),
+        _close_cached_request_openai_client=MagicMock(),
+    )
+
+    assert cleanup_dead_connections(agent) is True
+    agent._replace_primary_openai_client.assert_called_once_with(
+        reason="dead_connection_cleanup"
+    )
+    agent._close_cached_request_openai_client.assert_not_called()


### PR DESCRIPTION
Fixes #91286

## Summary

- Extend the pre-turn dead-socket sweep to the cached per-request OpenAI client used by sequential chat-completion calls.
- Rebuild the primary client only when its pool is unhealthy; retire a stale request client through its ownership-aware teardown hook.
- Add regression coverage for a half-closed cached pool and preserve the primary-client recovery path.

## Root cause

The reusable per-request client introduced in #82e2c9ce40 was separate from `agent.client`, but `cleanup_dead_connections()` continued to inspect only the primary client. A provider FIN could therefore leave the cached request pool holding a `CLOSE_WAIT` socket and hand that pool back to the next request.

## Validation

- Canonical runner: 49 focused request/lifecycle/socket tests passed.
- Ruff: changed files clean.
- Windows-footgun scan: changed files clean.
- Loopback reproduction: confirmed a provider half-close is detected and the cached client is retired.

The broader agent/runtime slice also completed with 6,740 passing tests; its 44 failures were unrelated environment/harness issues (optional Anthropic dependency, live-process guard, and `/tmp` Git-root assumptions).