### PR TITLE
fix(file_operations): correct total_lines for files without trailing newline

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -375,6 +375,74 @@ class TestShellFileOpsHelpers:
         assert "\x07" not in result.content
         assert "1|print('ok')" in result.content
 
+    def test_no_trailing_newline_counts_final_line(self, mock_env):
+        """wc -l undercounts when the final line has no trailing newline."""
+        content = "alpha\nbravo\ncharlie"  # 3 lines, no final LF
+
+        def side_effect(command, **kwargs):
+            if command.startswith("if [ -f ") or (
+                command.startswith("wc -c") and " < " in command
+            ):
+                return {"output": f"{len(content)}\n", "returncode": 0}
+            if command.startswith("head -c") and "| base64" in command:
+                import base64 as b64
+                return {
+                    "output": b64.b64encode(content.encode()).decode() + "\n",
+                    "returncode": 0,
+                }
+            if command.startswith("head -c"):
+                return {"output": content[:1000], "returncode": 0}
+            if command.startswith("sed -n"):
+                # cut always NL-terminates
+                return {"output": content + "\n", "returncode": 0}
+            if command.startswith("wc -l"):
+                return {"output": "2\n", "returncode": 0}
+            if command.startswith("tail -c 1") and "od " in command:
+                return {"output": "65\n", "returncode": 0}
+            if command.startswith("tail -c 1"):
+                # phantom-NL strip path: last byte not NL → wc -l == 0
+                return {"output": "0\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file("/tmp/test/no_nl.txt")
+        assert result.error is None, result
+        assert result.total_lines == 3
+
+    def test_trailing_newline_does_not_double_count(self, mock_env):
+        """Files that already end in LF must keep wc -l's count."""
+        content = "alpha\nbravo\ncharlie\n"
+
+        def side_effect(command, **kwargs):
+            if command.startswith("if [ -f ") or (
+                command.startswith("wc -c") and " < " in command
+            ):
+                return {"output": f"{len(content)}\n", "returncode": 0}
+            if command.startswith("head -c") and "| base64" in command:
+                import base64 as b64
+                return {
+                    "output": b64.b64encode(content.encode()).decode() + "\n",
+                    "returncode": 0,
+                }
+            if command.startswith("head -c"):
+                return {"output": content[:1000], "returncode": 0}
+            if command.startswith("sed -n"):
+                return {"output": content, "returncode": 0}
+            if command.startswith("wc -l"):
+                return {"output": "3\n", "returncode": 0}
+            if command.startswith("tail -c 1") and "od " in command:
+                return {"output": "0a\n", "returncode": 0}
+            if command.startswith("tail -c 1"):
+                return {"output": "1\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file("/tmp/test/with_nl.txt")
+        assert result.error is None, result
+        assert result.total_lines == 3
+
     def test_read_file_raw_strips_leaked_terminal_fence_markers(self, mock_env):
         leaked = (
             "__HERMES_FENCE_a9f7b3__\x07'\n"

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -375,10 +375,8 @@ class TestShellFileOpsHelpers:
         assert "\x07" not in result.content
         assert "1|print('ok')" in result.content
 
-    def test_no_trailing_newline_counts_final_line(self, mock_env):
-        """wc -l undercounts when the final line has no trailing newline."""
-        content = "alpha\nbravo\ncharlie"  # 3 lines, no final LF
-
+    def _read_side_effect(self, content, wc_lines, last_hex):
+        """Stub shell responses for read_file meta probe + content path."""
         def side_effect(command, **kwargs):
             if command.startswith("if [ -f ") or (
                 command.startswith("wc -c") and " < " in command
@@ -393,18 +391,23 @@ class TestShellFileOpsHelpers:
             if command.startswith("head -c"):
                 return {"output": content[:1000], "returncode": 0}
             if command.startswith("sed -n"):
-                # cut always NL-terminates
-                return {"output": content + "\n", "returncode": 0}
+                # cut always NL-terminates page output
+                out = content if content.endswith("\n") else content + "\n"
+                return {"output": out, "returncode": 0}
+            # Combined meta: `wc -l < path; tail -c 1 path | od ...`
+            if "wc -l <" in command and "od " in command:
+                return {"output": f"{wc_lines}\n{last_hex}\n", "returncode": 0}
             if command.startswith("wc -l"):
-                return {"output": "2\n", "returncode": 0}
+                return {"output": f"{wc_lines}\n", "returncode": 0}
             if command.startswith("tail -c 1") and "od " in command:
-                return {"output": "65\n", "returncode": 0}
-            if command.startswith("tail -c 1"):
-                # phantom-NL strip path: last byte not NL → wc -l == 0
-                return {"output": "0\n", "returncode": 0}
+                return {"output": f"{last_hex}\n", "returncode": 0}
             return {"output": "", "returncode": 0}
+        return side_effect
 
-        mock_env.execute.side_effect = side_effect
+    def test_no_trailing_newline_counts_final_line(self, mock_env):
+        """wc -l undercounts when the final line has no trailing newline."""
+        content = "alpha\nbravo\ncharlie"  # 3 lines, no final LF
+        mock_env.execute.side_effect = self._read_side_effect(content, wc_lines=2, last_hex="65")
         ops = ShellFileOperations(mock_env)
         result = ops.read_file("/tmp/test/no_nl.txt")
         assert result.error is None, result
@@ -413,35 +416,46 @@ class TestShellFileOpsHelpers:
     def test_trailing_newline_does_not_double_count(self, mock_env):
         """Files that already end in LF must keep wc -l's count."""
         content = "alpha\nbravo\ncharlie\n"
+        mock_env.execute.side_effect = self._read_side_effect(content, wc_lines=3, last_hex="0a")
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file("/tmp/test/with_nl.txt")
+        assert result.error is None, result
+        assert result.total_lines == 3
+
+    def test_empty_file_total_lines_zero(self, mock_env):
+        """size-0 files must stay at total_lines == 0 (no +1, no crash)."""
+        content = ""
 
         def side_effect(command, **kwargs):
             if command.startswith("if [ -f ") or (
                 command.startswith("wc -c") and " < " in command
             ):
-                return {"output": f"{len(content)}\n", "returncode": 0}
+                return {"output": "0\n", "returncode": 0}
             if command.startswith("head -c") and "| base64" in command:
-                import base64 as b64
-                return {
-                    "output": b64.b64encode(content.encode()).decode() + "\n",
-                    "returncode": 0,
-                }
+                return {"output": "\n", "returncode": 0}
             if command.startswith("head -c"):
-                return {"output": content[:1000], "returncode": 0}
+                return {"output": "", "returncode": 0}
             if command.startswith("sed -n"):
-                return {"output": content, "returncode": 0}
-            if command.startswith("wc -l"):
-                return {"output": "3\n", "returncode": 0}
-            if command.startswith("tail -c 1") and "od " in command:
-                return {"output": "0a\n", "returncode": 0}
-            if command.startswith("tail -c 1"):
-                return {"output": "1\n", "returncode": 0}
+                return {"output": "", "returncode": 0}
+            # empty file skips meta probe entirely
+            if "wc -l" in command:
+                raise AssertionError(f"unexpected wc probe on empty file: {command}")
             return {"output": "", "returncode": 0}
 
         mock_env.execute.side_effect = side_effect
         ops = ShellFileOperations(mock_env)
-        result = ops.read_file("/tmp/test/with_nl.txt")
+        result = ops.read_file("/tmp/test/empty.txt")
+        assert result.error is None or result.content == "" or result.total_lines == 0
+        assert result.total_lines == 0
+
+    def test_single_line_no_trailing_newline(self, mock_env):
+        """Single-line file without LF is one logical line (wc -l=0 → +1)."""
+        content = "x"
+        mock_env.execute.side_effect = self._read_side_effect(content, wc_lines=0, last_hex="78")
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file("/tmp/test/one_line.txt")
         assert result.error is None, result
-        assert result.total_lines == 3
+        assert result.total_lines == 1
 
     def test_read_file_raw_strips_leaked_terminal_fence_markers(self, mock_env):
         leaked = (

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -314,6 +314,8 @@ class TestShellFileOpsHelpers:
                 return {"output": "hello", "returncode": 0}
             if command.startswith("sed -n"):
                 return {"output": "hello\n", "returncode": 0}
+            if "wc -l <" in command and "od " in command:
+                return {"output": "1\n0a\n", "returncode": 0}
             if command.startswith("wc -l"):
                 return {"output": "1\n", "returncode": 0}
             return {"output": "", "returncode": 0}
@@ -332,7 +334,9 @@ class TestShellFileOpsHelpers:
         )
         assert commands[1] == "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null | base64"
         assert commands[2] == "sed -n '1,2000p' '/c/Users/alice/notes.txt' | cut -b1-8001"
-        assert commands[3] == "wc -l < '/c/Users/alice/notes.txt'"
+        assert commands[3].startswith("wc -l < '/c/Users/alice/notes.txt'")
+        assert "tail -c 1 '/c/Users/alice/notes.txt'" in commands[3]
+        assert "od -An -tx1" in commands[3]
 
     def test_is_likely_binary_by_extension(self, file_ops):
         assert file_ops._is_likely_binary("photo.png") is True

--- a/tests/tools/test_file_tools_live.py
+++ b/tests/tools/test_file_tools_live.py
@@ -149,6 +149,16 @@ class TestReadFile:
 # ── write_file ───────────────────────────────────────────────────────────
 
 class TestWriteFile:
+    def test_total_lines_no_trailing_newline(self, ops, tmp_path):
+        f = tmp_path / "no_trailing_lf.txt"
+        f.write_bytes(b"alpha\nbravo\ncharlie")
+        result = ops.read_file(str(f))
+        assert result.error is None
+        assert "alpha" in result.content
+        assert "charlie" in result.content
+        assert result.total_lines == 3
+        _assert_clean(result.content)
+
     def test_write_and_verify(self, ops, tmp_path):
         path = str(tmp_path / "written.txt")
         result = ops.write_file(path, SIMPLE_CONTENT)

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1601,7 +1601,20 @@ class ShellFileOperations(FileOperations):
             total_lines = int(wc_output.strip())
         except ValueError:
             total_lines = 0
-        
+
+        # wc -l counts newline characters, not lines. A file whose final line
+        # has no trailing newline therefore has one more line of content than
+        # wc -l reports. Detect this by inspecting the last byte of the file
+        # and, when it is not 0x0a (\n), account for the uncounted final line.
+        if file_size > 0:
+            tail_cmd = (
+                f"tail -c 1 {self._escape_shell_arg(path)} | od -An -tx1 | tr -d ' '"
+            )
+            tail_result = self._exec(tail_cmd)
+            last_byte = _strip_terminal_fence_leaks(tail_result.stdout).strip()
+            if last_byte and last_byte != "0a":
+                total_lines += 1
+
         # Check if truncated
         truncated = total_lines > end_line
         hint = None

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1593,27 +1593,43 @@ class ShellFileOperations(FileOperations):
         if offset == 1:
             read_output, _ = _strip_bom(read_output)
         
-        # Get total line count
-        wc_cmd = f"wc -l < {self._escape_shell_arg(path)}"
-        wc_result = self._exec(wc_cmd)
-        wc_output = _strip_terminal_fence_leaks(wc_result.stdout)
-        try:
-            total_lines = int(wc_output.strip())
-        except ValueError:
-            total_lines = 0
-
-        # wc -l counts newline characters, not lines. A file whose final line
-        # has no trailing newline therefore has one more line of content than
-        # wc -l reports. Detect this by inspecting the last byte of the file
-        # and, when it is not 0x0a (\n), account for the uncounted final line.
+        # Get total line count + last-byte probe in one shell round-trip.
+        # wc -l counts newline characters (0x0a), not logical lines. A file
+        # whose final line has no trailing LF therefore has one more line of
+        # content than wc -l reports. Only LF (0x0a) is treated as a line
+        # terminator here — a bare CR (0x0d, legacy Mac) is not, so such a
+        # final byte still triggers the +1 correction (same as "no LF").
+        escaped = self._escape_shell_arg(path)
         if file_size > 0:
-            tail_cmd = (
-                f"tail -c 1 {self._escape_shell_arg(path)} | od -An -tx1 | tr -d ' '"
+            meta_cmd = (
+                f"wc -l < {escaped}; "
+                f"tail -c 1 {escaped} | od -An -tx1 | tr -d ' \n\t\r'"
             )
-            tail_result = self._exec(tail_cmd)
-            last_byte = _strip_terminal_fence_leaks(tail_result.stdout).strip()
+            meta_result = self._exec(meta_cmd)
+            meta_out = _strip_terminal_fence_leaks(meta_result.stdout)
+            meta_lines = [ln.strip() for ln in meta_out.splitlines() if ln.strip() != ""]
+            try:
+                total_lines = int(meta_lines[0]) if meta_lines else 0
+            except ValueError:
+                total_lines = 0
+            last_byte = meta_lines[1].lower() if len(meta_lines) > 1 else ""
             if last_byte and last_byte != "0a":
                 total_lines += 1
+            elif not last_byte:
+                # od/BusyBox reduced builds may yield empty output; keep the
+                # uncorrected wc -l count but make the degraded mode visible.
+                try:
+                    import logging
+                    logging.getLogger(__name__).debug(
+                        "read_file last-byte probe empty for %s (file_size=%s); "
+                        "total_lines left at wc -l=%s",
+                        path, file_size, total_lines,
+                    )
+                except Exception:
+                    pass
+        else:
+            total_lines = 0
+            last_byte = "0a"  # empty file: no content lines, no phantom strip
 
         # Check if truncated
         truncated = total_lines > end_line
@@ -1624,12 +1640,9 @@ class ShellFileOperations(FileOperations):
         # ``cut`` (unlike sed -n p) always newline-terminates its output,
         # so a file whose final line has no trailing newline would grow a
         # phantom empty last line. Only possible when this page reaches the
-        # file's final line; probe the last byte and strip the artifact.
+        # file's final line; reuse last_byte from the meta probe above.
         if not truncated and read_output.endswith('\n'):
-            tail_cmd = f"tail -c 1 {self._escape_shell_arg(path)} | wc -l"
-            tail_result = self._exec(tail_cmd)
-            tail_output = _strip_terminal_fence_leaks(tail_result.stdout)
-            if tail_result.exit_code == 0 and tail_output.strip() == "0":
+            if last_byte and last_byte != "0a":
                 read_output = read_output[:-1]
 
         # Ambiguous-silence guards: an empty content string is


### PR DESCRIPTION
## Summary

`read_file()` derived `total_lines` from `wc -l`, which counts newline characters rather than lines. A file whose final line has no trailing newline is therefore undercounted by one, producing incorrect pagination hints and truncation flags.

## Motivation

Salvage of #20814 by @ms-alan. Supersedes stale/drifted #67355 — main grew a last-byte probe for phantom-NL stripping on content, but **still** assigns `total_lines` from raw `wc -l` with no correction. Unit stubs also needed the modern size-probe / base64 sample path.

## Changes

- After `wc -l`, if `file_size > 0`, inspect last byte via `tail -c 1 | od`; when not `0a`, `total_lines += 1`.
- Regression tests (stubbed `_exec` + live LocalEnvironment) for no-trailing-NL and trailing-NL cases.

## Verification

```
python3 -m pytest tests/tools/test_file_operations.py tests/tools/test_file_tools_live.py -q
90 passed, 2 skipped
```

Credit: @ms-alan (#20814). Prior salvage attempt: #67355.