### PR TITLE
fix(desktop): Windows glass windows stop rendering when they lose focus

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -280,10 +280,12 @@ import {
   glassActive,
   glassSupportedOn,
   normalizeState as normalizeTranslucency,
+  opacityNeedsSetting,
   translucencySupportedOn,
   vibrancyFor as vibrancyForTranslucency,
   windowBackingOptions,
-  windowOpacityFor
+  windowOpacityFor,
+  windowOpacityOptions
 } from './translucency'
 import {
   compareApiUrl,
@@ -908,15 +910,23 @@ let translucencyState = readPersistedTranslucency()
 // painting a themed backing onto them would turn them into opaque rectangles.
 const translucencyBackedWindows = new WeakSet()
 
-function windowOpacity() {
-  return windowOpacityFor(translucencyState)
+// Set a live window's native opacity, but only when the state asks it to fade
+// — or when the window is already faded and is on its way back to opaque. The
+// window's own opacity is the record of whether that door was ever opened; see
+// opacityNeedsSetting for why it matters that it stays shut.
+function applyWindowOpacity(win) {
+  const opacity = windowOpacityFor(translucencyState)
+
+  if (typeof win.setOpacity === 'function' && opacityNeedsSetting(opacity, win.getOpacity?.() ?? 1)) {
+    win.setOpacity(opacity)
+  }
 }
 
 // Re-apply translucency to a live window (runtime toggle, no recreation).
-// `setOpacity` is a no-op on Linux, which is fine — it just stays opaque there.
-// The backing swap is the glass half: Chromium composites the page against
-// the window backing BEFORE the OS composites the window, so glass needs the
-// backing dropped for the platform material to reach a transparent page, and
+// Opacity goes through applyWindowOpacity, which knows when the call is worth
+// making at all. The backing swap is the glass half: Chromium composites the
+// page against the window backing BEFORE the OS composites the window, so
+// glass needs the backing dropped for the platform material to reach it, and
 // every other state needs the opaque themed backing (anti-flash, and it is
 // what makes clear mode fade to the desktop instead of to black).
 //
@@ -965,8 +975,8 @@ function applyWindowTranslucency(win, changed = { backing: true, material: true,
       }
     }
 
-    if (changed.opacity && typeof win.setOpacity === 'function') {
-      win.setOpacity(windowOpacity())
+    if (changed.opacity) {
+      applyWindowOpacity(win)
     }
   } catch (error) {
     rememberLog(`[translucency] apply failed: ${error.message}`)
@@ -974,11 +984,12 @@ function applyWindowTranslucency(win, changed = { backing: true, material: true,
 }
 
 // Constructor options every chat window shares for its translucency surface:
-// the vibrancy material, the native opacity, and the webContents backing under
-// the CURRENT state. Glass omits backgroundColor so vibrancy shows from the
-// first frame (a non-transparent window silently ignores constructor alpha,
-// and runtime swaps are lost early in a window's life — see
-// applyWindowTranslucency); otherwise the opaque themed anti-flash backing.
+// the platform material, the webContents backing, and a native opacity only if
+// the state actually fades — all under the CURRENT state. Glass omits
+// backgroundColor so the material shows from the first frame (Electron hands a
+// translucent window a transparent default backing, and runtime swaps are lost
+// early in a window's life — see applyWindowTranslucency); otherwise the opaque
+// themed anti-flash backing.
 //
 // Call sites also register the window in translucencyBackedWindows so a live
 // toggle can re-apply. The HUD, pet overlay, quick entry and wake indicator
@@ -994,13 +1005,22 @@ function chatWindowSurfaceOptions() {
     // user's frost choice whenever they click elsewhere. Only observable
     // under glass — everywhere else the page buries the material.
     visualEffectState: IS_MAC ? ('active' as const) : undefined,
-    // Win11 DWM materials only reach the client area on a transparent window
-    // (electron#49443). Chat windows on glass-capable Windows are born
-    // transparent so a live Clear→Glass toggle doesn't need a recreate; the
-    // opaque themed backgroundColor covers it while glass is off.
-    ...(IS_WINDOWS && GLASS_SUPPORTED ? { transparent: true } : {}),
+    // NOT `transparent: true` on Windows. The backdrop material already makes
+    // the window translucent on its own: `IsTranslucent` answers yes off
+    // `background_material_` alone, which is what gives the page its transparent
+    // default backing, and `SetBackgroundMaterial` flips widget translucency
+    // live, so a Clear→Glass toggle needs no recreate either way. Its one gate
+    // is a frameless window, and `titleBarStyle: 'hidden'` already makes
+    // `has_frame()` false here.
+    //
+    // What `transparent` adds on top is permanent and unwanted: it pins the
+    // widget to kTranslucent for the window's whole life, so even glass-OFF
+    // windows pay a DirectComposition redraw per frame (electron#39895), and it
+    // opts into the documented transparent-window limits — including that a
+    // RESIZABLE transparent window is unsupported and breaks (electron#48421).
+    // Every chat window is resizable.
     backgroundMaterial: IS_WINDOWS && GLASS_SUPPORTED ? backgroundMaterialFor(translucencyState) : undefined,
-    opacity: windowOpacity(),
+    ...windowOpacityOptions(translucencyState),
     ...windowBackingOptions(translucencyState, getWindowBackgroundColor())
   }
 }

--- a/apps/desktop/electron/translucency.test.ts
+++ b/apps/desktop/electron/translucency.test.ts
@@ -31,6 +31,7 @@ import {
   normalizeMode,
   normalizeScope,
   normalizeState,
+  opacityNeedsSetting,
   resolveTranslucency,
   setTranslucencyValues,
   TRANSLUCENCY_CURVE,
@@ -42,6 +43,7 @@ import {
   vibrancyFor,
   windowBackingOptions,
   windowOpacityFor,
+  windowOpacityOptions,
   WINDOWS_BACKGROUND_MATERIALS,
   WINDOWS_GLASS_MIN_BUILD
 } from './translucency'
@@ -496,6 +498,53 @@ describe('windowBackingOptions', () => {
     expect(windowBackingOptions(glass(0), '#111111')).toEqual({ backgroundColor: '#111111' })
     expect(windowBackingOptions(clear(60), '#111111')).toEqual({ backgroundColor: '#111111' })
     expect(windowBackingOptions(clear(0), '#f7f7f7')).toEqual({ backgroundColor: '#f7f7f7' })
+  })
+})
+
+// A glass window on Windows is fully opaque natively — the tint is the
+// renderer's and fade defaults to zero — so it used to be handed `opacity: 1`
+// on every launch. Electron's Windows setOpacity layers the window before it
+// reads the value and never unlayers it, and a layered window is one DWM will
+// not draw acrylic behind: the window rendered while focused and went dead the
+// moment it lost focus. The no-op ask has to not be made.
+describe('windowOpacityOptions', () => {
+  it('omits opacity entirely when the window is fully opaque', () => {
+    expect(windowOpacityOptions(glass(60))).toStrictEqual({})
+    expect(windowOpacityOptions(clear(0))).toStrictEqual({})
+  })
+
+  it('passes it the moment the state actually fades', () => {
+    for (const state of [clear(1), clear(100), glass(60, DEFAULT_GLASS_MATERIAL, 1)]) {
+      expect(windowOpacityOptions(state)).toStrictEqual({ opacity: windowOpacityFor(state) })
+    }
+  })
+
+  // Windows sits at fade 0 in both appearances, so no Windows chat window is
+  // born asking to fade — the whole platform stays off the layered path until
+  // someone opts in.
+  it('leaves every untouched Windows window unlayered', () => {
+    for (const appearance of ['light', 'dark'] as const) {
+      const state = { ...defaultTranslucencyValues(appearance, true), mode: 'glass' as const }
+
+      expect(windowOpacityOptions(state), appearance).toStrictEqual({})
+    }
+  })
+})
+
+describe('opacityNeedsSetting', () => {
+  it('skips the call for an opaque window that has never been faded', () => {
+    expect(opacityNeedsSetting(1, 1)).toBe(false)
+  })
+
+  it('makes the call whenever the target fades', () => {
+    expect(opacityNeedsSetting(0.5, 1)).toBe(true)
+    expect(opacityNeedsSetting(0.9999, 1)).toBe(true)
+  })
+
+  // The way back. A window already at 0.5 has paid for the layering, so
+  // returning it to opaque is free — and skipping it would strand the fade.
+  it('makes the call to return an already-faded window to opaque', () => {
+    expect(opacityNeedsSetting(1, 0.5)).toBe(true)
   })
 })
 

--- a/apps/desktop/electron/translucency.ts
+++ b/apps/desktop/electron/translucency.ts
@@ -11,7 +11,7 @@
  * then fail to bundle.
  */
 
-import { glassActive, type TranslucencyState } from '../../shared/src/translucency'
+import { glassActive, type TranslucencyState, windowOpacityFor } from '../../shared/src/translucency'
 
 export {
   backgroundMaterialFor,
@@ -53,11 +53,12 @@ export {
  * BrowserWindow constructor options for a chat window's backing, given the
  * translucency state at creation time.
  *
- * Glass active → OMIT `backgroundColor` entirely: on a `vibrancy` window the
- * NSVisualEffectView then shows through a transparent page from the first
- * frame. Passing an alpha color instead does NOT work — Electron only supports
- * constructor alpha with `transparent: true`, and `#00000000` on a normal
- * window is quietly treated as opaque.
+ * Glass active → OMIT `backgroundColor` entirely. Electron reads a window as
+ * translucent when it carries a vibrancy or a backdrop material, and hands a
+ * translucent window a transparent default backing, so the platform material
+ * shows through the page from the first frame. Passing an alpha color instead
+ * does NOT work — constructor alpha needs `transparent: true`, and `#00000000`
+ * on a normal window is quietly treated as opaque.
  *
  * Glass inactive → the opaque themed backing (anti-flash paint before the
  * renderer's first paint, and what clear mode fades against).
@@ -70,4 +71,35 @@ export {
  */
 export function windowBackingOptions(state: TranslucencyState, themedColor: string): { backgroundColor?: string } {
   return glassActive(state) ? {} : { backgroundColor: themedColor }
+}
+
+/**
+ * Whether a window's native opacity is worth setting at all.
+ *
+ * Fully opaque is what a window already is, so asking for it looks free. On
+ * Windows it is the opposite of free: `setOpacity` puts `WS_EX_LAYERED` on the
+ * window and calls `SetLayeredWindowAttributes(..., LWA_ALPHA)` before it even
+ * looks at the value, and nothing ever takes the style back off
+ * (`NativeWindowViews::SetOpacity` → `SetLayered`). A layered window
+ * composites through the legacy redirection surface — which Windows documents
+ * as mutually exclusive with `UpdateLayeredWindow`, and which DWM will not
+ * draw a system backdrop behind. So `opacity: 1` on a glass window buys
+ * nothing and costs it its acrylic.
+ *
+ * `current` is the way back: a window that is already faded has already paid
+ * for the layering, and it has to be able to return to opaque — so it keeps
+ * getting the call even when the value it is going to is 1.
+ */
+export function opacityNeedsSetting(next: number, current = 1): boolean {
+  return next < 1 || current < 1
+}
+
+/**
+ * BrowserWindow constructor options for a chat window's native opacity. Empty
+ * unless the state actually asks the window to fade — see opacityNeedsSetting.
+ */
+export function windowOpacityOptions(state: TranslucencyState): { opacity?: number } {
+  const opacity = windowOpacityFor(state)
+
+  return opacityNeedsSetting(opacity) ? { opacity } : {}
 }

--- a/apps/desktop/electron/translucency.ts
+++ b/apps/desktop/electron/translucency.ts
@@ -89,6 +89,12 @@ export function windowBackingOptions(state: TranslucencyState, themedColor: stri
  * `current` is the way back: a window that is already faded has already paid
  * for the layering, and it has to be able to return to opaque — so it keeps
  * getting the call even when the value it is going to is 1.
+ *
+ * What this cannot do is un-layer. Electron offers no way back off
+ * `WS_EX_LAYERED`, so a Windows window that has been faded once keeps the
+ * layered compositing path until it is recreated. Not opening the door on the
+ * default path is the whole of the fix; someone who deliberately fades and
+ * then returns to glass still wants a restart.
  */
 export function opacityNeedsSetting(next: number, current = 1): boolean {
   return next < 1 || current < 1


### PR DESCRIPTION
A Windows chat window under glass renders while focused and goes dead the
moment it loses focus. Two options in `chatWindowSurfaceOptions` put the window
on a compositing path DWM will not draw acrylic behind. Both look like no-ops,
which is why they read as harmless; both landed latent in #89837 and only
surfaced when #90587 turned glass on by default and dropped the opaque
`backgroundColor` that had been covering for them.

Reported on Windows 11 after the theme/glass defaults change. No Windows box to
reproduce on, so the account below is read off the Electron 40 source rather
than a repro — the exact lines are named so the reasoning can be checked.

## `opacity: 1` was layering every window

Every chat window was handed `opacity: windowOpacity()`. Under glass on Windows
`fade` is 0 in both appearances, so the value is *always* 1 — the window's
existing opacity. But Electron's Windows `SetOpacity` doesn't look at the value
first:

```cpp
void NativeWindowViews::SetOpacity(const double opacity) {
  const double boundedOpacity = std::clamp(opacity, 0.0, 1.0);
  HWND hwnd = GetAcceleratedWidget();
  SetLayered();
  ::SetLayeredWindowAttributes(hwnd, 0, boundedOpacity * 255, LWA_ALPHA);
```

`SetLayered()` puts `WS_EX_LAYERED` on the window and nothing ever takes it off,
and the constructor runs this for any `opacity` present at all
(`native_window.cc`: `if (double val; options.Get(options::kOpacity, &val)) SetOpacity(val);`).
A layered window composites through the legacy redirection surface, which
Windows documents as [mutually exclusive with `UpdateLayeredWindow`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setlayeredwindowattributes),
and which a DWM system backdrop cannot sit behind.

Opacity is now only passed when the state actually asks the window to fade. The
runtime path keeps setting it for a window that is *already* faded, so a fade
dragged back down still returns to opaque rather than stranding at 0.99.

## `transparent: true` was never needed

Glass-capable Windows chat windows were born `transparent: true`, on the premise
that Win11 DWM materials only reach the client area that way — cited to
[electron#49443](https://github.com/electron/electron/issues/49443), which was
closed as need-info against an EOL Electron 28 and never confirmed.

The material does this itself. `IsTranslucent()` answers yes off
`background_material_` alone, which is what gives the page its transparent
default backing at construction, and `SetBackgroundMaterial` flips widget
translucency live (`SetIsTranslucent` + `UpdateWindowTransparency`) — so a
Clear→Glass toggle needs no recreate either way. Its one gate is a frameless
window (`!has_frame()`), and `has_frame_` is already false here because
`titleBarStyle: 'hidden'` sets it so.

What `transparent` added on top was permanent:

- it pins the widget to `WindowOpacity::kTranslucent` for the window's whole
  life, so `ShouldWindowContentsBeTransparent()` stays true even with the
  material at `none` — the per-frame DirectComposition redraw
  [electron#39895](https://github.com/electron/electron/pull/39895) exists to
  avoid;
- it opts into the documented transparent-window limitations, including that a
  **resizable** transparent window is unsupported and breaks
  ([electron#48421](https://github.com/electron/electron/issues/48421), and the
  same warning in the Custom Window Styles docs). Every chat window is
  resizable.

With glass off the window is now genuinely opaque with its themed backing,
which is what that state always meant. That also stops Electron suppressing the
window's shadow, since it suppresses it only for a translucent frameless window.

One thing this can't undo: Electron gives no way back off `WS_EX_LAYERED`, so a
window that has been faded once keeps the layered path until it's recreated.
Someone who deliberately fades and returns to glass still wants a restart. The
default path never opens the door, which is the case that matters.

## Test plan

- [x] `vitest run electron/` — 1496 passed, 3 skipped
- [x] `tsc -p tsconfig.electron.json --noEmit`, eslint, prettier
- [x] New contract tests: opacity is omitted whenever the window is fully
      opaque, passed the moment the state fades, and still issued to bring an
      already-faded window back to 1 — plus that neither Windows appearance
      default asks to fade, so no untouched Windows window reaches the layered
      path
- [ ] Needs a Windows 11 22H2+ check: glass still renders, the window keeps
      painting when it loses focus, and the glass-off window looks right with
      its shadow back

If DWM still flattens the backdrop on deactivate after this, that is a separate
and genuinely OS-level behavior ([electron#48031](https://github.com/electron/electron/issues/48031))
and wants its own fix; nothing here is speculative cover for it.
