### PR TITLE
feat(session-search): treat compression continuations as one conversation (lineage-aware recall)

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -46,6 +46,105 @@ _FTS5_SPECIAL_CHARS = '+{}():"^@/#&|~[]<>,;!?$=\\\''
 _FTS5_SPECIAL_RE = re.compile(f"[{re.escape(_FTS5_SPECIAL_CHARS)}]")
 
 
+# ---------------------------------------------------------------------------
+# Compression-lineage resolver (fork #68, reconstructed on current upstream).
+#
+# One logical session-search query resolves each ranked owner candidate to
+# its positive compression-continuation root with a query-local
+# memo/path-compression pass.  Generic parentage is NOT lineage: only a
+# child whose parent exists, whose parent ended by ``'compression'``, that is
+# not a ``tool`` session, and whose branch/delegate markers do not explicitly
+# point at that parent forms a compression edge.  Foreign markers pointing
+# elsewhere do not disqualify the edge.
+#
+# Safety is orthogonal to lineage identity: a traversal-local seen-set proves
+# cycles, and a global per-query work budget bounds indexed row fetches.  A
+# budget-exhausted partial path is operational uncertainty, never semantic
+# evidence, so it is not memoized as unresolved.
+_LINEAGE_WORK_BUDGET = 2000
+_UNRESOLVED = object()
+_BUDGET_EXHAUSTED = object()
+
+_LINEAGE_NODE_SQL = """
+SELECT
+    child.id,
+    child.parent_session_id,
+    child.source,
+    child.model_config,
+    parent.id AS parent_exists,
+    parent.end_reason AS parent_end_reason
+FROM sessions child
+LEFT JOIN sessions parent ON parent.id = child.parent_session_id
+WHERE child.id = ?
+"""
+
+
+def _lineage_markers(
+    model_config: Any,
+) -> Tuple[bool, Optional[str], Optional[str]]:
+    """Return ``(config_valid, branched_from, delegate_from)`` for a session.
+
+    Malformed / non-object ``model_config`` is treated as "no proven positive
+    edge" (the conservative direction): the current node becomes its own root
+    rather than traversing an unproven parent.
+    """
+    if model_config in (None, ""):
+        return True, None, None
+    value = model_config
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (TypeError, ValueError):
+            return False, None, None
+    if not isinstance(value, dict):
+        return False, None, None
+    markers: List[Optional[str]] = []
+    for key in ("_branched_from", "_delegate_from"):
+        marker = value.get(key)
+        if marker is None:
+            markers.append(None)
+        elif isinstance(marker, str) and marker:
+            markers.append(marker)
+        else:
+            return False, None, None
+    return True, markers[0], markers[1]
+
+
+class _LineageResolutionState:
+    """Per-logical-query resolver state for one winner search.
+
+    ``work`` counts exactly one successful uncached lineage-node row fetch;
+    memo hits, absent-row fetches, and local cycle checks consume nothing.
+    ``memo`` maps a lineage node to a resolved root string or ``_UNRESOLVED``.
+    A budget-exhausted partial path is never written to the memo.
+    """
+
+    __slots__ = (
+        "budget",
+        "work",
+        "memo",
+        "memo_hits",
+        "bound_hit",
+        "candidates_inspected",
+        "accepted_roots",
+    )
+
+    def __init__(self, budget: int = _LINEAGE_WORK_BUDGET) -> None:
+        self.budget = max(1, int(budget))
+        self.work = 0
+        self.memo: Dict[str, Any] = {}
+        self.memo_hits = 0
+        self.bound_hit = False
+        self.candidates_inspected = 0
+        self.accepted_roots = 0
+
+    def _memoize_unresolved(self, path: List[str], node: str) -> None:
+        """Mark *path* plus *node* as proven unresolved (zero later lookups)."""
+        for visited in path:
+            self.memo.setdefault(visited, _UNRESOLVED)
+        self.memo.setdefault(node, _UNRESOLVED)
+
+
 class SessionSearchMixin:
     """See module docstring — mixin for SessionDB (Search cluster)."""
 
@@ -2285,6 +2384,167 @@ class SessionSearchMixin:
         with self._read_ctx() as conn:
             rows = conn.execute(sql, params).fetchall()
         return [dict(r) for r in rows]
+
+    def _resolve_compression_lineage_on_conn(
+        self,
+        conn: sqlite3.Connection,
+        session_id: str,
+        state: _LineageResolutionState,
+    ) -> Any:
+        """Resolve *session_id* to its compression root on *conn*.
+
+        Returns the resolved root string, ``_UNRESOLVED`` for a proven
+        semantic unresolved outcome (missing row / dangling parent / positive
+        cycle), or ``_BUDGET_EXHAUSTED`` when the global work budget would be
+        exceeded by the next uncached lookup.
+
+        The loop ordering is correctness-significant at the B boundary:
+        memo lookup first, then traversal-local cycle proof, then the budget
+        check (only because another uncached lookup is now required), then the
+        one-node point lookup.
+        """
+        if not session_id:
+            return _UNRESOLVED
+        node = str(session_id)
+        path: List[str] = []
+        seen: set = set()
+
+        while True:
+            cached = state.memo.get(node)
+            if cached is _UNRESOLVED:
+                state.memo_hits += 1
+                for visited in path:
+                    state.memo.setdefault(visited, _UNRESOLVED)
+                return _UNRESOLVED
+            if cached is not None:
+                # Memo hit: path-compress the visited prefix to the known root.
+                state.memo_hits += 1
+                for visited in path:
+                    state.memo.setdefault(visited, cached)
+                return cached
+
+            if node in seen:
+                # Positive cycle proven from the traversal-local seen-set
+                # with no further DB lookup (valid even at work == B).
+                state._memoize_unresolved(path, node)
+                return _UNRESOLVED
+            seen.add(node)
+
+            if state.work >= state.budget:
+                # Another uncached lookup is required and the budget is gone.
+                # This is operational uncertainty, NOT semantic unresolved, so
+                # the partial path is left out of the memo.
+                state.bound_hit = True
+                return _BUDGET_EXHAUSTED
+
+            row = conn.execute(_LINEAGE_NODE_SQL, (node,)).fetchone()
+            if row is None:
+                # The node row itself is missing: zero successful-fetch work
+                # for that absent row; the traversed path is semantically
+                # unresolved.
+                state._memoize_unresolved(path, node)
+                return _UNRESOLVED
+            state.work += 1
+
+            current = str(row["id"])
+            path.append(current)
+            parent_id = row["parent_session_id"]
+            if parent_id is None:
+                root = current
+                break
+            parent_id = str(parent_id)
+
+            if row["parent_exists"] is None:
+                # Dangling parent: malformed lineage, fail closed.
+                state._memoize_unresolved(path, node)
+                return _UNRESOLVED
+
+            config_valid, branched_from, delegate_from = _lineage_markers(
+                row["model_config"]
+            )
+            positive_edge = (
+                config_valid
+                and row["parent_end_reason"] == "compression"
+                and row["source"] != "tool"
+                and branched_from != parent_id
+                and delegate_from != parent_id
+            )
+            if not positive_edge:
+                root = current
+                break
+
+            node = parent_id
+
+        for visited in path:
+            state.memo.setdefault(visited, root)
+        return root
+
+    def resolve_compression_lineage(
+        self,
+        session_id: str,
+        *,
+        work_budget: int = _LINEAGE_WORK_BUDGET,
+    ) -> Optional[str]:
+        """Resolve *session_id* to its positive compression-continuation root.
+
+        Returns the root id, or ``None`` when the outcome is a proven semantic
+        unresolved (missing row / dangling parent / positive cycle) or the work
+        budget is exhausted.  Never falls back to generic parent ancestry; an
+        unresolved session is kept separate instead of broadening exclusion to
+        an unproven ancestor.
+        """
+        if not session_id:
+            return None
+        with self._read_ctx() as conn:
+            started_tx = not conn.in_transaction
+            if started_tx:
+                conn.execute("BEGIN")
+            try:
+                state = _LineageResolutionState(work_budget)
+                outcome = self._resolve_compression_lineage_on_conn(
+                    conn, str(session_id), state
+                )
+            finally:
+                if started_tx and conn.in_transaction:
+                    conn.rollback()
+        if outcome is _UNRESOLVED or outcome is _BUDGET_EXHAUSTED:
+            return None
+        return outcome
+
+    def _current_lineage_ancestors_on_conn(
+        self,
+        conn: sqlite3.Connection,
+        session_id: str,
+        state: _LineageResolutionState,
+    ) -> set:
+        """Collect the current session's generic parent chain ids.
+
+        Current-session exclusion must also hide live-context ancestors that
+        are NOT compression lineage: a delegation/branch child is still
+        visible to its parent agent, so the parent's content stays excluded
+        even though the child is a distinct compression root (#68).  Walks
+        ``parent_session_id`` links on the same connection, counts successful
+        row fetches toward the work budget, and stops on a missing row, a
+        cycle, or budget exhaustion.
+        """
+        ancestors: set = set()
+        seen: set = set()
+        node = str(session_id) if session_id else None
+        while node and node not in seen:
+            seen.add(node)
+            if state.work >= state.budget:
+                state.bound_hit = True
+                break
+            row = conn.execute(_LINEAGE_NODE_SQL, (node,)).fetchone()
+            if row is None:
+                break
+            state.work += 1
+            parent = row["parent_session_id"]
+            if parent is None:
+                break
+            node = str(parent)
+            ancestors.add(node)
+        return ancestors
 
     def search_sessions_by_id(
         self,

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -132,7 +132,6 @@ class _LineageResolutionState:
         "memo_hits",
         "bound_hit",
         "candidates_inspected",
-        "accepted_roots",
     )
 
     def __init__(self, budget: int = _LINEAGE_WORK_BUDGET) -> None:
@@ -142,7 +141,6 @@ class _LineageResolutionState:
         self.memo_hits = 0
         self.bound_hit = False
         self.candidates_inspected = 0
-        self.accepted_roots = 0
 
     def _memoize_unresolved(self, path: List[str], node: str) -> None:
         """Mark *path* plus *node* as proven unresolved (zero later lookups)."""
@@ -2730,7 +2728,6 @@ class SessionSearchMixin:
                         continue
                     # First displayable hit of this owner in rank order.
                     seen_roots.add(root)
-                    state.accepted_roots = len(seen_roots)
                     winner = dict(candidate)
                     winner["lineage_root_id"] = root
                     winners.append(winner)

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -26,6 +26,7 @@ from hermes_state_common import (
     MAX_FTS5_QUERY_CHARS,
     SCHEMA_VERSION,
     _FTS_CJK_TRIGGERS,
+    _RESET_END_REASONS,
     escape_like as _escape_like,
 )
 
@@ -77,6 +78,11 @@ FROM sessions child
 LEFT JOIN sessions parent ON parent.id = child.parent_session_id
 WHERE child.id = ?
 """
+
+
+def _chunked(values: List[Any], size: int) -> List[List[Any]]:
+    """Split *values* into ``size``-bounded chunks (SQLite var-limit safety)."""
+    return [values[i:i + size] for i in range(0, len(values), size)]
 
 
 def _lineage_markers(
@@ -2545,6 +2551,220 @@ class SessionSearchMixin:
             node = str(parent)
             ancestors.add(node)
         return ancestors
+
+    def resolve_lineage_winners(
+        self,
+        candidates: List[Dict[str, Any]],
+        *,
+        result_limit: int = 3,
+        excluded_lineage_roots: Tuple[str, ...] = (),
+        current_session_id: Optional[str] = None,
+        work_budget: Optional[int] = None,
+        out_of_context_end_reasons: Optional[Collection[str]] = None,
+    ) -> Dict[str, Any]:
+        """Select ranked session-search winners from pre-ranked candidates.
+
+        Consumes the current-upstream ranked candidate rows produced by
+        ``search_messages()`` (already ordered by relevance/recency and
+        automation-demotion) and replaces the generic-parent ancestry walk
+        with the accepted #68 compression-continuation resolver: one
+        query-local memo/path-compression pass from candidate 1, one coherent
+        read snapshot, one work budget, fail-closed missing-parent/cycle
+        outcomes, and early-K stop.  It never rewrites the match anchor to the
+        root session.
+
+        ``candidates`` is the bounded ranked raw-hit set; each row must carry
+        at least ``id`` (message id) and ``session_id`` (owning session).
+        Winner dedupe, current-session exclusion, and exact-title exclusion
+        share the same compression-root meaning.  ``excluded_lineage_roots``
+        are pre-resolved by the caller with the same compression-lineage
+        implementation (exact-title slot).  ``current_session_id`` is
+        re-resolved inside this snapshot with the same memo/state used for
+        candidate roots.  ``out_of_context_end_reasons`` carries the tool
+        layer's fresh-reset set so a /new-style predecessor of the current
+        session stays discoverable (#85756).
+
+        Returns ``{"winners": [...], "stats": {...}}``.  ``stats`` reports
+        ``lineage_bound_hit`` so callers can surface a B-exhausted partial
+        prefix as an explicit truncation instead of a complete top-K answer.
+        """
+        result_limit = max(0, min(int(result_limit), 100))
+        # Resolved at call time so tests / diagnostics can override the module
+        # budget with a monkeypatch (same pattern as the accepted #68
+        # implementation, which reads the module global per query).
+        if work_budget is None:
+            work_budget = _LINEAGE_WORK_BUDGET
+        else:
+            work_budget = int(work_budget)
+        excluded_roots = {
+            str(root) for root in (excluded_lineage_roots or ()) if root
+        }
+        if out_of_context_end_reasons is None:
+            out_of_context_end_reasons = frozenset(_RESET_END_REASONS) | {
+                "new_session"
+            }
+
+        state = _LineageResolutionState(work_budget)
+        winners: List[Dict[str, Any]] = []
+        seen_roots: set = set()
+
+        with self._read_ctx() as conn:
+            started_tx = not conn.in_transaction
+            if started_tx:
+                conn.execute("BEGIN")
+            try:
+                # Batched archive metadata (owner end_reason + message
+                # compacted) used only by the current-context visibility
+                # check.  These are NOT lineage-node fetches and do not count
+                # toward the work budget.
+                end_reason_by_owner: Dict[str, Any] = {}
+                compacted_by_message: Dict[int, Any] = {}
+                owners = [
+                    str(c["session_id"])
+                    for c in candidates
+                    if c.get("session_id")
+                ]
+                messages = [
+                    c["id"] for c in candidates if c.get("id") is not None
+                ]
+                for chunk in _chunked(owners, 400):
+                    marks = ",".join("?" for _ in chunk)
+                    for row in conn.execute(
+                        f"SELECT id, end_reason FROM sessions "
+                        f"WHERE id IN ({marks})",
+                        chunk,
+                    ).fetchall():
+                        end_reason_by_owner[str(row["id"])] = row["end_reason"]
+                for chunk in _chunked(messages, 400):
+                    marks = ",".join("?" for _ in chunk)
+                    for row in conn.execute(
+                        f"SELECT id, compacted FROM messages "
+                        f"WHERE id IN ({marks})",
+                        chunk,
+                    ).fetchall():
+                        compacted_by_message[row["id"]] = row["compacted"]
+
+                def _is_archived(candidate: Dict[str, Any]) -> bool:
+                    """True when a hit's content left the live context.
+
+                    Matches the tool layer's ``_session_left_live_context``
+                    plus per-message in-place compaction: a compression-ended
+                    or fresh-reset owner, or an archived message row, is no
+                    longer in anyone's active context and stays discoverable.
+                    """
+                    end_reason = end_reason_by_owner.get(
+                        str(candidate.get("session_id") or "")
+                    )
+                    return (
+                        end_reason == "compression"
+                        or end_reason in out_of_context_end_reasons
+                        or int(compacted_by_message.get(candidate.get("id")) or 0) == 1
+                    )
+
+                current_root: Optional[str] = None
+                current_ancestors: set = set()
+                if current_session_id:
+                    # Re-resolve the raw current identity inside this winner
+                    # snapshot with the SAME memo/state so current-session
+                    # exclusion and candidate dedupe share one root meaning.
+                    outcome = self._resolve_compression_lineage_on_conn(
+                        conn, str(current_session_id), state
+                    )
+                    if outcome is _BUDGET_EXHAUSTED:
+                        state.bound_hit = True
+                    elif outcome is _UNRESOLVED:
+                        # Conservative: an unresolved current session excludes
+                        # only its own id rather than broadening exclusion to
+                        # an unproven ancestor.
+                        current_root = str(current_session_id)
+                    else:
+                        current_root = outcome
+                        current_ancestors = (
+                            self._current_lineage_ancestors_on_conn(
+                                conn, str(current_session_id), state
+                            )
+                        )
+
+                # Resolve each owner exactly ONCE (lazily, on first encounter)
+                # while iterating the bounded raw hits in rank order.  Winner
+                # ordering therefore follows the rank of each owner's FIRST
+                # displayable anchor — a live current-lineage hit is skipped
+                # so a later compacted-history hit of the same owner can still
+                # surface, but it must not let that owner jump ahead of a
+                # higher-ranked displayable winner from another session.
+                owner_resolved: set = set()
+                owner_root: Dict[str, Optional[str]] = {}
+                for candidate in candidates:
+                    if len(winners) >= result_limit:
+                        break
+                    owner = str(candidate["session_id"])
+                    if owner not in owner_resolved:
+                        owner_resolved.add(owner)
+                        state.candidates_inspected += 1
+                        outcome = self._resolve_compression_lineage_on_conn(
+                            conn, owner, state
+                        )
+                        if outcome is _BUDGET_EXHAUSTED:
+                            state.bound_hit = True
+                            # Stop the entire ranked scan: the bound candidate
+                            # may have produced a higher-ranked new root than
+                            # every later candidate, so skipping it would
+                            # violate ranking.
+                            break
+                        owner_root[owner] = (
+                            outcome if outcome is not _UNRESOLVED else None
+                        )
+                    root = owner_root[owner]
+                    if root is None:
+                        continue
+                    if root in excluded_roots or root in seen_roots:
+                        continue
+                    in_current_context = (
+                        (current_root is not None and root == current_root)
+                        or owner in current_ancestors
+                    )
+                    if in_current_context and not _is_archived(candidate):
+                        # Live content of the current lineage stays hidden;
+                        # the owner's displayable anchor is a later compacted
+                        # hit, so this hit does not (yet) produce a winner.
+                        continue
+                    # First displayable hit of this owner in rank order.
+                    seen_roots.add(root)
+                    state.accepted_roots = len(seen_roots)
+                    winner = dict(candidate)
+                    winner["lineage_root_id"] = root
+                    winners.append(winner)
+
+                stats = {
+                    "candidate_count": len(candidates),
+                    "candidate_unique_sessions": len(set(owners)),
+                    "lineage_count": len(seen_roots),
+                    "winner_count": len(winners),
+                    "lineage_work": state.work,
+                    "lineage_memo_hits": state.memo_hits,
+                    "lineage_memo_entries": len(state.memo),
+                    "lineage_candidates_inspected": state.candidates_inspected,
+                    "lineage_bound_hit": state.bound_hit,
+                }
+            finally:
+                if started_tx and conn.in_transaction:
+                    conn.rollback()
+
+        logger.info(
+            "SESSION_WINNERS_LINEAGE candidates=%d unique_sessions=%d "
+            "lineage_count=%d winner_count=%d lineage_work=%d "
+            "lineage_memo_hits=%d lineage_candidates_inspected=%d "
+            "lineage_bound_hit=%s",
+            stats["candidate_count"],
+            stats["candidate_unique_sessions"],
+            stats["lineage_count"],
+            stats["winner_count"],
+            stats["lineage_work"],
+            stats["lineage_memo_hits"],
+            stats["lineage_candidates_inspected"],
+            stats["lineage_bound_hit"],
+        )
+        return {"winners": winners, "stats": stats}
 
     def search_sessions_by_id(
         self,

--- a/tests/test_session_search_lineage.py
+++ b/tests/test_session_search_lineage.py
@@ -795,23 +795,9 @@ def _bulk_positive_chain(db, prefix, n, source="cli"):
 
 def _seed_bound_chain(db, n=6):
     """A positive compression chain longer than the monkeypatched budget."""
-    base = "bhit"
-    for i in range(n):
-        db.create_session(f"{base}-{i}", source="cli")
-    for i in range(n - 1):
-        child, parent = f"{base}-{i}", f"{base}-{i + 1}"
-        db._conn.execute("PRAGMA foreign_keys = OFF")
-        db._conn.execute(
-            "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
-            (parent, child),
-        )
-        db._conn.execute(
-            "UPDATE sessions SET end_reason = 'compression' WHERE id = ?",
-            (parent,),
-        )
-        db._conn.commit()
-        db._conn.execute("PRAGMA foreign_keys = ON")
-    db.append_message(f"{base}-0", role="user", content="bound needle chain")
+    ids = _chain_sessions(db, "bhit", n)
+    _link_positive_chain(db, ids)
+    db.append_message("bhit-0", role="user", content="bound needle chain")
 
 
 def test_discover_bound_hit_returns_truncated_safe_prefix(db, monkeypatch):

--- a/tests/test_session_search_lineage.py
+++ b/tests/test_session_search_lineage.py
@@ -1,0 +1,878 @@
+"""Regression tests for compression-aware session-search lineage (#129).
+
+Reconstructs the accepted #68 compression-root semantics on the current
+upstream seam: ``SessionDB.resolve_lineage_winners`` consumes the ranked
+raw-hit set from ``search_messages`` and replaces generic-parent dedup with
+positive compression-continuation roots — one query-local memo, one coherent
+read snapshot, one work budget, fail-closed missing-parent/cycle outcomes,
+early-K stop, and explicit bound-hit truncation.  The tool layer composes
+exact-title / current-session exclusion through the same root meaning and
+surfaces B exhaustion as an explicit truncation warning.
+"""
+import json
+
+import pytest
+
+from hermes_state import SessionDB
+from tools.session_search_tool import _order_for_recall, session_search
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def _message(db, session_id, content, role="user"):
+    return db.append_message(session_id, role=role, content=content)
+
+
+def _create(db, session_id, source="cli", parent=None):
+    db.create_session(session_id, source=source)
+    if parent is not None:
+        _set_parent(db, session_id, parent)
+
+
+def _set_parent(db, session_id, parent):
+    """Point *session_id* at *parent* (FK-safe for dangling parents)."""
+    db._conn.execute("PRAGMA foreign_keys = OFF")
+    db._conn.execute(
+        "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
+        (parent, session_id),
+    )
+    db._conn.commit()
+    db._conn.execute("PRAGMA foreign_keys = ON")
+
+
+def _set_marker(db, session_id, **markers):
+    """Write ``_branched_from`` / ``_delegate_from`` into model_config."""
+    row = db.get_session(session_id) or {}
+    config = row.get("model_config")
+    if isinstance(config, str):
+        config = json.loads(config) if config else {}
+    config = dict(config or {})
+    config.update(markers)
+    db._conn.execute(
+        "UPDATE sessions SET model_config = ? WHERE id = ?",
+        (json.dumps(config), session_id),
+    )
+    db._conn.commit()
+
+
+def _chain_sessions(db, prefix, n, source="cli"):
+    ids = [f"{prefix}-{i}" for i in range(n)]
+    for sid in ids:
+        db.create_session(sid, source=source)
+    return ids
+
+
+def _link_positive_chain(db, ids):
+    """Link ``ids[i] -> ids[i+1]`` with positive compression edges.
+
+    Each parent ends by ``'compression'``, so resolving ``ids[0]`` walks
+    ``len(ids)`` successful uncached point lookups to the root ``ids[-1]``.
+    Call AFTER appending messages (append_message refuses compression-ended
+    sessions).
+    """
+    for i in range(len(ids) - 1):
+        child, parent = ids[i], ids[i + 1]
+        db._conn.execute("PRAGMA foreign_keys = OFF")
+        db._conn.execute(
+            "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
+            (parent, child),
+        )
+        db._conn.execute(
+            "UPDATE sessions SET end_reason = 'compression' WHERE id = ?",
+            (parent,),
+        )
+        db._conn.commit()
+        db._conn.execute("PRAGMA foreign_keys = ON")
+
+
+def _candidate(db, session_id, role="user"):
+    """A minimal ranked candidate row for *session_id*'s first message."""
+    msgs = db.get_messages(session_id)
+    return {
+        "id": msgs[0]["id"],
+        "session_id": session_id,
+        "role": role,
+        "snippet": "needle",
+        "source": "cli",
+        "model": None,
+        "session_started": None,
+    }
+
+
+def _ranked(db, query, limit=300, sort=None):
+    """Ranked raw-hit candidates from the real FTS lane."""
+    return _order_for_recall(
+        db.search_messages(
+            query,
+            role_filter=["user"],
+            exclude_sources=["subagent", "tool"],
+            limit=limit,
+            sort=sort,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Compression-continuation semantics
+# ---------------------------------------------------------------------------
+
+
+def test_lineage_winners_dedupe_by_compression_root_and_preserve_anchor(db):
+    _create(db, "root", source="cli")
+    root_id = _message(db, "root", "needle root")
+    db.end_session("root", "compression")
+    _create(db, "child", source="cli", parent="root")
+    child_id = _message(db, "child", "needle child")
+    _message(db, "child", "needle child second")
+    _create(db, "other", source="cli")
+    other_id = _message(db, "other", "needle other")
+
+    result = db.resolve_lineage_winners(
+        [
+            _candidate(db, "root"),
+            _candidate(db, "child"),
+            _candidate(db, "other"),
+        ],
+        result_limit=2,
+    )
+
+    winners = result["winners"]
+    assert len(winners) == 2
+    assert {row["lineage_root_id"] for row in winners} == {"root", "other"}
+    assert {row["session_id"] for row in winners} == {"root", "other"}
+    # The compression child collapses into the root; the root's first hit is
+    # the anchor (highest-ranked raw hit of the lineage).
+    assert child_id not in {row["id"] for row in winners}
+    assert root_id in {row["id"] for row in winners}
+    assert other_id in {row["id"] for row in winners}
+    assert result["stats"]["candidate_count"] == 3
+    assert result["stats"]["candidate_unique_sessions"] == 3
+    assert all("content" not in row for row in winners)
+    assert all("context" not in row for row in winners)
+
+
+def test_lineage_winners_generic_parentage_not_lineage(db):
+    # A generic parent link (parent did NOT end by compression) keeps the
+    # child a distinct root: parentage alone never collapses conversations.
+    _create(db, "parent", source="cli")
+    _message(db, "parent", "needle generic")
+    _create(db, "child", source="cli", parent="parent")
+    _message(db, "child", "needle generic")
+
+    result = db.resolve_lineage_winners(
+        [_candidate(db, "parent"), _candidate(db, "child")],
+        result_limit=10,
+    )
+
+    assert {row["lineage_root_id"] for row in result["winners"]} == {
+        "parent",
+        "child",
+    }
+
+
+def test_lineage_winners_branch_marker_to_parent_stays_distinct(db):
+    _create(db, "broot", source="cli")
+    _message(db, "broot", "needle branch")
+    db.end_session("broot", "compression")
+    _create(db, "bchild", source="cli", parent="broot")
+    _message(db, "bchild", "needle branch")
+    _set_marker(db, "bchild", _branched_from="broot")
+
+    result = db.resolve_lineage_winners(
+        [_candidate(db, "bchild")], result_limit=10
+    )
+
+    assert result["winners"][0]["lineage_root_id"] == "bchild"
+
+
+def test_lineage_winners_delegate_marker_to_parent_stays_distinct(db):
+    _create(db, "droot", source="cli")
+    _message(db, "droot", "needle delegate")
+    db.end_session("droot", "compression")
+    _create(db, "dchild", source="cli", parent="droot")
+    _message(db, "dchild", "needle delegate")
+    _set_marker(db, "dchild", _delegate_from="droot")
+
+    result = db.resolve_lineage_winners(
+        [_candidate(db, "dchild")], result_limit=10
+    )
+
+    assert result["winners"][0]["lineage_root_id"] == "dchild"
+
+
+def test_lineage_winners_tool_child_stays_distinct(db):
+    _create(db, "troot", source="cli")
+    _message(db, "troot", "needle tool")
+    db.end_session("troot", "compression")
+    _create(db, "tchild", source="tool", parent="troot")
+    _message(db, "tchild", "needle tool")
+
+    result = db.resolve_lineage_winners(
+        [_candidate(db, "tchild")], result_limit=10
+    )
+
+    assert result["winners"][0]["lineage_root_id"] == "tchild"
+
+
+def test_lineage_winners_foreign_marker_does_not_block_continuation(db):
+    # A stale/foreign branch or delegate marker pointing somewhere OTHER than
+    # the parent must not disqualify a legitimate compression continuation.
+    _create(db, "froot", source="cli")
+    _message(db, "froot", "needle foreign")
+    db.end_session("froot", "compression")
+    _create(db, "fchild", source="cli", parent="froot")
+    _message(db, "fchild", "needle foreign")
+    _set_marker(db, "fchild", _branched_from="elsewhere")
+
+    result = db.resolve_lineage_winners(
+        [_candidate(db, "fchild")], result_limit=10
+    )
+
+    assert result["winners"][0]["lineage_root_id"] == "froot"
+
+
+def test_lineage_winners_missing_parent_fails_closed_and_memo_reuses(db):
+    _create(db, "m-bad", source="cli")
+    _message(db, "m-bad", "needle missing")
+    db.end_session("m-bad", "compression")
+    _set_parent(db, "m-bad", "m-missing")
+    _create(db, "m-bad-child", source="cli", parent="m-bad")
+    _message(db, "m-bad-child", "needle missing")
+    _create(db, "m-ok", source="cli")
+    _message(db, "m-ok", "needle missing")
+
+    result = db.resolve_lineage_winners(
+        [
+            _candidate(db, "m-bad"),
+            _candidate(db, "m-bad-child"),
+            _candidate(db, "m-ok"),
+        ],
+        result_limit=10,
+    )
+
+    assert [row["session_id"] for row in result["winners"]] == ["m-ok"]
+    # m-bad resolves with one lookup; m-bad-child walks one lookup then hits
+    # m-bad's proven-unresolved memo at zero additional work.
+    assert result["stats"]["lineage_work"] == 3
+    assert result["stats"]["lineage_memo_hits"] >= 1
+
+
+def test_lineage_winners_two_node_cycle_fails_closed(db):
+    _create(db, "c-a", source="cli")
+    _create(db, "c-b", source="cli")
+    _message(db, "c-a", "needle cycle")
+    _message(db, "c-b", "needle cycle")
+    db.end_session("c-a", "compression")
+    db.end_session("c-b", "compression")
+    _set_parent(db, "c-a", "c-b")
+    _set_parent(db, "c-b", "c-a")
+
+    result = db.resolve_lineage_winners(
+        [_candidate(db, "c-a"), _candidate(db, "c-b")], result_limit=10
+    )
+
+    assert result["winners"] == []
+
+
+def test_lineage_winners_long_cycle_fails_closed(db):
+    for sid in ("l-a", "l-b", "l-c"):
+        _create(db, sid, source="cli")
+        _message(db, sid, "needle cycle")
+        db.end_session(sid, "compression")
+    _set_parent(db, "l-a", "l-b")
+    _set_parent(db, "l-b", "l-c")
+    _set_parent(db, "l-c", "l-a")
+
+    result = db.resolve_lineage_winners(
+        [_candidate(db, "l-a"), _candidate(db, "l-b"), _candidate(db, "l-c")],
+        result_limit=10,
+    )
+
+    assert result["winners"] == []
+
+
+def test_lineage_winners_tail_entering_cycle_fails_closed(db):
+    _create(db, "t-a", source="cli")
+    _create(db, "t-b", source="cli")
+    _create(db, "t-c", source="cli")
+    _message(db, "t-a", "needle cycle")
+    _message(db, "t-b", "needle cycle")
+    _message(db, "t-c", "needle cycle")
+    db.end_session("t-b", "compression")
+    db.end_session("t-c", "compression")
+    _set_parent(db, "t-a", "t-b")
+    _set_parent(db, "t-b", "t-c")
+    _set_parent(db, "t-c", "t-b")
+
+    result = db.resolve_lineage_winners(
+        [_candidate(db, "t-a"), _candidate(db, "t-b")], result_limit=10
+    )
+
+    assert result["winners"] == []
+
+
+def test_lineage_winners_positive_lineage_memo_reuse(db):
+    # A 15-session positive lineage (observed depth-14/size-15 tail): every
+    # candidate in the lineage resolves to the same root, and after the
+    # first candidate all later ones are memo hits (zero extra lookups).
+    ids = _chain_sessions(db, "memo", 15)
+    for sid in ids:
+        _message(db, sid, "needle memo")
+    _link_positive_chain(db, ids)
+
+    result = db.resolve_lineage_winners(
+        [_candidate(db, sid) for sid in ids], result_limit=10
+    )
+
+    winners = result["winners"]
+    assert len(winners) == 1
+    assert winners[0]["lineage_root_id"] == ids[-1]
+    assert result["stats"]["lineage_work"] == 15
+    assert result["stats"]["lineage_memo_hits"] == 14
+    assert result["stats"]["lineage_memo_entries"] == 15
+
+
+def test_lineage_winners_owner_dedupe_preserves_best_anchor(db):
+    # Repeated raw hits from the same owner do not create repeated resolver
+    # candidates; the highest-ranked (first) anchor survives.
+    _create(db, "o", source="cli")
+    first = _message(db, "o", "needle first")
+    _message(db, "o", "needle second")
+    _create(db, "p", source="cli")
+    _message(db, "p", "needle other")
+
+    result = db.resolve_lineage_winners(
+        [
+            _candidate(db, "o"),
+            _candidate(db, "o"),
+            _candidate(db, "p"),
+        ],
+        result_limit=10,
+    )
+
+    assert len(result["winners"]) == 2
+    anchors = [row["id"] for row in result["winners"] if row["session_id"] == "o"]
+    assert anchors == [first]
+
+
+def test_lineage_winners_early_k_stops(db):
+    _create(db, "k0", source="cli")
+    db.end_session("k0", "compression")
+    for i in range(12):
+        _create(db, f"k0-child-{i}", source="cli", parent="k0")
+        _message(db, f"k0-child-{i}", "needle k")
+    for i in range(1, 15):
+        _create(db, f"k{i}", source="cli")
+        _message(db, f"k{i}", "needle k")
+
+    candidates = [
+        _candidate(db, f"k0-child-{i}") for i in range(12)
+    ] + [_candidate(db, f"k{i}") for i in range(1, 15)]
+    for k in (1, 3, 10):
+        result = db.resolve_lineage_winners(candidates, result_limit=k)
+        assert len(result["winners"]) == k
+        assert result["stats"]["lineage_bound_hit"] is False
+
+
+def test_lineage_winners_candidates_inspected_counts_distinct_owners(db):
+    _create(db, "m1", source="cli")
+    _message(db, "m1", "needle first")
+    _message(db, "m1", "needle second")
+    _create(db, "m2", source="cli")
+    _message(db, "m2", "needle other")
+
+    result = db.resolve_lineage_winners(
+        [_candidate(db, "m1"), _candidate(db, "m1"), _candidate(db, "m2")],
+        result_limit=5,
+    )
+
+    assert result["stats"]["candidate_count"] == 3  # raw hits
+    assert result["stats"]["candidate_unique_sessions"] == 2  # distinct owners
+    assert result["stats"]["lineage_candidates_inspected"] == 2  # not 3
+    assert len(result["winners"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Work budget B=2000: exact accounting, fail-closed, bound-hit
+# ---------------------------------------------------------------------------
+
+
+def test_lineage_winners_cycle_at_work_bound_is_cycle_not_bound_hit(db):
+    # A cycle provable from the traversal-local seen-set at work == B is
+    # classified as cycle, NOT bound-hit (no further DB lookup needed).
+    for sid in ("cb-a", "cb-b", "cb-c"):
+        _create(db, sid, source="cli")
+        _message(db, sid, "needle cycle")
+        db.end_session(sid, "compression")
+    _set_parent(db, "cb-a", "cb-b")
+    _set_parent(db, "cb-b", "cb-c")
+    _set_parent(db, "cb-c", "cb-a")
+
+    result = db.resolve_lineage_winners(
+        [_candidate(db, "cb-a")], result_limit=10, work_budget=3
+    )
+
+    assert result["winners"] == []
+    assert result["stats"]["lineage_bound_hit"] is False
+    assert result["stats"]["lineage_work"] == 3
+
+
+def test_lineage_winners_bound_hit_before_cycle_proof(db):
+    # Proving the cycle would need one MORE uncached lookup after the budget
+    # is exhausted -> bound-hit, and the partial path must not be memoized as
+    # unresolved (a fresh query resolves it).
+    ids = _chain_sessions(db, "bp", 5)
+    for sid in ids:
+        _message(db, sid, "needle cycle")
+    _link_positive_chain(db, ids)
+    # Close the 5-node chain into a cycle: bp-4 -> bp-0 (positive edge).
+    db._conn.execute(
+        "UPDATE sessions SET end_reason = 'compression' WHERE id = ?",
+        (ids[0],),
+    )
+    db._conn.commit()
+    _set_parent(db, ids[-1], ids[0])
+
+    result = db.resolve_lineage_winners(
+        [_candidate(db, ids[0])], result_limit=10, work_budget=4
+    )
+
+    assert result["winners"] == []
+    assert result["stats"]["lineage_bound_hit"] is True
+    assert result["stats"]["lineage_work"] == 4
+
+
+def test_lineage_winners_root_resolved_exactly_at_work_bound(db):
+    # A root resolved on successful lookup number B succeeds (the boundary is
+    # inclusive of legitimate completed work).
+    ids = _chain_sessions(db, "b5", 5)
+    _message(db, ids[0], "needle exact")
+    _link_positive_chain(db, ids)
+
+    result = db.resolve_lineage_winners(
+        [_candidate(db, ids[0])], result_limit=10, work_budget=5
+    )
+
+    assert result["winners"][0]["lineage_root_id"] == ids[-1]
+    assert result["stats"]["lineage_work"] == 5
+    assert result["stats"]["lineage_bound_hit"] is False
+
+
+def test_lineage_winners_lookup_beyond_work_bound_truncates(db):
+    # A resolution that requires lookup B+1 stops BEFORE that lookup, flags
+    # bound-hit, and returns only already-proven safe winners.  The bound is
+    # reached on the first (higher-ranked) candidate, so the scan stops
+    # rather than accepting the later safe candidate (ranking preserved).
+    ids = _chain_sessions(db, "b6", 6)
+    _message(db, ids[0], "needle trunc")
+    _link_positive_chain(db, ids)
+    _create(db, "trunc-safe", source="cli")
+    _message(db, "trunc-safe", "needle trunc")
+
+    result = db.resolve_lineage_winners(
+        [_candidate(db, ids[0]), _candidate(db, "trunc-safe")],
+        result_limit=10,
+        work_budget=5,
+    )
+
+    assert result["stats"]["lineage_bound_hit"] is True
+    assert result["winners"] == []
+
+
+def test_lineage_winners_bound_exhaustion_does_not_poison_memo(db):
+    ids = _chain_sessions(db, "poison", 5)
+    _message(db, ids[0], "needle poison")
+    _link_positive_chain(db, ids)
+
+    first = db.resolve_lineage_winners(
+        [_candidate(db, ids[0])], result_limit=10, work_budget=3
+    )
+    assert first["stats"]["lineage_bound_hit"] is True
+
+    # A fresh query (new memo + restored budget) resolves the same chain
+    # normally, proving the exhausted partial path was never memoized.
+    second = db.resolve_lineage_winners(
+        [_candidate(db, ids[0])], result_limit=10, work_budget=2000
+    )
+    assert second["stats"]["lineage_bound_hit"] is False
+    assert second["winners"][0]["lineage_root_id"] == ids[-1]
+
+
+def test_lineage_winners_stats_report_work_and_bound(db):
+    _create(db, "st-root", source="cli")
+    _message(db, "st-root", "needle stats")
+    db.end_session("st-root", "compression")
+    _create(db, "st-child", source="cli", parent="st-root")
+    _message(db, "st-child", "needle stats")
+    _create(db, "st-other", source="cli")
+    _message(db, "st-other", "needle stats")
+
+    result = db.resolve_lineage_winners(
+        [_candidate(db, "st-root"), _candidate(db, "st-child"), _candidate(db, "st-other")],
+        result_limit=5,
+    )
+
+    stats = result["stats"]
+    assert stats["candidate_count"] == 3
+    assert stats["candidate_unique_sessions"] == 3
+    assert stats["lineage_count"] == 2
+    assert stats["winner_count"] == 2
+    assert stats["lineage_work"] >= 1
+    assert stats["lineage_candidates_inspected"] == 3
+    assert stats["lineage_bound_hit"] is False
+
+
+def test_lineage_winners_match_resolve_compression_lineage_oracle(db):
+    # The real FTS lane (search_messages) + the same compression-lineage
+    # implementation used by the winner seam produce identical winners: this
+    # validates the candidate ranking / owner dedupe / early-K integration,
+    # not a second, generic-parent definition of lineage.
+    _create(db, "oracle-root", source="telegram")
+    _message(db, "oracle-root", "oracle needle root")
+    db.end_session("oracle-root", "compression")
+    _create(db, "oracle-child", source="cron", parent="oracle-root")
+    _create(db, "oracle-other", source="cli")
+    _create(db, "oracle-cron", source="cron")
+    _message(db, "oracle-child", "oracle needle child")
+    _message(db, "oracle-other", "oracle needle other")
+    _message(db, "oracle-cron", "oracle needle cron")
+
+    for sort in (None, "newest", "oldest"):
+        raw = db.search_messages(
+            "oracle",
+            role_filter=["user"],
+            exclude_sources=["subagent", "tool"],
+            limit=300,
+            sort=sort,
+        )
+        expected = []
+        seen = set()
+        for hit in _order_for_recall(raw):
+            root = db.resolve_compression_lineage(hit["session_id"])
+            if root is None:
+                continue
+            if root in seen:
+                continue
+            seen.add(root)
+            expected.append(
+                (
+                    hit["session_id"],
+                    root,
+                    hit["id"],
+                    hit["role"],
+                    hit["source"],
+                )
+            )
+            if len(expected) == 3:
+                break
+
+        actual = db.resolve_lineage_winners(
+            _order_for_recall(raw), result_limit=3
+        )["winners"]
+        actual = [
+            (
+                row["session_id"],
+                row["lineage_root_id"],
+                row["id"],
+                row["role"],
+                row["source"],
+            )
+            for row in actual
+        ]
+        assert actual == expected, f"sort={sort!r}"
+
+
+def test_lineage_winners_lineage_lookups_in_one_read_transaction(
+    db, monkeypatch
+):
+    # All lineage point lookups for one logical search run inside one explicit
+    # read transaction (one coherent logical snapshot).
+    original = SessionDB._resolve_compression_lineage_on_conn
+    observed = []
+
+    def spy(self, conn, session_id, state):
+        observed.append(conn.in_transaction)
+        return original(self, conn, session_id, state)
+
+    monkeypatch.setattr(SessionDB, "_resolve_compression_lineage_on_conn", spy)
+    _create(db, "root", source="cli")
+    _message(db, "root", "snap needle")
+    db.end_session("root", "compression")
+    _create(db, "child", source="cli", parent="root")
+    _message(db, "child", "snap needle")
+
+    db.resolve_lineage_winners(
+        [_candidate(db, "root"), _candidate(db, "child")], result_limit=5
+    )
+
+    assert observed
+    assert all(observed)
+
+
+# ---------------------------------------------------------------------------
+# Exclusion parity: current session + exact title share compression-root
+# ---------------------------------------------------------------------------
+
+
+def test_lineage_winners_current_exclusion_uses_same_root_semantics(db):
+    # The live continuation child is current-excluded; its compression-ended
+    # parent's archived content surfaces; a generic child of the current root
+    # keeps its own root and is NOT swallowed by current exclusion.
+    _create(db, "s_parent", source="cli")
+    _message(db, "s_parent", "filter needle")
+    db.end_session("s_parent", "compression")
+    _create(db, "s_current", source="cli", parent="s_parent")
+    _message(db, "s_current", "filter needle")
+    _create(db, "gen-child", source="cli", parent="s_current")
+    _message(db, "gen-child", "filter needle")
+    _create(db, "kept", source="cli")
+    _message(db, "kept", "filter needle")
+
+    result = db.resolve_lineage_winners(
+        [
+            _candidate(db, "s_current"),
+            _candidate(db, "s_parent"),
+            _candidate(db, "gen-child"),
+            _candidate(db, "kept"),
+        ],
+        result_limit=10,
+        current_session_id="s_current",
+    )
+
+    by_root = {row["lineage_root_id"] for row in result["winners"]}
+    # s_parent is in the current compression lineage but its content is
+    # archived (compression-ended) -> discoverable; gen-child is a distinct
+    # root; the current session itself never surfaces.
+    assert by_root == {"s_parent", "gen-child", "kept"}
+    assert all(row["session_id"] != "s_current" for row in result["winners"])
+
+
+def test_lineage_winners_fresh_reset_predecessor_stays_discoverable(db):
+    # A /new-style predecessor (fresh-reset end reason) of the current session
+    # is NOT in the current compression lineage, but it IS a live-context
+    # generic ancestor.  Its content left live context (fresh reset), so it
+    # must stay discoverable (#85756) — the base's reset boundary is
+    # preserved on top of compression-root semantics.
+    _create(db, "predecessor", source="cli")
+    _message(db, "predecessor", "reset needle")
+    db.end_session("predecessor", "idle")
+    _create(db, "current", source="cli", parent="predecessor")
+    _message(db, "current", "reset needle")
+
+    result = db.resolve_lineage_winners(
+        [_candidate(db, "predecessor"), _candidate(db, "current")],
+        result_limit=10,
+        current_session_id="current",
+    )
+
+    roots = [row["lineage_root_id"] for row in result["winners"]]
+    assert "predecessor" in roots
+    assert "current" not in roots
+
+
+def test_lineage_winners_exact_title_exclusion_uses_same_root_semantics(db):
+    # Exact-title exclusion arrives as the title's resolved root in
+    # excluded_lineage_roots: the whole compression lineage is fully excluded
+    # from content winners.
+    _create(db, "troot", source="cli")
+    _message(db, "troot", "needle title root")
+    db.end_session("troot", "compression")
+    _create(db, "tchild", source="cli", parent="troot")
+    _message(db, "tchild", "needle title child")
+    _create(db, "other", source="cli")
+    _message(db, "other", "needle title other")
+
+    result = db.resolve_lineage_winners(
+        [_candidate(db, "troot"), _candidate(db, "tchild"), _candidate(db, "other")],
+        result_limit=5,
+        excluded_lineage_roots=("troot",),
+    )
+
+    assert [row["session_id"] for row in result["winners"]] == ["other"]
+    assert result["stats"]["lineage_bound_hit"] is False
+
+
+def test_lineage_winners_compacted_history_anchor_fallback(db):
+    # In the current lineage, the newest hit is live (current-excluded), but
+    # the older compacted hit of the same owner must still surface AS THE
+    # ANCHOR — per-owner dedupe must never erase compacted history.
+    db.create_session("cur", source="cli")
+    compacted_id = _message(db, "cur", "old compacted needle")
+    db.archive_and_compact("cur", [{"role": "assistant", "content": "summary"}])
+    _message(db, "cur", "new live needle")
+
+    result = db.resolve_lineage_winners(
+        [
+            _candidate(db, "cur"),
+            {"id": compacted_id, "session_id": "cur", "role": "user",
+             "snippet": "needle", "source": "cli", "model": None,
+             "session_started": None},
+        ],
+        result_limit=5,
+        current_session_id="cur",
+    )
+
+    winners = result["winners"]
+    assert len(winners) == 1
+    assert winners[0]["session_id"] == "cur"
+    assert winners[0]["id"] == compacted_id
+
+
+def test_lineage_winners_displayable_anchor_ordering_not_live_rank(db):
+    # Winner ordering follows the rank of each owner's FIRST DISPLAYABLE
+    # anchor.  With K=1 and 'cur-live(#1) -> other(#2) -> cur-compacted(#3)',
+    # the higher-ranked displayable 'other' must win — cur's live #1 hit is
+    # current-excluded and must NOT let cur's later compacted anchor jump
+    # ahead of a genuinely higher-ranked winner.
+    import time
+
+    db.create_session("cur", source="cli")
+    compacted_id = _message(db, "cur", "old compacted needle")
+    db.archive_and_compact("cur", [{"role": "assistant", "content": "summary"}])
+    live_id = _message(db, "cur", "new live needle")
+    _create(db, "other-s", source="cli")
+    other_id = _message(db, "other-s", "needle other")
+    now = time.time()
+    db._conn.execute(
+        "UPDATE messages SET timestamp = ? WHERE id = ?", (now - 100, live_id)
+    )
+    db._conn.execute(
+        "UPDATE messages SET timestamp = ? WHERE id = ?", (now - 200, other_id)
+    )
+    db._conn.execute(
+        "UPDATE messages SET timestamp = ? WHERE id = ?", (now - 300, compacted_id)
+    )
+    db._conn.commit()
+
+    candidates = _ranked(db, "needle", sort="newest")
+    result = db.resolve_lineage_winners(
+        candidates, result_limit=1, current_session_id="cur"
+    )
+
+    winners = result["winners"]
+    assert len(winners) == 1
+    assert winners[0]["session_id"] == "other-s"
+    assert winners[0]["id"] == other_id
+
+
+# ---------------------------------------------------------------------------
+# Tool layer: dedupe composition, exact-title slot, truncation signal
+# ---------------------------------------------------------------------------
+
+
+def _seed_bound_chain(db, n=6):
+    """A positive compression chain longer than the monkeypatched budget."""
+    base = "bhit"
+    for i in range(n):
+        db.create_session(f"{base}-{i}", source="cli")
+    for i in range(n - 1):
+        child, parent = f"{base}-{i}", f"{base}-{i + 1}"
+        db._conn.execute("PRAGMA foreign_keys = OFF")
+        db._conn.execute(
+            "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
+            (parent, child),
+        )
+        db._conn.execute(
+            "UPDATE sessions SET end_reason = 'compression' WHERE id = ?",
+            (parent,),
+        )
+        db._conn.commit()
+        db._conn.execute("PRAGMA foreign_keys = ON")
+    db.append_message(f"{base}-0", role="user", content="bound needle chain")
+
+
+def test_discover_bound_hit_returns_truncated_safe_prefix(db, monkeypatch):
+    import hermes_state_search
+
+    monkeypatch.setattr(hermes_state_search, "_LINEAGE_WORK_BUDGET", 5)
+    db.create_session("safe", source="cli")
+    db.append_message("safe", role="user", content="bound needle safe")
+    _seed_bound_chain(db)
+
+    result = json.loads(session_search(query="bound needle", db=db))
+
+    assert result["success"] is True
+    assert result.get("truncated") is True
+    assert "warning" in result
+    assert result["count"] == 1
+    assert [r["session_id"] for r in result["results"]] == ["safe"]
+
+
+def test_discover_bound_hit_with_zero_winners_is_incomplete_not_no_match(
+    db, monkeypatch
+):
+    import hermes_state_search
+
+    monkeypatch.setattr(hermes_state_search, "_LINEAGE_WORK_BUDGET", 5)
+    _seed_bound_chain(db)
+
+    result = json.loads(session_search(query="bound needle", db=db))
+
+    assert result["success"] is True
+    assert result.get("truncated") is True
+    assert result["count"] == 0
+    assert "No matching sessions found" not in (result.get("message") or "")
+
+
+def test_discover_title_only_limit_one_surfaces_bound_exhaustion(
+    db, monkeypatch
+):
+    import hermes_state_search
+
+    monkeypatch.setattr(hermes_state_search, "_LINEAGE_WORK_BUDGET", 4)
+    # current session is the tip of a compression chain deeper than B
+    for i in range(6):
+        db.create_session(f"cur-{i}", source="cli")
+    for i in range(5):
+        child, parent = f"cur-{i}", f"cur-{i + 1}"
+        db._conn.execute("PRAGMA foreign_keys = OFF")
+        db._conn.execute(
+            "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
+            (parent, child),
+        )
+        db._conn.execute(
+            "UPDATE sessions SET end_reason = 'compression' WHERE id = ?",
+            (parent,),
+        )
+        db._conn.commit()
+        db._conn.execute("PRAGMA foreign_keys = ON")
+    db.create_session("title-session", source="cli")
+    db.set_session_title("title-session", "needle-title")
+    db.append_message("title-session", role="user", content="title content filler")
+
+    result = json.loads(
+        session_search(
+            query="needle-title", db=db, limit=1, current_session_id="cur-0"
+        )
+    )
+
+    assert result["success"] is True
+    assert result["count"] == 1
+    assert [r["session_id"] for r in result["results"]] == ["title-session"]
+    assert result.get("truncated") is True
+    assert "warning" in result
+
+
+def test_discover_compression_dedupe_and_exact_title_slot(db):
+    # Exact-title result occupies its slot; its compression-lineage members
+    # are excluded from the content lane.
+    _create(db, "t_parent", source="cli")
+    _message(db, "t_parent", "title content")
+    db.end_session("t_parent", "compression")
+    _create(db, "t_child", source="cli", parent="t_parent")
+    _message(db, "t_child", "title content")
+    db.set_session_title("t_parent", "needle-title")
+
+    result = json.loads(
+        session_search(query="needle-title", db=db, limit=1)
+    )
+
+    assert result["success"] is True
+    sids = [r["session_id"] for r in result["results"]]
+    # Title slot: t_parent. Content lane: t_child is the same compression
+    # lineage -> excluded, so the title is the only result.
+    assert sids == ["t_parent"]
+    assert result.get("truncated") is False

--- a/tests/test_session_search_lineage.py
+++ b/tests/test_session_search_lineage.py
@@ -10,6 +10,8 @@ exact-title / current-session exclusion through the same root meaning and
 surfaces B exhaustion as an explicit truncation warning.
 """
 import json
+import threading
+import time
 
 import pytest
 
@@ -763,6 +765,34 @@ def test_lineage_winners_displayable_anchor_ordering_not_live_rank(db):
 # ---------------------------------------------------------------------------
 
 
+def _bulk_positive_chain(db, prefix, n, source="cli"):
+    """Bulk-build a positive compression chain of *n* sessions, fast.
+
+    SessionDB's writer connection is autocommit, so per-row inserts would
+    fsync every row (~40x slower).  One explicit BEGIN/COMMIT keeps the
+    fixture fast enough for the real B=2000-boundary and 10k-chain tests.
+    """
+    base = prefix
+    now = time.time()
+    db._conn.execute("BEGIN")
+    db._conn.executemany(
+        "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+        [(f"{base}-{i}", source, now) for i in range(n)],
+    )
+    for i in range(n - 1):
+        child, parent = f"{base}-{i}", f"{base}-{i + 1}"
+        db._conn.execute(
+            "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
+            (parent, child),
+        )
+        db._conn.execute(
+            "UPDATE sessions SET end_reason = 'compression' WHERE id = ?",
+            (parent,),
+        )
+    db._conn.execute("COMMIT")
+    return [f"{base}-{i}" for i in range(n)]
+
+
 def _seed_bound_chain(db, n=6):
     """A positive compression chain longer than the monkeypatched budget."""
     base = "bhit"
@@ -876,3 +906,103 @@ def test_discover_compression_dedupe_and_exact_title_slot(db):
     # lineage -> excluded, so the title is the only result.
     assert sids == ["t_parent"]
     assert result.get("truncated") is False
+
+
+def test_lineage_winners_default_budget_1999_succeeds(db):
+    # A root resolved on successful lookup 1999 succeeds with the default B.
+    ids = _bulk_positive_chain(db, "b1999", 1999)
+    _message(db, ids[0], "needle 1999")
+
+    result = db.resolve_lineage_winners([_candidate(db, ids[0])], result_limit=5)
+    assert result["winners"][0]["lineage_root_id"] == ids[-1]
+    assert result["stats"]["lineage_work"] == 1999
+    assert result["stats"]["lineage_bound_hit"] is False
+
+
+def test_lineage_winners_default_budget_2000_succeeds(db):
+    # A root resolved on successful lookup 2000 (the boundary) succeeds with
+    # the default B.
+    ids = _bulk_positive_chain(db, "b2000", 2000)
+    _message(db, ids[0], "needle 2000")
+
+    result = db.resolve_lineage_winners([_candidate(db, ids[0])], result_limit=5)
+    assert result["winners"][0]["lineage_root_id"] == ids[-1]
+    assert result["stats"]["lineage_work"] == 2000
+    assert result["stats"]["lineage_bound_hit"] is False
+
+
+def test_lineage_winners_default_budget_2001_truncates(db):
+    # A resolution that would need lookup 2001 stops BEFORE it with the
+    # default B, flags bound-hit, and returns no fabricated winner.
+    ids = _bulk_positive_chain(db, "b2001", 2001)
+    _message(db, ids[0], "needle 2001")
+
+    result = db.resolve_lineage_winners([_candidate(db, ids[0])], result_limit=5)
+    assert result["stats"]["lineage_bound_hit"] is True
+    assert result["winners"] == []
+
+
+def test_lineage_winners_10k_chain_cut_by_default_budget(db):
+    # A real 10k-node acyclic chain is cut by the default B=2000 work budget,
+    # not by any semantic depth cap.
+    ids = _bulk_positive_chain(db, "path10k", 10000)
+    _message(db, ids[0], "needle path")
+
+    result = db.resolve_lineage_winners([_candidate(db, ids[0])], result_limit=5)
+    assert result["stats"]["lineage_bound_hit"] is True
+    assert result["stats"]["lineage_work"] == 2000
+    assert result["winners"] == []
+
+
+def test_lineage_winners_internal_k_stress(db):
+    # Larger internal K (beyond the public K<=10 tool path) is a defensive
+    # DB contract, not the normal product path.
+    for i in range(60):
+        _create(db, f"ik-{i}", source="cli")
+        _message(db, f"ik-{i}", "needle internal k")
+
+    candidates = [_candidate(db, f"ik-{i}") for i in range(60)]
+    result = db.resolve_lineage_winners(candidates, result_limit=60)
+    assert len(result["winners"]) == 60
+    assert result["stats"]["lineage_bound_hit"] is False
+
+
+def test_lineage_winners_lineage_reads_coherent_under_concurrent_writer(
+    db, monkeypatch,
+):
+    # A writer hammering session creation during a winner search cannot tear
+    # the resolver's lineage snapshot: lineage lookups observe one coherent
+    # root set from one logical moment.
+    original = SessionDB._resolve_compression_lineage_on_conn
+
+    def slow(self, conn, session_id, state):
+        time.sleep(0.02)
+        return original(self, conn, session_id, state)
+
+    monkeypatch.setattr(SessionDB, "_resolve_compression_lineage_on_conn", slow)
+    _create(db, "root", source="cli")
+    _message(db, "root", "snap needle")
+    db.end_session("root", "compression")
+    _create(db, "child", source="cli", parent="root")
+    _message(db, "child", "snap needle")
+    _create(db, "other", source="cli")
+    _message(db, "other", "snap needle")
+
+    candidates = [
+        _candidate(db, "root"),
+        _candidate(db, "child"),
+        _candidate(db, "other"),
+    ]
+
+    def writer():
+        for i in range(10):
+            db.create_session(f"cw-{i}", source="cli")
+
+    t = threading.Thread(target=writer)
+    t.start()
+    result = db.resolve_lineage_winners(candidates, result_limit=5)
+    t.join()
+
+    roots = {row["lineage_root_id"] for row in result["winners"]}
+    assert roots == {"root", "other"}
+    assert result["stats"]["lineage_bound_hit"] is False

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -18,7 +18,6 @@ from hermes_state import SessionDB
 from tools.session_search_tool import (
     SESSION_SEARCH_SCHEMA,
     _format_timestamp,
-    _is_compacted_message,
     _is_compression_ended,
     _resolve_to_parent,
     _session_link,
@@ -676,24 +675,6 @@ class TestResolveToParent:
         root, has_compression = _resolve_to_parent(db, "s_c")
         assert root == "s_gp"
         assert has_compression is True
-
-
-class TestIsCompactedMessage:
-    """Unit tests for the _is_compacted_message helper."""
-
-    def test_active_message_returns_false(self, db):
-        db.create_session("s1", source="cli")
-        mid = db.append_message("s1", role="user", content="hello")
-        assert _is_compacted_message(db, mid) is False
-
-    def test_compacted_message_returns_true(self, db):
-        db.create_session("s1", source="cli")
-        mid = db.append_message("s1", role="user", content="archived content")
-        db.archive_and_compact("s1", [
-            {"role": "assistant", "content": "compacted summary"},
-        ])
-        # mid is now active=0, compacted=1
-        assert _is_compacted_message(db, mid) is True
 
 
 class TestInPlaceCompactionDiscovery:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -171,16 +171,12 @@ def _resolve_lineage(db, session_id: str) -> Optional[str]:
     resolver used by winner selection.  Returns ``None`` when the outcome is
     unresolved / budget-exhausted — never a fabricated root (#68): a resource
     limit is not evidence, so a B-limited resolution must not pretend the
-    session is its own root.  The old generic-parent walk is kept only as a
-    compatibility fallback for small test doubles / older DB objects.
+    session is its own root.
     """
     if not session_id:
         return session_id
-    resolver = getattr(db, "resolve_compression_lineage", None)
-    if resolver is None:
-        return _resolve_to_parent(db, session_id)[0]
     try:
-        return resolver(session_id)
+        return db.resolve_compression_lineage(session_id)
     except Exception:
         logging.debug(
             "compression lineage resolution failed for %s",
@@ -828,33 +824,24 @@ def _discover(
     _truncated = bool(winner_stats.get("lineage_bound_hit"))
 
     if not winner_rows and not title_result:
+        _empty_payload = {
+            "success": True,
+            "mode": "discover",
+            "query": query,
+            "detail": detail,
+            "results": [],
+            "count": 0,
+            "truncated": _truncated,
+        }
         if _truncated:
             # The lineage safety work bound stopped the scan before any
             # winner: this is an incomplete result, never "no matches".
-            _empty_payload = {
-                "success": True,
-                "mode": "discover",
-                "query": query,
-                "detail": detail,
-                "results": [],
-                "count": 0,
-                "truncated": True,
-                "warning": (
-                    "Session search stopped at the lineage safety work bound; "
-                    "results are a safe ranked prefix and may be incomplete."
-                ),
-            }
+            _empty_payload["warning"] = (
+                "Session search stopped at the lineage safety work bound; "
+                "results are a safe ranked prefix and may be incomplete."
+            )
         else:
-            _empty_payload = {
-                "success": True,
-                "mode": "discover",
-                "query": query,
-                "detail": detail,
-                "results": [],
-                "count": 0,
-                "truncated": False,
-                "message": "No matching sessions found.",
-            }
+            _empty_payload["message"] = "No matching sessions found."
         _annotate_rebuild_status(db, _empty_payload)
         return json.dumps(_empty_payload, ensure_ascii=False)
 

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -164,9 +164,30 @@ def _resolve_to_parent(db, session_id: str) -> tuple[str, bool]:
     return cur, has_compression
 
 
-def _resolve_lineage(db, session_id: str) -> str:
-    """Convenience: return only the lineage root (ignores compression hop)."""
-    return _resolve_to_parent(db, session_id)[0]
+def _resolve_lineage(db, session_id: str) -> Optional[str]:
+    """Resolve the session-search compression lineage root.
+
+    Production ``SessionDB`` exposes the same positive compression-continuation
+    resolver used by winner selection.  Returns ``None`` when the outcome is
+    unresolved / budget-exhausted — never a fabricated root (#68): a resource
+    limit is not evidence, so a B-limited resolution must not pretend the
+    session is its own root.  The old generic-parent walk is kept only as a
+    compatibility fallback for small test doubles / older DB objects.
+    """
+    if not session_id:
+        return session_id
+    resolver = getattr(db, "resolve_compression_lineage", None)
+    if resolver is None:
+        return _resolve_to_parent(db, session_id)[0]
+    try:
+        return resolver(session_id)
+    except Exception:
+        logging.debug(
+            "compression lineage resolution failed for %s",
+            session_id,
+            exc_info=True,
+        )
+        return None
 
 
 def _session_end_reason(db, session_id: str) -> Optional[str]:
@@ -581,8 +602,12 @@ def _scroll(
 
     if current_session_id:
         anchor_session_id = owning_session_id or session_id
-        a_root = _resolve_lineage(db, anchor_session_id)
-        c_root = _resolve_lineage(db, current_session_id)
+        # Scroll's guard is about LIVE CONTEXT, not search lineage (#68): a
+        # live delegation/branch parent is still in the active context even
+        # though it is a distinct compression root.  Generic parentage is the
+        # correct model here, not compression-continuation lineage.
+        a_root = _resolve_to_parent(db, anchor_session_id)[0]
+        c_root = _resolve_to_parent(db, current_session_id)[0]
         if a_root and c_root and a_root == c_root:
             is_compacted_anchor = (
                 anchor_state is not None
@@ -629,8 +654,11 @@ def _scroll(
     if not messages:
         owning = owning_session_id
         if owning and owning != session_id:
-            a_root = _resolve_lineage(db, session_id)
-            o_root = _resolve_lineage(db, owning)
+            # Lineage rebind uses generic parentage too: a descendant in the
+            # same generic chain (compaction or delegation child) is the real
+            # owner of the anchor, regardless of compression semantics (#68).
+            a_root = _resolve_to_parent(db, session_id)[0]
+            o_root = _resolve_to_parent(db, owning)[0]
             if a_root and o_root and a_root == o_root:
                 try:
                     rebind_view = db.get_messages_around(owning, around_message_id, window=window)
@@ -789,75 +817,71 @@ def _discover(
     # within each class.
     raw_results = _order_for_recall(raw_results)
 
-    if not raw_results and not title_result:
-        _empty_payload = {
-            "success": True,
-            "mode": "discover",
-            "query": query,
-            "detail": detail,
-            "results": [],
-            "count": 0,
-            "message": "No matching sessions found.",
-        }
+    # Compression-lineage winner selection (#68): consumes the ranked raw-hit
+    # set and replaces generic-parent dedup with positive compression-root
+    # semantics — one query-local memo, one coherent read snapshot, one work
+    # budget, fail-closed missing-parent/cycle outcomes, and early-K stop.
+    # Exact-title exclusion shares the same compression-root meaning.  The
+    # winner phase always runs (even when the title already fills the only
+    # slot or no raw hit survives) so a B-exhausted current chain is surfaced
+    # as truncation instead of a silently complete answer.  The surviving
+    # rows keep the raw owning session_id (only that pairs validly with the
+    # FTS5 match id for the anchored window); parent_session_id is exposed
+    # separately when different.
+    title_lineage = title_result.get("_lineage_root") if title_result else None
+    try:
+        winner_response = db.resolve_lineage_winners(
+            candidates=raw_results,
+            result_limit=max(0, limit - (1 if title_result else 0)),
+            excluded_lineage_roots=(title_lineage,) if title_lineage else (),
+            current_session_id=current_session_id or None,
+            out_of_context_end_reasons=_FRESH_RESET_END_REASONS,
+        )
+    except Exception as e:
+        logging.error("Lineage winner selection failed: %s", e, exc_info=True)
+        return tool_error(f"Search failed: {e}", success=False)
+    winner_rows = winner_response.get("winners", [])
+    winner_stats = winner_response.get("stats", {})
+    _truncated = bool(winner_stats.get("lineage_bound_hit"))
+
+    if not winner_rows and not title_result:
+        if _truncated:
+            # The lineage safety work bound stopped the scan before any
+            # winner: this is an incomplete result, never "no matches".
+            _empty_payload = {
+                "success": True,
+                "mode": "discover",
+                "query": query,
+                "detail": detail,
+                "results": [],
+                "count": 0,
+                "truncated": True,
+                "warning": (
+                    "Session search stopped at the lineage safety work bound; "
+                    "results are a safe ranked prefix and may be incomplete."
+                ),
+            }
+        else:
+            _empty_payload = {
+                "success": True,
+                "mode": "discover",
+                "query": query,
+                "detail": detail,
+                "results": [],
+                "count": 0,
+                "truncated": False,
+                "message": "No matching sessions found.",
+            }
         _annotate_rebuild_status(db, _empty_payload)
         return json.dumps(_empty_payload, ensure_ascii=False)
 
-    # Dedupe by lineage. Keep the raw owning session_id on the surviving
-    # row — only that pairs validly with the FTS5 match id for the anchored
-    # window. parent_session_id is exposed separately when different.
-    seen_sessions = {}
     results = []
-
     if title_result:
-        title_lineage = title_result.pop("_lineage_root", None)
-        if title_lineage:
-            seen_sessions[title_lineage] = {"_title_only": True}
+        title_result.pop("_lineage_root", None)
         results.append(title_result)
 
-    for r in raw_results:
-        if len(seen_sessions) >= limit:
-            break
-        raw_sid = r["session_id"]
-        resolved_sid, _ = _resolve_to_parent(db, raw_sid)
-        # Skip the current session lineage — UNLESS the hit's transcript has
-        # left live context. Three sub-cases:
-        #
-        # Legacy compression rotation: the FTS hit lives in a session that
-        # itself ended with end_reason='compression'. That session's content
-        # has been replaced by a summary in the continuation child, so it
-        # must stay discoverable.
-        #
-        # /new-reset (and idle/daily/CLI new_session): the predecessor was
-        # ended without carrying any transcript into the child. Same lineage
-        # root, but the prior conversation is NOT in the active context —
-        # hiding it made gateway recall go blind after every /new (#85756).
-        # A live delegation child has end_reason=None, so it stays excluded.
-        #
-        # In-place compaction: the FTS hit lives on the SAME session_id as the
-        # current session, but the matched message row is an archived
-        # (active=0, compacted=1) row. The live-context load filters active=1,
-        # so that content is no longer in context — let it through.
-        is_compacted_hit = _is_compacted_message(db, r.get("id"))
-        is_ended_session = _session_left_live_context(db, raw_sid)
-        if current_lineage_root and resolved_sid == current_lineage_root:
-            if not (is_ended_session or is_compacted_hit):
-                continue
-        if current_session_id and raw_sid == current_session_id:
-            # Same-session hit: only skip if the matched message is still live
-            # (active=1). Archived/compacted rows are pre-compaction content
-            # that's been summarised away — let them through.
-            if not is_compacted_hit:
-                continue
-        if resolved_sid not in seen_sessions:
-            row = dict(r)
-            row["_lineage_root"] = resolved_sid
-            seen_sessions[resolved_sid] = row
-        if len(seen_sessions) >= limit:
-            break
-
-    for lineage_root, match_info in seen_sessions.items():
-        if match_info.get("_title_only"):
-            continue
+    for match_info in winner_rows:
+        lineage_root = match_info.get("lineage_root_id") or match_info.get("session_id")
         hit_sid = match_info.get("session_id") or lineage_root
         msg_id = match_info.get("id")
         try:
@@ -927,8 +951,15 @@ def _discover(
         "detail": detail,
         "results": results,
         "count": len(results),
-        "sessions_searched": len(seen_sessions),
+        "truncated": _truncated,
+        "sessions_searched": len(winner_rows) + (1 if title_result else 0),
     }
+    if _truncated:
+        # A partial safe prefix must never be presented as a complete top-K.
+        _final_payload["warning"] = (
+            "Session search stopped at the lineage safety work bound; "
+            "results are a safe ranked prefix and may be incomplete."
+        )
     _annotate_rebuild_status(db, _final_payload)
     return json.dumps(_final_payload, ensure_ascii=False)
 

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -260,23 +260,6 @@ def _get_message_storage_state(db, message_id) -> Optional[Dict[str, Any]]:
     return dict(row) if row is not None else None
 
 
-def _is_compacted_message(db, message_id) -> bool:
-    """Return True if *message_id* is a compaction-archived row.
-
-    Compaction archives are ``active=0, compacted=1`` — the content was
-    summarised away from live context by :meth:`archive_and_compact`.
-    Rewind/undo rows are ``active=0, compacted=0`` and must stay hidden.
-
-    Used by ``_discover`` to distinguish a compaction-archived FTS hit on the
-    current session (pre-compaction content no longer in live context — should
-    stay discoverable) from an active live hit (already in context — skip).
-    Returns False on any error so the caller falls back to the safe default
-    (skip the current session).
-    """
-    state = _get_message_storage_state(db, message_id)
-    return state is not None and state["active"] == 0 and state["compacted"] == 1
-
-
 def _annotate_rebuild_status(db, payload: Dict[str, Any]) -> None:
     """Add a rebuild-progress note when the deferred FTS backfill (schema
     v23) is still running, so the agent can tell the user why older results


### PR DESCRIPTION
## What does this PR do?

**The bug class.** Search results currently conflate generic parent ancestry with compression identity. A long conversation that context-compression rotated into a chain of physical session rows (root `-[compression]->` mid `-[compression]->` tip) is either merged with unrelated sessions — because *any* `parent_session_id` edge is treated as conversation identity — or split into fragments that recall misses: a match living only in a compressed continuation is dropped when the query is absent from the root transcript (upstream #6507). The same `_discover` seam already fails for `/new`-reset recall (#85756, fixed by #86652) and own-early-context recall (#90939, open #90974); this PR closes the compression-continuation half and makes the fresh-reset predecessor discoverable at the winner level.

**The invariant.** Only **positive compression-continuation edges** define one searchable conversation. The exact edge condition: the parent exists, the parent ended with `end_reason='compression'`, the child is not a `tool` session, and the child's `_branched_from`/`_delegate_from` markers do not explicitly point at that parent (foreign markers pointing elsewhere do **not** disqualify). Generic parent ancestry (branches, delegates/subagents, tool/reset children) is *not* conversation identity. Resolution is fail-closed for missing parents and proven cycles, and query-bounded (exact `B=2000` successful uncached-row-fetch budget, early-K stopping) with **no** semantic depth cap — a 10k-deep chain resolves correctly, not by capping depth.

## Concrete behavioral contracts (from the implementation)

- **Budget accounting is precise.** `B=2000` counts exactly one successful *uncached* lineage-node row fetch. Memo hits, absent-row fetches, and traversal-local cycle checks consume nothing; the archive-metadata batch queries (owner `end_reason` + per-message `compacted`) are not lineage-node fetches and do not count toward the budget.
- **Budget exhaustion is conservative and surfaced, never silent.** When a candidate's resolution would exceed the budget, the entire ranked scan stops — the bound candidate may own a higher-ranked root than every later candidate, so skipping it would violate ranking. The result is surfaced as `truncated: true` plus a warning ("results are a safe ranked prefix and may be incomplete") and `stats.lineage_bound_hit`; an exhausted partial path is *operational uncertainty, not semantic evidence*, so it is never memoized as unresolved and never fabricated into a root.
- **Live-context visibility check.** A hit whose content has left live context stays discoverable even when it belongs to the current lineage: owner ended by compression, owner has a fresh-reset end reason, or the matched message row is in-place-compacted (`compacted=1`).
- **Fresh-reset predecessors stay discoverable.** The winner phase threads `out_of_context_end_reasons` (reset set + `new_session`) so a `/new`-style predecessor of the current session is not hidden (#85756) — complementing #86652 at the winner level.
- **Ranking and anchors are preserved.** Winners follow the rank of each owner's *first displayable anchor*; a live current-lineage hit is skipped so a later compacted hit of the same owner can surface, but that owner never jumps ahead of a higher-ranked displayable winner from another session. The matched anchor keeps its raw owning `session_id` — it is **never rewritten to the root**.
- **Current-session unresolved handling is conservative.** An unresolved current session excludes only its own id, never broadening exclusion to an unproven ancestor.
- **`_scroll` is deliberately unchanged in identity semantics.** Scroll's guard is about *live context*, not search lineage: a live delegation/branch parent is still in the active context even though it is a distinct compression root, so scroll keeps generic parentage (#68). This PR changes only discovery/winner semantics.

## Snapshot / concurrent-writer note (explicit)

The winner phase runs inside a **single read context + `BEGIN` read transaction** (archive metadata, lineage resolution, and current-lineage ancestors; rolled back on exit). Candidate discovery (`search_messages`) happens on the existing connection model *before* that transaction, so the discover→resolve sequence is not one atomic snapshot; concurrent writers are not blocked. Missing parents and proven cycles are fail-closed at read time.

## Implementation choices supporting that contract

Query-local resolver memo + path compression (a memo hit path-compresses the visited prefix to the known root); winner dedupe, current-session exclusion, and exact-title exclusion all using the same compression-root meaning (the exact-title slot is pre-resolved with the same resolver); preservation of the highest-ranked anchor per conversation; deferred expensive hydration; `_chunked` (size 400) batch reads for SQLite var-limit safety; `SESSION_WINNERS_LINEAGE` telemetry logging candidate/winner/work/memo/bound-hit counts so truncation is observable.

## Related Issues

- **#6507 [open]** — *session_search drops child/continuation-session hits by summarizing only the lineage root.* This PR's compression-root composition is the compression-continuation half of this bug class: it resolves and composes the full lineage, keeps the matched anchor (never rewrites to root), and summarizes from the lineage transcript, not just the resolved root.
- **#85756 [closed, fixed by #86652 merged]** — *`/new`-reset lineage recall.* The `/new` case (upstream #86652) and the compression case (this PR) are two halves of the same "same-lineage content is already in context" guard in `_discover`; this PR also makes the fresh-reset predecessor discoverable at the winner level via `out_of_context_end_reasons`.
- **#90939 [open, #90974 open]** — *current session's own early context.* Same `_discover` seam; complementary.

## Overlap disposition (classified by contract, not file overlap)

### Prior art — closed/unmerged; this PR is the first to land the contract
- **#63144** — surface compaction-archived and compression-parent sessions in discovery (discovery half partially salvaged by #69544, merged).
- **#6536** — improve session_search lineage recall.
- **#23561 / #20794** — read content from matched / child session (earliest #6507 attempts).

### Open upstream PRs — COEXIST (different surface, no equivalent invariant implemented)
- **#81561 [open]** — Desktop compression-lineage *navigation* UI, lazy-loads exact read-only segments. Non-search surface; notably shares the strict compression-continuation traversal edge definition (mutual validation).
- **#53992 [open]** — export-path lineage stitching, reuses the **same** compression-only edge definition as `get_compression_tip`. Different surface (export), same edge semantics.
- **#83829 [open]** — scopes Telegram `session_search` to the current conversation; explicitly *preserves* compression-lineage recall. Different contract (scope).
- **#75496 [open] — COEXIST (watch item).** CLI `/sessions` list + `sessions search` UX with row-per-compression-chain dedupe. Its chain identity (compression-chain root, `COMPRESSION_CHAIN_MAX_HOPS`) **matches** this PR's positive-compression-continuation roots — not a conflicting identity — but its surface (listing/pagination/lane-scoping) is different and it does **not** implement this PR's bounded/fail-closed lineage reconstruction for the agent tool (no B=2000, no memo, no lineage summarization). **If #75496 merges before this PR:** stop mechanical rebasing, re-audit ownership of the lineage seams, and explicitly test whether its chain-identity semantics remain equivalent to compression-continuation roots. Its continued openness is not a veto on this PR.

### Merged substrate (reused, not replaced)
#69544, #12960, #38393, #39062, #57685, #86652, #90357.

## Test evidence

- `tests/test_session_search_lineage.py` — 37 tests: `B=1999/2000/2001` boundary, 10k-deep chain, `K=60` early-K, cycle/missing-parent fail-closed, current-session exclusion, anchor preservation, concurrent-writer lineage coherence.
- `tests/tools/test_session_search.py` — 51 tests.
- `tests/test_hermes_state.py -k search` — 19 state-search tests.
- **Broad wrapper** `scripts/run_tests.sh`: all three targeted files green. A full-suite run on a local Windows box is blocked by pre-existing environmental failures unrelated to this PR (POSIX-only modules `termios`/`os.chown`/`AF_UNIX`, missing `anthropic` SDK, broken `aiohttp` wheel, missing platform/API credentials); the run reached ~12k tests with **zero** failures in any file this PR touches. Upstream CI (Linux) is the authoritative broad gate.

## Notes for maintainers

- Both #53992 and #81561 independently use the same strict compression-continuation edge definition — strong cross-validation of this PR's identity semantics.
- Rebase note for #90974: both touch `_discover` in `tools/session_search_tool.py`; coordinate the compaction-escape-hatch handling (this PR replaces `_is_compacted_message` with the winner-phase `_is_archived` check, #90974 relies on the helper).
- Production code + tests only; no fork-internal docs.

## Checklist

- [x] Read the Contributing Guide
- [x] Conventional Commits
- [x] Searched for existing PRs — no duplicate (see Overlap disposition)
- [x] PR contains only changes related to this feature (4 files, +1551/-98)
- [x] Targeted suite via `scripts/run_tests.sh` — 107 passed (37+51+19)
- [x] Broad wrapper run — see Test evidence (Windows env limits noted)
- [x] Tests added (37 lineage tests + bound/cycle fixtures)
- [ ] Platform tested: Windows 11 (pending confirmation)
