### PR TITLE
fix(copilot): strip temperature for GPT-5.x on Responses API

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -687,6 +687,32 @@ class ResponsesApiTransport(ProviderTransport):
             ):
                 kwargs.pop("service_tier", None)
 
+        # GitHub Copilot's GPT-5.x models on the Responses API reject any
+        # non-default ``temperature`` (HTTP 400 "Unsupported parameter:
+        # temperature is not supported with this model"): live-verified on
+        # gpt-5.6-luna and gpt-5.5, which 400 on temperature=0.3 AND 0.0.
+        # Only the default value (1) or an omitted field is accepted (200),
+        # so callers that hardcode a non-default temperature — e.g. title
+        # generation at 0.3 (issue #72351) — silently 400 every turn. The
+        # safe fix is to drop the field so the server default applies.
+        # grok-4.6 / mai-code on the same Copilot Responses surface accept
+        # temperature (200 @ 0.3), and native codex/openai backends accept it
+        # too, so the strip is scoped to the gpt-5 family on the Copilot/GitHub
+        # Responses backend only. temperature arrives here via request_overrides.
+        # NB: ``startswith("gpt-5")`` (and the "/gpt-5" substring) also matches
+        # any as-yet-unnamed gpt-5 successor (gpt-5.7, gpt-50, gpt-51, ...). That
+        # breadth is intentional: every gpt-5 variant probed so far rejects a
+        # non-default temperature, so silently dropping the field for a future
+        # sibling is the safe default and beats a hard 400 on a model we have
+        # not enumerated. Do not narrow this into a per-version allowlist.
+        if is_github_responses:
+            _model_lower = str(model or "").strip().lower()
+            if (
+                kwargs.get("temperature", 1) != 1
+                and (_model_lower.startswith("gpt-5") or "/gpt-5" in _model_lower)
+            ):
+                kwargs.pop("temperature", None)
+
         # Forward per-request timeout to the SDK so OpenAI/Anthropic clients
         # honor it.  Without this, ``providers.<id>.request_timeout_seconds``
         # is silently dropped on the main agent Codex path while the

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -1353,3 +1353,115 @@ class TestPreflightSlashEnumStrip:
         assert params["properties"]["model_id"].get("enum") == [
             "Qwen/Qwen3.5-0.8B", "plain-id"
         ]
+
+
+class TestCopilotResponsesTemperatureStrip:
+    """GitHub Copilot's GPT-5.x models on the Responses API reject
+    ``temperature`` at any non-default value (HTTP 400 "Unsupported parameter:
+    temperature is not supported with this model"), live-verified on
+    gpt-5.6-luna and gpt-5.5 (400 on temperature=0.3 AND 0.0; only the default
+    value 1 or an omitted field is accepted). temperature leaks in via
+    request_overrides. The strip is scoped to the gpt-5 family on the
+    GitHub/Copilot Responses surface only: grok-4.6 / mai-code on the same
+    surface accept temperature, and native codex/openai backends accept it too,
+    so neither must be touched.
+    See issue #72351.
+    """
+
+    @pytest.fixture
+    def transport(self):
+        from agent.transports.codex import ResponsesApiTransport
+        return ResponsesApiTransport()
+
+    @pytest.mark.parametrize("model", ["gpt-5.6", "gpt-5.5"])
+    @pytest.mark.parametrize("temperature", [0.3, 0.0])
+    def test_gpt5_on_copilot_strips_temperature(self, transport, model, temperature):
+        """gpt-5.6 / gpt-5.5 on Copilot Responses must have temperature
+        stripped at both 0.3 and 0.0 (the live-verified 400 values)."""
+        kw = transport.build_kwargs(
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_github_responses=True,
+            request_overrides={"temperature": temperature},
+        )
+        assert "temperature" not in kw, (
+            f"temperature must be stripped for {model} on Copilot Responses, "
+            f"got {kw.get('temperature')!r}"
+        )
+
+    @pytest.mark.parametrize("model", ["openai/gpt-5.6", "openai/gpt-5.5-codex"])
+    def test_vendor_prefixed_gpt5_on_copilot_strips_temperature(self, transport, model):
+        """Vendor-prefixed ids (e.g. ``openai/gpt-5.6``) reach the strip via the
+        ``"/gpt-5" in _model_lower`` substring branch, not ``startswith``. Both
+        existing cases use bare names, so this pins that branch: the strip must
+        still apply when the gpt-5 family id carries a vendor prefix."""
+        kw = transport.build_kwargs(
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_github_responses=True,
+            request_overrides={"temperature": 0.3},
+        )
+        assert "temperature" not in kw, (
+            f"temperature must be stripped for vendor-prefixed {model} on "
+            f"Copilot Responses, got {kw.get('temperature')!r}"
+        )
+
+    def test_non_gpt5_prefixed_model_on_copilot_keeps_temperature(self, transport):
+        """A non-gpt-5 id that merely carries a vendor prefix (e.g.
+        ``openai/o4-mini``) must NOT match the ``"/gpt-5"`` substring and so must
+        keep its temperature. This guards the substring logic against
+        over-matching any ``openai/*`` id."""
+        kw = transport.build_kwargs(
+            model="openai/o4-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_github_responses=True,
+            request_overrides={"temperature": 0.3},
+        )
+        assert kw.get("temperature") == 0.3, (
+            "openai/o4-mini does not match the gpt-5 family and must keep "
+            f"temperature, got {kw.get('temperature')!r}"
+        )
+
+    def test_gpt5_on_copilot_keeps_supported_default_temperature(self, transport):
+        """The supported default value is not part of the compatibility strip."""
+        kw = transport.build_kwargs(
+            model="gpt-5.6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_github_responses=True,
+            request_overrides={"temperature": 1},
+        )
+        assert kw.get("temperature") == 1
+
+    def test_grok_on_copilot_keeps_temperature(self, transport):
+        """grok-4.6 on the same Copilot Responses surface accepts
+        temperature (200 @ 0.3), so it must NOT be stripped."""
+        kw = transport.build_kwargs(
+            model="grok-4.6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_github_responses=True,
+            request_overrides={"temperature": 0.3},
+        )
+        assert kw.get("temperature") == 0.3, (
+            "grok-4.6 on Copilot Responses accepts temperature and must keep it"
+        )
+
+    def test_native_codex_gpt5_keeps_temperature(self, transport):
+        """The strip is Copilot/GitHub-only. Native codex (OpenAI's own
+        Responses endpoint) accepts temperature for gpt-5.x, so stripping
+        there would silently drop a valid caller parameter."""
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_github_responses=False,
+            is_codex_backend=True,
+            request_overrides={"temperature": 0.3},
+        )
+        assert kw.get("temperature") == 0.3, (
+            "native codex must keep temperature for gpt-5.x"
+        )


### PR DESCRIPTION
## What does this PR do?

GitHub Copilot's Responses endpoint rejects non default `temperature` values for GPT 5.x models. Callers such as title generation can supply `0.3`, which otherwise turns a valid request into an HTTP 400 response.

This PR removes only non default temperatures for the GPT 5 family on the GitHub Copilot Responses path. It handles bare and vendor prefixed model identifiers. It preserves the supported default value, preserves temperatures for Grok and other model families, and leaves native Codex requests unchanged.

## Type of change

Bug fix with transport regression coverage.

## Changes made

`agent/transports/codex.py` strips a non default temperature after GitHub Responses routing is known and before the SDK request is built.

`tests/agent/transports/test_codex_transport.py` covers zero and fractional values, vendor prefixed GPT 5 identifiers, the supported default, a prefixed non GPT model, Grok, and native Codex.

## Verification

`scripts/run_tests.sh` passed 192 Codex transport, Responses adapter, and run agent integration tests. Ruff passes on both changed files.

## Related work

This is complementary to #72515 and #15627. Those changes address temperature handling in other request paths and model families. This PR covers the remaining GitHub Copilot Responses transport boundary without broadening their behavior.
