### PR TITLE
fix(gateway): allow guarded sibling profile restart

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -55,11 +55,19 @@ class GatewayLifecycleBlocked(ValueError):
 # actual shell-command-shaped strings, not on prose.
 _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     r"(?i)"
-    # Branch A: `hermes gateway restart|stop` — the canonical foot-gun.
+    # Branch A: `hermes [PROFILE] gateway [PROFILE] restart|stop` — the
+    # canonical foot-gun. Hermes accepts ``--profile NAME``, ``-p NAME``, and
+    # ``--profile=NAME`` anywhere before argument parsing; match selectors on
+    # either side of ``gateway``. The terminal tool narrowly exempts one proven
+    # direct sibling restart before consulting this broad script/chain detector.
     # `start` is intentionally excluded: starting a gateway from inside a
     # gateway is benign (a no-op or "already running" error), and a
     # legitimate cron job might start a sibling profile's gateway.
-    r"(?:hermes\s+gateway\s+(?:restart|stop))"
+    r"(?:hermes\s+"
+    r"(?:(?:--profile(?:=\S+|\s+\S+)|-p\s+\S+)\s+)?"
+    r"gateway\s+"
+    r"(?:(?:--profile(?:=\S+|\s+\S+)|-p\s+\S+)\s+)?"
+    r"(?:restart|stop))"
     # Branch B: launchctl ops on a hermes-gateway label. macOS launchd
     # labels look like `ai.hermes.gateway` / `hermes-gateway`. Requiring the
     # gateway identifier prevents blocking unrelated hermes services (e.g.
@@ -95,12 +103,74 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
 _SHELL_LINE_CONTINUATION = re.compile(r"\\\r?\n[ \t]*")
 
 
+def _contains_hermes_gateway_lifecycle_tokens(text: str) -> bool:
+    """Detect quoted/profile-qualified Hermes lifecycle command tokens.
+
+    The regex above intentionally handles prose cheaply, but raw text cannot
+    see through shell quoting. Tokenize command segments, remove profile
+    selectors using the same accepted spellings as the CLI pre-parser, and
+    look for the resulting ``gateway restart|stop`` pair. This remains a pure,
+    total string check; filesystem/script recursion is handled separately.
+    """
+    control_chars = frozenset(";&|()")
+    for line in text.splitlines() or [text]:
+        try:
+            lexer = shlex.shlex(line, posix=True, punctuation_chars=";&|()")
+            lexer.whitespace_split = True
+            lexer.commenters = "#"
+            tokens = list(lexer)
+        except ValueError:
+            continue
+
+        segments: list[list[str]] = []
+        current: list[str] = []
+        for token in tokens:
+            if token and set(token) <= control_chars:
+                if current:
+                    segments.append(current)
+                    current = []
+                continue
+            current.append(token)
+        if current:
+            segments.append(current)
+
+        for segment in segments:
+            for hermes_index, token in enumerate(segment):
+                executable = token.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+                if executable.lower() != "hermes":
+                    continue
+
+                filtered: list[str] = []
+                args = segment[hermes_index + 1 :]
+                index = 0
+                while index < len(args):
+                    argument = args[index]
+                    lowered = argument.lower()
+                    if lowered in {"--profile", "-p"}:
+                        index += 2
+                        continue
+                    if lowered.startswith("--profile="):
+                        index += 1
+                        continue
+                    filtered.append(lowered)
+                    index += 1
+
+                if filtered[:2] in (
+                    ["gateway", "restart"],
+                    ["gateway", "stop"],
+                ):
+                    return True
+    return False
+
+
 def contains_gateway_lifecycle_command(text: str) -> bool:
     """Return True if *text* contains a gateway lifecycle command pattern."""
     if not text:
         return False
     normalized = _SHELL_LINE_CONTINUATION.sub(" ", text)
-    return bool(_GATEWAY_LIFECYCLE_PATTERN.search(normalized))
+    return bool(_GATEWAY_LIFECYCLE_PATTERN.search(normalized)) or (
+        _contains_hermes_gateway_lifecycle_tokens(normalized)
+    )
 
 
 _SHELL_EXECUTABLES = frozenset({"sh", "bash", "dash", "ksh", "zsh"})

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -31,6 +31,16 @@ class TestGatewayLifecyclePattern:
         "hermes  gateway  restart",         # double spaces
         "Hermez Gateway Restart".lower().replace("z", "s"),  # case handled
         "HERMES GATEWAY RESTART",           # uppercase
+        "hermes --profile hermes-fo gateway restart",
+        "hermes --profile hermes-fo gateway stop",
+        "hermes -p hermes-fo gateway restart",
+        "hermes --profile=hermes-fo gateway restart",
+        "hermes gateway --profile hermes-fo restart",
+        "hermes gateway -p hermes-fo stop",
+        "hermes '--profile=hermes-fo' gateway restart",
+        "hermes '-p' hermes-fo gateway restart",
+        "hermes gateway '--profile=hermes-fo' restart",
+        "hermes 'gateway' restart",
     ])
     def test_hermes_gateway_commands(self, text):
         assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
@@ -102,6 +112,9 @@ class TestGatewayLifecyclePattern:
         "Monitor the gateway and tell me if a restart is recommended",
         "research how the OpenAI API gateway handles restart after rate limiting",
         "compare AWS API Gateway vs Cloudflare on restart latency",
+        "hermes mcp add server --args gateway restart",
+        "hermes chat --oneshot gateway restart",
+        "hermes config set note gateway restart",
     ])
     def test_safe_commands(self, text):
         assert not _contains_gateway_lifecycle_command(text), f"Should NOT match: {text!r}"
@@ -269,6 +282,16 @@ class TestTerminalToolGatewayLifecycleGuard:
         "systemctl --user restart hermes-gateway",
         "systemctl stop hermes-gateway.service",
         "hermes gateway restart",
+        "hermes --profile hermes-fo gateway stop",
+        "hermes --profile hermes-fo gateway restart; echo not-direct",
+        "_HERMES_GATEWAY=0 hermes -p default gateway restart",
+        "_HERMES_GATEWAY=0 hermes --profile=default gateway restart",
+        "_HERMES_GATEWAY=0 hermes gateway --profile default restart",
+        "_HERMES_GATEWAY=0 hermes gateway -p default stop",
+        "_HERMES_GATEWAY=0 hermes '--profile=default' gateway restart",
+        "_HERMES_GATEWAY=0 hermes '-p' default gateway restart",
+        "_HERMES_GATEWAY=0 hermes gateway '--profile=default' restart",
+        "_HERMES_GATEWAY=0 hermes 'gateway' restart",
         "launchctl kickstart gui/501/ai.hermes.gateway",
         # #62891 exact reported shape and its bootstrap sibling.
         "launchctl submit -l ai.hermes.gateway-hard-restart-no-photon-notice -- /bin/sh ~/.hermes/scripts/hard_restart_gateway_no_photon_notice.sh",
@@ -295,6 +318,141 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         assert result["exit_code"] == 1
         assert "Blocked" in result["error"]
+
+    def test_allows_direct_restart_of_running_sibling_profile_inside_gateway(
+        self, monkeypatch, tmp_path
+    ):
+        import os
+        import tools.terminal_tool as tt
+
+        calls = []
+
+        class _FakeEnv:
+            env = {}
+
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                return {"output": "restarted", "returncode": 0}
+
+        hermes_home = tmp_path / ".hermes"
+        sibling_home = hermes_home / "profiles" / "hermes-fo"
+        sibling_home.mkdir(parents=True)
+        (hermes_home / "gateway_state.json").write_text(
+            json.dumps({"pid": os.getpid(), "gateway_state": "running"}),
+            encoding="utf-8",
+        )
+        (sibling_home / "gateway_state.json").write_text(
+            json.dumps({"pid": os.getpid() + 1000, "gateway_state": "running"}),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=True)
+        monkeypatch.setattr(
+            "gateway.status.get_runtime_status_running_pid",
+            lambda runtime, expected_home: os.getpid() + 1000,
+        )
+        monkeypatch.setattr(
+            tt, "_check_all_guards", lambda command, env_type, **kwargs: {"approved": True}
+        )
+
+        result = json.loads(
+            tt.terminal_tool(command="hermes --profile hermes-fo gateway restart")
+        )
+
+        assert result["exit_code"] == 0
+        assert calls == [
+            "_HERMES_GATEWAY=0 hermes --profile hermes-fo gateway restart"
+        ]
+
+    def test_uses_process_home_when_turn_has_profile_context_override(
+        self, monkeypatch, tmp_path
+    ):
+        import os
+        import tools.terminal_tool as tt
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        hermes_home = tmp_path / ".hermes"
+        target_home = hermes_home / "profiles" / "hermes-fo"
+        routed_home = hermes_home / "profiles" / "routed"
+        target_home.mkdir(parents=True)
+        routed_home.mkdir(parents=True)
+        (hermes_home / "gateway_state.json").write_text(
+            json.dumps({"pid": os.getpid(), "gateway_state": "running"}),
+            encoding="utf-8",
+        )
+        (target_home / "gateway_state.json").write_text(
+            json.dumps({"pid": os.getpid() + 1000, "gateway_state": "running"}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(
+            "gateway.status.get_runtime_status_running_pid",
+            lambda runtime, expected_home: os.getpid() + 1000,
+        )
+
+        token = set_hermes_home_override(routed_home)
+        try:
+            execution_command = tt._direct_sibling_gateway_restart_execution_command(
+                "hermes --profile hermes-fo gateway restart",
+                env_type="local",
+                background=False,
+                pty=False,
+            )
+        finally:
+            reset_hermes_home_override(token)
+
+        assert execution_command == (
+            "_HERMES_GATEWAY=0 hermes --profile hermes-fo gateway restart"
+        )
+
+    def test_does_not_clear_gateway_marker_for_stale_sibling_state(
+        self, monkeypatch, tmp_path
+    ):
+        import os
+        import tools.terminal_tool as tt
+
+        calls = []
+
+        class _FakeEnv:
+            env = {}
+
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                return {"output": "blocked by child", "returncode": 1}
+
+        hermes_home = tmp_path / ".hermes"
+        sibling_home = hermes_home / "profiles" / "hermes-fo"
+        sibling_home.mkdir(parents=True)
+        (hermes_home / "gateway_state.json").write_text(
+            json.dumps({"pid": os.getpid(), "gateway_state": "running"}),
+            encoding="utf-8",
+        )
+        (sibling_home / "gateway_state.json").write_text(
+            json.dumps({"pid": 99999999, "gateway_state": "running"}),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=True)
+        monkeypatch.setattr(
+            "gateway.status.get_runtime_status_running_pid",
+            lambda runtime, expected_home: None,
+        )
+        monkeypatch.setattr(
+            tt, "_check_all_guards", lambda command, env_type, **kwargs: {"approved": True}
+        )
+
+        result = json.loads(
+            tt.terminal_tool(command="hermes --profile hermes-fo gateway restart")
+        )
+
+        assert result["exit_code"] == 1
+        assert "Blocked" in result["error"]
+        assert calls == []
 
     def test_blocks_lifecycle_command_hidden_in_referenced_script(
         self, monkeypatch, tmp_path

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2601,6 +2601,95 @@ def _resolve_command_cwd(
     return recorded or default_cwd
 
 
+def _direct_sibling_gateway_restart_execution_command(
+    command: str,
+    *,
+    env_type: str,
+    background: bool,
+    pty: bool,
+) -> Optional[str]:
+    """Return a child-safe command for one proven sibling-profile restart.
+
+    Gateway terminal children inherit ``_HERMES_GATEWAY=1``.  That marker is
+    intentionally a hard self-restart guard in ``hermes_cli.gateway``, but it
+    cannot distinguish an explicitly targeted sibling service.  Accept only the
+    exact direct CLI shape, prove both gateway identities from their state files,
+    and clear the marker for this one child process.  The original command still
+    flows through the normal approval/security checks.
+    """
+    if env_type != "local" or background or pty:
+        return None
+
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        return None
+
+    if len(tokens) != 5 or tokens[:2] != ["hermes", "--profile"]:
+        return None
+    profile_name = tokens[2]
+    suffix = tokens[3:]
+
+    if suffix != ["gateway", "restart"] or not profile_name:
+        return None
+
+    try:
+        from hermes_cli.profiles import (
+            get_profile_dir,
+            normalize_profile_name,
+            profile_exists,
+            validate_profile_name,
+        )
+        from gateway.status import _get_process_hermes_home
+
+        canonical_profile = normalize_profile_name(profile_name)
+        validate_profile_name(canonical_profile)
+        if not profile_exists(canonical_profile):
+            return None
+        current_home = _get_process_hermes_home().expanduser().resolve()
+        target_home = get_profile_dir(canonical_profile).expanduser().resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+    if current_home == target_home:
+        return None
+
+    def _gateway_pid(home: Path) -> Optional[int]:
+        try:
+            state = json.loads((home / "gateway_state.json").read_text(encoding="utf-8"))
+            if state.get("gateway_state") != "running":
+                return None
+            state_home = state.get("hermes_home")
+            if state_home and Path(state_home).expanduser().resolve() != home:
+                return None
+            pid = int(state.get("pid", 0))
+            return pid if pid > 0 else None
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return None
+
+    current_pid = _gateway_pid(current_home)
+    try:
+        from gateway.status import (
+            get_runtime_status_running_pid,
+            read_runtime_status,
+        )
+
+        target_runtime = read_runtime_status(target_home / "gateway_state.json")
+        if not target_runtime or target_runtime.get("gateway_state") != "running":
+            return None
+        target_pid = get_runtime_status_running_pid(
+            target_runtime,
+            expected_home=target_home,
+        )
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+
+    if current_pid != os.getpid() or target_pid is None or target_pid == current_pid:
+        return None
+
+    return f"_HERMES_GATEWAY=0 {shlex.join(tokens)}"
+
+
 def terminal_tool(
     command: str,
     background: bool = False,
@@ -2853,7 +2942,14 @@ def terminal_tool(
         # never restart. This mirrors the `hermes gateway restart` guard in
         # hermes_cli/gateway.py and the cron-path guard in hermes_cli/cron.py,
         # but applies unconditionally (force=True cannot help here).
+        gateway_execution_command: Optional[str] = None
         if os.environ.get("_HERMES_GATEWAY") == "1":
+            gateway_execution_command = _direct_sibling_gateway_restart_execution_command(
+                command,
+                env_type=env_type,
+                background=background,
+                pty=pty,
+            )
             from cron.lifecycle_guard import (
                 _MAX_REFERENCED_SCRIPT_BYTES,
                 contains_gateway_lifecycle_command_or_referenced_script,
@@ -2936,10 +3032,13 @@ def terminal_tool(
                     pass
                 return None
 
-            if contains_gateway_lifecycle_command_or_referenced_script(
-                command,
-                cwd=guard_cwd,
-                read_remote_script=_read_script_in_env,
+            if (
+                gateway_execution_command is None
+                and contains_gateway_lifecycle_command_or_referenced_script(
+                    command,
+                    cwd=guard_cwd,
+                    read_remote_script=_read_script_in_env,
+                )
             ):
                 return json.dumps({
                     "output": "",
@@ -3356,7 +3455,10 @@ def terminal_tool(
                         # reads, RPC reads) intentionally stay unbounded.
                         "bounded_capture": True,
                     }
-                    result = env.execute(command, **execute_kwargs)
+                    result = env.execute(
+                        gateway_execution_command or command,
+                        **execute_kwargs,
+                    )
                 except Exception as e:
                     error_str = str(e).lower()
                     if "timeout" in error_str:


### PR DESCRIPTION
## Summary

- allow a running Hermes gateway to invoke an exact direct restart of a different running profile
- prove current and target gateway identities before clearing the inherited `_HERMES_GATEWAY` marker for that one child process
- preserve all normal terminal approval and security checks
- broaden lifecycle-command detection for profile-qualified and quoted restart/stop forms

## Safety properties

- self-restarts remain blocked
- stale or mismatched gateway state fails closed
- compound commands, scripts, background jobs, PTY runs, remote environments, and `stop` commands are not exempted
- only `hermes --profile <name> gateway restart` receives the narrow sibling-profile exemption

## Verification

- `pytest tests/hermes_cli/test_gateway_restart_loop.py tests/tools/test_terminal_tool.py -q` — 167 passed
- adjacent terminal-tool suites — 26 passed
- `py_compile` passed
- `git diff --check` passed
- independent Claude Max security/correctness review: APPROVE
