### PR TITLE
fix(opencode): send Ox Alpha reasoning effort through Zen

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -158,7 +158,33 @@ class OpenCodeGoProfile(ProviderProfile):
         return extra_body, top_level
 
 
-opencode_zen = ProviderProfile(
+class OpenCodeZenProfile(ProviderProfile):
+    """OpenCode Zen - model-specific reasoning controls."""
+
+    def build_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, model: str | None = None, **context
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        if _flat_model_name(model) != "x-preview-f-free":
+            return {}, {}
+        if not isinstance(reasoning_config, dict):
+            return {}, {}
+        if reasoning_config.get("enabled") is False:
+            return {}, {}
+
+        effort = (reasoning_config.get("effort") or "").strip().lower()
+        if not effort or effort == "none":
+            return {}, {}
+
+        from agent.reasoning_effort import clamp_effort
+
+        supported_efforts = ("low", "high", "max")
+        clamped = clamp_effort(effort, supported_efforts, {"xhigh": "max"})
+        if clamped not in supported_efforts:
+            return {}, {}
+        return {}, {"reasoning_effort": clamped}
+
+
+opencode_zen = OpenCodeZenProfile(
     name="opencode-zen",
     aliases=("opencode", "opencode_zen", "zen"),
     env_vars=("OPENCODE_ZEN_API_KEY",),

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -16,6 +16,62 @@ def opencode_go_profile():
     return profile
 
 
+@pytest.fixture
+def opencode_zen_profile():
+    """Resolve the registered OpenCode Zen provider profile."""
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("opencode-zen")
+    assert profile is not None, "opencode-zen provider profile must be registered"
+    return profile
+
+
+class TestOpenCodeZenOxReasoning:
+    """Ox Alpha Free uses OpenCode Zen's native reasoning_effort control."""
+
+    def test_max_effort_is_emitted(self, opencode_zen_profile):
+        extra_body, top_level = opencode_zen_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "max"},
+            model="x-preview-f-free",
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "max"}
+
+    @pytest.mark.parametrize("reasoning_config", [None, {"enabled": False}])
+    def test_unset_or_disabled_preserves_server_default(
+        self, opencode_zen_profile, reasoning_config
+    ):
+        extra_body, top_level = opencode_zen_profile.build_api_kwargs_extras(
+            reasoning_config=reasoning_config,
+            model="x-preview-f-free",
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_other_zen_models_are_untouched(self, opencode_zen_profile):
+        extra_body, top_level = opencode_zen_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "max"},
+            model="gemini-3-flash",
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_max_reaches_chat_completions_request(self, opencode_zen_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="x-preview-f-free",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=opencode_zen_profile,
+            reasoning_config={"enabled": True, "effort": "max"},
+            base_url="https://opencode.ai/zen/v1",
+        )
+        assert "extra_body" not in kwargs
+        assert kwargs["reasoning_effort"] == "max"
+
+
 class TestOpenCodeGoKimiReasoning:
     """Kimi K2 models use Moonshot's thinking + reasoning_effort shape on OpenCode Go."""
 


### PR DESCRIPTION
## Problem

OpenCode Zen documents `x-preview-f-free` (Ox Alpha Free) as accepting `reasoning_effort` values `low`, `high`, and `max` on its Chat Completions endpoint. Hermes already exposes the model and resolves per-model reasoning overrides, but the Zen provider uses the base `ProviderProfile`, whose request extras are empty. A user can therefore select Max and receive a successful response while the outgoing request silently omits the setting and uses the server default.

## Change

- Add an `OpenCodeZenProfile` scoped only to `x-preview-f-free`.
- Forward the normalized top-level `reasoning_effort`.
- Map Hermes `xhigh` to OpenCode `max`.
- Preserve the server default when reasoning is unset or disabled.
- Leave every other OpenCode Zen model unchanged.

## Verification

- Added profile-level tests for max, unset, disabled, and non-target models.
- Added a full `ChatCompletionsTransport.build_kwargs` regression proving `reasoning_effort=max` reaches the outgoing request.
- `tests/plugins/model_providers/test_opencode_go_profile.py`: 25 passed.
- Ruff passed on both changed files.
- `git diff --check` passed.

A live call against the OpenCode Zen endpoint also accepted `reasoning_effort=max`; no credentials or live-response data are included in this PR.