### PR TITLE
fix(agent): read auth_token in request_dump so OAuth requests stop showing "Bearer None"

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1886,6 +1886,14 @@ def dump_api_request_debug(
         api_key = None
         try:
             api_key = getattr(agent.client, "api_key", None)
+            if not api_key:
+                # OAuth / setup-token credentials construct the Anthropic
+                # SDK client with auth_token= and leave api_key=None, so
+                # reading only api_key reports "Bearer None" for fully
+                # authenticated requests (#91319). The Entra-ID variant's
+                # auth_token is a documented sentinel — showing it masked
+                # keeps the dump honest about which auth surface is active.
+                api_key = getattr(agent.client, "auth_token", None)
         except Exception as e:
             _ra().logger.debug("Could not extract API key for debug dump: %s", e)
 

--- a/tests/agent/test_request_dump_auth_token.py
+++ b/tests/agent/test_request_dump_auth_token.py
@@ -37,14 +37,11 @@ class _StubAgent:
         return None
 
     def _mask_api_key_for_logs(self, key):
-        # Mirrors run_agent.Agent._mask_api_key_for_logs
-        if callable(key) and not isinstance(key, str):
-            return "<entra-id-bearer>"
-        if not key:
-            return None
-        if len(key) <= 12:
-            return "***"
-        return f"{key[:8]}...{key[-4:]}"
+        # Delegate to the production masker so the stub cannot drift from
+        # the real masking contract (length thresholds, sentinels).
+        from run_agent import AIAgent
+
+        return AIAgent._mask_api_key_for_logs(self, key)
 
 
 @pytest.fixture(autouse=True)
@@ -93,3 +90,14 @@ class TestRequestDumpAuthorization:
         """No credential at all keeps the explicit "Bearer None" marker."""
         payload = _dump(tmp_path, _StubClient(api_key=None, auth_token=None))
         assert payload["request"]["headers"]["Authorization"] == "Bearer None"
+
+    def test_callable_auth_token_reports_entra_id_sentinel(self, tmp_path):
+        """A callable auth_token (Entra ID bearer provider) resolves through
+        the fallback to the documented sentinel — the callable itself is
+        never invoked in the log path."""
+        payload = _dump(
+            tmp_path, _StubClient(api_key=None, auth_token=lambda: _FAKE_OAUTH)
+        )
+        assert (
+            payload["request"]["headers"]["Authorization"] == "Bearer <entra-id-bearer>"
+        )

--- a/tests/agent/test_request_dump_auth_token.py
+++ b/tests/agent/test_request_dump_auth_token.py
@@ -1,0 +1,95 @@
+"""request_dump Authorization must reflect the credential actually in use.
+
+OAuth / setup-token Anthropic clients are constructed with ``auth_token=`` and
+leave ``api_key=None``; the debug dump used to read only ``api_key`` and
+reported ``"Bearer None"`` for fully authenticated requests (#91319).
+"""
+
+import json
+
+import pytest
+
+# Placeholder-shaped fake credentials (no real key format), built by
+# repetition so the expected masked form is derivable without embedding
+# anything that resembles a usable secret.
+_FAKE_OAUTH = "oauth-" + "a" * 20          # len 26 → mask: first8...last4
+_FAKE_KEY = "key" + "b" * 20               # len 23 → mask: first8...last4
+
+
+class _StubClient:
+    def __init__(self, api_key=None, auth_token=None):
+        self.api_key = api_key
+        self.auth_token = auth_token
+
+
+class _StubAgent:
+    def __init__(self, tmp_path, client):
+        self.client = client
+        self.session_id = "sess-dump-test"
+        self.logs_dir = tmp_path / "logs"
+        self.logs_dir.mkdir(parents=True)
+        self.base_url = "https://api.anthropic.com"
+        self.api_mode = "anthropic_messages"
+        self.verbose_logging = False
+        self.log_prefix = "[test] "
+
+    def _vprint(self, *args, **kwargs):
+        return None
+
+    def _mask_api_key_for_logs(self, key):
+        # Mirrors run_agent.Agent._mask_api_key_for_logs
+        if callable(key) and not isinstance(key, str):
+            return "<entra-id-bearer>"
+        if not key:
+            return None
+        if len(key) <= 12:
+            return "***"
+        return f"{key[:8]}...{key[-4:]}"
+
+
+@pytest.fixture(autouse=True)
+def _identity_safe_sid(monkeypatch):
+    import run_agent
+    monkeypatch.setattr(
+        run_agent, "_safe_session_filename_component", lambda sid: sid,
+    )
+
+
+def _dump(tmp_path, client):
+    from agent.agent_runtime_helpers import dump_api_request_debug
+    agent = _StubAgent(tmp_path, client)
+    path = dump_api_request_debug(agent, {"model": "claude-x", "messages": []}, reason="test")
+    assert path is not None and path.exists()
+    return json.loads(path.read_text())
+
+
+def _masked(value: str) -> str:
+    return f"{value[:8]}...{value[-4:]}"
+
+
+class TestRequestDumpAuthorization:
+
+    def test_oauth_auth_token_not_reported_as_none(self, tmp_path):
+        """OAuth credential (auth_token=, api_key=None) must show up masked,
+        not as the misleading "Bearer None"."""
+        payload = _dump(tmp_path, _StubClient(api_key=None, auth_token=_FAKE_OAUTH))
+        assert payload["request"]["headers"]["Authorization"] != "Bearer None"
+        assert payload["request"]["headers"]["Authorization"] == f"Bearer {_masked(_FAKE_OAUTH)}"
+
+    def test_api_key_path_unchanged(self, tmp_path):
+        """Plain api_key credentials keep the existing masked output."""
+        payload = _dump(tmp_path, _StubClient(api_key=_FAKE_KEY))
+        assert payload["request"]["headers"]["Authorization"] == f"Bearer {_masked(_FAKE_KEY)}"
+
+    def test_api_key_wins_over_auth_token(self, tmp_path):
+        """When both are present the SDK sends api_key — the dump must match."""
+        payload = _dump(
+            tmp_path,
+            _StubClient(api_key=_FAKE_KEY, auth_token=_FAKE_OAUTH),
+        )
+        assert payload["request"]["headers"]["Authorization"] == f"Bearer {_masked(_FAKE_KEY)}"
+
+    def test_no_credentials_still_reports_none(self, tmp_path):
+        """No credential at all keeps the explicit "Bearer None" marker."""
+        payload = _dump(tmp_path, _StubClient(api_key=None, auth_token=None))
+        assert payload["request"]["headers"]["Authorization"] == "Bearer None"


### PR DESCRIPTION
## What does this PR do?

Fixes the request debug dump (`request_dump_*.json`) reporting `"Authorization": "Bearer None"` for fully authenticated Anthropic requests. OAuth / setup-token credentials construct the Anthropic SDK client with `auth_token=` and leave `client.api_key` as `None`; `dump_api_request_debug()` read only `api_key`, producing a debug artifact that looks exactly like a missing-credential bug and misdirects troubleshooting (#91319).

The fix falls back to `client.auth_token` when `api_key` is absent and still routes the value through `_mask_api_key_for_logs()`, so no credential material is ever written in the clear. The Azure Foundry Entra-ID variant's documented sentinel value stays identifiable in masked form, plain `api_key` credentials are unchanged, and a genuinely absent credential keeps the explicit `Bearer None` marker.

## Related Issue

Fixes #91319

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_runtime_helpers.py`: In `dump_api_request_debug()`, after reading `agent.client.api_key`, fall back to `agent.client.auth_token` when it is empty, with a comment explaining the OAuth construction shape and the Entra-ID sentinel.
- `tests/agent/test_request_dump_auth_token.py`: New `TestRequestDumpAuthorization` with 4 tests — OAuth token shown masked instead of `Bearer None`, plain `api_key` path unchanged, `api_key` winning when both are present, and the explicit no-credential marker preserved.

## How to Test

1. Use an OAuth/setup-token Anthropic credential (client built with `auth_token=`, `api_key=None`)
2. Trigger a provider-side failure that writes `request_dump_*.json`
3. The dump's `Authorization` header shows the masked token (`xxxxx...xxxx`) instead of the misleading `Bearer None` (Observed result: `test_oauth_auth_token_not_reported_as_none` fails on unpatched main with `Bearer None` and passes with this patch)
4. `scripts/run_tests.sh tests/agent/test_request_dump_auth_token.py -q` → should pass (Observed result: 4 passed)
5. Plain `api_key` credentials and the no-credential case are covered by the other three tests and keep their previous output

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
