### PR TITLE
fix(state): one literal grammar for session-title lineage resolution and allocation

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8479,6 +8479,27 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             row = cursor.fetchone()
         return self._session_row_dict(row) if row else None
 
+    def _numbered_title_variant_value(
+        self, candidate_title: str, base: str
+    ) -> Optional[int]:
+        """Return parsed N only when candidate is a strict literal
+        ``base + " #" + ASCII[0-9]+`` continuation; otherwise None.
+
+        This is the single admission grammar for numbered title variants.
+        Anything else -- Unicode digit lookalikes (``foo #２``), mixed suffixes
+        (``foo #2x``), or deeper chains (``foo #2 #5``) -- is NOT a direct
+        numbered child and must keep literal semantics.
+        """
+        if not base or not candidate_title:
+            return None
+        prefix = f"{base} #"
+        if not candidate_title.startswith(prefix):
+            return None
+        suffix = candidate_title[len(prefix):]
+        if not suffix or not suffix.isascii() or not suffix.isdigit():
+            return None
+        return int(suffix)
+
     def resolve_session_by_title(self, title: str) -> Optional[str]:
         """Resolve a title to a session ID, preferring the latest in a lineage.
 
@@ -8501,25 +8522,36 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             numbered = cursor.fetchall()
 
-        if numbered:
-            # Return the most recent numbered variant
-            return numbered[0]["id"]
-        elif exact:
+        # Only strict literal `base + " #" + ASCII[0-9]+` candidates may bind
+        # as numbered continuations; near-misses (foo #bar, foo #２, foo #2x)
+        # must not hijack exact title binding.
+        for row in numbered:
+            if self._numbered_title_variant_value(row["title"], title) is not None:
+                return row["id"]
+
+        if exact:
             return exact["id"]
         return None
 
     def get_next_title_in_lineage(self, base_title: str) -> str:
         """Generate the next title in a lineage (e.g., "my session" → "my session #2").
 
-        Strips any existing " #N" suffix to find the base name, then finds
-        the highest existing number and increments.
+        Only the unnumbered base and strict direct ASCII ``base #N`` children
+        occupy the base lineage's numbering namespace. Nonnumeric lookalikes
+        (``foo #bar``), Unicode digits (``foo #２``), and deeper suffixes
+        (``foo #2 #5``) are literal, not direct children.
         """
-        # Strip existing #N suffix to find the true base
-        match = re.match(r'^(.*?) #(\d+)$', base_title)
-        if match:
-            base = match.group(1)
-        else:
-            base = base_title
+        # Strip an existing strict " #N" suffix to find the true base; any
+        # other trailing " #..." stays part of the literal base.
+        base = base_title
+        sep = base_title.rfind(" #")
+        if sep != -1:
+            candidate_base = base_title[:sep]
+            if (
+                self._numbered_title_variant_value(base_title, candidate_base)
+                is not None
+            ):
+                base = candidate_base
 
         # Find all existing numbered variants
         # Escape SQL LIKE wildcards (%, _) in the base to prevent false matches
@@ -8531,15 +8563,21 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             existing = [row["title"] for row in cursor.fetchall()]
 
-        if not existing:
-            return base  # No conflict, use the base name as-is
-
-        # Find the highest number
+        # Only the exact base and strict direct ASCII "base #N" children occupy
+        # the base lineage's numbering namespace.
         max_num = 1  # The unnumbered original counts as #1
+        occupied = False
         for t in existing:
-            m = re.match(r'^.* #(\d+)$', t)
-            if m:
-                max_num = max(max_num, int(m.group(1)))
+            if t == base:
+                occupied = True
+                continue
+            n = self._numbered_title_variant_value(t, base)
+            if n is not None:
+                occupied = True
+                max_num = max(max_num, n)
+
+        if not occupied:
+            return base  # No conflict, use the base name as-is
 
         return f"{base} #{max_num + 1}"
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8504,9 +8504,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """Resolve a title to a session ID, preferring the latest in a lineage.
 
         If the exact title exists, returns that session's ID.
-        If not, searches for "title #N" variants and returns the latest one.
+        If not, searches for strict "title #N" variants and returns the latest one.
         If the exact title exists AND numbered variants exist, returns the
-        latest numbered variant (the most recent continuation).
+        latest strict-valid numbered variant (the most recent continuation).
+
+        A numbered variant is admitted only when the full title matches the
+        literal ``base + " #" + ASCII[0-9]+`` grammar (see
+        :meth:`_numbered_title_variant_value`); near-misses such as ``foo #bar``
+        or ``foo #２`` are ignored rather than hijacking exact title binding.
         """
         # First try exact match
         exact = self.get_session_by_title(title)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1902,15 +1902,20 @@ class TestTitleUniqueness:
 
 
 
+def _seed_title(db, sid, title, at=None):
+    """Create a titled session; pin started_at when *at* is given (ordering)."""
+    db.create_session(sid, "cli")
+    db.set_session_title(sid, title)
+    if at is not None:
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (at, sid))
+
+
 class TestTitleLineage:
     """Tests for title lineage resolution and auto-numbering."""
 
     def test_resolve_exact_title(self, db):
-        db.create_session("s1", "cli")
-        db.set_session_title("s1", "my project")
+        _seed_title(db, "s1", "my project")
         assert db.resolve_session_by_title("my project") == "s1"
-
-
 
     def test_resolve_nonexistent_title(self, db):
         assert db.resolve_session_by_title("nonexistent") is None
@@ -1918,27 +1923,15 @@ class TestTitleLineage:
     def test_resolve_ignores_newer_invalid_named_continuation(self, db):
         """A newer `foo #bar` must not hijack exact `foo` binding."""
         t0 = time.time() - 1000
-        db.create_session("s1", "cli")
-        db.set_session_title("s1", "foo")
-        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "s1"))
-        db.create_session("s2", "cli")
-        db.set_session_title("s2", "foo #bar")
-        db._conn.execute(
-            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 1000, "s2")
-        )
+        _seed_title(db, "s1", "foo", t0)
+        _seed_title(db, "s2", "foo #bar", t0 + 1000)
         assert db.resolve_session_by_title("foo") == "s1"
 
     def test_resolve_ignores_newer_fullwidth_digit_continuation(self, db):
         """A fullwidth-digit lookalike `foo #２` must not bind as a continuation."""
         t0 = time.time() - 1000
-        db.create_session("s1", "cli")
-        db.set_session_title("s1", "foo")
-        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "s1"))
-        db.create_session("s2", "cli")
-        db.set_session_title("s2", "foo #２")  # fullwidth ２ (U+FF12)
-        db._conn.execute(
-            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 1000, "s2")
-        )
+        _seed_title(db, "s1", "foo", t0)
+        _seed_title(db, "s2", "foo #２", t0 + 1000)  # fullwidth ２ (U+FF12)
         assert db.resolve_session_by_title("foo") == "s1"
 
     @pytest.mark.parametrize(
@@ -1951,63 +1944,31 @@ class TestTitleLineage:
     def test_resolve_rejects_invalid_near_miss_continuation(self, db, lookalike):
         """None of these near-misses may bind as a numbered continuation."""
         t0 = time.time() - 1000
-        db.create_session("s1", "cli")
-        db.set_session_title("s1", "foo")
-        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "s1"))
-        db.create_session("s2", "cli")
-        db.set_session_title("s2", lookalike)
-        db._conn.execute(
-            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 1000, "s2")
-        )
+        _seed_title(db, "s1", "foo", t0)
+        _seed_title(db, "s2", lookalike, t0 + 1000)
         assert db.resolve_session_by_title("foo") == "s1"
 
     def test_resolve_valid_continuation_beats_newer_invalid(self, db):
         """A valid `foo #2` wins even when a newer `foo #bar` exists."""
         t0 = time.time() - 1000
-        db.create_session("s1", "cli")
-        db.set_session_title("s1", "foo")
-        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "s1"))
-        db.create_session("s2", "cli")
-        db.set_session_title("s2", "foo #2")
-        db._conn.execute(
-            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 100, "s2")
-        )
-        db.create_session("s3", "cli")
-        db.set_session_title("s3", "foo #bar")
-        db._conn.execute(
-            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 1000, "s3")
-        )
+        _seed_title(db, "s1", "foo", t0)
+        _seed_title(db, "s2", "foo #2", t0 + 100)
+        _seed_title(db, "s3", "foo #bar", t0 + 1000)
         assert db.resolve_session_by_title("foo") == "s2"
 
     def test_resolve_multiple_valid_continuations_newest_wins(self, db):
         """Multiple valid continuations keep newest-by-started_at precedence."""
         t0 = time.time() - 1000
-        db.create_session("s1", "cli")
-        db.set_session_title("s1", "foo")
-        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "s1"))
-        db.create_session("s2", "cli")
-        db.set_session_title("s2", "foo #2")
-        db._conn.execute(
-            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 100, "s2")
-        )
-        db.create_session("s3", "cli")
-        db.set_session_title("s3", "foo #3")
-        db._conn.execute(
-            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 200, "s3")
-        )
+        _seed_title(db, "s1", "foo", t0)
+        _seed_title(db, "s2", "foo #2", t0 + 100)
+        _seed_title(db, "s3", "foo #3", t0 + 200)
         assert db.resolve_session_by_title("foo") == "s3"
 
     def test_resolve_leading_zero_continuation_accepted(self, db):
         """ASCII leading-zero `foo #01` stays a valid continuation (#15)."""
         t0 = time.time() - 1000
-        db.create_session("s1", "cli")
-        db.set_session_title("s1", "foo")
-        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "s1"))
-        db.create_session("s2", "cli")
-        db.set_session_title("s2", "foo #01")
-        db._conn.execute(
-            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 100, "s2")
-        )
+        _seed_title(db, "s1", "foo", t0)
+        _seed_title(db, "s2", "foo #01", t0 + 100)
         assert db.resolve_session_by_title("foo") == "s2"
 
     def test_next_title_no_existing(self, db):
@@ -2016,18 +1977,14 @@ class TestTitleLineage:
 
     def test_next_title_invalid_only_occupant_keeps_base(self, db):
         """Only `foo #bar` exists → next for `foo` stays `foo`, not `foo #2`."""
-        db.create_session("s1", "cli")
-        db.set_session_title("s1", "foo #bar")
+        _seed_title(db, "s1", "foo #bar")
         assert db.get_next_title_in_lineage("foo") == "foo"
 
     def test_next_title_ignores_deeper_suffix_inflation(self, db):
         """`foo #2 #5` is not a direct child of `foo`; next is `foo #3`."""
-        db.create_session("s1", "cli")
-        db.set_session_title("s1", "foo")
-        db.create_session("s2", "cli")
-        db.set_session_title("s2", "foo #2")
-        db.create_session("s3", "cli")
-        db.set_session_title("s3", "foo #2 #5")
+        _seed_title(db, "s1", "foo")
+        _seed_title(db, "s2", "foo #2")
+        _seed_title(db, "s3", "foo #2 #5")
         assert db.get_next_title_in_lineage("foo") == "foo #3"
 
     def test_next_title_fullwidth_digit_stays_literal_base(self, db):
@@ -2036,27 +1993,33 @@ class TestTitleLineage:
 
     def test_next_title_admits_leading_zero_direct_child(self, db):
         """ASCII `foo #01` is a valid direct child; next is `foo #2`."""
-        db.create_session("s1", "cli")
-        db.set_session_title("s1", "foo #01")
+        _seed_title(db, "s1", "foo #01")
         assert db.get_next_title_in_lineage("foo") == "foo #2"
 
     def test_next_title_embedded_hash_base(self, db):
         """`topic # hash` is the literal base; `topic # hash #2` is its child."""
-        db.create_session("s1", "cli")
-        db.set_session_title("s1", "topic # hash")
-        db.create_session("s2", "cli")
-        db.set_session_title("s2", "topic # hash #2")
+        _seed_title(db, "s1", "topic # hash")
+        _seed_title(db, "s2", "topic # hash #2")
         assert db.get_next_title_in_lineage("topic # hash") == "topic # hash #3"
 
-    def test_next_title_wildcard_cjk_bases_keep_literal_children(self, db):
+    @pytest.mark.parametrize(
+        ("base", "lookalike"),
+        [
+            ("100% sure", "100Xsure #5"),  # literal %
+            ("test_project", "testXproject #5"),  # literal _
+            ("path\\to", "pathXto #5"),  # literal backslash
+            ("專案報告", None),  # CJK — no ASCII lookalike widens
+        ],
+    )
+    def test_next_title_wildcard_cjk_bases_keep_literal_children(
+        self, db, base, lookalike
+    ):
         """`%`/`_`/`\\`/CJK bases count only their own direct children."""
-        db.create_session("s1", "cli")
-        db.set_session_title("s1", "100% sure")
-        db.create_session("s2", "cli")
-        db.set_session_title("s2", "100% sure #2")
-        db.create_session("s3", "cli")
-        db.set_session_title("s3", "100Xsure #5")  # must not count for "100% sure"
-        assert db.get_next_title_in_lineage("100% sure") == "100% sure #3"
+        _seed_title(db, "s1", base)
+        _seed_title(db, "s2", f"{base} #2")
+        if lookalike is not None:
+            _seed_title(db, "s3", lookalike)
+        assert db.get_next_title_in_lineage(base) == f"{base} #3"
 
 
 
@@ -2067,10 +2030,8 @@ class TestTitleSqlWildcards:
 
     def test_resolve_title_with_underscore(self, db):
         """A title like 'test_project' should not match 'testXproject #2'."""
-        db.create_session("s1", "cli")
-        db.set_session_title("s1", "test_project")
-        db.create_session("s2", "cli")
-        db.set_session_title("s2", "testXproject #2")
+        _seed_title(db, "s1", "test_project")
+        _seed_title(db, "s2", "testXproject #2")
         # Resolving "test_project" should return s1 (exact), not s2
         assert db.resolve_session_by_title("test_project") == "s1"
 
@@ -2087,14 +2048,8 @@ class TestTitleSqlWildcards:
     def test_literal_bases_admit_own_continuation(self, db, base):
         """Literal `%`/`_`/`\\`/`#`/CJK bases admit their own ` #2` continuation."""
         t0 = time.time() - 1000
-        db.create_session("s1", "cli")
-        db.set_session_title("s1", base)
-        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "s1"))
-        db.create_session("s2", "cli")
-        db.set_session_title("s2", f"{base} #2")
-        db._conn.execute(
-            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 100, "s2")
-        )
+        _seed_title(db, "s1", base, t0)
+        _seed_title(db, "s2", f"{base} #2", t0 + 100)
         assert db.resolve_session_by_title(base) == "s2"
 
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1915,9 +1915,148 @@ class TestTitleLineage:
     def test_resolve_nonexistent_title(self, db):
         assert db.resolve_session_by_title("nonexistent") is None
 
+    def test_resolve_ignores_newer_invalid_named_continuation(self, db):
+        """A newer `foo #bar` must not hijack exact `foo` binding."""
+        t0 = time.time() - 1000
+        db.create_session("s1", "cli")
+        db.set_session_title("s1", "foo")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "s1"))
+        db.create_session("s2", "cli")
+        db.set_session_title("s2", "foo #bar")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 1000, "s2")
+        )
+        assert db.resolve_session_by_title("foo") == "s1"
+
+    def test_resolve_ignores_newer_fullwidth_digit_continuation(self, db):
+        """A fullwidth-digit lookalike `foo #２` must not bind as a continuation."""
+        t0 = time.time() - 1000
+        db.create_session("s1", "cli")
+        db.set_session_title("s1", "foo")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "s1"))
+        db.create_session("s2", "cli")
+        db.set_session_title("s2", "foo #２")  # fullwidth ２ (U+FF12)
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 1000, "s2")
+        )
+        assert db.resolve_session_by_title("foo") == "s1"
+
+    @pytest.mark.parametrize(
+        # NOTE: `foo #2 ` (trailing space) is intentionally absent — the
+        # storage layer's sanitize_title() strips it to the valid `foo #2`,
+        # so it is unrepresentable as an invalid near-miss.
+        "lookalike",
+        ["foo #", "foo # 2", "foo #2x", "foo #2.0"],
+    )
+    def test_resolve_rejects_invalid_near_miss_continuation(self, db, lookalike):
+        """None of these near-misses may bind as a numbered continuation."""
+        t0 = time.time() - 1000
+        db.create_session("s1", "cli")
+        db.set_session_title("s1", "foo")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "s1"))
+        db.create_session("s2", "cli")
+        db.set_session_title("s2", lookalike)
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 1000, "s2")
+        )
+        assert db.resolve_session_by_title("foo") == "s1"
+
+    def test_resolve_valid_continuation_beats_newer_invalid(self, db):
+        """A valid `foo #2` wins even when a newer `foo #bar` exists."""
+        t0 = time.time() - 1000
+        db.create_session("s1", "cli")
+        db.set_session_title("s1", "foo")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "s1"))
+        db.create_session("s2", "cli")
+        db.set_session_title("s2", "foo #2")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 100, "s2")
+        )
+        db.create_session("s3", "cli")
+        db.set_session_title("s3", "foo #bar")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 1000, "s3")
+        )
+        assert db.resolve_session_by_title("foo") == "s2"
+
+    def test_resolve_multiple_valid_continuations_newest_wins(self, db):
+        """Multiple valid continuations keep newest-by-started_at precedence."""
+        t0 = time.time() - 1000
+        db.create_session("s1", "cli")
+        db.set_session_title("s1", "foo")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "s1"))
+        db.create_session("s2", "cli")
+        db.set_session_title("s2", "foo #2")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 100, "s2")
+        )
+        db.create_session("s3", "cli")
+        db.set_session_title("s3", "foo #3")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 200, "s3")
+        )
+        assert db.resolve_session_by_title("foo") == "s3"
+
+    def test_resolve_leading_zero_continuation_accepted(self, db):
+        """ASCII leading-zero `foo #01` stays a valid continuation (#15)."""
+        t0 = time.time() - 1000
+        db.create_session("s1", "cli")
+        db.set_session_title("s1", "foo")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "s1"))
+        db.create_session("s2", "cli")
+        db.set_session_title("s2", "foo #01")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 100, "s2")
+        )
+        assert db.resolve_session_by_title("foo") == "s2"
+
     def test_next_title_no_existing(self, db):
         """With no existing sessions, base title is returned as-is."""
         assert db.get_next_title_in_lineage("my project") == "my project"
+
+    def test_next_title_invalid_only_occupant_keeps_base(self, db):
+        """Only `foo #bar` exists → next for `foo` stays `foo`, not `foo #2`."""
+        db.create_session("s1", "cli")
+        db.set_session_title("s1", "foo #bar")
+        assert db.get_next_title_in_lineage("foo") == "foo"
+
+    def test_next_title_ignores_deeper_suffix_inflation(self, db):
+        """`foo #2 #5` is not a direct child of `foo`; next is `foo #3`."""
+        db.create_session("s1", "cli")
+        db.set_session_title("s1", "foo")
+        db.create_session("s2", "cli")
+        db.set_session_title("s2", "foo #2")
+        db.create_session("s3", "cli")
+        db.set_session_title("s3", "foo #2 #5")
+        assert db.get_next_title_in_lineage("foo") == "foo #3"
+
+    def test_next_title_fullwidth_digit_stays_literal_base(self, db):
+        """`foo #２` is not a numbered suffix; base stays literal `foo #２`."""
+        assert db.get_next_title_in_lineage("foo #２") == "foo #２"
+
+    def test_next_title_admits_leading_zero_direct_child(self, db):
+        """ASCII `foo #01` is a valid direct child; next is `foo #2`."""
+        db.create_session("s1", "cli")
+        db.set_session_title("s1", "foo #01")
+        assert db.get_next_title_in_lineage("foo") == "foo #2"
+
+    def test_next_title_embedded_hash_base(self, db):
+        """`topic # hash` is the literal base; `topic # hash #2` is its child."""
+        db.create_session("s1", "cli")
+        db.set_session_title("s1", "topic # hash")
+        db.create_session("s2", "cli")
+        db.set_session_title("s2", "topic # hash #2")
+        assert db.get_next_title_in_lineage("topic # hash") == "topic # hash #3"
+
+    def test_next_title_wildcard_cjk_bases_keep_literal_children(self, db):
+        """`%`/`_`/`\\`/CJK bases count only their own direct children."""
+        db.create_session("s1", "cli")
+        db.set_session_title("s1", "100% sure")
+        db.create_session("s2", "cli")
+        db.set_session_title("s2", "100% sure #2")
+        db.create_session("s3", "cli")
+        db.set_session_title("s3", "100Xsure #5")  # must not count for "100% sure"
+        assert db.get_next_title_in_lineage("100% sure") == "100% sure #3"
 
 
 
@@ -1934,6 +2073,29 @@ class TestTitleSqlWildcards:
         db.set_session_title("s2", "testXproject #2")
         # Resolving "test_project" should return s1 (exact), not s2
         assert db.resolve_session_by_title("test_project") == "s1"
+
+    @pytest.mark.parametrize(
+        "base",
+        [
+            "100% sure",  # literal %
+            "test_project",  # literal _
+            "path\\to",  # literal backslash
+            "topic # hash",  # embedded #
+            "專案報告",  # CJK
+        ],
+    )
+    def test_literal_bases_admit_own_continuation(self, db, base):
+        """Literal `%`/`_`/`\\`/`#`/CJK bases admit their own ` #2` continuation."""
+        t0 = time.time() - 1000
+        db.create_session("s1", "cli")
+        db.set_session_title("s1", base)
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "s1"))
+        db.create_session("s2", "cli")
+        db.set_session_title("s2", f"{base} #2")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 100, "s2")
+        )
+        assert db.resolve_session_by_title(base) == "s2"
 
 
 


### PR DESCRIPTION
## What does this PR do?

Session titles form a lineage: `my project`, `my project #2`, `my project #3`,
… . Two separate code paths decide what counts as a *direct numbered
continuation* of a base title — and today they disagree, in the same loose
direction:

- **Resolver.** `SessionDB.resolve_session_by_title()` treats **any**
  `base #%` LIKE candidate as a numbered variant and returns the newest one. So
  a session literally named `my project #bar` (or `my project #２`, a fullwidth
  Unicode digit) hijacks `resolve_session_by_title("my project")` and shadows
  the exact-title binding.
- **Allocator.** `SessionDB.get_next_title_in_lineage()` strips and scans with
  a greedy, Unicode-aware ` #\d+` pattern. A grandchild title `my project #2 #5`
  leaks its trailing `#5` into the base sequence (next becomes `#6`, skipping
  `#3`); a Unicode lookalike `foo #２` is counted as a numbered child; and when
  only invalid occupants (`foo #bar`) exist the allocator still forces
  `foo #2`.

The fix centralizes **one admission grammar** — the full title must be the
literal `<base> + " #" + ASCII [0-9]+` — in a single shared predicate
(`SessionDB._numbered_title_variant_value()`), reused by **both** paths so SQL
candidate selection and Python suffix parsing cannot drift:

- **Resolver:** post-filters LIKE candidates against the predicate. Near-misses
  (`foo #bar`, `foo #２`, `foo #2x`, `foo #2.0`, `foo # 2`) are ignored and no
  longer hijack exact binding; among *valid* continuations the newest-by-
  `started_at` still wins.
- **Allocator:** strips a trailing ` #N` only when it matches the strict
  grammar, and counts only the exact base + strict direct ASCII children toward
  the next number. An invalid-only occupant (`foo #bar`) now keeps the base
  title instead of forcing `foo #2`.

### Accepted / rejected as direct numbered continuations

```text
accept as direct child of "project":
  project #2
  project #123
  project #01        # leading zero is still ASCII digits

reject as direct child:
  project #２        # Unicode digit lookalike (U+FF12) — stays literal
  project #2 #5      # deeper descendant of "project #2"
  project #2x        # mixed suffix
  project #2.0       # non-integer suffix
  project #bar       # non-numeric suffix
```

### Relationship to #41223

#41223 (`fix(state): anchor lineage title numbering to the resolved base`)
already identifies and fixes the allocator half of this — the grandchild
`foo #2 #5` inflation — by anchoring extraction to the resolved base. This PR
follows that discovery and does not claim it as new.

It differs in the semantics the two agree on:

- **ASCII-only digits.** #41223 anchors with `re.escape(base) + r' #(\d+)$'`,
  which is still Unicode-aware: `foo #２` counts as a numbered child, and
  `get_next_title_in_lineage("foo #２")` resolves to `foo`. Under the strict
  grammar here, `foo #２` is a literal title that keeps its own lineage.
- **The resolver half.** `resolve_session_by_title` accepts broad
  `base + " #%"` candidates today, so resolution and allocation can disagree
  about what counts as a direct continuation. This PR applies one grammar to
  both.
- **Invalid-only occupants.** When only `foo #bar` exists, the allocator keeps
  `foo` as the next title rather than allocating `foo #2`.

Regression coverage proves these differences: the new matrix runs green on this
branch, and the Unicode-digit / invalid-only-occupant cases fail against
#41223's implementation as-is.

### Related work

- #26631 (TUI `/resume` via `resolve_session_by_title`) and #47442 (child-title
  inheritance via `get_next_title_in_lineage`) consume these functions and
  inherit the stricter, self-consistent grammar.
- #67381 moves session-search title matching to substring LIKE in
  `search_messages()`; this PR's resolver change is orthogonal.
- #79737 consolidated the `escape_like` seam this change builds on.

### What's preserved

- Exact-title binding is unchanged; the `started_at DESC` newest-continuation
  preference among *valid* variants is preserved.
- SQL LIKE wildcards (`%`, `_`), backslash, embedded `#`, and CJK bases keep
  literal semantics (see the wildcard/CJK regression matrix).
- No change to query or transaction shape — only candidate admission and suffix
  parsing.

## Related Issue

N/A (extends the allocator fix in #41223)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: add `SessionDB._numbered_title_variant_value()` — the
  single strict `base + " #" + ASCII[0-9]+` admission predicate.
- `hermes_state.py`: `resolve_session_by_title()` post-filters numbered LIKE
  candidates with the predicate (near-misses no longer hijack exact binding).
- `hermes_state.py`: `get_next_title_in_lineage()` strips/scans only strict
  direct ASCII children; invalid-only occupants keep the base.
- `tests/test_hermes_state.py`: extend `TestTitleLineage` + `TestTitleSqlWildcards`
  with the near-miss / Unicode-digit / deeper-suffix / leading-zero /
  wildcard-CJK-backslash matrix (via a shared `_seed_title` helper).

## How to Test

1. Create sessions titled `foo`, `foo #2`, `foo #2 #5`.
2. `db.get_next_title_in_lineage("foo")` returns `foo #3` (not `foo #6`).
3. Create a newer `foo #bar`; `db.resolve_session_by_title("foo")` still
   returns the `foo` session (not the `foo #bar` hijack).
4. `db.get_next_title_in_lineage("foo #２")` returns `foo #２` (literal).
5. Run `scripts/run_tests.sh tests/test_hermes_state.py -q` — 260 passed,
   2 skipped.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate (#41223 is referenced above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (touched-file suites: `test_hermes_state.py` 260 + title-touching suites 695 green)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure stdlib logic, no platform dependence
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
