### PR TITLE
fix(desktop): make hidden cron jobs discoverable in sidebar

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.test.tsx
@@ -112,6 +112,36 @@ describe('SidebarCronJobsSection load-more affordance', () => {
     fireEvent.click(loadMore)
 
     expect(screen.getByText('job-7')).toBeInTheDocument()
+    // Once every job is shown, the "N of M" badge and the load-more control
+    // must both disappear — the truncation affordance is gone.
+    expect(screen.queryByText('6 of 7', { exact: false })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Show 1 more…' })).not.toBeInTheDocument()
+  })
+
+  it('renders no count badge and no load-more row when all jobs already fit', () => {
+    // INITIAL_VISIBLE_JOBS is 6, so 6 jobs or fewer should show fully with
+    // neither the "N of M" badge nor the load-more control.
+    render(
+      <SidebarCronJobsSection
+        jobs={[
+          makeJob('job-1'),
+          makeJob('job-2'),
+          makeJob('job-3'),
+          makeJob('job-4'),
+          makeJob('job-5'),
+          makeJob('job-6')
+        ]}
+        label="Scheduled jobs"
+        onManageJob={vi.fn()}
+        onOpenRun={vi.fn()}
+        onToggle={vi.fn()}
+        onTriggerJob={vi.fn()}
+        open
+      />
+    )
+
+    expect(screen.getByText('job-6')).toBeInTheDocument()
+    expect(screen.queryByText(' of ', { exact: false })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /more/i })).not.toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.test.tsx
@@ -1,0 +1,117 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type * as React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { CronJob } from '@/types/hermes'
+
+import { SidebarCronJobsSection } from './cron-jobs-section'
+
+afterEach(cleanup)
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      common: { delete: 'Delete' },
+      sidebar: { loadCount: (n: number) => `Show ${n} more`, loadMore: 'Show more', loading: 'Loading…' },
+      cron: {
+        actionsTitle: 'Actions',
+        deleteDescPrefix: 'Delete ',
+        deleteDescSuffix: '?',
+        deleteTitle: 'Delete job',
+        deleted: 'Deleted',
+        failedDelete: 'Delete failed',
+        failedUpdate: 'Update failed',
+        hideRuns: 'Hide runs',
+        loading: 'Loading',
+        manage: 'Manage',
+        noRuns: 'No runs',
+        pause: 'Pause',
+        paused: 'Paused',
+        resume: 'Resume',
+        resumed: 'Resumed',
+        showRuns: 'Show runs',
+        shownOf: (shown: number, total: number) => `${shown} of ${total}`,
+        states: { scheduled: 'scheduled' },
+        triggerNow: 'Run now'
+      }
+    }
+  })
+}))
+
+vi.mock('@/components/pane-shell/pane-visibility', () => ({ usePaneVisible: () => true }))
+vi.mock('@nanostores/react', () => ({ useStore: () => null }))
+vi.mock('@/store/cron', () => ({ updateCronJobs: vi.fn() }))
+vi.mock('@/store/live-sync', () => ({ $changeEventsAvailable: {}, $cronChangeTick: {} }))
+vi.mock('@/store/session', () => ({ $selectedStoredSessionId: {} }))
+vi.mock('@/hermes', () => ({
+  deleteCronJob: vi.fn(),
+  getCronJobRuns: vi.fn(),
+  pauseCronJob: vi.fn(),
+  resumeCronJob: vi.fn()
+}))
+vi.mock('@/store/confirm', () => ({ confirm: vi.fn() }))
+vi.mock('@hermes/shared', () => ({
+  createCronTriggerController: () => ({ run: vi.fn() })
+}))
+vi.mock('@/components/ui/actions-menu', () => ({
+  ActionsContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  renderActionItem: () => null
+}))
+vi.mock('@/components/ui/codicon', () => ({ Codicon: () => null }))
+vi.mock('@/components/ui/disclosure-caret', () => ({ DisclosureCaret: () => null }))
+vi.mock('@/components/ui/glyph-spinner', () => ({ GlyphSpinner: () => null }))
+vi.mock('@/components/ui/sidebar', () => ({
+  SidebarGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarGroupContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}))
+vi.mock('@/components/ui/tooltip', () => ({ Tip: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
+vi.mock('../../shell/sidebar-label', () => ({
+  SidebarPanelLabel: ({ children }: { children: React.ReactNode }) => <span>{children}</span>
+}))
+vi.mock('./chrome', () => ({
+  SidebarRowBody: ({ children, ...props }: { children: React.ReactNode }) => <div {...props}>{children}</div>,
+  SidebarRowLabel: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  SidebarRowLead: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  SidebarRowShell: ({ children, actions }: { children: React.ReactNode; actions: React.ReactNode }) => (
+    <div>{children}{actions}</div>
+  )
+}))
+
+function makeJob(id: string) {
+  return { enabled: true, id, name: id, next_run_at: '2099-01-01T00:00:00Z', state: 'scheduled' } as unknown as CronJob
+}
+
+describe('SidebarCronJobsSection load-more affordance', () => {
+  it('shows the hidden count, renders a text row, and reveals the hidden job', () => {
+    render(
+      <SidebarCronJobsSection
+        jobs={[
+          makeJob('job-1'),
+          makeJob('job-2'),
+          makeJob('job-3'),
+          makeJob('job-4'),
+          makeJob('job-5'),
+          makeJob('job-6'),
+          makeJob('job-7')
+        ]}
+        label="Scheduled jobs"
+        onManageJob={vi.fn()}
+        onOpenRun={vi.fn()}
+        onToggle={vi.fn()}
+        onTriggerJob={vi.fn()}
+        open
+      />
+    )
+
+    expect(screen.getByText('Scheduled jobs')).toBeInTheDocument()
+    expect(screen.getByText('6 of 7', { exact: false })).toBeInTheDocument()
+    const loadMore = screen.getByRole('button', { name: 'Show 1 more…' })
+    expect(loadMore).toHaveTextContent('Show 1 more…')
+    expect(screen.queryByText('job-7')).not.toBeInTheDocument()
+
+    fireEvent.click(loadMore)
+
+    expect(screen.getByText('job-7')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Show 1 more…' })).not.toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -40,7 +40,7 @@ const PEEK_BACKSTOP_INTERVAL_MS = 60_000
 
 // Keep the section compact: show a few jobs up front, reveal more in larger
 // steps on demand (mirrors the messaging sections in the sidebar).
-const INITIAL_VISIBLE_JOBS = 3
+const INITIAL_VISIBLE_JOBS = 6
 const LOAD_MORE_STEP = 10
 
 function nextRunMs(job: CronJob): null | number {
@@ -90,6 +90,7 @@ export function SidebarCronJobsSection({
   onToggle,
   open
 }: SidebarCronJobsSectionProps) {
+  const { t } = useI18n()
   const [nowMs, setNowMs] = useState(() => Date.now())
   // Single-open inline peek so the section stays scannable.
   const [peekJobId, setPeekJobId] = useState<null | string>(null)
@@ -184,7 +185,15 @@ export function SidebarCronJobsSection({
           onClick={onToggle}
           type="button"
         >
-          <SidebarPanelLabel>{label}</SidebarPanelLabel>
+          <SidebarPanelLabel>
+            {label}
+            {hiddenCount > 0 && (
+              <span className="font-normal normal-case tracking-normal text-(--ui-text-tertiary)">
+                {' · '}
+                {t.cron.shownOf(shown.length, Math.min(sorted.length, max))}
+              </span>
+            )}
+          </SidebarPanelLabel>
           <DisclosureCaret
             className="text-(--ui-text-tertiary) opacity-0 transition group-hover/section-label:opacity-100"
             open={open}
@@ -210,6 +219,7 @@ export function SidebarCronJobsSection({
             <SidebarLoadMoreRow
               onClick={() => setVisibleCount(count => count + LOAD_MORE_STEP)}
               step={Math.min(LOAD_MORE_STEP, hiddenCount)}
+              variant="row"
             />
           )}
         </SidebarGroupContent>

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -190,6 +190,9 @@ export function SidebarCronJobsSection({
             {hiddenCount > 0 && (
               <span className="font-normal normal-case tracking-normal text-(--ui-text-tertiary)">
                 {' · '}
+                {/* The denominator is capped by the same `max` that limits the
+                    rows load-more can actually reveal, so the badge and the
+                    button always agree on how many jobs remain hidden. */}
                 {t.cron.shownOf(shown.length, Math.min(sorted.length, max))}
               </span>
             )}

--- a/apps/desktop/src/app/chat/sidebar/load-more-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/load-more-row.test.tsx
@@ -43,6 +43,17 @@ describe('SidebarLoadMoreRow', () => {
     expect(screen.getByRole('button', { name: 'Load 1 more…' })).toHaveTextContent('Load 1 more…')
   })
 
+  it('suppresses the ellipsis and shows a spinner in row variant while loading', () => {
+    render(<SidebarLoadMoreRow loading onClick={vi.fn()} step={1} variant="row" />)
+
+    const button = screen.getByRole('button', { name: 'Loading…' })
+    // The trailing "…" affordance must not be appended in the loading state,
+    // and the visible text stays the loading label (the spinner is the child).
+    expect(button).toHaveTextContent('Loading…')
+    expect(button).not.toHaveTextContent('Loading……')
+    expect(button).not.toHaveTextContent('more…')
+  })
+
   it('wraps the button in a Tip with the generic label when step is 0', () => {
     render(<SidebarLoadMoreRow onClick={vi.fn()} step={0} />)
 

--- a/apps/desktop/src/app/chat/sidebar/load-more-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/load-more-row.test.tsx
@@ -37,6 +37,12 @@ describe('SidebarLoadMoreRow', () => {
     expect(button.closest('[data-slot="tooltip-trigger"]')).toBeTruthy()
   })
 
+  it('renders the count label as visible text in row variant', () => {
+    render(<SidebarLoadMoreRow onClick={vi.fn()} step={1} variant="row" />)
+
+    expect(screen.getByRole('button', { name: 'Load 1 more…' })).toHaveTextContent('Load 1 more…')
+  })
+
   it('wraps the button in a Tip with the generic label when step is 0', () => {
     render(<SidebarLoadMoreRow onClick={vi.fn()} step={0} />)
 

--- a/apps/desktop/src/app/chat/sidebar/load-more-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/load-more-row.tsx
@@ -7,6 +7,7 @@ interface SidebarLoadMoreRowProps {
   step: number
   onClick: () => void
   loading?: boolean
+  variant?: 'icon' | 'row'
 }
 
 // Compact "load more" affordance shared by recents, messaging, and cron. Kept
@@ -14,21 +15,28 @@ interface SidebarLoadMoreRowProps {
 // so pagination reads as one interaction everywhere. It hangs off the list
 // instead of sitting in a row, so it repeats the row's trailing inset
 // (SidebarRowShell's `pr-2`) to stay on the edge the rows stop at.
-export function SidebarLoadMoreRow({ step, onClick, loading = false }: SidebarLoadMoreRowProps) {
+export function SidebarLoadMoreRow({ step, onClick, loading = false, variant = 'icon' }: SidebarLoadMoreRowProps) {
   const { t } = useI18n()
   const label = loading ? t.sidebar.loading : step > 0 ? t.sidebar.loadCount(step) : t.sidebar.loadMore
+  const visibleLabel = variant === 'row' && !loading ? `${label}…` : label
 
   return (
-    <Tip label={label}>
+    <Tip label={visibleLabel}>
       <button
-        aria-label={label}
-        className="mr-2 ml-auto grid size-5 place-items-center rounded-sm bg-transparent text-(--ui-text-tertiary) transition-colors hover:bg-(--ui-control-hover-background) hover:text-foreground disabled:cursor-default disabled:opacity-60 disabled:hover:bg-transparent disabled:hover:text-(--ui-text-tertiary)"
+        aria-label={visibleLabel}
+        className={
+          variant === 'row'
+            ? 'w-full rounded-md px-1.5 py-1 text-left text-[0.6875rem] text-(--ui-text-tertiary) transition-colors hover:bg-(--ui-control-hover-background) hover:text-foreground disabled:cursor-default disabled:opacity-60 disabled:hover:bg-transparent disabled:hover:text-(--ui-text-tertiary)'
+            : 'mr-2 ml-auto grid size-5 place-items-center rounded-sm bg-transparent text-(--ui-text-tertiary) transition-colors hover:bg-(--ui-control-hover-background) hover:text-foreground disabled:cursor-default disabled:opacity-60 disabled:hover:bg-transparent disabled:hover:text-(--ui-text-tertiary)'
+        }
         disabled={loading}
         onClick={onClick}
         type="button"
       >
         {loading ? (
           <GlyphSpinner ariaLabel={label} className="text-[0.75rem]" />
+        ) : variant === 'row' ? (
+          visibleLabel
         ) : (
           <Codicon name="ellipsis" size="0.75rem" />
         )}

--- a/apps/desktop/src/app/chat/sidebar/load-more-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/load-more-row.tsx
@@ -18,7 +18,13 @@ interface SidebarLoadMoreRowProps {
 export function SidebarLoadMoreRow({ step, onClick, loading = false, variant = 'icon' }: SidebarLoadMoreRowProps) {
   const { t } = useI18n()
   const label = loading ? t.sidebar.loading : step > 0 ? t.sidebar.loadCount(step) : t.sidebar.loadMore
-  const visibleLabel = variant === 'row' && !loading ? `${label}…` : label
+  // Row variant appends a trailing ellipsis as a "more" affordance. Strip any
+  // ellipsis a locale already puts at the end of its string (ASCII `.`, the
+  // horizontal ellipsis `…`, or the two-dot leader `‥`) so we never render
+  // doubled punctuation. The ellipsis is UI chrome, not translator-owned text,
+  // so it stays in code rather than in the i18n strings.
+  const visibleLabel =
+    variant === 'row' && !loading ? `${label.replace(/[.\u2026\u2025]+$/u, '')}…` : label
 
   return (
     <Tip label={visibleLabel}>

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1427,6 +1427,7 @@ export const ar = defineLocale({
     failedRename: 'فشل إعادة التسمية'
   },
   cron: {
+    shownOf: (shown, total) => `${shown} من ${total}`,
     close: 'إغلاق',
     modelImpact: {
       title: 'تحتاج المهام المجدولة إلى المراجعة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1848,6 +1848,7 @@ export const en: Translations = {
   },
 
   cron: {
+    shownOf: (shown, total) => `${shown} of ${total}`,
     close: 'Close cron',
     title: 'Scheduled jobs',
     count: count => `${count} ${count === 1 ? 'job' : 'jobs'}`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1560,6 +1560,7 @@ export const ja = defineLocale({
   },
 
   cron: {
+    shownOf: (shown, total) => `${shown} / ${total}`,
     close: 'Cron を閉じる',
     title: 'スケジュール済みジョブ',
     count: count => `${count} 件のジョブ`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1577,6 +1577,7 @@ export interface Translations {
     close: string
     title: string
     count: (count: number) => string
+    shownOf: (shown: number, total: number) => string
     modelImpact: {
       title: string
       message: (count: number) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1504,6 +1504,7 @@ export const zhHant = defineLocale({
   },
 
   cron: {
+    shownOf: (shown, total) => `${shown} / ${total}`,
     close: '關閉排程',
     title: '排程工作',
     count: count => `${count} 個工作`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2036,6 +2036,7 @@ export const zh: Translations = {
   },
 
   cron: {
+    shownOf: (shown, total) => `${shown} / ${total}`,
     close: '关闭定时任务',
     title: '定时任务',
     count: count => `${count} 个任务`,


### PR DESCRIPTION
Fixes #91278.

The cron sidebar hid the 4th+ job behind a tiny icon-only ellipsis (...) button, which read as silent data loss — users concluded the job was deleted or that Hermes caps at 3 jobs.

Changes:
- Raise INITIAL_VISIBLE_JOBS 3 -> 6 so typical job counts show fully (the section is already capped by max-h-72 with its own scroll).
- Show a 'N of M' count on the section header whenever jobs are hidden, so truncation is visible even when collapsed.
- Render the load-more control as a full-width 'Show N more...' row instead of an icon-only ellipsis.
- Add a cron.shownOf i18n key across all five locales (en/zh/zh-hant/ja/ar) and types.ts; the SidebarLoadMoreRow variant prop defaults to icon, so other sidebar sections are unchanged.
- Add a regression test for the cron section and a row-variant test for the load-more row.