### PR TITLE
fix(aux): gate OPENAI_API_KEY on OpenAI hosts for custom endpoints

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6508,10 +6508,20 @@ def resolve_provider_client(
             custom_base = _to_openai_base_url(explicit_base_url).strip()
             if api_mode == "anthropic_messages":
                 wrap_base = (explicit_base_url or "").strip().rstrip("/")
+            # Precedence: explicit key > host-matched custom_providers key >
+            # OPENAI_API_KEY (OpenAI hosts only) > no-key. Two rules the old
+            # chain broke: (1) a generic env var must not shadow a host-specific
+            # configured key — a profile .env exporting OPENAI_API_KEY sent the
+            # OpenAI key to api.fireworks.ai and every custom-endpoint call 401'd
+            # even though a valid Fireworks key was configured; (2) the env var
+            # must only go to authoritative OpenAI hosts — otherwise it leaks as
+            # a Bearer token to any host a custom endpoint names. Mirrors the
+            # #28660 host gating in hermes_cli/runtime_provider.py.
+            _custom_is_openai_url = base_url_host_matches(custom_base, "openai.com") or base_url_host_matches(custom_base, "openai.azure.com")
             custom_key = (
                 (explicit_api_key or "").strip()
-                or _scoped_key_env("OPENAI_API_KEY")
                 or _read_main_api_key_if_same_host(custom_base)
+                or (_scoped_key_env("OPENAI_API_KEY") if _custom_is_openai_url else "")
                 or "no-key-required"  # local servers don't need auth
             )
             if not custom_base:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4620,3 +4620,86 @@ class TestFastModelTier:
             _FAST_MODEL_TASKS
         )
         assert not overlap
+
+
+class TestCustomEndpointOpenAIKeyGating:
+    """resolve_provider_client("custom", explicit_base_url=...) must not send
+    OPENAI_API_KEY to non-OpenAI hosts, and a host-matched configured key must
+    beat the generic env var. Regression coverage for the shadowing bug where a
+    profile .env exporting OPENAI_API_KEY caused every custom-endpoint call
+    (e.g. api.fireworks.ai) to 401 with "The API key you provided is invalid."
+    Mirrors the #28660 host gating in hermes_cli/runtime_provider.py.
+    """
+
+    def _resolve(self, base_url, *, explicit_key="", env_key="", main_key=""):
+        from agent.auxiliary_client import resolve_provider_client
+
+        with (
+            patch(
+                "agent.auxiliary_client._scoped_key_env",
+                side_effect=lambda name: env_key if name == "OPENAI_API_KEY" else "",
+            ),
+            patch(
+                "agent.auxiliary_client._read_main_api_key_if_same_host",
+                return_value=main_key,
+            ),
+        ):
+            client, _model = resolve_provider_client(
+                "custom",
+                "some-model",
+                explicit_base_url=base_url,
+                explicit_api_key=explicit_key,
+            )
+        assert client is not None
+        return getattr(client, "api_key", None)
+
+    def test_env_openai_key_not_sent_to_non_openai_host(self):
+        """The core regression: Fireworks endpoint + OPENAI_API_KEY in env +
+        host-matched configured key -> the configured key wins."""
+        key = self._resolve(
+            "https://api.fireworks.ai/inference/v1",
+            env_key="sk-openai-should-not-leak",
+            main_key="fw-configured-key",
+        )
+        assert key == "fw-configured-key"
+
+    def test_explicit_key_wins_over_env_and_config(self):
+        key = self._resolve(
+            "https://api.fireworks.ai/inference/v1",
+            explicit_key="explicit-key",
+            env_key="sk-openai",
+            main_key="fw-configured-key",
+        )
+        assert key == "explicit-key"
+
+    def test_env_openai_key_used_for_openai_host(self):
+        key = self._resolve(
+            "https://api.openai.com/v1",
+            env_key="sk-openai",
+        )
+        assert key == "sk-openai"
+
+    def test_env_openai_key_used_for_openai_azure_host(self):
+        key = self._resolve(
+            "https://myresource.openai.azure.com/openai/v1",
+            env_key="sk-openai",
+        )
+        assert key == "sk-openai"
+
+    def test_host_suffix_spoofing_rejected(self):
+        for hostile in (
+            "https://api.openai.com.evil.test/v1",
+            "https://evilopenai.com/v1",
+            "https://openai.azure.com.evil.test/v1",
+        ):
+            key = self._resolve(hostile, env_key="sk-openai")
+            assert key == "no-key-required", hostile
+
+    def test_generic_proxy_does_not_get_openai_key(self):
+        """An OpenAI-compatible proxy that is not an OpenAI host must not
+        receive OPENAI_API_KEY implicitly — configure a key explicitly."""
+        key = self._resolve(
+            "https://proxy.example.com/v1",
+            env_key="sk-openai",
+        )
+        assert key == "no-key-required"

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -177,6 +177,17 @@ Custom endpoint pools are stored in `auth.json` under `credential_pool` with a `
 }
 ```
 
+### Which key does a custom endpoint use?
+
+For `provider: custom` calls (auxiliary tasks, delegation subagents), Hermes resolves the key in this order:
+
+1. An explicit `api_key` on the request or model entry.
+2. The host-matched configured key (a `providers:`/`custom_providers` entry or the main model's key, when the endpoint shares that host).
+3. `OPENAI_API_KEY` from the environment — **only when the endpoint host matches OpenAI-owned host suffixes** (`openai.com` and `openai.azure.com`, including subdomains; suffix-spoofing such as `api.openai.com.evil.test` does not match). The variable is never sent to third-party or self-hosted endpoints, so it cannot shadow your configured key or leak to a mistyped host.
+4. `no-key-required` (local servers).
+
+If you run an OpenAI-compatible proxy that expects your OpenAI key, set `api_key` explicitly on the endpoint — implicit env-var fallback no longer covers non-OpenAI hosts.
+
 ## Auto-Discovery
 
 Hermes automatically discovers credentials from multiple sources and seeds the pool on startup:


### PR DESCRIPTION
## What does this PR do?

`resolve_provider_client("custom", explicit_base_url=...)` resolved the API key as `explicit → OPENAI_API_KEY (unconditional) → host-matched configured key → no-key-required`. A profile that exports `OPENAI_API_KEY` (Hermes itself prompts for it) sent that key as a Bearer token to **any** host a custom endpoint named — and because the env var was checked first, it shadowed the endpoint's valid configured key. Observed in production: every auxiliary/delegation call to `api.fireworks.ai` failed with `401: The API key you provided is invalid` while all configured keys were valid.

New precedence: **explicit `api_key` → host-matched configured key → `OPENAI_API_KEY` (OpenAI hosts only) → `no-key-required`**. Host gating reuses `base_url_host_matches` — the same helper the main resolver's #28660 gating uses — which is exact-host/subdomain matching, robust to suffix spoofs (`api.openai.com.evil.test`), userinfo (`api.openai.com@evil.test`), case, and trailing dots (edge cases verified against the helper directly).

This extends the #28660 host-gating principle ("sending OPENAI_API_KEY to a local-llm endpoint leaks credentials") to the auxiliary resolver, which never got it.

## Related Issue

Fixes #91308

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `agent/auxiliary_client.py` — reordered + host-gated the custom-endpoint key chain in `resolve_provider_client` (explicit_base_url branch).
- `tests/agent/test_auxiliary_client.py` — new `TestCustomEndpointOpenAIKeyGating` (6 tests): env-key-never-sent-to-non-OpenAI-host (the core regression), explicit-key-wins, api.openai.com still uses the env key, *.openai.azure.com still uses the env key, suffix-spoof hosts rejected, generic proxy gets no implicit key. All hermetic — internals mocked, no network.
- `website/docs/user-guide/features/credential-pools.md` — documents the custom-endpoint key resolution order and the OpenAI-host gating, including guidance for OpenAI-compatible proxies (set `api_key` explicitly).

## How to Test

1. `export OPENAI_API_KEY=sk-anything`
2. Configure a custom provider with its own valid `api_key` (e.g. `https://api.fireworks.ai/inference/v1`)
3. Run an auxiliary task against it. Before: 401 (OpenAI key sent). After: the configured key is used.
4. `pytest tests/agent/test_auxiliary_client.py -q -k CustomEndpointOpenAIKeyGating` → 6 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] I searched for existing PRs — no duplicate (closest: #28660, which this extends to the auxiliary path)
- [x] PR contains only changes related to this fix
- [x] Tests: `pytest tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_main_first.py` → 203 passed. Note on the full serial suite: `tests/agent/test_auxiliary_main_first.py::TestResolveVisionCustomProvider::test_custom_main_forwards_runtime_endpoint` (and its copilot-gateway sibling) fail **identically on clean upstream main (40643cbaf9)** in the same environment — an order/environment-dependent flake that pre-exists this change; repro: `pytest tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_main_first.py -q` on a fresh upstream checkout. This branch's delta is +6 passing tests, zero new failures.
- [x] Tests added for the change (bug fix)
- [x] Tested on macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] Documentation updated (`website/docs/user-guide/features/credential-pools.md`)
- [x] `cli-config.yaml.example` — N/A (no config keys changed)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact — N/A (pure string/URL logic, no platform APIs)
- [x] Tool descriptions/schemas — N/A

## Behavior-change note for reviewers

One intentional behavior change to flag: a custom endpoint pointing at a non-OpenAI host that *relied* on implicitly receiving `OPENAI_API_KEY` (e.g. an OpenAI-compatible proxy expecting the user's OpenAI key) will now get `no-key-required` instead. That implicit behavior was the leak; the fix is setting `api_key` explicitly on the endpoint, now documented.