### PR TITLE
fix: OpenCode Zen free-tier models (Ox Alpha) no longer 401 — keyless routing for *-free slugs

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1286,6 +1286,19 @@ def init_agent(
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
             effective_base = base_url
+            # OpenCode Zen free tier (*-free slugs, e.g. x-preview-f-free /
+            # "Ox Alpha"): the Zen relay serves these ANONYMOUSLY and 401s any
+            # unrecognized bearer — including our keyless placeholder. Send an
+            # empty Authorization header to override the SDK's "Bearer <key>".
+            try:
+                from hermes_cli.models import (
+                    OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER,
+                    opencode_zen_free_headers,
+                )
+                if api_key == OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER:
+                    client_kwargs["default_headers"] = opencode_zen_free_headers()
+            except Exception:
+                pass
             if base_url_host_matches(effective_base, "openrouter.ai"):
                 from agent.auxiliary_client import build_or_headers
                 client_kwargs["default_headers"] = build_or_headers()

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -262,6 +262,21 @@ def _create_openai_client(*, api_key: str, base_url: str, **kwargs: Any) -> Any:
         # answer. Skip the openai import + httpx/SSL construction entirely.
         return _AuxProbeClientStub(api_key=api_key, base_url=base_url)
     kwargs = {**_openai_http_client_kwargs(base_url), **kwargs}
+    # OpenCode Zen free tier: the keyless placeholder must never reach the
+    # wire — the Zen relay serves free models anonymously but 401s any
+    # unrecognized bearer. Override the SDK's Authorization header with an
+    # empty value (single shared chokepoint for every aux client build).
+    try:
+        from hermes_cli.models import (
+            OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER,
+            opencode_zen_free_headers,
+        )
+        if api_key == OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER:
+            merged = dict(kwargs.get("default_headers") or {})
+            merged.update(opencode_zen_free_headers())
+            kwargs["default_headers"] = merged
+    except Exception:
+        pass
     # Hermes owns auxiliary retry + provider/model fallback policy (the
     # same-provider transient retry in call_llm plus the except-chain
     # fallback). The OpenAI SDK's own default (max_retries=2 → up to 3
@@ -6781,6 +6796,18 @@ def resolve_provider_client(
         raw_base_url = str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url
         if explicit_base_url:
             raw_base_url = explicit_base_url.strip().rstrip("/")
+        # OpenCode Zen free tier (*-free slugs): served anonymously on the
+        # Zen relay only — no credential needed, and any unknown bearer
+        # (including a Go subscription key) is rejected. Route through the
+        # keyless Zen runtime regardless of configured OpenCode credentials.
+        try:
+            from hermes_cli.models import opencode_zen_free_runtime as _oc_free_rt
+            _free_rt = _oc_free_rt(provider, model)
+        except Exception:
+            _free_rt = None
+        if _free_rt is not None:
+            api_key = _free_rt["api_key"]
+            raw_base_url = str(_free_rt["base_url"]).rstrip("/")
         if provider == "actual":
             try:
                 from hermes_cli.auth import (

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -5314,6 +5314,75 @@ def normalize_opencode_model_id(provider_id: Optional[str], model_id: Optional[s
     return current
 
 
+# OpenCode Zen free-tier models (``*-free`` slugs, e.g. x-preview-f-free /
+# "Ox Alpha") are served ANONYMOUSLY on the Zen relay: a request with no
+# Authorization header succeeds, while ANY non-empty bearer the relay doesn't
+# recognize is rejected with 401 "Invalid API key" — including our
+# "no-key-required" placeholder and OpenCode GO subscription keys (the Go
+# relay doesn't serve the free tier at all: "Model x is not supported").
+# Verified live 2026-08-21 against POST /zen/v1/chat/completions.
+OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER = "opencode-zen-free-keyless"
+_OPENCODE_ZEN_FREE_BASE_URL = "https://opencode.ai/zen/v1"
+
+
+def is_opencode_zen_free_model(model_id: Optional[str]) -> bool:
+    """True when ``model_id`` is an OpenCode Zen free-tier slug (``*-free``).
+
+    Tolerates provider-prefixed ids (``opencode-zen/x-preview-f-free``).
+    The Go catalog serves no ``-free`` models (verified 2026-08-21), so the
+    suffix alone identifies the Zen free tier across the OpenCode family.
+    """
+    bare = str(model_id or "").strip().rsplit("/", 1)[-1].lower()
+    return bool(bare) and bare.endswith("-free")
+
+
+def opencode_zen_free_headers() -> dict:
+    """Client default_headers for anonymous OpenCode Zen free-tier requests.
+
+    ``Authorization: ""`` overrides the OpenAI SDK's ``Bearer <api_key>``
+    header so the placeholder key never reaches the wire — the Zen relay
+    accepts anonymous requests for free models but 401s any unknown bearer.
+    Attribution headers mirror the opencode provider profile.
+    """
+    try:
+        from hermes_cli import __version__ as _v
+    except Exception:
+        _v = "0"
+    return {
+        "Authorization": "",
+        "HTTP-Referer": "https://hermes-agent.nousresearch.com",
+        "X-Title": "Hermes Agent",
+        "User-Agent": f"HermesAgent/{_v}",
+    }
+
+
+def opencode_zen_free_runtime(provider_id: Optional[str], model_id: Optional[str]) -> Optional[dict]:
+    """Keyless runtime entry for an OpenCode Zen free-tier model, or None.
+
+    Returns a resolve_runtime_provider-shaped dict pinning the request to the
+    Zen relay with the keyless placeholder whenever ``model_id`` is a
+    ``*-free`` slug and ``provider_id`` is in the OpenCode family. Free-tier
+    slugs live only on the Zen relay, so this also heals a selection made
+    under the opencode-go provider (the Go relay rejects them).
+    """
+    family = opencode_provider_family(provider_id)
+    if family is None or not is_opencode_zen_free_model(model_id):
+        return None
+    normalized = normalize_opencode_model_id(provider_id, model_id)
+    api_mode = opencode_model_api_mode("opencode-zen", normalized)
+    base_url = normalize_opencode_base_url(
+        "opencode-zen", api_mode, _OPENCODE_ZEN_FREE_BASE_URL
+    )
+    return {
+        "provider": family,
+        "api_mode": api_mode,
+        "base_url": base_url,
+        "api_key": OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER,
+        "default_headers": opencode_zen_free_headers(),
+        "source": "opencode-zen-free-keyless",
+    }
+
+
 def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str]) -> str:
     """Determine the API mode for an OpenCode Zen / Go model.
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1934,6 +1934,27 @@ def resolve_runtime_provider(
         explicit_base_url=explicit_base_url,
     )
     model_cfg = _get_model_config()
+
+    # OpenCode Zen free tier (*-free slugs, e.g. x-preview-f-free /
+    # "Ox Alpha"): served ANONYMOUSLY on the Zen relay ONLY. Any bearer the
+    # relay doesn't recognize is a 401 — and the Go relay doesn't serve the
+    # free tier at all ("Model x is not supported"), so a valid OpenCode GO
+    # subscription key still fails. Route free slugs through the keyless Zen
+    # runtime BEFORE the credential-pool / explicit / api_key paths so they
+    # work with any OpenCode credential state, including none.
+    from hermes_cli.models import (
+        opencode_provider_family as _oc_family_fn,
+        opencode_zen_free_runtime as _oc_free_runtime_fn,
+    )
+    if _oc_family_fn(provider) is not None:
+        _oc_model = str(
+            target_model or model_cfg.get("default") or model_cfg.get("model") or ""
+        ).strip()
+        _free_runtime = _oc_free_runtime_fn(provider, _oc_model)
+        if _free_runtime is not None:
+            _free_runtime["requested_provider"] = requested_provider
+            return _free_runtime
+
     explicit_runtime = _resolve_explicit_runtime(
         provider=provider,
         requested_provider=requested_provider,

--- a/tests/hermes_cli/test_opencode_zen_free_keyless.py
+++ b/tests/hermes_cli/test_opencode_zen_free_keyless.py
@@ -1,0 +1,124 @@
+"""OpenCode Zen free-tier keyless routing (x-preview-f-free / "Ox Alpha").
+
+The Zen relay serves ``*-free`` models ANONYMOUSLY: a request with no
+Authorization header succeeds, while any non-empty bearer the relay doesn't
+recognize — including our historical "no-key-required" placeholder and valid
+OpenCode GO subscription keys — is rejected with 401 "Invalid API key".
+The Go relay doesn't serve the free tier at all ("Model x is not supported").
+
+These tests pin the keyless routing added for the community report where the
+free Ox Alpha model failed under an OpenCode subscription:
+
+1. ``is_opencode_zen_free_model`` recognizes free slugs (bare + prefixed).
+2. ``opencode_zen_free_runtime`` pins free slugs to the Zen relay with the
+   keyless placeholder + empty-Authorization headers, for BOTH family
+   providers (Go selections heal to Zen).
+3. ``resolve_runtime_provider`` routes free slugs keylessly with no
+   OPENCODE_* credential present, and still fails closed for paid models.
+4. The keyless placeholder never reaches the wire: client default_headers
+   carry ``Authorization: ""`` overriding the SDK bearer.
+"""
+
+import os
+from unittest import mock
+
+import pytest
+
+from hermes_cli.models import (
+    OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER,
+    is_opencode_zen_free_model,
+    opencode_zen_free_headers,
+    opencode_zen_free_runtime,
+)
+
+
+class TestFreeSlugDetection:
+    def test_bare_free_slug(self):
+        assert is_opencode_zen_free_model("x-preview-f-free")
+
+    def test_provider_prefixed_slug(self):
+        assert is_opencode_zen_free_model("opencode-zen/x-preview-f-free")
+
+    def test_other_free_tier_slugs(self):
+        for slug in (
+            "hy3-free",
+            "laguna-s-2.1-free",
+            "mimo-v2.5-free",
+            "nemotron-3-ultra-free",
+        ):
+            assert is_opencode_zen_free_model(slug), slug
+
+    def test_paid_models_not_free(self):
+        for slug in ("claude-sonnet-5", "glm-5.2", "kimi-k3", "gpt-5.6-sol"):
+            assert not is_opencode_zen_free_model(slug), slug
+
+    def test_empty_and_none(self):
+        assert not is_opencode_zen_free_model("")
+        assert not is_opencode_zen_free_model(None)
+
+    def test_freedom_like_names_not_swept(self):
+        # suffix match must be exact "-free", not substring "free"
+        assert not is_opencode_zen_free_model("freeform-1")
+        assert not is_opencode_zen_free_model("model-freedom")
+
+
+class TestFreeRuntime:
+    def test_zen_provider_free_model(self):
+        rt = opencode_zen_free_runtime("opencode-zen", "x-preview-f-free")
+        assert rt is not None
+        assert rt["base_url"] == "https://opencode.ai/zen/v1"
+        assert rt["api_key"] == OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER
+        assert rt["api_mode"] == "chat_completions"
+        assert rt["default_headers"]["Authorization"] == ""
+
+    def test_go_provider_heals_to_zen(self):
+        # Free slugs only exist on the Zen relay; a Go selection must be
+        # routed to Zen (the Go relay rejects the model outright).
+        rt = opencode_zen_free_runtime("opencode-go", "x-preview-f-free")
+        assert rt is not None
+        assert rt["base_url"] == "https://opencode.ai/zen/v1"
+
+    def test_paid_model_returns_none(self):
+        assert opencode_zen_free_runtime("opencode-zen", "claude-sonnet-5") is None
+
+    def test_non_opencode_provider_returns_none(self):
+        assert opencode_zen_free_runtime("openrouter", "x-preview-f-free") is None
+        assert opencode_zen_free_runtime(None, "x-preview-f-free") is None
+
+    def test_headers_override_sdk_bearer(self):
+        headers = opencode_zen_free_headers()
+        assert headers["Authorization"] == ""
+        assert headers["X-Title"] == "Hermes Agent"
+
+
+class TestRuntimeProviderKeylessRouting:
+    @pytest.fixture(autouse=True)
+    def _no_opencode_creds(self, monkeypatch):
+        for var in ("OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+
+    def _resolve(self, provider, model):
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        with mock.patch(
+            "hermes_cli.runtime_provider._get_model_config",
+            return_value={"provider": provider, "model": model, "default": model},
+        ):
+            return resolve_runtime_provider(requested=provider, target_model=model)
+
+    def test_zen_free_model_resolves_keyless(self):
+        rt = self._resolve("opencode-zen", "x-preview-f-free")
+        assert rt["api_key"] == OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER
+        assert rt["base_url"] == "https://opencode.ai/zen/v1"
+        assert rt["api_mode"] == "chat_completions"
+
+    def test_go_free_model_resolves_keyless_on_zen(self):
+        rt = self._resolve("opencode-go", "x-preview-f-free")
+        assert rt["api_key"] == OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER
+        assert rt["base_url"] == "https://opencode.ai/zen/v1"
+
+    def test_paid_model_still_fails_closed_without_key(self):
+        from hermes_cli.auth import AuthError
+
+        with pytest.raises(AuthError):
+            self._resolve("opencode-zen", "claude-sonnet-5")


### PR DESCRIPTION
## Summary
The free "Ox Alpha" model (`x-preview-f-free`) on OpenCode now works in Hermes with any credential state — including none and including OpenCode Go subscription keys, both of which previously failed every request.

Root cause: the Zen relay serves `*-free` models ONLY anonymously — any Authorization bearer it doesn't recognize is a 401 `Invalid API key`. Hermes always sends a bearer: keyless setups got the `no-key-required` placeholder, and OpenCode subscribers sent their Go key to a relay that rejects it (the Go relay doesn't serve the free tier at all: `Model x-preview-f-free is not supported`). Community report surfaced as `HTTP 405: Upstream request failed ... not valid JSON`.

Fixed as a class for all 8 current `*-free` Zen slugs, not just Ox Alpha.

## Changes
- `hermes_cli/models.py`: one shared policy — `is_opencode_zen_free_model()` + `opencode_zen_free_runtime()` + `opencode_zen_free_headers()`. Free slugs pin to the Zen relay with a keyless placeholder and an empty `Authorization` header that overrides the OpenAI SDK's `Bearer <key>`.
- `hermes_cli/runtime_provider.py`: free slugs route through the keyless runtime before the credential-pool / explicit / api_key paths; Go selections heal to Zen. Paid models still fail closed without a key.
- `agent/agent_init.py`, `agent/auxiliary_client.py`: the placeholder swaps in the empty-Authorization headers at both client-build chokepoints (main agent + aux/router).
- `tests/hermes_cli/test_opencode_zen_free_keyless.py`: 14 tests — slug detection (incl. `-free` suffix exactness), runtime pinning, keyless resolution for both providers, paid-model fail-closed.

## Validation
| Check | Result |
|---|---|
| Live wire probes (keyless) | 200 on chat/completions incl. tools, streaming, 10x parallel; any bad bearer → 401; Go relay → model not supported |
| E2E `AIAgent` turn, temp HERMES_HOME, zero keys | completes under BOTH `opencode-zen` and `opencode-go`, incl. real terminal tool round-trip (2 api calls) |
| Sabotage run (fix stashed) | 2 routing tests fail, proving pin |
| Targeted suites | 107 passed (keyless + runtime resolution + opencode family + model validation) |
| Paid model keyless | still `AuthError` (fail closed) |

## Infographic

![OpenCode Zen free tier keyless routing](https://v3b.fal.media/files/b/0aa730c4/hZqHiIR1V_xZsQ2q5rvi6_jT0knx7l.png)
