### PR TITLE
fix(desktop): preserve session tiles after reconnect

### DIFF
--- a/apps/desktop/src/app/chat/session-tile.test.ts
+++ b/apps/desktop/src/app/chat/session-tile.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { sessionTileResumeFailure } from './session-tile'
+
+describe('sessionTileResumeFailure', () => {
+  it('keeps a confirmed durable session retryable instead of repeating a stale 404', () => {
+    expect(sessionTileResumeFailure('session not found', true, true)).toBe('Session is still available — retry resuming it.')
+  })
+
+  it('fails safe on an inconclusive durable lookup', () => {
+    expect(sessionTileResumeFailure('404', false, true)).toBe('Session unavailable — you can retry resuming it.')
+  })
+
+  it('does not overwrite a tile that rebound while the lookup was pending', () => {
+    expect(sessionTileResumeFailure('session not found', true, false)).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -72,6 +72,17 @@ import { ChatView } from '.'
 
 const NO_MESSAGES: ChatMessage[] = []
 
+export function sessionTileResumeFailure(
+  message: string,
+  durableSessionFound: boolean | undefined,
+  tileStillUnbound: boolean
+): string | undefined {
+  if (!tileStillUnbound) return undefined
+  if (!/session not found|\b404\b/i.test(message)) return message
+  if (durableSessionFound) return 'Session is still available — retry resuming it.'
+  return 'Session unavailable — you can retry resuming it.'
+}
+
 /** The tile's SessionView: the same atom shape the primary chat renders
  *  from, computed from this session's slice of `$sessionStates`. */
 function buildTileView(storedSessionId: string): SessionView {
@@ -323,10 +334,11 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
         // before releasing this resume attempt, then fail safe: a tile may be
         // retried by the user, but must never be deleted on an inconclusive
         // reconnect-time lookup.
-        await resolveStoredSession(storedSessionId).catch(() => undefined)
+        const durableSession = await resolveStoredSession(storedSessionId).catch(() => undefined)
         const current = $sessionTiles.get().find(candidate => candidate.storedSessionId === storedSessionId)
-        if (current && !current.runtimeId) {
-          patchSessionTile(storedSessionId, { error: message })
+        const error = sessionTileResumeFailure(message, Boolean(durableSession), Boolean(current && !current.runtimeId))
+        if (error) {
+          patchSessionTile(storedSessionId, { error })
         }
       })
       .finally(() => {

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -50,7 +50,6 @@ import {
   $sessionStates,
   $sessionTiles,
   closeSessionTile,
-  discardSessionTile,
   patchSessionTile,
   type SessionTile,
   sessionTileDelegate
@@ -238,6 +237,10 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
   const gatewayOpen = useStore($gatewayState) === 'open'
   const resumingRef = useRef(false)
   const view = useMemo(() => buildTileView(storedSessionId), [storedSessionId])
+  const storedSessionStillExists = useCallback(
+    () => $sessions.get().some(s => sessionMatchesStoredId(s, storedSessionId)),
+    [storedSessionId]
+  )
 
   // A tab-strip "+"/⌘T tab is created UNLISTED — its session stays out of
   // $sessions (no sidebar clutter) until it's actually used, so the tab shows
@@ -250,7 +253,7 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
   const hasMessages = useStore(view.$messagesEmpty) === false
 
   useEffect(() => {
-    const alreadyListed = () => $sessions.get().some(s => sessionMatchesStoredId(s, storedSessionId))
+    const alreadyListed = storedSessionStillExists
 
     if (!runtimeId || !hasMessages || alreadyListed()) {
       return
@@ -284,7 +287,7 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
         window.clearTimeout(timer)
       }
     }
-  }, [hasMessages, runtimeId, storedSessionId])
+  }, [hasMessages, runtimeId, storedSessionId, storedSessionStillExists])
 
   // Same gating as the primary's route resume (use-route-resume): never fire
   // session.resume before the gateway is OPEN. Persisted tiles mount at boot
@@ -307,22 +310,29 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
     delegate
       .resumeTile(storedSessionId)
       .then(id => patchSessionTile(storedSessionId, { error: undefined, runtimeId: id }))
-      .catch((err: unknown) => {
+      .catch(async (err: unknown) => {
         const message = err instanceof Error ? err.message : String(err)
 
-        // A gone session (404 / "Session not found") is terminal — a stale or
-        // cross-profile persisted tile. Discard it instead of latching an error
-        // that re-retries on every reconnect (the "Session not found" spam).
-        if (/session not found|\b404\b/i.test(message)) {
-          discardSessionTile(storedSessionId)
-        } else {
+        if (!/session not found|\b404\b/i.test(message)) {
+          patchSessionTile(storedSessionId, { error: message })
+          return
+        }
+
+        // A recents page is not authoritative, and resolveStoredSession()
+        // intentionally treats transient probe failures like a miss. Await it
+        // before releasing this resume attempt, then fail safe: a tile may be
+        // retried by the user, but must never be deleted on an inconclusive
+        // reconnect-time lookup.
+        await resolveStoredSession(storedSessionId).catch(() => undefined)
+        const current = $sessionTiles.get().find(candidate => candidate.storedSessionId === storedSessionId)
+        if (current && !current.runtimeId) {
           patchSessionTile(storedSessionId, { error: message })
         }
       })
       .finally(() => {
         resumingRef.current = false
       })
-  }, [gatewayOpen, runtimeId, storedSessionId, tile?.error])
+  }, [gatewayOpen, runtimeId, storedSessionId, storedSessionStillExists, tile?.error])
 
   // The gateway (re)opening invalidates any latched error — it likely came
   // from a not-yet-open gateway or the previous connection. Clearing it


### PR DESCRIPTION
Fixes #91276.

## Summary

A runtime session id can disappear after a remote-gateway reconnect while the durable stored session still exists. A tile resume previously treated a resulting 404 as terminal and discarded the tile.

- Confirm the durable session before applying a reconnect-time 404 result.
- Await that confirmation before releasing the resume guard, then re-check the tile has not already rebound.
- Preserve a retryable tile error on any absent or inconclusive lookup rather than deleting a potentially live chat.

## Safety invariant

A reconnect-time lookup must never delete a session tile unless durable absence can be established; a stale async 404 result must not overwrite a newly rebound runtime session.

## Validation

- `npm --workspace apps/desktop run test:ui -- src/app/chat/session-tile-attachments.test.tsx src/app/chat/session-tile-actions.test.ts` — 7 passed
- Snape independent review reran the tile-related suite: 13 passed
- `npm --workspace apps/desktop run typecheck`
- `git diff --check`