### PR TITLE
fix(gateway): notify on media delivery failure in more silent-swallow spots

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4454,8 +4454,10 @@ class BasePlatformAdapter(ABC):
                     )
                 if not img_result.success:
                     logger.error("[%s] Failed to send image: %s", self.name, img_result.error)
+                    await self._notify_media_delivery_failure(chat_id, image_url, metadata=metadata)
             except Exception as img_err:
                 logger.error("[%s] Error sending image: %s", self.name, img_err, exc_info=True)
+                await self._notify_media_delivery_failure(chat_id, image_url, metadata=metadata)
 
     async def send_image(
         self,
@@ -6665,6 +6667,10 @@ class BasePlatformAdapter(ABC):
                         )
                     except Exception as batch_err:
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
+                        for _img_url, _ in images:
+                            await self._notify_media_delivery_failure(
+                                event.source.chat_id, _img_url, metadata=_final_thread_metadata,
+                            )
 
 
                 # Send extracted media files — route by file type
@@ -6707,6 +6713,10 @@ class BasePlatformAdapter(ABC):
                         )
                     except Exception as batch_err:
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
+                        for _img_path in _image_paths:
+                            await self._notify_media_delivery_failure(
+                                event.source.chat_id, _img_path, metadata=_final_thread_metadata,
+                            )
 
                 if _non_image_media:
                     logger.info(
@@ -6754,6 +6764,12 @@ class BasePlatformAdapter(ABC):
                             )
                     except Exception as media_err:
                         logger.warning("[%s] Error sending media: %s", self.name, media_err)
+                        await self._notify_media_delivery_failure(
+                            event.source.chat_id,
+                            media_path,
+                            is_voice=is_voice,
+                            metadata=_final_thread_metadata,
+                        )
 
                 # Send auto-detected local non-image files as native attachments
                 for file_path in _non_image_local:
@@ -6787,6 +6803,11 @@ class BasePlatformAdapter(ABC):
                             )
                     except Exception as file_err:
                         logger.error("[%s] Error sending local file %s: %s", self.name, file_path, file_err)
+                        await self._notify_media_delivery_failure(
+                            event.source.chat_id,
+                            file_path,
+                            metadata=_final_thread_metadata,
+                        )
 
                 # A3 (#29346): if a non-empty response produced nothing
                 # deliverable, fail loudly rather than dropping it in silence.

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1947,6 +1947,9 @@ class WeixinAdapter(BasePlatformAdapter):
                     await _deliver_media(media_path, is_voice)
                 except Exception as exc:
                     logger.warning("[%s] media delivery failed for %s: %s", self.name, media_path, exc)
+                    await self._notify_media_delivery_failure(
+                        chat_id, media_path, is_voice=is_voice, metadata=metadata,
+                    )
 
             # Deliver bare local file paths.
             for file_path in local_files:
@@ -1954,6 +1957,9 @@ class WeixinAdapter(BasePlatformAdapter):
                     await _deliver_media(file_path, is_voice=False)
                 except Exception as exc:
                     logger.warning("[%s] local file delivery failed for %s: %s", self.name, file_path, exc)
+                    await self._notify_media_delivery_failure(
+                        chat_id, file_path, metadata=metadata,
+                    )
 
             # Deliver text content.
             chunks = [c for c in self._split_text(self.format_message(final_content)) if c and c.strip()]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22152,6 +22152,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                 except Exception as e:
                     logger.warning("[%s] Post-stream image batch delivery failed: %s", adapter.name, e)
+                    try:
+                        for _img_path in image_paths:
+                            await adapter._notify_media_delivery_failure(
+                                event.source.chat_id, _img_path, metadata=_thread_meta,
+                            )
+                    except Exception as _notice_err:
+                        logger.warning(
+                            "[%s] Failed to send media-delivery-failure notice: %s",
+                            adapter.name, _notice_err,
+                        )
 
             for media_path, is_voice in non_image_media:
                 try:
@@ -22176,6 +22186,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
                 except Exception as e:
                     logger.warning("[%s] Post-stream media delivery failed: %s", adapter.name, e)
+                    # A swallowed exception here previously left both the user and the
+                    # model with zero signal that delivery failed, so a model that
+                    # fabricated/forgot-to-copy a path would repeat the same broken
+                    # MEDIA: tag indefinitely. Reuse the same notify helper the
+                    # non-streaming path already uses for a graceful failure, so a
+                    # raised exception gets equivalent user-facing treatment.
+                    try:
+                        await adapter._notify_media_delivery_failure(
+                            event.source.chat_id,
+                            media_path,
+                            is_voice=is_voice,
+                            metadata=_thread_meta,
+                        )
+                    except Exception as _notice_err:
+                        logger.warning(
+                            "[%s] Failed to send media-delivery-failure notice: %s",
+                            adapter.name, _notice_err,
+                        )
 
         except Exception as e:
             logger.warning("Post-stream media extraction failed: %s", e)
@@ -22466,8 +22494,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             caption=alt_text,
                             metadata=_thread_metadata,
                         )
-                    except Exception:
-                        pass
+                    except Exception as _img_err:
+                        logger.warning(
+                            "[%s] Background-task image delivery failed: %s", adapter.name, _img_err,
+                        )
+                        try:
+                            await adapter._notify_media_delivery_failure(
+                                source.chat_id, image_url, metadata=_thread_metadata,
+                            )
+                        except Exception:
+                            pass
 
                 # Send media files, routing each by type so a TTS clip
                 # arrives as a voice bubble / a clip as a video rather than
@@ -22504,8 +22540,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 file_path=media_path,
                                 metadata=_thread_metadata,
                             )
-                    except Exception:
-                        pass
+                    except Exception as _media_err:
+                        logger.warning(
+                            "[%s] Background-task media delivery failed: %s", adapter.name, _media_err,
+                        )
+                        try:
+                            await adapter._notify_media_delivery_failure(
+                                source.chat_id, media_path, is_voice=_is_voice, metadata=_thread_metadata,
+                            )
+                        except Exception:
+                            pass
             else:
                 preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
                 await adapter.send(


### PR DESCRIPTION
## What does this PR do?

Several media-send exception handlers in the gateway only logged the error and otherwise dropped it silently — neither the user nor the model got any signal that a `MEDIA:` attachment never arrived. In practice this means a model that fabricates or mistypes a path keeps repeating the same broken tag indefinitely, with no feedback loop to correct it.

`_notify_media_delivery_failure()` already exists and is already called from several other spots in `gateway/platforms/base.py`. This extends the same, already-established pattern to the remaining silent handlers, rather than inventing a new mechanism.

Found through real, sustained production use of a Hermes gateway (heavy Telegram media traffic), not a code audit — happy to file a tracking issue first if that's preferred process here, just didn't want to hold up a small, self-contained fix on it.

## Related Issue

No existing issue — small enough that I went straight to a PR per the "self-contained" guidance in CONTRIBUTING.md. Can open one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: notify on single-image send failure (both the `!success` and exception branches), both image-batch fallback paths, non-image media send, and local-file send.
- `gateway/platforms/weixin.py`: notify on extracted-media delivery failure and bare local-file delivery failure.
- `gateway/run.py`: notify on post-stream image-batch delivery failure, post-stream media delivery failure, and both background-task delivery paths (image + media).

Deliberately **excludes** two adjacent spots that overlap with in-flight work, to avoid adding merge-conflict noise against open PRs:
- `gateway/run.py`'s `_send_voice_reply` — #65745 is already open against that exact `except Exception` block for a related but distinct case (`send_result.success is False` without a raised exception).
- `gateway/kanban_watchers.py` — #83952 is already open and replaces both handlers I'd otherwise touch with a larger SendResult-based rework.

## How to Test

1. Point a platform adapter's `send_image`/`send_multiple_images`/`send_voice`/`send_document` at a path that will raise (e.g. a nonexistent file, or mock the adapter method to raise) in each of the newly-covered call sites.
2. Before this change: the exception is logged at WARNING and nothing else happens — no user-facing signal.
3. After this change: `_notify_media_delivery_failure(...)` is called with the chat id / path / metadata for that failure, matching the behavior already present at the other call sites in `base.py` that weren't touched by this PR.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate — found real overlap on 2 adjacent call sites (#65745, #83952) and deliberately excluded both from this PR; the sites included here don't overlap with any open PR I could find.
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran `python -m py_compile` on all 3 changed files (clean); didn't run the full suite in this environment.
- [ ] I've added tests for my changes — `_notify_media_delivery_failure()` itself has zero existing test coverage anywhere in `tests/` (confirmed via grep), so there's no existing pattern to extend for these call sites. Happy to add tests if a maintainer can point at the preferred mocking setup for `BasePlatformAdapter` in this repo's test suite.
- [x] I've tested on my platform: Debian 13 (CT/LXC), Python 3.11 — this exact diff (same code, ported by hand from an older diverged fork) has been running in a live, actively-used production Hermes gateway for real-world verification, not just a local dry run.

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed.
