### PR TITLE
fix(kanban): preserve explicit project routing

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3278,6 +3278,31 @@ def create_task(
                 project_obj = _pdb.get_project(_pconn, project_id)
         except Exception:
             project_obj = None
+        if project_obj is None:
+            # Boards are shared across profiles, so their metadata is the
+            # cross-profile project registry for Kanban task routing. Resolve a
+            # reference that names the board (or its canonical project id)
+            # without consulting another profile's private projects.db.
+            board_slug = _normalize_board_slug(
+                board if board else get_current_board()
+            ) or DEFAULT_BOARD
+            board_meta = read_board_metadata(board_slug)
+            board_project_id = str(board_meta.get("project_id") or "").strip()
+            board_repo = str(board_meta.get("default_workdir") or "").strip()
+            board_refs = {board_slug}
+            if board_project_id:
+                board_refs.add(board_project_id)
+            if project_id in board_refs and board_repo and Path(board_repo).is_absolute():
+                project_slug = _pdb.normalize_slug(board_slug)
+                project_obj = _pdb.Project(
+                    id=board_project_id or project_slug,
+                    slug=project_slug,
+                    name=str(board_meta.get("name") or project_slug),
+                    created_at=int(board_meta.get("created_at") or 0),
+                    primary_path=board_repo,
+                    board_slug=board_slug,
+                )
+
         if project_obj is None and project_source_task_id:
             # Worker profiles have their own projects.db, while the Kanban DB is
             # intentionally shared. Recover routing only from a canonical
@@ -3286,9 +3311,31 @@ def create_task(
             # opening the creator profile's project store, and without reusing
             # the source task's literal worktree path.
             source_task = get_task(conn, str(project_source_task_id))
+            requested_project_slug = None
+            try:
+                requested_project_slug = _pdb.normalize_slug(project_id)
+            except ValueError:
+                pass
+            source_project_slug = None
+            if source_task is not None and source_task.branch_name:
+                prefix, separator, leaf = source_task.branch_name.partition("/")
+                if separator and (
+                    leaf == source_task.id
+                    or leaf.startswith(f"{source_task.id}-")
+                ):
+                    try:
+                        source_project_slug = _pdb.normalize_slug(prefix)
+                    except ValueError:
+                        pass
             if (
                 source_task is not None
-                and source_task.project_id == project_id
+                and (
+                    source_task.project_id == project_id
+                    or (
+                        requested_project_slug is not None
+                        and requested_project_slug == source_project_slug
+                    )
+                )
                 and source_task.workspace_kind == "worktree"
                 and source_task.workspace_path
             ):
@@ -3298,26 +3345,11 @@ def create_task(
                     and source_path.name == source_task.id
                     and source_path.parent.name == ".worktrees"
                 ):
-                    project_slug = None
-                    if source_task.branch_name:
-                        prefix, separator, leaf = source_task.branch_name.partition("/")
-                        if separator and (
-                            leaf == source_task.id
-                            or leaf.startswith(f"{source_task.id}-")
-                        ):
-                            try:
-                                project_slug = _pdb.normalize_slug(prefix)
-                            except ValueError:
-                                project_slug = None
-                    if project_slug is None:
-                        try:
-                            project_slug = _pdb.normalize_slug(project_id)
-                        except ValueError:
-                            project_slug = None
+                    project_slug = source_project_slug or requested_project_slug
                     if project_slug:
                         project_repo = str(source_path.parent.parent)
                         project_obj = _pdb.Project(
-                            id=project_id,
+                            id=source_task.project_id,
                             slug=project_slug,
                             name=project_slug,
                             created_at=0,
@@ -3327,10 +3359,10 @@ def create_task(
                             workspace_kind = "worktree"
 
         if project_obj is None:
-            # A project id/slug that doesn't resolve must not crash task
-            # creation or persist a dangling reference — drop the link and
-            # create the task as an ordinary (scratch) task.
-            project_id = None
+            raise ValueError(
+                f"project {project_id!r} was not found in the active profile "
+                "registry or the selected board"
+            )
         else:
             # Canonicalise (a slug may have been passed) and anchor the
             # worktree under the project's primary repo.

--- a/tests/hermes_cli/test_kanban_board_project.py
+++ b/tests/hermes_cli/test_kanban_board_project.py
@@ -85,3 +85,72 @@ def test_create_task_explicit_project_beats_board(fresh_home, tmp_path):
         assert kb.get_task(conn, tid).project_id == task_proj
     finally:
         conn.close()
+
+
+def test_non_director_profile_resolves_project_from_shared_board(fresh_home, tmp_path):
+    repo = tmp_path / "account-gen"
+    repo.mkdir()
+    kb.create_board(
+        "account-gen",
+        name="Account Gen",
+        default_workdir=str(repo),
+    )
+
+    conn = kb.connect(board="account-gen")
+    try:
+        tid = kb.create_task(
+            conn,
+            title="shared project",
+            board="account-gen",
+            project_id="account-gen",
+        )
+        task = kb.get_task(conn, tid)
+        assert task.project_id == "account-gen"
+        assert task.workspace_kind == "worktree"
+        assert task.workspace_path == str(repo / ".worktrees" / tid)
+        assert task.branch_name == f"account-gen/{tid}-shared-project"
+    finally:
+        conn.close()
+
+
+def test_unresolved_explicit_project_fails_without_creating_task(fresh_home):
+    kb.create_board("account-gen", name="Account Gen")
+    conn = kb.connect(board="account-gen")
+    try:
+        with pytest.raises(ValueError, match="project 'missing' was not found"):
+            kb.create_task(
+                conn,
+                title="must not silently drop",
+                board="account-gen",
+                project_id="missing",
+            )
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_explicit_worktree_and_branch_fallback_still_works(fresh_home, tmp_path):
+    repo = tmp_path / "account-gen"
+    repo.mkdir()
+    kb.create_board(
+        "account-gen",
+        name="Account Gen",
+        default_workdir=str(repo),
+    )
+
+    conn = kb.connect(board="account-gen")
+    try:
+        tid = kb.create_task(
+            conn,
+            title="fallback",
+            board="account-gen",
+            workspace_kind="worktree",
+            branch_name="account-gen/fallback",
+        )
+        task = kb.get_task(conn, tid)
+        assert task.project_id is None
+        assert task.workspace_kind == "worktree"
+        assert task.workspace_path == str(repo)
+        assert task.branch_name == "account-gen/fallback"
+    finally:
+        conn.close()

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -416,6 +416,72 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+@pytest.mark.parametrize("project_ref", ["id", "slug"])
+def test_create_explicit_worktree_recovers_parent_project(
+    monkeypatch, tmp_path, project_ref
+):
+    """A non-director worker can route a worktree child by project id or slug."""
+    from pathlib import Path as _Path
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import projects_db as pdb
+    from tools import kanban_tools as kt
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    repo = tmp_path / "account-gen"
+    repo.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "non-director")
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+
+    with pdb.connect_closing() as project_conn:
+        project_id = pdb.create_project(
+            project_conn,
+            name="Account Gen",
+            primary_path=str(repo),
+        )
+
+    conn = kb.connect()
+    try:
+        source_id = kb.create_task(
+            conn,
+            title="source",
+            assignee="non-director",
+            project_id=project_id,
+        )
+        kb.claim_task(conn, source_id)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", source_id)
+
+    # Simulate the non-director profile lacking this project registry row.
+    monkeypatch.setattr(pdb, "get_project", lambda _conn, _ref: None)
+    requested_project = project_id if project_ref == "id" else "account-gen"
+    out = json.loads(
+        kt._handle_create(
+            {
+                "title": f"child by {project_ref}",
+                "assignee": "peer",
+                "project": requested_project,
+                "workspace_kind": "worktree",
+            }
+        )
+    )
+    assert out["ok"] is True
+
+    conn = kb.connect()
+    try:
+        child = kb.get_task(conn, out["task_id"])
+        assert child.project_id == project_id
+        assert child.workspace_kind == "worktree"
+        assert child.workspace_path == str(repo / ".worktrees" / child.id)
+        assert child.branch_name == f"account-gen/{child.id}-child-by-{project_ref}"
+    finally:
+        conn.close()
+
+
 def test_link_happy_path(worker_env):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1426,12 +1426,16 @@ def _handle_create(args: dict, **kw) -> str:
             # A project link is safe to inherit because ``create_task`` turns
             # it into a fresh per-task worktree. Never inherit the parent's
             # literal workspace kind/path; directory sharing must be explicit.
-            if _inherit_project and project_id is None:
-                _self_tid = os.environ.get("HERMES_KANBAN_TASK")
-                if _self_tid:
-                    _self_task = kb.get_task(conn, _self_tid)
-                    if _self_task is not None and _self_task.project_id:
+            # The source-task hint is independent of workspace inheritance: it
+            # lets a non-director recover project identity even when the caller
+            # explicitly requests the mandatory fresh worktree shape.
+            _self_tid = os.environ.get("HERMES_KANBAN_TASK")
+            if _self_tid:
+                _self_task = kb.get_task(conn, _self_tid)
+                if _self_task is not None and _self_task.project_id:
+                    if _inherit_project and project_id is None:
                         project_id = _self_task.project_id
+                    if project_id is not None:
                         project_source_task_id = _self_task.id
             new_tid = kb.create_task(
                 conn,


### PR DESCRIPTION
Fixes explicit kanban project links being silently dropped for non-director workers. Resolves shared-board project metadata, fails closed on unresolved explicit references, keeps project recovery available with explicit worktree requests, and accepts canonical IDs or project slugs without sharing profile registries.\n\nVerification:\n- baseline regression failed for both ID and slug with project_id=None\n- 44 focused project/tool tests passed\n- all 72 tracked Kanban test files passed in isolated pytest processes\n- Ruff and git diff --check passed