### PR TITLE
fix(bot-mode): send @mention handoffs via query files

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5996,23 +5996,25 @@ function messagingProtocolSection(name, roster) {
     'You work alongside other named agents. Every agent (including you) has',
     'ONE canonical conversation titled "Bot Chat" — created with the agent,',
     'so it always exists. Agent-to-agent messages are delivered straight',
-    'into it, like a DM. To message a teammate, run:',
+    'into it, like a DM. To message a teammate, write the COMPLETE message',
+    'to a temporary file with the file tool FIRST — never inline message text',
+    'in a shell command. The file must open with the',
+    '"Message from \uD83E\uDD16 ' + handle + ' (@' + handle + '):" prefix. Then run:',
     '',
     '```',
-    'hermes -p <agent-name> chat --in ~ -c "Bot Chat" --create-if-missing -Q -q "Message from \uD83E\uDD16 ' + handle + ' (@' + handle + '): your message"',
-    '',
-    'Run the send with background=true and notify_on_complete=true on the',
-    'terminal tool, then finish your turn — the reply arrives later as a',
-    'background process notification. Never block waiting for it.',
+    'hermes -p <agent-name> chat --in ~ -c "Bot Chat" --create-if-missing -Q --query-file \'<message-file>\'',
     '```',
+    '',
+    'Use the exact file path from the file tool, shell-quoted as shown. Run the',
+    'send with background=true and notify_on_complete=true on the terminal',
+    'tool, then finish your turn — the reply arrives later as a background',
+    'process notification. Never block waiting for it.',
     '',
     '(`--in ~ -c "Bot Chat" --create-if-missing` resumes their canonical',
     'conversation in the home workspace, creating it if the target has no',
-    '"Bot Chat" yet. `-Q` keeps output clean. Always open with the',
-    '"Message from \uD83E\uDD16 ' + handle + ' (@' + handle + '):" prefix so they know',
-    'who is talking (the @handle lets the app show your avatar to them).',
-    'Their reply prints to stdout — relay the relevant part back to the',
-    'user, and say which agent it came from.)',
+    '"Bot Chat" yet. `-Q` keeps output clean. `--query-file` keeps the message',
+    'body out of shell parsing. Their reply prints to stdout — relay the',
+    'relevant part back to the user, and say which agent it came from.)',
     '',
     'If a message in YOUR chat starts with "Message from \uD83E\uDD16 <name>", it is',
     'a teammate messaging you, not the user. Answer it directly — your reply',
@@ -8549,13 +8551,6 @@ function normalizedProfileName(profile) {
 
 function shellQuote(value) {
   return `'${String(value).replaceAll("'", "'\"'\"'")}'`
-}
-
-/** Escape for interpolation INSIDE an existing double-quoted shell string:
- *  keeps ", `, $, and \ literal so free-text titles (which sync from ui_meta)
- *  and gateway profile names can't expand or break out of the quotes. */
-function shellDoubleQuote(value) {
-  return String(value).replace(/[\\"`$]/g, ch => '\\' + ch)
 }
 
 function routineInputError(title, instruction) {
@@ -11978,9 +11973,9 @@ export default {
           if (localMentions.length) {
             note +=
               '\n\n[@mention handoff — for each mentioned agent (' + localMentions.map(bot => botHandle(bot.name, bot)).join(', ') + '): ' +
-              'COMPOSE a message from you (' + senderName + ') to that agent conveying what the user wants — do not forward this text verbatim (avoid double quotes in your composed message). Send it with exactly one terminal call, run with background=true AND notify_on_complete=true (the recipient may take minutes; the user must not be blocked):\n' +
-              localMentions.map(bot => '`hermes -p ' + shellQuote(bot.name) + ' chat --in ~ -c "Bot Chat" --create-if-missing -Q -q "Message from 🤖 ' + shellDoubleQuote(senderName) + ' (@' + shellDoubleQuote(botHandle(live.name)) + '): <your composed message>"`').join('\n') +
-              '\nAfter dispatching, tell the user the message was sent and END YOUR TURN — do not wait or poll; when the background process completes, its notification carries the reply — relay it then, attributed to that agent. ' +
+              'COMPOSE a message from you (' + senderName + ') to that agent conveying what the user wants — do not forward this text verbatim. Write the COMPLETE message to a temporary file with the file tool FIRST; never inline the message body in a shell command. The file must begin with "Message from 🤖 ' + senderName + ' (@' + botHandle(live.name) + '):". Then send it with exactly one terminal call, run with background=true AND notify_on_complete=true (the recipient may take minutes; the user must not be blocked):\n' +
+              localMentions.map(bot => '`hermes -p ' + shellQuote(bot.name) + ' chat --in ~ -c "Bot Chat" --create-if-missing -Q --query-file ' + shellQuote(`<message-file-for-${botHandle(bot.name, bot)}>`) + '`').join('\n') +
+              '\nUse the exact file path from the file tool in place of the shell-quoted placeholder. After dispatching, tell the user the message was sent and END YOUR TURN — do not wait or poll; when the background process completes, its notification carries the reply — relay it then, attributed to that agent. ' +
               'Relay the reply back to the user, attributed to that agent.]'
           }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/mention-handoff-quoting.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/mention-handoff-quoting.test.mjs
@@ -95,10 +95,8 @@ test('security: a poisoned bot title stays literal in the handoff command', asyn
 
   const args = runHandoffCommand(result.text)
   assert.equal(args[args.indexOf('-p') + 1], 'ops')
-  assert.equal(
-    args[args.indexOf('-q') + 1],
-    `Message from \uD83E\uDD16 ${title} (@research): <your composed message>`
-  )
+  assert.equal(args[args.indexOf('--query-file') + 1], '<message-file-for-ops>')
+  assert.ok(result.text.includes(`Message from \uD83E\uDD16 ${title} (@research):`))
   assert.equal(existsSync(quoteSentinel), false)
   assert.equal(existsSync(subSentinel), false)
 })
@@ -113,10 +111,13 @@ test('security: a hostile active profile name stays literal in the handoff comma
 
   const args = runHandoffCommand(result.text)
   // displayName title-cases word boundaries inside the name — the shell
-  // metacharacters survive that transform, so they must arrive escaped.
-  assert.equal(
-    args[args.indexOf('-q') + 1],
-    `Message from \uD83E\uDD16 Res$(Touch /Tmp/Hbmmention${process.pid})Earch (@${activeProfile}): <your composed message>`
+  // metacharacters survive that transform, but they stay in file-content
+  // instructions and never enter the command's argv.
+  assert.equal(args[args.indexOf('--query-file') + 1], '<message-file-for-ops>')
+  assert.ok(
+    result.text.includes(
+      `Message from \uD83E\uDD16 Res$(Touch /Tmp/Hbmmention${process.pid})Earch (@${activeProfile}):`
+    )
   )
   assert.equal(existsSync(sentinel), false)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/mention-handoff-quoting.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/mention-handoff-quoting.test.mjs
@@ -57,7 +57,7 @@ function load({
     .replace(/^import .* from 'react'\r?\n/m, '')
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
-    .concat('\nglobalThis.__mention = { $botMeta };\n')
+    .concat('\nglobalThis.__mention = { $botMeta, messagingProtocolSection };\n')
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   context.__mention.$botMeta.set(title ? { [activeProfile]: { title } } : {})
 
@@ -65,7 +65,10 @@ function load({
   context.plugin.register({ storage: { get: () => null }, register: entry => registered.push(entry) })
   const middleware = registered.find(entry => entry.id === 'mention-middleware')
   assert.ok(middleware, 'mention middleware did not register')
-  return { handler: middleware.data.handler }
+  return {
+    handler: middleware.data.handler,
+    messagingProtocolSection: context.__mention.messagingProtocolSection
+  }
 }
 
 /** Run the note's first hermes command under a stub that echoes each argv
@@ -122,6 +125,24 @@ test('regression: the handoff command quotes the recipient argument', async () =
   const { handler } = load()
   const result = await handler({ text: 'ping @ops please' })
   assert.match(result.text, /`hermes -p 'ops' chat --in ~/)
+})
+
+test('security: composer handoff writes the message with the file tool and sends via --query-file', async () => {
+  const { handler } = load()
+  const result = await handler({ text: 'ask @ops to review code containing "quotes", `ticks`, and $(substitution)' })
+
+  assert.match(result.text, /file tool FIRST/i)
+  assert.match(result.text, /--query-file/)
+  assert.doesNotMatch(result.text, /\s-q\s/)
+})
+
+test('security: Bot SOUL messaging protocol never puts arbitrary text in -q', () => {
+  const { messagingProtocolSection } = load()
+  const section = messagingProtocolSection('research', [{ name: 'research' }, { name: 'ops' }])
+
+  assert.match(section, /file tool FIRST/i)
+  assert.match(section, /--query-file/)
+  assert.doesNotMatch(section, /\s-q\s/)
 })
 
 test('behavior: a renamed default profile routes from another focused Bot Chat', async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes Bot Mode's local bot-to-bot `@mention` handoff so arbitrary composed messages never enter shell parsing.

The Desktop protocol and composer middleware still embedded the message body in `-q "..."`. Quotes could truncate the message, while backticks or `$()` could be interpreted by the sender's shell. Both paths now require the agent to write the complete attributed message with the file tool first, then pass that exact, shell-quoted path to `hermes ... --query-file`.

The path is intentionally supplied by the file tool rather than hard-coded to `/tmp/dm.txt`: this keeps the handoff valid on Windows and prevents concurrent or multi-recipient handoffs from overwriting one shared file.

## Related Issue

Fixes #91105

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js`
  - Update `messagingProtocolSection` to require file-tool-first delivery through `--query-file`.
  - Update local composer `@mention` handoff instructions to use a distinct file-tool path for each recipient.
  - Preserve recipient quoting, canonical `Bot Chat`, `--in ~`, `--create-if-missing`, `-Q`, and background notification behavior.
  - Remove the obsolete inline-double-quote escape helper.
- `apps/desktop/src/plugins/hermes-bots/tests/mention-handoff-quoting.test.mjs`
  - Add contracts for both protocol surfaces.
  - Keep executable hostile title/profile and recipient-quoting regression coverage.

## How to Test

1. In Desktop Bot Mode, create two local bots (`Sender` and `Reviewer`).
2. From Sender's Bot Chat, `@reviewer` with a message containing double quotes, single quotes, backticks, and `$()`.
3. Verify Sender writes the complete attributed message through the file tool, candidate CLI exits 0 using `--query-file`, Reviewer receives the exact bytes, and the shell-substitution sentinel is not created.

Automated verification on Windows 11, final SHA `adc3a361b4d28a9b4df8f60ac1bdf526ed6bf265`:

```text
node --test apps/desktop/src/plugins/hermes-bots/tests/mention-handoff-quoting.test.mjs
7 passed

npm run check:test:plugins
378 passed

npm run typecheck
passed

npm run build
passed

pytest tests/hermes_cli/test_chat_query_file.py -q
4 passed

npx playwright test e2e/mock-backend-setup.spec.ts --reporter=list
4 passed

npx playwright test e2e/bot-mention-query-file.spec.ts --reporter=list
1 passed — real Electron → middleware → file tool → background terminal → candidate CLI → Reviewer backend
```

The feature E2E used a temporary deterministic mock-inference script to issue real `write_file` and `terminal` tool calls; that harness was removed after verification and is not part of this PR. It ran on pre-rebase SHA `b26473dd1`, whose production patch has the same stable patch-id (`5424a1c544b3cdf732dc216980b775607ff3d1c0`) as final SHA `adc3a361b`; after rebasing the unrelated upstream session-edit fix, focused tests, all plugin tests, typecheck, and production build were rerun on the final SHA.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

Duplicate check note: #91304 appeared after this work started. It currently includes an unrelated #89316 commit/files and a stale, much broader Desktop diff; it also hard-codes `/tmp/dm.txt`. This branch is rebased on current `main`, changes only the two #91105 files, and uses the exact path returned by the file tool for cross-platform and concurrent handoffs.

Full Python `pytest tests/ -q` was not run because this is a Desktop plugin-only change. The focused CLI `--query-file` suite and all Desktop plugin/type/build/Electron gates above passed.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no public API or configuration changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — uses the file tool's exact path rather than `/tmp`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The Electron E2E verified the complete attributed payload reached Reviewer byte-for-byte and that the `$()` sentinel did not execute. No UI screenshots are needed for this transport-only fix.
