### PR TITLE
fix(desktop): resolve remote @mentions from the connection-scoped roster cache

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -84,6 +84,27 @@ const createBudgetedLoop = typeof sdk === 'undefined' ? undefined : sdk.createBu
 
 const ID = 'hermes-bots'
 const ROSTER_KEY = [ID, 'roster']
+
+/** Roster snapshots are stored per active connection — useRoster keys them
+ *  [ID, 'roster', connectionId]. TanStack matches query keys EXACTLY, so
+ *  getQueryData([ID, 'roster']) always misses and the @-mention middleware /
+ *  completions silently degraded to the active gateway's local-only
+ *  profiles.list fallback — bots on other Connections could never be
+ *  @-mentioned (remoteSource rows were unreachable). Read across the
+ *  connection-scoped snapshots and take the freshest. */
+function cachedRoster() {
+  if (typeof queryClient === 'undefined' || !queryClient || typeof queryClient.getQueriesData !== 'function') {
+    return null
+  }
+
+  return (
+    queryClient
+      .getQueriesData({ queryKey: ROSTER_KEY })
+      .map(([, data]) => data)
+      .filter(data => data && Array.isArray(data.profiles))
+      .sort((a, b) => (b?.fetchedAt || 0) - (a?.fetchedAt || 0))[0] || null
+  )
+}
 const ROUTINES_KEY = [ID, 'routines']
 const NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
 
@@ -10501,7 +10522,7 @@ export default {
       area: COMPOSER_AREAS.atCompletions,
       data: {
         provide: query => {
-          const roster = queryClient.getQueryData(ROSTER_KEY)
+          const roster = cachedRoster()
           const profiles = Array.isArray(roster?.profiles) ? roster.profiles : []
 
           if (!profiles.length) {
@@ -10811,9 +10832,7 @@ export default {
             name: (host.state.profile.get() || 'default').trim() || 'default',
             connectionId: String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local')
           }
-          const cached = typeof queryClient !== 'undefined' && queryClient && typeof queryClient.getQueryData === 'function'
-            ? queryClient.getQueryData(ROSTER_KEY)
-            : null
+          const cached = cachedRoster()
           const roster = Array.isArray(cached?.profiles) ? cached.profiles : null
           let mentionedBots = roster ? resolveRosterMentions(text, roster, live) : []
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/mention-completions.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/mention-completions.test.mjs
@@ -39,6 +39,9 @@ function loadProvide({ roster, active = 'default', meta = {} } = {}) {
     document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
     queryClient: {
       getQueryData: () => roster,
+      // Roster snapshots live under connection-scoped keys ([ID,'roster',conn]);
+      // the middleware/completions read them via prefix-matching getQueriesData.
+      getQueriesData: () => [[['hermes-bots', 'roster', 'local'], roster]],
       invalidateQueries: () => undefined,
       setQueryData: () => undefined
     },

--- a/apps/desktop/src/plugins/hermes-bots/tests/mention-handoff-quoting.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/mention-handoff-quoting.test.mjs
@@ -124,18 +124,30 @@ test('behavior: @dixie on a Connections bot stays in this chat and does not herm
     PALETTE_AREA: 'palette',
     COMPOSER_AREAS: { middleware: 'middleware' },
     queryClient: {
-      getQueryData: () => ({
-        profiles: [
-          { name: 'default', connectionId: 'local' },
+      // REAL TanStack semantics (regression for the shipped bug): useRoster
+      // stores snapshots under connection-scoped keys ([ID,'roster',conn]) and
+      // getQueryData matches keys EXACTLY — so the bare [ID,'roster'] read the
+      // middleware used to make always missed, and Connections bots (dixie
+      // here) could never be @-mentioned. cachedRoster() must read via the
+      // prefix-matching getQueriesData instead.
+      getQueryData: () => undefined,
+      getQueriesData: () => [
+        [
+          ['hermes-bots', 'roster', 'local'],
           {
-            name: 'dixie',
-            connectionId: 'mac-mini',
-            connectionLabel: 'Mac Mini',
-            handle: 'dixie',
-            remoteSource: true
+            profiles: [
+              { name: 'default', connectionId: 'local' },
+              {
+                name: 'dixie',
+                connectionId: 'mac-mini',
+                connectionLabel: 'Mac Mini',
+                handle: 'dixie',
+                remoteSource: true
+              }
+            ]
           }
         ]
-      })
+      ]
     },
     document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
     host: {

--- a/apps/desktop/src/plugins/hermes-bots/tests/mention-renamed-bots.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/mention-renamed-bots.test.mjs
@@ -144,7 +144,14 @@ test('composer autocomplete offers the renamed tag and matches on the display na
       removeEventListener: () => undefined
     },
     document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
-    queryClient: { getQueryData: () => roster, invalidateQueries: () => undefined, setQueryData: () => undefined },
+    queryClient: {
+      getQueryData: () => roster,
+      // Roster snapshots live under connection-scoped keys ([ID,'roster',conn]);
+      // the middleware reads them via prefix-matching getQueriesData.
+      getQueriesData: () => [[['hermes-bots', 'roster', 'local'], roster]],
+      invalidateQueries: () => undefined,
+      setQueryData: () => undefined
+    },
     host: {
       state: { profile: { get: () => 'default', listen: () => () => undefined }, gateway: { get: () => null, listen: () => () => undefined } },
       request: async () => ({}),


### PR DESCRIPTION
## Summary

Fixes a bug where @-mentioning a bot on another **Connection** from the desktop app (e.g. `@crabia`) did nothing — the message passed through as plain text, even though the bot appeared in the sidebar roster.

**Root cause:** `useRoster` stores roster snapshots under the connection-scoped key `['hermes-bots', 'roster', connectionId]`, but the @mention middleware and the @-completions provider read the cache with the bare `['hermes-bots', 'roster']` key. TanStack React Query matches query keys **exactly**, so the read always missed and both paths silently fell back to the active gateway's `profiles.list` — which only contains **local** profiles. Remote bots were therefore unreachable via @mention, and the middleware never appended its delivery note.

**Fix:** new `cachedRoster()` helper reads across connection-scoped snapshots with `getQueriesData` (prefix match) and returns the freshest one. Used in both the mention middleware and the @-completions provider.

## Tests

- `341/341` plugin tests pass: `node --test src/plugins/*/tests/*.test.mjs`
- `mention-handoff-quoting.test.mjs`: its `queryClient` stub now mirrors **real TanStack semantics** (`getQueryData` on the bare key returns `undefined`, `getQueriesData` returns the connection-scoped snapshot). The existing remote-mention test (`@dixie` over Connections) **fails without this fix and passes with it** — regression coverage.
- `mention-completions` / `mention-renamed-bots`: stubs updated for the new read path.

## Behavior change

`@<remote-bot> …` in any chat now resolves and delivers over Connections (with the existing "stay on this device" note) instead of passing through untouched.