### PR TITLE
fix(models): add Ox Alpha to OpenRouter catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -133,6 +133,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # OpenRouter routers
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
     # Free tier
+    ("stealth/ox-alpha",                       "free"),
     ("openrouter/elephant-alpha",              "free"),
     ("poolside/laguna-m.1:free",               "free"),
     ("tencent/hy3:free",                       "free"),

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-17T19:11:38Z",
+  "updated_at": "2026-08-21T06:14:06Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -152,6 +152,10 @@
         {
           "id": "openrouter/pareto-code",
           "description": "auto-routes to cheapest coder meeting openrouter.min_coding_score"
+        },
+        {
+          "id": "stealth/ox-alpha",
+          "description": "free"
         },
         {
           "id": "openrouter/elephant-alpha",


### PR DESCRIPTION
## Summary
- add `stealth/ox-alpha` to the curated OpenRouter free-tier list
- regenerate the published remote model catalog so Hermes Desktop and `/model` can discover it

## Verification
- `python -m pytest tests/hermes_cli/test_model_catalog.py tests/hermes_cli/test_models.py -q`
- 98 passed
- live Hermes smoke test through OpenRouter returned `HERMES_OPENROUTER_OX_OK`