### PR TITLE
fix(profiles): stop isolated dashboards from enabling cross-profile prompt injection

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11503,6 +11503,12 @@ def cmd_dashboard(args):
         open_browser=not args.no_open,
         allow_public=getattr(args, "insecure", False),
         initial_profile=getattr(args, "open_profile", "") or "",
+        isolated_profile=(
+            _launch_profile
+            if getattr(args, "isolated", False)
+            and _launch_profile not in ("default", "custom")
+            else ""
+        ),
         headless=_headless_backend,
         ssh_session_token=_ssh_session_token,
         ssh_owner_nonce=_ssh_owner_nonce,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14663,11 +14663,23 @@ def _resolve_profile_dir(name: str) -> Path:
     from hermes_cli import profiles as profiles_mod
     try:
         profiles_mod.validate_profile_name(name)
+        canonical = profiles_mod.normalize_profile_name(name)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
-    if not profiles_mod.profile_exists(name):
+
+    isolated_profile = getattr(app.state, "isolated_profile", "")
+    if isolated_profile and canonical != isolated_profile:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"This server is isolated to profile '{isolated_profile}'; "
+                f"profile '{canonical}' is not accessible."
+            ),
+        )
+
+    if not profiles_mod.profile_exists(canonical):
         raise HTTPException(status_code=404, detail=f"Profile '{name}' does not exist.")
-    return profiles_mod.get_profile_dir(name)
+    return profiles_mod.get_profile_dir(canonical)
 
 
 def _profile_setup_command(name: str) -> str:
@@ -18851,6 +18863,7 @@ def start_server(
     open_browser: bool = True,
     allow_public: bool = False,
     initial_profile: str = "",
+    isolated_profile: str = "",
     headless: bool = False,
     ssh_session_token: Optional[str] = None,
     ssh_owner_nonce: Optional[str] = None,
@@ -18862,6 +18875,10 @@ def start_server(
     — used when a profile alias (``<profile> dashboard``) routes to the
     machine dashboard.
 
+    ``isolated_profile`` confines explicit profile-targeted API requests to the
+    named profile selected by ``--isolated``. The normal machine dashboard
+    passes an empty value and retains cross-profile management.
+
     ``headless`` is the ``serve`` path: the JSON-RPC/WS backend with no UI
     build and no SPA mount (mount_spa() honours ``HERMES_SERVE_HEADLESS``), so
     the banner announces the bind rather than a browser URL.
@@ -18871,6 +18888,7 @@ def start_server(
     """
     _apply_ssh_session_token(ssh_session_token or "")
     _apply_ssh_owner_nonce(ssh_owner_nonce)
+    app.state.isolated_profile = isolated_profile
 
     # Raise RLIMIT_NOFILE for dashboard-mode starts that don't route through
     # the `serve` path in main.py (which applies the same floor). Canonical

--- a/tests/hermes_cli/test_dashboard_web_dist_validation.py
+++ b/tests/hermes_cli/test_dashboard_web_dist_validation.py
@@ -28,6 +28,7 @@ def _args(**over):
         "no_open": True,
         "open_profile": None,
         "skip_build": False,
+        "isolated": False,
         "headless_backend": False,
         "tui": False,
     }
@@ -129,8 +130,35 @@ def test_skip_build_missing_dist_attempts_one_recovery_build(
     assert len(builds) == 1  # exactly ONE recovery build
     assert builds[0][0] == project_root / "web"
     assert len(started) == 1
+    assert started[0]["isolated_profile"] == ""
     out = capsys.readouterr().out
     assert "recovery build" in out.lower()
+
+
+def test_isolated_named_profile_is_forwarded_to_server(
+    main_mod, monkeypatch, tmp_path
+):
+    """The launch flag must become an API authorization scope, not just skip re-exec."""
+    _wire_common(main_mod, monkeypatch)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "alice"
+    )
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("<html></html>", encoding="utf-8")
+    monkeypatch.setenv("HERMES_WEB_DIST", str(dist))
+
+    started = []
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.web_server",
+        types.SimpleNamespace(start_server=lambda **k: started.append(k)),
+    )
+
+    main_mod.cmd_dashboard(_args(isolated=True))
+
+    assert len(started) == 1
+    assert started[0]["isolated_profile"] == "alice"
 
 
 

--- a/tests/hermes_cli/test_web_profile_soul_writes.py
+++ b/tests/hermes_cli/test_web_profile_soul_writes.py
@@ -32,9 +32,11 @@ def client(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "soul-test-token")
     from hermes_cli import web_server
 
+    web_server.app.state.isolated_profile = ""
     with TestClient(web_server.app, raise_server_exceptions=False) as c:
         c.headers["Authorization"] = "Bearer soul-test-token"
         yield c
+    web_server.app.state.isolated_profile = ""
 
 
 @pytest.fixture()
@@ -49,6 +51,38 @@ def profile_dir(tmp_path, monkeypatch) -> Path:
 
 
 class TestSoulWriteDurability:
+    def test_isolated_dashboard_rejects_cross_profile_access(
+        self, client, profile_dir: Path
+    ):
+        """An isolated profile server must not accept another profile in the URL."""
+        from hermes_cli import profiles as profiles_mod
+        from hermes_cli import web_server
+
+        other_dir = profiles_mod.get_profile_dir("other")
+        other_dir.mkdir(parents=True)
+        other_soul = other_dir / "SOUL.md"
+        other_soul.write_text("# Other\n", encoding="utf-8")
+        (profile_dir / "SOUL.md").write_text(SOUL, encoding="utf-8")
+        web_server.app.state.isolated_profile = "demo"
+
+        read = client.get("/api/profiles/other/soul")
+        write = client.put(
+            "/api/profiles/other/soul", json={"content": "# Clobbered\n"}
+        )
+
+        assert read.status_code == 403, read.text
+        assert write.status_code == 403, write.text
+        assert other_soul.read_text(encoding="utf-8") == "# Other\n"
+
+        own_read = client.get("/api/profiles/demo/soul")
+        own_write = client.put(
+            "/api/profiles/demo/soul", json={"content": "# Updated\n"}
+        )
+        assert own_read.status_code == 200, own_read.text
+        assert own_read.json()["content"] == SOUL
+        assert own_write.status_code == 200, own_write.text
+        assert (profile_dir / "SOUL.md").read_text(encoding="utf-8") == "# Updated\n"
+
     def test_put_replaces_soul(self, client, profile_dir: Path):
         """Happy path: the editor's Save still works."""
         (profile_dir / "SOUL.md").write_text(SOUL, encoding="utf-8")


### PR DESCRIPTION
## What does this PR do?

Hermes dashboards started with a named profile and `--isolated` currently accept profile-targeted SOUL API requests for every profile on the machine. That lets an authenticated Desktop client connected to an isolated dashboard read or overwrite another profile's instructions, creating a cross-profile data exposure and prompt-injection path. This change carries the isolated launch scope into the web server and rejects mismatched profile targets before filesystem resolution, while preserving normal cross-profile management in non-isolated dashboards.

### Symptom

Starting `hermes dashboard -p alice --isolated` still allows requests such as `GET /api/profiles/bob/soul` and `PUT /api/profiles/bob/soul`. Before this fix, those requests read and changed Bob's `SOUL.md` even though the server was launched for Alice.

### Impact

Any authenticated client connected to a named isolated dashboard can cross the intended profile boundary for profile-targeted SOUL reads and writes. A write can alter another profile's persistent agent instructions; a read exposes those instructions. The broader blast radius beyond this endpoint is unknown.

### Bug Cause

**Trigger:** `hermes_cli/web_server.py:_resolve_profile_dir` when a client supplies a profile name to a profile-targeted API.

**Causal chain:**
1. A named dashboard starts with `--isolated`, which skips the unified machine-dashboard re-exec.
2. The launch scope is not forwarded to `start_server`, so `_resolve_profile_dir` validates the requested name only against the machine-wide profile root.
3. A request naming another existing profile resolves that profile's directory and the SOUL endpoint reads or writes its file.

**Why it is wrong:** `--isolated` changes process launch behavior but previously did not establish an authorization boundary for client-supplied profile targets.

**Working sibling / contrast:** A normal non-isolated machine dashboard intentionally manages multiple profiles and must continue resolving explicit profile targets across the machine profile root.

**Ruled out:** Desktop rendering is not the source of the authorization failure. The same cross-profile access is reproducible directly against the FastAPI endpoints, so the boundary must be enforced by the backend.

### Fix

Forward the canonical named launch profile into `start_server` for isolated dashboards, store it as server state, and return HTTP 403 when `_resolve_profile_dir` receives a different canonical profile. Empty scope remains the default for non-isolated dashboards. Regression coverage verifies denied cross-profile GET and PUT requests do not mutate the target, own-profile access still works, and CLI launch propagation preserves unrestricted non-isolated behavior.

## Related Issue

Closes #91330

## Type of Change

- [x] Security fix

## Changes Made

- `hermes_cli/main.py` - forward the named isolated launch profile into the dashboard server.
- `hermes_cli/web_server.py` - enforce the isolated profile boundary before profile existence and filesystem resolution.
- `tests/hermes_cli/test_web_profile_soul_writes.py` - cover denied cross-profile reads and writes, target immutability, and allowed own-profile access.
- `tests/hermes_cli/test_dashboard_web_dist_validation.py` - cover isolated and non-isolated launch-scope propagation.

## How to Test

1. Start a dashboard for a named profile with `--isolated`.
2. Request another profile's SOUL endpoint and verify both GET and PUT return HTTP 403 without changing the target file.
3. Request the isolated profile's SOUL endpoint and verify GET and PUT still succeed.
4. Run the focused automated tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_web_profile_soul_writes.py -q
scripts/run_tests.sh tests/hermes_cli/test_dashboard_web_dist_validation.py -q
```

Verified locally: 7 passed, 2 skipped, 0 failed across the two focused files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant test files and all focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A because this restores the documented `--isolated` boundary
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; the authorization logic is platform-independent
- [x] Tool description and schema updates are N/A because no model tool behavior changed
