### PR TITLE
fix(teams-pipeline): parse Graph users('id') transcript webhooks

### DIFF
--- a/plugins/teams_pipeline/meetings.py
+++ b/plugins/teams_pipeline/meetings.py
@@ -13,8 +13,9 @@ from urllib.parse import quote, unquote
 from plugins.teams_pipeline.models import MeetingArtifact, TeamsMeetingRef
 from tools.microsoft_graph_client import MicrosoftGraphAPIError, MicrosoftGraphClient
 
+# Graph uses both slash keys (users/{id}/...) and quoted keys (users('{id}')/...).
 _USERS_MEETING_RE = re.compile(
-    r"(?i)(?:^|/)users/([^/]+)/onlineMeetings(?:\('([^']+)'\)|/([^/'?]+))"
+    r"(?i)(?:^|/)users(?:\('([^']+)'\)|/([^/'()]+))/onlineMeetings(?:\('([^']+)'\)|/([^/'?]+))"
 )
 _COMM_MEETING_RE = re.compile(
     r"(?i)(?:^|/)communications/onlineMeetings(?:\('([^']+)'\)|/([^/'?]+))"
@@ -58,8 +59,8 @@ def parse_graph_meeting_resource(resource: str) -> dict[str, str | None]:
 
     users_match = _USERS_MEETING_RE.search(text)
     if users_match:
-        organizer_user_id = unquote(users_match.group(1) or "").strip() or None
-        meeting_id = unquote(users_match.group(2) or users_match.group(3) or "").strip() or None
+        organizer_user_id = unquote(users_match.group(1) or users_match.group(2) or "").strip() or None
+        meeting_id = unquote(users_match.group(3) or users_match.group(4) or "").strip() or None
 
     if not meeting_id:
         comm_match = _COMM_MEETING_RE.search(text)

--- a/plugins/teams_pipeline/pipeline.py
+++ b/plugins/teams_pipeline/pipeline.py
@@ -340,12 +340,20 @@ class TeamsMeetingPipeline:
         try:
             job = self._persist_job(job, status="resolving_meeting")
             notification = meeting_ref.metadata.get("notification") if isinstance(meeting_ref.metadata, dict) else {}
+            meeting_id = meeting_ref.meeting_id
+            organizer_user_id = meeting_ref.organizer_user_id
+            if isinstance(notification, dict) and notification:
+                parsed_id, parsed_org, _extra = _meeting_ids_from_notification(notification)
+                if parsed_org:
+                    organizer_user_id = organizer_user_id or parsed_org
+                if parsed_id and not looks_like_transcript_id(parsed_id):
+                    meeting_id = parsed_id
             resolved_meeting = await resolve_meeting_reference(
                 self.graph_client,
-                meeting_id=meeting_ref.meeting_id,
+                meeting_id=meeting_id,
                 join_web_url=meeting_ref.join_web_url or meeting_ref.metadata.get("join_web_url"),
                 tenant_id=meeting_ref.tenant_id,
-                organizer_user_id=meeting_ref.organizer_user_id,
+                organizer_user_id=organizer_user_id,
             )
             if meeting_ref.metadata:
                 resolved_meeting.metadata = {**meeting_ref.metadata, **resolved_meeting.metadata}

--- a/tests/plugins/test_teams_pipeline_plugin.py
+++ b/tests/plugins/test_teams_pipeline_plugin.py
@@ -444,6 +444,28 @@ def test_parse_graph_meeting_resource_reads_quoted_users_transcript_path():
     assert parsed["recording_id"] is None
 
 
+def test_parse_graph_meeting_resource_reads_quoted_user_key_odata_id():
+    parsed = parse_graph_meeting_resource(
+        "users('org-1')/onlineMeetings('MSo-meeting')/transcripts('ktViz-transcript-TranscriptV2=')"
+    )
+
+    assert parsed["organizer_user_id"] == "org-1"
+    assert parsed["meeting_id"] == "MSo-meeting"
+    assert parsed["transcript_id"] == "ktViz-transcript-TranscriptV2="
+    assert parsed["recording_id"] is None
+
+
+def test_parse_graph_meeting_resource_reads_graph_url_quoted_user_key():
+    parsed = parse_graph_meeting_resource(
+        "https://graph.microsoft.com/v1.0/users('org-1')/onlineMeetings('MSo-meeting')"
+        "/transcripts('tx-1')"
+    )
+
+    assert parsed["organizer_user_id"] == "org-1"
+    assert parsed["meeting_id"] == "MSo-meeting"
+    assert parsed["transcript_id"] == "tx-1"
+
+
 def test_parse_graph_meeting_resource_ignores_get_all_transcripts_sentinel():
     parsed = parse_graph_meeting_resource("communications/onlineMeetings/getAllTranscripts")
 
@@ -506,6 +528,106 @@ def test_create_job_from_get_all_transcripts_uses_meeting_id_not_transcript_id(t
     assert job.meeting_ref.organizer_user_id == "976f4b31-fd01-4e0b-9178-29cc40c14438"
     assert job.meeting_ref.meeting_id != transcript_id
     assert job.meeting_ref.metadata.get("transcript_id") == transcript_id
+
+
+def test_create_job_from_quoted_user_odata_id_uses_meeting_id_not_transcript_id(tmp_path):
+    store = TeamsPipelineStore(tmp_path / "teams-store.json")
+    pipeline = TeamsMeetingPipeline(graph_client=FakeGraphClient(), store=store)
+    transcript_id = "ktVizInGAAAAi_B6lATZRTE5Om1lZXRpbmdfTranscriptV2="
+
+    job = pipeline.create_job_from_notification(
+        {
+            "id": "notif-quoted-user",
+            "changeType": "created",
+            "resource": "communications/onlineMeetings/getAllTranscripts",
+            "resourceData": {
+                "id": transcript_id,
+                "@odata.type": "#Microsoft.Graph.callTranscript",
+                "@odata.id": (
+                    "users('976f4b31-fd01-4e0b-9178-29cc40c14438')"
+                    f"/onlineMeetings('MSo-meeting-id')/transcripts('{transcript_id}')"
+                ),
+            },
+            "tenantId": "tenant-1",
+        }
+    )
+
+    assert job.meeting_ref is not None
+    assert job.meeting_ref.meeting_id == "MSo-meeting-id"
+    assert job.meeting_ref.organizer_user_id == "976f4b31-fd01-4e0b-9178-29cc40c14438"
+    assert job.meeting_ref.meeting_id != transcript_id
+    assert job.meeting_ref.metadata.get("transcript_id") == transcript_id
+
+
+@pytest.mark.anyio
+async def test_run_job_reparses_quoted_user_odata_id_when_stored_meeting_id_is_transcript(
+    tmp_path, monkeypatch
+):
+    from plugins.teams_pipeline import pipeline as pipeline_module
+    from plugins.teams_pipeline.models import TeamsMeetingRef
+
+    captured: dict[str, str | None] = {}
+
+    async def _resolve(client, *, meeting_id=None, join_web_url=None, tenant_id=None, organizer_user_id=None):
+        captured["meeting_id"] = meeting_id
+        captured["organizer_user_id"] = organizer_user_id
+        return TeamsMeetingRef(
+            meeting_id=str(meeting_id),
+            organizer_user_id=organizer_user_id,
+            tenant_id=tenant_id,
+            metadata={"subject": "Standup"},
+        )
+
+    async def _fetch_transcript(client, meeting_ref):
+        return (
+            MeetingArtifact(artifact_type="transcript", artifact_id="tx-1", display_name="meeting.vtt"),
+            "Decision: Re-parse stored Graph notifications on replay.\nAction: Confirm the meeting id is used.",
+        )
+
+    async def _summarize(**kwargs):
+        return pipeline_module.TeamsMeetingSummaryPayload(
+            meeting_ref=kwargs["resolved_meeting"],
+            title="Standup",
+            transcript_text=kwargs["transcript_text"],
+            summary="Reparsed",
+            source_artifacts=kwargs["artifacts"],
+        )
+
+    monkeypatch.setattr(pipeline_module, "resolve_meeting_reference", _resolve)
+    monkeypatch.setattr(pipeline_module, "fetch_preferred_transcript_text", _fetch_transcript)
+    monkeypatch.setattr(pipeline_module, "enrich_meeting_with_call_record", _no_call_record)
+
+    store = TeamsPipelineStore(tmp_path / "teams-store.json")
+    pipeline = TeamsMeetingPipeline(
+        graph_client=FakeGraphClient(),
+        store=store,
+        config={"transcript_min_chars": 20},
+        summarize_fn=_summarize,
+    )
+    transcript_id = "ktVizInGAAAAi_B6lATZRTE5Om1lZXRpbmdfTranscriptV2="
+    notification = {
+        "id": "notif-replay",
+        "changeType": "created",
+        "resource": "communications/onlineMeetings/getAllTranscripts",
+        "resourceData": {
+            "id": transcript_id,
+            "@odata.type": "#Microsoft.Graph.callTranscript",
+            "@odata.id": (
+                "users('org-1')/onlineMeetings('MSo-from-odata')/transcripts("
+                f"'{transcript_id}')"
+            ),
+        },
+    }
+    job = pipeline.create_job_from_notification(notification)
+    assert job.meeting_ref is not None
+    job.meeting_ref.meeting_id = transcript_id
+    store.upsert_job(job.job_id, job.to_dict())
+
+    ran = await pipeline.run_job(job.job_id)
+
+    assert captured["meeting_id"] == "MSo-from-odata"
+    assert captured["organizer_user_id"] == "org-1"
+    assert ran.status == "completed"
 
 
 def test_create_job_from_users_resource_path_without_odata_id(tmp_path):


### PR DESCRIPTION
## Summary
Teams pipeline Graph webhooks that use the quoted-user `@odata.id` shape (`users('id')/onlineMeetings('meetingId')/transcripts('transcriptId')`) now parse correctly, and jobs created before the fix recover on replay.

Follow-up to #89382 (salvage of #89285): that change stopped the Graph 400 and parsed slash-form paths; quoted-user keys were still missed.

## Changes
- `plugins/teams_pipeline/meetings.py`: `_USERS_MEETING_RE` regex widened to accept both `users('id')` and `users/id` forms. Group indices shifted to (1,2,3,4) where 1or2=organizer, 3or4=meeting.
- `plugins/teams_pipeline/pipeline.py`: `run_job()` re-parses stored notification via `_meeting_ids_from_notification()` before calling `resolve_meeting_reference()`, guarded by `looks_like_transcript_id()` — replaces stale transcript-id-as-meeting-id with the correctly parsed meeting_id.
- `tests/plugins/test_teams_pipeline_plugin.py`: 4 new tests covering quoted-user @odata.id parsing, full Graph URL, create_job with quoted @odata.id, and run_job replay recovery.

## Validation
| | Before | After |
|---|---|---|
| Quoted-user `@odata.id` parsing | Not matched → transcript id stored as meeting_id → "Refusing to GET" error | Correctly parsed meeting_id + organizer |
| Jobs created before fix (replay) | Permanent failure (transcript id as meeting_id) | Re-parsed on run, recovers correct meeting_id |
| Slash-form backward compat | Works | Works (unchanged) |
| Tests | 17 in file | 21 in file (all pass) |

Closes #90861.

Credit: @xxxigm original fix, cherry-picked with authorship preserved.
