### PR TITLE
fix(tools): harden Windows self-repo path guards

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1,6 +1,7 @@
 """Tests for the dangerous command approval module."""
 
 import os
+import shlex
 import threading
 import time
 from pathlib import Path
@@ -99,14 +100,20 @@ class TestDetectDangerousRm:
             assert "delete" in desc.lower()
 
 
-    def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self):
-        with mock_patch("tempfile.gettempdir", return_value="/tmp"):
+    def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(
+        self, tmp_path
+    ):
+        real_temp = tmp_path / "real-temp"
+        real_temp.mkdir()
+        with mock_patch("tempfile.gettempdir", return_value=str(real_temp)):
             for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
-                assert detect_dangerous_command(f"rm -f /tmp/{prefix}example.py") == (
-                    False,
-                    None,
-                    None,
-                )
+                artifact = real_temp / f"{prefix}example.py"
+                for spelling in (artifact.as_posix(), shlex.quote(str(artifact))):
+                    assert detect_dangerous_command(f"rm -f {spelling}") == (
+                        False,
+                        None,
+                        None,
+                    )
 
     def test_symlinked_temp_dir_only_exempts_canonical_target(self, tmp_path):
         real_temp = tmp_path / "real-temp"
@@ -116,12 +123,16 @@ class TestDetectDangerousRm:
         basename = "hermes-verify-example.py"
 
         with mock_patch("tempfile.gettempdir", return_value=str(linked_temp)):
-            assert detect_dangerous_command(f"rm -f {linked_temp / basename}")[0] is True
-            assert detect_dangerous_command(f"rm -f {real_temp / basename}") == (
-                False,
-                None,
-                None,
-            )
+            linked = linked_temp / basename
+            canonical = real_temp / basename
+            for spelling in (linked.as_posix(), shlex.quote(str(linked))):
+                assert detect_dangerous_command(f"rm -f {spelling}")[0] is True
+            for spelling in (canonical.as_posix(), shlex.quote(str(canonical))):
+                assert detect_dangerous_command(f"rm -f {spelling}") == (
+                    False,
+                    None,
+                    None,
+                )
 
     def test_verification_cleanup_exemption_rejects_broader_deletions(self):
         commands = (
@@ -141,6 +152,22 @@ class TestDetectDangerousRm:
                 assert is_dangerous is True, command
                 assert key is not None, command
                 assert "delete" in desc.lower(), command
+
+    def test_shell_safe_windows_verifier_broader_deletions_are_dangerous(
+        self, tmp_path
+    ):
+        real_temp = tmp_path / "real-temp"
+        real_temp.mkdir()
+        artifact = (real_temp / "hermes-verify-example.py").as_posix()
+        commands = (
+            f"rm -rf {artifact}",
+            f"rm -f {artifact} {(real_temp / 'other.py').as_posix()}",
+            f"rm -f {(real_temp / 'hermes-verify-*.py').as_posix()}",
+            f"rm -f {artifact}; touch pwned",
+        )
+        with mock_patch("tempfile.gettempdir", return_value=str(real_temp)):
+            for command in commands:
+                assert detect_dangerous_command(command)[0] is True, command
 
 
 class TestWindowsShellDestructiveCommands:

--- a/tests/tools/test_self_repo_guard.py
+++ b/tests/tools/test_self_repo_guard.py
@@ -1,5 +1,7 @@
 """Tests for tools/self_repo_guard.py — the running-source-checkout git guard."""
 
+import os
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -22,6 +24,17 @@ def repo(tmp_path):
 
 def _detect(command, cwd, root):
     return detect_self_repo_git_mutation(command, str(cwd), source_root=root)
+
+
+def _shell_path(path: Path) -> str:
+    """Render a native path as one shell-safe command argument."""
+    return shlex.quote(path.as_posix())
+
+
+def _msys_path(path: Path) -> str:
+    """Render a resolved Windows path using Git Bash's drive-root spelling."""
+    resolved = path.resolve()
+    return f"/{resolved.drive[0].lower()}{resolved.as_posix()[2:]}"
 
 
 class TestBlocksMutationsInSourceRepo:
@@ -55,11 +68,11 @@ class TestBlocksMutationsInSourceRepo:
         assert hit is True
 
     def test_dash_c_targeting_repo_from_outside(self, repo, tmp_path):
-        hit, _ = _detect(f"git -C {repo} checkout pr-51020", tmp_path, repo)
+        hit, _ = _detect(f"git -C {_shell_path(repo)} checkout pr-51020", tmp_path, repo)
         assert hit is True
 
     def test_cd_into_repo_then_checkout(self, repo, tmp_path):
-        hit, _ = _detect(f"cd {repo} && git checkout pr-51020", tmp_path, repo)
+        hit, _ = _detect(f"cd {_shell_path(repo)} && git checkout pr-51020", tmp_path, repo)
         assert hit is True
 
     def test_relative_cd_into_repo(self, repo):
@@ -105,12 +118,18 @@ class TestBlocksMutationsInSourceRepo:
         assert hit is True
 
     def test_explicit_work_tree_targeting_repo(self, repo, tmp_path):
-        command = f"git --git-dir={repo / '.git'} --work-tree={repo} checkout main"
+        command = (
+            f"git --git-dir={_shell_path(repo / '.git')} "
+            f"--work-tree={_shell_path(repo)} checkout main"
+        )
         hit, _ = _detect(command, tmp_path, repo)
         assert hit is True
 
     def test_git_environment_targeting_repo(self, repo, tmp_path):
-        command = f"GIT_DIR={repo / '.git'} GIT_WORK_TREE={repo} git checkout main"
+        command = (
+            f"GIT_DIR={_shell_path(repo / '.git')} "
+            f"GIT_WORK_TREE={_shell_path(repo)} git checkout main"
+        )
         hit, _ = _detect(command, tmp_path, repo)
         assert hit is True
 
@@ -149,6 +168,7 @@ class TestBlocksMutationsInSourceRepo:
 
     def test_tilde_dash_c_path(self, repo, monkeypatch, tmp_path):
         monkeypatch.setenv("HOME", str(repo.parent))
+        monkeypatch.setenv("USERPROFILE", str(repo.parent))
         hit, _ = _detect("git -C ~/hermes-agent checkout main", tmp_path, repo)
         assert hit is True
 
@@ -192,11 +212,11 @@ class TestAllowsSafeCommands:
         assert hit is False
 
     def test_dash_c_redirects_out_of_repo(self, repo, tmp_path):
-        hit, _ = _detect(f"git -C {tmp_path} checkout main", repo, repo)
+        hit, _ = _detect(f"git -C {_shell_path(tmp_path)} checkout main", repo, repo)
         assert hit is False
 
     def test_cd_out_of_repo_then_checkout(self, repo, tmp_path):
-        hit, _ = _detect(f"cd {tmp_path} && git checkout main", repo, repo)
+        hit, _ = _detect(f"cd {_shell_path(tmp_path)} && git checkout main", repo, repo)
         assert hit is False
 
     def test_mentioning_repo_path_without_targeting_it(self, repo, tmp_path):
@@ -282,16 +302,25 @@ class TestWorktreeTargetingSourceRoot:
 
     @pytest.mark.parametrize("action", ["remove", "remove -f", "remove --force"])
     def test_blocks_absolute_target_from_outside(self, repo, tmp_path, action):
-        hit, _ = _detect(f"git worktree {action} {repo}", tmp_path, repo)
+        hit, _ = _detect(
+            f"git worktree {action} {_shell_path(repo)}", tmp_path, repo
+        )
         assert hit is True
 
     def test_blocks_move_of_root_from_outside(self, repo, tmp_path):
-        command = f"git worktree move {repo} {tmp_path / 'moved'}"
+        command = (
+            f"git worktree move {_shell_path(repo)} "
+            f"{_shell_path(tmp_path / 'moved')}"
+        )
         hit, _ = _detect(command, tmp_path, repo)
         assert hit is True
 
     def test_blocks_dash_c_worktree_remove(self, repo, tmp_path):
-        hit, _ = _detect(f"git -C {tmp_path} worktree remove {repo}", tmp_path, repo)
+        hit, _ = _detect(
+            f"git -C {_shell_path(tmp_path)} worktree remove {_shell_path(repo)}",
+            tmp_path,
+            repo,
+        )
         assert hit is True
 
     def test_blocks_parent_relative_target_from_subdirectory(self, repo):
@@ -324,6 +353,192 @@ class TestWorktreeTargetingSourceRoot:
     @pytest.mark.parametrize("sub", ["", "remove", "move", "-f"])
     def test_incomplete_worktree_command_is_not_blocked(self, repo, sub):
         hit, _ = _detect(f"git worktree {sub}".strip(), repo, repo)
+        assert hit is False
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Git Bash drive paths are Windows-only")
+class TestWindowsMsysPathResolution:
+    def test_dash_c_targeting_repo(self, repo, tmp_path):
+        command = f"git -C {_shell_path(Path(_msys_path(repo)))} checkout main"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_cd_targeting_repo(self, repo, tmp_path):
+        command = f"cd {_shell_path(Path(_msys_path(repo)))} && git checkout main"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_dash_c_targeting_repo_with_spaces(self, tmp_path):
+        repo = tmp_path / "hermes agent"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q", str(repo)], check=True)
+        repo = repo.resolve()
+        command = f"git -C {_shell_path(Path(_msys_path(repo)))} checkout main"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_dash_c_redirecting_outside_repo(self, repo, tmp_path):
+        command = f"git -C {_shell_path(Path(_msys_path(tmp_path)))} checkout main"
+        hit, _ = _detect(command, repo, repo)
+        assert hit is False
+
+    def test_worktree_remove_targeting_repo(self, repo, tmp_path):
+        command = f"git worktree remove {_shell_path(Path(_msys_path(repo)))}"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_tilde_uses_git_bash_home(self, repo, monkeypatch, tmp_path):
+        monkeypatch.setenv("HOME", str(repo.parent))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path / "different-profile"))
+        hit, _ = _detect("git -C ~/hermes-agent checkout main", tmp_path, repo)
+        assert hit is True
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Native backslash paths are Windows-only")
+class TestWindowsQuotedNativePathResolution:
+    @pytest.mark.parametrize("quote", ["'", '"'])
+    def test_dash_c_targeting_repo(self, repo, tmp_path, quote):
+        command = f"git -C {quote}{repo}{quote} checkout main"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_explicit_work_tree_targeting_repo(self, repo, tmp_path):
+        command = f"git --work-tree='{repo}' checkout main"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_environment_work_tree_targeting_repo(self, repo, tmp_path):
+        command = f"GIT_WORK_TREE='{repo}' git checkout main"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    @pytest.mark.parametrize("style", ["printf", "printf-format", "backtick"])
+    def test_dash_c_literal_command_substitution_targeting_repo(
+        self, repo, tmp_path, style
+    ):
+        if style == "printf":
+            substitution = f"$(printf '{repo}')"
+        elif style == "printf-format":
+            substitution = f"$(printf '%s' '{repo}')"
+        else:
+            substitution = f"`printf '{repo}'`"
+        command = f'git -C "{substitution}" checkout main'
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_literal_command_substitution_preserves_unc_path(self):
+        import tools.self_repo_guard as mod
+
+        command = r'''git -C "$(printf '\\server\share\repo')" checkout main'''
+        assert mod._shell_words_at(command, 0)[2] == r"\\server\share\repo"
+
+    def test_literal_command_substitution_avoids_placeholder_collision(self):
+        import tools.self_repo_guard as mod
+
+        command = (
+            r'''git -C "__HERMES_WINDOWS_PATH_0__'''
+            r'''$(printf 'C:\repo')" checkout main'''
+        )
+        assert mod._shell_words_at(command, 0)[2] == (
+            r"__HERMES_WINDOWS_PATH_0__C:\repo"
+        )
+
+    def test_literal_command_substitution_avoids_private_sentinel_collision(self):
+        import tools.self_repo_guard as mod
+
+        literal_sentinel = "\ue000"
+        command = f'''git -C "{literal_sentinel}$(printf 'C:\\repo')" checkout main'''
+        assert mod._shell_words_at(command, 0)[2] == (
+            f"{literal_sentinel}C:\\repo"
+        )
+
+    @pytest.mark.parametrize(
+        "substitution",
+        [
+            '$(printf "{path}")',
+            '`printf "{path}"`',
+        ],
+    )
+    def test_single_quoted_substitution_remains_literal(
+        self, repo, tmp_path, substitution
+    ):
+        literal = substitution.format(path=repo.as_posix())
+        command = f"git -C '{literal}' checkout main"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is False
+
+    def test_double_quoted_substitution_is_evaluated(self, repo, tmp_path):
+        command = f'''git -C "$(printf '{repo}')" checkout main'''
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    @pytest.mark.parametrize(
+        "command_template",
+        [
+            '''git -C "$(printf '{path}')$(printf '')" checkout main''',
+            '''git -C "$(printf "$(printf '{path}')")" checkout main''',
+            '''git -C "$(printf '{path}')`printf ''`" checkout main''',
+        ],
+    )
+    def test_composed_literal_substitution_targets_repo(
+        self, repo, tmp_path, command_template
+    ):
+        command = command_template.format(path=repo)
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    @pytest.mark.parametrize(
+        "literal",
+        [
+            r'''\$(printf '{path}')''',
+            r'''\`printf '{path}'\`''',
+        ],
+    )
+    def test_escaped_substitution_remains_literal(self, repo, tmp_path, literal):
+        command = f'''git -C "{literal.format(path=repo.as_posix())}" checkout main'''
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is False
+
+    @pytest.mark.parametrize("variable", ["HOME", "PWD"])
+    def test_dynamic_parameter_targeting_repo_fails_closed(
+        self, repo, tmp_path, monkeypatch, variable
+    ):
+        monkeypatch.setenv(variable, str(repo))
+        command = f'''git -C "$(printf "${variable}")" checkout main'''
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_dynamic_environment_work_tree_fails_closed(
+        self, repo, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HOME", str(repo))
+        command = '''GIT_WORK_TREE="$HOME" git checkout main'''
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_dynamic_worktree_victim_fails_closed(
+        self, repo, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HOME", str(repo))
+        command = '''git worktree remove "$HOME"'''
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_dynamic_parameter_read_only_git_is_allowed(
+        self, repo, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HOME", str(repo))
+        command = '''git -C "$(printf "$HOME")" status'''
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is False
+
+    def test_single_quoted_parameter_remains_literal(self, repo, tmp_path):
+        command = "git -C '$HOME' checkout main"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is False
+
+    def test_unquoted_backslashes_follow_shell_escape_semantics(self, repo, tmp_path):
+        hit, _ = _detect(f"git -C {repo} checkout main", tmp_path, repo)
         assert hit is False
 
 

--- a/tests/tools/test_self_repo_guard.py
+++ b/tests/tools/test_self_repo_guard.py
@@ -541,6 +541,17 @@ class TestWindowsQuotedNativePathResolution:
         hit, _ = _detect(f"git -C {repo} checkout main", tmp_path, repo)
         assert hit is False
 
+    @pytest.mark.parametrize("quote", ["'", '"'])
+    def test_quoted_relative_native_path_targeting_repo(
+        self, repo, tmp_path, quote
+    ):
+        nested = repo / "nested"
+        nested.mkdir()
+        relative = f"{repo.name}\\nested"
+        command = f"git -C {quote}{relative}{quote} checkout main"
+        hit, _ = _detect(command, repo.parent, repo)
+        assert hit is True
+
 
 class TestSourceRootResolution:
     def test_resolves_to_repo_when_git_dir_present(self):

--- a/tests/tools/test_self_repo_guard.py
+++ b/tests/tools/test_self_repo_guard.py
@@ -402,6 +402,22 @@ class TestWindowsQuotedNativePathResolution:
         hit, _ = _detect(command, tmp_path, repo)
         assert hit is True
 
+    def test_dash_c_echo_literal_substitution_targeting_repo(self, repo, tmp_path):
+        # Git Bash executes POSIX substitutions on Windows before launching Git.
+        command = f'git -C "$(echo {repo.as_posix()})" checkout main'
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_dash_c_more_than_eight_nested_echo_substitutions(self, repo, tmp_path):
+        # Nine levels cross the production evaluator's ``depth > 8`` cap and
+        # must therefore fail closed for a mutating Git subcommand.
+        substitution = f"'{repo.as_posix()}'"
+        for _ in range(9):
+            substitution = f"$(echo {substitution})"
+        command = f'git -C "{substitution}" checkout main'
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
     def test_explicit_work_tree_targeting_repo(self, repo, tmp_path):
         command = f"git --work-tree='{repo}' checkout main"
         hit, _ = _detect(command, tmp_path, repo)

--- a/tests/tools/test_self_repo_guard.py
+++ b/tests/tools/test_self_repo_guard.py
@@ -589,8 +589,9 @@ class TestBlockMessageGuidance:
         assert "tmpfs" in msg
         assert "Delete the clone" in msg
 
-    def test_scratch_hint_honors_hermes_home(self, repo, monkeypatch):
-        monkeypatch.setenv("HERMES_HOME", "/custom/hermes-home")
+    def test_scratch_hint_honors_hermes_home(self, repo, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "custom-hermes-home"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         hit, msg = _detect("git rebase origin/main", repo, repo)
         assert hit is True
-        assert "/custom/hermes-home/scratch" in msg
+        assert str(hermes_home / "scratch") in msg

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2297,25 +2297,48 @@ def _command_detection_variants(command: str):
         yield variant
 
 
-def _is_verification_artifact_cleanup(command: str) -> bool:
-    """Return whether *command* only removes one Hermes ad-hoc temp script."""
+def _path_spelling_key(path: str) -> str:
+    """Normalize only platform separator and case, not path components."""
+    if os.altsep:
+        path = path.replace(os.altsep, os.sep)
+    return os.path.normcase(path)
+
+
+def _verification_artifact_cleanup_status(command: str) -> str | None:
+    """Classify a narrowly shaped Hermes ad-hoc temp-script cleanup."""
     try:
         argv = shlex.split(command, posix=True)
     except ValueError:
-        return False
-    if len(argv) != 3 or argv[0] != "rm" or argv[1] != "-f":
-        return False
+        return None
+    if not argv or argv[0] != "rm":
+        return None
+
+    verifier_operands = [
+        value
+        for value in argv[1:]
+        if os.path.basename(value).startswith(("hermes-verify-", "hermes-ad-hoc-"))
+    ]
+    if not verifier_operands:
+        return None
+    if len(argv) != 3 or argv[1] != "-f":
+        return "dangerous"
 
     operand = argv[2]
-    temp_dir = os.path.realpath(tempfile.gettempdir())
     basename = os.path.basename(operand)
-    if operand != os.path.join(temp_dir, basename):
-        return False
+    if re.fullmatch(r"hermes-(?:verify|ad-hoc)-[A-Za-z0-9_.-]+", basename) is None:
+        return "dangerous"
+
+    temp_dir = os.path.realpath(tempfile.gettempdir())
+    expected = os.path.join(temp_dir, basename)
+    if not os.path.isabs(operand):
+        return "dangerous"
+    if _path_spelling_key(operand) != _path_spelling_key(expected):
+        return "dangerous"
 
     target = os.path.realpath(operand)
-    if os.path.dirname(target) != temp_dir:
-        return False
-    return re.fullmatch(r"hermes-(?:verify|ad-hoc)-[A-Za-z0-9_.-]+", basename) is not None
+    if _path_spelling_key(os.path.dirname(target)) != _path_spelling_key(temp_dir):
+        return "dangerous"
+    return "safe"
 
 
 def detect_dangerous_command(command: str) -> tuple:
@@ -2326,8 +2349,12 @@ def detect_dangerous_command(command: str) -> tuple:
     """
     if _command_parser_limit_exceeded(command):
         return (True, _PARSER_LIMIT_DESCRIPTION, _PARSER_LIMIT_DESCRIPTION)
-    if _is_verification_artifact_cleanup(command):
+    cleanup_status = _verification_artifact_cleanup_status(command)
+    if cleanup_status == "safe":
         return (False, None, None)
+    if cleanup_status == "dangerous":
+        description = "delete noncanonical verification artifact path"
+        return (True, description, description)
 
     for command_variant in _command_detection_variants(command):
         command_lower = command_variant.lower()

--- a/tools/self_repo_guard.py
+++ b/tools/self_repo_guard.py
@@ -14,6 +14,9 @@ from tools.approval import (
     _deobfuscate_shell_word_for_detection,
     _iter_shell_command_starts,
     _read_shell_word,
+    _replace_simple_command_substitutions,
+    _scan_backtick_end,
+    _scan_dollar_paren_end,
 )
 
 
@@ -89,6 +92,21 @@ _KNOWN_GIT_BUILTINS = frozenset({
 })
 _SHELL_EXECUTABLES = frozenset({"bash", "dash", "ksh", "sh", "zsh"})
 _ASSIGNMENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*=(.*)", re.DOTALL)
+_WINDOWS_PATH_TOKEN_RE = re.compile(r"(?:^|=)(?:[A-Za-z]:[\\/]|\\\\)")
+_DYNAMIC_SHELL_PATH_MARKER = "\uf8ff"
+
+
+def _has_dynamic_shell_path(value: str) -> bool:
+    return bool(
+        "$" in value
+        or "`" in value
+        or any(char in value for char in "*?[")
+        or re.search(r"(?:^|[\"'])~(?:/|$)", value)
+    )
+
+
+def _strip_dynamic_shell_marker(value: str) -> str:
+    return value.replace(_DYNAMIC_SHELL_PATH_MARKER, "")
 _SUDO_OPTIONS_WITH_ARG = frozenset({
     "-C",
     "--chdir",
@@ -150,7 +168,29 @@ def get_running_source_root() -> Path | None:
 
 
 def _resolve(path_str: str, base: Path) -> Path:
-    path = Path(os.path.expanduser(path_str))
+    # This guard parses commands before Git Bash executes them.  On Windows,
+    # mirror the two shell spellings that pathlib does not understand:
+    # Git Bash expands ``~`` from HOME (Python's ntpath.expanduser uses
+    # USERPROFILE), and an MSYS drive path such as ``/c/Users/...`` targets
+    # the native ``C:/Users/...`` drive.  Keep other rooted paths unchanged;
+    # their MSYS mount mapping is not safely inferable here.
+    expanded = path_str
+    if os.name == "nt" and (expanded == "~" or expanded.startswith("~/")):
+        home = os.environ.get("HOME")
+        if home:
+            expanded = f"{home}{expanded[1:]}"
+        else:
+            expanded = os.path.expanduser(expanded)
+    else:
+        expanded = os.path.expanduser(expanded)
+
+    if os.name == "nt":
+        msys_drive = re.fullmatch(r"/([A-Za-z])(?:/(.*))?", expanded, re.DOTALL)
+        if msys_drive:
+            suffix = msys_drive.group(2) or ""
+            expanded = f"{msys_drive.group(1).upper()}:/{suffix}"
+
+    path = Path(expanded)
     if not path.is_absolute():
         path = base / path
     try:
@@ -170,6 +210,132 @@ def _executable_name(value: str) -> str:
     return Path(value.replace("\\", "/")).name.removesuffix(".exe").lower()
 
 
+def _literal_shell_output(
+    script: str, depth: int = 0
+) -> tuple[str, bool] | None:
+    """Evaluate a bounded literal echo/printf script without executing it."""
+    if depth > 8:
+        return None
+    masked, replacements, has_windows_path, _ = (
+        _replace_literal_windows_path_substitutions(script, depth=depth)
+    )
+    if any(marker in masked for marker in ("$(", "${", "`")):
+        return None
+    try:
+        tokens = shlex.split(masked, posix=True)
+    except ValueError:
+        return None
+    for index, token in enumerate(tokens):
+        for placeholder, replacement in replacements.items():
+            token = token.replace(placeholder, replacement)
+        tokens[index] = token
+    if not tokens:
+        return None
+    executable = _executable_name(tokens[0])
+    value: str | None = None
+    if executable == "printf":
+        if len(tokens) == 2 and "%" not in tokens[1]:
+            value = tokens[1]
+        elif len(tokens) == 3 and tokens[1] == "%s":
+            value = tokens[2]
+    elif executable == "echo" and len(tokens) == 2:
+        value = tokens[1]
+    if value is None or _has_dynamic_shell_path(value):
+        return None
+    return value, bool(
+        has_windows_path or _WINDOWS_PATH_TOKEN_RE.match(value)
+    )
+
+
+def _replace_literal_windows_path_substitutions(
+    word: str, depth: int = 0,
+) -> tuple[str, dict[str, str], bool, bool]:
+    """Mask executable path substitutions and protected quoted literals."""
+    chars: list[str] = []
+    replacements: dict[str, str] = {}
+    index = 0
+    in_single_quote = False
+    in_double_quote = False
+    has_verified_path = False
+    has_protected_literal = False
+
+    def next_placeholder() -> str:
+        codepoint = 0xE000
+        while chr(codepoint) in word or chr(codepoint) in replacements:
+            codepoint += 1
+        return chr(codepoint)
+
+    def protect(value: str) -> None:
+        placeholder = next_placeholder()
+        replacements[placeholder] = value
+        chars.append(placeholder)
+
+    while index < len(word):
+        char = word[index]
+        if char == "\\" and not in_single_quote and index + 1 < len(word):
+            if word[index + 1] in {"$", "`"}:
+                protect(word[index + 1])
+                has_protected_literal = True
+                index += 2
+                continue
+            chars.extend(word[index : index + 2])
+            index += 2
+            continue
+        if char == "'" and not in_double_quote:
+            in_single_quote = not in_single_quote
+            chars.append(char)
+            index += 1
+            continue
+        if char == '"' and not in_single_quote:
+            in_double_quote = not in_double_quote
+            chars.append(char)
+            index += 1
+            continue
+        if in_single_quote and char == "$":
+            protect(char)
+            has_protected_literal = True
+            index += 1
+            continue
+        if word.startswith("$(", index):
+            end = _scan_dollar_paren_end(word, index)
+            if end is not None:
+                if in_single_quote:
+                    protect(word[index:end])
+                    has_protected_literal = True
+                    index = end
+                    continue
+                result = _literal_shell_output(word[index + 2 : end - 1], depth + 1)
+                if result is not None:
+                    replacement, replacement_has_path = result
+                    protect(replacement)
+                    has_verified_path |= replacement_has_path
+                    index = end
+                    continue
+        if char == "`":
+            end = _scan_backtick_end(word, index)
+            if end is not None:
+                if in_single_quote:
+                    protect(word[index:end])
+                    has_protected_literal = True
+                    index = end
+                    continue
+                result = _literal_shell_output(word[index + 1 : end - 1], depth + 1)
+                if result is not None:
+                    replacement, replacement_has_path = result
+                    protect(replacement)
+                    has_verified_path |= replacement_has_path
+                    index = end
+                    continue
+        chars.append(char)
+        index += 1
+    return (
+        "".join(chars),
+        replacements,
+        has_verified_path,
+        has_protected_literal,
+    )
+
+
 def _shell_words_at(command: str, start: int) -> list[str]:
     words: list[str] = []
     cursor = start
@@ -179,7 +345,52 @@ def _shell_words_at(command: str, start: int) -> list[str]:
             break
         if words and "\n" in command[cursor:word_start]:
             break
-        words.append(_deobfuscate_shell_word_for_detection(raw_word))
+        decoded = None
+        replacements: dict[str, str] = {}
+        has_verified_path = False
+        has_protected_literal = False
+        if os.name == "nt":
+            (
+                literal_word,
+                replacements,
+                has_verified_path,
+                has_protected_literal,
+            ) = _replace_literal_windows_path_substitutions(raw_word)
+        else:
+            literal_word = raw_word
+        has_dynamic_path = _has_dynamic_shell_path(literal_word)
+        literal_word = _replace_simple_command_substitutions(literal_word)
+        if os.name == "nt" and not any(
+            marker in literal_word for marker in ("$(", "${", "`")
+        ):
+            # The generic detector intentionally deobfuscates twice.  That is
+            # useful for command spellings, but a quoted native path loses its
+            # quotes on pass one and then loses literal backslashes on pass
+            # two.  Prefer shlex's quote-correct value only for an actual
+            # Windows path token; leave every other word on the established
+            # deobfuscation path.
+            try:
+                shell_values = shlex.split(literal_word, posix=True)
+            except ValueError:
+                shell_values = []
+            if len(shell_values) == 1:
+                candidate = shell_values[0]
+                for placeholder, replacement in replacements.items():
+                    candidate = candidate.replace(placeholder, replacement)
+                if has_verified_path or (
+                    not has_protected_literal
+                    and _WINDOWS_PATH_TOKEN_RE.search(candidate)
+                ):
+                    decoded = candidate
+        if decoded is None:
+            fallback_word = literal_word if has_protected_literal else raw_word
+            decoded = _deobfuscate_shell_word_for_detection(fallback_word)
+            if has_protected_literal:
+                for placeholder, replacement in replacements.items():
+                    decoded = decoded.replace(placeholder, replacement)
+        if has_dynamic_path:
+            decoded += _DYNAMIC_SHELL_PATH_MARKER
+        words.append(decoded)
         cursor = word_end
     return words
 
@@ -457,9 +668,10 @@ def _git_target_and_subcommand(
     args: list[str],
     current_dir: Path,
     env: dict[str, str],
-) -> tuple[Path, str | None, list[str], dict[str, str]]:
+) -> tuple[Path, str | None, list[str], dict[str, str], bool]:
     target = current_dir
     work_tree: str | None = None
+    has_dynamic_target = False
     aliases: dict[str, str] = {}
     index = 0
 
@@ -469,11 +681,15 @@ def _git_target_and_subcommand(
             index += 1
             break
         if arg == "-C" and index + 1 < len(args):
-            target = _resolve(args[index + 1], target)
+            value = args[index + 1]
+            has_dynamic_target |= _DYNAMIC_SHELL_PATH_MARKER in value
+            target = _resolve(_strip_dynamic_shell_marker(value), target)
             index += 2
             continue
         if arg.startswith("-C") and len(arg) > 2:
-            target = _resolve(arg[2:], target)
+            value = arg[2:]
+            has_dynamic_target |= _DYNAMIC_SHELL_PATH_MARKER in value
+            target = _resolve(_strip_dynamic_shell_marker(value), target)
             index += 1
             continue
         if arg in {"--work-tree", "--git-dir", "--namespace", "--exec-path"}:
@@ -504,9 +720,10 @@ def _git_target_and_subcommand(
 
     explicit_work_tree = work_tree or env.get("GIT_WORK_TREE")
     if explicit_work_tree:
-        target = _resolve(explicit_work_tree, target)
+        has_dynamic_target = _DYNAMIC_SHELL_PATH_MARKER in explicit_work_tree
+        target = _resolve(_strip_dynamic_shell_marker(explicit_work_tree), target)
     subcommand = args[index].lower() if index < len(args) else None
-    return target, subcommand, args[index + 1 :], aliases
+    return target, subcommand, args[index + 1 :], aliases, has_dynamic_target
 
 
 def _mutates_worktree(subcommand: str, args: list[str]) -> bool:
@@ -559,7 +776,10 @@ def _inspect_git_worktree(args: list[str], cwd: Path, root: Path) -> str | None:
     target_index = _next_positional(args, action_index + 1)
     if target_index >= len(args):
         return None
-    if _resolve(args[target_index], cwd) == root:
+    target = args[target_index]
+    if _DYNAMIC_SHELL_PATH_MARKER in target:
+        return f"git worktree {action}"
+    if _resolve(_strip_dynamic_shell_marker(target), cwd) == root:
         return f"git worktree {action}"
     return None
 
@@ -587,14 +807,18 @@ def _inspect_git(
     root: Path,
     depth: int,
 ) -> str | None:
-    target, subcommand, sub_args, inline_aliases = _git_target_and_subcommand(
+    target, subcommand, sub_args, inline_aliases, has_dynamic_target = (
+        _git_target_and_subcommand(
         args, current_dir, env
+        )
     )
     if subcommand is None:
         return None
     # `worktree` names its victim as an argument, so the cwd check does not apply.
     if subcommand == "worktree":
         return _inspect_git_worktree(sub_args, target, root)
+    if has_dynamic_target and _mutates_worktree(subcommand, sub_args):
+        return f"git {subcommand}"
     if not _is_within(target, root):
         return None
     if _mutates_worktree(subcommand, sub_args):

--- a/tools/self_repo_guard.py
+++ b/tools/self_repo_guard.py
@@ -377,9 +377,18 @@ def _shell_words_at(command: str, start: int) -> list[str]:
                 candidate = shell_values[0]
                 for placeholder, replacement in replacements.items():
                     candidate = candidate.replace(placeholder, replacement)
+                is_quoted_relative_windows_path = (
+                    len(raw_word) >= 2
+                    and raw_word[0] in {"'", '"'}
+                    and raw_word[-1] == raw_word[0]
+                    and "\\" in candidate
+                )
                 if has_verified_path or (
                     not has_protected_literal
-                    and _WINDOWS_PATH_TOKEN_RE.search(candidate)
+                    and (
+                        _WINDOWS_PATH_TOKEN_RE.search(candidate)
+                        or is_quoted_relative_windows_path
+                    )
                 ):
                     decoded = candidate
         if decoded is None:


### PR DESCRIPTION
## Summary

- harden the running-source checkout guard for Windows native paths, MSYS drive paths, quoted relative paths, Git `-C`/work-tree targeting, and bounded literal shell substitutions
- fail closed for mutating Git commands whose target remains dynamic, while preserving read-only Git operations
- tighten the narrow `rm -f` verifier-artifact exemption so noncanonical, symlinked, globbed, or broader deletion shapes require approval
- add Windows Git Bash and path-spelling regression coverage, including the evaluator depth boundary

## Test plan

- [x] `pytest -q tests/tools/test_approval.py tests/tools/test_self_repo_guard.py` — **252 passed**
- [x] `ruff check tools/approval.py tools/self_repo_guard.py tests/tools/test_approval.py tests/tools/test_self_repo_guard.py`
- [x] `git diff --check 524b062289e9d64b2112b8c9caaf0c7f59cb463d..110ac03316a97c699f7d91d68a1ab5c2e882d8dc`
- [x] Scheduled Task XML SHA-256 unchanged before/after test execution
- [x] desktop/task widget PID identities unchanged before/after test execution
- [x] five stable patch IDs preserved across the final upstream rebase
- [x] bounded Claude Code and `gpt-5.3-codex-spark` reviews independently adjudicated; no confirmed P0–P2 remains

## Scope

This PR changes only:

- `tools/approval.py`
- `tools/self_repo_guard.py`
- `tests/tools/test_approval.py`
- `tests/tools/test_self_repo_guard.py`

No installer, gateway, desktop runtime, or persistence configuration is modified.
