### PR TITLE
fix(gateway): never merge text batches across different authors

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -94,6 +94,29 @@ class MessageDeduplicator:
 # ─── Text Batch Aggregation ──────────────────────────────────────────────────
 
 
+def batch_authors_match(existing: "MessageEvent", event: "MessageEvent") -> bool:
+    """True when two batched events come from the same author.
+
+    Text debounce batching keys on the SESSION, and shared group sessions
+    (``group_sessions_per_user: false``) scope one session to the whole
+    group — so rapid-fire messages from DIFFERENT people land on the same
+    batch key. Merging across authors rewrites who said what: the combined
+    event keeps the first sender's identity and the gateway prefixes every
+    line with that one name (observed live 2026-08-20: a turn tagged with user A's
+    name carrying a line user B wrote, and the agent then addressing A
+    about B's statement). Callers must flush instead of merging when this
+    returns False. Events with no identifiers at all (both ids and names
+    None) compare equal, preserving legacy single-user behavior.
+    """
+    ex_src = getattr(existing, "source", None)
+    ev_src = getattr(event, "source", None)
+    ex_id = getattr(ex_src, "user_id", None) or getattr(ex_src, "user_id_alt", None)
+    ev_id = getattr(ev_src, "user_id", None) or getattr(ev_src, "user_id_alt", None)
+    if ex_id is not None or ev_id is not None:
+        return ex_id == ev_id
+    return getattr(ex_src, "user_name", None) == getattr(ev_src, "user_name", None)
+
+
 class TextBatchAggregator:
     """Aggregates rapid-fire text events into single messages.
 
@@ -137,6 +160,17 @@ class TextBatchAggregator:
         """Add *event* to the pending batch for *key*."""
         chunk_len = len(event.text or "")
         existing = self._pending.get(key)
+        if existing and not batch_authors_match(existing, event):
+            # Different author on a shared-session key: never merge across
+            # people (identity rewrite). Dispatch the pending batch now and
+            # start a fresh one for the new author.
+            prior = self._pending_tasks.get(key)
+            if prior and not prior.done():
+                prior.cancel()
+            flushed = self._pending.pop(key, None)
+            if flushed:
+                asyncio.create_task(self._dispatch_now(flushed, key))
+            existing = None
         if not existing:
             event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
             self._pending[key] = event
@@ -149,6 +183,13 @@ class TextBatchAggregator:
         if prior and not prior.done():
             prior.cancel()
         self._pending_tasks[key] = asyncio.create_task(self._flush(key))
+
+    async def _dispatch_now(self, event: "MessageEvent", key: str) -> None:
+        """Dispatch *event* immediately (author-change flush; no quiet wait)."""
+        try:
+            await self._handler(event)
+        except Exception:
+            logger.exception("[TextBatchAggregator] Error dispatching author-flush event for %s", key)
 
     async def _flush(self, key: str) -> None:
         """Wait then dispatch the batched event for *key*."""

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9663,6 +9663,18 @@ class TelegramAdapter(BasePlatformAdapter):
         key = self._text_batch_key(event)
         existing = self._pending_text_batches.get(key)
         chunk_len = len(event.text or "")
+        if existing is not None:
+            from gateway.platforms.helpers import batch_authors_match
+            if not batch_authors_match(existing, event):
+                # Shared group session: different author during the debounce
+                # window — flush instead of merging (authorship rewrite).
+                prior = self._pending_text_batch_tasks.get(key)
+                if prior and not prior.done():
+                    prior.cancel()
+                flushed = self._pending_text_batches.pop(key, None)
+                if flushed is not None:
+                    asyncio.create_task(self.handle_message(flushed))
+                existing = None
         if existing is None:
             event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
             self._pending_text_batches[key] = event

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1412,6 +1412,20 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         key = self._text_batch_key(event)
         existing = self._pending_text_batches.get(key)
         chunk_len = len(event.text or "")
+        if existing is not None:
+            from gateway.platforms.helpers import batch_authors_match
+            if not batch_authors_match(existing, event):
+                # Shared group session: a DIFFERENT person wrote during the
+                # debounce window. Merging would rewrite authorship (the
+                # 2026-08-20 cross-author merge incident) — flush the pending
+                # batch as its own turn and start fresh for the new author.
+                prior = self._pending_text_batch_tasks.get(key)
+                if prior and not prior.done():
+                    prior.cancel()
+                flushed = self._pending_text_batches.pop(key, None)
+                if flushed is not None:
+                    asyncio.create_task(self.handle_message(flushed))
+                existing = None
         if existing is None:
             event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
             self._pending_text_batches[key] = event

--- a/tests/gateway/test_text_batch_author_isolation.py
+++ b/tests/gateway/test_text_batch_author_isolation.py
@@ -1,0 +1,112 @@
+"""Regression tests: text debounce batching must never merge messages from
+different authors.
+
+Incident 2026-08-20 (WhatsApp group, shared session / group_sessions_per_user
+false): user A sent a message; seconds later user B sent a short reply inside the
+debounce window. Both landed on the same batch key, were concatenated, and the
+gateway ingested the combined text under user A's tag — the agent then
+addressed A about a line B wrote. Batching keys on the SESSION, so shared
+group sessions make cross-author collisions routine.
+"""
+
+import asyncio
+
+import pytest
+
+from gateway.platforms.helpers import TextBatchAggregator, batch_authors_match
+from gateway.platforms.base import MessageEvent
+from gateway.session import Platform, SessionSource
+
+
+def _event(text: str, user_id: str, user_name: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        source=SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="120363000000000000@g.us",
+            chat_type="group",
+            user_id=user_id,
+            user_name=user_name,
+        ),
+    )
+
+
+def test_batch_authors_match_same_and_different():
+    a1 = _event("hola", "111@lid", "Alice")
+    a2 = _event("sigo yo", "111@lid", "Alice")
+    b = _event("quick interjection", "222@lid", "Bruna")
+    assert batch_authors_match(a1, a2)
+    assert not batch_authors_match(a1, b)
+
+
+def test_batch_authors_match_no_ids_falls_back_to_name():
+    x = _event("a", None, "OnlyName")
+    y = _event("b", None, "OnlyName")
+    z = _event("c", None, "Other")
+    assert batch_authors_match(x, y)
+    assert not batch_authors_match(x, z)
+
+
+@pytest.mark.asyncio
+async def test_aggregator_never_merges_across_authors():
+    """The exact incident: two authors, one shared session key."""
+    dispatched = []
+
+    async def handler(event):
+        dispatched.append((event.source.user_name, event.text))
+
+    agg = TextBatchAggregator(handler=handler, batch_delay=0.05, split_delay=0.05)
+    key = "agent:main:whatsapp:group:120363000000000000@g.us"
+
+    agg.enqueue(_event("first message line one", "111@lid", "Alice"), key)
+    agg.enqueue(_event("first message line two", "111@lid", "Alice"), key)
+    agg.enqueue(_event("quick interjection", "222@lid", "Bruna"), key)
+    await asyncio.sleep(0.3)
+
+    assert len(dispatched) == 2, dispatched
+    by_author = dict(dispatched)
+    assert by_author["Alice"] == (
+        "first message line one\nfirst message line two"
+    )
+    assert by_author["Bruna"] == "quick interjection"
+
+
+@pytest.mark.asyncio
+async def test_aggregator_still_merges_same_author():
+    dispatched = []
+
+    async def handler(event):
+        dispatched.append(event.text)
+
+    agg = TextBatchAggregator(handler=handler, batch_delay=0.05, split_delay=0.05)
+    agg.enqueue(_event("linea 1", "111@lid", "Alice"), "k")
+    agg.enqueue(_event("linea 2", "111@lid", "Alice"), "k")
+    await asyncio.sleep(0.2)
+    assert dispatched == ["linea 1\nlinea 2"]
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_adapter_enqueue_flushes_on_author_change():
+    """Same guard in the WhatsApp adapter's own implementation."""
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._text_batch_delay_seconds = 0.05
+    adapter._text_batch_split_delay_seconds = 0.05
+    dispatched = []
+
+    async def fake_handle(event):
+        dispatched.append((event.source.user_name, event.text))
+
+    adapter.handle_message = fake_handle  # type: ignore[method-assign]
+    adapter._text_batch_key = lambda e: "sharedkey"  # type: ignore[method-assign]
+
+    adapter._enqueue_text_event(_event("text from alice", "111@lid", "Alice"))
+    adapter._enqueue_text_event(_event("text from bruna", "222@lid", "Bruna"))
+    await asyncio.sleep(0.3)
+
+    assert ("Alice", "text from alice") in dispatched
+    assert ("Bruna", "text from bruna") in dispatched
+    assert len(dispatched) == 2


### PR DESCRIPTION
## What & why

Text debounce batching (the anti-fragment aggregation used by WhatsApp, Telegram, and the shared `TextBatchAggregator` consumed by discord/matrix/wecom/feishu) keys pending batches on the **session key**. With shared group sessions (`group_sessions_per_user: false`), one key covers the whole group — so rapid-fire messages from **different people** land on the same pending batch and get concatenated into a single `MessageEvent` that keeps only the **first** sender's `source`.

Downstream, the gateway prefixes the combined text with that one author's name: **user B's message is attributed to user A**. Observed live (2026-08-20, WhatsApp group, 5s debounce window): user A asked a question, user B sent a short interjection ~5s later, both were ingested as one `[A]`-tagged turn, and the agent then addressed A about the line B wrote. The merged row's stored timestamp is the *last* fragment's — forensic marker of the merge.

## The fix (class, all three implementations)

- `batch_authors_match()` in `gateway/platforms/helpers.py`: compares `user_id`/`user_id_alt`, falling back to `user_name` when neither event carries ids (events with no identifiers at all still compare equal, preserving legacy single-user behavior).
- All three batching implementations — `TextBatchAggregator.enqueue` (shared), `WhatsAppAdapter._enqueue_text_event`, `TelegramAdapter._enqueue_text_event` — now **flush the pending batch immediately and start a fresh one** when the author changes, instead of merging. Nothing is dropped: both messages arrive as two correctly-attributed turns.
- Same-author rapid-fire messages still batch exactly as before.

## How to test

```bash
pytest tests/gateway/test_text_batch_author_isolation.py -v
```

5 regression tests. RED-verified against the unpatched helper: the old `TextBatchAggregator` reproduces the incident exactly — one dispatched event `("UserA", "userA text\nuserB text")`.

Manual: in a group with shared sessions, have two people send messages within the debounce window (5s on WhatsApp) — before the fix the second person's text is swallowed into the first person's turn; after, two separate correctly-tagged turns.

## Platforms

Linux (Ubuntu aarch64, production gateway). Pure-Python; touches WhatsApp + Telegram adapters and the shared helper used by discord/matrix/wecom/feishu.

## Related

#36758 touches text-batch dispatch for wecom (content-dedup key) — different mechanism, no overlap.
