### PR TITLE
fix(redact): default missing session_tag so RedactingFormatter survives factory replacement

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -1423,5 +1423,14 @@ class RedactingFormatter(logging.Formatter):
         super().__init__(fmt, datefmt, style, **kwargs)
 
     def format(self, record: logging.LogRecord) -> str:
+        # Third-party code can replace the global LogRecord factory
+        # (logging.setLogRecordFactory) with a chain that drops Hermes'
+        # session_tag injector. ``%(session_tag)s`` is hardcoded in the
+        # shared log formats, and ``logging.Formatter.format()`` raises
+        # ValueError for a missing field — crashing EVERY record. Restore
+        # the field's factory default (empty string = no active session)
+        # so formatting stays robust regardless of who owns the record
+        # factory (#91348).
+        record.__dict__.setdefault("session_tag", "")
         original = super().format(record)
         return redact_sensitive_text(original)

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -338,6 +338,48 @@ class TestRedactingFormatter:
         assert "abc123def456" not in result
         assert "sk-pro" in result
 
+    def test_missing_session_tag_field_does_not_crash(self):
+        """A third-party logging.setLogRecordFactory() chain that drops
+        Hermes' session_tag injector must not crash every record: the
+        shared formats hardcode %(session_tag)s and stdlib formatting
+        raises ValueError on a missing field (#91348)."""
+        fmt = (
+            "%(asctime)s %(levelname)s%(session_tag)s %(name)s: %(message)s"
+        )
+        formatter = RedactingFormatter(fmt)
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="hello without a session",
+            args=(),
+            exc_info=None,
+        )
+        # No session_tag attribute — as if the factory chain was replaced.
+        assert not hasattr(record, "session_tag")
+        result = formatter.format(record)  # must not raise ValueError
+        assert "hello without a session" in result
+        # The default restores the factory's no-session shape: no tag text.
+        assert " test:" in result
+
+    def test_existing_session_tag_preserved(self):
+        """Records that DO carry a session_tag keep it — the fallback only
+        fills in the missing case."""
+        fmt = "%(levelname)s%(session_tag)s %(message)s"
+        formatter = RedactingFormatter(fmt)
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="with session",
+            args=(),
+            exc_info=None,
+        )
+        record.session_tag = " [abc123]"
+        assert formatter.format(record) == "INFO [abc123] with session"
+
 
 class TestPrintenvSimulation:
     """Simulate what happens when the agent runs `env` or `printenv`."""


### PR DESCRIPTION
## What does this PR do?

Stops `RedactingFormatter` from crashing on **every** log record after a third-party plugin/library replaces the global `LogRecord` factory. Hermes' shared log formats hardcode `%(session_tag)s`, and the factory Hermes installs at import time injects that field on each record — but any later `logging.setLogRecordFactory()` call with its own chain silently drops the injector. Stdlib `logging.Formatter.format()` then raises `ValueError: Formatting field not found in record: 'session_tag'` for every record, taking down all logging.

The fix restores the field's factory default (empty string = no active session) via `record.__dict__.setdefault("session_tag", "")` in `RedactingFormatter.format()` before delegating. All Hermes handlers route through `RedactingFormatter`, so this single point covers every format referencing the field; records that do carry a tag are untouched, and redaction still runs on the formatted output.

## Related Issue

Fixes #91348

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/redact.py`: In `RedactingFormatter.format()`, default the `session_tag` record field to `""` before calling `super().format(record)`, with a comment explaining the factory-replacement failure mode.
- `tests/agent/test_redact.py`: Extend `TestRedactingFormatter` with two tests — a record lacking `session_tag` formats without raising (using the real shared format string shape) and a record carrying a tag keeps it verbatim.

## How to Test

1. In a process where a plugin has called `logging.setLogRecordFactory()` without chaining Hermes' injector, emit any log line through a Hermes handler — before the fix every record raises `ValueError: Formatting field not found in record: 'session_tag'`; after it, the line formats normally with no tag text (Observed result: `test_missing_session_tag_field_does_not_crash` fails on unpatched main with that ValueError and passes with this patch)
2. Records created by the normal Hermes factory still render ` [session-id]` tags (Observed result: `test_existing_session_tag_preserved` passes, output verbatim `INFO [abc123] with session`)
3. `scripts/run_tests.sh tests/agent/test_redact.py -q` → should pass (Observed result: 99 passed locally)
4. `scripts/run_tests.sh tests/test_hermes_logging.py -q` → should pass (Observed result: 26 passed, 3 skipped locally)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
