### PR TITLE
fix(gateway): use SIGUSR1 graceful restart on launchd, not bare SIGTERM

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5119,7 +5119,6 @@ def _wait_for_gateway_exit(
 def launchd_restart():
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
-    drain_timeout = _get_restart_drain_timeout()
     from gateway.status import get_running_pid
 
     try:
@@ -5143,26 +5142,43 @@ def launchd_restart():
             _escalate_wedged_gateway(pid)
             pid = None
         if pid is not None:
-            # Announce the drain BEFORE waiting on it. This wait can run for
-            # the full drain budget (180s by default) while the old gateway
-            # finishes in-flight agent runs, and it streams into surfaces with
-            # no other feedback — the desktop updater's live output most of
-            # all, where a silent stop here reads as "update stuck" (#44515).
-            # Mirrors the systemd branch's "draining (up to Ns)..." line.
+            # Graceful in-band restart, mirroring the systemd branch.
+            #
+            # Previously this sent a bare SIGTERM and waited
+            # ``_get_restart_drain_timeout()`` — which defaults to 0, so the
+            # wait could never succeed and every restart fell through to
+            # ``kickstart -k``. A bare SIGTERM also leaves
+            # ``restart_requested`` False, so the gateway exits 1 instead of
+            # 75 and reports itself to chat as "shutting down" rather than
+            # "restarting", losing the resume_pending handoff.
+            #
+            # SIGUSR1 is the drain-aware path: refuse new turns, wait for
+            # in-flight work (``agent.restart_after_turn_timeout``), then
+            # stop() within ``agent.restart_drain_timeout``. The wait budget
+            # must cover BOTH phases plus headroom (#77184) — the raw drain
+            # timeout covers only the second.
+            #
+            # Announce the wait BEFORE it runs: it can last the full budget
+            # while the old gateway finishes in-flight agent runs, and it
+            # streams into surfaces with no other feedback — the desktop
+            # updater's live output most of all, where a silent stop here
+            # reads as "update stuck" (#44515).
+            wait_budget = _get_restart_exit_wait_budget()
             print(
                 f"→ Stopping gateway (PID {pid}) — draining in-flight runs "
-                f"(up to {drain_timeout:.0f}s)..."
+                f"(up to {wait_budget:.0f}s)..."
             )
-            try:
-                terminate_pid(pid, force=False)
-            except (ProcessLookupError, PermissionError, OSError):
-                pid = None
-            if pid is not None:
-                exited = _wait_for_gateway_exit(timeout=drain_timeout, force_after=None)
-                if not exited:
-                    print(
-                        f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart"
-                    )
+            if _graceful_restart_via_sigusr1(pid, wait_budget):
+                # The gateway exited with the planned-restart code and
+                # launchd's unconditional KeepAlive revives it. Do NOT
+                # kickstart here: the replacement may already be up, and
+                # ``-k`` would kill it and restart a second time.
+                print("✓ Service restart requested")
+                _clear_launchd_unsupported_marker()
+                return
+            print(
+                f"⚠ Gateway drain timed out after {wait_budget:.0f}s — forcing launchd restart"
+            )
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
         print("✓ Service restarted")
         _clear_launchd_unsupported_marker()

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -764,8 +764,60 @@ class TestGatewaySystemServiceRouting:
         assert "21627" not in out  # must use the mocked budget, not live defaults
         assert "27" in out
 
+    def test_launchd_restart_uses_sigusr1_and_exit_wait_budget(self, monkeypatch, capsys):
+        """launchd_restart must take the same graceful path as systemd_restart.
 
+        Regression: it previously sent a bare SIGTERM and waited
+        ``_get_restart_drain_timeout()`` (default 0), so the wait could never
+        succeed and every restart fell through to ``kickstart -k``. A bare
+        SIGTERM leaves ``restart_requested`` False, so the gateway exits 1
+        instead of 75 and announces itself as "shutting down" rather than
+        "restarting", dropping the resume_pending handoff.
+        """
+        calls = []
 
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda *a, **k: 654)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "probe_gateway_loop_liveness",
+            lambda pid, **kw: gateway_cli.GATEWAY_LOOP_ALIVE,
+        )
+        # Wait budget covers after-turn deferral + drain + headroom (#77184);
+        # the raw drain timeout (0 by default) must not be used here.
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 0.0)
+        monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 27.0)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: calls.append(("graceful", pid, timeout)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "terminate_pid",
+            lambda pid, force=False: calls.append(("sigterm", pid)),
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *a, **k: calls.append(("kickstart", a[0])) or SimpleNamespace(
+                returncode=0, stdout="", stderr=""
+            ),
+        )
+        monkeypatch.setattr(gateway_cli, "_clear_launchd_unsupported_marker", lambda: None)
+
+        gateway_cli.launchd_restart()
+
+        assert ("graceful", 654, 27.0) in calls
+        # A bare SIGTERM would strand the gateway on the unplanned-shutdown path.
+        assert not any(call[0] == "sigterm" for call in calls)
+        # ``-k`` after a successful graceful exit would kill the replacement.
+        assert not any(call[0] == "kickstart" for call in calls)
+        out = capsys.readouterr().out
+        assert "27" in out
+        assert "up to 0s" not in out
 
 
 

--- a/tests/hermes_cli/test_update_wedged_gateway.py
+++ b/tests/hermes_cli/test_update_wedged_gateway.py
@@ -193,6 +193,8 @@ class TestLaunchdRestartWedgedIntegration:
         monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
         monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 180.0)
+        # Wait budget covers after-turn deferral + drain + headroom (#77184).
+        monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 195.0)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda *a, **k: 4242)
         monkeypatch.setattr(
             gateway_cli, "_request_gateway_self_restart", lambda pid: False
@@ -212,10 +214,11 @@ class TestLaunchdRestartWedgedIntegration:
             "terminate_pid",
             lambda pid, force=False: events.append("sigterm"),
         )
+        # Never let a real SIGUSR1 escape to PID 4242 during tests.
         monkeypatch.setattr(
             gateway_cli,
-            "_wait_for_gateway_exit",
-            lambda timeout, force_after=None: events.append(("drain", timeout)) or True,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: events.append(("drain", pid, timeout)) or True,
         )
         monkeypatch.setattr(
             gateway_cli.subprocess,
@@ -241,11 +244,11 @@ class TestLaunchdRestartWedgedIntegration:
         events = self._setup(monkeypatch, gateway_cli.GATEWAY_LOOP_ALIVE)
         gateway_cli.launchd_restart()
         assert "escalate" not in events
-        assert ("drain", 180.0) in events
+        assert ("drain", 4242, 195.0) in events
 
     def test_unknown_liveness_keeps_full_drain_budget(self, monkeypatch):
         """Ambiguity (no heartbeat) must never trigger escalation."""
         events = self._setup(monkeypatch, gateway_cli.GATEWAY_LOOP_UNKNOWN)
         gateway_cli.launchd_restart()
         assert "escalate" not in events
-        assert ("drain", 180.0) in events
+        assert ("drain", 4242, 195.0) in events


### PR DESCRIPTION
## Summary

On macOS, `hermes gateway restart` never takes the graceful SIGUSR1 path. Every restart — including a deliberate, operator-initiated one — is delivered to the gateway as a bare SIGTERM, so it exits `1` instead of `75` and announces itself to chat as **"Gateway shutting down"** rather than **"Gateway restarting"**, dropping the `resume_pending` handoff.

`launchd_restart()` has drifted from `systemd_restart()`. There are two independent defects; either alone is sufficient to break the path.

## Defect 1 — the ancestry-gated helper

`launchd_restart()` calls `_request_gateway_self_restart(pid)` (`hermes_cli/gateway.py:5127`), which is gated on `_is_pid_ancestor_of_current_process(pid)`. That walks the *caller's* process tree, so it is only ever true when the CLI was spawned **by** the gateway — i.e. an in-chat `/restart`. Invoked from a shell, the gateway is a sibling, the guard returns `False`, and SIGUSR1 is never sent.

The correct helper already exists: `_graceful_restart_via_sigusr1()` (`gateway.py:255`) — same job, no ancestry gate, docstring describing it as *"the drain-aware alternative to `systemctl restart` / SIGTERM."* Its call sites:

```
hermes_cli/gateway.py:3971     ← systemd_restart()
hermes_cli/update_cmd.py:6337  ← updater
hermes_cli/update_cmd.py:6626  ← updater
```

None from the launchd branch.

## Defect 2 — the wrong wait budget

`launchd_restart()` waits `_get_restart_drain_timeout()`, which **defaults to 0**. `gateway/restart.py` documents that as intentional for the in-`stop()` force-interrupt budget:

> `restart_drain_timeout` defaults to 0 because interrupting a *chat* turn is cheap and recoverable

But it is not a valid *wait-for-exit* budget: `_wait_for_gateway_exit(timeout=0.0)` can never succeed, so the fallthrough to `kickstart -k` is unconditional. `systemd_restart()` uses `_get_restart_exit_wait_budget()` (`drain + after_turn + 15s` headroom), and `resolve_restart_exit_wait_budget()` warns:

> Callers that fall back to a hard kill on wait expiry must cover both phases or they reintroduce #77184.

`launchd_restart()` falls back to a hard kill on wait expiry and covers only the second phase.

## Side by side

```
systemd_restart()  (line 3963)          launchd_restart()  (line 5119)
────────────────────────────────        ────────────────────────────────
_get_restart_exit_wait_budget()         _get_restart_drain_timeout()
    → drain + after_turn + 15               → 0.0
_graceful_restart_via_sigusr1(          _request_gateway_self_restart(pid)
    pid, wait_budget)                       └─ ancestry gate → False
    └─ no ancestry gate                 terminate_pid(force=False) → SIGTERM
    └─ SIGUSR1 → exit 75                _wait_for_gateway_exit(0.0) → fails
"Gateway restarting" + resume           launchctl kickstart -k
                                        "Gateway shutting down", exit 1
```

The gateway's SIGUSR1 handler is wired and healthy throughout (`gateway/run.py:30326`); it simply never receives one on macOS.

## Reproduction

macOS 27.0 (arm64), Hermes 0.20.4, Python 3.11.16, launchd-supervised gateway (`ai.hermes.gateway`, `KeepAlive=true`).

```
$ hermes gateway restart
→ Stopping gateway (PID 49787) — draining in-flight runs (up to 0s)...
⚠ Gateway PID 49787 still running after 0.0s — restart may fail
⚠ Gateway drain timed out after 0s — forcing launchd restart
✓ Service restarted
```

`logs/gateway.log` for the same restart:

```
Received SIGTERM — initiating shutdown
Shutdown context: signal=SIGTERM under_systemd=no ...
Sent shutdown notification to home channel slack:<redacted>
Gateway stopped by an unexpected signal — persisting gateway_state=running ...
Exiting with code 1 (signal-initiated shutdown without restart request) ...
```

Slack receives `⚠️ Gateway shutting down — Your current task will be interrupted.` — no *"Send any message after restart and I'll try to resume where you left off."*

## Impact

Every macOS restart is misreported as an unplanned shutdown. Concretely:

- Sessions are not pre-marked `resume_pending`, so in-flight work is not resumed after the bounce.
- In-flight turns get no drain at all — the wait is 0s, then `kickstart -k`.
- The chat banner is indistinguishable from a genuine crash, so operators cannot tell a deliberate restart from an unplanned one. (This is how the bug was found: a recurring "shutting down" banner that looked like instability.)

## Fix

Make the launchd branch mirror the systemd one — send SIGUSR1 with the exit-wait budget, and return on success so launchd's unconditional `KeepAlive` revives the process. `kickstart -k` stays as the fallback for a genuine drain timeout, but must not run after a successful graceful exit or it kills the replacement instance.

The wedged-loop escalation (#81642) still short-circuits ahead of the graceful attempt, so a provably dead event loop is never handed a signal it cannot process.

```python
 def launchd_restart():
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
-    drain_timeout = _get_restart_drain_timeout()
     from gateway.status import get_running_pid
     ...
         if pid is not None:
+            wait_budget = _get_restart_exit_wait_budget()
             print(
                 f"→ Stopping gateway (PID {pid}) — draining in-flight runs "
-                f"(up to {drain_timeout:.0f}s)..."
+                f"(up to {wait_budget:.0f}s)..."
             )
-            try:
-                terminate_pid(pid, force=False)
-            except (ProcessLookupError, PermissionError, OSError):
-                pid = None
-            if pid is not None:
-                exited = _wait_for_gateway_exit(timeout=drain_timeout, force_after=None)
-                if not exited:
-                    print(f"⚠ Gateway drain timed out after {drain_timeout:.0f}s ...")
+            if _graceful_restart_via_sigusr1(pid, wait_budget):
+                print("✓ Service restart requested")
+                _clear_launchd_unsupported_marker()
+                return
+            print(f"⚠ Gateway drain timed out after {wait_budget:.0f}s ...")
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
```

The existing `try/except (ProcessLookupError, PermissionError, OSError)` around `terminate_pid` is no longer needed: `_graceful_restart_via_sigusr1()` already returns `True` on `ProcessLookupError` (already gone) and `False` on `PermissionError`/`OSError` (fall through to the hard path).

## Tests

- **Added** `test_launchd_restart_uses_sigusr1_and_exit_wait_budget`, a launchd counterpart to the existing `test_systemd_restart_gracefully_restarts_running_service_and_waits`. Asserts SIGUSR1 with the exit-wait budget, and no bare SIGTERM or `kickstart` on success. Verified to fail on unpatched `main` with exactly the reproduction output above.
- **Updated** the three `TestLaunchdRestartWedgedIntegration` tests, which asserted the old SIGTERM-plus-drain shape. They now also stub `_graceful_restart_via_sigusr1` so no real SIGUSR1 escapes to the fake PID 4242 — previously latent, since the old code path never signalled.

Verification on the branch:

- `tests/hermes_cli/test_gateway_service.py` + `tests/hermes_cli/test_update_wedged_gateway.py`: **101 passed, 1 skipped**.
- All restart-related tests repo-wide (`-k "restart or launchd or sigusr1 or gateway_service or wedged"`): **457 passed, 2 failed** — both in `tests/tools/test_daytona_environment.py`, confirmed failing identically on clean `main` (unrelated; they match only on the word "restart").

Note for reviewers: the suite needs `pytest-asyncio`. Without it ~289 async tests error out with `PytestUnknownMarkWarning: Unknown pytest.mark.asyncio`, which is easy to mistake for real breakage.
