### PR TITLE
fix(tools): fingerprint tool config by content

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -260,6 +260,20 @@ _RAW_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
 # calls read_raw_config. Also covers mutation of the module-level cache
 # dicts above.
 _CONFIG_LOCK = threading.RLock()
+
+
+def invalidate_config_read_caches(config_path: Optional[Path] = None) -> None:
+    """Drop metadata-keyed config reads for one profile's config path.
+
+    Last-known-good state and managed-scope caches are deliberately retained;
+    the next load still applies their existing fallback and overlay semantics.
+    """
+    with _CONFIG_LOCK:
+        path_key = str(config_path if config_path is not None else get_config_path())
+        _LOAD_CONFIG_CACHE.pop(path_key, None)
+        _RAW_CONFIG_CACHE.pop(path_key, None)
+
+
 # Env var names written to .env that aren't in OPTIONAL_ENV_VARS
 # (managed by setup/provider flows directly).
 _EXTRA_ENV_KEYS = frozenset({

--- a/model_tools.py
+++ b/model_tools.py
@@ -314,7 +314,12 @@ _TOOL_DEFS_CACHE_MAX = 8
 
 
 def _config_content_fingerprint(config_path) -> bytes:
-    """Return a bounded-memory content fingerprint for a config file."""
+    """Return a content fingerprint, deliberately hashing the file each call.
+
+    Metadata-only shortcuts cannot detect rewrites that preserve both size and
+    mtime. Streaming bounds memory use while correctness takes priority over
+    the small cost of reading and hashing the config.
+    """
     digest = hashlib.sha256()
     with config_path.open("rb") as config_file:
         for chunk in iter(lambda: config_file.read(64 * 1024), b""):

--- a/model_tools.py
+++ b/model_tools.py
@@ -20,6 +20,7 @@ Public API (signatures preserved from the original 2,400-line version):
     check_tool_availability(quiet) -> tuple
 """
 
+import hashlib
 import os
 import json
 import re
@@ -312,6 +313,15 @@ _tool_defs_cache_lock = threading.Lock()
 _TOOL_DEFS_CACHE_MAX = 8
 
 
+def _config_content_fingerprint(config_path) -> bytes:
+    """Return a bounded-memory content fingerprint for a config file."""
+    digest = hashlib.sha256()
+    with config_path.open("rb") as config_file:
+        for chunk in iter(lambda: config_file.read(64 * 1024), b""):
+            digest.update(chunk)
+    return digest.digest()
+
+
 def _clear_tool_defs_cache() -> None:
     """Drop memoized get_tool_definitions() results. Called when dynamic
     schema dependencies change (e.g. discord capability cache reset,
@@ -348,7 +358,7 @@ def get_tool_definitions(
     # The cache key captures every argument-level input; the registry
     # generation captures registry mutations (MCP refresh, plugin load).
     # check_fn results are TTL-cached one level down, inside
-    # registry.get_definitions. The config-mtime fingerprint below captures
+    # registry.get_definitions. The config-content fingerprint below captures
     # user-visible config edits that affect dynamic schemas (execute_code
     # mode, discord action allowlist, etc.) without needing an explicit
     # invalidate hook on every config-writer.
@@ -357,8 +367,7 @@ def get_tool_definitions(
         try:
             from hermes_cli.config import get_config_path
             cfg_path = get_config_path()
-            cfg_stat = cfg_path.stat()
-            cfg_fp = (cfg_stat.st_mtime_ns, cfg_stat.st_size)
+            cfg_fp = _config_content_fingerprint(cfg_path)
         except (FileNotFoundError, OSError, ImportError):
             cfg_fp = None
         profile_scope = check_fn_cache_scope()

--- a/model_tools.py
+++ b/model_tools.py
@@ -368,6 +368,7 @@ def get_tool_definitions(
     # mode, discord action allowlist, etc.) without needing an explicit
     # invalidate hook on every config-writer.
     cache_key = None
+    cfg_path = None
     if quiet_mode:
         try:
             from hermes_cli.config import get_config_path
@@ -399,6 +400,14 @@ def get_tool_definitions(
             # Return a shallow copy of the list but share the dict references —
             # schemas are treated as read-only by all known callers.
             return list(cached)
+
+    if quiet_mode and cache_key is not None and cfg_path is not None:
+        # A content-fingerprint miss can coexist with a metadata-cache hit in
+        # the config layer when a writer preserves both size and mtime. Ensure
+        # dynamic schemas rebuild from disk, scoped to this profile only.
+        from hermes_cli.config import invalidate_config_read_caches
+
+        invalidate_config_read_caches(cfg_path)
 
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
                                        skip_tool_search_assembly=skip_tool_search_assembly)

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 import os
-from pathlib import Path
 from threading import Barrier
 
 import pytest
@@ -74,23 +73,6 @@ class TestQuietModeCacheIsolation:
         )
 
         assert calls == 2
-
-    def test_config_fingerprint_reads_in_bounded_chunks(self, tmp_path, monkeypatch):
-        """The hot cache path must not allocate the entire config file."""
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text("toolsets:\n  - file\n", encoding="utf-8")
-        monkeypatch.setattr(
-            "hermes_cli.config.get_config_path", lambda: config_file
-        )
-
-        def fail_read_bytes(_path):
-            raise AssertionError("cache fingerprint must not use Path.read_bytes()")
-
-        monkeypatch.setattr(Path, "read_bytes", fail_read_bytes)
-
-        assert model_tools.get_tool_definitions(
-            enabled_toolsets=["file"], quiet_mode=True
-        )
 
     def test_first_uncached_call_returns_fresh_list(self):
         """The first quiet_mode call must not alias the cached object \u2014

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -17,6 +17,8 @@ These tests pin:
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+import os
+from pathlib import Path
 from threading import Barrier
 
 import pytest
@@ -33,6 +35,62 @@ def _clear_cache():
 
 
 class TestQuietModeCacheIsolation:
+
+    def test_same_size_same_mtime_config_rewrite_recomputes_definitions(
+        self, tmp_path, monkeypatch
+    ):
+        """A content edit must invalidate the quiet-mode cache even when a
+        writer preserves both the config file's size and nanosecond mtime."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("toolsets:\n  - file\n", encoding="utf-8")
+        original_stat = config_file.stat()
+        monkeypatch.setattr(
+            "hermes_cli.config.get_config_path", lambda: config_file
+        )
+
+        calls = 0
+        original_compute = model_tools._compute_tool_definitions
+
+        def compute(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return original_compute(*args, **kwargs)
+
+        monkeypatch.setattr(model_tools, "_compute_tool_definitions", compute)
+
+        model_tools.get_tool_definitions(
+            enabled_toolsets=["file"], quiet_mode=True
+        )
+        config_file.write_text("toolsets:\n  - test\n", encoding="utf-8")
+        os.utime(
+            config_file,
+            ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+        )
+        assert config_file.stat().st_size == original_stat.st_size
+        assert config_file.stat().st_mtime_ns == original_stat.st_mtime_ns
+
+        model_tools.get_tool_definitions(
+            enabled_toolsets=["file"], quiet_mode=True
+        )
+
+        assert calls == 2
+
+    def test_config_fingerprint_reads_in_bounded_chunks(self, tmp_path, monkeypatch):
+        """The hot cache path must not allocate the entire config file."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("toolsets:\n  - file\n", encoding="utf-8")
+        monkeypatch.setattr(
+            "hermes_cli.config.get_config_path", lambda: config_file
+        )
+
+        def fail_read_bytes(_path):
+            raise AssertionError("cache fingerprint must not use Path.read_bytes()")
+
+        monkeypatch.setattr(Path, "read_bytes", fail_read_bytes)
+
+        assert model_tools.get_tool_definitions(
+            enabled_toolsets=["file"], quiet_mode=True
+        )
 
     def test_first_uncached_call_returns_fresh_list(self):
         """The first quiet_mode call must not alias the cached object \u2014

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -41,26 +41,39 @@ class TestQuietModeCacheIsolation:
         """A content edit must invalidate the quiet-mode cache even when a
         writer preserves both the config file's size and nanosecond mtime."""
         config_file = tmp_path / "config.yaml"
-        config_file.write_text("toolsets:\n  - file\n", encoding="utf-8")
+        config_file.write_text(
+            "delegation:\n"
+            "  max_concurrent_children: 4\n"
+            "code_execution:\n"
+            "  mode: project\n",
+            encoding="utf-8",
+        )
         original_stat = config_file.stat()
         monkeypatch.setattr(
             "hermes_cli.config.get_config_path", lambda: config_file
         )
 
-        calls = 0
-        original_compute = model_tools._compute_tool_definitions
-
-        def compute(*args, **kwargs):
-            nonlocal calls
-            calls += 1
-            return original_compute(*args, **kwargs)
-
-        monkeypatch.setattr(model_tools, "_compute_tool_definitions", compute)
-
-        model_tools.get_tool_definitions(
-            enabled_toolsets=["file"], quiet_mode=True
+        initial = model_tools.get_tool_definitions(
+            enabled_toolsets=["delegation", "code_execution"],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
         )
-        config_file.write_text("toolsets:\n  - test\n", encoding="utf-8")
+        initial_by_name = {tool["function"]["name"]: tool for tool in initial}
+        assert "up to 4" in initial_by_name["delegate_task"]["function"][
+            "parameters"
+        ]["properties"]["tasks"]["description"]
+        assert (
+            "session's working directory"
+            in initial_by_name["execute_code"]["function"]["description"]
+        )
+
+        config_file.write_text(
+            "delegation:\n"
+            "  max_concurrent_children: 7\n"
+            "code_execution:\n"
+            "  mode: strict \n",
+            encoding="utf-8",
+        )
         os.utime(
             config_file,
             ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
@@ -68,11 +81,20 @@ class TestQuietModeCacheIsolation:
         assert config_file.stat().st_size == original_stat.st_size
         assert config_file.stat().st_mtime_ns == original_stat.st_mtime_ns
 
-        model_tools.get_tool_definitions(
-            enabled_toolsets=["file"], quiet_mode=True
+        refreshed = model_tools.get_tool_definitions(
+            enabled_toolsets=["delegation", "code_execution"],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
         )
+        refreshed_by_name = {tool["function"]["name"]: tool for tool in refreshed}
 
-        assert calls == 2
+        assert "up to 7" in refreshed_by_name["delegate_task"]["function"][
+            "parameters"
+        ]["properties"]["tasks"]["description"]
+        assert (
+            "own temp dir"
+            in refreshed_by_name["execute_code"]["function"]["description"]
+        )
 
     def test_first_uncached_call_returns_fresh_list(self):
         """The first quiet_mode call must not alias the cached object \u2014


### PR DESCRIPTION
## What does this PR do?

Fixes quiet-mode tool-definition cache invalidation when `config.yaml` is rewritten with different content but the same byte length and restored nanosecond mtime. The cache key now uses a streaming SHA-256 content digest (64 KiB chunks), avoiding unbounded config-file allocation on the gateway hot path.

## Related Issue

No issue exists. Searched open/closed/merged PRs and issues for tool-definition config-cache/mtime fingerprints; no equivalent fix found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `model_tools.py`: fingerprint config contents for the quiet-mode cache key using bounded-memory streaming reads.
- `tests/test_get_tool_definitions_cache_isolation.py`: cover same-size/same-mtime content rewrites and confirm the fingerprint does not use whole-file reads.

## How to Test

1. Run `scripts/run_tests.sh tests/test_get_tool_definitions_cache_isolation.py -q`.
2. Run `scripts/run_tests.sh tests/test_model_tools.py -q`.
3. The new regression proves a same-size config rewrite with its original mtime restored recomputes definitions.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (full wrapper run is blocked by pre-existing missing `anthropic` dependency failures and timed out after 600s)
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu 24.04
- [x] Documentation/config/schema updates: N/A
- [x] Cross-platform impact considered: `pathlib` streaming reads are cross-platform
