### PR TITLE
fix(kanban): route TUI completions to the originating session

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -882,6 +882,7 @@ def test_create_subscribes_tui_session_via_session_key(monkeypatch, worker_env):
     monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
     monkeypatch.setenv("HERMES_SESSION_KEY", "tui-session-abc")
+    monkeypatch.setenv("HERMES_UI_SESSION_ID", "tui-ui-session-123")
     monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
 
     out = kt._handle_create({
@@ -899,6 +900,9 @@ def test_create_subscribes_tui_session_via_session_key(monkeypatch, worker_env):
     assert subs[0]["chat_id"] == "tui-session-abc"
     assert subs[0]["chat_type"] == "dm"
     assert subs[0]["delivery_mode"] == "notify"
+    assert subs[0]["delivery_metadata"] == {
+        "origin_ui_session_id": "tui-ui-session-123",
+    }
 
 
 def test_create_does_not_subscribe_in_cli_session(monkeypatch, worker_env):

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -27,11 +27,22 @@ def _session(key: str = SESSION_KEY) -> dict:
     return {"session_key": key}
 
 
-def _create_subscribed_task(*, chat_id: str = SESSION_KEY, platform: str = "tui"):
+def _create_subscribed_task(
+    *,
+    chat_id: str = SESSION_KEY,
+    platform: str = "tui",
+    delivery_metadata: dict | None = None,
+):
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="notify tui", assignee="worker")
-        kb.add_notify_sub(conn, task_id=tid, platform=platform, chat_id=chat_id)
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform=platform,
+            chat_id=chat_id,
+            delivery_metadata=delivery_metadata,
+        )
         return tid
     finally:
         conn.close()
@@ -60,7 +71,7 @@ class TestCollectKanbanNotifications:
         kb.create_board("second-board")
 
         with patch.object(kb, "connect", wraps=kb.connect) as spy_connect:
-            texts = _collect_kanban_notifications(_session())
+            texts = _collect_kanban_notifications(_session(), "sid-current")
 
         assert texts == []
         spy_connect.assert_not_called()
@@ -69,7 +80,7 @@ class TestCollectKanbanNotifications:
         tid = _create_subscribed_task()
         _complete(tid, summary="shipped the fix")
 
-        first = _collect_kanban_notifications(_session())
+        first = _collect_kanban_notifications(_session(), "sid-current")
 
         assert len(first) == 1
         assert tid in first[0]
@@ -80,7 +91,7 @@ class TestCollectKanbanNotifications:
         first_cursor = rows[0]["last_event_id"]
 
         # The retained subscription must not replay the completed event.
-        assert _collect_kanban_notifications(_session()) == []
+        assert _collect_kanban_notifications(_session(), "sid-current") == []
 
         conn = kb.connect()
         try:
@@ -93,7 +104,7 @@ class TestCollectKanbanNotifications:
         finally:
             conn.close()
 
-        reopened = _collect_kanban_notifications(_session())
+        reopened = _collect_kanban_notifications(_session(), "sid-current")
 
         assert len(reopened) == 2
         assert "ready" in reopened[0]
@@ -102,7 +113,7 @@ class TestCollectKanbanNotifications:
         assert len(rows) == 1
         assert rows[0]["chat_id"] == SESSION_KEY
         assert rows[0]["last_event_id"] > first_cursor
-        assert _collect_kanban_notifications(_session()) == []
+        assert _collect_kanban_notifications(_session(), "sid-current") == []
 
         conn = kb.connect()
         try:
@@ -111,7 +122,7 @@ class TestCollectKanbanNotifications:
             conn.close()
 
         # Archive is notification-terminal and removes the retained route.
-        assert _collect_kanban_notifications(_session()) == []
+        assert _collect_kanban_notifications(_session(), "sid-current") == []
         assert _sub_rows(tid) == []
 
     def test_matching_tui_sub_delivers_and_advances_cursor(self):
@@ -124,8 +135,8 @@ class TestCollectKanbanNotifications:
             conn.close()
 
         with patch.object(kb, "connect", wraps=kb.connect) as spy_connect:
-            first = _collect_kanban_notifications(_session())
-            second = _collect_kanban_notifications(_session())
+            first = _collect_kanban_notifications(_session(), "sid-current")
+            second = _collect_kanban_notifications(_session(), "sid-current")
 
         assert len(first) == 1
         assert "blocked" in first[0]
@@ -146,7 +157,7 @@ class TestCollectKanbanNotifications:
         _complete(tid)
 
         with patch.object(kb, "connect", wraps=kb.connect) as spy_connect:
-            texts = _collect_kanban_notifications(_session())
+            texts = _collect_kanban_notifications(_session(), "sid-current")
 
         assert texts == []
         spy_connect.assert_not_called()
@@ -160,13 +171,63 @@ class TestCollectKanbanNotifications:
         _complete(tid)
 
         with patch.object(kb, "connect", wraps=kb.connect) as spy_connect:
-            texts = _collect_kanban_notifications(_session())
+            texts = _collect_kanban_notifications(_session(), "sid-current")
 
         assert texts == []
         spy_connect.assert_not_called()
         rows = _sub_rows(tid)
         assert len(rows) == 1
         assert rows[0]["last_event_id"] == pre_cursor
+
+    def test_origin_ui_session_wins_same_key_race(self, monkeypatch):
+        import tui_gateway.server as server
+
+        origin = _session()
+        sibling = _session()
+        monkeypatch.setattr(
+            server,
+            "_sessions",
+            {"origin-sid": origin, "sibling-sid": sibling},
+        )
+        monkeypatch.setattr(server, "_get_db", lambda: None)
+        tid = _create_subscribed_task(
+            delivery_metadata={"origin_ui_session_id": "origin-sid"},
+        )
+        pre_cursor = _sub_rows(tid)[0]["last_event_id"]
+        _complete(tid, summary="owned completion")
+
+        assert _collect_kanban_notifications(sibling, "sibling-sid") == []
+        assert _sub_rows(tid)[0]["last_event_id"] == pre_cursor
+
+        texts = _collect_kanban_notifications(origin, "origin-sid")
+
+        assert len(texts) == 1
+        assert "owned completion" in texts[0]
+        assert _sub_rows(tid)[0]["last_event_id"] > pre_cursor
+
+    def test_finalized_origin_falls_back_to_live_continuation(self, monkeypatch):
+        import tui_gateway.server as server
+
+        finalized_origin = {"session_key": SESSION_KEY, "_finalized": True}
+        continuation = _session()
+        monkeypatch.setattr(
+            server,
+            "_sessions",
+            {
+                "origin-sid": finalized_origin,
+                "continuation-sid": continuation,
+            },
+        )
+        monkeypatch.setattr(server, "_get_db", lambda: None)
+        tid = _create_subscribed_task(
+            delivery_metadata={"origin_ui_session_id": "origin-sid"},
+        )
+        _complete(tid, summary="continued completion")
+
+        texts = _collect_kanban_notifications(continuation, "continuation-sid")
+
+        assert len(texts) == 1
+        assert "continued completion" in texts[0]
 
     def test_probe_error_falls_back_to_writable_delivery(self, monkeypatch):
         tid = _create_subscribed_task()
@@ -177,7 +238,7 @@ class TestCollectKanbanNotifications:
 
         monkeypatch.setattr(kb, "count_notify_subs", fail_probe)
         with patch.object(kb, "connect", wraps=kb.connect) as spy_connect:
-            texts = _collect_kanban_notifications(_session())
+            texts = _collect_kanban_notifications(_session(), "sid-current")
 
         assert len(texts) == 1
         assert tid in texts[0]
@@ -187,8 +248,12 @@ class TestCollectKanbanNotifications:
         tid = _create_subscribed_task()
         _complete(tid)
 
-        assert _collect_kanban_notifications({"session_key": ""}) == []
-        assert _collect_kanban_notifications({"session_key": None}) == []
+        assert (
+            _collect_kanban_notifications({"session_key": ""}, "sid-current") == []
+        )
+        assert (
+            _collect_kanban_notifications({"session_key": None}, "sid-current") == []
+        )
         assert len(_sub_rows(tid)) == 1
 
     def test_profile_scoped_session_reads_the_shared_board(self, tmp_path):
@@ -218,7 +283,7 @@ class TestCollectKanbanNotifications:
         # active while the poller collects (as a profile-bound RPC would set).
         token = set_hermes_home_override(str(other_profile_home))
         try:
-            texts = _collect_kanban_notifications(session)
+            texts = _collect_kanban_notifications(session, "sid-current")
         finally:
             reset_hermes_home_override(token)
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1506,10 +1506,11 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
       are intentionally cleared (TUI is a single-channel local UI, not
       a multi-tenant chat surface), but the agent subprocess inherits
       ``HERMES_SESSION_KEY`` from the parent session. We subscribe with
-      ``platform="tui"`` and ``chat_id=<key>``; the TUI notification
-      poller (``tui_gateway/server.py``) reads ``kanban_notify_subs``
-      for these rows and posts the completion message into the running
-      session.
+      ``platform="tui"`` and ``chat_id=<key>``, and persist the concrete
+      ``HERMES_UI_SESSION_ID`` as the preferred live owner; the TUI
+      notification poller (``tui_gateway/server.py``) reads
+      ``kanban_notify_subs`` for these rows and posts the completion message
+      into the originating session.
 
     - **CLI / cron / test / unattached**: no persistent delivery channel,
       no-op.
@@ -1574,6 +1575,10 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             except Exception:
                 notifier_profile = "default"
         delivery_metadata: dict[str, Any] = {}
+        if platform == "tui":
+            origin_ui_session_id = get_session_env("HERMES_UI_SESSION_ID", "")
+            if origin_ui_session_id:
+                delivery_metadata["origin_ui_session_id"] = origin_ui_session_id
         if thread_id:
             delivery_metadata["thread_id"] = thread_id
         if chat_type:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9979,7 +9979,7 @@ def _format_kanban_event_text(sub: dict, task, ev, board_slug: str) -> Optional[
     return None
 
 
-def _collect_kanban_notifications(session: dict) -> list:
+def _collect_kanban_notifications(session: dict, sid: str) -> list:
     """Claim unseen terminal kanban events for this TUI session's subscriptions.
 
     ``kanban_create`` auto-subscribes TUI/desktop sessions with
@@ -10052,6 +10052,22 @@ def _collect_kanban_notifications(session: dict) -> list:
                 if (sub.get("platform") or "").lower() != "tui":
                     continue
                 if sub.get("chat_id") != session_key:
+                    continue
+                metadata = sub.get("delivery_metadata") or {}
+                origin_ui_session_id = str(
+                    metadata.get("origin_ui_session_id") or ""
+                )
+                if origin_ui_session_id and _notification_event_belongs_elsewhere(
+                    sid,
+                    session,
+                    {
+                        "origin_ui_session_id": origin_ui_session_id,
+                        "session_key": sub.get("chat_id") or "",
+                    },
+                ):
+                    # Leave the shared cursor untouched for the originating UI.
+                    # Once that UI finalizes, durable-key fallback allows its
+                    # continuation to claim on a later poll.
                     continue
                 _old, _new, events = _kb.claim_unseen_events_for_sub(
                     conn,
@@ -10130,7 +10146,7 @@ def _notification_poller_loop(
         if _now - _last_kanban_poll >= _KANBAN_POLL_SECONDS:
             _last_kanban_poll = _now
             try:
-                _kanban_texts = _collect_kanban_notifications(session)
+                _kanban_texts = _collect_kanban_notifications(session, sid)
             except Exception as _kb_exc:
                 print(
                     f"[tui_gateway] kanban notification poll failed: "


### PR DESCRIPTION
## Summary

- persist the concrete `HERMES_UI_SESSION_ID` on auto-created TUI Kanban subscriptions
- apply the existing live-session and continuation ownership routing before atomically claiming a completion cursor
- preserve durable-key fallback for legacy subscriptions and finalized origin sessions

## Problem

A TUI Kanban subscription previously stored only the durable `HERMES_SESSION_KEY`. When two live UI sessions shared that key, either poller could claim the shared subscription cursor first, so the completion could surface in the wrong tab and become unavailable to the originating one.

The exact UI owner now wins while it is live. If that owner has finalized, the existing durable-key and compression-continuation fallback can still claim the event. Rows created before this metadata was added retain their current behavior.

## Tests

- `uv run --extra dev ruff check tools/kanban_tools.py tui_gateway/server.py tests/tools/test_kanban_tools.py tests/tui_gateway/test_kanban_notify_poller.py`
- `uv run --extra dev pytest tests/tools/test_kanban_tools.py tests/tui_gateway/test_kanban_notify_poller.py -q` (48 passed)
- `uv run --extra dev pytest tests/test_tui_gateway_server.py -k "notification_event_routing_by_session_key or async_delegation_event_prefers_origin_ui_session or notification_event_follows_compression_continuation or finalized_origin_ui_session_falls_back_to_live_continuation" -q` (4 passed)

Fixes #91037