### PR TITLE
fix(kanban): make task idempotency race safe

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -134,6 +134,15 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 
+# SQLite-expressie-indexen kunnen Python's Unicode-whitespace-semantiek niet
+# veilig persistent maken. Deze vaste ASCII-set is daarom het contract voor
+# zowel de Python-normalisatie als alle SQLite-canonicalisatie.
+_IDEMPOTENCY_KEY_WHITESPACE = " \t\n\r\v\f"
+_IDEMPOTENCY_KEY_SQL_EXPR = (
+    "TRIM(idempotency_key, char(9) || char(10) || char(11) || "
+    "char(12) || char(13) || ' ')"
+)
+
 
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
     """Normalize a per-task reasoning effort into a storable level.
@@ -2538,10 +2547,10 @@ def _dedupe_active_idempotency_keys(conn: sqlite3.Connection) -> None:
     normal archive lifecycle, including closing a leaked active run.
     """
     duplicate_keys = conn.execute(
-        "SELECT idempotency_key FROM tasks "
-        "WHERE idempotency_key IS NOT NULL AND TRIM(idempotency_key) != '' "
+        f"SELECT {_IDEMPOTENCY_KEY_SQL_EXPR} AS canonical_key FROM tasks "
+        f"WHERE idempotency_key IS NOT NULL AND {_IDEMPOTENCY_KEY_SQL_EXPR} != '' "
         "AND status != 'archived' "
-        "GROUP BY idempotency_key HAVING COUNT(*) > 1"
+        f"GROUP BY {_IDEMPOTENCY_KEY_SQL_EXPR} HAVING COUNT(*) > 1"
     ).fetchall()
     if not duplicate_keys:
         return
@@ -2555,9 +2564,9 @@ def _dedupe_active_idempotency_keys(conn: sqlite3.Connection) -> None:
     can_close_runs = "current_run_id" in task_columns and runs_exist
 
     for key_row in duplicate_keys:
-        key = key_row["idempotency_key"]
+        key = key_row["canonical_key"]
         rows = conn.execute(
-            "SELECT id FROM tasks WHERE idempotency_key = ? "
+            f"SELECT id FROM tasks WHERE {_IDEMPOTENCY_KEY_SQL_EXPR} = ? "
             "AND status != 'archived' "
             "ORDER BY created_at DESC, id DESC",
             (key,),
@@ -2772,20 +2781,25 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # pre-check above, own the active-key invariant. Dirty boards are deduped
     # and evidenced in the same write transaction before the index is rebuilt.
     if "status" in cols:
-        with write_txn(conn):
+        # Legacy ALTER/UPDATE steps may have opened SQLite's implicit
+        # transaction already. A savepoint preserves the direct-helper
+        # contract in that case; without an outer transaction write_txn still
+        # provides the production BEGIN IMMEDIATE/COMMIT atomic boundary.
+        with write_txn(conn, allow_nested=True):
             _dedupe_active_idempotency_keys(conn)
             conn.execute("DROP INDEX IF EXISTS idx_tasks_idempotency")
             conn.execute(
-                "CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_idempotency "
-                "ON tasks(idempotency_key) "
-                "WHERE idempotency_key IS NOT NULL AND TRIM(idempotency_key) != '' "
+                f"CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_idempotency "
+                f"ON tasks({_IDEMPOTENCY_KEY_SQL_EXPR}) "
+                f"WHERE idempotency_key IS NOT NULL AND {_IDEMPOTENCY_KEY_SQL_EXPR} != '' "
                 "AND status != 'archived'"
             )
     else:
         # Keep synthetic/very old schemas without a task status column
         # migratable; they have no active/archive lifecycle to constrain.
+        conn.execute("DROP INDEX IF EXISTS idx_tasks_idempotency")
         conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency ON tasks(idempotency_key)"
+            f"CREATE INDEX idx_tasks_idempotency ON tasks({_IDEMPOTENCY_KEY_SQL_EXPR})"
         )
     notify_table_exists = conn.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='kanban_notify_subs'"
@@ -2854,7 +2868,7 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         "SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'"
     ).fetchone() is not None
     if runs_exist:
-        with write_txn(conn):
+        with write_txn(conn, allow_nested=True):
             inflight = conn.execute(
                 "SELECT id, assignee, claim_lock, claim_expires, worker_pid, "
                 "       max_runtime_seconds, last_heartbeat_at, started_at "
@@ -3234,6 +3248,13 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+def _canonical_idempotency_key(value: Optional[str]) -> Optional[str]:
+    """Normalize supported ASCII surrounding whitespace, preserving other text."""
+    if value is None:
+        return None
+    return str(value).strip(_IDEMPOTENCY_KEY_WHITESPACE) or None
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -3275,6 +3296,10 @@ def create_task(
     same key already exists, returns the existing task's id instead of
     creating a duplicate. Useful for retried webhooks / automation that
     should not double-write.
+
+    Surrounding key whitespace is limited to ASCII space, tab, LF, CR, VT,
+    and FF so the Python and persistent SQLite index semantics remain exact;
+    other whitespace is part of the key.
 
     ``max_runtime_seconds`` caps how long a worker may run before the
     dispatcher SIGTERMs (then SIGKILLs after a grace window) and
@@ -3325,8 +3350,7 @@ def create_task(
         raise ValueError("branch_name is only valid for worktree workspaces")
     # Empty / whitespace-only keys mean "no idempotency". Store them as NULL
     # so repeated keyless creates remain independent under the partial index.
-    if idempotency_key is not None:
-        idempotency_key = str(idempotency_key).strip() or None
+    idempotency_key = _canonical_idempotency_key(idempotency_key)
 
     # Inherit the board's scoped project when the caller didn't name one, so a
     # project-scoped board anchors every new task to that project's repo
@@ -3483,7 +3507,7 @@ def create_task(
     # SELECT and the INSERT.
     if idempotency_key:
         row = conn.execute(
-            "SELECT id FROM tasks WHERE idempotency_key = ? "
+            f"SELECT id FROM tasks WHERE {_IDEMPOTENCY_KEY_SQL_EXPR} = ? "
             "AND status != 'archived' "
             "ORDER BY created_at DESC, id DESC LIMIT 1",
             (idempotency_key,),
@@ -3641,13 +3665,17 @@ def create_task(
             return task_id
         except sqlite3.IntegrityError as exc:
             error_text = str(exc)
-            if "UNIQUE constraint failed: tasks.idempotency_key" in error_text:
+            idempotency_conflict = (
+                "UNIQUE constraint failed: index 'idx_tasks_idempotency'"
+                in error_text
+            )
+            if idempotency_conflict:
                 # The UNIQUE partial index rejected this insert because a
                 # concurrent writer committed the same active key. The failed
                 # write transaction has rolled back, so this read sees the
                 # committed winner and preserves the create_task API.
                 winner = conn.execute(
-                    "SELECT id FROM tasks WHERE idempotency_key = ? "
+                    f"SELECT id FROM tasks WHERE {_IDEMPOTENCY_KEY_SQL_EXPR} = ? "
                     "AND status != 'archived' "
                     "ORDER BY created_at DESC, id DESC LIMIT 1",
                     (idempotency_key,),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2528,6 +2528,69 @@ def init_db(
     return path
 
 
+def _dedupe_active_idempotency_keys(conn: sqlite3.Connection) -> None:
+    """Archive older active duplicates before creating the unique index.
+
+    Boards created before the race fix may already contain duplicate active
+    rows. Keep the row that the existing idempotency lookup resolves to and
+    retain every duplicate row and event; only its lifecycle status changes.
+    The ``archived`` event is durable migration evidence and mirrors the
+    normal archive lifecycle, including closing a leaked active run.
+    """
+    duplicate_keys = conn.execute(
+        "SELECT idempotency_key FROM tasks "
+        "WHERE idempotency_key IS NOT NULL AND TRIM(idempotency_key) != '' "
+        "AND status != 'archived' "
+        "GROUP BY idempotency_key HAVING COUNT(*) > 1"
+    ).fetchall()
+    if not duplicate_keys:
+        return
+
+    task_columns = {
+        row["name"] for row in conn.execute("PRAGMA table_info(tasks)")
+    }
+    runs_exist = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'task_runs'"
+    ).fetchone() is not None
+    can_close_runs = "current_run_id" in task_columns and runs_exist
+
+    for key_row in duplicate_keys:
+        key = key_row["idempotency_key"]
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ? "
+            "AND status != 'archived' "
+            "ORDER BY created_at DESC, id DESC",
+            (key,),
+        ).fetchall()
+        for duplicate in rows[1:]:
+            task_id = duplicate["id"]
+            run_id = None
+            if can_close_runs:
+                run_id = _end_run(
+                    conn,
+                    task_id,
+                    outcome="reclaimed",
+                    status="reclaimed",
+                    summary="task archived during idempotency-key migration",
+                )
+            conn.execute(
+                "UPDATE tasks SET status = 'archived', "
+                "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
+                "WHERE id = ? AND status != 'archived'",
+                (task_id,),
+            )
+            _append_event(
+                conn,
+                task_id,
+                "archived",
+                {
+                    "reason": "duplicate_idempotency_key_migration",
+                    "idempotency_key": key,
+                },
+                run_id=run_id,
+            )
+
+
 def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     """Add columns that were introduced after v1 release to legacy DBs.
 
@@ -2688,9 +2751,6 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # (where the columns already exist from SCHEMA_SQL).
     conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_tenant ON tasks(tenant)")
     conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency ON tasks(idempotency_key)"
-    )
-    conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
     )
 
@@ -2708,6 +2768,25 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         "ON task_events(run_id, id)"
     )
 
+    # Adapted from upstream PR #57832: make the database, rather than the
+    # pre-check above, own the active-key invariant. Dirty boards are deduped
+    # and evidenced in the same write transaction before the index is rebuilt.
+    if "status" in cols:
+        with write_txn(conn):
+            _dedupe_active_idempotency_keys(conn)
+            conn.execute("DROP INDEX IF EXISTS idx_tasks_idempotency")
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_idempotency "
+                "ON tasks(idempotency_key) "
+                "WHERE idempotency_key IS NOT NULL AND TRIM(idempotency_key) != '' "
+                "AND status != 'archived'"
+            )
+    else:
+        # Keep synthetic/very old schemas without a task status column
+        # migratable; they have no active/archive lifecycle to constrain.
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency ON tasks(idempotency_key)"
+        )
     notify_table_exists = conn.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='kanban_notify_subs'"
     ).fetchone() is not None
@@ -3244,6 +3323,10 @@ def create_task(
         branch_name = str(branch_name).strip() or None
     if branch_name and workspace_kind != "worktree":
         raise ValueError("branch_name is only valid for worktree workspaces")
+    # Empty / whitespace-only keys mean "no idempotency". Store them as NULL
+    # so repeated keyless creates remain independent under the partial index.
+    if idempotency_key is not None:
+        idempotency_key = str(idempotency_key).strip() or None
 
     # Inherit the board's scoped project when the caller didn't name one, so a
     # project-scoped board anchors every new task to that project's repo
@@ -3395,14 +3478,14 @@ def create_task(
 
     # Idempotency check — return the existing task instead of creating a
     # duplicate. Done BEFORE entering write_txn to keep the fast path fast
-    # and to avoid holding a write lock during the lookup. Race is
-    # acceptable: two concurrent creators with the same key might both
-    # insert, at which point both rows exist but the next lookup stabilises.
+    # and to avoid holding a write lock during the lookup. This is only a
+    # fast path: the UNIQUE partial index below closes the race between this
+    # SELECT and the INSERT.
     if idempotency_key:
         row = conn.execute(
             "SELECT id FROM tasks WHERE idempotency_key = ? "
             "AND status != 'archived' "
-            "ORDER BY created_at DESC LIMIT 1",
+            "ORDER BY created_at DESC, id DESC LIMIT 1",
             (idempotency_key,),
         ).fetchone()
         if row:
@@ -3556,10 +3639,28 @@ def create_task(
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
-        except sqlite3.IntegrityError:
+        except sqlite3.IntegrityError as exc:
+            error_text = str(exc)
+            if "UNIQUE constraint failed: tasks.idempotency_key" in error_text:
+                # The UNIQUE partial index rejected this insert because a
+                # concurrent writer committed the same active key. The failed
+                # write transaction has rolled back, so this read sees the
+                # committed winner and preserves the create_task API.
+                winner = conn.execute(
+                    "SELECT id FROM tasks WHERE idempotency_key = ? "
+                    "AND status != 'archived' "
+                    "ORDER BY created_at DESC, id DESC LIMIT 1",
+                    (idempotency_key,),
+                ).fetchone()
+                if winner is not None:
+                    return winner["id"]
+            elif "UNIQUE constraint failed: tasks.id" not in error_text:
+                # Do not turn unrelated constraint failures into retries or
+                # incorrectly return an existing task for the same key.
+                raise
             if attempt == 1:
                 raise
-            # Retry with a fresh id.
+            # No matching key: this was a genuine task-id collision.
             continue
     raise RuntimeError("unreachable")
 

--- a/tests/hermes_cli/test_kanban_idempotency_race.py
+++ b/tests/hermes_cli/test_kanban_idempotency_race.py
@@ -1,0 +1,176 @@
+"""Regression coverage for Kanban task idempotency-key races and migration."""
+
+import sqlite3
+import threading
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Use an isolated, initialized Kanban database."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_create_task_idempotency_key_is_race_safe(kanban_home, monkeypatch):
+    """Three connections racing after the lookup return one task id."""
+    key = "dod:fix:v1:race-safe-check"
+    results: dict[int, str] = {}
+    errors: dict[int, str] = {}
+    gate = threading.Barrier(3)
+    gated_threads: set[int] = set()
+    gate_lock = threading.Lock()
+    original_new_task_id = kb._new_task_id
+
+    def gated_new_task_id() -> str:
+        task_id = original_new_task_id()
+        thread_id = threading.get_ident()
+        with gate_lock:
+            first_call = thread_id not in gated_threads
+            if first_call:
+                gated_threads.add(thread_id)
+        # Synchronize after every caller has missed the fast-path SELECT, but
+        # before any caller enters write_txn. Retries do not re-enter the gate.
+        if first_call:
+            gate.wait(timeout=10)
+        return task_id
+
+    monkeypatch.setattr(kb, "_new_task_id", gated_new_task_id)
+
+    def worker(number: int) -> None:
+        try:
+            with kb.connect_closing() as conn:
+                results[number] = kb.create_task(
+                    conn, title=f"racer-{number}", idempotency_key=key
+                )
+        except Exception as exc:  # noqa: BLE001 - surfaced by assertions below
+            errors[number] = repr(exc)
+
+    threads = [threading.Thread(target=worker, args=(number,)) for number in range(3)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=15)
+
+    assert not any(thread.is_alive() for thread in threads), "race test deadlocked"
+    assert not errors, f"create_task raised under concurrency: {errors!r}"
+    assert results.keys() == {0, 1, 2}
+    assert len(set(results.values())) == 1, f"racers got different ids: {results!r}"
+
+    with kb.connect_closing() as conn:
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ? "
+            "AND status != 'archived'",
+            (key,),
+        ).fetchall()
+    assert len(rows) == 1, f"expected one active row for key, got {len(rows)}"
+
+
+def test_empty_and_whitespace_idempotency_keys_are_absent(kanban_home):
+    """Empty keys do not turn otherwise independent creates into duplicates."""
+    with kb.connect_closing() as conn:
+        task_ids = [
+            kb.create_task(conn, title="empty", idempotency_key=""),
+            kb.create_task(conn, title="whitespace", idempotency_key="   "),
+            kb.create_task(conn, title="none", idempotency_key=None),
+        ]
+        stored = conn.execute(
+            "SELECT idempotency_key FROM tasks ORDER BY created_at, id"
+        ).fetchall()
+
+    assert len(set(task_ids)) == 3
+    assert [row["idempotency_key"] for row in stored] == [None, None, None]
+
+
+def test_idempotency_key_can_be_reused_after_archive(kanban_home):
+    """Archiving releases a key while retaining the archived task row."""
+    key = "dod:fix:v1:archive-reuse"
+    with kb.connect_closing() as conn:
+        archived_id = kb.create_task(conn, title="first", idempotency_key=key)
+        assert kb.archive_task(conn, archived_id)
+        active_id = kb.create_task(conn, title="second", idempotency_key=key)
+
+        rows = conn.execute(
+            "SELECT id, status FROM tasks WHERE idempotency_key = ? ORDER BY id",
+            (key,),
+        ).fetchall()
+
+    assert active_id != archived_id
+    assert {row["status"] for row in rows} == {"archived", "ready"}
+
+
+def test_migration_archives_duplicate_active_keys_without_losing_history(kanban_home):
+    """Dirty pre-fix boards migrate with durable archive evidence and history."""
+    key = "dod:fix:v1:legacy-dupe"
+    path = kb.kanban_db_path()
+
+    with kb.connect_closing() as conn:
+        # Recreate the pre-fix schema state: the old index allowed duplicates.
+        conn.execute("DROP INDEX IF EXISTS idx_tasks_idempotency")
+        conn.execute("CREATE INDEX idx_tasks_idempotency ON tasks(idempotency_key)")
+        for task_id, title, created_at in (
+            ("dupe-old", "legacy-old", 100),
+            ("dupe-new", "legacy-new", 200),
+        ):
+            conn.execute(
+                "INSERT INTO tasks "
+                "(id, title, status, created_at, idempotency_key) "
+                "VALUES (?, ?, 'ready', ?, ?)",
+                (task_id, title, created_at, key),
+            )
+            conn.execute(
+                "INSERT INTO task_events (task_id, kind, payload, created_at) "
+                "VALUES (?, 'legacy_history', ?, ?)",
+                (task_id, '{"source":"before-migration"}', created_at + 1),
+            )
+
+    kb.init_db(path)
+
+    with kb.connect_closing() as conn:
+        active = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ? "
+            "AND status != 'archived'",
+            (key,),
+        ).fetchall()
+        archived = conn.execute(
+            "SELECT id, status, claim_lock, claim_expires, worker_pid "
+            "FROM tasks WHERE id = 'dupe-old'"
+        ).fetchone()
+        old_events = kb.list_events(conn, "dupe-old")
+        new_events = kb.list_events(conn, "dupe-new")
+        index = conn.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'index' AND name = 'idx_tasks_idempotency'"
+        ).fetchone()["sql"]
+        with pytest.raises(sqlite3.IntegrityError):
+            with kb.write_txn(conn):
+                conn.execute(
+                    "INSERT INTO tasks "
+                    "(id, title, status, created_at, idempotency_key) "
+                    "VALUES ('dupe-attempt', 'legacy-attempt', 'ready', 300, ?)",
+                    (key,),
+                )
+
+    assert [row["id"] for row in active] == ["dupe-new"]
+    assert archived["status"] == "archived"
+    assert archived["claim_lock"] is None
+    assert archived["claim_expires"] is None
+    assert archived["worker_pid"] is None
+    assert [event.kind for event in old_events] == ["legacy_history", "archived"]
+    assert old_events[0].payload == {"source": "before-migration"}
+    assert old_events[1].payload == {
+        "reason": "duplicate_idempotency_key_migration",
+        "idempotency_key": key,
+    }
+    assert [event.kind for event in new_events] == ["legacy_history"]
+    assert index is not None
+    assert "CREATE UNIQUE INDEX" in index.upper()
+    assert "status != 'archived'" in index

--- a/tests/hermes_cli/test_kanban_idempotency_race.py
+++ b/tests/hermes_cli/test_kanban_idempotency_race.py
@@ -174,3 +174,121 @@ def test_migration_archives_duplicate_active_keys_without_losing_history(kanban_
     assert index is not None
     assert "CREATE UNIQUE INDEX" in index.upper()
     assert "status != 'archived'" in index
+
+
+@pytest.mark.parametrize(
+    "legacy_key, canonical_key",
+    [
+        ("\tkey\t", "key"),
+        ("\nkey\r\n", "key"),
+    ],
+)
+def test_legacy_whitespace_keys_share_canonical_active_task(
+    kanban_home, legacy_key, canonical_key,
+):
+    """ASCII tab/newline legacy keys dedupe without rewriting history/text."""
+    path = kb.kanban_db_path()
+
+    with kb.connect_closing() as conn:
+        conn.execute("DROP INDEX IF EXISTS idx_tasks_idempotency")
+        conn.execute("CREATE INDEX idx_tasks_idempotency ON tasks(idempotency_key)")
+        for task_id, created_at, key in (
+            ("legacy-old", 100, legacy_key),
+            ("canonical-new", 200, canonical_key),
+        ):
+            conn.execute(
+                "INSERT INTO tasks "
+                "(id, title, status, created_at, idempotency_key) "
+                "VALUES (?, ?, 'ready', ?, ?)",
+                (task_id, task_id, created_at, key),
+            )
+            conn.execute(
+                "INSERT INTO task_events (task_id, kind, payload, created_at) "
+                "VALUES (?, 'legacy_history', ?, ?)",
+                (task_id, '{"source":"before-migration"}', created_at + 1),
+            )
+
+    kb.init_db(path)
+
+    with kb.connect_closing() as conn:
+        active = conn.execute(
+            "SELECT id FROM tasks "
+            f"WHERE {kb._IDEMPOTENCY_KEY_SQL_EXPR} = ? "
+            "AND status != 'archived'",
+            (canonical_key,),
+        ).fetchall()
+        archived = conn.execute(
+            "SELECT id, idempotency_key, status FROM tasks WHERE id = 'legacy-old'"
+        ).fetchone()
+        stored_keys = conn.execute(
+            "SELECT idempotency_key FROM tasks ORDER BY created_at, id"
+        ).fetchall()
+        index = conn.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'index' AND name = 'idx_tasks_idempotency'"
+        ).fetchone()["sql"]
+
+        assert (
+            kb.create_task(conn, title="replayed", idempotency_key=canonical_key)
+            == "canonical-new"
+        )
+        with pytest.raises(
+            sqlite3.IntegrityError,
+            match="index 'idx_tasks_idempotency'",
+        ):
+            with kb.write_txn(conn):
+                conn.execute(
+                    "INSERT INTO tasks "
+                    "(id, title, status, created_at, idempotency_key) "
+                    "VALUES ('legacy-attempt', 'attempt', 'ready', 300, ?)",
+                    (legacy_key,),
+                )
+        old_events = kb.list_events(conn, "legacy-old")
+        new_events = kb.list_events(conn, "canonical-new")
+
+    assert [row["id"] for row in active] == ["canonical-new"]
+    assert archived["status"] == "archived"
+    assert archived["idempotency_key"] == legacy_key
+    assert [row["idempotency_key"] for row in stored_keys] == [legacy_key, canonical_key]
+    assert [event.kind for event in old_events] == ["legacy_history", "archived"]
+    assert [event.kind for event in new_events] == ["legacy_history"]
+    expected_sql_expression = (
+        "TRIM(idempotency_key, char(9) || char(10) || char(11) || "
+        "char(12) || char(13) || ' ')"
+    )
+    assert expected_sql_expression in index
+
+
+@pytest.mark.parametrize("winner_key", ("\tkey\t", "\nkey\r"))
+def test_integrity_error_recovery_uses_canonical_key(
+    kanban_home, monkeypatch, winner_key,
+):
+    """Raced tab/newline legacy keys resolve through the expression index."""
+    with kb.connect_closing() as conn, kb.connect_closing() as winner_conn:
+        def insert_winner() -> str:
+            with kb.write_txn(winner_conn):
+                winner_conn.execute(
+                    "INSERT INTO tasks "
+                    "(id, title, status, created_at, idempotency_key) "
+                    "VALUES ('spaced-winner', 'winner', 'ready', 1, ?)",
+                    (winner_key,),
+                )
+            return "losing-id"
+
+        monkeypatch.setattr(kb, "_new_task_id", insert_winner)
+        assert (
+            kb.create_task(conn, title="raced", idempotency_key="key")
+            == "spaced-winner"
+        )
+
+
+def test_unrelated_integrity_error_is_not_misclassified(kanban_home, monkeypatch):
+    """A task-id conflict is still raised instead of becoming an idempotent hit."""
+    with kb.connect_closing() as conn:
+        existing_id = kb.create_task(
+            conn, title="existing", idempotency_key="existing-key"
+        )
+        monkeypatch.setattr(kb, "_new_task_id", lambda: existing_id)
+
+        with pytest.raises(sqlite3.IntegrityError, match="tasks.id"):
+            kb.create_task(conn, title="collision", idempotency_key="new-key")


### PR DESCRIPTION
## Summary

- Add a database-enforced partial unique invariant for active Kanban task idempotency keys.
- Normalize empty keys and a documented deterministic ASCII whitespace set consistently in Python and SQLite.
- Deduplicate legacy active duplicates during migration by archiving older duplicates while preserving rows, events, and stored historical key text.
- Return the committed winner when concurrent creators race on the same active key.
- Preserve archived-key reuse and propagate unrelated integrity errors.

## Correctness boundaries

- Dedupe, expression index, fast lookup, and race recovery use one shared canonical SQL expression.
- Space, tab, LF, CR, VT, and FF semantics match exactly between Python and the persistent SQLite expression index.
- Migration works both under the production transaction and when the helper is called inside an existing implicit transaction.
- Failed duplicate inserts cannot create a second active task, while archived history remains addressable.

## Validation

- Final targeted matrix: 17 passed, 0 failed.
- Includes three-caller concurrency, legacy space/tab/newline dedupe, expression-index enforcement, race winner recovery, unrelated integrity-error propagation, archived-key reuse, nested/implicit migration transactions, and adjacent notification migrations.
- SQLite 3.46.1 expression/partial-index probe: pass.
- `python3 -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_idempotency_race.py`: pass.
- `git diff --check`: pass.
- Independent review found the initial non-space whitespace mismatch; the final correction closes it.

## Related work and credit

This hardens the race-safety direction proposed in #57832 by Andrew Lord and preserves its intent while adding active-only lifecycle, legacy migration, and canonicalization guarantees.
